### PR TITLE
Fix flaky test 04207_pr_additional_filters

### DIFF
--- a/tests/queries/0_stateless/04207_pr_additional_filters.sql
+++ b/tests/queries/0_stateless/04207_pr_additional_filters.sql
@@ -2,7 +2,9 @@
 -- ^ failpoint
 
 DROP TABLE IF EXISTS atf_p;
-CREATE TABLE atf_p (x UInt64) ENGINE = MergeTree ORDER BY tuple();
+-- Pin index_granularity so EXPLAIN ... distributed=1 reports a stable granule count;
+-- random index_granularity splits the 10 rows into >1 granule and breaks the reference.
+CREATE TABLE atf_p (x UInt64) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
 INSERT INTO atf_p SELECT number FROM numbers(10);
 
 -- The failpoint disables cancellation of unused replicas after all ranges


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flaky `04207_pr_additional_filters`.

The test ends with `EXPLAIN PLAN actions=1, distributed=1`, whose output includes the per-part granule count of the local `ReadFromMergeTree` step. The table is created without an explicit `index_granularity`, so CI random MergeTree settings can pick a small `index_granularity` (e.g. 8). With a wide part (`min_bytes_for_wide_part=0`) that splits the 10 rows into two granules, turning the reference line `Granules: 1` into `Granules: 2` and failing the test.

Fix: pin `index_granularity = 8192` in the `CREATE TABLE`. The granule count becomes deterministic while all other randomization stays enabled, preserving the test's coverage of `additional_table_filters` with parallel replicas.

Master failure that prompted this: 2026-05-29, `Stateless tests (amd_msan, WasmEdge, sequential, 2/2)`, culprit MergeTree settings `--index_granularity 8 --min_bytes_for_wide_part 0` (from the CI randomized-settings diagnosis).
Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9b2349ab6aa28fdd4484d6875617d8c7dd0c9a6e&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20sequential%2C%202%2F2%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.652`
<!-- ch-version-info:end -->