### PR TITLE
Fix flaky test 03594_constraint_subqery_logical_error

### DIFF
--- a/tests/queries/0_stateless/03594_constraint_subqery_logical_error.sql
+++ b/tests/queries/0_stateless/03594_constraint_subqery_logical_error.sql
@@ -1,3 +1,6 @@
+-- Tags: no-async-insert
+-- - no-async-insert -- with wait_for_async_insert=0 the INSERT is fire-and-forget, so the constraint error is raised in the background flush and never reaches the client, breaking the { serverError } assertion.
+
 CREATE TABLE check_constraint (c0 Int) ENGINE = MergeTree() ORDER BY tuple();
 INSERT INTO TABLE check_constraint (c0) VALUES (1);
 ALTER TABLE check_constraint ADD CONSTRAINT c0 CHECK (SELECT 1);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

`03594_constraint_subqery_logical_error` asserts that an INSERT into a table whose CHECK constraint contains a subquery is rejected at INSERT time with `UNKNOWN_IDENTIFIER` (error 47):

```sql
ALTER TABLE check_constraint ADD CONSTRAINT c0 CHECK (SELECT 1);
INSERT INTO TABLE check_constraint (c0) VALUES (1); -- { serverError UNKNOWN_IDENTIFIER }
```

In CI runs that exercise the async-insert mode (`async_insert=1`, `wait_for_async_insert=0`), the INSERT is fire-and-forget: the client returns success immediately and the constraint error is raised later, during the background flush, so it never reaches the client. The `{ serverError UNKNOWN_IDENTIFIER }` assertion then sees no server error and the test fails with `Expected server error code '47' but got no server error`.

Fix: add the `no-async-insert` tag so the test is skipped under the async-insert run mode. This matches the existing convention used by `01286_constraints_on_default.sql`, a constraints test with the same INSERT-time `serverError` assertion.

The test is not a real engine bug: the row is still correctly rejected (the table row count is unchanged); the error simply goes to the background flush / `system.asynchronous_insert_log` instead of the client when `wait_for_async_insert=0`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.656`
<!-- ch-version-info:end -->