### PR TITLE
Fix flaky test 03800_projection_row_policy_filter_column

### DIFF
--- a/tests/queries/0_stateless/03800_projection_row_policy_filter_column.sql
+++ b/tests/queries/0_stateless/03800_projection_row_policy_filter_column.sql
@@ -13,7 +13,9 @@ CREATE TABLE test_rls_projection
     )
 )
 ENGINE = MergeTree()
-ORDER BY (tenant_id, id);
+ORDER BY (tenant_id, id)
+-- Pin index_granularity: the EXPLAIN indexes section below asserts an exact granule count.
+SETTINGS index_granularity = 8192;
 
 INSERT INTO test_rls_projection VALUES
     (1, 'tenant_A', 'item_1'),


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Flaky under CI's randomized `index_granularity`. The test asserts an exact granule count in its `EXPLAIN indexes = 1` section (`Granules: 1/1`). With `index_granularity = 1` each row is its own granule, so the projection scan reads `3/5` and the EXPLAIN diverges. The runner's own settings auto-diagnosis minimized the culprit to `--index_granularity 1`.

Results, projection-used and PREWHERE checks are unaffected; only the granule count changes. Pin `index_granularity = 8192` in the CREATE TABLE SETTINGS so the asserted count is deterministic, matching the test's existing `enable_parallel_replicas = 0` pin. The full EXPLAIN assertion is preserved.

No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.663`
<!-- ch-version-info:end -->