### PR TITLE
Fix Keeper crash on stale snapshot chunk request

### DIFF
--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -1544,9 +1544,13 @@ int IKeeperStateMachine::read_logical_snp_obj(
     auto * ctx = reinterpret_cast<SnapshotTransferCtx *>(user_snp_ctx);
     if (!ctx)
     {
-        LOG_WARNING(log, "Snapshot transfer context is null for obj_id {}", obj_id);
+        /// A non-initial chunk request without a transfer context is a stale
+        /// request after the peer's sync context was reset; decline it (NuRaft
+        /// restarts from obj_id 0). Like the missing-pin deferral, not a failure.
+        LOG_WARNING(log, "Snapshot transfer context is null for obj_id {}; declining transfer", obj_id);
         free_user_snp_ctx(user_snp_ctx);
-        chassert(false); /// This should not happen, catch in CI.
+        ProfileEvents::increment(ProfileEvents::KeeperReadSnapshotDeferred);
+        success = true;
         return -1;
     }
 

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -1381,4 +1381,48 @@ TEST(KeeperSnapshotManagerCleanupTest, CreateSnapshotKeepsPreviousMetadataAndAll
     EXPECT_FALSE(fs::exists("./snapshots/tmp_snapshot_2.bin.zstd"));
 }
 
+TYPED_TEST(CoordinationTest, ReadSnapshotChunkWithoutContextDoesNotCrash)
+{
+    /// A chunk request (obj_id > 0) can reach read_logical_snp_obj with a null
+    /// user_snp_ctx after the peer's sync context was reset; it must be declined,
+    /// not abort the server.
+    getContext(); /// needed for DiskObjectStorage background threads
+
+    ChangelogDirTest snap_meta("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setSnapshotDirectory("./snapshots");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snap(&storage, 50, nullptr, this->keeper_context->getWriteSnapshotVersion());
+    auto snap_buf = manager.serializeSnapshotToBuffer(snap);
+    manager.serializeSnapshotBufferToDisk(*snap_buf, 50);
+
+    DB::SnapshotsQueue leader_snapshots_queue{1};
+    auto leader = std::make_shared<DB::KeeperStateMachine<Storage>>(
+        nullptr, leader_snapshots_queue, this->keeper_context, nullptr);
+    leader->init();
+
+    nuraft::snapshot s(50, 0, std::make_shared<nuraft::cluster_config>());
+
+    /// A follow-up chunk request (obj_id > 0) arriving with no transfer
+    /// context must be declined with rc < 0 instead of asserting.
+    void * user_snp_ctx = nullptr;
+    nuraft::ptr<nuraft::buffer> data_out;
+    bool is_last = false;
+    int rc = leader->read_logical_snp_obj(s, user_snp_ctx, /*obj_id=*/1, data_out, is_last);
+    EXPECT_LT(rc, 0);
+    EXPECT_EQ(user_snp_ctx, nullptr);
+
+    /// The leader must stay healthy: a normal transfer that starts at obj_id 0
+    /// still succeeds afterwards.
+    rc = leader->read_logical_snp_obj(s, user_snp_ctx, /*obj_id=*/0, data_out, is_last);
+    EXPECT_GE(rc, 0);
+    leader->free_user_snp_ctx(user_snp_ctx);
+}
+
 #endif


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104941
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `Keeper` server crash (`Logical error: 'false'`) that could happen during snapshot transfer to a recovering follower while snapshots were rotating. A stale snapshot chunk request is now declined instead of aborting the server.


### Description

`IKeeperStateMachine::read_logical_snp_obj` aborted with `chassert(false)` when NuRaft called it with `obj_id > 0` and a null `user_snp_ctx`.

That state is reachable during snapshot rotation under write load. The `obj_id == 0` request can return `-1` without creating a transfer context (the requested snapshot was retired so its pin is missing, or the loader failed to init). NuRaft then resets the peer's `snapshot_sync_ctx` but keeps its `offset > 0`, so the next `async_io_loop` iteration asks for a later chunk while the fresh context has `user_snp_ctx == nullptr`, and the leader aborts.

This is a legitimate stale request, not an invariant violation, so the chunk is now declined the same way as the existing missing-pin deferral: free the context, count it as `KeeperReadSnapshotDeferred`, and return `-1`. NuRaft restarts the install from `obj_id 0` against the latest snapshot. Marking it as a deferral rather than a failure also stops it from inflating `KeeperReadSnapshotFailed`.

Introduced by #104941. Surfaced by the `test_keeper_snapshot_rotation_race` integration test on master (`Logical error: 'false'` in `read_logical_snp_obj`, and `KeeperReadSnapshotFailed delta = 1`). Added a deterministic unit test (`ReadSnapshotChunkWithoutContextDoesNotCrash`) that drives the exact state: it aborts the server on the current code and passes with this fix.
