### PR TITLE
Route mixed settings/comment ALTER ON CLUSTER to every replica

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -827,12 +827,17 @@ bool DDLWorker::taskShouldBeExecutedOnLeader(const ASTPtr & ast_ddl, const Stora
 
     if (auto * alter = ast_ddl->as<ASTAlterQuery>())
     {
-        // Setting alters should be executed on all replicas
+        // Setting/comment alters should be executed on all replicas, including
+        // mixed batches (e.g. MODIFY COMMENT ..., MODIFY SETTING ...) that match
+        // neither single-type predicate. The storage layer applies such commands
+        // as local metadata without a replicated log entry, so leader-only routing
+        // would leave the followers diverged.
         if (alter->isSettingsAlter() ||
             alter->isFreezeAlter() ||
             alter->isUnlockSnapshot() ||
             alter->isMovePartitionToDiskOrVolumeAlter() ||
-            alter->isCommentAlter())
+            alter->isCommentAlter() ||
+            alter->isSettingsOrCommentAlter())
             return false;
     }
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -654,14 +654,11 @@ bool ASTAlterQuery::isCommentAlter() const
 namespace
 {
 
-/// `MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN`, but the resolved
-/// `AlterCommand::isCommentAlter` (Storages/AlterCommands.cpp) treats it as
-/// comment-only and the storage layer applies it as local metadata, so the
-/// routing predicate must recognise the same shape. Mirror that resolved check
-/// exactly: a comment plus no type / codec / default / TTL change. Placement
-/// (AFTER/FIRST) and per-column settings are deliberately not inspected because
-/// `AlterCommand::isCommentAlter` ignores them too; treating those shapes as
-/// non-replicated keeps DDLWorker routing in step with the storage fast path.
+/// True only for a pure comment-only `MODIFY COLUMN c COMMENT 'x'`, mirroring the
+/// resolved `AlterCommand::isCommentAlter` (Storages/AlterCommands.cpp) so DDL
+/// routing and the storage fast path agree. Placement (FIRST/AFTER) and
+/// per-column SETTINGS are excluded: they alter the replicated /columns and must
+/// take the full replicated path.
 bool isCommentOnlyModifyColumn(const ASTAlterCommand & command)
 {
     if (command.type != ASTAlterCommand::MODIFY_COLUMN)
@@ -675,7 +672,12 @@ bool isCommentOnlyModifyColumn(const ASTAlterCommand & command)
         && col_decl->getType() == nullptr
         && col_decl->getCodec() == nullptr
         && col_decl->getDefaultExpression() == nullptr
-        && col_decl->getTTL() == nullptr;
+        && col_decl->getTTL() == nullptr
+        && col_decl->getSettings() == nullptr
+        && command.settings_changes == nullptr
+        && command.settings_resets == nullptr
+        && command.column == nullptr
+        && !command.first;
 }
 
 }

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/ServerSettings.h>
 #include <IO/Operators.h>
+#include <Parsers/ASTColumnDeclaration.h>
 #include <base/scope_guard.h>
 #include <Common/quoteString.h>
 
@@ -648,6 +649,71 @@ bool ASTAlterQuery::isDropPartitionAlter() const
 bool ASTAlterQuery::isCommentAlter() const
 {
     return isOneCommandTypeOnly(ASTAlterCommand::COMMENT_COLUMN) || isOneCommandTypeOnly(ASTAlterCommand::MODIFY_COMMENT);
+}
+
+namespace
+{
+
+/// `MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN`, but the resolved
+/// `AlterCommand::isCommentAlter` treats it as comment-only, so the storage layer
+/// applies it as local metadata. Recognise the same shape here, intentionally
+/// stricter: any extra column property or surrounding modifier rejects it, which
+/// just routes the ALTER to every replica (the safe default).
+bool isCommentOnlyModifyColumn(const ASTAlterCommand & command)
+{
+    if (command.type != ASTAlterCommand::MODIFY_COLUMN)
+        return false;
+
+    const auto * col_decl = command.col_decl ? command.col_decl->as<ASTColumnDeclaration>() : nullptr;
+    if (!col_decl || col_decl->getComment() == nullptr)
+        return false;
+
+    if (col_decl->getType() || col_decl->getDefaultExpression() || col_decl->getCodec()
+        || col_decl->getTTL() || col_decl->getStatisticsDesc() || col_decl->getSettings()
+        || col_decl->getCollation())
+        return false;
+
+    if (col_decl->null_modifier.has_value()
+        || col_decl->default_specifier != ColumnDefaultSpecifier::Empty
+        || col_decl->ephemeral_default
+        || col_decl->primary_key_specifier)
+        return false;
+
+    if (!command.remove_property.empty()
+        || command.settings_changes != nullptr
+        || command.settings_resets != nullptr
+        || command.column != nullptr
+        || command.first)
+        return false;
+
+    return true;
+}
+
+}
+
+bool ASTAlterQuery::isSettingsOrCommentAlter() const
+{
+    if (!command_list || command_list->children.empty())
+        return false;
+    for (const auto & child : command_list->children)
+    {
+        const auto & command = child->as<const ASTAlterCommand &>();
+        switch (command.type)
+        {
+            case ASTAlterCommand::MODIFY_SETTING:
+            case ASTAlterCommand::RESET_SETTING:
+            case ASTAlterCommand::COMMENT_COLUMN:
+            case ASTAlterCommand::MODIFY_COMMENT:
+                break;
+            case ASTAlterCommand::MODIFY_COLUMN:
+                if (!isCommentOnlyModifyColumn(command))
+                    return false;
+                break;
+            default:
+                return false;
+        }
+    }
+    return true;
 }
 
 bool ASTAlterQuery::isMovePartitionToDiskOrVolumeAlter() const

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -655,38 +655,27 @@ namespace
 {
 
 /// `MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN`, but the resolved
-/// `AlterCommand::isCommentAlter` treats it as comment-only, so the storage layer
-/// applies it as local metadata. Recognise the same shape here, intentionally
-/// stricter: any extra column property or surrounding modifier rejects it, which
-/// just routes the ALTER to every replica (the safe default).
+/// `AlterCommand::isCommentAlter` (Storages/AlterCommands.cpp) treats it as
+/// comment-only and the storage layer applies it as local metadata, so the
+/// routing predicate must recognise the same shape. Mirror that resolved check
+/// exactly: a comment plus no type / codec / default / TTL change. Placement
+/// (AFTER/FIRST) and per-column settings are deliberately not inspected because
+/// `AlterCommand::isCommentAlter` ignores them too; treating those shapes as
+/// non-replicated keeps DDLWorker routing in step with the storage fast path.
 bool isCommentOnlyModifyColumn(const ASTAlterCommand & command)
 {
     if (command.type != ASTAlterCommand::MODIFY_COLUMN)
         return false;
 
     const auto * col_decl = command.col_decl ? command.col_decl->as<ASTColumnDeclaration>() : nullptr;
-    if (!col_decl || col_decl->getComment() == nullptr)
+    if (!col_decl)
         return false;
 
-    if (col_decl->getType() || col_decl->getDefaultExpression() || col_decl->getCodec()
-        || col_decl->getTTL() || col_decl->getStatisticsDesc() || col_decl->getSettings()
-        || col_decl->getCollation())
-        return false;
-
-    if (col_decl->null_modifier.has_value()
-        || col_decl->default_specifier != ColumnDefaultSpecifier::Empty
-        || col_decl->ephemeral_default
-        || col_decl->primary_key_specifier)
-        return false;
-
-    if (!command.remove_property.empty()
-        || command.settings_changes != nullptr
-        || command.settings_resets != nullptr
-        || command.column != nullptr
-        || command.first)
-        return false;
-
-    return true;
+    return col_decl->getComment() != nullptr
+        && col_decl->getType() == nullptr
+        && col_decl->getCodec() == nullptr
+        && col_decl->getDefaultExpression() == nullptr
+        && col_decl->getTTL() == nullptr;
 }
 
 }

--- a/src/Parsers/ASTAlterQuery.h
+++ b/src/Parsers/ASTAlterQuery.h
@@ -272,6 +272,11 @@ public:
 
     bool isCommentAlter() const;
 
+    /// Every command modifies settings or comments: any mix of MODIFY SETTING /
+    /// RESET SETTING / COMMENT COLUMN / MODIFY COMMENT / comment-only MODIFY COLUMN.
+    /// The single-type isSettingsAlter / isCommentAlter miss such mixed batches.
+    bool isSettingsOrCommentAlter() const;
+
     String getID(char) const override;
 
     ASTPtr clone() const override;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1225,7 +1225,11 @@ bool AlterCommand::isCommentAlter() const
     }
     if (type == MODIFY_COLUMN)
     {
-        return comment.has_value() && codec == nullptr && data_type == nullptr && default_expression == nullptr && ttl == nullptr;
+        /// Placement (FIRST/AFTER) and per-column SETTINGS change the replicated
+        /// /columns (ColumnsDescription::operator== compares column order and
+        /// settings, ignoring only the comment), so they are not comment-only.
+        return comment.has_value() && codec == nullptr && data_type == nullptr && default_expression == nullptr && ttl == nullptr
+            && settings_changes.empty() && settings_resets.empty() && after_column.empty() && !first;
     }
     return false;
 }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4418,7 +4418,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             "Vector similarity index can only be used with MergeTree setting 'index_granularity_bytes' != 0");
 
     for (const auto & disk : getDisks())
-        if (!disk->supportsHardLinks() && !commands.isSettingsAlter() && !commands.isCommentAlter())
+        if (!disk->supportsHardLinks() && !commands.areNonReplicatedAlterCommands())
             throw Exception(
                 ErrorCodes::SUPPORT_IS_DISABLED,
                 "ALTER TABLE commands are not supported on immutable disk '{}', except for setting and comment alteration",

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6792,6 +6792,21 @@ void StorageReplicatedMergeTree::alter(
         return;
     }
 
+    /// A batch that mixes settings and comments (e.g. MODIFY SETTING ..., MODIFY COMMENT ...)
+    /// matches neither single-type predicate above. Apply it locally like both of them combined
+    /// instead of writing a replicated log entry, so it stays consistent with the DDLWorker
+    /// routing (ASTAlterQuery::isSettingsOrCommentAlter) that sends it to every replica.
+    if (commands.areNonReplicatedAlterCommands())
+    {
+        merge_strategy_picker.refreshState();
+        changeSettings(future_metadata.settings_changes, table_lock_holder);
+        setInMemoryMetadata(future_metadata);
+
+        /// It is safe to ignore exceptions here as only settings and comments are changed, neither of which is validated in `alterTable`
+        DatabaseCatalog::instance().getDatabase(table_id.database_name)->alterTable(query_context, table_id, future_metadata, /*validate_new_create_query=*/true);
+        return;
+    }
+
     if (!query_settings[Setting::allow_suspicious_primary_key])
     {
         MergeTreeData::verifySortingKey(future_metadata.sorting_key);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6800,6 +6800,15 @@ void StorageReplicatedMergeTree::alter(
     {
         merge_strategy_picker.refreshState();
         changeSettings(future_metadata.settings_changes, table_lock_holder);
+
+        /// changeSettings is the sole writer of the setting-derived escape fields and has
+        /// already committed them; carry them into future_metadata so the comment commit
+        /// below does not revert the index filename policy (commands.apply never sets them).
+        auto committed_metadata = getInMemoryMetadataPtr(query_context, /*bypass_metadata_cache=*/true);
+        future_metadata.escape_index_filenames = committed_metadata->escape_index_filenames;
+        for (auto & index : future_metadata.secondary_indices)
+            index.escape_filenames = committed_metadata->escape_index_filenames;
+
         setInMemoryMetadata(future_metadata);
 
         /// It is safe to ignore exceptions here as only settings and comments are changed, neither of which is validated in `alterTable`

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/configs/config.d/clusters.xml
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/configs/config.d/clusters.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+<remote_servers>
+    <cluster>
+        <shard>
+            <internal_replication>true</internal_replication>
+            <replica>
+                <host>ch1</host>
+                <port>9000</port>
+            </replica>
+            <replica>
+                <host>ch2</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </cluster>
+</remote_servers>
+</clickhouse>

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/configs/config.d/distributed_ddl.xml
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/configs/config.d/distributed_ddl.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+<distributed_ddl>
+    <path>/clickhouse/task_queue/ddl</path>
+</distributed_ddl>
+</clickhouse>

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -151,6 +151,27 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
         assert "modcol-comment-v3" in show_create, (node.name, show_create)
         assert "table-comment-modcol" in show_create, (node.name, show_create)
 
+    # Comment-only `MODIFY COLUMN ... FIRST`: a positional modifier still parses
+    # as comment-only (no type change), so the storage layer applies it as local
+    # metadata via the comment fast path. The column comment and the new column
+    # order must both converge on every replica.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-placement-comment' FIRST",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-placement-comment" in show_create, (node.name, show_create)
+        order = node.query(
+            database="test_db",
+            sql="SELECT name FROM system.columns WHERE database = 'test_db' AND table = 'modcol_comment' ORDER BY position FORMAT TSVRaw",
+        ).split()
+        assert order == ["x", "id"], (node.name, order)
+
     # Negative case: `MODIFY COLUMN` with a real type change must still route as a
     # full replicated ALTER and converge across replicas through the replication log.
     ch1.query(

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -10,6 +10,7 @@ ch1 = cluster.add_instance(
         "configs/config.d/distributed_ddl.xml",
     ],
     with_zookeeper=True,
+    stay_alive=True,
 )
 ch2 = cluster.add_instance(
     "ch2",
@@ -18,6 +19,7 @@ ch2 = cluster.add_instance(
         "configs/config.d/distributed_ddl.xml",
     ],
     with_zookeeper=True,
+    stay_alive=True,
 )
 
 
@@ -132,26 +134,31 @@ def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
 
 
 def test_modify_column_comment_only_on_cluster(started_cluster):
-    # `ALTER ... MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN` but the
-    # storage layer recognises it as comment-only and applies it as local
-    # metadata, so it must also be routed to every replica. A MODIFY COLUMN with
-    # a real type change instead takes the full replicated-log path (negative
-    # case below). Both must converge across replicas.
+    # A pure `ALTER ... MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN` but
+    # the storage layer recognises it as comment-only and applies it as local
+    # metadata, so it must also be routed to every replica. A MODIFY COLUMN that
+    # carries a type change, a positional modifier (FIRST/AFTER) or per-column
+    # SETTINGS is NOT comment-only and must take the full replicated-log path
+    # (negative cases below). All must converge across replicas.
+    zookeeper_path = "/clickhouse/tables/modcol_comment"
     ch1.query(
         database="test_db",
-        sql="CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('/clickhouse/tables/modcol_comment', 'r1') ORDER BY id",
+        sql=f"CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('{zookeeper_path}', 'r1') ORDER BY id",
     )
     ch2.query(
         database="test_db",
-        sql="CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('/clickhouse/tables/modcol_comment', 'r2') ORDER BY id",
+        sql=f"CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('{zookeeper_path}', 'r2') ORDER BY id",
     )
 
-    # `MODIFY COLUMN ... COMMENT '...'` only.
+    # `MODIFY COLUMN ... COMMENT '...'` only: comment-only, local fast path on
+    # every replica, ZK /metadata version must not move.
+    version_before = get_zk_metadata_version(ch1, zookeeper_path)
     ch1.query(
         database="test_db",
         sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-comment-v1'",
     )
 
+    assert get_zk_metadata_version(ch1, zookeeper_path) == version_before
     for node in [ch1, ch2]:
         show_create = node.query(
             database="test_db",
@@ -187,15 +194,21 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
         assert "modcol-comment-v3" in show_create, (node.name, show_create)
         assert "table-comment-modcol" in show_create, (node.name, show_create)
 
-    # Comment-only `MODIFY COLUMN ... FIRST`: a positional modifier still parses
-    # as comment-only (no type change), so the storage layer applies it as local
-    # metadata via the comment fast path. The column comment and the new column
-    # order must both converge on every replica.
+    # Positional `MODIFY COLUMN ... COMMENT '...' FIRST`: a placement modifier
+    # reorders the column, which is serialized into the replicated /columns
+    # (ColumnsDescription::operator== compares column order). It is therefore NOT
+    # comment-only and must take the full replicated path: the ZK /metadata
+    # version moves, /columns is rewritten in ZooKeeper, and every replica picks
+    # up the new order through the replication log. If it were wrongly applied via
+    # the local comment fast path, the leader would reorder its local columns
+    # without updating ZK /columns and throw INCOMPATIBLE_COLUMNS on restart.
+    version_before = get_zk_metadata_version(ch1, zookeeper_path)
     ch1.query(
         database="test_db",
         sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-placement-comment' FIRST",
     )
 
+    assert get_zk_metadata_version(ch1, zookeeper_path) > version_before
     for node in [ch1, ch2]:
         show_create = node.query(
             database="test_db",
@@ -207,6 +220,23 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
             sql="SELECT name FROM system.columns WHERE database = 'test_db' AND table = 'modcol_comment' ORDER BY position FORMAT TSVRaw",
         ).split()
         assert order == ["x", "id"], (node.name, order)
+
+    # Restart both replicas: the local columns (reordered to x, id) must match the
+    # ZK /columns written by the replicated ALTER, so the table loads without
+    # INCOMPATIBLE_COLUMNS and the order survives the restart.
+    for node in [ch1, ch2]:
+        node.restart_clickhouse()
+    for node in [ch1, ch2]:
+        order = node.query(
+            database="test_db",
+            sql="SELECT name FROM system.columns WHERE database = 'test_db' AND table = 'modcol_comment' ORDER BY position FORMAT TSVRaw",
+        ).split()
+        assert order == ["x", "id"], (node.name, order)
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-placement-comment" in show_create, (node.name, show_create)
 
     # Negative case: `MODIFY COLUMN` with a real type change must still route as a
     # full replicated ALTER and converge across replicas through the replication log.

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -43,6 +43,22 @@ def get_zk_metadata_version(node, zookeeper_path):
     )
 
 
+def list_part_index_files(node, database, table, part_name):
+    # The on-disk secondary index filename is the materialisation of the in-memory
+    # IndexDescription::escape_filenames flag (escaped: skp_idx_<escaped>.idx,
+    # unescaped: skp_idx_<raw>.idx), so listing it is how we observe the index
+    # filename policy actually in effect on a replica without restarting it.
+    data_path = node.query(
+        f"SELECT arrayElement(data_paths, 1) FROM system.tables WHERE database = '{database}' AND name = '{table}'"
+    ).strip()
+    files = node.exec_in_container(
+        ["bash", "-c", f"ls {data_path}/{part_name}/ | grep '^skp_idx_' || true"]
+    )
+    # The skip-index data file is .idx or .idx2 depending on the part format version;
+    # the basename before the extension carries the escaping we care about.
+    return sorted(f for f in files.splitlines() if f.endswith((".idx", ".idx2")))
+
+
 def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
     # ON CLUSTER ALTER batches mixing MODIFY SETTING / RESET SETTING with
     # column or table comments must converge on every replica. The storage
@@ -209,4 +225,61 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
     ch1.query(
         database="test_db",
         sql="DROP TABLE modcol_comment ON CLUSTER 'cluster' SYNC",
+    )
+
+
+def test_mixed_setting_escape_index_filenames_on_cluster(started_cluster):
+    # escape_index_filenames is a setting whose value drives derived metadata:
+    # changeSettings rewrites StorageInMemoryMetadata::escape_index_filenames and the
+    # per-index escape_filenames flag, which controls the on-disk index filename. A
+    # mixed `MODIFY SETTING escape_index_filenames = 0, MODIFY COMMENT` batch must apply
+    # that derived metadata locally on every replica, not just record the setting in
+    # SHOW CREATE. The index name has a non-word character so escaping changes the file.
+    zookeeper_path = "/clickhouse/tables/escape_mixed"
+    # PARTITION BY x so each replica writes its own part in its own partition; a part
+    # keeps the index filenames of whoever wrote it, even after replication fetches it,
+    # so inspecting a node's own partition isolates that node's in-memory policy.
+    create_sql = (
+        "CREATE TABLE escape_mixed (x UInt64, INDEX `idx-esc` x TYPE minmax GRANULARITY 1) "
+        "ENGINE=ReplicatedMergeTree('{zk}', '{replica}') ORDER BY x PARTITION BY x "
+        "SETTINGS escape_index_filenames = 1, min_bytes_for_wide_part = 0"
+    )
+    ch1.query(database="test_db", sql=create_sql.format(zk=zookeeper_path, replica="r1"))
+    ch2.query(database="test_db", sql=create_sql.format(zk=zookeeper_path, replica="r2"))
+
+    # Mixed batch: turn escaping off and set a comment in one ON CLUSTER ALTER.
+    # MODIFY COMMENT is placed first because MODIFY SETTING parses a comma-separated
+    # list, so a trailing comma after it would be read as another setting change.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE escape_mixed ON CLUSTER 'cluster' MODIFY COMMENT 'escape-mixed', MODIFY SETTING escape_index_filenames = 0",
+    )
+
+    # Each replica writes a part locally (distinct partition) after the alter, so the
+    # new part uses whatever index filename policy is actually in memory on that replica.
+    # With escaping disabled, the unescaped index file (skp_idx_idx-esc.idx) must be
+    # written; a replica that reverted to the old policy would write skp_idx_idx%2Desc.idx.
+    for value, node in [(1, ch1), (2, ch2)]:
+        node.query(database="test_db", sql=f"INSERT INTO escape_mixed VALUES ({value})")
+        part_name = node.query(
+            database="test_db",
+            sql=f"SELECT name FROM system.parts WHERE database = 'test_db' AND table = 'escape_mixed' AND active = 1 AND partition = '{value}'",
+        ).strip()
+        index_files = list_part_index_files(node, "test_db", "escape_mixed", part_name)
+        # Escaping disabled -> the raw index name (idx-esc) appears in the filename.
+        # If a replica reverted to escaping, the name would be skp_idx_idx%2Desc.idx*.
+        assert len(index_files) == 1 and index_files[0].startswith("skp_idx_idx-esc."), (
+            node.name,
+            index_files,
+        )
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE escape_mixed FORMAT TSVRaw",
+        )
+        assert "escape_index_filenames = 0" in show_create, (node.name, show_create)
+        assert "escape-mixed" in show_create, (node.name, show_create)
+
+    ch1.query(
+        database="test_db",
+        sql="DROP TABLE escape_mixed ON CLUSTER 'cluster' SYNC",
     )

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -31,26 +31,46 @@ def started_cluster():
         cluster.shutdown()
 
 
+def get_zk_metadata_version(node, zookeeper_path):
+    # The ZooKeeper `/metadata` node version is only bumped by the replicated
+    # ALTER_METADATA path. A local settings/comment fast path leaves it
+    # untouched, so it is a precise signal for "this ALTER did not write a
+    # replicated log entry".
+    return int(
+        node.query(
+            f"SELECT version FROM system.zookeeper WHERE path = '{zookeeper_path}' AND name = 'metadata'"
+        ).strip()
+    )
+
+
 def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
     # ON CLUSTER ALTER batches mixing MODIFY SETTING / RESET SETTING with
     # column or table comments must converge on every replica. The storage
     # layer applies settings/comments as local metadata (never via the
     # replicated log), so convergence relies on DDLWorker forwarding the
     # query to all replicas rather than just the leader.
+    zookeeper_path = "/clickhouse/tables/mixed_alter"
     ch1.query(
         database="test_db",
-        sql="CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/mixed_alter', 'r1') ORDER BY tuple()",
+        sql=f"CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('{zookeeper_path}', 'r1') ORDER BY tuple()",
     )
     ch2.query(
         database="test_db",
-        sql="CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/mixed_alter', 'r2') ORDER BY tuple()",
+        sql=f"CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('{zookeeper_path}', 'r2') ORDER BY tuple()",
     )
 
     # MODIFY COMMENT + MODIFY SETTING in a single ON CLUSTER ALTER.
+    version_before = get_zk_metadata_version(ch1, zookeeper_path)
     ch1.query(
         database="test_db",
         sql="ALTER TABLE mixed_alter ON CLUSTER 'cluster' MODIFY COMMENT 'mixed-on-cluster', MODIFY SETTING old_parts_lifetime = 123",
     )
+
+    # The mixed batch must take the local fast path on every replica, not the
+    # replicated ALTER_METADATA path. Otherwise both replicas race for the same
+    # /metadata version, one wins and the others retry with CANNOT_ASSIGN_ALTER
+    # while appending no-op log entries. The ZK metadata version must not move.
+    assert get_zk_metadata_version(ch1, zookeeper_path) == version_before
 
     # Both replicas must see the new comment and the new setting value.
     for node in [ch1, ch2]:

--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -1,0 +1,171 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+ch1 = cluster.add_instance(
+    "ch1",
+    main_configs=[
+        "configs/config.d/clusters.xml",
+        "configs/config.d/distributed_ddl.xml",
+    ],
+    with_zookeeper=True,
+)
+ch2 = cluster.add_instance(
+    "ch2",
+    main_configs=[
+        "configs/config.d/clusters.xml",
+        "configs/config.d/distributed_ddl.xml",
+    ],
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        ch1.query("CREATE DATABASE test_db ON CLUSTER 'cluster'")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
+    # ON CLUSTER ALTER batches mixing MODIFY SETTING / RESET SETTING with
+    # column or table comments must converge on every replica. The storage
+    # layer applies settings/comments as local metadata (never via the
+    # replicated log), so convergence relies on DDLWorker forwarding the
+    # query to all replicas rather than just the leader.
+    ch1.query(
+        database="test_db",
+        sql="CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/mixed_alter', 'r1') ORDER BY tuple()",
+    )
+    ch2.query(
+        database="test_db",
+        sql="CREATE TABLE mixed_alter (x UInt64) ENGINE=ReplicatedMergeTree('/clickhouse/tables/mixed_alter', 'r2') ORDER BY tuple()",
+    )
+
+    # MODIFY COMMENT + MODIFY SETTING in a single ON CLUSTER ALTER.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE mixed_alter ON CLUSTER 'cluster' MODIFY COMMENT 'mixed-on-cluster', MODIFY SETTING old_parts_lifetime = 123",
+    )
+
+    # Both replicas must see the new comment and the new setting value.
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        )
+        assert "old_parts_lifetime = 123" in show_create, (node.name, show_create)
+        assert "mixed-on-cluster" in show_create, (node.name, show_create)
+
+    # MODIFY COMMENT + RESET SETTING - same shape, mixed setting / comment kinds.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE mixed_alter ON CLUSTER 'cluster' MODIFY COMMENT 'second-mixed', RESET SETTING old_parts_lifetime",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        )
+        assert "old_parts_lifetime = 123" not in show_create, (node.name, show_create)
+        assert "second-mixed" in show_create, (node.name, show_create)
+
+    # COMMENT COLUMN + MODIFY SETTING - column-comment variant.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE mixed_alter ON CLUSTER 'cluster' COMMENT COLUMN x 'x-col-comment', MODIFY SETTING old_parts_lifetime = 234",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        )
+        assert "old_parts_lifetime = 234" in show_create, (node.name, show_create)
+        assert "x-col-comment" in show_create, (node.name, show_create)
+
+    ch1.query(
+        database="test_db",
+        sql="DROP TABLE mixed_alter ON CLUSTER 'cluster' SYNC",
+    )
+
+
+def test_modify_column_comment_only_on_cluster(started_cluster):
+    # `ALTER ... MODIFY COLUMN c COMMENT 'x'` parses as `MODIFY_COLUMN` but the
+    # storage layer recognises it as comment-only and applies it as local
+    # metadata, so it must also be routed to every replica. A MODIFY COLUMN with
+    # a real type change instead takes the full replicated-log path (negative
+    # case below). Both must converge across replicas.
+    ch1.query(
+        database="test_db",
+        sql="CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('/clickhouse/tables/modcol_comment', 'r1') ORDER BY id",
+    )
+    ch2.query(
+        database="test_db",
+        sql="CREATE TABLE modcol_comment (id UInt64, x String) ENGINE=ReplicatedMergeTree('/clickhouse/tables/modcol_comment', 'r2') ORDER BY id",
+    )
+
+    # `MODIFY COLUMN ... COMMENT '...'` only.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-comment-v1'",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-comment-v1" in show_create, (node.name, show_create)
+
+    # Mixed: `MODIFY COLUMN ... COMMENT '...'` + `MODIFY SETTING`.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-comment-v2', MODIFY SETTING old_parts_lifetime = 345",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-comment-v2" in show_create, (node.name, show_create)
+        assert "old_parts_lifetime = 345" in show_create, (node.name, show_create)
+
+    # Mixed: `MODIFY COLUMN ... COMMENT '...'` + `MODIFY COMMENT '...'`.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x COMMENT 'modcol-comment-v3', MODIFY COMMENT 'table-comment-modcol'",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-comment-v3" in show_create, (node.name, show_create)
+        assert "table-comment-modcol" in show_create, (node.name, show_create)
+
+    # Negative case: `MODIFY COLUMN` with a real type change must still route as a
+    # full replicated ALTER and converge across replicas through the replication log.
+    ch1.query(
+        database="test_db",
+        sql="ALTER TABLE modcol_comment ON CLUSTER 'cluster' MODIFY COLUMN x String COMMENT 'modcol-with-type'",
+    )
+
+    for node in [ch1, ch2]:
+        show_create = node.query(
+            database="test_db",
+            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        )
+        assert "modcol-with-type" in show_create, (node.name, show_create)
+
+    ch1.query(
+        database="test_db",
+        sql="DROP TABLE modcol_comment ON CLUSTER 'cluster' SYNC",
+    )


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/43843
Related: https://github.com/ClickHouse/ClickHouse/pull/105111
-->

Related: #43843 (`ALTER TABLE ... ON CLUSTER ... RESET SETTING` not applied on every replica) - same metadata-divergence class.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ALTER TABLE ... ON CLUSTER` batches that mix `MODIFY SETTING`/`RESET SETTING` with a comment change (for example `MODIFY COMMENT 'x', MODIFY SETTING old_parts_lifetime = 123`) being applied only on the leader replica, leaving the other replicas diverged. Also fix a positional or per-column-`SETTINGS` `MODIFY COLUMN ... COMMENT` being misclassified as a local comment-only metadata change, which left the column reorder out of the replicated metadata and could cause `INCOMPATIBLE_COLUMNS` on replica restart.


### Description
`DDLWorker::taskShouldBeExecutedOnLeader` recognized only single-type settings or comment ALTERs (via `isSettingsAlter`/`isCommentAlter`, which require every command in the batch to be the same type). A mixed batch matched neither, so it was routed leader-only. Since settings and comments are applied as local metadata and never written to the replicated log, leader-only routing left the followers without the new setting/comment.

The fix adds `ASTAlterQuery::isSettingsOrCommentAlter` (the AST-side equivalent of `AlterCommands::areNonReplicatedAlterCommands`): it returns true when every command is `MODIFY SETTING`, `RESET SETTING`, `COMMENT COLUMN`, `MODIFY COMMENT`, or a comment-only `MODIFY COLUMN`, and wires it into the routing so such mixed batches run on every replica. It also switches the immutable-disk gate in `MergeTreeData::checkAlterIsPossible` to `areNonReplicatedAlterCommands` so the same mixed metadata-only batches are accepted there instead of throwing `SUPPORT_IS_DISABLED`.

`StorageReplicatedMergeTree::alter` also gets a matching fast path. It only short-circuited the replicated log for a pure settings batch or a pure comment batch; a mixed batch fell through to the versioned ALTER_METADATA path. With the router now sending mixed batches to every replica, each replica raced for the same `/metadata` version, one winning and the rest retrying with `CANNOT_ASSIGN_ALTER`. A third path gated on `commands.areNonReplicatedAlterCommands()` now applies these batches locally (settings then comments) and returns before any replicated log entry, keeping the storage classification in lockstep with the router predicate.

This is the same bug class as #43843 (`RESET SETTING ON CLUSTER` not applied on every replica), fixed the same way.

That storage fast path runs `changeSettings` before committing the comment metadata. `changeSettings` is the sole writer of the setting-derived fields `escape_index_filenames` (and the per-index `escape_filenames` flag), which `commands.apply` never sets, so committing the comment metadata afterwards reverted the index filename policy until restart. The fix carries those fields from the snapshot `changeSettings` just committed into the metadata before the comment commit, so a mixed `MODIFY COMMENT 'x', MODIFY SETTING escape_index_filenames = 0` keeps escaping off on every replica.

Finally, a comment-only `MODIFY COLUMN` is local-only only when it changes nothing but the comment. A positional modifier (`FIRST`/`AFTER`) reorders the column and per-column `SETTINGS` change column metadata, both of which are serialized into the replicated `/columns` (`ColumnsDescription::operator==` compares `toString(false)`, which includes column order and settings and excludes only the comment). `AlterCommand::isCommentAlter` previously ignored placement and per-column settings, so `MODIFY COLUMN x COMMENT 'c' FIRST` took the local comment fast path: the leader reordered its columns without writing the replicated `/columns`, and on restart `checkTableStructureAttempt` compared the locally reordered columns against the stale Keeper `/columns` and threw `INCOMPATIBLE_COLUMNS`. This is a pre-existing replicated-storage bug, independent of `ON CLUSTER`. The fix tightens both `AlterCommand::isCommentAlter` and the mirroring `ASTAlterQuery::isCommentOnlyModifyColumn` to require no placement and no per-column settings; such shapes now take the full replicated `ALTER_METADATA` path (versioned `/metadata` + `/columns` rewrite), while a pure comment-only `MODIFY COLUMN` stays local.

Added `tests/integration/test_alter_settings_or_comment_on_cluster`, a two-replica `ReplicatedMergeTree` regression test covering mixed settings/comment batches, comment-only `MODIFY COLUMN`, a positional `MODIFY COLUMN ... COMMENT ... FIRST` shape (asserting the ZooKeeper `/metadata` version moves and that both replicas survive a restart with the new order and no `INCOMPATIBLE_COLUMNS`), and a mixed `MODIFY SETTING escape_index_filenames = 0` batch (asserting the on-disk index filename, not just `SHOW CREATE`). It also asserts the ZooKeeper `/metadata` version does not move for a pure settings/comment batch (no replicated log entry, no `CANNOT_ASSIGN_ALTER` churn). Verified on a debug build that the cases fail on master and pass with this change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.786`
<!-- ch-version-info:end -->