### PR TITLE
Fix flaky test 03222_json_squashing (timeout on sanitizers)

### DIFF
--- a/tests/queries/0_stateless/03222_json_squashing.sql
+++ b/tests/queries/0_stateless/03222_json_squashing.sql
@@ -1,4 +1,6 @@
--- Tags: long
+-- Tags: long, no-random-merge-tree-settings
+-- no-random-merge-tree-settings: randomized small index_granularity (e.g. 1-3) makes the
+-- repeated JSON path scans over 20000-row inserts time out on sanitizer builds (600s limit).
 
 SET enable_json_type = 1;
 set max_block_size = 1000;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`03222_json_squashing` is a chronic flaky test that times out (600s) on sanitizer builds.

Root cause: the test inserts 20000 rows of JSON across several blocks and repeatedly scans `JSONAllPaths`/`JSONDynamicPaths`/`JSONSharedDataPaths`. The CI test runner randomizes MergeTree settings, and small `index_granularity` (1-3), forced wide parts (`min_bytes_for_wide_part=0`), or tiny `index_granularity_bytes` make these scans many times slower. On the slow sanitizer builds (tsan/msan/asan) this pushes the `long` test past the 600s limit, so it times out. The randomized layout does not affect the test output, only its runtime.

CIDB confirms every meaningful failure is a 600s timeout, always on a sanitizer config:

| Config | Duration |
|---|---|
| `amd_tsan, s3 storage` | 600.0s |
| `amd_msan, WasmEdge` (master) | 600.2s |
| `amd_msan, WasmEdge` | 600.1s |
| `arm_asan_ubsan, azure` (master) | 600.0s |
| `amd_tsan` | 600.2s |

Local reproduction (debug build): with `index_granularity=1 + min_bytes_for_wide_part=0 + index_granularity_bytes=1024` the test takes 42s vs 0.6s with default settings, and the output is identical in both cases (confirming this is purely a timeout, not a correctness issue).

Fix: disable MergeTree settings randomization for this test via `no-random-merge-tree-settings`, matching the existing pattern in `03208_array_of_json_read_subcolumns_2_memory` (same JSON-timeout-on-sanitizers failure mode). This does not change what the test verifies, since the dynamic/shared path classification is determined by `max_dynamic_paths` at insert time, not by storage layout.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107055&sha=abaf807551653c4e0472b778199bae9ac3b0e58c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.686`
<!-- ch-version-info:end -->