### PR TITLE
Fix flaky test 03802_insert_stream_timeout_flush

### DIFF
--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.reference
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.reference
@@ -1,2 +1,2 @@
-Total records inserted: 82
+Total records inserted: 200
 Number of parts created: 2

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -39,20 +39,23 @@ ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow
 client_pid=$!
 
 # Open the write end. This blocks until the client opens the read end, synchronizing start.
-exec 3>"$fifo"
+# Let bash pick the descriptor (stream_fd) instead of hardcoding fd 3: shell_config.sh routes
+# bash xtrace to fd 3 under CI (BASH_XTRACEFD), so writing the rows to fd 3 would interleave
+# trace output into the INSERT stream and break parsing.
+exec {stream_fd}>"$fifo"
 
 for iteration in 1 2; do
     for i in $(seq 1 40); do
-        echo "{\"id\":$(( (iteration*100) + i )),\"data\":\"batch_${iteration}\"}" >&3
+        echo "{\"id\":$(( (iteration*100) + i )),\"data\":\"batch_${iteration}\"}" >&${stream_fd}
     done
 
     sleep 6
 
-    echo "{\"id\":$(( (iteration*100) + 99 )),\"data\":\"trigger_${iteration}\"}" >&3
+    echo "{\"id\":$(( (iteration*100) + 99 )),\"data\":\"trigger_${iteration}\"}" >&${stream_fd}
 done
 
 # Close the write end so the client finishes the INSERT.
-exec 3>&-
+exec {stream_fd}>&-
 wait "$client_pid"
 rm -f "$fifo"
 

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -11,20 +11,18 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_insert_timeout"
 
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_insert_timeout (id UInt64, data String) ENGINE MergeTree ORDER BY id"
 
-# Feed the rows through a FIFO instead of piping a subshell straight into the client.
-# A subshell pipe (`{ ...; sleep; ... } | client`) is racy under CI load: the producer can
-# write every row and exit before a slow client starts draining stdin, so the client never
-# observes an idle gap, the block-wait timeout never fires, and all rows land in one part.
-# Writing to a FIFO the client already holds open keeps each per-interval idle gap real on a
-# live pipe, so the timeout-driven partial flush is deterministic.
+# Feed the rows through a FIFO the client already holds open, and gate the inter-batch idle gap
+# on a real client-readiness handshake instead of a blind sleep that races client startup.
 fifo="${CLICKHOUSE_TMP}/03802_insert_stream_timeout.fifo"
 rm -f "$fifo"
 mkfifo "$fifo"
 
 # Tag the INSERT with an explicit query_id so the part count below can be scoped to exactly
-# this INSERT. With async_insert disabled (no-async-insert tag) the parts are written in the
-# INSERT's own context, so part_log.query_id equals this id.
+# this INSERT, and so the readiness handshake can find it in system.processes. With async_insert
+# disabled (no-async-insert tag) the parts are written in the INSERT's own context, so
+# part_log.query_id equals this id.
 insert_query_id="03802_${CLICKHOUSE_DATABASE}_$$"
+rows_per_batch=41
 
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow" \
     --query_id="$insert_query_id" \
@@ -36,23 +34,39 @@ ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow
     < "$fifo" &
 client_pid=$!
 
-# Open the write end. This blocks until the client opens the read end, synchronizing start.
-# Let bash pick the descriptor (stream_fd) instead of hardcoding fd 3: shell_config.sh routes
-# bash xtrace to fd 3 under CI (BASH_XTRACEFD), so writing the rows to fd 3 would interleave
-# trace output into the INSERT stream and break parsing.
+# Open the write end. Let bash pick the descriptor (stream_fd) instead of hardcoding fd 3:
+# shell_config.sh routes bash xtrace to fd 3 under CI (BASH_XTRACEFD), so writing rows to fd 3
+# would interleave trace output into the INSERT stream and break parsing.
 exec {stream_fd}>"$fifo"
 
-for iteration in 1 2; do
-    for i in $(seq 1 40); do
-        echo "{\"id\":$(( (iteration*100) + i )),\"data\":\"batch_${iteration}\"}" >&${stream_fd}
+emit_batch() {
+    local base=$1
+    for i in $(seq 1 "$rows_per_batch"); do
+        echo "{\"id\":$(( base + i )),\"data\":\"batch\"}" >&${stream_fd}
     done
+}
 
-    sleep 6
-
-    echo "{\"id\":$(( (iteration*100) + 99 )),\"data\":\"trigger_${iteration}\"}" >&${stream_fd}
+# Batch 1, then wait for the INSERT to appear in system.processes. Opening the FIFO write end
+# only proves the child shell opened the read end; the client still has to connect and reach its
+# stdin poll loop afterwards. The query registers once the client has sent its first block, which
+# proves it is now draining stdin, so a later idle gap really reaches its poll() instead of being
+# pre-buffered ahead of a slow client. Wall-clock deadline so slow CI builds still catch it.
+emit_batch 100
+deadline=$(( $(date +%s) + 120 ))
+while (( $(date +%s) < deadline )); do
+    started=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = '$insert_query_id'")
+    if (( started >= 1 )); then
+        break
+    fi
+    sleep 0.2
 done
 
-# Close the write end so the client finishes the INSERT.
+# The client is confirmed reading, so this idle gap (> input_format_max_block_wait_ms) reaches
+# its poll() and fires the block-wait timeout, closing batch 1 into its own block.
+sleep 3
+emit_batch 200
+
+# Close the write end so the client flushes the final block and finishes the INSERT.
 exec {stream_fd}>&-
 wait "$client_pid"
 rm -f "$fifo"

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-async-insert, no-fasttest
+# Tags: no-async-insert, no-fasttest, no-random-detach
 # no-fasttest: Too slow for fast test (~14s), covered by regular stateless runs.
 # no-async-insert: Test expects new part for each time interval
-
+# no-random-detach: a randomized DETACH/ATTACH before the streaming INSERT disrupts the
+#                   timing-sensitive partial flush.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -12,47 +13,59 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_insert_timeout"
 
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_insert_timeout (id UInt64, data String) ENGINE MergeTree ORDER BY id"
 
+# Feed the rows through a FIFO instead of piping a subshell straight into the client.
+# A subshell pipe (`{ ...; sleep; ... } | client`) is racy under CI load: the producer can
+# write every row and exit before a slow client starts draining stdin, so the client never
+# observes an idle gap, the block-wait timeout never fires, and all rows land in one part.
+# Writing to a FIFO the client already holds open keeps each per-interval idle gap real on a
+# live pipe, so the timeout-driven partial flush is deterministic.
+fifo="${CLICKHOUSE_TMP}/03802_insert_stream_timeout.fifo"
+rm -f "$fifo"
+mkfifo "$fifo"
 
-
-  {
-    for iteration in 1 2; do
-        for i in $(seq 1 40); do
-            echo "{\"id\":$(( (iteration*100) + i )),\"data\":\"batch_${iteration}\"}"
-        done
-        
-        sleep 6
-        
-        echo "{\"id\":$(( (iteration*100) + 99 )),\"data\":\"trigger_${iteration}\"}"
-    done
-}  | ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow" \
+${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow" \
     --max_insert_block_size=1000 \
     --input_format_connection_handling=1 \
     --input_format_max_block_wait_ms=2000 \
     --min_insert_block_size_bytes=0 \
-    --min_insert_block_size_rows=0
-sleep 1
+    --min_insert_block_size_rows=0 \
+    < "$fifo" &
+client_pid=$!
+
+# Open the write end. This blocks until the client opens the read end, synchronizing start.
+exec 3>"$fifo"
+
+for iteration in 1 2; do
+    for i in $(seq 1 40); do
+        echo "{\"id\":$(( (iteration*100) + i )),\"data\":\"batch_${iteration}\"}" >&3
+    done
+
+    sleep 6
+
+    echo "{\"id\":$(( (iteration*100) + 99 )),\"data\":\"trigger_${iteration}\"}" >&3
+done
+
+# Close the write end so the client finishes the INSERT.
+exec 3>&-
+wait "$client_pid"
+rm -f "$fifo"
+
 record_count=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM test_insert_timeout")
 echo "Total records inserted: ${record_count}"
 
-$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log, part_log;"
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS part_log"
 
+# Count parts the INSERT itself created. merge_reason = 'NotAMerge' excludes parts produced
+# by a background merge, so a merge firing during the test cannot reduce the count (counting
+# system.parts active would). No query_log join, so parallel replicas cannot break it either.
 parts_count=$(${CLICKHOUSE_CLIENT} --query "
-SELECT count(*) 
+SELECT count()
 FROM system.part_log
-WHERE event_date >= yesterday() AND event_time >= now() - 600
+WHERE database = currentDatabase()
   AND table = 'test_insert_timeout'
   AND event_type = 'NewPart'
-  AND query_id = (
-        SELECT argMax(query_id, event_time)
-        FROM system.query_log
-        WHERE event_date >= yesterday() AND event_time >= now() - 600
-          AND query LIKE '%INSERT INTO test_insert_timeout%'
-          AND current_database = currentDatabase()
-    )
-")
-
+  AND merge_reason = 'NotAMerge'")
 
 echo "Number of parts created: ${parts_count}"
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_insert_timeout"
-

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-async-insert, no-fasttest, no-random-detach
+# Tags: no-async-insert, no-fasttest
 # no-fasttest: Too slow for fast test (~14s), covered by regular stateless runs.
 # no-async-insert: Test expects new part for each time interval
-# no-random-detach: a randomized DETACH/ATTACH before the streaming INSERT disrupts the
-#                   timing-sensitive partial flush.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -11,18 +11,29 @@ ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_insert_timeout"
 
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_insert_timeout (id UInt64, data String) ENGINE MergeTree ORDER BY id"
 
-# Feed the rows through a FIFO the client already holds open, and gate the inter-batch idle gap
-# on a real client-readiness handshake instead of a blind sleep that races client startup.
+# Feed the rows through a FIFO the client reads as stdin. The synchronisation that makes the
+# timeout flush deterministic is OS pipe back-pressure: a fresh pipe holds 64 KiB, so a first
+# batch larger than that cannot be fully written until clickhouse-client is up and draining
+# stdin. The producer's write() therefore blocks until the client is actually consuming rows,
+# which is a stronger guarantee than any server-side readiness probe (a query is registered in
+# system.processes before the client reaches its stdin poll loop, so polling it can race a slow
+# client and let both batches be buffered as one block).
 fifo="${CLICKHOUSE_TMP}/03802_insert_stream_timeout.fifo"
 rm -f "$fifo"
 mkfifo "$fifo"
 
-# Tag the INSERT with an explicit query_id so the part count below can be scoped to exactly
-# this INSERT, and so the readiness handshake can find it in system.processes. With async_insert
-# disabled (no-async-insert tag) the parts are written in the INSERT's own context, so
-# part_log.query_id equals this id.
+# A wide payload so the first batch alone exceeds the 64 KiB pipe buffer. With 100 rows of ~1 KiB
+# each the batch is ~100 KiB, which both forces back-pressure and stays below max_insert_block_size
+# so it is parsed as a single block (and parses fast, so the block-wait timeout cannot fire and
+# split the batch before the idle gap below).
+payload=$(printf 'x%.0s' $(seq 1 1024))
+rows_per_batch=100
+
+# Explicit query_id so the part count below can be scoped to exactly this INSERT. part_log is
+# append-only across DROP TABLE, so a rerun reusing the table name would otherwise see earlier
+# rows; with async_insert disabled (no-async-insert tag) the parts are written in the INSERT's
+# own context, so part_log.query_id equals this id.
 insert_query_id="03802_${CLICKHOUSE_DATABASE}_$$"
-rows_per_batch=41
 
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow" \
     --query_id="$insert_query_id" \
@@ -34,35 +45,24 @@ ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow
     < "$fifo" &
 client_pid=$!
 
-# Open the write end. Let bash pick the descriptor (stream_fd) instead of hardcoding fd 3:
-# shell_config.sh routes bash xtrace to fd 3 under CI (BASH_XTRACEFD), so writing rows to fd 3
-# would interleave trace output into the INSERT stream and break parsing.
+# Let bash pick the write descriptor instead of hardcoding fd 3: shell_config.sh routes bash
+# xtrace to fd 3 under CI (BASH_XTRACEFD), so writing rows to fd 3 would interleave trace output
+# into the INSERT stream and break parsing.
 exec {stream_fd}>"$fifo"
 
 emit_batch() {
     local base=$1
     for i in $(seq 1 "$rows_per_batch"); do
-        echo "{\"id\":$(( base + i )),\"data\":\"batch\"}" >&${stream_fd}
+        echo "{\"id\":$(( base + i )),\"data\":\"${payload}\"}" >&${stream_fd}
     done
 }
 
-# Batch 1, then wait for the INSERT to appear in system.processes. Opening the FIFO write end
-# only proves the child shell opened the read end; the client still has to connect and reach its
-# stdin poll loop afterwards. The query registers once the client has sent its first block, which
-# proves it is now draining stdin, so a later idle gap really reaches its poll() instead of being
-# pre-buffered ahead of a slow client. Wall-clock deadline so slow CI builds still catch it.
+# Batch 1 is larger than the pipe buffer, so this write blocks until the client has drained the
+# pipe, i.e. is past startup and actively reading stdin.
 emit_batch 100
-deadline=$(( $(date +%s) + 120 ))
-while (( $(date +%s) < deadline )); do
-    started=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.processes WHERE query_id = '$insert_query_id'")
-    if (( started >= 1 )); then
-        break
-    fi
-    sleep 0.2
-done
 
-# The client is confirmed reading, so this idle gap (> input_format_max_block_wait_ms) reaches
-# its poll() and fires the block-wait timeout, closing batch 1 into its own block.
+# The client is now reading, so this idle gap (> input_format_max_block_wait_ms) elapses inside
+# its stdin poll() and fires the block-wait timeout, closing batch 1 into its own block.
 sleep 3
 emit_batch 200
 
@@ -77,9 +77,8 @@ echo "Total records inserted: ${record_count}"
 ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS part_log"
 
 # Count parts this INSERT created. query_id scopes the count to this exact INSERT, so part_log
-# rows left by an earlier run reusing the table name (part_log is append-only across DROP) are
-# excluded. merge_reason = 'NotAMerge' drops parts from a background merge. No query_log join,
-# so parallel replicas cannot break it either.
+# rows left by an earlier run reusing the table name are excluded. merge_reason = 'NotAMerge'
+# drops parts from a background merge. No query_log join, so parallel replicas cannot break it.
 parts_count=$(${CLICKHOUSE_CLIENT} --query "
 SELECT count()
 FROM system.part_log

--- a/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
+++ b/tests/queries/0_stateless/03802_insert_stream_timeout_flush.sh
@@ -23,7 +23,13 @@ fifo="${CLICKHOUSE_TMP}/03802_insert_stream_timeout.fifo"
 rm -f "$fifo"
 mkfifo "$fifo"
 
+# Tag the INSERT with an explicit query_id so the part count below can be scoped to exactly
+# this INSERT. With async_insert disabled (no-async-insert tag) the parts are written in the
+# INSERT's own context, so part_log.query_id equals this id.
+insert_query_id="03802_${CLICKHOUSE_DATABASE}_$$"
+
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO test_insert_timeout FORMAT JSONEachRow" \
+    --query_id="$insert_query_id" \
     --max_insert_block_size=1000 \
     --input_format_connection_handling=1 \
     --input_format_max_block_wait_ms=2000 \
@@ -55,16 +61,16 @@ echo "Total records inserted: ${record_count}"
 
 ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS part_log"
 
-# Count parts the INSERT itself created. merge_reason = 'NotAMerge' excludes parts produced
-# by a background merge, so a merge firing during the test cannot reduce the count (counting
-# system.parts active would). No query_log join, so parallel replicas cannot break it either.
+# Count parts this INSERT created. query_id scopes the count to this exact INSERT, so part_log
+# rows left by an earlier run reusing the table name (part_log is append-only across DROP) are
+# excluded. merge_reason = 'NotAMerge' drops parts from a background merge. No query_log join,
+# so parallel replicas cannot break it either.
 parts_count=$(${CLICKHOUSE_CLIENT} --query "
 SELECT count()
 FROM system.part_log
-WHERE database = currentDatabase()
-  AND table = 'test_insert_timeout'
-  AND event_type = 'NewPart'
-  AND merge_reason = 'NotAMerge'")
+WHERE event_type = 'NewPart'
+  AND merge_reason = 'NotAMerge'
+  AND query_id = '$insert_query_id'")
 
 echo "Number of parts created: ${parts_count}"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107148
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Fixes flaky `03802_insert_stream_timeout_flush` (no related open issue found). CIDB: 19 failures over 90 days across 8+ unrelated PRs on multiple sanitizers (amd_tsan, amd_msan WasmEdge, amd_debug, arm_binary) plus 1 master hit, all reporting a part count differing from the expected 2.

The test streams two batches of JSON rows into one INSERT with a gap between them. The block-wait timeout (`input_format_max_block_wait_ms`) should fire during the gap and flush the first batch into its own part, so the INSERT produces two parts.

`clickhouse-client` parses stdin client-side and only flushes a partial block when it is blocked on `poll()` of stdin during the gap. The flake: if the producer can buffer both gap-separated batches before a slow/cold client (TSAN, CI load) reaches its poll loop, the client reads everything with no idle gap and emits one block, giving 1 part instead of 2.

Fix: synchronise with OS pipe back-pressure. A fresh pipe buffers 64 KiB, so the first batch is sized larger than that (100 rows of ~1 KiB); the producer's `write()` then blocks until clickhouse-client is up and draining stdin. This is a stronger readiness guarantee than a `system.processes` probe (the query enters ProcessList before the client reaches its poll loop, and no per-query progress is observable mid-INSERT on the native-client path). The batch stays below `max_insert_block_size` so it remains a single block and parses fast enough that the timeout cannot split it before the idle gap. Reference is now 200 rows total.

Part counting uses `system.part_log` filtered by `event_type='NewPart'`, `merge_reason='NotAMerge'`, and the INSERT's explicit `query_id` (immune to parallel replicas and to background merges, and unaffected by `part_log` being append-only across `DROP TABLE`). The FIFO write end uses a bash-allocated descriptor rather than fd 3, which `shell_config.sh` reserves for xtrace under CI `--trace`.

Validated: 30/30 pass via `clickhouse-test --trace` with randomization; deterministic 2 parts across simulated client startup delays of 0/5/12/20s; with the flush disabled (`input_format_max_block_wait_ms=0`) the test reports 1 part and fails, so it still detects a broken flush.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.921`
<!-- ch-version-info:end -->