### PR TITLE
Fix flaky test_gcs_decompressive_transcoding

### DIFF
--- a/tests/integration/test_storage_s3/s3_mocks/gcs_transcode_mock.py
+++ b/tests/integration/test_storage_s3/s3_mocks/gcs_transcode_mock.py
@@ -38,4 +38,5 @@ class Handler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-http.server.HTTPServer(("0.0.0.0", int(sys.argv[1])), Handler).serve_forever()
+# Threaded: a pooled/idle client connection must not block the real request.
+http.server.ThreadingHTTPServer(("0.0.0.0", int(sys.argv[1])), Handler).serve_forever()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky hang/timeout of `test_storage_s3/test.py::test_gcs_decompressive_transcoding` (Integration tests, intermittent, sanitizer-skewed; ~18 hits over 3 weeks across unrelated PRs, 0 on master).

Root cause: `tests/integration/test_storage_s3/s3_mocks/gcs_transcode_mock.py` used a single-threaded `http.server.HTTPServer`, which serves one TCP connection at a time and blocks in `handle_one_request()` on any idle/slow connection. ClickHouse's S3 client uses an HTTP connection pool, so a pooled/probe connection opened concurrently with the real request can be accepted first; the server then blocks on the idle one and never accepts the connection carrying the actual GET, so the query hangs until the 600s integration timeout.

Fix: switch the mock to `http.server.ThreadingHTTPServer`, matching the sibling mocks `unstable_server.py` and `no_list_objects.py` that already use threaded servers for the same reason. Test logic is unchanged; the mock still omits `Content-Length` on HEAD and GET to exercise the GCS decompressive-transcoding read path.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.958`
<!-- ch-version-info:end -->