### PR TITLE
Do not embed user-authored free text into the praktika data job output

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -74,14 +74,21 @@ if __name__ == "__main__":
                 "WARNING: Could not find master parent commit (HEAD^1), skipping perf test commit storage"
             )
 
-        file_diff = {}
-        for file in changed_files:
-            if file.startswith("tests/integration/test") and file.endswith(".py"):
-                file_diff[file] = Shell.get_output(
-                    f"git diff $(git merge-base master HEAD)..HEAD -- {file}",
-                    verbose=True,
-                )
-        info.store_kv_data("file_diff", file_diff)
+        # Record which integration test files changed so a downstream job can
+        # find the changed test cases (TODO). Store only the file paths, never
+        # the raw `git diff` output: that diff is user-authored free text and
+        # ends up serialized into the initial `Config Workflow` job's `data`
+        # output (see Runner.run). The GitHub Actions runner scans job outputs
+        # with built-in secret patterns and silently drops the whole output on
+        # a match (e.g. a test fixture containing `Authorization: Bearer ...`),
+        # which makes every downstream job skip. A consumer can recompute the
+        # diff for these paths on demand.
+        changed_integration_tests = [
+            file
+            for file in changed_files
+            if file.startswith("tests/integration/test") and file.endswith(".py")
+        ]
+        info.store_kv_data("changed_integration_tests", changed_integration_tests)
 
     elif info.git_branch == "master" and info.repo_name == "ClickHouse/ClickHouse":
         # store commit sha of release branch base to find binary for performance comparison in the job script later

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -265,6 +265,29 @@ class _Environment(MetaClasses.Serializable):
         config_job_data = workflow_status_data.get(normalized_job_name, {})
         data_str = config_job_data.get("outputs", {}).get("data", "{}")
         env_dict = json.loads(data_str) if isinstance(data_str, str) else data_str
+        if not env_dict or "SHA" not in env_dict:
+            raise RuntimeError(
+                f"Job output [data] of the [{Settings.CI_CONFIG_JOB_NAME}] job is empty or missing. "
+                "If that job itself succeeded, the runner has likely suppressed the output: "
+                "it refuses to export a job output that matches a secret pattern "
+                "(look for a [##[warning]Skip output 'data' since it may contain secret] line "
+                f"at the very end of the [{Settings.CI_CONFIG_JOB_NAME}] job log)"
+            )
+
+        # User-authored free text is stripped from the initial job's output
+        # (see Runner.run: the runner drops outputs matching secret patterns) -
+        # restore it from the local event payload
+        event_file_path = os.getenv("GITHUB_EVENT_PATH", "")
+        if event_file_path and Path(event_file_path).is_file():
+            with open(event_file_path, "r", encoding="utf-8") as f:
+                github_event = json.load(f)
+            if "pull_request" in github_event:
+                env_dict["PR_BODY"] = github_event["pull_request"]["body"] or ""
+                env_dict["PR_TITLE"] = github_event["pull_request"]["title"] or ""
+            elif github_event.get("head_commit"):
+                env_dict["COMMIT_MESSAGE"] = (
+                    github_event["head_commit"]["message"] or ""
+                )
 
         # Reread instance metadata from the host
         env_dict["INSTANCE_TYPE"] = (

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -263,8 +263,14 @@ class _Environment(MetaClasses.Serializable):
         # Job names are normalized in the workflow status file
         normalized_job_name = Utils.normalize_string(Settings.CI_CONFIG_JOB_NAME)
         config_job_data = workflow_status_data.get(normalized_job_name, {})
-        data_str = config_job_data.get("outputs", {}).get("data", "{}")
-        env_dict = json.loads(data_str) if isinstance(data_str, str) else data_str
+        data_str = config_job_data.get("outputs", {}).get("data", "")
+        # A suppressed output may surface either as a missing key or as a blank
+        # string - do not let json.loads choke on the latter before the
+        # explicit error below
+        if isinstance(data_str, str):
+            env_dict = json.loads(data_str) if data_str.strip() else None
+        else:
+            env_dict = data_str
         if not env_dict or "SHA" not in env_dict:
             raise RuntimeError(
                 f"Job output [data] of the [{Settings.CI_CONFIG_JOB_NAME}] job is empty or missing. "

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -280,6 +280,16 @@ class _Environment(MetaClasses.Serializable):
                 f"at the very end of the [{Settings.CI_CONFIG_JOB_NAME}] job log)"
             )
 
+        # JOB_KV_DATA is stored as opaque base64 in the initial job's output
+        # (see Runner.run) to keep user-authored strings such as changed file
+        # paths from matching a secret pattern and suppressing the output -
+        # decode it back into a dict here
+        kv_data = env_dict.get("JOB_KV_DATA")
+        if isinstance(kv_data, str):
+            env_dict["JOB_KV_DATA"] = (
+                json.loads(Utils.from_base64(kv_data)) if kv_data else {}
+            )
+
         # User-authored free text is stripped from the initial job's output
         # (see Runner.run: the runner drops outputs matching secret patterns) -
         # restore it from the local event payload

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -671,6 +671,17 @@ class Runner:
             output["PR_BODY"] = ""
             output["PR_TITLE"] = ""
             output["COMMIT_MESSAGE"] = ""
+            # JOB_KV_DATA carries user-authored strings too (e.g. the
+            # `changed_files`/`changed_integration_tests` paths a PR can name
+            # arbitrarily), so a path matching a secret pattern would suppress
+            # the whole output the same way. The downstream-visible `data`
+            # output only needs `workflow_config` as plain JSON (for the GitHub
+            # Actions `if: fromJson(...).workflow_config` expressions); the rest
+            # is consumed solely by _Environment.from_workflow_data. Encode the
+            # whole bucket as opaque base64 so no raw user text can match a
+            # pattern - base64 is already used for `cache_success_base64` in the
+            # same output, so it is known to pass the masker.
+            output["JOB_KV_DATA"] = Utils.to_base64(json.dumps(env.JOB_KV_DATA))
         else:
             output = job_outputs
         with open(env.JOB_OUTPUT_STREAM, "a", encoding="utf8") as f:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -662,6 +662,15 @@ class Runner:
         if is_initial_job:
             output = dataclasses.asdict(env)
             output["pipeline_status"] = "success"
+            # User-authored free text must not be embedded into the job output:
+            # the GitHub Actions runner scans outputs with built-in secret
+            # patterns (e.g. "Bearer <chars>") and silently drops the whole
+            # output on a match, which makes every downstream job skip.
+            # Downstream jobs restore these fields from the event payload in
+            # _Environment.from_workflow_data.
+            output["PR_BODY"] = ""
+            output["PR_TITLE"] = ""
+            output["COMMIT_MESSAGE"] = ""
         else:
             output = job_outputs
         with open(env.JOB_OUTPUT_STREAM, "a", encoding="utf8") as f:

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -631,6 +631,13 @@ class Utils:
         return base64_string
 
     @staticmethod
+    def from_base64(value):
+        assert isinstance(value, str), f"TODO: not supported for {type(value)}"
+        base64_bytes = value.encode("utf-8")
+        string_bytes = base64.b64decode(base64_bytes)
+        return string_bytes.decode("utf-8")
+
+    @staticmethod
     def is_hex(s):
         try:
             int(s, 16)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Do not embed user-authored free text (`PR_BODY`, `PR_TITLE`, `COMMIT_MESSAGE`) into the praktika `data` job output, so that a PR description matching a built-in GitHub Actions secret pattern no longer silently skips the whole CI.

The GitHub Actions runner scans job outputs with built-in secret patterns and silently refuses to export an output that matches one, leaving only a log warning:

```
##[warning]Skip output 'data' since it may contain secret.
```

The initial praktika job (`Config Workflow`) serializes the entire `_Environment` into its `data` output — including `PR_BODY`, `PR_TITLE` and `COMMIT_MESSAGE`. If the PR description contains anything matching such a pattern (it is a *pattern*, not an exact secret value — e.g. the literal placeholder `Bearer <token>` in a documentation example triggers it), the runner suppresses the entire output. Every downstream job's `if:` expression calls `fromJson(needs.config_workflow.outputs.data)`, which then fails on the empty output, so all ~160 jobs are skipped, and `Finish Workflow` crashes with a cryptic `_Environment.__init__() missing 18 required positional arguments` while reading the empty workflow status.

This is exactly what kept https://github.com/ClickHouse/ClickHouse/pull/79589 at zero CI for weeks: its description demonstrates the new `body(...)` argument of the `url` table function with `headers('Content-Type', 'application/json', 'Authorization', 'Bearer ...')` examples. Both `Bearer ...` and `Bearer <token>` matched the pattern (rendered as `***` in the job log). Removing the `Bearer` prefix from the description immediately unblocked CI ([run 27328650091](https://github.com/ClickHouse/ClickHouse/actions/runs/27328650091), attempt 3 shows `Set output 'data'` and real jobs running).

The fix:
- `Runner` blanks `PR_BODY`, `PR_TITLE` and `COMMIT_MESSAGE` in the initial job's `data` output.
- `_Environment.from_workflow_data` restores them from the local event payload (`GITHUB_EVENT_PATH`), which every job of the run has: `PR_BODY`/`PR_TITLE` for `pull_request` events, `COMMIT_MESSAGE` for push events.
- `_Environment.from_workflow_data` now raises a clear `RuntimeError` pointing at the runner's `Skip output` behavior when the `data` output is missing or blank, instead of the cryptic `TypeError`.
- The `Config Workflow` pre-hook (`store_data.py`) no longer stores the raw `git diff` of changed `tests/integration/test*.py` files under `JOB_KV_DATA["file_diff"]` — that diff is user-authored free text and was serialized into the same `data` output. It now records only the list of changed integration test paths (`changed_integration_tests`); the diff value was never read (it was a `TODO: find changed test cases`) and a consumer can recompute it on demand.

Residual risk (out of scope): the remaining free-ish-text fields (`TRACEBACKS`, `REPORT_MESSAGES`) could in principle also match a pattern; they are praktika-authored and much less likely to contain credential-shaped text, and blanking them would break error propagation. The new explicit error makes any such case diagnosable in seconds rather than weeks.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Related: https://github.com/ClickHouse/ClickHouse/pull/79589


