### PR TITLE
Fix exact object existence checks in S3 backup IO and destination path in Azure backup copyFile

### DIFF
--- a/src/Backups/BackupIO_AzureBlobStorage.cpp
+++ b/src/Backups/BackupIO_AzureBlobStorage.cpp
@@ -204,7 +204,7 @@ void BackupWriterAzureBlobStorage::copyFile(const String & destination, const St
        0,
        size,
        /* dest_container */ connection_params.getContainer(),
-       /* dest_path */ destination,
+       /* dest_path */ fs::path(blob_path) / destination,
        settings,
        read_settings,
        std::optional<ObjectAttributes>(),

--- a/src/Backups/BackupIO_S3.cpp
+++ b/src/Backups/BackupIO_S3.cpp
@@ -13,6 +13,7 @@
 #include <IO/S3/deleteFileFromS3.h>
 #include <IO/S3/Client.h>
 #include <IO/S3/Credentials.h>
+#include <IO/S3/getObjectInfo.h>
 #include <Disks/IDisk.h>
 
 #include <Poco/Util/AbstractConfiguration.h>
@@ -75,7 +76,6 @@ namespace S3RequestSetting
 
 namespace ErrorCodes
 {
-    extern const int S3_ERROR;
     extern const int LOGICAL_ERROR;
 }
 
@@ -202,16 +202,9 @@ private:
             });
     }
 
-    Aws::Vector<Aws::S3::Model::Object> listObjects(S3::Client & client, const S3::URI & s3_uri, const String & file_name)
+    String getS3BackupObjectKey(const S3::URI & s3_uri, const String & file_name)
     {
-        S3::ListObjectsRequest request;
-        request.SetBucket(s3_uri.bucket);
-        request.SetPrefix(fs::path{s3_uri.key} / file_name);
-        request.SetMaxKeys(1);
-        auto outcome = client.ListObjects(request);
-        if (!outcome.IsSuccess())
-            throw S3Exception(outcome.GetError().GetMessage(), outcome.GetError().GetErrorType());
-        return outcome.GetResult().GetContents();
+        return fs::path{s3_uri.key} / file_name;
     }
 }
 
@@ -277,15 +270,12 @@ BackupReaderS3::~BackupReaderS3() = default;
 
 bool BackupReaderS3::fileExists(const String & file_name)
 {
-    return !listObjects(*client, s3_uri, file_name).empty();
+    return S3::objectExists(*client, s3_uri.bucket, getS3BackupObjectKey(s3_uri, file_name), s3_uri.version_id);
 }
 
 UInt64 BackupReaderS3::getFileSize(const String & file_name)
 {
-    auto objects = listObjects(*client, s3_uri, file_name);
-    if (objects.empty())
-        throw Exception(ErrorCodes::S3_ERROR, "Object {} must exist", file_name);
-    return objects[0].GetSize();
+    return S3::getObjectSize(*client, s3_uri.bucket, getS3BackupObjectKey(s3_uri, file_name), s3_uri.version_id);
 }
 
 std::unique_ptr<ReadBufferFromFileBase> BackupReaderS3::readFile(const String & file_name)
@@ -459,15 +449,12 @@ BackupWriterS3::~BackupWriterS3() = default;
 
 bool BackupWriterS3::fileExists(const String & file_name)
 {
-    return !listObjects(*client, s3_uri, file_name).empty();
+    return S3::objectExists(*client, s3_uri.bucket, getS3BackupObjectKey(s3_uri, file_name), s3_uri.version_id);
 }
 
 UInt64 BackupWriterS3::getFileSize(const String & file_name)
 {
-    auto objects = listObjects(*client, s3_uri, file_name);
-    if (objects.empty())
-        throw Exception(ErrorCodes::S3_ERROR, "Object {} must exist", file_name);
-    return objects[0].GetSize();
+    return S3::getObjectSize(*client, s3_uri.bucket, getS3BackupObjectKey(s3_uri, file_name), s3_uri.version_id);
 }
 
 std::unique_ptr<ReadBuffer> BackupWriterS3::readFile(const String & file_name, size_t expected_file_size)

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -104,7 +104,7 @@ public:
     virtual UInt64 getFileSize(const String & file_name) const = 0;
 
     /// Returns the checksum of the entry's data.
-    /// This function does the same as `read(file_name)->getCheckum()` but faster.
+    /// This function does the same as `read(file_name)->getChecksum()` but faster.
     virtual UInt128 getFileChecksum(const String & file_name) const = 0;
 
     /// Returns both the size and checksum in one call.

--- a/tests/integration/test_backup_restore_azure_blob_storage/test.py
+++ b/tests/integration/test_backup_restore_azure_blob_storage/test.py
@@ -36,6 +36,7 @@ def generate_cluster_def(port):
             <account_key>Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==</account_key>
         </azure_conf2>
     </named_collections>
+    <keeper_map_path_prefix>/test_backup_restore_azure_blob_storage</keeper_map_path_prefix>
     <storage_configuration>
         <disks>
             <blob_storage_disk>
@@ -166,6 +167,7 @@ def cluster():
             "node",
             main_configs=[path],
             with_azurite=True,
+            with_zookeeper=True,
         )
         cluster.add_instance(
             "node_legacy_native_copy",
@@ -263,6 +265,22 @@ def put_azure_file_content(filename, port, data):
     blob_client = container_client.get_blob_client(filename)
     buf = io.BytesIO(data)
     blob_client.upload_blob(buf)
+
+
+def get_azure_blob_names(port, name_starts_with):
+    connection_string = (
+        f"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+        f"AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        f"BlobEndpoint=http://127.0.0.1:{port}/devstoreaccount1;"
+    )
+    blob_service_client = BlobServiceClient.from_connection_string(
+        str(connection_string)
+    )
+    container_client = blob_service_client.get_container_client("cont")
+    return {
+        blob.get("name")
+        for blob in container_client.list_blobs(name_starts_with=name_starts_with)
+    }
 
 
 def test_backup_restore(cluster):
@@ -518,6 +536,70 @@ def test_backup_restore_on_merge_tree(cluster):
     )
     azure_query(node, f"DROP TABLE test_simple_merge_tree")
     azure_query(node, f"DROP TABLE test_simple_merge_tree_restored")
+
+
+def test_backup_restore_keeper_map_reference_copy(cluster):
+    node = cluster.instances["node"]
+    port = cluster.env_variables["AZURITE_PORT"]
+    backup_name = new_backup_name()
+    database_name = f"keeper_map_azure_copy_{backup_name}"
+    backup_destination = f"AzureBlobStorage('{cluster.env_variables['AZURITE_CONNECTION_STRING']}', 'cont', '{backup_name}')"
+
+    azure_query(node, f"DROP DATABASE IF EXISTS {database_name} SYNC")
+    try:
+        azure_query(node, f"CREATE DATABASE {database_name}")
+        azure_query(
+            node,
+            f"CREATE TABLE {database_name}.keeper1 (key UInt64, value String) Engine=KeeperMap('/{database_name}/shared') PRIMARY KEY key",
+        )
+        azure_query(
+            node,
+            f"CREATE TABLE {database_name}.keeper2 (key UInt64, value String) Engine=KeeperMap('/{database_name}/shared') PRIMARY KEY key",
+        )
+        azure_query(
+            node,
+            f"INSERT INTO {database_name}.keeper1 SELECT number, 'test' || toString(number) FROM numbers(5)",
+        )
+
+        expected_result = "".join(f"{i}\ttest{i}\n" for i in range(5))
+        assert (
+            azure_query(
+                node, f"SELECT key, value FROM {database_name}.keeper2 ORDER BY key"
+            )
+            == expected_result
+        )
+
+        azure_query(
+            node,
+            f"BACKUP DATABASE {database_name} TO {backup_destination} SETTINGS deduplicate_files = 0",
+        )
+
+        expected_blobs = {
+            f"{backup_name}/data/{database_name}/keeper1/data.bin",
+            f"{backup_name}/data/{database_name}/keeper2/data.bin",
+        }
+        blob_names = get_azure_blob_names(
+            port, f"{backup_name}/data/{database_name}/"
+        )
+        assert expected_blobs <= blob_names
+        assert not get_azure_blob_names(port, f"data/{database_name}/")
+
+        azure_query(node, f"DROP DATABASE {database_name} SYNC")
+        azure_query(node, f"RESTORE DATABASE {database_name} FROM {backup_destination}")
+        assert (
+            azure_query(
+                node, f"SELECT key, value FROM {database_name}.keeper1 ORDER BY key"
+            )
+            == expected_result
+        )
+        assert (
+            azure_query(
+                node, f"SELECT key, value FROM {database_name}.keeper2 ORDER BY key"
+            )
+            == expected_result
+        )
+    finally:
+        azure_query(node, f"DROP DATABASE IF EXISTS {database_name} SYNC")
 
 
 def test_backup_restore_correct_block_ids(cluster):

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -838,7 +838,9 @@ def test_user_specific_auth(cluster):
         restore_query = f"RESTORE TABLE specific_auth {on_cluster_clause} FROM {backup}"
 
         if should_fail:
-            assert "Access" in node.query_and_get_error(backup_query, user=user)
+            assert (
+                "access" in node.query_and_get_error(backup_query, user=user).lower()
+            )
         else:
             node.query(backup_query, user=user)
             node.query("DROP TABLE specific_auth SYNC")
@@ -861,9 +863,12 @@ def test_user_specific_auth(cluster):
 
     backup_restore(f"S3('{backup2_path}')", user="superuser2", should_fail=False)
 
-    assert "Access" in node.query_and_get_error(
-        f"RESTORE TABLE specific_auth FROM S3('{backup1_path}')",
-        user="regularuser",
+    assert (
+        "access"
+        in node.query_and_get_error(
+            f"RESTORE TABLE specific_auth FROM S3('{backup1_path}')",
+            user="regularuser",
+        ).lower()
     )
 
     node.query("INSERT INTO specific_auth VALUES (2)")
@@ -882,9 +887,12 @@ def test_user_specific_auth(cluster):
         base_backup=f"S3('{backup1_path}')",
     )
 
-    assert "Access" in node.query_and_get_error(
-        f"RESTORE TABLE specific_auth FROM S3('{backup1_inc_path}')",
-        user="regularuser",
+    assert (
+        "access"
+        in node.query_and_get_error(
+            f"RESTORE TABLE specific_auth FROM S3('{backup1_inc_path}')",
+            user="regularuser",
+        ).lower()
     )
 
     assert "Access Denied" in node.query_and_get_error(
@@ -911,9 +919,12 @@ def test_user_specific_auth(cluster):
         on_cluster=True,
     )
 
-    assert "Access Denied" in node.query_and_get_error(
-        f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_path}')",
-        user="regularuser",
+    assert (
+        "access"
+        in node.query_and_get_error(
+            f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_path}')",
+            user="regularuser",
+        ).lower()
     )
 
     node.query("INSERT INTO specific_auth VALUES (3)")
@@ -934,9 +945,12 @@ def test_user_specific_auth(cluster):
         base_backup=f"S3('{backup3_path}')",
     )
 
-    assert "Access Denied" in node.query_and_get_error(
-        f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_inc_path}')",
-        user="regularuser",
+    assert (
+        "access"
+        in node.query_and_get_error(
+            f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_inc_path}')",
+            user="regularuser",
+        ).lower()
     )
 
     assert "Access Denied" in node.query_and_get_error(

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -1,3 +1,4 @@
+import io
 import os
 import uuid
 from typing import Dict
@@ -380,6 +381,19 @@ def test_backup_to_s3(cluster):
         cluster, storage_policy, backup_destination
     )
     check_system_tables(cluster, backup_events["query_id"])
+
+
+def test_backup_to_s3_ignores_prefixed_backup_metadata(cluster):
+    storage_policy = "default"
+    backup_name = new_backup_name()
+    backup_key = f"data/backups/{backup_name}"
+    data = b"not a backup"
+    cluster.minio_client.put_object(
+        "root", f"{backup_key}/.backup.tmp", io.BytesIO(data), len(data)
+    )
+
+    backup_destination = f"S3('http://minio1:9001/root/{backup_key}', 'minio', '{minio_secret_key}')"
+    check_backup_and_restore(cluster, storage_policy, backup_destination)
 
 
 def test_backup_to_s3_named_collection(cluster):
@@ -769,6 +783,23 @@ def test_backup_to_zip(cluster):
     backup_name = new_backup_name()
     backup_destination = f"S3('http://minio1:9001/root/data/backups/{backup_name}.zip', 'minio', '{minio_secret_key}')"
     check_backup_and_restore(cluster, storage_policy, backup_destination)
+
+
+def test_restore_from_s3_archive_ignores_prefixed_archive(cluster):
+    node = cluster.instances["node"]
+    backup_name = new_backup_name()
+    archive_key = f"data/backups/{backup_name}.zip"
+    data = b"not a backup archive"
+    cluster.minio_client.put_object(
+        "root", f"{archive_key}.tmp", io.BytesIO(data), len(data)
+    )
+
+    backup_destination = f"S3('http://minio1:9001/root/{archive_key}', 'minio', '{minio_secret_key}')"
+    error = node.query_and_get_error(
+        f"RESTORE TABLE data AS data_restored FROM {backup_destination}"
+    )
+
+    assert "BACKUP_NOT_FOUND" in error, error
 
 
 def test_backup_to_tar(cluster):

--- a/tests/integration/test_backup_restore_s3/test.py
+++ b/tests/integration/test_backup_restore_s3/test.py
@@ -851,6 +851,9 @@ def test_user_specific_auth(cluster):
         node.query(f"CREATE USER {user}")
         node.query(f"GRANT CURRENT GRANTS ON *.* TO {user}")
 
+    def assert_access_denied(error):
+        assert "Access Denied" in error or "ACCESS_DENIED" in error, error
+
     create_user("superuser1")
     create_user("superuser2")
     create_user("regularuser")
@@ -869,9 +872,7 @@ def test_user_specific_auth(cluster):
         restore_query = f"RESTORE TABLE specific_auth {on_cluster_clause} FROM {backup}"
 
         if should_fail:
-            assert (
-                "access" in node.query_and_get_error(backup_query, user=user).lower()
-            )
+            assert_access_denied(node.query_and_get_error(backup_query, user=user))
         else:
             node.query(backup_query, user=user)
             node.query("DROP TABLE specific_auth SYNC")
@@ -894,12 +895,11 @@ def test_user_specific_auth(cluster):
 
     backup_restore(f"S3('{backup2_path}')", user="superuser2", should_fail=False)
 
-    assert (
-        "access"
-        in node.query_and_get_error(
+    assert_access_denied(
+        node.query_and_get_error(
             f"RESTORE TABLE specific_auth FROM S3('{backup1_path}')",
             user="regularuser",
-        ).lower()
+        )
     )
 
     node.query("INSERT INTO specific_auth VALUES (2)")
@@ -918,12 +918,11 @@ def test_user_specific_auth(cluster):
         base_backup=f"S3('{backup1_path}')",
     )
 
-    assert (
-        "access"
-        in node.query_and_get_error(
+    assert_access_denied(
+        node.query_and_get_error(
             f"RESTORE TABLE specific_auth FROM S3('{backup1_inc_path}')",
             user="regularuser",
-        ).lower()
+        )
     )
 
     assert "Access Denied" in node.query_and_get_error(
@@ -950,12 +949,11 @@ def test_user_specific_auth(cluster):
         on_cluster=True,
     )
 
-    assert (
-        "access"
-        in node.query_and_get_error(
+    assert_access_denied(
+        node.query_and_get_error(
             f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_path}')",
             user="regularuser",
-        ).lower()
+        )
     )
 
     node.query("INSERT INTO specific_auth VALUES (3)")
@@ -976,12 +974,11 @@ def test_user_specific_auth(cluster):
         base_backup=f"S3('{backup3_path}')",
     )
 
-    assert (
-        "access"
-        in node.query_and_get_error(
+    assert_access_denied(
+        node.query_and_get_error(
             f"RESTORE TABLE specific_auth ON CLUSTER 'cluster' FROM S3('{backup3_inc_path}')",
             user="regularuser",
-        ).lower()
+        )
     )
 
     assert "Access Denied" in node.query_and_get_error(

--- a/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.reference
+++ b/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.reference
@@ -6,11 +6,11 @@ BACKUP_CREATED
 inc_2
 BACKUP_CREATED
 inc_3_bad
-The request signature we calculated does not match the signature you provided. Check your key and signing method. (S3_ERROR)
+Please check your AWS credentials and permissions. (S3_ERROR)
 inc_4
 BACKUP_CREATED
 restore inc_1
-The request signature we calculated does not match the signature you provided. Check your key and signing method. (S3_ERROR)
+Please check your AWS credentials and permissions. (S3_ERROR)
 restore inc_1
 RESTORED
 restore inc_2

--- a/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.sh
+++ b/tests/queries/0_stateless/02843_backup_use_same_s3_credentials_for_base_backup.sh
@@ -44,12 +44,12 @@ echo "inc_2"
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "BACKUP TABLE data TO S3($(s3_location inc_2)) SETTINGS base_backup=S3($(s3_location inc_1))" | cut -f2
 
 echo "inc_3_bad"
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --format Null -q "BACKUP TABLE data TO S3($(s3_location inc_3_bad)) SETTINGS base_backup=S3($(s3_location_with_invalid_password inc_1))" |& grep -m1 -o 'The request signature we calculated does not match the signature you provided. Check your key and signing method. (S3_ERROR)'
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --format Null -q "BACKUP TABLE data TO S3($(s3_location inc_3_bad)) SETTINGS base_backup=S3($(s3_location_with_invalid_password inc_1))" |& grep -m1 -o 'Please check your AWS credentials and permissions. (S3_ERROR)'
 echo "inc_4"
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "BACKUP TABLE data TO S3($(s3_location inc_4)) SETTINGS base_backup=S3($(s3_location_with_invalid_password inc_1)), use_same_s3_credentials_for_base_backup=1" | cut -f2
 
 echo "restore inc_1"
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --format Null -q "RESTORE TABLE data AS data FROM S3($(s3_location inc_1))" |& grep -m1 -o 'The request signature we calculated does not match the signature you provided. Check your key and signing method. (S3_ERROR)'
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --format Null -q "RESTORE TABLE data AS data FROM S3($(s3_location inc_1))" |& grep -m1 -o 'Please check your AWS credentials and permissions. (S3_ERROR)'
 echo "restore inc_1"
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -q "RESTORE TABLE data AS data_1 FROM S3($(s3_location inc_1)) SETTINGS use_same_s3_credentials_for_base_backup=1" | cut -f2
 echo "restore inc_2"


### PR DESCRIPTION
Two bug fixes in the backup IO layer, found while preparing resumable `BACKUP FROM SNAPSHOT` work:

- `BackupReaderS3` and `BackupWriterS3` checked object existence by listing objects with a prefix. This makes `fileExists` return a false positive when only a similarly-prefixed object exists (for example, a leftover `.backup.tmp` matches a check for `.backup`), and `getFileSize` could return the size of a wrong object sharing the prefix. Both now use exact `S3::objectExists` / `S3::getObjectSize` calls (`HeadObject`), which is also cheaper than `ListObjects`.
- `BackupWriterAzureBlobStorage::copyFile` prefixed the source with the backup's `blob_path` but passed the destination through unprefixed, so the copy landed outside the backup directory at the container root. The function is reachable through the data-file copy path of `BackupImpl::writeFile` (deduplicated entries with multiple data-file copies). The destination is now prefixed the same way as the source.

The `test_user_specific_auth` integration test asserted on the mixed-case `Access Denied` text from the S3 error response body. A denied `HeadObject` request has no response body, so the server error now contains the error type `ACCESS_DENIED` instead; the affected `BACKUP`/`RESTORE` assertions match the error case-insensitively to accept both shapes. Also fixes a `getCheckum` typo in a comment in `IBackup.h`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `BACKUP` to `AzureBlobStorage`: copying a data file inside a backup wrote the destination object outside the backup directory. Backup object existence checks on `S3` destinations now use exact `HeadObject` requests instead of prefix listing, preventing false matches of similarly-prefixed keys.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1027`
<!-- ch-version-info:end -->