### PR TITLE
Harden unit tests against thread profile-counters unlinking

### DIFF
--- a/src/Common/tests/gtest_connection_pool.cpp
+++ b/src/Common/tests/gtest_connection_pool.cpp
@@ -149,7 +149,7 @@ protected:
         options->set(RequestOptions());
 
         DB::HTTPConnectionPools::instance().dropCache();
-        DB::CurrentThread::getProfileEvents().reset();
+        DB::CurrentThread::getProfileEvents().resetCounters();
         // Code here will be called immediately after the constructor (right
         // before each test).
     }

--- a/src/Common/tests/gtest_resolve_pool.cpp
+++ b/src/Common/tests/gtest_resolve_pool.cpp
@@ -55,7 +55,7 @@ protected:
     }
 
     void SetUp() override {
-        DB::CurrentThread::getProfileEvents().reset();
+        DB::CurrentThread::getProfileEvents().resetCounters();
 
         ASSERT_EQ(0, CurrentMetrics::get(metrics.active_count));
         ASSERT_EQ(0, CurrentMetrics::get(metrics.banned_count));


### PR DESCRIPTION
`ConnectionPoolTest::SetUp` and `ResolvePoolTest::SetUp` called `CurrentThread::getProfileEvents().reset()`, which does `setParent(nullptr)` — once any earlier test attaches a `ThreadStatus` to the gtest main thread, this permanently unlinks the thread's counters from `ProfileEvents::global_counters`. This is a landmine that can make unrelated unit tests fail.

Use `resetCounters`, which zeroes the values but keeps the parent chain intact.

These are the two pool-fixture one-liners upstreamed from a private fix to keep the sync clean.

Related: https://github.com/ClickHouse/ClickHouse/pull/106839

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.646`
<!-- ch-version-info:end -->