### PR TITLE
Fix crash on REFRESH ... DEPENDS ON shadowed by a temporary table

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -82,6 +82,28 @@ namespace ErrorCodes
     extern const int TABLE_UUID_MISMATCH;
 }
 
+namespace
+{
+
+/// Build the dependency StorageIDs, resolving unqualified names against the view's database.
+/// An empty database would later throw from StorageID::getFullTableName() during scheduling.
+std::vector<StorageID> parseRefreshDependencies(const ASTRefreshStrategy & strategy, const String & default_database)
+{
+    std::vector<StorageID> deps;
+    if (!strategy.dependencies)
+        return deps;
+    for (auto && dependency : strategy.dependencies->children)
+    {
+        StorageID id = dependency->as<const ASTTableIdentifier &>();
+        if (id.database_name.empty() && !default_database.empty())
+            id.database_name = default_database;
+        deps.push_back(std::move(id));
+    }
+    return deps;
+}
+
+}
+
 RefreshTask::RefreshTask(
     StorageMaterializedView * view_, ContextPtr context, const DB::ASTRefreshStrategy & strategy, std::vector<StorageID> initial_dependencies_, bool attach, bool coordinated, bool empty, bool is_restore_from_backup)
     : view(view_)
@@ -193,10 +215,7 @@ OwnedRefreshTask RefreshTask::create(
     bool empty,
     bool is_restore_from_backup)
 {
-    std::vector<StorageID> deps;
-    if (strategy.dependencies)
-        for (auto && dependency : strategy.dependencies->children)
-            deps.emplace_back(dependency->as<const ASTTableIdentifier &>());
+    std::vector<StorageID> deps = parseRefreshDependencies(strategy, view->getStorageID().database_name);
 
     auto task = std::make_shared<RefreshTask>(view, context, strategy, std::move(deps), attach, coordinated, empty, is_restore_from_backup);
 
@@ -380,10 +399,8 @@ void RefreshTask::alterRefreshParams(const DB::ASTRefreshStrategy & new_strategy
         std::lock_guard guard(mutex);
 
         refresh_schedule = RefreshSchedule(new_strategy);
-        std::vector<StorageID> deps;
-        if (new_strategy.dependencies)
-            for (auto && dependency : new_strategy.dependencies->children)
-                deps.emplace_back(dependency->as<const ASTTableIdentifier &>());
+        std::vector<StorageID> deps = parseRefreshDependencies(
+            new_strategy, view ? view->getStorageID().database_name : String{});
 
         /// Update dependency graph.
         if (set_handle)

--- a/tests/queries/0_stateless/04329_refreshable_mv_depends_on_database_qualification.reference
+++ b/tests/queries/0_stateless/04329_refreshable_mv_depends_on_database_qualification.reference
@@ -1,0 +1,6 @@
+1. temporary-table-named dependency, settled status and empty exception:
+MissingDependencies	1
+2. same view after detach/attach (attach-from-metadata path), settled status and empty exception:
+MissingDependencies	1
+3. server alive:
+1

--- a/tests/queries/0_stateless/04329_refreshable_mv_depends_on_database_qualification.sh
+++ b/tests/queries/0_stateless/04329_refreshable_mv_depends_on_database_qualification.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Tags: atomic-database, memory-engine
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Regression test for issue #106737 (STID 2508-3e7b):
+#   Logical error 'Unexpected exception in refresh scheduling'.
+#
+# `REFRESH ... DEPENDS ON <table>` dependencies were turned into StorageIDs straight from the
+# AST. When a bare dependency name matched a TEMPORARY table (or CTE alias),
+# AddDefaultDatabaseVisitor leaves it unqualified, so the StorageID had an empty database. On the
+# first scheduling pass StorageID::getFullTableName() threw UNKNOWN_DATABASE, the catch-all in
+# RefreshTask::doScheduling re-raised it as a LOGICAL_ERROR and the server aborted (then
+# crash-looped on restart, because the bad definition was persisted).
+#
+# The fix resolves any still-unqualified dependency against the view's database in
+# RefreshTask::create / alterRefreshParams (which also covers the attach-from-metadata path that
+# has no session). The state assertion below catches the bug even in non-sanitizer builds, where
+# the catch-all does not abort: with the empty-database bug the scheduler records the exception
+# and stops (Disabled with a non-empty exception) instead of settling at MissingDependencies.
+
+DB2="${CLICKHOUSE_DATABASE}_mv"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$DB2\` SYNC"
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$DB2\`"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE \`$DB2\`.t (a UInt64) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE \`$DB2\`.dst1 (a UInt64) ENGINE = MergeTree ORDER BY a"
+
+# Poll until the view's refresh has settled (left the transient Scheduling state), then print the
+# settled status and whether the exception is empty. The dependency `t` resolves to a plain table
+# (never a refreshable MV), so the scheduler settles permanently at MissingDependencies with no
+# exception. With the original empty-database bug it settles at Disabled with a non-empty
+# exception instead (or, in debug/sanitizer builds, the server aborts before reaching here).
+report_refresh_state() {
+    local view="$1"
+    local status=""
+    local i
+    for i in $(seq 1 120); do
+        status=$(${CLICKHOUSE_CLIENT} -q "SELECT status FROM system.view_refreshes WHERE database = '$DB2' AND view = '$view'")
+        if [ -n "$status" ] && [ "$status" != "Scheduling" ]; then
+            break
+        fi
+        sleep 0.5
+    done
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT status, exception = '' AS no_exception
+        FROM system.view_refreshes WHERE database = '$DB2' AND view = '$view' FORMAT TSV"
+}
+
+# 1. A temporary table shadowing the dependency name must not crash the refresh scheduler.
+#    The temporary table and the MV must be created in the SAME client session, so the temporary
+#    table is visible while the CREATE is interpreted and AddDefaultDatabaseVisitor leaves the
+#    bare `t` unqualified. The dependency must not be left with an empty database (which crashed
+#    scheduling); it must settle at MissingDependencies.
+${CLICKHOUSE_CLIENT} --multiquery -q "
+    CREATE TEMPORARY TABLE t (a UInt64) ENGINE = Memory;
+    CREATE MATERIALIZED VIEW \`$DB2\`.mv_tmp REFRESH EVERY 1 SECOND DEPENDS ON t
+        TO \`$DB2\`.dst1 AS SELECT a FROM \`$DB2\`.t;
+"
+echo "1. temporary-table-named dependency, settled status and empty exception:"
+report_refresh_state mv_tmp
+
+# 2. The persisted definition must survive a server restart without crash-looping. Detaching and
+#    re-attaching the view replays the attach-from-metadata code path (no session), where the
+#    empty-database dependency previously aborted the server on the first scheduling pass.
+${CLICKHOUSE_CLIENT} -q "DETACH TABLE \`$DB2\`.mv_tmp"
+${CLICKHOUSE_CLIENT} -q "ATTACH TABLE \`$DB2\`.mv_tmp"
+echo "2. same view after detach/attach (attach-from-metadata path), settled status and empty exception:"
+report_refresh_state mv_tmp
+
+# 3. The server must still be alive (it would have aborted without the fix in debug/sanitizer builds).
+echo "3. server alive:"
+${CLICKHOUSE_CLIENT} -q "SELECT 1"
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE \`$DB2\` SYNC"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106737
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server crash (`LOGICAL_ERROR` "Unexpected exception in refresh scheduling", followed by a crash-loop on restart) when a refreshable materialized view has a `REFRESH ... DEPENDS ON <name>` dependency whose unqualified name matches a temporary table or a CTE name.

### Description

Closes: #106737

`REFRESH ... DEPENDS ON <name>` dependencies are built into `StorageID`s directly from the AST in `RefreshTask::create` / `RefreshTask::alterRefreshParams`. `AddDefaultDatabaseVisitor` skips qualifying a bare name that matches a temporary table or a CTE, so such a dependency kept an empty database. On the first scheduling pass `StorageID::getFullTableName()` threw `UNKNOWN_DATABASE` "Database name is empty", the catch-all in `RefreshTask::doScheduling` re-raised it as a `LOGICAL_ERROR` and the server aborted; the bad definition was persisted, so the server then crash-looped on restart.

Fix: resolve any still-unqualified dependency against the view's database in `RefreshTask::create` / `alterRefreshParams`. This is the correct database for the no-session paths (attach-from-metadata on restart, background scheduling) and matches the database `AddDefaultDatabaseVisitor` would have used for a non-shadowed name.

The change is limited to the empty-database dependency. It does not change how a refreshable MV's `SELECT` or `DEPENDS ON` clause resolves unqualified names in the normal (non-shadowed) case: both still resolve in the session database at `CREATE` time, as before.

The regression test `04329_refreshable_mv_depends_on_database_qualification.sh` reproduces the original crash via a temporary table shadowing the dependency name, and asserts `system.view_refreshes` settles at `MissingDependencies` with an empty `exception` (instead of `Disabled` with an exception), so it catches the regression in non-sanitizer functional CI as well as in debug/sanitizer builds where the catch-all aborts. It also covers the detach/attach (attach-from-metadata) path.

CI report for the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107156&sha=d1c5d0ef9aad5b1c5c71acda4fb8e98495cf0ab7&name_0=PR

Found by issue #106737 (STID 2508-3e7b).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1076`
<!-- ch-version-info:end -->