### PR TITLE
Fix outdated disk recovery log messages referencing SYSTEM RESTART DISK

### DIFF
--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -815,8 +815,8 @@ void DiskLocal::setup()
         {
             LOG_WARNING(
                 logger,
-                "Cannot create/write to {0}. Disk {1} is either readonly or broken. Without setting up disk checker file, DiskLocalCheckThread "
-                "will not be started. Disk is assumed to be RW. Try manually fix the disk and do `SYSTEM RESTART DISK {1}`",
+                "Cannot create/write to {}. Disk {} is either readonly or broken. Without setting up disk checker file, DiskLocalCheckThread "
+                "will not be started. Disk is assumed to be RW. Try to manually fix the disk and restart the server",
                 disk_checker_path,
                 name);
             disk_checker_can_check_read = false;

--- a/src/Disks/DiskLocalCheckThread.cpp
+++ b/src/Disks/DiskLocalCheckThread.cpp
@@ -58,7 +58,7 @@ void DiskLocalCheckThread::run()
     if (can_read)
     {
         if (disk->broken)
-            LOG_INFO(log, "Disk {0} seems to be fine. It can be recovered using `SYSTEM RESTART DISK {0}`", disk->getName());
+            LOG_INFO(log, "Disk {} seems to be fine. It is recovered automatically", disk->getName());
         retry = 0;
         if (can_write)
             disk->readonly = false;


### PR DESCRIPTION
Fixes the outdated log messages reported in https://github.com/ClickHouse/ClickHouse/issues/98581.

`DiskLocalCheckThread` and `DiskLocal::setup` suggested recovering a broken local disk with the `SYSTEM RESTART DISK` command, which was removed in https://github.com/ClickHouse/ClickHouse/pull/44647. The suggestion was confusing because the command no longer exists. A broken local disk is now recovered automatically by `DiskLocalCheckThread` once it becomes readable again, and when the disk checker file cannot be created the disk must be fixed manually and the server restarted. The messages are updated to reflect the current behavior.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update outdated local disk recovery log messages that referenced the removed `SYSTEM RESTART DISK` command.
