### PR TITLE
DO NOT MERGE: ASan heap corruption repro — plain master, without distributed queries

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -16,7 +16,9 @@ extern "C" {
 #ifdef ADDRESS_SANITIZER
 const char * __asan_default_options()
 {
-    return "halt_on_error=1 abort_on_error=1";
+    /// Large quarantine keeps freed memory poisoned longer so a wild write is reported as
+    /// heap-use-after-free with full stacks instead of corrupting recycled allocations silently.
+    return "halt_on_error=1 abort_on_error=1 quarantine_size_mb=2048 malloc_context_size=30";
 }
 const char * __lsan_default_options()
 {

--- a/tests/config/config.d/thread_pool_trim.xml
+++ b/tests/config/config.d/thread_pool_trim.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <!-- Aggressive idle-thread trimming to maximize OS-thread teardown frequency. This is the
+         amplifier that turned the latent heap corruption into mass failures on 2026-06-10. -->
+    <max_thread_pool_free_size>16</max_thread_pool_free_size>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -167,6 +167,7 @@ function is_sanitizer_build()
 }
 if is_sanitizer_build; then
     ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
+    ln -sf $SRC_PATH/config.d/thread_pool_trim.xml $DEST_SERVER_PATH/config.d/
 fi
 ln -sf $SRC_PATH/config.d/memory_profiler.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107122

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Draft, never to be merged: a CI reproduction setup for the ASan heap corruption (`sanitizer_allocator_secondary.h:200` CHECK) that #107122 attributed to the distributed-query infrastructure. CI history suggests the corruption predates #106020: similar reports exist from Nov 2025 (AST fuzzer on master), March 2026 (an unrelated PR), and May 2026 (the Parquet-parallelism PR) — all without the distributed feature.

This PR is **plain master without the distributed-query feature**, plus two settings that make the corruption more likely to fire and easier to diagnose:
- `max_thread_pool_free_size = 16` for sanitizer test configs — destroys idle threads much more aggressively than the value that triggered the June 10 failures.
- A large ASan quarantine (`quarantine_size_mb=2048`) with deeper stack capture — freed memory stays poisoned longer, so a stray write into it produces a `heap-use-after-free` report with full stacks instead of silently corrupting reused memory.

There is a second PR with the same two settings on top of the #107146 branch (with the distributed feature). If sanitizer jobs crash in **both** PRs, the corruption lives in shared infrastructure and #106020 is exonerated. If they crash **only in the other PR**, the feature is implicated — and the quarantine setting should produce a report naming the buggy code, which the #107122 reports could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)