### PR TITLE
Fix/cluster discovery keeper exception

### DIFF
--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -779,6 +779,8 @@ bool ClusterDiscovery::runMainThread(std::function<void()> up_to_date_callback)
                 continue;
             }
             auto & cluster_info = cluster_info_it->second;
+            auto zk = context->getDefaultOrAuxiliaryZooKeeper(cluster_info.zk_name);
+            registerInZk(zk, cluster_info);
             if (upsertCluster(cluster_info))
             {
                 cluster_info.watch.restart();

--- a/tests/integration/test_cluster_discovery/test_dynamic_clusters.py
+++ b/tests/integration/test_cluster_discovery/test_dynamic_clusters.py
@@ -46,6 +46,51 @@ def get_clusters_hosts(node, expected):
     return hosts
 
 
+def test_dynamic_cluster_root_without_shards(start_cluster):
+    expected_initial_clusters = [
+        ["test_auto_cluster1", "node0"],
+        ["test_auto_cluster1", "node1"],
+        ["test_auto_cluster2", "node2"],
+        ["test_auto_cluster3", "node3"],
+    ]
+    for node in nodes.values():
+        assert get_clusters_hosts(node, len(expected_initial_clusters)) == expected_initial_clusters
+
+    zk = cluster.get_kazoo_client("zoo1")
+    discovery_path = "/clickhouse/discovery/test_zk_only_cluster"
+
+    try:
+        if zk.exists(discovery_path):
+            zk.delete(discovery_path, recursive=True)
+        zk.ensure_path(discovery_path)
+
+        for _ in range(30):
+            if zk.exists(f"{discovery_path}/shards"):
+                break
+            time.sleep(1)
+        else:
+            pytest.fail("ClusterDiscovery did not create the missing /shards path")
+
+        zk.create(
+            f"{discovery_path}/shards/node0",
+            b'{"version":1,"address":"node0:9000","shard_id":1}',
+        )
+
+        for _ in range(30):
+            count = nodes["node_observer"].query(
+                "SELECT count() FROM system.clusters "
+                "WHERE cluster = 'test_zk_only_cluster'"
+            )
+            if count.strip() == "1":
+                break
+            time.sleep(1)
+        else:
+            pytest.fail("The dynamically discovered cluster did not become available")
+    finally:
+        if zk.exists(discovery_path):
+            zk.delete(discovery_path, recursive=True)
+
+
 def test_cluster_discovery_startup_and_stop(start_cluster):
     """
     Start cluster, check nodes count in system.clusters,


### PR DESCRIPTION
`ClusterDiscovery` failed to retry a dynamic cluster after a `KEEPER_EXCEPTION`               
  when the `/shards` path did not yet exist in Keeper at discovery time.

When a dynamic cluster first fails to insert, it is scheduled for retry via                   
  `clusters_to_update`. On the next iteration that retry goes through the `clusters`            
  loop where `upsertCluster` had no `try/catch`, causing the exception to propagate             
  out of `runMainThread` entirely and fall into the outer backoff loop instead of               
  retrying cleanly within the `wait()` mechanism. Added the same `try/catch` guard              
  that the `clusters_to_insert` path already has. 

Closes: https://github.com/ClickHouse/ClickHouse/issues/102164   


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry 
Fixed `ClusterDiscovery` not retrying a dynamic cluster insertion after a `KEEPER_EXCEPTION`  
  caused by the `/shards` path not yet existing in Keeper.

