### PR TITLE
backfill_distroless: tolerate com.clickhoghuse typo on historical keeper tags

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -78,17 +78,22 @@ jobs:
               return 1
             }
 
+            # Read the canonical com.clickhouse.build.version label, falling
+            # back to the misspelled com.clickhoghuse.build.version that some
+            # historical floating-tag pushes used. Once this run overwrites
+            # those tags with correctly-keyed labels the fallback will go
+            # unused, but we need to accept it now to bootstrap past the
+            # transition.
             local label
             label=$(echo "$manifest_raw" | jq -r '
               (.image // {}) as $img |
-              if ($img | has("config")) then
-                $img.config.Labels["com.clickhouse.build.version"] // ""
-              else
-                ($img | to_entries[]? | .value.config.Labels["com.clickhouse.build.version"]) // ""
-              end' 2>/dev/null | grep -v '^$' | head -1)
+              (if ($img | has("config")) then $img.config.Labels
+               else ($img | to_entries[0]?.value.config.Labels) end) as $lbl |
+              ($lbl["com.clickhouse.build.version"] //
+               $lbl["com.clickhoghuse.build.version"] // "")' 2>/dev/null | grep -v '^$' | head -1)
 
             if [ -z "$label" ]; then
-              echo "ERROR: ${image}:${tag} has no com.clickhouse.build.version label" >&2
+              echo "ERROR: ${image}:${tag} has no com.clickhouse.build.version label (also tried com.clickhoghuse.build.version fallback)" >&2
               return 1
             fi
 


### PR DESCRIPTION
The cross-run guard from #106932 bailed out mid-run on https://github.com/ClickHouse/ClickHouse/actions/runs/27304321038 because some older keeper floating tags carry the version label under a misspelled key — `com.clickhoghuse.build.version` instead of `com.clickhouse.build.version`. The server side finished fine, all three refs got the correct labels, then the keeper job hit the typo'd tags and the guard refused to overwrite ("no `com.clickhouse.build.version` label").

Fix is to read the canonical key, then fall back to the misspelled one. Once this run actually completes, those floating refs get rewritten with the correct key and the fallback becomes dead code.

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

#### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.667`
<!-- ch-version-info:end -->