### PR TITLE
Properly validate CrossTab aggregate function states on deserialization

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionTheilsU.h
+++ b/src/AggregateFunctions/AggregateFunctionTheilsU.h
@@ -153,12 +153,7 @@ struct TheilsUWindowData : CrossTabCountsState
 
     void deserialize(ReadBuffer & buf)
     {
-        clear();
-
-        readBinary(count, buf);
-        count_a.read(buf);
-        count_b.read(buf);
-        count_ab.read(buf);
+        CrossTabCountsState::deserialize(buf);
 
         /// Restore cached Σ n logn sums
         sum_a_nlogn = recomputeNLogNSum(count_a);
@@ -216,17 +211,6 @@ private:
             return 0.0;
         const Float64 xf = static_cast<Float64>(x);
         return xf * std::log(xf);
-    }
-
-    void clear()
-    {
-        count = 0;
-        count_a.clear();
-        count_b.clear();
-        count_ab.clear();
-        sum_a_nlogn = 0.0;
-        sum_b_nlogn = 0.0;
-        sum_ab_nlogn = 0.0;
     }
 
     template <typename Map, typename Key>

--- a/src/AggregateFunctions/CrossTab.h
+++ b/src/AggregateFunctions/CrossTab.h
@@ -3,6 +3,7 @@
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/UniqVariadicHash.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <base/arithmeticOverflow.h>
 #include <Common/Exception.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/VectorWithMemoryTracking.h>
@@ -82,6 +83,84 @@ struct CrossTabCountsState
         count_a.read(buf);
         count_b.read(buf);
         count_ab.read(buf);
+
+        validateDeserialized(count, count_a, count_b, count_ab);
+    }
+
+    /// Aggregate function states can be constructed from untrusted data, e.g. by `CAST` from `String`,
+    /// so deserialization has to check all invariants that the calculations rely on
+    /// (a genuine state produced by `add` and `merge` satisfies them by construction):
+    ///  - all joint counts in `count_ab` are positive;
+    ///  - `count_a` and `count_b` are exactly the marginal sums of `count_ab`;
+    ///  - the joint counts sum up to `count`.
+    /// These invariants guarantee that the state describes a valid contingency table, which in turn
+    /// guarantees the theoretical bounds asserted during finalization (e.g. 0 <= φ² <= min(|A|, |B|) - 1).
+    static void validateDeserialized(UInt64 count, const auto & count_a, const auto & count_b, const auto & count_ab)
+    {
+        UInt64 total = 0;
+        HashMapWithStackMemory<UInt64, UInt64, TrivialHash, 4> marginal_a;
+        HashMapWithStackMemory<UInt64, UInt64, TrivialHash, 4> marginal_b;
+
+        for (const auto & [key, value] : count_ab)
+        {
+            if (value == 0)
+                throw Exception(
+                    ErrorCodes::CORRUPTED_DATA,
+                    "Corrupted aggregate function state: the joint count of the value pair with hashes ({}, {}) is zero",
+                    key.items[UInt128::_impl::little(0)],
+                    key.items[UInt128::_impl::little(1)]);
+
+            if (common::addOverflow(total, value, total))
+                throw Exception(ErrorCodes::CORRUPTED_DATA, "Corrupted aggregate function state: the sum of joint counts overflows UInt64");
+
+            /// The marginal sums cannot overflow if the total sum does not: each of them is bounded by `total`.
+            marginal_a[key.items[UInt128::_impl::little(0)]] += value;
+            marginal_b[key.items[UInt128::_impl::little(1)]] += value;
+        }
+
+        if (total != count)
+            throw Exception(
+                ErrorCodes::CORRUPTED_DATA,
+                "Corrupted aggregate function state: the joint counts sum up to {}, while the total count is {}",
+                total,
+                count);
+
+        auto check_marginals = [](const auto & expected, const auto & stored, const char * side)
+        {
+            if (expected.size() != stored.size())
+                throw Exception(
+                    ErrorCodes::CORRUPTED_DATA,
+                    "Corrupted aggregate function state: there are {} distinct values of the {} argument, "
+                    "while the joint counts imply {}",
+                    stored.size(),
+                    side,
+                    expected.size());
+
+            for (const auto & [key, value] : expected)
+            {
+                const auto * it = stored.find(key);
+                if (it == stored.end())
+                    throw Exception(
+                        ErrorCodes::CORRUPTED_DATA,
+                        "Corrupted aggregate function state: the value with hash {} of the {} argument is present "
+                        "in the joint counts but has no marginal count",
+                        key,
+                        side);
+
+                if (it->getMapped() != value)
+                    throw Exception(
+                        ErrorCodes::CORRUPTED_DATA,
+                        "Corrupted aggregate function state: the marginal count of the value with hash {} "
+                        "of the {} argument is {}, while its joint counts sum up to {}",
+                        key,
+                        side,
+                        it->getMapped(),
+                        value);
+            }
+        };
+
+        check_marginals(marginal_a, count_a, "first");
+        check_marginals(marginal_b, count_b, "second");
     }
 };
 
@@ -507,6 +586,8 @@ struct CrossTabPhiSquaredWindowData
                 count_ab.size(),
                 INVALID_EDGE_IDX - 1);
 
+        CrossTabCountsState::validateDeserialized(count, count_a, count_b, count_ab);
+
         /// Update the internal states
         a_hash_by_index.reserve(count_a.size());
         a_marginal_count.reserve(count_a.size());
@@ -561,9 +642,7 @@ struct CrossTabPhiSquaredWindowData
             const Float64 a = static_cast<Float64>(a_marginal_count[a_idx]);
             const Float64 b = static_cast<Float64>(b_marginal_count[b_idx]);
 
-            if (unlikely(a <= 0 || b <= 0))
-                throw Exception(
-                    ErrorCodes::CORRUPTED_DATA, "Corrupted aggregate function state: value frequency must be positive (a={}, b={})", a, b);
+            chassert(a > 0 && b > 0 && "value frequencies are positive after validation");
 
             phi_term_sum += phiTerm(cnt_ab, a, b);
         }

--- a/tests/queries/0_stateless/04336_crosstab_corrupted_state_deserialization.reference
+++ b/tests/queries/0_stateless/04336_crosstab_corrupted_state_deserialization.reference
@@ -1,0 +1,10 @@
+OK fuzzer query
+OK foreign state
+0
+OK total count mismatch
+OK marginal count mismatch
+OK zero pair count
+OK cramersV
+OK cramersVBiasCorrected
+OK theilsU
+1	1	1	1

--- a/tests/queries/0_stateless/04336_crosstab_corrupted_state_deserialization.sh
+++ b/tests/queries/0_stateless/04336_crosstab_corrupted_state_deserialization.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Deserialization of CrossTab-family aggregate function states (`contingency`, `cramersV`,
+# `cramersVBiasCorrected`, `theilsU`) must validate that the counts form a valid contingency table:
+# the joint counts are positive, the value counts are exactly the marginal sums of the pair counts,
+# and the pair counts sum up to the total count. Otherwise finalization of a forged state
+# (e.g. constructed by `CAST` from `String`) could fail an assertion or divide by zero.
+
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+function expect_corrupted_data()
+{
+    local name="$1"
+    local query="$2"
+    $CLICKHOUSE_LOCAL --query "$query" 2>&1 \
+        | grep -q -F 'CORRUPTED_DATA' && echo "OK $name" || echo "FAIL $name"
+}
+
+# The exact query found by the fuzzer: a window `argMin` state reinterpreted as a `contingency`
+# state. It previously failed the assertion `phi_squared > -1e-4`.
+expect_corrupted_data 'fuzzer query' "
+    SELECT round(roundtrip, 2147483647) AS roundtrip, abs(direct - roundtrip) < 1e-9, round(direct) AS direct FROM (SELECT finalizeAggregation(st_win) AS direct, finalizeAggregation(CAST(CAST(st_win, 'String'), 'AggregateFunction(contingency, UInt8, UInt8)')) AS roundtrip FROM (SELECT argMinState(toUInt8(number % 10), *) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS st_win FROM numbers(10000) ORDER BY number DESC NULLS FIRST LIMIT 9223372036854775807))"
+
+# A simplified version of the fuzzer query: the same foreign state built by a plain aggregation.
+expect_corrupted_data 'foreign state' "
+    SELECT finalizeAggregation(CAST(CAST(argMinState(toUInt8(number % 10), number), 'String'), 'AggregateFunction(contingency, UInt8, UInt8)'))
+    FROM numbers(10000)"
+
+# The following byte strings are based on the serialization of `contingencyState(toUInt8(1), toUInt8(2))`
+# over two rows: total count 2, then three hash maps (count_a, count_b, count_ab), each serialized as
+# a varint size followed by (key, value) pairs.
+
+# A genuine state: deserializes and finalizes normally.
+$CLICKHOUSE_LOCAL --query "
+    SELECT finalizeAggregation(CAST(unhex('0200000000000000014769A5692A310962020000000000000001D2D33DBDEA4FD1AC0200000000000000014769A5692A310962D2D33DBDEA4FD1AC0200000000000000'), 'AggregateFunction(contingency, UInt8, UInt8)'))"
+
+# The total count is changed from 2 to 3: it does not match the sum of the pair counts.
+expect_corrupted_data 'total count mismatch' "
+    SELECT finalizeAggregation(CAST(unhex('0300000000000000014769A5692A310962020000000000000001D2D33DBDEA4FD1AC0200000000000000014769A5692A310962D2D33DBDEA4FD1AC0200000000000000'), 'AggregateFunction(contingency, UInt8, UInt8)'))"
+
+# The count of the first value is changed from 2 to 3: it does not match the marginal sum of the pair counts.
+expect_corrupted_data 'marginal count mismatch' "
+    SELECT finalizeAggregation(CAST(unhex('0200000000000000014769A5692A310962030000000000000001D2D33DBDEA4FD1AC0200000000000000014769A5692A310962D2D33DBDEA4FD1AC0200000000000000'), 'AggregateFunction(contingency, UInt8, UInt8)'))"
+
+# The pair count is changed from 2 to 0: pair counts must be positive.
+expect_corrupted_data 'zero pair count' "
+    SELECT finalizeAggregation(CAST(unhex('0200000000000000014769A5692A310962020000000000000001D2D33DBDEA4FD1AC0200000000000000014769A5692A310962D2D33DBDEA4FD1AC0000000000000000'), 'AggregateFunction(contingency, UInt8, UInt8)'))"
+
+# All functions of the family share the state format and the validation.
+for func in cramersV cramersVBiasCorrected theilsU
+do
+    expect_corrupted_data "$func" "
+        SELECT finalizeAggregation(CAST(unhex('0300000000000000014769A5692A310962020000000000000001D2D33DBDEA4FD1AC0200000000000000014769A5692A310962D2D33DBDEA4FD1AC0200000000000000'), 'AggregateFunction($func, UInt8, UInt8)'))"
+done
+
+# Genuine states still survive a roundtrip through `String` and finalize to the same results.
+$CLICKHOUSE_LOCAL --query "
+    SELECT
+        finalizeAggregation(st_c) = finalizeAggregation(CAST(CAST(st_c, 'String'), 'AggregateFunction(contingency, UInt16, UInt16)')),
+        finalizeAggregation(st_v) = finalizeAggregation(CAST(CAST(st_v, 'String'), 'AggregateFunction(cramersV, UInt16, UInt16)')),
+        finalizeAggregation(st_b) = finalizeAggregation(CAST(CAST(st_b, 'String'), 'AggregateFunction(cramersVBiasCorrected, UInt16, UInt16)')),
+        finalizeAggregation(st_u) = finalizeAggregation(CAST(CAST(st_u, 'String'), 'AggregateFunction(theilsU, UInt16, UInt16)'))
+    FROM
+    (
+        SELECT
+            contingencyState(toUInt16(number % 17), toUInt16(number % 9)) AS st_c,
+            cramersVState(toUInt16(number % 17), toUInt16(number % 9)) AS st_v,
+            cramersVBiasCorrectedState(toUInt16(number % 17), toUInt16(number % 9)) AS st_b,
+            theilsUState(toUInt16(number % 17), toUInt16(number % 9)) AS st_u
+        FROM numbers(1000)
+    )"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


The following query throws logical error. It was fed meaningless bytes (via `CAST(string_bytes, AggregateFunction(contingency, ...))`) and it deserialized and later broke invariant during result computation. This PR adds more robust validation to deserialization so that malformed bytes are rejected.

```sql
SELECT round(roundtrip, 2147483647) AS roundtrip, abs(direct - roundtrip) < 1e-9, round(direct) AS direct FROM (SELECT finalizeAggregation(st_win) AS direct, finalizeAggregation(CAST(CAST(st_win, 'String'), 'AggregateFunction(contingency, UInt8, UInt8)')) AS roundtrip FROM (SELECT argMinState(toUInt8(number % 10), *) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS st_win FROM numbers(10000) ORDER BY number DESC NULLS FIRST LIMIT 9223372036854775807));
```

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Deserialization of the states of the `contingency`, `cramersV`, `cramersVBiasCorrected`, and `theilsU` aggregate functions now validates that the stored counts form a consistent contingency table and throws a `CORRUPTED_DATA` exception otherwise. Closes https://github.com/ClickHouse/ClickHouse/issues/106899.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.676`
<!-- ch-version-info:end -->