### PR TITLE
Add test: Flattened `xxxMap` inside a `Tuple` whose key array is in the sorting key is excluded from summation — `break` at SummingSortedAlgorithm.cpp:495 untested

### DIFF
--- a/tests/queries/0_stateless/04335_summing_merge_tree_tuple_map_in_sorting_key.reference
+++ b/tests/queries/0_stateless/04335_summing_merge_tree_tuple_map_in_sorting_key.reference
@@ -1,0 +1,4 @@
+map key in sorting key (excluded):
+1	(([1,2],[10,20]))
+map not in sorting key (summed):
+1	(([1,2],[110,220]))

--- a/tests/queries/0_stateless/04335_summing_merge_tree_tuple_map_in_sorting_key.sql
+++ b/tests/queries/0_stateless/04335_summing_merge_tree_tuple_map_in_sorting_key.sql
@@ -1,0 +1,32 @@
+-- Test: flattened xxxMap inside a Tuple whose key array is in the sorting key is excluded from summation
+DROP TABLE IF EXISTS t_flat_map_in_sk;
+DROP TABLE IF EXISTS t_flat_map_not_in_sk;
+
+-- Map key sub-column in the sorting key: the map must NOT be summed (rows merge, first value kept).
+CREATE TABLE t_flat_map_in_sk (
+    id UInt64,
+    metrics Tuple(ratesMap Tuple(ID Array(UInt64), Value Array(UInt64)))
+) ENGINE = SummingMergeTree ORDER BY (id, metrics.ratesMap.ID)
+SETTINGS allow_tuple_element_aggregation = 1;
+
+INSERT INTO t_flat_map_in_sk VALUES (1, (([1,2],[10,20]))), (1, (([1,2],[100,200])));
+OPTIMIZE TABLE t_flat_map_in_sk FINAL;
+
+SELECT 'map key in sorting key (excluded):';
+SELECT id, metrics FROM t_flat_map_in_sk ORDER BY id;
+
+-- Contrast: same data, map not in sorting key -> map is summed by key.
+CREATE TABLE t_flat_map_not_in_sk (
+    id UInt64,
+    metrics Tuple(ratesMap Tuple(ID Array(UInt64), Value Array(UInt64)))
+) ENGINE = SummingMergeTree ORDER BY id
+SETTINGS allow_tuple_element_aggregation = 1;
+
+INSERT INTO t_flat_map_not_in_sk VALUES (1, (([1,2],[10,20]))), (1, (([1,2],[100,200])));
+OPTIMIZE TABLE t_flat_map_not_in_sk FINAL;
+
+SELECT 'map not in sorting key (summed):';
+SELECT id, metrics FROM t_flat_map_not_in_sk ORDER BY id;
+
+DROP TABLE t_flat_map_in_sk;
+DROP TABLE t_flat_map_not_in_sk;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #98039](https://github.com/ClickHouse/ClickHouse/pull/98039).
That PR Adds immutable MergeTree setting `allow_tuple_element_aggregation` (default off). When enabled, `SummingMergeTree`/`AggregatingMergeTree`/`CoalescingMergeTree` recursively flatten `Tuple` columns via new `Nested::flattenTupleRecursive`/`reconstructTupleColumnsRecursive` helpers and aggregate each le

**1. Flattened `xxxMap` inside a `Tuple` whose key array is in the sorting key is excluded from summation — `break` at SummingSortedAlgorithm.cpp:495 untested**
  `src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp:495`
  **Risk:** `defineColumns` discovers the flattened leaves `metrics.ratesMap.ID`/`metrics.ratesMap.Value` as a real sumMap, then the map loop at SummingSortedAlgorithm.cpp:491-495 checks whether any map column is in the sorting/partition key and, if so, `break`s to push the whole map into `column_numbers_not_to_aggregate`. RISK: if this exclusion is broken/inverted, a map keyed by a sort-key column would be silently merged by key, producing wrong aggregated results and potential sort-order violations …
  **What's unique vs PR tests:** PR Test 9 (`03802_summing_merge_tree_tuple_element.sql`) covers a flattened map with `ORDER BY id` where the map IS summed. No PR test places the flattened map's key leaf in the sorting key, so the map-exclusion `break` at line 495 is never exercised by the PR's own tests.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/e7634bd2-0847-4c50-91fc-d94c089b5981)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.670`
<!-- ch-version-info:end -->