### PR TITLE
Add `readBigStrict` and use it in buffer deserialization

### DIFF
--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -854,15 +854,8 @@ void SerializationString::deserializeBinaryBulkWithSizeStream(
     size_t initial_size = data.size();
     data.resize(initial_size + bytes_to_read);
     stream->ignore(bytes_to_skip);
-    size_t size = stream->readBig(reinterpret_cast<char*>(&data[initial_size]), bytes_to_read);
-    if (size != bytes_to_read)
-        throw Exception(
-            ErrorCodes::INCORRECT_DATA,
-            "Cannot read all String data: the size stream declares {} bytes for the current range but only {} bytes "
-            "are available in the data stream. The String size and data streams are inconsistent (truncated or corrupted part).",
-            bytes_to_read,
-            size);
-    data.resize(initial_size + size);
+    stream->readBigStrict(reinterpret_cast<char*>(&data[initial_size]), bytes_to_read);
+    data.resize(initial_size + bytes_to_read);
     column = std::move(mutable_column);
     addColumnWithNumReadRowsToSubstreamsCache(cache, settings.path, column, num_read_rows);
     settings.path.pop_back();

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -855,6 +855,13 @@ void SerializationString::deserializeBinaryBulkWithSizeStream(
     data.resize(initial_size + bytes_to_read);
     stream->ignore(bytes_to_skip);
     size_t size = stream->readBig(reinterpret_cast<char*>(&data[initial_size]), bytes_to_read);
+    if (size != bytes_to_read)
+        throw Exception(
+            ErrorCodes::INCORRECT_DATA,
+            "Cannot read all String data: the size stream declares {} bytes for the current range but only {} bytes "
+            "are available in the data stream. The String size and data streams are inconsistent (truncated or corrupted part).",
+            bytes_to_read,
+            size);
     data.resize(initial_size + size);
     column = std::move(mutable_column);
     addColumnWithNumReadRowsToSubstreamsCache(cache, settings.path, column, num_read_rows);

--- a/src/IO/ReadBuffer.cpp
+++ b/src/IO/ReadBuffer.cpp
@@ -61,10 +61,18 @@ namespace
 
 void ReadBuffer::readStrict(char * to, size_t n)
 {
-    auto read_bytes = read(to, n);
+    size_t read_bytes = read(to, n);
     if (n != read_bytes)
         throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
                         "Cannot read all data. Bytes read: {}. Bytes expected: {}.", read_bytes, std::to_string(n));
+}
+
+void ReadBuffer::readBigStrict(char * to, size_t n)
+{
+    size_t read_bytes = readBig(to, n);
+    if (n != read_bytes)
+        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+                        "Cannot read all data with readBig. Bytes read: {}. Bytes expected: {}.", read_bytes, std::to_string(n));
 }
 
 void ReadBuffer::throwReadAfterEOF()

--- a/src/IO/ReadBuffer.h
+++ b/src/IO/ReadBuffer.h
@@ -166,7 +166,7 @@ public:
         return bytes_copied;
     }
 
-    /** Reads n bytes, if there are less - throws an exception. */
+    /** Reads n bytes with read, if there are less - throws an exception. */
     void readStrict(char * to, size_t n);
 
     /** A method that can be more efficiently implemented in derived classes, in the case of reading large enough blocks.
@@ -176,6 +176,9 @@ public:
       * Don't use for small reads.
       */
     [[nodiscard]] virtual size_t readBig(char * to, size_t n) { return read(to, n); }
+
+    /** Reads n bytes with readBig, if there are less - throws an exception. */
+    void readBigStrict(char * to, size_t n);
 
     /** Do something to allow faster subsequent call to 'nextImpl' if possible.
       * It's used for asynchronous readers with double-buffering.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Add a size match check after `readBig`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.707`
<!-- ch-version-info:end -->