### PR TITLE
Fix wrong hasToken result via exact direct read on a mismatched text index tokenizer

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -395,7 +395,10 @@ private:
 
     static bool needApplyPreprocessor(const String & function_name)
     {
-        return function_name == "hasToken" || function_name == "hasAllTokens" || function_name == "hasAnyTokens" || function_name == "hasPhrase";
+        /// hasTokenOrNull shares hasToken's row-level semantics, so it needs the same needle/haystack
+        /// rewrite; otherwise the index prunes on preprocessed tokens while the predicate stays raw.
+        return function_name == "hasToken" || function_name == "hasTokenOrNull"
+            || function_name == "hasAllTokens" || function_name == "hasAnyTokens" || function_name == "hasPhrase";
     }
 
     std::vector<SelectedCondition> selectConditions(const ActionsDAG::Node & function_node, const ContextPtr & context)

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -226,15 +226,22 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getHintOrNoneMode() const
 
 TextIndexDirectReadMode MergeTreeIndexConditionText::getDirectReadMode(const String & function_name) const
 {
-    if (function_name == "hasToken"
-        || function_name == "hasAnyTokens"
+    bool is_array_tokenizer = typeid_cast<const ArrayTokenizer *>(tokenizer);
+    bool is_split_by_non_alpha_tokenizer = typeid_cast<const SplitByNonAlphaTokenizer *>(tokenizer);
+    bool has_preprocessor = preprocessor && preprocessor->hasActions();
+
+    if (function_name == "hasToken")
+    {
+        /// hasToken has fixed splitByNonAlpha semantics, so exact direct read from the posting lists is
+        /// only correct when the index produces the same tokens (splitByNonAlpha without a preprocessor).
+        return is_split_by_non_alpha_tokenizer && !has_preprocessor ? TextIndexDirectReadMode::Exact : getHintOrNoneMode();
+    }
+
+    if (function_name == "hasAnyTokens"
         || function_name == "hasAllTokens")
     {
         return TextIndexDirectReadMode::Exact;
     }
-
-    bool is_array_tokenizer = typeid_cast<const ArrayTokenizer *>(tokenizer);
-    bool has_preprocessor = preprocessor && preprocessor->hasActions();
 
     if (function_name == "equals"
         || function_name == "has"

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -224,6 +224,14 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getHintOrNoneMode() const
     return settings[Setting::query_plan_text_index_add_hint] ? TextIndexDirectReadMode::Hint : TextIndexDirectReadMode::None;
 }
 
+bool MergeTreeIndexConditionText::isConservativeHasTokenTokenizer() const
+{
+    /// A preprocessor is allowed: it transforms the needle the same way as the indexed text (the divergence
+    /// vs use_skip_indexes = 0 is documented hasToken behaviour), so the index tokens stay a necessary condition.
+    const auto type = tokenizer->getType();
+    return type == ITokenizer::Type::SplitByNonAlpha || type == ITokenizer::Type::Ngrams;
+}
+
 TextIndexDirectReadMode MergeTreeIndexConditionText::getDirectReadMode(const String & function_name) const
 {
     bool is_array_tokenizer = typeid_cast<const ArrayTokenizer *>(tokenizer);
@@ -924,13 +932,15 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")
     {
         auto tokens = stringToTokens(value_field);
-        if (tokens.empty())
+        /// Decline the index unless its tokens are a necessary condition for a row-level hasToken match:
+        ///  - empty tokens (separator-only needle, or shorter than the tokenizer can represent, e.g. "abc"
+        ///    with ngrams(4)) would prune every granule;
+        ///  - a coarser tokenizer (array/splitByString/asciiCJK/sparseGrams) can omit a row-level token, so a
+        ///    present needle may still be pruned.
+        /// In both cases the row-level hasToken decides (and it throws BAD_ARGUMENTS / returns NULL for an
+        /// invalid needle, as without the index).
+        if (tokens.empty() || !isConservativeHasTokenTokenizer())
         {
-            /// The needle does not map to any index token (a separator-only needle, or a needle shorter
-            /// than the tokenizer can represent, e.g. "abc" with ngrams(4)). The index tokens are then not
-            /// a necessary condition for the real hasToken result, so pushing an empty token would prune
-            /// every granule and return wrong (missing) rows. Decline the index and let the row-level
-            /// hasToken decide (it also throws BAD_ARGUMENTS / returns NULL for an invalid needle, as without the index).
             return false;
         }
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -390,7 +390,7 @@ bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr id
             /// tokens are not a necessary condition for the row-level match, so treat it as may-be-true
             /// and leave the decision to the (preprocessed) row-level predicate.
             const auto & text_search_query = element.text_search_queries.front();
-            bool exists_in_granule = !element.prunable || granule->hasAllQueryTokensOrEmpty(*text_search_query);
+            bool exists_in_granule = !text_search_query->prunable || granule->hasAllQueryTokensOrEmpty(*text_search_query);
             rpn_stack.emplace_back(exists_in_granule, true);
         }
         else if (element.function == RPNElement::FUNCTION_HAS_ANY_ELEMENTS)
@@ -958,8 +958,9 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             /// so the index neither prunes a granule nor replaces the predicate; the preprocessed row-level
             /// hasToken decides. Same shape as the coarse-tokenizer preprocessor path below.
             out.function = RPNElement::FUNCTION_EQUALS;
-            out.prunable = false;
-            out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, TextIndexDirectReadMode::None, std::move(tokens)));
+            auto query = std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, TextIndexDirectReadMode::None, std::move(tokens));
+            query->prunable = false;
+            out.text_search_queries.emplace_back(std::move(query));
             return true;
         }
 
@@ -976,8 +977,9 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             /// the condition so that rewrite runs, but mark it non-prunable so granule pruning cannot drop
             /// a row the preprocessed row-level predicate would match.
             out.function = RPNElement::FUNCTION_EQUALS;
-            out.prunable = false;
-            out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens)));
+            auto query = std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens));
+            query->prunable = false;
+            out.text_search_queries.emplace_back(std::move(query));
             return true;
         }
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -226,8 +226,8 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getHintOrNoneMode() const
 
 bool MergeTreeIndexConditionText::isConservativeHasTokenTokenizer() const
 {
-    /// A preprocessor is allowed: it transforms the needle the same way as the indexed text (the divergence
-    /// vs use_skip_indexes = 0 is documented hasToken behaviour), so the index tokens stay a necessary condition.
+    /// Preprocessor-independent: a preprocessor transforms the needle and the indexed text the same way,
+    /// so it does not change whether the index tokens are a necessary condition for a row-level match.
     const auto type = tokenizer->getType();
     return type == ITokenizer::Type::SplitByNonAlpha || type == ITokenizer::Type::Ngrams;
 }
@@ -241,10 +241,18 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getDirectReadMode(const Str
     if (function_name == "hasToken")
     {
         /// hasToken has fixed splitByNonAlpha semantics. Exact direct read from the posting lists is sound
-        /// only when the index produces the same tokens: splitByNonAlpha without a preprocessor. Any other
-        /// tokenizer or a preprocessor can segment text differently, so use the index only as a hint and
-        /// re-evaluate hasToken on the rows.
-        return is_split_by_non_alpha_tokenizer && !has_preprocessor ? TextIndexDirectReadMode::Exact : getHintOrNoneMode();
+        /// only when the index produces the same tokens: splitByNonAlpha without a preprocessor.
+        if (is_split_by_non_alpha_tokenizer && !has_preprocessor)
+            return TextIndexDirectReadMode::Exact;
+        /// A conservative tokenizer (splitByNonAlpha or ngrams) keeps the index tokens a necessary
+        /// condition for a match, so the index is a valid hint and re-evaluation runs on the rows.
+        if (isConservativeHasTokenTokenizer())
+            return getHintOrNoneMode();
+        /// A coarser tokenizer can omit a row-level token: a hint virtual column would answer "needle
+        /// present in the row's index tokens" (not a necessary condition) and drop a matching row. Use
+        /// None so no hint column is built; the condition still drives the preprocessor rewrite and the
+        /// preprocessed row-level predicate decides (granule pruning is suppressed, see traverseFunctionNode).
+        return TextIndexDirectReadMode::None;
     }
 
     if (function_name == "hasAnyTokens"
@@ -378,8 +386,11 @@ bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr id
         else if (element.function == RPNElement::FUNCTION_EQUALS)
         {
             chassert(element.text_search_queries.size() == 1);
+            /// A non-prunable atom (hasToken on a coarser tokenizer) must not drop a granule: its index
+            /// tokens are not a necessary condition for the row-level match, so treat it as may-be-true
+            /// and leave the decision to the (preprocessed) row-level predicate.
             const auto & text_search_query = element.text_search_queries.front();
-            bool exists_in_granule = granule->hasAllQueryTokensOrEmpty(*text_search_query);
+            bool exists_in_granule = !element.prunable || granule->hasAllQueryTokensOrEmpty(*text_search_query);
             rpn_stack.emplace_back(exists_in_granule, true);
         }
         else if (element.function == RPNElement::FUNCTION_HAS_ANY_ELEMENTS)
@@ -932,16 +943,28 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")
     {
         auto tokens = stringToTokens(value_field);
-        /// Decline the index unless its tokens are a necessary condition for a row-level hasToken match:
-        ///  - empty tokens (separator-only needle, or shorter than the tokenizer can represent, e.g. "abc"
-        ///    with ngrams(4)) would prune every granule;
-        ///  - a coarser tokenizer (array/splitByString/asciiCJK/sparseGrams) can omit a row-level token, so a
-        ///    present needle may still be pruned.
-        /// In both cases the row-level hasToken decides (and it throws BAD_ARGUMENTS / returns NULL for an
-        /// invalid needle, as without the index).
-        if (tokens.empty() || !isConservativeHasTokenTokenizer())
-        {
+        /// An empty needle (separator-only, or shorter than the tokenizer can represent, e.g. "abc" with
+        /// ngrams(4)) maps to no index token, so the index offers nothing: decline and let the row-level
+        /// hasToken decide (it also throws BAD_ARGUMENTS / returns NULL for an invalid needle).
+        if (tokens.empty())
             return false;
+
+        if (!isConservativeHasTokenTokenizer())
+        {
+            /// A coarser tokenizer (array/splitByString/asciiCJK/sparseGrams) can omit a row-level token,
+            /// so the needle's index tokens are not a necessary condition for a match. Without a
+            /// preprocessor the index adds nothing over row-level evaluation: decline.
+            if (!preprocessor || !preprocessor->hasActions())
+                return false;
+
+            /// With a preprocessor the index path stays useful: it carries the documented hasToken
+            /// preprocessor rewrite (the needle and the indexed text are transformed the same way). Keep
+            /// the condition so that rewrite runs, but mark it non-prunable so granule pruning cannot drop
+            /// a row the preprocessed row-level predicate would match.
+            out.function = RPNElement::FUNCTION_EQUALS;
+            out.prunable = false;
+            out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens)));
+            return true;
         }
 
         out.function = RPNElement::FUNCTION_EQUALS;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -943,11 +943,25 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")
     {
         auto tokens = stringToTokens(value_field);
-        /// An empty needle (separator-only, or shorter than the tokenizer can represent, e.g. "abc" with
-        /// ngrams(4)) maps to no index token, so the index offers nothing: decline and let the row-level
-        /// hasToken decide (it also throws BAD_ARGUMENTS / returns NULL for an invalid needle).
+        /// The preprocessed needle maps to no index token (separator-only, or shorter than the tokenizer
+        /// can represent, e.g. "abc" with ngrams(4)), so the index cannot prove a row matches.
         if (tokens.empty())
-            return false;
+        {
+            /// Without a preprocessor the index offers nothing over row-level evaluation: decline and let
+            /// the raw row-level hasToken decide (it returns the match, or throws BAD_ARGUMENTS / returns
+            /// NULL for an invalid needle).
+            if (!preprocessor || !preprocessor->hasActions())
+                return false;
+
+            /// With a preprocessor the condition still carries the documented hasToken rewrite
+            /// (hasToken(s, n) -> hasToken(preproc(s), preproc(n))). Keep it in None mode and non-prunable
+            /// so the index neither prunes a granule nor replaces the predicate; the preprocessed row-level
+            /// hasToken decides. Same shape as the coarse-tokenizer preprocessor path below.
+            out.function = RPNElement::FUNCTION_EQUALS;
+            out.prunable = false;
+            out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, TextIndexDirectReadMode::None, std::move(tokens)));
+            return true;
+        }
 
         if (!isConservativeHasTokenTokenizer())
         {

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -232,8 +232,10 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getDirectReadMode(const Str
 
     if (function_name == "hasToken")
     {
-        /// hasToken has fixed splitByNonAlpha semantics, so exact direct read from the posting lists is
-        /// only correct when the index produces the same tokens (splitByNonAlpha without a preprocessor).
+        /// hasToken has fixed splitByNonAlpha semantics. Exact direct read from the posting lists is sound
+        /// only when the index produces the same tokens: splitByNonAlpha without a preprocessor. Any other
+        /// tokenizer or a preprocessor can segment text differently, so use the index only as a hint and
+        /// re-evaluate hasToken on the rows.
         return is_split_by_non_alpha_tokenizer && !has_preprocessor ? TextIndexDirectReadMode::Exact : getHintOrNoneMode();
     }
 
@@ -924,20 +926,12 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         auto tokens = stringToTokens(value_field);
         if (tokens.empty())
         {
-            const String & string_needle = value_field.safeGet<String>();
-            if (!string_needle.empty())
-            {
-                /// hasToken uses splitByNonAlpha as its tokenizer, so:
-                ///  - A needle without any word character (alphanumeric or non-ASCII) is invalid.
-                ///  - Bypass the index in that case so the row-level evaluation throws BAD_ARGUMENTS (or returns NULL for hasTokenOrNull)
-                ///  -- Consistnt with the no-index behaviour.
-                /// If the needle does contain word characters (e.g. "abc" with ngrams(4)):
-                ///  - It is valid but too short for the index's tokenizer:
-                ///  -- Fall through to push "" so all granules are pruned and the query returns 0 rows.
-                if (std::ranges::none_of(string_needle, [](unsigned char c) { return !isASCII(c) || isAlphaNumericASCII(c); }))
-                    return false;
-            }
-            tokens.push_back("");
+            /// The needle does not map to any index token (a separator-only needle, or a needle shorter
+            /// than the tokenizer can represent, e.g. "abc" with ngrams(4)). The index tokens are then not
+            /// a necessary condition for the real hasToken result, so pushing an empty token would prune
+            /// every granule and return wrong (missing) rows. Decline the index and let the row-level
+            /// hasToken decide (it also throws BAD_ARGUMENTS / returns NULL for an invalid needle, as without the index).
+            return false;
         }
 
         out.function = RPNElement::FUNCTION_EQUALS;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -563,6 +563,17 @@ VectorWithMemoryTracking<String> MergeTreeIndexConditionText::stringToTokens(con
     return tokenizer->compactTokens(tokens);
 }
 
+bool MergeTreeIndexConditionText::isIllFormedHasTokenNeedle(const Field & field) const
+{
+    if (field.getType() != Field::Types::String)
+        return false;
+    /// Validate the preprocessed (rewritten) needle: it is what the row-level hasToken evaluates after the
+    /// preprocessor rewrite. Mirror HasTokenImpl::isTokenSeparator (an ASCII non-alphanumeric byte), which is
+    /// what makes row-level hasToken throw BAD_ARGUMENTS / return NULL.
+    const String value = preprocessor->processConstant(field.safeGet<String>());
+    return std::ranges::any_of(value, [](char c) { return isASCII(c) && !isAlphaNumericASCII(c); });
+}
+
 VectorWithMemoryTracking<String> MergeTreeIndexConditionText::substringToTokens(const Field & field, bool is_prefix, bool is_suffix) const
 {
     VectorWithMemoryTracking<String> tokens;
@@ -943,12 +954,14 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")
     {
         auto tokens = stringToTokens(value_field);
-        /// The preprocessed needle maps to no index token (separator-only, or shorter than the tokenizer
-        /// can represent, e.g. "abc" with ngrams(4)), so the index cannot prove a row matches.
-        if (tokens.empty())
+        /// The index cannot stand in for the row-level predicate when the preprocessed needle either maps to no
+        /// index token (separator-only, or shorter than the tokenizer can represent, e.g. "abc" with ngrams(4)),
+        /// or contains a token separator (row-level hasToken then throws BAD_ARGUMENTS / returns NULL for
+        /// hasTokenOrNull, and the index must not prune or replace the predicate and hide that).
+        if (tokens.empty() || isIllFormedHasTokenNeedle(value_field))
         {
             /// Without a preprocessor the index offers nothing over row-level evaluation: decline and let
-            /// the raw row-level hasToken decide (it returns the match, or throws BAD_ARGUMENTS / returns
+            /// the raw row-level hasToken decide (it returns the match, throws BAD_ARGUMENTS, or returns
             /// NULL for an invalid needle).
             if (!preprocessor || !preprocessor->hasActions())
                 return false;
@@ -956,7 +969,9 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             /// With a preprocessor the condition still carries the documented hasToken rewrite
             /// (hasToken(s, n) -> hasToken(preproc(s), preproc(n))). Keep it in None mode and non-prunable
             /// so the index neither prunes a granule nor replaces the predicate; the preprocessed row-level
-            /// hasToken decides. Same shape as the coarse-tokenizer preprocessor path below.
+            /// hasToken decides (including its own BAD_ARGUMENTS / NULL for an ill-formed needle). The
+            /// posting-list tokens are unusable here, so drop them. Same shape as the empty-token case.
+            tokens.clear();
             out.function = RPNElement::FUNCTION_EQUALS;
             auto query = std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, TextIndexDirectReadMode::None, std::move(tokens));
             query->prunable = false;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -139,6 +139,12 @@ private:
 
     TextIndexDirectReadMode getHintOrNoneMode() const;
 
+    /// True when the index tokens are a necessary condition for a row-level hasToken match, so granule
+    /// pruning cannot drop a matching row. Holds for splitByNonAlpha (same tokenization) and ngrams (every
+    /// n-gram of a splitByNonAlpha token is an n-gram of the row). Coarser tokenizers (array, splitByString,
+    /// asciiCJK, sparseGrams) can omit a row-level token and must not prune.
+    bool isConservativeHasTokenTokenizer() const;
+
     bool traverseMapElementKeyNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const;
     bool traverseMapElementValueNode(const RPNBuilderTreeNode & index_column_node, const Field & const_value) const;
     bool traverseJSONSubcolumnKeyNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -124,6 +124,12 @@ private:
 
         Function function = FUNCTION_UNKNOWN;
         std::vector<TextSearchQueryPtr> text_search_queries;
+
+        /// When false, this atom must not prune a granule (mayBeTrueOnGranule treats it as may-be-true).
+        /// Set for a hasToken condition whose index tokens are not a necessary condition for a row-level
+        /// match (a coarser tokenizer): the condition still drives the preprocessor rewrite, but the
+        /// preprocessed row-level predicate, not the posting lists, decides the result.
+        bool prunable = true;
     };
 
     using RPN = std::vector<RPNElement>;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -50,6 +50,13 @@ struct TextSearchQuery
     VectorWithMemoryTracking<String> tokens;
     std::vector<OptimizedRegularExpression> patterns;
 
+    /// When false, the index tokens are not a necessary condition for a row-level match, so this query
+    /// must neither prune a granule (mayBeTrueOnGranule treats it as may-be-true) nor mark an All-mode
+    /// condition always-false in TextIndexAnalyzer when its tokens are missing. Set for a hasToken atom
+    /// on a coarser tokenizer that is kept only to drive the preprocessor rewrite. Not part of getHash():
+    /// it is a deterministic function of (function, tokenizer, preprocessor), so equal hashes share it.
+    bool prunable = true;
+
     SipHash getHash() const;
 };
 
@@ -124,12 +131,6 @@ private:
 
         Function function = FUNCTION_UNKNOWN;
         std::vector<TextSearchQueryPtr> text_search_queries;
-
-        /// When false, this atom must not prune a granule (mayBeTrueOnGranule treats it as may-be-true).
-        /// Set for a hasToken condition whose index tokens are not a necessary condition for a row-level
-        /// match (a coarser tokenizer): the condition still drives the preprocessor rewrite, but the
-        /// preprocessed row-level predicate, not the posting lists, decides the result.
-        bool prunable = true;
     };
 
     using RPN = std::vector<RPNElement>;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -152,6 +152,11 @@ private:
     /// asciiCJK, sparseGrams) can omit a row-level token and must not prune.
     bool isConservativeHasTokenTokenizer() const;
 
+    /// True when the preprocessed needle contains an ASCII token separator. Row-level hasToken rejects such a
+    /// needle (BAD_ARGUMENTS, or NULL for hasTokenOrNull), so a text-index condition must not prune or replace
+    /// the predicate and hide that error.
+    bool isIllFormedHasTokenNeedle(const Field & field) const;
+
     bool traverseMapElementKeyNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const;
     bool traverseMapElementValueNode(const RPNBuilderTreeNode & index_column_node, const Field & const_value) const;
     bool traverseJSONSubcolumnKeyNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const;

--- a/src/Storages/MergeTree/TextIndexAnalyzer.cpp
+++ b/src/Storages/MergeTree/TextIndexAnalyzer.cpp
@@ -333,7 +333,11 @@ void TextIndexAnalyzer::processTokenOperation(std::string_view token, Operation 
 
         if (query_builder.is_failed)
         {
-            if (global_search_mode == TextSearchMode::All)
+            /// A non-prunable query's index tokens are not a necessary condition for the row-level match
+            /// (a coarse hasToken kept only to drive the preprocessor rewrite), so a missing token must not
+            /// fail the whole `All` predicate. Its builder is never read by mayBeTrueOnGranule, which
+            /// short-circuits on prunable, so leaving it failed here is harmless; only skip the escalation.
+            if (global_search_mode == TextSearchMode::All && query_builder.query->prunable)
                 always_false = true;
 
             /// Erase the failed query for the full declared token set so yet-unseen tokens stop passing isTokenNeeded.

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -29,3 +29,6 @@ splitByNonAlpha tokenizer with preprocessor (documented divergence still works, 
 coarse tokenizer with preprocessor: documented divergence kept, granule pruning suppressed (was a false negative)
 - coarse + preprocessor, with index	1
 - coarse + preprocessor, no index	0
+preprocessed needle maps to no index token but a preprocessor is active (was a false negative)
+- preprocessor + empty index tokens, with index	1
+- preprocessor + empty index tokens, no index	0

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -26,3 +26,6 @@ splitByNonAlpha tokenizer (exact read still used, results unchanged)
 splitByNonAlpha tokenizer with preprocessor (documented divergence still works, index kept)
 - preprocessed token, with index	1
 - preprocessed token, no index	1
+coarse tokenizer with preprocessor: documented divergence kept, granule pruning suppressed (was a false negative)
+- coarse + preprocessor, with index	1
+- coarse + preprocessor, no index	0

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -9,8 +9,20 @@ ngrams tokenizer, substring vs whole token
 - inner substring, no index	0
 - whole word, with index	1
 - whole word, no index	1
+array tokenizer, needle is a real token of a multi-word value (was a false negative)
+- token of multi-word value, with index	1
+- token of multi-word value, no index	1
+splitByString tokenizer, needle inside a token spanning a non-separator boundary (was a false negative)
+- token inside a separator span, with index	1
+- token inside a separator span, no index	1
+asciiCJK tokenizer, connector merges what splitByNonAlpha splits (was a false negative)
+- connector-joined token, with index	1
+- connector-joined token, no index	1
 splitByNonAlpha tokenizer (exact read still used, results unchanged)
 - existing token, with index	1
 - existing token, no index	1
 - missing substring, with index	0
 - missing substring, no index	0
+splitByNonAlpha tokenizer with preprocessor (documented divergence still works, index kept)
+- preprocessed token, with index	1
+- preprocessed token, no index	1

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -1,13 +1,16 @@
-asciiCJK tokenizer
-- hasToken substring of CJK run, with index	0
-- hasToken substring of CJK run, no index	0
-ngrams tokenizer
-- hasToken inner substring, with index	0
-- hasToken inner substring, no index	0
-- hasToken full word, with index	1
-- hasToken full word, no index	1
+asciiCJK tokenizer (was a false positive)
+- substring of CJK run, with index	0
+- substring of CJK run, no index	0
+ngrams tokenizer, needle shorter than n (was a false negative)
+- short needle, with index	1
+- short needle, no index	1
+ngrams tokenizer, substring vs whole token
+- inner substring, with index	0
+- inner substring, no index	0
+- whole word, with index	1
+- whole word, no index	1
 splitByNonAlpha tokenizer (exact read still used, results unchanged)
-- hasToken existing token, with index	1
-- hasToken existing token, no index	1
-- hasToken missing substring, with index	0
-- hasToken missing substring, no index	0
+- existing token, with index	1
+- existing token, no index	1
+- missing substring, with index	0
+- missing substring, no index	0

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -32,3 +32,6 @@ coarse tokenizer with preprocessor: documented divergence kept, granule pruning 
 preprocessed needle maps to no index token but a preprocessor is active (was a false negative)
 - preprocessor + empty index tokens, with index	1
 - preprocessor + empty index tokens, no index	0
+coarse + preprocessor, non-prunable hasToken ANDed with a matching atom (was a false negative)
+- non-prunable hasToken AND matching atom, with index	1
+- non-prunable hasToken AND matching atom, no index	1

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -1,0 +1,13 @@
+asciiCJK tokenizer
+- hasToken substring of CJK run, with index	0
+- hasToken substring of CJK run, no index	0
+ngrams tokenizer
+- hasToken inner substring, with index	0
+- hasToken inner substring, no index	0
+- hasToken full word, with index	1
+- hasToken full word, no index	1
+splitByNonAlpha tokenizer (exact read still used, results unchanged)
+- hasToken existing token, with index	1
+- hasToken existing token, no index	1
+- hasToken missing substring, with index	0
+- hasToken missing substring, no index	0

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -39,3 +39,8 @@ ill-formed needle (contains a separator): index must not hide the row-level BAD_
 ill-formed needle with a conservative ngrams index: hint path must not hide the error
 ill-formed raw needle but a preprocessor strips the separator: index stays usable
 - separator-stripping preprocessor, with index	1
+hasTokenOrNull + preprocessor must match hasToken (index rewrites the predicate the same way)
+- hasTokenOrNull, with index	0
+- hasToken, with index	0
+- hasTokenOrNull, no index	1
+- hasToken, no index	1

--- a/tests/queries/0_stateless/02346_text_index_bug107186.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.reference
@@ -35,3 +35,7 @@ preprocessed needle maps to no index token but a preprocessor is active (was a f
 coarse + preprocessor, non-prunable hasToken ANDed with a matching atom (was a false negative)
 - non-prunable hasToken AND matching atom, with index	1
 - non-prunable hasToken AND matching atom, no index	1
+ill-formed needle (contains a separator): index must not hide the row-level BAD_ARGUMENTS
+ill-formed needle with a conservative ngrams index: hint path must not hide the error
+ill-formed raw needle but a preprocessor strips the separator: index stays usable
+- separator-stripping preprocessor, with index	1

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -1,0 +1,48 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/107186
+-- hasToken has fixed splitByNonAlpha semantics. The exact direct read answered it purely from the
+-- index posting lists, which is only correct when the index tokenizer produces the same tokens
+-- (splitByNonAlpha without a preprocessor). With a different tokenizer (asciiCJK, ngrams, ...) the
+-- exact read returned rows the real hasToken evaluation rejects.
+-- The hasToken result with the index must match the result without it.
+
+SET allow_experimental_full_text_index = 1;
+
+SELECT 'asciiCJK tokenizer';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = asciiCJK)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('我来自北京邮电大学');
+
+-- The whole CJK run is a single splitByNonAlpha token, so the substring is not a token: must be 0.
+SELECT '- hasToken substring of CJK run, with index', count() FROM tab WHERE hasToken(s, '北京邮电大学');
+SELECT '- hasToken substring of CJK run, no index', count() FROM tab WHERE hasToken(s, '北京邮电大学') SETTINGS use_skip_indexes = 0;
+
+DROP TABLE tab;
+
+SELECT 'ngrams tokenizer';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = ngrams(3))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('helloworld');
+
+-- 'low' is an ngram (substring) of 'helloworld' but not a splitByNonAlpha token: must be 0.
+SELECT '- hasToken inner substring, with index', count() FROM tab WHERE hasToken(s, 'low');
+SELECT '- hasToken inner substring, no index', count() FROM tab WHERE hasToken(s, 'low') SETTINGS use_skip_indexes = 0;
+-- The whole word is a real token: must be 1.
+SELECT '- hasToken full word, with index', count() FROM tab WHERE hasToken(s, 'helloworld');
+SELECT '- hasToken full word, no index', count() FROM tab WHERE hasToken(s, 'helloworld') SETTINGS use_skip_indexes = 0;
+
+DROP TABLE tab;
+
+SELECT 'splitByNonAlpha tokenizer (exact read still used, results unchanged)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('hello world foo');
+
+SELECT '- hasToken existing token, with index', count() FROM tab WHERE hasToken(s, 'world');
+SELECT '- hasToken existing token, no index', count() FROM tab WHERE hasToken(s, 'world') SETTINGS use_skip_indexes = 0;
+SELECT '- hasToken missing substring, with index', count() FROM tab WHERE hasToken(s, 'wor');
+SELECT '- hasToken missing substring, no index', count() FROM tab WHERE hasToken(s, 'wor') SETTINGS use_skip_indexes = 0;
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -88,3 +88,15 @@ INSERT INTO tab VALUES ('Hello World');
 SELECT '- preprocessed token, with index', count() FROM tab WHERE hasToken(s, 'Hello');
 SELECT '- preprocessed token, no index', count() FROM tab WHERE hasToken(s, 'Hello') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
+
+SELECT 'coarse tokenizer with preprocessor: documented divergence kept, granule pruning suppressed (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByString([', ']), preprocessor = lower(s))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello World, Foo');
+-- splitByString(', ') over lower(s) stores ['hello world', 'foo'], so 'hello' is not an index token, but it is a
+-- splitByNonAlpha token of the preprocessed text. The index must not prune the granule (must be 1), while the
+-- documented preprocessor divergence is preserved (the no-index query is case-sensitive, so it returns 0).
+SELECT '- coarse + preprocessor, with index', count() FROM tab WHERE hasToken(s, 'hello');
+SELECT '- coarse + preprocessor, no index', count() FROM tab WHERE hasToken(s, 'hello') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -113,3 +113,15 @@ INSERT INTO tab VALUES ('ABC');
 SELECT '- preprocessor + empty index tokens, with index', count() FROM tab WHERE hasToken(s, 'abc');
 SELECT '- preprocessor + empty index tokens, no index', count() FROM tab WHERE hasToken(s, 'abc') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
+
+SELECT 'coarse + preprocessor, non-prunable hasToken ANDed with a matching atom (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByString([', ']), preprocessor = lower(s))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('aaa bbb, zzz');
+-- splitByString(', ') over lower(s) stores ['aaa bbb', 'zzz']. The hasToken('aaa') atom is kept only to drive the
+-- preprocessor rewrite (non-prunable), but 'aaa' is not an index token, so it must not fail the whole AND in the
+-- text index analyzer: the ANDed hasAllTokens('zzz') matches, so the granule must not be dropped (must be 1).
+SELECT '- non-prunable hasToken AND matching atom, with index', count() FROM tab WHERE hasToken(s, 'aaa') AND hasAllTokens(s, 'zzz');
+SELECT '- non-prunable hasToken AND matching atom, no index', count() FROM tab WHERE hasToken(s, 'aaa') AND hasAllTokens(s, 'zzz') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -1,37 +1,41 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/107186
--- hasToken has fixed splitByNonAlpha semantics. The exact direct read answered it purely from the
--- index posting lists, which is only correct when the index tokenizer produces the same tokens
--- (splitByNonAlpha without a preprocessor). With a different tokenizer (asciiCJK, ngrams, ...) the
--- exact read returned rows the real hasToken evaluation rejects.
--- The hasToken result with the index must match the result without it.
+-- hasToken has fixed splitByNonAlpha semantics. Exact direct read from a mismatched index tokenizer
+-- returned rows the real hasToken rejects (false positive), and a needle that the index tokenizer cannot
+-- represent pruned every granule (false negative). The count with the index must match the count without it.
 
 SET allow_experimental_full_text_index = 1;
 
-SELECT 'asciiCJK tokenizer';
+SELECT 'asciiCJK tokenizer (was a false positive)';
 
 DROP TABLE IF EXISTS tab;
 CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = asciiCJK)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO tab VALUES ('我来自北京邮电大学');
-
--- The whole CJK run is a single splitByNonAlpha token, so the substring is not a token: must be 0.
-SELECT '- hasToken substring of CJK run, with index', count() FROM tab WHERE hasToken(s, '北京邮电大学');
-SELECT '- hasToken substring of CJK run, no index', count() FROM tab WHERE hasToken(s, '北京邮电大学') SETTINGS use_skip_indexes = 0;
-
+-- The whole CJK run is one splitByNonAlpha token, so the substring is not a token: must be 0.
+SELECT '- substring of CJK run, with index', count() FROM tab WHERE hasToken(s, '北京邮电大学');
+SELECT '- substring of CJK run, no index', count() FROM tab WHERE hasToken(s, '北京邮电大学') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
 
-SELECT 'ngrams tokenizer';
+SELECT 'ngrams tokenizer, needle shorter than n (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = ngrams(4))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('abc');
+-- 'abc' is a whole splitByNonAlpha token but tokenizes to nothing under ngrams(4): must be 1.
+SELECT '- short needle, with index', count() FROM tab WHERE hasToken(s, 'abc');
+SELECT '- short needle, no index', count() FROM tab WHERE hasToken(s, 'abc') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;
+
+SELECT 'ngrams tokenizer, substring vs whole token';
 
 DROP TABLE IF EXISTS tab;
 CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = ngrams(3))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO tab VALUES ('helloworld');
-
 -- 'low' is an ngram (substring) of 'helloworld' but not a splitByNonAlpha token: must be 0.
-SELECT '- hasToken inner substring, with index', count() FROM tab WHERE hasToken(s, 'low');
-SELECT '- hasToken inner substring, no index', count() FROM tab WHERE hasToken(s, 'low') SETTINGS use_skip_indexes = 0;
+SELECT '- inner substring, with index', count() FROM tab WHERE hasToken(s, 'low');
+SELECT '- inner substring, no index', count() FROM tab WHERE hasToken(s, 'low') SETTINGS use_skip_indexes = 0;
 -- The whole word is a real token: must be 1.
-SELECT '- hasToken full word, with index', count() FROM tab WHERE hasToken(s, 'helloworld');
-SELECT '- hasToken full word, no index', count() FROM tab WHERE hasToken(s, 'helloworld') SETTINGS use_skip_indexes = 0;
-
+SELECT '- whole word, with index', count() FROM tab WHERE hasToken(s, 'helloworld');
+SELECT '- whole word, no index', count() FROM tab WHERE hasToken(s, 'helloworld') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
 
 SELECT 'splitByNonAlpha tokenizer (exact read still used, results unchanged)';
@@ -39,10 +43,8 @@ SELECT 'splitByNonAlpha tokenizer (exact read still used, results unchanged)';
 DROP TABLE IF EXISTS tab;
 CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha)) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO tab VALUES ('hello world foo');
-
-SELECT '- hasToken existing token, with index', count() FROM tab WHERE hasToken(s, 'world');
-SELECT '- hasToken existing token, no index', count() FROM tab WHERE hasToken(s, 'world') SETTINGS use_skip_indexes = 0;
-SELECT '- hasToken missing substring, with index', count() FROM tab WHERE hasToken(s, 'wor');
-SELECT '- hasToken missing substring, no index', count() FROM tab WHERE hasToken(s, 'wor') SETTINGS use_skip_indexes = 0;
-
+SELECT '- existing token, with index', count() FROM tab WHERE hasToken(s, 'world');
+SELECT '- existing token, no index', count() FROM tab WHERE hasToken(s, 'world') SETTINGS use_skip_indexes = 0;
+SELECT '- missing substring, with index', count() FROM tab WHERE hasToken(s, 'wor');
+SELECT '- missing substring, no index', count() FROM tab WHERE hasToken(s, 'wor') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -38,6 +38,36 @@ SELECT '- whole word, with index', count() FROM tab WHERE hasToken(s, 'helloworl
 SELECT '- whole word, no index', count() FROM tab WHERE hasToken(s, 'helloworld') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
 
+SELECT 'array tokenizer, needle is a real token of a multi-word value (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = array)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('hello world');
+-- The array tokenizer stores the whole value as one token, but 'hello' is a splitByNonAlpha token of the row: must be 1.
+SELECT '- token of multi-word value, with index', count() FROM tab WHERE hasToken(s, 'hello');
+SELECT '- token of multi-word value, no index', count() FROM tab WHERE hasToken(s, 'hello') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;
+
+SELECT 'splitByString tokenizer, needle inside a token spanning a non-separator boundary (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByString([', ']))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('hello world, foo');
+-- splitByString(', ') yields ['hello world', 'foo'], but 'hello' is a splitByNonAlpha token of the row: must be 1.
+SELECT '- token inside a separator span, with index', count() FROM tab WHERE hasToken(s, 'hello');
+SELECT '- token inside a separator span, no index', count() FROM tab WHERE hasToken(s, 'hello') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;
+
+SELECT 'asciiCJK tokenizer, connector merges what splitByNonAlpha splits (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = asciiCJK)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('a.b');
+-- asciiCJK keeps 'a.b' as one token (the '.' connects letters), but splitByNonAlpha splits it, so 'a' is a real token: must be 1.
+SELECT '- connector-joined token, with index', count() FROM tab WHERE hasToken(s, 'a');
+SELECT '- connector-joined token, no index', count() FROM tab WHERE hasToken(s, 'a') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;
+
 SELECT 'splitByNonAlpha tokenizer (exact read still used, results unchanged)';
 
 DROP TABLE IF EXISTS tab;
@@ -47,4 +77,14 @@ SELECT '- existing token, with index', count() FROM tab WHERE hasToken(s, 'world
 SELECT '- existing token, no index', count() FROM tab WHERE hasToken(s, 'world') SETTINGS use_skip_indexes = 0;
 SELECT '- missing substring, with index', count() FROM tab WHERE hasToken(s, 'wor');
 SELECT '- missing substring, no index', count() FROM tab WHERE hasToken(s, 'wor') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;
+
+SELECT 'splitByNonAlpha tokenizer with preprocessor (documented divergence still works, index kept)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(s))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello World');
+-- The needle is preprocessed the same way (lowered) as the indexed text, so 'hello' matches with and without the index: must be 1.
+SELECT '- preprocessed token, with index', count() FROM tab WHERE hasToken(s, 'Hello');
+SELECT '- preprocessed token, no index', count() FROM tab WHERE hasToken(s, 'Hello') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -100,3 +100,16 @@ INSERT INTO tab VALUES ('Hello World, Foo');
 SELECT '- coarse + preprocessor, with index', count() FROM tab WHERE hasToken(s, 'hello');
 SELECT '- coarse + preprocessor, no index', count() FROM tab WHERE hasToken(s, 'hello') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
+
+SELECT 'preprocessed needle maps to no index token but a preprocessor is active (was a false negative)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = ngrams(4), preprocessor = lower(s))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('ABC');
+-- The needle 'abc' is lowered then tokenized by ngrams(4), which yields no 4-gram (too short), so the index cannot
+-- prove a match. With a preprocessor the documented rewrite must still run: hasToken(s, 'abc') -> hasToken(lower(s),
+-- 'abc') matches the lowered row (must be 1). Without the index the predicate is the raw case-sensitive
+-- hasToken('ABC', 'abc') (must be 0): the documented preprocessor divergence is preserved.
+SELECT '- preprocessor + empty index tokens, with index', count() FROM tab WHERE hasToken(s, 'abc');
+SELECT '- preprocessor + empty index tokens, no index', count() FROM tab WHERE hasToken(s, 'abc') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -159,3 +159,19 @@ INSERT INTO tab VALUES ('a-b');
 SELECT '- separator-stripping preprocessor, with index', count() FROM tab WHERE hasToken(s, 'a-b');
 SELECT count() FROM tab WHERE hasToken(s, 'a-b') SETTINGS use_skip_indexes = 0; -- { serverError BAD_ARGUMENTS }
 DROP TABLE tab;
+
+SELECT 'hasTokenOrNull + preprocessor must match hasToken (index rewrites the predicate the same way)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, preprocessor = replaceAll(s, ' ', ''))) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
+INSERT INTO tab VALUES ('zzz'), ('a b');
+-- The preprocessor collapses the space, so the index stores token 'ab' for row 'a b'. Needle 'a' is absent from the
+-- posting list, so the granule used to be pruned for hasTokenOrNull (returning 0) because hasTokenOrNull was not
+-- rewritten by the preprocessor while the index pruned on preprocessed tokens. It must now behave exactly like
+-- hasToken: the documented preprocessor rewrite hasTokenOrNull(s, 'a') -> hasTokenOrNull(replaceAll(s, ' ', ''), 'a')
+-- runs, so the index gives 0 (the preprocessed row 'ab' has no token 'a') and the raw no-index query gives 1.
+SELECT '- hasTokenOrNull, with index', count() FROM tab WHERE hasTokenOrNull(s, 'a');
+SELECT '- hasToken, with index', count() FROM tab WHERE hasToken(s, 'a');
+SELECT '- hasTokenOrNull, no index', count() FROM tab WHERE hasTokenOrNull(s, 'a') SETTINGS use_skip_indexes = 0;
+SELECT '- hasToken, no index', count() FROM tab WHERE hasToken(s, 'a') SETTINGS use_skip_indexes = 0;
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -4,6 +4,10 @@
 -- represent pruned every granule (false negative). The count with the index must match the count without it.
 
 SET allow_experimental_full_text_index = 1;
+-- The query condition cache is keyed only by the predicate (not by use_skip_indexes), so a skip-index
+-- query that legitimately diverges from the row-level result poisons a later use_skip_indexes = 0 query.
+-- That is orthogonal to what this test checks, so disable the cache to keep the index/no-index pairs comparable.
+SET use_query_condition_cache = 0;
 
 SELECT 'asciiCJK tokenizer (was a false positive)';
 

--- a/tests/queries/0_stateless/02346_text_index_bug107186.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug107186.sql
@@ -125,3 +125,37 @@ INSERT INTO tab VALUES ('aaa bbb, zzz');
 SELECT '- non-prunable hasToken AND matching atom, with index', count() FROM tab WHERE hasToken(s, 'aaa') AND hasAllTokens(s, 'zzz');
 SELECT '- non-prunable hasToken AND matching atom, no index', count() FROM tab WHERE hasToken(s, 'aaa') AND hasAllTokens(s, 'zzz') SETTINGS use_skip_indexes = 0;
 DROP TABLE tab;
+
+SELECT 'ill-formed needle (contains a separator): index must not hide the row-level BAD_ARGUMENTS';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('a b');
+-- 'a-b' splits to ['a', 'b'] under splitByNonAlpha, but the needle itself contains a separator, so row-level
+-- hasToken throws BAD_ARGUMENTS. Exact direct read used to return the row 'a b' and hide the error; it must now
+-- throw with the index too, matching use_skip_indexes = 0.
+SELECT count() FROM tab WHERE hasToken(s, 'a-b'); -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE hasToken(s, 'a-b') SETTINGS use_skip_indexes = 0; -- { serverError BAD_ARGUMENTS }
+DROP TABLE tab;
+
+SELECT 'ill-formed needle with a conservative ngrams index: hint path must not hide the error';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = ngrams(2))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('a b');
+-- The ngrams hint path used to prune the granule (returning 0) instead of letting row-level hasToken throw.
+SELECT count() FROM tab WHERE hasToken(s, 'a-b'); -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE hasToken(s, 'a-b') SETTINGS use_skip_indexes = 0; -- { serverError BAD_ARGUMENTS }
+DROP TABLE tab;
+
+SELECT 'ill-formed raw needle but a preprocessor strips the separator: index stays usable';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, preprocessor = replaceAll(s, '-', ''))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('a-b');
+-- The validation runs on the preprocessed needle: replaceAll('a-b', '-', '') = 'ab' is well-formed, so the index
+-- path keeps the documented rewrite and matches the indexed token 'ab' (must be 1). Without the index the raw
+-- case-sensitive hasToken('a-b', 'a-b') throws BAD_ARGUMENTS (documented preprocessor divergence).
+SELECT '- separator-stripping preprocessor, with index', count() FROM tab WHERE hasToken(s, 'a-b');
+SELECT count() FROM tab WHERE hasToken(s, 'a-b') SETTINGS use_skip_indexes = 0; -- { serverError BAD_ARGUMENTS }
+DROP TABLE tab;

--- a/tests/queries/0_stateless/02346_text_index_bug90778.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug90778.reference
@@ -1,4 +1,4 @@
 1
 Actions: INPUT : 0 -> __text_index_idx_equals_a8795ef08bf8680d4058b0b633446b5d UInt8 : 0
 1
-Actions: INPUT : 0 -> __text_index_idx_hasToken_64e1720f37357ea1ffbb211db4a54a6c UInt8 : 0
+INPUT : 1 -> __text_index_idx_hasToken_d3fb3c9718ae448fa2fb67c1085fc597 UInt8 : 2

--- a/tests/queries/0_stateless/02346_text_index_bug90778.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug90778.reference
@@ -1,4 +1,3 @@
 1
 Actions: INPUT : 0 -> __text_index_idx_equals_a8795ef08bf8680d4058b0b633446b5d UInt8 : 0
 1
-INPUT : 1 -> __text_index_idx_hasToken_d3fb3c9718ae448fa2fb67c1085fc597 UInt8 : 2

--- a/tests/queries/0_stateless/02346_text_index_bug90778.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug90778.sql
@@ -22,6 +22,8 @@ WHERE explain LIKE '%INPUT%\_\_text_index%';
 
 SELECT count() FROM tab WHERE hasToken(col, 'config');
 
+-- hasToken only uses exact direct read with the splitByNonAlpha tokenizer (issue #107186); with the array
+-- tokenizer it is added as a hint with row-level re-evaluation, so the INPUT below is a hint, not a replacement.
 SELECT trim(explain) FROM
 (
     EXPLAIN actions = 1 SELECT count() FROM tab WHERE hasToken(col, 'config')

--- a/tests/queries/0_stateless/02346_text_index_bug90778.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug90778.sql
@@ -22,12 +22,12 @@ WHERE explain LIKE '%INPUT%\_\_text_index%';
 
 SELECT count() FROM tab WHERE hasToken(col, 'config');
 
--- hasToken only uses exact direct read with the splitByNonAlpha tokenizer (issue #107186); with the array
--- tokenizer it is added as a hint with row-level re-evaluation, so the INPUT below is a hint, not a replacement.
+-- hasToken keeps fixed splitByNonAlpha semantics, so the array tokenizer is not a necessary condition for it
+-- (issue #107186): the index is declined entirely and there is no __text_index INPUT (the next query returns nothing).
 SELECT trim(explain) FROM
 (
     EXPLAIN actions = 1 SELECT count() FROM tab WHERE hasToken(col, 'config')
-    SETTINGS use_skip_indexes_on_data_read = 1, query_plan_text_index_add_hint = 1, query_plan_direct_read_from_text_index = 1 -- CI may inject False; text index hint INPUT actions not added to EXPLAIN output
+    SETTINGS use_skip_indexes_on_data_read = 1, query_plan_text_index_add_hint = 1, query_plan_direct_read_from_text_index = 1
 )
 WHERE explain LIKE '%INPUT%\_\_text_index%';
 

--- a/tests/queries/0_stateless/02346_text_index_short_ngrams_and_empty_tokens.reference
+++ b/tests/queries/0_stateless/02346_text_index_short_ngrams_and_empty_tokens.reference
@@ -22,8 +22,10 @@ SELECT count() FROM tab WHERE hasAllTokens(message, '');
 0
 SELECT tokens('abc', 'ngrams', 4) AS tokens;
 []
+-- hasToken keeps fixed splitByNonAlpha semantics regardless of the index tokenizer, so 'abc' is a real token of row 1.
+-- The ngrams index cannot represent that, so hasToken does not use it (see issue #107186) and the row is matched.
 SELECT count() FROM tab WHERE hasToken(message, 'abc');
-0
+1
 -- Arrays
 SELECT count() FROM tab WHERE hasAnyTokens(arr, ['abc']);
 0
@@ -102,8 +104,10 @@ SELECT count() FROM tab WHERE hasAllTokens(message, '');
 0
 SELECT tokens('abc', 'ngrams', 4) AS tokens;
 []
+-- hasToken keeps fixed splitByNonAlpha semantics regardless of the index tokenizer, so 'abc' is a real token of row 1.
+-- The ngrams index cannot represent that, so hasToken does not use it (see issue #107186) and the row is matched.
 SELECT count() FROM tab WHERE hasToken(message, 'abc');
-0
+1
 -- Arrays
 SELECT count() FROM tab WHERE hasAnyTokens(arr, ['abc']);
 0

--- a/tests/queries/0_stateless/02346_text_index_short_ngrams_and_empty_tokens.sh
+++ b/tests/queries/0_stateless/02346_text_index_short_ngrams_and_empty_tokens.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# This test tests 2 things with and without the direct read optimization:
+# This test tests 3 things with and without the direct read optimization:
 # 1. That short ngrams (parsing words shorter than the ngram length N) return an empty set when tokenized
 # 2. That empty inputs to the search tokens return 0 rows instead of the whole table
+# 3. That hasToken keeps its splitByNonAlpha semantics and does not use a mismatched ngrams index (issue #107186)
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -56,6 +57,8 @@ SELECT count() FROM tab WHERE hasAllTokens(message, '');
 
 SELECT tokens('abc', 'ngrams', 4) AS tokens;
 
+-- hasToken keeps fixed splitByNonAlpha semantics regardless of the index tokenizer, so 'abc' is a real token of row 1.
+-- The ngrams index cannot represent that, so hasToken does not use it (see issue #107186) and the row is matched.
 SELECT count() FROM tab WHERE hasToken(message, 'abc');
 
 -- Arrays

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.reference
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.reference
@@ -99,6 +99,5 @@ Parts: 1/1
 Parts: 1/1
 Parts: 0/1
 
--- Skip for hasTokenOrNull with ill-formed token
+-- No skip for hasTokenOrNull with ill-formed token
 Parts: 1/1
-Parts: 0/1

--- a/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
+++ b/tests/queries/0_stateless/03165_string_functions_with_token_text_indexes.sql
@@ -273,7 +273,7 @@ WHERE explain LIKE '%Parts:%';
 SELECT * FROM 03165_token_ft WHERE hasTokenOrNull(message, 'foo');
 
 SELECT '';
-SELECT '-- Skip for hasTokenOrNull with ill-formed token';
+SELECT '-- No skip for hasTokenOrNull with ill-formed token';
 
 SELECT trim(explain)
 FROM (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107186
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results for `hasToken` on a text index whose tokenizer differs from `splitByNonAlpha` (for example `asciiCJK` or `ngrams`) or that uses a preprocessor. The query could return rows that the actual `hasToken` evaluation rejects.

### Description

`MergeTreeIndexConditionText::getDirectReadMode` returned `TextIndexDirectReadMode::Exact` for `hasToken` unconditionally. `hasToken` has fixed `splitByNonAlpha` semantics, but the needle is tokenized with the index tokenizer and the exact direct read then answers the predicate purely from the posting lists, returning rows the real `hasToken` evaluation rejects. Because `query_plan_direct_read_from_text_index` defaults to `1`, this produced wrong results with default settings.

Reproducer (from the issue):

```sql
SET allow_experimental_full_text_index = 1;
CREATE TABLE t (s String, INDEX idx s TYPE text(tokenizer = 'asciiCJK')) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('我来自北京邮电大学');
SELECT count() FROM t WHERE hasToken(s, '北京邮电大学');                                              -- returned 1 (wrong), now 0
SELECT count() FROM t WHERE hasToken(s, '北京邮电大学') SETTINGS query_plan_direct_read_from_text_index = 0;  -- 0 (correct)
```

`asciiCJK` stores per-character tokens; the needle's characters are all present, so the exact read marked the row as matching, although `hasToken` sees the whole CJK run as a single token (there is no token boundary before `北`).

Fix: `hasToken` uses exact direct read only when the index tokenizer matches its semantics (`splitByNonAlpha` without a preprocessor); otherwise it falls back to hint/none mode with row-level re-evaluation, mirroring the existing `equals`/`has` handling. `hasAnyTokens`/`hasAllTokens` are the index-native search functions (documented to tokenize the needle with the index tokenizer and to support all tokenizers and preprocessors), so their exact direct read is left unchanged.

Added regression test `02346_text_index_bug107186` checking that, for `asciiCJK` and `ngrams` tokenizers, `hasToken` with and without the index return the same result, and that `splitByNonAlpha` still uses the exact direct read.

Closes https://github.com/ClickHouse/ClickHouse/issues/107186