### PR TITLE
Make contrib/update-submodules.sh portable to BSD grep and find

### DIFF
--- a/contrib/update-submodules.sh
+++ b/contrib/update-submodules.sh
@@ -37,8 +37,8 @@ git config --file .gitmodules --get-regexp '.*path' | sed 's/[^ ]* //' | xargs -
 # corrosion: Used to build rust (Does not make sense to replace)
 # rust_vendor: Used to build rust
 # wasmtime: uses build.rs script that requires cmake files to be present
-grep -o -P '"contrib/[^"]+"' .gitmodules |
-  grep -v -P 'contrib/(llvm-project|corrosion|rust_vendor|wasmtime)' |
+grep -o -E '"contrib/[^"]+"' .gitmodules |
+  grep -v -E 'contrib/(llvm-project|corrosion|rust_vendor|wasmtime)' |
   xargs -I@ find @ \
-    -'(' -name 'CMakeLists.txt' -or -name '*.cmake' -')' -and -not -name '*.h.cmake' \
+    '(' -name 'CMakeLists.txt' -or -name '*.cmake' ')' -and -not -name '*.h.cmake' \
     -delete


### PR DESCRIPTION
Make `contrib/update-submodules.sh` portable to BSD `grep` and `find` so it can run on macOS, not only GNU/Linux build environments.

The contrib CMake-cleanup step used GNU-only constructs that fail under the BSD userland on macOS:

- `grep -P` (PCRE) is a GNU extension; BSD `grep` rejects it with `invalid option -- P`. The patterns only use POSIX features (character classes, alternation), so this uses `grep -E` instead.
- The `find` grouping operators were written as `-'('` / `-')'`. GNU `find` leniently accepts a leading dash, but BSD `find` rejects `-(` with `unknown primary or operator`. This uses the bare `'('` / `')'`, which is POSIX and works on both.

Both forms were verified to produce identical output on BSD `find`/`grep` (macOS) and GNU `find`/`grep` (Linux/CI).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

> Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.824`
<!-- ch-version-info:end -->