### PR TITLE
Stop test 04119 from tripping the CI logical-error log scanner

### DIFF
--- a/tests/queries/0_stateless/04119_object_storage_bad_arg_count_no_logical_error.sql
+++ b/tests/queries/0_stateless/04119_object_storage_bad_arg_count_no_logical_error.sql
@@ -2,21 +2,16 @@
 -- ^ no-fasttest: azure/s3/hdfs table functions are gated on build flags
 -- ^ no-msan: `delta-kernel-rs` is disabled under MSan, so `DeltaLakeAzure` is unavailable
 
--- Regression test for STID 4283-5f31:
--- BuzzHouse hit `Logical error: Expected 3 to 10 arguments in table function azureBlobStorage, got 1`
--- via `CREATE TABLE ... ENGINE = DeltaLakeAzure(<single-arg>)`. The defensive arg-count check
--- inside `addStructureAndFormatToArgsIfNeededAzure` (and its S3/HDFS/file-like siblings) used
--- `LOGICAL_ERROR`, which `abortOnFailedAssertion` aborts in debug builds and is treated as a
--- server bug.
+-- Regression test for STID 4283-5f31 (fixed in PR #103544): a bad argument count
+-- for the object-storage table functions and engines (file/url/s3/hdfs/azureBlobStorage
+-- and the DeltaLake* engines) must raise NUMBER_OF_ARGUMENTS_DOESNT_MATCH, not a
+-- LOGICAL_ERROR that aborts debug builds.
 --
--- The same anti-pattern existed in 4 places:
---   src/Storages/ObjectStorage/Azure/Configuration.cpp  - addStructureAndFormatToArgsIfNeededAzure
---   src/Storages/ObjectStorage/HDFS/Configuration.cpp   - addStructureAndFormatToArgsIfNeededHDFS
---   src/Storages/ObjectStorage/S3/Configuration.cpp     - addStructureAndFormatToArgsIfNeededS3
---   src/TableFunctions/ITableFunctionFileLike.h         - updateStructureAndFormatArgumentsIfNeeded
---
--- All four now throw `NUMBER_OF_ARGUMENTS_DOESNT_MATCH` instead, matching the upstream
--- `*StorageParsedArguments::fromAST` validation and giving users a graceful, well-typed error.
+-- NOTE: every query below throws on purpose, so the server logs its full query text
+-- (this comment included) at Error level. Keep this file free of the verbatim crash
+-- message that ci/jobs/scripts/log_parser.py greps the server log for, otherwise the
+-- scanner false-matches this comment and reports a bogus failure. Refer to the error
+-- by its code name LOGICAL_ERROR; never spell out the runtime message text.
 
 -- ---- Table function paths ----
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/71028
Related: https://github.com/ClickHouse/ClickHouse/pull/103544
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test-only fix for a CI false positive that appears on `master` and across many
unrelated PRs since 2026-06-09 (e.g. STID 3574-4812 / 2508-4994), raised by
@alexey-milovidov on #71028.

`04119_object_storage_bad_arg_count_no_logical_error` is a regression test for
#103544: every query in it throws on purpose (expected `serverError
NUMBER_OF_ARGUMENTS_DOESNT_MATCH`). On a thrown query, `executeQuery` logs the
full query text at `Error` level via `toOneLineQuery`, which keeps comment
tokens verbatim, so the file's leading comment lands in
`clickhouse-server.err.log`. That comment quoted the original pre-fix crash
message word for word (`Logical error: Expected 3 to 10 arguments in table
function azureBlobStorage, got 1`). The CI server-log scanner
(`ci/jobs/scripts/log_parser.py`) greps the server log with
`rg --text -A 10 -o 'Logical error.*'`, matched the comment, used its first line
as the failure title and a nearby unrelated stack for the STID, and reported a
bogus blocking failure.

After #103544 merged on 2026-06-09 the server can no longer emit that message
(it throws `NUMBER_OF_ARGUMENTS_DOESNT_MATCH`), so the only remaining source of
the string was this comment, which is why the failure started exactly that day.
Not caused by #71028.

Fix: reword the comment so it no longer contains the verbatim runtime message
(refer to the error by its code name `LOGICAL_ERROR`), and add a note telling
future editors to keep the file free of scanner trigger strings. The queries and
their expected errors are unchanged and the test still passes.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.687`
<!-- ch-version-info:end -->