### PR TITLE
Run azure stateless tests on runners with more memory

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2676,7 +2676,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_binary_excluded_from_llvm)' --workflow "MasterCI" --ci --timestamp
 
   stateless_tests_arm_asan_ubsan_azure_parallel:
-    runs-on: [self-hosted, arm-medium]
+    runs-on: [self-hosted, arm-medium-mem]
     needs: [build_arm_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhcm1fYXNhbl91YnNhbiwgYXp1cmUsIHBhcmFsbGVsKQ==') }}
     name: "Stateless tests (arm_asan_ubsan, azure, parallel)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2713,7 +2713,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (arm_binary, sequential)' --workflow "PR" --ci --timestamp
 
   stateless_tests_arm_asan_ubsan_azure_parallel:
-    runs-on: [self-hosted, pr-arm-medium]
+    runs-on: [self-hosted, pr-arm-medium-mem]
     needs: [build_amd_asan_ubsan, build_amd_debug, build_amd_tsan, build_arm_asan_ubsan, build_arm_binary, build_arm_tidy, ci_tests, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, stateless_tests_amd_asan_ubsan_distributed_plan_parallel_1_2, stateless_tests_amd_asan_ubsan_distributed_plan_parallel_2_2, stateless_tests_amd_debug_parallel, stateless_tests_amd_tsan_parallel_1_2, stateless_tests_amd_tsan_parallel_2_2, stateless_tests_arm_binary_parallel, style_check]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhcm1fYXNhbl91YnNhbiwgYXp1cmUsIHBhcmFsbGVsKQ==') }}
     name: "Stateless tests (arm_asan_ubsan, azure, parallel)"

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -723,7 +723,7 @@ class JobConfigs:
     ).parametrize(
         Job.ParamSet(
             parameter="arm_asan_ubsan, azure, parallel",
-            runs_on=RunnerLabels.ARM_MEDIUM,
+            runs_on=RunnerLabels.ARM_MEDIUM_MEM,
             requires=[ArtifactNames.CH_ARM_ASAN_UBSAN],
         ),
         Job.ParamSet(


### PR DESCRIPTION
Closes: #107037

`Stateless tests (arm_asan_ubsan, azure, parallel)` chronically runs into memory limit. Tagging tests is not a fix as the victims are arbitrary, so skipping them just moves failures to other tests. 

After #106020 merged, [hundreds distinct tests failed this way within three days](https://play.clickhouse.com/play?user=play#U0VMRUNUCiAgICB0b1N0YXJ0T2ZJbnRlcnZhbChjaGVja19zdGFydF90aW1lLCBJTlRFUlZBTCA2IEhPVVIpIEFTIHQsCiAgICB1bmlxRXhhY3QoY2hlY2tfc3RhcnRfdGltZSwgY29tbWl0X3NoYSkgQVMgcnVucywKICAgIHVuaXFFeGFjdElmKChjaGVja19zdGFydF90aW1lLCBjb21taXRfc2hhKSwgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgICAgICBBTkQgdGVzdF9jb250ZXh0X3JhdyBMSUtFICclTUVNT1JZX0xJTUlUX0VYQ0VFREVEJScpIEFTIGJhZF9ydW5zLAogICAgcm91bmQoYmFkX3J1bnMgLyBydW5zICogMTAwLCAxKSBBUyBiYWRfcnVuc19wY3QsCiAgICBjb3VudElmKHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICAgICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJU1FTU9SWV9MSU1JVF9FWENFRURFRCUnKSBBUyBmYWlsZWRfdGVzdHMsCiAgICB1bmlxRXhhY3RJZih0ZXN0X25hbWUsIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICAgICAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJU1FTU9SWV9MSU1JVF9FWENFRURFRCUnKSBBUyB1bmlxX2ZhaWxlZF90ZXN0cywKICAgIGJhcih1bmlxX2ZhaWxlZF90ZXN0cywgMCwgMjAwLCAyMCkgQVMgY2hhcnQKRlJPTSBjaGVja3MKV0hFUkUgY2hlY2tfc3RhcnRfdGltZSA+PSAnMjAyNi0wNi0wNicKICAgIEFORCBjaGVja19uYW1lID0gJ1N0YXRlbGVzcyB0ZXN0cyAoYXJtX2FzYW5fdWJzYW4sIGF6dXJlLCBwYXJhbGxlbCknCkdST1VQIEJZIHQKT1JERVIgQlkgdAo=). The revert (#107122) brought the rate back to the baseline (not 0). The revert revert (#107146) fixes the memory consumption, but it's generally expected that larger number of tests would increase memory consumption. Let's merge this PR if we see that even after the fix the tests fail.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Move `Stateless tests (arm_asan_ubsan, azure, parallel)` from `arm-medium` to `arm-medium-mem`