### PR TITLE
Improve canceling queries MySQLOutputFormat

### DIFF
--- a/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/MySQLOutputFormat.cpp
@@ -1,6 +1,8 @@
 #include <Processors/Formats/Impl/MySQLOutputFormat.h>
 #include <Common/CurrentThread.h>
+#include <Common/Exception.h>
 #include <Common/formatReadable.h>
+#include <Common/logger_useful.h>
 #include <Core/MySQL/PacketsGeneric.h>
 #include <Core/MySQL/PacketsProtocolBinary.h>
 #include <Core/MySQL/PacketsProtocolText.h>
@@ -18,6 +20,11 @@ using namespace MySQLProtocol;
 using namespace MySQLProtocol::Generic;
 using namespace MySQLProtocol::ProtocolText;
 using namespace MySQLProtocol::ProtocolBinary;
+
+namespace ErrorCodes
+{
+    extern const int QUERY_WAS_CANCELLED;
+}
 
 MySQLOutputFormat::MySQLOutputFormat(WriteBuffer & out_, SharedHeader header_, const FormatSettings & settings_)
     : IOutputFormat(header_, out_)
@@ -69,10 +76,18 @@ void MySQLOutputFormat::writePrefix()
 
 void MySQLOutputFormat::consume(Chunk chunk)
 {
+    LOG_TEST(getLogger("MySQLOutputFormat"), "Consume a chunk");
+
+    if (isCancelled())
+        throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+
     if (!use_binary_result_set)
     {
         for (size_t row = 0; row < chunk.getNumRows(); ++row)
         {
+            if (isCancelled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+
             ProtocolText::ResultSetRow row_packet(serializations, data_types, chunk.getColumns(), row);
             packet_endpoint->sendPacket(row_packet, false);
         }
@@ -81,6 +96,9 @@ void MySQLOutputFormat::consume(Chunk chunk)
     {
         for (size_t row = 0; row < chunk.getNumRows(); ++row)
         {
+            if (isCancelled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+
             ProtocolBinary::ResultSetRow row_packet(serializations, data_types, chunk.getColumns(), row);
             packet_endpoint->sendPacket(row_packet, false);
         }

--- a/tests/integration/test_mysql_protocol/test_kill_query.py
+++ b/tests/integration/test_mysql_protocol/test_kill_query.py
@@ -1,0 +1,72 @@
+import threading
+import time
+
+import pymysql
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+MYSQL_PORT = 9001
+
+SELECT_FROM_NUMBERS = """SELECT toString(number), repeat('x', 100) FROM numbers(20000000)
+SETTINGS max_block_size = 20000000"""
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/mysql.xml"],
+    user_configs=["configs/users.xml"],
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        node.wait_for_log_line("MySQL compatibility protocol")
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_kill_query_during_output(started_cluster):
+    def execute_query():
+        conn = pymysql.connections.Connection(
+            host=started_cluster.get_instance_ip("node"),
+            port=MYSQL_PORT,
+            user="default",
+            password="123",
+            database="default",
+        )
+        try:
+            with conn.cursor() as cur:
+                cur.execute(SELECT_FROM_NUMBERS)
+                for _ in cur:
+                    pass
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    query_thread = threading.Thread(target=execute_query)
+    query_thread.start()
+
+    node.wait_for_log_line("Consume a chunk")
+    time.sleep(1)
+
+    node.query(
+        "KILL QUERY WHERE user='default' AND query LIKE 'SELECT toString(number)%' SYNC",
+        user="default",
+        password="123",
+    )
+
+    query_thread.join()
+
+    result = node.query(
+        "SELECT count(*) FROM system.processes WHERE user='default' AND query LIKE 'SELECT toString(number)%'",
+        user="default",
+        password="123",
+    )
+    assert int(result.strip()) == 0
+
+    assert node.contains_in_log("QUERY_WAS_CANCELLED")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced cancellation latency for queries running over the MySQL wire protocol: KILL QUERY now interrupts output serialization within a single chunk instead of waiting for the entire chunk to be sent to the client.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.817`
<!-- ch-version-info:end -->