### PR TITLE
Pass-through row count estimation for row-preserving transforming steps

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -421,14 +421,14 @@ static RelationStats estimateReadRowsCount(QueryPlan::Node & node, const Actions
         return stats;
     }
 
-    if (const auto * transform = dynamic_cast<const ITransformingStep *>(step);
-        transform && transform->getTransformTraits().preserves_number_of_rows)
-        return estimateReadRowsCount(*node.children.front(), filter);
-
 #if CLICKHOUSE_CLOUD
     if (dynamic_cast<LogicalExchangeStep *>(step))
         return estimateReadRowsCount(*node.children.front(), filter);
 #endif
+
+    if (const auto * transform = dynamic_cast<const ITransformingStep *>(step);
+        transform && transform->getTransformTraits().preserves_number_of_rows)
+        return estimateReadRowsCount(*node.children.front(), filter);
 
     return {};
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -420,10 +420,16 @@ static RelationStats estimateReadRowsCount(QueryPlan::Node & node, const Actions
         }
         return stats;
     }
+
+    if (const auto * transform = dynamic_cast<const ITransformingStep *>(step);
+        transform && transform->getTransformTraits().preserves_number_of_rows)
+        return estimateReadRowsCount(*node.children.front(), filter);
+
 #if CLICKHOUSE_CLOUD
     if (dynamic_cast<LogicalExchangeStep *>(step))
         return estimateReadRowsCount(*node.children.front(), filter);
 #endif
+
 
     return {};
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -430,7 +430,6 @@ static RelationStats estimateReadRowsCount(QueryPlan::Node & node, const Actions
         return estimateReadRowsCount(*node.children.front(), filter);
 #endif
 
-
     return {};
 }
 


### PR DESCRIPTION
Add pass-through for generic transform which preserve row count

From #106955

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improved query plan when JOIN uses runtime filters (default-on `enable_join_runtime_filters`): the join-reorder cost model now sees through `WindowTransform` (and other row-preserving plan steps) on the right subtree and
  uses the underlying row count and per-column NDV instead of falling back to no statistics

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.774`
<!-- ch-version-info:end -->