### PR TITLE
Make 02352_lightweight_delete faster by reducing dataset 10x

### DIFF
--- a/tests/queries/0_stateless/02352_lightweight_delete.reference
+++ b/tests/queries/0_stateless/02352_lightweight_delete.reference
@@ -1,36 +1,36 @@
-Rows in parts	1000000
-Count	1000000
+Rows in parts	100000
+Count	100000
 First row	0	10
-Delete 100K rows using lightweight DELETE
-Rows in parts	1000000
-Count	900000
-First row	100000	10
+Delete 10K rows using lightweight DELETE
+Rows in parts	100000
+Count	90000
+First row	10000	10
 Force merge to cleanup deleted rows
-Rows in parts	900000
-Count	900000
-First row	100000	10
-Delete 100K more rows using lightweight DELETE
-Rows in parts	900000
-Count	800000
-First row	200000	10
+Rows in parts	90000
+Count	90000
+First row	10000	10
+Delete 10K more rows using lightweight DELETE
+Rows in parts	90000
+Count	80000
+First row	20000	10
 Do UPDATE mutation
-Rows in parts	900000
-Count	800000
-First row	200000	1
+Rows in parts	90000
+Count	80000
+First row	20000	1
 Force merge to cleanup deleted rows
-Rows in parts	800000
-Count	800000
-First row	200000	1
-Delete 100K more rows using lightweight DELETE
-Rows in parts	800000
-Count	700000
-First row	300000	1
+Rows in parts	80000
+Count	80000
+First row	20000	1
+Delete 10K more rows using lightweight DELETE
+Rows in parts	80000
+Count	70000
+First row	30000	1
 Do ALTER DELETE mutation that does a "heavyweight" delete
-Rows in parts	466666
-Count	466666
-First row	300001	10
-Delete 100K more rows using lightweight DELETE
+Rows in parts	46666
+Count	46666
+First row	30001	10
+Delete 10K more rows using lightweight DELETE
 Force merge to cleanup deleted rows
-Rows in parts	400000
-Count	400000
-First row	400000	1
+Rows in parts	40000
+Count	40000
+First row	40000	1

--- a/tests/queries/0_stateless/02352_lightweight_delete.sql
+++ b/tests/queries/0_stateless/02352_lightweight_delete.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS lwd_test;
 
 CREATE TABLE lwd_test (id UInt64 , value String) ENGINE MergeTree() ORDER BY id SETTINGS index_granularity=8192, index_granularity_bytes='10Mi';
 
-INSERT INTO lwd_test SELECT number, randomString(10) FROM system.numbers LIMIT 1000000;
+INSERT INTO lwd_test SELECT number, randomString(10) FROM system.numbers LIMIT 100000;
 
 SET mutations_sync = 0;
 
@@ -11,9 +11,9 @@ SELECT 'Count', count() FROM lwd_test;
 SELECT 'First row', id, length(value) FROM lwd_test ORDER BY id LIMIT 1;
 
 
-SELECT 'Delete 100K rows using lightweight DELETE';
+SELECT 'Delete 10K rows using lightweight DELETE';
 --ALTER TABLE lwd_test UPDATE _row_exists = 0 WHERE id < 3000000;
-DELETE FROM lwd_test WHERE id < 100000;
+DELETE FROM lwd_test WHERE id < 10000;
 
 SELECT 'Rows in parts', SUM(rows) FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_test' AND active;
 SELECT 'Count', count() FROM lwd_test;
@@ -28,8 +28,8 @@ SELECT 'Count', count() FROM lwd_test;
 SELECT 'First row', id, length(value) FROM lwd_test ORDER BY id LIMIT 1;
 
 
-SELECT 'Delete 100K more rows using lightweight DELETE';
-DELETE FROM lwd_test WHERE id < 200000;
+SELECT 'Delete 10K more rows using lightweight DELETE';
+DELETE FROM lwd_test WHERE id < 20000;
 
 SELECT 'Rows in parts', SUM(rows) FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_test' AND active;
 SELECT 'Count', count() FROM lwd_test;
@@ -52,8 +52,8 @@ SELECT 'Count', count() FROM lwd_test;
 SELECT 'First row', id, length(value) FROM lwd_test ORDER BY id LIMIT 1;
 
 
-SELECT 'Delete 100K more rows using lightweight DELETE';
-DELETE FROM lwd_test WHERE id < 300000;
+SELECT 'Delete 10K more rows using lightweight DELETE';
+DELETE FROM lwd_test WHERE id < 30000;
 
 SELECT 'Rows in parts', SUM(rows) FROM system.parts WHERE database = currentDatabase() AND table = 'lwd_test' AND active;
 SELECT 'Count', count() FROM lwd_test;
@@ -67,8 +67,8 @@ SELECT 'Rows in parts', SUM(rows) FROM system.parts WHERE database = currentData
 SELECT 'Count', count() FROM lwd_test;
 SELECT 'First row', id, length(value) FROM lwd_test ORDER BY id LIMIT 1;
 
-SELECT 'Delete 100K more rows using lightweight DELETE';
-DELETE FROM lwd_test WHERE id >= 300000 and id < 400000;
+SELECT 'Delete 10K more rows using lightweight DELETE';
+DELETE FROM lwd_test WHERE id >= 30000 and id < 40000;
 
 
 SELECT 'Force merge to cleanup deleted rows';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/76867
Related: https://github.com/ClickHouse/ClickHouse/pull/106034
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/76867
Related: https://github.com/ClickHouse/ClickHouse/pull/106034

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02352_lightweight_delete` inserts 1M rows and then runs 3 `OPTIMIZE TABLE ... FINAL` rewrites plus 2 full-table mutations. On debug and sanitizer builds under the Flaky Check (which repeats each test ~50x with randomized settings and `page_cache_inject_eviction`), a single run clustered around the 180s per-test cap and occasionally tripped it (199s observed on #76867; historical 185/199/221/243s).

This reduces the inserted rows from 1M to 100k and scales the four lightweight-delete boundaries by 10x. Everything that the test verifies is preserved:

- Same operations in the same order: 4 lightweight `DELETE`, 3 `OPTIMIZE FINAL`, 1 `ALTER UPDATE`, 1 heavyweight `ALTER DELETE`.
- Data still spans 13 granules (`index_granularity=8192`), so multi-granule lightweight delete, mark ranges, OPTIMIZE materialization, and the mutation interactions are all still exercised.
- The reference asserts `SUM(rows)`/`count()`/first-row `id`+`length` only, which are independent of part type, so randomized `min_bytes_for_wide_part` (Compact vs Wide) is unaffected.

The reference is regenerated from a real run rather than naively divided: the heavyweight-delete result is 46666 (`[30000,100000)` minus `id%3==0`), not 1/10 of 466666.

Verified locally on a debug build: a single run now takes under 1s, and the test passed 50/50 under randomized settings.

Background: this replaces #106034 (raise the global flaky-check timeout 180s->300s), which was closed after Algunenano noted that the proper fix is to make slow tests faster rather than raising the cap. cc @alexey-milovidov (who originally flagged the timeout on #76867).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.698`
<!-- ch-version-info:end -->