### PR TITLE
Fix flaky test 04027_system_start_replicated_view

### DIFF
--- a/tests/queries/0_stateless/04027_system_start_replicated_view.sh
+++ b/tests/queries/0_stateless/04027_system_start_replicated_view.sh
@@ -58,7 +58,9 @@ $CLICKHOUSE_CLIENT -q "system start replicated view ${db}.rmv"
 # The bug: the view stayed Disabled forever here because the children watch
 # was not re-registered after the stop event consumed it.
 # Wait for the view to leave Disabled state and complete at least one more refresh.
-for _ in $(seq 1 30); do
+# Budget must cover resume detection plus a full refresh run, so it is not shorter
+# than the initial-refresh wait above.
+for _ in $(seq 1 120); do
     cnt_after=$($CLICKHOUSE_CLIENT -q "select count() from ${db}.rmv")
     if [ "$cnt_after" -gt "$cnt_before" ]; then
         break


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `04027_system_start_replicated_view`, seen on `Stateless tests (arm_asan_ubsan, azure, parallel)` (0 master hits; self-heals on rerun).

The `<4: new rows>` assertion waits for the resumed refreshable view to complete at least one more refresh after `SYSTEM START REPLICATED VIEW`. That wait was 30 iterations of 0.5s (15s), while both the initial-refresh wait and the stop wait earlier in the same test use 60 iterations (30s).

After resume, with `REFRESH AFTER 1 SECOND` the next refresh is scheduled in the past and fires immediately, but the `BackgroundSchedulePool` wake plus the Keeper round-trips to run the refresh and `APPEND` a row take at least as long as the initial refresh, plus an extra coordination watch round-trip. Under load this can exceed 15s, so the loop gives up before the row is appended and the test reports `<4: new rows> 0`. The engine behavior is correct: the view leaves `Disabled` (`<3: restarted> 1` always passes) and a rerun succeeds.

This extends the restart wait to 120 iterations (60s) so the budget covers resume detection plus a full refresh run and is no shorter than the initial-refresh wait. Assertions and reference output are unchanged.

Reproduced deterministically by making the refresh body sleep ~18s: the old 15s loop reports `<4: new rows> 0`, a 60s loop reports `1`. With the fix, 50/50 runs pass with randomization enabled.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.697`
<!-- ch-version-info:end -->