### PR TITLE
Fix flaky test 00061_storage_buffer

### DIFF
--- a/tests/queries/0_stateless/00061_storage_buffer.sql
+++ b/tests/queries/0_stateless/00061_storage_buffer.sql
@@ -1,4 +1,5 @@
--- Tags: stateful
+-- Tags: stateful, no-parallel
+-- no-parallel: the synchronous OPTIMIZE buffer flush is slow under parallel CI load and can hit the 300s client receive_timeout.
 DROP TABLE IF EXISTS hits_dst;
 DROP TABLE IF EXISTS hits_buffer;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107248
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes #107248.

Mark `00061_storage_buffer` `no-parallel` to stop spurious `OPTIMIZE` timeouts.

The test inserts ~77k wide `test.hits` rows into a `Buffer`, then runs `OPTIMIZE TABLE hits_buffer`, which synchronously flushes the buffer into the destination `MergeTree`. The 300s limit it hits is the client-side `receive_timeout` (`ClientBase.cpp`), fixed at connect time. Under parallel CI load on slow sanitizer builds the synchronous flush occasionally exceeds it, giving `Timeout exceeded while receiving data from server` (return code 159).

Evidence it is a load/timing flake, not a regression:
- CIDB: 0 master failures in 90 days; 9 PR-only failures across `amd_tsan`, `amd_msan`, `amd_asan_ubsan`, `amd_llvm_coverage` (all "parallel" buckets).
- The auto-generated flaky-test issue's own re-run with identical randomized settings passed.
- The PR where it last failed (#107193) is an unrelated `SummingSortedAlgorithm` test.

`no-parallel` routes the test to the sequential group so the slow flush runs without concurrent test contention - the same approach used by the sibling Buffer flakes `01870_buffer_flush` and `02391_recursive_buffer`. No query behavior changes; all assertions and the full dataset are preserved.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.998`
<!-- ch-version-info:end -->