### PR TITLE
Increase disks app interactive test command timeout

### DIFF
--- a/tests/integration/test_disks_app_interactive/test.py
+++ b/tests/integration/test_disks_app_interactive/test.py
@@ -82,7 +82,9 @@ class DisksClient(object):
             self.proc.stderr.fileno(): self.proc.stderr,
         }
 
-    def execute_query(self, query: str, timeout: float = 5.0) -> str:
+    # Generous deadline: under sanitizer builds (e.g. MSAN) and CI host
+    # contention the disks subprocess can be slow to produce its first output.
+    def execute_query(self, query: str, timeout: float = 60.0) -> str:
         output = io.BytesIO()
 
         self.proc.stdin.write(query.encode() + b"\n")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106650
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Separate fix requested by @ alexey-milovidov so it can merge sooner than #106650.

`test_disks_app_interactive` drives `clickhouse disks --test-mode` as a subprocess and waits up to 5s (`poller.poll`) for each command's output. Under sanitizer builds (MSAN, roughly 3-5x slower) at high host parallelism the subprocess can be CPU-starved past that 5s wall-clock deadline before it emits its first byte, raising a spurious `TimeoutError: Disks client returned no output` on trivial cleanup commands such as `rm`. The disks operations themselves are correct and fast.

This raises the default deadline to 60s. `poll()` returns as soon as output is ready, so a larger deadline never delays a fast response; the 900s pytest-timeout remains the real hang guard.

Observed `amd_msan` only, with 0 master failures in the last 14 days (CIDB). This is the residual failure mode left after #106730 (which made the assertions sort-order-independent); it is unrelated to the ipnsort/driftsort sort change in #106650.
