### PR TITLE
Wait for consumer streaming before polling in test_rabbitmq_many_inserts

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1038,6 +1038,8 @@ def test_rabbitmq_many_inserts(rabbitmq_cluster, db, unique):
     """
     )
 
+    instance.wait_for_log_line("Started streaming to 1 attached views")
+
     for thread in threads:
         thread.join()
 

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -1038,7 +1038,11 @@ def test_rabbitmq_many_inserts(rabbitmq_cluster, db, unique):
     """
     )
 
-    instance.wait_for_log_line("Started streaming to 1 attached views")
+    # db is per-test unique, so scoping to it avoids matching a stale
+    # "Started streaming" line from an earlier RabbitMQ test in the tail buffer.
+    instance.wait_for_log_line(
+        rf"StorageRabbitMQ \({db}\.rabbitmq_consume\).*Started streaming to 1 attached views"
+    )
 
     for thread in threads:
         thread.join()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/97540
Related: https://github.com/ClickHouse/ClickHouse/issues/71049
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_rabbitmq_many_inserts` occasionally fails with `Time limit of 60 seconds reached without any RabbitMQ consumption` (e.g. PR #97540, arm_binary distributed-plan batch). Root cause: the test starts the result-count poll immediately after creating the materialized view, with no gate for the consumer to actually begin streaming. `check_expected_result_polling` only extends its fixed 60s deadline after the first row is consumed (`if result > prev_result: deadline += 1`); during consumer warmup `result` stays 0, so on a slow/loaded runner the budget can elapse before any consumption registers.

Fix: wait for the `Started streaming to 1 attached views` log line before polling, matching the sibling heavy test `test_rabbitmq_overloaded_insert` (which already does this and shows zero no-consumption failures in CIDB over 60 days, vs. this test being the only place the mode appears).

Found while investigating the CI failure flagged on PR #97540. Test-only change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.709`
<!-- ch-version-info:end -->