### PR TITLE
Fix Bad cast crash for an explicit JOIN USING key with a Dynamic supertype

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -1239,10 +1239,11 @@ IdentifierResolveResult IdentifierResolver::tryResolveIdentifierFromJoin(const I
         auto current_type = resolved_column.getColumnType();
         auto result_type = using_column_node_it->second->getColumnType();
 
-        /// If current column is Nullable because it comes from previous OUTER JOIN, keep nullability,
-        /// even if USING column itself is not Nullable (for LEFT/RIGHT JOIN).
+        /// Current column is Nullable from a previous OUTER JOIN but the USING supertype is not:
+        /// keep the supertype's value type and re-apply nullability. Safe variant leaves a type
+        /// that cannot be inside Nullable (e.g. Dynamic) as-is instead of throwing.
         if (isNullableOrLowCardinalityNullable(current_type) && !isNullableOrLowCardinalityNullable(result_type))
-            result_type = makeNullableOrLowCardinalityNullable(current_type);
+            result_type = makeNullableOrLowCardinalityNullableSafe(result_type);
 
         if (!result_type->equals(*current_type))
         {

--- a/tests/queries/0_stateless/04335_join_using_dynamic_key_aggregate.reference
+++ b/tests/queries/0_stateless/04335_join_using_dynamic_key_aggregate.reference
@@ -1,0 +1,5 @@
+3	2
+Dynamic
+Dynamic
+3
+3

--- a/tests/queries/0_stateless/04335_join_using_dynamic_key_aggregate.sql
+++ b/tests/queries/0_stateless/04335_join_using_dynamic_key_aggregate.sql
@@ -1,0 +1,31 @@
+-- An explicit reference t.key to a JOIN USING key whose merged supertype is Dynamic must be
+-- typed with that supertype, not the table's own type. Otherwise an aggregate over it is built
+-- from the wrong (Nullable) type while the planner produces a Dynamic column, and the Null
+-- combinator aborts with "Bad cast from type DB::ColumnDynamic to DB::ColumnNullable".
+
+SET enable_analyzer = 1;
+SET allow_dynamic_type_in_join_keys = 1;
+
+DROP TABLE IF EXISTS t_nt;
+DROP TABLE IF EXISTS t_dyn;
+
+CREATE TABLE t_nt (x Nullable(String)) ENGINE = Memory;
+INSERT INTO t_nt VALUES ('id'), (NULL), ('1');
+
+CREATE TABLE t_dyn (x Dynamic) ENGINE = Memory;
+INSERT INTO t_dyn VALUES ('id'), (NULL), ('1');
+
+-- The crashing query: count(...) IGNORE NULLS uses the Null combinator.
+SELECT count(t1.x) IGNORE NULLS, sum(isNotNull(t1.x))
+FROM t_nt AS t1 INNER JOIN t_dyn USING (x);
+
+-- The explicit reference adopts the Dynamic supertype, matching the unqualified key.
+SELECT toTypeName(t1.x) FROM t_nt AS t1 INNER JOIN t_dyn USING (x) LIMIT 1;
+SELECT toTypeName(x) FROM t_nt AS t1 INNER JOIN t_dyn USING (x) LIMIT 1;
+
+-- Plain count and LEFT JOIN must work too.
+SELECT count(t1.x) FROM t_nt AS t1 INNER JOIN t_dyn USING (x);
+SELECT count(t1.x) IGNORE NULLS FROM t_nt AS t1 LEFT JOIN t_dyn USING (x);
+
+DROP TABLE t_nt;
+DROP TABLE t_dyn;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107129
-->

Related: #107129

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `Bad cast from type DB::ColumnDynamic to DB::ColumnNullable` logical error (server crash in debug builds) when an explicit reference to a `JOIN ... USING` key whose common supertype is `Dynamic` is passed to an aggregate function, for example `count(t.key) IGNORE NULLS` with `allow_dynamic_type_in_join_keys = 1`.

### Description

Found by the AST fuzzer (STID 3520-4a13).

An explicit reference `t.key` to a `JOIN ... USING` key adopts the merged key type (the common supertype of the joined keys) in `IdentifierResolver::tryResolveIdentifierFromJoin`. When the current column was `Nullable` from a previous OUTER JOIN but the merged supertype was not `Nullable`, the code re-derived the type from the current column rather than from the supertype, discarding the supertype's value type.

For a key whose supertype is `Dynamic` (for example `Nullable(String)` joined with a `Dynamic` key under `allow_dynamic_type_in_join_keys = 1`), this left the query tree typed `Nullable(String)` while the planner casts the key to `Dynamic`. An aggregate over the explicit reference (`count(t.key) IGNORE NULLS`) was then built with the `Null` combinator from the declared `Nullable` type, and its `assert_cast<const ColumnNullable*>` aborted on the runtime `ColumnDynamic`.

The fix keeps the merged key's value type and re-applies nullability from the current column, using `makeNullableOrLowCardinalityNullableSafe` so a supertype that cannot be wrapped in `Nullable` (such as `Dynamic`) is left as-is. This is the explicit-reference counterpart of the qualified-matcher fix in #107129 (`QueryAnalyzer::updateMatchedColumnsFromJoinUsing`), addressing the same "USING can cast to any supertype, not just nullability" class of bug.

Reproducer:

```sql
SET allow_dynamic_type_in_join_keys = 1;
CREATE TABLE t_nt (x Nullable(String)) ENGINE = Memory;
INSERT INTO t_nt VALUES ('id'), (NULL), ('1');
CREATE TABLE t_dyn (x Dynamic) ENGINE = Memory;
INSERT INTO t_dyn VALUES ('id'), (NULL), ('1');
SELECT count(t1.x) IGNORE NULLS FROM t_nt AS t1 INNER JOIN t_dyn USING (x);
```
