### PR TITLE
typo: docs/en/sql-reference/data-types

### DIFF
--- a/docs/en/sql-reference/data-types/uuid.md
+++ b/docs/en/sql-reference/data-types/uuid.md
@@ -31,7 +31,7 @@ While this is fine for UUIDv4 values, this can deteriorate performance with UUID
 More specifically, UUIDv7 values consist of a timestamp in the first half and a counter in the second half.
 UUIDv7 sorting in sparse primary key indexes (i.e., the first values of each index granule) will therefore be by counter field.
 Assuming UUIDs were sorted by the first half (timestamp), then the primary key index analysis step at the beginning of queries is expected to prune all marks in all but one part.
-However, with sorting by the second half (counter), at least one mark is expected to be returned for all parts, leading to unnecessary unnecessary disk accesses.
+However, with sorting by the second half (counter), at least one mark is expected to be returned for all parts, leading to unnecessary disk accesses.
 :::
 
 Example:


### PR DESCRIPTION
Typo in docs:
https://clickhouse.com/docs/sql-reference/data-types/uuid
or
https://github.com/ClickHouse/ClickHouse/blob/master/docs/en/sql-reference/data-types/uuid.md

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.834`
<!-- ch-version-info:end -->