### PR TITLE
Fix data race on ContextSharedPart::trace_collector

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -736,8 +736,10 @@ struct ContextSharedPart : boost::noncopyable
     RemoteHostFilter remote_host_filter;                    /// Allowed URL from config.xml
     HTTPHeaderFilter http_header_filter;                    /// Forbidden HTTP headers from config.xml
 
-    /// No lock required for trace_collector modified only during initialization
     std::optional<TraceCollector> trace_collector;          /// Thread collecting traces from threads executing queries
+    /// Presence flag read concurrently by worker threads (ThreadStatus::initGlobalProfiler)
+    /// while shutdown() destroys trace_collector, so it must be atomic rather than optional::has_value().
+    std::atomic<bool> has_trace_collector = false;
 
     /// Clusters for distributed tables
     /// Initialized on demand (on distributed storages initialization) since Settings should be initialized
@@ -1121,6 +1123,7 @@ struct ContextSharedPart : boost::noncopyable
             delete_access_control = std::move(access_control);
 
             /// Stop trace collector if any
+            has_trace_collector = false;
             trace_collector.reset();
         }
 
@@ -1184,7 +1187,7 @@ struct ContextSharedPart : boost::noncopyable
 
     bool hasTraceCollector() const
     {
-        return trace_collector.has_value();
+        return has_trace_collector.load();
     }
 
     void initializeTraceCollector(std::shared_ptr<TraceLog> trace_log)
@@ -1197,10 +1200,11 @@ struct ContextSharedPart : boost::noncopyable
 
     void createTraceCollector()
     {
-        if (hasTraceCollector())
+        if (trace_collector.has_value())
             return;
 
         trace_collector.emplace();
+        has_trace_collector = true;
     }
 
     void addOrUpdateWarningMessage(Context::WarningType warning, const PreformattedMessage & message) TSA_REQUIRES(mutex)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106285
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a data race on the server-global trace collector between a worker thread starting its profiler and server shutdown.

### Description
`hasTraceCollector()` read `std::optional<TraceCollector>::has_value()` while another thread mutated the optional (`initGlobalProfiler` reads it during worker startup; `shutdown()` does `trace_collector.reset()`). Presence is now tracked in a `std::atomic<bool>`, set after `emplace()` and cleared before `reset()`.

TSan report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104174&sha=69ecaa0b61b45941c982c8482896b34455b1c68d&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29 (STID 2604-3ab7, `test_keeper_incorrect_config::test_invalid_configs`). Write `trace_collector.reset()` in `ContextSharedPart::shutdown()` (Context.cpp:1069) vs read `has_value()` in `hasTraceCollector()` (Context.cpp:1131).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.849` (included in `26.7` and later)
<!-- ch-version-info:end -->