### PR TITLE
Fix flaky test `02161_addressToLineWithInlines`

### DIFF
--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -11,14 +11,24 @@ SELECT count() FROM numbers_mt(10000000000) SETTINGS log_comment='02161_test_cas
 SET log_queries = 0;
 SET query_profiler_cpu_time_period_ns = 0;
 SYSTEM FLUSH LOGS query_log, trace_log;
-SET max_execution_time = 300;
 
 WITH
     lineWithInlines AS
     (
-        SELECT DISTINCT addressToLineWithInlines(arrayJoin(trace)) AS lineWithInlines FROM system.trace_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id =
+        -- Deduplicate addresses before calling addressToLineWithInlines to avoid
+        -- calling the slow DWARF-lookup function for every occurrence of an address
+        -- across all trace samples (which can be thousands with certain randomised
+        -- settings such as max_threads=1).
+        SELECT addressToLineWithInlines(addr) AS lineWithInlines
+        FROM
         (
-            SELECT query_id FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = currentDatabase() AND log_comment='02161_test_case' ORDER BY event_time DESC LIMIT 1
+            SELECT DISTINCT arrayJoin(trace) AS addr
+            FROM system.trace_log
+            WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id =
+            (
+                SELECT query_id FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = currentDatabase() AND log_comment='02161_test_case' ORDER BY event_time DESC LIMIT 1
+            )
+            LIMIT 1000
         )
     )
 SELECT 'has inlines:', or(max(length(lineWithInlines)) > 1, max(locate(lineWithInlines[1], ':')) = 0) FROM lineWithInlines SETTINGS short_circuit_function_evaluation='enable';

--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -1,4 +1,4 @@
--- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-llvm-coverage, no-flaky-check
+-- Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-llvm-coverage
 
 SET allow_introspection_functions = 0;
 SELECT addressToLineWithInlines(1); -- { serverError FUNCTION_NOT_ALLOWED }
@@ -28,7 +28,6 @@ WITH
             (
                 SELECT query_id FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = currentDatabase() AND log_comment='02161_test_case' ORDER BY event_time DESC LIMIT 1
             )
-            LIMIT 1000
         )
     )
 SELECT 'has inlines:', or(max(length(lineWithInlines)) > 1, max(locate(lineWithInlines[1], ':')) = 0) FROM lineWithInlines SETTINGS short_circuit_function_evaluation='enable';


### PR DESCRIPTION


<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Deduplicate addresses before DWARF lookup

### Description
`addressToLineWithInlines` is a slow DWARF-lookup function (~100 ms per call against the large ClickHouse binary).  The original query used `SELECT DISTINCT addressToLineWithInlines(arrayJoin(trace))`, which evaluated the function for every address occurrence across all profiler samples before deduplication — potentially tens of thousands of calls when randomised test settings include `max_threads=1` or a small `max_block_size`.

Fix: deduplicate the raw addresses with an inner `SELECT DISTINCT arrayJoin(trace) LIMIT 1000` first, then call the function only on the resulting unique set.

Failure example:

```
--- Randomized settings diagnosis ---
Step 1: Re-running with the same randomized settings (budget: 60s)...
  Runs: 1, Failed: 0, Passed: 1, Other: 0
Result: All reruns passed. The failure is not reproducible (likely a transient issue).

2026-06-12 13:16:23 Reason: return code:  159
2026-06-12 13:16:23 Received exception from server (version 26.6.1):
2026-06-12 13:16:23 Code: 159. DB::Exception: Received from localhost:9000. DB::Exception: Timeout exceeded: elapsed 352311.223986 ms, maximum: 300000 ms. (TIMEOUT_EXCEEDED)
2026-06-12 13:16:23 (query: WITH
2026-06-12 13:16:23     lineWithInlines AS
2026-06-12 13:16:23     (
2026-06-12 13:16:23         SELECT DISTINCT addressToLineWithInlines(arrayJoin(trace)) AS lineWithInlines FROM system.trace_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id =
2026-06-12 13:16:23         (
2026-06-12 13:16:23             SELECT query_id FROM system.query_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = currentDatabase() AND log_comment='02161_test_case' ORDER BY event_time DESC LIMIT 1
2026-06-12 13:16:23         )
2026-06-12 13:16:23     )
2026-06-12 13:16:23 SELECT 'has inlines:', or(max(length(lineWithInlines)) > 1, max(locate(lineWithInlines[1], ':')) = 0) FROM lineWithInlines SETTINGS short_circuit_function_evaluation='enable';), result:
2026-06-12 13:16:23 
2026-06-12 13:16:23 10000000000
2026-06-12 13:16:23 
2026-06-12 13:16:23 stdout:
2026-06-12 13:16:23 10000000000
2026-06-12 13:16:23 
2026-06-12 13:16:23 
2026-06-12 13:16:23 Settings used in the test: --max_insert_threads 2 --group_by_two_level_threshold 1 --group_by_two_level_threshold_bytes 50000000 --distributed_aggregation_memory_efficient 1 --fsync_metadata 0 --output_format_parallel_formatting 0 --input_format_parallel_parsing 1 --min_chunk_bytes_for_parallel_parsing 17198530 --max_read_buffer_size 770123 --prefer_localhost_replica 0 --max_block_size 12111 --max_joined_block_size_rows 22477 --joined_block_split_single_row 0 --join_output_by_rowlist_perkey_rows_threshold 1 --max_threads 1 --optimize_append_index 0 --use_hedged_requests 0 --optimize_if_chain_to_multiif 0 --optimize_if_transform_strings_to_enum 0 --optimize_read_in_order 0 --optimize_or_like_chain 0 --optimize_substitute_columns 1 --enable_multiple_prewhere_read_steps 0 --read_in_order_two_level_merge_threshold 43 --optimize_aggregation_in_order 1 --aggregation_in_order_max_block_bytes 21886800 --use_uncompressed_cache 1 --min_bytes_to_use_direct_io 10737418240 --min_bytes_to_use_mmap_io 3362575190 --local_filesystem_read_method read --local_filesystem_read_prefetch 1 --filesystem_cache_segments_batch_size 0 --read_from_filesystem_cache_if_exists_otherwise_bypass_cache 1 --throw_on_error_from_cache_on_write_operations 1 --remote_filesystem_read_prefetch 1 --distributed_cache_discard_connection_if_unread_data 0 --distributed_cache_use_clients_cache_for_write 0 --distributed_cache_use_clients_cache_for_read 1 --allow_prefetched_read_pool_for_remote_filesystem 0 --filesystem_prefetch_max_memory_usage 64Mi --filesystem_prefetches_limit 0 --filesystem_prefetch_min_bytes_for_single_read_task 8Mi --filesystem_prefetch_step_marks 0 --filesystem_prefetch_step_bytes 100Mi --enable_filesystem_cache 1 --enable_filesystem_cache_on_write_operations 1 --compile_expressions 1 --compile_aggregate_expressions 1 --compile_sort_description 0 --merge_tree_coarse_index_granularity 5 --optimize_distinct_in_order 0 --max_bytes_before_remerge_sort 1157387842 --min_compress_block_size 1726999 --max_compress_block_size 2292732 --merge_tree_compact_parts_min_granules_to_multibuffer_read 104 --optimize_sorting_by_input_stream_properties 0 --http_response_buffer_size 7079704 --http_wait_end_of_query False --enable_memory_bound_merging_of_aggregation_results 1 --min_count_to_compile_expression 0 --min_count_to_compile_aggregate_expression 3 --min_count_to_compile_sort_description 0 --session_timezone Africa/Juba --use_page_cache_for_disks_without_file_cache True --use_page_cache_for_local_disks False --use_page_cache_for_object_storage False --page_cache_inject_eviction True --merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability 0.27 --prefer_external_sort_block_bytes 100000000 --cross_join_min_rows_to_compress 1 --cross_join_min_bytes_to_compress 0 --min_external_table_block_size_bytes 0 --max_parsing_threads 1 --optimize_functions_to_subcolumns 0 --parallel_replicas_local_plan 0 --query_plan_join_swap_table auto --enable_vertical_final 0 --optimize_extract_common_expressions 0 --optimize_rewrite_array_exists_to_has False --optimize_skip_unused_shards True --optimize_trivial_approximate_count_query False --optimize_trivial_insert_select True --optimize_using_constraints False --optimize_syntax_fuse_functions False --optimize_aggregators_of_group_by_keys True --optimize_and_compare_chain True --optimize_arithmetic_operations_in_aggregate_functions True --optimize_count_from_files True --optimize_distributed_group_by_sharding_key True --optimize_empty_string_comparisons True --optimize_group_by_constant_keys True --optimize_group_by_function_keys True --optimize_injective_functions_in_group_by True --optimize_injective_functions_inside_uniq True --optimize_inverse_dictionary_lookup True --optimize_move_to_prewhere True --optimize_multiif_to_if False --optimize_normalize_count_variants True --optimize_on_insert True --optimize_redundant_functions_in_order_by True --optimize_respect_aliases True --optimize_rewrite_aggregate_function_with_if True --optimize_rewrite_regexp_functions True --optimize_rewrite_sum_if_to_count_if True --optimize_skip_unused_shards_rewrite_in True --optimize_time_filter_with_preimage True --optimize_trivial_count_query True --optimize_uniq_to_count True --optimize_use_projections True --optimize_use_implicit_projections True --optimize_use_projection_filtering True --query_plan_optimize_lazy_materialization True --query_plan_optimize_prewhere True --use_async_executor_for_materialized_views 1 --use_query_condition_cache 0 --secondary_indices_enable_bulk_filtering 1 --use_skip_indexes_if_final 1 --use_skip_indexes_on_data_read 1 --optimize_rewrite_like_perfect_affix 1 --enable_lazy_columns_replication 0 --allow_special_serialization_kinds_in_output_formats 1 --use_skip_indexes_for_top_k 1 --use_top_k_dynamic_filtering 0 --query_plan_max_limit_for_top_k_optimization 0 --query_plan_read_in_order_through_join 1 --read_in_order_use_virtual_row 1 --short_circuit_function_evaluation_for_nulls_threshold 1.0978848513872042 --automatic_parallel_replicas_mode 0 --temporary_files_buffer_size 833604 --query_plan_optimize_join_order_algorithm greedy --max_bytes_before_external_join 1000000000 --grace_hash_join_initial_buckets 8 --use_top_k_dynamic_filtering_for_variable_length_types False --page_cache_max_coalesced_bytes 65536 --optimize_dictget_tuple_element True --execute_exists_as_scalar_subquery True --normalize_function_names True --enable_join_runtime_filters True --enable_parallel_blocks_marshalling True --query_plan_reuse_storage_ordering_for_window_functions False --query_plan_join_shard_by_pk_ranges False --count_distinct_optimization True --enable_add_distinct_to_in_subqueries False --use_statistics True --use_statistics_cache True --enable_optimize_predicate_expression True --enable_optimize_predicate_expression_to_final_subquery True --enable_software_prefetch_in_aggregation True --allow_reorder_prewhere_conditions True --query_plan_merge_filters False --query_plan_remove_unused_columns True --query_plan_convert_outer_join_to_inner_join True --query_plan_convert_any_join_to_semi_or_anti_join False --query_plan_merge_filter_into_join_condition False --query_plan_enable_multithreading_after_window_functions True --query_plan_max_limit_for_lazy_materialization 1 --query_plan_optimize_join_order_limit 1 --query_plan_direct_read_from_text_index True --query_plan_text_index_add_hint True --optimize_truncate_order_by_after_group_by_keys True --enable_automatic_decision_for_merging_across_partitions_for_final True --parallel_non_joined_rows_processing True --use_skip_indexes_for_disjunctions True --use_hash_table_stats_for_join_reordering True --allow_calculating_subcolumns_sizes_for_merge_tree_reading True --use_join_disjunctions_push_down True --enable_join_transitive_predicates False --max_bytes_before_external_sort 0 --max_bytes_before_external_group_by 0 --max_bytes_ratio_before_external_sort 0.0 --max_bytes_ratio_before_external_group_by 0.12 --use_skip_indexes_if_final_exact_mode 1
2026-06-12 13:16:23 
2026-06-12 13:16:23 MergeTree settings used in test: --ratio_of_defaults_for_sparse_serialization 1.0 --prefer_fetch_merged_part_size_threshold 10737418240 --vertical_merge_algorithm_min_rows_to_activate 1 --vertical_merge_algorithm_min_columns_to_activate 1 --allow_vertical_merges_from_compact_to_wide_parts 1 --min_merge_bytes_to_use_direct_io 1 --index_granularity_bytes 10472004 --merge_max_block_size 2964 --index_granularity 51574 --min_bytes_for_wide_part 1073741824 --marks_compress_block_size 83526 --primary_key_compress_block_size 39648 --replace_long_file_name_to_hash 1 --max_file_name_length 128 --min_bytes_for_full_part_storage 536870912 --compact_parts_max_bytes_to_buffer 95219250 --compact_parts_max_granules_to_buffer 55 --compact_parts_merge_max_bytes_to_prefetch_part 5266594 --cache_populated_by_fetch 1 --concurrent_part_removal_threshold 27 --old_parts_lifetime 288 --prewarm_mark_cache 0 --use_const_adaptive_granularity 1 --enable_index_granularity_compression 0 --enable_block_number_column 1 --enable_block_offset_column 1 --use_primary_key_cache 0 --prewarm_primary_key_cache 1 --object_serialization_version v3 --object_shared_data_serialization_version map_with_buckets --object_shared_data_serialization_version_for_zero_level_parts map --object_shared_data_buckets_for_compact_part 18 --object_shared_data_buckets_for_wide_part 15 --dynamic_serialization_version v2 --serialization_info_version with_types --string_serialization_version single_stream --nullable_serialization_version basic --enable_shared_storage_snapshot_in_query 1 --min_columns_to_activate_adaptive_write_buffer 210 --reduce_blocking_parts_sleep_ms 1238 --shared_merge_tree_outdated_parts_group_size 2 --shared_merge_tree_max_outdated_parts_to_process_at_once 4 --map_serialization_version with_buckets --map_serialization_version_for_zero_level_parts basic --max_buckets_in_map 91 --map_buckets_strategy linear --map_buckets_min_avg_size 213 --map_buckets_coefficient 1.01 --propagate_types_serialization_versions_to_nested_types 1 --compress_per_column_in_compact_parts 0
2026-06-12 13:16:23 
2026-06-12 13:16:23 Database: test_laqip9uu
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.829`
<!-- ch-version-info:end -->