### PR TITLE
Fix session_timezone ignored on LowCardinality(DateTime)

### DIFF
--- a/src/DataTypes/Serializations/SerializationLowCardinality.cpp
+++ b/src/DataTypes/Serializations/SerializationLowCardinality.cpp
@@ -44,11 +44,22 @@ SerializationLowCardinality::SerializationLowCardinality(const DataTypePtr & dic
 
 UInt128 SerializationLowCardinality::getHash(const DataTypePtr & dictionary_type_)
 {
+    /// The dictionary type name alone is not enough: a type whose default
+    /// serialization depends on session settings (DateTime under session_timezone)
+    /// needs a distinct pool entry per effective serialization.
+    auto nested_serialization = dictionary_type_->getDefaultSerialization();
+    auto dict_inner_serialization = removeNullable(dictionary_type_)->getDefaultSerialization();
+
     SipHash hash;
     hash.update("LowCardinality");
     auto dict_type_name = dictionary_type_->getName();
     hash.update(dict_type_name.size());
     hash.update(dict_type_name);
+    if (nested_serialization->supportsPooling())
+        hash.update(nested_serialization->getHash());
+    if (dict_inner_serialization->supportsPooling()
+        && dict_inner_serialization.get() != nested_serialization.get())
+        hash.update(dict_inner_serialization->getHash());
     return hash.get128();
 }
 

--- a/tests/queries/0_stateless/04322_106474_session_timezone_lowcardinality_datetime_csv_roundtrip.reference
+++ b/tests/queries/0_stateless/04322_106474_session_timezone_lowcardinality_datetime_csv_roundtrip.reference
@@ -1,0 +1,3 @@
+2026-06-01 10:00:00
+thimphu-bytes-equal	1
+tokyo-bytes-equal	1

--- a/tests/queries/0_stateless/04322_106474_session_timezone_lowcardinality_datetime_csv_roundtrip.sh
+++ b/tests/queries/0_stateless/04322_106474_session_timezone_lowcardinality_datetime_csv_roundtrip.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: uses clickhouse-local.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -e
+
+# Run in a private clickhouse-local process so the global serialization pool is
+# uncontended: the bug only reproduces when an entry warmed under one timezone
+# is reused for output under another, and a fresh process makes that
+# deterministic regardless of what other tests run concurrently on a shared server.
+workdir="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}.d"
+rm -rf "${workdir}"
+mkdir -p "${workdir}"
+
+cleanup() {
+    rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+(
+cd "${workdir}"
+${CLICKHOUSE_LOCAL} --path . -nm --query "
+SET allow_suspicious_low_cardinality_types = 1;
+SET engine_file_truncate_on_insert = 1;
+
+CREATE TABLE t_106474_lc (c0 LowCardinality(DateTime)) ENGINE = MergeTree() ORDER BY tuple();
+CREATE TABLE t_106474_dt (c0 DateTime) ENGINE = MergeTree() ORDER BY tuple();
+
+INSERT INTO t_106474_lc (c0) VALUES ('2026-06-01 10:00:00');
+INSERT INTO t_106474_dt (c0) SELECT c0 FROM t_106474_lc;
+
+-- Warm the LowCardinality(DateTime) serialization under the default timezone.
+SELECT c0 FROM t_106474_lc FORMAT TSV;
+
+SET session_timezone = 'Asia/Thimphu';
+INSERT INTO TABLE FUNCTION file('lc_thimphu.csv', 'CSV', 'c0 LowCardinality(DateTime)') SELECT c0 FROM t_106474_lc;
+INSERT INTO TABLE FUNCTION file('dt_thimphu.csv', 'CSV', 'c0 DateTime') SELECT c0 FROM t_106474_dt;
+
+SET session_timezone = 'Asia/Tokyo';
+INSERT INTO TABLE FUNCTION file('lc_tokyo.csv', 'CSV', 'c0 LowCardinality(DateTime)') SELECT c0 FROM t_106474_lc;
+INSERT INTO TABLE FUNCTION file('dt_tokyo.csv', 'CSV', 'c0 DateTime') SELECT c0 FROM t_106474_dt;
+"
+)
+
+# Both tables hold the same unix timestamp, so under any session_timezone the
+# CSV output for LowCardinality(DateTime) and DateTime must be identical.
+echo -n 'thimphu-bytes-equal	'
+if cmp -s "${workdir}/lc_thimphu.csv" "${workdir}/dt_thimphu.csv"; then echo 1; else echo 0; fi
+echo -n 'tokyo-bytes-equal	'
+if cmp -s "${workdir}/lc_tokyo.csv" "${workdir}/dt_tokyo.csv"; then echo 1; else echo 0; fi


### PR DESCRIPTION
<!--
Linked issues and pull requests.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106474
Related: https://github.com/ClickHouse/ClickHouse/pull/106634
Related: https://github.com/ClickHouse/ClickHouse/pull/107315
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/106474
Related: https://github.com/ClickHouse/ClickHouse/pull/106634 (reverted by #107315)
Related: https://github.com/ClickHouse/ClickHouse/pull/107315

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `session_timezone` being ignored when formatting a `LowCardinality(DateTime)` column. The cached `LowCardinality` serialization froze the first effective timezone, so later output under a different `session_timezone` used the wrong timezone while a plain `DateTime` column was formatted correctly.


### Description

Reintroduction of #106634, which was reverted in #107315 because its regression test was flaky.

Root cause (unchanged from #106634): `SerializationLowCardinality::getHash` only mixed the dictionary type NAME into the global `SerializationObjectPool` key. Every sibling wrapper serialization (`Nullable`, `Array`, `Map`, `Tuple`, `MapKeysOrValues`) also mixes its nested serialization hash into the key; `LowCardinality` was the lone exception. As a result the cached `SerializationLowCardinality(DateTime)` froze whichever effective `session_timezone` was resolved first, so a later CSV write under a different `session_timezone` reused the stale serialization and emitted the wrong wall-clock string. The fix mixes the nested (and dict-inner) serialization hashes into the pool key, matching the sibling pattern.

Why the previous test was flaky and how this one is stable: the reverted test drove the repro through the shared stateless test server. The `SerializationObjectPool` is process-global and shared by all concurrent tests on that server, so on the slow `amd_llvm_coverage` + `ParallelReplicas` + `s3 storage` variant the byte-equality check was non-deterministic (`thimphu-bytes-equal` flapped to `0`). The reintroduced test runs the entire repro inside a private `clickhouse-local` process, so the pool is uncontended and the assertion is deterministic on every variant, while still failing on the unfixed `getHash`.

Validation: the regression test FAILS before the fix and PASSES after (verified by rebuilding the binary both ways). With the fix it is stable across 40 runs with random settings on s3 storage and with parallel replicas forced.
