### PR TITLE
Fix flaky Kafka integration tests: retry get_admin_client on NoBrokersAvailable

### DIFF
--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -110,10 +110,20 @@ def existing_kafka_topic(admin_client, topic_name, max_retries=50):
         kafka_delete_topic(admin_client, topic_name, max_retries)
 
 
-def get_admin_client(kafka_cluster):
-    return KafkaAdminClient(
-        bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
-    )
+def get_admin_client(kafka_cluster, retries=15):
+    # Broker may not be reachable yet; retry like get_kafka_producer() instead of
+    # raising NoBrokersAvailable on the first attempt.
+    errors = []
+    for _ in range(retries):
+        try:
+            return KafkaAdminClient(
+                bootstrap_servers="localhost:{}".format(kafka_cluster.kafka_port)
+            )
+        except kafka.errors.NoBrokersAvailable as e:
+            errors += [str(e)]
+            time.sleep(1)
+
+    raise Exception("Admin client connection not established, {}".format(errors))
 
 
 def kafka_produce(kafka_cluster, topic, messages, timestamp=None, retries=15):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`helpers/kafka/common.py::get_admin_client` built `KafkaAdminClient` with no retry. When the broker has not finished its metadata bootstrap yet, the constructor raises `kafka.errors.NoBrokersAvailable` and fails the test. It is called from the autouse `kafka_setup_teardown` fixture in several suites, so one transient hiccup fails every test in the file.

Fix: retry the same way `get_kafka_producer` already does (15 attempts, 1s apart), catching only `NoBrokersAvailable` so genuine failures still surface once retries are exhausted. `retries` defaults to 15, so all 62 existing callers are unaffected.

Observed via CIDB across 7 Kafka integration test files / 10 unrelated PRs in the last 30 days (e.g. `test_kafka_zone_awareness`, `test_mv_target_missing`, `test_batch_fast`, `test_batch_slow_2`), 0 master failures (PR-randomization-only signature).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.723`
<!-- ch-version-info:end -->