### PR TITLE
Fix `abseil` header-only source detection

### DIFF
--- a/contrib/abseil-cpp-cmake/CMakeLists.txt
+++ b/contrib/abseil-cpp-cmake/CMakeLists.txt
@@ -33,7 +33,7 @@ function(absl_cc_library)
   # Check if this is a header-only library
   set(ABSL_CC_SRCS "${ABSL_CC_LIB_SRCS}")
   foreach(src_file IN LISTS ABSL_CC_SRCS)
-    if(${src_file} MATCHES ".*\\.(h|inc)")
+    if(${src_file} MATCHES ".*\\.(h|inc)$")
       list(REMOVE_ITEM ABSL_CC_SRCS "${src_file}")
     endif()
   endforeach()


### PR DESCRIPTION
Fix `absl_cc_library` source classification by anchoring the header extension match to the end of the path.

Without the anchor, a checkout path containing a segment such as `/home/user.name/` can make `.cc` sources match `.h`, so `abseil` libraries are incorrectly created as header-only interface targets and dependent executables fail to link.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix building `abseil` when the ClickHouse checkout path contains a substring matching a header extension.

### Documentation entry:
- [x] Documentation is not required for this change.