### PR TITLE
Skip signalling for every log message

### DIFF
--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -358,7 +358,7 @@ void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
     /// Request the thread to flush as fast as possible (without acquiring the mutex every time)
     if (current_size > max_size / 2)
         request_flush = true;
-    if (unlikely(current_size == 1))
+    if (unlikely(current_size == 0))
         condition.notify_all();
 }
 

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -358,7 +358,7 @@ void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
     /// Request the thread to flush as fast as possible (without acquiring the mutex every time)
     if (current_size > max_size / 2)
         request_flush = true;
-    if (unlikely(current_size = 0))
+    if (unlikely(current_size = 1))
         condition.notify_all();
 }
 

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -358,7 +358,8 @@ void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
     /// Request the thread to flush as fast as possible (without acquiring the mutex every time)
     if (current_size > max_size / 2)
         request_flush = true;
-    condition.notify_one();
+    if (unlikely(current_size = 0))
+        condition.notify_all();
 }
 
 AsyncLogMessagePtr AsyncLogMessageQueue::waitDequeueMessage()

--- a/src/Loggers/OwnSplitChannel.cpp
+++ b/src/Loggers/OwnSplitChannel.cpp
@@ -358,7 +358,7 @@ void AsyncLogMessageQueue::enqueueMessage(AsyncLogMessagePtr message)
     /// Request the thread to flush as fast as possible (without acquiring the mutex every time)
     if (current_size > max_size / 2)
         request_flush = true;
-    if (unlikely(current_size = 1))
+    if (unlikely(current_size == 1))
         condition.notify_all();
 }
 


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced CPU overhead of asynchronous logging under high log rates by notifying the log consumer only on the empty-to-non-empty queue transition instead of on every message.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.815`
- Backported to: `26.5.3.36`, `26.4.5.41`
<!-- ch-version-info:end -->