### PR TITLE
Fix arm_tidy build: initialize out_of_range_value in applyHistogramQuantile

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.cpp
@@ -128,7 +128,7 @@ SQLQueryPiece applyHistogramQuantile(
         ASTPtr quantile_expr;
         if (std::isnan(phi) || phi < 0.0 || phi > 1.0)
         {
-            Float64 out_of_range_value;
+            Float64 out_of_range_value = std::numeric_limits<Float64>::quiet_NaN();
             if (std::isnan(phi))
                 out_of_range_value = std::numeric_limits<Float64>::quiet_NaN();
             else if (phi < 0.0)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/103477
-->

Related: #103477

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Build (arm_tidy)` is failing on master since #103477 was merged (commit `2e8e7f1eac35730248415d79f9c60a7e68d0c223`, 2026-06-12 18:23 UTC). `cppcoreguidelines-init-variables` (warnings-as-errors) rejects the uninitialized `Float64 out_of_range_value` in the new file `src/Storages/TimeSeries/PrometheusQueryToSQL/applyHistogramQuantile.cpp:131`:

```
applyHistogramQuantile.cpp:131:21: error: variable 'out_of_range_value' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
1 warning treated as error
```

arm_tidy is not a merge-queue gate, so the diagnostic was not blocking at merge time. All three branches below assign the variable, so it is logically safe, but the declaration must be initialized. Initialize it to `quiet_NaN()` at declaration (matches the `isnan(phi)` branch). No behavior change.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2e8e7f1eac35730248415d79f9c60a7e68d0c223&name_0=MasterCI&name_1=Build%20%28arm_tidy%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.731`
<!-- ch-version-info:end -->