### PR TITLE
Fix ORDER BY WITH FILL ignoring collation when grouping by sorting prefix

### DIFF
--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -587,6 +587,33 @@ bool FillingTransform::generateSuffixIfNeeded(
     return true;
 }
 
+/// Whether the sorting-prefix columns are equal at two positions, using the ORDER BY
+/// collation (the stream is sorted by it). Mirrors LimitTransform::sortColumnsEqualAt.
+template <typename LhsColumns, typename RhsColumns>
+static bool sortPrefixEqualAt(
+    const LhsColumns & lhs_columns,
+    size_t lhs_row,
+    const RhsColumns & rhs_columns,
+    size_t rhs_row,
+    const SortDescription & sort_prefix)
+{
+    for (size_t i = 0, size = sort_prefix.size(); i < size; ++i)
+    {
+        const IColumn & lhs = *lhs_columns[i];
+        const IColumn & rhs = *rhs_columns[i];
+
+        int res;
+        if (sort_prefix[i].collator && lhs.isCollationSupported())
+            res = lhs.compareAtWithCollation(lhs_row, rhs_row, rhs, sort_prefix[i].nulls_direction, *sort_prefix[i].collator);
+        else
+            res = lhs.compareAt(lhs_row, rhs_row, rhs, sort_prefix[i].nulls_direction);
+
+        if (res != 0)
+            return false;
+    }
+    return true;
+}
+
 template <typename Predicate>
 size_t getRangeEnd(size_t begin, size_t end, Predicate pred)
 {
@@ -857,16 +884,7 @@ void FillingTransform::transform(Chunk & chunk)
         for (size_t pos : sort_prefix_positions)
             last_sort_prefix_columns.push_back(last_row[pos].get());
 
-        new_sort_prefix = false;
-        for (size_t i = 0; i < input_sort_prefix_columns.size(); ++i)
-        {
-            const int res = input_sort_prefix_columns[i]->compareAt(0, 0, *last_sort_prefix_columns[i], sort_prefix[i].nulls_direction);
-            if (res != 0)
-            {
-                new_sort_prefix = true;
-                break;
-            }
-        }
+        new_sort_prefix = !sortPrefixEqualAt(input_sort_prefix_columns, 0, last_sort_prefix_columns, 0, sort_prefix);
     }
 
     for (size_t row_ind = 0; row_ind < num_rows;)
@@ -877,14 +895,8 @@ void FillingTransform::transform(Chunk & chunk)
             num_rows,
             [&](size_t pos_with_current_sort_prefix, size_t row_pos)
             {
-                for (size_t i = 0; i < input_sort_prefix_columns.size(); ++i)
-                {
-                    const int res = input_sort_prefix_columns[i]->compareAt(
-                        pos_with_current_sort_prefix, row_pos, *input_sort_prefix_columns[i], sort_prefix[i].nulls_direction);
-                    if (res != 0)
-                        return false;
-                }
-                return true;
+                return sortPrefixEqualAt(
+                    input_sort_prefix_columns, pos_with_current_sort_prefix, input_sort_prefix_columns, row_pos, sort_prefix);
             });
 
         /// generate suffix for the previous range

--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -602,7 +602,7 @@ static bool sortPrefixEqualAt(
         const IColumn & lhs = *lhs_columns[i];
         const IColumn & rhs = *rhs_columns[i];
 
-        int res;
+        int res = 0;
         if (sort_prefix[i].collator && lhs.isCollationSupported())
             res = lhs.compareAtWithCollation(lhs_row, rhs_row, rhs, sort_prefix[i].nulls_direction, *sort_prefix[i].collator);
         else

--- a/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.reference
+++ b/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.reference
@@ -1,0 +1,43 @@
+-- { echoOn }
+SET use_with_fill_by_sorting_prefix = 1;
+DROP TABLE IF EXISTS t_fill_collation;
+CREATE TABLE t_fill_collation (s String, n UInt64) ENGINE = Memory;
+-- Collation-equal spellings ('a' and 'A' under case-insensitive collation) must form a
+-- single fill group; otherwise each spelling is filled over the whole domain and produces
+-- spurious rows. Expected 6 rows (groups {'a','A'} and {'b'}), not 9.
+INSERT INTO t_fill_collation VALUES ('a', 1), ('A', 2), ('b', 1), ('b', 3);
+SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 4;
+a	1
+A	2
+A	3
+b	1
+b	2
+b	3
+-- Long run (> 16 rows, switches getRangeEnd to binary search) and short run (linear probe)
+-- of the same shape must group identically: one collation group of 'a'/'A'. Expected 16.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number = 8, 'A', 'a'), number + 1 FROM numbers(16);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 17);
+16
+-- Same shape, short run (< 16 rows). Expected 8, matching the long-run grouping above.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number = 4, 'A', 'a'), number + 1 FROM numbers(8);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 9);
+8
+-- Grouping must survive across chunk boundaries: interleaved 'a'/'A' over many blocks stay
+-- one collation group, so no fill rows are inserted. Expected 40000 (the original rows).
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number % 2 = 0, 'a', 'A'), number + 1 FROM numbers(40000);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL) SETTINGS max_block_size = 16384;
+40000
+-- DESC collated prefix: two groups {'b'} then {'a','A'}, 6 rows.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation VALUES ('a', 1), ('A', 2), ('b', 1), ('b', 3);
+SELECT s, n FROM t_fill_collation ORDER BY s DESC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 4;
+b	1
+b	2
+b	3
+a	1
+A	2
+A	3
+DROP TABLE t_fill_collation;

--- a/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.reference
+++ b/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.reference
@@ -1,4 +1,5 @@
 -- { echoOn }
+-- Tags: no-fasttest
 SET use_with_fill_by_sorting_prefix = 1;
 DROP TABLE IF EXISTS t_fill_collation;
 CREATE TABLE t_fill_collation (s String, n UInt64) ENGINE = Memory;

--- a/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.sql
+++ b/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.sql
@@ -1,0 +1,35 @@
+-- { echoOn }
+SET use_with_fill_by_sorting_prefix = 1;
+
+DROP TABLE IF EXISTS t_fill_collation;
+CREATE TABLE t_fill_collation (s String, n UInt64) ENGINE = Memory;
+
+-- Collation-equal spellings ('a' and 'A' under case-insensitive collation) must form a
+-- single fill group; otherwise each spelling is filled over the whole domain and produces
+-- spurious rows. Expected 6 rows (groups {'a','A'} and {'b'}), not 9.
+INSERT INTO t_fill_collation VALUES ('a', 1), ('A', 2), ('b', 1), ('b', 3);
+SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 4;
+
+-- Long run (> 16 rows, switches getRangeEnd to binary search) and short run (linear probe)
+-- of the same shape must group identically: one collation group of 'a'/'A'. Expected 16.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number = 8, 'A', 'a'), number + 1 FROM numbers(16);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 17);
+
+-- Same shape, short run (< 16 rows). Expected 8, matching the long-run grouping above.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number = 4, 'A', 'a'), number + 1 FROM numbers(8);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 9);
+
+-- Grouping must survive across chunk boundaries: interleaved 'a'/'A' over many blocks stay
+-- one collation group, so no fill rows are inserted. Expected 40000 (the original rows).
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation SELECT if(number % 2 = 0, 'a', 'A'), number + 1 FROM numbers(40000);
+SELECT count() FROM (SELECT s, n FROM t_fill_collation ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL) SETTINGS max_block_size = 16384;
+
+-- DESC collated prefix: two groups {'b'} then {'a','A'}, 6 rows.
+TRUNCATE TABLE t_fill_collation;
+INSERT INTO t_fill_collation VALUES ('a', 1), ('A', 2), ('b', 1), ('b', 3);
+SELECT s, n FROM t_fill_collation ORDER BY s DESC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 4;
+
+DROP TABLE t_fill_collation;

--- a/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.sql
+++ b/tests/queries/0_stateless/03935_with_fill_by_sorting_prefix_collation.sql
@@ -1,4 +1,5 @@
 -- { echoOn }
+-- Tags: no-fasttest
 SET use_with_fill_by_sorting_prefix = 1;
 
 DROP TABLE IF EXISTS t_fill_collation;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107361
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/107361

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ORDER BY ... WITH FILL` producing extra rows when an ORDER BY column before the fill column uses a `COLLATE` collation. The rows are now grouped by the sorting prefix using that collation, matching the sort order.

### Description
With `use_with_fill_by_sorting_prefix` enabled (the default), `FillingTransform` groups rows by the ORDER BY columns that precede the fill column and fills each group independently. The grouping compared the prefix columns bytewise via `IColumn::compareAt`, ignoring the ORDER BY collator. Because the stream is sorted by that collator, the bytewise equality predicate disagrees with the sort order, which caused two wrong-result bugs:

1. Collation-equal spellings (for example `'a'` and `'A'` under the case-insensitive `en-u-ks-level2` collation) were split into separate groups, so each spelling was filled over the whole fill domain and produced spurious extra rows.
2. `getRangeEnd` switches from a linear probe to a binary search after 16 rows; the binary search assumes equal rows are contiguous, which a collated sort does not guarantee for bytewise comparison. The same data shape was grouped differently depending on run length.

The fix makes the prefix comparison collation-aware via a small helper that mirrors `LimitTransform::sortColumnsEqualAt` (`compareAtWithCollation` when a collator is present and the column supports it, else `compareAt`), used at both the intra-chunk `getRangeEnd` predicate and the cross-chunk prefix check. Once the equality predicate matches the collated sort order, equal rows are contiguous again, so the binary search is valid too.

Minimal reproducer from the issue:
```sql
CREATE TABLE t (s String, n UInt64) ENGINE = Memory;
INSERT INTO t VALUES ('a', 1), ('A', 2), ('b', 1), ('b', 3);
SELECT s, n FROM t ORDER BY s ASC COLLATE 'en-u-ks-level2', n ASC WITH FILL FROM 1 TO 4;
```
Returned 9 rows before the fix (`'a'` and `'A'` filled as separate groups); returns the expected 6 rows after.

New stateless test `03935_with_fill_by_sorting_prefix_collation` covers the minimal collation-split case, the long-run vs short-run consistency case, grouping across chunk boundaries, and a DESC collated prefix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.735`
<!-- ch-version-info:end -->