### PR TITLE
Make test_postgresql_protocol::test_dotnet_client robust to build noise

### DIFF
--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -513,11 +513,11 @@ def test_dotnet_client(started_cluster):
             f"cd /pg_testapp && dotnet run -- --host {node.hostname} --port {server_port} --username default --password 123",
         ],
     )
-    # `dotnet run` builds first, so the .NET SDK can prepend build diagnostics
-    # (e.g. a Roslyn `CSC : warning AD0001` analyzer crash) to stdout. Match the
-    # reference as a substring so such environmental noise does not break the
-    # protocol assertion. Mirrors test_mysql_protocol::test_mysql_dotnet_client.
-    assert reference in res
+    # `dotnet run` builds first, so the .NET SDK can prepend build diagnostics to
+    # stdout. That noise only appears before the client output, so tolerate it
+    # with a directional suffix check while still catching any trailing or
+    # inserted protocol divergence.
+    assert res.endswith(reference)
 
 
 def test_restricted_user_cannot_bypass_grants(started_cluster):

--- a/tests/integration/test_postgresql_protocol/test.py
+++ b/tests/integration/test_postgresql_protocol/test.py
@@ -513,7 +513,11 @@ def test_dotnet_client(started_cluster):
             f"cd /pg_testapp && dotnet run -- --host {node.hostname} --port {server_port} --username default --password 123",
         ],
     )
-    assert res == reference
+    # `dotnet run` builds first, so the .NET SDK can prepend build diagnostics
+    # (e.g. a Roslyn `CSC : warning AD0001` analyzer crash) to stdout. Match the
+    # reference as a substring so such environmental noise does not break the
+    # protocol assertion. Mirrors test_mysql_protocol::test_mysql_dotnet_client.
+    assert reference in res
 
 
 def test_restricted_user_cannot_bypass_grants(started_cluster):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/103786
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/103786

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a fragile assertion in `test_postgresql_protocol/test.py::test_dotnet_client`.

The test runs `cd /pg_testapp && dotnet run` inside the client container. `dotnet run` builds the project first, so the .NET SDK can emit build diagnostics to the same stdout that the test captures. In one CI run (PR #103786, `Integration tests (arm_binary, distributed plan, 3/4)`, 2026-06-07) the Roslyn analyzer crashed and the C# compiler prepended this line to stdout:

```
CSC : warning AD0001: Analyzer 'Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpDetectPreviewFeatureAnalyzer' threw an exception of type 'System.NullReferenceException' with message 'Object reference not set to an instance of an object.'. [/pg_testapp/testapp.csproj]
```

That noise line broke the exact-match `assert res == reference`. It is an environmental .NET SDK / Roslyn analyzer flake, not a server or protocol regression (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103786&sha=29572639d6267a40cbf6aeaa13257d3bfc5ffb9c&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29).

The sibling test `test_mysql_protocol/test.py::test_mysql_dotnet_client` already guards against this with a substring match (`assert reference in res`, commented "there is some thrash at the beggining of output"). This change applies the same approach to the PostgreSQL test. The full reference must still appear contiguously, so any real change to the wire-protocol output is still caught; only leading/trailing build-tool noise is tolerated.

Surfaced and requested by @alexey-milovidov on #103786 (the AD0001 line is unrelated to that PR, which only touches the C++ HTTP connection pool / host resolver).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.737`
<!-- ch-version-info:end -->