### PR TITLE
Batch CREATE TABLE loop in test_replicated_database::test_sync_replica

### DIFF
--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -1219,13 +1219,14 @@ def test_sync_replica(started_cluster):
     with PartitionManager() as pm:
         pm.drop_instance_zk_connections(dummy_node)
 
-        for i in range(number_of_tables):
-            main_node.query(
-                "CREATE TABLE test_sync_database.table_{} (n int) ENGINE=MergeTree order by n".format(
-                    i
-                ),
-                settings=settings,
+        # Single client invocation: one process spawn instead of N.
+        create_queries = "\n".join(
+            "CREATE TABLE test_sync_database.table_{} (n int) ENGINE=MergeTree order by n;".format(
+                i
             )
+            for i in range(number_of_tables)
+        )
+        main_node.query(create_queries, settings=settings)
 
     # wait for host to reconnect
     dummy_node.query_with_retry("SELECT * FROM system.zookeeper WHERE path='/'")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107378
-->

Closes: #107378

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_replicated_database::test_sync_replica` created 1000 tables in a Python loop, one `node.query()` per table. The integration harness (`tests/integration/helpers/client.py`) spawns a fresh `clickhouse-client` subprocess per `node.query()`, so each table paid process start + TCP connect + auth + teardown.

Measured on the failing flavor (`amd_asan_ubsan, db disk, old analyzer`): server-side CREATE was ~33ms median, but the harness idled ~406ms between requests, so ~87% of the ~0.47s per-table wall time was harness overhead, not the engine. Total runtime crept to ~915s and crossed the 900s pytest-timeout (#107378).

Fix: submit all 1000 CREATE statements in a single client invocation (one multi-statement string through one `node.query()`). This keeps the original 1000-table count, so the disconnected-replica DDL-log catch-up coverage is unchanged (each CREATE is still its own DDL queue entry, replayed on reconnect via `SYSTEM SYNC DATABASE REPLICA`), while removing the per-table process spawn.

Runtime on the same flavor (`Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/6)`) drops from ~915s to 224s, verified locally (1 passed in 223.66s).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.879` (included in `26.6` and later)
- Backported to: `26.5.6.110`
<!-- ch-version-info:end -->