### PR TITLE
Fix broken-promise server abort in threadPoolCallbackRunnerUnsafe on shutdown

### DIFF
--- a/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
+++ b/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
@@ -70,9 +70,10 @@ TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
             {
                 pool.wait();
             }
-            catch (...)
+            catch (const std::exception &)
             {
-                /// The blocker's std::runtime_error is rethrown here; expected.
+                /// The blocker's std::runtime_error is rethrown here; expected. Catch the concrete
+                /// std::exception (not catch-all) so anything unexpected propagates and fails the test.
             }
             /// Pool destructor (finalize) runs at scope exit and joins the worker.
         }

--- a/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
+++ b/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
@@ -1,0 +1,102 @@
+#include <Common/threadPoolCallbackRunner.h>
+#include <Common/ThreadPool.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/Exception.h>
+#include <Common/setThreadName.h>
+
+#include <future>
+#include <vector>
+#include <gtest/gtest.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric LocalThread;
+    extern const Metric LocalThreadActive;
+    extern const Metric LocalThreadScheduled;
+}
+
+using namespace DB;
+
+/// Regression test for the broken-promise abort (STID 2508-38c6).
+///
+/// A task scheduled through threadPoolCallbackRunnerUnsafe that the pool drops unrun during
+/// shutdown must NOT leave its std::promise unsatisfied. A std::packaged_task destroyed unrun
+/// stores a broken-promise std::future_error (a std::logic_error) into the shared state; when a
+/// waiter observes it via future.get(), the server reports it as a LOGICAL_ERROR
+/// (getCurrentExceptionMessageAndPattern -> abortOnFailedAssertion), aborting the process.
+///
+/// The runner must instead store a normal DB::Exception so future.get() throws an ordinary,
+/// catchable error and nothing aborts. DB::Exception is NOT a std::logic_error, so even if the
+/// waiter feeds it through the server's exception reporting it will not abort.
+TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
+{
+    for (size_t iteration = 0; iteration < 20; ++iteration)
+    {
+        constexpr size_t num_victims = 32;
+
+        std::vector<std::future<void>> victim_futures;
+        victim_futures.reserve(num_victims);
+
+        std::promise<void> release;
+        std::shared_future<void> release_future = release.get_future().share();
+
+        {
+            /// shutdown_on_exception = true (default): when the blocker throws, the worker sets
+            /// shutdown=true and then drains the remaining queued jobs without running them.
+            ThreadPool pool(
+                CurrentMetrics::LocalThread,
+                CurrentMetrics::LocalThreadActive,
+                CurrentMetrics::LocalThreadScheduled,
+                /*max_threads=*/ 1,
+                /*max_free_threads=*/ 1,
+                /*queue_size=*/ 1000);
+
+            /// Occupy the single worker. It blocks until we release it, guaranteeing the victim
+            /// tasks below are all queued behind it. On release it throws, which triggers shutdown.
+            pool.scheduleOrThrowOnError([release_future]()
+            {
+                release_future.wait();
+                throw std::runtime_error("trigger shutdown_on_exception");
+            });
+
+            auto runner = threadPoolCallbackRunnerUnsafe<void>(pool, ThreadName::UNKNOWN);
+            for (size_t i = 0; i < num_victims; ++i)
+                victim_futures.push_back(runner([]() {}, Priority{}));
+
+            /// Release the blocker -> it throws -> worker sets shutdown and drains the victims unrun.
+            release.set_value();
+
+            try
+            {
+                pool.wait();
+            }
+            catch (...)
+            {
+                /// The blocker's std::runtime_error is rethrown here; expected.
+            }
+            /// Pool destructor (finalize) runs at scope exit and joins the worker.
+        }
+
+        /// Each victim either ran (set_value) or was dropped on shutdown. A dropped task must carry
+        /// a normal DB::Exception, never a broken-promise std::future_error. Catch future_error
+        /// specifically and fail if we see it -- that is the bug.
+        for (auto & future : victim_futures)
+        {
+            ASSERT_TRUE(future.valid());
+            try
+            {
+                future.get();
+            }
+            catch (const std::future_error & e)
+            {
+                FAIL() << "iteration " << iteration
+                       << ": victim task was dropped without satisfying its promise (broken promise): "
+                       << e.what();
+            }
+            catch (const Exception &)
+            {
+                /// Expected for dropped tasks: a normal, catchable DB::Exception (CANNOT_SCHEDULE_TASK).
+            }
+        }
+    }
+}

--- a/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
+++ b/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
@@ -70,10 +70,11 @@ TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
             {
                 pool.wait();
             }
-            catch (const std::exception &)
+            catch (const std::exception & e)
             {
                 /// The blocker's std::runtime_error is rethrown here; expected. Catch the concrete
                 /// std::exception (not catch-all) so anything unexpected propagates and fails the test.
+                SUCCEED() << "pool.wait() rethrew the expected shutdown exception: " << e.what();
             }
             /// Pool destructor (finalize) runs at scope exit and joins the worker.
         }
@@ -94,9 +95,10 @@ TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
                        << ": victim task was dropped without satisfying its promise (broken promise): "
                        << e.what();
             }
-            catch (const Exception &)
+            catch (const Exception & e)
             {
                 /// Expected for dropped tasks: a normal, catchable DB::Exception (CANNOT_SCHEDULE_TASK).
+                EXPECT_EQ(e.code(), ErrorCodes::CANNOT_SCHEDULE_TASK) << e.what();
             }
         }
     }

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -93,14 +93,28 @@ struct CallbackRunnerTask
         if (was_run)
             return;
 
-        /// Task dropped unrun (the pool was shut down while it was still queued). Satisfy the promise
-        /// with a normal exception instead of letting ~promise() store the broken-promise
-        /// std::future_error (a std::logic_error that aborts the server).
+        /// The task was dropped without running (the pool was shut down while it was still queued,
+        /// so ThreadPool::worker drains it via job_data.reset()). Mirror the run() path above:
         ///
-        /// Build the exception_ptr first: constructing the DB::Exception captures a stack trace and
-        /// may itself throw (e.g. std::bad_alloc under shutdown memory pressure). If it does, fall
-        /// back to the in-flight exception so the promise is NEVER left unset (an unset promise here
-        /// recreates the very broken-promise std::future_error this class exists to prevent).
+        /// 1. Release the callback (destroying its captures) under the task's thread group and
+        ///    BEFORE satisfying the promise. set_exception can wake a waiter immediately; a waiter
+        ///    that treats future.get() as "the task is done" may then tear down state that the
+        ///    captures reference, so the captures must be gone first (same ordering the run path
+        ///    keeps with ThreadGroupSwitcher + SCOPE_EXIT_SAFE before set_value). ThreadGroupSwitcher's
+        ///    ctor is noexcept and a no-op for a null/identical group, so this is safe on the drain
+        ///    thread; SCOPE_EXIT_SAFE keeps a throwing capture destructor from escaping this destructor.
+        {
+            ThreadGroupSwitcher switcher(thread_group, thread_name);
+            SCOPE_EXIT_SAFE({ [[maybe_unused]] auto released = std::move(callback); });
+        }
+
+        /// 2. Satisfy the promise with a normal DB::Exception instead of letting ~promise() store a
+        ///    broken-promise std::future_error (a std::logic_error reported via
+        ///    getCurrentExceptionMessageAndPattern -> abortOnFailedAssertion, which aborts the server).
+        ///    Build the exception_ptr first: constructing the DB::Exception captures a stack trace and
+        ///    may itself throw (e.g. std::bad_alloc under shutdown memory pressure). If it does, fall
+        ///    back to the in-flight exception so the promise is NEVER left unset (an unset promise here
+        ///    recreates the very broken-promise std::future_error this class exists to prevent).
         std::exception_ptr eptr;
         try
         {

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -93,18 +93,33 @@ struct CallbackRunnerTask
         if (was_run)
             return;
 
-        /// The task was dropped without running (e.g. the thread pool was shut down while it was
-        /// still queued). Satisfy the promise with a normal exception so the waiter does not observe
-        /// a broken-promise std::future_error (a std::logic_error that aborts the server).
+        /// Task dropped unrun (the pool was shut down while it was still queued). Satisfy the promise
+        /// with a normal exception instead of letting ~promise() store the broken-promise
+        /// std::future_error (a std::logic_error that aborts the server).
+        ///
+        /// Build the exception_ptr first: constructing the DB::Exception captures a stack trace and
+        /// may itself throw (e.g. std::bad_alloc under shutdown memory pressure). If it does, fall
+        /// back to the in-flight exception so the promise is NEVER left unset (an unset promise here
+        /// recreates the very broken-promise std::future_error this class exists to prevent).
+        std::exception_ptr eptr;
         try
         {
-            promise.set_exception(std::make_exception_ptr(
-                Exception(ErrorCodes::CANNOT_SCHEDULE_TASK, "Task was dropped before execution (thread pool is shutting down)")));
+            eptr = std::make_exception_ptr(
+                Exception(ErrorCodes::CANNOT_SCHEDULE_TASK, "Task was dropped before execution (thread pool is shutting down)"));
+        }
+        catch (...)
+        {
+            eptr = std::current_exception();
+        }
+
+        try
+        {
+            promise.set_exception(eptr);
         }
         catch (...) // NOLINT(bugprone-empty-catch)
         {
-            /// set_exception throws only if the promise was already satisfied, which cannot happen
-            /// here because run() (the only other place that touches it) sets was_run first.
+            /// Ok: set_exception throws only if the promise is already satisfied, impossible here
+            /// because run() (the only other writer) sets was_run first.
         }
     }
 };

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -13,6 +13,7 @@ namespace DB
 namespace ErrorCodes
 {
 extern const int LOGICAL_ERROR;
+extern const int CANNOT_SCHEDULE_TASK;
 }
 
 enum class ThreadName : uint8_t;
@@ -26,32 +27,103 @@ using ThreadPoolCallbackRunnerUnsafe = std::function<std::future<Result>(Callbac
 /// A common mistake is capturing some local objects in lambda and passing it to the runner.
 /// In case of exception, these local objects will be destroyed before scheduled tasks are finished.
 
+namespace detail
+{
+
+/// Runnable wrapper around a callback and its std::promise, used by threadPoolCallbackRunnerUnsafe.
+///
+/// Unlike a bare std::packaged_task, this satisfies the promise from its own destructor when the
+/// task was never run. A queued task can be dropped without running when ThreadPool::finalize()
+/// drains the queue on shutdown (ThreadPool::worker destroys the pending job via job_data.reset()).
+/// A bare packaged_task left unrun would destruct its std::promise with no stored value, so
+/// ~promise() stores a broken-promise std::future_error -- which is a std::logic_error and is
+/// therefore reported by the server as a LOGICAL_ERROR (getCurrentExceptionMessageAndPattern ->
+/// abortOnFailedAssertion), aborting the process during shutdown. Storing a normal DB::Exception
+/// instead lets the waiter observe an ordinary, catchable error from future.get().
+template <typename Result, typename Callback>
+struct CallbackRunnerTask
+{
+    std::promise<Result> promise;
+    ThreadGroupPtr thread_group;
+    ThreadName thread_name;
+    Callback callback;
+    bool was_run = false;
+
+    CallbackRunnerTask(ThreadGroupPtr thread_group_, ThreadName thread_name_, Callback && callback_)
+        : thread_group(std::move(thread_group_)), thread_name(thread_name_), callback(std::move(callback_))
+    {
+    }
+
+    void run()
+    {
+        was_run = true;
+        try
+        {
+            if constexpr (std::is_void_v<Result>)
+            {
+                {
+                    ThreadGroupSwitcher switcher(thread_group, thread_name);
+                    SCOPE_EXIT_SAFE({ [[maybe_unused]] auto tmp = std::move(callback); });
+                    callback();
+                }
+                /// The ThreadGroupSwitcher is destroyed (thread group detached) and the callback is
+                /// released before satisfying the promise, otherwise the waiter could race with the
+                /// detaching thread (see "Destroy ThreadGroupSwitcher before set value in std::future").
+                promise.set_value();
+            }
+            else
+            {
+                std::optional<Result> res;
+                {
+                    ThreadGroupSwitcher switcher(thread_group, thread_name);
+                    SCOPE_EXIT_SAFE({ [[maybe_unused]] auto tmp = std::move(callback); });
+                    res.emplace(callback());
+                }
+                promise.set_value(std::move(*res));
+            }
+        }
+        catch (...)
+        {
+            promise.set_exception(std::current_exception());
+        }
+    }
+
+    ~CallbackRunnerTask()
+    {
+        if (was_run)
+            return;
+
+        /// The task was dropped without running (e.g. the thread pool was shut down while it was
+        /// still queued). Satisfy the promise with a normal exception so the waiter does not observe
+        /// a broken-promise std::future_error (a std::logic_error that aborts the server).
+        try
+        {
+            promise.set_exception(std::make_exception_ptr(
+                Exception(ErrorCodes::CANNOT_SCHEDULE_TASK, "Task was dropped before execution (thread pool is shutting down)")));
+        }
+        catch (...) // NOLINT(bugprone-empty-catch)
+        {
+            /// set_exception throws only if the promise was already satisfied, which cannot happen
+            /// here because run() (the only other place that touches it) sets was_run first.
+        }
+    }
+};
+
+}
+
 /// Creates CallbackRunner that runs every callback with 'pool->scheduleOrThrowOnError()'.
 template <typename Result, typename Callback = std::function<Result()>>
 ThreadPoolCallbackRunnerUnsafe<Result, Callback> threadPoolCallbackRunnerUnsafe(ThreadPool & pool, ThreadName thread_name)
 {
     return [my_pool = &pool, thread_group = getCurrentThreadGroup(), thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
     {
-        auto task = std::make_shared<std::packaged_task<Result()>>([thread_group, thread_name, my_callback = std::move(callback)]() mutable -> Result
-        {
-            ThreadGroupSwitcher switcher(thread_group, thread_name);
+        auto task = std::make_shared<detail::CallbackRunnerTask<Result, Callback>>(thread_group, thread_name, std::move(callback));
 
-            SCOPE_EXIT_SAFE(
-            {
-                /// Release all captured resources before detaching thread group
-                /// Releasing has to use proper memory tracker which has been set here before callback
-
-                [[maybe_unused]] auto tmp = std::move(my_callback);
-            });
-
-            return my_callback();
-        });
-
-        auto future = task->get_future();
+        auto future = task->promise.get_future();
 
         /// Note: calling method scheduleOrThrowOnError in intentional, because we don't want to throw exceptions
         /// in critical places where this callback runner is used (e.g. loading or deletion of parts)
-        my_pool->scheduleOrThrowOnError([my_task = std::move(task)]{ (*my_task)(); }, priority);
+        my_pool->scheduleOrThrowOnError([my_task = std::move(task)]{ my_task->run(); }, priority);
 
         return future;
     };


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/73629
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a rare server abort during shutdown (`std::future_error`, "The associated promise has been destructed prior to the associated state becoming ready") caused by a task scheduled through `threadPoolCallbackRunnerUnsafe` being dropped from the thread pool queue before it ran.

### Description

`threadPoolCallbackRunnerUnsafe` wrapped work in a `std::packaged_task` and scheduled it on a `ThreadPool`. When the pool is shut down (`ThreadPool::finalize` sets `shutdown` and the worker drains the queue with `job_data.reset()`), a still-queued task is destroyed without running. The bare `packaged_task` then destructs its `std::promise` with no stored value, so `~promise()` stores a broken-promise `std::future_error`.

`std::future_error` derives from `std::logic_error`, so when a waiter observes it via `future.get()` the server reports it through `getCurrentExceptionMessageAndPattern`, which calls `abortOnFailedAssertion` on any `std::logic_error` in debug/sanitizer builds, aborting the process during shutdown.

Observed in CI as a `Stress test` / `serverfuzz` abort (STID 2508-38c6): a `TaskTracker` flush task scheduled through `threadPoolCallbackRunnerUnsafe` (async `WriteBufferFromS3` path) was dropped on shutdown, and the waiting merge task (`MergePlainMergeTreeTask::executeStep`) aborted.

Report (arm_tsan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105248&sha=c8f5c4e0660ad27d0509192338a1e38e4dcad792&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29

Fix: replace the `packaged_task` with a small runnable that owns its `std::promise` and, when destroyed without having run, satisfies the promise with a normal `DB::Exception` (`CANNOT_SCHEDULE_TASK`) instead of leaving it broken. `DB::Exception` is not a `std::logic_error`, so the waiter now gets an ordinary, catchable error and the server no longer aborts. This mirrors the explicit-promise handling already used by the sibling `ThreadPoolCallbackRunnerLocal` (PR #73629) and preserves the existing `ThreadGroupSwitcher`-before-`set_value` ordering and the `SCOPE_EXIT_SAFE` callback release.

Added a unit test (`gtest_thread_pool_callback_runner_shutdown`) that deterministically drops queued runner tasks on shutdown and asserts their futures never carry a broken-promise `std::future_error`.

No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.191` (included in `26.7` and later)
<!-- ch-version-info:end -->