### PR TITLE
Reject REPLACE/MOVE/DETACH PARTITION with pending lightweight-update patches in plain MergeTree

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2361,6 +2361,17 @@ void StorageMergeTree::dropPart(const String & part_name, bool detach, ContextPt
         /// This protects against "revival" of data for a removed partition after completion of merge.
         auto merge_blocker = stopMergesAndWait();
 
+        /// Only the base part is detached; the pending patch is left behind, so re-attaching would
+        /// silently revert the update. Reject instead (same guard as the Replicated engine).
+        if (detach && supportsLightweightUpdate())
+        {
+            if (auto part = getPartIfExists(part_name, {MergeTreeDataPartState::Active}))
+            {
+                auto patch_parts = getPatchPartsVectorForPartition(part->info.getPartitionId());
+                assertNoPatchesForParts({part}, patch_parts, "DETACH PART " + part_name);
+            }
+        }
+
         Stopwatch watch;
         ProfileEventsScope profile_events_scope;
 
@@ -2423,6 +2434,39 @@ void StorageMergeTree::dropPartition(const ASTPtr & partition, bool detach, Cont
         /// Asks to complete merges and does not allow them to start.
         /// This protects against "revival" of data for a removed partition after completion of merge.
         auto merge_blocker = stopMergesAndWait();
+
+        /// Only base parts are detached; pending patches are left behind, so re-attaching would
+        /// silently revert the update. Reject instead (same guard as the Replicated engine).
+        if (detach && supportsLightweightUpdate())
+        {
+            auto data_parts_lock = lockParts();
+            DataPartsVector parts_to_detach;
+            String guard_partition_id;
+            if (partition_ast && partition_ast->all)
+            {
+                parts_to_detach = getVisibleDataPartsVectorUnlocked(query_context, data_parts_lock);
+            }
+            else
+            {
+                guard_partition_id = getPartitionIDFromQuery(partition, query_context, &data_parts_lock);
+                parts_to_detach = getVisibleDataPartsVectorInPartition(query_context, guard_partition_id, data_parts_lock);
+            }
+
+            NameSet partition_ids;
+            for (const auto & part : parts_to_detach)
+                partition_ids.insert(part->info.getPartitionId());
+
+            for (const auto & partition_id : partition_ids)
+            {
+                DataPartsVector partition_parts;
+                for (const auto & part : parts_to_detach)
+                    if (part->info.getPartitionId() == partition_id)
+                        partition_parts.push_back(part);
+
+                auto patch_parts = getPatchPartsVectorForPartition(partition_id, data_parts_lock);
+                assertNoPatchesForParts(partition_parts, patch_parts, "DETACH PARTITION " + partition_id);
+            }
+        }
 
         Stopwatch watch;
         ProfileEventsScope profile_events_scope;
@@ -2620,6 +2664,33 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
     else
         src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id);
 
+    /// Only base parts are cloned below; pending patch parts are not, so reject when the
+    /// source partition has unapplied patches (same guard as the Replicated engine).
+    if (is_all)
+    {
+        NameSet src_partition_ids;
+        for (const auto & src_part : src_parts)
+            src_partition_ids.insert(src_part->info.getPartitionId());
+
+        for (const auto & src_partition_id : src_partition_ids)
+        {
+            DataPartsVector partition_parts;
+            for (const auto & src_part : src_parts)
+                if (src_part->info.getPartitionId() == src_partition_id)
+                    partition_parts.push_back(src_part);
+
+            auto src_patch_parts = src_data.getPatchPartsVectorForPartition(src_partition_id);
+            src_data.assertNoPatchesForParts(partition_parts, src_patch_parts,
+                fmt::format("{} PARTITION {} FROM", replace ? "REPLACE" : "ATTACH", src_partition_id));
+        }
+    }
+    else
+    {
+        auto src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id);
+        src_data.assertNoPatchesForParts(src_parts, src_patch_parts,
+            fmt::format("{} PARTITION {} FROM", replace ? "REPLACE" : "ATTACH", partition_id));
+    }
+
     MutableDataPartsVector dst_parts;
     std::vector<scope_guard> dst_parts_locks;
 
@@ -2779,6 +2850,14 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
     String partition_id = getPartitionIDFromQuery(partition, local_context);
 
     DataPartsVector src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id);
+
+    /// Patch parts are not moved with the base parts; reject when the source partition has
+    /// unapplied patches (same guard as the Replicated engine, see replacePartitionFrom).
+    {
+        auto src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id);
+        src_data.assertNoPatchesForParts(src_parts, src_patch_parts, "MOVE PARTITION " + partition_id);
+    }
+
     if (src_parts.size() > settings[Setting::max_parts_to_move])
     {
         /// Moving a large number of parts at once can take a long time or get stuck in a retry loop in case of an S3 error, for example.

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2658,15 +2658,36 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
 
     MergeTreeData & src_data = checkStructureAndGetMergeTreeData(source_table, source_metadata_snapshot, my_metadata_snapshot);
     DataPartsVector src_parts;
+    DataPartsVector src_patch_parts;
 
-    if (is_all)
-        src_parts = src_data.getVisibleDataPartsVector(local_context);
-    else
-        src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id);
+    /// Read the base parts to clone and the patch parts under a single source-side parts lock, so a
+    /// concurrent APPLY PATCHES on the source cannot drop a patch between selecting the base parts
+    /// and checking for patches. Only base parts are cloned below; pending patches are not carried,
+    /// so reject when the source has unapplied patches (same as StorageReplicatedMergeTree).
+    {
+        auto src_parts_lock = src_data.lockParts();
+        if (is_all)
+        {
+            src_parts = src_data.getVisibleDataPartsVectorUnlocked(local_context, src_parts_lock);
+            NameSet src_partition_ids;
+            for (const auto & src_part : src_parts)
+                src_partition_ids.insert(src_part->info.getPartitionId());
+            for (const auto & src_partition_id : src_partition_ids)
+            {
+                auto partition_patches = src_data.getPatchPartsVectorForPartition(src_partition_id, src_parts_lock);
+                src_patch_parts.insert(src_patch_parts.end(), partition_patches.begin(), partition_patches.end());
+            }
+        }
+        else
+        {
+            src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id, src_parts_lock);
+            src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id, src_parts_lock);
+        }
+    }
 
-    /// Only base parts are cloned below; pending patch parts are not, so reject when the
-    /// source partition has unapplied patches (same guard as the Replicated engine).
-    if (is_all)
+    /// Reject when the source partition has unapplied patches (assertNoPatchesForParts is a no-op
+    /// when there are none, so this is free for tables without lightweight updates). The check is
+    /// per partition because patches and parts are matched by partition id.
     {
         NameSet src_partition_ids;
         for (const auto & src_part : src_parts)
@@ -2679,16 +2700,14 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
                 if (src_part->info.getPartitionId() == src_partition_id)
                     partition_parts.push_back(src_part);
 
-            auto src_patch_parts = src_data.getPatchPartsVectorForPartition(src_partition_id);
-            src_data.assertNoPatchesForParts(partition_parts, src_patch_parts,
+            DataPartsVector partition_patches;
+            for (const auto & patch_part : src_patch_parts)
+                if (isPatchForPartition(patch_part->info, src_partition_id))
+                    partition_patches.push_back(patch_part);
+
+            src_data.assertNoPatchesForParts(partition_parts, partition_patches,
                 fmt::format("{} PARTITION {} FROM", replace ? "REPLACE" : "ATTACH", src_partition_id));
         }
-    }
-    else
-    {
-        auto src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id);
-        src_data.assertNoPatchesForParts(src_parts, src_patch_parts,
-            fmt::format("{} PARTITION {} FROM", replace ? "REPLACE" : "ATTACH", partition_id));
     }
 
     MutableDataPartsVector dst_parts;
@@ -2849,14 +2868,20 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
     MergeTreeData & src_data = dest_table_storage->checkStructureAndGetMergeTreeData(*this, metadata_snapshot, dest_metadata_snapshot);
     String partition_id = getPartitionIDFromQuery(partition, local_context);
 
-    DataPartsVector src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id);
+    DataPartsVector src_parts;
+    DataPartsVector src_patch_parts;
 
-    /// Patch parts are not moved with the base parts; reject when the source partition has
-    /// unapplied patches (same guard as the Replicated engine, see replacePartitionFrom).
+    /// Read the parts to move and the patch parts under a single source-side lock, so a concurrent
+    /// APPLY PATCHES on the source cannot drop a patch between the two reads. Patch parts are not
+    /// moved with the base parts; reject when the source partition has unapplied patches (same guard
+    /// as the Replicated engine, see replacePartitionFrom).
     {
-        auto src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id);
-        src_data.assertNoPatchesForParts(src_parts, src_patch_parts, "MOVE PARTITION " + partition_id);
+        auto src_parts_lock = src_data.readLockParts();
+        src_parts = src_data.getVisibleDataPartsVectorInPartition(local_context, partition_id, src_parts_lock);
+        src_patch_parts = src_data.getPatchPartsVectorForPartition(partition_id, src_parts_lock);
     }
+
+    src_data.assertNoPatchesForParts(src_parts, src_patch_parts, "MOVE PARTITION " + partition_id);
 
     if (src_parts.size() > settings[Setting::max_parts_to_move])
     {

--- a/tests/queries/0_stateless/03100_lwu_51_replace_partition_pending_patch.reference
+++ b/tests/queries/0_stateless/03100_lwu_51_replace_partition_pending_patch.reference
@@ -1,0 +1,8 @@
+src	[11,15]
+after rejected REPLACE self	[11,15]
+after rejected REPLACE other	[100]
+after rejected MOVE src	[11,15]
+after rejected MOVE dst	[100]
+after rejected DETACH PARTITION	[11,15]
+after rejected DETACH PART	[11,15]
+after APPLY PATCHES + REPLACE	[11,15]

--- a/tests/queries/0_stateless/03100_lwu_51_replace_partition_pending_patch.sql
+++ b/tests/queries/0_stateless/03100_lwu_51_replace_partition_pending_patch.sql
@@ -1,0 +1,65 @@
+-- Tags: no-replicated-database
+-- no-replicated-database: fails due to additional shard.
+
+-- Plain (non-replicated) MergeTree REPLACE/MOVE/DETACH PARTITION and DETACH PART must reject a
+-- source that has unapplied patch parts (from a not-yet-materialized lightweight UPDATE), exactly
+-- like ReplicatedMergeTree already does (see 03100_lwu_22_detach_attach_patches.sql). These ops
+-- clone/keep only the base parts, so the pending patch is orphaned and the update silently reverts
+-- (DETACH then ATTACH would bring the base part back at the pre-update value). DROP stays allowed.
+
+DROP TABLE IF EXISTS t_lwu_51_src;
+DROP TABLE IF EXISTS t_lwu_51_dst;
+
+SET enable_lightweight_update = 1;
+SET mutations_sync = 2;
+
+CREATE TABLE t_lwu_51_src (c0 Int)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+CREATE TABLE t_lwu_51_dst (c0 Int)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+-- Pin the part layout (two separate parts, an unapplied patch part) so the patch is not
+-- merged away and the DETACH PART name below stays deterministic under randomized settings.
+SYSTEM STOP MERGES t_lwu_51_src;
+SYSTEM STOP MERGES t_lwu_51_dst;
+
+INSERT INTO t_lwu_51_src VALUES (1);
+INSERT INTO t_lwu_51_src VALUES (5);
+UPDATE t_lwu_51_src SET c0 = c0 + 10 WHERE TRUE;
+
+SELECT 'src', arraySort(groupArray(c0)) FROM t_lwu_51_src;
+
+-- REPLACE PARTITION FROM self (logical no-op) must not silently drop the pending update.
+ALTER TABLE t_lwu_51_src REPLACE PARTITION ID 'all' FROM t_lwu_51_src; -- { serverError SUPPORT_IS_DISABLED }
+SELECT 'after rejected REPLACE self', arraySort(groupArray(c0)) FROM t_lwu_51_src;
+
+-- REPLACE PARTITION from a different source that has pending patches.
+INSERT INTO t_lwu_51_dst VALUES (100);
+ALTER TABLE t_lwu_51_dst REPLACE PARTITION ID 'all' FROM t_lwu_51_src; -- { serverError SUPPORT_IS_DISABLED }
+SELECT 'after rejected REPLACE other', arraySort(groupArray(c0)) FROM t_lwu_51_dst;
+
+-- MOVE PARTITION from a source that has pending patches.
+ALTER TABLE t_lwu_51_src MOVE PARTITION ID 'all' TO TABLE t_lwu_51_dst; -- { serverError SUPPORT_IS_DISABLED }
+SELECT 'after rejected MOVE src', arraySort(groupArray(c0)) FROM t_lwu_51_src;
+SELECT 'after rejected MOVE dst', arraySort(groupArray(c0)) FROM t_lwu_51_dst;
+
+-- DETACH PARTITION on a partition with pending patches (re-attach would revert the update).
+ALTER TABLE t_lwu_51_src DETACH PARTITION ID 'all'; -- { serverError SUPPORT_IS_DISABLED }
+SELECT 'after rejected DETACH PARTITION', arraySort(groupArray(c0)) FROM t_lwu_51_src;
+
+-- DETACH PART on a part with pending patches.
+ALTER TABLE t_lwu_51_src DETACH PART 'all_1_1_0'; -- { serverError SUPPORT_IS_DISABLED }
+SELECT 'after rejected DETACH PART', arraySort(groupArray(c0)) FROM t_lwu_51_src;
+
+-- After APPLY PATCHES the patched data must travel with the partition.
+-- (Re-enable merges first: APPLY PATCHES materializes the patch via a mutation.)
+SYSTEM START MERGES t_lwu_51_src;
+ALTER TABLE t_lwu_51_src APPLY PATCHES IN PARTITION ID 'all';
+ALTER TABLE t_lwu_51_dst REPLACE PARTITION ID 'all' FROM t_lwu_51_src;
+SELECT 'after APPLY PATCHES + REPLACE', arraySort(groupArray(c0)) FROM t_lwu_51_dst;
+
+DROP TABLE t_lwu_51_src;
+DROP TABLE t_lwu_51_dst;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix silent data loss on plain (non-replicated) `MergeTree` when `REPLACE PARTITION`, `MOVE PARTITION`, `DETACH PARTITION`, or `DETACH PART` is run on a partition that still has unapplied lightweight `UPDATE` patches. These operations now reject the command (as `ReplicatedMergeTree` already does), pointing to `ALTER TABLE ... APPLY PATCHES`, instead of silently reverting the committed update.


### Description

A lightweight `UPDATE` records, per row, the source part's data version in a
separate patch part. Plain `StorageMergeTree` partition operations clone or keep
only the base data parts and renumber them to new, higher block numbers, while
the pending patch part is left behind. On the next read the renamed base part's
version is above the patch's recorded version, so the patch is dropped and the
committed update is silently reverted (data loss).

Minimal reproducer (returns `[5,1]` instead of `[11,15]` before this change):

```sql
SET enable_lightweight_update = 1;
CREATE TABLE t (c0 Int) ENGINE = MergeTree ORDER BY tuple()
  SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
INSERT INTO t VALUES (1);
INSERT INTO t VALUES (5);
UPDATE t SET c0 = c0 + 10 WHERE TRUE;        -- [11,15]
ALTER TABLE t REPLACE PARTITION ID 'all' FROM t;
SELECT groupArray(c0) FROM t;                -- was [5,1], now rejected
```

The same silent revert happened for `REPLACE`/`ATTACH PARTITION FROM` another
table whose source partition has pending patches, `MOVE PARTITION TO TABLE`,
`DETACH PARTITION`, and `DETACH PART`.

`StorageReplicatedMergeTree` already guards exactly these operations with
`getPatchPartsVectorForPartition` + `assertNoPatchesForParts`, rejecting them
with an actionable `SUPPORT_IS_DISABLED` message that points at `APPLY PATCHES`.
This brings plain `StorageMergeTree` to the same behavior. `DROP PARTITION`
stays allowed, matching the Replicated engine (it destroys data by design).

No existing GitHub issue found.

Tested locally on a debug build: new test `03100_lwu_51_replace_partition_pending_patch`
fails on master HEAD (the operations silently succeed and the data reverts) and
passes with this change; the existing `03100_lwu_*` patch-parts suite (including
`03100_lwu_22_detach_attach_patches`) and the `00626/00975/01818/02271/02731`
partition-op tests are unaffected.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1157`
<!-- ch-version-info:end -->