### PR TITLE
Fix LOGICAL_ERROR in deduplication info on async INSERT into Alias with strict block limits

### DIFF
--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -72,11 +72,13 @@ public:
     AliasSink(
         StorageAlias & storage_,
         ContextPtr context_,
-        const StorageMetadataPtr & metadata_snapshot_)
+        const StorageMetadataPtr & metadata_snapshot_,
+        bool async_insert_)
         : SinkToStorage(std::make_shared<const Block>(metadata_snapshot_->getSampleBlock()))
         , WithContext(context_)
         , storage(storage_)
         , non_materialized_header(metadata_snapshot_->getSampleBlockNonMaterialized())
+        , async_insert(async_insert_)
     {
     }
 
@@ -94,13 +96,17 @@ public:
         insert_context->makeQueryContext();
         addInterpreterContext(insert_context);
 
+        /// Thread the outer async-insert flag into the nested target pipeline so INSERT through
+        /// Alias matches a direct insert: async batches select async dedup settings and skip the
+        /// strict block-limit squashing that would slice their multi-token DeduplicationInfo and
+        /// break its row/offset invariant.
         InterpreterInsertQuery interpreter(
             query_ptr,
             insert_context,
             /* allow_materialized */ false,
             /* no_squash */ false,
             /* no_destination */ false,
-            /* async_insert */ false);
+            /* async_insert */ async_insert);
 
         block_io = interpreter.execute();
         executor = std::make_unique<PushingPipelineExecutor>(block_io.pipeline);
@@ -144,6 +150,7 @@ public:
 private:
     StorageAlias & storage;
     Block non_materialized_header;
+    bool async_insert;
     BlockIO block_io;
     std::unique_ptr<PushingPipelineExecutor> executor;
 };
@@ -184,14 +191,14 @@ SinkToStoragePtr StorageAlias::write(
     const ASTPtr & /*query*/,
     const StorageMetadataPtr & /*metadata_snapshot*/,
     ContextPtr local_context,
-    bool /*async_insert*/)
+    bool async_insert)
 {
     auto target_storage = getTargetTable(TargetAccess{local_context, AccessType::INSERT});
     auto target_metadata = target_storage->getInMemoryMetadataPtr(local_context, false);
 
     /// Use AliasSink which executes full INSERT pipeline on target
     /// Therefore it will trigger the MV on the target
-    return std::make_shared<AliasSink>(*this, local_context, target_metadata);
+    return std::make_shared<AliasSink>(*this, local_context, target_metadata, async_insert);
 }
 
 void StorageAlias::alter(

--- a/tests/queries/0_stateless/04204_alias_async_insert_dedup_strict_block_limits.reference
+++ b/tests/queries/0_stateless/04204_alias_async_insert_dedup_strict_block_limits.reference
@@ -1,0 +1,2 @@
+ok	1
+parity	1

--- a/tests/queries/0_stateless/04204_alias_async_insert_dedup_strict_block_limits.sh
+++ b/tests/queries/0_stateless/04204_alias_async_insert_dedup_strict_block_limits.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-fasttest
+# no-fasttest: needs ZooKeeper for ReplicatedMergeTree.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# --- Part 1: async insert into Alias with strict limits must not abort the server ---
+# Crash regression for the chassert 'block.rows() == getRows()' in DeduplicationInfo. Observable on
+# debug/asan builds where the assert fires; on a release build it only proves the server survived.
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS alias_strict_target SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS alias_strict_alias SYNC"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE alias_strict_target (a UInt64)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/alias_strict', '{replica}')
+    ORDER BY a"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE alias_strict_alias ENGINE = Alias(currentDatabase(), 'alias_strict_target')"
+
+# Queue 20 async inserts from a single connection into one flush batch (a busy timeout long
+# enough that nothing auto-fires, then one explicit flush). The queue batches them into a single
+# multi-token DeduplicationInfo (one token per entry) whose offsets describe the whole batch.
+# Routed through the alias nested pipeline with strict block limits and max block size 2, the
+# unfixed code sliced that chunk and aborted the server in DeduplicationInfo. One client process
+# keeps memory low under sanitizers.
+QUERIES=""
+for i in $(seq 1 20); do
+    QUERIES="$QUERIES INSERT INTO alias_strict_alias (a) VALUES ($i),($((i+50))),($((i+100)));"
+done
+${CLICKHOUSE_CLIENT} \
+    --async_insert=1 --wait_for_async_insert=0 \
+    --async_insert_busy_timeout_max_ms=600000 --async_insert_busy_timeout_min_ms=600000 \
+    --async_insert_use_adaptive_busy_timeout=0 \
+    --insert_deduplicate=1 --async_insert_deduplicate=1 \
+    --use_strict_insert_block_limits=1 --max_insert_block_size=2 --min_insert_block_size_rows=2 \
+    --multiquery -q "$QUERIES"
+# Table-scoped flush (the queue key stores the resolved INSERT table_id) so we drain only this
+# test's batch instead of flushAll, which sets flush_stopped and serializes unrelated parallel tests.
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE alias_strict_alias"
+
+# If the server survived (no abort), it answers and the rows are present.
+${CLICKHOUSE_CLIENT} -q "SELECT 'ok', count() > 0 FROM alias_strict_target"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE alias_strict_alias SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE alias_strict_target SYNC"
+
+# --- Part 2: async insert through Alias must use ASYNC deduplication, like a direct insert ---
+# User-visible on every build (no chassert needed), so it discriminates the bug under the release
+# build used by Bugfix validation. The unfixed code ran the alias target pipeline with
+# async_insert=false, so it picked the SYNC deduplication window; the fix threads async_insert
+# through, so it picks the async window like a direct insert.
+#
+# Both targets disable the sync window and enable the async one. A direct async insert deduplicates
+# the two identical batches via the async window (3 rows). The alias must behave identically. With
+# the unfixed code the alias used the sync window (= 0, no dedup) and kept both batches (6 rows).
+
+two_identical_async_batches() {
+    local table=$1
+    ${CLICKHOUSE_CLIENT} --async_insert=1 --wait_for_async_insert=1 --async_insert_deduplicate=1 \
+        -q "INSERT INTO $table VALUES (1),(2),(3)"
+    ${CLICKHOUSE_CLIENT} --async_insert=1 --wait_for_async_insert=1 --async_insert_deduplicate=1 \
+        -q "INSERT INTO $table VALUES (1),(2),(3)"
+}
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS dedup_direct SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS dedup_target SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS dedup_alias SYNC"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE dedup_direct (a UInt64)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/dedup_direct', '{replica}')
+    ORDER BY a
+    SETTINGS replicated_deduplication_window = 0, replicated_deduplication_window_for_async_inserts = 10000"
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE dedup_target (a UInt64)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/$CLICKHOUSE_TEST_ZOOKEEPER_PREFIX/dedup_target', '{replica}')
+    ORDER BY a
+    SETTINGS replicated_deduplication_window = 0, replicated_deduplication_window_for_async_inserts = 10000"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE dedup_alias ENGINE = Alias(currentDatabase(), 'dedup_target')"
+
+two_identical_async_batches dedup_direct
+two_identical_async_batches dedup_alias
+
+# The alias count must equal the direct count (3, deduplicated via the async window). The unfixed
+# code produced 6 for the alias, so the equality fails there.
+${CLICKHOUSE_CLIENT} -q "
+    SELECT 'parity', (SELECT count() FROM dedup_alias) = (SELECT count() FROM dedup_direct)"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE dedup_alias SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE dedup_target SYNC"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE dedup_direct SYNC"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

No related open issue found.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`block.rows() == getRows()`) that could abort the server on an async `INSERT` into an `Alias` table when `use_strict_insert_block_limits` was enabled.


### Description

Found by the BuzzHouse server-side fuzzer on master (`BuzzHouse (experimental, serverfuzz, arm_asan_ubsan)`, commit 8734da661b1216ca84e67ae84ffc2bc32d941c0f). CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8734da661b1216ca84e67ae84ffc2bc32d941c0f&name_0=MasterCI&name_1=BuzzHouse%20%28experimental%2C%20serverfuzz%2C%20arm_asan_ubsan%29

An async `INSERT` into an `Alias` table over a (Replicated)MergeTree target could abort the server with `Logical error: 'block.rows() == getRows()'` in `DeduplicationInfo::calculateDataHashRowWise` when `use_strict_insert_block_limits=1`.

Root cause: the async insert queue attaches a multi-token `DeduplicationInfo` to the chunk, whose `offsets` describe the full batch. `AliasSink` runs a nested `INSERT` pipeline on the target, but constructed the nested `InterpreterInsertQuery` with `async_insert` hardcoded to `false`. With the sync semantics, the engine-wide rule `use_strict_insert_block_limits && !async_insert` kept strict squashing on, so the chunk was sliced and `original_block.rows()` no longer equalled `offsets.back()`, tripping the assertion while computing deduplication hashes. The same hardcoded `false` also made the target pipeline pick the sync deduplication settings (`insert_deduplicate`, `replicated_deduplication_window`) instead of the async ones (`async_insert_deduplicate`, `replicated_deduplication_window_for_async_inserts`), so `INSERT` through `Alias` deduplicated async batches differently from a direct async `INSERT`.

Fix: thread the outer `async_insert` flag from `StorageAlias::write` into `AliasSink` and into the nested `InterpreterInsertQuery` instead of hardcoding `false`. The `use_strict_insert_block_limits && !async_insert` rule then disables strict splitting for async automatically (no separate setting override), and the target pipeline picks the async deduplication settings like a direct async insert. Synchronous `Alias` inserts still get `async_insert=false`, so their block-limit and deduplication behavior is unchanged and matches direct inserts.

Regression test `04204_alias_async_insert_dedup_strict_block_limits`: Part 1 is the crash regression (one client process to stay within sanitizer memory limits). Part 2 makes the fix observable on the release build used by Bugfix validation, where the `chassert` is compiled out: with the target's sync dedup window set to 0 and the async window non-zero, a direct async insert deduplicates two identical batches via the async window (3 rows); the alias must match. Before the fix the alias used the sync window (0, no dedup) and kept both batches (6 rows), so the parity check fails on the unfixed build and passes with the fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.899`
<!-- ch-version-info:end -->