### PR TITLE
Fix logical error in disjunction filter push-down through JOIN with type-changing USING key

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -33,6 +33,7 @@
 #include <Core/Settings.h>
 #include <fmt/ranges.h>
 #include <Core/Joins.h>
+#include <base/scope_guard.h>
 #include <ranges>
 
 
@@ -1093,13 +1094,19 @@ IdentifierResolveResult IdentifierResolver::tryResolveIdentifierFromJoin(const I
 
     auto try_resolve_identifier_from_join_tree_node = [&](const QueryTreeNodePtr & join_tree_node, bool may_be_override_by_using_column)
     {
+        /// scope.join_using_columns holds raw pointers to this stack-local map. The pop must run
+        /// even if tryResolveIdentifierFromJoinTreeNode throws: an UNKNOWN_IDENTIFIER from a
+        /// statically-dead if/multiIf branch is caught and swallowed during resolution, and a
+        /// leftover pointer would dangle once this frame unwinds.
+        bool pushed = false;
         if (may_be_override_by_using_column && !join_using_column_name_to_column_node.empty())
+        {
             scope.join_using_columns.push_back(&join_using_column_name_to_column_node);
+            pushed = true;
+        }
+        SCOPE_EXIT({ if (pushed) scope.join_using_columns.pop_back(); });
 
         auto res = tryResolveIdentifierFromJoinTreeNode(identifier_lookup, join_tree_node, scope);
-
-        if (may_be_override_by_using_column && !join_using_column_name_to_column_node.empty())
-            scope.join_using_columns.pop_back();
 
         return std::move(res.resolved_identifier);
     };

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -559,7 +559,7 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         equivalent_expressions.append_range(std::move(extra_equivalent_expressions));
     }
 
-    auto get_available_columns_for_filter = [&](bool push_to_left_stream, bool filter_push_down_input_columns_available)
+    auto get_available_columns_for_filter = [&](bool push_to_left_stream, bool filter_push_down_input_columns_available, bool require_stable_types = false)
     {
         Names available_input_columns_for_filter;
 
@@ -579,7 +579,11 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             /// (e.g. UInt8 in the input becomes Nullable(UInt8) in the join output), pushing a
             /// filter built for the join output directly to the input side causes a type mismatch.
             /// JoinStepLogical handles this via fix_predicate_for_join_logical_step below.
-            if (!logical_join && !input_header->getByName(name).type->equals(*join_header->getByName(name).type))
+            ///
+            /// The disjunction (partial predicate) push-down path has no such type-fixup, so it
+            /// passes require_stable_types to also exclude type-changing columns for JoinStepLogical.
+            if ((!logical_join || require_stable_types)
+                && !input_header->getByName(name).type->equals(*join_header->getByName(name).type))
                 continue;
 
             available_input_columns_for_filter.push_back(name);
@@ -906,8 +910,18 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
             return updated_steps;
         }
 
+        /// Unlike the main push-down above, addFilterOnTop builds the partial FilterStep directly
+        /// against the join input header without fix_predicate_for_join_logical_step. So a function
+        /// node whose type was computed for the join output (e.g. equals over a USING key widened to
+        /// Nullable) would be applied to the non-widened input column and trip the result-type check
+        /// in updateHeader. Restrict the partial predicate to columns with stable types across the join.
+        Names left_stream_stable_columns_to_push_down = get_available_columns_for_filter(
+            true /*push_to_left_stream*/, left_stream_filter_push_down_input_columns_available, /*require_stable_types=*/true);
+        Names right_stream_stable_columns_to_push_down = get_available_columns_for_filter(
+            false /*push_to_left_stream*/, right_stream_filter_push_down_input_columns_available, /*require_stable_types=*/true);
+
         {
-            auto left_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), left_stream_available_columns_to_push_down);
+            auto left_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), left_stream_stable_columns_to_push_down);
             if (left_partial_filter_dag.has_value())
             {
                 const auto partial_predicate_column_name = left_partial_filter_dag->getOutputs().front()->result_name;
@@ -921,7 +935,7 @@ static size_t tryPushDownOverJoinStep(QueryPlan::Node * parent_node, QueryPlan::
         }
 
         {
-            auto right_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), right_stream_available_columns_to_push_down);
+            auto right_partial_filter_dag = tryToExtractPartialPredicate(filter->getExpression(), filter->getFilterColumnName(), right_stream_stable_columns_to_push_down);
             if (right_partial_filter_dag.has_value())
             {
                 const auto partial_predicate_column_name = right_partial_filter_dag->getOutputs().front()->result_name;

--- a/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.reference
+++ b/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.reference
@@ -7,3 +7,5 @@ Filter column: or(and(equals(__table1.x, \'FRANCE\'_String), equals(__table2.y, 
 --- result (enabled) ---
 FRANCE	GERMANY
 GERMANY	FRANCE
+--- analyzer no crash ---
+1

--- a/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.reference
+++ b/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.reference
@@ -1,0 +1,9 @@
+--- plan (enabled) ---
+Filter column: or(and(equals(__table1.x, \'FRANCE\'_String), equals(__table2.y, \'GERMANY\'_String)), and(equals(__table1.x, \'GERMANY\'_String), equals(__table2.y, \'FRANCE\'_String))) (removed)
+Filter column: or(equals(__table1.x, \'FRANCE\'_String), equals(__table1.x, \'GERMANY\'_String)) (removed)
+Filter column: or(equals(__table2.y, \'GERMANY\'_String), equals(__table2.y, \'FRANCE\'_String)) (removed)
+--- plan (disabled) ---
+Filter column: or(and(equals(__table1.x, \'FRANCE\'_String), equals(__table2.y, \'GERMANY\'_String)), and(equals(__table1.x, \'GERMANY\'_String), equals(__table2.y, \'FRANCE\'_String))) (removed)
+--- result (enabled) ---
+FRANCE	GERMANY
+GERMANY	FRANCE

--- a/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.sql
+++ b/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.sql
@@ -1,0 +1,80 @@
+-- Tags: no-parallel-replicas
+
+SET enable_analyzer = 1;
+SET use_join_disjunctions_push_down = 1;
+
+DROP TABLE IF EXISTS t04330;
+DROP TABLE IF EXISTS nr04330;
+
+CREATE TABLE nr04330 (x Nullable(UInt32), s Nullable(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO nr04330 VALUES (2, NULL);
+
+CREATE TABLE t04330 (x UInt32, s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t04330 VALUES (1, 'l');
+
+-- The USING key x is UInt32 on the left and Nullable(UInt32) on the right, so the join
+-- output column is widened to Nullable. A predicate over x is built against that widened
+-- type, but the disjunction (partial predicate) push-down used to apply it to the
+-- non-widened input column, tripping a result-type check inside FilterStep:
+--   "Unexpected return type from equals. Expected Nullable(UInt8). Got UInt8"
+-- The query must plan and execute without a logical error.
+SELECT t04330.x
+FROM t04330 AS l
+SEMI LEFT JOIN nr04330 AS r USING (x)
+WHERE and(or(and(and(equals(or(divide(NULL, '922337203685477580.7'), toString(NULL, NULL)), r.s), equals(r.s, '127.0.0.1')), equals(t04330.x, toLowCardinality(-9223372036854775808))), greater(l.s, toString(NULL, 0.0001))), greater(r.s, toString(10.0001, NULL)))
+QUALIFY 1024
+LIMIT 0;
+
+DROP TABLE t04330;
+DROP TABLE nr04330;
+
+DROP TABLE IF EXISTS l04330;
+DROP TABLE IF EXISTS r04330;
+
+CREATE TABLE l04330 (a UInt32, x String) ENGINE = Memory;
+CREATE TABLE r04330 (a UInt32, y String) ENGINE = Memory;
+INSERT INTO l04330 VALUES (1, 'FRANCE'), (2, 'GERMANY');
+INSERT INTO r04330 VALUES (1, 'GERMANY'), (2, 'FRANCE');
+
+-- Disjunction push-down must still fire for columns whose type is stable across the join.
+-- The plan assertion proves it: with push-down enabled the per-side pre-join filters
+-- (one over the left x, one over the right y) are added in addition to the outer
+-- disjunction filter; with push-down disabled only the outer filter remains.
+-- enable_join_runtime_filters=0 keeps the plan free of non-deterministic runtime-filter ids.
+SELECT '--- plan (enabled) ---';
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN actions = 1
+    SELECT l.x, r.y
+    FROM l04330 AS l
+    INNER JOIN r04330 AS r USING (a)
+    WHERE (l.x = 'FRANCE' AND r.y = 'GERMANY') OR (l.x = 'GERMANY' AND r.y = 'FRANCE')
+    ORDER BY l.x
+)
+WHERE explain ILIKE '%Filter column: %' SETTINGS use_join_disjunctions_push_down = 1, enable_join_runtime_filters = 0, enable_parallel_replicas = 0
+FORMAT TSV;
+
+SELECT '--- plan (disabled) ---';
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN actions = 1
+    SELECT l.x, r.y
+    FROM l04330 AS l
+    INNER JOIN r04330 AS r USING (a)
+    WHERE (l.x = 'FRANCE' AND r.y = 'GERMANY') OR (l.x = 'GERMANY' AND r.y = 'FRANCE')
+    ORDER BY l.x
+)
+WHERE explain ILIKE '%Filter column: %' SETTINGS use_join_disjunctions_push_down = 0, enable_join_runtime_filters = 0, enable_parallel_replicas = 0
+FORMAT TSV;
+
+-- Result must be identical with push-down enabled (sanity check that the optimization is result-preserving).
+SELECT '--- result (enabled) ---';
+SELECT l.x, r.y
+FROM l04330 AS l
+INNER JOIN r04330 AS r USING (a)
+WHERE (l.x = 'FRANCE' AND r.y = 'GERMANY') OR (l.x = 'GERMANY' AND r.y = 'FRANCE')
+ORDER BY l.x
+FORMAT TSV;
+
+DROP TABLE l04330;
+DROP TABLE r04330;

--- a/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.sql
+++ b/tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.sql
@@ -76,5 +76,25 @@ WHERE (l.x = 'FRANCE' AND r.y = 'GERMANY') OR (l.x = 'GERMANY' AND r.y = 'FRANCE
 ORDER BY l.x
 FORMAT TSV;
 
+-- Analyzer identifier-resolution crash (NULL deref) reachable from this query family.
+-- scope.join_using_columns holds raw pointers to a stack-local map pushed while resolving
+-- one JOIN side; a statically-dead if/multiIf branch that references an unknown identifier
+-- throws UNKNOWN_IDENTIFIER, which the constant-fold path swallows. The push was not undone
+-- on that throw, so a later identifier lookup dereferenced a dangling pointer. Must not crash.
+SELECT '--- analyzer no crash ---';
+SELECT count() > 0
+FROM viewExplain('EXPLAIN', 'actions = 1', (
+    SELECT DISTINCT l.x, r.y
+    FROM l04330 AS l
+    SEMI LEFT JOIN r04330 AS r USING (a)
+    WHERE xor(toLowCardinality(100), '1' = l.x, multiIf(toString(NULL),
+        plus(if(and(divide('9', NULL), toString(NULL, NULL)),
+            isNull(toFixedString('9', t04330.x, 20)), notEquals('9', r.s)), 0),
+        and(toString(NULL, NULL), divide(NULL, ';'))))
+    ORDER BY l.x DESC NULLS FIRST
+))
+SETTINGS use_join_disjunctions_push_down = 1, enable_join_runtime_filters = 0, enable_parallel_replicas = 0
+FORMAT TSV;
+
 DROP TABLE l04330;
 DROP TABLE r04330;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/89802
Related: https://github.com/ClickHouse/ClickHouse/pull/68978
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error (`Unexpected return type from equals. Expected Nullable(UInt8). Got UInt8`) when the disjunction (partial predicate) push-down optimization pushes a condition over a `USING` key whose type is widened by the JOIN. Also fix a server crash (segmentation fault) in the analyzer when resolving identifiers in `JOIN ... USING` queries that contain constant-foldable `if`/`multiIf` branches referencing unknown identifiers.

### Description

Found by the AST fuzzer on PR #68978: [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=68978&sha=3bbaa475daacda056942db17fae1846cf969f420&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29), check `AST fuzzer (arm_asan_ubsan)`, STID 3262-3b6a. The crash is a pre-existing trunk bug unrelated to that PR. Same class as the open fuzz issue #89802.

Minimal reproducer:
```sql
CREATE TABLE nr (x Nullable(UInt32), s Nullable(String)) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE t  (x UInt32, s LowCardinality(String)) ENGINE = MergeTree ORDER BY tuple();

SELECT t.x FROM t AS l SEMI LEFT JOIN nr AS r USING (x)
WHERE and(or(and(and(equals(or(divide(NULL, '922337203685477580.7'), toString(NULL, NULL)), r.s), equals(r.s, '127.0.0.1')), equals(t.x, toLowCardinality(-9223372036854775808))), greater(l.s, toString(NULL, 0.0001))), greater(r.s, toString(10.0001, NULL)))
QUALIFY 1024 LIMIT 0;
```

Root cause: the `USING (x)` key is `UInt32` on the left and `Nullable(UInt32)` on the right, so the column is widened to `Nullable` in the JOIN output. A predicate over `x` is built against that widened type (so `equals` returns `Nullable(UInt8)`). The main filter push-down path repairs such type changes for `JoinStepLogical` via `fix_predicate_for_join_logical_step`, and `get_available_columns_for_filter` therefore intentionally allows type-changing columns through. But the disjunction (partial predicate) push-down path (`tryToExtractPartialPredicate` + `addFilterOnTop`) reuses the same column lists and builds a `FilterStep` directly against the non-widened JOIN input header, with no type-fixup. `ActionsDAG::updateHeader` then re-evaluates `equals` as `UInt8` while the node still claims `Nullable(UInt8)`, tripping the result-type check in `executeActionForPartialResult` and aborting on debug/sanitizer builds.

Fix: restrict the disjunction push-down to columns whose type is stable across the JOIN boundary (input type equals JOIN-output type), via a new `require_stable_types` flag on `get_available_columns_for_filter`. Partial push-down is an opportunistic broadening pre-filter (the full filter still runs above the JOIN), so skipping type-changing columns is safe and only forgoes a pre-filter that cannot be correctly typed without the fixup the main path applies. Push-down for stable-type columns is unchanged.

A regression test is added in `tests/queries/0_stateless/04330_join_disjunctions_pushdown_using_type_mismatch.sql`. It fails (aborts) without the fix and passes with it, and also asserts the optimization still fires for a stable-type disjunction.


### Additional fix in this PR: analyzer NULL deref in JOIN USING identifier resolution

While fuzzing the new 04330 seed query, the `AST fuzzer (amd_debug, targeted)` hit a separate, pre-existing crash: a NULL pointer read (SIGSEGV) in `IdentifierResolver::tryBindIdentifierToJoinUsingColumn`. STID 5737-6ff0, check `AST fuzzer (amd_debug, targeted)`: [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107407&sha=03a72c1e1778546ee40b98227c1515c4a7ad47d0&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29).

Root cause: `scope.join_using_columns` is a list of raw pointers to a stack-local map that `tryResolveIdentifierFromJoin` pushes while recursing into one JOIN side and pops afterwards. The push/pop wrapped the recursive `tryResolveIdentifierFromJoinTreeNode` call without an exception guard. The `if`/`multiIf` constant-fold special cases in `resolveFunction.cpp` resolve statically-dead branches inside a `try/catch` and swallow the exception; when a dead branch referenced an unknown identifier, the resulting `UNKNOWN_IDENTIFIER` unwound past the pop, the stack-local map was destroyed, and the dangling pointer was left in `scope.join_using_columns`. A later `tryBindIdentifierToJoinUsingColumn` dereferenced it and crashed.

Fix: run the pop on every exit path with `SCOPE_EXIT`, balanced against a captured flag so each push is matched by exactly one pop. Pre-existing bug, independent of the push-down change above. A regression query is added to the same 04330 test (crashes without the fix, returns a result with it).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.960` (included in `26.6` and later)
- Backported to: `26.5.5.8`, `26.4.5.86`
<!-- ch-version-info:end -->