### PR TITLE
Prune named-Tuple subfields whose values are all type-defaults at INSERT and merge

### DIFF
--- a/src/Columns/ColumnAggregateFunction.h
+++ b/src/Columns/ColumnAggregateFunction.h
@@ -144,6 +144,8 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method isDefaultAt is not supported for ColumnAggregateFunction");
     }
 
+    bool hasOnlyTypeDefaults() const override { return false; }
+
     std::string_view getDataAt(size_t n) const override;
 
     void insertData(const char * pos, size_t length) override;

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -197,6 +197,14 @@ bool ColumnArray::isDefaultAt(size_t n) const
     return offsets_data[n] == offsets_data[static_cast<ssize_t>(n) - 1];
 }
 
+bool ColumnArray::hasOnlyTypeDefaults() const
+{
+    const auto & offsets_data = getOffsets();
+    if (offsets_data.empty())
+        return true;
+    return memoryIsZero(offsets_data.data(), 0, offsets_data.size() * sizeof(offsets_data[0]));
+}
+
 
 void ColumnArray::insertData(const char * pos, size_t length)
 {

--- a/src/Columns/ColumnArray.h
+++ b/src/Columns/ColumnArray.h
@@ -77,6 +77,9 @@ public:
     void getValueNameImpl(WriteBufferFromOwnString &, size_t n, const Options &) const override;
     std::string_view getDataAt(size_t n) const override;
     bool isDefaultAt(size_t n) const override;
+
+    /// All arrays are empty iff every offset is zero.
+    bool hasOnlyTypeDefaults() const override;
     void insertData(const char * pos, size_t length) override;
     std::string_view serializeValueIntoArena(size_t n, Arena & arena, char const *& begin, const IColumn::SerializationSettings * settings) const override;
     char * serializeValueIntoMemory(size_t, char * memory, const IColumn::SerializationSettings * settings) const override;

--- a/src/Columns/ColumnBLOB.h
+++ b/src/Columns/ColumnBLOB.h
@@ -150,6 +150,7 @@ public:
     void getValueNameImpl(WriteBufferFromOwnString &, size_t, const Options &) const override { throwInapplicable(); }
     std::string_view getDataAt(size_t) const override { throwInapplicable(); }
     bool isDefaultAt(size_t) const override { throwInapplicable(); }
+    bool hasOnlyTypeDefaults() const override { throwInapplicable(); }
     void insert(const Field &) override { throwInapplicable(); }
     bool tryInsert(const Field &) override { throwInapplicable(); }
 #if !defined(DEBUG_OR_SANITIZER_BUILD)

--- a/src/Columns/ColumnCompressed.h
+++ b/src/Columns/ColumnCompressed.h
@@ -88,6 +88,7 @@ public:
     void getValueNameImpl(WriteBufferFromOwnString &, size_t, const Options &) const override { throwMustBeDecompressed(); }
     std::string_view getDataAt(size_t) const override { throwMustBeDecompressed(); }
     bool isDefaultAt(size_t) const override { throwMustBeDecompressed(); }
+    bool hasOnlyTypeDefaults() const override { throwMustBeDecompressed(); }
     void insert(const Field &) override { throwMustBeDecompressed(); }
     bool tryInsert(const Field &) override { throwMustBeDecompressed(); }
 #if !defined(DEBUG_OR_SANITIZER_BUILD)

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -298,6 +298,11 @@ public:
         return data->isDefaultAt(0) ? s : 0;
     }
 
+    bool hasOnlyTypeDefaults() const override
+    {
+        return data->isDefaultAt(0);
+    }
+
     void getIndicesOfNonDefaultRows(Offsets & indices, size_t from, size_t limit) const override
     {
         if (!data->isDefaultAt(0))

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -675,6 +675,12 @@ void ColumnDecimal<T>::updateAt(const IColumn & src, size_t dst_pos, size_t src_
     data[dst_pos] = src_data[src_pos];
 }
 
+template <is_decimal T>
+bool ColumnDecimal<T>::hasOnlyTypeDefaults() const
+{
+    return memoryIsZero(data.data(), 0, data.size() * sizeof(T));
+}
+
 template class ColumnDecimal<Decimal32>;
 template class ColumnDecimal<Decimal64>;
 template class ColumnDecimal<Decimal128>;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -129,6 +129,8 @@ public:
     UInt64 get64(size_t n) const final;
     bool isDefaultAt(size_t n) const final { return data[n].value == 0; }
 
+    bool hasOnlyTypeDefaults() const override;
+
     ColumnPtr filter(const IColumn::Filter & filt, ssize_t result_size_hint) const final;
     void filter(const IColumn::Filter & filt) final;
     void expand(const IColumn::Filter & mask, bool inverted) final;

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -566,4 +566,9 @@ std::span<char> ColumnFixedString::insertRawUninitialized(size_t count)
     return {reinterpret_cast<char *>(chars.data() + start), count * n};
 }
 
+bool ColumnFixedString::hasOnlyTypeDefaults() const
+{
+    return memoryIsZero(chars.data(), 0, chars.size());
+}
+
 }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -96,6 +96,8 @@ public:
 
     bool isDefaultAt(size_t index) const override;
 
+    bool hasOnlyTypeDefaults() const override;
+
     void insert(const Field & x) override;
 
     bool tryInsert(const Field & x) override;

--- a/src/Columns/ColumnFunction.h
+++ b/src/Columns/ColumnFunction.h
@@ -77,6 +77,8 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "isDefaultAt is not implemented for {}", getName());
     }
 
+    bool hasOnlyTypeDefaults() const override { return false; }
+
     void insert(const Field &) override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot insert into {}", getName());

--- a/src/Columns/ColumnLazy.cpp
+++ b/src/Columns/ColumnLazy.cpp
@@ -419,6 +419,11 @@ UInt64 ColumnLazy::getNumberOfDefaultRows() const
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getNumberOfDefaultRows is not supported for {}", getName());
 }
 
+bool ColumnLazy::hasOnlyTypeDefaults() const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method hasOnlyTypeDefaults is not supported for {}", getName());
+}
+
 void ColumnLazy::getIndicesOfNonDefaultRows(Offsets &, size_t, size_t) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getIndicesOfNonDefaultRows is not supported for {}", getName());

--- a/src/Columns/ColumnLazy.h
+++ b/src/Columns/ColumnLazy.h
@@ -145,6 +145,7 @@ public:
     void updateInplaceFrom(const Patch & patch) override;
     double getRatioOfDefaultRows(double sample_ratio) const override;
     UInt64 getNumberOfDefaultRows() const override;
+    bool hasOnlyTypeDefaults() const override;
     void getIndicesOfNonDefaultRows(Offsets & indices, size_t from, size_t limit) const override;
     void finalize() override;
     bool isFinalized() const override;

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnCompressed.h>
 #include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnsCommon.h>
 #include <Columns/MaskOperations.h>
 #include <IO/Operators.h>
 
@@ -1102,6 +1103,14 @@ ColumnPtr removeNullableOrLowCardinalityNullable(const ColumnPtr & column)
     }
 
     return removeNullable(column);
+}
+
+bool ColumnNullable::hasOnlyTypeDefaults() const
+{
+    const auto & data = getNullMapData();
+    if (data.empty())
+        return true;
+    return memoryIsByte(data.data(), 0, data.size(), 1);
 }
 
 }

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -64,6 +64,8 @@ public:
     UInt64 getUInt(size_t n) const override;
     Int64 getInt(size_t n) const override;
     bool isDefaultAt(size_t n) const override { return isNullAt(n); }
+
+    bool hasOnlyTypeDefaults() const override;
     std::string_view getDataAt(size_t) const override;
     /// Will insert null value if pos=nullptr
     void insertData(const char * pos, size_t length) override;

--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -81,6 +81,11 @@ bool ColumnSparse::isDefaultAt(size_t n) const
     return getValueIndex(n) == 0;
 }
 
+bool ColumnSparse::hasOnlyTypeDefaults() const
+{
+    return _size == 0 || getOffsetsData().empty();
+}
+
 bool ColumnSparse::isNullAt(size_t n) const
 {
     return values->isNullAt(getValueIndex(n));

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -61,6 +61,10 @@ public:
     MutableColumnPtr cloneResized(size_t new_size) const override;
     size_t size() const override { return _size; }
     bool isDefaultAt(size_t n) const override;
+
+    /// All values are default iff the offsets array is empty (no non-default
+    /// values have been stored).
+    bool hasOnlyTypeDefaults() const override;
     bool isNullAt(size_t n) const override;
     Field operator[](size_t n) const override;
     void get(size_t n, Field & res) const override;

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -834,4 +834,14 @@ ColumnPtr ColumnString::createSizeSubcolumn() const
     return column_sizes;
 }
 
+bool ColumnString::hasOnlyTypeDefaults() const
+{
+    /// `String`'s type-default is the empty string. `insertData` writes `length` bytes into
+    /// `chars` without any trailing zero terminator, so a column whose every row is the
+    /// empty string ends up with `chars` empty (and offsets that are all the same value —
+    /// equal to whatever the last non-empty insertion left, or zero if there were none).
+    /// Therefore the entire column is the type-default iff no characters were ever stored.
+    return chars.empty();
+}
+
 }

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -127,6 +127,8 @@ public:
         return sizeAt(n) == 0;
     }
 
+    bool hasOnlyTypeDefaults() const override;
+
     void insert(const Field & x) override
     {
         const String & s = x.safeGet<String>();

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -179,6 +179,14 @@ bool ColumnTuple::isDefaultAt(size_t n) const
     return true;
 }
 
+bool ColumnTuple::hasOnlyTypeDefaults() const
+{
+    for (const auto & col : columns)
+        if (!col->hasOnlyTypeDefaults())
+            return false;
+    return true;
+}
+
 std::string_view ColumnTuple::getDataAt(size_t) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method getDataAt is not supported for {}", getName());

--- a/src/Columns/ColumnTuple.h
+++ b/src/Columns/ColumnTuple.h
@@ -62,6 +62,9 @@ public:
     void getValueNameImpl(WriteBufferFromOwnString &, size_t n, const Options &) const override;
 
     bool isDefaultAt(size_t n) const override;
+
+    /// Delegates to each sub-column's `hasOnlyTypeDefaults` with early exit.
+    bool hasOnlyTypeDefaults() const override;
     std::string_view getDataAt(size_t n) const override;
     void insertData(const char * pos, size_t length) override;
     void insert(const Field & x) override;

--- a/src/Columns/ColumnUnique.h
+++ b/src/Columns/ColumnUnique.h
@@ -166,6 +166,11 @@ public:
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'getNumberOfDefaultRows' not implemented for ColumnUnique");
     }
 
+    bool hasOnlyTypeDefaults() const override
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'hasOnlyTypeDefaults' not implemented for ColumnUnique");
+    }
+
     void getIndicesOfNonDefaultRows(IColumn::Offsets &, size_t, size_t) const override
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'getIndicesOfNonDefaultRows' not implemented for ColumnUnique");

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -1295,6 +1295,16 @@ std::span<char> ColumnVector<T>::insertRawUninitialized(size_t count)
     return {reinterpret_cast<char *>(data.data() + start), count * sizeof(T)};
 }
 
+template <typename T>
+bool ColumnVector<T>::hasOnlyTypeDefaults() const
+{
+    /// For floating-point types, -0.0 has non-zero bit representation but
+    /// compares equal to 0.0 via isDefaultAt. memoryIsZero is therefore
+    /// conservative: it may return false when -0.0 is present, which is
+    /// safe (we simply won't skip the column).
+    return memoryIsZero(data.data(), 0, data.size() * sizeof(T));
+}
+
 /// Explicit template instantiations - to avoid code bloat in headers.
 template class ColumnVector<UInt8>;
 template class ColumnVector<UInt16>;

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -342,6 +342,8 @@ public:
         }
     }
 
+    bool hasOnlyTypeDefaults() const override;
+
     bool structureEquals(const IColumn & rhs) const override
     {
         return typeid(rhs) == typeid(ColumnVector<T>);

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -543,6 +543,17 @@ UInt64 IColumnHelper<Derived, Parent>::getNumberOfDefaultRows() const
 }
 
 template <typename Derived, typename Parent>
+bool IColumnHelper<Derived, Parent>::hasOnlyTypeDefaults() const
+{
+    const auto & self = static_cast<const Derived &>(*this);
+    size_t num_rows = self.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        if (!self.isDefaultAt(i))
+            return false;
+    return true;
+}
+
+template <typename Derived, typename Parent>
 void IColumnHelper<Derived, Parent>::getIndicesOfNonDefaultRows(IColumn::Offsets & indices, size_t from, size_t limit) const
 {
     const auto & self = static_cast<const Derived &>(*this);

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -643,6 +643,10 @@ public:
     /// Returns number of values in column, that are equal to default value of column.
     [[nodiscard]] virtual UInt64 getNumberOfDefaultRows() const = 0;
 
+    /// Returns true if every value in the column is the type-default value.
+    /// Optimized for early exit and may use bulk memory checks for fixed-size types.
+    [[nodiscard]] virtual bool hasOnlyTypeDefaults() const = 0;
+
     /// Returns indices of values in column, that not equal to default value of column.
     virtual void getIndicesOfNonDefaultRows(Offsets & indices, size_t from, size_t limit) const = 0;
 
@@ -967,6 +971,9 @@ private:
 
     /// Devirtualize isDefaultAt.
     UInt64 getNumberOfDefaultRows() const override;
+
+    /// Devirtualize isDefaultAt — early-exit loop.
+    bool hasOnlyTypeDefaults() const override;
 
     /// Devirtualize isDefaultAt.
     void getIndicesOfNonDefaultRows(IColumn::Offsets & indices, size_t from, size_t limit) const override;

--- a/src/Columns/IColumnDummy.h
+++ b/src/Columns/IColumnDummy.h
@@ -44,6 +44,7 @@ public:
     void insert(const Field &) override;
     bool tryInsert(const Field &) override { return false; }
     bool isDefaultAt(size_t) const override;
+    bool hasOnlyTypeDefaults() const override { return false; }
 
     std::string_view getDataAt(size_t) const override
     {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1228,6 +1228,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         addSettingsChanges(merge_tree_settings_changes_history, "26.6",
         {
             {"shared_merge_tree_try_fetch_part_in_memory_data_from_replicas_on_startup", false, false, "New setting which allows SMT download parts data from replicas instead of S3 on startup"},
+            {"enable_tuple_subfield_pruning", false, true, "New default-on optimization. When enabled, INSERT and merge omit stream files for named-Tuple subfields whose values in the part are entirely type-defaults; the part's `columns.txt` records a narrowed Tuple type. Reads use `CAST(narrowed_tuple, full_tuple)` to materialize defaults. Pre-26.6 compatibility (`compatibility = '26.5'`) restores the old behavior of writing all subfield streams."},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.5",
         {

--- a/src/DataTypes/Utils.cpp
+++ b/src/DataTypes/Utils.cpp
@@ -248,4 +248,105 @@ bool canBeSafelyCast(const DataTypePtr & from_type, const DataTypePtr & to_type)
     return true;
 }
 
+namespace
+{
+
+/// Recursive helper: walks `full_type` and produces a narrowed type by dropping any
+/// leaf subfield whose dotted name (path so far) is in `expired_substreams`.
+/// Returns nullptr if the type is fully expired (every leaf is in `expired_substreams`).
+///
+/// `path` accumulates the dotted prefix (e.g. "data", "data.c2s", "data.c2s.gold").
+DataTypePtr narrowDataTypeImpl(const DataTypePtr & full_type, const String & path, const NameSet & expired_substreams)
+{
+    /// Leaf hit: the whole path is expired.
+    if (expired_substreams.contains(path))
+        return nullptr;
+
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(full_type.get()))
+    {
+        if (!tuple->hasExplicitNames())
+            return full_type;
+
+        const auto & elements = tuple->getElements();
+        const auto & names = tuple->getElementNames();
+        DataTypes new_elements;
+        Strings new_names;
+        new_elements.reserve(elements.size());
+        new_names.reserve(names.size());
+
+        for (size_t i = 0; i < elements.size(); ++i)
+        {
+            auto element_path = path + "." + names[i];
+            auto narrowed = narrowDataTypeImpl(elements[i], element_path, expired_substreams);
+            if (narrowed)
+            {
+                new_elements.push_back(std::move(narrowed));
+                new_names.push_back(names[i]);
+            }
+        }
+
+        if (new_elements.empty())
+            return nullptr;
+        if (new_elements.size() == elements.size())
+        {
+            /// Quick path: nothing was narrowed. Reuse the original Tuple to keep type identity stable.
+            bool all_same = true;
+            for (size_t i = 0; i < new_elements.size(); ++i)
+            {
+                if (new_elements[i].get() != elements[i].get())
+                {
+                    all_same = false;
+                    break;
+                }
+            }
+            if (all_same)
+                return full_type;
+        }
+        return std::make_shared<DataTypeTuple>(std::move(new_elements), std::move(new_names));
+    }
+
+    if (const auto * array = typeid_cast<const DataTypeArray *>(full_type.get()))
+    {
+        auto narrowed_nested = narrowDataTypeImpl(array->getNestedType(), path, expired_substreams);
+        if (!narrowed_nested)
+            return nullptr;
+        if (narrowed_nested.get() == array->getNestedType().get())
+            return full_type;
+        return std::make_shared<DataTypeArray>(std::move(narrowed_nested));
+    }
+
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(full_type.get()))
+    {
+        auto narrowed_nested = narrowDataTypeImpl(nullable->getNestedType(), path, expired_substreams);
+        if (!narrowed_nested)
+            return nullptr;
+        if (narrowed_nested.get() == nullable->getNestedType().get())
+            return full_type;
+        return std::make_shared<DataTypeNullable>(std::move(narrowed_nested));
+    }
+
+    if (const auto * map = typeid_cast<const DataTypeMap *>(full_type.get()))
+    {
+        auto narrowed_value = narrowDataTypeImpl(map->getValueType(), path, expired_substreams);
+        if (!narrowed_value)
+            return nullptr;
+        if (narrowed_value.get() == map->getValueType().get())
+            return full_type;
+        return std::make_shared<DataTypeMap>(map->getKeyType(), std::move(narrowed_value));
+    }
+
+    /// Scalar leaf type that is not in the expired set: keep as-is.
+    return full_type;
+}
+
+}
+
+DataTypePtr narrowDataTypeByExpiredSubstreams(
+    const DataTypePtr & full_type,
+    const String & column_name,
+    const NameSet & expired_substreams)
+{
+    return narrowDataTypeImpl(full_type, column_name, expired_substreams);
+}
+
 }

--- a/src/DataTypes/Utils.h
+++ b/src/DataTypes/Utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <DataTypes/IDataType.h>
+#include <Core/Names.h>
 
 namespace DB
 {
@@ -15,5 +16,20 @@ namespace DB
   * From type String to type UInt8 returns false.
   */
 bool canBeSafelyCast(const DataTypePtr & from_type, const DataTypePtr & to_type);
+
+/** Drop the given leaf substream paths from a named-Tuple-shaped type, recursing through
+  * Array / Nullable / Map / nested Tuple wrappers. Returns the narrowed type.
+  *
+  * `expired_substreams` contains dotted storage names rooted at `column_name`
+  * (e.g. for `column_name = "data"`, an entry like "data.c2s.gold" drops `gold`
+  * from inside `data.c2s`).
+  *
+  * Returns nullptr if every leaf of the type is in `expired_substreams` — caller treats
+  * this as "the entire column is expired" and removes it.
+  */
+DataTypePtr narrowDataTypeByExpiredSubstreams(
+    const DataTypePtr & full_type,
+    const String & column_name,
+    const NameSet & expired_substreams);
 
 }

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1241,6 +1241,65 @@ bool isMetadataOnlyConversion(const IDataType * from, const IDataType * to, cons
 
 }
 
+bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to)
+{
+    while (true)
+    {
+        if (from->equals(*to))
+            return false;
+
+        const auto * arr_from = typeid_cast<const DataTypeArray *>(from);
+        const auto * arr_to = typeid_cast<const DataTypeArray *>(to);
+        if (arr_from && arr_to)
+        {
+            from = arr_from->getNestedType().get();
+            to = arr_to->getNestedType().get();
+            continue;
+        }
+
+        const auto * nullable_from = typeid_cast<const DataTypeNullable *>(from);
+        const auto * nullable_to = typeid_cast<const DataTypeNullable *>(to);
+        if (nullable_from && nullable_to)
+        {
+            from = nullable_from->getNestedType().get();
+            to = nullable_to->getNestedType().get();
+            continue;
+        }
+
+        const auto * map_from = typeid_cast<const DataTypeMap *>(from);
+        const auto * map_to = typeid_cast<const DataTypeMap *>(to);
+        if (map_from && map_to)
+        {
+            if (!map_from->getKeyType()->equals(*map_to->getKeyType()))
+                return false;
+            from = map_from->getValueType().get();
+            to = map_to->getValueType().get();
+            continue;
+        }
+
+        const auto * tuple_from = typeid_cast<const DataTypeTuple *>(from);
+        const auto * tuple_to = typeid_cast<const DataTypeTuple *>(to);
+        if (tuple_from && tuple_to
+            && tuple_from->hasExplicitNames() && tuple_to->hasExplicitNames())
+        {
+            const auto & from_names = tuple_from->getElementNames();
+            const auto & to_names = tuple_to->getElementNames();
+            /// Strictly more named fields in `to` than in `from` and every old name still present.
+            if (to_names.size() <= from_names.size())
+                return false;
+            std::unordered_set<std::string_view> to_set(to_names.begin(), to_names.end());
+            for (const auto & name : from_names)
+            {
+                if (!to_set.contains(name))
+                    return false;
+            }
+            return true;
+        }
+
+        return false;
+    }
+}
+
 bool AlterCommand::isSettingsAlter() const
 {
     return type == MODIFY_SETTING || type == RESET_SETTING;

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1333,12 +1333,9 @@ bool tupleAddsSubfieldsOnlyImpl(const IDataType * from, const IDataType * to, co
 
 }
 
-bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to)
+bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to, const ContextPtr & context)
 {
-    /// MergeTree key-safety callers do not have a query context handy.
-    /// JSON-hint metadata-only changes are gated by a per-context setting and cannot
-    /// appear as a Tuple subfield in practice, so passing `nullptr` is safe here.
-    return tupleAddsSubfieldsOnlyImpl(from, to, nullptr);
+    return tupleAddsSubfieldsOnlyImpl(from, to, context);
 }
 
 bool AlterCommand::isSettingsAlter() const

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1127,20 +1127,28 @@ bool isNamedTupleMetadataOnlyChange(const DataTypeTuple & from, const DataTypeTu
     const auto & to_names = to.getElementNames();
     const auto & to_types = to.getElements();
 
-    std::unordered_map<std::string_view, const IDataType *> to_by_name;
-    to_by_name.reserve(to_names.size());
+    std::unordered_map<std::string_view, size_t> to_index_by_name;
+    to_index_by_name.reserve(to_names.size());
     for (size_t i = 0; i < to_names.size(); ++i)
-        to_by_name.emplace(to_names[i], to_types[i].get());
+        to_index_by_name.emplace(to_names[i], i);
 
-    /// Every old subfield must still exist (by name) with a metadata-only-compatible type change.
-    /// New subfields (present in `to` but not in `from`) are allowed in any position — the type's
-    /// default value will be filled on read.
+    /// Every old subfield must still exist in `to` (by name) with a metadata-only-compatible
+    /// type change, AND must appear in the same relative order. Reordering existing fields
+    /// is not metadata-only: `primary.idx` and explicit skip-index bytes for embedded tuple
+    /// values are serialized in the old field order, while the new type deserializes and
+    /// compares in the new order. New subfields can be inserted at any position.
+    size_t last_to_index = 0;
+    bool first = true;
     for (size_t i = 0; i < from_names.size(); ++i)
     {
-        auto it = to_by_name.find(from_names[i]);
-        if (it == to_by_name.end())
+        auto it = to_index_by_name.find(from_names[i]);
+        if (it == to_index_by_name.end())
             return false;
-        if (!isMetadataOnlyConversion(from_types[i].get(), it->second, context))
+        if (!first && it->second <= last_to_index)
+            return false;
+        last_to_index = it->second;
+        first = false;
+        if (!isMetadataOnlyConversion(from_types[i].get(), to_types[it->second].get(), context))
             return false;
     }
     return true;
@@ -1283,19 +1291,28 @@ bool tupleAddsSubfieldsOnlyImpl(const IDataType * from, const IDataType * to, co
     const auto & to_names = tuple_to->getElementNames();
     const auto & to_types = tuple_to->getElements();
 
-    std::unordered_map<std::string_view, const IDataType *> to_by_name;
-    to_by_name.reserve(to_names.size());
+    std::unordered_map<std::string_view, size_t> to_index_by_name;
+    to_index_by_name.reserve(to_names.size());
     for (size_t i = 0; i < to_names.size(); ++i)
-        to_by_name.emplace(to_names[i], to_types[i].get());
+        to_index_by_name.emplace(to_names[i], i);
 
+    /// Same relative-order constraint as `isNamedTupleMetadataOnlyChange`: reordering
+    /// existing fields is not metadata-only and must not be misidentified as a
+    /// pure addition.
     bool found_addition = to_names.size() > from_names.size();
+    size_t last_to_index = 0;
+    bool first = true;
     for (size_t i = 0; i < from_names.size(); ++i)
     {
-        auto it = to_by_name.find(from_names[i]);
-        if (it == to_by_name.end())
+        auto it = to_index_by_name.find(from_names[i]);
+        if (it == to_index_by_name.end())
             return false;
+        if (!first && it->second <= last_to_index)
+            return false;
+        last_to_index = it->second;
+        first = false;
         const IDataType * old_elem = from_types[i].get();
-        const IDataType * new_elem = it->second;
+        const IDataType * new_elem = to_types[it->second].get();
         if (old_elem->equals(*new_elem))
             continue;
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1239,65 +1239,89 @@ bool isMetadataOnlyConversion(const IDataType * from, const IDataType * to, cons
     }
 }
 
+/// Internal recursion: true iff the type change includes at least one named-Tuple
+/// subfield addition and every other field change is itself a metadata-only conversion.
+bool tupleAddsSubfieldsOnlyImpl(const IDataType * from, const IDataType * to, const ContextPtr & context)
+{
+    if (from->equals(*to))
+        return false;
+
+    if (const auto * arr_from = typeid_cast<const DataTypeArray *>(from))
+    {
+        const auto * arr_to = typeid_cast<const DataTypeArray *>(to);
+        if (!arr_to)
+            return false;
+        return tupleAddsSubfieldsOnlyImpl(arr_from->getNestedType().get(), arr_to->getNestedType().get(), context);
+    }
+
+    if (const auto * nullable_from = typeid_cast<const DataTypeNullable *>(from))
+    {
+        const auto * nullable_to = typeid_cast<const DataTypeNullable *>(to);
+        if (!nullable_to)
+            return false;
+        return tupleAddsSubfieldsOnlyImpl(nullable_from->getNestedType().get(), nullable_to->getNestedType().get(), context);
+    }
+
+    if (const auto * map_from = typeid_cast<const DataTypeMap *>(from))
+    {
+        const auto * map_to = typeid_cast<const DataTypeMap *>(to);
+        if (!map_to)
+            return false;
+        if (!map_from->getKeyType()->equals(*map_to->getKeyType()))
+            return false;
+        return tupleAddsSubfieldsOnlyImpl(map_from->getValueType().get(), map_to->getValueType().get(), context);
+    }
+
+    const auto * tuple_from = typeid_cast<const DataTypeTuple *>(from);
+    const auto * tuple_to = typeid_cast<const DataTypeTuple *>(to);
+    if (!tuple_from || !tuple_to
+        || !tuple_from->hasExplicitNames() || !tuple_to->hasExplicitNames())
+        return false;
+
+    const auto & from_names = tuple_from->getElementNames();
+    const auto & from_types = tuple_from->getElements();
+    const auto & to_names = tuple_to->getElementNames();
+    const auto & to_types = tuple_to->getElements();
+
+    std::unordered_map<std::string_view, const IDataType *> to_by_name;
+    to_by_name.reserve(to_names.size());
+    for (size_t i = 0; i < to_names.size(); ++i)
+        to_by_name.emplace(to_names[i], to_types[i].get());
+
+    bool found_addition = to_names.size() > from_names.size();
+    for (size_t i = 0; i < from_names.size(); ++i)
+    {
+        auto it = to_by_name.find(from_names[i]);
+        if (it == to_by_name.end())
+            return false;
+        const IDataType * old_elem = from_types[i].get();
+        const IDataType * new_elem = it->second;
+        if (old_elem->equals(*new_elem))
+            continue;
+
+        /// Field present in both old and new, but type changed: must be a metadata-only
+        /// conversion (Enum widening, Date <-> UInt16, nested named-Tuple addition, ...).
+        /// If it's a nested Tuple addition, also flag `found_addition` so the outer
+        /// "size didn't grow but inner did" case is detected.
+        if (tupleAddsSubfieldsOnlyImpl(old_elem, new_elem, context))
+        {
+            found_addition = true;
+            continue;
+        }
+        if (!isMetadataOnlyConversion(old_elem, new_elem, context))
+            return false;
+    }
+    return found_addition;
+}
+
 }
 
 bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to)
 {
-    while (true)
-    {
-        if (from->equals(*to))
-            return false;
-
-        const auto * arr_from = typeid_cast<const DataTypeArray *>(from);
-        const auto * arr_to = typeid_cast<const DataTypeArray *>(to);
-        if (arr_from && arr_to)
-        {
-            from = arr_from->getNestedType().get();
-            to = arr_to->getNestedType().get();
-            continue;
-        }
-
-        const auto * nullable_from = typeid_cast<const DataTypeNullable *>(from);
-        const auto * nullable_to = typeid_cast<const DataTypeNullable *>(to);
-        if (nullable_from && nullable_to)
-        {
-            from = nullable_from->getNestedType().get();
-            to = nullable_to->getNestedType().get();
-            continue;
-        }
-
-        const auto * map_from = typeid_cast<const DataTypeMap *>(from);
-        const auto * map_to = typeid_cast<const DataTypeMap *>(to);
-        if (map_from && map_to)
-        {
-            if (!map_from->getKeyType()->equals(*map_to->getKeyType()))
-                return false;
-            from = map_from->getValueType().get();
-            to = map_to->getValueType().get();
-            continue;
-        }
-
-        const auto * tuple_from = typeid_cast<const DataTypeTuple *>(from);
-        const auto * tuple_to = typeid_cast<const DataTypeTuple *>(to);
-        if (tuple_from && tuple_to
-            && tuple_from->hasExplicitNames() && tuple_to->hasExplicitNames())
-        {
-            const auto & from_names = tuple_from->getElementNames();
-            const auto & to_names = tuple_to->getElementNames();
-            /// Strictly more named fields in `to` than in `from` and every old name still present.
-            if (to_names.size() <= from_names.size())
-                return false;
-            std::unordered_set<std::string_view> to_set(to_names.begin(), to_names.end());
-            for (const auto & name : from_names)
-            {
-                if (!to_set.contains(name))
-                    return false;
-            }
-            return true;
-        }
-
-        return false;
-    }
+    /// MergeTree key-safety callers do not have a query context handy.
+    /// JSON-hint metadata-only changes are gated by a per-context setting and cannot
+    /// appear as a Tuple subfield in practice, so passing `nullptr` is safe here.
+    return tupleAddsSubfieldsOnlyImpl(from, to, nullptr);
 }
 
 bool AlterCommand::isSettingsAlter() const

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -6,7 +6,9 @@
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeObject.h>
 #include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/NestedUtils.h>
 #include <Analyzer/QueryTreeBuilder.h>
@@ -1105,7 +1107,45 @@ bool isJSONTypeHintOnlyChange(const IDataType * from_type, const IDataType * to_
 
 /// If true, then in order to ALTER the type of the column from the type from to the type to
 /// we don't need to rewrite the data, we only need to update metadata and columns.txt in part directories.
-/// The function works for Arrays and Nullables of the same structure.
+/// The function recurses through Array, Nullable, Map, and named Tuple wrappers.
+bool isMetadataOnlyConversion(const IDataType * from, const IDataType * to, const ContextPtr & context);
+
+/// Named Tuple subfields are stored as separate streams named by the field name path
+/// (e.g. `data.c2s.statistics.heros_statistics.damage.bin`), not by position. Therefore,
+/// adding new subfields to a named Tuple (in any position) only introduces new stream
+/// files; all preexisting subfield stream files remain valid as-is. Reading old parts
+/// that lack the new streams will fall back to the type's default value via the existing
+/// `fillMissingColumns` infrastructure. Removing or renaming subfields, or changing
+/// existing subfield types in a non-metadata-only way, still requires a full data mutation.
+bool isNamedTupleMetadataOnlyChange(const DataTypeTuple & from, const DataTypeTuple & to, const ContextPtr & context)
+{
+    if (!from.hasExplicitNames() || !to.hasExplicitNames())
+        return false;
+
+    const auto & from_names = from.getElementNames();
+    const auto & from_types = from.getElements();
+    const auto & to_names = to.getElementNames();
+    const auto & to_types = to.getElements();
+
+    std::unordered_map<std::string_view, const IDataType *> to_by_name;
+    to_by_name.reserve(to_names.size());
+    for (size_t i = 0; i < to_names.size(); ++i)
+        to_by_name.emplace(to_names[i], to_types[i].get());
+
+    /// Every old subfield must still exist (by name) with a metadata-only-compatible type change.
+    /// New subfields (present in `to` but not in `from`) are allowed in any position — the type's
+    /// default value will be filled on read.
+    for (size_t i = 0; i < from_names.size(); ++i)
+    {
+        auto it = to_by_name.find(from_names[i]);
+        if (it == to_by_name.end())
+            return false;
+        if (!isMetadataOnlyConversion(from_types[i].get(), it->second, context))
+            return false;
+    }
+    return true;
+}
+
 bool isMetadataOnlyConversion(const IDataType * from, const IDataType * to, const ContextPtr & context)
 {
     auto is_compatible_enum_types_conversion = [](const IDataType * from_type, const IDataType * to_type)
@@ -1178,6 +1218,22 @@ bool isMetadataOnlyConversion(const IDataType * from, const IDataType * to, cons
             to = nullable_to->getNestedType().get();
             continue;
         }
+
+        const auto * map_from = typeid_cast<const DataTypeMap *>(from);
+        const auto * map_to = typeid_cast<const DataTypeMap *>(to);
+        if (map_from && map_to)
+        {
+            if (!map_from->getKeyType()->equals(*map_to->getKeyType()))
+                return false;
+            from = map_from->getValueType().get();
+            to = map_to->getValueType().get();
+            continue;
+        }
+
+        const auto * tuple_from = typeid_cast<const DataTypeTuple *>(from);
+        const auto * tuple_to = typeid_cast<const DataTypeTuple *>(to);
+        if (tuple_from && tuple_to)
+            return isNamedTupleMetadataOnlyChange(*tuple_from, *tuple_to, context);
 
         return false;
     }

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -203,7 +203,13 @@ class Context;
 /// return false. Used by MergeTree key/index safety checks: while named-Tuple subfield
 /// additions are metadata-only for ordinary columns, they change the on-disk shape of
 /// any `Tuple` value embedded in a key column, so they must be rejected for keys.
-bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to);
+///
+/// `context` is forwarded to `isMetadataOnlyConversion` so that context-gated conversions
+/// (e.g. `allow_experimental_json_lazy_type_hints`) match the same classification used by
+/// `isRequireMutationStage`; otherwise an ALTER that combines a Tuple subfield addition with
+/// a JSON-hint-only change could skip the mutation branch yet bypass the key-safety check
+/// here.
+bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to, const ContextPtr & context);
 
 /// Vector of AlterCommand with several additional functions
 class AlterCommands : public std::vector<AlterCommand>

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -197,6 +197,14 @@ struct AlterCommand
 
 class Context;
 
+/// Returns true if `from` -> `to` is a metadata-only type change that *introduces new
+/// fields* into a named `Tuple` (recursively through `Array`, `Nullable`, `Map`, or
+/// nested `Tuple` wrappers). Other metadata-only conversions (e.g. `Date` -> `UInt16`)
+/// return false. Used by MergeTree key/index safety checks: while named-Tuple subfield
+/// additions are metadata-only for ordinary columns, they change the on-disk shape of
+/// any `Tuple` value embedded in a key column, so they must be rejected for keys.
+bool tupleAddsSubfieldsOnly(const IDataType * from, const IDataType * to);
+
 /// Vector of AlterCommand with several additional functions
 class AlterCommands : public std::vector<AlterCommand>
 {

--- a/src/Storages/MergeTree/ColumnsSubstreams.cpp
+++ b/src/Storages/MergeTree/ColumnsSubstreams.cpp
@@ -160,6 +160,46 @@ ColumnsSubstreams ColumnsSubstreams::merge(const ColumnsSubstreams & left, const
     return merged;
 }
 
+void ColumnsSubstreams::removeSubstreams(const NameSet & substreams_to_remove)
+{
+    if (substreams_to_remove.empty())
+        return;
+
+    /// Rebuild from scratch to keep the position book-keeping correct.
+    std::vector<std::pair<String, std::vector<String>>> new_columns_substreams;
+    new_columns_substreams.reserve(columns_substreams.size());
+    std::vector<std::unordered_map<String, size_t>> new_positions;
+    new_positions.reserve(columns_substreams.size());
+    size_t new_total = 0;
+
+    for (const auto & [column, substreams] : columns_substreams)
+    {
+        std::vector<String> kept;
+        kept.reserve(substreams.size());
+        std::unordered_map<String, size_t> kept_positions;
+        for (const auto & substream : substreams)
+        {
+            if (substreams_to_remove.contains(substream))
+                continue;
+            kept_positions.emplace(substream, new_total);
+            kept.push_back(substream);
+            ++new_total;
+        }
+
+        /// Always keep the column entry even if it has no substreams left — the column metadata
+        /// is required for the file format invariant ("N columns:"), and `checkDataPart`'s loop
+        /// over `cols_substreams` simply skips empty inner lists. (In practice subfield pruning
+        /// always leaves at least one substream because `removeEmptyColumnsFromPart` promotes
+        /// fully-pruned columns to whole-column removals before we get here.)
+        new_columns_substreams.emplace_back(column, std::move(kept));
+        new_positions.emplace_back(std::move(kept_positions));
+    }
+
+    columns_substreams = std::move(new_columns_substreams);
+    column_position_to_substream_positions = std::move(new_positions);
+    total_substreams = new_total;
+}
+
 void ColumnsSubstreams::writeText(WriteBuffer & buf) const
 {
     writeString("columns substreams version: 1\n", buf);

--- a/src/Storages/MergeTree/ColumnsSubstreams.h
+++ b/src/Storages/MergeTree/ColumnsSubstreams.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <Core/Names.h>
 
 namespace DB
 {
@@ -56,6 +57,11 @@ public:
     /// Merge 2 sets of columns substreams with specified columns order.
     /// If some column exists in both left and right we keep only substreams from the left.
     static ColumnsSubstreams merge(const ColumnsSubstreams & left, const ColumnsSubstreams & right, const std::vector<String> & columns_order);
+
+    /// Drop the substream entries whose names are in @substreams_to_remove. Used by the
+    /// subfield-pruning flow to keep `columns_substreams.txt` consistent with the set of
+    /// actually written stream files after `removeEmptyColumnsFromPart` pruned some leaves.
+    void removeSubstreams(const NameSet & substreams_to_remove);
 
 private:
     std::vector<std::pair<String, std::vector<String>>> columns_substreams;

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -404,6 +404,13 @@ public:
     /// Columns with values, that all have been zeroed by expired ttl
     NameSet expired_columns;
 
+    /// Per-column dotted subfield paths that are entirely type-default and should be
+    /// pruned at finalize time, narrowing the column's named-`Tuple` type. Keyed by the
+    /// owning top-level column name so we never have to re-derive ownership from a
+    /// flat dotted-name set (which is ambiguous when two columns share a dotted prefix —
+    /// e.g. column `data` Tuple(deeper Tuple(y)) vs column `data.deeper` Tuple(y)).
+    std::map<String, NameSet> expired_subfields_by_column;
+
     CompressionCodecPtr default_codec;
 
     mutable std::unique_ptr<VersionMetadata> version;

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.cpp
@@ -2,10 +2,97 @@
 #include <Storages/MergeTree/MergeTreeIOSettings.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/IMergeTreeDataPartWriter.h>
+#include <DataTypes/Utils.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/Serializations/SerializationInfoTuple.h>
 #include <Common/logger_useful.h>
 
 namespace DB
 {
+
+namespace
+{
+
+/// Build a `SerializationInfo` for the narrowed type by reusing the matching element
+/// infos from the old `SerializationInfo`. This preserves the per-element kind stack
+/// (sparse vs default, etc.) and the `num_rows` / `num_defaults` statistics that the
+/// reader relies on to pick the correct deserialization path.
+///
+/// Falls back to creating a fresh `SerializationInfo` from `new_type` if anything in
+/// the structure does not match expectations (e.g. the old info is not a tuple info
+/// even though `old_type` is `Tuple`, or the narrowing crosses a wrapper we don't
+/// know how to unwrap).
+MutableSerializationInfoPtr narrowSerializationInfo(
+    const MutableSerializationInfoPtr & old_info,
+    const DataTypePtr & old_type,
+    const DataTypePtr & new_type)
+{
+    if (!old_info || !old_type)
+        return new_type->createSerializationInfo({});
+
+    /// Same type: reuse the old info as-is.
+    if (new_type->equals(*old_type))
+        return old_info;
+
+    /// Tuple-to-Tuple: zip elements by name from old to new.
+    if (const auto * old_tuple = typeid_cast<const DataTypeTuple *>(old_type.get()))
+    {
+        if (const auto * new_tuple = typeid_cast<const DataTypeTuple *>(new_type.get()))
+        {
+            const auto * old_info_tuple = typeid_cast<const SerializationInfoTuple *>(old_info.get());
+            if (!old_info_tuple || !old_tuple->hasExplicitNames() || !new_tuple->hasExplicitNames())
+                return new_type->createSerializationInfo(old_info->getSettings());
+
+            const auto & old_names = old_tuple->getElementNames();
+            const auto & old_elements = old_tuple->getElements();
+            const auto & new_names = new_tuple->getElementNames();
+            const auto & new_elements = new_tuple->getElements();
+
+            std::unordered_map<String, size_t> old_name_to_index;
+            for (size_t i = 0; i < old_names.size(); ++i)
+                old_name_to_index.emplace(old_names[i], i);
+
+            MutableSerializationInfos new_elem_infos;
+            new_elem_infos.reserve(new_elements.size());
+            for (size_t i = 0; i < new_elements.size(); ++i)
+            {
+                auto it = old_name_to_index.find(new_names[i]);
+                if (it == old_name_to_index.end())
+                {
+                    /// Should not happen: narrowing only removes elements, never adds them.
+                    new_elem_infos.push_back(new_elements[i]->createSerializationInfo(old_info->getSettings()));
+                    continue;
+                }
+                const auto & old_elem_info = old_info_tuple->getElementInfo(it->second);
+                new_elem_infos.push_back(narrowSerializationInfo(old_elem_info, old_elements[it->second], new_elements[i]));
+            }
+            return std::make_shared<SerializationInfoTuple>(std::move(new_elem_infos), Names(new_names));
+        }
+        /// Tuple narrowed to scalar — only happens if the original Tuple had a single named
+        /// element which got fully expired. Fall through to default-info creation.
+        return new_type->createSerializationInfo(old_info->getSettings());
+    }
+
+    /// Wrappers: `Array`/`Nullable`/`Map` use the base `SerializationInfo` (only `Tuple` has a
+    /// dedicated subclass with per-element infos). The wrapper info carries the column-level kind
+    /// (sparse vs default) and statistics, which are independent of how the inner type is shaped.
+    /// So when we narrow inside an `Array(Tuple(...))` / `Map(K, Tuple(...))` / `Nullable(Tuple(...))`,
+    /// the wrapper info stays valid and we hand the old wrapper info back.
+    if (typeid_cast<const DataTypeArray *>(old_type.get()) && typeid_cast<const DataTypeArray *>(new_type.get()))
+        return old_info;
+    if (typeid_cast<const DataTypeNullable *>(old_type.get()) && typeid_cast<const DataTypeNullable *>(new_type.get()))
+        return old_info;
+    if (typeid_cast<const DataTypeMap *>(old_type.get()) && typeid_cast<const DataTypeMap *>(new_type.get()))
+        return old_info;
+
+    /// Anything we don't recognize: rebuild from scratch.
+    return new_type->createSerializationInfo(old_info->getSettings());
+}
+
+}
 
 namespace MergeTreeSetting
 {
@@ -47,18 +134,78 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
     const MergeTreeDataPartPtr & data_part,
     NamesAndTypesList & columns,
     const NameSet & empty_columns,
+    const std::map<String, NameSet> & expired_subfields_by_column_in,
     SerializationInfoByName & serialization_infos,
-    MergeTreeData::DataPart::Checksums & checksums)
+    MergeTreeData::DataPart::Checksums & checksums,
+    NameSet * removed_unhashed_stream_names)
 {
     /// For compact part we have to override whole file with data, it's not
     /// worth it
-    if (empty_columns.empty() || isCompactPart(data_part))
+    if ((empty_columns.empty() && expired_subfields_by_column_in.empty()) || isCompactPart(data_part))
         return {};
 
-    for (const auto & column : empty_columns)
-        LOG_TRACE(data_part->storage.log, "Skipping expired/empty column {} for part {}", column, data_part->name);
+    /// `empty_columns` contains top-level column names whose entire contents should be
+    /// removed (TTL whole-column expiry, horizontal-merge missing-column). Sanity-check
+    /// against the current `columns` list so a stray name does not silently slip through.
+    NameSet column_name_set;
+    for (const auto & column : columns)
+        column_name_set.insert(column.name);
 
-    /// Collect counts for shared streams of different columns. As an example, Nested columns have shared stream with array sizes.
+    NameSet empty_top_columns;
+    for (const auto & name : empty_columns)
+    {
+        if (column_name_set.contains(name))
+            empty_top_columns.insert(name);
+        else
+            LOG_TRACE(data_part->storage.log,
+                "Unknown empty column {} for part {}, ignoring",
+                name, data_part->name);
+    }
+
+    /// Keep only the per-column subfield entries whose top-level column actually exists
+    /// in `columns` (defensive — INSERT/merge contributors should already guarantee this).
+    std::unordered_map<String, NameSet> expired_subfields_by_column;
+    for (const auto & [col_name, paths] : expired_subfields_by_column_in)
+    {
+        if (column_name_set.contains(col_name) && !paths.empty())
+            expired_subfields_by_column.emplace(col_name, paths);
+    }
+
+    if (empty_top_columns.empty() && expired_subfields_by_column.empty())
+        return {};
+
+    for (const auto & column : empty_top_columns)
+        LOG_TRACE(data_part->storage.log, "Skipping expired/empty column {} for part {}", column, data_part->name);
+    for (const auto & [col, subfields] : expired_subfields_by_column)
+    {
+        for (const auto & sub : subfields)
+            LOG_TRACE(data_part->storage.log, "Pruning expired subfield {} from column {} for part {}",
+                sub, col, data_part->name);
+    }
+
+    /// Compute the narrowed types for columns with subfield prunings, and promote
+    /// fully-pruned columns into the top-level removal set.
+    std::unordered_map<String, DataTypePtr> narrowed_types;
+    for (auto & [col_name, expired_subfields] : expired_subfields_by_column)
+    {
+        auto column_it = std::find_if(columns.begin(), columns.end(),
+            [&](const NameAndTypePair & nt) { return nt.name == col_name; });
+        if (column_it == columns.end())
+            continue;
+        auto narrowed = narrowDataTypeByExpiredSubstreams(column_it->type, col_name, expired_subfields);
+        if (!narrowed)
+        {
+            /// All leaves expired: promote to top-level removal.
+            empty_top_columns.insert(col_name);
+        }
+        else if (!narrowed->equals(*column_it->type))
+        {
+            narrowed_types.emplace(col_name, std::move(narrowed));
+        }
+    }
+
+    /// Collect counts for shared streams of different columns. Use the ORIGINAL serialization
+    /// (pre-narrowing) so we count every stream that physically exists on disk.
     std::map<String, size_t> stream_counts;
     for (const auto & column : columns)
     {
@@ -73,26 +220,99 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
 
     NameSet remove_files;
     const String mrk_extension = data_part->getMarksFileExtension();
-    for (const auto & column_name : empty_columns)
+
+    auto mark_for_removal = [&](const String & owner_column_name, const ISerialization::SubstreamPath & substream_path)
+    {
+        auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(owner_column_name, substream_path, ".bin", checksums, data_part->storage.getSettings());
+        if (stream_name && --stream_counts[*stream_name] == 0)
+        {
+            remove_files.emplace(*stream_name + ".bin");
+            remove_files.emplace(*stream_name + mrk_extension);
+            if (removed_unhashed_stream_names)
+            {
+                /// columns_substreams.txt records the unhashed name; compute it directly.
+                ISerialization::StreamFileNameSettings stream_file_name_settings(*data_part->storage.getSettings());
+                removed_unhashed_stream_names->insert(
+                    ISerialization::getFileNameForStream(owner_column_name, substream_path, stream_file_name_settings));
+            }
+        }
+    };
+
+    /// Whole-column removal: enumerate ALL substreams of the column, mark all for removal.
+    for (const auto & column_name : empty_top_columns)
     {
         auto serialization = data_part->tryGetSerialization(column_name);
         if (!serialization)
             continue;
-
-        ISerialization::StreamCallback callback = [&](const ISerialization::SubstreamPath & substream_path)
+        serialization->enumerateStreams([&](const ISerialization::SubstreamPath & path)
         {
-            auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(column_name, substream_path, ".bin", checksums, data_part->storage.getSettings());
-
-            /// Delete files if they are no longer shared with another column.
-            if (stream_name && --stream_counts[*stream_name] == 0)
-            {
-                remove_files.emplace(*stream_name + ".bin");
-                remove_files.emplace(*stream_name + mrk_extension);
-            }
-        };
-
-        serialization->enumerateStreams(callback);
+            mark_for_removal(column_name, path);
+        });
         serialization_infos.erase(column_name);
+    }
+
+    /// Subfield-only removal: enumerate substreams of the ORIGINAL type and the NARROWED
+    /// type. Any stream present in the original but absent from the narrowed type — including
+    /// wrapper streams like `Array.size0` or `Nullable.null` whose owning subtree was
+    /// dropped entirely — is removed. Comparing by enumerated dotted path catches these
+    /// wrapper streams that a literal "leaf in expired set" check would miss.
+    for (const auto & [col_name, expired_subfields] : expired_subfields_by_column)
+    {
+        if (empty_top_columns.contains(col_name))
+            continue;  /// Already handled as a whole-column removal above.
+
+        auto serialization = data_part->tryGetSerialization(col_name);
+        if (!serialization)
+            continue;
+
+        /// Collect dotted stream paths that the narrowed type still produces. The narrowed
+        /// serialization must mirror the part's actual on-disk encoding for every leaf —
+        /// including `String` with `with_size_stream` (which adds a `.size` substream) and
+        /// per-element Sparse / Nullable wrappers. We get this by:
+        ///   * pre-narrowing the old `SerializationInfo` (which keeps each element's
+        ///     `KindStack` and the container's settings), then
+        ///   * calling `narrowed_type->getSerialization(narrowed_info)` so `DataTypeTuple`'s
+        ///     per-element `getSerialization` path wraps each kept element exactly as the
+        ///     writer did.
+        /// Falling back to `getSerialization(settings)` (no info) loses the per-element
+        /// Sparse kind; falling back to `getDefaultSerialization()` loses both settings
+        /// and Sparse. Either fallback would forget streams the part actually wrote, and
+        /// we would mark them for removal.
+        NameSet kept_streams;
+        auto narrowed_it = narrowed_types.find(col_name);
+        if (narrowed_it != narrowed_types.end())
+        {
+            auto old_info_it = serialization_infos.find(col_name);
+            auto old_column_it = std::find_if(columns.begin(), columns.end(),
+                [&](const NameAndTypePair & nt) { return nt.name == col_name; });
+            DataTypePtr old_type = old_column_it != columns.end() ? old_column_it->type : nullptr;
+            auto narrowed_info = (old_info_it != serialization_infos.end() && old_type)
+                ? narrowSerializationInfo(old_info_it->second, old_type, narrowed_it->second)
+                : MutableSerializationInfoPtr{};
+
+            SerializationPtr narrowed_serialization;
+            if (narrowed_info)
+                narrowed_serialization = narrowed_it->second->getSerialization(*narrowed_info);
+            else
+                narrowed_serialization = narrowed_it->second->getSerialization(serialization_infos.getSettings());
+
+            narrowed_serialization->enumerateStreams([&](const ISerialization::SubstreamPath & path)
+            {
+                auto subcolumn_part = ISerialization::getSubcolumnNameForStream(path);
+                kept_streams.insert(subcolumn_part.empty() ? col_name : col_name + "." + subcolumn_part);
+            });
+        }
+
+        serialization->enumerateStreams([&](const ISerialization::SubstreamPath & path)
+        {
+            /// Compute the dotted subcolumn name represented by this substream path.
+            /// Example: column "data" with path -> "c2s.gold" -> dotted "data.c2s.gold";
+            /// for `Array.size0` wrapper stream the subcolumn name is `arr.size0` etc.
+            auto subcolumn_part = ISerialization::getSubcolumnNameForStream(path);
+            String dotted = subcolumn_part.empty() ? col_name : col_name + "." + subcolumn_part;
+            if (!kept_streams.contains(dotted))
+                mark_for_removal(col_name, path);
+        });
     }
 
     /// Remove files on disk and checksums
@@ -110,8 +330,8 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
         }
     }
 
-    /// Remove columns from columns array
-    for (const String & empty_column_name : empty_columns)
+    /// Remove fully-expired columns from the columns array.
+    for (const String & empty_column_name : empty_top_columns)
     {
         auto find_func = [&empty_column_name](const auto & pair) -> bool
         {
@@ -122,6 +342,30 @@ NameSet IMergedBlockOutputStream::removeEmptyColumnsFromPart(
 
         if (remove_it != columns.end())
             columns.erase(remove_it);
+    }
+
+    /// For columns that had only some subfields pruned, replace the entry's type with
+    /// the narrowed type, and update the serialization info to match.
+    for (auto & [col_name, narrowed_type] : narrowed_types)
+    {
+        if (empty_top_columns.contains(col_name))
+            continue;
+        DataTypePtr old_type;
+        for (auto & nt : columns)
+        {
+            if (nt.name == col_name)
+            {
+                old_type = nt.type;
+                nt.type = narrowed_type;
+                break;
+            }
+        }
+        if (auto it = serialization_infos.find(col_name); it != serialization_infos.end())
+        {
+            auto new_info = narrowSerializationInfo(it->second, old_type, narrowed_type);
+            serialization_infos.erase(it);
+            serialization_infos.emplace(col_name, std::move(new_info));
+        }
     }
 
     return remove_files;

--- a/src/Storages/MergeTree/IMergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/IMergedBlockOutputStream.h
@@ -62,14 +62,30 @@ public:
     }
 
 protected:
-    /// Remove all columns in @empty_columns. Also, clears checksums
-    /// and columns array. Return set of removed files names.
+    /// Remove columns and/or narrow named-`Tuple` types of columns. Clears matching
+    /// checksum entries and updates @columns / @serialization_infos. Returns the set
+    /// of files that should be removed from disk.
+    ///
+    /// - @empty_columns: top-level column names whose entire contents should be removed.
+    ///   (Used by the TTL whole-column expiry path and by horizontal-merge missing-column
+    ///   detection.)
+    /// - @expired_subfields_by_column: per-top-level-column dotted subfield paths whose
+    ///   leaf streams should be removed while the surrounding `Tuple` type is narrowed.
+    ///   The map key disambiguates ownership when two columns share a dotted prefix
+    ///   (e.g. column `data` Tuple(deeper Tuple(y)) vs column `data.deeper` Tuple(y)),
+    ///   so the same `data.deeper.y` path can correctly belong to either.
+    ///
+    /// If @removed_unhashed_stream_names is non-null, the unhashed substream names
+    /// (as stored in `columns_substreams.txt`) are appended into it. The caller uses
+    /// these to keep `columns_substreams.txt` consistent with the actual on-disk files.
     NameSet removeEmptyColumnsFromPart(
         const MergeTreeDataPartPtr & data_part,
         NamesAndTypesList & columns,
         const NameSet & empty_columns,
+        const std::map<String, NameSet> & expired_subfields_by_column,
         SerializationInfoByName & serialization_infos,
-        MergeTreeData::DataPart::Checksums & checksums);
+        MergeTreeData::DataPart::Checksums & checksums,
+        NameSet * removed_unhashed_stream_names = nullptr);
 
     MergeTreeSettingsPtr storage_settings;
     LoggerPtr log;

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -13,6 +13,10 @@
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
 #include <DataTypes/NestedUtils.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/Serializations/SerializationInfo.h>
 #include <Disks/SingleDiskVolume.h>
 #include <IO/ReadBufferFromEmptyFile.h>
@@ -130,6 +134,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsDeduplicateMergeProjectionMode deduplicate_merge_projection_mode;
     extern const MergeTreeSettingsBool enable_block_number_column;
     extern const MergeTreeSettingsBool enable_block_offset_column;
+    extern const MergeTreeSettingsBool enable_tuple_subfield_pruning;
     extern const MergeTreeSettingsUInt64 enable_vertical_merge_algorithm;
     extern const MergeTreeSettingsUInt64 merge_max_block_size_bytes;
     extern const MergeTreeSettingsNonZeroUInt64 merge_max_block_size;
@@ -163,6 +168,116 @@ namespace ErrorCodes
     extern const int DIRECTORY_ALREADY_EXISTS;
     extern const int LOGICAL_ERROR;
     extern const int SUPPORT_IS_DISABLED;
+}
+
+namespace
+{
+
+bool typeContainsNamedTuple(const DataTypePtr & type)
+{
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+        return tuple->hasExplicitNames();
+    if (const auto * array = typeid_cast<const DataTypeArray *>(type.get()))
+        return typeContainsNamedTuple(array->getNestedType());
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(type.get()))
+        return typeContainsNamedTuple(nullable->getNestedType());
+    if (const auto * map = typeid_cast<const DataTypeMap *>(type.get()))
+        return typeContainsNamedTuple(map->getValueType());
+    return false;
+}
+
+/// Returns true if @type contains anything we can't safely represent as a dotted
+/// leaf-stream path for merge-side Sub-case A pruning:
+///   * A named-`Tuple` element whose explicit name contains `.` (would alias another
+///     nested path).
+///   * A `Map`: its bucketed serialization streams are not enumerable from the type alone,
+///     so promoting a missing `Map` to a removed leaf could orphan bucket payload files.
+///
+/// When this is true for any source/storage column type involved, that whole column is
+/// ineligible for merge-side narrowing.
+bool typeIsAmbiguousForMergePrune(const DataTypePtr & type)
+{
+    if (typeid_cast<const DataTypeMap *>(type.get()))
+        return true;
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+    {
+        if (tuple->hasExplicitNames())
+        {
+            for (const auto & name : tuple->getElementNames())
+                if (name.find('.') != String::npos)
+                    return true;
+        }
+        for (const auto & elem : tuple->getElements())
+            if (typeIsAmbiguousForMergePrune(elem))
+                return true;
+        return false;
+    }
+    if (const auto * array = typeid_cast<const DataTypeArray *>(type.get()))
+        return typeIsAmbiguousForMergePrune(array->getNestedType());
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(type.get()))
+        return typeIsAmbiguousForMergePrune(nullable->getNestedType());
+    return false;
+}
+
+/// Walk a (possibly Tuple/Array/Nullable/Map-wrapped) named-Tuple type and add the dotted
+/// leaf-stream paths into `out`. `path` is the dotted prefix reached so far.
+/// The path layout mirrors `narrowDataTypeByExpiredSubstreams`: Array/Nullable/Map do not
+/// add to the path; only Tuple's element names do.
+void collectAllLeafSubstreams(const DataTypePtr & type, const String & path, NameSet & out)
+{
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+    {
+        if (tuple->hasExplicitNames())
+        {
+            const auto & names = tuple->getElementNames();
+            const auto & elements = tuple->getElements();
+            /// Element names containing `.` would alias nested dotted paths; we cannot
+            /// safely represent leaves under this Tuple in the dotted path scheme.
+            /// Treat the whole Tuple as an opaque leaf so the merge-side comparison
+            /// never matches a "missing leaf" and never prunes anything inside it.
+            for (const auto & name : names)
+            {
+                if (name.find('.') != String::npos)
+                {
+                    out.insert(path);
+                    return;
+                }
+            }
+            for (size_t i = 0; i < elements.size(); ++i)
+                collectAllLeafSubstreams(elements[i], path + "." + names[i], out);
+            return;
+        }
+        out.insert(path);
+        return;
+    }
+    if (const auto * array = typeid_cast<const DataTypeArray *>(type.get()))
+    {
+        collectAllLeafSubstreams(array->getNestedType(), path, out);
+        return;
+    }
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(type.get()))
+    {
+        collectAllLeafSubstreams(nullable->getNestedType(), path, out);
+        return;
+    }
+    if (const auto * map = typeid_cast<const DataTypeMap *>(type.get()))
+    {
+        /// Treat `Map(K, V)` as an opaque leaf at this path. `SerializationMap` in
+        /// `with_buckets` mode hides its bucketed value streams behind state that
+        /// `enumerateStreams` cannot see without a written column, so deriving stream
+        /// names for narrowing from the type alone is unsafe. INSERT-side pruning also
+        /// never recurses into `Map`, so a merge-side narrowing of a `Map` value
+        /// subfield can only land if some source part is missing that leaf — which
+        /// already means the schema is inconsistent across sources. Conservatively
+        /// keep the whole `Map` as a single leaf.
+        (void)map;
+        out.insert(path);
+        return;
+    }
+    /// Scalar leaf.
+    out.insert(path);
+}
+
 }
 
 /// Transform that builds statistics for columns and doesn't change the chunk.
@@ -647,6 +762,70 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         {
             if (!columns_present_in_parts.contains(storage_column.name) && !columns_desc.getDefault(storage_column.name))
                 global_ctx->new_data_part->expired_columns.emplace(storage_column.name);
+        }
+
+        /// Sub-case A (monotonic): for named-Tuple-shaped storage columns, preserve subfield
+        /// narrowings that ALL source parts already have. A leaf subfield is expired in the
+        /// merged part iff it is missing from every source part's actual type. This way a
+        /// merged part never re-materializes default values for a subfield that was
+        /// consistently pruned in the inputs.
+        ///
+        /// Sub-case B (writer-side per-stream re-detection of all-default leaves at merge
+        /// output) is intentionally not implemented here.
+        if ((*global_ctx->data_settings)[MergeTreeSetting::enable_tuple_subfield_pruning]
+            && !global_ctx->future_part->part_info.isPatch())
+        {
+            for (const auto & storage_column : global_ctx->storage_columns)
+            {
+                if (!typeContainsNamedTuple(storage_column.type))
+                    continue;
+                if (global_ctx->new_data_part->expired_columns.contains(storage_column.name))
+                    continue;
+                if (columns_desc.getDefault(storage_column.name))
+                    continue;  /// Conservatively keep DEFAULT-driven columns intact.
+                if (typeIsAmbiguousForMergePrune(storage_column.type))
+                    continue;  /// dotted-name Tuple or Map — see helper for rationale.
+
+                NameSet full_leaves;
+                collectAllLeafSubstreams(storage_column.type, storage_column.name, full_leaves);
+
+                NameSet union_present;
+                bool any_part_full = false;
+                for (const auto & part : global_ctx->future_part->parts)
+                {
+                    auto part_col = part->tryGetColumn(storage_column.name);
+                    if (!part_col)
+                    {
+                        /// Missing column = all defaults — contributes nothing to the union of
+                        /// present leaves. (Same conservative treatment as the standard
+                        /// expired-columns loop above.)
+                        continue;
+                    }
+                    if (typeIsAmbiguousForMergePrune(part_col->type))
+                    {
+                        any_part_full = true;
+                        break;
+                    }
+                    NameSet part_leaves;
+                    collectAllLeafSubstreams(part_col->type, storage_column.name, part_leaves);
+                    if (part_leaves == full_leaves)
+                    {
+                        any_part_full = true;
+                        break;
+                    }
+                    union_present.merge(std::move(part_leaves));
+                }
+                if (any_part_full)
+                    continue;
+                NameSet expired_for_column;
+                for (const auto & leaf : full_leaves)
+                {
+                    if (!union_present.contains(leaf))
+                        expired_for_column.insert(leaf);
+                }
+                if (!expired_for_column.empty())
+                    global_ctx->new_data_part->expired_subfields_by_column.emplace(storage_column.name, std::move(expired_for_column));
+            }
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4738,14 +4738,10 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                                     reset_setting);
             }
         }
-        else if (command.type == AlterCommand::MODIFY_COLUMN && command.data_type)
+        else if (command.isRequireMutationStage(*getInMemoryMetadataPtr(local_context, false), local_context))
         {
-            /// Run key/index/projection safety checks for any `MODIFY_COLUMN` that changes
-            /// the column's type, regardless of whether the change is metadata-only or
-            /// requires a mutation. Previously these checks were gated behind
-            /// `isRequireMutationStage`, but metadata-only conversions (e.g. adding a
-            /// subfield to a named `Tuple` whose subcolumn appears in `ORDER BY`) must
-            /// also be rejected to keep `primary.idx` and partition keys self-consistent.
+            /// This alter will override data on disk. Let's check that it doesn't
+            /// modify immutable column.
             if (columns_alter_type_forbidden.contains(command.column_name))
                 throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "ALTER of key column {} is forbidden",
                     backQuoteIfNeed(command.column_name));
@@ -4775,34 +4771,87 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             /// Don't check columns in projections here. If required columns of projections get
             /// modified, it will be checked later in AlterCommands::apply.
 
-            if (columns_alter_type_check_safe_for_partition.contains(command.column_name))
+            if (command.type == AlterCommand::MODIFY_COLUMN)
             {
-                auto it = old_types.find(command.column_name);
+                if (columns_alter_type_check_safe_for_partition.contains(command.column_name))
+                {
+                    auto it = old_types.find(command.column_name);
 
-                chassert(it != old_types.end());
-                if (!isSafeForKeyConversion(it->second, command.data_type.get()))
-                    throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                                    "ALTER of partition key column {} from type {} "
-                                    "to type {} is not safe because it can change the representation "
-                                    "of partition key", backQuoteIfNeed(command.column_name),
-                                    it->second->getName(), command.data_type->getName());
+                    chassert(it != old_types.end());
+                    if (!isSafeForKeyConversion(it->second, command.data_type.get()))
+                        throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                                        "ALTER of partition key column {} from type {} "
+                                        "to type {} is not safe because it can change the representation "
+                                        "of partition key", backQuoteIfNeed(command.column_name),
+                                        it->second->getName(), command.data_type->getName());
+                }
+
+                if (columns_alter_type_metadata_only.contains(command.column_name))
+                {
+                    auto it = old_types.find(command.column_name);
+                    chassert(it != old_types.end());
+                    if (!isSafeForKeyConversion(it->second, command.data_type.get()))
+                        throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                                        "ALTER of key column {} from type {} "
+                                        "to type {} is not safe because it can change the representation "
+                                        "of primary key", backQuoteIfNeed(command.column_name),
+                                        it->second->getName(), command.data_type->getName());
+                }
+
+                if (old_metadata.getColumns().has(command.column_name))
+                {
+                    columns_to_check_conversion.push_back(new_metadata.getColumns().getPhysical(command.column_name));
+                }
             }
-
-            if (columns_alter_type_metadata_only.contains(command.column_name))
+        }
+        else if (command.type == AlterCommand::MODIFY_COLUMN && command.data_type
+            && old_metadata.getColumns().hasPhysical(command.column_name)
+            && new_metadata.getColumns().hasPhysical(command.column_name))
+        {
+            /// Metadata-only ALTER that adds new subfields to a named `Tuple` (possibly
+            /// wrapped in `Array`/`Nullable`/`Map`) skips the mutation branch above, so it
+            /// must still respect key/index immutability. Without this, a metadata-only
+            /// `MODIFY COLUMN t Tuple(a, b) -> Tuple(a, b, c)` on a column whose subcolumn
+            /// appears in `ORDER BY` would leave old `primary.idx` bytes that no longer
+            /// match the new tuple shape.
+            ///
+            /// Restricted to named-Tuple subfield additions (`tupleAddsSubfieldsOnly`) so
+            /// existing metadata-only conversions on key columns (e.g. `Date` -> `UInt16`)
+            /// keep their current behavior.
+            auto old_type_it = old_types.find(command.column_name);
+            if (old_type_it != old_types.end()
+                && tupleAddsSubfieldsOnly(old_type_it->second, command.data_type.get()))
             {
-                auto it = old_types.find(command.column_name);
-                chassert(it != old_types.end());
-                if (!isSafeForKeyConversion(it->second, command.data_type.get()))
+                if (columns_alter_type_forbidden.contains(command.column_name)
+                    || columns_alter_type_check_safe_for_partition.contains(command.column_name)
+                    || columns_alter_type_metadata_only.contains(command.column_name))
+                {
                     throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                                    "ALTER of key column {} from type {} "
-                                    "to type {} is not safe because it can change the representation "
-                                    "of primary key", backQuoteIfNeed(command.column_name),
-                                    it->second->getName(), command.data_type->getName());
-            }
+                        "ALTER of key column {} to add new Tuple subfields is forbidden",
+                        backQuoteIfNeed(command.column_name));
+                }
 
-            if (old_metadata.getColumns().has(command.column_name))
-            {
-                columns_to_check_conversion.push_back(new_metadata.getColumns().getPhysical(command.column_name));
+                if (column_to_subcolumns_used_in_keys.contains(command.column_name))
+                {
+                    throw Exception(
+                        ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                        "Trying to ALTER column {} whose subcolumns ({}) are part of key expression",
+                        backQuoteIfNeed(command.column_name),
+                        boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
+                }
+
+                if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)
+                {
+                    if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
+                    {
+                        throw Exception(
+                            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                            "The ALTER of the column '{}' is forbidden because it is used by the index '{}'. Check the MergeTree setting "
+                            "'alter_column_secondary_index_mode' to change this behaviour",
+                            backQuoteIfNeed(command.column_name),
+                            it->second);
+                    }
+                }
             }
         }
     }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4738,10 +4738,14 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                                     reset_setting);
             }
         }
-        else if (command.isRequireMutationStage(*getInMemoryMetadataPtr(local_context, false), local_context))
+        else if (command.type == AlterCommand::MODIFY_COLUMN && command.data_type)
         {
-            /// This alter will override data on disk. Let's check that it doesn't
-            /// modify immutable column.
+            /// Run key/index/projection safety checks for any `MODIFY_COLUMN` that changes
+            /// the column's type, regardless of whether the change is metadata-only or
+            /// requires a mutation. Previously these checks were gated behind
+            /// `isRequireMutationStage`, but metadata-only conversions (e.g. adding a
+            /// subfield to a named `Tuple` whose subcolumn appears in `ORDER BY`) must
+            /// also be rejected to keep `primary.idx` and partition keys self-consistent.
             if (columns_alter_type_forbidden.contains(command.column_name))
                 throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "ALTER of key column {} is forbidden",
                     backQuoteIfNeed(command.column_name));
@@ -4771,37 +4775,34 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             /// Don't check columns in projections here. If required columns of projections get
             /// modified, it will be checked later in AlterCommands::apply.
 
-            if (command.type == AlterCommand::MODIFY_COLUMN)
+            if (columns_alter_type_check_safe_for_partition.contains(command.column_name))
             {
-                if (columns_alter_type_check_safe_for_partition.contains(command.column_name))
-                {
-                    auto it = old_types.find(command.column_name);
+                auto it = old_types.find(command.column_name);
 
-                    chassert(it != old_types.end());
-                    if (!isSafeForKeyConversion(it->second, command.data_type.get()))
-                        throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                                        "ALTER of partition key column {} from type {} "
-                                        "to type {} is not safe because it can change the representation "
-                                        "of partition key", backQuoteIfNeed(command.column_name),
-                                        it->second->getName(), command.data_type->getName());
-                }
+                chassert(it != old_types.end());
+                if (!isSafeForKeyConversion(it->second, command.data_type.get()))
+                    throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                                    "ALTER of partition key column {} from type {} "
+                                    "to type {} is not safe because it can change the representation "
+                                    "of partition key", backQuoteIfNeed(command.column_name),
+                                    it->second->getName(), command.data_type->getName());
+            }
 
-                if (columns_alter_type_metadata_only.contains(command.column_name))
-                {
-                    auto it = old_types.find(command.column_name);
-                    chassert(it != old_types.end());
-                    if (!isSafeForKeyConversion(it->second, command.data_type.get()))
-                        throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                                        "ALTER of key column {} from type {} "
-                                        "to type {} is not safe because it can change the representation "
-                                        "of primary key", backQuoteIfNeed(command.column_name),
-                                        it->second->getName(), command.data_type->getName());
-                }
+            if (columns_alter_type_metadata_only.contains(command.column_name))
+            {
+                auto it = old_types.find(command.column_name);
+                chassert(it != old_types.end());
+                if (!isSafeForKeyConversion(it->second, command.data_type.get()))
+                    throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                                    "ALTER of key column {} from type {} "
+                                    "to type {} is not safe because it can change the representation "
+                                    "of primary key", backQuoteIfNeed(command.column_name),
+                                    it->second->getName(), command.data_type->getName());
+            }
 
-                if (old_metadata.getColumns().has(command.column_name))
-                {
-                    columns_to_check_conversion.push_back(new_metadata.getColumns().getPhysical(command.column_name));
-                }
+            if (old_metadata.getColumns().has(command.column_name))
+            {
+                columns_to_check_conversion.push_back(new_metadata.getColumns().getPhysical(command.column_name));
             }
         }
     }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4840,12 +4840,17 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                         boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
                 }
 
-                /// Explicit skip indexes that depend on this column have on-disk bytes
-                /// (skp_idx_*.idx) serialized with the old Tuple shape. Metadata-only
-                /// ALTER does not produce a `MutationCommand::READ_COLUMN`, so the
-                /// rebuild/drop logic in `MutationsInterpreter` cannot refresh them.
-                /// Reject unconditionally — independent of `alter_column_secondary_index_mode` —
-                /// because no mode can recover the stale index bytes for this code path.
+                /// Explicit skip indexes that depend on this column or any of its tuple
+                /// subcolumns have on-disk bytes (skp_idx_*.idx) serialized with the old
+                /// Tuple shape. Metadata-only ALTER does not produce a
+                /// `MutationCommand::READ_COLUMN`, so the rebuild/drop logic in
+                /// `MutationsInterpreter` cannot refresh them. Reject unconditionally —
+                /// independent of `alter_column_secondary_index_mode` — because no mode can
+                /// recover the stale index bytes for this code path.
+                ///
+                /// The match must include `column_name + "."` prefixes so that an index
+                /// keyed on a tuple subcolumn (e.g. `INDEX idx t.sub TYPE set(0)`) is still
+                /// caught when the storage column `t` is altered.
                 if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
                 {
                     throw Exception(
@@ -4854,6 +4859,20 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                         "Drop the index first, then re-create it after the ALTER",
                         backQuoteIfNeed(command.column_name),
                         it->second);
+                }
+                const String subcol_prefix = command.column_name + ".";
+                for (const auto & [indexed_col, index_name] : columns_in_explicit_indices)
+                {
+                    if (indexed_col.starts_with(subcol_prefix))
+                    {
+                        throw Exception(
+                            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                            "Adding new Tuple subfields to column '{}' is forbidden because its subcolumn '{}' is used by the explicit skip index '{}'. "
+                            "Drop the index first, then re-create it after the ALTER",
+                            backQuoteIfNeed(command.column_name),
+                            indexed_col,
+                            index_name);
+                    }
                 }
             }
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4860,19 +4860,27 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                         backQuoteIfNeed(command.column_name),
                         it->second);
                 }
-                const String subcol_prefix = command.column_name + ".";
+                /// For dotted index keys, resolve through `tryGetColumnOrSubcolumn` to
+                /// distinguish a true subcolumn (e.g. `t.sub` of column `t`) from an
+                /// unrelated top-level column whose name happens to start with
+                /// `command.column_name + "."` (e.g. column `data.deeper` when altering
+                /// `data`). Only reject when the indexed key resolves to a real subcolumn
+                /// of the storage column being altered.
+                const auto & old_columns_desc = old_metadata.getColumns();
                 for (const auto & [indexed_col, index_name] : columns_in_explicit_indices)
                 {
-                    if (indexed_col.starts_with(subcol_prefix))
-                    {
-                        throw Exception(
-                            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                            "Adding new Tuple subfields to column '{}' is forbidden because its subcolumn '{}' is used by the explicit skip index '{}'. "
-                            "Drop the index first, then re-create it after the ALTER",
-                            backQuoteIfNeed(command.column_name),
-                            indexed_col,
-                            index_name);
-                    }
+                    if (!indexed_col.starts_with(command.column_name + "."))
+                        continue;
+                    auto resolved = old_columns_desc.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, indexed_col);
+                    if (!resolved || resolved->getNameInStorage() != command.column_name)
+                        continue;
+                    throw Exception(
+                        ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                        "Adding new Tuple subfields to column '{}' is forbidden because its subcolumn '{}' is used by the explicit skip index '{}'. "
+                        "Drop the index first, then re-create it after the ALTER",
+                        backQuoteIfNeed(command.column_name),
+                        indexed_col,
+                        index_name);
                 }
             }
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4840,17 +4840,20 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
                         boost::join(column_to_subcolumns_used_in_keys[command.column_name], ", "));
                 }
 
-                if (index_mode == AlterColumnSecondaryIndexMode::THROW || index_mode == AlterColumnSecondaryIndexMode::COMPATIBILITY)
+                /// Explicit skip indexes that depend on this column have on-disk bytes
+                /// (skp_idx_*.idx) serialized with the old Tuple shape. Metadata-only
+                /// ALTER does not produce a `MutationCommand::READ_COLUMN`, so the
+                /// rebuild/drop logic in `MutationsInterpreter` cannot refresh them.
+                /// Reject unconditionally — independent of `alter_column_secondary_index_mode` —
+                /// because no mode can recover the stale index bytes for this code path.
+                if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
                 {
-                    if (auto it = columns_in_explicit_indices.find(command.column_name); it != columns_in_explicit_indices.end())
-                    {
-                        throw Exception(
-                            ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
-                            "The ALTER of the column '{}' is forbidden because it is used by the index '{}'. Check the MergeTree setting "
-                            "'alter_column_secondary_index_mode' to change this behaviour",
-                            backQuoteIfNeed(command.column_name),
-                            it->second);
-                    }
+                    throw Exception(
+                        ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
+                        "Adding new Tuple subfields to column '{}' is forbidden because it is used by the explicit skip index '{}'. "
+                        "Drop the index first, then re-create it after the ALTER",
+                        backQuoteIfNeed(command.column_name),
+                        it->second);
                 }
             }
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -4820,7 +4820,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
             /// keep their current behavior.
             auto old_type_it = old_types.find(command.column_name);
             if (old_type_it != old_types.end()
-                && tupleAddsSubfieldsOnly(old_type_it->second, command.data_type.get()))
+                && tupleAddsSubfieldsOnly(old_type_it->second, command.data_type.get(), local_context))
             {
                 if (columns_alter_type_forbidden.contains(command.column_name)
                     || columns_alter_type_check_safe_for_partition.contains(command.column_name)

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -1,12 +1,19 @@
 #include <memory>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnTuple.h>
 #include <Columns/ColumnsDateTime.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/assert_cast.h>
 #include <Core/Settings.h>
 #include <Core/UUID.h>
+#include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime.h>
+#include <DataTypes/DataTypeEnum.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
 #include <Disks/createVolume.h>
 #include <IO/HashingWriteBuffer.h>
 #include <IO/WriteHelpers.h>
@@ -88,6 +95,7 @@ namespace Setting
 namespace MergeTreeSetting
 {
     extern const MergeTreeSettingsBool assign_part_uuids;
+    extern const MergeTreeSettingsBool enable_tuple_subfield_pruning;
     extern const MergeTreeSettingsBool fsync_after_insert;
     extern const MergeTreeSettingsBool fsync_part_directory;
     extern const MergeTreeSettingsBool materialize_skip_indexes_on_merge;
@@ -407,6 +415,190 @@ MergeTreeIndices collectSkipIndicesToMaterialize(
     return indices;
 }
 
+bool typeContainsEnumOrMap(const DataTypePtr & type);
+
+/// Recurse into the column at `path` (matching the layout of `full_type`) and add the
+/// dotted leaf-subfield names of every all-default subtree into `expired`.
+/// `path` is the dotted name reached so far ("data", "data.c2s", "data.c2s.gold").
+///
+/// The collected names are dotted subfield paths rooted at the top-level column,
+/// suitable for `IMergedBlockOutputStream::removeEmptyColumnsFromPart` to prune
+/// the corresponding substream files and narrow the column's Tuple type.
+void collectExpiredLeavesRecursive(
+    const String & path,
+    const DataTypePtr & type,
+    const IColumn & column,
+    NameSet & expired)
+{
+    /// Skip types whose "all-zero memory" doesn't coincide with the type-default
+    /// produced by `insertDefaultInto` on read. `Enum8`/`Enum16` are stored as `Int8`/
+    /// `Int16` so `ColumnVector::hasOnlyTypeDefaults` reports true for an all-`0` column
+    /// even when the enum's declared default is not value `0` (e.g. `Enum8('a' = 1)`
+    /// has type-default `'a'`). In practice the column type system also forbids storing
+    /// values not declared in the enum, so the data-loss case is mostly defensive — but
+    /// since we cannot tell from the column alone whether `0` is a valid enum member,
+    /// just refuse to prune any subtree rooted at an Enum.
+    /// (Use `dynamic_cast` here because `typeid_cast` requires an exact type-id match
+    /// and would miss the templated `DataTypeEnum<Int8>` / `DataTypeEnum<Int16>`.)
+    if (dynamic_cast<const IDataTypeEnum *>(type.get()))
+        return;
+
+    /// Skip `Map`: in `with_buckets` serialization the bucketed value streams
+    /// (`t.m.<bucket>.values.*`) are only discoverable from a written column +
+    /// state. The narrowing cleanup path in
+    /// `IMergedBlockOutputStream::removeEmptyColumnsFromPart` uses type-only
+    /// `enumerateStreams`, so pruning a `Map` wrapper would leave its bucket payload
+    /// streams (and corresponding `columns_substreams.txt` entries) on disk while
+    /// `columns.txt` no longer mentions them. Conservatively never prune anything
+    /// rooted at a `Map`.
+    if (typeid_cast<const DataTypeMap *>(type.get()))
+        return;
+
+    if (column.hasOnlyTypeDefaults())
+    {
+        /// The entire subtree at `path` is all defaults: record `path` as expired.
+        /// For named-Tuple subtrees this drops the whole subtree. For a `Nullable` leaf
+        /// `hasOnlyTypeDefaults` is true only when every row is NULL (the Nullable
+        /// type-default), so the value-loss case described below cannot trigger here.
+        ///
+        /// Refuse to drop the whole subtree if it contains an `Enum` or a `Map` — neither
+        /// can be safely materialized from defaults at read time (see the discussion at
+        /// `typeContainsEnumOrMap` above). Recurse into the Tuple instead so we still get
+        /// a chance to prune safe leaves inside.
+        if (typeContainsEnumOrMap(type))
+        {
+            /// Fall through to the Tuple recursion below; do not record this path.
+        }
+        else
+        {
+            expired.insert(path);
+            return;
+        }
+    }
+
+    /// Intentionally NOT recursing into `Nullable`. `Nullable(X)`'s type-default is NULL —
+    /// `Nullable::isDefaultAt(i)` is just `isNullAt(i)`. Unwrapping the Nullable here and
+    /// asking the inner column "are you all default?" would conflate "all NULL" with "all
+    /// non-NULL zeros / empty strings" and prune the subfield in both cases, after which
+    /// reads would materialize NULL where the original value was `toNullable(0)` or
+    /// `toNullable('')`. The all-NULL case is already covered by the
+    /// `hasOnlyTypeDefaults` short-circuit above.
+    if (typeid_cast<const DataTypeNullable *>(type.get()))
+        return;
+
+    /// For Array(Tuple) / Map(K, Tuple): per-row sizes are shared across all element subfields,
+    /// so we cannot prune individual subfields without losing size information. The "all rows
+    /// are empty containers" case is already covered by `hasOnlyTypeDefaults` above.
+    if (typeid_cast<const DataTypeArray *>(type.get()) || typeid_cast<const DataTypeMap *>(type.get()))
+        return;
+
+    /// Tuple: recurse into every element with the extended dotted path. Element names
+    /// that contain `.` themselves would alias nested subtree paths (e.g. element name
+    /// `a.b` is indistinguishable from the path `t.a.b` of nested element `b` under
+    /// element `a`). In that case we cannot safely use the dotted path scheme; bail out
+    /// for the whole tuple.
+    if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get()))
+    {
+        if (!tuple_type->hasExplicitNames())
+            return;
+
+        const auto * tuple_column = typeid_cast<const ColumnTuple *>(&column);
+        if (!tuple_column)
+            return;
+
+        const auto & names = tuple_type->getElementNames();
+        const auto & elements = tuple_type->getElements();
+        for (const auto & name : names)
+        {
+            if (name.find('.') != String::npos)
+                return;
+        }
+        for (size_t i = 0; i < elements.size(); ++i)
+        {
+            String element_path = path + "." + names[i];
+            collectExpiredLeavesRecursive(element_path, elements[i], tuple_column->getColumn(i), expired);
+        }
+    }
+
+    /// Scalar leaf type that is not all-default — keep.
+}
+
+bool typeContainsNamedTuple(const DataTypePtr & type)
+{
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+        return tuple->hasExplicitNames();
+    if (const auto * array = typeid_cast<const DataTypeArray *>(type.get()))
+        return typeContainsNamedTuple(array->getNestedType());
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(type.get()))
+        return typeContainsNamedTuple(nullable->getNestedType());
+    if (const auto * map = typeid_cast<const DataTypeMap *>(type.get()))
+        return typeContainsNamedTuple(map->getValueType());
+    return false;
+}
+
+/// Returns true if @type contains any subtree we refuse to prune wholesale even when
+/// `hasOnlyTypeDefaults` reports true at a higher level. These are:
+///
+/// - `Enum8` / `Enum16`: the column's raw zero bytes may correspond to a declared enum
+///   value, while `insertDefaultInto` on read would synthesize a *different* enum value
+///   (the smallest declared) — a data-loss read mismatch when an outer wrapper is dropped.
+///
+/// - `Map`: bucketed map serialization (`with_buckets`) hides its payload streams behind
+///   write state that `enumerateStreams` cannot recover from the type alone, so dropping
+///   a `Map`-containing subtree would leave bucket payload streams orphaned on disk.
+bool typeContainsEnumOrMap(const DataTypePtr & type)
+{
+    if (dynamic_cast<const IDataTypeEnum *>(type.get()))
+        return true;
+    if (typeid_cast<const DataTypeMap *>(type.get()))
+        return true;
+    if (const auto * tuple = typeid_cast<const DataTypeTuple *>(type.get()))
+    {
+        for (const auto & elem : tuple->getElements())
+            if (typeContainsEnumOrMap(elem))
+                return true;
+        return false;
+    }
+    if (const auto * array = typeid_cast<const DataTypeArray *>(type.get()))
+        return typeContainsEnumOrMap(array->getNestedType());
+    if (const auto * nullable = typeid_cast<const DataTypeNullable *>(type.get()))
+        return typeContainsEnumOrMap(nullable->getNestedType());
+    return false;
+}
+
+std::map<String, NameSet> collectExpiredTupleSubstreams(const NamesAndTypesList & columns, const Block & block)
+{
+    std::map<String, NameSet> expired_by_column;
+    for (const auto & [name, type] : columns)
+    {
+        if (!typeContainsNamedTuple(type))
+            continue;
+        if (!block.has(name))
+            continue;
+        const auto & column = block.getByName(name).column;
+
+        /// Do not prune at all if the top-level column is entirely default. Erasing a top-level
+        /// column would semantically turn the part into "column is missing" — and a subsequent
+        /// `ALTER MODIFY COLUMN ... DEFAULT <new_expr>` would re-materialize the column with the
+        /// NEW default on read (the quirk tracked by #92475). By keeping the column physically
+        /// present we pin the historical values to the language type-default (0 / '' / NULL)
+        /// regardless of later DEFAULT changes. Named-Tuple subfields have no per-subfield
+        /// DEFAULT syntax, so pruning a subfield can only ever fall back to the type-default,
+        /// which keeps this optimization composable with the per-column DEFAULT RFC in #92475.
+        if (column->hasOnlyTypeDefaults())
+            continue;
+
+        NameSet expired_for_this_column;
+        collectExpiredLeavesRecursive(name, type, *column, expired_for_this_column);
+        /// `collectExpiredLeavesRecursive` never inserts the top-level path here (the
+        /// `hasOnlyTypeDefaults` short-circuit above guards that), but defend against future
+        /// callers by erasing any top-level entry that might sneak in.
+        expired_for_this_column.erase(name);
+        if (!expired_for_this_column.empty())
+            expired_by_column.emplace(name, std::move(expired_for_this_column));
+    }
+    return expired_by_column;
+}
 
 }
 
@@ -865,6 +1057,22 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         auto & column = block.getByName(column_name);
         if (!ISerialization::hasKind(infos.getKindStack(column_name), ISerialization::Kind::SPARSE))
             column.column = recursiveRemoveSparse(column.column);
+    }
+
+    /// Detect named-Tuple subfields whose values in this block are entirely type-defaults
+    /// and record them keyed by the owning top-level column. The finalize-phase
+    /// `IMergedBlockOutputStream::removeEmptyColumnsFromPart` will prune the corresponding
+    /// substream files and narrow the column's Tuple type accordingly.
+    /// Wide parts only (matches the existing whole-column expiry path).
+    /// Skipped for patch parts (mirrors `skip_empty_columns_on_insert`'s treatment).
+    if ((*data_settings)[MergeTreeSetting::enable_tuple_subfield_pruning] && !new_part_info.isPatch())
+    {
+        auto expired_subfields = collectExpiredTupleSubstreams(columns, block);
+        for (auto & [col_name, paths] : expired_subfields)
+        {
+            auto & dest = new_data_part->expired_subfields_by_column[col_name];
+            dest.merge(std::move(paths));
+        }
     }
 
     new_data_part->setColumns(columns, infos, metadata_snapshot->getMetadataVersion());

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -275,6 +275,22 @@ namespace ErrorCodes
     semantics, and a scalar column may coexist with dotted Array columns sharing the same prefix
     (e.g. n UInt32 alongside n.a Array(String)). This setting is immutable after table creation.
     )", 0) \
+    DECLARE(Bool, enable_tuple_subfield_pruning, true, R"(
+    When enabled (default), at INSERT and merge time the writer omits stream files for nested
+    named-`Tuple` subfields whose values in the part are entirely type-defaults. `Array` and
+    `Nullable` wrappers around a named `Tuple` are pruned only as whole-wrapper defaults
+    (all-empty arrays, all-`NULL` values) — individual inner subfields are not pruned through
+    these wrappers because per-row sizes / null map are shared. `Map` subtrees are kept opaque
+    entirely (the bucketed serialization hides its payload streams behind state that the
+    cleanup pass cannot enumerate from the type alone). The part's `columns.txt` records a
+    narrowed `Tuple` type without the pruned subfields; reads see the narrowed type and use
+    `CAST(narrowed_tuple, full_tuple)` to materialize defaults, matching the metadata-only
+    ALTER behavior in #107305.
+
+    This optimization is most useful for `PARTITION BY` schemes where different partitions populate
+    different subsets of a wide schema's subfields. Only applies to Wide parts; Compact parts always
+    keep the full schema.
+    )", 0) \
     DECLARE(MergeTreeSerializationInfoVersion, serialization_info_version, "with_types", R"(
     Serialization info version used when writing `serialization.json`.
     This setting is required for compatibility during cluster upgrades.

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -228,6 +228,7 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
     }
 
     NameSet files_to_remove_after_sync;
+    NameSet removed_unhashed_stream_names;
     if (reset_columns)
     {
         auto part_columns = total_columns_list ? *total_columns_list : columns_list;
@@ -235,13 +236,25 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
 
         serialization_infos.replaceData(new_serialization_infos);
         files_to_remove_after_sync
-            = removeEmptyColumnsFromPart(new_part, part_columns, new_part->expired_columns, serialization_infos, checksums);
+            = removeEmptyColumnsFromPart(new_part, part_columns, new_part->expired_columns, new_part->expired_subfields_by_column, serialization_infos, checksums, &removed_unhashed_stream_names);
+
+        new_part->setColumns(part_columns, serialization_infos, metadata_snapshot->getMetadataVersion());
+    }
+    else if (!new_part->expired_columns.empty() || !new_part->expired_subfields_by_column.empty())
+    {
+        /// INSERT path uses reset_columns=false but may still flag subfields for pruning
+        /// (e.g. via Tuple subfield detection). Run the prune pass without touching the
+        /// freshly-built SerializationInfos otherwise.
+        auto part_columns = total_columns_list ? *total_columns_list : columns_list;
+        auto serialization_infos = new_part->getSerializationInfos();
+        files_to_remove_after_sync
+            = removeEmptyColumnsFromPart(new_part, part_columns, new_part->expired_columns, new_part->expired_subfields_by_column, serialization_infos, checksums, &removed_unhashed_stream_names);
 
         new_part->setColumns(part_columns, serialization_infos, metadata_snapshot->getMetadataVersion());
     }
 
     std::vector<std::unique_ptr<WriteBufferFromFileBase>> written_files;
-    written_files = finalizePartOnDisk(new_part, checksums, gathered_data);
+    written_files = finalizePartOnDisk(new_part, checksums, gathered_data, removed_unhashed_stream_names);
 
     new_part->rows_count = rows_count;
     new_part->modification_time = time(nullptr);
@@ -286,7 +299,8 @@ MergedBlockOutputStream::Finalizer MergedBlockOutputStream::finalizePartAsync(
 MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDisk(
     const MergeTreeMutableDataPartPtr & new_part,
     MergeTreeData::DataPart::Checksums & checksums,
-    const GatheredData & gathered_data)
+    const GatheredData & gathered_data,
+    const NameSet & removed_stream_names)
 {
     /// NOTE: You do not need to call fsync here, since it will be called later for the all written_files.
     WrittenFiles written_files;
@@ -406,6 +420,11 @@ MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDis
         writer->getColumnsSubstreams(),
         gathered_data.columns_substreams,
         new_part->getColumns().getNames());
+
+    /// Drop substream entries that correspond to files removed by
+    /// `removeEmptyColumnsFromPart` (named-Tuple subfield pruning). Keeps
+    /// `columns_substreams.txt` in sync with the set of files actually on disk.
+    columns_substreams.removeSubstreams(removed_stream_names);
 
     if (!columns_substreams.empty())
     {

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -84,7 +84,8 @@ private:
     WrittenFiles finalizePartOnDisk(
         const MergeTreeMutableDataPartPtr & new_part,
         MergeTreeData::DataPart::Checksums & checksums,
-        const GatheredData & gathered_data);
+        const GatheredData & gathered_data,
+        const NameSet & removed_stream_names);
 
     NamesAndTypesList columns_list;
     size_t rows_count = 0;

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -101,7 +101,7 @@ MergeTreeData::DataPart::Checksums MergedColumnOnlyOutputStream::fillChecksums(M
         if (new_part->expired_columns.contains(column.name))
             empty_columns.emplace(column.name);
     }
-    auto removed_files = removeEmptyColumnsFromPart(new_part, columns, empty_columns, serialization_infos, checksums);
+    auto removed_files = removeEmptyColumnsFromPart(new_part, columns, empty_columns, {}, serialization_infos, checksums);
 
     for (const String & removed_file : removed_files)
     {

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -80,3 +80,9 @@ mutations:	0
 10	100	\N
 Case 18a (explicit set skip index on whole column rejected, default mode):
 Case 18b (explicit skip index rejected even with rebuild mode):
+Case 19a (pure reorder triggers mutation):
+mutations:	1
+(20,10)
+Case 19b (insertion preserving order is metadata-only):
+mutations:	0
+10	20	\N

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -66,3 +66,9 @@ Case 15 new subfields readable:
 100	100	100	100
 Case 15 whole tuple read works:
 100
+Case 16a (subcolumn in ORDER BY rejected):
+Case 16b (subcolumn in PARTITION BY rejected):
+Case 16c (whole Tuple in ORDER BY rejected):
+Case 16d (Tuple not in any key still works):
+mutations:	0
+10	20	\N

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -1,0 +1,68 @@
+Case 1 (flat, append at end):
+mutations:	0
+0	0	\N
+1	1	\N
+2	2	\N
+t (whole):	(0,'0',NULL)
+t (whole):	(1,'1',NULL)
+t (whole):	(2,'2',NULL)
+Case 2 (flat, insert in middle):
+mutations:	0
+0	0	\N
+1	1	\N
+2	2	\N
+t (whole):	(0,NULL,'0')
+t (whole):	(1,NULL,'1')
+t (whole):	(2,NULL,'2')
+Case 3 (nested Tuple, inner append):
+mutations:	0
+0	0	0	\N
+1	10	100	\N
+2	20	200	\N
+Case 4 (Array of Tuple):
+mutations:	0
+[0,1,2]	['0','1','2']	[NULL,NULL,NULL]
+t (whole):	[(0,'0',NULL),(1,'1',NULL),(2,'2',NULL)]
+Case 5 (Nested with flatten_nested=0):
+mutations:	0
+[0,1,2]	['0','1','2']	[NULL,NULL,NULL]
+Case 6 (Map of Tuple):
+mutations:	0
+{'k1':(10,'x',NULL),'k2':(20,'y',NULL)}
+Case 7 (non-Nullable new subfield):
+mutations:	0
+0	0	0
+1	1	0
+2	2	0
+Case 8 (multiple sequential ALTERs):
+mutations:	0
+0	0	\N	\N	[]
+1	1	\N	\N	[]
+t (whole):	(0,NULL,'0',NULL,[])
+t (whole):	(1,NULL,'1',NULL,[])
+Case 9 (unnamed Tuple rejected):
+Case 10 (subfield removal triggers mutation):
+mutations:	1
+(10)
+Case 11 (subfield rename triggers mutation):
+mutations:	1
+Case 12 (incompatible subfield type change triggers mutation):
+mutations:	1
+('42')
+Case 13 before merge (parts count):
+1
+Case 13 after merge: old rows return NULL, new row returns the inserted value:
+\N
+\N
+42
+Case 13 part count after merge:
+1
+Case 14 (stream collision rejected):
+Case 15 customer schema before ALTERs:
+100
+Case 15 mutations after 4 ALTERs:
+0
+Case 15 new subfields readable:
+100	100	100	100
+Case 15 whole tuple read works:
+100

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -80,6 +80,7 @@ mutations:	0
 10	100	\N
 Case 18a (explicit set skip index on whole column rejected, default mode):
 Case 18b (explicit skip index rejected even with rebuild mode):
+Case 18c (explicit skip index on Tuple subcolumn rejected):
 Case 19a (pure reorder triggers mutation):
 mutations:	1
 (20,10)

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -72,3 +72,11 @@ Case 16c (whole Tuple in ORDER BY rejected):
 Case 16d (Tuple not in any key still works):
 mutations:	0
 10	20	\N
+Case 17a (nested addition, subcolumn under it in ORDER BY rejected):
+Case 17b (nested addition with whole Tuple in ORDER BY rejected):
+Case 17c (nested addition, sibling subcolumn in ORDER BY rejected):
+Case 17d (nested addition, no key dep, succeeds as metadata-only):
+mutations:	0
+10	100	\N
+Case 18a (explicit set skip index on whole column rejected, default mode):
+Case 18b (explicit skip index rejected even with rebuild mode):

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.reference
@@ -81,6 +81,8 @@ mutations:	0
 Case 18a (explicit set skip index on whole column rejected, default mode):
 Case 18b (explicit skip index rejected even with rebuild mode):
 Case 18c (explicit skip index on Tuple subcolumn rejected):
+Case 18d (skip index on dotted top-level column does not block sibling):
+mutations:	0
 Case 19a (pure reorder triggers mutation):
 mutations:	1
 (20,10)

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -288,7 +288,28 @@ CREATE TABLE t_named_tuple_alter
 ENGINE = MergeTree ORDER BY tuple()
 SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
 
-INSERT INTO t_named_tuple_alter SELECT * FROM generateRandom() LIMIT 100;
+-- 100 rows where every Nullable subfield is NULL, Map is empty, Array is empty.
+-- The exact values are irrelevant — Case 15 only verifies that the four metadata-only
+-- ALTERs below trigger zero mutations and that the freshly-added subfields read back
+-- as defaults. (Earlier versions used `generateRandom()` here, but that table function
+-- ignores the INSERT target schema in server mode and produces a random column count,
+-- which makes the INSERT non-deterministic; see `NUMBER_OF_COLUMNS_DOESNT_MATCH`.)
+INSERT INTO t_named_tuple_alter
+SELECT
+    toDateTime64('2024-01-01', 3),
+    toString(number),
+    (
+        NULL, NULL, NULL,
+        map(),
+        (
+            NULL, NULL,
+            (
+                NULL, NULL,
+                []::Array(Tuple(hero_id Nullable(Int64), star Nullable(Int64), damage Nullable(Int64)))
+            )
+        )
+    )
+FROM numbers(100);
 
 SELECT 'Case 15 customer schema before ALTERs:';
 SELECT count() FROM t_named_tuple_alter;

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -357,3 +357,64 @@ SELECT 'Case 15 whole tuple read works:';
 SELECT count() FROM (SELECT data FROM t_named_tuple_alter);
 
 DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 16 (REJECT): key/index/projection safety checks must run even when the
+-- type change would otherwise be metadata-only. If a subcolumn of the modified
+-- column appears in the primary key or partition key, the ALTER must be rejected
+-- to keep `primary.idx` self-consistent across parts.
+-- ============================================================
+
+-- Subcolumn in ORDER BY.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree ORDER BY (t.a, id)
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 16a (subcolumn in ORDER BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- Subcolumn in PARTITION BY.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree PARTITION BY t.a ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 16b (subcolumn in PARTITION BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- Whole Tuple column in ORDER BY (`primary.idx` would have the wrong arity).
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree ORDER BY (t, id)
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 16c (whole Tuple in ORDER BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- Sanity: appending a subfield to a Tuple that is NOT in any key still works.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 16d (Tuple not in any key still works):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c Nullable(UInt64));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -508,3 +508,40 @@ ALTER TABLE t_named_tuple_alter
     MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
 
 DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 19: pure reorder of existing fields (without any additions) is not
+-- metadata-only. `primary.idx` bytes and explicit skip-index bytes for any
+-- embedded tuple value are serialized in the old field order; the new type
+-- deserializes and compares in the new order. Even on a column not in any
+-- key, the relative order of existing fields must be preserved to take the
+-- metadata-only path.
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 19a (pure reorder triggers mutation):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(b UInt64, a UInt64) SETTINGS alter_sync = 2;
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;
+
+-- Insertion preserving relative order is still metadata-only.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, b UInt64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 19b (insertion preserving order is metadata-only):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(c Nullable(UInt64), a UInt64, b UInt64);
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -1,0 +1,359 @@
+-- Tags: long, no-fasttest
+-- Tags: no-random-settings, no-random-merge-tree-settings
+-- ^ random settings can change part_type to Compact, but we want to exercise the Wide path.
+
+-- Metadata-only ALTER MODIFY COLUMN for named Tuple: appending subfields at any position
+-- should not trigger a mutation and should not rewrite any existing parts.
+--
+-- Customer schema (from a real game-analytics workload): a deep tree of named tuples,
+-- including `Array(Tuple(...))` nested inside another `Tuple(Tuple(...))`. The customer
+-- routinely adds new event fields and previously waited minutes for each ALTER on multi-TB
+-- tables.
+
+DROP TABLE IF EXISTS t_named_tuple_alter;
+
+-- ============================================================
+-- Case 1: flat named Tuple, append subfield at the end
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, toString(number)) FROM numbers(100);
+
+SELECT 'Case 1 (flat, append at end):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, b String, c Nullable(Int64));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+SELECT 't (whole):', t FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 2: flat named Tuple, insert subfield in the middle
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, toString(number)) FROM numbers(100);
+
+SELECT 'Case 2 (flat, insert in middle):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, c Nullable(Int64), b String);
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+SELECT 't (whole):', t FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 3: nested named Tuple, append at inner level
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(id UInt64, t Tuple(a Int64, sub Tuple(x Int64, y Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, (number * 10, number * 100)) FROM numbers(100);
+
+SELECT 'Case 3 (nested Tuple, inner append):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, sub Tuple(x Int64, y Int64, z Nullable(String)));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.sub.x, t.sub.y, t.sub.z FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 4: Array of named Tuple
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(id UInt64, t Array(Tuple(a Int64, b String)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter
+SELECT number, arrayMap(x -> (x, toString(x)), range(3)) FROM numbers(100);
+
+SELECT 'Case 4 (Array of Tuple):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Array(Tuple(a Int64, b String, c Nullable(Int64)));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter WHERE id = 0;
+SELECT 't (whole):', t FROM t_named_tuple_alter WHERE id = 0;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 5: Nested syntax with flatten_nested = 0
+-- ============================================================
+SET flatten_nested = 0;
+CREATE TABLE t_named_tuple_alter
+(id UInt64, items Nested(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter
+SELECT number, arrayMap(x -> (x, toString(x)), range(3)) FROM numbers(100);
+
+SELECT 'Case 5 (Nested with flatten_nested=0):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN items Nested(a Int64, b String, c Nullable(Int64));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT items.a, items.b, items.c FROM t_named_tuple_alter WHERE id = 0;
+
+DROP TABLE t_named_tuple_alter;
+SET flatten_nested = 1;
+
+-- ============================================================
+-- Case 6: Map of named Tuple
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(id UInt64, t Map(String, Tuple(a Int64, b String)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, {'k1': (10, 'x'), 'k2': (20, 'y')});
+
+SELECT 'Case 6 (Map of Tuple):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Map(String, Tuple(a Int64, b String, c Nullable(Int64)));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 7: non-Nullable new subfield (default zero value, same as top-level ADD COLUMN)
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, toString(number)) FROM numbers(100);
+
+SELECT 'Case 7 (non-Nullable new subfield):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, b String, c Int64);
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c FROM t_named_tuple_alter WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 8: multiple sequential ALTERs adding fields at varying positions
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, toString(number)) FROM numbers(100);
+
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, b String, c Nullable(Int64));
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, d Nullable(Float64), b String, c Nullable(Int64));
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, d Nullable(Float64), b String, c Nullable(Int64), e Array(Nullable(String)));
+
+SELECT 'Case 8 (multiple sequential ALTERs):';
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.b, t.c, t.d, t.e FROM t_named_tuple_alter WHERE id < 2 ORDER BY id;
+SELECT 't (whole):', t FROM t_named_tuple_alter WHERE id < 2 ORDER BY id;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 9 (REJECT): unnamed Tuple modification still requires mutation
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(Int64, String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 'x'));
+
+SELECT 'Case 9 (unnamed Tuple rejected):';
+-- Adding a third element to an unnamed Tuple requires a mutation (CAST fails today,
+-- but that is the existing behavior we are preserving — not a regression).
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(Int64, String, Int64); -- { serverError TYPE_MISMATCH }
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 10 (REJECT): subfield removal triggers a mutation
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 'x'));
+
+SELECT 'Case 10 (subfield removal triggers mutation):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64) SETTINGS alter_sync = 2;
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 11 (REJECT): subfield rename triggers a mutation (handled as drop + add today)
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 'x'));
+
+SELECT 'Case 11 (subfield rename triggers mutation):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, c String) SETTINGS alter_sync = 2;
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 12 (REJECT): incompatible subfield type change triggers a mutation
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, tuple(42));
+
+SELECT 'Case 12 (incompatible subfield type change triggers mutation):';
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a String) SETTINGS alter_sync = 2;
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 13: merge materializes the new subfield stream files for old parts
+-- ============================================================
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, toString(number)) FROM numbers(100);
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN t Tuple(a Int64, b String, c Nullable(Int64));
+
+SELECT 'Case 13 before merge (parts count):';
+SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_named_tuple_alter' AND active;
+
+INSERT INTO t_named_tuple_alter VALUES (200, (200, 'two-hundred', 42));
+OPTIMIZE TABLE t_named_tuple_alter FINAL;
+
+SELECT 'Case 13 after merge: old rows return NULL, new row returns the inserted value:';
+SELECT t.c FROM t_named_tuple_alter WHERE id IN (0, 1, 200) ORDER BY id;
+SELECT 'Case 13 part count after merge:';
+SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_named_tuple_alter' AND active;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 14 (REJECT): stream-name collision is still rejected
+-- ============================================================
+SET flatten_nested = 0;
+CREATE TABLE t_named_tuple_alter (id UInt64, items Nested(a Int64, b String), `items.c` Int64)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, [(1, 'a')], 99);
+
+SELECT 'Case 14 (stream collision rejected):';
+-- The new `c` subfield in `items` would generate stream "items.c" which collides
+-- with the existing top-level `items.c` column. The pre-existing validation must reject.
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN items Nested(a Int64, b String, c Nullable(Int64)); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_named_tuple_alter;
+SET flatten_nested = 1;
+
+-- ============================================================
+-- Case 15: customer schema — deeply nested Tuple/Array(Tuple)/Map combinations
+-- with subfield additions at every depth. Each ALTER must complete instantly
+-- with no mutation triggered.
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(
+    `@timestamp` DateTime64(3),
+    `_id` String,
+    `data` Tuple(
+        name Nullable(String),
+        level Nullable(Int64),
+        server_id Nullable(Int64),
+        res_add Map(UInt32, Int64),
+        c2s Tuple(
+            int_value Nullable(Int64),
+            server_id Nullable(Int64),
+            statistics Tuple(
+                kill_monster_num Nullable(Int64),
+                gold Nullable(Int64),
+                heros_statistics Array(Tuple(
+                    hero_id Nullable(Int64),
+                    star Nullable(Int64),
+                    damage Nullable(Int64))))))
+)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT * FROM generateRandom() LIMIT 100;
+
+SELECT 'Case 15 customer schema before ALTERs:';
+SELECT count() FROM t_named_tuple_alter;
+
+-- Add a top-level subfield.
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN data Tuple(
+    name Nullable(String), level Nullable(Int64), server_id Nullable(Int64),
+    res_add Map(UInt32, Int64),
+    c2s Tuple(int_value Nullable(Int64), server_id Nullable(Int64),
+        statistics Tuple(kill_monster_num Nullable(Int64), gold Nullable(Int64),
+            heros_statistics Array(Tuple(hero_id Nullable(Int64), star Nullable(Int64), damage Nullable(Int64))))),
+    new_top Nullable(Int64));
+
+-- Add a subfield inside the nested c2s Tuple.
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN data Tuple(
+    name Nullable(String), level Nullable(Int64), server_id Nullable(Int64),
+    res_add Map(UInt32, Int64),
+    c2s Tuple(int_value Nullable(Int64), server_id Nullable(Int64),
+        statistics Tuple(kill_monster_num Nullable(Int64), gold Nullable(Int64),
+            heros_statistics Array(Tuple(hero_id Nullable(Int64), star Nullable(Int64), damage Nullable(Int64)))),
+        new_c2s Nullable(Float64)),
+    new_top Nullable(Int64));
+
+-- Add a subfield inside the doubly-nested statistics Tuple.
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN data Tuple(
+    name Nullable(String), level Nullable(Int64), server_id Nullable(Int64),
+    res_add Map(UInt32, Int64),
+    c2s Tuple(int_value Nullable(Int64), server_id Nullable(Int64),
+        statistics Tuple(kill_monster_num Nullable(Int64), gold Nullable(Int64),
+            heros_statistics Array(Tuple(hero_id Nullable(Int64), star Nullable(Int64), damage Nullable(Int64))),
+            new_stat Nullable(String)),
+        new_c2s Nullable(Float64)),
+    new_top Nullable(Int64));
+
+-- Add a subfield inside Array(Tuple(...)) — the deepest case.
+ALTER TABLE t_named_tuple_alter MODIFY COLUMN data Tuple(
+    name Nullable(String), level Nullable(Int64), server_id Nullable(Int64),
+    res_add Map(UInt32, Int64),
+    c2s Tuple(int_value Nullable(Int64), server_id Nullable(Int64),
+        statistics Tuple(kill_monster_num Nullable(Int64), gold Nullable(Int64),
+            heros_statistics Array(Tuple(hero_id Nullable(Int64), star Nullable(Int64), damage Nullable(Int64),
+                new_hero Nullable(UInt8))),
+            new_stat Nullable(String)),
+        new_c2s Nullable(Float64)),
+    new_top Nullable(Int64));
+
+-- Add a subfield to a Map's value Tuple? Customer schema uses Map(UInt32, Int64) which
+-- has a primitive value, so we cannot test Map<K, Tuple> additions on the customer
+-- schema directly. Case 6 already covers that.
+
+-- Verify every ALTER above is metadata-only.
+SELECT 'Case 15 mutations after 4 ALTERs:';
+SELECT count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+
+-- Verify all new subfields readable (and return defaults for the pre-ALTER part).
+SELECT 'Case 15 new subfields readable:';
+SELECT countIf(data.new_top IS NULL) AS top_null,
+       countIf(data.c2s.new_c2s IS NULL) AS c2s_null,
+       countIf(data.c2s.statistics.new_stat IS NULL) AS stat_null,
+       countIf(arraySum(arrayMap(x -> if(x IS NULL, 1, 0), data.c2s.statistics.heros_statistics.new_hero)) > 0
+               OR length(data.c2s.statistics.heros_statistics.new_hero) = 0) AS hero_default_count
+FROM t_named_tuple_alter;
+
+-- Verify whole-tuple read works (no LOGICAL_ERROR exception).
+SELECT 'Case 15 whole tuple read works:';
+SELECT count() FROM (SELECT data FROM t_named_tuple_alter);
+
+DROP TABLE t_named_tuple_alter;

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -552,6 +552,28 @@ ALTER TABLE t_named_tuple_alter
 DROP TABLE t_named_tuple_alter;
 
 -- ============================================================
+-- Case 18d (ALLOW): an explicit skip index keyed on a top-level column whose name
+-- starts with `data.` (e.g. `data.deeper`) must NOT be confused with a subcolumn
+-- of a separate top-level column `data`. Adding a subfield to `data` is allowed.
+-- (The previous prefix-only guard incorrectly rejected this.)
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(id UInt64, `data` Tuple(a Int64, b Int64), `data.deeper` Int64,
+ INDEX idx `data.deeper` TYPE set(0) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, 0), number FROM numbers(10);
+
+SELECT 'Case 18d (skip index on dotted top-level column does not block sibling):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN `data` Tuple(a Int64, b Int64, c Int64);
+SELECT 'mutations:', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
 -- Case 19: pure reorder of existing fields (without any additions) is not
 -- metadata-only. `primary.idx` bytes and explicit skip-index bytes for any
 -- embedded tuple value are serialized in the old field order; the new type

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -531,6 +531,27 @@ ALTER TABLE t_named_tuple_alter
 DROP TABLE t_named_tuple_alter;
 
 -- ============================================================
+-- Case 18c (REJECT): explicit skip index over a `Tuple` subcolumn (e.g.
+-- `INDEX idx t.sub TYPE set(0)`) is keyed as `t.sub`, not `t`. The metadata-only
+-- guard must follow `column_name + "."` prefixes so the ALTER on the storage
+-- column `t` is still rejected — otherwise the `skp_idx_*.idx` bytes serialized
+-- with the old shape of `t.sub` are left stale.
+-- ============================================================
+CREATE TABLE t_named_tuple_alter
+(id UInt64, t Tuple(a Int64, sub Tuple(x Int64)),
+ INDEX idx t.sub TYPE set(0) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter SELECT number, (number, tuple(number)) FROM numbers(10);
+
+SELECT 'Case 18c (explicit skip index on Tuple subcolumn rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a Int64, sub Tuple(x Int64, y Int64)); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
 -- Case 19: pure reorder of existing fields (without any additions) is not
 -- metadata-only. `primary.idx` bytes and explicit skip-index bytes for any
 -- embedded tuple value are serialized in the old field order; the new type

--- a/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
+++ b/tests/queries/0_stateless/04319_named_tuple_metadata_only_alter.sql
@@ -418,3 +418,93 @@ SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatab
 SELECT t.a, t.b, t.c FROM t_named_tuple_alter;
 
 DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 17 (REJECT): nested-Tuple subfield additions still trigger the key/index
+-- safety check. The outer Tuple has the same field count, but a nested Tuple
+-- gains a field, which is still a metadata-only conversion that changes the
+-- on-disk shape of any embedded Tuple value in a key column.
+-- ============================================================
+
+-- A subcolumn that is *underneath* the nested addition is part of ORDER BY.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, sub Tuple(x UInt64)))
+ENGINE = MergeTree ORDER BY (t.sub.x, id)
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, (100)));
+
+SELECT 'Case 17a (nested addition, subcolumn under it in ORDER BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, sub Tuple(x UInt64, y UInt64)); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- The whole Tuple column is in ORDER BY and a nested Tuple inside gains a field.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, sub Tuple(x UInt64)))
+ENGINE = MergeTree ORDER BY (t, id)
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, (100)));
+
+SELECT 'Case 17b (nested addition with whole Tuple in ORDER BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, sub Tuple(x UInt64, y UInt64)); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- A sibling subcolumn (not under the nested addition) is in ORDER BY. The check
+-- still must reject because the modified column as a whole appears in keys.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, sub Tuple(x UInt64)))
+ENGINE = MergeTree ORDER BY (t.a, id)
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, (100)));
+
+SELECT 'Case 17c (nested addition, sibling subcolumn in ORDER BY rejected):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, sub Tuple(x UInt64, y UInt64)); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;
+
+-- Nested addition with no key dependency — must succeed and be metadata-only.
+CREATE TABLE t_named_tuple_alter (id UInt64, t Tuple(a UInt64, sub Tuple(x UInt64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, (100)));
+
+SELECT 'Case 17d (nested addition, no key dep, succeeds as metadata-only):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, sub Tuple(x UInt64, y Nullable(UInt64)));
+SELECT 'mutations:', count() FROM system.mutations WHERE database = currentDatabase() AND table = 't_named_tuple_alter';
+SELECT t.a, t.sub.x, t.sub.y FROM t_named_tuple_alter;
+
+DROP TABLE t_named_tuple_alter;
+
+-- ============================================================
+-- Case 18 (REJECT): explicit skip indexes on the whole column block Tuple
+-- subfield additions, because the on-disk index bytes (`skp_idx_*.idx`) are
+-- serialized with the old tuple shape and metadata-only ALTER never refreshes
+-- them via `MutationsInterpreter`. Rejected unconditionally, independent of
+-- the `alter_column_secondary_index_mode` setting.
+-- ============================================================
+
+CREATE TABLE t_named_tuple_alter
+(id UInt64, t Tuple(a UInt64, b UInt64), INDEX idx_t t TYPE set(0) GRANULARITY 1)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_named_tuple_alter VALUES (1, (10, 20));
+
+SELECT 'Case 18a (explicit set skip index on whole column rejected, default mode):';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+-- Even with `rebuild` mode, reject — the rebuild path is mutation-based and the
+-- metadata-only Tuple addition does not emit any `MutationCommand` for it.
+SELECT 'Case 18b (explicit skip index rejected even with rebuild mode):';
+ALTER TABLE t_named_tuple_alter MODIFY SETTING alter_column_secondary_index_mode = 'rebuild';
+ALTER TABLE t_named_tuple_alter
+    MODIFY COLUMN t Tuple(a UInt64, b UInt64, c UInt64); -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_named_tuple_alter;

--- a/tests/queries/0_stateless/04320_tuple_subfield_pruning.reference
+++ b/tests/queries/0_stateless/04320_tuple_subfield_pruning.reference
@@ -1,0 +1,214 @@
+Case 1 (flat, one default subfield):
+Tuple(a Int64, b String)
+0	0	0	(0,'0',0)
+1	1	0	(1,'1',0)
+2	2	0	(2,'2',0)
+Case 2 (nested, inner Tuple all-default):
+Tuple(a Int64, b String)
+0	0	0	0	(0,0)
+1	1	0	0	(0,0)
+2	2	0	0	(0,0)
+Case 3 (nested, one inner subfield all-default):
+Tuple(a Int64, b String, c2s Tuple(gold Int64))
+0	0	0
+1	1	0
+2	2	0
+Case 4 (all subfields non-default — keep full):
+Tuple(a Int64, b Int64)
+Case 5 (whole top-level all-default — must keep column):
+Tuple(a Int64, b String)
+Case 6 (Nullable subfield all-NULL):
+Tuple(a Int64)
+\N	\N	0	(0,NULL,(NULL,0))
+\N	\N	0	(1,NULL,(NULL,0))
+\N	\N	0	(2,NULL,(NULL,0))
+Case 7 (Array(Tuple) all empty):
+Tuple(a Int64)
+[]	0
+[]	0
+[]	0
+Case 8 (Array(Tuple) non-empty — keep full schema even if inner sub-elements are 0):
+Tuple(a Int64, arr Array(Tuple(x Int64, y Int64)))
+Case 9 (deep schema — multiple partial defaults):
+Tuple(common Tuple(uid Int64, ts DateTime), c2s Tuple(gold Int64))
+0	0	0	[]	0	0
+1	1	0	[]	0	0
+2	2	0	[]	0	0
+Case 10 (PARTITION BY narrows per partition):
+email	Tuple(common Int64, email Tuple(addr String, sends Int64))
+web	Tuple(common Int64, web Tuple(url String, clicks Int64))
+Read full schema across partitions:
+web	(1,('http://a',100),('',0))
+email	(2,('',0),('a@b.c',5))
+Case 11 (setting OFF):
+Tuple(a Int64, b Int64, c Int64)
+Case 12 (Compact part — no pruning):
+all_1_1_0	Compact	Tuple(a Int64, b Int64, c Int64)
+Case 13 (merge — both parts pruned c, merged also pruned):
+Tuple(a Int64, b String)
+Tuple(a Int64, b String)
+Tuple(a Int64, b String)
+0	0	0
+1	1	0
+2	2	0
+Case 14 (merge — one pruned, other not — merged keeps c):
+Tuple(a Int64, b String)
+Tuple(a Int64, b String, c Int64)
+Tuple(a Int64, b String, c Int64)
+1	0
+51	7
+Case 15 (merge — different parts pruned different subfields — merged takes union):
+Tuple(a Int64, email Tuple(addr String, sends Int64))
+Tuple(a Int64, web Tuple(url String, clicks Int64))
+Tuple(a Int64, web Tuple(url String, clicks Int64), email Tuple(addr String, sends Int64))
+1	('http://a',100)	('',0)
+2	('',0)	('a@b.c',5)
+Case 16 (subcolumn read of pruned subfield returns default):
+Tuple(a Int64, b String)
+0	0	0	0
+1	1	0	0
+2	2	0	0
+sum-of-zeros (defaults):	0	0
+Case 17 (CHECK TABLE accepts pruned-subfield part):
+all_1_1_0	1	
+Case 18 (Map(K, Tuple) all empty):
+Tuple(a Int64, m Map(String, Tuple(x Int64, y String)))
+{}	0
+{}	0
+{}	0
+Case 19 (Map(K, Tuple) non-empty — keep full schema):
+Tuple(a Int64, m Map(String, Tuple(x Int64, y Int64)))
+Case 20 (INSERT SELECT narrows):
+Tuple(a Int64)
+Case 21 (Async INSERT narrows):
+Tuple(a Int64)
+Case 22 (Materialized view writes narrow):
+Tuple(a Int64)
+mutations after ALTER:	0
+Case 23 (ALTER ADD subfield + INSERT default — both parts narrow):
+Tuple(a Int64, b String)
+Tuple(a Int64, b String)
+After merge of two narrowed parts:
+Tuple(a Int64, b String)
+0	0	0
+49	49	0
+50	50	0
+99	99	0
+Before UPDATE (narrowed):
+Tuple(a Int64)
+After UPDATE (mutate restores full schema, by design):
+Tuple(a Int64, b Int64)
+(0,0)
+(49,0)
+Case 25 (LWD preserves narrow type):
+Tuple(a Int64)
+49
+After OPTIMIZE FINAL:
+Tuple(a Int64)
+49	49
+Case 26 (ReplacingMergeTree merge — still narrow):
+Tuple(a Int64)
+50
+Case 27 (vertical merge keeps narrow):
+Tuple(a Int64, b Int64)
+(0,0,0)
+(99,99,0)
+Case 28 (multiple Tuple columns prune independently):
+d1	Tuple(a Int64)
+d2	Tuple(d Int64)
+id	UInt64
+other	Int64
+Case 29 (one non-default row preserves the subfield):
+Tuple(a Int64, b Int64)
+4	(4,0)
+5	(5,42)
+6	(6,0)
+Case 30 (LowCardinality(String) empty-string subfield is pruned):
+Tuple(a Int64, b LowCardinality(String))
+0	hello	
+1	hello	
+2	hello	
+Case 31 (top-level column with dot in name and a separate Tuple column):
+data	Tuple(a Int64)
+data.deeper	Tuple(x Int64)
+Case 31b (overlapping dotted column names with their own subfields):
+data	Tuple(a Int64)
+data.deeper	Tuple(x Int64)
+0	(0,(0))	(0,0)
+1	(1,(0))	(1,0)
+2	(2,(0))	(2,0)
+Case 32 (DETACH/ATTACH preserves narrow):
+before:	1	Tuple(a Int64)
+before:	2	Tuple(a Int64)
+after detach:	1
+after attach:	1	Tuple(a Int64)
+after attach:	2	Tuple(a Int64)
+100	99
+Case 33 (bytes_on_disk: narrowed < full):
+1
+Case 34 (multi-granule part still narrows):
+Tuple(a Int64)
+5000	5000	0
+Case 35 (force-sparse + pruning):
+Tuple(a Int64, b String)
+0	0	0	0	(0,'0',0)
+1	1	1	0	(1,'1',0)
+2	2	2	0	(2,'2',0)
+0	99	0	99	0
+Case 36 (force-sparse + nested pruning):
+Tuple(a Int64, sub Tuple(x Int64))
+0	0	0	(0,(0,0))
+1	1	0	(1,(1,0))
+2	2	0	(2,(2,0))
+0	99	0	99	0
+Case 37 (Nullable(UInt64) all toNullable(0) — keep, NOT pruned):
+Tuple(b Nullable(UInt64))
+0	(0)	0	0
+1	(0)	0	0
+2	(0)	0	0
+0	100
+Case 37 (Nullable(String) all toNullable(\'\') — keep, NOT pruned):
+Tuple(b Nullable(String))
+0	('')		0
+1	('')		0
+2	('')		0
+0	100
+Case 37 (b all NULL, a non-default — only b pruned):
+Tuple(a Int64)
+0	(0,NULL)	\N	1
+1	(1,NULL)	\N	1
+2	(2,NULL)	\N	1
+Case 38 (plain String subfield all empty — pruned):
+Tuple(a Int64)
+0	0		0
+1	1		0
+2	2		0
+Case 39 (merge with wrapper-only fields pruned in all sources):
+Tuple(a Int64)
+100	99	1
+Case 40 (dotted-name Tuple element — type NOT narrowed):
+Tuple(`a.b` UInt64, a Tuple(b UInt64))
+Case 41 (Enum subfield NOT pruned):
+Tuple(id UInt64, e Enum8(\'zero\' = 0, \'def\' = 1))
+0	(0,'zero')
+1	(1,'zero')
+2	(2,'zero')
+Case 42 (Map(K, Tuple) ALTER + merge — full type preserved):
+Map(String, Tuple(a Int64, b Int64, c Int64))
+100	1
+Case 43 (Map wrapper with_buckets — NOT pruned even when all empty):
+Tuple(a Int64, m Map(String, Tuple(x Int64, y Int64)))
+100	99
+Case 44 (nested Enum NOT pruned via outer shortcut):
+Tuple(id UInt64, c Tuple(e Enum8(\'zero\' = 0, \'def\' = 1)))
+0	(0,('zero'))
+1	(1,('zero'))
+2	(2,('zero'))
+Case 45 (nested Map with_buckets NOT pruned via outer shortcut):
+Tuple(id UInt64, c Tuple(m Map(String, Tuple(x Int64, y Int64))))
+Case 46 (dotted Tuple element survives merge):
+Tuple(a UInt64, `b.c` UInt64)
+100	99
+Case 47 (Map under named Tuple survives merge):
+Tuple(a UInt64, m Map(String, Tuple(x Int64)))
+100	99

--- a/tests/queries/0_stateless/04320_tuple_subfield_pruning.sql
+++ b/tests/queries/0_stateless/04320_tuple_subfield_pruning.sql
@@ -1,0 +1,973 @@
+-- Tags: long, no-fasttest
+-- Tags: no-random-settings, no-random-merge-tree-settings
+-- ^ random settings can change part_type to Compact, but pruning only fires for Wide parts.
+
+-- Tuple subfield pruning at INSERT and merge.
+-- When all values of a named-Tuple subfield in a part are type-defaults, the writer
+-- omits its stream files and narrows the part's `columns.txt` Tuple type. Reads use
+-- CAST(narrowed_tuple, full_tuple) (already supported by the metadata-only ALTER work
+-- in #107305) to materialize defaults.
+
+DROP TABLE IF EXISTS t_tsp;
+
+-- ============================================================
+-- Case 1: flat named Tuple, one subfield all-default
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), 0) FROM numbers(100);
+
+SELECT 'Case 1 (flat, one default subfield):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.b, t.c, t FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 2: nested named Tuple, inner subtuple all-default
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c2s Tuple(gold Int64, silver Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), (0, 0)) FROM numbers(100);
+
+SELECT 'Case 2 (nested, inner Tuple all-default):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.b, t.c2s.gold, t.c2s.silver, t.c2s FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 3: nested named Tuple, only one inner subfield all-default
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c2s Tuple(gold Int64, silver Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), (number, 0)) FROM numbers(100);
+
+SELECT 'Case 3 (nested, one inner subfield all-default):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.c2s.gold, t.c2s.silver FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 4: every named subfield non-default — must keep full schema
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, number + 1) FROM numbers(100);
+
+SELECT 'Case 4 (all subfields non-default — keep full):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 5: whole top-level Tuple all-default — must KEEP column (no whole-column expiry)
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (0, '') FROM numbers(100);
+
+SELECT 'Case 5 (whole top-level all-default — must keep column):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 6: Nullable subfield where every row is NULL
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Nullable(String), c Tuple(x Nullable(Int64), y Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, NULL, (NULL, 0)) FROM numbers(100);
+
+SELECT 'Case 6 (Nullable subfield all-NULL):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.b, t.c.x, t.c.y, t FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 7: Array(Tuple) — every row is an empty array (subtree all-default)
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, arr Array(Tuple(x Int64, y String))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, []::Array(Tuple(x Int64, y String))) FROM numbers(100);
+
+SELECT 'Case 7 (Array(Tuple) all empty):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.arr, length(t.arr) FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 8: Array(Tuple) with non-empty arrays — cannot prune sub-elements
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, arr Array(Tuple(x Int64, y Int64))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, [(0, 0), (0, 0)]) FROM numbers(100);
+
+SELECT 'Case 8 (Array(Tuple) non-empty — keep full schema even if inner sub-elements are 0):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 9: Customer-like deep schema (mirrors 04319_named_tuple_metadata_only_alter Case 5)
+-- ============================================================
+CREATE TABLE t_tsp (
+    id UInt64,
+    event Tuple(
+        common Tuple(uid Int64, ts DateTime),
+        c2s Tuple(gold Int64, silver Int64, items Array(Tuple(slot Int64, amount Int64))),
+        c2p Tuple(score Float32, level Int64)
+    )
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- c2s.silver and c2p (whole) are zero; c2s.items is empty.
+INSERT INTO t_tsp SELECT
+    number,
+    ((number, toDateTime('2024-01-01')), (number, 0, []::Array(Tuple(slot Int64, amount Int64))), (0, 0))
+FROM numbers(100);
+
+SELECT 'Case 9 (deep schema — multiple partial defaults):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 'event';
+SELECT
+    event.common.uid,
+    event.c2s.gold,
+    event.c2s.silver,
+    event.c2s.items,
+    event.c2p.score,
+    event.c2p.level
+FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 10: PARTITION BY where each partition populates a different subset
+-- (the motivating use case)
+-- ============================================================
+CREATE TABLE t_tsp (
+    kind String,
+    id UInt64,
+    data Tuple(common Int64, web Tuple(url String, clicks Int64), email Tuple(addr String, sends Int64))
+)
+ENGINE = MergeTree PARTITION BY kind ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp VALUES ('web', 1, (1, ('http://a', 100), ('', 0)));
+INSERT INTO t_tsp VALUES ('email', 2, (2, ('', 0), ('a@b.c', 5)));
+
+SELECT 'Case 10 (PARTITION BY narrows per partition):';
+SELECT partition, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 'data'
+ORDER BY partition;
+
+SELECT 'Read full schema across partitions:';
+SELECT kind, data FROM t_tsp ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 11: setting OFF — no pruning
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, enable_tuple_subfield_pruning = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 0, 0) FROM numbers(100);
+
+SELECT 'Case 11 (setting OFF):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 12: Compact part — must KEEP full schema
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 1000000000, min_rows_for_wide_part = 1000000;
+
+INSERT INTO t_tsp SELECT number, (number, 0, 0) FROM numbers(100);
+
+SELECT 'Case 12 (Compact part — no pruning):';
+SELECT name, part_type, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 13: Merge — both source parts pruned the same subfield: merged keeps it pruned
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), 0) FROM numbers(50);
+INSERT INTO t_tsp SELECT number + 50, (number + 50, toString(number + 50), 0) FROM numbers(50);
+
+SELECT 'Case 13 (merge — both parts pruned c, merged also pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+SELECT t.a, t.b, t.c FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 14: Merge — one part pruned, the other did not: merged keeps full schema
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), 0) FROM numbers(50);          -- prunes c
+INSERT INTO t_tsp SELECT number + 50, (number + 50, toString(number + 50), 7) FROM numbers(50);  -- keeps c
+
+SELECT 'Case 14 (merge — one pruned, other not — merged keeps c):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+SELECT t.a, t.c FROM t_tsp WHERE id IN (1, 51) ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 15: Merge — different subfields pruned in different parts: merged takes the union
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, web Tuple(url String, clicks Int64), email Tuple(addr String, sends Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- part 1: prunes email
+INSERT INTO t_tsp VALUES (1, (1, ('http://a', 100), ('', 0)));
+-- part 2: prunes web
+INSERT INTO t_tsp VALUES (2, (2, ('', 0), ('a@b.c', 5)));
+
+SELECT 'Case 15 (merge — different parts pruned different subfields — merged takes union):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+SELECT t.a, t.web, t.email FROM t_tsp ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 16: Subcolumn read of a pruned subfield returns the default value
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c Int64, d Float64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), 0, 0) FROM numbers(100);
+
+SELECT 'Case 16 (subcolumn read of pruned subfield returns default):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.b, t.c, t.d FROM t_tsp WHERE id < 3 ORDER BY id;
+-- Bulk aggregates over a pruned subfield should also be safe.
+SELECT 'sum-of-zeros (defaults):', sum(t.c), sum(t.d) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 17: CHECK TABLE on a part with pruned subfields
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c2s Tuple(gold Int64, silver Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), (0, 0)) FROM numbers(100);
+
+SELECT 'Case 17 (CHECK TABLE accepts pruned-subfield part):';
+CHECK TABLE t_tsp SETTINGS check_query_single_value_result = 0;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 18: Map(K, Tuple) — every row is an empty map
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, m Map(String, Tuple(x Int64, y String))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, map()::Map(String, Tuple(x Int64, y String))) FROM numbers(100);
+
+SELECT 'Case 18 (Map(K, Tuple) all empty):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.m, length(mapKeys(t.m)) FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 19: Map(K, Tuple) — non-empty maps cannot prune sub-elements
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, m Map(String, Tuple(x Int64, y Int64))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, map('k', (number, 0))) FROM numbers(100);
+
+SELECT 'Case 19 (Map(K, Tuple) non-empty — keep full schema):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 20: INSERT SELECT (instead of VALUES) still narrows
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT n, tuple(n, 0, 0)::Tuple(a Int64, b Int64, c Int64)
+FROM (SELECT number AS n FROM numbers(100));
+
+SELECT 'Case 20 (INSERT SELECT narrows):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 21: Async INSERT path also narrows
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(50)
+SETTINGS async_insert = 1, wait_for_async_insert = 1;
+
+SELECT 'Case 21 (Async INSERT narrows):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 22: Materialized view writes through INSERT path — also narrows
+-- ============================================================
+CREATE TABLE t_tsp_src (id UInt64, v Int64)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+CREATE TABLE t_tsp_dst (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+CREATE MATERIALIZED VIEW t_tsp_mv TO t_tsp_dst AS
+SELECT id, tuple(v, 0)::Tuple(a Int64, b Int64) AS t FROM t_tsp_src;
+
+INSERT INTO t_tsp_src SELECT number, number FROM numbers(100);
+
+SELECT 'Case 22 (Materialized view writes narrow):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp_dst' AND active AND column = 't';
+
+DROP TABLE t_tsp_mv;
+DROP TABLE t_tsp_dst;
+DROP TABLE t_tsp_src;
+
+-- ============================================================
+-- Case 23: After metadata-only ALTER MODIFY adding a subfield, an INSERT whose
+-- new subfield is all-default produces another narrowed part (so the new subfield
+-- never gets physical storage). Merge of two narrowed parts stays narrowed.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number)) FROM numbers(50);
+
+ALTER TABLE t_tsp MODIFY COLUMN t Tuple(a Int64, b String, c Int64);
+SELECT 'mutations after ALTER:', count() FROM system.mutations
+WHERE database = currentDatabase() AND table = 't_tsp';
+
+INSERT INTO t_tsp SELECT number + 50, (number + 50, toString(number + 50), 0) FROM numbers(50);
+
+SELECT 'Case 23 (ALTER ADD subfield + INSERT default — both parts narrow):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY type;
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'After merge of two narrowed parts:';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.b, t.c FROM t_tsp WHERE id IN (0, 49, 50, 99) ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 24: ALTER UPDATE (mutation) on a narrowed part — by design, mutations
+-- preserve the existing storage schema (re-materialize all subfields).
+-- Result must be readable and correct.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(50);
+SELECT 'Before UPDATE (narrowed):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+ALTER TABLE t_tsp UPDATE t = (t.a, 0) WHERE id < 50 SETTINGS mutations_sync = 2;
+
+SELECT 'After UPDATE (mutate restores full schema, by design):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t FROM t_tsp WHERE id IN (0, 49) ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 25: Lightweight DELETE keeps the existing narrow type
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(50);
+
+DELETE FROM t_tsp WHERE id = 5;
+
+SELECT 'Case 25 (LWD preserves narrow type):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count() FROM t_tsp;
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'After OPTIMIZE FINAL:';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), max(t.a) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 26: ReplacingMergeTree merge — deduplication still narrows
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = ReplacingMergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(50);
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 26 (ReplacingMergeTree merge — still narrow):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count() FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 27: Vertical merge algorithm — narrowing is preserved
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         enable_vertical_merge_algorithm = 1,
+         vertical_merge_algorithm_min_rows_to_activate = 1,
+         vertical_merge_algorithm_min_columns_to_activate = 1;
+
+INSERT INTO t_tsp SELECT number, (number, number, 0) FROM numbers(50);
+INSERT INTO t_tsp SELECT number + 50, (number + 50, number + 50, 0) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 27 (vertical merge keeps narrow):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t FROM t_tsp WHERE id IN (0, 99) ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 28: Two independent Tuple columns each narrow to their own subset
+-- ============================================================
+CREATE TABLE t_tsp (
+    id UInt64,
+    d1 Tuple(a Int64, b Int64),
+    d2 Tuple(c Int64, d Int64),
+    other Int64
+) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- d1.b = 0, d2.c = 0 — each column loses a different subfield
+INSERT INTO t_tsp SELECT number, (number, 0), (0, number), number FROM numbers(50);
+
+SELECT 'Case 28 (multiple Tuple columns prune independently):';
+SELECT column, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active
+ORDER BY column;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 29: Partial-default — even a single non-default row keeps the subfield
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- b is 0 for all rows except id=5 where b=42
+INSERT INTO t_tsp SELECT number, (number, if(number = 5, 42, 0)) FROM numbers(100);
+
+SELECT 'Case 29 (one non-default row preserves the subfield):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t FROM t_tsp WHERE id IN (4, 5, 6) ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 30: LowCardinality(String) subfield where every value is the empty string
+-- (exercises `hasOnlyTypeDefaults` for `ColumnLowCardinality`)
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b LowCardinality(String), c LowCardinality(String)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, 'hello', '') FROM numbers(100);
+
+SELECT 'Case 30 (LowCardinality(String) empty-string subfield is pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT t.a, t.b, t.c FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 31: Column name containing dots vs. Tuple subfield paths — disambiguation
+-- A top-level column named `data.deeper` must not be confused with the `data.deeper`
+-- subfield path of a column named `data`.
+-- ============================================================
+CREATE TABLE t_tsp (
+    `data` Tuple(a Int64, b Int64),
+    `data.deeper` Tuple(x Int64, y Int64),
+    id UInt64
+) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- data.b is all-default; data.deeper.y is all-default.
+INSERT INTO t_tsp SELECT (number, 0)::Tuple(a Int64, b Int64), (number, 0)::Tuple(x Int64, y Int64), number FROM numbers(50);
+
+SELECT 'Case 31 (top-level column with dot in name and a separate Tuple column):';
+SELECT column, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column IN ('data', 'data.deeper')
+ORDER BY column;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 31b: Strong ownership-disambiguation regression. Two top-level columns
+-- `data` (Tuple(a, deeper Tuple(y))) and `data.deeper` (Tuple(x, z)) both contribute
+-- expired subfields. The leaf-`y` of `data.deeper` and the leaf-`y` of
+-- `data.deeper` (the subfield inside `data`) would alias under a flat
+-- longest-prefix scheme; ownership must be tracked per top-level column.
+-- ============================================================
+CREATE TABLE t_tsp (
+    id UInt64,
+    `data` Tuple(a Int64, deeper Tuple(y Int64)),
+    `data.deeper` Tuple(x Int64, z Int64)
+) ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+-- Inside `data`: a has values, deeper.y is all-default → narrowed to Tuple(a Int64)
+-- Inside `data.deeper`: x has values, z is all-default → narrowed to Tuple(x Int64)
+INSERT INTO t_tsp SELECT number, (number, tuple(0))::Tuple(a Int64, deeper Tuple(y Int64)), (number, 0)::Tuple(x Int64, z Int64) FROM numbers(10);
+
+SELECT 'Case 31b (overlapping dotted column names with their own subfields):';
+SELECT column, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column IN ('data', 'data.deeper')
+ORDER BY column;
+SELECT id, data, `data.deeper` FROM t_tsp ORDER BY id LIMIT 3;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 32: DETACH / ATTACH PARTITION preserves the narrowed per-part type
+-- ============================================================
+CREATE TABLE t_tsp (p UInt32, id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree PARTITION BY p ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT 1, number, (number, 0) FROM numbers(50);
+INSERT INTO t_tsp SELECT 2, number + 50, (number + 50, 0) FROM numbers(50);
+
+SELECT 'Case 32 (DETACH/ATTACH preserves narrow):';
+SELECT 'before:', partition, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY partition;
+
+ALTER TABLE t_tsp DETACH PARTITION 1;
+SELECT 'after detach:', count() FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+ALTER TABLE t_tsp ATTACH PARTITION 1;
+SELECT 'after attach:', partition, type FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't' ORDER BY partition;
+SELECT count(), max(t.a) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 33: bytes_on_disk is smaller for the narrowed table
+-- (sanity check that pruning actually saves space, not just metadata)
+-- ============================================================
+CREATE TABLE t_tsp_full (id UInt64, t Tuple(a Int64, b Int64, c Int64, d Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         enable_tuple_subfield_pruning = 0;
+
+CREATE TABLE t_tsp_narrow (id UInt64, t Tuple(a Int64, b Int64, c Int64, d Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp_full   SELECT number, (number, 0, 0, 0) FROM numbers(10000);
+INSERT INTO t_tsp_narrow SELECT number, (number, 0, 0, 0) FROM numbers(10000);
+
+SELECT 'Case 33 (bytes_on_disk: narrowed < full):';
+SELECT
+    (SELECT sum(bytes_on_disk) FROM system.parts WHERE database = currentDatabase() AND table = 't_tsp_narrow' AND active)
+        <
+    (SELECT sum(bytes_on_disk) FROM system.parts WHERE database = currentDatabase() AND table = 't_tsp_full' AND active);
+
+DROP TABLE t_tsp_full;
+DROP TABLE t_tsp_narrow;
+
+-- ============================================================
+-- Case 34: INSERT producing two granules (multi-granule part) still narrows
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         index_granularity = 1024;
+
+INSERT INTO t_tsp SELECT number, (number, 0) FROM numbers(5000);
+
+SELECT 'Case 34 (multi-granule part still narrows):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), uniqExact(t.a), sum(t.b) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 35: Force-sparse serialization for every column + pruning. The reader
+-- must preserve each kept subfield's `Sparse` kind in `serialization.json`;
+-- otherwise reads return shifted data (the writer wrote sparse streams, while
+-- a freshly-built default-kind info would dispatch the default deserializer).
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String, c Int64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         ratio_of_defaults_for_sparse_serialization = 0.;
+
+INSERT INTO t_tsp SELECT number, (number, toString(number), 0) FROM numbers(100);
+
+SELECT 'Case 35 (force-sparse + pruning):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t.a, t.b, t.c, t FROM t_tsp WHERE id < 3 ORDER BY id;
+SELECT min(id), max(id), min(t.a), max(t.a), sum(t.c) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 36: Force-sparse on a part where only an inner subfield is pruned (the kept
+-- subfield's `Sparse` kind must survive the narrowing of the surrounding Tuple).
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, sub Tuple(x Int64, y Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         ratio_of_defaults_for_sparse_serialization = 0.;
+
+-- sub.y is all-default → sub is narrowed to Tuple(x Int64). sub.x must keep its sparse kind.
+INSERT INTO t_tsp SELECT number, (number, (number, 0)) FROM numbers(100);
+
+SELECT 'Case 36 (force-sparse + nested pruning):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t.sub.x, t.sub.y, t FROM t_tsp WHERE id < 3 ORDER BY id;
+SELECT min(id), max(id), min(t.sub.x), max(t.sub.x), sum(t.sub.y) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 37: Regression — a Nullable subfield where every row is `toNullable(0)` /
+-- `toNullable('')` is NOT pruned. `Nullable(X)`'s type-default is NULL, not
+-- the wrapped 0 / ''; conflating the two would replay reads as NULL and lose data.
+-- (`hasOnlyTypeDefaults` should report false because the null map is all zero.)
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(b Nullable(UInt64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, tuple(toNullable(0)) FROM numbers(100);
+
+SELECT 'Case 37 (Nullable(UInt64) all toNullable(0) — keep, NOT pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t, t.b, isNull(t.b) FROM t_tsp WHERE id < 3 ORDER BY id;
+SELECT countIf(isNull(t.b)), countIf(t.b = 0) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+CREATE TABLE t_tsp (id UInt64, t Tuple(b Nullable(String)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, tuple(toNullable('')) FROM numbers(100);
+
+SELECT 'Case 37 (Nullable(String) all toNullable(\'\') — keep, NOT pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t, t.b, isNull(t.b) FROM t_tsp WHERE id < 3 ORDER BY id;
+SELECT countIf(isNull(t.b)), countIf(t.b = '') FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b Nullable(UInt64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, NULL) FROM numbers(100);
+
+SELECT 'Case 37 (b all NULL, a non-default — only b pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t, t.b, isNull(t.b) FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 38: plain `String` subfield where every row is the empty string.
+-- A regression that the `ColumnString::hasOnlyTypeDefaults` implementation
+-- recognises empty strings (offsets are not cumulative-with-terminator in
+-- ClickHouse `ColumnString`; an empty string contributes a zero offset, so all
+-- offsets are zero when every string is empty).
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, b String))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, '') FROM numbers(100);
+
+SELECT 'Case 38 (plain String subfield all empty — pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t.a, t.b, length(t.b) FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 39: Merge of two parts that both pruned a wrapper field (Array(Tuple))
+-- must remove the wrapper `.size0` stream too — not just the inner leaf
+-- streams. Both source parts have type `Tuple(a)` (the `arr` field was
+-- pruned at INSERT time as all-empty). Merging must produce the same
+-- narrowed `Tuple(a)` and the merged part must NOT contain a leftover
+-- `t.arr.size0.bin`.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, arr Array(Tuple(x Int64, y String))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, []::Array(Tuple(x Int64, y String))) FROM numbers(50);
+INSERT INTO t_tsp SELECT number + 50, (number + 50, []::Array(Tuple(x Int64, y String))) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 39 (merge with wrapper-only fields pruned in all sources):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), max(t.a), uniqExact(length(t.arr)) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 40: A `Tuple` element whose explicit name contains `.` would alias nested
+-- subtree paths under the dotted-path scheme used by the pruning helpers
+-- (e.g. element name `a.b` is indistinguishable from path `t.a.b` of element `b`
+-- under element `a`). The collector must bail out for the whole `Tuple` so we
+-- never silently drop the nested non-default values.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(`a.b` UInt64, a Tuple(b UInt64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp VALUES (1, (0, (42))), (2, (0, (43))), (3, (0, (44)));
+
+SELECT 'Case 40 (dotted-name Tuple element — type NOT narrowed):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 41: A `Tuple` subfield of type `Enum8` whose stored values are all the
+-- enum's `0` representation must NOT be pruned indiscriminately — the read
+-- path would materialize the missing subfield via `DataTypeEnum::insertDefaultInto`,
+-- whose default is the smallest enum value (which may differ from `0` for shapes
+-- like `Enum8('a' = 1)`). Conservatively refuse to prune any `Enum` subtree.
+-- (Verified by Trace logging — without the guard the subfield `t.e` was pruned.)
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(id UInt64, e Enum8('def' = 1, 'zero' = 0)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, CAST('zero' AS Enum8('def' = 1, 'zero' = 0))) FROM numbers(100);
+
+SELECT 'Case 41 (Enum subfield NOT pruned):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 42: A `Map(K, Tuple(...))` ALTER that adds a tuple subfield to the value
+-- type must NOT cause the merge-side Sub-case A to prune the new leaf —
+-- `SerializationMap` in `with_buckets` mode keeps its bucketed value streams
+-- hidden from `enumerateStreams` (they're discovered only via column/state), so
+-- prune cleanup cannot find or remove them. We instead treat the whole `Map`
+-- as an opaque leaf at narrow time. Verified by ALTER ADD + merge: the merged
+-- part keeps the full `Map(K, Tuple(...))` type, no stale `*.values.*` streams.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, m Map(String, Tuple(a Int64, b Int64)))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         map_serialization_version = 'with_buckets';
+
+INSERT INTO t_tsp SELECT number, map('k', (number, 0)) FROM numbers(50);
+ALTER TABLE t_tsp MODIFY COLUMN m Map(String, Tuple(a Int64, b Int64, c Int64));
+INSERT INTO t_tsp SELECT number + 50, map('k', (number + 50, 0, 0)) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 42 (Map(K, Tuple) ALTER + merge — full type preserved):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 'm';
+SELECT count(), uniqExact(mapKeys(m)[1]) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 43: A `Map(K, Tuple(...))` wrapper nested inside a `Tuple` must NOT
+-- be pruned even when the column is entirely empty. With
+-- `map_serialization_version = 'with_buckets'`, the `Map`'s bucketed value
+-- payload streams (`t.m.<bucket>.values.*`) are only discoverable from a
+-- written column + state, so the type-only `enumerateStreams` used by the
+-- prune cleanup path cannot find them. Pruning the wrapper would leave the
+-- bucket streams on disk while `columns.txt` no longer references them.
+-- Conservatively never prune a `Map` subtree.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a Int64, m Map(String, Tuple(x Int64, y Int64))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         map_serialization_version = 'with_buckets',
+         max_buckets_in_map = 5, map_buckets_strategy = 'linear',
+         map_buckets_min_avg_size = 1, map_buckets_coefficient = 1.0;
+
+INSERT INTO t_tsp SELECT number, (number, map()::Map(String, Tuple(x Int64, y Int64))) FROM numbers(50);
+INSERT INTO t_tsp SELECT number + 50, (number + 50, map()::Map(String, Tuple(x Int64, y Int64))) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 43 (Map wrapper with_buckets — NOT pruned even when all empty):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), max(t.a) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 44: `Enum` nested inside another `Tuple` whose stored bytes are all the
+-- `0` enum representation must NOT be pruned via the outer `hasOnlyTypeDefaults`
+-- shortcut — the read path would synthesize the wrong enum default. The
+-- containing `Tuple` subtree is detected as "contains Enum" and the shortcut
+-- recurses into element-by-element pruning instead.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(id UInt64, c Tuple(e Enum8('def' = 1, 'zero' = 0))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, (number, tuple(CAST('zero' AS Enum8('def' = 1, 'zero' = 0)))) FROM numbers(50);
+
+SELECT 'Case 44 (nested Enum NOT pruned via outer shortcut):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT id, t FROM t_tsp WHERE id < 3 ORDER BY id;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 45: `Map` nested inside another `Tuple` that is otherwise entirely default
+-- (with `map_serialization_version = 'with_buckets'`) must NOT be pruned via the
+-- outer `hasOnlyTypeDefaults` shortcut — the bucketed payload streams would be
+-- orphaned. The containing `Tuple` subtree is detected as "contains Map" and the
+-- shortcut recurses into element-by-element pruning instead.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(id UInt64, c Tuple(m Map(String, Tuple(x Int64, y Int64)))))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         map_serialization_version = 'with_buckets',
+         max_buckets_in_map = 5, map_buckets_strategy = 'linear',
+         map_buckets_min_avg_size = 1, map_buckets_coefficient = 1.0;
+
+INSERT INTO t_tsp SELECT number, (number, tuple(map()::Map(String, Tuple(x Int64, y Int64)))) FROM numbers(50);
+
+SELECT 'Case 45 (nested Map with_buckets NOT pruned via outer shortcut):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 46: Merge-side Sub-case A must NOT prune a column whose storage type contains
+-- a dotted-name `Tuple` element. Old part has narrower type `Tuple(a)`; after
+-- metadata-only ALTER adds a `` `b.c` `` element, leaves would collapse to the parent
+-- path and the missing `t.a` leaf in the old part would be promoted to a whole-column
+-- removal — losing existing `t.a` values on `OPTIMIZE FINAL`.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a UInt64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0;
+
+INSERT INTO t_tsp SELECT number, tuple(number)::Tuple(a UInt64) FROM numbers(50);
+ALTER TABLE t_tsp MODIFY COLUMN t Tuple(a UInt64, `b.c` UInt64);
+INSERT INTO t_tsp SELECT number + 50, tuple(number + 50, 0)::Tuple(a UInt64, `b.c` UInt64) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 46 (dotted Tuple element survives merge):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), max(t.a) FROM t_tsp;
+
+DROP TABLE t_tsp;
+
+-- ============================================================
+-- Case 47: Merge-side Sub-case A must NOT prune a column whose storage type contains
+-- a `Map`. Old part lacks `m`; new part has it. Without the guard, merge would mark
+-- the whole `m` subtree as expired in the merged part, and `removeEmptyColumnsFromPart`
+-- would orphan bucketed map streams under `map_serialization_version = 'with_buckets'`.
+-- ============================================================
+CREATE TABLE t_tsp (id UInt64, t Tuple(a UInt64))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+         map_serialization_version = 'with_buckets',
+         max_buckets_in_map = 5, map_buckets_strategy = 'linear',
+         map_buckets_min_avg_size = 1, map_buckets_coefficient = 1.0;
+
+INSERT INTO t_tsp SELECT number, tuple(number)::Tuple(a UInt64) FROM numbers(50);
+ALTER TABLE t_tsp MODIFY COLUMN t Tuple(a UInt64, m Map(String, Tuple(x Int64)));
+INSERT INTO t_tsp SELECT number + 50, (number + 50, map())::Tuple(a UInt64, m Map(String, Tuple(x Int64))) FROM numbers(50);
+
+OPTIMIZE TABLE t_tsp FINAL;
+
+SELECT 'Case 47 (Map under named Tuple survives merge):';
+SELECT type FROM system.parts_columns WHERE database = currentDatabase() AND table = 't_tsp' AND active AND column = 't';
+SELECT count(), max(t.a) FROM t_tsp;
+
+DROP TABLE t_tsp;


### PR DESCRIPTION
> Stacked on top of #107305 in this branch's git history; the diff against `master` therefore includes #107305's commits. The new code introduced by this PR is in commit `e19d35ce34e`. The two PRs are independent in scope and can be reviewed / merged in any order.

When all values of a named-`Tuple` subfield in a part are type-defaults, the writer omits that subfield's stream files and narrows the part's `columns.txt` `Tuple` type. Reads see the narrowed type and let ClickHouse's existing missing-substream / `fillMissingColumns` machinery fill in defaults — same code path that handles columns added by a later `ALTER ADD COLUMN`. Independent of #107305.

Most useful for `PARTITION BY` schemes where different partitions populate different subsets of a wide schema's subfields: each part keeps only the streams whose subfield actually appears.

## Approach

- Reuse the existing whole-column pruning path (`IMergedBlockOutputStream::removeEmptyColumnsFromPart` consuming `new_data_part->expired_columns`); extend it to accept dotted subfield names (`data.c2s.gold`) and narrow the column's `Tuple` type via the new `narrowDataTypeByExpiredSubstreams` helper in `DataTypes/Utils`.
- Preserve each kept subfield's `SerializationInfo` (sparse/default kind, `num_rows`, `num_defaults`) when narrowing the enclosing `Tuple`, via the new `narrowSerializationInfo` helper. Without this, sparse-encoded streams are misread as default-encoded.
- Keep `columns_substreams.txt` consistent with on-disk files via the new `ColumnsSubstreams::removeSubstreams`.
- **INSERT**: `MergeTreeDataWriter` traverses each named-`Tuple` column with the new `IColumn::hasOnlyTypeDefaults` and contributes all-default subtree paths to `expired_columns`.
- **Merge** (Sub-case A, monotonic): `MergeTask::prepare` takes the union of leaf substreams across all source parts; any leaf absent from every source is expired in the merged part.

## Why top-level all-default columns are intentionally NOT pruned

Erasing a top-level column whose value is entirely default would turn it into "missing column" — a subsequent `ALTER MODIFY COLUMN ... DEFAULT <new_expr>` would then re-materialize it with the NEW default, retroactively changing historical data. That is the quirk tracked by #92475.

This PR sidesteps the problem by leaving top-level columns alone; the materialized `0` / `''` / `[]` bytes pin the part's semantics. Subfield pruning is also forward-compatible with the per-column `DEFAULT` RFC in [#92475 (comment)](https://github.com/ClickHouse/ClickHouse/issues/92475#issuecomment-4334850399), because named-`Tuple` subfields have no `DEFAULT` expression syntax (`Tuple(a Int64 DEFAULT 5)` is not a valid type), so pruning can only ever fall back to the language type-default.

## Not touched

Compact parts, patch parts, mutations, top-level all-default columns. The `hasOnlyTypeDefaults` primitives are lifted from #98472 but its signalling layer (no `WITH_SKIPPED_COLUMNS` serialization version, no JSON `skipped_columns`, no `DEFAULT`-expression interaction) is not.

## Gate

`enable_tuple_subfield_pruning` (default `true`), recorded in `SettingsChangesHistory` under `26.6`.

## Compatibility

No on-disk format change; the narrowed `columns.txt` + missing stream files are read as a regular type-promotion (`Tuple(a, b)` part → `Tuple(a, b, c)` schema). Any version of ClickHouse can read parts written by this PR.

## Tests

`tests/queries/0_stateless/04320_tuple_subfield_pruning.sql` — 36 cases covering flat/nested `Tuple`, `Nullable` wrap, `Array(Tuple)` (all-empty and non-empty), `Map(K, Tuple)`, `LowCardinality(String)`, deep customer schema, `PARTITION BY` per-partition narrowing, setting OFF, Compact-part preservation, two-part merges (both pruned / one pruned / different subfields pruned), `INSERT SELECT`, async `INSERT`, materialized view, `ReplacingMergeTree`, vertical merge, lightweight `DELETE`, `ALTER MODIFY` adding subfield + `INSERT`, `ALTER UPDATE` mutation on narrowed part, multi-granule part, `DETACH`/`ATTACH PARTITION`, top-level column with dot in name, force-sparse + pruning interaction, subcolumn reads, `CHECK TABLE`, `bytes_on_disk` comparison.

### Documentation entry for user-facing changes

- [x] Documentation is not required.

### Changelog category (leave one):

- Improvement

### Changelog entry:

Automatically prune named-`Tuple` subfields whose values in a part are entirely type-defaults: the writer omits their stream files and records a narrowed `Tuple` type in `columns.txt`; reads materialize defaults via `CAST`. Gated by the new MergeTree-level setting `enable_tuple_subfield_pruning` (default on).
