### PR TITLE
Fix flaky test_keeper_session_loss_during_coordinated_refresh

### DIFF
--- a/tests/integration/test_refreshable_mv_keeper_loss/test.py
+++ b/tests/integration/test_refreshable_mv_keeper_loss/test.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
 
 cluster = ClickHouseCluster(__file__, zookeeper_config_path="configs/zookeeper.xml")
 
@@ -129,20 +130,44 @@ def test_keeper_session_loss_during_coordinated_refresh(started_cluster):
     wait_for_status(node2, "a", "Running", timeout=30)
     wait_for_status(node1, "a", "RunningOnAnotherReplica", timeout=30)
 
-    # Restart all keeper nodes. With session_timeout_ms=5000 (see zookeeper.xml)
-    # and >5s of total quorum-loss below, every client session expires, so
-    # node2's 'running' ephemeral disappears -- but node2's SELECT keeps
-    # running because query execution is independent of keeper. This is the
-    # bug's trigger condition and mirrors the user's manual repro.
-    started_cluster.stop_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    started_cluster.start_zookeeper_nodes(["zoo1", "zoo2", "zoo3"])
-    started_cluster.wait_zookeeper_nodes_to_start(["zoo1", "zoo2", "zoo3"], timeout=60)
-
-    # Make node1 want to refresh for the same yearly timeslot. With the fix,
-    # node1 sees `refresh_running=true` in the root znode and waits for node2
-    # to finish; without the fix, node1 races and APPENDs a duplicate row.
+    # Put node1 on the fake clock for node2's timeslot and START its view BEFORE
+    # touching keeper. node1's 'running' ephemeral check in RefreshTask runs
+    # before the stop_requested check, so node1 is already coordinating
+    # (RunningOnAnotherReplica) regardless of START/STOP; what matters is that
+    # node1 is now on the fake clock while node2's ephemeral is still present, so
+    # it has not yet entered the missing-znode grace path.
+    #
+    # This ordering is the crux of the fix: node1's grace deadline is computed
+    # from currentTime(), which returns the frozen fake clock once set. If node1
+    # recorded running_znode_missing_since while still on the real clock (i.e. if
+    # the ephemeral disappeared before this SET FAKE TIME) and we then jumped its
+    # clock forward, the real-clock deadline would already be in the past and
+    # node1 would clear the lock immediately, producing the duplicate this test
+    # only wants to see when the coordination fix is absent. Setting the fake
+    # clock first makes node1 record grace-start on the frozen clock instead.
     node1.query(f"SYSTEM TEST VIEW re.a SET FAKE TIME '{node1_fake}'")
     node1.query("SYSTEM START VIEW re.a")
+    wait_for_status(node1, "a", "RunningOnAnotherReplica", timeout=30)
+
+    # Cut only node2 off from keeper instead of restarting the whole keeper
+    # cluster. Keeper stays healthy for node1, so node1's session never expires
+    # and its watches keep firing. node2's session expires
+    # (>session_timeout_ms=5000, see zookeeper.xml) so its 'running' ephemeral
+    # disappears, but its SELECT keeps running because query execution is
+    # independent of keeper -- the bug's trigger condition.
+    with PartitionManager() as pm:
+        pm.drop_instance_zk_connections(node2)
+
+        # Wait until node1 actually notices the missing 'running' ephemeral and
+        # enters its crash-detection grace period, then restore node2 at once.
+        # Chaining the restore to this log line (instead of a fixed sleep)
+        # removes the load-dependent race: node2 reconnects ~1s after node1
+        # starts the grace period, always well within the ~6.25s window,
+        # regardless of how loaded the runner is. With the fix node1 waits and
+        # sees node2 re-register; without it node1 has no grace and APPENDs a
+        # duplicate row.
+        node1.wait_for_log_line("no corresponding ephemeral znode", timeout=60)
+        pm.restore_instance_zk_connections(node2)
 
     # Wait for the dust to settle: node2's refresh completes (~30s SELECT +
     # post-keeper INSERT) and propagates to keeper, then both replicas idle.
@@ -150,9 +175,10 @@ def test_keeper_session_loss_during_coordinated_refresh(started_cluster):
     wait_for_status(node2, "a", "Scheduled", timeout=120)
 
     # Pull both replicas' parts before counting -- otherwise the count races
-    # against ReplicatedMergeTree replication.
-    node1.query("SYSTEM SYNC REPLICA re.tgt")
-    node2.query("SYSTEM SYNC REPLICA re.tgt")
+    # against ReplicatedMergeTree replication. Retry: a replica may still be
+    # transiently read-only right after re-establishing its keeper session.
+    node1.query_with_retry("SYSTEM SYNC REPLICA re.tgt")
+    node2.query_with_retry("SYSTEM SYNC REPLICA re.tgt")
 
     rows = node1.query("SELECT toInt64(t), i, _part FROM re.tgt ORDER BY t")
     final_count = int(node1.query("SELECT count() FROM re.tgt").strip())


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/104051
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Stabilizes the flaky integration test
`test_refreshable_mv_keeper_loss/test.py::test_keeper_session_loss_during_coordinated_refresh`
(added in #104051). Test-only change; no product behavior changes.

Related: #104051

**Flakiness:** 8 failures across 8 unrelated PRs in 30 days, 0 on master (4036 master runs). The two observed modes:
- `assert 2 == 1` / "Expected 1 row APPENDed for the timeslot, got 2" (3 of 4 recent).
- `Code: 242 ... Table is in readonly mode` during `SYSTEM SYNC REPLICA` (1 of 4).

**Root cause (from CI server logs):** the test restarted all three keeper nodes to expire the running replica's (node2) session so its `running` ephemeral disappears, then made node1 want to refresh the same timeslot. On a loaded runner keeper quorum reforms slowly; node2's session expired three times over ~30s while quorum reformed. node1's crash-detection grace period is a hard-coded `1.25x session_timeout` (6.25s with `session_timeout_ms=5000`), so node1 declared node2 crashed, cleared the coordination lock, and started a duplicate refresh before node2 could reconnect and re-register. That duplicate-after-extended-outage is by design, so the assertion is stronger than what the product guarantees under a long/flapping outage. The readonly mode is node1's target table being briefly read-only right after a keeper session re-establish.

**Fix (test-only):**
- Isolate only node2 from keeper with `PartitionManager.drop_instance_zk_connections` instead of restarting the whole cluster. Keeper stays healthy for node1, so its grace period ticks from a stable clock, and node2 reconnects promptly (~1s) after restore, well within grace. This is exactly the "brief keeper connection loss on the running replica" condition #104051 guards against. node1 still enters the grace-period wait while node2's ephemeral is missing, so the test still fails if the coordination fix is reverted (teeth preserved).
- Use `query_with_retry` for `SYSTEM SYNC REPLICA` to tolerate a replica being briefly read-only after re-establishing its session.

**Verification:** 18/18 local runs pass with the change. Server logs confirm node1 takes the grace-period wait path ("refresh is running on replica '2', ... Waiting for 6250 ms ...") and node2 re-creates its ephemeral within grace, so exactly one refresh runs (no duplicate). The failing CI report this was found from: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=566bdf29bbc637b8e193a4a89be1417799fc6dc6&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.790`
<!-- ch-version-info:end -->