### PR TITLE
Filesystem cache: avoid redundant opendir per key directory on load

### DIFF
--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1904,7 +1904,11 @@ void FileCache::loadMetadataImpl()
 
 void FileCache::loadMetadataForKey(const fs::path & key_directory, const OriginInfo & origin_info)
 {
-    if (fs::is_empty(key_directory))
+    /// Open the directory once and reuse the iterator for the scan below.
+    /// `fs::is_empty` would open the directory just to test for emptiness,
+    /// which costs a redundant opendir/readdir per key directory.
+    fs::directory_iterator offset_it{key_directory};
+    if (offset_it == fs::directory_iterator())
     {
         LOG_DEBUG(log, "Removing empty key directory: {}", key_directory.string());
         fs::remove(key_directory);
@@ -1929,7 +1933,7 @@ void FileCache::loadMetadataForKey(const fs::path & key_directory, const OriginI
     };
     std::vector<SegmentToLoad> segments;
 
-    for (fs::directory_iterator offset_it{key_directory}; offset_it != fs::directory_iterator(); ++offset_it)
+    for (; offset_it != fs::directory_iterator(); ++offset_it)
     {
         auto offset_with_suffix = offset_it->path().filename().string();
         bool parsed = false;


### PR DESCRIPTION
On server startup, `FileCache::loadMetadataForKey` opened each cache key directory twice: once via `fs::is_empty` to test for emptiness, then again via `fs::directory_iterator` to scan the segment files. For caches with many keys, startup metadata loading is dominated by filesystem metadata latency, so the redundant `opendir`/`readdir` is pure overhead.

This change opens the directory only once and reuses the iterator: an empty directory is detected when the freshly-constructed iterator already equals the end iterator. The behavior is otherwise identical.

Related: https://github.com/ClickHouse/ClickHouse/pull/107415
Related: https://github.com/ClickHouse/ClickHouse/pull/107416

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up filesystem cache loading on startup by avoiding a redundant directory open per cache key.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.805`
- Backported to: `26.5.3.31`, `26.4.5.39`
<!-- ch-version-info:end -->