### PR TITLE
Filesystem cache: let listing threads help load after listing finishes

### DIFF
--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1783,8 +1783,32 @@ void FileCache::loadMetadataImpl()
         key_dirs_queue.finish();
     };
 
+    /// Load enqueued key directories until the queue is exhausted and finished.
+    /// pop() blocks when the queue is empty until either a new item is pushed by a listing
+    /// thread or finish() is called (after all listing threads stopped producing).
+    auto drain_queue = [&]()
+    {
+        std::pair<fs::path, OriginInfo> item;
+        while (key_dirs_queue.pop(item))
+        {
+            if (stop_loading_metadata)
+                return;
+            try
+            {
+                loadMetadataForKey(item.first, item.second);
+            }
+            catch (...)
+            {
+                handle_exception();
+                return;
+            }
+        }
+    };
+
     /// Listing threads: each picks up key_prefix_dirs in parallel and enqueues individual key dirs.
-    /// The last listing thread to finish calls finish() on the queue.
+    /// Once all prefixes are listed, the last listing thread calls finish() on the queue, and every
+    /// listing thread then joins the loading threads in draining it (so all threads load the - usually
+    /// dominant - remaining keys instead of sitting idle once listing is done).
     std::vector<ThreadFromGlobalPool> listing_threads;
     for (UInt64 i = 0; i < num_listing_threads; ++i)
     {
@@ -1844,6 +1868,9 @@ void FileCache::loadMetadataImpl()
 
                 if (listing_threads_remaining.fetch_sub(1) == 1)
                     key_dirs_queue.finish();
+
+                /// Listing is done for this thread; help load the remaining enqueued keys.
+                drain_queue();
             });
         }
         catch (...)
@@ -1859,26 +1886,7 @@ void FileCache::loadMetadataImpl()
     {
         try
         {
-            loading_threads.emplace_back([&]
-            {
-                /// pop() blocks when the queue is empty until either a new item is pushed
-                /// by a listing thread or finish() is called (after all listing threads exit).
-                std::pair<fs::path, OriginInfo> item;
-                while (key_dirs_queue.pop(item))
-                {
-                    if (stop_loading_metadata)
-                        return;
-                    try
-                    {
-                        loadMetadataForKey(item.first, item.second);
-                    }
-                    catch (...)
-                    {
-                        handle_exception();
-                        return;
-                    }
-                }
-            });
+            loading_threads.emplace_back([&] { drain_queue(); });
         }
         catch (...)
         {


### PR DESCRIPTION
Startup metadata loading splits `load_metadata_threads` into *listing* threads (walk key-prefix directories, enqueue individual key directories) and *loading* threads (drain the queue, build in-memory metadata per key). Listing threads previously exited as soon as all prefixes were listed, leaving only the loading threads (half of `load_metadata_threads`) to process the — usually dominant — remaining keys. Up to half the threads sat idle for the bulk of the work.

Now, once a listing thread runs out of prefixes to list, it joins the loading threads in draining the queue (the shared `drain_queue` helper), so all `load_metadata_threads` threads load keys during the tail of the operation.

The listing/loading split and the startup log line are unchanged. Behavior is otherwise identical; covered by the existing `test_parallel_cache_loading_on_startup` integration test.

Related: https://github.com/ClickHouse/ClickHouse/pull/107414
Related: https://github.com/ClickHouse/ClickHouse/pull/107415

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up filesystem cache loading on startup by letting directory-listing threads help load cache metadata once listing is finished, instead of leaving half the threads idle.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.806`
<!-- ch-version-info:end -->