### PR TITLE
Add regression test for `Merge` over `Distributed` virtual columns with `JOIN`

### DIFF
--- a/tests/queries/0_stateless/04338_merge_distributed_virtual_columns_with_join.reference
+++ b/tests/queries/0_stateless/04338_merge_distributed_virtual_columns_with_join.reference
@@ -1,0 +1,6 @@
+tbl	1
+tbl	2
+1	1	tbl
+2	1	tbl
+1	1	tbl
+2	1	tbl

--- a/tests/queries/0_stateless/04338_merge_distributed_virtual_columns_with_join.sql
+++ b/tests/queries/0_stateless/04338_merge_distributed_virtual_columns_with_join.sql
@@ -1,0 +1,44 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/84139
+-- Fixed by https://github.com/ClickHouse/ClickHouse/pull/102304 and
+-- https://github.com/ClickHouse/ClickHouse/pull/102471, which made `Merge`
+-- always proxy virtual columns to the underlying storages, so `_database`
+-- and `_table` are produced natively by the nested `Distributed` query.
+--
+-- Before the fix, with the analyzer enabled, selecting `_table` (and/or
+-- `_database`) from a `Merge` over a `Distributed` table together with a
+-- `LEFT JOIN` returned default (empty) values instead of the real ones,
+-- and could also scramble other columns (e.g. `id` was returned as `0`).
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS tbl;
+DROP TABLE IF EXISTS distributed_table;
+DROP TABLE IF EXISTS mergetable_dist;
+
+CREATE TABLE tbl (id Int64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tbl (id) VALUES (1), (2);
+
+CREATE TABLE distributed_table AS tbl
+    ENGINE = Distributed(test_shard_localhost, currentDatabase(), 'tbl');
+
+CREATE TABLE mergetable_dist AS tbl
+    ENGINE = Merge(currentDatabase(), 'distributed_table');
+
+SELECT _table AS `_table`, *
+FROM mergetable_dist
+LEFT JOIN (SELECT 1 AS id) AS t USING (id)
+ORDER BY id;
+
+SELECT id, _database = currentDatabase(), _table
+FROM mergetable_dist
+LEFT JOIN (SELECT 1 AS id) AS t USING (id)
+ORDER BY id;
+
+SELECT id, m._database = currentDatabase(), m._table
+FROM mergetable_dist AS m
+LEFT JOIN (SELECT 1 AS id) AS t USING (id)
+ORDER BY id;
+
+DROP TABLE tbl;
+DROP TABLE distributed_table;
+DROP TABLE mergetable_dist;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/84139
Related: https://github.com/ClickHouse/ClickHouse/pull/102304
Related: https://github.com/ClickHouse/ClickHouse/pull/102471
Related: https://github.com/ClickHouse/ClickHouse/pull/85917
-->

Adds a regression test for the analyzer issue where selecting `_table` (and/or `_database`) from a `Merge` over a `Distributed` table together with a `LEFT JOIN` returned default (empty) values instead of the real ones, and could also scramble other columns (e.g. `id` was returned as `0`).

The bug is no longer reproducible on `master`: it was fixed by `#102304` ("Native Common Virtuals for Remaining Storage") and `#102471` ("Storage `merge` always proxy virtuals to underlying storages"), which made `Merge` always proxy virtual columns to the underlying storages, so `_database` and `_table` are produced natively by the nested `Distributed` query and no longer require ad-hoc rewrites in `StorageMerge`.

This test is the regression-only follow-up to `#85917`, with the expected output updated to match the post-refactor behavior (correct `_database` and `_table` values).

Closes: https://github.com/ClickHouse/ClickHouse/issues/84139
Related: https://github.com/ClickHouse/ClickHouse/pull/102304
Related: https://github.com/ClickHouse/ClickHouse/pull/102471
Related: https://github.com/ClickHouse/ClickHouse/pull/85917

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add a regression test for `Merge` over `Distributed` virtual columns (`_table`, `_database`) with `LEFT JOIN` under the analyzer.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c770f5-b5e6-44fd-86af-b0a425c1dc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c770f5-b5e6-44fd-86af-b0a425c1dc36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.792`
<!-- ch-version-info:end -->