### PR TITLE
Retry the changed-files GitHub API call and report failures clearly

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/feature_docs.py
+++ b/ci/jobs/scripts/workflow_hooks/feature_docs.py
@@ -42,6 +42,11 @@ def check_docs():
     info = Info()
     if Labels.PR_FEATURE in info.pr_labels:
         changed_files = info.get_kv_data("changed_files")
+        assert changed_files is not None, (
+            "changed_files is not populated in JOB_KV_DATA: the store_data pre-hook "
+            "most likely failed to fetch the PR file list from the GitHub API. "
+            "See the Config Workflow logs for the underlying error."
+        )
         has_doc_changes = any(
             file.startswith("docs/")
             or file in embedded_doc_files

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -246,6 +246,11 @@ def check_labels(category, info):
 
     if info.pr_number:
         changed_files = info.get_kv_data("changed_files")
+        assert changed_files is not None, (
+            "changed_files is not populated in JOB_KV_DATA: the store_data pre-hook "
+            "most likely failed to fetch the PR file list from the GitHub API. "
+            "See the Config Workflow logs for the underlying error."
+        )
         if "contrib/" in " ".join(changed_files):
             pr_labels_to_add.append(Labels.SUBMODULE_CHANGED)
 

--- a/ci/jobs/scripts/workflow_hooks/team_notifications.py
+++ b/ci/jobs/scripts/workflow_hooks/team_notifications.py
@@ -10,6 +10,11 @@ def check():
     info = Info()
 
     changed_files = info.get_kv_data("changed_files")
+    assert changed_files is not None, (
+        "changed_files is not populated in JOB_KV_DATA: the store_data pre-hook "
+        "most likely failed to fetch the PR file list from the GitHub API. "
+        "See the Config Workflow logs for the underlying error."
+    )
     for file in changed_files:
         if any(file.startswith(f) for f in integrations_ecosystem_files):
             GH.post_updateable_comment(

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -91,18 +91,30 @@ class GH:
         # HEAD, same as deleted files, which were always included.
         jq_both_sides = ".filename, (.previous_filename // empty)"
 
-        for attempt in range(3):
-            # store changed files
-            if info.pr_number > 0:
-                exit_code, changed_files_str, err = Shell.get_res_stdout_stderr(
-                    f"gh api repos/{repo_name}/pulls/{info.pr_number}/files --paginate --jq '.[] | {jq_both_sides}'",
-                )
-                assert exit_code == 0, "Failed to retrieve changed files list"
-            else:
-                exit_code, changed_files_str, err = Shell.get_res_stdout_stderr(
-                    f"gh api repos/{repo_name}/commits/{sha} --jq '.files[] | {jq_both_sides}'",
-                )
+        if info.pr_number > 0:
+            command = (
+                f"gh api repos/{repo_name}/pulls/{info.pr_number}/files "
+                f"--paginate --jq '.[] | {jq_both_sides}'"
+            )
+        else:
+            command = (
+                f"gh api repos/{repo_name}/commits/{sha} "
+                f"--jq '.files[] | {jq_both_sides}'"
+            )
 
+        # The GitHub API call is an idempotent read that occasionally fails with
+        # a transient error (rate limiting, a 5xx, or a GraphQL "Something went
+        # wrong" hiccup). Retry a few times with a small backoff so a momentary
+        # blip does not take down the whole workflow. Every non-zero exit code
+        # is treated as retryable: this is a read, so a spurious retry is cheap
+        # and we cannot reliably tell transient from permanent errors apart by
+        # the exit code alone.
+        attempts = 5
+        last_exit_code = 0
+        last_err = ""
+        last_out = ""
+        for attempt in range(attempts):
+            exit_code, changed_files_str, err = Shell.get_res_stdout_stderr(command)
             if exit_code == 0:
                 res = (
                     list(dict.fromkeys(changed_files_str.split("\n")))
@@ -110,19 +122,30 @@ class GH:
                     else []
                 )
                 break
-            else:
-                print(
-                    f"Failed to get changed files, attempt [{attempt+1}], exit code [{exit_code}], error [{err}]"
-                )
-                if exit_code > 1:
-                    # assume that exit code == 1 is retryable - Fix if not true
-                    # exit_code 1 for this type of errors:  WARNING: stderr: GraphQL: Something went wrong while executing your query on 2025-08-05T15:33:56Z. Please include `E746:1CAA99:44F9F67:8B9B520:68922464` when reporting this issue.
-                    print("error is not retryable - break")
-                    break
-                time.sleep(1)
 
-        if res is None and strict:
-            raise RuntimeError("Failed to get changed files")
+            last_exit_code, last_err, last_out = exit_code, err, changed_files_str
+            print(
+                f"Failed to get changed files, attempt [{attempt + 1}/{attempts}], "
+                f"exit code [{exit_code}], stderr [{err}]"
+            )
+            if attempt + 1 < attempts:
+                time.sleep(attempt + 1)
+
+        if res is None:
+            # Surface the actual command, exit code and stderr so the failure is
+            # diagnosable directly from the report, instead of resurfacing later
+            # as a confusing "NoneType is not iterable" in a downstream consumer
+            # that read the (never stored) changed files from the KV data.
+            message = (
+                f"Failed to retrieve the list of changed files after {attempts} attempts.\n"
+                f"  command:   {command}\n"
+                f"  exit code: {last_exit_code}\n"
+                f"  stderr:    {last_err}\n"
+                f"  stdout:    {last_out}"
+            )
+            print(message)
+            if strict:
+                raise RuntimeError(message)
 
         return res
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/74691
-->

`GH.get_changed_files` fetches the list of files a PR touches via `gh api .../pulls/<n>/files`. The `store_data` pre-hook fetches it once and stores it into the job KV data; several other workflow hooks (`pr_labels_and_category`, `team_notifications`, `feature_docs`, ...) read it back from there.

The function had a `for attempt in range(3)` retry loop, but for the PR path it was dead code: an `assert exit_code == 0` ran immediately after the `gh api` call, so the very first transient failure raised before any retry could happen. When the GitHub API hiccupped (rate limiting, a 5xx, or a GraphQL "Something went wrong" error), `store_data` aborted without populating `changed_files`, and every downstream hook then read `None` from the KV data and died far away with an opaque `TypeError: 'NoneType' object is not iterable` / `can only join an iterable` — with nothing in the report pointing at the real cause. Because these are pre-hooks of the `Config Workflow`, the whole pipeline was blocked and no real jobs were dispatched.

Changes:

- Make the retry actually retry: drop the premature `assert`, unify the PR and commit code paths into a single command, and retry every non-zero exit code (this is an idempotent read, so a spurious retry is cheap and the exit code alone does not reliably distinguish transient from permanent errors). Five attempts with a small linear backoff.
- On final failure, print and (when `strict`) raise a message that includes the command, exit code, stderr and stdout, so the failure is diagnosable directly from the report. The non-strict contract of returning `None` is preserved for callers that tolerate it (`Runner` and the master/release path of `store_data`).
- In the three consumer hooks, `assert changed_files is not None` with an actionable message instead of letting a missing value surface as a bare `TypeError`.

Observed on [PR #74691](https://github.com/ClickHouse/ClickHouse/pull/74691) (commit `8e08fc02`): [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=74691&sha=8e08fc02490688916fb3bffe4e897cbe50f2702a&name_0=PR&name_1=Config%20Workflow).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)