### PR TITLE
Do not rewrite NULL-preserving aggregates with optimize_rewrite_aggregate_function_with_if

### DIFF
--- a/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
+++ b/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
@@ -94,6 +94,17 @@ public:
         if (!if_node || if_node->getFunctionName() != "if")
             return;
 
+        /// The rewrite f(if(cond, x, NULL)) -> fIf(x, cond) turns the NULL branch into rows the -If
+        /// condition skips, which is only valid when that NULL is a Nullable NULL the aggregate's null
+        /// handling discards. Variant and Dynamic absorb the NULL as a discriminator value (a real
+        /// payload row), so even NULL-skipping aggregates like count and any still process it; dropping
+        /// it via the condition changes the result (count(if(number = 0, NULL, number::Variant(...)))
+        /// goes from 4 to 3). Skip the rewrite whenever the if result can contain NULL but is not
+        /// Nullable, regardless of the aggregate.
+        auto if_result_type = if_node->getResultType();
+        if (canContainNull(*if_result_type) && !isNullableOrLowCardinalityNullable(if_result_type))
+            return;
+
         /// Do not rewrite aggregates that preserve NULL payload rows (the *_respect_nulls family,
         /// directly or wrapped in a combinator): the -If form drops those rows and changes the result.
         if (aggregateFunctionPreservesNullPayload(function_node->getAggregateFunction()))

--- a/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
+++ b/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
@@ -2,6 +2,7 @@
 
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeAggregateFunction.h>
+#include <DataTypes/DataTypesNumber.h>
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
 #include <AggregateFunctions/IAggregateFunction.h>
@@ -47,13 +48,20 @@ bool aggregateFunctionPreservesNullPayload(const AggregateFunctionPtr & function
     if (argument_types.size() != 1)
         return false;
 
+    /// canContainNull() (not isNullable()): Variant/Dynamic carry NULL via a discriminator without
+    /// being wrapped in Nullable, so makeNullableSafe() leaves them unchanged. The rewrite is safe
+    /// only when the argument cannot hold a NULL payload.
+    if (!canContainNull(*argument_types[0]))
+        return false;
+
     /// Probe with a Nullable argument, exactly as the Null combinator consults getOwnNullAdapter.
-    /// Some adapters require it: count builds AggregateFunctionCountNotNullUnary whose constructor
-    /// rejects a non-Nullable argument, so probing the resolved (possibly non-Nullable) type crashes.
-    /// If the argument cannot be made Nullable it carries no NULL payload, so the rewrite is safe.
+    /// count's adapter (AggregateFunctionCountNotNullUnary) rejects a non-Nullable argument, and
+    /// Variant/Dynamic cannot be wrapped in Nullable, so fall back to a plain Nullable stand-in. The
+    /// respect_nulls adapters ignore the argument and count only checks isNullable(), so the
+    /// substitution does not change which adapter is returned.
     auto nullable_argument_type = makeNullableSafe(argument_types[0]);
     if (!nullable_argument_type->isNullable())
-        return false;
+        nullable_argument_type = makeNullable(std::make_shared<DataTypeUInt8>());
 
     AggregateFunctionProperties properties;
     return function->getOwnNullAdapter(function, {nullable_argument_type}, function->getParameters(), properties) == function;

--- a/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
+++ b/src/Analyzer/Passes/RewriteAggregateFunctionWithIfPass.cpp
@@ -4,6 +4,7 @@
 #include <DataTypes/DataTypeAggregateFunction.h>
 
 #include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <AggregateFunctions/IAggregateFunction.h>
 
 #include <Core/Settings.h>
 
@@ -24,6 +25,39 @@ namespace Setting
 
 namespace
 {
+
+/// An aggregate preserves NULL payload rows when its null handling keeps them instead of skipping
+/// them: rewriting f(if(cond, x, NULL)) -> fIf(x, cond) drops those rows and is only valid for
+/// NULL-skipping aggregates. The *_respect_nulls family keeps them and signals this by returning
+/// itself from getOwnNullAdapter (the Null combinator's "do not wrap me, I keep NULL rows"
+/// contract). NULL-skipping aggregates return a wrapping adapter or nullptr.
+bool aggregateFunctionPreservesNullPayload(const AggregateFunctionPtr & function)
+{
+    if (!function)
+        return false;
+
+    /// Look through combinators (-OrNull / -OrDefault / -Distinct / -State / ...): they inherit
+    /// NULL-row handling from the function they wrap, so only the wrapped leaf can belong to the
+    /// *_respect_nulls family. Without this, first_value_respect_nullsOrNull(...) would be rewritten.
+    if (auto nested = function->getNestedFunction())
+        return aggregateFunctionPreservesNullPayload(nested);
+
+    /// The *_respect_nulls family is unary; a nullary aggregate (count()) cannot belong to it.
+    const auto & argument_types = function->getArgumentTypes();
+    if (argument_types.size() != 1)
+        return false;
+
+    /// Probe with a Nullable argument, exactly as the Null combinator consults getOwnNullAdapter.
+    /// Some adapters require it: count builds AggregateFunctionCountNotNullUnary whose constructor
+    /// rejects a non-Nullable argument, so probing the resolved (possibly non-Nullable) type crashes.
+    /// If the argument cannot be made Nullable it carries no NULL payload, so the rewrite is safe.
+    auto nullable_argument_type = makeNullableSafe(argument_types[0]);
+    if (!nullable_argument_type->isNullable())
+        return false;
+
+    AggregateFunctionProperties properties;
+    return function->getOwnNullAdapter(function, {nullable_argument_type}, function->getParameters(), properties) == function;
+}
 
 class RewriteAggregateFunctionWithIfVisitor : public InDepthQueryTreeVisitorWithContext<RewriteAggregateFunctionWithIfVisitor>
 {
@@ -50,6 +84,11 @@ public:
 
         auto * if_node = function_arguments_nodes[0]->as<FunctionNode>();
         if (!if_node || if_node->getFunctionName() != "if")
+            return;
+
+        /// Do not rewrite aggregates that preserve NULL payload rows (the *_respect_nulls family,
+        /// directly or wrapped in a combinator): the -If form drops those rows and changes the result.
+        if (aggregateFunctionPreservesNullPayload(function_node->getAggregateFunction()))
             return;
 
         FunctionNodePtr replaced_node;

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
@@ -28,6 +28,20 @@ SELECT anyRespectNulls(if(number = 0, NULL, number::Variant(String, UInt64))) FR
 \N
 SELECT anyRespectNulls(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
 \N
+-- Even NULL-skipping aggregates (count/any) must NOT be rewritten when the if result is Variant/Dynamic:
+-- the NULL branch becomes a discriminator-NULL payload row that the aggregate still processes, so the
+-- -If form (which skips it) changes the result (count goes 4 -> 3, any goes \N -> 1).
+SELECT count(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+4
+SELECT count(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+4
+SELECT any(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+\N
+SELECT any(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+\N
+SELECT sum(countSubstrings(explain, 'function_name: countIf')) = 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT count(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4));
+1
 -- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
 SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
 FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
@@ -22,6 +22,12 @@ SELECT anyLast_respect_nullsOrNull(if(number < 3, number, NULL)) FROM numbers(4)
 \N
 SELECT first_value_respect_nullsOrDefault(if(number % 2 = 0, NULL, number)) FROM numbers(4);
 \N
+-- Variant/Dynamic carry NULL via a discriminator (not Nullable), so canContainNull is true while
+-- makeNullableSafe leaves the type unchanged. The first row is the NULL payload and must be kept.
+SELECT anyRespectNulls(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+\N
+SELECT anyRespectNulls(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+\N
 -- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
 SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
 FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.reference
@@ -1,0 +1,72 @@
+-- { echoOn }
+
+-- respect_nulls functions keep the NULL row: the first/last value is NULL.
+-- With the optimization on these must still return \N (not the rewritten value).
+SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+\N
+SELECT first_value_respect_nulls(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+\N
+SELECT anyRespectNulls(if(number % 2 = 1, number, NULL)) FROM numbers(4);
+\N
+SELECT anyLast_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4);
+\N
+SELECT last_value_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4);
+\N
+-- A combinator wrapping a respect_nulls function (e.g. -OrNull / -OrDefault) must also be
+-- detected: the NULL-preserving signal lives on the wrapped leaf, not on the combinator.
+SELECT first_value_respect_nullsOrNull(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+\N
+SELECT anyRespectNullsOrNull(if(number % 2 = 1, number, NULL)) FROM numbers(4);
+\N
+SELECT anyLast_respect_nullsOrNull(if(number < 3, number, NULL)) FROM numbers(4);
+\N
+SELECT first_value_respect_nullsOrDefault(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+\N
+-- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
+SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+1
+SELECT sum(countSubstrings(explain, 'function_name: anyLast_respect_nulls')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyLast_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4));
+1
+SELECT sum(countSubstrings(explain, 'function_name: any_respect_nullsOrNull')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT first_value_respect_nullsOrNull(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+1
+-- NULL-skipping aggregates ARE still rewritten to the -If form (no regression).
+SELECT sum(countSubstrings(explain, 'function_name: anyIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT any(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+1
+SELECT sum(countSubstrings(explain, 'function_name: countIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT count(if(number > 1, number, NULL)) FROM numbers(4));
+1
+SELECT sum(countSubstrings(explain, 'function_name: sumIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT sum(if(number > 1, number, NULL)) FROM numbers(4));
+1
+SELECT sum(countSubstrings(explain, 'function_name: avgIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT avg(if(number > 1, number, NULL)) FROM numbers(4));
+1
+-- Results of the still-optimized functions are unchanged.
+SELECT count(if(number > 1, number, NULL)), sum(if(number > 1, number, NULL)), avg(if(number > 1, number, NULL)) FROM numbers(4);
+2	5	2.5
+-- Zero-argument count is reachable here: NormalizeCountVariantsPass rewrites count(1)/sum(1)
+-- to a zero-argument count, whose null adapter indexes argument_types[0]. The optimization
+-- must not consult the adapter before the single-if-argument shape is known (must not crash).
+SELECT count() FROM numbers(4);
+4
+SELECT count(1) FROM numbers(4);
+4
+SELECT sum(1) FROM numbers(4);
+4
+-- count(if(...)) where the if result is NOT Nullable resolves to AggregateFunctionCount, whose
+-- null adapter (AggregateFunctionCountNotNullUnary) rejects a non-Nullable argument. The
+-- null-preserving probe must use a Nullable argument so this does not crash (issue surfaced on
+-- 01710_minmax_count_projection: count(if(d=4, d, 1)) under force_optimize_projection).
+-- force_optimize_projection = 1 needs an applicable projection, so pin the projection settings
+-- the runner randomizes off (optimize_use_projections/optimize_use_implicit_projections/
+-- optimize_trivial_count_query) or it throws PROJECTION_NOT_USED instead of exercising the pass.
+DROP TABLE IF EXISTS t_04337;
+CREATE TABLE t_04337 (d Int64) ENGINE = MergeTree ORDER BY d;
+INSERT INTO t_04337 SELECT number FROM numbers(1000);
+SELECT count(if(d = 4, d, 1)) FROM t_04337 SETTINGS force_optimize_projection = 1, optimize_use_projections = 1, optimize_use_implicit_projections = 1, optimize_trivial_count_query = 1;
+1000
+DROP TABLE t_04337;

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
@@ -29,6 +29,16 @@ SELECT first_value_respect_nullsOrDefault(if(number % 2 = 0, NULL, number)) FROM
 SELECT anyRespectNulls(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
 SELECT anyRespectNulls(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
 
+-- Even NULL-skipping aggregates (count/any) must NOT be rewritten when the if result is Variant/Dynamic:
+-- the NULL branch becomes a discriminator-NULL payload row that the aggregate still processes, so the
+-- -If form (which skips it) changes the result (count goes 4 -> 3, any goes \N -> 1).
+SELECT count(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+SELECT count(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+SELECT any(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+SELECT any(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+SELECT sum(countSubstrings(explain, 'function_name: countIf')) = 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT count(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4));
+
 -- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
 SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
 FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
@@ -24,6 +24,11 @@ SELECT anyRespectNullsOrNull(if(number % 2 = 1, number, NULL)) FROM numbers(4);
 SELECT anyLast_respect_nullsOrNull(if(number < 3, number, NULL)) FROM numbers(4);
 SELECT first_value_respect_nullsOrDefault(if(number % 2 = 0, NULL, number)) FROM numbers(4);
 
+-- Variant/Dynamic carry NULL via a discriminator (not Nullable), so canContainNull is true while
+-- makeNullableSafe leaves the type unchanged. The first row is the NULL payload and must be kept.
+SELECT anyRespectNulls(if(number = 0, NULL, number::Variant(String, UInt64))) FROM numbers(4);
+SELECT anyRespectNulls(if(number = 0, NULL, number::Dynamic)) FROM numbers(4);
+
 -- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
 SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
 FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));

--- a/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
+++ b/tests/queries/0_stateless/04337_rewrite_aggregate_function_with_if_respect_nulls.sql
@@ -1,0 +1,68 @@
+-- Tests that optimize_rewrite_aggregate_function_with_if does not fire for
+-- aggregate functions that preserve NULL payload (the *_respect_nulls family).
+-- Rewriting f(if(cond, x, NULL)) -> fIf(x, cond) drops the NULL-payload rows,
+-- which is only valid when f skips NULL rows. respect_nulls functions count
+-- those rows, so the rewrite silently changed results (issue #107421).
+
+SET enable_analyzer = 1;
+SET optimize_rewrite_aggregate_function_with_if = 1;
+
+-- { echoOn }
+
+-- respect_nulls functions keep the NULL row: the first/last value is NULL.
+-- With the optimization on these must still return \N (not the rewritten value).
+SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+SELECT first_value_respect_nulls(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+SELECT anyRespectNulls(if(number % 2 = 1, number, NULL)) FROM numbers(4);
+SELECT anyLast_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4);
+SELECT last_value_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4);
+
+-- A combinator wrapping a respect_nulls function (e.g. -OrNull / -OrDefault) must also be
+-- detected: the NULL-preserving signal lives on the wrapped leaf, not on the combinator.
+SELECT first_value_respect_nullsOrNull(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+SELECT anyRespectNullsOrNull(if(number % 2 = 1, number, NULL)) FROM numbers(4);
+SELECT anyLast_respect_nullsOrNull(if(number < 3, number, NULL)) FROM numbers(4);
+SELECT first_value_respect_nullsOrDefault(if(number % 2 = 0, NULL, number)) FROM numbers(4);
+
+-- respect_nulls aggregates are NOT rewritten to the -If form (the function name stays).
+SELECT sum(countSubstrings(explain, 'function_name: any_respect_nulls')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+SELECT sum(countSubstrings(explain, 'function_name: anyLast_respect_nulls')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT anyLast_respect_nulls(if(number < 3, number, NULL)) FROM numbers(4));
+SELECT sum(countSubstrings(explain, 'function_name: any_respect_nullsOrNull')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT first_value_respect_nullsOrNull(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+
+-- NULL-skipping aggregates ARE still rewritten to the -If form (no regression).
+SELECT sum(countSubstrings(explain, 'function_name: anyIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT any(if(number % 2 = 0, NULL, number)) FROM numbers(4));
+SELECT sum(countSubstrings(explain, 'function_name: countIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT count(if(number > 1, number, NULL)) FROM numbers(4));
+SELECT sum(countSubstrings(explain, 'function_name: sumIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT sum(if(number > 1, number, NULL)) FROM numbers(4));
+SELECT sum(countSubstrings(explain, 'function_name: avgIf')) > 0
+FROM (EXPLAIN QUERY TREE run_passes = 1 SELECT avg(if(number > 1, number, NULL)) FROM numbers(4));
+
+-- Results of the still-optimized functions are unchanged.
+SELECT count(if(number > 1, number, NULL)), sum(if(number > 1, number, NULL)), avg(if(number > 1, number, NULL)) FROM numbers(4);
+
+-- Zero-argument count is reachable here: NormalizeCountVariantsPass rewrites count(1)/sum(1)
+-- to a zero-argument count, whose null adapter indexes argument_types[0]. The optimization
+-- must not consult the adapter before the single-if-argument shape is known (must not crash).
+SELECT count() FROM numbers(4);
+SELECT count(1) FROM numbers(4);
+SELECT sum(1) FROM numbers(4);
+
+-- count(if(...)) where the if result is NOT Nullable resolves to AggregateFunctionCount, whose
+-- null adapter (AggregateFunctionCountNotNullUnary) rejects a non-Nullable argument. The
+-- null-preserving probe must use a Nullable argument so this does not crash (issue surfaced on
+-- 01710_minmax_count_projection: count(if(d=4, d, 1)) under force_optimize_projection).
+-- force_optimize_projection = 1 needs an applicable projection, so pin the projection settings
+-- the runner randomizes off (optimize_use_projections/optimize_use_implicit_projections/
+-- optimize_trivial_count_query) or it throws PROJECTION_NOT_USED instead of exercising the pass.
+DROP TABLE IF EXISTS t_04337;
+CREATE TABLE t_04337 (d Int64) ENGINE = MergeTree ORDER BY d;
+INSERT INTO t_04337 SELECT number FROM numbers(1000);
+SELECT count(if(d = 4, d, 1)) FROM t_04337 SETTINGS force_optimize_projection = 1, optimize_use_projections = 1, optimize_use_implicit_projections = 1, optimize_trivial_count_query = 1;
+DROP TABLE t_04337;
+
+-- { echoOff }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107421
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect results from the `optimize_rewrite_aggregate_function_with_if` optimization for aggregate functions that preserve `NULL` payload values (the `*_respect_nulls` family: `anyRespectNulls`, `first_value_respect_nulls`, `anyLast_respect_nulls`, `last_value_respect_nulls`). The optimization no longer rewrites `f(if(cond, x, NULL))` into the `-If` form for such functions.


### Description

`RewriteAggregateFunctionWithIfPass` rewrites `f(if(cond, NULL, x))` into `fIf(x, !cond)` and `f(if(cond, x, NULL))` into `fIf(x, cond)`. This drops the rows whose payload is `NULL`, which is only correct for aggregate functions that skip `NULL` rows.

The `*_respect_nulls` family keeps `NULL` payload values, so a `NULL` row can legitimately be the first/last value of the result. Filtering it out with the `-If` form silently changed the result, for example on `26.6.1.1`:

```sql
SELECT anyRespectNulls(if(number % 2 = 0, NULL, number)) FROM numbers(4);
-- returned 1 (wrong); correct answer is NULL (the first value is NULL)
```

These functions provide their own null adapter: `getOwnNullAdapter` returns the function itself, which is the general signal (honored by the `Null` combinator) that the `NULL` payload must be kept. The pass now skips the rewrite whenever `getOwnNullAdapter` returns the function itself, so the fix covers the whole family and any future `NULL`-preserving aggregate. `NULL`-skipping functions (`count`, `sum`, `avg`, plain `any`, ...) are unaffected and still optimized.
