### PR TITLE
Fix filesystem_error in LocalObjectStorage::listObjects on concurrent file removal

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -436,37 +436,73 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
     /// error (EACCES, EIO, ...) is propagated, so a caller never reads a
     /// silently truncated listing. The same tolerance is applied by
     /// `tryGetObjectMetadata` below for the per-entry metadata stat.
-    auto throw_unless_vanished = [&](const std::error_code & e)
+    auto throw_unless_vanished = [&](const std::error_code & e, const fs::path & at)
     {
         if (!isVanishedEntryError(e))
-            throw fs::filesystem_error("Cannot list local object storage directory", path, e);
+            throw fs::filesystem_error("Cannot list local object storage directory", at, e);
     };
 
-    std::error_code ec;
-    fs::recursive_directory_iterator it(path, ec);
-    if (ec)
-    {
-        throw_unless_vanished(ec);
-        return;
-    }
+    /// We descend with an explicit stack of non-recursive `directory_iterator`s
+    /// rather than a single `recursive_directory_iterator`. The recursive
+    /// iterator opens each child directory with `opendir` while incrementing and,
+    /// if that `opendir` fails (e.g. the directory was concurrently removed), it
+    /// resets itself to `end()` - silently dropping every later, still-present
+    /// sibling. Listing only the open directory at a time lets a vanished
+    /// directory skip just its own subtree while the remaining entries are still
+    /// reported. Each directory is fully drained before any subdirectory is
+    /// opened, so an invalid path (e.g. a NUL-truncated argument) fails fast on
+    /// the per-entry stat instead of recursing.
+    std::vector<fs::path> pending_dirs;
+    pending_dirs.emplace_back(path);
 
-    const fs::recursive_directory_iterator end;
-    while (it != end)
+    while (!pending_dirs.empty())
     {
-        const bool is_dir = it->is_directory(ec);
+        const fs::path dir = std::move(pending_dirs.back());
+        pending_dirs.pop_back();
+
+        std::error_code ec;
+        fs::directory_iterator it(dir, ec);
         if (ec)
-            throw_unless_vanished(ec); /// entry vanished before we could stat it: skip it
-        else if (!is_dir)
         {
-            if (auto metadata = tryGetObjectMetadata(it->path(), /*with_tags=*/ false))
-                children.emplace_back(std::make_shared<RelativePathWithMetadata>(it->path(), std::move(*metadata)));
+            /// The directory itself vanished (or a path component was replaced)
+            /// before we could open it: omit only this subtree, keep the rest.
+            throw_unless_vanished(ec, dir);
+            continue;
         }
 
-        it.increment(ec);
-        if (ec)
+        const fs::directory_iterator end;
+        while (it != end)
         {
-            throw_unless_vanished(ec);
-            return; /// increment resets the iterator to end() on error
+            const fs::path entry_path = it->path();
+            const bool is_dir = it->is_directory(ec); /// follows symlinks
+            if (ec)
+            {
+                throw_unless_vanished(ec, entry_path); /// entry vanished before we could stat it: skip it
+            }
+            else if (is_dir)
+            {
+                /// Descend only into real subdirectories, never into symlinks,
+                /// matching the no-follow-symlink default of the recursive
+                /// iterator (avoids cycles). A symlink-to-directory is neither
+                /// descended into nor reported as an object.
+                std::error_code sym_ec;
+                if (!it->is_symlink(sym_ec) && !sym_ec)
+                    pending_dirs.push_back(entry_path);
+            }
+            else
+            {
+                if (auto metadata = tryGetObjectMetadata(entry_path, /*with_tags=*/ false))
+                    children.emplace_back(std::make_shared<RelativePathWithMetadata>(entry_path, std::move(*metadata)));
+            }
+
+            it.increment(ec);
+            if (ec)
+            {
+                /// `increment` resets the iterator to end() on error; a vanished
+                /// entry only affects this directory, the worklist preserves the rest.
+                throw_unless_vanished(ec, dir);
+                break;
+            }
         }
     }
 }

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -396,8 +396,14 @@ std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std
         throw fs::filesystem_error("Got unexpected error while getting last write time", path, error);
     }
 
-    /// no_such_file_or_directory is ignored only for last_write_time for consistency
-    object_metadata.size_bytes = fs::file_size(path);
+    object_metadata.size_bytes = fs::file_size(path, error);
+    if (error)
+    {
+        /// The file may vanish between the two stat calls (concurrent removal).
+        if (error == std::errc::no_such_file_or_directory)
+            return {};
+        throw fs::filesystem_error("Got unexpected error while getting file size", path, error);
+    }
 
     object_metadata.etag = std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(time.time_since_epoch()).count());
     object_metadata.last_modified = Poco::Timestamp::fromEpochTime(
@@ -410,12 +416,29 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
     if (!fs::exists(path) || !fs::is_directory(path))
         return;
 
-    for (const auto & entry : fs::recursive_directory_iterator(path))
+    /// Listing is a best-effort snapshot: entries may be created or removed
+    /// concurrently (e.g. an external writer atomically replacing a file via
+    /// rename). Drive the iterator with the non-throwing `error_code` overloads
+    /// and skip entries that vanish mid-listing, mirroring how a remote object
+    /// store simply omits a concurrently-deleted object. The previous code used
+    /// the throwing overloads, so a file removed between enumeration and the
+    /// metadata stat aborted the whole listing with a `filesystem_error`.
+    std::error_code ec;
+    fs::recursive_directory_iterator it(path, ec);
+    if (ec)
+        return;
+
+    const fs::recursive_directory_iterator end;
+    for (; it != end; it.increment(ec))
     {
-        if (entry.is_directory())
+        if (ec)
+            return;
+
+        if (it->is_directory(ec) || ec)
             continue;
 
-        children.emplace_back(std::make_shared<RelativePathWithMetadata>(entry.path(), getObjectMetadata(entry.path(), false)));
+        if (auto metadata = tryGetObjectMetadata(it->path(), /*with_tags=*/ false))
+            children.emplace_back(std::make_shared<RelativePathWithMetadata>(it->path(), std::move(*metadata)));
     }
 }
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -484,9 +484,15 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
                 /// Descend only into real subdirectories, never into symlinks,
                 /// matching the no-follow-symlink default of the recursive
                 /// iterator (avoids cycles). A symlink-to-directory is neither
-                /// descended into nor reported as an object.
+                /// descended into nor reported as an object. The symlink probe
+                /// is the fourth stat in this path: route its error through the
+                /// same disappearance filter so a real error (EACCES, EIO) is
+                /// not silently dropped while a vanished entry is skipped.
                 std::error_code sym_ec;
-                if (!it->is_symlink(sym_ec) && !sym_ec)
+                const bool is_symlink = it->is_symlink(sym_ec);
+                if (sym_ec)
+                    throw_unless_vanished(sym_ec, entry_path);
+                else if (!is_symlink)
                     pending_dirs.push_back(entry_path);
             }
             else

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -368,6 +368,18 @@ void LocalObjectStorage::removeObjectsIfExist(const StoredObjects & objects)
         removeObjectIfExists(object);
 }
 
+namespace
+{
+/// The concurrent-disappearance class for a best-effort local listing: an entry
+/// removed mid-stat (ENOENT) or whose parent path component was concurrently
+/// replaced by a non-directory (ENOTDIR). Mirrors libc++'s own `__is_dne_error`.
+/// Every other error (EACCES, EIO, ...) is a real failure and must propagate.
+bool isVanishedEntryError(const std::error_code & error)
+{
+    return error == std::errc::no_such_file_or_directory || error == std::errc::not_a_directory;
+}
+}
+
 ObjectMetadata LocalObjectStorage::getObjectMetadata(const std::string & path, bool) const
 {
     ObjectMetadata object_metadata;
@@ -391,7 +403,7 @@ std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std
     auto time = fs::last_write_time(path, error);
     if (error)
     {
-        if (error == std::errc::no_such_file_or_directory)
+        if (isVanishedEntryError(error))
             return {};
         throw fs::filesystem_error("Got unexpected error while getting last write time", path, error);
     }
@@ -399,8 +411,9 @@ std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std
     object_metadata.size_bytes = fs::file_size(path, error);
     if (error)
     {
-        /// The file may vanish between the two stat calls (concurrent removal).
-        if (error == std::errc::no_such_file_or_directory)
+        /// The entry may vanish between the two stat calls (concurrent removal),
+        /// or a parent path component may be concurrently replaced by a file.
+        if (isVanishedEntryError(error))
             return {};
         throw fs::filesystem_error("Got unexpected error while getting file size", path, error);
     }
@@ -417,15 +430,15 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
         return;
 
     /// Listing is a best-effort snapshot driven with the non-throwing
-    /// `error_code` overloads. Tolerate ONLY the concurrent-disappearance race:
-    /// an entry removed mid-listing (ENOENT), or a directory concurrently
-    /// replaced by a non-directory (ENOTDIR) - such an entry is simply omitted,
-    /// mirroring how a remote object store omits a concurrently-deleted object.
-    /// Any other error (EACCES, EIO, ...) is propagated as `filesystem_error`,
-    /// so a caller never reads a silently truncated listing.
+    /// `error_code` overloads. Tolerate ONLY the concurrent-disappearance class
+    /// (see `isVanishedEntryError`) - such an entry is simply omitted, mirroring
+    /// how a remote object store omits a concurrently-deleted object. Any other
+    /// error (EACCES, EIO, ...) is propagated, so a caller never reads a
+    /// silently truncated listing. The same tolerance is applied by
+    /// `tryGetObjectMetadata` below for the per-entry metadata stat.
     auto throw_unless_vanished = [&](const std::error_code & e)
     {
-        if (e != std::errc::no_such_file_or_directory && e != std::errc::not_a_directory)
+        if (!isVanishedEntryError(e))
             throw fs::filesystem_error("Cannot list local object storage directory", path, e);
     };
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -416,29 +416,45 @@ void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWith
     if (!fs::exists(path) || !fs::is_directory(path))
         return;
 
-    /// Listing is a best-effort snapshot: entries may be created or removed
-    /// concurrently (e.g. an external writer atomically replacing a file via
-    /// rename). Drive the iterator with the non-throwing `error_code` overloads
-    /// and skip entries that vanish mid-listing, mirroring how a remote object
-    /// store simply omits a concurrently-deleted object. The previous code used
-    /// the throwing overloads, so a file removed between enumeration and the
-    /// metadata stat aborted the whole listing with a `filesystem_error`.
+    /// Listing is a best-effort snapshot driven with the non-throwing
+    /// `error_code` overloads. Tolerate ONLY the concurrent-disappearance race:
+    /// an entry removed mid-listing (ENOENT), or a directory concurrently
+    /// replaced by a non-directory (ENOTDIR) - such an entry is simply omitted,
+    /// mirroring how a remote object store omits a concurrently-deleted object.
+    /// Any other error (EACCES, EIO, ...) is propagated as `filesystem_error`,
+    /// so a caller never reads a silently truncated listing.
+    auto throw_unless_vanished = [&](const std::error_code & e)
+    {
+        if (e != std::errc::no_such_file_or_directory && e != std::errc::not_a_directory)
+            throw fs::filesystem_error("Cannot list local object storage directory", path, e);
+    };
+
     std::error_code ec;
     fs::recursive_directory_iterator it(path, ec);
     if (ec)
+    {
+        throw_unless_vanished(ec);
         return;
+    }
 
     const fs::recursive_directory_iterator end;
-    for (; it != end; it.increment(ec))
+    while (it != end)
     {
+        const bool is_dir = it->is_directory(ec);
         if (ec)
-            return;
+            throw_unless_vanished(ec); /// entry vanished before we could stat it: skip it
+        else if (!is_dir)
+        {
+            if (auto metadata = tryGetObjectMetadata(it->path(), /*with_tags=*/ false))
+                children.emplace_back(std::make_shared<RelativePathWithMetadata>(it->path(), std::move(*metadata)));
+        }
 
-        if (it->is_directory(ec) || ec)
-            continue;
-
-        if (auto metadata = tryGetObjectMetadata(it->path(), /*with_tags=*/ false))
-            children.emplace_back(std::make_shared<RelativePathWithMetadata>(it->path(), std::move(*metadata)));
+        it.increment(ec);
+        if (ec)
+        {
+            throw_unless_vanished(ec);
+            return; /// increment resets the iterator to end() on error
+        }
     }
 }
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.cpp
@@ -426,6 +426,18 @@ std::optional<ObjectMetadata> LocalObjectStorage::tryGetObjectMetadata(const std
 
 void LocalObjectStorage::listObjects(const std::string & path, RelativePathsWithMetadata & children, size_t/* max_keys */) const
 {
+    /// A path with an embedded NUL is malformed: libc truncates every syscall
+    /// argument at the NUL while our `std::string`/`fs::path` keep the full
+    /// value, so the traversal below would re-open the same truncated directory
+    /// and queue ever-longer NUL-bearing child paths that never converge (an
+    /// unbounded loop for a directory that holds only subdirectories). A
+    /// `readdir` entry name never contains a NUL, so this single up-front check
+    /// guarantees no path derived during traversal can reintroduce one.
+    if (path.find('\0') != std::string::npos)
+        throw fs::filesystem_error(
+            "Path contains an embedded NUL byte", path,
+            std::make_error_code(std::errc::invalid_argument));
+
     if (!fs::exists(path) || !fs::is_directory(path))
         return;
 

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -352,6 +352,105 @@ TEST(LocalObjectStorage, TryGetObjectMetadataToleratesNonDirectoryPathComponent)
     }
 }
 
+/// Regression test for the third clickhouse-gh[bot] review on PR #107432.
+/// Tolerating the disappearance class is not enough: with a single
+/// `recursive_directory_iterator`, a vanished *directory* aborts the entire
+/// traversal. libc++ opens each child directory with `opendir` while
+/// incrementing (`__try_recursion`); if that `opendir` fails (the directory was
+/// concurrently removed), the iterator resets itself to `end()`, so every later,
+/// still-present sibling is silently dropped. A caller such as
+/// `DataLakeCommon::listFiles` then reads a truncated listing with no error.
+///
+/// The fix descends with an explicit worklist of non-recursive
+/// `directory_iterator`s, so a vanished directory skips only its own subtree.
+/// This test churns several subdirectories (create inner file, then remove the
+/// whole directory) next to a fixed set of stable files, and asserts that every
+/// successful listing still reports ALL stable files. Before the fix the listing
+/// is intermittently truncated (a stable file goes missing); after it, the stable
+/// set is always complete.
+TEST(LocalObjectStorage, ListObjectsKeepsSiblingsWhenADirectoryVanishesMidTraversal)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_vanish_dir");
+    const auto & root = tmp.path;
+
+    /// A spread of stable files. Some will be enumerated after a churning
+    /// directory, so a truncating listing would lose at least one of them.
+    constexpr int stable_count = 24;
+    for (int i = 0; i < stable_count; ++i)
+        std::ofstream(root / ("stable_" + std::to_string(i) + ".txt")) << i;
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> listing_threw{false};
+    std::atomic<bool> listing_truncated{false};
+    std::atomic<size_t> listings_done{0};
+
+    /// Writers: repeatedly create a subdirectory with a file inside and then
+    /// remove the whole subtree, reproducing a directory that exists during
+    /// enumeration but vanishes when the lister tries to descend into it.
+    auto writer_loop = [&](int w)
+    {
+        const fs::path dir = root / ("churn_dir_" + std::to_string(w));
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            std::error_code ec;
+            fs::create_directory(dir, ec);
+            std::ofstream(dir / "inner.txt") << w;
+            fs::remove_all(dir, ec);
+        }
+    };
+
+    /// Readers: list the directory in a tight loop. A throw, or a listing that is
+    /// missing any stable file, fails the test.
+    auto reader_loop = [&]()
+    {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            DB::RelativePathsWithMetadata children;
+            try
+            {
+                storage->listObjects(root.string(), children, /* max_keys */ 0);
+            }
+            catch (...)
+            {
+                /// Ok: catch-all is the test's failure assertion. Record only an atomic
+                /// flag (not the message) so the reader threads stay data-race-free under TSAN.
+                listing_threw.store(true, std::memory_order_relaxed);
+                return;
+            }
+
+            size_t stable_seen = 0;
+            for (const auto & c : children)
+                if (fs::path(c->relative_path).filename().string().starts_with("stable_"))
+                    ++stable_seen;
+
+            if (stable_seen != static_cast<size_t>(stable_count))
+            {
+                listing_truncated.store(true, std::memory_order_relaxed);
+                return;
+            }
+            listings_done.fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int w = 0; w < 4; ++w)
+        threads.emplace_back(writer_loop, w);
+    for (int r = 0; r < 4; ++r)
+        threads.emplace_back(reader_loop);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    stop.store(true, std::memory_order_relaxed);
+    for (auto & t : threads)
+        t.join();
+
+    EXPECT_FALSE(listing_threw.load()) << "listObjects threw on a concurrently-removed directory";
+    EXPECT_FALSE(listing_truncated.load())
+        << "listObjects dropped stable siblings when a directory vanished mid-traversal";
+    EXPECT_GT(listings_done.load(), 0u) << "no listing completed";
+}
+
 /// A non-existent or non-directory input must return an empty listing,
 /// never throw or crash.
 TEST(LocalObjectStorage, ListObjectsHandlesMissingAndNonDirectoryPaths)

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -5,10 +5,12 @@
 #include <unistd.h> /// for ::getpid
 
 #include <algorithm> /// for std::sort
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <system_error>
+#include <thread>
 #include <vector>
 
 namespace fs = std::filesystem;
@@ -185,6 +187,86 @@ TEST(LocalObjectStorage, ListObjectsHandlesPathWithEmbeddedNul)
 
     /// Sanity: the test finished (no crash / no infinite loop).
     SUCCEED();
+}
+
+/// Regression test for the Iceberg `test_format_version_upgrade_concurrent_reads`
+/// flake. `listObjects` enumerated the directory and then stat-ed each entry with
+/// the *throwing* `fs::last_write_time` / `fs::file_size`. When a concurrent writer
+/// atomically replaced a file (`write tmp; rename tmp -> final`, exactly what the
+/// Iceberg metadata-upgrade path does), the transient name could vanish between
+/// enumeration and the stat, so `last_write_time` threw `no_such_file_or_directory`
+/// and aborted the whole listing with a `filesystem_error` (surfaced as a query
+/// failure: `SELECT ... FROM iceberg_table`). Listing is a best-effort snapshot, so
+/// a concurrently-removed entry must simply be omitted, never throw.
+///
+/// This test reproduces the race deterministically: writer threads churn the
+/// directory with atomic renames while reader threads call `listObjects` in a tight
+/// loop. Before the fix this reliably throws within a few milliseconds; after it,
+/// every listing succeeds.
+TEST(LocalObjectStorage, ListObjectsToleratesConcurrentAtomicRename)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_race");
+    const auto & root = tmp.path;
+
+    /// A few stable files so a successful listing is non-empty.
+    for (int i = 0; i < 4; ++i)
+        std::ofstream(root / ("stable_" + std::to_string(i) + ".txt")) << i;
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> listing_threw{false};
+    std::atomic<size_t> listings_done{0};
+
+    /// Writers: continuously replace `churn_<w>.json` via the same
+    /// write-temp-then-rename dance used by the Iceberg metadata writer.
+    auto writer_loop = [&](int w)
+    {
+        const fs::path final_path = root / ("churn_" + std::to_string(w) + ".json");
+        size_t gen = 0;
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            const fs::path tmp_path = root / ("churn_" + std::to_string(w) + ".json.tmp." + std::to_string(gen++));
+            { std::ofstream(tmp_path) << "{\"v\":" << gen << "}"; }
+            std::error_code ec;
+            fs::rename(tmp_path, final_path, ec);
+            if (ec)
+                fs::remove(tmp_path, ec);
+        }
+    };
+
+    /// Readers: list the directory in a tight loop. A single throw fails the test.
+    auto reader_loop = [&]()
+    {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            try
+            {
+                DB::RelativePathsWithMetadata children;
+                storage->listObjects(root.string(), children, /* max_keys */ 0);
+                listings_done.fetch_add(1, std::memory_order_relaxed);
+            }
+            catch (...)
+            {
+                listing_threw.store(true, std::memory_order_relaxed);
+                return;
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int w = 0; w < 3; ++w)
+        threads.emplace_back(writer_loop, w);
+    for (int r = 0; r < 4; ++r)
+        threads.emplace_back(reader_loop);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    stop.store(true, std::memory_order_relaxed);
+    for (auto & t : threads)
+        t.join();
+
+    EXPECT_FALSE(listing_threw.load()) << "listObjects threw on a concurrently-renamed entry";
+    EXPECT_GT(listings_done.load(), 0u) << "no listing completed";
 }
 
 /// A non-existent or non-directory input must return an empty listing,

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -248,6 +248,8 @@ TEST(LocalObjectStorage, ListObjectsToleratesConcurrentAtomicRename)
             }
             catch (...)
             {
+                /// Ok: catch-all is the test's failure assertion. Record only an atomic
+                /// flag (not the message) so the reader threads stay data-race-free under TSAN.
                 listing_threw.store(true, std::memory_order_relaxed);
                 return;
             }

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -309,6 +309,49 @@ TEST(LocalObjectStorage, ListObjectsThrowsOnPermissionDeniedSubdirectory)
     fs::permissions(no_access, fs::perms::owner_all, fs::perm_options::replace, ec);
 }
 
+/// Regression test for the follow-up clickhouse-gh[bot] review on PR #107432.
+/// The iterator tolerates the disappearance class (ENOENT + ENOTDIR), but the
+/// per-entry metadata stat (`tryGetObjectMetadata`) must apply the same tolerance:
+/// after `is_directory` succeeds on a yielded child `<root>/d/file`, the parent
+/// `<root>/d` can be concurrently replaced by a file, so `fs::last_write_time` /
+/// `fs::file_size` on `<root>/d/file` return `not_a_directory` (ENOTDIR). That
+/// is the same race the PR promises to omit, so it must yield an empty optional,
+/// not abort the listing. A genuine error (EACCES) must still propagate.
+TEST(LocalObjectStorage, TryGetObjectMetadataToleratesNonDirectoryPathComponent)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_enotdir");
+    const auto & root = tmp.path;
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    /// `<root>/d` is a regular file, so stat-ing `<root>/d/file` walks through a
+    /// non-directory component and fails with ENOTDIR (`not_a_directory`).
+    std::ofstream(root / "d") << "x";
+    EXPECT_NO_THROW({
+        auto metadata = storage->tryGetObjectMetadata((root / "d" / "file").string(), /*with_tags=*/ false);
+        EXPECT_FALSE(metadata.has_value()) << "a vanished (ENOTDIR) entry must be omitted, not reported";
+    });
+
+    /// A genuine, non-disappearance error must still propagate. A subdirectory
+    /// stripped of all permissions makes the traversal fail with EACCES.
+    if (::geteuid() != 0) /// root bypasses permission bits
+    {
+        const auto no_access = root / "noaccess";
+        fs::create_directories(no_access);
+        std::ofstream(no_access / "hidden.txt") << "1";
+
+        std::error_code ec;
+        fs::permissions(no_access, fs::perms::none, fs::perm_options::replace, ec);
+        ASSERT_FALSE(ec) << "Failed to chmod 000 the subdirectory: " << ec.message();
+
+        EXPECT_THROW(
+            storage->tryGetObjectMetadata((no_access / "hidden.txt").string(), /*with_tags=*/ false),
+            fs::filesystem_error);
+
+        fs::permissions(no_access, fs::perms::owner_all, fs::perm_options::replace, ec);
+    }
+}
+
 /// A non-existent or non-directory input must return an empty listing,
 /// never throw or crash.
 TEST(LocalObjectStorage, ListObjectsHandlesMissingAndNonDirectoryPaths)

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -6,8 +6,12 @@
 
 #include <algorithm> /// for std::sort
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -187,6 +191,80 @@ TEST(LocalObjectStorage, ListObjectsHandlesPathWithEmbeddedNul)
 
     /// Sanity: the test finished (no crash / no infinite loop).
     SUCCEED();
+}
+
+/// Regression test for the fifth clickhouse-gh[bot] review on PR #107432.
+/// The explicit-stack traversal can loop forever on an embedded-NUL root when
+/// the real directory contains ONLY subdirectories (no regular file to trip the
+/// per-entry stat). Trace: `path = <root>\0tail`, `<root>` contains only `d1/`.
+/// `directory_iterator(path)` opens `<root>` (truncated at the NUL), yields
+/// `<root>\0tail/d1`; that child path is queued; the next
+/// `directory_iterator(<root>\0tail/d1)` is truncated by libc back to `<root>`,
+/// re-yields `d1`, queues `<root>\0tail/d1/d1`, ... unbounded. The earlier
+/// `ListObjectsHandlesPathWithEmbeddedNul` test escapes only because its
+/// top-level `top.txt` reaches `tryGetObjectMetadata`, whose truncated stat
+/// targets the `<root>` directory and throws before the phantom directory is
+/// drained. A directory-only root never reaches that stat, so the loop never
+/// terminates. The fix rejects embedded-NUL input up front, so the call throws
+/// immediately regardless of the directory contents. The listing runs on a
+/// worker thread guarded by a deadline so a regression manifests as a fast FAIL
+/// rather than hanging the whole test binary.
+TEST(LocalObjectStorage, ListObjectsRejectsEmbeddedNulRootWithOnlySubdirectories)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_nul_dirs_only");
+    const auto & root = tmp.path;
+
+    /// Only subdirectories, NO regular file at any level: nothing trips the
+    /// per-entry metadata stat, so the pre-fix loop has no escape hatch.
+    fs::create_directories(root / "d1" / "d2");
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    /// `<root>\0tail` - every syscall sees just `<root>` (truncated at the NUL).
+    std::string nul_injected = root.string();
+    nul_injected.push_back('\0');
+    nul_injected.append("this_part_is_never_seen_by_the_kernel");
+
+    auto state = std::make_shared<std::mutex>();
+    auto cv = std::make_shared<std::condition_variable>();
+    auto done = std::make_shared<bool>(false);
+    auto threw_filesystem_error = std::make_shared<bool>(false);
+
+    /// Detached so a (regressed) infinite loop cannot wedge `join()`.
+    std::thread([storage, nul_injected, state, cv, done, threw_filesystem_error]()
+    {
+        bool local_threw = false;
+        try
+        {
+            DB::RelativePathsWithMetadata children;
+            storage->listObjects(nul_injected, children, /* max_keys */ 0);
+        }
+        catch (const fs::filesystem_error &)
+        {
+            local_threw = true; /// expected: embedded NUL rejected up front
+        }
+        catch (...) // NOLINT(bugprone-empty-catch)
+        {
+            /// Ok: any other exception type leaves `local_threw` false, so the
+            /// EXPECT below fails informatively; swallowing here only keeps an
+            /// unexpected type from terminating the detached thread.
+        }
+        {
+            std::lock_guard lock(*state);
+            *threw_filesystem_error = local_threw;
+            *done = true;
+        }
+        cv->notify_one();
+    }).detach();
+
+    {
+        std::unique_lock lock(*state);
+        const bool finished = cv->wait_for(lock, std::chrono::seconds(20), [&] { return *done; });
+        ASSERT_TRUE(finished) << "listObjects did not return on an embedded-NUL directory-only root "
+                                 "(unbounded traversal loop regressed)";
+        EXPECT_TRUE(*threw_filesystem_error)
+            << "embedded-NUL input must be rejected with a filesystem_error";
+    }
 }
 
 /// Regression test for the Iceberg `test_format_version_upgrade_concurrent_reads`

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -451,6 +451,61 @@ TEST(LocalObjectStorage, ListObjectsKeepsSiblingsWhenADirectoryVanishesMidTraver
     EXPECT_GT(listings_done.load(), 0u) << "no listing completed";
 }
 
+/// Regression test for the fourth clickhouse-gh[bot] review on PR #107432.
+/// Each directory-typed entry is probed with `is_symlink(sym_ec)` so symlinked
+/// directories are skipped (no-follow, avoids cycles) while real subdirectories
+/// are descended. That probe is the fourth stat in the listing path, so its
+/// error_code is routed through the same disappearance filter as iterator
+/// construction / `is_directory` / `increment`: a real error (EACCES, EIO)
+/// propagates, a vanished entry (ENOENT/ENOTDIR) is skipped. A non-disappearance
+/// error silently dropped here would truncate the listing without an exception.
+///
+/// A deterministic EACCES-at-`is_symlink` case is not portably constructible: on
+/// filesystems that report `d_type` in `readdir` (ext4/xfs/tmpfs, i.e. the CI
+/// runners) libc++'s `directory_iterator` caches the entry type, so
+/// `directory_entry::is_symlink` answers from cache with no syscall and `sym_ec`
+/// can only be clear or ENOENT, never EACCES/EIO. The error routing is therefore
+/// correct by construction and uniform with the other three stat sites; what is
+/// testable here is the descend-vs-skip decision the probe drives. This test pins
+/// that decision: a real subdirectory is descended (its file is listed) while a
+/// symlink-to-directory is neither descended nor reported as an object.
+TEST(LocalObjectStorage, ListObjectsDescendsRealDirsButSkipsSymlinkedDirs)
+{
+    ScopedTempDir tmp("ch_gtest_local_object_storage_symlink_dir");
+    const auto & root = tmp.path;
+
+    /// root/
+    ///   realdir/inside.txt    <- real subdir: descended, file listed
+    ///   target/leaf.txt       <- real subdir (the symlink target)
+    ///   linkdir -> target     <- symlink-to-dir: not descended, not reported
+    fs::create_directories(root / "realdir");
+    fs::create_directories(root / "target");
+    std::ofstream(root / "realdir" / "inside.txt") << "a";
+    std::ofstream(root / "target" / "leaf.txt") << "b";
+
+    std::error_code ec;
+    fs::create_directory_symlink("target", root / "linkdir", ec);
+    ASSERT_FALSE(ec) << "Failed to create directory symlink: " << ec.message();
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    DB::RelativePathsWithMetadata children;
+    storage->listObjects(root.string(), children, /* max_keys */ 0);
+
+    std::vector<std::string> paths;
+    paths.reserve(children.size());
+    for (const auto & c : children)
+        paths.push_back(c->relative_path);
+    std::sort(paths.begin(), paths.end());
+
+    /// Only the two real files via the real directories: `linkdir` is a
+    /// symlink-to-dir, so it is neither descended (no `linkdir/leaf.txt`) nor
+    /// reported as an object itself.
+    ASSERT_EQ(paths.size(), 2u) << "Unexpected listing size " << paths.size();
+    EXPECT_EQ(paths[0], (root / "realdir" / "inside.txt").string());
+    EXPECT_EQ(paths[1], (root / "target" / "leaf.txt").string());
+}
+
 /// A non-existent or non-directory input must return an empty listing,
 /// never throw or crash.
 TEST(LocalObjectStorage, ListObjectsHandlesMissingAndNonDirectoryPaths)

--- a/src/Disks/tests/gtest_local_object_storage.cpp
+++ b/src/Disks/tests/gtest_local_object_storage.cpp
@@ -271,6 +271,44 @@ TEST(LocalObjectStorage, ListObjectsToleratesConcurrentAtomicRename)
     EXPECT_GT(listings_done.load(), 0u) << "no listing completed";
 }
 
+/// Regression test for the clickhouse-gh[bot] review on PR #107432. The
+/// concurrent-rename fix must suppress ONLY the disappearance race (an entry
+/// removed mid-listing); a real I/O or permission error must still propagate so
+/// callers never read a silently truncated `icebergLocal`/local-object-storage
+/// listing. Here a subdirectory is made unreadable (mode 000): the iterator can
+/// see the entry but recursing into it fails with EACCES, which must surface as
+/// a `filesystem_error` rather than a short listing.
+TEST(LocalObjectStorage, ListObjectsThrowsOnPermissionDeniedSubdirectory)
+{
+    /// Running as root bypasses permission bits, so EACCES would never trigger.
+    if (::geteuid() == 0)
+        GTEST_SKIP() << "must not run as root (permission checks are bypassed)";
+
+    ScopedTempDir tmp("ch_gtest_local_object_storage_eacces");
+    const auto & root = tmp.path;
+
+    std::ofstream(root / "top.txt") << "0";
+    const auto no_access = root / "noaccess";
+    fs::create_directories(no_access);
+    std::ofstream(no_access / "hidden.txt") << "1";
+
+    /// Strip every permission bit: the `noaccess` entry stays visible from the
+    /// root, but opening it to recurse fails with EACCES.
+    std::error_code ec;
+    fs::permissions(no_access, fs::perms::none, fs::perm_options::replace, ec);
+    ASSERT_FALSE(ec) << "Failed to chmod 000 the subdirectory: " << ec.message();
+
+    auto storage = makeLocalObjectStorage(root.string());
+
+    DB::RelativePathsWithMetadata children;
+    EXPECT_THROW(
+        storage->listObjects(root.string(), children, /* max_keys */ 0),
+        fs::filesystem_error);
+
+    /// Restore permissions so ScopedTempDir can remove the tree on teardown.
+    fs::permissions(no_access, fs::perms::owner_all, fs::perm_options::replace, ec);
+}
+
 /// A non-existent or non-directory input must return an empty listing,
 /// never throw or crash.
 TEST(LocalObjectStorage, ListObjectsHandlesMissingAndNonDirectoryPaths)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106231
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/106231

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a spurious `filesystem error: in last_write_time: No such file or directory` exception when listing a local-disk object storage directory (e.g. an Iceberg table on a `local` disk) while files are being concurrently replaced. A concurrently removed entry is now omitted from the listing instead of aborting it.

### Description

`LocalObjectStorage::listObjects()` enumerated the directory and then called the throwing `getObjectMetadata()` (`fs::last_write_time` / `fs::file_size` with no `error_code`) for each entry. When a file vanished between enumeration and the metadata stat — for example an external writer atomically replacing a file via write-temp + rename, exactly what the Iceberg metadata-upgrade path does — the stat threw `filesystem_error` and aborted the entire listing, so a concurrent `SELECT` failed with `Code: 1001`.

A directory listing is a best-effort snapshot: an entry removed concurrently must simply be omitted (the way a remote object store omits a concurrently-deleted object), never abort the listing. This switches `listObjects` to the tolerant `tryGetObjectMetadata()` (returns `nullopt` on a vanished entry) and drives the iterator with the non-throwing `error_code` overloads. The strict `getObjectMetadata()` contract is unchanged for its other callers.

Surfaced as a ~1% flake in the Iceberg integration test `test_storage_iceberg_with_spark/test_format_version_upgrade.py::test_format_version_upgrade_concurrent_reads[local]` on `Integration tests (arm_binary, distributed plan, 4/4)`. Failure report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106231&sha=961fa8acd4c3bc1269ed1b18344999ebebff89c7&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

A new gtest (`LocalObjectStorage.ListObjectsToleratesConcurrentAtomicRename`) reproduces the race deterministically: writer threads churn the directory with atomic renames while reader threads list it. It throws within milliseconds before the fix and passes after.
