### PR TITLE
Optimize bucketed LowCardinality map reconstruction

### DIFF
--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -1,4 +1,5 @@
 #include <DataTypes/Serializations/SerializationMap.h>
+#include <DataTypes/Serializations/SerializationMapLowCardinalityBuckets.h>
 
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -1091,18 +1092,41 @@ void SerializationMap::collectMapFromBuckets(const VectorWithMemoryTracking<Colu
     map_offsets.reserve(map_offsets.size() + num_rows);
     map_keys_column.prepareForSquashing(map_keys_buckets, 1);
     map_values_column.prepareForSquashing(map_values_buckets, 1);
-    for (size_t i = 0; i != num_rows; ++i)
-    {
-        for (size_t bucket = 0; bucket != map_buckets.size(); ++bucket)
-        {
-            size_t offset_start = (*map_offsets_buckets[bucket])[ssize_t(i) - 1];
-            size_t offset_end = (*map_offsets_buckets[bucket])[ssize_t(i)];
-            map_keys_column.insertRangeFrom(*map_keys_buckets[bucket], offset_start, offset_end - offset_start);
-            map_values_column.insertRangeFrom(*map_values_buckets[bucket], offset_start, offset_end - offset_start);
-        }
 
-        map_offsets.push_back(map_keys_column.size());
-    }
+    bool keys_collected = BucketedMapLowCardinality::collectDataFromBuckets(
+        map_keys_buckets, map_offsets_buckets, num_rows, map_keys_column, &map_offsets);
+    bool values_collected = BucketedMapLowCardinality::collectDataFromBuckets(
+        map_values_buckets, map_offsets_buckets, num_rows, map_values_column, keys_collected ? nullptr : &map_offsets);
+
+    auto collect_from_buckets = [&]<bool insert_keys, bool insert_values, bool append_offsets>()
+    {
+        for (size_t i = 0; i != num_rows; ++i)
+        {
+            for (size_t bucket = 0; bucket != map_buckets.size(); ++bucket)
+            {
+                size_t offset_start = (*map_offsets_buckets[bucket])[ssize_t(i) - 1];
+                size_t offset_end = (*map_offsets_buckets[bucket])[ssize_t(i)];
+                size_t length = offset_end - offset_start;
+
+                if constexpr (insert_keys)
+                    map_keys_column.insertRangeFrom(*map_keys_buckets[bucket], offset_start, length);
+                if constexpr (insert_values)
+                    map_values_column.insertRangeFrom(*map_values_buckets[bucket], offset_start, length);
+            }
+
+            if constexpr (append_offsets)
+                map_offsets.push_back(map_keys_column.size());
+        }
+    };
+
+    if (keys_collected && values_collected)
+        return;
+    else if (keys_collected)
+        collect_from_buckets.template operator()<false, true, false>();
+    else if (values_collected)
+        collect_from_buckets.template operator()<true, false, false>();
+    else
+        collect_from_buckets.template operator()<true, true, true>();
 }
 
 void SerializationMap::serializeBinaryBulkWithMultipleStreams(

--- a/src/DataTypes/Serializations/SerializationMapKeysOrValues.cpp
+++ b/src/DataTypes/Serializations/SerializationMapKeysOrValues.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/Serializations/SerializationMapKeysOrValues.h>
 #include <DataTypes/Serializations/SerializationMap.h>
+#include <DataTypes/Serializations/SerializationMapLowCardinalityBuckets.h>
 #include <Columns/ColumnArray.h>
 #include <Common/SipHash.h>
 
@@ -173,6 +174,10 @@ void collectMapKeysOrValuesFromBuckets(const VectorWithMemoryTracking<ColumnPtr>
     size_t num_rows = keys_or_values_buckets[0]->size();
     offsets.reserve(offsets.size() + num_rows);
     data.prepareForSquashing(data_buckets, 1);
+
+    if (BucketedMapLowCardinality::collectDataFromBuckets(data_buckets, offsets_buckets, num_rows, data, &offsets))
+        return;
+
     for (size_t i = 0; i != num_rows; ++i)
     {
         for (size_t bucket = 0; bucket != keys_or_values_buckets.size(); ++bucket)

--- a/src/DataTypes/Serializations/SerializationMapLowCardinalityBuckets.h
+++ b/src/DataTypes/Serializations/SerializationMapLowCardinalityBuckets.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnIndex.h>
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnsNumber.h>
+#include <Columns/IColumn.h>
+#include <Common/VectorWithMemoryTracking.h>
+
+#include <vector>
+
+namespace DB
+{
+
+namespace BucketedMapLowCardinality
+{
+
+inline bool collectDataFromBuckets(
+    const VectorWithMemoryTracking<ColumnPtr> & data_buckets,
+    const std::vector<const ColumnArray::Offsets *> & offsets_buckets,
+    size_t num_rows,
+    IColumn & data,
+    ColumnArray::Offsets * output_offsets = nullptr)
+{
+    auto * low_cardinality_data = typeid_cast<ColumnLowCardinality *>(&data);
+    if (!low_cardinality_data)
+        return false;
+
+    VectorWithMemoryTracking<ColumnPtr> dictionary_columns;
+    std::vector<ColumnPtr> bucket_index_columns;
+    dictionary_columns.reserve(data_buckets.size());
+    bucket_index_columns.reserve(data_buckets.size());
+
+    /// Convert each bucket to a compact dictionary + indexes pair.
+    size_t total_indexes = 0;
+    for (const auto & data_bucket : data_buckets)
+    {
+        const auto * low_cardinality_bucket = typeid_cast<const ColumnLowCardinality *>(data_bucket.get());
+        if (!low_cardinality_bucket)
+            return false;
+
+        auto dictionary_encoded = low_cardinality_bucket->getMinimalDictionaryEncodedColumn(0, low_cardinality_bucket->size());
+        total_indexes += dictionary_encoded.indexes->size();
+        dictionary_columns.push_back(std::move(dictionary_encoded.dictionary));
+        bucket_index_columns.push_back(std::move(dictionary_encoded.indexes));
+    }
+
+    /// Concatenate bucket dictionaries into one temporary dictionary.
+    auto dictionary = low_cardinality_data->getDictionary().getNestedColumn()->cloneEmpty();
+    dictionary->prepareForSquashing(dictionary_columns, 1);
+
+    std::vector<size_t> dictionary_offsets;
+    dictionary_offsets.reserve(dictionary_columns.size());
+    for (const auto & dictionary_column : dictionary_columns)
+    {
+        dictionary_offsets.push_back(dictionary->size());
+        dictionary->insertRangeFrom(*dictionary_column, 0, dictionary_column->size());
+    }
+
+    /// Rebuild the row/bucket order as indexes into the temporary dictionary.
+    /// If `output_offsets` is provided, append output offsets in the same pass.
+    ColumnIndex indexes;
+    indexes.reserve(total_indexes);
+
+    size_t current_offset = output_offsets && !output_offsets->empty() ? output_offsets->back() : 0;
+    for (size_t row = 0; row != num_rows; ++row)
+    {
+        for (size_t bucket = 0; bucket != data_buckets.size(); ++bucket)
+        {
+            const auto & offsets = *offsets_buckets[bucket];
+            size_t offset_start = offsets[ssize_t(row) - 1];
+            size_t offset_end = offsets[row];
+            size_t length = offset_end - offset_start;
+            const auto & bucket_indexes = *bucket_index_columns[bucket];
+            size_t dictionary_offset = dictionary_offsets[bucket];
+
+            if (length)
+            {
+                size_t bucket_dictionary_size = dictionary_columns[bucket]->size();
+                indexes.insertIndexesRangeWithShift(
+                    bucket_indexes, offset_start, length, dictionary_offset, dictionary_offset + bucket_dictionary_size - 1);
+            }
+
+            if (output_offsets)
+                current_offset += length;
+        }
+
+        if (output_offsets)
+            output_offsets->push_back(current_offset);
+    }
+
+    /// Merge the temporary dictionary-encoded stream into the output LC dictionary.
+    low_cardinality_data->insertRangeFromDictionaryEncodedColumn(*dictionary, *indexes.getIndexes());
+    return true;
+}
+
+}
+
+}

--- a/tests/performance/map_bucketed_low_cardinality_reconstruction.xml
+++ b/tests/performance/map_bucketed_low_cardinality_reconstruction.xml
@@ -1,0 +1,62 @@
+<test>
+    <!-- Exercises bucketed Map reconstruction when keys and/or values are LowCardinality.
+         The queries read the full map or the keys/values subcolumns, forcing all buckets
+         to be reassembled into one logical column. -->
+
+    <settings>
+        <max_insert_threads>4</max_insert_threads>
+        <use_query_condition_cache>0</use_query_condition_cache>
+    </settings>
+
+    <create_query>
+        CREATE TABLE map_lc_reconstruction
+        (
+            id UInt64,
+            m_str Map(String, String),
+            m_key_lc Map(LowCardinality(String), String),
+            m_value_lc Map(String, LowCardinality(String)),
+            m_both_lc Map(LowCardinality(String), LowCardinality(String))
+        )
+        ENGINE = MergeTree
+        ORDER BY id
+        SETTINGS
+            map_serialization_version = 'with_buckets',
+            map_serialization_version_for_zero_level_parts = 'with_buckets',
+            map_buckets_strategy = 'constant',
+            max_buckets_in_map = 32,
+            map_buckets_min_avg_size = 0
+    </create_query>
+
+    <fill_query>
+        INSERT INTO map_lc_reconstruction
+        SELECT
+            number,
+            mapFromArrays(keys, values),
+            mapFromArrays(keys, values),
+            mapFromArrays(keys, values),
+            mapFromArrays(keys, values)
+        FROM
+        (
+            SELECT
+                number,
+                arrayMap(i -> concat('key', toString(i)), range(200)) AS keys,
+                arrayMap(i -> concat('value', toString(i)), range(200)) AS values
+            FROM numbers(50000)
+        )
+    </fill_query>
+
+    <query>SELECT m_str FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT m_key_lc FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT m_value_lc FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT m_both_lc FROM map_lc_reconstruction FORMAT Null</query>
+
+    <query>SELECT mapKeys(m_key_lc) FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT mapValues(m_value_lc) FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT mapKeys(m_both_lc), mapValues(m_both_lc) FROM map_lc_reconstruction FORMAT Null</query>
+
+    <query>SELECT m_key_lc['key7'], m_key_lc FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT m_value_lc['key7'], m_value_lc FROM map_lc_reconstruction FORMAT Null</query>
+    <query>SELECT m_both_lc['key7'], m_both_lc FROM map_lc_reconstruction FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS map_lc_reconstruction</drop_query>
+</test>

--- a/tests/queries/0_stateless/04337_map_bucketed_low_cardinality_reconstruction.reference
+++ b/tests/queries/0_stateless/04337_map_bucketed_low_cardinality_reconstruction.reference
@@ -1,0 +1,15 @@
+full maps sorted by key
+1	{'alpha':'one','beta':'two','delta':'four','gamma':'three'}	{'alpha':'one','beta':'two','delta':'four','gamma':'three'}	{'alpha':'one','beta':'two','delta':'four','gamma':'three'}
+2	{'beta':'twenty','epsilon':'five','zeta':'six'}	{'beta':'twenty','epsilon':'five','zeta':'six'}	{'beta':'twenty','epsilon':'five','zeta':'six'}
+3	{}	{}	{}
+4	{'alpha':'again','eta':'seven'}	{'alpha':'again','eta':'seven'}	{'alpha':'again','eta':'seven'}
+keys and values subcolumns
+1	['alpha','beta','delta','gamma']	['four','one','three','two']	['alpha','beta','delta','gamma']	['four','one','three','two']
+2	['beta','epsilon','zeta']	['five','six','twenty']	['beta','epsilon','zeta']	['five','six','twenty']
+3	[]	[]	[]	[]
+4	['alpha','eta']	['again','seven']	['alpha','eta']	['again','seven']
+full map together with key lookups and subcolumns
+1	one	two		{'alpha':'one','beta':'two','delta':'four','gamma':'three'}	['alpha','beta','delta','gamma']	['four','one','three','two']
+2		twenty	five	{'beta':'twenty','epsilon':'five','zeta':'six'}	['beta','epsilon','zeta']	['five','six','twenty']
+3				{}	[]	[]
+4	again			{'alpha':'again','eta':'seven'}	['alpha','eta']	['again','seven']

--- a/tests/queries/0_stateless/04337_map_bucketed_low_cardinality_reconstruction.sql
+++ b/tests/queries/0_stateless/04337_map_bucketed_low_cardinality_reconstruction.sql
@@ -1,0 +1,56 @@
+DROP TABLE IF EXISTS t_map_lc_reconstruct;
+
+CREATE TABLE t_map_lc_reconstruct
+(
+    id UInt64,
+    m_key_lc Map(LowCardinality(String), String),
+    m_value_lc Map(String, LowCardinality(String)),
+    m_both_lc Map(LowCardinality(String), LowCardinality(String))
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    map_serialization_version = 'with_buckets',
+    map_serialization_version_for_zero_level_parts = 'with_buckets',
+    map_buckets_strategy = 'constant',
+    max_buckets_in_map = 4,
+    map_buckets_min_avg_size = 0,
+    min_rows_for_wide_part = 1,
+    min_bytes_for_wide_part = 1;
+
+INSERT INTO t_map_lc_reconstruct
+SELECT
+    id,
+    mapFromArrays(keys, vals),
+    mapFromArrays(keys, vals),
+    mapFromArrays(keys, vals)
+FROM values(
+    'id UInt64, keys Array(String), vals Array(String)',
+    (1, ['alpha', 'beta', 'gamma', 'delta'], ['one', 'two', 'three', 'four']),
+    (2, ['beta', 'epsilon', 'zeta'], ['twenty', 'five', 'six']),
+    (3, [], []),
+    (4, ['alpha', 'eta'], ['again', 'seven']));
+
+SELECT 'full maps sorted by key';
+SELECT id, mapSort(m_key_lc), mapSort(m_value_lc), mapSort(m_both_lc)
+FROM t_map_lc_reconstruct
+ORDER BY id;
+
+SELECT 'keys and values subcolumns';
+SELECT id, arraySort(mapKeys(m_key_lc)), arraySort(mapValues(m_value_lc)), arraySort(mapKeys(m_both_lc)), arraySort(mapValues(m_both_lc))
+FROM t_map_lc_reconstruct
+ORDER BY id;
+
+SELECT 'full map together with key lookups and subcolumns';
+SELECT
+    id,
+    m_key_lc['alpha'],
+    m_value_lc['beta'],
+    m_both_lc['epsilon'],
+    mapSort(m_key_lc),
+    arraySort(mapKeys(m_key_lc)),
+    arraySort(mapValues(m_value_lc))
+FROM t_map_lc_reconstruct
+ORDER BY id;
+
+DROP TABLE t_map_lc_reconstruct;


### PR DESCRIPTION
Reading a bucketed `Map` back as a full map has to stitch the per-bucket streams back into row order.  Before this change, a `LowCardinality` key or value column used the generic insertion path for each small row/bucket slice.  Each of those tiny inserts had to translate source bucket dictionary indexes into the destination dictionary, so the read paid the dictionary-remapping overhead over and over again.

This keeps the same logical reconstruction order, but does the `LowCardinality` remapping in bulk.  Each bucket is first represented as a compact dictionary plus indexes.  The bucket dictionaries are concatenated into a temporary dictionary, a single row-ordered index stream is built, and that temporary dictionary-encoded stream is merged into the output `ColumnLowCardinality` once.

The same helper is used for full `Map` reconstruction and for `mapKeys` / `mapValues` bucket reassembly.  In full `Map` reconstruction, the helper is tried independently for keys and values, so it handles `Map(LowCardinality(K), V)`, `Map(K, LowCardinality(V))`, and `Map(LowCardinality(K), LowCardinality(V))`.  The first successful `LowCardinality` collection also builds the shared map offsets from bucket lengths; when both streams are collected, the old row/bucket insertion loop is skipped entirely.

The temporary dictionary is only an intermediate representation.  `insertRangeFromDictionaryEncodedColumn` still inserts into the destination dictionary using the normal `ColumnLowCardinality` path, so unexpected duplicate temporary dictionary values remain correct.  In the expected bucketed-map case, keys should be disjoint across buckets because bucket assignment is deterministic by key.

Local benchmark details: `clickhouse local` with `--print-profile-events --profile-events-delay-ms=-1`.  CPU numbers are `OSCPUVirtualTimeMicroseconds` medians; lower is better.  The main benchmark uses 50k rows, 200 keys/row, and 32 buckets.

Bucketed reconstruction, true baseline vs current patch:

<table>
  <tr><th>Shape</th><th>Query</th><th>Baseline CPU</th><th>Current CPU</th><th>Speedup</th></tr>
  <tr><td><code>Map(LC(String), String)</code></td><td>full map</td><td>1.866s</td><td>0.883s</td><td>2.1x</td></tr>
  <tr><td><code>Map(LC(String), String)</code></td><td><code>mapKeys</code></td><td>1.224s</td><td>0.266s</td><td>4.6x</td></tr>
  <tr><td><code>Map(LC(String), String)</code></td><td><code>mapKeys</code> + <code>mapValues</code></td><td>1.879s</td><td>0.904s</td><td>2.1x</td></tr>
  <tr><td><code>Map(String, LC(String))</code></td><td>full map</td><td>1.239s</td><td>0.335s</td><td>3.7x</td></tr>
  <tr><td><code>Map(String, LC(String))</code></td><td><code>mapValues</code></td><td>1.077s</td><td>0.100s</td><td>10.8x</td></tr>
  <tr><td><code>Map(String, LC(String))</code></td><td>key lookup + full map</td><td>1.395s</td><td>0.377s</td><td>3.7x</td></tr>
  <tr><td><code>Map(LC(String), LC(String))</code></td><td>full map</td><td>2.128s</td><td>0.158s</td><td>13.5x</td></tr>
  <tr><td><code>Map(LC(String), LC(String))</code></td><td><code>mapKeys</code> + <code>mapValues</code></td><td>2.284s</td><td>0.358s</td><td>6.4x</td></tr>
</table>

Query-shape comparison against non-bucketed/basic serialization for `Map(LowCardinality(String), String)`:

<table>
  <tr><th>Query</th><th>Basic CPU</th><th>Bucketed baseline CPU</th><th>Bucketed current CPU</th><th>Bucketed current vs basic</th></tr>
  <tr><td>full map</td><td>0.354s</td><td>1.866s</td><td>0.883s</td><td>2.5x slower</td></tr>
  <tr><td>one key + full map</td><td>0.475s</td><td>1.954s</td><td>0.916s</td><td>1.9x slower</td></tr>
  <tr><td>81 keys + full map</td><td>3.029s</td><td>4.575s</td><td>3.550s</td><td>1.2x slower</td></tr>
  <tr><td>81 keys only</td><td>3.319s</td><td>0.887s</td><td>0.885s</td><td>3.8x faster</td></tr>
</table>

Non-`LowCardinality` sanity check from the same run.  These paths continue through the existing generic insertion path:

<table>
  <tr><th>Shape</th><th>Query</th><th>Baseline CPU</th><th>Current CPU</th></tr>
  <tr><td><code>Map(String, String)</code></td><td>full map</td><td>1.146s</td><td>1.149s</td></tr>
  <tr><td><code>Map(String, String)</code></td><td><code>mapKeys</code></td><td>0.383s</td><td>0.378s</td></tr>
  <tr><td><code>Map(String, String)</code></td><td><code>mapValues</code></td><td>0.767s</td><td>0.794s</td></tr>
</table>

The optimization narrows the full-map regression of bucketed `Map(LowCardinality(...), ...)` reads while preserving the main benefit of bucketed maps: reading one or many specific keys without the full map remains much faster than basic serialization.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimized loading `LowCardinality` data when reading `mapKeys(m)`, `mapValues(m)`, or the whole map, when using the bucketed map serialization.
