### PR TITLE
Run fixed-port Azurite integration tests sequentially

### DIFF
--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -49,11 +49,6 @@ TEST_CONFIGS = [
         "pins azurite to fixed host port 10000 (emulator mode); concurrent --dist=each workers collide on bind",
     ),
     TC(
-        "test_storage_delta/test_cdf.py",
-        True,
-        "pins azurite to fixed host port 10000 (emulator mode); concurrent --dist=each workers collide on bind",
-    ),
-    TC(
         "test_storage_iceberg_interoperability_azure/",
         True,
         "pins azurite to fixed host port 10000 (Spark emulator mode); concurrent --dist=each workers collide on bind",

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -43,6 +43,21 @@ TEST_CONFIGS = [
     TC("test_storage_iceberg_no_spark/", False, "minio/azurite per cluster; fully isolated"),
     TC("test_storage_iceberg_with_spark_cache/", False, "package-scoped Spark session; each xdist worker gets its own instance"),
     TC("test_storage_iceberg_concurrent/", False, "package-scoped Spark session; each xdist worker gets its own instance"),
+    TC(
+        "test_storage_delta/test_azure_cluster.py",
+        True,
+        "pins azurite to fixed host port 10000 (emulator mode); concurrent --dist=each workers collide on bind",
+    ),
+    TC(
+        "test_storage_delta/test_cdf.py",
+        True,
+        "pins azurite to fixed host port 10000 (emulator mode); concurrent --dist=each workers collide on bind",
+    ),
+    TC(
+        "test_storage_iceberg_interoperability_azure/",
+        True,
+        "pins azurite to fixed host port 10000 (Spark emulator mode); concurrent --dist=each workers collide on bind",
+    ),
 ]
 
 IMAGES_ENV = {

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -53,7 +53,7 @@ from helpers.spark_tools import ResilientSparkSession, write_spark_log_config
 SCRIPT_DIR = "/var/lib/clickhouse/user_files" + os.path.join(
     os.path.dirname(os.path.realpath(__file__))
 )
-cluster = ClickHouseCluster(__file__, with_spark=True, azurite_default_port=10000)
+cluster = ClickHouseCluster(__file__, with_spark=True)
 
 S3_DATA = [
     "field_ids_struct_test/data/00000-1-7cad83a6-af90-42a9-8a10-114cbc862a42-0-00001.parquet",


### PR DESCRIPTION
<!--
Linked issues and pull requests.

Related: https://github.com/ClickHouse/ClickHouse/pull/102033
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Three integration test modules pin Azurite to the fixed host port `10000` because their host-side writers run in Azure Storage Emulator mode (delta-rs `AZURE_STORAGE_USE_EMULATOR=true`; Spark `hadoop-azure` emulator), which assumes `127.0.0.1:10000`:

- `test_storage_delta/test_azure_cluster.py`
- `test_storage_delta/test_cdf.py`
- `test_storage_iceberg_interoperability_azure/` (port set in its `conftest.py`)

In the flaky/targeted integration jobs, parallel modules run under `-n {workers} --dist=each`, so every xdist worker (`gw0`, `gw1`, ...) runs the same module concurrently, each in its own docker-compose project but all binding the same fixed host port 10000. One worker wins the bind; the rest fail in the `started_cluster` fixture before any test code runs:

```
Container ...-azurite1-1  Starting
Error response from daemon: driver failed programming external connectivity on endpoint ...-azurite1-1:
Bind for 0.0.0.0:10000 failed: port is already allocated
```

Marking these modules `is_sequential=True` runs them with `-n 1 --dist=loadfile`, so a single worker runs them one at a time and the duplicate-bind cannot happen. This mirrors the existing entries for `test_server_overload/` ("sensitive to concurrent CPU load") and `test_profile_max_sessions_for_user/` ("uses fixed internal ports"). Modules in `test_storage_delta/` that use the default dynamic Azurite port (`test.py`, `test_imds.py`) stay parallel.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.848`
<!-- ch-version-info:end -->