### PR TITLE
Lower test concurrency on the azure ASan functional shard

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -297,6 +297,11 @@ def main():
         elif "msan" in args.options:
             # MSan is slow
             nproc = int(Utils.cpu_count() * 0.4)
+        elif is_azure_storage:
+            # azure FT runs only under ASan; concurrent heavy queries overrun the
+            # shared server memory cap, so the OvercommitTracker kills queries across
+            # all co-scheduled tests. Lower concurrency to keep peak total RSS under it.
+            nproc = int(Utils.cpu_count() * 0.4)
         elif is_per_test_coverage:
             cidb_cluster = CIDBCluster()
             if not info.is_local_run:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/107414

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `Stateless tests (arm_asan_ubsan, azure, parallel)` shard fell through to the default worker count (`cpu_count() * 0.6`, ~19 on the ARM_MEDIUM runner) with no memory-aware reduction, unlike MSan and DatabaseReplicated (both `* 0.4`).

That shard runs only under ASan (resident set roughly tripled) plus azurite. With ~19 heavy queries co-scheduled the aggregate hits the shared server cap (`current RSS: 53.69 GiB, maximum: 53.69 GiB`) and the OvercommitTracker stops queries across all concurrent tests at once, knocking out several unrelated tests in one ~30s window.

CIDB over the last ~28 days, excluding the 2026-06-09/06-10 Azure outage days: 187 OvercommitTracker / RSS-cap failures across 148 distinct tests and 59 PRs (`00084_external_aggregation` alone on 6 PRs).

Fix: apply the same lever already accepted for MSan (commit e1705ed0e13, "reduce number of tests in parallel for MSan, from 19 to 12") to the azure ASan shard, `cpu_count() * 0.4`. On a 32-core runner this is 19 -> 12 workers; peak concurrent RSS stays under the cap. No other shard is affected.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.794`
<!-- ch-version-info:end -->