### PR TITLE
Fix flaky test 03560_parallel_replicas_memory_bound_merging_projection

### DIFF
--- a/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.sql
+++ b/tests/queries/0_stateless/03560_parallel_replicas_memory_bound_merging_projection.sql
@@ -12,6 +12,9 @@ set enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tre
 set distributed_aggregation_memory_efficient = 1, enable_memory_bound_merging_of_aggregation_results = 1;
 set enable_analyzer = 1, parallel_replicas_local_plan = 1, optimize_use_projections = 1, parallel_replicas_support_projection = 1;
 set read_in_order_two_level_merge_threshold = 1000;
+-- Plan/result test, not a perf test: the test-env estimated-time guard false-positives
+-- (TOO_SLOW) when randomized settings make the parallel-replicas in-order read start slowly.
+set max_estimated_execution_time = 0;
 
 -- { echoOn } --
 set optimize_aggregation_in_order = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fix flaky `03560_parallel_replicas_memory_bound_merging_projection`. It fails intermittently with `Code 160 TOO_SLOW`:

```
Estimated query execution time (1198.32 seconds) is too long. Maximum: 600.
Estimated rows to process: 1000000 (291662 read in 349.50 seconds)
While executing MergeTreeSelect(pool: ReadPoolParallelReplicasInOrder, algorithm: InOrder)
```

The CI test env sets `max_estimated_execution_time=600` (`tests/config/users.d/limits.yaml`). Under randomized settings and slow storage (observed on the `amd_tsan, s3 storage` shard), the parallel-replicas in-order read starts slowly, so the linear extrapolation in `ExecutionSpeedLimits::throttle` over-predicts the runtime and aborts before the query finishes. The `clickhouse-test` randomized-settings minimizer confirms it: 28/28 runs pass with randomization disabled.

This test checks projection plans and results, not execution speed, so the estimated-time guard is irrelevant here. Set `max_estimated_execution_time=0` for the test (before the `echoOn` block, so the reference output is unchanged).

Found on the CI run of #107429 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107429&sha=66a87ef6ab08d65dfc9b94686bedd0eb50a62a7d&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29)); unrelated to that PR's NuRaft change. No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.800`
<!-- ch-version-info:end -->