### PR TITLE
Avoid materializing LowCardinality(String) inside Array and Map

### DIFF
--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -466,6 +466,22 @@ bool isLowCardinalityType(const IDataType & type)
     return typeid_cast<const DataTypeLowCardinality *>(&type) != nullptr;
 }
 
+bool convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args)
+{
+    bool converted = false;
+    for (auto & column : args)
+    {
+        auto column_without_low_cardinality = recursiveRemoveLowCardinality(column.column);
+        auto type_without_low_cardinality = recursiveRemoveLowCardinality(column.type);
+
+        converted |= type_without_low_cardinality.get() != column.type.get();
+
+        column.column = std::move(column_without_low_cardinality);
+        column.type = std::move(type_without_low_cardinality);
+    }
+    return converted;
+}
+
 /// Note that, for historical reasons, most of the functions use the first argument size to determine which is the
 /// size of all the columns. When short circuit optimization was introduced, `input_rows_count` was also added for
 /// all functions, but many have not been adjusted

--- a/src/Functions/FunctionHelpers.cpp
+++ b/src/Functions/FunctionHelpers.cpp
@@ -466,6 +466,27 @@ bool isLowCardinalityType(const IDataType & type)
     return typeid_cast<const DataTypeLowCardinality *>(&type) != nullptr;
 }
 
+bool hasLowCardinalityTypes(const ColumnsWithTypeAndName & args)
+{
+    for (const auto & column : args)
+    {
+        /// recursiveRemoveLowCardinality returns the very same type object when nothing was removed.
+        if (column.type && recursiveRemoveLowCardinality(column.type).get() != column.type.get())
+            return true;
+    }
+    return false;
+}
+
+bool allArgumentColumnsAreConstant(const ColumnsWithTypeAndName & args)
+{
+    for (const auto & column : args)
+    {
+        if (!column.column || !isColumnConst(*column.column))
+            return false;
+    }
+    return true;
+}
+
 bool convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args)
 {
     bool converted = false;

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -212,6 +212,11 @@ NullPresence getNullPresense(const ColumnsWithTypeAndName & args);
 
 bool isDecimalOrNullableDecimal(const DataTypePtr & type);
 bool isLowCardinalityType(const IDataType & type);
+/// Returns true if any of the argument types is or contains LowCardinality
+/// (e.g. LowCardinality(UInt8), Array(LowCardinality(String)) or Map(LowCardinality(String), String)).
+bool hasLowCardinalityTypes(const ColumnsWithTypeAndName & args);
+/// Returns true if all of the arguments have constant columns.
+bool allArgumentColumnsAreConstant(const ColumnsWithTypeAndName & args);
 bool convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args);
 
 void checkFunctionArgumentSizes(const ColumnsWithTypeAndName & arguments, size_t input_rows_count);

--- a/src/Functions/FunctionHelpers.h
+++ b/src/Functions/FunctionHelpers.h
@@ -212,6 +212,7 @@ NullPresence getNullPresense(const ColumnsWithTypeAndName & args);
 
 bool isDecimalOrNullableDecimal(const DataTypePtr & type);
 bool isLowCardinalityType(const IDataType & type);
+bool convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args);
 
 void checkFunctionArgumentSizes(const ColumnsWithTypeAndName & arguments, size_t input_rows_count);
 }

--- a/src/Functions/FunctionLowCardinalityFastPath.h
+++ b/src/Functions/FunctionLowCardinalityFastPath.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Functions/IFunctionAdaptors.h>
+#include <Interpreters/Context_fwd.h>
+
+#include <concepts>
+#include <memory>
+
+namespace DB
+{
+
+/// A function provides its specialized LowCardinality execution path by implementing this hook.
+/// It returns the result column, or nullptr when it cannot handle this particular call, in which
+/// case the arguments are processed as if the hook did not exist.
+template <typename Base>
+concept HasLowCardinalityFastPath = requires(
+    const Base & base, const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count)
+{
+    { base.tryExecuteLowCardinality(arguments, result_type, input_rows_count) } -> std::same_as<ColumnPtr>;
+};
+
+/** Adds a specialized LowCardinality execution path to an existing function.
+  *
+  * Normally LowCardinality arguments are converted to full columns before executeImpl runs (or
+  * the function is executed once per dictionary entry, when possible). A function that wants to
+  * see the LowCardinality columns themselves has to disable that conversion, and with it loses
+  * everything else the generic code does for LowCardinality arguments: wrapping the result type
+  * in LowCardinality, making the result Nullable for LowCardinality(Nullable) arguments,
+  * execution on the dictionary, constant folding. This mixin restores those behaviors, so that
+  * Base only implements the fast path itself: a tryExecuteLowCardinality method that returns
+  * nullptr when it does not apply (see HasLowCardinalityFastPath above). Base must otherwise be
+  * an ordinary stateless, default-constructible IFunction with all default implementations left
+  * enabled. The function is registered as FunctionWithLowCardinalityFastPath<Base>.
+  *
+  * The mixin inherits from Base instead of wrapping it, because IFunction has dozens of other
+  * virtual methods (isDeterministic, getMonotonicityForRange, ...) that a wrapper would have to
+  * forward one by one, and a missed one would go unnoticed. Only four methods are overridden:
+  *
+  * - useDefaultImplementationForLowCardinalityColumns() returns false, so executeImpl sees the
+  *   original LowCardinality columns.
+  *
+  * - useDefaultImplementationForConstants() must then also return false. The generic code
+  *   handles LowCardinality before constants, and execution on the dictionary requires constant
+  *   arguments to still be constants (it resizes them to the dictionary size). If constants were
+  *   already unwrapped to full columns here, redoing the call (below) would run the dictionary
+  *   code on mismatched row counts.
+  *
+  * - executeImpl() tries the fast path first. If it declines and any argument type contains
+  *   LowCardinality (or all arguments are constant, since that default is off too), the call is
+  *   redone on a plain Base instance with the defaults enabled, which behaves exactly like the
+  *   function did before the fast path existed. Redoing the call is deliberately preferred over
+  *   reimplementing the default handling here: the declared type and the produced column must
+  *   agree, and the rules for wrapping results in LowCardinality and for handling
+  *   Nullable inside LowCardinality are easy to get wrong.
+  *
+  * - getReturnTypeImpl(ColumnsWithTypeAndName) is likewise redone on the plain Base instance
+  *   whenever an argument type contains LowCardinality, since disabling the conversion also
+  *   changes how the return type is deduced (a LowCardinality(Nullable) argument no longer makes
+  *   the result Nullable, and the result type is no longer wrapped in LowCardinality).
+  */
+template <typename Base>
+requires HasLowCardinalityFastPath<Base>
+class FunctionWithLowCardinalityFastPath : public Base
+{
+public:
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionWithLowCardinalityFastPath>(); }
+
+    FunctionWithLowCardinalityFastPath() : delegate(std::make_shared<Base>()) { }
+
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+    bool useDefaultImplementationForConstants() const override { return false; }
+
+    using Base::getReturnTypeImpl;
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        if (hasLowCardinalityTypes(arguments))
+            return FunctionToOverloadResolverAdaptor(delegate).getReturnType(arguments);
+
+        return Base::getReturnTypeImpl(arguments);
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        if (auto result = Base::tryExecuteLowCardinality(arguments, result_type, input_rows_count))
+            return result;
+
+        if (hasLowCardinalityTypes(arguments) || allArgumentColumnsAreConstant(arguments))
+            return FunctionToExecutableFunctionAdaptor(delegate).execute(arguments, result_type, input_rows_count, /*dry_run=*/ false);
+
+        return Base::executeImpl(arguments, result_type, input_rows_count);
+    }
+
+private:
+    /// The delegate is stateless, so it is created once and shared across calls.
+    std::shared_ptr<Base> delegate;
+};
+
+}

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -121,14 +121,7 @@ ColumnPtr replaceLowCardinalityColumnsByNestedAndGetDictionaryIndexes(
     return indexes;
 }
 
-void convertLowCardinalityColumnsToFull(ColumnsWithTypeAndName & args)
-{
-    for (auto & column : args)
-    {
-        column.column = recursiveRemoveLowCardinality(column.column);
-        column.type = recursiveRemoveLowCardinality(column.type);
-    }
-}
+
 }
 
 ColumnPtr IExecutableFunction::defaultImplementationForConstantArguments(
@@ -464,9 +457,6 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
     {
-        if ((result = executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run)))
-            return result;
-
         if (const auto * res_low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(result_type.get()))
         {
             ColumnsWithTypeAndName columns_without_low_cardinality = arguments;

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -464,6 +464,9 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
     {
+        if ((result = executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run)))
+            return result;
+
         if (const auto * res_low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(result_type.get()))
         {
             ColumnsWithTypeAndName columns_without_low_cardinality = arguments;

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -98,6 +98,15 @@ protected:
       */
     virtual bool useDefaultImplementationForLowCardinalityColumns() const { return true; }
 
+    virtual ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & /*arguments*/,
+        const DataTypePtr & /*result_type*/,
+        size_t /*input_rows_count*/,
+        bool /*dry_run*/) const
+    {
+        return nullptr;
+    }
+
     /** If function arguments has single sparse column and all other arguments are constants, call function on nested column.
       * Otherwise, convert all sparse columns to ordinary columns.
       * If default value doesn't change after function execution, returns sparse column as a result.
@@ -564,6 +573,15 @@ public:
       * Returns ColumnLowCardinality if at least one argument is ColumnLowCardinality.
       */
     virtual bool useDefaultImplementationForLowCardinalityColumns() const { return true; }
+
+    virtual ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & /*arguments*/,
+        const DataTypePtr & /*result_type*/,
+        size_t /*input_rows_count*/,
+        bool /*dry_run*/) const
+    {
+        return nullptr;
+    }
 
     /** If function arguments has single sparse column and all other arguments are constants, call function on nested column.
       * Otherwise, convert all sparse columns to ordinary columns.

--- a/src/Functions/IFunction.h
+++ b/src/Functions/IFunction.h
@@ -98,15 +98,6 @@ protected:
       */
     virtual bool useDefaultImplementationForLowCardinalityColumns() const { return true; }
 
-    virtual ColumnPtr executeWithLowCardinalityColumns(
-        const ColumnsWithTypeAndName & /*arguments*/,
-        const DataTypePtr & /*result_type*/,
-        size_t /*input_rows_count*/,
-        bool /*dry_run*/) const
-    {
-        return nullptr;
-    }
-
     /** If function arguments has single sparse column and all other arguments are constants, call function on nested column.
       * Otherwise, convert all sparse columns to ordinary columns.
       * If default value doesn't change after function execution, returns sparse column as a result.
@@ -573,15 +564,6 @@ public:
       * Returns ColumnLowCardinality if at least one argument is ColumnLowCardinality.
       */
     virtual bool useDefaultImplementationForLowCardinalityColumns() const { return true; }
-
-    virtual ColumnPtr executeWithLowCardinalityColumns(
-        const ColumnsWithTypeAndName & /*arguments*/,
-        const DataTypePtr & /*result_type*/,
-        size_t /*input_rows_count*/,
-        bool /*dry_run*/) const
-    {
-        return nullptr;
-    }
 
     /** If function arguments has single sparse column and all other arguments are constants, call function on nested column.
       * Otherwise, convert all sparse columns to ordinary columns.

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -25,6 +25,17 @@ protected:
     bool useDefaultImplementationForConstants() const final { return function->useDefaultImplementationForConstants(); }
     bool useDefaultImplementationForLowCardinalityColumns() const final { return function->useDefaultImplementationForLowCardinalityColumns(); }
     bool useDefaultImplementationForSparseColumns() const final { return function->useDefaultImplementationForSparseColumns(); }
+
+    /// Companion hook for useDefaultImplementationForLowCardinalityColumns.
+    ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        bool dry_run) const final
+    {
+        return function->executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
+    }
+
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const final { return function->getArgumentsThatAreAlwaysConstant(); }
     bool canBeExecutedOnDefaultArguments() const override { return function->canBeExecutedOnDefaultArguments(); }
     /// TODO: replace isSuitableForShortCircuitArgumentsExecution with a dedicated canThrow interface on functions.

--- a/src/Functions/IFunctionAdaptors.h
+++ b/src/Functions/IFunctionAdaptors.h
@@ -26,16 +26,6 @@ protected:
     bool useDefaultImplementationForLowCardinalityColumns() const final { return function->useDefaultImplementationForLowCardinalityColumns(); }
     bool useDefaultImplementationForSparseColumns() const final { return function->useDefaultImplementationForSparseColumns(); }
 
-    /// Companion hook for useDefaultImplementationForLowCardinalityColumns.
-    ColumnPtr executeWithLowCardinalityColumns(
-        const ColumnsWithTypeAndName & arguments,
-        const DataTypePtr & result_type,
-        size_t input_rows_count,
-        bool dry_run) const final
-    {
-        return function->executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
-    }
-
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const final { return function->getArgumentsThatAreAlwaysConstant(); }
     bool canBeExecutedOnDefaultArguments() const override { return function->canBeExecutedOnDefaultArguments(); }
     /// TODO: replace isSuitableForShortCircuitArgumentsExecution with a dedicated canThrow interface on functions.

--- a/src/Functions/LowCardinalityExecutionHelpers.h
+++ b/src/Functions/LowCardinalityExecutionHelpers.h
@@ -1,17 +1,169 @@
 #pragma once
 
+#include <Columns/ColumnArray.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/ColumnsNumber.h>
 #include <Columns/IColumn.h>
+#include <Core/Field.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/IDataType.h>
 #include <Interpreters/castColumn.h>
+
+#include <optional>
 
 namespace DB
 {
 
 namespace LowCardinalityExecutionHelpers
 {
+
+/// Convert a constant arrayElement index to a zero-based position within one array row.
+/// Returns empty for out-of-bounds indexes, which means arrayElement should return the default value.
+inline std::optional<size_t> adjustedIndexFromField(const Field & index, size_t array_size)
+{
+    if (index.getType() == Field::Types::UInt64 || (index.getType() == Field::Types::Int64 && index.safeGet<Int64>() >= 0))
+    {
+        UInt64 positive_index = index.safeGet<UInt64>();
+        if (positive_index > 0 && positive_index <= array_size)
+            return positive_index - 1;
+    }
+    else if (index.getType() == Field::Types::Int64)
+    {
+        /// Cast to UInt64 before negation allows to avoid undefined behaviour for negation of the most negative number.
+        UInt64 index_from_end = -static_cast<UInt64>(index.safeGet<Int64>());
+        if (index_from_end <= array_size)
+            return array_size - index_from_end;
+    }
+
+    return {};
+}
+
+struct FilterAndOffsets
+{
+    IColumn::Filter filter;
+    ColumnArray::ColumnOffsets::MutablePtr offsets;
+    size_t result_size = 0;
+};
+
+/// View of an Array(LowCardinality(T))-shaped column: LC element indexes plus row offsets.
+/// Keep this header-only so callers can compile the row loops down to the same code as local loops.
+struct LowCardinalityArrayView
+{
+    const ColumnLowCardinality & elements;
+    const ColumnArray::Offsets & offsets;
+    size_t rows;
+
+    template <typename Function>
+    inline void forEachRange(Function && function) const
+    {
+        for (size_t row = 0; row != rows; ++row)
+        {
+            size_t begin = offsets[ssize_t(row) - 1];
+            size_t end = offsets[row];
+            function(row, begin, end);
+        }
+    }
+
+    /// Build arrayElement(Array(LowCardinality), const) by selecting dictionary values through LC indexes,
+    /// instead of materializing the whole nested array first.
+    inline ColumnPtr arrayElementConst(const Field & index, const IDataType & result_type) const
+    {
+        auto result = result_type.createColumn();
+        result->reserve(rows);
+
+        const auto & dictionary = *elements.getDictionary().getNestedColumn();
+        forEachRange([&](size_t, size_t begin, size_t end)
+        {
+            if (auto adjusted_index = adjustedIndexFromField(index, end - begin))
+                result->insertFrom(dictionary, elements.getIndexAt(begin + *adjusted_index));
+            else
+                result->insertDefault();
+        });
+
+        return result;
+    }
+
+    /// Given a per-dictionary-entry predicate result, compute whether any element in each array row matches.
+    inline ColumnUInt8::MutablePtr existsByDictionaryMatches(const PaddedPODArray<UInt8> & dictionary_matches) const
+    {
+        auto result = ColumnUInt8::create();
+        auto & result_data = result->getData();
+        result_data.resize_fill(rows);
+
+        forEachRange([&](size_t row, size_t begin, size_t end)
+        {
+            for (size_t i = begin; i != end; ++i)
+            {
+                if (dictionary_matches[elements.getIndexAt(i)])
+                {
+                    result_data[row] = 1;
+                    break;
+                }
+            }
+        });
+
+        return result;
+    }
+
+    /// Given a per-dictionary-entry predicate result, build a filter and offsets for matching array elements.
+    inline FilterAndOffsets filterByDictionaryMatches(const PaddedPODArray<UInt8> & dictionary_matches) const
+    {
+        FilterAndOffsets result{.filter = IColumn::Filter(elements.size()), .offsets = ColumnArray::ColumnOffsets::create()};
+        auto & new_offsets = result.offsets->getData();
+        new_offsets.reserve(rows);
+
+        forEachRange([&](size_t, size_t begin, size_t end)
+        {
+            for (size_t i = begin; i != end; ++i)
+            {
+                UInt8 matched = dictionary_matches[elements.getIndexAt(i)];
+                result.filter[i] = matched;
+                result.result_size += matched;
+            }
+            new_offsets.push_back(result.result_size);
+        });
+
+        return result;
+    }
+};
+
+/// Evaluate a predicate over LC dictionary entries, either over the whole dictionary or only over
+/// dictionary indexes used by this block. [evaluate] must return a UInt8 column sized like its input.
+template <typename Evaluate>
+inline ColumnPtr dictionaryMatchesForSelectedIndexes(
+    const ColumnLowCardinality & low_cardinality_column,
+    Evaluate && evaluate,
+    /// Local benchmarks chose 4 to keep full-dictionary scans for normal LC blocks but avoid O(dictionary) LIKE work for small slices.
+    size_t max_dictionary_to_elements_ratio_for_full_scan = 4)
+{
+    size_t dictionary_size = low_cardinality_column.getDictionary().size();
+    size_t selected_elements = low_cardinality_column.size();
+
+    /// For small dictionaries it is cheaper to evaluate every dictionary value than to build distinct selected indexes.
+    if (selected_elements != 0 && dictionary_size <= selected_elements * max_dictionary_to_elements_ratio_for_full_scan)
+        return evaluate(low_cardinality_column.getDictionary().getNestedColumn());
+
+    auto sparse_matches = ColumnUInt8::create(dictionary_size, UInt8{0});
+    auto & sparse_matches_data = sparse_matches->getData();
+
+    auto distinct_indexes = low_cardinality_column.getDistinctIndexes(0, selected_elements);
+    if (distinct_indexes.empty())
+        return sparse_matches;
+
+    auto distinct_indexes_column = ColumnUInt64::create();
+    distinct_indexes_column->getData() = std::move(distinct_indexes);
+    const auto & distinct_indexes_data = distinct_indexes_column->getData();
+
+    auto dictionary_values = low_cardinality_column.getDictionary().getNestedColumn()->index(*distinct_indexes_column, 0);
+    auto selected_matches_column = evaluate(std::move(dictionary_values));
+    const auto & selected_matches = assert_cast<const ColumnUInt8 &>(*selected_matches_column).getData();
+
+    for (size_t i = 0; i != distinct_indexes_data.size(); ++i)
+        sparse_matches_data[distinct_indexes_data[i]] = selected_matches[i];
+
+    return sparse_matches;
+}
 
 /// Returns false if the constant value is not present in the dictionary. If the constant is NULL,
 /// returns true and sets [dictionary_index] to the default LC null index, matching the existing

--- a/src/Functions/LowCardinalityExecutionHelpers.h
+++ b/src/Functions/LowCardinalityExecutionHelpers.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/IDataType.h>
+#include <Interpreters/castColumn.h>
+
+namespace DB
+{
+
+namespace LowCardinalityExecutionHelpers
+{
+
+/// Returns false if the constant value is not present in the dictionary. If the constant is NULL,
+/// returns true and sets [dictionary_index] to the default LC null index, matching the existing
+/// Array(LowCardinality) index-function behavior.
+/// Keep this inlined: the Array(LowCardinality) index functions are sensitive to this setup codegen.
+inline __attribute__((always_inline)) bool dictionaryIndexForConstant(
+    const ColumnLowCardinality & low_cardinality_data,
+    const ColumnPtr & value_column,
+    const DataTypePtr & value_type,
+    const DataTypePtr & target_type,
+    UInt64 & dictionary_index)
+{
+    dictionary_index = 0;
+
+    auto value = recursiveRemoveLowCardinality(value_column);
+    if (value->isNullAt(0))
+        return true;
+
+    auto value_type_without_low_cardinality = recursiveRemoveLowCardinality(value_type);
+    value = castColumn({value, value_type_without_low_cardinality, ""}, target_type);
+
+    if (value->isNullable())
+        value = assert_cast<const ColumnNullable &>(*value).getNestedColumnPtr();
+
+    std::string_view elem = value->getDataAt(0);
+    if (auto maybe_index = low_cardinality_data.getDictionary().getOrFindValueIndex(elem))
+    {
+        dictionary_index = *maybe_index;
+        return true;
+    }
+
+    return false;
+}
+
+}
+
+}

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -54,7 +54,25 @@ class FunctionMapToArrayAdapter final : public IFunction
 public:
     static constexpr auto name = Name::name;
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionMapToArrayAdapter>(); }
+
+    /// A specialized LowCardinality execution path (if the adapter provides one) requires opting
+    /// out of the default LowCardinality implementation, so that executeImpl can see
+    /// LowCardinality columns. When the specialized path does not apply, both return type
+    /// deduction and execution delegate to an instance created with
+    /// `use_low_cardinality_fast_path = false`, which restores the default framework behavior
+    /// for LowCardinality arguments.
+    explicit FunctionMapToArrayAdapter(bool use_low_cardinality_fast_path_ = true)
+        : use_low_cardinality_fast_path(use_low_cardinality_fast_path_)
+    {
+    }
+
     String getName() const override { return name; }
+
+    static constexpr bool has_low_cardinality_specialization
+        = requires(const ColumnsWithTypeAndName & args, const DataTypePtr & type, size_t rows)
+        {
+            Adapter::executeWithLowCardinalityColumns(args, type, rows);
+        };
 
     /// Functions that return a Map by selecting or reordering the original key-value pairs
     /// (`mapFilter`, `mapSort` and its variants, `mapConcat`) must keep the exact key and value
@@ -71,13 +89,24 @@ public:
     bool useDefaultImplementationForNulls() const override { return impl.useDefaultImplementationForNulls(); }
     bool useDefaultImplementationForLowCardinalityColumns() const override
     {
-        if constexpr (requires { Adapter::use_default_implementation_for_low_cardinality_columns; })
-            return Adapter::use_default_implementation_for_low_cardinality_columns;
+        if constexpr (has_low_cardinality_specialization)
+            return !use_low_cardinality_fast_path;
         if constexpr (preserve_nested_low_cardinality)
             return false;
         return impl.useDefaultImplementationForLowCardinalityColumns();
     }
-    bool useDefaultImplementationForConstants() const override { return impl.useDefaultImplementationForConstants(); }
+    /// The default implementation for constants must stay disabled together with the default
+    /// LowCardinality implementation: it normally runs after it and would otherwise unwrap
+    /// constants that the delegated LowCardinality handling relies on (see executeImpl).
+    bool useDefaultImplementationForConstants() const override
+    {
+        if constexpr (has_low_cardinality_specialization)
+        {
+            if (use_low_cardinality_fast_path)
+                return false;
+        }
+        return impl.useDefaultImplementationForConstants();
+    }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override  { return false; }
 
     /// Reflect the SQL-level signature, not the internal `impl` plumbing.
@@ -100,6 +129,18 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
+        if constexpr (has_low_cardinality_specialization)
+        {
+            /// Opting out of the default LowCardinality implementation also disables the default
+            /// return type deduction for LowCardinality arguments (in particular, the nullability
+            /// of a LowCardinality(Nullable) pattern and the LowCardinality wrapping of the result
+            /// type). Delegate to an instance with the default implementation enabled, so that the
+            /// deduced type is exactly the same as if the specialized LowCardinality path did not exist.
+            if (use_low_cardinality_fast_path && hasLowCardinalityTypes(arguments))
+                return FunctionToOverloadResolverAdaptor(std::make_shared<FunctionMapToArrayAdapter>(/*use_low_cardinality_fast_path_=*/ false))
+                    .getReturnType(arguments);
+        }
+
         if (arguments.empty())
             throw Exception(
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
@@ -147,17 +188,24 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        if constexpr (requires { Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count); })
+        if constexpr (has_low_cardinality_specialization)
         {
-            if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
-                return result;
-            auto arguments_to_execute = arguments;
-            if (convertLowCardinalityColumnsToFull(arguments_to_execute))
+            if (use_low_cardinality_fast_path)
             {
-                /// Re-enter the function through the framework so that the default implementations
-                /// (in particular for Nullable arguments uncovered by removing LowCardinality) are applied.
-                return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionMapToArrayAdapter>())
-                    .execute(arguments_to_execute, result_type, input_rows_count, /*dry_run=*/ false);
+                if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
+                    return result;
+
+                if (hasLowCardinalityTypes(arguments) || allArgumentColumnsAreConstant(arguments))
+                {
+                    /// The specialized LowCardinality path does not apply. Re-enter the function
+                    /// through the framework with the default implementations (for LowCardinality
+                    /// and constant arguments) enabled, so that conversion of LowCardinality
+                    /// arguments or execution on the dictionary, constant unwrapping and Nullable
+                    /// handling are applied in the usual order, exactly as if the specialized path
+                    /// did not exist.
+                    return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionMapToArrayAdapter>(/*use_low_cardinality_fast_path_=*/ false))
+                        .execute(arguments, result_type, input_rows_count, /*dry_run=*/ false);
+                }
             }
         }
 
@@ -190,6 +238,7 @@ public:
 
 private:
     Impl impl;
+    bool use_low_cardinality_fast_path = true;
 };
 
 
@@ -406,10 +455,10 @@ struct MapLikeAdapter
     /// The SQL-level signature is `(Map, String pattern)`; the lambda is constructed internally,
     /// so the first user-facing argument is not a lambda.
     static constexpr bool first_argument_is_lambda = false;
-    static constexpr bool use_default_implementation_for_low_cardinality_columns = false;
 
     /// These functions match keys/values with `LIKE`, which is defined only for String/FixedString.
-    /// Their LowCardinality handling is left to the generic machinery (nested LowCardinality is not preserved).
+    /// Their LowCardinality handling is left to the generic machinery (nested LowCardinality is not
+    /// preserved), except for the specialized path in executeWithLowCardinalityColumns.
     static constexpr bool preserve_low_cardinality = false;
 
     static void checkTypes(const DataTypes & types)

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -152,7 +152,13 @@ public:
         {
             if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
                 return result;
-            convertLowCardinalityColumnsToFull(arguments_to_execute);
+            if (convertLowCardinalityColumnsToFull(arguments_to_execute))
+            {
+                /// Re-enter the function through the framework so that the default implementations
+                /// (in particular for Nullable arguments uncovered by removing LowCardinality) are applied.
+                return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionMapToArrayAdapter>())
+                    .execute(arguments_to_execute, result_type, input_rows_count, /*dry_run=*/ false);
+            }
         }
 
         auto nested_arguments = arguments_to_execute;

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -147,11 +147,11 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        auto arguments_to_execute = arguments;
         if constexpr (requires { Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count); })
         {
             if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
                 return result;
+            auto arguments_to_execute = arguments;
             if (convertLowCardinalityColumnsToFull(arguments_to_execute))
             {
                 /// Re-enter the function through the framework so that the default implementations
@@ -161,7 +161,7 @@ public:
             }
         }
 
-        auto nested_arguments = arguments_to_execute;
+        auto nested_arguments = arguments;
         Adapter::extractNestedTypesAndColumns(nested_arguments);
 
         if constexpr (preserve_nested_low_cardinality)

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -69,15 +69,14 @@ public:
     bool isVariadic() const override { return impl.isVariadic(); }
     size_t getNumberOfArguments() const override { return impl.getNumberOfArguments(); }
     bool useDefaultImplementationForNulls() const override { return impl.useDefaultImplementationForNulls(); }
-
     bool useDefaultImplementationForLowCardinalityColumns() const override
     {
+        if constexpr (requires { Adapter::use_default_implementation_for_low_cardinality_columns; })
+            return Adapter::use_default_implementation_for_low_cardinality_columns;
         if constexpr (preserve_nested_low_cardinality)
             return false;
-        else
-            return impl.useDefaultImplementationForLowCardinalityColumns();
+        return impl.useDefaultImplementationForLowCardinalityColumns();
     }
-
     bool useDefaultImplementationForConstants() const override { return impl.useDefaultImplementationForConstants(); }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override  { return false; }
 
@@ -148,7 +147,15 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        auto nested_arguments = arguments;
+        auto arguments_to_execute = arguments;
+        if constexpr (requires { Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count); })
+        {
+            if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
+                return result;
+            convertLowCardinalityColumnsToFull(arguments_to_execute);
+        }
+
+        auto nested_arguments = arguments_to_execute;
         Adapter::extractNestedTypesAndColumns(nested_arguments);
 
         if constexpr (preserve_nested_low_cardinality)
@@ -173,18 +180,6 @@ public:
         }
         else
             return Adapter::wrapColumn(impl.executeImpl(nested_arguments, Adapter::extractResultType(result_type), input_rows_count));
-    }
-
-    ColumnPtr executeWithLowCardinalityColumns(
-        const ColumnsWithTypeAndName & arguments,
-        const DataTypePtr & result_type,
-        size_t input_rows_count,
-        bool dry_run) const override
-    {
-        if constexpr (requires { Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run); })
-            return Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
-        else
-            return nullptr;
     }
 
 private:
@@ -405,6 +400,7 @@ struct MapLikeAdapter
     /// The SQL-level signature is `(Map, String pattern)`; the lambda is constructed internally,
     /// so the first user-facing argument is not a lambda.
     static constexpr bool first_argument_is_lambda = false;
+    static constexpr bool use_default_implementation_for_low_cardinality_columns = false;
 
     /// These functions match keys/values with `LIKE`, which is defined only for String/FixedString.
     /// Their LowCardinality handling is left to the generic machinery (nested LowCardinality is not preserved).
@@ -421,7 +417,7 @@ struct MapLikeAdapter
         if (!map_type)
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "First argument for function {} must be a Map", Name::name);
 
-        if (!isStringOrFixedString(types[1]))
+        if (!isStringOrFixedString(removeLowCardinality(types[1])))
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Second argument for function {} must be String or FixedString", Name::name);
 
         auto subcolumn_type = removeLowCardinality(position == 0 ? map_type->getKeyType() : map_type->getValueType());
@@ -434,8 +430,11 @@ struct MapLikeAdapter
     {
         checkTypes(types);
         const auto & map_type = assert_cast<const DataTypeMap &>(*types[0]);
+        auto pattern_type = removeLowCardinality(types[1]);
+        auto key_type = recursiveRemoveLowCardinality(map_type.getKeyType());
+        auto value_type = recursiveRemoveLowCardinality(map_type.getValueType());
 
-        DataTypes lambda_argument_types{types[1], map_type.getKeyType(), map_type.getValueType()};
+        DataTypes lambda_argument_types{pattern_type, key_type, value_type};
 
         DataTypePtr result_type;
 
@@ -444,16 +443,17 @@ struct MapLikeAdapter
         else
             result_type = FunctionMapValueLike().getReturnTypeImpl(lambda_argument_types);
 
-        DataTypes argument_types{map_type.getKeyType(), map_type.getValueType()};
+        DataTypes argument_types{key_type, value_type};
         auto function_type = std::make_shared<DataTypeFunction>(argument_types, result_type);
 
-        types = {function_type, types[0]};
+        types = {function_type, std::make_shared<DataTypeMap>(key_type, value_type)};
         MapToNestedAdapter<Name, returns_map>::extractNestedTypes(types);
     }
 
     static void extractNestedTypesAndColumns(ColumnsWithTypeAndName & arguments)
     {
         checkTypes(DataTypes{std::from_range_t{}, arguments | std::views::transform([](auto & elem) { return elem.type; })});
+        convertLowCardinalityColumnsToFull(arguments);
 
         const auto & map_type = assert_cast<const DataTypeMap &>(*arguments[0].type);
         const auto & pattern_arg = arguments[1];
@@ -489,12 +489,11 @@ struct MapLikeAdapter
     static ColumnPtr executeWithLowCardinalityColumns(
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr &,
-        size_t input_rows_count,
-        bool dry_run)
+        size_t input_rows_count)
     {
         /// This fast path builds one dictionary-match bitmap for the whole block, so the LIKE pattern must be constant.
         /// Non-constant patterns remain supported by falling back to the generic LowCardinality handling below.
-        if (dry_run || arguments.size() != 2 || !arguments[0].column || !arguments[1].column || !isColumnConst(*arguments[1].column))
+        if (arguments.size() != 2 || !arguments[0].column || !arguments[1].column || !isColumnConst(*arguments[1].column))
             return nullptr;
 
         if (getNullPresense(arguments).has_nullable)

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -1,7 +1,9 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnFunction.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnTuple.h>
+#include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnConst.h>
 
 #include <DataTypes/DataTypeArray.h>
@@ -12,6 +14,7 @@
 
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunctionAdaptors.h>
+#include <Functions/LowCardinalityExecutionHelpers.h>
 #include <Functions/like.h>
 #include <Functions/array/arrayConcat.h>
 #include <Functions/array/arrayFilter.h>
@@ -170,6 +173,18 @@ public:
         }
         else
             return Adapter::wrapColumn(impl.executeImpl(nested_arguments, Adapter::extractResultType(result_type), input_rows_count));
+    }
+
+    ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr & result_type,
+        size_t input_rows_count,
+        bool dry_run) const override
+    {
+        if constexpr (requires { Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run); })
+            return Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
+        else
+            return nullptr;
     }
 
 private:
@@ -409,7 +424,7 @@ struct MapLikeAdapter
         if (!isStringOrFixedString(types[1]))
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Second argument for function {} must be String or FixedString", Name::name);
 
-        auto subcolumn_type = position == 0 ? map_type->getKeyType() : map_type->getValueType();
+        auto subcolumn_type = removeLowCardinality(position == 0 ? map_type->getKeyType() : map_type->getValueType());
 
         if (!isStringOrFixedString(subcolumn_type))
             throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "{} type of map for function {} must be String or FixedString", position == 0 ? "Key" : "Value", Name::name);
@@ -469,6 +484,81 @@ struct MapLikeAdapter
         ColumnWithTypeAndName function_arg{function_column, function_type, position == 0 ? "__function_map_key_like" :  "__function_map_value_like"};
         arguments = {function_arg, arguments[0]};
         MapToNestedAdapter<Name, returns_map>::extractNestedTypesAndColumns(arguments);
+    }
+
+    static ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & arguments,
+        const DataTypePtr &,
+        size_t input_rows_count,
+        bool dry_run)
+    {
+        /// This fast path builds one dictionary-match bitmap for the whole block, so the LIKE pattern must be constant.
+        /// Non-constant patterns remain supported by falling back to the generic LowCardinality handling below.
+        if (dry_run || arguments.size() != 2 || !arguments[0].column || !arguments[1].column || !isColumnConst(*arguments[1].column))
+            return nullptr;
+
+        if (getNullPresense(arguments).has_nullable)
+            return nullptr;
+
+        /// The generic LowCardinality handling already supports LowCardinality(String) patterns.
+        /// Keep this specialized path to ordinary constant patterns, which can be cloned directly for dictionary evaluation.
+        if (typeid_cast<const DataTypeLowCardinality *>(arguments[1].type.get()))
+            return nullptr;
+
+        DataTypes types;
+        types.reserve(arguments.size());
+        for (const auto & argument : arguments)
+            types.push_back(argument.type);
+        checkTypes(types);
+
+        const auto * map_column = checkAndGetColumn<ColumnMap>(arguments[0].column.get());
+        if (!map_column)
+            return nullptr;
+
+        const auto & map = *map_column;
+        const auto * low_cardinality_column = typeid_cast<const ColumnLowCardinality *>(&map.getNestedData().getColumn(position));
+        if (!low_cardinality_column)
+            return nullptr;
+
+        const auto & map_type = assert_cast<const DataTypeMap &>(*arguments[0].type);
+        DataTypePtr selected_type = position == 0 ? map_type.getKeyType() : map_type.getValueType();
+        DataTypePtr selected_dictionary_type = removeLowCardinality(selected_type);
+
+        auto run_like_on_dictionary_values = [&](ColumnPtr dictionary_values)
+        {
+            auto pattern_column = arguments[1].column->cloneResized(dictionary_values->size());
+            ColumnsWithTypeAndName like_arguments{
+                {dictionary_values, selected_dictionary_type, ""},
+                {std::move(pattern_column), arguments[1].type, ""},
+            };
+
+            FunctionLike like(/*context*/ nullptr);
+            auto like_result_type = like.getReturnTypeImpl(DataTypes{selected_dictionary_type, arguments[1].type});
+            return like.executeImpl(like_arguments, like_result_type, like_arguments[0].column->size());
+        };
+
+        auto dictionary_matches_column = LowCardinalityExecutionHelpers::dictionaryMatchesForSelectedIndexes(
+            *low_cardinality_column, run_like_on_dictionary_values);
+        const auto & dictionary_matches = assert_cast<const ColumnUInt8 &>(*dictionary_matches_column).getData();
+
+        auto low_cardinality_view = LowCardinalityExecutionHelpers::LowCardinalityArrayView{
+            .elements = *low_cardinality_column,
+            .offsets = map.getNestedColumn().getOffsets(),
+            .rows = input_rows_count,
+        };
+        if constexpr (returns_map)
+        {
+            auto filter_and_offsets = low_cardinality_view.filterByDictionaryMatches(dictionary_matches);
+            auto filtered_nested_data = map.getNestedData().filter(filter_and_offsets.filter, filter_and_offsets.result_size);
+            ColumnPtr filtered_map = ColumnMap::create(
+                ColumnArray::create(std::move(filtered_nested_data), std::move(filter_and_offsets.offsets)));
+            filtered_map = recursiveRemoveLowCardinality(filtered_map);
+            return filtered_map;
+        }
+        else
+        {
+            return low_cardinality_view.existsByDictionaryMatches(dictionary_matches);
+        }
     }
 
     static DataTypePtr extractResultType(const DataTypePtr & result_type)

--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -13,6 +13,7 @@
 #include <DataTypes/DataTypeTuple.h>
 
 #include <Functions/FunctionHelpers.h>
+#include <Functions/FunctionLowCardinalityFastPath.h>
 #include <Functions/IFunctionAdaptors.h>
 #include <Functions/LowCardinalityExecutionHelpers.h>
 #include <Functions/like.h>
@@ -49,22 +50,11 @@ namespace ErrorCodes
   * from Map arguments and possibly modify other columns.
 */
 template <typename Impl, typename Adapter, typename Name>
-class FunctionMapToArrayAdapter final : public IFunction
+class FunctionMapToArrayAdapter : public IFunction
 {
 public:
     static constexpr auto name = Name::name;
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionMapToArrayAdapter>(); }
-
-    /// A specialized LowCardinality execution path (if the adapter provides one) requires opting
-    /// out of the default LowCardinality implementation, so that executeImpl can see
-    /// LowCardinality columns. When the specialized path does not apply, both return type
-    /// deduction and execution delegate to an instance created with
-    /// `use_low_cardinality_fast_path = false`, which restores the default framework behavior
-    /// for LowCardinality arguments.
-    explicit FunctionMapToArrayAdapter(bool use_low_cardinality_fast_path_ = true)
-        : use_low_cardinality_fast_path(use_low_cardinality_fast_path_)
-    {
-    }
 
     String getName() const override { return name; }
 
@@ -73,6 +63,16 @@ public:
         {
             Adapter::executeWithLowCardinalityColumns(args, type, rows);
         };
+
+    /// Fast path hook for FunctionWithLowCardinalityFastPath (see FunctionLowCardinalityFastPath.h).
+    /// Only adapters that implement executeWithLowCardinalityColumns have it, and only those
+    /// functions are registered wrapped in the mixin.
+    ColumnPtr tryExecuteLowCardinality(
+        const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
+        requires has_low_cardinality_specialization
+    {
+        return Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count);
+    }
 
     /// Functions that return a Map by selecting or reordering the original key-value pairs
     /// (`mapFilter`, `mapSort` and its variants, `mapConcat`) must keep the exact key and value
@@ -89,24 +89,11 @@ public:
     bool useDefaultImplementationForNulls() const override { return impl.useDefaultImplementationForNulls(); }
     bool useDefaultImplementationForLowCardinalityColumns() const override
     {
-        if constexpr (has_low_cardinality_specialization)
-            return !use_low_cardinality_fast_path;
         if constexpr (preserve_nested_low_cardinality)
             return false;
         return impl.useDefaultImplementationForLowCardinalityColumns();
     }
-    /// The default implementation for constants must stay disabled together with the default
-    /// LowCardinality implementation: it normally runs after it and would otherwise unwrap
-    /// constants that the delegated LowCardinality handling relies on (see executeImpl).
-    bool useDefaultImplementationForConstants() const override
-    {
-        if constexpr (has_low_cardinality_specialization)
-        {
-            if (use_low_cardinality_fast_path)
-                return false;
-        }
-        return impl.useDefaultImplementationForConstants();
-    }
+    bool useDefaultImplementationForConstants() const override { return impl.useDefaultImplementationForConstants(); }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override  { return false; }
 
     /// Reflect the SQL-level signature, not the internal `impl` plumbing.
@@ -129,18 +116,6 @@ public:
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if constexpr (has_low_cardinality_specialization)
-        {
-            /// Opting out of the default LowCardinality implementation also disables the default
-            /// return type deduction for LowCardinality arguments (in particular, the nullability
-            /// of a LowCardinality(Nullable) pattern and the LowCardinality wrapping of the result
-            /// type). Delegate to an instance with the default implementation enabled, so that the
-            /// deduced type is exactly the same as if the specialized LowCardinality path did not exist.
-            if (use_low_cardinality_fast_path && hasLowCardinalityTypes(arguments))
-                return FunctionToOverloadResolverAdaptor(std::make_shared<FunctionMapToArrayAdapter>(/*use_low_cardinality_fast_path_=*/ false))
-                    .getReturnType(arguments);
-        }
-
         if (arguments.empty())
             throw Exception(
                 ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
@@ -188,27 +163,6 @@ public:
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        if constexpr (has_low_cardinality_specialization)
-        {
-            if (use_low_cardinality_fast_path)
-            {
-                if (auto result = Adapter::executeWithLowCardinalityColumns(arguments, result_type, input_rows_count))
-                    return result;
-
-                if (hasLowCardinalityTypes(arguments) || allArgumentColumnsAreConstant(arguments))
-                {
-                    /// The specialized LowCardinality path does not apply. Re-enter the function
-                    /// through the framework with the default implementations (for LowCardinality
-                    /// and constant arguments) enabled, so that conversion of LowCardinality
-                    /// arguments or execution on the dictionary, constant unwrapping and Nullable
-                    /// handling are applied in the usual order, exactly as if the specialized path
-                    /// did not exist.
-                    return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionMapToArrayAdapter>(/*use_low_cardinality_fast_path_=*/ false))
-                        .execute(arguments, result_type, input_rows_count, /*dry_run=*/ false);
-                }
-            }
-        }
-
         auto nested_arguments = arguments;
         Adapter::extractNestedTypesAndColumns(nested_arguments);
 
@@ -238,7 +192,6 @@ public:
 
 private:
     Impl impl;
-    bool use_low_cardinality_fast_path = true;
 };
 
 
@@ -659,16 +612,20 @@ struct NameMapAll { static constexpr auto name = "mapAll"; };
 using FunctionMapAll = FunctionMapToArrayAdapter<FunctionArrayAll, MapToNestedAdapter<NameMapAll, false>, NameMapAll>;
 
 struct NameMapContainsKeyLike { static constexpr auto name = "mapContainsKeyLike"; };
-using FunctionMapContainsKeyLike = FunctionMapToArrayAdapter<FunctionArrayExists, MapLikeAdapter<NameMapContainsKeyLike, false, 0>, NameMapContainsKeyLike>;
+using FunctionMapContainsKeyLike = FunctionWithLowCardinalityFastPath<
+    FunctionMapToArrayAdapter<FunctionArrayExists, MapLikeAdapter<NameMapContainsKeyLike, false, 0>, NameMapContainsKeyLike>>;
 
 struct NameMapContainsValueLike { static constexpr auto name = "mapContainsValueLike"; };
-using FunctionMapContainsValueLike = FunctionMapToArrayAdapter<FunctionArrayExists, MapLikeAdapter<NameMapContainsValueLike, false, 1>, NameMapContainsValueLike>;
+using FunctionMapContainsValueLike = FunctionWithLowCardinalityFastPath<
+    FunctionMapToArrayAdapter<FunctionArrayExists, MapLikeAdapter<NameMapContainsValueLike, false, 1>, NameMapContainsValueLike>>;
 
 struct NameMapExtractKeyLike { static constexpr auto name = "mapExtractKeyLike"; };
-using FunctionMapExtractKeyLike = FunctionMapToArrayAdapter<FunctionArrayFilter, MapLikeAdapter<NameMapExtractKeyLike, true, 0>, NameMapExtractKeyLike>;
+using FunctionMapExtractKeyLike = FunctionWithLowCardinalityFastPath<
+    FunctionMapToArrayAdapter<FunctionArrayFilter, MapLikeAdapter<NameMapExtractKeyLike, true, 0>, NameMapExtractKeyLike>>;
 
 struct NameMapExtractValueLike { static constexpr auto name = "mapExtractValueLike"; };
-using FunctionMapExtractValueLike = FunctionMapToArrayAdapter<FunctionArrayFilter, MapLikeAdapter<NameMapExtractValueLike, true, 1>, NameMapExtractValueLike>;
+using FunctionMapExtractValueLike = FunctionWithLowCardinalityFastPath<
+    FunctionMapToArrayAdapter<FunctionArrayFilter, MapLikeAdapter<NameMapExtractValueLike, true, 1>, NameMapExtractValueLike>>;
 
 struct NameMapSort { static constexpr auto name = "mapSort"; };
 struct NameMapReverseSort { static constexpr auto name = "mapReverseSort"; };

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1922,7 +1922,7 @@ bool castColumnString(const IColumn * column, F && f)
     return castTypeToEither<ColumnString, ColumnFixedString>(column, std::forward<F>(f));
 }
 
-static bool isStringOrFixedStringColumn(const IColumn & column)
+bool isStringOrFixedStringColumn(const IColumn & column)
 {
     return typeid_cast<const ColumnString *>(&column) || typeid_cast<const ColumnFixedString *>(&column);
 }

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -62,14 +62,28 @@ public:
     static constexpr auto name = (mode == ArrayElementExceptionMode::Zero) ? "arrayElement" : "arrayElementOrNull";
     static FunctionPtr create(ContextPtr context_);
 
+    /// The specialized LowCardinality execution path requires opting out of the default
+    /// LowCardinality implementation, so that executeImpl can see LowCardinality columns.
+    /// When the specialized path does not apply, both return type deduction and execution
+    /// delegate to an instance created with `use_low_cardinality_fast_path = false`, which
+    /// restores the default framework behavior for LowCardinality arguments.
+    explicit FunctionArrayElement(bool use_low_cardinality_fast_path_ = true)
+        : use_low_cardinality_fast_path(use_low_cardinality_fast_path_)
+    {
+    }
+
     String getName() const override;
 
-    bool useDefaultImplementationForConstants() const override { return true; }
-    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+    /// The default implementation for constants must stay disabled together with the default
+    /// LowCardinality implementation: it normally runs after it and would otherwise unwrap
+    /// constants that the delegated LowCardinality handling relies on (see executeImpl).
+    bool useDefaultImplementationForConstants() const override { return !use_low_cardinality_fast_path; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return !use_low_cardinality_fast_path; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 2; }
 
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
 
     ColumnPtr
     executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
@@ -189,6 +203,8 @@ private:
     template <typename Matcher>
     static void
     executeMatchConstKeyToIndex(size_t num_rows, size_t num_values, PaddedPODArray<UInt64> & matched_idxs, const Matcher & matcher);
+
+    bool use_low_cardinality_fast_path = true;
 };
 
 
@@ -2178,14 +2194,36 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
 }
 
 template <ArrayElementExceptionMode mode>
+DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
+{
+    /// Opting out of the default LowCardinality implementation also disables the default return
+    /// type deduction for LowCardinality arguments (in particular, the nullability of a
+    /// LowCardinality(Nullable) index and the LowCardinality wrapping of the result type).
+    /// Delegate to an instance with the default implementation enabled, so that the deduced type
+    /// is exactly the same as if the specialized LowCardinality path did not exist.
+    if (use_low_cardinality_fast_path && hasLowCardinalityTypes(arguments))
+        return FunctionToOverloadResolverAdaptor(std::make_shared<FunctionArrayElement<mode>>(/*use_low_cardinality_fast_path_=*/ false))
+            .getReturnType(arguments);
+
+    DataTypes data_types(arguments.size());
+    for (size_t i = 0; i < arguments.size(); ++i)
+        data_types[i] = arguments[i].type;
+
+    return getReturnTypeImpl(data_types);
+}
+
+template <ArrayElementExceptionMode mode>
 ColumnPtr FunctionArrayElement<mode>::executeLowCardinality(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
     if (arguments.size() != 2 || !isColumnConst(*arguments[1].column))
         return nullptr;
 
-    if (getNullPresense(arguments).has_nullable)
-        return nullptr;
+    /// Nullable and LowCardinality(Nullable) arguments make the result type Nullable,
+    /// which this path does not produce. Leave them to the default implementations.
+    for (const auto & argument : arguments)
+        if (isNullableOrLowCardinalityNullable(argument.type))
+            return nullptr;
 
     Field index = (*arguments[1].column)[0];
     if ((index.getType() == Field::Types::UInt64 && index.safeGet<UInt64>() == 0)
@@ -2229,16 +2267,21 @@ template <ArrayElementExceptionMode mode>
 ColumnPtr FunctionArrayElement<mode>::executeImpl(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
-    if (auto result = executeLowCardinality(arguments, result_type, input_rows_count))
-        return result;
-
-    auto arguments_without_low_cardinality = arguments;
-    if (convertLowCardinalityColumnsToFull(arguments_without_low_cardinality))
+    if (use_low_cardinality_fast_path)
     {
-        /// Re-enter the function through the framework so that the default implementations
-        /// (in particular for Nullable arguments uncovered by removing LowCardinality) are applied.
-        return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionArrayElement<mode>>())
-            .execute(arguments_without_low_cardinality, result_type, input_rows_count, /*dry_run=*/ false);
+        if (auto result = executeLowCardinality(arguments, result_type, input_rows_count))
+            return result;
+
+        if (hasLowCardinalityTypes(arguments) || allArgumentColumnsAreConstant(arguments))
+        {
+            /// The specialized LowCardinality path does not apply. Re-enter the function through
+            /// the framework with the default implementations (for LowCardinality and constant
+            /// arguments) enabled, so that conversion of LowCardinality arguments or execution on
+            /// the dictionary, constant unwrapping and Nullable handling are applied in the usual
+            /// order, exactly as if the specialized path did not exist.
+            return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionArrayElement<mode>>(/*use_low_cardinality_fast_path_=*/ false))
+                .execute(arguments, result_type, input_rows_count, /*dry_run=*/ false);
+        }
     }
 
     const auto * col_map = checkAndGetColumn<ColumnMap>(arguments[0].column.get());

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1,6 +1,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
@@ -15,6 +16,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Functions/LowCardinalityExecutionHelpers.h>
 #include <Functions/castTypeToEither.h>
 #include <Interpreters/Context_fwd.h>
 #include <Common/assert_cast.h>
@@ -69,6 +71,9 @@ public:
 
     ColumnPtr
     executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
+
+    ColumnPtr executeWithLowCardinalityColumns(
+        const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const override;
 
 private:
     ColumnPtr perform(
@@ -1922,13 +1927,42 @@ template <ArrayElementExceptionMode mode>
 bool FunctionArrayElement<mode>::matchKeyToIndexStringConst(
     const IColumn & data, const Offsets & offsets, const Field & index, PaddedPODArray<UInt64> & matched_idxs)
 {
+    if (index.getType() != Field::Types::String)
+        return false;
+
+    if (const auto * low_cardinality_data = typeid_cast<const ColumnLowCardinality *>(&data))
+    {
+        const auto & requested_key = index.safeGet<String>();
+        auto dictionary_index = low_cardinality_data->getDictionary().getOrFindValueIndex(requested_key);
+        matched_idxs.reserve(offsets.size());
+
+        if (!dictionary_index)
+        {
+            matched_idxs.resize_fill(offsets.size());
+            return true;
+        }
+
+        struct MatcherLowCardinalityStringConst
+        {
+            const ColumnLowCardinality & data;
+            UInt64 dictionary_index;
+
+            bool match(size_t row_data, size_t /* row_index */) const
+            {
+                return data.getIndexAt(row_data) == dictionary_index;
+            }
+        };
+
+        MatcherLowCardinalityStringConst matcher{*low_cardinality_data, *dictionary_index};
+        executeMatchKeyToIndex(offsets, matched_idxs, matcher);
+        return true;
+    }
+
     return castColumnString(
         &data,
         [&](const auto & data_column)
         {
             using DataColumn = std::decay_t<decltype(data_column)>;
-            if (index.getType() != Field::Types::String)
-                return false;
             MatcherStringConst<DataColumn> matcher{data_column, index.safeGet<String>()};
             executeMatchKeyToIndex(offsets, matched_idxs, matcher);
             return true;
@@ -2138,6 +2172,54 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
 
     auto nested_type = array_type->getNestedType();
     return is_null_mode && nested_type->canBeInsideNullable() ? makeNullable(nested_type) : nested_type;
+}
+
+template <ArrayElementExceptionMode mode>
+ColumnPtr FunctionArrayElement<mode>::executeWithLowCardinalityColumns(
+    const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+{
+    if (dry_run || arguments.size() != 2 || !isColumnConst(*arguments[1].column))
+        return nullptr;
+
+    if (getNullPresense(arguments).has_nullable)
+        return nullptr;
+
+    Field index = (*arguments[1].column)[0];
+    if ((index.getType() == Field::Types::UInt64 && index.safeGet<UInt64>() == 0)
+        || (index.getType() == Field::Types::Int64 && index.safeGet<Int64>() == 0))
+        return nullptr;
+
+    /// Only optimize arrayElement here. arrayElementOrNull would need to build the null map
+    /// for out-of-bounds rows, which is a separate path from the measured materialization hot spot.
+    if constexpr (!is_null_mode)
+    {
+        if (const auto * col_array = checkAndGetColumn<ColumnArray>(arguments[0].column.get()))
+        {
+            const auto * low_cardinality_data = typeid_cast<const ColumnLowCardinality *>(&col_array->getData());
+            const auto & array_type = assert_cast<const DataTypeArray &>(*arguments[0].type);
+            if (low_cardinality_data
+                && isStringOrFixedString(removeLowCardinality(array_type.getNestedType()))
+                && (index.getType() == Field::Types::UInt64 || index.getType() == Field::Types::Int64))
+                return LowCardinalityExecutionHelpers::LowCardinalityArrayView{
+                    .elements = *low_cardinality_data,
+                    .offsets = col_array->getOffsets(),
+                    .rows = input_rows_count,
+                }.arrayElementConst(index, *result_type);
+        }
+    }
+
+    const auto * col_map = checkAndGetColumn<ColumnMap>(arguments[0].column.get());
+    if (!col_map)
+        return nullptr;
+
+    const auto & map_column = *col_map;
+    if (!typeid_cast<const ColumnLowCardinality *>(&map_column.getNestedData().getColumn(0)))
+        return nullptr;
+
+    if (index.getType() != Field::Types::String)
+        return nullptr;
+
+    return recursiveRemoveLowCardinality(executeMap(arguments, result_type, input_rows_count));
 }
 
 template <ArrayElementExceptionMode mode>

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1941,6 +1941,11 @@ bool castColumnString(const IColumn * column, F && f)
     return castTypeToEither<ColumnString, ColumnFixedString>(column, std::forward<F>(f));
 }
 
+static bool isStringOrFixedStringColumn(const IColumn & column)
+{
+    return typeid_cast<const ColumnString *>(&column) || typeid_cast<const ColumnFixedString *>(&column);
+}
+
 template <ArrayElementExceptionMode mode>
 bool FunctionArrayElement<mode>::matchKeyToIndexStringConst(
     const IColumn & data, const Offsets & offsets, const Field & index, PaddedPODArray<UInt64> & matched_idxs)
@@ -1948,7 +1953,12 @@ bool FunctionArrayElement<mode>::matchKeyToIndexStringConst(
     if (index.getType() != Field::Types::String)
         return false;
 
-    if (const auto * low_cardinality_data = typeid_cast<const ColumnLowCardinality *>(&data))
+    /// The dictionary lookup below is defined only for String and FixedString keys. For other
+    /// LowCardinality key types, fall through so that the regular dispatch reports the type error
+    /// instead of silently finding no match.
+    const auto * low_cardinality_data = typeid_cast<const ColumnLowCardinality *>(&data);
+    if (low_cardinality_data
+        && isStringOrFixedStringColumn(*low_cardinality_data->getDictionary().getNestedNotNullableColumn()))
     {
         const auto & requested_key = index.safeGet<String>();
         auto dictionary_index = low_cardinality_data->getDictionary().getOrFindValueIndex(requested_key);
@@ -2255,6 +2265,13 @@ ColumnPtr FunctionArrayElement<mode>::executeLowCardinality(
 
     const auto & map_column = *col_map;
     if (!typeid_cast<const ColumnLowCardinality *>(&map_column.getNestedData().getColumn(0)))
+        return nullptr;
+
+    /// The string key lookup below is defined only for String and FixedString keys. For other
+    /// LowCardinality key types, leave the arguments to the default implementations so that the
+    /// regular dispatch reports the type error, exactly as without the specialized path.
+    const auto & map_type = assert_cast<const DataTypeMap &>(*arguments[0].type);
+    if (!isStringOrFixedString(removeLowCardinality(map_type.getKeyType())))
         return nullptr;
 
     if (index.getType() != Field::Types::String)

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -64,6 +64,7 @@ public:
     String getName() const override;
 
     bool useDefaultImplementationForConstants() const override { return true; }
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 2; }
 
@@ -72,10 +73,10 @@ public:
     ColumnPtr
     executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
 
-    ColumnPtr executeWithLowCardinalityColumns(
-        const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const override;
-
 private:
+    ColumnPtr executeLowCardinality(
+        const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const;
+
     ColumnPtr perform(
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
@@ -2147,7 +2148,7 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
 {
     if (const auto * map_type = checkAndGetDataType<DataTypeMap>(arguments[0].get()))
     {
-        auto value_type = map_type->getValueType();
+        auto value_type = recursiveRemoveLowCardinality(map_type->getValueType());
         return is_null_mode && value_type->canBeInsideNullable() ? makeNullable(value_type) : value_type;
     }
 
@@ -2170,15 +2171,15 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
             arguments[1]->getName());
     }
 
-    auto nested_type = array_type->getNestedType();
+    auto nested_type = recursiveRemoveLowCardinality(array_type->getNestedType());
     return is_null_mode && nested_type->canBeInsideNullable() ? makeNullable(nested_type) : nested_type;
 }
 
 template <ArrayElementExceptionMode mode>
-ColumnPtr FunctionArrayElement<mode>::executeWithLowCardinalityColumns(
-    const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count, bool dry_run) const
+ColumnPtr FunctionArrayElement<mode>::executeLowCardinality(
+    const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
-    if (dry_run || arguments.size() != 2 || !isColumnConst(*arguments[1].column))
+    if (arguments.size() != 2 || !isColumnConst(*arguments[1].column))
         return nullptr;
 
     if (getNullPresense(arguments).has_nullable)
@@ -2226,6 +2227,13 @@ template <ArrayElementExceptionMode mode>
 ColumnPtr FunctionArrayElement<mode>::executeImpl(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
+    if (auto result = executeLowCardinality(arguments, result_type, input_rows_count))
+        return result;
+
+    auto arguments_without_low_cardinality = arguments;
+    if (convertLowCardinalityColumnsToFull(arguments_without_low_cardinality))
+        return executeImpl(arguments_without_low_cardinality, result_type, input_rows_count);
+
     const auto * col_map = checkAndGetColumn<ColumnMap>(arguments[0].column.get());
     const auto * col_const_map = checkAndGetColumnConst<ColumnMap>(arguments[0].column.get());
 

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -2162,7 +2162,8 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
             arguments[0]->getName());
     }
 
-    if (!isNativeInteger(arguments[1]))
+    auto index_type = removeNullable(removeLowCardinality(arguments[1]));
+    if (!isNativeInteger(index_type))
     {
         throw Exception(
             ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -15,8 +15,8 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
+#include <Functions/FunctionLowCardinalityFastPath.h>
 #include <Functions/IFunction.h>
-#include <Functions/IFunctionAdaptors.h>
 #include <Functions/LowCardinalityExecutionHelpers.h>
 #include <Functions/castTypeToEither.h>
 #include <Interpreters/Context_fwd.h>
@@ -55,43 +55,33 @@ class NullMapBuilder;
   * The index begins with 1. Also, the index can be negative - then it is counted from the end of the array.
   */
 template <ArrayElementExceptionMode mode = ArrayElementExceptionMode::Zero>
-class FunctionArrayElement final : public IFunction
+class FunctionArrayElement : public IFunction
 {
 public:
     static constexpr bool is_null_mode = (mode == ArrayElementExceptionMode::Null);
     static constexpr auto name = (mode == ArrayElementExceptionMode::Zero) ? "arrayElement" : "arrayElementOrNull";
-    static FunctionPtr create(ContextPtr context_);
-
-    /// The specialized LowCardinality execution path requires opting out of the default
-    /// LowCardinality implementation, so that executeImpl can see LowCardinality columns.
-    /// When the specialized path does not apply, both return type deduction and execution
-    /// delegate to an instance created with `use_low_cardinality_fast_path = false`, which
-    /// restores the default framework behavior for LowCardinality arguments.
-    explicit FunctionArrayElement(bool use_low_cardinality_fast_path_ = true)
-        : use_low_cardinality_fast_path(use_low_cardinality_fast_path_)
-    {
-    }
 
     String getName() const override;
 
-    /// The default implementation for constants must stay disabled together with the default
-    /// LowCardinality implementation: it normally runs after it and would otherwise unwrap
-    /// constants that the delegated LowCardinality handling relies on (see executeImpl).
-    bool useDefaultImplementationForConstants() const override { return !use_low_cardinality_fast_path; }
-    bool useDefaultImplementationForLowCardinalityColumns() const override { return !use_low_cardinality_fast_path; }
+    bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
     size_t getNumberOfArguments() const override { return 2; }
 
+    /// Keep the inherited getReturnTypeImpl(ColumnsWithTypeAndName) visible alongside the
+    /// overload declared below; FunctionWithLowCardinalityFastPath calls it by qualified name.
+    using IFunction::getReturnTypeImpl;
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override;
-    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override;
 
     ColumnPtr
     executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override;
 
-private:
-    ColumnPtr executeLowCardinality(
+    /// Fast path hook for FunctionWithLowCardinalityFastPath (see FunctionLowCardinalityFastPath.h):
+    /// element access over Array(LowCardinality(String)) and Map with LowCardinality string keys
+    /// without materializing the dictionary into full columns. Returns nullptr to decline.
+    ColumnPtr tryExecuteLowCardinality(
         const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const;
 
+private:
     ColumnPtr perform(
         const ColumnsWithTypeAndName & arguments,
         const DataTypePtr & result_type,
@@ -203,8 +193,6 @@ private:
     template <typename Matcher>
     static void
     executeMatchConstKeyToIndex(size_t num_rows, size_t num_values, PaddedPODArray<UInt64> & matched_idxs, const Matcher & matcher);
-
-    bool use_low_cardinality_fast_path = true;
 };
 
 
@@ -892,13 +880,6 @@ struct ArrayElementGenericImpl
 };
 
 }
-
-template <ArrayElementExceptionMode mode>
-FunctionPtr FunctionArrayElement<mode>::create(ContextPtr)
-{
-    return std::make_shared<FunctionArrayElement>();
-}
-
 
 template <ArrayElementExceptionMode mode>
 template <typename DataType>
@@ -2204,26 +2185,7 @@ DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const DataTypes & argu
 }
 
 template <ArrayElementExceptionMode mode>
-DataTypePtr FunctionArrayElement<mode>::getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const
-{
-    /// Opting out of the default LowCardinality implementation also disables the default return
-    /// type deduction for LowCardinality arguments (in particular, the nullability of a
-    /// LowCardinality(Nullable) index and the LowCardinality wrapping of the result type).
-    /// Delegate to an instance with the default implementation enabled, so that the deduced type
-    /// is exactly the same as if the specialized LowCardinality path did not exist.
-    if (use_low_cardinality_fast_path && hasLowCardinalityTypes(arguments))
-        return FunctionToOverloadResolverAdaptor(std::make_shared<FunctionArrayElement<mode>>(/*use_low_cardinality_fast_path_=*/ false))
-            .getReturnType(arguments);
-
-    DataTypes data_types(arguments.size());
-    for (size_t i = 0; i < arguments.size(); ++i)
-        data_types[i] = arguments[i].type;
-
-    return getReturnTypeImpl(data_types);
-}
-
-template <ArrayElementExceptionMode mode>
-ColumnPtr FunctionArrayElement<mode>::executeLowCardinality(
+ColumnPtr FunctionArrayElement<mode>::tryExecuteLowCardinality(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
     if (arguments.size() != 2 || !isColumnConst(*arguments[1].column))
@@ -2284,23 +2246,6 @@ template <ArrayElementExceptionMode mode>
 ColumnPtr FunctionArrayElement<mode>::executeImpl(
     const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
-    if (use_low_cardinality_fast_path)
-    {
-        if (auto result = executeLowCardinality(arguments, result_type, input_rows_count))
-            return result;
-
-        if (hasLowCardinalityTypes(arguments) || allArgumentColumnsAreConstant(arguments))
-        {
-            /// The specialized LowCardinality path does not apply. Re-enter the function through
-            /// the framework with the default implementations (for LowCardinality and constant
-            /// arguments) enabled, so that conversion of LowCardinality arguments or execution on
-            /// the dictionary, constant unwrapping and Nullable handling are applied in the usual
-            /// order, exactly as if the specialized path did not exist.
-            return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionArrayElement<mode>>(/*use_low_cardinality_fast_path_=*/ false))
-                .execute(arguments, result_type, input_rows_count, /*dry_run=*/ false);
-        }
-    }
-
     const auto * col_map = checkAndGetColumn<ColumnMap>(arguments[0].column.get());
     const auto * col_const_map = checkAndGetColumnConst<ColumnMap>(arguments[0].column.get());
 
@@ -2514,7 +2459,7 @@ Operator `[n]` provides the same functionality.
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
-    factory.registerFunction<FunctionArrayElement<ArrayElementExceptionMode::Zero>>(documentation);
+    factory.registerFunction<FunctionWithLowCardinalityFastPath<FunctionArrayElement<ArrayElementExceptionMode::Zero>>>(documentation);
 
     FunctionDocumentation::Description description_null = R"(
 Gets the element of the provided array with index `n` where `n` can be any integer type.
@@ -2540,6 +2485,6 @@ Negative indexes are supported. In this case, it selects the corresponding eleme
     FunctionDocumentation::Category category_null = FunctionDocumentation::Category::Array;
     FunctionDocumentation documentation_null = {description_null, syntax_null, arguments_null, {}, returned_value_null, examples_null, introduced_in_null, category_null};
 
-    factory.registerFunction<FunctionArrayElement<ArrayElementExceptionMode::Null>>(documentation_null);
+    factory.registerFunction<FunctionWithLowCardinalityFastPath<FunctionArrayElement<ArrayElementExceptionMode::Null>>>(documentation_null);
 }
 }

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -16,6 +16,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
+#include <Functions/IFunctionAdaptors.h>
 #include <Functions/LowCardinalityExecutionHelpers.h>
 #include <Functions/castTypeToEither.h>
 #include <Interpreters/Context_fwd.h>
@@ -2233,7 +2234,12 @@ ColumnPtr FunctionArrayElement<mode>::executeImpl(
 
     auto arguments_without_low_cardinality = arguments;
     if (convertLowCardinalityColumnsToFull(arguments_without_low_cardinality))
-        return executeImpl(arguments_without_low_cardinality, result_type, input_rows_count);
+    {
+        /// Re-enter the function through the framework so that the default implementations
+        /// (in particular for Nullable arguments uncovered by removing LowCardinality) are applied.
+        return FunctionToExecutableFunctionAdaptor(std::make_shared<FunctionArrayElement<mode>>())
+            .execute(arguments_without_low_cardinality, result_type, input_rows_count, /*dry_run=*/ false);
+    }
 
     const auto * col_map = checkAndGetColumn<ColumnMap>(arguments[0].column.get());
     const auto * col_const_map = checkAndGetColumnConst<ColumnMap>(arguments[0].column.get());

--- a/src/Functions/array/arrayIndex.h
+++ b/src/Functions/array/arrayIndex.h
@@ -6,6 +6,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
+#include <Functions/LowCardinalityExecutionHelpers.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -862,36 +863,20 @@ private:
 
         const auto & array_type  = assert_cast<const DataTypeArray &>(*arguments[0].type);
         const auto target_type = recursiveRemoveLowCardinality(array_type.getNestedType());
-        auto right = recursiveRemoveLowCardinality(right_const->getDataColumnPtr());
 
         UInt64 index = 0;
         UInt64 left_size = arguments[0].column->size();
         ResultColumnPtr col_result = ResultColumnType::create();
 
-        if (!right->isNullAt(0))
+        if (!LowCardinalityExecutionHelpers::dictionaryIndexForConstant(
+                *left_lc, right_const->getDataColumnPtr(), arguments[1].type, target_type, index))
         {
-            auto right_type = recursiveRemoveLowCardinality(arguments[1].type);
-            right = castColumn({right, right_type, ""}, target_type);
+            col_result->getData().resize_fill(col_array->size());
 
-            if (right->isNullable())
-                right = checkAndGetColumn<ColumnNullable>(*right).getNestedColumnPtr();
+            if (col_array_const)
+                return ColumnConst::create(std::move(col_result), left_size);
 
-            std::string_view elem = right->getDataAt(0);
-            const auto & left_dict = left_lc->getDictionary();
-
-            if (std::optional<UInt64> maybe_index = left_dict.getOrFindValueIndex(elem); maybe_index)
-            {
-                index = *maybe_index;
-            }
-            else
-            {
-                col_result->getData().resize_fill(col_array->size());
-
-                if (col_array_const)
-                    return ColumnConst::create(std::move(col_result), left_size);
-
-                return col_result;
-            }
+            return col_result;
         }
 
         Impl::Main<ConcreteAction, true>::vector(

--- a/tests/performance/low_cardinality_nested_function_fast_paths.xml
+++ b/tests/performance/low_cardinality_nested_function_fast_paths.xml
@@ -1,0 +1,34 @@
+<test>
+    <create_query>DROP TABLE IF EXISTS perf_nested_lc_functions</create_query>
+    <create_query>CREATE TABLE perf_nested_lc_functions
+        (
+            id UInt64,
+            arr_lc Array(LowCardinality(String)),
+            map_key_lc Map(LowCardinality(String), String),
+            map_value_lc Map(String, LowCardinality(String))
+        )
+        ENGINE = MergeTree
+        ORDER BY id
+    </create_query>
+
+    <fill_query>INSERT INTO perf_nested_lc_functions
+        SELECT
+            number AS id,
+            arrayMap(x -> concat('k', toString((id + x) % 128)), range(16)) AS arr_lc,
+            mapFromArrays(
+                arrayMap(x -> concat('k', toString((id + x) % 128)), range(16)),
+                arrayMap(x -> concat('v', toString((id + x) % 128)), range(16))) AS map_key_lc,
+            mapFromArrays(
+                arrayMap(x -> concat('k', toString((id + x) % 128)), range(16)),
+                arrayMap(x -> concat('v', toString((id + x) % 128)), range(16))) AS map_value_lc
+        FROM numbers(1000000)
+    </fill_query>
+
+    <query>SELECT sum(length(arr_lc[7])) FROM perf_nested_lc_functions</query>
+    <query>SELECT sum(toUInt64(mapContainsKeyLike(map_key_lc, 'k1%'))) FROM perf_nested_lc_functions</query>
+    <query>SELECT sum(length(mapExtractKeyLike(map_key_lc, 'k1%'))) FROM perf_nested_lc_functions</query>
+    <query>SELECT sum(toUInt64(mapContainsValueLike(map_value_lc, 'v1%'))) FROM perf_nested_lc_functions</query>
+    <query>SELECT sum(length(mapExtractValueLike(map_value_lc, 'v1%'))) FROM perf_nested_lc_functions</query>
+
+    <drop_query>DROP TABLE IF EXISTS perf_nested_lc_functions</drop_query>
+</test>

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
@@ -51,3 +51,6 @@ low cardinality nullable patterns
 {'key1':'v'}	Map(String, String)
 1	Nullable(UInt8)
 {'k':'val1'}	Map(String, String)
+low cardinality map key type checks
+v	String
+	String

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
@@ -31,3 +31,4 @@ x	Nullable(String)
 \N	{}
 1	{'k1':'alpha'}
 \N	{}
+10

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
@@ -32,3 +32,22 @@ x	Nullable(String)
 1	{'k1':'alpha'}
 \N	{}
 10
+low cardinality nullable arguments
+\N	Nullable(String)
+x	Nullable(String)
+\N	Nullable(String)
+x	Nullable(String)
+\N	Nullable(String)
+v	Nullable(String)
+\N	Nullable(String)
+10	LowCardinality(Nullable(UInt8))
+10	LowCardinality(Nullable(UInt8))
+low cardinality result types
+x	LowCardinality(String)
+x	LowCardinality(Nullable(String))
+low cardinality nullable patterns
+1	Nullable(UInt8)
+\N	Nullable(UInt8)
+{'key1':'v'}	Map(String, String)
+1	Nullable(UInt8)
+{'k':'val1'}	Map(String, String)

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.reference
@@ -1,0 +1,33 @@
+arrayElement Array(LowCardinality)
+1	alpha	beta	gamma	
+2	beta	delta	delta	
+3				
+4	alpha	alphabet	alphabet	
+mapContainsKeyLike and mapExtractKeyLike
+1	1	1	{'alpha':'one'}
+2	0	0	{}
+3	0	0	{}
+4	1	1	{'alpha':'again','alphabet':'letters'}
+mapContainsValueLike and mapExtractValueLike
+1	1	1	{'k1':'alpha'}
+2	0	0	{}
+3	0	0	{}
+4	1	1	{'k1':'alpha','k5':'alphabet'}
+constant map fallbacks
+0	one
+1	one
+0	String	one
+1	String	one
+0	1	{'alpha':'one'}
+1	1	{'alpha':'one'}
+0	1	{'alpha':'one'}
+1	1	{'alpha':'one'}
+0	1	{'k1':'alpha'}
+1	1	{'k1':'alpha'}
+nullable argument fallbacks
+x	Nullable(String)
+\N	Nullable(String)
+1	{'alpha':'one'}
+\N	{}
+1	{'k1':'alpha'}
+\N	{}

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
@@ -66,6 +66,7 @@ SELECT mapContainsKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinal
 SELECT mapContainsKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), CAST(NULL, 'Nullable(String)')), mapSort(mapExtractKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), CAST(NULL, 'Nullable(String)')));
 SELECT mapContainsValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), toNullable('alp%')), mapSort(mapExtractValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), toNullable('alp%')));
 SELECT mapContainsValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), CAST(NULL, 'Nullable(String)')), mapSort(mapExtractValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), CAST(NULL, 'Nullable(String)')));
+SELECT [[10, 2, 13, 15][toNullable(toLowCardinality(1))]][materialize(toLowCardinality(1))];
 
 SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[0]; -- { serverError ZERO_ARRAY_OR_TUPLE_INDEX }
 

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
@@ -1,0 +1,72 @@
+DROP TABLE IF EXISTS t_nested_lc_fast_paths;
+
+CREATE TABLE t_nested_lc_fast_paths
+(
+    id UInt64,
+    arr_lc Array(LowCardinality(String)),
+    map_key_lc Map(LowCardinality(String), String),
+    map_value_lc Map(String, LowCardinality(String))
+)
+ENGINE = Memory;
+
+INSERT INTO t_nested_lc_fast_paths VALUES
+    (1, ['alpha', 'beta', 'gamma'], {'alpha' : 'one', 'beta' : 'two', 'other' : 'zzz'}, {'k1' : 'alpha', 'k2' : 'beta', 'other' : 'zzz'}),
+    (2, ['beta', 'delta'], {'beta' : 'twenty', 'delta' : 'four'}, {'k1' : 'beta', 'k4' : 'delta'}),
+    (3, [], {}, {}),
+    (4, ['alpha', 'alphabet'], {'alpha' : 'again', 'alphabet' : 'letters'}, {'k1' : 'alpha', 'k5' : 'alphabet'});
+
+SELECT 'arrayElement Array(LowCardinality)';
+SELECT id, arr_lc[1], arr_lc[2], arr_lc[-1], arr_lc[99]
+FROM t_nested_lc_fast_paths
+ORDER BY id;
+
+SELECT 'mapContainsKeyLike and mapExtractKeyLike';
+SELECT
+    id,
+    mapContainsKeyLike(map_key_lc, 'alpha'),
+    mapContainsKeyLike(map_key_lc, 'alp%'),
+    mapSort(mapExtractKeyLike(map_key_lc, 'alp%'))
+FROM t_nested_lc_fast_paths
+ORDER BY id;
+
+SELECT 'mapContainsValueLike and mapExtractValueLike';
+SELECT
+    id,
+    mapContainsValueLike(map_value_lc, 'alpha'),
+    mapContainsValueLike(map_value_lc, 'alp%'),
+    mapSort(mapExtractValueLike(map_value_lc, 'alp%'))
+FROM t_nested_lc_fast_paths
+ORDER BY id;
+
+SELECT 'constant map fallbacks';
+SELECT number, map(toLowCardinality('alpha'), 'one')['alpha']
+FROM numbers(2)
+ORDER BY number;
+SELECT number, toTypeName(value), value
+FROM
+(
+    SELECT number, materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), LowCardinality(String))'))['alpha'] AS value
+    FROM numbers(2)
+)
+ORDER BY number;
+SELECT number, mapContainsKeyLike(map(toLowCardinality('alpha'), 'one'), 'alp%'), mapSort(mapExtractKeyLike(map(toLowCardinality('alpha'), 'one'), 'alp%'))
+FROM numbers(2)
+ORDER BY number;
+SELECT number, mapContainsKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), toLowCardinality('alp%')), mapSort(mapExtractKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), toLowCardinality('alp%')))
+FROM numbers(2)
+ORDER BY number;
+SELECT number, mapContainsValueLike(map('k1', toLowCardinality('alpha')), 'alp%'), mapSort(mapExtractValueLike(map('k1', toLowCardinality('alpha')), 'alp%'))
+FROM numbers(2)
+ORDER BY number;
+
+SELECT 'nullable argument fallbacks';
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[toNullable(1)], toTypeName(materialize(CAST(['x'], 'Array(LowCardinality(String))'))[toNullable(1)]);
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[CAST(NULL, 'Nullable(UInt8)')], toTypeName(materialize(CAST(['x'], 'Array(LowCardinality(String))'))[CAST(NULL, 'Nullable(UInt8)')]);
+SELECT mapContainsKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), toNullable('alp%')), mapSort(mapExtractKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), toNullable('alp%')));
+SELECT mapContainsKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), CAST(NULL, 'Nullable(String)')), mapSort(mapExtractKeyLike(materialize(CAST(map('alpha', 'one'), 'Map(LowCardinality(String), String)')), CAST(NULL, 'Nullable(String)')));
+SELECT mapContainsValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), toNullable('alp%')), mapSort(mapExtractValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), toNullable('alp%')));
+SELECT mapContainsValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), CAST(NULL, 'Nullable(String)')), mapSort(mapExtractValueLike(materialize(CAST(map('k1', 'alpha'), 'Map(String, LowCardinality(String))')), CAST(NULL, 'Nullable(String)')));
+
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[0]; -- { serverError ZERO_ARRAY_OR_TUPLE_INDEX }
+
+DROP TABLE t_nested_lc_fast_paths;

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
@@ -70,4 +70,27 @@ SELECT [[10, 2, 13, 15][toNullable(toLowCardinality(1))]][materialize(toLowCardi
 
 SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[0]; -- { serverError ZERO_ARRAY_OR_TUPLE_INDEX }
 
+SELECT 'low cardinality nullable arguments';
+SET allow_suspicious_low_cardinality_types = 1;
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[CAST(NULL, 'LowCardinality(Nullable(UInt8))')] AS v, toTypeName(v);
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[CAST(1, 'LowCardinality(Nullable(UInt8))')] AS v, toTypeName(v);
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[materialize(CAST(NULL, 'LowCardinality(Nullable(UInt8))'))] AS v, toTypeName(v);
+SELECT materialize(CAST(['x'], 'Array(LowCardinality(String))'))[materialize(CAST(1, 'LowCardinality(Nullable(UInt8))'))] AS v, toTypeName(v);
+SELECT arrayElementOrNull(materialize(CAST(['x'], 'Array(LowCardinality(String))')), CAST(NULL, 'LowCardinality(Nullable(UInt8))')) AS v, toTypeName(v);
+SELECT materialize(CAST(map('k', 'v'), 'Map(LowCardinality(String), String)'))[CAST('k', 'LowCardinality(Nullable(String))')] AS v, toTypeName(v);
+SELECT materialize(CAST(map('k', 'v'), 'Map(LowCardinality(String), String)'))[CAST(NULL, 'LowCardinality(Nullable(String))')] AS v, toTypeName(v);
+SELECT [10, 2, 13, 15][toNullable(toLowCardinality(1))] AS v, toTypeName(v);
+SELECT [[10, 2, 13, 15][toNullable(toLowCardinality(1))]][materialize(toLowCardinality(1))] AS v, toTypeName(v);
+
+SELECT 'low cardinality result types';
+SELECT CAST(['x'], 'Array(LowCardinality(String))')[materialize(toLowCardinality(1))] AS v, toTypeName(v);
+SELECT CAST(['x'], 'Array(String)')[materialize(CAST(1, 'LowCardinality(Nullable(UInt8))'))] AS v, toTypeName(v);
+
+SELECT 'low cardinality nullable patterns';
+SELECT mapContainsKeyLike(materialize(CAST(map('key1', 'v'), 'Map(LowCardinality(String), String)')), CAST('k%', 'LowCardinality(Nullable(String))')) AS v, toTypeName(v);
+SELECT mapContainsKeyLike(materialize(CAST(map('key1', 'v'), 'Map(LowCardinality(String), String)')), CAST(NULL, 'LowCardinality(Nullable(String))')) AS v, toTypeName(v);
+SELECT mapSort(mapExtractKeyLike(materialize(CAST(map('key1', 'v'), 'Map(LowCardinality(String), String)')), CAST('k%', 'LowCardinality(Nullable(String))'))) AS v, toTypeName(v);
+SELECT mapContainsValueLike(materialize(CAST(map('k', 'val1'), 'Map(String, LowCardinality(String))')), CAST('v%', 'LowCardinality(Nullable(String))')) AS v, toTypeName(v);
+SELECT mapSort(mapExtractValueLike(materialize(CAST(map('k', 'val1'), 'Map(String, LowCardinality(String))')), CAST('v%', 'LowCardinality(Nullable(String))'))) AS v, toTypeName(v);
+
 DROP TABLE t_nested_lc_fast_paths;

--- a/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
+++ b/tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql
@@ -93,4 +93,10 @@ SELECT mapSort(mapExtractKeyLike(materialize(CAST(map('key1', 'v'), 'Map(LowCard
 SELECT mapContainsValueLike(materialize(CAST(map('k', 'val1'), 'Map(String, LowCardinality(String))')), CAST('v%', 'LowCardinality(Nullable(String))')) AS v, toTypeName(v);
 SELECT mapSort(mapExtractValueLike(materialize(CAST(map('k', 'val1'), 'Map(String, LowCardinality(String))')), CAST('v%', 'LowCardinality(Nullable(String))'))) AS v, toTypeName(v);
 
+SELECT 'low cardinality map key type checks';
+SELECT materialize(CAST(map('ab', 'v'), 'Map(LowCardinality(FixedString(2)), String)'))['ab'] AS v, toTypeName(v);
+SELECT materialize(CAST(map('ab', 'v'), 'Map(LowCardinality(FixedString(2)), String)'))['a'] AS v, toTypeName(v);
+SELECT materialize(CAST(map(1, 'v'), 'Map(LowCardinality(UInt8), String)'))['1']; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT CAST(map(1, 'v'), 'Map(LowCardinality(UInt8), String)')['1']; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
 DROP TABLE t_nested_lc_fast_paths;


### PR DESCRIPTION
This PR avoids materializing `LowCardinality(String)` values inside `Array` and `Map` columns for a few common functions.

The PR is intended to be reviewed one commit at a time.

1. `Share LowCardinality dictionary lookup for array indexes`
   - Pure refactor of the existing `Array(LowCardinality)` implementation for `has`, `indexOf`, and `countEqual`.
   - Moves the conversion from constant value to LowCardinality dictionary index from `arrayIndex.h` into `LowCardinalityExecutionHelpers::dictionaryIndexForConstant`.
   - The row scan in `has`, `indexOf`, and `countEqual` is unchanged.
   - The helper is forced inline because this setup code is sensitive to code generation.

2. `Avoid materializing LowCardinality strings inside Array and Map`
   - Adds `executeWithLowCardinalityColumns`, which lets functions handle LowCardinality arguments before the generic implementation materializes them.
   - Adds shared helper code:
     - `LowCardinalityArrayView`: combines LowCardinality element indexes with array or map row offsets.
     - `dictionaryMatchesForSelectedIndexes`: evaluates a predicate on dictionary values, either for the whole dictionary or only for dictionary indexes used by the current block.
   - Uses dictionary indexes directly for:
     - `arrayElement(Array(LowCardinality(String)), const)`
     - `arrayElement(Map(LowCardinality(String), ...), const_string_key)`
     - `mapContainsKeyLike` / `mapExtractKeyLike` over `Map(LowCardinality(String), ...)`
     - `mapContainsValueLike` / `mapExtractValueLike` over `Map(..., LowCardinality(String))`

Scalar `LIKE(LowCardinality(String), const)` already executes over the LowCardinality dictionary. This PR handles the cases where the `LowCardinality(String)` is inside an `Array` or `Map`, where the generic implementation otherwise materializes strings before running the function.

Related: https://github.com/ClickHouse/ClickHouse/pull/107434
Closes: https://github.com/ClickHouse/ClickHouse/issues/103804

Benchmark notes: all numbers are from `clickhouse local` with `--print-profile-events --profile-events-delay-ms=-1`. CPU is median `OSCPUVirtualTimeMicroseconds`; lower is better.

The `x81` cases mean 81 repeated projections in one query, for example:

```sql
SELECT
    mapContainsKeyLike(m, 'k0'),
    mapContainsKeyLike(m, 'k1'),
    ...,
    mapContainsKeyLike(m, 'k80')
FROM t
FORMAT Null
```

The first commit is only a refactor, so this is a no-regression check rather than a claimed optimization:

<table>
  <tr><th>Query</th><th>Baseline CPU</th><th>Current CPU</th></tr>
  <tr><td><code>has(arr_lc, ...)</code> x81</td><td>1.847s</td><td>1.840s</td></tr>
  <tr><td><code>indexOf(arr_lc, ...)</code> x81</td><td>1.825s</td><td>1.391s</td></tr>
  <tr><td><code>countEqual(arr_lc, ...)</code> x81</td><td>6.885s</td><td>5.486s</td></tr>
</table>

The main benchmark uses 200k `MergeTree` rows and 200 `LowCardinality(String)` elements per row.

<table>
  <tr><th>Query</th><th>Baseline CPU</th><th>Current CPU</th><th>Speedup</th></tr>
  <tr><td><code>arrayElement(Array(LowCardinality(String)), const)</code> x81</td><td>10.174s</td><td>0.328s</td><td>31.00x</td></tr>
  <tr><td><code>mapContainsKeyLike</code> x81</td><td>18.899s</td><td>1.347s</td><td>14.03x</td></tr>
  <tr><td><code>mapExtractKeyLike</code> x20</td><td>9.338s</td><td>1.509s</td><td>6.19x</td></tr>
  <tr><td><code>mapContainsValueLike</code> x81</td><td>18.744s</td><td>0.780s</td><td>24.04x</td></tr>
  <tr><td><code>mapExtractValueLike</code> x20</td><td>8.997s</td><td>1.181s</td><td>7.62x</td></tr>
</table>

For queries that also read the full bucketed map, the work includes both the repeated function calls and returning the full map. The improvement is therefore smaller than in the isolated function benchmark above.

<table>
  <tr><th>Query</th><th>Bucketed baseline</th><th>With PR 107434</th><th>With this PR</th></tr>
  <tr><td>81 <code>map['k']</code> projections + full map</td><td>4.603s</td><td>3.734s</td><td>2.013s</td></tr>
</table>

The benefit increases with repeated projections. On 1M rows with 64 map entries per row, a single `mapContainsValueLike` improved from `1.632s` to `0.493s` CPU (`3.31x`), while 8 repeated projections improved `17.08x` and 32 repeated projections improved `19.82x`.

For map LIKE functions, the implementation evaluates LIKE over the whole dictionary only when the dictionary is not much larger than the selected elements. Otherwise it evaluates LIKE only for dictionary indexes used by the current block. Local benchmarks chose the ratio `4` to keep the cheap full-dictionary implementation for normal LowCardinality blocks while avoiding O(dictionary) LIKE work for small selected slices.

A broader regression sweep over small dictionaries, unique dictionaries, selected ranges, full reads, matching patterns, and nonmatching patterns was mostly parity or faster. The one slower case found was a tiny selected-range `mapContainsKeyLike` all-match query (`0.00225s` CPU to `0.00267s` CPU, same wall time), where the absolute cost is very small and the distinct-index setup can dominate.

Validation:

- Built `programs/clickhouse`.
- Ran `tests/queries/0_stateless/04337_low_cardinality_nested_function_fast_paths.sql` with `clickhouse local --multiquery`; output diffed cleanly against the new `.reference` file.
- Added and smoke tested `tests/performance/low_cardinality_nested_function_fast_paths.xml` locally with `clickhouse local`.
- Reran true baseline vs current benchmarks for the affected functions.
- Reran common full map queries.
- Reran single-predicate scaling checks.
- Ran a regression sweep over small and unique LowCardinality dictionaries, selected ranges and full reads, and matching and nonmatching LIKE patterns.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry:
Improve execution of `arrayElement` on `Array(LowCardinality(String))` and map LIKE functions on maps with `LowCardinality(String)` keys or values by avoiding unnecessary string materialization.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.2.73`
<!-- ch-version-info:end -->