### PR TITLE
Use COW-safe `IColumn::mutate` when finalizing merge output columns

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -248,9 +248,10 @@ try
         {
             chassert(read_task_info->merged_part_offsets->isFinalized());
 
-            result_column = result_column->convertToFullColumnIfSparse();
-            auto & column = result_column->assumeMutableRef();
-            auto & offset_data = assert_cast<ColumnUInt64 &>(column).getData();
+            /// Use `IColumn::mutate` instead of `assumeMutableRef` so the column is cloned
+            /// when it is shared. Mutating a shared column in place is a copy-on-write violation.
+            auto mutable_column = IColumn::mutate(result_column->convertToFullColumnIfSparse());
+            auto & offset_data = assert_cast<ColumnUInt64 &>(*mutable_column).getData();
             if (read_task_info->merged_part_offsets->isMappingEnabled())
             {
                 for (auto & offset : offset_data)
@@ -261,8 +262,14 @@ try
                 for (auto & offset : offset_data)
                     offset += read_task_info->part_starting_offset_in_query;
             }
+            result_column = std::move(mutable_column);
         }
-        result_column->assumeMutableRef().shrinkToFit();
+
+        /// `shrinkToFit` reallocates the column's data. Go through `IColumn::mutate` so a shared
+        /// column is cloned first: mutating a column still referenced elsewhere is a use-after-free hazard.
+        auto mutable_column = IColumn::mutate(std::move(result_column));
+        mutable_column->shrinkToFit();
+        result_column = std::move(mutable_column);
     }
 
     auto result = Chunk(std::move(result_columns), read_result.num_rows);


### PR DESCRIPTION
<!--
Linked issues and pull requests.
-->

Hardens a copy-on-write violation on the merge write path that can lead to a heap use-after-free.

`MergeTreeSequentialSource::generate` finalized the merge output columns through `assumeMutableRef()` — once to run `shrinkToFit()`, and once to rewrite the `_parent_part_offset` column for projection parts. `assumeMutableRef()` bypasses copy-on-write, so when a column is shared, mutating it in place (and, for `shrinkToFit`, reallocating its buffer) corrupts or frees data that may still be referenced by another owner. These two sites now go through `IColumn::mutate`, which clones the column only when it is shared (`use_count > 1`) and is a no-op when it is uniquely owned (the common case), so the normal merge path is unchanged.

Motivated by an `AddressSanitizer` `heap-use-after-free` reported in MasterCI during a horizontal merge — the writer (`MergeTreeDataPartWriterWide::writeSingleGranule`) serialized a plain `UInt16` column whose buffer had already been freed:

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0577669cbc1cc363bbcd38da7a9e2668c7fed077&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20distributed%20plan%2C%20sequential%29

The crash is intermittent and could not be reproduced locally, so this is a targeted copy-on-write hardening on the merge output-production path rather than a confirmed fix for that exact report; the ASan CI is the validation.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required (CI Fix or Improvement).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.799`
<!-- ch-version-info:end -->