### PR TITLE
Use COW-safe `IColumn::mutate` for in-place column mutation on read/build paths

### DIFF
--- a/src/DataTypes/Serializations/SerializationObjectCombinedPath.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectCombinedPath.cpp
@@ -166,13 +166,15 @@ void SerializationObjectCombinedPath::deserializeBinaryBulkWithMultipleStreams(
         sub_object_column, rows_offset, limit, nested_settings, combined_state->sub_object_state, cache);
 
     size_t rows = literal_column->size();
-    auto & result = result_column->assumeMutableRef();
+    auto mutable_column = IColumn::mutate(std::move(result_column));
+    auto & result = *mutable_column;
 
     /// If sub-object contains only empty objects, append literal column directly.
     const auto * sub_object_typed_column = assert_cast<const ColumnObject *>(sub_object_column.get());
     if (!sub_object_typed_column->hasNonEmptyRows())
     {
         result.insertRangeFrom(*literal_column, 0, rows);
+        result_column = std::move(mutable_column);
         return;
     }
 
@@ -190,6 +192,8 @@ void SerializationObjectCombinedPath::deserializeBinaryBulkWithMultipleStreams(
         else
             result.insertDefault();
     }
+
+    result_column = std::move(mutable_column);
 }
 
 }

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -1961,7 +1961,8 @@ void HashJoin::tryRerangeRightTableDataImpl(Map & map [[maybe_unused]])
             {
                 for (size_t i = 0; i < columns_info.columns.size(); ++i)
                 {
-                    auto & col = columns_info.columns[i]->assumeMutableRef();
+                    auto mutable_column = IColumn::mutate(std::move(columns_info.columns[i]));
+                    auto & col = *mutable_column;
                     /// Check if we insert into non replicated column from a replicated column.
                     if (!columns_info.replicated_columns[i] && it->columns_info->replicated_columns[i])
                     {
@@ -1972,6 +1973,7 @@ void HashJoin::tryRerangeRightTableDataImpl(Map & map [[maybe_unused]])
                     {
                         col.insertFrom(*(it->columns_info->columns[i]), it->row_num);
                     }
+                    columns_info.columns[i] = std::move(mutable_column);
                 }
             }
             size_t new_rows = columns_info.columns.at(0)->size();

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -1957,12 +1957,19 @@ void HashJoin::tryRerangeRightTableDataImpl(Map & map [[maybe_unused]])
 
             auto & columns_info = columns_list.back().columns_info;
             size_t start_row = columns_info.columns.at(0)->size();
+
+            /// Detach all destination columns once (COW-safe: clones only if shared) and append through the
+            /// mutable handles, then move them back. This keeps the per-row append loop free of COW plumbing.
+            MutableColumns mutable_columns;
+            mutable_columns.reserve(columns_info.columns.size());
+            for (auto & column : columns_info.columns)
+                mutable_columns.push_back(IColumn::mutate(std::move(column)));
+
             for (; it.ok(); ++it)
             {
-                for (size_t i = 0; i < columns_info.columns.size(); ++i)
+                for (size_t i = 0; i < mutable_columns.size(); ++i)
                 {
-                    auto mutable_column = IColumn::mutate(std::move(columns_info.columns[i]));
-                    auto & col = *mutable_column;
+                    auto & col = *mutable_columns[i];
                     /// Check if we insert into non replicated column from a replicated column.
                     if (!columns_info.replicated_columns[i] && it->columns_info->replicated_columns[i])
                     {
@@ -1973,9 +1980,12 @@ void HashJoin::tryRerangeRightTableDataImpl(Map & map [[maybe_unused]])
                     {
                         col.insertFrom(*(it->columns_info->columns[i]), it->row_num);
                     }
-                    columns_info.columns[i] = std::move(mutable_column);
                 }
             }
+
+            for (size_t i = 0; i < mutable_columns.size(); ++i)
+                columns_info.columns[i] = std::move(mutable_columns[i]);
+
             size_t new_rows = columns_info.columns.at(0)->size();
             if (new_rows > start_row)
             {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1777,7 +1777,9 @@ Block MergeTreeData::getBlockWithVirtualsForFilter(
         for (auto & column : block)
         {
             auto field = getFieldForConstVirtualColumn(column.name, *part.data_part);
-            column.column->assumeMutableRef().insert(field);
+            auto mutable_column = IColumn::mutate(std::move(column.column));
+            mutable_column->insert(field);
+            column.column = std::move(mutable_column);
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -188,17 +188,28 @@ void MergeTreeIndexBulkGranulesSet::deserializeBinary(size_t granule_num, ReadBu
         serializations[i]->deserializeBinaryBulkStatePrefix(settings, state, nullptr);
         serializations[i]->deserializeBinaryBulkWithMultipleStreams(column, 0, rows_to_read, settings, state, nullptr);
 
-        block.getByPosition(i).column->assumeMutableRef().insertRangeFrom(*column, 0, rows_to_read);
-        column->assumeMutableRef().popBack(rows_to_read);
+        {
+            auto mutable_column = IColumn::mutate(std::move(block.getByPosition(i).column));
+            mutable_column->insertRangeFrom(*column, 0, rows_to_read);
+            block.getByPosition(i).column = std::move(mutable_column);
+        }
+
+        {
+            auto mutable_column = IColumn::mutate(std::move(column));
+            mutable_column->popBack(rows_to_read);
+            column = std::move(mutable_column);
+        }
     }
 
     /// The last column is designating the granule
     auto & elem = block.getByPosition(num_columns);
-    MutableColumnPtr granule_num_column = elem.column->assumeMutable();
+    MutableColumnPtr granule_num_column = IColumn::mutate(std::move(elem.column));
 
     auto & data = assert_cast<ColumnUInt64 &>(*granule_num_column).getData();
     for (size_t i = 0; i < rows_to_read; ++i)
         data.push_back(granule_num);
+
+    elem.column = std::move(granule_num_column);
 }
 
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -182,7 +182,9 @@ void MergeTreeIndexBulkGranulesSet::deserializeBinary(size_t granule_num, ReadBu
     /// Due to using of position-dependent encoding, we have to read into a temporary block and then move to the accumulating block.
     for (size_t i = 0; i < num_columns; ++i)
     {
-        auto column = block_for_reading.getByPosition(i).column;
+        /// A reference into the scratch block (not a copy), so it stays uniquely owned: `mutate` below is a no-op
+        /// and the `popBack` reset is written back, leaving the scratch column empty for the next granule.
+        auto & column = block_for_reading.getByPosition(i).column;
         ISerialization::DeserializeBinaryBulkStatePtr state;
 
         serializations[i]->deserializeBinaryBulkStatePrefix(settings, state, nullptr);

--- a/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderCompact.cpp
@@ -288,9 +288,15 @@ void MergeTreeReaderCompact::readData(
 
                 /// TODO: Avoid extra copying.
                 if (column->empty())
+                {
                     column = IColumn::mutate(subcolumn);
+                }
                 else
-                    column->assumeMutable()->insertRangeFrom(*subcolumn, 0, subcolumn->size());
+                {
+                    auto mutable_column = IColumn::mutate(std::move(column));
+                    mutable_column->insertRangeFrom(*subcolumn, 0, subcolumn->size());
+                    column = std::move(mutable_column);
+                }
             }
         }
         else

--- a/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
@@ -101,7 +101,7 @@ size_t MergeTreeReaderIndex::readRows(
         /// If there are rows to read, apply bitmap filtering.
         if (max_rows_to_read > 0)
         {
-            auto mutable_filter_column = filter_column->assumeMutable();
+            auto mutable_filter_column = IColumn::mutate(std::move(filter_column));
             auto & filter_data = static_cast<ColumnUInt8 &>(*mutable_filter_column).getData();
             index_read_result->projection_index_read_result->appendToFilter(filter_data, starting_row, max_rows_to_read);
             filter_column = std::move(mutable_filter_column);
@@ -129,7 +129,7 @@ size_t MergeTreeReaderIndex::readRows(
         /// If there are rows to read, apply bitmap filtering.
         if (max_rows_to_read > 0)
         {
-            auto mutable_filter_column = filter_column->assumeMutable();
+            auto mutable_filter_column = IColumn::mutate(std::move(filter_column));
             auto & filter_data = static_cast<ColumnUInt8 &>(*mutable_filter_column).getData();
             size_t old_size = filter_data.size();
             filter_data.resize(old_size + max_rows_to_read);

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -415,7 +415,8 @@ size_t MergeTreeReaderTextIndex::readRows(
 
         for (size_t i = 0; i < res_columns.size(); ++i)
         {
-            auto & column_mutable = res_columns[i]->assumeMutableRef();
+            auto mutable_column = IColumn::mutate(std::move(res_columns[i]));
+            auto & column_mutable = *mutable_column;
 
             if (is_always_true[i])
             {
@@ -439,6 +440,8 @@ size_t MergeTreeReaderTextIndex::readRows(
             {
                 fillColumn(column_mutable, mark_postings[i], from_row, rows_to_read);
             }
+
+            res_columns[i] = std::move(mutable_column);
         }
 
         ++from_mark;

--- a/src/Storages/StorageExecutable.cpp
+++ b/src/Storages/StorageExecutable.cpp
@@ -84,7 +84,9 @@ namespace
                     auto & block_column = result.safeGetByPosition(result_block_index);
                     auto & result_block_column = result_block.safeGetByPosition(result_block_index);
 
-                    result_block_column.column->assumeMutable()->insertRangeFrom(*block_column.column, 0, block_column.column->size());
+                    auto mutable_column = IColumn::mutate(std::move(result_block_column.column));
+                    mutable_column->insertRangeFrom(*block_column.column, 0, block_column.column->size());
+                    result_block_column.column = std::move(mutable_column);
                 }
             }
 

--- a/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
+++ b/src/Storages/TimeSeries/PrometheusRemoteWriteProtocol.cpp
@@ -118,7 +118,11 @@ namespace
         {
             if (!block_from_executor.empty())
             {
-                MutableColumnPtr id_column_part = block_from_executor.getByName(id_name).column->assumeMutable();
+                /// The column comes from a pipeline block and may be shared. Use COW-safe
+                /// `IColumn::mutate` (which clones only when the column is shared) instead of
+                /// `assumeMutable`, so that growing the accumulator in place via `insertRangeFrom`
+                /// below never reallocates a buffer still referenced elsewhere.
+                MutableColumnPtr id_column_part = IColumn::mutate(std::move(block_from_executor.getByName(id_name).column));
                 if (id_column)
                     id_column->insertRangeFrom(*id_column_part, 0, id_column_part->size());
                 else

--- a/src/Storages/VirtualColumnUtils.cpp
+++ b/src/Storages/VirtualColumnUtils.cpp
@@ -285,7 +285,12 @@ static void addPathAndFileToVirtualColumns(
     bool parse_hive_columns)
 {
     if (block.has("_path"))
-        block.getByName("_path").column->assumeMutableRef().insert(path);
+    {
+        auto & holder = block.getByName("_path").column;
+        auto mutable_column = IColumn::mutate(std::move(holder));
+        mutable_column->insert(path);
+        holder = std::move(mutable_column);
+    }
 
     if (block.has("_file"))
     {
@@ -296,7 +301,10 @@ static void addPathAndFileToVirtualColumns(
         else
             file = path;
 
-        block.getByName("_file").column->assumeMutableRef().insert(file);
+        auto & holder = block.getByName("_file").column;
+        auto mutable_column = IColumn::mutate(std::move(holder));
+        mutable_column->insert(file);
+        holder = std::move(mutable_column);
     }
 
     if (parse_hive_columns)
@@ -307,12 +315,20 @@ static void addPathAndFileToVirtualColumns(
             if (const auto * column = block.findByName(key))
             {
                 ReadBufferFromString buf(value);
-                column->type->getDefaultSerialization()->deserializeWholeText(column->column->assumeMutableRef(), buf, format_settings);
+                auto & holder = block.getByName(column->name).column;
+                auto mutable_column = IColumn::mutate(std::move(holder));
+                column->type->getDefaultSerialization()->deserializeWholeText(*mutable_column, buf, format_settings);
+                holder = std::move(mutable_column);
             }
         }
     }
 
-    block.getByName("_idx").column->assumeMutableRef().insert(idx);
+    {
+        auto & holder = block.getByName("_idx").column;
+        auto mutable_column = IColumn::mutate(std::move(holder));
+        mutable_column->insert(idx);
+        holder = std::move(mutable_column);
+    }
 }
 
 std::optional<ActionsDAG> createPathAndFileFilterDAG(

--- a/src/Storages/VirtualColumnUtils.cpp
+++ b/src/Storages/VirtualColumnUtils.cpp
@@ -277,34 +277,31 @@ VirtualColumnsDescription getVirtualsForFileLikeStorage(
     return desc;
 }
 
+/// Appends one row to the already-detached mutable columns of `block`. The columns are detached once
+/// by the caller (see `getFilterByPathAndFileIndexes`) so this per-row helper does not pay any
+/// copy-on-write plumbing: it inserts directly through the mutable holders. `block` is used only for
+/// name/type/position lookup; its columns have been moved out into `columns`.
 static void addPathAndFileToVirtualColumns(
-    Block & block,
+    const Block & block,
+    MutableColumns & columns,
     const String & path,
     size_t idx,
     const FormatSettings & format_settings,
     bool parse_hive_columns)
 {
     if (block.has("_path"))
-    {
-        auto & holder = block.getByName("_path").column;
-        auto mutable_column = IColumn::mutate(std::move(holder));
-        mutable_column->insert(path);
-        holder = std::move(mutable_column);
-    }
+        columns[block.getPositionByName("_path")]->insert(path);
 
     if (block.has("_file"))
     {
-        auto pos = path.find_last_of('/');
+        auto slash = path.find_last_of('/');
         String file;
-        if (pos != std::string::npos)
-            file = path.substr(pos + 1);
+        if (slash != std::string::npos)
+            file = path.substr(slash + 1);
         else
             file = path;
 
-        auto & holder = block.getByName("_file").column;
-        auto mutable_column = IColumn::mutate(std::move(holder));
-        mutable_column->insert(file);
-        holder = std::move(mutable_column);
+        columns[block.getPositionByName("_file")]->insert(file);
     }
 
     if (parse_hive_columns)
@@ -315,20 +312,13 @@ static void addPathAndFileToVirtualColumns(
             if (const auto * column = block.findByName(key))
             {
                 ReadBufferFromString buf(value);
-                auto & holder = block.getByName(column->name).column;
-                auto mutable_column = IColumn::mutate(std::move(holder));
-                column->type->getDefaultSerialization()->deserializeWholeText(*mutable_column, buf, format_settings);
-                holder = std::move(mutable_column);
+                column->type->getDefaultSerialization()->deserializeWholeText(
+                    *columns[block.getPositionByName(column->name)], buf, format_settings);
             }
         }
     }
 
-    {
-        auto & holder = block.getByName("_idx").column;
-        auto mutable_column = IColumn::mutate(std::move(holder));
-        mutable_column->insert(idx);
-        holder = std::move(mutable_column);
-    }
+    columns[block.getPositionByName("_idx")]->insert(idx);
 }
 
 std::optional<ActionsDAG> createPathAndFileFilterDAG(
@@ -383,15 +373,21 @@ ColumnPtr getFilterByPathAndFileIndexes(
     const auto hive_format_settings = HivePartitioningUtils::buildHiveFormatSettings(format_settings, context);
     const bool parse_hive_columns = context->getSettingsRef()[Setting::use_hive_partitioning] || !hive_columns.empty();
 
+    /// Detach all block columns into mutable holders once, append all rows through them, and
+    /// assign them back once. This keeps `IColumn::mutate` (and its recursive subcolumn re-wrapping
+    /// for `LowCardinality` virtuals such as `_path`/`_file`) off the per-row append path.
+    MutableColumns columns = block.mutateColumns();
     for (size_t i = 0; i != paths.size(); ++i)
     {
         addPathAndFileToVirtualColumns(
             block,
+            columns,
             paths[i],
             /* idx */i,
             hive_format_settings,
             parse_hive_columns);
     }
+    block.setColumns(std::move(columns));
 
     filterBlockWithExpression(actions, block);
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107451
-->

Proactive copy-on-write (COW) safety sweep, following the same fix as #107451.

Several places obtained a mutable column via `assumeMutable` / `assumeMutableRef` (which bypass copy-on-write with a bare `const_cast`) and then mutated or reallocated it in place. When such a column happens to be shared (`use_count > 1`), this corrupts or frees data that may still be referenced elsewhere — the class of bug fixed in #107451.

These sites are replaced with `IColumn::mutate(std::move(...))`, which clones only when the column is shared and is a **no-op (same cost) when it is uniquely owned**, writing the mutated result back into its holder. The common uniquely-owned path is unchanged; the shared path becomes safe.

Converted sites:
- MergeTree readers: `MergeTreeReaderTextIndex`, `MergeTreeReaderCompact`, `MergeTreeReaderIndex`
- `MergeTreeIndexSet` granule builder
- virtual-column / minmax block builders: `VirtualColumnUtils`, `MergeTreeData::getBlockWithVirtualsForFilter`
- `SerializationObjectCombinedPath` deserialization
- `HashJoin::tryRerangeRightTableDataImpl`
- `StorageExecutable` result accumulation
- Prometheus remote-write id-column accumulator

Intentionally **left as-is** (converting would force a clone — a regression — or change semantics, because the column is deliberately shared and reallocation does not happen):
- the COW `create(const ColumnPtr &)` factories
- the patch-parts in-place write-back (`applyPatches`)
- the substreams-cache offsets grow-in-place (`SerializationSparse`)
- the in-place column-algorithm subcolumn idioms (`ColumnArray`/`ColumnObject`/`ColumnVariant`/…)

`ProtobufSerializer` is left for a follow-up that makes it operate on mutable columns directly (it keeps a persistently shared `ColumnPtr` alias to the row format's columns, so it needs a small refactor rather than a per-call `mutate`).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required (internal copy-on-write safety hardening, no user-facing behavior change).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1002`
<!-- ch-version-info:end -->