### PR TITLE
CI: drop dangling stack-trace promise from parsed failure names

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -8,6 +8,14 @@ from ci.praktika.utils import Shell
 
 class FuzzerLogParser:
     UNKNOWN_ERROR = "Unknown error"
+    # Exception messages carry the trailing ", Stack trace (when copying this message,
+    # always include the lines below):" marker, but the frames it promises are on the
+    # following log lines. The failure name is built from the first line only, so the
+    # marker would otherwise dangle with no lines after it (the frames are still kept in
+    # the separate "Stack trace:" section of the info). Drop the marker from the name.
+    STACK_TRACE_MARKER = (
+        ", Stack trace (when copying this message, always include the lines below):"
+    )
     MAX_INLINE_REPRODUCE_COMMANDS = 20
     SANITIZER_ERROR_PATTERN = (
         r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*|"
@@ -140,6 +148,12 @@ class FuzzerLogParser:
 
         error_lines = error_output.splitlines()
         result_name = error_lines[0].removesuffix(".")
+        # The first line may end with the "...always include the lines below):" marker
+        # whose frames are on later lines; cutting it here keeps the name from promising
+        # lines it does not contain.
+        marker_pos = result_name.find(self.STACK_TRACE_MARKER)
+        if marker_pos != -1:
+            result_name = result_name[:marker_pos].rstrip().removesuffix(".")
         format_message = ""
         for i, line in enumerate(error_lines):
             if "Format string: " in line:

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -80,3 +80,39 @@ def test_parse_failure_asan_check_failed_with_stack_trace(tmp_path):
     assert "Assertion 'px != 0' failed" not in info
     assert "dpkg" not in info
     assert files == []
+
+
+def test_parse_failure_logical_error_name_drops_dangling_stack_trace_marker(tmp_path):
+    server_log = tmp_path / "clickhouse-server.err.log"
+
+    server_log.write_text(
+        "2026.06.14 20:00:01.000000 [ 200 ] {} <Fatal> : Logical error: "
+        "'std::exception. Code: 1001, type: std::__1::future_error, "
+        "e.what() = The associated promise has been destructed prior to the "
+        "associated state becoming ready., Stack trace (when copying this "
+        "message, always include the lines below):\n"
+        "\n"
+        "0. ./contrib/llvm-project/libcxx/include/future:509:25: "
+        "std::promise<void>::~promise() @ 0x000000002cbf6d04\n"
+        "2026.06.14 20:00:02.000000 [ 200 ] {} <Fatal> BaseDaemon: Stack trace:\n"
+        "2026.06.14 20:00:02.000000 [ 200 ] {} <Fatal> BaseDaemon: "
+        "1. ./src/Common/Exception.cpp:60: DB::abortOnFailedAssertion() @ 0x14d2262e\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log="",
+        fuzzer_log="",
+    )
+
+    result_name, info, files = parser.parse_failure()
+
+    # The failure name must not end with the "always include the lines below):"
+    # promise when no frames follow it (the first log line is all the name has).
+    assert "always include the lines below" not in result_name
+    assert result_name.startswith("Logical error: 'std::exception.")
+    assert "The associated promise has been destructed" in result_name
+    assert "(STID:" in result_name
+    # The frames are still preserved in the separate stack-trace section of the info.
+    assert "abortOnFailedAssertion" in info


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105711
-->

Related: #105711


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The praktika failure-log parser (`ci/jobs/scripts/log_parser.py`) builds the
failure name shown in CI reports and stored in CIDB `test_name` from the first
line of the matched error. ClickHouse exception messages end that line with
`, Stack trace (when copying this message, always include the lines below):`,
but the frames it promises are on the following log lines, which the name never
includes. The reported name therefore ends with the "always include the lines
below:" promise and nothing after it (only ` (STID: ...)`).

Example from a recent run (STID 2508-3dee):

```
Logical error: 'std::exception. Code: 1001, type: std::__1::future_error,
e.what() = The associated promise has been destructed prior to the associated
state becoming ready., Stack trace (when copying this message, always include
the lines below): (STID: 2508-3dee)
```

This violates the message's own rule: it tells the reader to always include the
lines below, then drops them.

Fix: cut the marker off the failure name. The stack frames are still kept in the
separate "Stack trace:" section of the failure info, so no diagnostic information
is lost. This mirrors the server-side fix in commit `a11cdca398c` ("Don't print
empty stack trace section in exception messages").

Added a regression test in `ci/tests/test_log_parser.py`. Reported in
https://github.com/ClickHouse/ClickHouse/pull/105711.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.798`
<!-- ch-version-info:end -->