### PR TITLE
Enable disk spill for TPC-H and TPC-DS functional tests

### DIFF
--- a/tests/queries/0_stateless/04033_tpc_ds.lib
+++ b/tests/queries/0_stateless/04033_tpc_ds.lib
@@ -13,3 +13,14 @@ _tpcds_output=$(jq -e -r '
 ' "$TPCDS_SETTINGS_JSON")
 readarray -t _tpcds_lines <<< "$_tpcds_output"
 SETTINGS+=("${_tpcds_lines[@]}")
+
+# Disk spill for GROUP BY and joins. Kept here (not in settings.json) on purpose:
+# tests/performance/tpcds.xml reads the same settings.json and must stay in-memory.
+SETTINGS+=(
+    --max_bytes_before_external_group_by 314572800
+    --max_bytes_before_external_join 314572800
+)
+
+# Plan/result test, not a perf test: spilling to disk starts slowly, so the test-env
+# estimated-time guard false-positives (TOO_SLOW) under sanitizer builds. Disable it.
+SETTINGS+=(--max_estimated_execution_time 0)

--- a/tests/queries/0_stateless/04040_tpc_h.lib
+++ b/tests/queries/0_stateless/04040_tpc_h.lib
@@ -11,3 +11,14 @@ _tpch_output=$(jq -e -r '
 ' "$TPCH_SETTINGS_JSON")
 readarray -t _tpch_lines <<< "$_tpch_output"
 SETTINGS+=("${_tpch_lines[@]}")
+
+# Disk spill for GROUP BY and joins. Kept here (not in settings.json) on purpose:
+# tests/performance/tpch.xml reads the same settings.json and must stay in-memory.
+SETTINGS+=(
+    --max_bytes_before_external_group_by 314572800
+    --max_bytes_before_external_join 314572800
+)
+
+# Plan/result test, not a perf test: spilling to disk starts slowly, so the test-env
+# estimated-time guard false-positives (TOO_SLOW) under sanitizer builds. Disable it.
+SETTINGS+=(--max_estimated_execution_time 0)


### PR DESCRIPTION
<!--
Linked issues and pull requests.

Related: https://github.com/ClickHouse/ClickHouse/pull/107441
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #107441 (requested by alexey-milovidov): enable disk spill in the TPC-H and TPC-DS functional tests to lower their peak memory and exercise the external aggregation / external join code paths.

The settings are added to the shared `04033_tpc_ds.lib` and `04040_tpc_h.lib`, consumed by the `04033_tpc_ds_*` and `04040_tpc_h_*` stateless tests:

```
--max_bytes_before_external_group_by 314572800
--max_bytes_before_external_join     314572800
--max_estimated_execution_time       0
```

They are placed in the `.lib`, not in `tests/benchmarks/tpc-{ds,h}/settings.json`, because `tests/performance/tpc{ds,h}.xml` read the same `settings.json` and the performance benchmarks must keep running in memory.

The join spill uses the default `join_algorithm` (no override). `max_bytes_before_external_join` now spills on the default algorithm via `SpillingHashJoin` (recently on master), so the tests keep verifying the default join experience while still capping peak memory.

`max_estimated_execution_time = 0` disables the test-env estimated-time guard, which false-positives with `TOO_SLOW` on the deliberately slower-starting spilling queries under sanitizer builds (same class as #107444).

Measured peak memory on SF1 (debug build, default `join_algorithm`), baseline then with spill, in MiB:

| query | baseline | with spill |
|---|---|---|
| TPC-H q5 | 5051 | 650 |
| TPC-H q8 | 2600 | 1865 |
| TPC-H q9 | 1943 | 1720 |
| TPC-H q3 | 1346 | 1121 |
| TPC-DS q50 | 2039 | 534 |
| TPC-DS q39 | 1108 | 388 |
| TPC-DS q21 | 828 | 325 |
| TPC-DS q23 | 1457 | 646 |
| TPC-DS q47 | 808 | 582 |

`max_bytes_before_external_join` is the main mover (TPC-H q5 -87%, TPC-DS q50 -74%); `max_bytes_before_external_group_by` helps the aggregation-heavy queries (TPC-DS q23 -56%). `max_bytes_before_external_sort` was measured as a no-op on every query and is not included.

Output is byte-identical with and without spill for all 22 TPC-H queries and the verified TPC-DS subset.
