### PR TITLE
Make SetVariants::init exception-safe

### DIFF
--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -16,9 +16,9 @@ namespace ErrorCodes
 template <typename Variant>
 void SetVariantsTemplate<Variant>::init(Type type_)
 {
-    type = type_;
-
-    switch (type)
+    /// Allocate before changing `type`: if make_unique throws, the object stays EMPTY
+    /// instead of having `type != EMPTY` with a null variant pointer (matches AggregatedDataVariants::init).
+    switch (type_)
     {
         case Type::EMPTY: break;
 
@@ -27,6 +27,8 @@ void SetVariantsTemplate<Variant>::init(Type type_)
         APPLY_FOR_SET_VARIANTS(M)
     #undef M
     }
+
+    type = type_;
 }
 
 template <typename Variant>

--- a/src/Interpreters/tests/gtest_set_variants_init_exception_safety.cpp
+++ b/src/Interpreters/tests/gtest_set_variants_init_exception_safety.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <Common/CurrentThread.h>
+#include <Common/MemoryTracker.h>
+#include <Common/ThreadStatus.h>
+#include <Common/scope_guard_safe.h>
+#include <Interpreters/SetVariants.h>
+
+using namespace DB;
+
+/// init() must be exception-safe: if the variant allocation throws (e.g. under a memory
+/// limit), the object must stay EMPTY rather than ending up with `type != EMPTY` and a null
+/// variant pointer. A half-initialized object crashes the next reader, e.g.
+/// getTotalRowCount() -> (NAME)->data.size() dereferences null.
+TEST(SetVariants, InitIsExceptionSafeUnderMemoryLimit)
+{
+    MainThreadStatus::getInstance();
+
+    auto & thread_tracker = CurrentThread::get().memory_tracker;
+    total_memory_tracker.resetCounters();
+    thread_tracker.resetCounters();
+
+    /// Force every allocation to reach the tracker (default 4 MiB per-thread buffer would
+    /// otherwise hide the small variant allocation).
+    const Int64 saved_untracked_limit = CurrentThread::get().untracked_memory_limit;
+    CurrentThread::get().untracked_memory_limit = 0;
+
+    total_memory_tracker.setHardLimit(1);
+    thread_tracker.setHardLimit(1);
+
+    SCOPE_EXIT_SAFE({
+        total_memory_tracker.setHardLimit(0);
+        thread_tracker.setHardLimit(0);
+        CurrentThread::get().untracked_memory_limit = saved_untracked_limit;
+    });
+
+    SetVariants variants;
+
+    bool threw = false;
+    try
+    {
+        variants.init(SetVariants::Type::key64);
+    }
+    catch (const DB::Exception &)
+    {
+        threw = true;
+    }
+
+    /// Lift the limit before touching the object so the assertions themselves can allocate.
+    total_memory_tracker.setHardLimit(0);
+    thread_tracker.setHardLimit(0);
+    CurrentThread::get().untracked_memory_limit = saved_untracked_limit;
+
+    ASSERT_TRUE(threw) << "init() was expected to throw under the memory limit";
+
+    /// The allocation failed, so the object must be back to a consistent EMPTY state.
+    /// Without the fix, type == key64 while the key64 pointer is null, so empty() is false
+    /// and getTotalRowCount() dereferences a null pointer.
+    EXPECT_TRUE(variants.empty());
+    EXPECT_EQ(variants.getTotalRowCount(), 0u);
+}

--- a/src/Interpreters/tests/gtest_set_variants_init_exception_safety.cpp
+++ b/src/Interpreters/tests/gtest_set_variants_init_exception_safety.cpp
@@ -1,10 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <Common/CurrentMemoryTracker.h>
 #include <Common/CurrentThread.h>
 #include <Common/MemoryTracker.h>
 #include <Common/ThreadStatus.h>
 #include <Common/scope_guard_safe.h>
 #include <Interpreters/SetVariants.h>
+
+#include <limits>
 
 using namespace DB;
 
@@ -17,24 +20,38 @@ TEST(SetVariants, InitIsExceptionSafeUnderMemoryLimit)
     MainThreadStatus::getInstance();
 
     auto & thread_tracker = CurrentThread::get().memory_tracker;
+
+    /// Construct the object before arming the limit so only init()'s allocation can throw.
+    SetVariants variants;
+
+    const Int64 saved_untracked_limit = CurrentThread::get().untracked_memory_limit;
+    const Int64 saved_thread_hard_limit = thread_tracker.getHardLimit();
+    const Int64 saved_total_hard_limit = total_memory_tracker.getHardLimit();
+    const UInt64 saved_min_alloc_to_throw = CurrentMemoryTracker::getMinAllocationSizeBytesToThrow();
+
+    SCOPE_EXIT_SAFE({
+        total_memory_tracker.setHardLimit(saved_total_hard_limit);
+        thread_tracker.setHardLimit(saved_thread_hard_limit);
+        CurrentThread::get().untracked_memory_limit = saved_untracked_limit;
+        CurrentMemoryTracker::setMinAllocationSizeBytesToThrow(saved_min_alloc_to_throw);
+    });
+
+    /// The throwing operator new routes through CurrentMemoryTracker::allocThrow, which only
+    /// enforces the hard limit for allocations of at least this many bytes. The default is
+    /// disabled (UINT64_MAX), so without lowering it the 1-byte limit below is ignored and
+    /// init()'s make_unique succeeds, making this test pass even without the fix.
+    CurrentMemoryTracker::setMinAllocationSizeBytesToThrow(1);
+
+    /// Make sure the small variant allocation reaches the tracker: drop the per-thread
+    /// untracked-memory buffer (default 4 MiB) and flush whatever is already buffered before
+    /// resetting counters, otherwise the buffered bytes hide the allocation.
+    CurrentThread::get().untracked_memory_limit = 0;
+    CurrentThread::flushUntrackedMemory();
     total_memory_tracker.resetCounters();
     thread_tracker.resetCounters();
 
-    /// Force every allocation to reach the tracker (default 4 MiB per-thread buffer would
-    /// otherwise hide the small variant allocation).
-    const Int64 saved_untracked_limit = CurrentThread::get().untracked_memory_limit;
-    CurrentThread::get().untracked_memory_limit = 0;
-
     total_memory_tracker.setHardLimit(1);
     thread_tracker.setHardLimit(1);
-
-    SCOPE_EXIT_SAFE({
-        total_memory_tracker.setHardLimit(0);
-        thread_tracker.setHardLimit(0);
-        CurrentThread::get().untracked_memory_limit = saved_untracked_limit;
-    });
-
-    SetVariants variants;
 
     bool threw = false;
     try
@@ -46,10 +63,11 @@ TEST(SetVariants, InitIsExceptionSafeUnderMemoryLimit)
         threw = true;
     }
 
-    /// Lift the limit before touching the object so the assertions themselves can allocate.
-    total_memory_tracker.setHardLimit(0);
-    thread_tracker.setHardLimit(0);
+    /// Lift the limits before touching the object so the assertions themselves can allocate.
+    total_memory_tracker.setHardLimit(saved_total_hard_limit);
+    thread_tracker.setHardLimit(saved_thread_hard_limit);
     CurrentThread::get().untracked_memory_limit = saved_untracked_limit;
+    CurrentMemoryTracker::setMinAllocationSizeBytesToThrow(saved_min_alloc_to_throw);
 
     ASSERT_TRUE(threw) << "init() was expected to throw under the memory limit";
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a rare server crash in `DISTINCT` processing that could occur when an allocation failed (for example, when hitting a memory limit) while the set of distinct keys was being initialized.


### Description

`SetVariantsTemplate::init` assigned `type` before allocating the variant hash table with `make_unique`. If that allocation threw (e.g. under a memory limit), the object was left half-initialized: `type != EMPTY` but the variant pointer null. Because `empty()` only checks `type == EMPTY`, the next access treated the object as initialized and dereferenced the null pointer, e.g. `getTotalRowCount()` -> `(NAME)->data.size()`, crashing with a SIGSEGV at a small fixed offset.

The fix allocates first and assigns `type` last, so a throwing allocation leaves the object in a consistent `EMPTY` state. This matches the order already used by `AggregatedDataVariants::init` (the analogous aggregation path, which is correct). The bug dates back to 2020.

Surfaced as a single-occurrence `Stress test (amd_tsan)` crash on `INSERT INTO ... SELECT DISTINCT number + 1, number FROM numbers_mt(1000000)` (from `02956_rocksdb_bulk_sink.sh`) while `memory_tracker_fault_probability` was active:
- Site: `SetVariants.cpp:41` `case Type::NAME: return (NAME)->data.size();` (null deref, `Address: 0x18`)
- Caller: `DistinctTransform::transform` (`DistinctTransform.cpp:229`)
- CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101039&sha=04b49c54bb80ea3ea9f207d88005cb46789586df&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29

A unit test (`gtest_set_variants_init_exception_safety`) forces `init()` to throw under a memory limit and asserts the object stays `empty()`. It fails (object left non-empty) without the fix and passes with it.
