### PR TITLE
Compare performance tests against the previous commit on master

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -31,7 +31,17 @@ if __name__ == "__main__":
         )
         commits = raw.splitlines()
 
+        # Drop commits newer than the one under test (they may have been pushed
+        # after this run was triggered) so that commits[0] is the current commit.
         while commits and commits[0] != info.sha:
+            commits.pop(0)
+
+        # Drop the current commit itself so the performance test compares against
+        # the previous commit on master (commit-to-commit). Otherwise the job picks
+        # the current commit's own build as the baseline and compares it against
+        # itself, so a red status could never point at the commit that introduced
+        # a regression.
+        if commits and commits[0] == info.sha:
             commits.pop(0)
 
         info.store_kv_data("master_track_commits_sha", commits)


### PR DESCRIPTION
On master, the `Performance Comparison` jobs were comparing each commit against **itself**, so they could never surface a real regression (any red was pure measurement noise).

`ci/jobs/performance_tests.py` resolves the baseline build with `find_prev_build`, which walks `master_track_commits_sha` and uses the first commit whose build exists. In `store_data.py` that list was built so that, after dropping commits newer than the one under test, `commits[0]` was the commit under test itself — and its build is always present (the perf job depends on it). So the baseline resolved to the current commit's own build.

Evidence (`query_metrics_v2`, last 14 days): **99.7%** of master perf rows have `old_sha == new_sha` (baseline equal to the tested commit).

Fix: drop the current commit from the list, so the baseline is the **previous commit on master** (commit-to-commit), matching the PR path (which already starts from `HEAD^1`). A red status now signals a regression introduced by that specific commit.

Only the `master_head` comparison is affected. The separate `release_base` comparison (against the latest release) is intentionally left unchanged.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.828`
<!-- ch-version-info:end -->