### PR TITLE
Replace querying L2 cache size via sysconf() with CPUID check

### DIFF
--- a/base/base/CMakeLists.txt
+++ b/base/base/CMakeLists.txt
@@ -14,6 +14,7 @@ set (SRCS
     Decimal.cpp
     getAvailableMemoryAmount.cpp
     getFQDNOrHostName.cpp
+    getL2CacheSize.cpp
     getMemoryAmount.cpp
     getPageSize.cpp
     getThreadId.cpp

--- a/base/base/getL2CacheSize.cpp
+++ b/base/base/getL2CacheSize.cpp
@@ -1,0 +1,76 @@
+#include <base/getL2CacheSize.h>
+
+#if defined(__x86_64__)
+#    include <cpuid.h>
+#endif
+
+namespace
+{
+    constexpr size_t default_l2_size = 256 * 1024;
+
+#if defined(__x86_64__)
+    /// Read L2 data/unified cache size via CPUID deterministic cache parameters
+    /// (Intel leaf 4, AMD leaf 0x8000001D; identical sub-leaf format).
+    size_t readL2FromCPUID()
+    {
+        const unsigned leaves[] = {0x4u, 0x8000001Du};
+        for (unsigned leaf : leaves)
+        {
+            /// Probe maximum supported leaf for the corresponding range.
+            unsigned max_eax = 0;
+            unsigned ign_ebx = 0;
+            unsigned ign_ecx = 0;
+            unsigned ign_edx = 0;
+            __cpuid(leaf & 0x80000000u, max_eax, ign_ebx, ign_ecx, ign_edx);
+            if (leaf > max_eax)
+                continue;
+
+            for (unsigned sub = 0; sub < 32; ++sub)
+            {
+                unsigned eax = 0;
+                unsigned ebx = 0;
+                unsigned ecx = 0;
+                unsigned edx = 0;
+                __cpuid_count(leaf, sub, eax, ebx, ecx, edx);
+
+                unsigned cache_type = eax & 0x1Fu;
+                if (cache_type == 0)
+                    break; /// no more cache descriptors
+
+                unsigned cache_level = (eax >> 5) & 0x7u;
+                if (cache_level != 2)
+                    continue;
+                /// 1 = data, 2 = instruction, 3 = unified. We want bytes accessible to loads/stores.
+                if (cache_type != 1 && cache_type != 3)
+                    continue;
+
+                unsigned line_size  = (ebx & 0xFFFu) + 1;
+                unsigned partitions = ((ebx >> 12) & 0x3FFu) + 1;
+                unsigned ways       = ((ebx >> 22) & 0x3FFu) + 1;
+                unsigned sets       = ecx + 1;
+                return static_cast<size_t>(line_size) * partitions * ways * sets;
+            }
+        }
+        return 0;
+    }
+#endif
+
+    size_t getL2CacheSizeImpl()
+    {
+#if defined(__x86_64__)
+        if (size_t v = readL2FromCPUID())
+            return v;
+#endif
+        /// No `sysconf(_SC_LEVEL2_CACHE_SIZE)` fallback: it is x86-only in glibc
+        /// and unimplemented in musl. 256 KiB is a safe default on non-x86.
+        return default_l2_size;
+    }
+}
+
+/// Function-local static: computed once, and LTO-safe (a namespace-scope
+/// dynamic initializer can be DCE'd).
+size_t getL2CacheSize()
+{
+    static const size_t result = getL2CacheSizeImpl();
+    return result;
+}

--- a/base/base/getL2CacheSize.cpp
+++ b/base/base/getL2CacheSize.cpp
@@ -2,6 +2,12 @@
 
 #if defined(__x86_64__)
 #    include <cpuid.h>
+#elif defined(OS_DARWIN)
+#    include <sys/sysctl.h>
+#elif defined(OS_LINUX)
+#    include <filesystem>
+#    include <fstream>
+#    include <string>
 #endif
 
 namespace
@@ -53,6 +59,64 @@ namespace
         }
         return 0;
     }
+#elif defined(OS_DARWIN)
+    /// Apple Silicon does not expose CPUID; the kernel reports the size via sysctl.
+    size_t readL2FromSysctl()
+    {
+        uint64_t value = 0;
+        size_t size = sizeof(value);
+        if (sysctlbyname("hw.l2cachesize", &value, &size, nullptr, 0) == 0)
+            return static_cast<size_t>(value);
+        return 0;
+    }
+#elif defined(OS_LINUX)
+    /// Non-x86 Linux (e.g. aarch64): read the cache geometry the kernel exposes
+    /// under sysfs. Iterate the per-CPU cache descriptors and pick the L2
+    /// data/unified one, mirroring the level/type filtering done for CPUID.
+    size_t readL2FromSysfs()
+    {
+        namespace fs = std::filesystem;
+        const fs::path base = "/sys/devices/system/cpu/cpu0/cache";
+
+        std::error_code ec;
+        for (unsigned index = 0; ; ++index)
+        {
+            const fs::path dir = base / ("index" + std::to_string(index));
+            if (!fs::exists(dir, ec))
+                break;
+
+            unsigned level = 0;
+            {
+                std::ifstream level_file(dir / "level");
+                if (!(level_file >> level))
+                    continue;
+            }
+            if (level != 2)
+                continue;
+
+            std::string type;
+            {
+                std::ifstream type_file(dir / "type");
+                std::getline(type_file, type);
+            }
+            if (type != "Data" && type != "Unified")
+                continue;
+
+            /// "size" is a number with an optional unit suffix, e.g. "2048K" or "1M".
+            size_t value = 0;
+            char suffix = 0;
+            {
+                std::ifstream size_file(dir / "size");
+                size_file >> value >> suffix;
+            }
+            if (suffix == 'K' || suffix == 'k')
+                value *= 1024;
+            else if (suffix == 'M' || suffix == 'm')
+                value *= 1024 * 1024;
+            return value;
+        }
+        return 0;
+    }
 #endif
 
     size_t getL2CacheSizeImpl()
@@ -60,9 +124,15 @@ namespace
 #if defined(__x86_64__)
         if (size_t v = readL2FromCPUID())
             return v;
+#elif defined(OS_DARWIN)
+        if (size_t v = readL2FromSysctl())
+            return v;
+#elif defined(OS_LINUX)
+        if (size_t v = readL2FromSysfs())
+            return v;
 #endif
         /// No `sysconf(_SC_LEVEL2_CACHE_SIZE)` fallback: it is x86-only in glibc
-        /// and unimplemented in musl. 256 KiB is a safe default on non-x86.
+        /// and unimplemented in musl. 256 KiB is a safe default if probing fails.
         return default_l2_size;
     }
 }

--- a/base/base/getL2CacheSize.h
+++ b/base/base/getL2CacheSize.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <cstddef>
+
+/// L2 data/unified cache size in bytes for the current CPU. Read from CPUID on
+/// x86_64 (Intel leaf 4 / AMD 0x8000001D); defaults to 256 KiB elsewhere.
+/// Computed once and cached.
+size_t getL2CacheSize();

--- a/base/base/getL2CacheSize.h
+++ b/base/base/getL2CacheSize.h
@@ -3,6 +3,7 @@
 #include <cstddef>
 
 /// L2 data/unified cache size in bytes for the current CPU. Read from CPUID on
-/// x86_64 (Intel leaf 4 / AMD 0x8000001D); defaults to 256 KiB elsewhere.
+/// x86_64 (Intel leaf 4 / AMD 0x8000001D), from sysfs on non-x86 Linux, and
+/// from `sysctl` on Darwin; defaults to 256 KiB if probing fails.
 /// Computed once and cached.
 size_t getL2CacheSize();

--- a/src/Common/ColumnsHashing.h
+++ b/src/Common/ColumnsHashing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <base/demangle.h>
+#include <base/getL2CacheSize.h>
 #include <Common/HashTable/HashTable.h>
 #include <Common/HashTable/HashTableKeyHolder.h>
 #include <Common/ColumnsHashing/HashMethod.h>
@@ -510,11 +511,7 @@ struct HashMethodSerialized
         return true;
 #endif
 
-        size_t l2_size = 256 * 1024;
-#if defined(OS_LINUX) && defined(_SC_LEVEL2_CACHE_SIZE)
-        if (auto ret = sysconf(_SC_LEVEL2_CACHE_SIZE); ret != -1)
-            l2_size = ret;
-#endif
+        size_t l2_size = getL2CacheSize();
         // Calculate the average row size.
         size_t avg_row_size = total_size / std::max(row_sizes.size(), 1UL);
         // Use batch serialization only if total size fits in 4x L2 cache and average row size is small.

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -5,9 +5,7 @@
 
 #include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 
-#ifdef OS_LINUX
-#    include <unistd.h>
-#endif
+#include <base/getL2CacheSize.h>
 
 #include <AggregateFunctions/AggregateFunctionCount.h>
 #include <AggregateFunctions/Combinators/AggregateFunctionArray.h>
@@ -220,15 +218,8 @@ concept HasPrefetchMemberFunc = requires
 
 size_t getMinBytesForPrefetch()
 {
-    size_t l2_size = 0;
-
-#if defined(OS_LINUX) && defined(_SC_LEVEL2_CACHE_SIZE)
-    if (auto ret = sysconf(_SC_LEVEL2_CACHE_SIZE); ret != -1)
-        l2_size = ret;
-#endif
-
-    /// 256KB looks like a reasonable default L2 size. 4 is empirical constant.
-    return 4 * std::max<size_t>(l2_size, 256 * 1024);
+    /// 4 is empirical constant.
+    return 4 * getL2CacheSize();
 }
 
 UInt64 & getCountState(DB::AggregateDataPtr __restrict place) /// NOLINT(readability-non-const-parameter)

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -7,6 +7,8 @@
 #    include <unistd.h>
 #endif
 
+#include <base/getL2CacheSize.h>
+
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnNullable.h>
@@ -60,16 +62,8 @@ extern const int INVALID_JOIN_ON_EXPRESSION;
 size_t getMinBytesForPrefetchInJoin()
 {
     /// Prefetching doesn't make sense for small hash tables, because they fit in caches entirely.
-    /// Threshold: 4 * max(L2 cache size, 256KB). Cached after first call.
-    static const size_t result = []
-    {
-        size_t l2_size = 0;
-#if defined(OS_LINUX) && defined(_SC_LEVEL2_CACHE_SIZE)
-        if (auto ret = sysconf(_SC_LEVEL2_CACHE_SIZE); ret != -1)
-            l2_size = ret;
-#endif
-        return 4 * std::max<size_t>(l2_size, 256 * 1024);
-    }();
+    /// Threshold: 4 * L2 cache size (`getL2CacheSize` defaults to 256 KiB). Cached after first call.
+    static const size_t result = 4 * getL2CacheSize();
     return result;
 }
 

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -3,10 +3,6 @@
 #include <memory>
 #include <vector>
 
-#ifdef OS_LINUX
-#    include <unistd.h>
-#endif
-
 #include <base/getL2CacheSize.h>
 
 #include <Columns/ColumnConst.h>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/97452

Determine the L2 data cache size from `CPUID` on `x86_64` (Intel leaf 4, AMD leaf `0x8000001D`) instead of `sysconf(_SC_LEVEL2_CACHE_SIZE)`, falling back to a 256 KiB default on other architectures. The value feeds the prefetch thresholds in `Aggregator` and `HashJoin` and the batch-serialization heuristic in `HashMethodSerialized`.

Motivation: `sysconf(_SC_LEVEL2_CACHE_SIZE)` is a glibc extension implemented only on x86. musl libc does not implement it at all (returns `-1`), and even glibc on aarch64 returns a constant `0` for it (only the L1 cache *line* sizes are real, derived from `CTR_EL0`). Reading `CPUID` directly drops the libc dependency for the size we actually use, which is a prerequisite for building ClickHouse against musl (#97452). Behavior is unchanged on existing platforms: x86 now reads the same cache geometry glibc would have via `CPUID`, and aarch64 keeps the 256 KiB default it has effectively always used.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Determine the L2 cache size from `CPUID` on x86_64 instead of the glibc-specific `sysconf(_SC_LEVEL2_CACHE_SIZE)`, which is not available under musl libc.


- [ ] Documentation entry for user-facing changes is not required.
