### PR TITLE
Increase stack size for musl builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,9 +421,12 @@ include(cmake/limit_jobs.cmake)
 # Turns on all external libs like s3, kafka, ODBC, ...
 option(ENABLE_LIBRARIES "Enable all external libraries by default" ON)
 
-# Increase stack size on Musl. We need big stack for our recursive-descend parser.
+# Increase stack size on Musl. We need big stack for our recursive-descend parser
+# and for analyzer passes that recurse on deeply-nested join trees (e.g.
+# 1000-join queries). Match glibc's 8 MiB default; musl reads this from
+# PT_GNU_STACK and clamps it to DEFAULT_STACK_MAX (also 8 MiB).
 if (USE_MUSL)
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=2097152")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,stack-size=8388608")
 endif ()
 
 include(cmake/dbms_glob_sources.cmake)

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4915,6 +4915,8 @@ static bool getOrderedColumnsFromTableExpression(const QueryTreeNodePtr & root_t
 /// Resolve join node in scope
 void QueryAnalyzer::resolveJoin(QueryTreeNodePtr & join_node, IdentifierResolveScope & scope, QueryExpressionsAliasVisitor & expressions_visitor)
 {
+    checkStackSize();
+
     auto & join_node_typed = join_node->as<JoinNode &>();
 
     resolveQueryJoinTreeNode(join_node_typed.getLeftTableExpression(), scope, expressions_visitor);
@@ -5375,6 +5377,8 @@ void QueryAnalyzer::inlineViewSubqueryIfNeeded(QueryTreeNodePtr & join_tree_node
   */
 void QueryAnalyzer::resolveQueryJoinTreeNode(QueryTreeNodePtr & join_tree_node, IdentifierResolveScope & scope, QueryExpressionsAliasVisitor & expressions_visitor)
 {
+    checkStackSize();
+
     auto from_node_type = join_tree_node->getNodeType();
 
     auto try_get_original_cte_node = [this](const QueryTreeNodePtr & node) -> QueryTreeNodePtr


### PR DESCRIPTION
Increase the linker stack size for musl builds from 2 MiB to 8 MiB, matching glibc's default. Musl reads the stack size from `PT_GNU_STACK` and clamps it to `DEFAULT_STACK_MAX` (also 8 MiB), so 8 MiB is the effective maximum. The bigger stack is needed by the recursive-descent parser and by analyzer passes that recurse on deeply-nested join trees (e.g. 1000-join queries).

Also add `checkStackSize` calls in `QueryAnalyzer::resolveJoin` and `QueryAnalyzer::resolveQueryJoinTreeNode` so deep join-tree recursion raises a controlled `TOO_DEEP_RECURSION` exception instead of overflowing the stack.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Increase the stack size for musl builds to 8 MiB to support deeply-nested queries.


- [ ] Documentation entry for user-facing changes is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.819`
<!-- ch-version-info:end -->