### PR TITLE
Reset adopted part level to 0 on cross-engine ATTACH/CLONE/MOVE PARTITION

### DIFF
--- a/src/Processors/Merges/Algorithms/Graphite.cpp
+++ b/src/Processors/Merges/Algorithms/Graphite.cpp
@@ -227,6 +227,18 @@ bool operator==(const Pattern & a, const Pattern & b)
     return a.retentions == b.retentions;
 }
 
+bool operator==(const Params & a, const Params & b)
+{
+    return a.path_column_name == b.path_column_name
+        && a.time_column_name == b.time_column_name
+        && a.value_column_name == b.value_column_name
+        && a.version_column_name == b.version_column_name
+        && a.patterns_typed == b.patterns_typed
+        && a.patterns == b.patterns
+        && a.patterns_plain == b.patterns_plain
+        && a.patterns_tagged == b.patterns_tagged;
+}
+
 std::ostream & operator<<(std::ostream & stream, const Pattern & a)
 {
     stream << "{ rule_type = " << ruleTypeStr(a.rule_type);

--- a/src/Processors/Merges/Algorithms/Graphite.cpp
+++ b/src/Processors/Merges/Algorithms/Graphite.cpp
@@ -219,8 +219,10 @@ bool operator==(const Pattern & a, const Pattern & b)
     {
         return false;
     }
-    else if (a.function->getName() != b.function->getName())
+    else if (a.function->getName() != b.function->getName()
+        || a.function->getParameters() != b.function->getParameters())
     {
+        /// Keep in lockstep with Pattern::updateHash, which hashes both the name and the parameters.
         return false;
     }
 

--- a/src/Processors/Merges/Algorithms/Graphite.h
+++ b/src/Processors/Merges/Algorithms/Graphite.h
@@ -151,6 +151,8 @@ struct Params
     void updateHash(SipHash & hash) const;
 };
 
+bool operator==(const Params & a, const Params & b);
+
 using RollupRule = std::pair<const RetentionPattern *, const AggregationPattern *>;
 
 Graphite::RollupRule selectPatternForPath(const Graphite::Params & params, std::string_view path);

--- a/src/Processors/Merges/Algorithms/tests/gtest_graphite.cpp
+++ b/src/Processors/Merges/Algorithms/tests/gtest_graphite.cpp
@@ -297,6 +297,51 @@ TEST(GraphiteTest, testSelectPattern)
 }
 
 
+TEST(GraphiteTest, testParamsEqualityComparesFunctionParameters)
+{
+    tryRegisterAggregateFunctions();
+
+    auto make_params = [](const char * function_with_params)
+    {
+        std::string xml = std::string(R"END(<clickhouse>
+<graphite_rollup>
+    <pattern>
+        <regexp>\.quantile$</regexp>
+        <function>)END") + function_with_params + R"END(</function>
+    </pattern>
+    <default>
+        <function>avg</function>
+        <retention>
+            <age>0</age>
+            <precision>60</precision>
+        </retention>
+    </default>
+</graphite_rollup>
+</clickhouse>
+)END";
+        auto config = loadConfigurationFromString(xml);
+        ContextMutablePtr context = getContext().context;
+        return setGraphitePatterns(context, config);
+    };
+
+    Graphite::Params quantile_50 = make_params("quantile(0.5)");
+    Graphite::Params quantile_50_again = make_params("quantile(0.5)");
+    Graphite::Params quantile_90 = make_params("quantile(0.9)");
+    Graphite::Params max_func = make_params("max");
+
+    /// Same function name and parameters compare equal.
+    EXPECT_TRUE(quantile_50 == quantile_50_again);
+    /// Different function name compares unequal (always did).
+    EXPECT_FALSE(quantile_50 == max_func);
+    /// Same function name but different parameters must compare unequal, matching
+    /// Pattern::updateHash which hashes both the name and the parameters. Without this
+    /// (issue #106798 follow-up), a GraphiteMergeTree part adopted between configs with
+    /// quantile(0.5) and quantile(0.9) would keep its merge level and the destination
+    /// would skip the rollup under its own parameters.
+    EXPECT_FALSE(quantile_50 == quantile_90);
+}
+
+
 namespace DB::Graphite
 {
     std::string buildTaggedRegex(std::string regexp_str);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1118,6 +1118,15 @@ public:
     MergeTreeData & checkStructureAndGetMergeTreeData(const StoragePtr & source_table, const StorageMetadataPtr & src_snapshot, const StorageMetadataPtr & my_snapshot) const;
     MergeTreeData & checkStructureAndGetMergeTreeData(IStorage & source_table, const StorageMetadataPtr & src_snapshot, const StorageMetadataPtr & my_snapshot) const;
 
+    /// Level to assign to a part adopted from `source_data` (ATTACH/REPLACE PARTITION FROM,
+    /// CLONE AS, MOVE PARTITION TO TABLE). Reset to 0 when the merge mode differs from the
+    /// source's: a lone level>0 part merged under different semantics is otherwise treated as
+    /// fully-merged and skipped by FINAL/OPTIMIZE, leaving duplicate keys (issue #106798).
+    UInt32 getLevelForAdoptedPart(const MergeTreeData & source_data, UInt32 source_level) const
+    {
+        return merging_params.mode == source_data.merging_params.mode ? source_level : 0;
+    }
+
     std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> cloneAndLoadDataPart(
         const MergeTreeData::DataPartPtr & src_part,
         const String & tmp_part_prefix,

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -475,6 +475,20 @@ public:
         void check(const MergeTreeSettings & settings, const StorageInMemoryMetadata & metadata) const;
 
         String getModeName() const;
+
+        /// True when both tables would merge a part with identical semantics, i.e. every
+        /// field that feeds the merge transforms matches. Used to decide whether an adopted
+        /// part's merge level may be preserved (see getLevelForAdoptedPart).
+        bool hasSameMergeSemantics(const MergingParams & rhs) const
+        {
+            return mode == rhs.mode
+                && sign_column == rhs.sign_column
+                && is_deleted_column == rhs.is_deleted_column
+                && columns_to_sum == rhs.columns_to_sum
+                && version_column == rhs.version_column
+                && allow_tuple_element_aggregation == rhs.allow_tuple_element_aggregation
+                && graphite_params == rhs.graphite_params;
+        }
     };
 
     /// Attach the table corresponding to the directory in full_path inside policy (must end with /), with the given columns.
@@ -1118,13 +1132,13 @@ public:
     MergeTreeData & checkStructureAndGetMergeTreeData(const StoragePtr & source_table, const StorageMetadataPtr & src_snapshot, const StorageMetadataPtr & my_snapshot) const;
     MergeTreeData & checkStructureAndGetMergeTreeData(IStorage & source_table, const StorageMetadataPtr & src_snapshot, const StorageMetadataPtr & my_snapshot) const;
 
-    /// Level to assign to a part adopted from `source_data` (ATTACH/REPLACE PARTITION FROM,
-    /// CLONE AS, MOVE PARTITION TO TABLE). Reset to 0 when the merge mode differs from the
-    /// source's: a lone level>0 part merged under different semantics is otherwise treated as
-    /// fully-merged and skipped by FINAL/OPTIMIZE, leaving duplicate keys (issue #106798).
+    /// Level for a part adopted from `source_data` (ATTACH/REPLACE PARTITION FROM, CLONE AS,
+    /// MOVE PARTITION TO TABLE). Preserve the source level only when this table merges parts
+    /// identically; otherwise reset to 0 so FINAL/OPTIMIZE re-merge the lone part instead of
+    /// trusting it as already-merged (issue #106798).
     UInt32 getLevelForAdoptedPart(const MergeTreeData & source_data, UInt32 source_level) const
     {
-        return merging_params.mode == source_data.merging_params.mode ? source_level : 0;
+        return merging_params.hasSameMergeSemantics(source_data.merging_params) ? source_level : 0;
     }
 
     std::pair<MergeTreeData::MutableDataPartPtr, scope_guard> cloneAndLoadDataPart(

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2638,7 +2638,7 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
 
         /// This will generate unique name in scope of current server process.
         Int64 temp_index = insert_increment.get();
-        MergeTreePartInfo dst_part_info(partition_id, temp_index, temp_index, src_part->info.level);
+        MergeTreePartInfo dst_part_info(partition_id, temp_index, temp_index, getLevelForAdoptedPart(src_data, src_part->info.level));
 
         IDataPartStorage::ClonePartParams clone_params{.txn = local_context->getCurrentTransaction()};
         if (replace)
@@ -2805,7 +2805,7 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
 
         /// This will generate unique name in scope of current server process.
         Int64 temp_index = insert_increment.get();
-        MergeTreePartInfo dst_part_info(partition_id, temp_index, temp_index, src_part->info.level);
+        MergeTreePartInfo dst_part_info(partition_id, temp_index, temp_index, dest_table_storage->getLevelForAdoptedPart(src_data, src_part->info.level));
 
         IDataPartStorage::ClonePartParams clone_params
         {

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9140,7 +9140,7 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             }
 
             UInt64 index = lock.getNumber();
-            MergeTreePartInfo dst_part_info(partition_id, index, index, src_part->info.level);
+            MergeTreePartInfo dst_part_info(partition_id, index, index, getLevelForAdoptedPart(src_data, src_part->info.level));
 
             IDataPartStorage::ClonePartParams clone_params
             {
@@ -9427,7 +9427,7 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
             }
 
             UInt64 index = lock.getNumber();
-            MergeTreePartInfo dst_part_info(partition_id, index, index, src_part->info.level);
+            MergeTreePartInfo dst_part_info(partition_id, index, index, dest_table_storage->getLevelForAdoptedPart(src_data, src_part->info.level));
 
             /// Don't do hardlinks in case of zero-copy at any side (defensive programming)
             bool zero_copy_enabled = (*storage_settings_ptr)[MergeTreeSetting::allow_remote_fs_zero_copy_replication]

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
@@ -1,0 +1,13 @@
+src level	1
+clone level	0
+clone final	1
+clone after optimize	1
+attach level	0
+attach final	1
+summing final	1	30
+aggregating level	0
+aggregating final	1	30
+move level	0
+move final	1
+same engine level preserved	1
+same engine final	1

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.reference
@@ -11,3 +11,7 @@ move level	0
 move final	1
 same engine level preserved	1
 same engine final	1
+summing diff columns_to_sum level	0
+summing diff columns_to_sum rows	1	5	7
+replacing diff is_deleted level	0
+replacing diff is_deleted final	0

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
@@ -4,8 +4,12 @@
 -- Adopting a part from a plain MergeTree into a collapsing engine (Replacing/Summing/
 -- Aggregating) used to keep the source part's merge level. A lone level>0 part is treated
 -- as fully merged and skipped by FINAL/OPTIMIZE, so duplicate ORDER BY keys survived
--- (issue #106798). The adopted part's level is now reset to 0 when the source and target
--- engines differ, so FINAL/OPTIMIZE deduplicate it.
+-- (issue #106798). The adopted part's level is now reset to 0 unless this table would merge
+-- the part with identical semantics, so FINAL/OPTIMIZE deduplicate it. The level is only
+-- preserved when the full merge semantics match (mode and every MergingParams field), not
+-- just the mode: same-mode tables can differ in columns_to_sum / is_deleted_column / etc.,
+-- and the destination would otherwise treat a part merged under different semantics as
+-- already-merged.
 
 DROP TABLE IF EXISTS src_mt;
 DROP TABLE IF EXISTS dst_rmt_clone;
@@ -17,6 +21,10 @@ DROP TABLE IF EXISTS src_mt_move;
 DROP TABLE IF EXISTS dst_rmt_move;
 DROP TABLE IF EXISTS src_rmt_same;
 DROP TABLE IF EXISTS dst_rmt_same;
+DROP TABLE IF EXISTS src_smt_b;
+DROP TABLE IF EXISTS dst_smt_c;
+DROP TABLE IF EXISTS src_rmt_ver;
+DROP TABLE IF EXISTS dst_rmt_ver_del;
 
 -- A source MergeTree part at level 1 (merged, but no dedup under MergeTree semantics).
 CREATE TABLE src_mt (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
@@ -74,6 +82,34 @@ ALTER TABLE dst_rmt_same ATTACH PARTITION tuple() FROM src_rmt_same;
 SELECT 'same engine level preserved', max(level) > 0 FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_same' AND active;
 SELECT 'same engine final', count() FROM dst_rmt_same FINAL;
 
+-- Same mode (Summing), DIFFERENT columns_to_sum. checkStructureAndGetMergeTreeData does not
+-- compare MergingParams, so this ATTACH is allowed. The source row (2, 9, 0) has its
+-- destination-summed column c = 0; under the destination's columns_to_sum = c it is an
+-- all-zero row that must be dropped on merge. If the level>0 part were preserved, OPTIMIZE
+-- with optimize_skip_merged_partitions would skip the lone part and the row would survive.
+CREATE TABLE src_smt_b (k UInt32, b Int64, c Int64) ENGINE = SummingMergeTree(b) ORDER BY k;
+INSERT INTO src_smt_b VALUES (1, 5, 7);
+INSERT INTO src_smt_b VALUES (2, 9, 0);
+OPTIMIZE TABLE src_smt_b FINAL;
+CREATE TABLE dst_smt_c (k UInt32, b Int64, c Int64) ENGINE = SummingMergeTree(c) ORDER BY k;
+ALTER TABLE dst_smt_c ATTACH PARTITION tuple() FROM src_smt_b;
+SELECT 'summing diff columns_to_sum level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_smt_c' AND active;
+OPTIMIZE TABLE dst_smt_c FINAL SETTINGS optimize_skip_merged_partitions = 1;
+SELECT 'summing diff columns_to_sum rows', k, b, c FROM dst_smt_c ORDER BY k;
+
+-- Same mode (Replacing), DIFFERENT is_deleted_column. The source has no is_deleted handling;
+-- the destination uses del as is_deleted, so a level>0 part merged under the source's
+-- semantics must not be trusted as already-merged. Reset to 0 lets FINAL apply the
+-- destination's is_deleted cleanup.
+CREATE TABLE src_rmt_ver (k UInt32, ver UInt64, del UInt8) ENGINE = ReplacingMergeTree(ver) ORDER BY k;
+INSERT INTO src_rmt_ver VALUES (1, 1, 0);
+INSERT INTO src_rmt_ver VALUES (1, 2, 1);
+OPTIMIZE TABLE src_rmt_ver FINAL;
+CREATE TABLE dst_rmt_ver_del (k UInt32, ver UInt64, del UInt8) ENGINE = ReplacingMergeTree(ver, del) ORDER BY k;
+ALTER TABLE dst_rmt_ver_del ATTACH PARTITION tuple() FROM src_rmt_ver;
+SELECT 'replacing diff is_deleted level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_ver_del' AND active;
+SELECT 'replacing diff is_deleted final', count() FROM dst_rmt_ver_del FINAL;
+
 DROP TABLE src_mt;
 DROP TABLE dst_rmt_clone;
 DROP TABLE dst_rmt_attach;
@@ -84,3 +120,7 @@ DROP TABLE src_mt_move;
 DROP TABLE dst_rmt_move;
 DROP TABLE src_rmt_same;
 DROP TABLE dst_rmt_same;
+DROP TABLE src_smt_b;
+DROP TABLE dst_smt_c;
+DROP TABLE src_rmt_ver;
+DROP TABLE dst_rmt_ver_del;

--- a/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
+++ b/tests/queries/0_stateless/04001_attach_clone_part_level_reset.sql
@@ -1,0 +1,86 @@
+-- Tags: no-random-merge-tree-settings
+-- ^ test asserts exact part levels, which randomized merge tree settings can perturb
+
+-- Adopting a part from a plain MergeTree into a collapsing engine (Replacing/Summing/
+-- Aggregating) used to keep the source part's merge level. A lone level>0 part is treated
+-- as fully merged and skipped by FINAL/OPTIMIZE, so duplicate ORDER BY keys survived
+-- (issue #106798). The adopted part's level is now reset to 0 when the source and target
+-- engines differ, so FINAL/OPTIMIZE deduplicate it.
+
+DROP TABLE IF EXISTS src_mt;
+DROP TABLE IF EXISTS dst_rmt_clone;
+DROP TABLE IF EXISTS dst_rmt_attach;
+DROP TABLE IF EXISTS dst_smt;
+DROP TABLE IF EXISTS src_mt_agg;
+DROP TABLE IF EXISTS dst_amt;
+DROP TABLE IF EXISTS src_mt_move;
+DROP TABLE IF EXISTS dst_rmt_move;
+DROP TABLE IF EXISTS src_rmt_same;
+DROP TABLE IF EXISTS dst_rmt_same;
+
+-- A source MergeTree part at level 1 (merged, but no dedup under MergeTree semantics).
+CREATE TABLE src_mt (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src_mt VALUES (1, 10);
+INSERT INTO src_mt VALUES (1, 20);
+OPTIMIZE TABLE src_mt FINAL;
+SELECT 'src level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'src_mt' AND active;
+
+-- CLONE AS into ReplacingMergeTree: adopted part must be reset to level 0 and dedup.
+CREATE TABLE dst_rmt_clone CLONE AS src_mt ENGINE = ReplacingMergeTree;
+SELECT 'clone level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_clone' AND active;
+SELECT 'clone final', count() FROM dst_rmt_clone FINAL;
+OPTIMIZE TABLE dst_rmt_clone FINAL;
+SELECT 'clone after optimize', count() FROM dst_rmt_clone FINAL;
+
+-- ATTACH PARTITION FROM into ReplacingMergeTree.
+CREATE TABLE dst_rmt_attach (a UInt32, b UInt32) ENGINE = ReplacingMergeTree ORDER BY a;
+ALTER TABLE dst_rmt_attach ATTACH PARTITION tuple() FROM src_mt;
+SELECT 'attach level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_attach' AND active;
+SELECT 'attach final', count() FROM dst_rmt_attach FINAL;
+
+-- CLONE AS into SummingMergeTree: rows with the same key must sum.
+CREATE TABLE dst_smt CLONE AS src_mt ENGINE = SummingMergeTree;
+SELECT 'summing final', a, b FROM dst_smt FINAL ORDER BY a;
+
+-- ATTACH PARTITION FROM into AggregatingMergeTree (source column type matches the target's
+-- SimpleAggregateFunction state, as ATTACH PARTITION FROM requires identical structure).
+CREATE TABLE src_mt_agg (a UInt32, b SimpleAggregateFunction(sum, UInt64)) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src_mt_agg VALUES (1, 10);
+INSERT INTO src_mt_agg VALUES (1, 20);
+OPTIMIZE TABLE src_mt_agg FINAL;
+CREATE TABLE dst_amt (a UInt32, b SimpleAggregateFunction(sum, UInt64)) ENGINE = AggregatingMergeTree ORDER BY a;
+ALTER TABLE dst_amt ATTACH PARTITION tuple() FROM src_mt_agg;
+SELECT 'aggregating level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_amt' AND active;
+SELECT 'aggregating final', a, b FROM dst_amt FINAL ORDER BY a;
+
+-- MOVE PARTITION TO TABLE (MergeTree -> ReplacingMergeTree).
+CREATE TABLE src_mt_move (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO src_mt_move VALUES (1, 10);
+INSERT INTO src_mt_move VALUES (1, 20);
+OPTIMIZE TABLE src_mt_move FINAL;
+CREATE TABLE dst_rmt_move (a UInt32, b UInt32) ENGINE = ReplacingMergeTree ORDER BY a;
+ALTER TABLE src_mt_move MOVE PARTITION tuple() TO TABLE dst_rmt_move;
+SELECT 'move level', max(level) FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_move' AND active;
+SELECT 'move final', count() FROM dst_rmt_move FINAL;
+
+-- Same engine on both sides: the part keeps its level (nothing to re-merge, and resetting
+-- would lose the optimize_on_insert signal). Verify the level is preserved, not reset.
+CREATE TABLE src_rmt_same (a UInt32, b UInt32) ENGINE = ReplacingMergeTree ORDER BY a;
+INSERT INTO src_rmt_same VALUES (1, 10);
+INSERT INTO src_rmt_same VALUES (1, 20);
+OPTIMIZE TABLE src_rmt_same FINAL;
+CREATE TABLE dst_rmt_same (a UInt32, b UInt32) ENGINE = ReplacingMergeTree ORDER BY a;
+ALTER TABLE dst_rmt_same ATTACH PARTITION tuple() FROM src_rmt_same;
+SELECT 'same engine level preserved', max(level) > 0 FROM system.parts WHERE database = currentDatabase() AND table = 'dst_rmt_same' AND active;
+SELECT 'same engine final', count() FROM dst_rmt_same FINAL;
+
+DROP TABLE src_mt;
+DROP TABLE dst_rmt_clone;
+DROP TABLE dst_rmt_attach;
+DROP TABLE dst_smt;
+DROP TABLE src_mt_agg;
+DROP TABLE dst_amt;
+DROP TABLE src_mt_move;
+DROP TABLE dst_rmt_move;
+DROP TABLE src_rmt_same;
+DROP TABLE dst_rmt_same;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106798
Related: https://github.com/ClickHouse/ClickHouse/issues/70667
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/106798

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SELECT ... FINAL` and `OPTIMIZE TABLE ... FINAL` returning duplicate rows after `CREATE TABLE ... CLONE AS`, `ATTACH PARTITION ... FROM` or `MOVE PARTITION ... TO TABLE` adopted parts from a plain `MergeTree` into a `ReplacingMergeTree`, `SummingMergeTree` or `AggregatingMergeTree`. The adopted part's merge level is now reset to 0 when the source and destination engines differ, so the destination deduplicates it on the next merge.


### Description

A part adopted via `CLONE AS`, `ATTACH`/`REPLACE PARTITION ... FROM` or `MOVE PARTITION ... TO TABLE` kept the source part's merge level. A lone part at level greater than 0 is treated by `FINAL`/`OPTIMIZE` as already fully merged, so the row-collapsing transform of `ReplacingMergeTree`/`SummingMergeTree`/`AggregatingMergeTree` is skipped. When the source is a plain `MergeTree` (no row collapsing on merge), such a part still holds duplicate ORDER BY keys, so they survived `SELECT ... FINAL` and `OPTIMIZE TABLE ... FINAL`.

The fix resets the adopted part's level to 0 when the destination merge mode differs from the source's, so the destination re-merges the part under its own semantics. Same-engine adoption keeps the level unchanged, preserving the existing `optimize_on_insert` behavior (test `03283_optimize_on_insert_level`) and avoiding a pointless re-merge. Applied at the four part-adoption sites in `StorageMergeTree` and `StorageReplicatedMergeTree` (replace and move partition) through a shared helper.

This implements the approach picked by tuanpach in the issue discussion (reset level to 0 only when source and target engines differ).

Reproduction (now returns 1 on patched server, returned 2 before):
```
CREATE TABLE t_mt (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY a;
INSERT INTO t_mt VALUES (1, 10);
INSERT INTO t_mt VALUES (1, 20);
OPTIMIZE TABLE t_mt FINAL;
CREATE TABLE t_rmt CLONE AS t_mt ENGINE = ReplacingMergeTree;
SELECT count() FROM t_rmt FINAL;
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.835` (included in `26.6` and later)
- Backported to: `26.5.6.40`, `26.4.5.127`, `26.3.17.44`
<!-- ch-version-info:end -->