### PR TITLE
Reject duplicate paths for `encrypted` disks

### DIFF
--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -189,8 +189,12 @@ namespace
     }
 
     /// Reads the name of a wrapped disk & the path on the wrapped disk and then finds that disk in a disk map.
-    void getDiskAndPathFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, const DisksMap & map,
-                                  DiskPtr & out_disk, String & out_path)
+    void getDiskAndPathFromConfig(
+        const Poco::Util::AbstractConfiguration & config,
+        const String & config_prefix,
+        const DisksMap & map,
+        DiskPtr & out_disk,
+        String & out_path)
     {
         String disk_name = config.getString(config_prefix + ".disk", "");
         if (disk_name.empty())
@@ -207,6 +211,32 @@ namespace
         out_path = config.getString(config_prefix + ".path", "");
         if (!out_path.empty() && (out_path.back() != '/'))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Disk path must ends with '/', but '{}' doesn't.", quoteString(out_path));
+
+        /// The path must be relative to the wrapped disk's root. An absolute path would escape the delegate:
+        /// `DiskLocal` joins paths with `fs::path(delegate_root) / out_path`, and `fs::path::operator/` discards
+        /// the left-hand side when the right-hand side is absolute, so the files would land outside the delegate.
+        /// It also makes storage namespace identity unreliable, because disks over different delegates would appear
+        /// distinct while operating on the same underlying files. Rejecting absolute paths keeps the delegate's root
+        /// as a prefix of the effective path.
+        if (!out_path.empty() && (out_path.front() == '/'))
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disk path must be relative to the wrapped disk, but '{}' is absolute.",
+                quoteString(out_path));
+
+        /// `DiskLocal` resolves the wrapped path on the filesystem, so traversal (`..`), current-directory (`.`)
+        /// and repeated-separator components are collapsed when files are accessed. Normalize the effective path
+        /// before checking that it stays under the delegate's root.
+        const fs::path delegate_root = fs::path(out_disk->getPath()).lexically_normal();
+        const fs::path effective_path = fs::path(out_disk->getPath() + out_path).lexically_normal();
+        if (const auto relative_to_root = effective_path.lexically_relative(delegate_root);
+            relative_to_root.empty() || *relative_to_root.begin() == "..")
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disk path '{}' must stay within the wrapped disk's root '{}'.",
+                quoteString(out_path),
+                quoteString(out_disk->getPath()));
+
     }
 
     /// Parses the settings of an encrypted disk from the configuration.

--- a/src/Disks/StoragePolicy.cpp
+++ b/src/Disks/StoragePolicy.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <exception>
+#include <filesystem>
 #include <ranges>
 #include <set>
 
@@ -117,6 +118,7 @@ StoragePolicy::StoragePolicy(
                         "Disk move factor have to be in [0., 1.] interval, but set to {} in storage policy {}",
                         move_factor, backQuote(name));
 
+    validateDisksHaveDistinctStorageNamespaces();
     buildVolumeIndices();
     LOG_TRACE(log, "Storage policy {} created, total volumes {}", name, volumes.size());
 }
@@ -136,6 +138,7 @@ StoragePolicy::StoragePolicy(String name_, Volumes volumes_, double move_factor_
                         "Disk move factor have to be in [0., 1.] interval, but set to {} in storage policy {}",
                         move_factor, backQuote(name));
 
+    validateDisksHaveDistinctStorageNamespaces();
     buildVolumeIndices();
     LOG_TRACE(log, "Storage policy {} created, total volumes {}", name, volumes.size());
 }
@@ -170,6 +173,8 @@ StoragePolicy::StoragePolicy(StoragePolicyPtr storage_policy,
             }
         }
     }
+
+    validateDisksHaveDistinctStorageNamespaces();
 }
 
 
@@ -467,6 +472,46 @@ void StoragePolicy::buildVolumeIndices()
 
             volume_index_by_disk_name[disk_name] = index;
         }
+    }
+}
+
+void StoragePolicy::validateDisksHaveDistinctStorageNamespaces() const
+{
+    struct StorageNamespace
+    {
+        DataSourceType type;
+        ObjectStorageType object_storage_type;
+        String description;
+        String path;
+
+        auto operator<=>(const StorageNamespace &) const = default;
+    };
+
+    std::map<StorageNamespace, String> disk_by_namespace;
+    for (const auto & disk : getDisks())
+    {
+        const auto data_source = disk->getDataSourceDescription();
+
+        /// Separate in-memory disks do not share a persistent namespace even though their paths are empty.
+        if (data_source.type == DataSourceType::RAM)
+            continue;
+
+        StorageNamespace storage_namespace{
+            .type = data_source.type,
+            .object_storage_type = data_source.object_storage_type,
+            .description = data_source.type == DataSourceType::ObjectStorage ? data_source.description : String{},
+            .path = std::filesystem::path(disk->getPath()).lexically_normal().string(),
+        };
+
+        auto [it, inserted] = disk_by_namespace.emplace(storage_namespace, disk->getName());
+        if (!inserted && it->second != disk->getName())
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Disks {} and {} in storage policy {} resolve to the same storage namespace ({})",
+                backQuote(it->second),
+                backQuote(disk->getName()),
+                backQuote(name),
+                quoteString(storage_namespace.path));
     }
 }
 

--- a/src/Disks/StoragePolicy.h
+++ b/src/Disks/StoragePolicy.h
@@ -102,6 +102,7 @@ private:
     double move_factor = 0.1; /// by default move factor is 10%
 
     void buildVolumeIndices();
+    void validateDisksHaveDistinctStorageNamespaces() const;
 
     LoggerPtr log;
 };

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -9,6 +9,8 @@
 #include <Disks/IDisk.h>
 #include <Disks/DiskLocal.h>
 #include <Disks/DiskEncrypted.h>
+#include <Disks/SingleDiskVolume.h>
+#include <Disks/StoragePolicy.h>
 #include <IO/FileEncryptionCommon.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
@@ -54,6 +56,26 @@ protected:
         settings->disk_path = path;
         encrypted_disk = std::make_shared<DiskEncrypted>("encrypted_disk", std::move(settings));
         return encrypted_disk;
+    }
+
+    static void configureEncryptedDisk(
+        Poco::Util::XMLConfiguration & config,
+        const String & prefix,
+        const String & wrapped_disk,
+        const std::optional<String> & path)
+    {
+        config.setString(prefix + ".key", "1234567890123456");
+        config.setString(prefix + ".disk", wrapped_disk);
+        if (path)
+            config.setString(prefix + ".path", *path);
+    }
+
+    static std::shared_ptr<DiskEncrypted> makeConfiguredEncryptedDisk(
+        const String & name,
+        const Poco::Util::XMLConfiguration & config,
+        const DisksMap & disks)
+    {
+        return std::make_shared<DiskEncrypted>(name, config, name, disks);
     }
 
     String getFileNames()
@@ -481,4 +503,159 @@ TEST_F(DiskEncryptedTest, DoubleEncrypted)
     auto double_encrypted_disk = makeEncryptedDisk(FileEncryption::Algorithm::AES_128_CTR, "1234567890123456", single_encrypted_disk);
 
     testSeekAndReadUntilPosition(encrypted_disk, "a.txt", {});
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationAllowsSameDelegateAndExplicitPathInDifferentPolicies)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    EXPECT_NO_THROW(StoragePolicy("policy1", Volumes{std::make_shared<SingleDiskVolume>("volume1", encrypted1)}, 0.0));
+    EXPECT_NO_THROW(StoragePolicy("policy2", Volumes{std::make_shared<SingleDiskVolume>("volume2", encrypted2)}, 0.0));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsSameDelegateAndExplicitPath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsSameNamespaceOverDifferentDelegates)
+{
+    auto nested_local_disk = std::make_shared<DiskLocal>("nested_local_disk", getDirectory() + "data/");
+
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "nested_local_disk", "encrypted/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "data/encrypted/");
+
+    DisksMap disks{{"local_disk", local_disk}, {"nested_local_disk", nested_local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationRejectsAbsolutePath)
+{
+    /// An absolute `path` would escape the wrapped disk: `DiskLocal` joins paths with `fs::path(root) / path`,
+    /// and `fs::path::operator/` discards the root when the right-hand side is absolute. Such a path must be rejected
+    /// before storage-policy namespace validation because it violates the delegate boundary.
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "/data/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsTraversalAliasOfSamePath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "a/../b/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "b/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationRejectsPathEscapingDelegateRoot)
+{
+    /// A relative `path` that escapes the delegate's root via `..` lands outside the wrapped disk, just like an
+    /// absolute path and breaks isolation. It must be rejected.
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "../escape/");
+
+    DisksMap disks{{"local_disk", local_disk}};
+    EXPECT_THROW(makeConfiguredEncryptedDisk("encrypted1", *config, disks), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, ConfigurationAllowsDifferentPathsOrDelegates)
+{
+    auto other_local_disk = std::make_shared<DiskLocal>("other_local_disk", getDirectory() + "other/");
+
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", "data/");
+    configureEncryptedDisk(*config, "encrypted2", "local_disk", "other_data/");
+    configureEncryptedDisk(*config, "encrypted3", "other_local_disk", "data/");
+
+    DisksMap disks{{"local_disk", local_disk}, {"other_local_disk", other_local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+    disks.emplace("encrypted1", encrypted1);
+    auto encrypted2 = makeConfiguredEncryptedDisk("encrypted2", *config, disks);
+    disks.emplace("encrypted2", encrypted2);
+    auto encrypted3 = makeConfiguredEncryptedDisk("encrypted3", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", encrypted1),
+        std::make_shared<SingleDiskVolume>("volume2", encrypted2),
+        std::make_shared<SingleDiskVolume>("volume3", encrypted3),
+    };
+    EXPECT_NO_THROW(StoragePolicy("policy", std::move(volumes), 0.1));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyAllowsEncryptedWithoutPathAsOnlyDisk)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", std::nullopt);
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+
+    EXPECT_NO_THROW(StoragePolicy("policy", Volumes{std::make_shared<SingleDiskVolume>("volume", encrypted1)}, 0.0));
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsDelegateAndEncryptedWithoutPath)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());
+    configureEncryptedDisk(*config, "encrypted1", "local_disk", std::nullopt);
+
+    DisksMap disks{{"local_disk", local_disk}};
+    auto encrypted1 = makeConfiguredEncryptedDisk("encrypted1", *config, disks);
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("plain_volume", local_disk),
+        std::make_shared<SingleDiskVolume>("encrypted_volume", encrypted1),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
+}
+
+TEST_F(DiskEncryptedTest, StoragePolicyRejectsLocalDiskAliases)
+{
+    auto local_disk_alias = std::make_shared<DiskLocal>("local_disk_alias", getDirectory());
+
+    Volumes volumes{
+        std::make_shared<SingleDiskVolume>("volume1", local_disk),
+        std::make_shared<SingleDiskVolume>("volume2", local_disk_alias),
+    };
+    EXPECT_THROW(StoragePolicy("policy", std::move(volumes), 0.1), DB::Exception);
 }


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/88808

Two `encrypted` disks could resolve to the same underlying disk path. ClickHouse accepted this configuration, so both disks operated on the same underlying files. After a restart, parts could be identified as duplicates and removed, causing data loss.

Reject an `encrypted` disk configuration when another `encrypted` disk already uses the same resolved path. The validation applies during initial configuration parsing and configuration reload, while excluding the disk itself during reload. Tests cover explicit and default paths, allowed combinations with different effective paths, same resolved paths produced by different delegate roots and relative `path` values, and configuration reload.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject configurations where multiple `encrypted` disks use the same underlying disk path, which could cause data loss after a server restart.

### Documentation entry:
- [ ] Documentation is written (mandatory for new features)