### PR TITLE
docs: clarify that parallel_view_processing only applies to INSERT ... SELECT

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3954,6 +3954,7 @@ If it is set to true, then a user is allowed to executed DDL queries.
 )", 0) \
     DECLARE(Bool, parallel_view_processing, false, R"(
 Enables pushing to attached views concurrently instead of sequentially.
+Note: this setting only applies to INSERT ... SELECT queries. For INSERT ... VALUES queries, view processing parallelism is controlled by the max_threads setting. Buffer engine tables always process views sequentially, regardless of this setting.
 )", 0) \
     DECLARE(Bool, enable_unaligned_array_join, false, R"(
 Allow ARRAY JOIN with multiple arrays that have different sizes. When this settings is enabled, arrays will be resized to the longest one.


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106845

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
No changelog entry required for documentation fixes.