### PR TITLE
Follow-up for silk fibers aware sockets

### DIFF
--- a/base/poco/Net/include/Poco/Net/SocketImpl.h
+++ b/base/poco/Net/include/Poco/Net/SocketImpl.h
@@ -391,6 +391,10 @@ namespace Net
         /// Returns true iff an external poller can drive this socket's
         /// readiness (the non-blocking / EAGAIN model).
 
+        virtual bool connectionOpen();
+        /// Returns true iff the peer has not closed the connection,
+        /// checked without consuming pending data or blocking.
+
         int socketError();
         /// Returns the value of the SO_ERROR socket option.
 

--- a/base/poco/Net/src/SocketImpl.cpp
+++ b/base/poco/Net/src/SocketImpl.cpp
@@ -502,6 +502,23 @@ bool SocketImpl::supportsExternalPolling() const
 }
 
 
+bool SocketImpl::connectionOpen()
+{
+	if (_sockfd == POCO_INVALID_SOCKET)
+		return false;
+
+	char b = 0;
+	int rc = ::recv(_sockfd, &b, 1, MSG_DONTWAIT | MSG_PEEK);
+	if (rc > 0)
+		return true;
+	if (rc == 0)
+		return false;
+
+	int err = lastError();
+	return err == POCO_EAGAIN || err == POCO_EWOULDBLOCK;
+}
+
+
 bool SocketImpl::pollImpl(Poco::Timespan& remainingTime, int mode)
 {
 	poco_socket_t sockfd = _sockfd;

--- a/src/IO/SilkFiberStreamSocketImpl.cpp
+++ b/src/IO/SilkFiberStreamSocketImpl.cpp
@@ -116,46 +116,39 @@ int FiberStreamSocketImpl::sendBytes(const void * buffer, int length, int flags)
             "Silk::FiberStreamSocketImpl::sendBytes: non-zero flags ({}) not supported",
             flags);
 
-    int total = 0;
-    const char * ptr = static_cast<const char *>(buffer);
-    Poco::Timespan timeout = getSendTimeout();
-    while (total < length)
+    throttleSend(static_cast<size_t>(length), getBlocking());
+
+    uint64_t bytes_written = 0;
+    silk::FiberScheduler::IoFuture future;
+    iovec iov{const_cast<void *>(buffer), static_cast<size_t>(length)};
+    silk::FiberScheduler::write(sockfd(), &iov, 1, 0, &bytes_written, &future);
+
+    const Poco::Timespan timeout = getSendTimeout();
+    int r = 0;
+    if (timeout.totalMicroseconds() > 0)
     {
-        throttleSend(static_cast<size_t>(length - total), getBlocking());
-
-        uint64_t bytes_written = 0;
-        silk::FiberScheduler::IoFuture future;
-        iovec iov{const_cast<char *>(ptr), static_cast<size_t>(length - total)};
-        silk::FiberScheduler::write(sockfd(), &iov, 1, 0, &bytes_written, &future);
-
-        int r = 0;
-        if (timeout.totalMicroseconds() > 0)
+        r = silk::FiberFuture::waitWithTimeout(
+            &future,
+            static_cast<uint64_t>(timeout.totalMicroseconds()) * 1000);
+        if (r == ETIMEDOUT)
         {
-            r = silk::FiberFuture::waitWithTimeout(
-                &future,
-                static_cast<uint64_t>(timeout.totalMicroseconds()) * 1000);
-            if (r == ETIMEDOUT)
-            {
-                future.cancel();
-                r = future.wait();
-                if (r == ECANCELED)
-                    throw Poco::TimeoutException("Send timed out", peerAddress().toString());
-            }
-        }
-        else
-        {
+            future.cancel();
             r = future.wait();
+            if (r == ECANCELED)
+                throw Poco::TimeoutException("Send timed out", peerAddress().toString());
         }
-
-        if (r)
-            error(r, "send");
-
-        useSendThrottlerBudget(static_cast<int>(bytes_written));
-
-        total += static_cast<int>(bytes_written);
-        ptr += bytes_written;
     }
-    return total;
+    else
+    {
+        r = future.wait();
+    }
+
+    if (r)
+        error(r, "send");
+
+    useSendThrottlerBudget(static_cast<int>(bytes_written));
+
+    return static_cast<int>(bytes_written);
 }
 
 int FiberStreamSocketImpl::receiveBytes(void * buffer, int length, int flags)
@@ -199,6 +192,16 @@ int FiberStreamSocketImpl::receiveBytes(void * buffer, int length, int flags)
     useRecvThrottlerBudget(static_cast<int>(bytes_read));
 
     return static_cast<int>(bytes_read);
+}
+
+void FiberStreamSocketImpl::setBlocking(bool flag)
+{
+    if (!flag)
+        throw DB::Exception(
+            DB::ErrorCodes::LOGICAL_ERROR,
+            "Non-blocking mode is not supported for Silk fibers aware sockets.");
+
+    Poco::Net::StreamSocketImpl::setBlocking(flag);
 }
 
 }

--- a/src/IO/SilkFiberStreamSocketImpl.h
+++ b/src/IO/SilkFiberStreamSocketImpl.h
@@ -21,6 +21,7 @@ public:
     bool pollImpl(Poco::Timespan & timeout, int mode) override;
     int sendBytes(const void * buffer, int length, int flags) override;
     int receiveBytes(void * buffer, int length, int flags) override;
+    void setBlocking(bool flag) override;
     bool supportsExternalPolling() const override { return false; }
 };
 

--- a/src/IO/tests/gtest_silk_fiber_stream_socket.cpp
+++ b/src/IO/tests/gtest_silk_fiber_stream_socket.cpp
@@ -26,10 +26,9 @@
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Timespan.h>
 
-#include <chrono>
 #include <cstdint>
+#include <latch>
 #include <string>
-#include <thread>
 
 
 namespace
@@ -162,10 +161,13 @@ TYPED_TEST(SilkFiberSocketTest, PollAndReceiveTimeout)
     auto listener = this->policy.makeListener();
     const uint16_t port = listener.address().port();
 
+    std::latch negative_poll_done{1};
+
     struct Params
     {
         uint16_t port;
         Poco::Net::StreamSocketImpl * impl;
+        std::latch * negative_poll_done;
     };
 
     silk::FiberFuture client_future;
@@ -188,6 +190,7 @@ TYPED_TEST(SilkFiberSocketTest, PollAndReceiveTimeout)
             }
 
             EXPECT_FALSE(socket.poll(Poco::Timespan(0, 50'000), Poco::Net::Socket::SELECT_READ));
+            p->negative_poll_done->count_down();
             EXPECT_TRUE(socket.poll(Poco::Timespan(0, 500'000), Poco::Net::Socket::SELECT_READ));
 
             char data[1] = {};
@@ -198,7 +201,7 @@ TYPED_TEST(SilkFiberSocketTest, PollAndReceiveTimeout)
             socket.close();
             return 0;
         },
-        Params{port, this->policy.makeClient()},
+        Params{port, this->policy.makeClient(), &negative_poll_done},
         &client_future);
     ASSERT_EQ(run_result, 0);
 
@@ -213,7 +216,7 @@ TYPED_TEST(SilkFiberSocketTest, PollAndReceiveTimeout)
     }
     peer.sendBytes("pong", 4);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    negative_poll_done.wait();
     peer.sendBytes("x", 1);
 
     client_future.wait();

--- a/src/Server/HTTP/HTTPServerRequest.cpp
+++ b/src/Server/HTTP/HTTPServerRequest.cpp
@@ -113,21 +113,7 @@ HTTPServerRequest::HTTPServerRequest(HTTPContextPtr context, HTTPServerResponse 
 
 bool HTTPServerRequest::checkPeerConnected() const
 {
-    try
-    {
-        char b = 0;
-        if (!socket->receiveBytes(&b, 1, MSG_DONTWAIT | MSG_PEEK))
-            return false;
-    }
-    catch (Poco::TimeoutException &) // NOLINT(bugprone-empty-catch)
-    {
-    }
-    catch (const std::exception &)
-    {
-        return false;
-    }
-
-    return true;
+    return socket->connectionOpen();
 }
 
 #if USE_SSL


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/106078

Follow-ups to #106078 (silk fibers aware socket implementations), addressing review feedback. Four small changes:

- **`FiberStreamSocketImpl::sendBytes` is now single-shot** — one write returning the (possibly partial) byte count, matching the `Poco::Net::StreamSocketImpl` contract and mirroring `receiveBytes`. `WriteBufferFromPocoSocket` already loops on partial writes, so the internal loop was redundant and re-armed the send timeout on every iteration.
- **`setBlocking(false)` is rejected** — non-blocking mode is incompatible with the fiber model, where the scheduler owns I/O readiness. This is symmetric with the existing rejection of non-zero `flags` (covering `MSG_DONTWAIT`) and the `supportsExternalPolling` guard on async callbacks.
- **New `SocketImpl::connectionOpen`** — peer-liveness detection used `receiveBytes(&b, 1, MSG_DONTWAIT | MSG_PEEK)` directly in `HTTPServerRequest::checkPeerConnected`, which would throw on fiber sockets (they reject non-zero receive flags). The new `Poco::Net::SocketImpl` virtual encapsulates the non-destructive, non-blocking peek behind an explicit name. The base implementation (a direct recv on the transport fd) is inherited unchanged by plain, secure, and fiber sockets.
- **Test race fix** — `PollAndReceiveTimeout` in the gtest used a `sleep` to order the server's send after the client's negative poll, which was racy under scheduling jitter. Replaced with a `std::latch` so the ordering is a happens-before guarantee.

Built locally; the silk gtest suite passes for both the plain and TLS policies.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
