### PR TITLE
Fix "Not-ready Set" error for IN subquery wrapped in an expression on partitioned tables

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2376,12 +2376,6 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
             storage_snapshot->metadata,
             skip_partition_pruning);
 
-        /// KeyCondition only builds sets for top-level IN atoms, so an IN wrapped in a larger
-        /// expression would be executed unbuilt during partition pruning ("Not-ready Set").
-        /// Must run after buildIndexes and before the PREWHERE builds; GLOBAL IN is excluded.
-        if (index_filter_dag)
-            VirtualColumnUtils::buildSetsForDAGExcludingGlobalIn(*index_filter_dag, context);
-
         /// Build sets for PREWHERE and row_level_filter synchronously during applyFilters.
         /// PREWHERE is evaluated at the storage level during data reading, before the
         /// pipeline-level CreatingSetsStep has a chance to execute. Although CreatingSetsStep

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2376,6 +2376,12 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
             storage_snapshot->metadata,
             skip_partition_pruning);
 
+        /// KeyCondition only builds sets for top-level IN atoms, so an IN wrapped in a larger
+        /// expression would be executed unbuilt during partition pruning ("Not-ready Set").
+        /// Must run after buildIndexes and before the PREWHERE builds; GLOBAL IN is excluded.
+        if (index_filter_dag)
+            VirtualColumnUtils::buildSetsForDAGExcludingGlobalIn(*index_filter_dag, context);
+
         /// Build sets for PREWHERE and row_level_filter synchronously during applyFilters.
         /// PREWHERE is evaluated at the storage level during data reading, before the
         /// pipeline-level CreatingSetsStep has a chance to execute. Although CreatingSetsStep

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2778,10 +2778,12 @@ bool KeyCondition::isKeyPossiblyWrappedByMonotonicFunctionsImpl(
     {
         auto function_node = node.toFunctionNode();
 
-        /// GLOBAL IN / GLOBAL NOT IN sets are not built before index analysis (ReadFromRemote fills
-        /// them later), so they must not enter the monotonic function chain or pruning would execute
-        /// them against an unbuilt set ("Not-ready Set").
-        if (functionIsGlobalInOperator(function_node.getFunctionName()))
+        /// A top-level IN atom builds its set via tryPrepareSetIndexForIn, but an IN wrapped in a
+        /// larger expression reaches here as a chain link. Its set is not built for this analysis
+        /// (and GLOBAL IN sets are filled later by ReadFromRemote), so keep all IN operators out of
+        /// the monotonic function chain or pruning would execute them against an unbuilt set
+        /// ("Not-ready Set").
+        if (functionIsInOrGlobalInOperator(function_node.getFunctionName()))
             return false;
 
         size_t arguments_size = function_node.getArgumentsSize();

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2778,6 +2778,12 @@ bool KeyCondition::isKeyPossiblyWrappedByMonotonicFunctionsImpl(
     {
         auto function_node = node.toFunctionNode();
 
+        /// GLOBAL IN / GLOBAL NOT IN sets are not built before index analysis (ReadFromRemote fills
+        /// them later), so they must not enter the monotonic function chain or pruning would execute
+        /// them against an unbuilt set ("Not-ready Set").
+        if (functionIsGlobalInOperator(function_node.getFunctionName()))
+            return false;
+
         size_t arguments_size = function_node.getArgumentsSize();
         if (arguments_size > 2 || arguments_size == 0)
             return false;

--- a/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.reference
+++ b/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.reference
@@ -9,3 +9,11 @@
 -- partitioned + top-level IN
 2
 3
+-- partitioned + wrapped GLOBAL IN
+2
+3
+-- partitioned + wrapped GLOBAL NOT IN
+1
+-- partitioned + top-level GLOBAL IN
+2
+3

--- a/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.reference
+++ b/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.reference
@@ -1,0 +1,11 @@
+-- partitioned + wrapped IN
+2
+3
+-- partitioned + wrapped NOT IN
+1
+-- non-partitioned control
+2
+3
+-- partitioned + top-level IN
+2
+3

--- a/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.sql
+++ b/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.sql
@@ -1,0 +1,37 @@
+-- Regression test for "Not-ready Set" error during partition pruning when an
+-- IN (subquery) condition is wrapped inside a larger expression (e.g. `... != 0`)
+-- on a table with a PARTITION BY key.
+-- https://github.com/ClickHouse/ClickHouse/issues/107503
+--
+-- The wrapped IN is not a top-level filter atom, so KeyCondition does not build
+-- its set. The set was then executed unbuilt during PartitionPruner key analysis,
+-- raising "Not-ready Set is passed as the second argument for function 'in'".
+-- This is the partition-pruning counterpart of the PREWHERE fix in #100375.
+
+DROP TABLE IF EXISTS t_107503_part;
+DROP TABLE IF EXISTS t_107503_set;
+DROP TABLE IF EXISTS t_107503_nopart;
+
+CREATE TABLE t_107503_part (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY c0;
+CREATE TABLE t_107503_set (c2 Int32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_107503_nopart (c0 Int32) ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_107503_part VALUES (1), (2), (3);
+INSERT INTO t_107503_set VALUES (2), (3);
+INSERT INTO t_107503_nopart VALUES (1), (2), (3);
+
+SELECT '-- partitioned + wrapped IN';
+SELECT c0 FROM t_107503_part WHERE (c0 IN (SELECT c2 FROM t_107503_set)) != 0 ORDER BY c0;
+
+SELECT '-- partitioned + wrapped NOT IN';
+SELECT c0 FROM t_107503_part WHERE (c0 NOT IN (SELECT c2 FROM t_107503_set)) != 0 ORDER BY c0;
+
+SELECT '-- non-partitioned control';
+SELECT c0 FROM t_107503_nopart WHERE (c0 IN (SELECT c2 FROM t_107503_set)) != 0 ORDER BY c0;
+
+SELECT '-- partitioned + top-level IN';
+SELECT c0 FROM t_107503_part WHERE c0 IN (SELECT c2 FROM t_107503_set) ORDER BY c0;
+
+DROP TABLE t_107503_part;
+DROP TABLE t_107503_set;
+DROP TABLE t_107503_nopart;

--- a/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.sql
+++ b/tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.sql
@@ -7,6 +7,11 @@
 -- its set. The set was then executed unbuilt during PartitionPruner key analysis,
 -- raising "Not-ready Set is passed as the second argument for function 'in'".
 -- This is the partition-pruning counterpart of the PREWHERE fix in #100375.
+--
+-- A wrapped GLOBAL IN / GLOBAL NOT IN hits the same partition-pruning path but its
+-- set is intentionally never built before reading (ReadFromRemote fills it later),
+-- so it must be kept out of the single-point monotonic chain entirely, otherwise
+-- pruning raised "Not-ready Set ... for function 'globalIn'".
 
 DROP TABLE IF EXISTS t_107503_part;
 DROP TABLE IF EXISTS t_107503_set;
@@ -31,6 +36,15 @@ SELECT c0 FROM t_107503_nopart WHERE (c0 IN (SELECT c2 FROM t_107503_set)) != 0 
 
 SELECT '-- partitioned + top-level IN';
 SELECT c0 FROM t_107503_part WHERE c0 IN (SELECT c2 FROM t_107503_set) ORDER BY c0;
+
+SELECT '-- partitioned + wrapped GLOBAL IN';
+SELECT c0 FROM t_107503_part WHERE (c0 GLOBAL IN (SELECT c2 FROM t_107503_set)) != 0 ORDER BY c0;
+
+SELECT '-- partitioned + wrapped GLOBAL NOT IN';
+SELECT c0 FROM t_107503_part WHERE (c0 GLOBAL NOT IN (SELECT c2 FROM t_107503_set)) != 0 ORDER BY c0;
+
+SELECT '-- partitioned + top-level GLOBAL IN';
+SELECT c0 FROM t_107503_part WHERE c0 GLOBAL IN (SELECT c2 FROM t_107503_set) ORDER BY c0;
 
 DROP TABLE t_107503_part;
 DROP TABLE t_107503_set;


### PR DESCRIPTION
<!--
Linked issues and pull requests.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107503
-->

Closes: #107503


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `Not-ready Set is passed as the second argument for function 'in'` (`LOGICAL_ERROR`) when querying a table with a `PARTITION BY` key and an `IN`/`NOT IN` subquery wrapped inside a larger expression, for example `WHERE (c0 IN (SELECT ...)) != 0`.


### Description

`ReadFromMergeTree::applyFilters` builds `IN`-subquery sets synchronously for the PREWHERE and row-level-filter DAGs (the latter was the fix for #100375), but not for the index/partition-pruning DAG. `KeyCondition` only builds sets for top-level `IN` atoms, so when the `IN` is wrapped in an expression the set is never prepared and is then executed unbuilt during `PartitionPruner` key analysis, raising the error.

This builds the sets for the index filter DAG as well, using the existing `buildSetsForDAGExcludingGlobalIn` helper. It prefers the ordered build (so the set retains explicit elements that `KeyCondition` needs for primary-key and skip-index analysis) and excludes GLOBAL `IN`, whose sets must be populated by `ReadFromRemote` first. The call is placed after `buildIndexes` and before the PREWHERE builds. This is the partition-pruning counterpart of the PREWHERE fix in #100375.

Reproducer (fails on master, returns `2`, `3` with this fix):
```sql
CREATE TABLE t_part (c0 Int32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY c0;
CREATE TABLE t_set  (c2 Int32) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t_part VALUES (1), (2), (3);
INSERT INTO t_set  VALUES (2), (3);
SELECT c0 FROM t_part WHERE (c0 IN (SELECT c2 FROM t_set)) != 0 ORDER BY c0;
```

A regression test is added in `tests/queries/0_stateless/04339_in_subquery_partition_pruning_not_ready_set.sql` covering wrapped `IN`, wrapped `NOT IN`, a non-partitioned control, and a top-level `IN`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.873`
<!-- ch-version-info:end -->