### PR TITLE
Raise per-worker memory budget for --dist=each integration checks

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -31,6 +31,12 @@ mem_gb = round(Utils.physical_memory() // (1024**3), 1)
 
 MAX_CPUS_PER_WORKER = 5
 MAX_MEM_PER_WORKER = 11
+# Flaky/targeted checks run with --dist=each, so every worker runs the full set
+# of changed modules concurrently (each with its own Docker cluster) instead of
+# splitting modules across workers. A worker's peak footprint is therefore much
+# larger, so it needs a bigger memory budget to avoid exhausting the container
+# cgroup and tripping the kernel OOM killer (see OOM_IN_DMESG_TEST_NAME).
+MAX_MEM_PER_WORKER_DIST_EACH = 20
 
 INFRASTRUCTURE_ERROR_PATTERNS = [
     "timed out after",
@@ -640,9 +646,16 @@ tar -czf ./ci/tmp/logs.tar.gz \
     if args.workers:
         workers = args.workers
     else:
+        # --dist=each (flaky/targeted checks) makes every worker run all modules,
+        # so budget more memory per worker than the module-splitting loadfile runs.
+        mem_per_worker = (
+            MAX_MEM_PER_WORKER_DIST_EACH
+            if is_flaky_check or is_targeted_check
+            else MAX_MEM_PER_WORKER
+        )
         print("ncpu:", ncpu)
         print("mem_gb:", mem_gb)
-        workers = min(ncpu // MAX_CPUS_PER_WORKER, mem_gb // MAX_MEM_PER_WORKER) or 1
+        workers = min(ncpu // MAX_CPUS_PER_WORKER, mem_gb // mem_per_worker) or 1
 
     clickhouse_path = f"{Utils.cwd()}/ci/tmp/clickhouse"
     clickhouse_server_config_dir = f"{Utils.cwd()}/programs/server"


### PR DESCRIPTION
The flaky and targeted integration checks run `pytest` with `--dist=each`, so every
xdist worker runs the full set of changed modules concurrently, each in its own Docker
cluster, instead of splitting modules across workers like the `--dist=loadfile` runs.

The worker count still used the loadfile budget of 11 GB per worker. A PR that changes
many memory-heavy modules (Spark JVMs plus several Address Sanitizer server clusters)
could therefore start more concurrent workers than fit the container memory cgroup. The
kernel OOM killer then fired and the `OOM in dmesg` check failed the job, even though the
victim picked by `oom_score_adj` was an unrelated Spark `java` process rather than the
real consumer (the ClickHouse servers).

This uses a separate, larger memory budget of 20 GB per worker for the `--dist=each`
path. On a 16 vCPU / 60 GB runner it drops the flaky check from 3 to 2 workers, cutting
peak memory by about a third while keeping a meaningful flakiness signal (sequential
repeats stay at `max(3, workers)`). The `--dist=loadfile` runs are unchanged.

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106855&sha=42de24e863b6181d0e1c88201f4acbf83905922d&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20flaky%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.905`
<!-- ch-version-info:end -->