### PR TITLE
ci: fix INSERTs into ci-logs with "User memory limit exceeded: would use 29.80 GiB"

### DIFF
--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -78,6 +78,10 @@ class LogCluster:
             "query": query,
             "date_time_input_format": "best_effort",
             "send_logs_level": "warning",
+            # Override the per-user memory limit from the cluster's default
+            # profile, which otherwise aborts large INSERTs with
+            # "User memory limit exceeded" via the OvercommitTracker.
+            "max_memory_usage_for_user": 0,
         }
         if db_name:
             params["database"] = db_name

--- a/tests/config/users.d/ci_logs_sender.yaml
+++ b/tests/config/users.d/ci_logs_sender.yaml
@@ -10,6 +10,8 @@ profiles:
         # Avoid polluting caches
         enable_filesystem_cache_on_write_operations: 0
         write_through_distributed_cache: 0
+        # Override local default limit of 32G
+        max_memory_usage_for_user: 0
 users:
     ci_logs_sender:
         profile: ci_logs_sender


### PR DESCRIPTION
While sending data to ci-logs the query may fail with:

    Code: 241. DB::Exception: User memory limit exceeded: would use 29.80 GiB (attempt to allocate chunk of 4.92 MiB), maximum: 29.80 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker: While executing ParallelParsingBlockInputFormat. (MEMORY_LIMIT_EXCEEDED) (version 26.6.1.701 (official build))
    assert self._log_cluster.do_query(query, data=data_fd, timeout=50)

But, nobody sets this limit, the problem is that it is applied due to it is in default profile in limits.yaml for CI.

Reset limit for ci_logs_sender.

And I do not see that we need to override smth else - https://pastila.nl/?0033e77c/eeb1821ba3bd53bc396f395b10af58e3#qHIKYqYNQYhlVuhNrgTTOw==GCM

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.916`
<!-- ch-version-info:end -->