### PR TITLE
CI: emit only job-added KV data in per-job output

### DIFF
--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -44,6 +44,11 @@ class _Environment(MetaClasses.Serializable):
     TRACEBACKS: List[str] = dataclasses.field(default_factory=list)
     WORKFLOW_JOB_DATA: Dict[str, Any] = dataclasses.field(default_factory=dict)
     JOB_KV_DATA: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Keys present in JOB_KV_DATA when the job started, i.e. inherited from the
+    # initial (config) job. Used in Runner._post_run to emit only the KV data a
+    # job itself added as the job's `data` output, instead of re-emitting the
+    # whole inherited bucket into every job's output (toJson(needs)).
+    JOB_KV_DATA_BASE_KEYS: List[str] = dataclasses.field(default_factory=list)
     COMMIT_AUTHORS: List[str] = dataclasses.field(default_factory=list)
     WORKFLOW_CONFIG: Optional[Dict[str, Any]] = None
     name = "environment"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -152,6 +152,10 @@ class Runner:
         else:
             print("Read GH Environment from workflow data")
             env = _Environment.from_workflow_data()
+        # Record the KV-data keys inherited from the initial (config) job so the
+        # job's `data` output later carries only what this job itself added (see
+        # _post_run), not the whole inherited bucket duplicated into every job.
+        env.JOB_KV_DATA_BASE_KEYS = list(env.JOB_KV_DATA.keys())
         env.JOB_NAME = job.name
         os.environ["JOB_NAME"] = job.name
         os.environ["CHECK_NAME"] = job.name
@@ -657,7 +661,14 @@ class Runner:
                     result.set_link(link)
 
         # run after post hooks as they might modify workflow kv data
-        job_outputs = env.JOB_KV_DATA
+        # Non-initial jobs inherit the whole JOB_KV_DATA from the initial (config)
+        # job at startup (see _setup_env / _Environment.from_workflow_data). Emit
+        # only the keys this job itself added, so every job's `data` output does
+        # not re-duplicate the inherited bucket into toJson(needs).
+        base_keys = set(env.JOB_KV_DATA_BASE_KEYS or [])
+        job_outputs = {
+            k: v for k, v in env.JOB_KV_DATA.items() if k not in base_keys
+        }
         print(f"Job's output: [{list(job_outputs.keys())}]")
         if is_initial_job:
             output = dataclasses.asdict(env)


### PR DESCRIPTION
Every CI job loads `JOB_KV_DATA` from the initial (config) job at startup (`_Environment.from_workflow_data`), so at the start of each job its `JOB_KV_DATA` is already a full copy of the config job's KV data (`changed_files`, `master_commits`, `build_digest`, `version`, ...). In `Runner._post_run` a non-initial job then wrote its entire `JOB_KV_DATA` as the job's `data` output, so `${{ toJson(needs) }}` duplicated the whole inherited bucket once per job. This payload is never read for non-config jobs — only the config job's `data` is consumed downstream — and it bloats the workflow status JSON enough that GitHub can fail to process it.

This snapshots the inherited KV-data keys in `_setup_env` into a new `JOB_KV_DATA_BASE_KEYS` env field, and in `_post_run` emits only the keys a job itself added. The initial (config) job's output is unchanged: it still base64-encodes the full `JOB_KV_DATA`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.894`
<!-- ch-version-info:end -->