### PR TITLE
Clear LimitByTransform output_slices at transform entry

### DIFF
--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -5,6 +5,7 @@
 #include <Core/Block.h>
 #include <DataTypes/IDataType.h>
 #include <base/defines.h>
+#include <base/scope_guard.h>
 #include <Common/Exception.h>
 
 #include <algorithm>
@@ -266,6 +267,13 @@ void LimitByTransform::transform(Chunk & chunk)
     if (row_count == 0)
         return;
 
+    /// `output_slices` is a member scratch buffer reused across chunks. If anything
+    /// below throws (e.g. MEMORY_LIMIT_EXCEEDED while growing the grouping hash table),
+    /// `ISimpleTransform::work` keeps this transform alive and may call `transform`
+    /// again on the next chunk, so the buffer must be cleared on every exit path, not
+    /// only on success.
+    SCOPE_EXIT({ output_slices.clear(); });
+
     auto chunk_columns = chunk.detachColumns();
 
     /// `filterNonConstKeys` removed all grouping keys, so every row in this chunk
@@ -308,8 +316,8 @@ void LimitByTransform::transform(Chunk & chunk)
     if (output_slices.empty())
         return;
 
+    /// `output_slices` is reset by the SCOPE_EXIT above.
     const UInt64 output_row_count = materializeSlicesIntoChunk(chunk, std::move(chunk_columns), row_count, output_slices);
-    output_slices.clear();
 
     if (rows_before_limit_at_least)
         rows_before_limit_at_least->add(output_row_count);
@@ -381,6 +389,12 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
     if (row_count == 0)
         return;
 
+    /// `output_slices` is a member scratch buffer reused across chunks. If anything
+    /// below throws, `ISimpleTransform::work` keeps this transform alive and may call
+    /// `transform` again on the next chunk, so the buffer must be cleared on every exit
+    /// path, not only on success.
+    SCOPE_EXIT({ output_slices.clear(); });
+
     auto chunk_columns = chunk.detachColumns();
 
     Columns normalized_grouping_key_columns;
@@ -422,8 +436,8 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
     if (output_slices.empty())
         return;
 
+    /// `output_slices` is reset by the SCOPE_EXIT above.
     const UInt64 output_row_count = materializeSlicesIntoChunk(chunk, std::move(chunk_columns), row_count, output_slices);
-    output_slices.clear();
 
     if (rows_before_limit_at_least)
         rows_before_limit_at_least->add(output_row_count);

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -263,16 +263,16 @@ void LimitByTransform::transform(Chunk & chunk)
 {
     chassert(output_slices.empty());
 
-    const UInt64 row_count = chunk.getNumRows();
-    if (row_count == 0)
-        return;
-
     /// `output_slices` is a member scratch buffer reused across chunks. If anything
     /// below throws (e.g. MEMORY_LIMIT_EXCEEDED while growing the grouping hash table),
     /// `ISimpleTransform::work` keeps this transform alive and may call `transform`
-    /// again on the next chunk, so the buffer must be cleared on every exit path, not
-    /// only on success.
+    /// again on the next chunk, so the buffer must be cleared on every exit path,
+    /// including the empty-chunk early return below.
     SCOPE_EXIT({ output_slices.clear(); });
+
+    const UInt64 row_count = chunk.getNumRows();
+    if (row_count == 0)
+        return;
 
     auto chunk_columns = chunk.detachColumns();
 
@@ -385,15 +385,15 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
 {
     chassert(output_slices.empty());
 
-    const UInt64 row_count = chunk.getNumRows();
-    if (row_count == 0)
-        return;
-
     /// `output_slices` is a member scratch buffer reused across chunks. If anything
     /// below throws, `ISimpleTransform::work` keeps this transform alive and may call
     /// `transform` again on the next chunk, so the buffer must be cleared on every exit
-    /// path, not only on success.
+    /// path, including the empty-chunk early return below.
     SCOPE_EXIT({ output_slices.clear(); });
+
+    const UInt64 row_count = chunk.getNumRows();
+    if (row_count == 0)
+        return;
 
     auto chunk_columns = chunk.detachColumns();
 

--- a/src/Processors/Transforms/LimitByTransform.cpp
+++ b/src/Processors/Transforms/LimitByTransform.cpp
@@ -5,7 +5,6 @@
 #include <Core/Block.h>
 #include <DataTypes/IDataType.h>
 #include <base/defines.h>
-#include <base/scope_guard.h>
 #include <Common/Exception.h>
 
 #include <algorithm>
@@ -261,14 +260,11 @@ void LimitByTransform::consumeImpl(Method & hash_method, const ColumnRawPtrs & g
 
 void LimitByTransform::transform(Chunk & chunk)
 {
-    chassert(output_slices.empty());
-
-    /// `output_slices` is a member scratch buffer reused across chunks. If anything
-    /// below throws (e.g. MEMORY_LIMIT_EXCEEDED while growing the grouping hash table),
-    /// `ISimpleTransform::work` keeps this transform alive and may call `transform`
-    /// again on the next chunk, so the buffer must be cleared on every exit path,
-    /// including the empty-chunk early return below.
-    SCOPE_EXIT({ output_slices.clear(); });
+    /// `output_slices` is a member scratch buffer reused across chunks. A previous call may
+    /// have thrown after populating it (for example MEMORY_LIMIT_EXCEEDED while the grouping
+    /// hash table grows), and `ISimpleTransform::work` keeps this transform alive and calls
+    /// it again on the next chunk, so always start from an empty buffer.
+    output_slices.clear();
 
     const UInt64 row_count = chunk.getNumRows();
     if (row_count == 0)
@@ -316,7 +312,6 @@ void LimitByTransform::transform(Chunk & chunk)
     if (output_slices.empty())
         return;
 
-    /// `output_slices` is reset by the SCOPE_EXIT above.
     const UInt64 output_row_count = materializeSlicesIntoChunk(chunk, std::move(chunk_columns), row_count, output_slices);
 
     if (rows_before_limit_at_least)
@@ -383,13 +378,9 @@ void LimitBySortedStreamTransform::processRun(UInt64 run_start_row, UInt64 run_r
 
 void LimitBySortedStreamTransform::transform(Chunk & chunk)
 {
-    chassert(output_slices.empty());
-
-    /// `output_slices` is a member scratch buffer reused across chunks. If anything
-    /// below throws, `ISimpleTransform::work` keeps this transform alive and may call
-    /// `transform` again on the next chunk, so the buffer must be cleared on every exit
-    /// path, including the empty-chunk early return below.
-    SCOPE_EXIT({ output_slices.clear(); });
+    /// See `LimitByTransform::transform`: a previous call may have thrown after populating
+    /// this reused scratch buffer, so start each chunk from empty.
+    output_slices.clear();
 
     const UInt64 row_count = chunk.getNumRows();
     if (row_count == 0)
@@ -436,7 +427,6 @@ void LimitBySortedStreamTransform::transform(Chunk & chunk)
     if (output_slices.empty())
         return;
 
-    /// `output_slices` is reset by the SCOPE_EXIT above.
     const UInt64 output_row_count = materializeSlicesIntoChunk(chunk, std::move(chunk_columns), row_count, output_slices);
 
     if (rows_before_limit_at_least)

--- a/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
+++ b/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Core/Names.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Processors/Chunk.h>
+#include <Processors/ISimpleTransform.h>
+#include <Processors/Transforms/LimitByTransform.h>
+#include <Common/CurrentThread.h>
+#include <Common/MemoryTracker.h>
+#include <Common/ThreadStatus.h>
+#include <base/scope_guard.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+extern const int MEMORY_LIMIT_EXCEEDED;
+}
+
+namespace
+{
+
+/// `transform(Chunk &)` is `protected` in the concrete transform but `public` in the
+/// abstract `ISimpleTransform` base, so the test drives it through the base reference,
+/// which virtual-dispatches to the override (exactly what the pipeline executor does).
+void runTransform(ISimpleTransform & transform, Chunk & chunk)
+{
+    transform.transform(chunk);
+}
+
+SharedHeader makeHeader()
+{
+    Block header{
+        ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), "key"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), "value"),
+    };
+    return std::make_shared<const Block>(std::move(header));
+}
+
+/// One chunk with `count` rows where every row has a distinct grouping key starting at
+/// `first_key`. Distinct keys force a new run (and therefore a pushed output slice) on
+/// every row boundary, so `output_slices` is non-empty well before the chunk is fully
+/// consumed.
+Chunk makeDistinctKeyChunk(UInt64 first_key, UInt64 count)
+{
+    auto key_column = ColumnUInt64::create();
+    auto value_column = ColumnUInt64::create();
+    for (UInt64 i = 0; i < count; ++i)
+    {
+        key_column->insertValue(first_key + i);
+        value_column->insertValue(i);
+    }
+    return Chunk(Columns{std::move(key_column), std::move(value_column)}, count);
+}
+
+}
+
+/// Regression test for the AST fuzzer finding "Logical error: 'output_slices.empty()'"
+/// (STID 2508-2fed). `output_slices` is a member scratch buffer that was cleared only on
+/// the success path. When `transform` threw after populating it (for example
+/// MEMORY_LIMIT_EXCEEDED while the grouping hash table grows), `ISimpleTransform::work`
+/// kept the transform alive and could call `transform` again on the next chunk, tripping
+/// the entry `chassert(output_slices.empty())`. The fix clears the buffer on every exit.
+TEST(LimitByTransform, ClearsOutputSlicesWhenTransformThrows)
+{
+    MainThreadStatus::getInstance();
+    auto & thread_tracker = CurrentThread::get().memory_tracker;
+    const Int64 prev_hard_limit = thread_tracker.getHardLimit();
+
+    CurrentThread::flushUntrackedMemory();
+    SCOPE_EXIT({
+        thread_tracker.setHardLimit(prev_hard_limit);
+        CurrentThread::flushUntrackedMemory();
+    });
+
+    /// `LIMIT 1 BY key` over the non-constant "key" column -> hash-map variant.
+    LimitByTransform transform(makeHeader(), /*group_length_=*/ 1, /*group_offset_=*/ 0, Names{"key"});
+
+    /// First chunk: many distinct groups. Clamp the hard limit just above the current
+    /// usage so that growing the grouping hash table overshoots and throws part way
+    /// through, after at least one output slice has already been pushed.
+    Chunk first_chunk = makeDistinctKeyChunk(/*first_key=*/ 0, /*count=*/ 500000);
+
+    CurrentThread::flushUntrackedMemory();
+    thread_tracker.setHardLimit(thread_tracker.get() + 64 * 1024);
+
+    bool threw = false;
+    try
+    {
+        runTransform(transform, first_chunk);
+    }
+    catch (const Exception & e)
+    {
+        threw = (e.code() == ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+    }
+
+    /// Lift the limit before doing anything else so cleanup and the second chunk run freely.
+    thread_tracker.setHardLimit(prev_hard_limit);
+    CurrentThread::flushUntrackedMemory();
+
+    ASSERT_TRUE(threw) << "expected the first chunk to hit the memory limit mid-transform";
+
+    /// Re-enter `transform` exactly as the pipeline executor would after catching the
+    /// exception. Before the fix this tripped `chassert(output_slices.empty())` in debug
+    /// builds (and used stale, out-of-range slices in release builds). Use keys outside
+    /// the first chunk's range so the result is independent of how far the first chunk got.
+    Chunk second_chunk = makeDistinctKeyChunk(/*first_key=*/ 1000000000, /*count=*/ 4);
+    ASSERT_NO_THROW(runTransform(transform, second_chunk));
+
+    /// Every distinct key survives `LIMIT 1 BY key`, and the output columns must agree on
+    /// the row count (a leaked slice would corrupt this).
+    EXPECT_EQ(second_chunk.getNumRows(), 4u);
+    for (const auto & column : second_chunk.getColumns())
+        EXPECT_EQ(column->size(), second_chunk.getNumRows());
+}

--- a/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
+++ b/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
@@ -83,8 +83,9 @@ Chunk makeSortedGroupedChunk(UInt64 first_key, UInt64 num_groups, UInt64 group_s
 /// (STID 2508-2fed). `output_slices` is a member scratch buffer that was cleared only on
 /// the success path. When `transform` threw after populating it (for example
 /// MEMORY_LIMIT_EXCEEDED while the grouping hash table grows), `ISimpleTransform::work`
-/// kept the transform alive and could call `transform` again on the next chunk, tripping
-/// the entry `chassert(output_slices.empty())`. The fix clears the buffer on every exit.
+/// kept the transform alive and could call `transform` again on the next chunk, where the
+/// stale slices corrupted the next result (and tripped a `chassert`). The fix clears the
+/// buffer at the start of `transform`.
 TEST(LimitByTransform, ClearsOutputSlicesWhenTransformThrows)
 {
     MainThreadStatus::getInstance();
@@ -125,9 +126,9 @@ TEST(LimitByTransform, ClearsOutputSlicesWhenTransformThrows)
     ASSERT_TRUE(threw) << "expected the first chunk to hit the memory limit mid-transform";
 
     /// Re-enter `transform` exactly as the pipeline executor would after catching the
-    /// exception. Before the fix this tripped `chassert(output_slices.empty())` in debug
-    /// builds (and used stale, out-of-range slices in release builds). Use keys outside
-    /// the first chunk's range so the result is independent of how far the first chunk got.
+    /// exception. Before the fix the leaked slices from the first chunk corrupted this call
+    /// (out-of-range reuse, tripping a `chassert` in debug builds). Use keys outside the
+    /// first chunk's range so the result is independent of how far the first chunk got.
     Chunk second_chunk = makeDistinctKeyChunk(/*first_key=*/ 1000000000, /*count=*/ 4);
     ASSERT_NO_THROW(runTransform(transform, second_chunk));
 
@@ -141,8 +142,8 @@ TEST(LimitByTransform, ClearsOutputSlicesWhenTransformThrows)
 /// Same regression but for the sorted-stream variant `LimitBySortedStreamTransform`, which
 /// has its own `output_slices` scratch buffer and its own after-slice throw point: the
 /// chunk-sized filter mask allocated inside `materializeSlicesIntoChunk` once the slices are
-/// populated. Without the matching SCOPE_EXIT clear in `LimitBySortedStreamTransform::transform`,
-/// re-entry on the next chunk trips `chassert(output_slices.empty())`.
+/// populated. Without the matching clear in `LimitBySortedStreamTransform::transform`,
+/// re-entry on the next chunk reuses the stale slices.
 TEST(LimitBySortedStreamTransform, ClearsOutputSlicesWhenTransformThrows)
 {
     MainThreadStatus::getInstance();
@@ -186,8 +187,8 @@ TEST(LimitBySortedStreamTransform, ClearsOutputSlicesWhenTransformThrows)
     ASSERT_TRUE(threw) << "expected the first chunk to hit the memory limit mid-transform";
 
     /// Re-enter `transform` exactly as the pipeline executor would after catching the
-    /// exception. Before the fix this tripped `chassert(output_slices.empty())` in debug
-    /// builds (and used stale, out-of-range slices in release builds). Keys ascend past the
+    /// exception. Before the fix the leaked slices from the first chunk corrupted this call
+    /// (out-of-range reuse, tripping a `chassert` in debug builds). Keys ascend past the
     /// first chunk's range so the second chunk stays valid sorted-stream input.
     Chunk second_chunk = makeDistinctKeyChunk(/*first_key=*/ 1000000000, /*count=*/ 4);
     ASSERT_NO_THROW(runTransform(transform, second_chunk));

--- a/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
+++ b/src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp
@@ -56,6 +56,27 @@ Chunk makeDistinctKeyChunk(UInt64 first_key, UInt64 count)
     return Chunk(Columns{std::move(key_column), std::move(value_column)}, count);
 }
 
+/// One sorted chunk of `num_groups` contiguous groups, each `group_size` rows, with ascending
+/// keys `first_key, first_key + 1, ...`. This is valid sorted-stream input. Under `LIMIT 1 BY
+/// key` only the first row of each group survives, so the kept rows are sparse across a large
+/// chunk: `LimitBySortedStreamTransform::transform` populates all slices in the run loop and
+/// then reaches `materializeSlicesIntoChunk`, whose mask allocation (sized to the whole chunk)
+/// is the after-slice throw point. Keep `num_groups` small so `output_slices` itself never
+/// trips the limit during the loop; keep `group_size` large so the mask allocation does.
+Chunk makeSortedGroupedChunk(UInt64 first_key, UInt64 num_groups, UInt64 group_size)
+{
+    auto key_column = ColumnUInt64::create();
+    auto value_column = ColumnUInt64::create();
+    for (UInt64 g = 0; g < num_groups; ++g)
+        for (UInt64 i = 0; i < group_size; ++i)
+        {
+            key_column->insertValue(first_key + g);
+            value_column->insertValue(i);
+        }
+    const UInt64 count = num_groups * group_size;
+    return Chunk(Columns{std::move(key_column), std::move(value_column)}, count);
+}
+
 }
 
 /// Regression test for the AST fuzzer finding "Logical error: 'output_slices.empty()'"
@@ -107,6 +128,67 @@ TEST(LimitByTransform, ClearsOutputSlicesWhenTransformThrows)
     /// exception. Before the fix this tripped `chassert(output_slices.empty())` in debug
     /// builds (and used stale, out-of-range slices in release builds). Use keys outside
     /// the first chunk's range so the result is independent of how far the first chunk got.
+    Chunk second_chunk = makeDistinctKeyChunk(/*first_key=*/ 1000000000, /*count=*/ 4);
+    ASSERT_NO_THROW(runTransform(transform, second_chunk));
+
+    /// Every distinct key survives `LIMIT 1 BY key`, and the output columns must agree on
+    /// the row count (a leaked slice would corrupt this).
+    EXPECT_EQ(second_chunk.getNumRows(), 4u);
+    for (const auto & column : second_chunk.getColumns())
+        EXPECT_EQ(column->size(), second_chunk.getNumRows());
+}
+
+/// Same regression but for the sorted-stream variant `LimitBySortedStreamTransform`, which
+/// has its own `output_slices` scratch buffer and its own after-slice throw point: the
+/// chunk-sized filter mask allocated inside `materializeSlicesIntoChunk` once the slices are
+/// populated. Without the matching SCOPE_EXIT clear in `LimitBySortedStreamTransform::transform`,
+/// re-entry on the next chunk trips `chassert(output_slices.empty())`.
+TEST(LimitBySortedStreamTransform, ClearsOutputSlicesWhenTransformThrows)
+{
+    MainThreadStatus::getInstance();
+    auto & thread_tracker = CurrentThread::get().memory_tracker;
+    const Int64 prev_hard_limit = thread_tracker.getHardLimit();
+
+    CurrentThread::flushUntrackedMemory();
+    SCOPE_EXIT({
+        thread_tracker.setHardLimit(prev_hard_limit);
+        CurrentThread::flushUntrackedMemory();
+    });
+
+    /// Sorted-stream `LIMIT 1 BY key` over the non-constant "key" column.
+    LimitBySortedStreamTransform transform(makeHeader(), /*group_length_=*/ 1, /*group_offset_=*/ 0, Names{"key"});
+
+    /// First chunk: a few large contiguous groups (already sorted by key). The sorted-stream
+    /// variant has no grouping hash table, so its after-slice throw point is the chunk-sized
+    /// filter mask inside `materializeSlicesIntoChunk`. `LIMIT 1 BY key` keeps only each
+    /// group's first row, so survival is sparse and that mask (one byte per source row) is
+    /// allocated after every slice has been pushed. Clamp the hard limit just above current
+    /// usage so that mask allocation overshoots and throws.
+    Chunk first_chunk = makeSortedGroupedChunk(/*first_key=*/ 0, /*num_groups=*/ 4, /*group_size=*/ 2000000);
+
+    CurrentThread::flushUntrackedMemory();
+    thread_tracker.setHardLimit(thread_tracker.get() + 64 * 1024);
+
+    bool threw = false;
+    try
+    {
+        runTransform(transform, first_chunk);
+    }
+    catch (const Exception & e)
+    {
+        threw = (e.code() == ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+    }
+
+    /// Lift the limit before doing anything else so cleanup and the second chunk run freely.
+    thread_tracker.setHardLimit(prev_hard_limit);
+    CurrentThread::flushUntrackedMemory();
+
+    ASSERT_TRUE(threw) << "expected the first chunk to hit the memory limit mid-transform";
+
+    /// Re-enter `transform` exactly as the pipeline executor would after catching the
+    /// exception. Before the fix this tripped `chassert(output_slices.empty())` in debug
+    /// builds (and used stale, out-of-range slices in release builds). Keys ascend past the
+    /// first chunk's range so the second chunk stays valid sorted-stream input.
     Chunk second_chunk = makeDistinctKeyChunk(/*first_key=*/ 1000000000, /*count=*/ 4);
     ASSERT_NO_THROW(runTransform(transform, second_chunk));
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/36934
-->

Closes https://github.com/ClickHouse/ClickHouse/issues/107172.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Found by the AST fuzzer (STID 2508-2fed): `Logical error: 'output_slices.empty()'` in `AST fuzzer (amd_debug, targeted, old_compatibility)`.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104608&sha=83a3d77d7de3dc67334b38616546758b9c50b1ff&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29

`LimitByTransform` and `LimitBySortedStreamTransform` accumulate the current chunk's kept-row slices in the `output_slices` member buffer (part of the unreleased "Optimize LIMIT BY" rewrite) and clear it after `materializeSlicesIntoChunk`. The clear only ran on the success path, so if `transform()` threw after some slices were pushed (for example `MEMORY_LIMIT_EXCEEDED`), the buffer was left populated. `ISimpleTransform::work()` catches the exception and keeps the transform alive, so the executor can call `transform()` again on the next chunk, where the stale buffer tripped the entry `chassert(output_slices.empty())` (debug abort) or reused out-of-range slices (release).

Fix: clear `output_slices` at the start of `transform()` in both variants, so each chunk starts from an empty buffer regardless of how the previous call exited.

Regression test (`src/Processors/tests/gtest_limit_by_transform_exception_safety.cpp`) covers both variants: it forces `MEMORY_LIMIT_EXCEEDED` mid-chunk after slices are populated, then re-enters `transform()`. Both cases abort on a build without the entry clear and pass with the fix. Existing `LIMIT BY` functional tests are unaffected.

This code is not in any released version, so the change is not for changelog.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.855`
<!-- ch-version-info:end -->