### PR TITLE
Analyzer: suggest cross-database table name in UNKNOWN_TABLE error

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -14,6 +14,7 @@
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/JoinUtils.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/TableNameHints.h>
 
 #include <Analyzer/Utils.h>
 #include <Analyzer/IdentifierNode.h>
@@ -350,6 +351,34 @@ IdentifierResolveResult IdentifierResolver::tryResolveTableIdentifierFromDatabas
         return { .resolved_identifier = std::move(result), .resolve_place = IdentifierResolvePlace::DATABASE_CATALOG };
 
     return {};
+}
+
+std::pair<String, String> IdentifierResolver::tryGetTableNameHint(const Identifier & table_identifier, const ContextPtr & context)
+{
+    size_t parts_size = table_identifier.getPartsSize();
+    if (parts_size < 1 || parts_size > 2)
+        return {};
+
+    String database_name;
+    String table_name;
+    if (table_identifier.isCompound())
+    {
+        database_name = table_identifier[0];
+        table_name = table_identifier[1];
+    }
+    else
+    {
+        table_name = table_identifier[0];
+    }
+
+    /// Resolve the database the same way table resolution does, so the hint search starts from
+    /// the right database (the current one for a bare name) and can fall back to other databases.
+    if (database_name.empty())
+        database_name = context->getCurrentDatabase();
+
+    auto database = DatabaseCatalog::instance().tryGetDatabase(database_name);
+    TableNameHints hints(database, context);
+    return hints.getHintForTable(table_name);
 }
 
 /// Resolve identifier from compound expression

--- a/src/Analyzer/Resolve/IdentifierResolver.h
+++ b/src/Analyzer/Resolve/IdentifierResolver.h
@@ -83,6 +83,13 @@ public:
         const Identifier & table_identifier,
         const ContextPtr & context);
 
+    /// Suggest a same/similar-named table when a table identifier cannot be resolved,
+    /// possibly in another database (e.g. `system.functions` for a bare `functions`).
+    /// Returns a (database, table) pair, or an empty pair when there is no good hint.
+    static std::pair<String, String> tryGetTableNameHint(
+        const Identifier & table_identifier,
+        const ContextPtr & context);
+
     QueryTreeNodePtr tryResolveIdentifierFromCompoundExpression(
         const Identifier & expression_identifier,
         size_t identifier_bind_size,

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -3838,10 +3838,23 @@ void QueryAnalyzer::initializeQueryJoinTreeNode(QueryTreeNodePtr & join_tree_nod
                 auto resolved_identifier = table_identifier_resolve_result.resolved_identifier;
 
                 if (!resolved_identifier)
+                {
+                    /// Suggest a similar table name, possibly from another database (e.g.
+                    /// `system.functions` for a bare `functions`), matching the old analyzer's hint.
+                    auto [hint_database_name, hint_table_name]
+                        = IdentifierResolver::tryGetTableNameHint(from_table_identifier.getIdentifier(), scope.context);
+                    if (!hint_database_name.empty())
+                        throw Exception(ErrorCodes::UNKNOWN_TABLE,
+                            "Unknown table expression identifier '{}' in scope {}. Maybe you meant {}.{}?",
+                            from_table_identifier.getIdentifier().getFullName(),
+                            scope.scope_node->formatASTForErrorMessage(),
+                            backQuoteIfNeed(hint_database_name),
+                            backQuoteIfNeed(hint_table_name));
                     throw Exception(ErrorCodes::UNKNOWN_TABLE,
                         "Unknown table expression identifier '{}' in scope {}",
                         from_table_identifier.getIdentifier().getFullName(),
                         scope.scope_node->formatASTForErrorMessage());
+                }
 
                 resolved_identifier = resolved_identifier->clone();
                 if (table_identifier_lookup.original_ast_node)

--- a/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.reference
+++ b/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.reference
@@ -1,2 +1,6 @@
 Maybe you meant system.functions?
 Maybe you meant system.functions?
+UNKNOWN_DATABASE
+0
+UNKNOWN_DATABASE
+0

--- a/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.reference
+++ b/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.reference
@@ -1,0 +1,2 @@
+Maybe you meant system.functions?
+Maybe you meant system.functions?

--- a/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.sh
+++ b/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Tags: no-parallel-replicas
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# A bare `functions` does not exist in the current database, only in `system`.
+# Both analyzers must suggest the cross-database table `system.functions`.
+# `system.functions` is an exact (distance 0) match, so it is a stable hint
+# even when concurrent tests have similarly named tables in other databases.
+
+# grep -m1: with --send_logs_level the server also echoes the exception as a log event,
+# so the hint can appear more than once; take a single match to stay deterministic.
+$CLICKHOUSE_CLIENT --enable_analyzer=1 -q "SELECT * FROM functions" 2>&1 | grep -oF -m1 "Maybe you meant system.functions?"
+$CLICKHOUSE_CLIENT --enable_analyzer=0 -q "SELECT * FROM functions" 2>&1 | grep -oF -m1 "Maybe you meant system.functions?"

--- a/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.sh
+++ b/tests/queries/0_stateless/04338_analyzer_unknown_table_cross_database_hint.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-# Tags: no-parallel-replicas
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# https://github.com/ClickHouse/ClickHouse/issues/107538
 # A bare `functions` does not exist in the current database, only in `system`.
 # Both analyzers must suggest the cross-database table `system.functions`.
 # `system.functions` is an exact (distance 0) match, so it is a stable hint
 # even when concurrent tests have similarly named tables in other databases.
-
+#
 # grep -m1: with --send_logs_level the server also echoes the exception as a log event,
 # so the hint can appear more than once; take a single match to stay deterministic.
 $CLICKHOUSE_CLIENT --enable_analyzer=1 -q "SELECT * FROM functions" 2>&1 | grep -oF -m1 "Maybe you meant system.functions?"
 $CLICKHOUSE_CLIENT --enable_analyzer=0 -q "SELECT * FROM functions" 2>&1 | grep -oF -m1 "Maybe you meant system.functions?"
+
+# When the DATABASE part of a compound name does not exist, the database is resolved
+# (and rejected) before the table, so the error stays UNKNOWN_DATABASE and must NOT fall
+# back to a cross-database table hint such as `system.functions`. Verify both analyzers.
+$CLICKHOUSE_CLIENT --enable_analyzer=1 -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_missing.functions" 2>&1 | grep -oF -m1 "UNKNOWN_DATABASE"
+$CLICKHOUSE_CLIENT --enable_analyzer=1 -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_missing.functions" 2>&1 | grep -c -F "Maybe you meant system.functions?" || true
+$CLICKHOUSE_CLIENT --enable_analyzer=0 -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_missing.functions" 2>&1 | grep -oF -m1 "UNKNOWN_DATABASE"
+$CLICKHOUSE_CLIENT --enable_analyzer=0 -q "SELECT * FROM ${CLICKHOUSE_DATABASE}_missing.functions" 2>&1 | grep -c -F "Maybe you meant system.functions?" || true


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/107538
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
With `enable_analyzer = 1` (the default), querying a table by its bare name when it only exists in another database now suggests the right table, e.g. `SELECT * FROM functions` reports `Maybe you meant system.functions?`. Previously the new analyzer gave a hint-less `Unknown table expression identifier` error, while the old analyzer already produced the helpful suggestion.


### Description

`SELECT * FROM functions` (when the current database is `default` and `functions` exists only in `system`) behaved differently between analyzers:

- `enable_analyzer = 0`: `Table default.functions does not exist. Maybe you meant system.functions?` (helpful)
- `enable_analyzer = 1` (default): `Unknown table expression identifier 'functions' in scope ...` (no hint)

Root cause: the new analyzer has a single `UNKNOWN_TABLE` throw site in `QueryAnalyzer::initializeQueryJoinTreeNode`. It never consulted the table-name hint mechanism that the old interpreter path uses (`TableNameHints` in `DatabaseCatalog`/`IDatabase`, which searches the current database and then falls back across all local databases by Levenshtein distance).

Fix: add `IdentifierResolver::tryGetTableNameHint`, which resolves the database the same way table resolution does (current database for a bare name) and runs the existing `TableNameHints::getHintForTable`. The throw site appends `. Maybe you meant <db>.<table>?` when a hint exists. The message prefix is unchanged, so existing callers that match on it keep working.

Added a stateless regression test `04338_analyzer_unknown_table_cross_database_hint` that asserts the cross-database hint under both analyzers. `system.functions` is an exact (distance 0) match, so the hint is stable under parallel test execution.

Found via ClickGap automated review.

Closes https://github.com/ClickHouse/ClickHouse/issues/107538

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.858`
<!-- ch-version-info:end -->