### PR TITLE
PromQL: Support specifying database and table name in query parameters

### DIFF
--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -187,9 +187,9 @@ protected:
         if (name.empty())
             return false;
 
-        /// Some parameters (database, default_format, everything used in the code above) do not
-        /// belong to the Settings class.
-        static const NameSet reserved_param_names{"user", "password", "quota_key", "stacktrace", "role", "query_id"};
+        /// Some parameters (default_format, everything used in the code above) do not belong to the
+        /// Settings class.
+        static const NameSet reserved_param_names{"user", "password", "quota_key", "stacktrace", "role", "query_id", "database", "table"};
         return !reserved_param_names.contains(name);
     }
 
@@ -227,6 +227,47 @@ protected:
         context->setCurrentQueryId(query_id);
     }
 
+    /// Resolves the time series table for the current request. Each of the database and table names comes
+    /// either from the configuration or from the URL query parameter 'database' and 'table'.
+    /// A query parameter can't override a value set in the configuration.
+    /// If the database isn't set, the table name is treated as a possibly-qualified  `database.table` name,
+    /// and if the table name is not a qualified name then the database name falls back to "default".
+    StorageID getTimeSeriesTableID()
+    {
+        QualifiedTableName full_name;
+        full_name.database = config().time_series_table_name.database;
+        full_name.table = config().time_series_table_name.table;
+
+        if (params->has("database"))
+        {
+            if (!full_name.database.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "The database is set in the configuration of this prometheus handler and cannot be overridden by the 'database' query parameter");
+            full_name.database = params->get("database");
+        }
+
+        if (params->has("table"))
+        {
+            if (!full_name.table.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "The table is set in the configuration of this prometheus handler and cannot be overridden by the 'table' query parameter");
+            full_name.table = params->get("table");
+        }
+
+        if (full_name.table.empty())
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "The time series table name is not set; specify it in the configuration or in the 'table' query parameter");
+
+        if (full_name.database.empty())
+        {
+            full_name = QualifiedTableName::parseFromString(full_name.table);
+            if (full_name.database.empty())
+                full_name.database = "default";
+        }
+
+        return StorageID{full_name};
+    }
+
     void onException() override
     {
         // So that the next requests on the connection have to always start afresh in case of exceptions.
@@ -259,6 +300,8 @@ public:
         checkHTTPHeader(request, "Content-Type", "application/x-protobuf");
         checkHTTPHeader(request, "Content-Encoding", "snappy");
 
+        auto table = DatabaseCatalog::instance().getTable(getTimeSeriesTableID(), context);
+        PrometheusRemoteWriteProtocol protocol{table, context};
 
         prometheus::WriteRequest write_request;
 
@@ -269,9 +312,6 @@ public:
             if (!write_request.ParsePartialFromZeroCopyStream(&zero_copy_input_stream))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot parse WriteRequest");
         }
-
-        auto table = DatabaseCatalog::instance().getTable(StorageID{config().time_series_table_name}, context);
-        PrometheusRemoteWriteProtocol protocol{table, context};
 
         if (write_request.timeseries_size())
             protocol.writeTimeSeries(write_request.timeseries());
@@ -306,7 +346,7 @@ public:
         checkHTTPHeader(request, "Content-Type", "application/x-protobuf");
         checkHTTPHeader(request, "Content-Encoding", "snappy");
 
-        auto table = DatabaseCatalog::instance().getTable(StorageID{config().time_series_table_name}, context);
+        auto table = DatabaseCatalog::instance().getTable(getTimeSeriesTableID(), context);
         PrometheusRemoteReadProtocol protocol{table, context};
 
         prometheus::ReadRequest read_request;
@@ -371,17 +411,14 @@ public:
         if (name.empty())
             return false;
 
-        /// Some parameters (database, default_format, everything used in the code above) do not
-        /// belong to the Settings class.
-        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step"};
+        /// Some parameters (default_format, everything used in the code above) do not belong to the
+        /// Settings class.
+        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step", "database", "table"};
         return !reserved_param_names.contains(name);
     }
 
     void handlingRequestWithContext(HTTPServerRequest & request, HTTPServerResponse & response) override
     {
-        auto table = DatabaseCatalog::instance().getTable(StorageID{config().time_series_table_name}, context);
-        PrometheusHTTPProtocolAPI protocol{table, context};
-
         const String & uri = request.getURI();
         LOG_DEBUG(log(), "Processing Query API request: method={}, uri={}", request.getMethod(), uri);
 
@@ -389,6 +426,9 @@ public:
 
         try
         {
+            auto table = DatabaseCatalog::instance().getTable(getTimeSeriesTableID(), context);
+            PrometheusHTTPProtocolAPI protocol{table, context};
+
             if (uri.starts_with("/api/v1/query_range"))
             {
                 String query = params->get("query", "");

--- a/src/Server/PrometheusRequestHandlerConfig.h
+++ b/src/Server/PrometheusRequestHandlerConfig.h
@@ -36,7 +36,7 @@ struct PrometheusRequestHandlerConfig
     bool expose_histograms = false;
     bool expose_dimensional_metrics = false;
 
-    /// Settings for types RemoteWrite, RemoteRead:
+    /// Settings for types RemoteWrite, RemoteRead, QueryAPI.
     QualifiedTableName time_series_table_name;
 
     size_t keep_alive_timeout = 0;

--- a/src/Server/PrometheusRequestHandlerFactory.cpp
+++ b/src/Server/PrometheusRequestHandlerFactory.cpp
@@ -50,21 +50,21 @@ namespace
         return res;
     }
 
-    /// Extracts a qualified table name from the config. It can be set either as
-    ///     <table>mydb.prometheus</table>
-    /// or
-    ///     <database>mydb</database>
-    ///     <table>prometheus</table>
-    QualifiedTableName parseTableNameFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+    /// Reads the database and table names of the time series table from the configuration.
+    /// If either the database name or the table name isn't set in the configuration then we take it from the URL
+    /// query parameters 'database' or 'table'.
+    void parseTableNameFromConfig(const Poco::Util::AbstractConfiguration & config, const String & config_prefix, PrometheusRequestHandlerConfig & res)
     {
-        QualifiedTableName res;
-        res.table = config.getString(config_prefix + ".table", "prometheus");
-        res.database = config.getString(config_prefix + ".database", "");
-        if (res.database.empty())
-            res = QualifiedTableName::parseFromString(res.table);
-        if (res.database.empty())
-            res.database = "default";
-        return res;
+        res.time_series_table_name.database = config.getString(config_prefix + ".database", "");
+        res.time_series_table_name.table = config.getString(config_prefix + ".table", "");
+
+        /// When the table is given as a qualified `database.table` name, we resolve it now and set the database name
+        /// so it can't be overridden by URL query parameters.
+        if (res.time_series_table_name.database.empty() && !res.time_series_table_name.table.empty())
+        {
+            if (auto parsed = QualifiedTableName::tryParseFromString(res.time_series_table_name.table); parsed && !parsed->database.empty())
+                res.time_series_table_name = *parsed;
+        }
     }
 
     /// Parses a configuration like this:
@@ -74,7 +74,7 @@ namespace
     {
         PrometheusRequestHandlerConfig res;
         res.type = PrometheusRequestHandlerConfig::Type::RemoteWrite;
-        res.time_series_table_name = parseTableNameFromConfig(config, config_prefix);
+        parseTableNameFromConfig(config, config_prefix, res);
         parseCommonConfig(config, res);
         return res;
     }
@@ -86,7 +86,7 @@ namespace
     {
         PrometheusRequestHandlerConfig res;
         res.type = PrometheusRequestHandlerConfig::Type::RemoteRead;
-        res.time_series_table_name = parseTableNameFromConfig(config, config_prefix);
+        parseTableNameFromConfig(config, config_prefix, res);
         parseCommonConfig(config, res);
         if (config.has(config_prefix + ".user"))
         {
@@ -103,7 +103,7 @@ namespace
     {
         PrometheusRequestHandlerConfig res;
         res.type = PrometheusRequestHandlerConfig::Type::QueryAPI;
-        res.time_series_table_name = parseTableNameFromConfig(config, config_prefix);
+        parseTableNameFromConfig(config, config_prefix, res);
         parseCommonConfig(config, res);
         if (config.has(config_prefix + ".user"))
         {

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -71,6 +71,24 @@
                     <table>default.prometheus</table>
                 </handler>
             </my_rule_9>
+
+            <my_rule_10>
+                <!-- This handler sets no database and no table, so both database and table names
+                     come from the query parameters. -->
+                <url>/api/v1/query_dynamic_table</url>
+                <handler>
+                    <type>query_api</type>
+                </handler>
+            </my_rule_10>
+
+            <my_rule_11>
+                <!-- This handler sets only database, so the table name comes from the query parameters. -->
+                <url>/api/v1/query_dynamic_table_and_fixed_db</url>
+                <handler>
+                    <type>query_api</type>
+                    <database>default</database>
+                </handler>
+            </my_rule_11>
         </handlers>
     </prometheus>
 </clickhouse>

--- a/tests/integration/test_prometheus_protocols/prometheus_test_utils.py
+++ b/tests/integration/test_prometheus_protocols/prometheus_test_utils.py
@@ -194,7 +194,7 @@ def get_response_to_http_api_query(host, port, path, query, timestamp=None, para
     if timestamp is not None:
         url += f"&time={timestamp}"
     for name, value in (params or {}).items():
-        url += f"&{name}={urllib.parse.quote_plus(value, safe='')}"
+        url += f"&{urllib.parse.quote_plus(str(name), safe='')}={urllib.parse.quote_plus(str(value), safe='')}"
     return get_response_to_http_api(url)
 
 
@@ -204,7 +204,7 @@ def get_response_to_http_api_range_query(
     escaped_query = urllib.parse.quote_plus(query, safe="")
     url = f"http://{host}:{port}/{path.strip('/')}?query={escaped_query}&start={start_timestamp}&end={end_timestamp}&step={step}"
     for name, value in (params or {}).items():
-        url += f"&{name}={urllib.parse.quote_plus(value, safe='')}"
+        url += f"&{urllib.parse.quote_plus(str(name), safe='')}={urllib.parse.quote_plus(str(value), safe='')}"
     return get_response_to_http_api(url)
 
 

--- a/tests/integration/test_prometheus_protocols/prometheus_test_utils.py
+++ b/tests/integration/test_prometheus_protocols/prometheus_test_utils.py
@@ -165,40 +165,46 @@ def extract_protobuf_from_remote_read_response(response):
 
 
 # Executes an instant query using Prometheus HTTP API.
+# `params` is a dict {"param_name": "param_value", ...} of additional URL query parameters.
 def execute_query_via_http_api(
-    host, port, path, query, timestamp=None, expect_error=False
+    host, port, path, query, timestamp=None, params=None, expect_error=False
 ):
-    response = get_response_to_http_api_query(host, port, path, query, timestamp)
+    response = get_response_to_http_api_query(host, port, path, query, timestamp, params)
     if expect_error:
         return extract_error_from_http_api_response(response)
     return extract_data_from_http_api_response(response)
 
 
 # Executes a range query using Prometheus HTTP API.
+# `params` is a dict {"param_name": "param_value", ...} of additional URL query parameters.
 def execute_range_query_via_http_api(
-    host, port, path, query, start_timestamp, end_timestamp, step, expect_error=False
+    host, port, path, query, start_timestamp, end_timestamp, step, params=None, expect_error=False
 ):
     response = get_response_to_http_api_range_query(
-        host, port, path, query, start_timestamp, end_timestamp, step
+        host, port, path, query, start_timestamp, end_timestamp, step, params
     )
     if expect_error:
         return extract_error_from_http_api_response(response)
     return extract_data_from_http_api_response(response)
 
 
-def get_response_to_http_api_query(host, port, path, query, timestamp=None):
+def get_response_to_http_api_query(host, port, path, query, timestamp=None, params=None):
     escaped_query = urllib.parse.quote_plus(query, safe="")
     url = f"http://{host}:{port}/{path.strip('/')}?query={escaped_query}"
     if timestamp is not None:
         url += f"&time={timestamp}"
+    for name, value in (params or {}).items():
+        url += f"&{name}={urllib.parse.quote_plus(value, safe='')}"
     return get_response_to_http_api(url)
 
 
 def get_response_to_http_api_range_query(
-    host, port, path, query, start_timestamp, end_timestamp, step
+    host, port, path, query, start_timestamp, end_timestamp, step, params=None
 ):
     escaped_query = urllib.parse.quote_plus(query, safe="")
     url = f"http://{host}:{port}/{path.strip('/')}?query={escaped_query}&start={start_timestamp}&end={end_timestamp}&step={step}"
+    for name, value in (params or {}).items():
+        url += f"&{name}={urllib.parse.quote_plus(value, safe='')}"
     return get_response_to_http_api(url)
 
 

--- a/tests/integration/test_prometheus_protocols/test_query_api.py
+++ b/tests/integration/test_prometheus_protocols/test_query_api.py
@@ -159,3 +159,62 @@ def test_query_after_response_sent():
         
         with pytest.raises(requests.exceptions.ChunkedEncodingError):
             response.content  # Reading property response.content hits the chunked-stream abort
+
+
+# Checks the case when the database and table names come from the URL query parameters.
+def test_table_query_param():
+    query = 'foo{shape="square"}'
+    timestamp = 150
+
+    expected = '{"resultType": "vector", "result": [{"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "value": [150, "40"]}]}'
+    assert execute_query_via_http_api(node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp) == expected
+
+    # Both database and table names come from the URL query as two separate parameters
+    # `database` and `table`.
+    assert (
+        execute_query_via_http_api(
+            node.ip_address, 9093, "/api/v1/query_dynamic_table", query, timestamp=timestamp,
+            params={"database": "default", "table": "prometheus"},
+        )
+        == expected
+    )
+
+    # A single `table` parameter carries the qualified `database.table` name.
+    assert (
+        execute_query_via_http_api(
+            node.ip_address, 9093, "/api/v1/query_dynamic_table", query, timestamp=timestamp,
+            params={"table": "default.prometheus"},
+        )
+        == expected
+    )
+
+    # A request without a `table` parameter fails.
+    error = execute_query_via_http_api(
+        node.ip_address, 9093, "/api/v1/query_dynamic_table", query, timestamp=timestamp,
+        expect_error=True,
+    )
+    assert "table name is not set" in error
+
+    # The table name comes from the URL query, and the database name comes from the configuration.
+    assert (
+        execute_query_via_http_api(
+            node.ip_address, 9093, "/api/v1/query_dynamic_table_and_fixed_db", query, timestamp=timestamp,
+            params={"table": "prometheus"},
+        )
+        == expected
+    )
+
+    # The configured database cannot be overridden by the `database` query parameter.
+    error = execute_query_via_http_api(
+        node.ip_address, 9093, "/api/v1/query_dynamic_table_and_fixed_db", query, timestamp=timestamp,
+        params={"database": "default", "table": "prometheus"}, expect_error=True,
+    )
+    assert "cannot be overridden" in error
+
+    # A qualified `<table>default.prometheus</table>` in the configuration (the static `/api/v1/query`
+    # handler) sets the database too, so it cannot be overridden by the `database` query parameter.
+    error = execute_query_via_http_api(
+        node.ip_address, 9093, "/api/v1/query", query, timestamp=timestamp,
+        params={"database": "other"}, expect_error=True,
+    )
+    assert "cannot be overridden" in error


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL: Support specifying database and table name in URL query parameters:
```
.../api/v1/query?query=foo&time=1781546730&database=mydb&table=mytable
```
or
```
.../api/v1/query?query=foo&time=1781546730&table=mydb.mytable
```
If there is no database name or table name set in the config, they're parsed from the URL query parameters.

This PR also drops the default value: previously if a table name wasn't specified in the config, `default.prometheus` was used by default. Now it's required to be specified either in the config or in the URL query parameters.