### PR TITLE
Track rapidjson allocations against the memory tracker

### DIFF
--- a/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.cpp
+++ b/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.cpp
@@ -1,0 +1,78 @@
+#include <Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h>
+
+#if USE_RAPIDJSON
+
+#include <limits>
+
+#include <Common/Allocator.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_ALLOCATE_MEMORY;
+}
+
+namespace
+{
+
+/// `DB::Allocator` aligns the block base to at least MALLOC_MIN_ALIGNMENT; keep the header that
+/// size so the payload handed to rapidjson keeps the same alignment.
+constexpr size_t header_size = MALLOC_MIN_ALIGNMENT >= sizeof(size_t) ? MALLOC_MIN_ALIGNMENT : sizeof(size_t);
+
+/// Size of the block including the header, refusing requests so large that adding the header would
+/// wrap around (which would otherwise allocate a tiny block and hand out a pointer past its end).
+/// Such a request cannot be satisfied anyway.
+size_t withHeader(size_t size)
+{
+    if (size > std::numeric_limits<size_t>::max() - header_size)
+        throw Exception(ErrorCodes::CANNOT_ALLOCATE_MEMORY, "Cannot allocate {} bytes for rapidjson: size is too large", size);
+    return header_size + size;
+}
+
+}
+
+void * RapidJSONMemoryTrackerAllocator::Malloc(size_t size)
+{
+    if (size == 0)
+        return nullptr;
+
+    char * base = static_cast<char *>(Allocator<false>().alloc(withHeader(size)));
+    *reinterpret_cast<size_t *>(base) = size;
+    return base + header_size;
+}
+
+void * RapidJSONMemoryTrackerAllocator::Realloc(void * original_ptr, size_t /*original_size*/, size_t new_size)
+{
+    if (new_size == 0)
+    {
+        Free(original_ptr);
+        return nullptr;
+    }
+
+    if (original_ptr == nullptr)
+        return Malloc(new_size);
+
+    char * base = static_cast<char *>(original_ptr) - header_size;
+    const size_t old_size = *reinterpret_cast<size_t *>(base);
+
+    char * new_base = static_cast<char *>(Allocator<false>().realloc(base, withHeader(old_size), withHeader(new_size)));
+    *reinterpret_cast<size_t *>(new_base) = new_size;
+    return new_base + header_size;
+}
+
+void RapidJSONMemoryTrackerAllocator::Free(void * ptr) noexcept
+{
+    if (ptr == nullptr)
+        return;
+
+    char * base = static_cast<char *>(ptr) - header_size;
+    const size_t size = *reinterpret_cast<size_t *>(base);
+    Allocator<false>().free(base, header_size + size);
+}
+
+}
+
+#endif

--- a/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
+++ b/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
@@ -5,6 +5,8 @@
 #if USE_RAPIDJSON
 
 #include <cstddef>
+#include <limits>
+#include <new>
 
 #include <Common/Allocator.h>
 
@@ -36,7 +38,7 @@ public:
         if (size == 0)
             return nullptr;
 
-        char * base = static_cast<char *>(Allocator<false>().alloc(header_size + size));
+        char * base = static_cast<char *>(Allocator<false>().alloc(withHeader(size)));
         *reinterpret_cast<size_t *>(base) = size;
         return base + header_size;
     }
@@ -56,7 +58,7 @@ public:
         const size_t old_size = *reinterpret_cast<size_t *>(base);
 
         char * new_base
-            = static_cast<char *>(Allocator<false>().realloc(base, header_size + old_size, header_size + new_size));
+            = static_cast<char *>(Allocator<false>().realloc(base, withHeader(old_size), withHeader(new_size)));
         *reinterpret_cast<size_t *>(new_base) = new_size;
         return new_base + header_size;
     }
@@ -78,6 +80,16 @@ private:
     /// `DB::Allocator` aligns the block base to at least MALLOC_MIN_ALIGNMENT; keep the header that
     /// size so the payload handed to rapidjson keeps the same alignment.
     static constexpr size_t header_size = MALLOC_MIN_ALIGNMENT >= sizeof(size_t) ? MALLOC_MIN_ALIGNMENT : sizeof(size_t);
+
+    /// Size of the block including the header, refusing requests so large that adding the header
+    /// would wrap around (which would otherwise allocate a tiny block and hand out a pointer past
+    /// its end). Such a request cannot be satisfied anyway.
+    static size_t withHeader(size_t size)
+    {
+        if (size > std::numeric_limits<size_t>::max() - header_size)
+            throw std::bad_alloc();
+        return header_size + size;
+    }
 };
 
 }

--- a/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
+++ b/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
@@ -5,10 +5,6 @@
 #if USE_RAPIDJSON
 
 #include <cstddef>
-#include <limits>
-#include <new>
-
-#include <Common/Allocator.h>
 
 namespace DB
 {
@@ -33,63 +29,12 @@ public:
     /// rapidjson must call `Free` to release the blocks we hand out (they carry a header).
     static constexpr bool kNeedFree = true;
 
-    void * Malloc(size_t size)
-    {
-        if (size == 0)
-            return nullptr;
-
-        char * base = static_cast<char *>(Allocator<false>().alloc(withHeader(size)));
-        *reinterpret_cast<size_t *>(base) = size;
-        return base + header_size;
-    }
-
-    void * Realloc(void * original_ptr, size_t /*original_size*/, size_t new_size)
-    {
-        if (new_size == 0)
-        {
-            Free(original_ptr);
-            return nullptr;
-        }
-
-        if (original_ptr == nullptr)
-            return Malloc(new_size);
-
-        char * base = static_cast<char *>(original_ptr) - header_size;
-        const size_t old_size = *reinterpret_cast<size_t *>(base);
-
-        char * new_base
-            = static_cast<char *>(Allocator<false>().realloc(base, withHeader(old_size), withHeader(new_size)));
-        *reinterpret_cast<size_t *>(new_base) = new_size;
-        return new_base + header_size;
-    }
-
-    static void Free(void * ptr) noexcept
-    {
-        if (ptr == nullptr)
-            return;
-
-        char * base = static_cast<char *>(ptr) - header_size;
-        const size_t size = *reinterpret_cast<size_t *>(base);
-        Allocator<false>().free(base, header_size + size);
-    }
+    void * Malloc(size_t size);
+    void * Realloc(void * original_ptr, size_t original_size, size_t new_size);
+    static void Free(void * ptr) noexcept;
 
     bool operator==(const RapidJSONMemoryTrackerAllocator &) const noexcept { return true; }
     bool operator!=(const RapidJSONMemoryTrackerAllocator &) const noexcept { return false; }
-
-private:
-    /// `DB::Allocator` aligns the block base to at least MALLOC_MIN_ALIGNMENT; keep the header that
-    /// size so the payload handed to rapidjson keeps the same alignment.
-    static constexpr size_t header_size = MALLOC_MIN_ALIGNMENT >= sizeof(size_t) ? MALLOC_MIN_ALIGNMENT : sizeof(size_t);
-
-    /// Size of the block including the header, refusing requests so large that adding the header
-    /// would wrap around (which would otherwise allocate a tiny block and hand out a pointer past
-    /// its end). Such a request cannot be satisfied anyway.
-    static size_t withHeader(size_t size)
-    {
-        if (size > std::numeric_limits<size_t>::max() - header_size)
-            throw std::bad_alloc();
-        return header_size + size;
-    }
 };
 
 }

--- a/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
+++ b/src/Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "config.h"
+
+#if USE_RAPIDJSON
+
+#include <cstddef>
+
+#include <Common/Allocator.h>
+
+namespace DB
+{
+
+/// An allocator implementing the rapidjson `Allocator` concept that accounts every allocation
+/// against ClickHouse's `MemoryTracker` by delegating to `DB::Allocator`.
+///
+/// rapidjson's default `CrtAllocator` calls raw `malloc`/`realloc`, bypassing the memory tracker
+/// entirely. A pathological input (for example a deeply nested JSON pretty-printed with wide
+/// indentation) can then grow rapidjson's internal stacks or output buffer without bound, which
+/// either runs the server out of memory or trips the sanitizer's allocation-size cap in tests.
+/// Going through `DB::Allocator` turns that into a clean `MEMORY_LIMIT_EXCEEDED` exception bounded
+/// by `max_memory_usage`, and reuses its tracking, rollback and large-allocation `mmap` path.
+///
+/// The only thing this adapter adds on top of `DB::Allocator` is shape: rapidjson needs
+/// `Malloc`/`Realloc`/`Free`, and its `Free` is static and is not given the allocation size, while
+/// `DB::Allocator::free` requires the size. So the size of every block is stored in a suitably
+/// aligned header placed in front of the memory handed out.
+class RapidJSONMemoryTrackerAllocator
+{
+public:
+    /// rapidjson must call `Free` to release the blocks we hand out (they carry a header).
+    static constexpr bool kNeedFree = true;
+
+    void * Malloc(size_t size)
+    {
+        if (size == 0)
+            return nullptr;
+
+        char * base = static_cast<char *>(Allocator<false>().alloc(header_size + size));
+        *reinterpret_cast<size_t *>(base) = size;
+        return base + header_size;
+    }
+
+    void * Realloc(void * original_ptr, size_t /*original_size*/, size_t new_size)
+    {
+        if (new_size == 0)
+        {
+            Free(original_ptr);
+            return nullptr;
+        }
+
+        if (original_ptr == nullptr)
+            return Malloc(new_size);
+
+        char * base = static_cast<char *>(original_ptr) - header_size;
+        const size_t old_size = *reinterpret_cast<size_t *>(base);
+
+        char * new_base
+            = static_cast<char *>(Allocator<false>().realloc(base, header_size + old_size, header_size + new_size));
+        *reinterpret_cast<size_t *>(new_base) = new_size;
+        return new_base + header_size;
+    }
+
+    static void Free(void * ptr) noexcept
+    {
+        if (ptr == nullptr)
+            return;
+
+        char * base = static_cast<char *>(ptr) - header_size;
+        const size_t size = *reinterpret_cast<size_t *>(base);
+        Allocator<false>().free(base, header_size + size);
+    }
+
+    bool operator==(const RapidJSONMemoryTrackerAllocator &) const noexcept { return true; }
+    bool operator!=(const RapidJSONMemoryTrackerAllocator &) const noexcept { return false; }
+
+private:
+    /// `DB::Allocator` aligns the block base to at least MALLOC_MIN_ALIGNMENT; keep the header that
+    /// size so the payload handed to rapidjson keeps the same alignment.
+    static constexpr size_t header_size = MALLOC_MIN_ALIGNMENT >= sizeof(size_t) ? MALLOC_MIN_ALIGNMENT : sizeof(size_t);
+};
+
+}
+
+#endif

--- a/src/Common/JSONParsers/RapidJSONParser.h
+++ b/src/Common/JSONParsers/RapidJSONParser.h
@@ -11,6 +11,7 @@
 #include <base/defines.h>
 #include <rapidjson/document.h>
 #include <Common/JSONParsers/ElementTypes.h>
+#include <Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h>
 #include <Common/StringUtils.h>
 
 namespace DB
@@ -20,6 +21,13 @@ namespace DB
 /// It provides ability to parse JSONs using rapidjson library.
 struct RapidJSONParser
 {
+    /// The DOM, parser stack and string copies are accounted against the memory tracker, so a
+    /// huge or deeply nested untrusted document is rejected with MEMORY_LIMIT_EXCEEDED instead of
+    /// allocating without bound (see RapidJSONMemoryTrackerAllocator).
+    using PoolAllocator = rapidjson::MemoryPoolAllocator<RapidJSONMemoryTrackerAllocator>;
+    using Value = rapidjson::GenericValue<rapidjson::UTF8<>, PoolAllocator>;
+    using Document = rapidjson::GenericDocument<rapidjson::UTF8<>, PoolAllocator, RapidJSONMemoryTrackerAllocator>;
+
     class Array;
     class Object;
 
@@ -29,7 +37,7 @@ struct RapidJSONParser
     {
     public:
         ALWAYS_INLINE Element() = default;
-        ALWAYS_INLINE Element(const rapidjson::Value & value_) : ptr(&value_) {} /// NOLINT
+        ALWAYS_INLINE Element(const Value & value_) : ptr(&value_) {} /// NOLINT
 
         ALWAYS_INLINE ElementType type() const
         {
@@ -63,7 +71,7 @@ struct RapidJSONParser
         Object getObject() const;
 
     private:
-        const rapidjson::Value * ptr = nullptr;
+        const Value * ptr = nullptr;
     };
 
     /// References an array in a JSON document.
@@ -73,24 +81,24 @@ struct RapidJSONParser
         class Iterator
         {
         public:
-            ALWAYS_INLINE Iterator(const rapidjson::Value::ConstValueIterator & it_) : it(it_) {} /// NOLINT
+            ALWAYS_INLINE Iterator(const Value::ConstValueIterator & it_) : it(it_) {} /// NOLINT
             ALWAYS_INLINE Element operator*() const { return *it; } /// NOLINT
             ALWAYS_INLINE Iterator & operator ++() { ++it; return *this; }
             ALWAYS_INLINE Iterator operator ++(int) { auto res = *this; ++it; return res; } /// NOLINT
             ALWAYS_INLINE friend bool operator ==(const Iterator & left, const Iterator & right) { return left.it == right.it; }
             ALWAYS_INLINE friend bool operator !=(const Iterator & left, const Iterator & right) { return !(left == right); }
         private:
-            rapidjson::Value::ConstValueIterator it;
+            Value::ConstValueIterator it;
         };
 
-        ALWAYS_INLINE Array(const rapidjson::Value & value_) : ptr(&value_) {} /// NOLINT
+        ALWAYS_INLINE Array(const Value & value_) : ptr(&value_) {} /// NOLINT
         ALWAYS_INLINE Iterator begin() const { return ptr->Begin(); }
         ALWAYS_INLINE Iterator end() const { return ptr->End(); }
         ALWAYS_INLINE size_t size() const { return ptr->Size(); }
         ALWAYS_INLINE Element operator[](size_t index) const { chassert(index < size()); return *(ptr->Begin() + index); }
 
     private:
-        const rapidjson::Value * ptr = nullptr;
+        const Value * ptr = nullptr;
     };
 
     using KeyValuePair = std::pair<std::string_view, Element>;
@@ -102,17 +110,17 @@ struct RapidJSONParser
         class Iterator
         {
         public:
-            ALWAYS_INLINE Iterator(const rapidjson::Value::ConstMemberIterator & it_) : it(it_) {} /// NOLINT
+            ALWAYS_INLINE Iterator(const Value::ConstMemberIterator & it_) : it(it_) {} /// NOLINT
             ALWAYS_INLINE KeyValuePair operator *() const { std::string_view key{it->name.GetString(), it->name.GetStringLength()}; return {key, it->value}; }
             ALWAYS_INLINE Iterator & operator ++() { ++it; return *this; }
             ALWAYS_INLINE Iterator operator ++(int) { auto res = *this; ++it; return res; } /// NOLINT
             ALWAYS_INLINE friend bool operator ==(const Iterator & left, const Iterator & right) { return left.it == right.it; }
             ALWAYS_INLINE friend bool operator !=(const Iterator & left, const Iterator & right) { return !(left == right); }
         private:
-            rapidjson::Value::ConstMemberIterator it;
+            Value::ConstMemberIterator it;
         };
 
-        ALWAYS_INLINE Object(const rapidjson::Value & value_) : ptr(&value_) {} /// NOLINT
+        ALWAYS_INLINE Object(const Value & value_) : ptr(&value_) {} /// NOLINT
         ALWAYS_INLINE Iterator begin() const { return ptr->MemberBegin(); }
         ALWAYS_INLINE Iterator end() const { return ptr->MemberEnd(); }
         ALWAYS_INLINE size_t size() const { return ptr->MemberCount(); }
@@ -167,7 +175,7 @@ struct RapidJSONParser
         }
 
     private:
-        const rapidjson::Value * ptr = nullptr;
+        const Value * ptr = nullptr;
     };
 
     /// Parses a JSON document, returns the reference to its root element if succeeded.
@@ -188,7 +196,7 @@ struct RapidJSONParser
 #endif
 
 private:
-    rapidjson::Document document;
+    Document document;
 };
 
 inline ALWAYS_INLINE RapidJSONParser::Array RapidJSONParser::Element::getArray() const

--- a/src/Functions/jsonMergePatch.cpp
+++ b/src/Functions/jsonMergePatch.cpp
@@ -19,6 +19,8 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/error/en.h>
 
+#include <Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h>
+
 
 namespace DB
 {
@@ -31,6 +33,16 @@ namespace ErrorCodes
 
 namespace
 {
+    /// rapidjson types whose DOM, parser stack and output buffer are all accounted against the
+    /// memory tracker, so a pathological input cannot allocate without bound (see
+    /// RapidJSONMemoryTrackerAllocator).
+    using TrackedPoolAllocator = rapidjson::MemoryPoolAllocator<RapidJSONMemoryTrackerAllocator>;
+    using TrackedValue = rapidjson::GenericValue<rapidjson::UTF8<char>, TrackedPoolAllocator>;
+    using TrackedDocument = rapidjson::GenericDocument<rapidjson::UTF8<char>, TrackedPoolAllocator, RapidJSONMemoryTrackerAllocator>;
+    using TrackedStringBuffer = rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, RapidJSONMemoryTrackerAllocator>;
+    using TrackedWriter
+        = rapidjson::Writer<TrackedStringBuffer, rapidjson::UTF8<char>, rapidjson::UTF8<char>, RapidJSONMemoryTrackerAllocator>;
+
     // select JSONMergePatch('{"a":1}','{"name": "joey"}','{"name": "tom"}','{"name": "zoey"}');
     //           ||
     //           \/
@@ -65,18 +77,18 @@ namespace
         {
             chassert(!arguments.empty());
 
-            rapidjson::Document::AllocatorType allocator;
-            std::function<void(rapidjson::Value &, const rapidjson::Value &)> merge_objects;
+            TrackedPoolAllocator allocator;
+            std::function<void(TrackedValue &, const TrackedValue &)> merge_objects;
 
-            merge_objects = [&merge_objects, &allocator](rapidjson::Value & dest, const rapidjson::Value & src) -> void
+            merge_objects = [&merge_objects, &allocator](TrackedValue & dest, const TrackedValue & src) -> void
             {
                 if (!src.IsObject())
                     return;
 
                 for (auto it = src.MemberBegin(); it != src.MemberEnd(); ++it)
                 {
-                    rapidjson::Value key(it->name, allocator);
-                    rapidjson::Value value(it->value, allocator);
+                    TrackedValue key(it->name, allocator);
+                    TrackedValue value(it->value, allocator);
                     if (dest.HasMember(key))
                     {
                         if (dest[key].IsObject() && value.IsObject())
@@ -91,7 +103,7 @@ namespace
                 }
             };
 
-            auto parse_json_document = [](const ColumnString & column, rapidjson::Document & document, size_t i)
+            auto parse_json_document = [](const ColumnString & column, TrackedDocument & document, size_t i)
             {
                 auto str_ref = column.getDataAt(i);
                 document.Parse(std::string{str_ref}.c_str());
@@ -111,7 +123,7 @@ namespace
             if (!first_column_arg_string)
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Arguments of function {} must be strings", getName());
 
-            VectorWithMemoryTracking<rapidjson::Document> merged_jsons;
+            VectorWithMemoryTracking<TrackedDocument> merged_jsons;
             merged_jsons.reserve(input_rows_count);
 
             for (size_t i = 0; i < input_rows_count; ++i)
@@ -135,7 +147,7 @@ namespace
 
                 for (size_t i = 0; i < input_rows_count; ++i)
                 {
-                    rapidjson::Document document(&allocator);
+                    TrackedDocument document(&allocator);
                     if (is_const)
                         parse_json_document(*column_arg_string, document, 0);
                     else
@@ -146,12 +158,11 @@ namespace
 
             auto result = ColumnString::create();
             auto & result_string = assert_cast<ColumnString &>(*result);
-            rapidjson::CrtAllocator buffer_allocator;
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                rapidjson::StringBuffer buffer(&buffer_allocator);
-                rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                TrackedStringBuffer buffer;
+                TrackedWriter writer(buffer);
 
                 merged_jsons[i].Accept(writer);
                 result_string.insertData(buffer.GetString(), buffer.GetSize());

--- a/src/Functions/prettyPrintJSON.cpp
+++ b/src/Functions/prettyPrintJSON.cpp
@@ -18,6 +18,8 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/error/en.h>
 
+#include <Common/JSONParsers/RapidJSONMemoryTrackerAllocator.h>
+
 namespace DB
 {
 
@@ -29,6 +31,13 @@ namespace ErrorCodes
 
 namespace
 {
+
+/// rapidjson types whose internal stacks and output buffer are accounted against the memory
+/// tracker, so a pathological input cannot allocate without bound (see RapidJSONMemoryTrackerAllocator).
+using TrackedStringBuffer = rapidjson::GenericStringBuffer<rapidjson::UTF8<char>, RapidJSONMemoryTrackerAllocator>;
+using TrackedPrettyWriter
+    = rapidjson::PrettyWriter<TrackedStringBuffer, rapidjson::UTF8<char>, rapidjson::UTF8<char>, RapidJSONMemoryTrackerAllocator>;
+using TrackedReader = rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, RapidJSONMemoryTrackerAllocator>;
 
 class FunctionPrettyPrintJSON : public IFunction
 {
@@ -91,15 +100,17 @@ public:
                     "Invalid JSON string in function {}: embedded NULL byte",
                     getName());
 
-            rapidjson::StringBuffer buffer;
-            rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+            TrackedStringBuffer buffer;
+            TrackedPrettyWriter writer(buffer);
             writer.SetIndent(' ', indent_count);
 
             /// Stream JSON directly from Reader to PrettyWriter without building
             /// a DOM. Both Reader (with kParseIterativeFlag) and PrettyWriter use
-            /// heap-allocated stacks, so arbitrarily deep nesting is safe.
+            /// heap-allocated stacks, so arbitrarily deep nesting is safe. The stacks and the
+            /// output buffer are accounted against the memory tracker, so an input that would
+            /// produce an enormous output is rejected with MEMORY_LIMIT_EXCEEDED.
             rapidjson::MemoryStream ms(str_view.data(), str_view.size());
-            rapidjson::Reader reader;
+            TrackedReader reader;
             auto parse_result = reader.Parse(ms, writer);
 
             if (parse_result.IsError())

--- a/tests/queries/0_stateless/04340_rapidjson_memory_tracking.reference
+++ b/tests/queries/0_stateless/04340_rapidjson_memory_tracking.reference
@@ -1,0 +1,3 @@
+{\n    "a": 1,\n    "b": "hello"\n}
+{"a":1,"name":"zoey"}
+4

--- a/tests/queries/0_stateless/04340_rapidjson_memory_tracking.sql
+++ b/tests/queries/0_stateless/04340_rapidjson_memory_tracking.sql
@@ -1,0 +1,22 @@
+-- Tags: no-fasttest
+-- no-fasttest: rapidjson is required for prettyPrintJSON, JSONMergePatch and the rapidjson JSON parser.
+
+-- Normal behaviour is unchanged.
+SELECT prettyPrintJSON('{"a":1,"b":"hello"}');
+SELECT JSONMergePatch('{"a":1}', '{"name": "joey"}', '{"name": "tom"}', '{"name": "zoey"}');
+SELECT JSONLength('[1,2,3,4]') SETTINGS allow_simdjson = 0;
+
+-- prettyPrintJSON: a tiny, deeply nested input pretty-prints to an enormous output (indentation
+-- grows per level, so the output is on the order of tens of GiB). The rapidjson output buffer is
+-- now accounted against the memory tracker, so this is rejected early (after only ~50 MiB) with a
+-- clean MEMORY_LIMIT_EXCEEDED, which keeps the query cheap. Before the fix the buffer used a raw
+-- allocator that bypassed the tracker, so the allocation grew unbounded and aborted the server
+-- (tripping the sanitizer allocation-size cap, or running out of memory) instead.
+SELECT length(prettyPrintJSON(concat(repeat('[', 40000), repeat(']', 40000)), 32))
+SETTINGS max_memory_usage = 50000000; -- { serverError MEMORY_LIMIT_EXCEEDED }
+
+-- rapidjson JSON parser (allow_simdjson = 0): the DOM built while parsing a large untrusted
+-- document is now accounted against the memory tracker, so this is rejected with
+-- MEMORY_LIMIT_EXCEEDED. Before the fix the DOM used a raw allocator that bypassed the tracker.
+SELECT JSONLength(concat('[0', repeat(',0', 1000000), repeat(',0', 1000000), ']'))
+SETTINGS allow_simdjson = 0, max_memory_usage = 48000000; -- { serverError MEMORY_LIMIT_EXCEEDED }

--- a/tests/queries/0_stateless/04340_rapidjson_memory_tracking.sql
+++ b/tests/queries/0_stateless/04340_rapidjson_memory_tracking.sql
@@ -20,3 +20,9 @@ SETTINGS max_memory_usage = 50000000; -- { serverError MEMORY_LIMIT_EXCEEDED }
 -- MEMORY_LIMIT_EXCEEDED. Before the fix the DOM used a raw allocator that bypassed the tracker.
 SELECT JSONLength(concat('[0', repeat(',0', 1000000), repeat(',0', 1000000), ']'))
 SETTINGS allow_simdjson = 0, max_memory_usage = 48000000; -- { serverError MEMORY_LIMIT_EXCEEDED }
+
+-- JSONMergePatch: the parsed DOM is now accounted against the memory tracker. A single large
+-- object is rejected with MEMORY_LIMIT_EXCEEDED; the result length is tiny, so without the fix the
+-- untracked DOM would have parsed successfully instead.
+SELECT length(JSONMergePatch(concat('{"a":0', repeat(',"a":0', 1000000), '}')))
+SETTINGS max_memory_usage = 24000000; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
<!--
Closes: 
Related: 
-->

rapidjson's default `CrtAllocator` uses raw `malloc`/`realloc`, bypassing ClickHouse's `MemoryTracker`. A pathological input (for example a deeply nested JSON pretty-printed with wide indentation, or a huge document parsed into a DOM) could grow rapidjson's output buffer, parser stack or DOM without bound, tripping the sanitizer allocation-size cap in tests or running the server out of memory.

This adds a thin allocator implementing the rapidjson `Allocator` concept that delegates to `DB::Allocator` (so tracking, rollback, the large-allocation `mmap` path and profiler sampling are all reused), and uses it in `prettyPrintJSON`, `JSONMergePatch` and the `RapidJSONParser` DOM (`JSONExtract*`, `JSONLength`, the `JSON` type serialization, etc. when `allow_simdjson = 0`). Such inputs are now rejected with `MEMORY_LIMIT_EXCEEDED`.

Found by `Stress test (amd_tsan)` on master: `allocation-size-too-big` in `realloc` from `prettyPrintJSON`.
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f6b752a3cd9ea68e2c3adce70c65e18e440bb170&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

cc @avogar

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Account memory used by the rapidjson library (in `prettyPrintJSON`, `JSONMergePatch` and the rapidjson JSON parser) against the memory tracker, so pathological inputs are rejected with `MEMORY_LIMIT_EXCEEDED` instead of allocating without bound.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.857`
<!-- ch-version-info:end -->