### PR TITLE
Add FunctionGenerateRandomStructure into dbms to fix benchmarks linkage

### DIFF
--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -53,6 +53,7 @@ set(DBMS_FUNCTIONS
     FunctionTopKFilter.cpp # createInternalFunctionTopKFilterResolver used from optimizeTopK.cpp
     extractTimeZoneFromFunctionArguments.cpp # extractTimeZoneFromFunctionArguments (DateTimeTransforms.h, FunctionsConversion.cpp)
     generateSnowflakeID.cpp
+    FunctionGenerateRandomStructure.cpp # FunctionGenerateRandomStructure::generateRandomDataType (Used by StorageGenerateRandom.cpp)
 )
 extract_into_parent_list(clickhouse_functions_sources dbms_sources ${DBMS_FUNCTIONS})
 extract_into_parent_list(clickhouse_functions_headers dbms_headers


### PR DESCRIPTION
    $ ninja src/Common/benchmarks/wrap_in_nullable
    FAILED: [code=1] src/Common/benchmarks/wrap_in_nullable
    ...
    ld.lld: error: undefined symbol: DB::FunctionGenerateRandomStructure::generateRandomDataType(pcg_detail::engine<unsigned long, unsigned __int128, pcg_detail::xsl_rr_mixin<unsigned long, unsigned __int128>, false, pcg_detail::specific_stream<unsigned __int128>, pcg_detail::default_multiplier<unsigned __int128>>&, bool, bool)
    >>> referenced by StorageGenerateRandom.cpp:290 (/src/ch/clickhouse/src/Storages/StorageGenerateRandom.cpp:290)
    >>>               StorageGenerateRandom.cpp.o:(DB::(anonymous namespace)::appendFuzzyRandomString(DB::PODArray<char8_t, 4096ul, Allocator<false, false>, 63ul, 64ul>&, unsigned long, pcg_detail::engine<unsigned long, unsigned __int128, pcg_detail::xsl_rr_mixin<unsigned long, unsigned __int128>, false, pcg_detail::specific_stream<unsigned __int128>, pcg_detail::default_multiplier<unsigned __int128>>&)) in archive src/libdbms.a
    clang++: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.874`
<!-- ch-version-info:end -->