### PR TITLE
Add hash_function_seed setting to seed hash functions

### DIFF
--- a/docs/en/sql-reference/functions/hash-functions.md
+++ b/docs/en/sql-reference/functions/hash-functions.md
@@ -23,6 +23,16 @@ SELECT cityHash64(tuple(NULL))
 To calculate hash of the whole contents of a table, use `sum(cityHash64(tuple(*)))` (or other hash function). `tuple` ensures that rows with NULL values are not skipped. `sum` ensures that the order of rows doesn't matter.
 :::
 
+:::note Seeding hash functions
+The [`hash_function_seed`](/operations/settings/settings#hash_function_seed) setting provides a seed for the hash functions that implement a seeded algorithm: `xxHash32`, `xxHash64`, `xxh3`, `xxh3_128`, `murmurHash2_32`, `murmurHash2_64`, `murmurHash3_32`, `murmurHash3_64`, `murmurHash3_128` and `wyHash64`. The default value `0` reproduces the previous, unseeded results, so existing queries are unaffected.
+
+```sql
+SELECT xxHash64('Hello, world!') SETTINGS hash_function_seed = 42;
+```
+
+Hash functions that do not implement a seeded algorithm (such as `cityHash64`, `farmHash64`, `halfMD5`), functions with a fixed compatibility seed (`gccMurmurHash`, `kafkaMurmurHash`) and the cryptographic hashes ignore this setting. The `sipHash*` functions accept keys via their dedicated `*Keyed` variants.
+:::
+
 <!-- 
 The inner content of the tags below are replaced at doc framework build time with 
 docs generated from system.functions. Please do not modify or remove the tags.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -385,6 +385,13 @@ Connection timeout if there are no replicas.
     DECLARE(Milliseconds, handshake_timeout_ms, 10000, R"(
 Timeout in milliseconds for receiving Hello packet from replicas during handshake.
 )", 0) \
+    DECLARE(UInt64, hash_function_seed, 0, R"(
+Seed for hash functions that implement a seeded algorithm: `xxHash32`, `xxHash64`, `xxh3`, `xxh3_128`, `murmurHash2_32`, `murmurHash2_64`, `murmurHash3_32`, `murmurHash3_64`, `murmurHash3_128` and `wyHash64`. These functions read the seed from this setting instead of using a fixed seed of 0.
+
+A value of `0` (the default) reproduces the previous, unseeded behavior, so existing results are unchanged. Functions whose seed is 32 bits wide (`xxHash32`, `murmurHash2_32`, `murmurHash3_32`, `murmurHash3_64`, `murmurHash3_128`) use the lower 32 bits of the value.
+
+Hash functions that do not implement a seeded algorithm (for example `cityHash64`, `farmHash64`, `halfMD5`), functions with a fixed compatibility seed (`gccMurmurHash`, `kafkaMurmurHash`) and the cryptographic hashes ignore this setting. `sipHash*` functions support keys via their dedicated `*Keyed` variants.
+)", 0) \
     DECLARE(Milliseconds, connect_timeout_with_failover_ms, 1000, R"(
 The timeout in milliseconds for connecting to a remote server for a Distributed table engine, if the 'shard' and 'replica' sections are used in the cluster definition.
 If unsuccessful, several attempts are made to connect to various replicas.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.6",
         {
+            {"hash_function_seed", 0, 0, "New setting to provide a seed for seedable hash functions (xxHash, murmurHash, wyHash64); default 0 keeps the previous unseeded behavior."},
             {"enable_join_runtime_filter_shared_fixed_hash_table", false, true, "New setting to share the hash join's FixedHashMap as the runtime filter for the probe side, replacing the Set/BloomFilter built upstream by the runtime filter framework."},
             {"ai_function_embedding_max_batch_size", 100, 100, "New setting"},
             {"enable_sharding_aggregator", false, false, "New setting to enable sharded `GROUP BY` optimization that distributes rows across threads by hashing the grouping key, so each thread aggregates a disjoint subset of keys without a merge phase; this is efficient for high cardinality keys with evenly distributed data."},

--- a/src/Functions/FunctionsHashing.h
+++ b/src/Functions/FunctionsHashing.h
@@ -64,6 +64,11 @@ namespace ErrorCodes
     extern const int OPENSSL_ERROR;
 }
 
+namespace Setting
+{
+    extern const SettingsUInt64 hash_function_seed;
+}
+
 namespace impl
 {
     struct SipHashKey
@@ -401,6 +406,10 @@ struct MurmurHash2Impl32
     {
         return MurmurHash2(data, size, 0);
     }
+    static UInt32 apply(const char * data, const size_t size, UInt64 seed)
+    {
+        return MurmurHash2(data, size, static_cast<uint32_t>(seed));
+    }
 
     static UInt32 combineHashes(UInt32 h1, UInt32 h2)
     {
@@ -419,6 +428,10 @@ struct MurmurHash2Impl64
     static UInt64 apply(const char * data, const size_t size)
     {
         return MurmurHash64A(data, size, 0);
+    }
+    static UInt64 apply(const char * data, const size_t size, UInt64 seed)
+    {
+        return MurmurHash64A(data, size, seed);
     }
 
     static UInt64 combineHashes(UInt64 h1, UInt64 h2)
@@ -480,12 +493,16 @@ struct MurmurHash3Impl32
 
     static UInt32 apply(const char * data, const size_t size)
     {
+        return apply(data, size, 0);
+    }
+    static UInt32 apply(const char * data, const size_t size, UInt64 seed)
+    {
         union // NOLINT(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         {
             UInt32 h;
             char bytes[sizeof(h)];
         };
-        MurmurHash3_x86_32(data, size, 0, bytes);
+        MurmurHash3_x86_32(data, size, static_cast<uint32_t>(seed), bytes);
         return h;
     }
 
@@ -505,12 +522,16 @@ struct MurmurHash3Impl64
 
     static UInt64 apply(const char * data, const size_t size)
     {
+        return apply(data, size, 0);
+    }
+    static UInt64 apply(const char * data, const size_t size, UInt64 seed)
+    {
         union // NOLINT(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
         {
             UInt64 h[2];
             char bytes[16];
         };
-        MurmurHash3_x64_128(data, size, 0, bytes);
+        MurmurHash3_x64_128(data, size, static_cast<uint32_t>(seed), bytes);
         return h[0] ^ h[1];
     }
 
@@ -528,8 +549,12 @@ struct MurmurHash3Impl128
 
     static UInt128 apply(const char * data, const size_t size)
     {
+        return apply(data, size, 0);
+    }
+    static UInt128 apply(const char * data, const size_t size, UInt64 seed)
+    {
         char bytes[16];
-        MurmurHash3_x64_128(data, size, 0, bytes);
+        MurmurHash3_x64_128(data, size, static_cast<uint32_t>(seed), bytes);
         return *reinterpret_cast<UInt128 *>(bytes);
     }
 
@@ -713,6 +738,7 @@ struct ImplXxHash32
     using ReturnType = UInt32;
 
     static auto apply(const char * s, const size_t len) { return XXH_INLINE_XXH32(s, len, 0); }
+    static auto apply(const char * s, const size_t len, UInt64 seed) { return XXH_INLINE_XXH32(s, len, static_cast<XXH32_hash_t>(seed)); }
     /**
       *  With current implementation with more than 1 arguments it will give the results
       *  non-reproducible from outside of CH.
@@ -735,6 +761,7 @@ struct ImplXxHash64
     using uint128_t = CityHash_v1_0_2::uint128;
 
     static auto apply(const char * s, const size_t len) { return XXH_INLINE_XXH64(s, len, 0); }
+    static auto apply(const char * s, const size_t len, UInt64 seed) { return XXH_INLINE_XXH64(s, len, seed); }
 
     /*
        With current implementation with more than 1 arguments it will give the results
@@ -753,6 +780,8 @@ struct ImplXXH3
     using uint128_t = CityHash_v1_0_2::uint128;
 
     static auto apply(const char * s, const size_t len) { return XXH_INLINE_XXH3_64bits(s, len); }
+    /// withSeed short-circuits to the unseeded path when seed == 0, so the default stays identical.
+    static auto apply(const char * s, const size_t len, UInt64 seed) { return XXH_INLINE_XXH3_64bits_withSeed(s, len, seed); }
 
     /*
        With current implementation with more than 1 arguments it will give the results
@@ -772,6 +801,12 @@ struct ImplXXH3_128
     static UInt128 apply(const char * s, const size_t len)
     {
         auto hash = XXH_INLINE_XXH3_128bits(s, len);
+        return {hash.low64, hash.high64};
+    }
+    /// withSeed short-circuits to the unseeded path when seed == 0, so the default stays identical.
+    static UInt128 apply(const char * s, const size_t len, UInt64 seed)
+    {
+        auto hash = XXH_INLINE_XXH3_128bits_withSeed(s, len, seed);
         return {hash.low64, hash.high64};
     }
 
@@ -938,8 +973,13 @@ public:
     /// Keep default implementation of useDefaultImplementationForNulls for compatibility.
     /// E.g. someHash(NULL) is NULL, but someHash(tuple(NULL)) is not NULL.
 
+    explicit FunctionAnyHash(UInt64 seed_ = 0) : seed(seed_) {}
+
 private:
     using ToType = typename Impl::ReturnType;
+
+    /// Value of the `hash_function_seed` setting; 0 reproduces the previous unseeded behaviour.
+    const UInt64 seed = 0;
 
     template <typename FromType, bool first>
     void executeIntType(const KeyColumnsType & key_cols, const IColumn * column, typename ColumnVector<ToType>::Container & vec_to) const
@@ -1568,15 +1608,18 @@ public:
         return col_to;
     }
 
-    static ToType apply(const KeyType & key, const char * begin, size_t size)
+    ToType apply(const KeyType & key, const char * begin, size_t size) const
     {
         if constexpr (Keyed)
             return Impl::applyKeyed(key, begin, size);
+        /// Seedable algorithms expose a three-argument apply(begin, size, seed) overload.
+        else if constexpr (requires { Impl::apply(begin, size, seed); })
+            return Impl::apply(begin, size, seed);
         else
             return Impl::apply(begin, size);
     }
 
-    static ToType combineHashes(const KeyType & key, ToType h1, ToType h2)
+    ToType combineHashes(const KeyType & key, ToType h1, ToType h2) const
     {
         if constexpr (Keyed)
             return Impl::combineHashesKeyed(key, h1, h2);
@@ -1591,16 +1634,19 @@ template <typename Impl, bool Keyed = false, typename KeyType = char, typename K
 class FunctionAnyHash : public TargetSpecific::Default::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>
 {
 public:
-    explicit FunctionAnyHash(ContextPtr context) : selector(context)
+    explicit FunctionAnyHash(ContextPtr context)
+        : TargetSpecific::Default::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>(context->getSettingsRef()[Setting::hash_function_seed])
+        , selector(context)
     {
+        const UInt64 seed = context->getSettingsRef()[Setting::hash_function_seed];
         selector
-            .registerImplementation<TargetArch::Default, TargetSpecific::Default::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();
+            .registerImplementation<TargetArch::Default, TargetSpecific::Default::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>(seed);
 
 #if USE_MULTITARGET_CODE
         /// See the note in `FunctionIntHash`: `FunctionsHashingMisc.cpp` is at v2, so `Default` is v2 and the runtime
         /// dispatcher needs the per-function v3 specialization to recover AVX2 codegen.
-        selector.registerImplementation<TargetArch::x86_64_v3, TargetSpecific::x86_64_v3::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();
-        selector.registerImplementation<TargetArch::x86_64_v4, TargetSpecific::x86_64_v4::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>();
+        selector.registerImplementation<TargetArch::x86_64_v3, TargetSpecific::x86_64_v3::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>(seed);
+        selector.registerImplementation<TargetArch::x86_64_v4, TargetSpecific::x86_64_v4::FunctionAnyHash<Impl, Keyed, KeyType, KeyColumnsType>>(seed);
 #endif
     }
 
@@ -1830,6 +1876,7 @@ struct ImplWyHash64
     using ReturnType = UInt64;
 
     static UInt64 apply(const char * s, const size_t len) { return wyhash(s, len, 0, _wyp); }
+    static UInt64 apply(const char * s, const size_t len, UInt64 seed) { return wyhash(s, len, seed, _wyp); }
     static UInt64 combineHashes(UInt64 h1, UInt64 h2) { return combineHashesFunc<UInt64, ImplWyHash64>(h1, h2); }
 
     static constexpr bool use_int_hash_for_pods = false;

--- a/tests/queries/0_stateless/04340_hash_function_seed.reference
+++ b/tests/queries/0_stateless/04340_hash_function_seed.reference
@@ -1,0 +1,42 @@
+-- default (seed = 0) is unchanged --
+834093149
+17691043854468224118
+17564966470555134057
+ADE2B2886B80787BBB5CA743B534F2FA
+1077681669
+11600739918808951577
+3224780355
+15952677324548579515
+DF65D6D2D12D51F164C5F3A85066322C
+7490563016637708689
+-- not setting the seed equals seed = 0 --
+1
+-- xxHash matches the canonical xxHash test vectors with a seed --
+1042293711
+4152504606
+-- a non-zero seed changes the result of every seedable function (1 = changed) --
+1
+1
+1
+1
+1
+1
+1
+1
+1
+1
+-- the same seed is deterministic across statements (1 = equal) --
+2654233727439105466
+2654233727439105466
+-- the seed applies to non-String inputs too (1 = changed) --
+1
+-- the seed applies per row, not just to constants (1 = changed) --
+1
+-- non-seedable functions ignore the setting (1 = unchanged) --
+1
+1
+1
+1
+1
+1
+1

--- a/tests/queries/0_stateless/04340_hash_function_seed.sql
+++ b/tests/queries/0_stateless/04340_hash_function_seed.sql
@@ -1,0 +1,55 @@
+-- Tests the `hash_function_seed` setting for seedable hash functions (issue #63482).
+-- Each statement sets the seed at the top level (the setting is read once when the function
+-- is constructed for the query), which is the way the setting is meant to be used.
+
+SELECT '-- default (seed = 0) is unchanged --';
+-- The default of 0 must reproduce the historical, unseeded values.
+SELECT xxHash32('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT xxHash64('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT xxh3('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT hex(xxh3_128('Hello, world!')) SETTINGS hash_function_seed = 0;
+SELECT murmurHash2_32('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT murmurHash2_64('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT murmurHash3_32('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT murmurHash3_64('Hello, world!') SETTINGS hash_function_seed = 0;
+SELECT hex(murmurHash3_128('Hello, world!')) SETTINGS hash_function_seed = 0;
+SELECT wyHash64('Hello, world!') SETTINGS hash_function_seed = 0;
+
+SELECT '-- not setting the seed equals seed = 0 --';
+SELECT xxHash64('Hello, world!') = 17691043854468224118;
+
+SELECT '-- xxHash matches the canonical xxHash test vectors with a seed --';
+-- XXH32("test", seed=0) = 1042293711, XXH32("test", seed=1) = 4152504606
+SELECT xxHash32('test') SETTINGS hash_function_seed = 0;
+SELECT xxHash32('test') SETTINGS hash_function_seed = 1;
+
+SELECT '-- a non-zero seed changes the result of every seedable function (1 = changed) --';
+SELECT xxHash32('Hello, world!')       != 834093149            SETTINGS hash_function_seed = 12345;
+SELECT xxHash64('Hello, world!')       != 17691043854468224118 SETTINGS hash_function_seed = 12345;
+SELECT xxh3('Hello, world!')           != 17564966470555134057 SETTINGS hash_function_seed = 12345;
+SELECT hex(xxh3_128('Hello, world!'))  != 'ADE2B2886B80787BBB5CA743B534F2FA' SETTINGS hash_function_seed = 12345;
+SELECT murmurHash2_32('Hello, world!') != 1077681669           SETTINGS hash_function_seed = 12345;
+SELECT murmurHash2_64('Hello, world!') != 11600739918808951577 SETTINGS hash_function_seed = 12345;
+SELECT murmurHash3_32('Hello, world!') != 3224780355           SETTINGS hash_function_seed = 12345;
+SELECT murmurHash3_64('Hello, world!') != 15952677324548579515 SETTINGS hash_function_seed = 12345;
+SELECT hex(murmurHash3_128('Hello, world!')) != 'DF65D6D2D12D51F164C5F3A85066322C' SETTINGS hash_function_seed = 12345;
+SELECT wyHash64('Hello, world!')       != 7490563016637708689  SETTINGS hash_function_seed = 12345;
+
+SELECT '-- the same seed is deterministic across statements (1 = equal) --';
+SELECT xxHash64('Hello, world!') SETTINGS hash_function_seed = 999;
+SELECT xxHash64('Hello, world!') SETTINGS hash_function_seed = 999;
+
+SELECT '-- the seed applies to non-String inputs too (1 = changed) --';
+SELECT xxHash64(toUInt32(123)) != 18259948255902865962 SETTINGS hash_function_seed = 5;
+
+SELECT '-- the seed applies per row, not just to constants (1 = changed) --';
+SELECT sum(xxHash64(toString(number))) != 9447509538163294618 FROM numbers(100) SETTINGS hash_function_seed = 5;
+
+SELECT '-- non-seedable functions ignore the setting (1 = unchanged) --';
+SELECT cityHash64('Hello, world!')      = 2359500134450972198  SETTINGS hash_function_seed = 777;
+SELECT farmHash64('Hello, world!')      = 1915388679533807205  SETTINGS hash_function_seed = 777;
+SELECT halfMD5('Hello, world!')         = 7841705306765501771  SETTINGS hash_function_seed = 777;
+SELECT gccMurmurHash('Hello, world!')   = 12518601801603912089 SETTINGS hash_function_seed = 777;
+SELECT kafkaMurmurHash('Hello, world!') = 1052416786           SETTINGS hash_function_seed = 777;
+SELECT sipHash64('Hello, world!')       = 12560575472004092239 SETTINGS hash_function_seed = 777;
+SELECT metroHash64('Hello, world!')     = 676721872007707627   SETTINGS hash_function_seed = 777;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/63482
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/63482

### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a new setting `hash_function_seed` that lets users specify a seed for the hash functions that implement a seeded algorithm (`xxHash32`, `xxHash64`, `xxh3`, `xxh3_128`, `murmurHash2_32`, `murmurHash2_64`, `murmurHash3_32`, `murmurHash3_64`, `murmurHash3_128`, `wyHash64`). The default value `0` reproduces the previous unseeded results.

### Description

Implements the feature requested in #63482, using the approach decided by @rschu1ze in https://github.com/ClickHouse/ClickHouse/issues/63482#issuecomment-4707980206: a session setting rather than a parametric form or per-function `*Seed` overloads.

`hash_function_seed` (UInt64, default 0). When set, the seedable hash functions read the seed from the query context and pass it to their underlying algorithm instead of the fixed seed of 0. The 32-bit-seed functions (`xxHash32`, `murmurHash2_32`, `murmurHash3_*`) use the lower 32 bits.

A default of 0 is byte-identical to the previous behavior, so existing results are unchanged (verified: the existing hash tests `00678_murmurhash`, `00803_xxhash`, `02481_xxh3_hash_function`, `02286_function_wyhash`, `03825/03826_xxh3_128`, `00259/00746_hashing_tuples` all pass). For `xxh3`/`xxh3_128` the `withSeed` variant short-circuits internally to the unseeded path when the seed is 0, so the default has no overhead.

Out of scope (and unaffected by the setting), noted for reviewers:
- `metroHash64`: integer inputs take an int-hash fast path that bypasses the metro algorithm, so a seed would only affect string inputs (asymmetric). Left out; can be added if desired.
- `gccMurmurHash` / `kafkaMurmurHash`: fixed compatibility seeds, intentionally not configurable.
- `cityHash64` / `farmHash64` / `farmFingerprint64`: no seed parameter in the algorithm.
- `sipHash*`: already seedable via the `*Keyed` variants.

Includes documentation (settings reference is autogenerated from `Settings.cpp`; a note added to `hash-functions.md`), a `SettingsChangesHistory.cpp` entry, and a stateless test `04340_hash_function_seed` that checks the default values are unchanged, that a non-zero seed changes every seedable function, that the same seed is deterministic, that non-seedable functions ignore the setting, and that the canonical xxHash test vectors match.
