### PR TITLE
Make `getPageSize` a function with a function-local static

### DIFF
--- a/base/base/getPageSize.cpp
+++ b/base/base/getPageSize.cpp
@@ -13,4 +13,8 @@ namespace
     }
 }
 
-Int64 staticPageSize = getPageSizeImpl();
+Int64 getPageSize()
+{
+    static const Int64 page_size = getPageSizeImpl();
+    return page_size;
+}

--- a/base/base/getPageSize.h
+++ b/base/base/getPageSize.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#include <base/defines.h>
 #include <base/types.h>
 
-extern Int64 staticPageSize;
-
-/// Get memory page size
-Int64 inline ALWAYS_INLINE getPageSize()
-{
-    return staticPageSize;
-}
+/// Get memory page size.
+Int64 getPageSize();

--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -65,7 +65,7 @@ void prefaultPages([[maybe_unused]] void * buf_, [[maybe_unused]] size_t len_)
     if (!is_supported_by_kernel) [[unlikely]]
         return;
 
-    auto [buf, len] = adjustToPageSize(buf_, len_, staticPageSize);
+    auto [buf, len] = adjustToPageSize(buf_, len_, ::getPageSize());
     ::madvise(buf, len, MADV_POPULATE_WRITE);
 #endif
 }


### PR DESCRIPTION
Extracted from https://github.com/ClickHouse/ClickHouse/pull/97452.

Turn `getPageSize` into a real function backed by a function-local `static` instead of a namespace-scope `staticPageSize` global with a dynamic initializer.

Motivation: with the namespace-scope variable, LTO has been observed to DCE the `__cxx_global_var_init` for this translation unit on the musl/aarch64 static build, leaving `staticPageSize` at `0` and breaking the first `aligned_alloc(page_size, ...)` at startup. A function-local static initializes lazily on first call and survives LTO. The only direct user of `staticPageSize` (`prefaultPages` in `Allocator.cpp`) now calls `getPageSize` instead.

Related: https://github.com/ClickHouse/ClickHouse/pull/97452

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
