### PR TITLE
Add a SIMD-friendly memcmp to glibc-compatibility

### DIFF
--- a/base/glibc-compatibility/CMakeLists.txt
+++ b/base/glibc-compatibility/CMakeLists.txt
@@ -4,6 +4,11 @@ if (GLIBC_COMPATIBILITY)
         set(MEMCPY_LIBRARY memcpy)
     endif()
 
+    add_subdirectory(memcmp)
+    if(TARGET memcmp)
+        set(MEMCMP_LIBRARY memcmp)
+    endif()
+
     enable_language(ASM)
 
     add_headers_and_sources(glibc_compatibility .)
@@ -46,7 +51,7 @@ if (GLIBC_COMPATIBILITY)
         target_compile_options(glibc-compatibility PRIVATE -fPIC)
     endif ()
 
-    target_link_libraries(global-libs INTERFACE glibc-compatibility ${MEMCPY_LIBRARY})
+    target_link_libraries(global-libs INTERFACE glibc-compatibility ${MEMCPY_LIBRARY} ${MEMCMP_LIBRARY})
 
     message (STATUS "Some symbols from glibc will be replaced for compatibility")
 

--- a/base/glibc-compatibility/memcmp/CMakeLists.txt
+++ b/base/glibc-compatibility/memcmp/CMakeLists.txt
@@ -1,0 +1,8 @@
+if (ARCH_AMD64 OR ARCH_AARCH64)
+    add_library(memcmp STATIC memcmp.cpp)
+
+    # We allow to include memcmp.h from user code for better inlining.
+    target_include_directories(memcmp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+    target_compile_options(memcmp PRIVATE -fno-builtin-memcmp)
+endif ()

--- a/base/glibc-compatibility/memcmp/memcmp.cpp
+++ b/base/glibc-compatibility/memcmp/memcmp.cpp
@@ -1,0 +1,7 @@
+#include "memcmp.h"
+
+__attribute__((no_sanitize("coverage")))
+extern "C" int memcmp(const void * a, const void * b, size_t size)
+{
+    return inline_memcmp(a, b, size);
+}

--- a/base/glibc-compatibility/memcmp/memcmp.h
+++ b/base/glibc-compatibility/memcmp/memcmp.h
@@ -1,0 +1,81 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+#  include <emmintrin.h> /* SSE2 */
+#endif
+
+#if defined(__aarch64__)
+#  include <arm_neon.h>
+#endif
+
+
+/** Custom memcmp implementation for ClickHouse.
+  *
+  * The motivation is the same as for the custom memcpy (see ../memcpy/memcpy.h):
+  * to avoid a dependency on a specific libc symbol version and to allow inlining
+  * inline_memcmp directly at call sites.
+  *
+  * Some libc implementations (notably musl) ship a naive byte-by-byte memcmp that
+  * the compiler cannot auto-vectorize because of the early-exit on mismatch. For
+  * typical ClickHouse workloads (hash aggregation / join on string keys) that loop
+  * dominates the profile. This implementation compares 16 bytes at a time using
+  * SSE2 on x86_64 and NEON on aarch64, with word-at-a-time and byte-at-a-time tails.
+  *
+  * It matches the C memcmp contract: returns the signed difference of the first
+  * pair of differing bytes (as unsigned char), or 0 if the ranges are equal.
+  */
+inline int inline_memcmp(const void * vl, const void * vr, size_t n)
+{
+    const unsigned char * l = reinterpret_cast<const unsigned char *>(vl);
+    const unsigned char * r = reinterpret_cast<const unsigned char *>(vr);
+
+#if defined(__x86_64__) || defined(__i386__)
+    while (n >= 16)
+    {
+        __m128i a = _mm_loadu_si128(reinterpret_cast<const __m128i *>(l));
+        __m128i b = _mm_loadu_si128(reinterpret_cast<const __m128i *>(r));
+        __m128i eq = _mm_cmpeq_epi8(a, b);
+        unsigned mask = static_cast<unsigned>(_mm_movemask_epi8(eq)) ^ 0xFFFFu;
+        if (mask)
+        {
+            unsigned idx = static_cast<unsigned>(__builtin_ctz(mask));
+            return static_cast<int>(l[idx]) - static_cast<int>(r[idx]);
+        }
+        l += 16; r += 16; n -= 16;
+    }
+#elif defined(__aarch64__)
+    while (n >= 16)
+    {
+        uint8x16_t a = vld1q_u8(l);
+        uint8x16_t b = vld1q_u8(r);
+        uint8x16_t eq = vceqq_u8(a, b);
+        /* Compress each byte's top bit to a 64-bit mask (4 bits per lane). */
+        uint64_t mask = vgetq_lane_u64(vreinterpretq_u64_u8(
+            vcombine_u8(vshrn_n_u16(vreinterpretq_u16_u8(eq), 4), vdup_n_u8(0))), 0);
+        if (mask != UINT64_C(0xFFFFFFFFFFFFFFFF))
+        {
+            unsigned idx = static_cast<unsigned>(__builtin_ctzll(~mask) >> 2);
+            return static_cast<int>(l[idx]) - static_cast<int>(r[idx]);
+        }
+        l += 16; r += 16; n -= 16;
+    }
+#endif
+
+    /* Word-at-a-time for the middle (useful on platforms without SIMD, and
+       for the 8..15 byte tail on SIMD platforms). */
+    while (n >= sizeof(size_t))
+    {
+        size_t wl = 0;
+        size_t wr = 0;
+        __builtin_memcpy(&wl, l, sizeof(size_t));
+        __builtin_memcpy(&wr, r, sizeof(size_t));
+        if (wl != wr)
+            break;
+        l += sizeof(size_t); r += sizeof(size_t); n -= sizeof(size_t);
+    }
+
+    for (; n && *l == *r; n--, l++, r++)
+        ;
+    return n ? static_cast<int>(*l) - static_cast<int>(*r) : 0;
+}


### PR DESCRIPTION
Split out of #97452 (`Build musl from sources`): the `memcmp` specialization is independent of the rest of that PR, so it lives on its own here.

Adds a ClickHouse replacement for the libc `memcmp`, built and linked into `GLIBC_COMPATIBILITY` builds alongside the existing custom `memcpy` (`base/glibc-compatibility/memcpy`). `inline_memcmp` compares 16 bytes at a time using SSE2 on x86_64 and NEON on aarch64, with word-at-a-time and byte-at-a-time tails. It is exposed through `memcmp.h` for inlining at call sites and as a strong `extern "C"` `memcmp` symbol in `memcmp.cpp`.

Motivation: the default `memcmp` in some libc implementations (notably `musl`) is a naive byte-by-byte loop that the compiler cannot auto-vectorize because of the early-exit on mismatch. For typical ClickHouse workloads (hash aggregation / join on long string keys) that loop dominates the profile.

Correctness was fuzzed against the reference memcmp (602k cases each on x86_64/SSE2 and aarch64/NEON under qemu), covering all branches, unaligned offsets, and sign cases.

Draft, because there is a tradeoff to discuss: on glibc builds this overrides glibc's IFUNC-dispatched AVX2 memcmp, which is faster than this SSE2/NEON version (measured ~0.22s vs ~0.26s on group_by_multiple_strings). The win only materializes against musl's naive loop. The linking strategy (always override vs. only when the libc memcmp is slow) is open for review.

Related: https://github.com/ClickHouse/ClickHouse/pull/97452

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a SIMD-friendly `memcmp` implementation (SSE2 on x86_64, NEON on aarch64) for builds that use glibc compatibility.
