### PR TITLE
Support keys{32,64} in SetVariants

### DIFF
--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -146,6 +146,10 @@ typename SetVariantsTemplate<Variant>::Type SetVariantsTemplate<Variant>::choose
     }
 
     /// If the keys fit in N bits, we will use a hash table for N-bit-packed keys
+    if (all_fixed && keys_bytes <= 4)
+        return Type::keys32;
+    if (all_fixed && keys_bytes <= 8)
+        return Type::keys64;
     if (all_fixed && keys_bytes <= 16)
         return Type::keys128;
     if (all_fixed && keys_bytes <= 32)

--- a/src/Interpreters/SetVariants.h
+++ b/src/Interpreters/SetVariants.h
@@ -196,6 +196,8 @@ struct NonClearableSet
     std::unique_ptr<SetMethodOneNumber<UInt64, HashSet<UInt64, HashCRC32<UInt64>>>>          key64;
     std::unique_ptr<SetMethodString<HashSetWithSavedHash<std::string_view>>>                        key_string;
     std::unique_ptr<SetMethodFixedString<HashSetWithSavedHash<std::string_view>>>                   key_fixed_string;
+    std::unique_ptr<SetMethodKeysFixed<HashSet<UInt32, HashCRC32<UInt32>>>>                  keys32;
+    std::unique_ptr<SetMethodKeysFixed<HashSet<UInt64, HashCRC32<UInt64>>>>                  keys64;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt128, UInt128HashCRC32>>>                  keys128;
     std::unique_ptr<SetMethodKeysFixed<HashSet<UInt256, UInt256HashCRC32>>>                  keys256;
     std::unique_ptr<SetMethodHashed<HashSet<UInt128, UInt128TrivialHash>>>                   hashed;
@@ -218,6 +220,8 @@ struct ClearableSet
     std::unique_ptr<SetMethodOneNumber<UInt64, ClearableHashSet<UInt64, HashCRC32<UInt64>>>>         key64;
     std::unique_ptr<SetMethodString<ClearableHashSetWithSavedHash<std::string_view>>>                       key_string;
     std::unique_ptr<SetMethodFixedString<ClearableHashSetWithSavedHash<std::string_view>>>                  key_fixed_string;
+    std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt32, HashCRC32<UInt32>>>>                 keys32;
+    std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt64, HashCRC32<UInt64>>>>                 keys64;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt128, UInt128HashCRC32>>>                 keys128;
     std::unique_ptr<SetMethodKeysFixed<ClearableHashSet<UInt256, UInt256HashCRC32>>>                 keys256;
     std::unique_ptr<SetMethodHashed<ClearableHashSet<UInt128, UInt128TrivialHash>>>                  hashed;
@@ -243,6 +247,8 @@ struct SetVariantsTemplate: public Variant
         M(key64)                \
         M(key_string)           \
         M(key_fixed_string)     \
+        M(keys32)               \
+        M(keys64)               \
         M(keys128)              \
         M(keys256)              \
         M(nullable_keys128)     \

--- a/tests/performance/set_packed_keys.xml
+++ b/tests/performance/set_packed_keys.xml
@@ -1,0 +1,15 @@
+<test>
+    <!--
+        A set over a composite fixed key that fits in 4 or 8 bytes now uses the packed keys32 / keys64
+        methods instead of collapsing to keys128. The per-key slot becomes 4 or 8 bytes instead of 16,
+        which shrinks the hash set (better cache behaviour) and uses cheaper hashing/comparison, so both
+        building the set and probing it get faster. The set has ~1M distinct keys and is probed by 50M
+        rows via `(a, b) IN (subset)`.
+    -->
+
+    <!-- keys32: two UInt16 columns (4 bytes). -->
+    <query>SELECT count() FROM numbers_mt(50000000) WHERE (toUInt16(number), toUInt16(intHash32(number))) IN (SELECT toUInt16(number), toUInt16(intHash32(number)) FROM numbers(1000000))</query>
+
+    <!-- keys64: two UInt32 columns (8 bytes). -->
+    <query>SELECT count() FROM numbers_mt(50000000) WHERE (toUInt32(number), toUInt32(intHash64(number))) IN (SELECT toUInt32(number), toUInt32(intHash64(number)) FROM numbers(1000000))</query>
+</test>

--- a/tests/queries/0_stateless/04335_packed_composite_key_set.reference
+++ b/tests/queries/0_stateless/04335_packed_composite_key_set.reference
@@ -1,0 +1,10 @@
+in_keys32	1
+notin_keys32	1
+distinct_keys32	1
+intersect_keys32	1
+except_keys32	1
+in_keys64	1
+notin_keys64	1
+distinct_keys64	1
+intersect_keys64	1
+except_keys64	1

--- a/tests/queries/0_stateless/04335_packed_composite_key_set.sql
+++ b/tests/queries/0_stateless/04335_packed_composite_key_set.sql
@@ -1,0 +1,42 @@
+-- A composite fixed set key that fits in 4 or 8 bytes now uses the packed keys32 / keys64 set
+-- methods instead of collapsing to keys128. This checks results stay correct across the set
+-- consumers (IN, NOT IN, DISTINCT, INTERSECT, EXCEPT) for both widths, against independent oracles.
+-- Each query prints 1 when the set-based result equals the oracle.
+
+-- The IN / NOT IN oracles use SEMI / ANTI joins, which only the hash algorithm implements.
+SET join_algorithm = 'hash';
+
+DROP TABLE IF EXISTS sk_t16;
+DROP TABLE IF EXISTS sk_r16;
+DROP TABLE IF EXISTS sk_t32;
+DROP TABLE IF EXISTS sk_r32;
+
+-- keys32: two UInt16 columns (4 bytes). The right side covers only half the (a, b) pairs, so some
+-- rows match and some do not.
+CREATE TABLE sk_t16 (a UInt16, b UInt16) ENGINE = Memory;
+CREATE TABLE sk_r16 (a UInt16, b UInt16) ENGINE = Memory;
+INSERT INTO sk_t16 SELECT number % 1000, (number * 7) % 1000 FROM numbers(20000);
+INSERT INTO sk_r16 SELECT number % 1000, (number * 7) % 1000 FROM numbers(20000) WHERE number % 1000 < 500;
+
+SELECT 'in_keys32',        (SELECT count() FROM sk_t16 WHERE (a, b) IN (SELECT a, b FROM sk_r16))     = (SELECT count() FROM sk_t16 SEMI JOIN sk_r16 USING (a, b));
+SELECT 'notin_keys32',     (SELECT count() FROM sk_t16 WHERE (a, b) NOT IN (SELECT a, b FROM sk_r16)) = (SELECT count() FROM sk_t16 ANTI JOIN sk_r16 USING (a, b));
+SELECT 'distinct_keys32',  (SELECT count() FROM (SELECT DISTINCT a, b FROM sk_t16))                   = (SELECT uniqExact((a, b)) FROM sk_t16);
+SELECT 'intersect_keys32', (SELECT count() FROM (SELECT a, b FROM sk_t16 INTERSECT DISTINCT SELECT a, b FROM sk_r16)) = (SELECT uniqExact((a, b)) FROM sk_t16 WHERE (a, b) IN (SELECT a, b FROM sk_r16));
+SELECT 'except_keys32',    (SELECT count() FROM (SELECT a, b FROM sk_t16 EXCEPT DISTINCT SELECT a, b FROM sk_r16))    = (SELECT uniqExact((a, b)) FROM sk_t16 WHERE (a, b) NOT IN (SELECT a, b FROM sk_r16));
+
+-- keys64: two UInt32 columns (8 bytes).
+CREATE TABLE sk_t32 (a UInt32, b UInt32) ENGINE = Memory;
+CREATE TABLE sk_r32 (a UInt32, b UInt32) ENGINE = Memory;
+INSERT INTO sk_t32 SELECT number % 1000, (number * 7) % 1000 FROM numbers(20000);
+INSERT INTO sk_r32 SELECT number % 1000, (number * 7) % 1000 FROM numbers(20000) WHERE number % 1000 < 500;
+
+SELECT 'in_keys64',        (SELECT count() FROM sk_t32 WHERE (a, b) IN (SELECT a, b FROM sk_r32))     = (SELECT count() FROM sk_t32 SEMI JOIN sk_r32 USING (a, b));
+SELECT 'notin_keys64',     (SELECT count() FROM sk_t32 WHERE (a, b) NOT IN (SELECT a, b FROM sk_r32)) = (SELECT count() FROM sk_t32 ANTI JOIN sk_r32 USING (a, b));
+SELECT 'distinct_keys64',  (SELECT count() FROM (SELECT DISTINCT a, b FROM sk_t32))                   = (SELECT uniqExact((a, b)) FROM sk_t32);
+SELECT 'intersect_keys64', (SELECT count() FROM (SELECT a, b FROM sk_t32 INTERSECT DISTINCT SELECT a, b FROM sk_r32)) = (SELECT uniqExact((a, b)) FROM sk_t32 WHERE (a, b) IN (SELECT a, b FROM sk_r32));
+SELECT 'except_keys64',    (SELECT count() FROM (SELECT a, b FROM sk_t32 EXCEPT DISTINCT SELECT a, b FROM sk_r32))    = (SELECT uniqExact((a, b)) FROM sk_t32 WHERE (a, b) NOT IN (SELECT a, b FROM sk_r32));
+
+DROP TABLE sk_t16;
+DROP TABLE sk_r16;
+DROP TABLE sk_t32;
+DROP TABLE sk_r32;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support packed keys32 and keys64 methods in Set.

---

<img width="994" height="115" alt="Screenshot 2026-06-16 at 11 45 50" src="https://github.com/user-attachments/assets/283c0edb-32de-4205-8ab4-117c43863c60" />

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.907`
<!-- ch-version-info:end -->