### PR TITLE
Add discard_select_result setting

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -545,7 +545,8 @@ bool LocalConnection::poll(size_t)
         state->sent_totals = true;
         Block totals;
 
-        if (state->executor)
+        /// null_format suppresses the result stream; totals are part of the result, so skip them too.
+        if (state->executor && !state->io.null_format)
             totals = state->executor->getTotalsBlock();
 
         if (!totals.empty())
@@ -561,7 +562,8 @@ bool LocalConnection::poll(size_t)
         state->sent_extremes = true;
         Block extremes;
 
-        if (state->executor)
+        /// null_format suppresses the result stream; extremes are part of the result, so skip them too.
+        if (state->executor && !state->io.null_format)
             extremes = state->executor->getExtremesBlock();
 
         if (!extremes.empty())

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -816,6 +816,19 @@ When stream-like engine reads from multiple queues, the user will need to select
     DECLARE(Bool, dictionary_validate_primary_key_type, false, R"(
 Validate primary key type for dictionaries. By default id type for simple layouts will be implicitly converted to UInt64.
 )", 0) \
+    DECLARE(Bool, discard_select_result, false, R"(
+When enabled, a top-level `SELECT` runs its full pipeline on real data, but no result rows are returned to the client over any protocol (native, HTTP, MySQL, PostgreSQL, gRPC), regardless of the query's `FORMAT`. `Totals` and `Extremes` are discarded as well, and `INTO OUTFILE` is rejected. `SHOW`, `DESCRIBE` and `EXPLAIN` are not affected.
+
+Intended to be pinned non-overridably via a settings-profile constraint so an operator can reproduce a query on real data without seeing the result:
+
+``` sql
+CREATE SETTINGS PROFILE debug_no_data SETTINGS discard_select_result = 1 CONST;
+CREATE USER debugger SETTINGS PROFILE debug_no_data;
+GRANT SELECT ON *.* TO debugger;
+```
+
+The setting only secures the result channel. Writes and external sinks (`INSERT`, `INSERT INTO FUNCTION url/s3/file`, `CREATE ... AS SELECT`), exception-message exfiltration (e.g. `throwIf`) and timing side channels stay the deployment's responsibility via grants and quotas.
+)", 0) \
     DECLARE(Bool, distributed_insert_skip_read_only_replicas, false, R"(
 Enables skipping read-only replicas for INSERT queries into Distributed.
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,6 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"output_format_image_width", 1024, 1024, "New setting controlling the width of the output image for image output formats such as PNG."},
             {"output_format_image_height", 1024, 1024, "New setting controlling the height of the output image for image output formats such as PNG."},
             {"output_format_image_terminal_mode", "", "", "New setting controlling whether image output formats such as PNG are rendered directly to the terminal using an inline image protocol."},
+            {"discard_select_result", false, false, "New setting to execute a top-level SELECT on real data but return no result (rows, totals and extremes) to the client over any protocol; intended to be pinned via a settings profile."},
             {"enable_join_runtime_filter_shared_fixed_hash_table", false, true, "New setting to share the hash join's FixedHashMap as the runtime filter for the probe side, replacing the Set/BloomFilter built upstream by the runtime filter framework."},
             {"ai_function_embedding_max_batch_size", 100, 100, "New setting"},
             {"enable_sharding_aggregator", false, false, "New setting to enable sharded `GROUP BY` optimization that distributes rows across threads by hashing the grouping key, so each thread aggregates a disjoint subset of keys without a merge phase; this is efficient for high cardinality keys with evenly distributed data."},

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -132,6 +132,7 @@ namespace Setting
     extern const SettingsBool calculate_text_stack_trace;
     extern const SettingsBool deduplicate_blocks_in_dependent_materialized_views;
     extern const SettingsDialect dialect;
+    extern const SettingsBool discard_select_result;
     extern const SettingsOverflowMode distinct_overflow_mode;
     extern const SettingsBool enable_global_with_statement;
     extern const SettingsBool enable_reads_from_query_cache;
@@ -2004,6 +2005,24 @@ static BlockIO executeQueryImpl(
         throw;
     }
 
+    /// When 'discard_select_result' is enabled, a top-level SELECT runs its full pipeline on real data
+    /// but no result is returned to the client. Setting 'null_format' here is the single result barrier
+    /// for the native protocol (TCP/gRPC/LocalConnection), which streams Blocks directly and is not
+    /// gated by the output FORMAT; it also makes the formatted (HTTP/MySQL/PostgreSQL) path use the Null
+    /// output format below.
+    /// Only the top-level (non-internal) query result is suppressed: SHOW/DESCRIBE/EXPLAIN have a
+    /// different query kind, and the SELECT that some of them are rewritten into runs as an internal
+    /// query, so its data is still produced for the metadata answer.
+    if (out_ast && !internal && context->getSettingsRef()[Setting::discard_select_result]
+        && out_ast->getQueryKind() == IAST::QueryKind::Select)
+    {
+        if (const auto * ast_with_output = dynamic_cast<const ASTQueryWithOutput *>(out_ast.get());
+            ast_with_output && ast_with_output->out_file)
+            throw Exception(ErrorCodes::INTO_OUTFILE_NOT_ALLOWED, "INTO OUTFILE is not allowed when discard_select_result is enabled");
+
+        res.null_format = true;
+    }
+
     return res;
 }
 
@@ -2481,6 +2500,11 @@ void executeQuery(
             const bool ignore_null_for_explain = context->getSettingsRef()[Setting::ignore_format_null_for_explain];
             if (boost::iequals(format_name, "Null") && ast->as<ASTExplainQuery>() && ignore_null_for_explain)
                 format_name = context->getDefaultFormat();
+
+            /// 'null_format' (set by 'discard_select_result' or by an explicit 'FORMAT Null') means the formatted
+            /// result must be empty: the Null output format discards rows, totals and extremes.
+            if (streams.null_format)
+                format_name = "Null";
 
             WriteBuffer * out_buf = &ostr;
             if (ast_query_with_output && ast_query_with_output->out_file)

--- a/src/Server/GRPCServer.cpp
+++ b/src/Server/GRPCServer.cpp
@@ -1355,8 +1355,12 @@ namespace
 
             if (!isQueryCancelled())
             {
-                addTotalsToResult(executor->getTotalsBlock());
-                addExtremesToResult(executor->getExtremesBlock());
+                /// null_format suppresses the result stream; totals and extremes are part of the result, so skip them too.
+                if (!io.null_format)
+                {
+                    addTotalsToResult(executor->getTotalsBlock());
+                    addExtremesToResult(executor->getExtremesBlock());
+                }
                 addProfileInfoToResult(executor->getProfileInfo());
             }
         }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1539,8 +1539,12 @@ void TCPHandler::processOrdinaryQuery(QueryState & state)
 
         receivePacketsExpectCancel(state);
 
-        sendTotals(state, executor.getTotalsBlock());
-        sendExtremes(state, executor.getExtremesBlock());
+        /// null_format suppresses the result stream; totals and extremes are part of the result, so skip them too.
+        if (!state.io.null_format)
+        {
+            sendTotals(state, executor.getTotalsBlock());
+            sendExtremes(state, executor.getExtremesBlock());
+        }
         sendProfileInfo(state, executor.getProfileInfo());
         sendProgress(state);
         sendLogs(state);

--- a/tests/queries/0_stateless/04338_discard_select_result.reference
+++ b/tests/queries/0_stateless/04338_discard_select_result.reference
@@ -1,0 +1,24 @@
+--- default off: data is returned ---
+0
+1
+2
+--- native protocol: no rows for any FORMAT ---
+native: no rows
+--- native protocol: totals and extremes are suppressed ---
+native: no totals/extremes
+--- HTTP: no rows for any FORMAT ---
+http: no rows
+--- HTTP: totals and extremes are suppressed ---
+http: no totals/extremes
+--- the query really executes on real data (side effects happen) ---
+pipeline executed
+--- SHOW / DESCRIBE / EXPLAIN are unaffected ---
+describe: ok
+show: ok
+explain: ok
+--- INTO OUTFILE is rejected ---
+INTO OUTFILE is not allowed when discard_select_result is enabled
+--- pinned non-overridably via a settings profile (CONST) ---
+pinned user result (expected empty):
+pinned user override attempt:
+Setting discard_select_result should not be changed

--- a/tests/queries/0_stateless/04338_discard_select_result.sh
+++ b/tests/queries/0_stateless/04338_discard_select_result.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# ^ no-parallel: creates a settings profile and a user with fixed names.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# discard_select_result: the SELECT runs on real data, but no result is returned
+# to the client over any protocol or FORMAT. SHOW/DESCRIBE/EXPLAIN stay unaffected.
+
+echo "--- default off: data is returned ---"
+${CLICKHOUSE_CLIENT} --query "SELECT number FROM numbers(3) ORDER BY number"
+
+echo "--- native protocol: no rows for any FORMAT ---"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SELECT number FROM numbers(3) ORDER BY number"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SELECT number FROM numbers(3) ORDER BY number FORMAT JSONEachRow"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SELECT number FROM numbers(3) ORDER BY number FORMAT Values"
+echo "native: no rows"
+
+echo "--- native protocol: totals and extremes are suppressed ---"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --extremes 1 --query "SELECT number FROM numbers(3) GROUP BY number WITH TOTALS ORDER BY number"
+echo "native: no totals/extremes"
+
+echo "--- HTTP: no rows for any FORMAT ---"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&discard_select_result=1" -d "SELECT number FROM numbers(3) ORDER BY number"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&discard_select_result=1" -d "SELECT number FROM numbers(3) ORDER BY number FORMAT JSONEachRow"
+echo "http: no rows"
+
+echo "--- HTTP: totals and extremes are suppressed ---"
+${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&discard_select_result=1&extremes=1" -d "SELECT number FROM numbers(3) GROUP BY number WITH TOTALS ORDER BY number"
+echo "http: no totals/extremes"
+
+echo "--- the query really executes on real data (side effects happen) ---"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SELECT throwIf(number = 2, 'pipeline executed') FROM numbers(3)" 2>&1 | grep -o "pipeline executed" | head -n 1
+
+echo "--- SHOW / DESCRIBE / EXPLAIN are unaffected ---"
+[[ $(${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "DESCRIBE (SELECT 1 AS x, 'a' AS y)" | wc -l) -eq 2 ]] && echo "describe: ok"
+[[ $(${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SHOW DATABASES" | wc -l) -gt 0 ]] && echo "show: ok"
+[[ $(${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "EXPLAIN SELECT 1" | wc -l) -gt 0 ]] && echo "explain: ok"
+
+echo "--- INTO OUTFILE is rejected ---"
+${CLICKHOUSE_CLIENT} --discard_select_result 1 --query "SELECT 1 INTO OUTFILE '${CLICKHOUSE_TMP}/04338_out.tsv'" 2>&1 | grep -o "INTO OUTFILE is not allowed when discard_select_result is enabled"
+
+echo "--- pinned non-overridably via a settings profile (CONST) ---"
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS user_04338_discard"
+${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE IF EXISTS profile_04338_discard"
+${CLICKHOUSE_CLIENT} --query "CREATE SETTINGS PROFILE profile_04338_discard SETTINGS discard_select_result = 1 CONST"
+${CLICKHOUSE_CLIENT} --query "CREATE USER user_04338_discard SETTINGS PROFILE profile_04338_discard"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON *.* TO user_04338_discard"
+echo "pinned user result (expected empty):"
+${CLICKHOUSE_CLIENT} --user user_04338_discard --query "SELECT number FROM numbers(3) ORDER BY number"
+echo "pinned user override attempt:"
+${CLICKHOUSE_CLIENT} --user user_04338_discard --query "SELECT number FROM numbers(3) SETTINGS discard_select_result = 0" 2>&1 | grep -o "Setting discard_select_result should not be changed" | head -n 1
+${CLICKHOUSE_CLIENT} --query "DROP USER user_04338_discard"
+${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE profile_04338_discard"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/104719
-->


### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a new setting `discard_select_result` (default `false`). When enabled, a top-level `SELECT` runs its full pipeline on real data but no result is returned to the client over any protocol or `FORMAT` (rows, `WITH TOTALS` and `extremes` are all discarded), and `INTO OUTFILE` is rejected. `SHOW`, `DESCRIBE` and `EXPLAIN` are not affected. Intended to be pinned non-overridably via a settings-profile constraint (`CREATE SETTINGS PROFILE p SETTINGS discard_select_result = 1 CONST`) so an operator can reproduce a query on real data without seeing the result.


### Description

Implements the server-enforced setting from #104719 (proposed there as an alternative to a `SELECT_NULL` RBAC privilege). A setting rather than a grant means the operator runs the query verbatim with any `FORMAT`, and it propagates to shards automatically through serialized secondary-query settings, so each node executes on real data and discards its own output.

Implementation:
- Enforced in `executeQueryImpl` by driving `BlockIO::null_format` for top-level (non-internal) `SELECT` queries. `null_format` is the single result barrier for the native protocol (TCP/gRPC/`LocalConnection`), which streams `Block`s directly and is not gated by the output `FORMAT`; it also forces the formatted (HTTP/MySQL/PostgreSQL) path to the `Null` output format. `INTO OUTFILE` is rejected.
- `SHOW`/`DESCRIBE`/`EXPLAIN` are unaffected: they have a different query kind, and the `SELECT` some of them are rewritten into runs as an internal query, so its data is still produced for the metadata answer.
- Closes an existing gap so `null_format` is a complete result barrier: `Totals` and `Extremes` were sent regardless of `null_format` in `TCPHandler`, `GRPCServer` and `LocalConnection`. They are part of the result, so they are now suppressed too. This also tightens explicit `FORMAT Null`.

Scope: the setting only secures the result channel (completely, across all protocols and shards). Writes and external sinks (`INSERT`, `INSERT INTO FUNCTION url/s3/file`, `CREATE ... AS SELECT`), exception-message exfiltration (`throwIf`) and timing side channels stay the deployment's responsibility via grants and quotas, as discussed in the issue.

Test: `tests/queries/0_stateless/04338_discard_select_result.sh` covers native and HTTP protocols, multiple `FORMAT`s, `WITH TOTALS`/`extremes` suppression, that the pipeline still executes on real data, that `SHOW`/`DESCRIBE`/`EXPLAIN` are unaffected, `INTO OUTFILE` rejection, and the `CONST` settings-profile pinning (including override rejection).
