### PR TITLE
Derive Rust C-symbol localization from reference libraries

### DIFF
--- a/cmake/localize_rust_c_symbols.sh
+++ b/cmake/localize_rust_c_symbols.sh
@@ -1,18 +1,34 @@
 #!/usr/bin/env bash
 #
-# Localize known C library symbols in a Rust static library (.a).
+# Localize the C library symbols a Rust static library (.a) defines that
+# ClickHouse also provides its own definitions for.
 #
 # Rust static libraries bundle compiler_builtins and libm, which export
-# standard C symbols (cbrt, fma, sin, memcpy, __muloti4, etc.) as globals.
-# When linked before our own C implementations (libllvmlibc, glibc-compat),
-# these silently win — bypassing our -falign-functions=64, -march, and other
-# optimization flags.
+# standard C symbols (compiler-rt builtins like __multi3/__divti3, libm
+# functions like cbrt/sqrt, etc.) as globals.  When linked before our own
+# implementations, these silently win, bypassing our -falign-functions=64,
+# -march and other optimization flags.
 #
-# This script localizes those known C library symbols so the linker picks
-# our own implementations instead.  All other symbols (Rust-mangled, crate
-# FFI, etc.) are left untouched.
+# Rather than a hand-maintained allowlist, we localize exactly the set of
+# symbols that BOTH the Rust archive defines as globals AND the reference
+# libraries (libllvmlibc, compiler-rt builtins, the platform libm) define.
+# This is self-maintaining and fail-safe:
+#   - A symbol is localized only when another definition exists in a library
+#     that the final binary links, so the link always resolves it to that copy.
+#   - Symbols Rust defines that nothing else provides (crate FFI entry points
+#     such as prql_to_sql, Rust runtime helpers, and even libm functions absent
+#     from these references) are never in the intersection and are left untouched.
 #
-# Usage: localize_rust_c_symbols.sh <library.a> <ar> <objcopy> <nm>
+# Functions like memcpy/memset appear only as undefined references in the Rust
+# archives, so they resolve from our implementations at link time anyway and
+# need no localization here.
+#
+# Usage: localize_rust_c_symbols.sh <library.a> <ar> <objcopy> <nm> <ref>...
+#
+# <ref>... are the reference libraries whose defined symbols determine what to
+# localize: libllvmlibc and clang_rt_builtins (ClickHouse-built static archives)
+# and the platform libm (a sysroot/toolchain static archive or shared object).
+# At least one is required; CMake passes the ones that exist for the target.
 #
 # The ar/objcopy/nm tools must come from a compatible LLVM toolchain
 # (e.g. llvm-ar, llvm-objcopy, llvm-nm).  CMake resolves them via
@@ -27,9 +43,16 @@ OBJCOPY="${3:-}"
 NM="${4:-}"
 
 if [ -z "$LIB_PATH" ] || [ -z "$AR" ] || [ -z "$OBJCOPY" ] || [ -z "$NM" ]; then
-    echo "Usage: $0 <library.a> <ar> <objcopy> <nm>" >&2
+    echo "Usage: $0 <library.a> <ar> <objcopy> <nm> <ref>..." >&2
     exit 1
 fi
+shift 4
+
+if [ "$#" -eq 0 ]; then
+    echo "Error: no reference libraries given; cannot decide which symbols to localize" >&2
+    exit 1
+fi
+REF_LIBS=("$@")
 
 if [ ! -f "$LIB_PATH" ]; then
     echo "Error: Rust library not found: $LIB_PATH" >&2
@@ -38,88 +61,69 @@ if [ ! -f "$LIB_PATH" ]; then
     exit 1
 fi
 
-# Known C library symbols that Rust's compiler_builtins / libm may export.
-# This list covers:
-#   - C math functions (libm)
-#   - Compiler-rt builtins (__muloti4, __divti3, etc.)
-#   - C string/memory functions that may be provided by Rust
-KNOWN_C_SYMBOLS=(
-    # Math functions (float64)
-    cbrt cos sin tan acos asin atan atan2
-    exp exp2 exp10 log log2 log10 log1p expm1
-    pow sqrt hypot
-    fma fmod remainder
-    ceil floor round trunc nearbyint rint
-    copysign fabs fdim fmax fmin
-    erf erfc tgamma lgamma
-    frexp ldexp modf scalbn ilogb logb
-    nextafter nexttoward
-    # Math functions (float32)
-    cbrtf cosf sinf tanf acosf asinf atanf atan2f
-    expf exp2f exp10f logf log2f log10f log1pf expm1f
-    powf sqrtf hypotf
-    fmaf fmodf remainderf
-    ceilf floorf roundf truncf nearbyintf rintf
-    copysignf fabsf fdimf fmaxf fminf
-    erff erfcf tgammaf lgammaf
-    frexpf ldexpf modff scalbnf ilogbf logbf
-    nextafterf nexttowardf
-    # Math functions (long double)
-    ceill floorl roundl truncl
-    sqrtl frexpl ldexpl scalbnl
-    # Compiler-rt integer builtins
-    __absvdi2 __absvsi2 __absvti2
-    __addvdi3 __addvsi3 __addvti3
-    __cmpdi2 __cmpti2
-    __divdc3 __divsc3
-    __muldc3 __mulsc3
-    __mulvdi3 __mulvsi3 __mulvti3
-    __negdf2 __negsf2 __negdi2 __negti2
-    __negvdi2 __negvsi2 __negvti2
-    __paritydi2 __paritysi2 __parityti2
-    __popcountdi2 __popcountsi2 __popcountti2
-    __muloti4
-)
-
-# Collect which of these actually exist as global symbols in the library
 TMPFILE=$(mktemp)
+REF_SYMS=$(mktemp)
+LOCALIZE_FILE=$(mktemp)
 WORK_DIR=""
-cleanup() { rm -f "$TMPFILE"; [ -n "$WORK_DIR" ] && rm -rf "$WORK_DIR"; true; }
+cleanup() { rm -f "$TMPFILE" "$REF_SYMS" "$LOCALIZE_FILE"; [ -n "$WORK_DIR" ] && rm -rf "$WORK_DIR"; true; }
 trap cleanup EXIT
 
-# Get all global defined symbols from the library. nm may print per-member errors for non-ELF archive
-# members (e.g. debug metadata objects) - those are non-fatal as long as at least one ELF member is read.
-# A truly broken/missing archive produces empty output and is caught below.
-"$NM" "$LIB_PATH" 2>/dev/null \
-    | grep -E '^[0-9a-f]+ [TDBCWV] ' \
-    | awk '{print $3}' \
-    | sort -u \
-    > "$TMPFILE" || true
+# Print the names of all globally-defined symbols in a library.  Handles both
+# static archives (plain nm) and shared objects (nm -D reads the dynamic symbol
+# table of an otherwise-stripped .so); the union covers either kind.  Glibc
+# version suffixes such as @@GLIBC_2.27 are stripped so names compare against the
+# Rust archive.  nm may print per-member errors for non-ELF members (debug
+# metadata, linker scripts); those are non-fatal as long as one member is read.
+# T/D/B/C/W/V are the defined globals and i is an IFUNC (glibc resolves ceil,
+# rint, trunc, ... this way); undefined (U) and local (lowercase) are excluded.
+defined_globals() {
+    { "$NM" "$1" 2>/dev/null; "$NM" -D "$1" 2>/dev/null; } \
+        | grep -E '^[0-9a-f]+ [TDBCWVi] ' \
+        | awk '{print $3}' \
+        | sed 's/@.*//'
+}
+
+# Defined globals from our own reference libraries: the set we are allowed to
+# localize in the Rust archive.
+for ref in "${REF_LIBS[@]}"; do
+    if [ ! -f "$ref" ]; then
+        echo "Error: reference library not found: $ref" >&2
+        exit 1
+    fi
+done
+
+for ref in "${REF_LIBS[@]}"; do
+    defined_globals "$ref"
+done | sort -u > "$REF_SYMS"
+
+if [ ! -s "$REF_SYMS" ]; then
+    echo "Error: reference libraries produced no symbols; cannot localize Rust C symbols" >&2
+    exit 1
+fi
+
+# Defined globals from the Rust archive.  A truly broken/missing archive
+# produces empty output and is caught below.
+defined_globals "$LIB_PATH" | sort -u > "$TMPFILE" || true
 
 if [ ! -s "$TMPFILE" ]; then
     echo "Error: $NM produced no symbols for $LIB_PATH; cannot localize Rust C symbols" >&2
     exit 1
 fi
 
-# Build objcopy flags for symbols that exist in both lists
-LOCALIZE_FLAGS=""
-for sym in "${KNOWN_C_SYMBOLS[@]}"; do
-    if grep -qxF "$sym" "$TMPFILE"; then
-        LOCALIZE_FLAGS="$LOCALIZE_FLAGS --localize-symbol=$sym"
-    fi
-done
+# Localize the intersection: symbols the Rust archive defines that we also define.
+comm -12 "$TMPFILE" "$REF_SYMS" > "$LOCALIZE_FILE"
 
-if [ -n "$LOCALIZE_FLAGS" ]; then
+if [ -s "$LOCALIZE_FILE" ]; then
     # Try direct objcopy on the archive first (fast path).
     # Some Rust archives contain non-ELF members (e.g. debug metadata objects)
     # that cause llvm-objcopy to fail.  In that case, fall back to extracting
     # individual members, processing only valid ELF objects, and repacking.
-    if ! $OBJCOPY $LOCALIZE_FLAGS "$LIB_PATH" 2>/dev/null; then
+    if ! "$OBJCOPY" --localize-symbols="$LOCALIZE_FILE" "$LIB_PATH" 2>/dev/null; then
         WORK_DIR=$(mktemp -d)
 
         (cd "$WORK_DIR" && "$AR" x "$LIB_PATH")
         for obj in "$WORK_DIR"/*.o; do
-            $OBJCOPY $LOCALIZE_FLAGS "$obj" 2>/dev/null || true
+            "$OBJCOPY" --localize-symbols="$LOCALIZE_FILE" "$obj" 2>/dev/null || true
         done
         "$AR" rcs "$LIB_PATH" "$WORK_DIR"/*.o
     fi

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -294,13 +294,114 @@ function(clickhouse_config_crate_flags target_name)
                 "clickhouse_config_crate_flags().  Expected library: ${_rust_lib_path}")
         endif()
 
-        add_custom_target(localize_rust_c_${target_name}
-            COMMAND bash "${ClickHouse_SOURCE_DIR}/cmake/localize_rust_c_symbols.sh"
-                "${_rust_lib_path}" "${CMAKE_AR}" "${CMAKE_OBJCOPY}" "${NM_PATH}"
-            COMMENT "Localizing C-namespace symbols in ${target_name}"
-            VERBATIM
-        )
-        add_dependencies(localize_rust_c_${target_name} cargo-build_${target_name})
-        add_dependencies(${target_name} localize_rust_c_${target_name})
+        # Reference libraries that define the C symbols Rust bundles.  The script
+        # localizes exactly the symbols defined by both these libraries and the
+        # Rust archive, so the binary's own copies win at link time.
+        #
+        # libllvmlibc (our optimized libm, AMD64/AARCH64 only) and clang_rt_builtins
+        # (compiler-rt, every ELF target) are contrib targets, defined before any
+        # caller of this function.
+        set(_localize_ref_libs "")
+        set(_localize_ref_deps "")
+        foreach (_ref_target libllvmlibc clang_rt_builtins)
+            if (TARGET ${_ref_target})
+                list(APPEND _localize_ref_libs "$<TARGET_FILE:${_ref_target}>")
+                list(APPEND _localize_ref_deps ${_ref_target})
+            endif()
+        endforeach()
+
+        # Platform math provider: the library supplying the libm functions
+        # libllvmlibc lacks (round, copysign, the ceil/rint/trunc IFUNCs, ...) and
+        # the only such provider on arches without libllvmlibc.  Glibc keeps them
+        # in libm (dynamic, -lm); musl's libm.a is an empty stub and the math
+        # actually lives in libc.a, which the -static -lc link pulls in (see
+        # cmake/linux/default_libs.cmake).  It is a prebuilt sysroot/toolchain
+        # file, so no build dependency is needed.
+        #
+        # Resolve it once with the same constraints the toolchain compiles with
+        # (--target/--sysroot/--gcc-toolchain/--no-default-config); otherwise
+        # -print-file-name can return a host multiarch library.  Reject any result
+        # outside the sysroot/toolchain tree, or one defining no symbols (an empty
+        # stub): a wrong or empty reference would leave Rust's libm exports global
+        # and shadow the platform's (e.g. in the -static musl link).
+        if (NOT DEFINED CACHE{CH_RUST_LOCALIZE_MATHLIB})
+            set(_math_probe_flags "")
+            set(_math_roots "")
+            if (CMAKE_C_COMPILER_TARGET)
+                list(APPEND _math_probe_flags "--target=${CMAKE_C_COMPILER_TARGET}")
+            endif()
+            if (CMAKE_SYSROOT)
+                list(APPEND _math_probe_flags "--sysroot=${CMAKE_SYSROOT}")
+                list(APPEND _math_roots "${CMAKE_SYSROOT}")
+            endif()
+            if (TOOLCHAIN_PATH)
+                list(APPEND _math_probe_flags "--gcc-toolchain=${TOOLCHAIN_PATH}" "--no-default-config")
+                list(APPEND _math_roots "${TOOLCHAIN_PATH}")
+            endif()
+
+            if (USE_MUSL)
+                set(_math_candidates libc.a)
+            else()
+                set(_math_candidates libm.so.6 libm.a libm.so)
+            endif()
+
+            set(_found_math "")
+            foreach (_math_name ${_math_candidates})
+                execute_process(
+                    COMMAND "${CMAKE_C_COMPILER}" ${_math_probe_flags} "-print-file-name=${_math_name}"
+                    OUTPUT_VARIABLE _math_out OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+                if (NOT _math_out OR NOT EXISTS "${_math_out}")
+                    continue()
+                endif()
+                # Must live inside the sysroot/toolchain tree (skipped only for a
+                # sysroot-less native build, where the host library is correct).
+                if (_math_roots)
+                    set(_in_tree FALSE)
+                    get_filename_component(_math_real "${_math_out}" REALPATH)
+                    foreach (_root ${_math_roots})
+                        get_filename_component(_root_real "${_root}" REALPATH)
+                        string(FIND "${_math_real}" "${_root_real}/" _math_pos)
+                        if (_math_pos EQUAL 0)
+                            set(_in_tree TRUE)
+                            break()
+                        endif()
+                    endforeach()
+                    if (NOT _in_tree)
+                        continue()
+                    endif()
+                endif()
+                # Must define symbols (static archive: nm; shared object: nm -D);
+                # an empty stub such as musl's libm.a is unusable.
+                execute_process(COMMAND "${NM_PATH}" "${_math_out}" OUTPUT_VARIABLE _nm_a ERROR_QUIET)
+                execute_process(COMMAND "${NM_PATH}" -D "${_math_out}" OUTPUT_VARIABLE _nm_d ERROR_QUIET)
+                if (NOT "${_nm_a}${_nm_d}" MATCHES "[0-9a-f] [TDBCWVi] ")
+                    continue()
+                endif()
+                set(_found_math "${_math_out}")
+                break()
+            endforeach()
+            set(CH_RUST_LOCALIZE_MATHLIB "${_found_math}" CACHE INTERNAL
+                "Platform libm/libc used as a reference for localizing Rust C symbols")
+        endif()
+        if (CH_RUST_LOCALIZE_MATHLIB)
+            list(APPEND _localize_ref_libs "${CH_RUST_LOCALIZE_MATHLIB}")
+        endif()
+
+        if (_localize_ref_libs)
+            add_custom_target(localize_rust_c_${target_name}
+                COMMAND bash "${ClickHouse_SOURCE_DIR}/cmake/localize_rust_c_symbols.sh"
+                    "${_rust_lib_path}" "${CMAKE_AR}" "${CMAKE_OBJCOPY}" "${NM_PATH}"
+                    ${_localize_ref_libs}
+                COMMENT "Localizing C-namespace symbols in ${target_name}"
+                VERBATIM
+            )
+            add_dependencies(localize_rust_c_${target_name}
+                cargo-build_${target_name} ${_localize_ref_deps})
+            add_dependencies(${target_name} localize_rust_c_${target_name})
+        else()
+            message(STATUS
+                "localize_rust_c_symbols: no reference C libraries for this "
+                "platform; skipping symbol localization for ${target_name}")
+        endif()
     endif()
 endfunction()


### PR DESCRIPTION
`localize_rust_c_symbols.sh` localized symbols matching a hand-maintained allowlist of libm and compiler-rt names. The list was incomplete: it missed the int128 compiler-rt builtins (`__multi3`, `__divti3`, `__udivti3`, the shift and `*ti3` overflow helpers) and the soft-float family (`__adddf3`, `__divdf3`, `__float*`, `__fix*`, ...). Rust's `compiler_builtins` defines these as weak globals, so they won over our own implementations at link time, bypassing our `-march`/`-falign-functions` flags.

Replace the allowlist with the intersection of the symbols the Rust archive defines as globals and the symbols our reference libraries define (`libllvmlibc`, `clang_rt_builtins`, and the platform math library). This is self-maintaining (toolchain bumps are covered automatically) and fail-safe: a symbol is localized only when another definition exists in a library the final binary links, so the link always resolves it to that copy, and crate FFI entry points such as `prql_to_sql` are never touched.

The reference libraries are build dependencies of the localization step so they exist before it runs, and the script errors out if a reference is missing or yields no symbols. The platform math library is resolved with the same constraints the toolchain compiles with (`--target`, `--sysroot`, `--gcc-toolchain`, `--no-default-config`) and is rejected unless it lives inside the sysroot/toolchain tree and defines symbols, so a host multiarch library or empty stub is never used. For musl the math lives in `libc.a` (its `libm.a` is an empty stub and the link is `-static -lc`); glibc keeps it in `libm`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Derive the set of C library symbols localized in Rust static libraries from the actual reference libraries instead of a hand-maintained allowlist, so all compiler-rt builtins and platform libm functions are covered.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.859`
<!-- ch-version-info:end -->