### PR TITLE
Fix nested cluster table function task iterator via a setting (prototype, alternative to #107107)

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7483,6 +7483,9 @@ The timeout in milliseconds for connecting to a remote replica during query exec
     DECLARE(Bool, parallel_replicas_for_cluster_engines, true, R"(
 Replace table function engines with their -Cluster alternatives
 )", 0) \
+    DECLARE(Bool, cluster_function_distributed_read, true, R"(
+Internal. Whether a `*Cluster` table function (`s3Cluster`, `urlCluster`, `fileCluster`, ...) running as a secondary query may read its data distributed via the initiator's read-task iterator. The server clears it on the inner secondary query of a plain `Distributed` / parallel-replicas broadcast (e.g. `clusterAllReplicas(..., s3Cluster(...))`), where the initiator installed no such iterator, so the nested cluster function degrades to a local read instead of throwing `Distributed task iterator is not initialized`. Not intended to be set by users.
+)", 0) \
     DECLARE(Bool, parallel_replicas_allow_materialized_views, true, R"(
 Allow usage of materialized views with parallel replicas
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -42,6 +42,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "26.6",
         {
             {"ai_function_embedding_max_batch_size", 100, 100, "New setting"},
+            {"cluster_function_distributed_read", true, true, "New internal setting: the server clears it on the inner secondary query of a Distributed/parallel-replicas broadcast so a nested `*Cluster` table function degrades to a local read instead of throwing `Distributed task iterator is not initialized`."},
             {"enable_sharding_aggregator", false, false, "New setting to enable sharded `GROUP BY` optimization that distributes rows across threads by hashing the grouping key, so each thread aggregates a disjoint subset of keys without a merge phase; this is efficient for high cardinality keys with evenly distributed data."},
             {"allow_experimental_text_index_lazy_apply", false, false, "New setting to gate experimental lazy posting list apply mode"},
             {"text_index_posting_list_apply_mode", "materialize", "materialize", "New setting for lazy posting list apply mode"},

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -701,13 +701,12 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         return storage_cluster;
     }
 
-    /// Unlike table functions (s3, url, etc.), DataLake tables are queried as
-    /// `SELECT * FROM catalog.table` — the query sent to shards cannot be rewritten
-    /// into a Cluster table function variant. So when the initiator created a
-    /// StorageObjectStorageCluster (the branch above) and the shard is collaborating
-    /// with it, we need distributed_processing=true to use the task iterator.
+    /// Only enable task-based reading when the initiator installed a cluster-function read-task
+    /// iterator for us. A plain Distributed / parallel-replicas broadcast sets
+    /// collaborate_with_initiator but installs no iterator, so a ReadTaskRequest would hit a
+    /// LOGICAL_ERROR ("Distributed task iterator is not initialized", issue #91736).
     const bool distributed_processing =
-        context_->getClientInfo().collaborate_with_initiator
+        context_->canUseClusterFunctionDistributedRead()
         && can_use_parallel_replicas;
 
     auto result_storage = std::make_shared<StorageObjectStorage>(

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -50,6 +50,7 @@ namespace Setting
     extern const SettingsMap additional_table_filters;
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
+    extern const SettingsBool cluster_function_distributed_read;
     extern const SettingsUInt64 force_optimize_skip_unused_shards;
     extern const SettingsUInt64 force_optimize_skip_unused_shards_nesting;
     extern const SettingsUInt64 limit;
@@ -116,6 +117,13 @@ static ContextMutablePtr updateSettingsAndClientInfoForCluster(const Cluster & c
     ClientInfo new_client_info = context->getClientInfo();
     Settings new_settings {settings};
     new_settings[Setting::queue_max_wait_ms] = Cluster::saturate(new_settings[Setting::queue_max_wait_ms], settings[Setting::max_execution_time]);
+
+    /// This is a plain Distributed / remote() / clusterAllReplicas broadcast: we send the inner query
+    /// to shards but we do not install a cluster-function read-task iterator for them. If that inner
+    /// query contains a nested `*Cluster` table function, the worker must read it locally rather than
+    /// request read tasks back (there is no iterator), otherwise it throws "Distributed task iterator
+    /// is not initialized" (issue #91736). Clear the flag on the secondary query to signal that.
+    new_settings[Setting::cluster_function_distributed_read] = false;
 
     /// In case of interserver mode we should reset initial_user for remote() function to use passed user from the query.
     if (is_remote_function)
@@ -528,6 +536,12 @@ static ContextMutablePtr updateContextForParallelReplicas(const LoggerPtr & logg
 {
     const auto & settings = context->getSettingsRef();
     auto context_mutable = Context::createCopy(context);
+
+    /// Parallel replicas read from the MergeTree coordinator, not from a cluster-function read-task
+    /// iterator. If the query reads a nested `*Cluster` table function on each replica, the worker
+    /// must read it locally instead of requesting read tasks back (there is no such iterator),
+    /// otherwise it throws "Distributed task iterator is not initialized" (issue #91736).
+    context_mutable->setSetting("cluster_function_distributed_read", Field{false});
 
     /// check hedged connections setting
     if (settings[Setting::use_hedged_requests].value)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -281,6 +281,7 @@ namespace Setting
     extern const SettingsUInt64 automatic_parallel_replicas_mode;
     extern const SettingsMilliseconds async_insert_poll_timeout_ms;
     extern const SettingsBool azure_allow_parallel_part_upload;
+    extern const SettingsBool cluster_function_distributed_read;
     extern const SettingsString cluster_for_parallel_replicas;
     extern const SettingsBool cloud_mode;
     extern const SettingsBool enable_filesystem_cache;
@@ -7470,6 +7471,27 @@ void Context::setClusterFunctionReadTaskCallback(ClusterFunctionReadTaskCallback
 bool Context::hasClusterFunctionReadTaskCallback() const
 {
     return next_task_callback.has_value();
+}
+
+bool Context::canUseClusterFunctionDistributedRead() const
+{
+    /// A read-task callback must exist for us to request tasks at all. It is installed for every
+    /// secondary query, so on its own it cannot tell a legitimate cluster-function distribution
+    /// from a nested one.
+    if (!hasClusterFunctionReadTaskCallback())
+        return false;
+
+    /// The precise signal is the `cluster_function_distributed_read` setting. It defaults to true and
+    /// is cleared by the initiator (in ClusterProxy::updateSettingsAndClientInfoForCluster and
+    /// updateContextForParallelReplicas) on the inner secondary query of a plain Distributed /
+    /// parallel-replicas broadcast - exactly the case where no cluster-function read-task iterator was
+    /// installed, so requesting tasks would throw "Distributed task iterator is not initialized"
+    /// (issue #91736). A top-level *Cluster table function and INSERT INTO distributed SELECT FROM
+    /// *Cluster build their own secondary-query context that does not clear the setting, so they keep
+    /// reading each task once. An older initiator that does not know the setting leaves it at its
+    /// default (true): the pre-existing nested-case crash from such an initiator is unchanged and is
+    /// fixed once it upgrades, while every legitimate path keeps working on mixed-version clusters.
+    return getSettingsRef()[Setting::cluster_function_distributed_read];
 }
 
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1764,6 +1764,12 @@ public:
     void setClusterFunctionReadTaskCallback(ClusterFunctionReadTaskCallback && callback);
     bool hasClusterFunctionReadTaskCallback() const;
 
+    /// Whether a *Cluster table function running as a secondary query on this worker may
+    /// enable distributed (task-based) reading. Gated on the `cluster_function_distributed_read`
+    /// setting, which the initiator clears on the inner secondary query of a plain Distributed /
+    /// parallel-replicas broadcast (where no cluster-function read-task iterator was installed).
+    bool canUseClusterFunctionDistributedRead() const;
+
     MergeTreeReadTaskCallback getMergeTreeReadTaskCallback() const;
     void setMergeTreeReadTaskCallback(MergeTreeReadTaskCallback && callback);
 

--- a/src/TableFunctions/TableFunctionFileCluster.cpp
+++ b/src/TableFunctions/TableFunctionFileCluster.cpp
@@ -22,6 +22,12 @@ StoragePtr TableFunctionFileCluster::getStorage(
 
     if (context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {
+        /// Only enable task-based reading when the initiator installed a cluster-function read-task
+        /// iterator for us. When this fileCluster is nested under a plain Distributed /
+        /// parallel-replicas broadcast the initiator has no such iterator, so a ReadTaskRequest
+        /// would hit a LOGICAL_ERROR ("Distributed task iterator is not initialized", issue #91736).
+        const bool distributed_processing = context->canUseClusterFunctionDistributedRead();
+
         /// On worker node this filename won't contain any globs
         StorageFile::CommonArguments args{
             WithContext(context),
@@ -34,7 +40,7 @@ StoragePtr TableFunctionFileCluster::getStorage(
             String{},
             context->getSettingsRef()[Setting::rename_files_after_processing]};
 
-        storage = std::make_shared<StorageFile>(StorageFile::FileSource::parse(filename, context), /* distributed_processing = */ true, args);
+        storage = std::make_shared<StorageFile>(StorageFile::FileSource::parse(filename, context), distributed_processing, args);
     }
     else
     {

--- a/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
+++ b/src/TableFunctions/TableFunctionObjectStorageCluster.cpp
@@ -45,9 +45,11 @@ StoragePtr TableFunctionObjectStorageCluster<Definition, Configuration, is_data_
 
     if (client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {
-        bool can_use_distributed_iterator =
-            client_info.collaborate_with_initiator &&
-            context->hasClusterFunctionReadTaskCallback();
+        /// Only enable task-based reading when the initiator installed a cluster-function read-task
+        /// iterator for us. When this cluster function is nested under a plain Distributed /
+        /// parallel-replicas broadcast the initiator has no such iterator, so a ReadTaskRequest
+        /// would hit a LOGICAL_ERROR ("Distributed task iterator is not initialized", issue #91736).
+        bool can_use_distributed_iterator = context->canUseClusterFunctionDistributedRead();
 
         /// On worker node this filename won't contains globs
         storage = std::make_shared<StorageObjectStorage>(

--- a/src/TableFunctions/TableFunctionURLCluster.cpp
+++ b/src/TableFunctions/TableFunctionURLCluster.cpp
@@ -10,8 +10,15 @@ StoragePtr TableFunctionURLCluster::getStorage(
     const String & /*source*/, const String & /*format_*/, const ColumnsDescription & columns, ContextPtr context,
     const std::string & table_name, const String & /*compression_method_*/, bool /*is_insert_query*/) const
 {
-    if (context->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
+    const auto & client_info = context->getClientInfo();
+    if (client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY)
     {
+        /// Only enable task-based reading when the initiator installed a cluster-function read-task
+        /// iterator for us. When this urlCluster is nested under a plain Distributed /
+        /// parallel-replicas broadcast the initiator has no such iterator, so a ReadTaskRequest
+        /// would hit a LOGICAL_ERROR ("Distributed task iterator is not initialized", issue #91736).
+        const bool distributed_processing = context->canUseClusterFunctionDistributedRead();
+
         //On worker node this uri won't contain globs
         return std::make_shared<StorageURL>(
             filename,
@@ -26,7 +33,7 @@ StoragePtr TableFunctionURLCluster::getStorage(
             configuration.headers,
             configuration.http_method,
             nullptr,
-            /*distributed_processing=*/ true);
+            distributed_processing);
     }
 
     return std::make_shared<StorageURLCluster>(

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -838,6 +838,55 @@ def test_cluster_select(started_cluster):
     assert node2.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`", settings={"parallel_replicas_for_cluster_engines":1, 'enable_parallel_replicas': 2, 'cluster_for_parallel_replicas': 'cluster_simple', 'parallel_replicas_for_cluster_engines' : 1}) == 'pablo\n'
 
 
+def test_cluster_select_nested(started_cluster):
+    # Regression for issue #91736 on the DataLakeCatalog path.
+    # A DataLake table read on a parallel-replicas worker must not enable object-storage
+    # distributed_processing unless the initiator actually installed a cluster-function
+    # read-task iterator for it. Here the initiator distributes a plain parallel-replicas
+    # read of a local MergeTree table and joins the DataLake table on each replica. The
+    # secondary query carries a parallel_reading_coordinator but no cluster-function task
+    # iterator, yet the worker still sees collaborate_with_initiator together with the
+    # forwarded parallel_replicas_for_cluster_engines/cluster_for_parallel_replicas
+    # settings. The DataLake stack reaches the read-task iterator through a different gate
+    # (DatabaseDataLake::tryGetTableImpl) than the *Cluster table functions, so before the
+    # fix the worker sent a ReadTaskRequest back to an initiator with no iterator and the
+    # server aborted with "Distributed task iterator is not initialized". The read must
+    # instead fall back to a local read and complete.
+    node1 = started_cluster.instances["node1"]
+    node2 = started_cluster.instances["node2"]
+
+    test_ref = f"test_nested_cluster_{uuid.uuid4().hex}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+    driver_table = f"{test_ref}_driver"
+
+    load_catalog_impl(started_cluster)
+    create_clickhouse_iceberg_database(started_cluster, node1, CATALOG_NAME)
+    create_clickhouse_iceberg_database(started_cluster, node2, CATALOG_NAME)
+    create_clickhouse_iceberg_table(started_cluster, node1, root_namespace, table_name, "(x String)")
+    node1.query(f"INSERT INTO {CATALOG_NAME}.`{root_namespace}.{table_name}` VALUES ('pablo');", settings={"allow_insert_into_iceberg": 1, 'write_full_path_in_iceberg_metadata': 1})
+
+    # Local MergeTree driver table present on both replicas so parallel replicas can
+    # coordinate over it; its read of the DataLake table runs on each worker replica.
+    for node in [node1, node2]:
+        node.query(f"DROP TABLE IF EXISTS {driver_table} SYNC")
+        node.query(f"CREATE TABLE {driver_table} (x String) ENGINE = MergeTree ORDER BY x")
+    node1.query(f"INSERT INTO {driver_table} VALUES ('pablo')")
+    node2.query(f"INSERT INTO {driver_table} VALUES ('pablo')")
+
+    assert node1.query(
+        f"SELECT DISTINCT d.x FROM {driver_table} AS d WHERE d.x IN (SELECT x FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`)",
+        settings={
+            "allow_experimental_parallel_reading_from_replicas": 2,
+            "max_parallel_replicas": 2,
+            "cluster_for_parallel_replicas": "cluster_simple",
+            "parallel_replicas_for_cluster_engines": 1,
+            "parallel_replicas_for_non_replicated_merge_tree": 1,
+            "prefer_localhost_replica": 0,
+        },
+    ) == 'pablo\n'
+
+
 def test_used_storages_in_query_log(started_cluster):
     node1 = started_cluster.instances["node1"]
     node2 = started_cluster.instances["node2"]

--- a/tests/queries/0_stateless/03850_nested_cluster_table_function_task_iterator.reference
+++ b/tests/queries/0_stateless/03850_nested_cluster_table_function_task_iterator.reference
@@ -1,0 +1,14 @@
+--- clusterAllReplicas(urlCluster(SELECT 1)) ---
+1
+--- clusterAllReplicas(urlCluster(...)) with WHERE ---
+1
+--- clusterAllReplicas(fileCluster(...)) ---
+1
+--- clusterAllReplicas(s3Cluster(...)) ---
+1
+--- top-level urlCluster still works ---
+1
+--- INSERT INTO distributed SELECT FROM urlCluster reads each task once ---
+3
+--- server alive ---
+1

--- a/tests/queries/0_stateless/03850_nested_cluster_table_function_task_iterator.sh
+++ b/tests/queries/0_stateless/03850_nested_cluster_table_function_task_iterator.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: uses urlCluster/s3Cluster over the HTTP port and Minio, and several test clusters
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/91736
+#
+# A cluster table function (urlCluster, s3Cluster, fileCluster) nested inside an
+# outer distribution (clusterAllReplicas / parallel replicas) used to abort the
+# server with "Distributed task iterator is not initialized" (LOGICAL_ERROR in
+# RemoteQueryExecutor::processReadTaskRequest).
+#
+# The outer clusterAllReplicas ships `SELECT ... FROM urlCluster(...)` to its
+# replicas as secondary queries. On a replica the inner urlCluster saw
+# query_kind == SECONDARY_QUERY and enabled distributed_processing, so it sent a
+# ReadTaskRequest back to the outer initiator - a plain StorageDistributed that
+# had set up no cluster-function task iterator for it, hence the logical error.
+#
+# PR #100146 fixed the auto-converted non-cluster path (url/s3 promoted to cluster
+# mode by parallel_replicas_for_cluster_engines); this covers the explicit
+# *Cluster table functions nested under another distribution. The worker now keys
+# distributed_processing on an explicit initiator signal
+# (ClientInfo::is_cluster_function_distributed_read) instead of just
+# collaborate_with_initiator, so a legitimate INSERT INTO distributed SELECT FROM
+# *Cluster (distributed_depth == 1, iterator present) keeps reading each task once.
+#
+# The exact row count depends on replica selection (e.g. prefer_localhost_replica)
+# so the queries are wrapped in `count() >= 1` - what matters is that they run to
+# completion and the server does not abort.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -eu
+
+echo "--- clusterAllReplicas(urlCluster(SELECT 1)) ---"
+$CLICKHOUSE_CLIENT --query "
+SELECT count() >= 1
+FROM clusterAllReplicas(
+    'test_cluster_one_shard_three_replicas_localhost',
+    urlCluster('test_cluster_two_shards', 'http://localhost:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+1', 'TSV', 'x UInt8'))
+"
+
+echo "--- clusterAllReplicas(urlCluster(...)) with WHERE ---"
+# The WHERE filter must reference the inner column directly. clusterAllReplicas ships
+# the inner SELECT to its replicas without the outer alias, so a `t.`-qualified filter
+# is unresolvable there under the old analyzer (Missing columns: 't.x').
+$CLICKHOUSE_CLIENT --query "
+SELECT count() >= 1
+FROM clusterAllReplicas(
+    'test_cluster_one_shard_three_replicas_localhost',
+    urlCluster('test_cluster_two_shards', 'http://localhost:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+1', 'TSV', 'x UInt8'))
+WHERE x = 1
+"
+
+# fileCluster nested inside clusterAllReplicas. Reads a file from user_files.
+DATA_FILE="${CLICKHOUSE_DATABASE}_03850.tsv"
+DATA_PATH="${USER_FILES_PATH}/${DATA_FILE}"
+printf '1\n2\n3\n' > "${DATA_PATH}"
+
+echo "--- clusterAllReplicas(fileCluster(...)) ---"
+$CLICKHOUSE_CLIENT --query "
+SELECT count() >= 1
+FROM clusterAllReplicas(
+    'test_cluster_one_shard_three_replicas_localhost',
+    fileCluster('test_cluster_two_shards', '${DATA_FILE}', 'TSV', 'x UInt8'))
+"
+
+# s3Cluster nested inside clusterAllReplicas. The object-storage *Cluster stack
+# (s3Cluster/icebergCluster/...) goes through a different iterator path
+# (StorageObjectStorageSource::createFileIterator -> ReadTaskIterator) wired in
+# TableFunctionObjectStorageCluster, so it must be covered separately from the
+# url/file path above. Writes a small object to the localhost Minio test bucket first.
+# prefer_localhost_replica=0 forces the outer clusterAllReplicas to ship the inner
+# query to remote replicas as a real secondary query (otherwise it runs locally and
+# the broken nested path is never exercised - the pre-fix server aborts here with
+# "Distributed task iterator is not initialized").
+S3_PATH="http://localhost:11111/test/${CLICKHOUSE_DATABASE}_03850.tsv"
+$CLICKHOUSE_CLIENT --query "
+INSERT INTO FUNCTION s3('${S3_PATH}', 'TSV', 'x UInt8')
+SETTINGS s3_truncate_on_insert = 1
+VALUES (1), (2), (3)
+"
+
+echo "--- clusterAllReplicas(s3Cluster(...)) ---"
+$CLICKHOUSE_CLIENT --query "
+SELECT count() >= 1
+FROM clusterAllReplicas(
+    'test_cluster_one_shard_three_replicas_localhost',
+    s3Cluster('test_cluster_two_shards', '${S3_PATH}', 'TSV', 'x UInt8'))
+SETTINGS prefer_localhost_replica = 0
+"
+
+# The legitimate top-level cluster table function must still distribute correctly
+# (the fix must not disable distributed_processing for the real, non-nested case).
+echo "--- top-level urlCluster still works ---"
+$CLICKHOUSE_CLIENT --query "
+SELECT count()
+FROM urlCluster('test_cluster_one_shard_three_replicas_localhost', 'http://localhost:${CLICKHOUSE_PORT_HTTP}/?query=SELECT+1', 'TSV', 'x UInt8')
+"
+
+# INSERT INTO distributed SELECT FROM urlCluster(...) with parallel_distributed_insert_select=2
+# is a legitimate cluster-function distribution at distributed_depth == 1: the initiator DOES
+# install a read-task iterator, so each globbed task must be read exactly once. The fix must
+# keep this working (a depth-based guard would wrongly disable it and each replica would re-read
+# the whole glob, duplicating rows). The source URL serves the three values {1,2,3} as separate
+# tasks; the destination is a single-shard cluster, so exactly 3 rows must be inserted (the same
+# shape as the existing 01099_parallel_distributed_insert_select coverage).
+echo "--- INSERT INTO distributed SELECT FROM urlCluster reads each task once ---"
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS local_03850 SYNC"
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS dist_03850 SYNC"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE local_03850 (s String) ENGINE = MergeTree ORDER BY s"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE dist_03850 AS local_03850 ENGINE = Distributed('test_cluster_one_shard_three_replicas_localhost', currentDatabase(), local_03850, rand())"
+$CLICKHOUSE_CLIENT --query "
+INSERT INTO dist_03850
+SELECT * FROM urlCluster('test_cluster_two_shards', 'http://localhost:${CLICKHOUSE_PORT_HTTP}/?query=select+{1,2,3}+format+TSV', 'TSV', 's String')
+SETTINGS parallel_distributed_insert_select = 2
+"
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM dist_03850"
+$CLICKHOUSE_CLIENT --query "DROP TABLE local_03850 SYNC"
+$CLICKHOUSE_CLIENT --query "DROP TABLE dist_03850 SYNC"
+
+# The server must still be alive after the queries above.
+echo "--- server alive ---"
+$CLICKHOUSE_CLIENT --query "SELECT 1"
+
+rm -f "${DATA_PATH}"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107107
Related: https://github.com/ClickHouse/ClickHouse/issues/91736
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` "Distributed task iterator is not initialized" when a cluster table function (`urlCluster`, `s3Cluster`, `fileCluster`, object-storage and DataLake `*Cluster` variants) is nested inside an outer distribution such as `clusterAllReplicas(..., s3Cluster(...))` or a parallel-replicas read.


### Description

**Draft / prototype. Do not merge.** This is an alternative implementation of #107107, opened for side-by-side comparison per a review request on that PR. It should be reviewed against #107107, and only one of the two will be kept.

Same bug as #107107 (BuzzHouse fuzzer, issue #91736): a `*Cluster` table function nested inside a plain `Distributed` / parallel-replicas broadcast (e.g. `clusterAllReplicas('cluster', s3Cluster(...))`) aborts the server with `Distributed task iterator is not initialized`. The outer broadcast ships the inner `SELECT ... FROM *Cluster(...)` to its replicas as a secondary query; on a replica the `*Cluster` function sees `query_kind == SECONDARY_QUERY` and enabled distributed (task-based) reading, sending a `ReadTaskRequest` back to an initiator that installed no cluster-function task iterator for it.

**Difference from #107107.** #107107 adds a new positional `ClientInfo::is_cluster_function_distributed_read` field gated on a protocol-revision bump. This branch instead uses an internal `Bool` setting:

- New setting `cluster_function_distributed_read` (default `true`).
- The initiator clears it on the inner secondary query of a broadcast, in `ClusterProxy::updateSettingsAndClientInfoForCluster` (covers `Distributed` / `remote` / `clusterAllReplicas`) and `updateContextForParallelReplicas` (covers parallel-replicas-from-MergeTree).
- The worker gate `Context::canUseClusterFunctionDistributedRead()` returns the setting (after the existing read-task-callback check). A nested `*Cluster` function therefore degrades to a local read.
- A top-level `*Cluster` function (`IStorageCluster::read`) and `INSERT INTO distributed SELECT FROM *Cluster` build their own secondary-query context that does not clear the setting, so they keep reading each task exactly once.

**Why this is also worth considering.** It leaves the persisted async `Distributed` insert-header layout untouched (the field approach appended a field inside the embedded `ClientInfo`, which an older binary draining the queue would misread), and a non-`IMPORTANT` setting unknown to an older worker is tolerated (warn and skip) rather than corrupting the header. No protocol bump is needed.

Verified locally (debug build) in both directions, on a single server with the test clusters repointed to one loopback so the nested query runs as a real secondary query:

- Without the two setting-clears: `clusterAllReplicas('...', urlCluster(...))` aborts with the exact `Distributed task iterator is not initialized` fatal error.
- With the fix: the nested `urlCluster` / `fileCluster` / `s3Cluster` cases complete, the server stays alive, top-level `urlCluster` still distributes, and `INSERT INTO distributed SELECT FROM urlCluster(...) SETTINGS parallel_distributed_insert_select = 2` reads each globbed task exactly once (3 rows, the `01099_parallel_distributed_insert_select` shape, not regressed).

The regression tests are the same as #107107 (`03850_nested_cluster_table_function_task_iterator` and the `test_database_iceberg` nested case).
