### PR TITLE
Add missing bounds checks in Elf.cpp and DWARFBlockInputFormat

### DIFF
--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -14,7 +14,7 @@ namespace ErrorCodes
 }
 
 
-/// Check that the byte range [offset, offset + length) fits within a region of `total` bytes.
+/// Whether [offset, offset + length) is within `total` bytes, computed so it can't overflow.
 static bool rangeWithin(uint64_t offset, uint64_t length, uint64_t total)
 {
     return offset <= total && length <= total - offset;
@@ -75,9 +75,7 @@ void Elf::init(const char * data, size_t size, const std::string & path_)
     section_names = reinterpret_cast<const char *>(mapped + section_names_offset);
     section_names_size = section_names_table_size;
 
-    /// The ELF spec guarantees that a string table's last byte is a NUL. Verify it once here so
-    /// that name() can return a C string for any in-bounds offset without scanning for a
-    /// terminator on every call: a NUL at the end bounds any forward scan to within the table.
+    /// Require the trailing NUL (guaranteed by the ELF spec) so name() can return C strings without re-scanning.
     if (section_names_size == 0 || section_names[section_names_size - 1] != '\0')
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' has a section names string table that is not zero-terminated", path);
 
@@ -168,7 +166,6 @@ String Elf::getBuildID() const
 
         if (phdr.type == ProgramHeaderType::NOTE)
         {
-            /// `offset` and `filesz` come straight from the file and are not validated elsewhere.
             if (!rangeWithin(phdr.offset, phdr.filesz, elf_size))
                 continue;
             return getBuildID(mapped + phdr.offset, phdr.filesz);
@@ -184,7 +181,6 @@ String Elf::getBuildID(const char * nhdr_pos, size_t size)
 
     while (nhdr_pos < nhdr_end)
     {
-        /// There must be room for the note header itself.
         if (static_cast<size_t>(nhdr_end - nhdr_pos) < sizeof(ElfNameHeader))
             break;
 
@@ -221,8 +217,7 @@ const char * Elf::Section::name() const
     if (!elf.section_names)
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "Section names are not initialized");
 
-    /// The offset must point inside the table; init() verified the table ends with a NUL, so any
-    /// forward scan from an in-bounds offset (e.g. strcmp) stays within the mapped file.
+    /// init() verified the table ends with a NUL, so a forward scan from any in-bounds offset stays in-bounds.
     if (header.name >= elf.section_names_size)
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "Section name offset is out of bounds");
 

--- a/src/Common/Elf.cpp
+++ b/src/Common/Elf.cpp
@@ -14,6 +14,13 @@ namespace ErrorCodes
 }
 
 
+/// Check that the byte range [offset, offset + length) fits within a region of `total` bytes.
+static bool rangeWithin(uint64_t offset, uint64_t length, uint64_t total)
+{
+    return offset <= total && length <= total - offset;
+}
+
+
 Elf::Elf(const std::string & path_)
 {
     in.emplace(path_, 0);
@@ -46,7 +53,7 @@ void Elf::init(const char * data, size_t size, const std::string & path_)
 
     if (!section_header_offset
         || !section_header_num_entries
-        || section_header_offset + section_header_num_entries * sizeof(ElfSectionHeader) > elf_size)
+        || !rangeWithin(section_header_offset, section_header_num_entries * sizeof(ElfSectionHeader), elf_size))
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' is truncated (section header points after end of file)", path);
 
     section_headers = reinterpret_cast<const ElfSectionHeader *>(mapped + section_header_offset);
@@ -61,10 +68,18 @@ void Elf::init(const char * data, size_t size, const std::string & path_)
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' doesn't have string table with section names", path);
 
     uint64_t section_names_offset = section_names_strtab->header.offset;
-    if (section_names_offset >= elf_size)
+    uint64_t section_names_table_size = section_names_strtab->header.size;
+    if (!rangeWithin(section_names_offset, section_names_table_size, elf_size))
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' is truncated (section names string table points after end of file)", path);
 
     section_names = reinterpret_cast<const char *>(mapped + section_names_offset);
+    section_names_size = section_names_table_size;
+
+    /// The ELF spec guarantees that a string table's last byte is a NUL. Verify it once here so
+    /// that name() can return a C string for any in-bounds offset without scanning for a
+    /// terminator on every call: a NUL at the end bounds any forward scan to within the table.
+    if (section_names_size == 0 || section_names[section_names_size - 1] != '\0')
+        throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' has a section names string table that is not zero-terminated", path);
 
     /// Get program headers
 
@@ -73,7 +88,7 @@ void Elf::init(const char * data, size_t size, const std::string & path_)
 
     if (!program_header_offset
         || !program_header_num_entries
-        || program_header_offset + program_header_num_entries * sizeof(ElfProgramHeader) > elf_size)
+        || !rangeWithin(program_header_offset, program_header_num_entries * sizeof(ElfProgramHeader), elf_size))
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "The ELF '{}' is truncated (program header points after end of file)", path);
 
     program_headers = reinterpret_cast<const ElfProgramHeader *>(mapped + program_header_offset);
@@ -92,8 +107,8 @@ bool Elf::iterateSections(std::function<bool(const Section & section, size_t idx
     {
         Section section(section_headers[idx], *this);
 
-        /// Sections spans after end of file.
-        if (section.header.offset + section.header.size > elf_size)
+        /// Skip sections that span past the end of file.
+        if (!rangeWithin(section.header.offset, section.header.size, elf_size))
             continue;
 
         if (pred(section, idx))
@@ -152,7 +167,12 @@ String Elf::getBuildID() const
         const ElfProgramHeader & phdr = program_headers[idx];
 
         if (phdr.type == ProgramHeaderType::NOTE)
+        {
+            /// `offset` and `filesz` come straight from the file and are not validated elsewhere.
+            if (!rangeWithin(phdr.offset, phdr.filesz, elf_size))
+                continue;
             return getBuildID(mapped + phdr.offset, phdr.filesz);
+        }
     }
 
     return {};
@@ -164,14 +184,23 @@ String Elf::getBuildID(const char * nhdr_pos, size_t size)
 
     while (nhdr_pos < nhdr_end)
     {
-        ElfNameHeader nhdr = unalignedLoad<ElfNameHeader>(nhdr_pos);
+        /// There must be room for the note header itself.
+        if (static_cast<size_t>(nhdr_end - nhdr_pos) < sizeof(ElfNameHeader))
+            break;
 
-        nhdr_pos += sizeof(ElfNameHeader) + nhdr.namesz;
+        ElfNameHeader nhdr = unalignedLoad<ElfNameHeader>(nhdr_pos);
+        nhdr_pos += sizeof(ElfNameHeader);
+
+        if (nhdr.namesz > static_cast<size_t>(nhdr_end - nhdr_pos))
+            break;
+        nhdr_pos += nhdr.namesz;
+
+        if (nhdr.descsz > static_cast<size_t>(nhdr_end - nhdr_pos))
+            break;
+
         if (nhdr.type == NameHeaderType::GNU_BUILD_ID)
-        {
-            const char * build_id = nhdr_pos;
-            return {build_id, nhdr.descsz};
-        }
+            return {nhdr_pos, nhdr.descsz};
+
         nhdr_pos += nhdr.descsz;
     }
 
@@ -192,7 +221,11 @@ const char * Elf::Section::name() const
     if (!elf.section_names)
         throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "Section names are not initialized");
 
-    /// TODO buffer overflow is possible, we may need to check strlen.
+    /// The offset must point inside the table; init() verified the table ends with a NUL, so any
+    /// forward scan from an in-bounds offset (e.g. strcmp) stays within the mapped file.
+    if (header.name >= elf.section_names_size)
+        throw Exception(ErrorCodes::CANNOT_PARSE_ELF, "Section name offset is out of bounds");
+
     return elf.section_names + header.name;
 }
 

--- a/src/Common/Elf.h
+++ b/src/Common/Elf.h
@@ -163,6 +163,7 @@ private:
     const ElfSectionHeader * section_headers{};
     const ElfProgramHeader * program_headers{};
     const char * section_names = nullptr;
+    size_t section_names_size = 0; // bytes available starting at `section_names`, for bounds checking
 
     void init(const char * data, size_t size, const std::string & path_);
 };

--- a/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
@@ -787,9 +787,7 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
                 break;
             case COL_DECL_FILE:
             {
-                /// A unit may have no DW_AT_stmt_list (no .debug_line filename table), in which case
-                /// filename_table is null and all indexes are 0. Provide a minimal dictionary so we
-                /// don't construct a LowCardinality column with a null dictionary.
+                /// A unit without DW_AT_stmt_list has no filename table; use a minimal dictionary instead of null.
                 ColumnPtr filename_table = unit.filename_table;
                 if (filename_table == nullptr)
                 {
@@ -919,10 +917,13 @@ void DWARFBlockInputFormat::parseRanges(
                 throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "DW_FORM_rnglistx offset out of bounds: rnglists_base {}, idx {} vs {}", unit.rnglists_base, offset, section_size);
             uint64_t lists_offset = unit.rnglists_base + offset * entry_size;
 
-            offset = 0;
-            memcpy(&offset, debug_rnglists_extractor->getData().data() + lists_offset, entry_size);
+            uint64_t list_entry = 0;
+            memcpy(&list_entry, debug_rnglists_extractor->getData().data() + lists_offset, entry_size);
 
-            offset += unit.rnglists_base;
+            /// The offset read from the table is untrusted; the subtraction also stops rnglists_base + list_entry from wrapping.
+            if (list_entry > section_size - unit.rnglists_base)
+                throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "DW_FORM_rnglistx points out of bounds: rnglists_base {}, entry {} vs {}", unit.rnglists_base, list_entry, section_size);
+            offset = unit.rnglists_base + list_entry;
         }
 
         llvm::DWARFDebugRnglist list;

--- a/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/DWARFBlockInputFormat.cpp
@@ -786,8 +786,20 @@ Chunk DWARFBlockInputFormat::parseEntries(UnitState & unit)
                 cols.push_back(std::exchange(col_linkage_name, nullptr));
                 break;
             case COL_DECL_FILE:
-                cols.push_back(ColumnLowCardinality::create(unit.filename_table, col_decl_file.detachIndexes(), /*is_shared*/ true));
+            {
+                /// A unit may have no DW_AT_stmt_list (no .debug_line filename table), in which case
+                /// filename_table is null and all indexes are 0. Provide a minimal dictionary so we
+                /// don't construct a LowCardinality column with a null dictionary.
+                ColumnPtr filename_table = unit.filename_table;
+                if (filename_table == nullptr)
+                {
+                    auto dict = ColumnString::create();
+                    dict->insertDefault();
+                    filename_table = ColumnUnique<ColumnString>::create(std::move(dict), /*is_nullable*/ false);
+                }
+                cols.push_back(ColumnLowCardinality::create(filename_table, col_decl_file.detachIndexes(), /*is_shared*/ true));
                 break;
+            }
             case COL_DECL_LINE:
                 cols.push_back(std::exchange(col_decl_line, nullptr));
                 break;
@@ -859,9 +871,10 @@ uint64_t DWARFBlockInputFormat::fetchFromDebugAddr(uint64_t addr_base, uint64_t 
         throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Missing .debug_addr section.");
     if (addr_base == UINT64_MAX)
         throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Missing DW_AT_addr_base");
+    uint64_t section_size = debug_addr_section->size();
+    if (addr_base > section_size || idx >= (section_size - addr_base) / 8)
+        throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, ".debug_addr offset out of bounds: addr_base {}, idx {} vs {}.", addr_base, idx, section_size);
     uint64_t offset = addr_base + idx * 8;
-    if (offset + 8 > debug_addr_section->size())
-        throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, ".debug_addr offset out of bounds: {} vs {}.", offset, debug_addr_section->size());
     uint64_t res = 0;
     memcpy(&res, debug_addr_section->data() + offset, 8);
     return res;
@@ -900,9 +913,11 @@ void DWARFBlockInputFormat::parseRanges(
             if (unit.rnglists_base == UINT64_MAX)
                 throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "Missing DW_AT_rnglists_base");
             uint64_t entry_size = unit.dwarf_unit->getFormParams().getDwarfOffsetByteSize();
+            uint64_t section_size = debug_rnglists_extractor->size();
+            if (entry_size == 0 || unit.rnglists_base > section_size
+                || offset >= (section_size - unit.rnglists_base) / entry_size)
+                throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "DW_FORM_rnglistx offset out of bounds: rnglists_base {}, idx {} vs {}", unit.rnglists_base, offset, section_size);
             uint64_t lists_offset = unit.rnglists_base + offset * entry_size;
-            if (lists_offset + entry_size > debug_rnglists_extractor->size())
-                throw Exception(ErrorCodes::CANNOT_PARSE_DWARF, "DW_FORM_rnglistx offset out of bounds: {} vs {}", lists_offset, debug_rnglists_extractor->size());
 
             offset = 0;
             memcpy(&offset, debug_rnglists_extractor->getData().data() + lists_offset, entry_size);
@@ -1033,16 +1048,16 @@ void registerInputFormatDWARF(FormatFactory & factory)
 
 ## Description {#description}
 
-The `DWARF` format parses DWARF debug symbols from an ELF file (executable, library, or object file). 
-It is similar to `dwarfdump`, but much faster (hundreds of MB/s) and supporting SQL. 
-It produces one row for each Debug Information Entry (DIE) in the `.debug_info` section 
+The `DWARF` format parses DWARF debug symbols from an ELF file (executable, library, or object file).
+It is similar to `dwarfdump`, but much faster (hundreds of MB/s) and supporting SQL.
+It produces one row for each Debug Information Entry (DIE) in the `.debug_info` section
 and includes "null"-entries that the DWARF encoding uses to terminate lists of children in the tree.
 
 :::info
-`.debug_info` consists of *units*, which correspond to compilation units: 
-- Each unit is a tree of *DIE*s, with a `compile_unit` DIE as its root. 
-- Each DIE has a *tag* and a list of *attributes*. 
-- Each attribute has a *name* and a *value* (and also a *form*, which specifies how the value is encoded). 
+`.debug_info` consists of *units*, which correspond to compilation units:
+- Each unit is a tree of *DIE*s, with a `compile_unit` DIE as its root.
+- Each DIE has a *tag* and a list of *attributes*.
+- Each attribute has a *name* and a *value* (and also a *form*, which specifies how the value is encoded).
 
 The DIEs represent things from the source code, and their *tag* tells you what kind of thing it is. For example, there are:
 

--- a/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.reference
+++ b/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.reference
@@ -1,0 +1,4 @@
+overflow_shoff: rejected
+overflow_phoff: rejected
+too_small: rejected
+no_sections: rejected

--- a/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.sh
+++ b/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: the DWARF format requires the DWARF parser, which is not built in fasttest.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Regression test for bounds checking in Common/Elf (used by the DWARF input format).
+# Feed deliberately malformed ELF files to the DWARF format and check that each is rejected
+# with a clean exception instead of reading out of bounds. The crafted offsets are close to
+# UINT64_MAX so that the unchecked `offset + size` additions would overflow and pass naive
+# bounds checks, leading to wild pointer dereferences. All these inputs are rejected during
+# ELF header validation, before any DWARF parsing, so the test is sanitizer-safe.
+
+WORK_DIR="${CLICKHOUSE_TMP}/malformed_elf_$$"
+mkdir -p "$WORK_DIR"
+
+python3 - "$WORK_DIR" <<'PY'
+import struct, sys, os
+work = sys.argv[1]
+
+def elf_header(shoff, shnum, phoff, phnum, shstrndx=0):
+    # 64-byte ELF64 header.
+    return (b'\x7fELF' + bytes(12)
+        + struct.pack('<HHIQQQIHHHHHH', 2, 0x3e, 1, 0, phoff, shoff, 0, 64, 56, phnum, 64, shnum, shstrndx))
+
+def section_header(name, stype, offset, size):
+    # 64-byte ELF64 section header.
+    return struct.pack('<IIQQQQIIQQ', name, stype, 0, 0, offset, size, 0, 0, 0, 0)
+
+# Section header table offset close to UINT64_MAX: shoff + shnum * entsize overflows.
+open(os.path.join(work, 'overflow_shoff'), 'wb').write(elf_header(0xFFFFFFFFFFFFFFF0, 1, 64, 1))
+
+# Valid section header and section-names string table, but program header table offset close to
+# UINT64_MAX so that phoff + phnum * entsize overflows. Reaches the program header check.
+SHT_STRTAB = 3
+body = elf_header(shoff=64, shnum=1, phoff=0xFFFFFFFFFFFFFFF0, phnum=1, shstrndx=0)
+body += section_header(name=0, stype=SHT_STRTAB, offset=128, size=1)
+body += b'\x00'
+open(os.path.join(work, 'overflow_phoff'), 'wb').write(body)
+
+# Truncated: only the ELF magic.
+open(os.path.join(work, 'too_small'), 'wb').write(b'\x7fELF')
+
+# Valid magic, everything else zero (no section headers).
+open(os.path.join(work, 'no_sections'), 'wb').write(elf_header(0, 0, 0, 0) + bytes(64))
+PY
+
+for name in overflow_shoff overflow_phoff too_small no_sections
+do
+    if ${CLICKHOUSE_LOCAL} -q "SELECT count() FROM file('${WORK_DIR}/${name}', DWARF)" >/dev/null 2>"${WORK_DIR}/err"
+    then
+        echo "${name}: UNEXPECTED SUCCESS"
+    elif grep -q "CANNOT_PARSE_ELF" "${WORK_DIR}/err"
+    then
+        echo "${name}: rejected"
+    else
+        echo "${name}: UNEXPECTED ERROR"
+        cat "${WORK_DIR}/err"
+    fi
+done
+
+rm -rf "$WORK_DIR"

--- a/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.sh
+++ b/tests/queries/0_stateless/04340_malformed_elf_dwarf_bounds.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-msan
 # no-fasttest: the DWARF format requires the DWARF parser, which is not built in fasttest.
+# no-msan: the DWARF input format is not built under MSan (LLVM, which the DWARF parser depends on, is excluded from MSan builds), so the format is unknown there.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added missing bounds checks in Elf and DWARF parsing.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1017`
- Backported to: `26.5.4.2`, `26.4.5.60`, `26.3.15.2`, `25.8.25.30`
<!-- ch-version-info:end -->