### PR TITLE
Fix unauthenticated memory-exhaustion DoS in MySQL handshake (length-encoded auth_response)

### DIFF
--- a/src/Core/MySQL/IMySQLReadPacket.cpp
+++ b/src/Core/MySQL/IMySQLReadPacket.cpp
@@ -9,6 +9,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int UNKNOWN_PACKET_FROM_CLIENT;
+    extern const int CANNOT_READ_ALL_DATA;
 }
 
 namespace MySQLProtocol
@@ -83,8 +84,20 @@ uint64_t readLengthEncodedNumber(ReadBuffer & buffer)
 void readLengthEncodedString(String & s, ReadBuffer & buffer)
 {
     uint64_t len = readLengthEncodedNumber(buffer);
-    s.resize(len);
-    buffer.readStrict(reinterpret_cast<char *>(s.data()), len);
+    /// `len` is fully attacker-controlled (up to 2^64-1 via the 0xfe prefix). Grow the string in
+    /// bounded chunks as bytes actually arrive instead of resizing to `len` up front, so a bogus
+    /// length cannot trigger a huge pre-emptive allocation (pre-auth on the MySQL handshake path).
+    s.clear();
+    while (s.size() < len)
+    {
+        if (buffer.eof())
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+                "Cannot read all data for a length-encoded string. Expected: {}, read: {}", len, s.size());
+        size_t chunk = std::min(static_cast<uint64_t>(buffer.available()), len - s.size());
+        size_t old_size = s.size();
+        s.resize(old_size + chunk);
+        buffer.readStrict(s.data() + old_size, chunk);
+    }
 }
 
 }

--- a/src/Core/tests/gtest_mysql_read_length_encoded_string.cpp
+++ b/src/Core/tests/gtest_mysql_read_length_encoded_string.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <Core/MySQL/IMySQLReadPacket.h>
+#include <IO/ReadBufferFromString.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+using namespace DB::MySQLProtocol;
+
+namespace
+{
+
+/// A length-encoded string with a value < 0xfb encodes its length in a single byte.
+TEST(MySQLReadLengthEncodedString, ReadsInRangeString)
+{
+    String wire("\x03""abc", 4);
+    ReadBufferFromString buffer(wire);
+    String s;
+    readLengthEncodedString(s, buffer);
+    EXPECT_EQ(s, "abc");
+}
+
+/// The 0xfe prefix carries an 8-byte length. A malicious value far larger than the data that
+/// actually follows must not be allocated up front: the read fails cleanly instead of trying
+/// to resize the string to gigabytes (pre-auth DoS on the MySQL handshake path).
+TEST(MySQLReadLengthEncodedString, RejectsOversizedLengthWithoutHugeAllocation)
+{
+    /// 0xfe + little-endian 0x7000000000000000, with no body bytes following.
+    String wire("\xfe\x00\x00\x00\x00\x00\x00\x00\x70", 9);
+    ReadBufferFromString buffer(wire);
+    String s;
+    try
+    {
+        readLengthEncodedString(s, buffer);
+        FAIL() << "expected an exception for an oversized length-encoded string";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_NE(e.message().find("length-encoded string"), String::npos) << e.message();
+    }
+}
+
+/// A length that overruns the available data is reported after reading what is present,
+/// without pre-allocating the full claimed length.
+TEST(MySQLReadLengthEncodedString, RejectsLengthLongerThanData)
+{
+    String wire("\x0a""abc", 4); /// claims 10 bytes, only 3 are present
+    ReadBufferFromString buffer(wire);
+    String s;
+    try
+    {
+        readLengthEncodedString(s, buffer);
+        FAIL() << "expected an exception when the data is shorter than the encoded length";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_NE(e.message().find("length-encoded string"), String::npos) << e.message();
+    }
+}
+
+}


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107384

## Problem

A malicious, unauthenticated MySQL client can exhaust server memory through the MySQL protocol port (`mysql_port`, 9004, enabled by default). PR #107384 fixed the signed-`char` length read in the `CLIENT_SECURE_CONNECTION` branch of the handshake, but the sibling `CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA` branch remained vulnerable and is strictly worse:

- The length is a length-encoded integer fully controlled by the client (up to 2^64-1 via the `0xfe` prefix), versus the 255-byte cap of the fixed branch.
- It is architecture-independent (`uint64_t`, no signed-`char` trick), so it affects ARM/Graviton — unlike the originally reported bug, which was x86-only.
- It is reachable pre-authentication, so a handful of concurrent handshakes can drive the server to OOM.

## Root cause

`HandshakeResponse::readPayloadImpl` (`src/Core/MySQL/PacketsConnection.cpp`) takes the `CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA` branch into `readLengthEncodedString` (`src/Core/MySQL/IMySQLReadPacket.cpp`), which did `s.resize(len)` before reading any body bytes. A bogus `len` therefore triggers a multi-gigabyte allocation regardless of how few bytes actually follow.

## Fix

`readLengthEncodedString` now grows the string in bounded chunks (`min(available, remaining)`) as bytes actually arrive, instead of pre-sizing to the attacker-controlled length. A length that overruns the available data throws `CANNOT_READ_ALL_DATA` after reading what is present, with no large pre-emptive allocation. Fixing the shared helper also covers the other call sites (`ColumnDefinition`, `OK_Packet`) on the MySQL-client paths.

A new gtest (`src/Core/tests/gtest_mysql_read_length_encoded_string.cpp`) exercises the helper directly. A black-box protocol test cannot cover this: a handshake-parse exception is caught by the outer `catch (Poco::Exception)` in `MySQLHandler::run` and only logged — no ERR packet is returned — so before/after are identical on the wire. On the unfixed code the oversized-length case throws `std::bad_alloc` from the resize; with the fix all cases pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix an unauthenticated memory-exhaustion denial of service on the MySQL protocol port.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1095`
<!-- ch-version-info:end -->