### PR TITLE
CI: do not report "Server died" when a run stops on --max-failures

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -22,6 +22,7 @@ _clickhouse_test = Path(__file__).resolve().parents[3] / "tests" / "clickhouse-t
 _clickhouse_test_globals = runpy.run_path(str(_clickhouse_test))
 STOP_TESTING_EXIT_CODE = _clickhouse_test_globals["STOP_TESTING_EXIT_CODE"]
 GLOBAL_TIME_LIMIT_EXIT_CODE = _clickhouse_test_globals["GLOBAL_TIME_LIMIT_EXIT_CODE"]
+MAX_FAILURES_EXIT_CODE = _clickhouse_test_globals["MAX_FAILURES_EXIT_CODE"]
 
 # Exit codes that mean the run was aborted mid-flight, so per-test results
 # (if any) are incomplete and we cannot trust which test "caused" the
@@ -45,6 +46,9 @@ GLOBAL_TIME_LIMIT_EXIT_CODE = _clickhouse_test_globals["GLOBAL_TIME_LIMIT_EXIT_C
 # checks (final hung-check, `runner_process_killed`, `total_tests_run == 0`)
 # that run AFTER all tests have finished. Per-test results in that case are
 # complete and authoritative and must not be demoted.
+# `MAX_FAILURES_EXIT_CODE` is likewise excluded: the run stopped early because
+# too many tests failed, but the server is alive and those failures are real
+# and already attributed - so they must be reported as FAIL, not "Server died".
 ABORTED_RUN_EXIT_CODES = frozenset(
     {
         STOP_TESTING_EXIT_CODE,
@@ -238,6 +242,21 @@ class FTResultsProcessor:
                 # Single test failed - sequential run, this test is the culprit.
                 failed_results[0].status = Result.Status.ERROR
             test_results.append(Result("Server died", Result.Status.FAIL, info="Server died"))
+        elif runner_exit_code == MAX_FAILURES_EXIT_CODE:
+            # The run stopped early because too many tests failed
+            # (`--max-failures` / `--max-failures-chain`). Unlike the aborted-run
+            # branch above, the server is alive and the parsed failures are real
+            # and correctly attributed - so leave them as FAIL (do not demote to
+            # UNKNOWN, do not synthesize a "Server died" leaf) and just add an
+            # informational summary. `state` stays FAIL from the parsed failures.
+            state = Result.Status.FAIL
+            test_results.append(
+                Result(
+                    "Too many test failures",
+                    Result.Status.FAIL,
+                    info="Stopped early after reaching the --max-failures limit. The failing tests above are the real failures.",
+                )
+            )
         elif runner_exit_code == GLOBAL_TIME_LIMIT_EXIT_CODE:
             # The run stopped gracefully because the global time limit was
             # reached. This is the *expected* stop condition for the flaky and

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -663,14 +663,18 @@
         const statusLower = (status || '').toLowerCase();
         if (statusLower.includes('error')) return 0;
         if (statusLower.includes('fail') && statusLower !== 'xfail') return 1;
-        if (statusLower === 'xpass') return 2;
-        if (statusLower.includes('running')) return 3;
-        if (statusLower.includes('dropped')) return 4;
-        if (statusLower.includes('pending')) return 5;
-        if (statusLower === 'ok' || statusLower.includes('success')) return 6;
-        if (statusLower === 'xfail') return 7;
-        if (statusLower.includes('skipped')) return 8;
-        return 9;
+        // Keep UNKNOWN right under the errors/failures: these are tests whose real
+        // result was lost (e.g. demoted when the run aborted), so they are the rows
+        // worth looking at first, not buried below all the OK rows.
+        if (statusLower.includes('unknown')) return 2;
+        if (statusLower === 'xpass') return 3;
+        if (statusLower.includes('running')) return 4;
+        if (statusLower.includes('dropped')) return 5;
+        if (statusLower.includes('pending')) return 6;
+        if (statusLower === 'ok' || statusLower.includes('success')) return 7;
+        if (statusLower === 'xfail') return 8;
+        if (statusLower.includes('skipped')) return 9;
+        return 10;
     }
 
     function formatTimestamp(timestamp, showDate = true) {

--- a/ci/tests/test_functional_tests_results.py
+++ b/ci/tests/test_functional_tests_results.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for `FTResultsProcessor`, the job-side parser that turns
+`clickhouse-test` output + its exit code into the report tree.
+
+Focus: a run stopped early by `--max-failures` / `--max-failures-chain`
+(exit code `MAX_FAILURES_EXIT_CODE`) must be reported as real failures plus a
+"Too many test failures" leaf - NOT as "Server died" with the per-test
+attribution demoted to UNKNOWN (which is what the aborted-run exit codes do).
+"""
+
+import os
+import sys
+
+# Repo root so `ci.*` resolves; the `ci` dir so the bare `from praktika...`
+# import inside `functional_tests_results` resolves the same way it does when
+# the praktika job runner imports it.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ci.jobs.scripts.functional_tests_results import (
+    MAX_FAILURES_EXIT_CODE,
+    STOP_TESTING_EXIT_CODE,
+    FTResultsProcessor,
+)
+from ci.praktika.result import Result
+
+# Two real failures from a parallel run that stopped early. No "All tests have
+# finished" line, because the run was aborted before completing.
+_TWO_FAILURES = (
+    "00001_first_failing_test: [ FAIL ] 1.23 sec.\n"
+    "some failure details\n"
+    "00002_second_failing_test: [ FAIL ] 0.50 sec.\n"
+    "more failure details\n"
+)
+
+
+def _process(tmp_path, output, runner_exit_code):
+    (tmp_path / "test_result.txt").write_text(output, encoding="utf-8")
+    return FTResultsProcessor(wd=str(tmp_path)).run(runner_exit_code=runner_exit_code)
+
+
+def _named(result, name):
+    return [r for r in result.results if r.name == name]
+
+
+def test_max_failures_keeps_real_failures_and_adds_summary(tmp_path):
+    result = _process(tmp_path, _TWO_FAILURES, MAX_FAILURES_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+
+    # The informational leaf is present...
+    summary = _named(result, "Too many test failures")
+    assert len(summary) == 1
+    assert summary[0].status == Result.Status.FAIL
+
+    # ...no synthetic "Server died" leaf is added...
+    assert not _named(result, "Server died")
+
+    # ...and both real failures stay FAIL (not demoted to UNKNOWN).
+    for name in ("00001_first_failing_test", "00002_second_failing_test"):
+        entries = _named(result, name)
+        assert len(entries) == 1, name
+        assert entries[0].status == Result.Status.FAIL, name
+
+
+def test_aborted_run_still_reports_server_died(tmp_path):
+    """Contrast: the same output with an aborted-run exit code keeps the old
+    behavior - "Server died" plus the failures demoted to UNKNOWN."""
+    result = _process(tmp_path, _TWO_FAILURES, STOP_TESTING_EXIT_CODE)
+
+    assert result.status == Result.Status.FAIL
+    assert len(_named(result, "Server died")) == 1
+    assert not _named(result, "Too many test failures")
+    for name in ("00001_first_failing_test", "00002_second_failing_test"):
+        entries = _named(result, name)
+        assert len(entries) == 1, name
+        assert entries[0].status == Result.Status.UNKNOWN, name

--- a/ci/tests/test_max_failures_exit_code.py
+++ b/ci/tests/test_max_failures_exit_code.py
@@ -1,0 +1,83 @@
+"""
+End-to-end test for the `--max-failures` / `--max-failures-chain` exit code in
+parallel runs of `tests/clickhouse-test`.
+
+When a parallel worker reaches the failure limit it raises `StopTesting` inside
+its own process. That exit code only reaches the launcher if the parent
+survives the worker's shutdown and re-raises with `MAX_FAILURES_EXIT_CODE`.
+A worker that broadcast SIGTERM to the whole group (via `stop_tests`) would
+kill the parent first, so the run would exit 143 and the job side would
+misreport it as "Server died". This test pins the exit code to
+`MAX_FAILURES_EXIT_CODE` for both the chain-limit and total-limit paths.
+
+Needs a running ClickHouse server (provided by the CI Tests job).
+"""
+
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CLICKHOUSE_TEST = str(_REPO_ROOT / "tests" / "clickhouse-test")
+
+_ct = runpy.run_path(_CLICKHOUSE_TEST)
+MAX_FAILURES_EXIT_CODE = _ct["MAX_FAILURES_EXIT_CODE"]
+STOP_TESTING_EXIT_CODE = _ct["STOP_TESTING_EXIT_CODE"]
+
+
+def _make_failing_suite(queries_dir: Path, count: int):
+    """Create `count` always-failing parallel `.sh` tests (stdout never matches
+    the reference) under `<queries_dir>/0_stateless`."""
+    suite = queries_dir / "0_stateless"
+    suite.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        name = f"{i:05d}_always_fail"
+        script = suite / f"{name}.sh"
+        script.write_text("#!/usr/bin/env bash\necho fail\n", encoding="utf-8")
+        script.chmod(0o755)
+        (suite / f"{name}.reference").write_text("ok\n", encoding="utf-8")
+
+
+def _run(queries_dir: Path, extra_args):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            _CLICKHOUSE_TEST,
+            "--queries",
+            str(queries_dir),
+            "--no-stateful",
+            "-j",
+            "2",
+            *extra_args,
+            "00",  # name filter: matches all the fixtures above
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return proc
+
+
+def test_parallel_chain_limit_exits_with_max_failures_code(tmp_path):
+    """`--max-failures-chain` only (`--max-failures 0`) - the path the old code
+    misreported, because the parent never re-raised with the right code."""
+    _make_failing_suite(tmp_path, count=4)
+    proc = _run(tmp_path, ["--max-failures", "0", "--max-failures-chain", "1"])
+    assert proc.returncode == MAX_FAILURES_EXIT_CODE, (
+        f"expected {MAX_FAILURES_EXIT_CODE}, got {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert proc.returncode != STOP_TESTING_EXIT_CODE
+    assert proc.returncode != 128 + 15  # not SIGTERM-killed (143 -> "Server died")
+
+
+def test_parallel_total_limit_exits_with_max_failures_code(tmp_path):
+    """`--max-failures` total limit, chain effectively disabled."""
+    _make_failing_suite(tmp_path, count=4)
+    proc = _run(tmp_path, ["--max-failures", "2", "--max-failures-chain", "1000"])
+    assert proc.returncode == MAX_FAILURES_EXIT_CODE, (
+        f"expected {MAX_FAILURES_EXIT_CODE}, got {proc.returncode}\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -92,6 +92,14 @@ STOP_TESTING_EXIT_CODE = 2
 # `ci/jobs/scripts/functional_tests_results.py`.
 GLOBAL_TIME_LIMIT_EXIT_CODE = 3
 
+# Exit code returned when the run stopped early because the `--max-failures` /
+# `--max-failures-chain` limit was reached. The server is alive and the failing
+# tests are real and already attributed - so this must NOT be conflated with
+# `STOP_TESTING_EXIT_CODE` (reported as "Server died", which also blanks out the
+# per-test attribution). Kept in sync with `MAX_FAILURES_EXIT_CODE` in
+# `ci/jobs/scripts/functional_tests_results.py`.
+MAX_FAILURES_EXIT_CODE = 4
+
 USE_JINJA = True
 try:
     import jinja2
@@ -4158,8 +4166,10 @@ class StopTesting(Exception):
     "Test run aborted:" so it stands out in the log, and exits with
     `exit_code` so the job side can distinguish the cause: the default
     `STOP_TESTING_EXIT_CODE` means the run was catastrophically interrupted
-    (reported as "Server died"), while `GLOBAL_TIME_LIMIT_EXIT_CODE` means a
-    benign, expected stop after the time budget was reached.
+    (reported as "Server died"), `GLOBAL_TIME_LIMIT_EXIT_CODE` means a
+    benign, expected stop after the time budget was reached, and
+    `MAX_FAILURES_EXIT_CODE` means too many tests failed (real failures, server
+    still alive) so the run stopped early.
     """
 
     def __init__(self, message, exit_code=STOP_TESTING_EXIT_CODE):
@@ -4524,7 +4534,8 @@ def run_tests_array(
                             stop_tests()
                             stop_testing.set()
                             raise StopTesting(
-                                f"reached --max-failures limit ({args.max_failures})"
+                                f"reached --max-failures limit ({args.max_failures})",
+                                exit_code=MAX_FAILURES_EXIT_CODE,
                             )
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
@@ -4538,7 +4549,8 @@ def run_tests_array(
             stop_tests()
             stop_testing.set()
             raise StopTesting(
-                f"reached --max-failures-chain limit ({args.max_failures_chain})"
+                f"reached --max-failures-chain limit ({args.max_failures_chain})",
+                exit_code=MAX_FAILURES_EXIT_CODE,
             )
 
     if failures_total > 0:
@@ -5053,6 +5065,15 @@ def do_run_tests(
                     raise StopTesting(
                         "global time limit reached",
                         exit_code=GLOBAL_TIME_LIMIT_EXIT_CODE,
+                    )
+                # A worker that hit `--max-failures` set `stop_testing` and bumped
+                # the shared counter before exiting. The server is alive and the
+                # failing tests are real (and already attributed), so report this
+                # as a max-failures stop, not "Server died".
+                if args.max_failures > 0 and total_failures_shared.value >= args.max_failures:
+                    raise StopTesting(
+                        f"reached --max-failures limit ({args.max_failures})",
+                        exit_code=MAX_FAILURES_EXIT_CODE,
                     )
                 raise StopTesting(
                     "test run was stopped (see earlier output for the cause)"

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4319,6 +4319,7 @@ def run_tests_array(
         multiprocessing.sharedctypes.Synchronized,
         multiprocessing.sharedctypes.Synchronized,
         int,
+        multiprocessing.sharedctypes.Synchronized,
     ],
 ):
     (
@@ -4335,6 +4336,7 @@ def run_tests_array(
         total_failures_shared,
         progress_counter,
         total_tests,
+        stop_exit_code,
     ) = all_tests_with_params
 
     os.environ["LLVM_PROFILE_FILE"] = f"clickhouse-client-proc{process_index}-%2m.profraw"
@@ -4407,6 +4409,14 @@ def run_tests_array(
             break
 
         if stop_testing.is_set():
+            if is_concurrent:
+                # Another worker (or the parent) requested the stop. Break
+                # quietly and let the parent orchestrate the shutdown and the
+                # exit code; do NOT call `stop_tests()` here - its `killpg`
+                # broadcasts SIGTERM to the whole group, including the parent,
+                # which would die with 143 (reported as "Server died") before it
+                # could re-raise with the real cause's exit code.
+                break
             stop_tests()
             raise StopTesting(
                 "another component requested stop (see earlier output for the cause)"
@@ -4531,7 +4541,14 @@ def run_tests_array(
                     with total_failures_shared.get_lock():
                         total_failures_shared.value += 1
                         if total_failures_shared.value >= args.max_failures:
-                            stop_tests()
+                            # Unlike the server-died case above, do NOT call
+                            # `stop_tests()` here: its `killpg` broadcasts SIGTERM
+                            # to the whole group, including the parent, which would
+                            # die with 143 (reported as "Server died") before it
+                            # could re-raise with `MAX_FAILURES_EXIT_CODE`. Just
+                            # signal the stop; the parent masks SIGTERM and then
+                            # terminates the workers in an orderly way.
+                            stop_exit_code.value = MAX_FAILURES_EXIT_CODE
                             stop_testing.set()
                             raise StopTesting(
                                 f"reached --max-failures limit ({args.max_failures})",
@@ -4546,7 +4563,10 @@ def run_tests_array(
             raise e
 
         if failures_chain >= args.max_failures_chain:
-            stop_tests()
+            # See the --max-failures branch above: skip `stop_tests()` so the
+            # worker's SIGTERM broadcast does not kill the parent before it can
+            # re-raise with `MAX_FAILURES_EXIT_CODE`.
+            stop_exit_code.value = MAX_FAILURES_EXIT_CODE
             stop_testing.set()
             raise StopTesting(
                 f"reached --max-failures-chain limit ({args.max_failures_chain})",
@@ -4891,6 +4911,12 @@ def do_run_tests(
     )
     total_tests = len(test_suite.sequential_tests) + len(test_suite.parallel_tests)
     progress_counter = multiprocessing.Value('i', 0)
+    # Exit code a worker wants the whole run to stop with. A worker raises
+    # `StopTesting` inside its own process, so that exception never reaches the
+    # parent; the parent only sees `stop_testing`. The worker records its exit
+    # code here (before setting `stop_testing`) so the parent can re-raise with
+    # the same code instead of defaulting to "Server died". 0 means unset.
+    stop_exit_code = multiprocessing.Value('i', 0)
 
     if test_suite.parallel_tests:
         tests_n = len(test_suite.parallel_tests)
@@ -4952,6 +4978,7 @@ def do_run_tests(
                         total_failures_shared,
                         progress_counter,
                         total_tests,
+                        stop_exit_code,
                     ),
                 ),
             )
@@ -5066,14 +5093,15 @@ def do_run_tests(
                         "global time limit reached",
                         exit_code=GLOBAL_TIME_LIMIT_EXIT_CODE,
                     )
-                # A worker that hit `--max-failures` set `stop_testing` and bumped
-                # the shared counter before exiting. The server is alive and the
-                # failing tests are real (and already attributed), so report this
-                # as a max-failures stop, not "Server died".
-                if args.max_failures > 0 and total_failures_shared.value >= args.max_failures:
+                # A worker that hit `--max-failures` or `--max-failures-chain`
+                # recorded its exit code in `stop_exit_code` before setting
+                # `stop_testing`. The server is alive and the failing tests are
+                # real (and already attributed), so report this with the worker's
+                # code, not "Server died".
+                if stop_exit_code.value != 0:
                     raise StopTesting(
-                        f"reached --max-failures limit ({args.max_failures})",
-                        exit_code=MAX_FAILURES_EXIT_CODE,
+                        "reached the --max-failures / --max-failures-chain limit",
+                        exit_code=stop_exit_code.value,
                     )
                 raise StopTesting(
                     "test run was stopped (see earlier output for the cause)"
@@ -5108,6 +5136,7 @@ def do_run_tests(
                 seq_total_failures,
                 progress_counter,
                 total_tests,
+                stop_exit_code,
             )
         )
 


### PR DESCRIPTION
The "Stateless tests (flaky check)" job reports **"Server died"** and demotes every failing test to **UNKNOWN** whenever a run stops on `--max-failures`, even though the server is perfectly alive. `clickhouse-test` raised `StopTesting` with the default `STOP_TESTING_EXIT_CODE` (2) — the same code used for a real server death — so the job side could not tell the two apart and hid which test actually failed.

This gives the `--max-failures` / `--max-failures-chain` stop its own exit code (`MAX_FAILURES_EXIT_CODE = 4`), distinct from server death and the global time limit. The job now reports it as **"Too many test failures"** and keeps the failing tests as `FAIL` (real, already-attributed failures) instead of demoting them to `UNKNOWN` and synthesizing a "Server died" leaf.

It also fixes the HTML report ordering: `getStatusPriority` in `ci/praktika/json.html` had no branch for `UNKNOWN`, so `UNKNOWN` rows sorted below all the `OK` rows (`fail > ok > unknown`). `UNKNOWN` now ranks right under the errors and failures, so rows whose real result was lost are visible at the top.

Example report where the mislabel is visible — a single failing test (`deltaLakeLocal` is not built with MSan) shown as a generic "Server died" plus five `UNKNOWN` reruns: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107341&sha=49c86b80ca9c46024be1ec61a1c3ba97a45544b8&name_0=PR&name_1=Stateless+tests+%28amd_msan%2C+flaky+check%29&name_2=Tests

Related: https://github.com/ClickHouse/ClickHouse/pull/107341

cc @leshikus

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog (CI only).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.882`
<!-- ch-version-info:end -->