### PR TITLE
Fix path traversal in replicated part fetch

### DIFF
--- a/src/Storages/MergeTree/DataPartsExchange.cpp
+++ b/src/Storages/MergeTree/DataPartsExchange.cpp
@@ -26,6 +26,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/FailPoint.h>
+#include <Common/filesystemHelpers.h>
 #include <Common/Jemalloc.h>
 #include <Common/JemallocMergeTreeArena.h>
 #include <Common/randomDelay.h>
@@ -106,6 +107,15 @@ struct ReplicatedFetchReadCallback
         }
     }
 };
+
+/// Validate a projection name from an untrusted replica before it is used to build a path.
+/// It becomes a single directory component ("<name>.proj"), so it must be non-empty and contain
+/// no '/'. Standalone "." and ".." are safe here ("..proj"/"...proj" are single components).
+bool isProjectionNameSafe(const std::string & projection_name)
+{
+    return !projection_name.empty()
+        && projection_name.find('/') == std::string::npos;
+}
 
 }
 
@@ -705,14 +715,15 @@ void Fetcher::downloadBaseOrProjectionPartToDisk(
         readStringBinary(file_name, in);
         readBinary(file_size, in);
 
-        /// File must be inside "absolute_part_path" directory.
-        /// Otherwise malicious ClickHouse replica may force us to write to arbitrary path.
-        String absolute_file_path = fs::weakly_canonical(fs::path(data_part_storage->getRelativePath()) / file_name);
-        if (!startsWith(absolute_file_path, fs::weakly_canonical(data_part_storage->getRelativePath()).string()))
+        /// Guard against a malicious replica writing outside the part directory.
+        /// Runs for both the base part and projection parts.
+        const auto absolute_file_path = fs::weakly_canonical(fs::path(data_part_storage->getRelativePath()) / file_name);
+        if (!pathStartsWith(absolute_file_path, fs::path(data_part_storage->getRelativePath())))
             throw Exception(ErrorCodes::INSECURE_PATH,
                 "File path ({}) doesn't appear to be inside part path ({}). "
                 "This may happen if we are trying to download part from malicious replica or logical error.",
-                absolute_file_path, data_part_storage->getRelativePath());
+                absolute_file_path.string(),
+                data_part_storage->getRelativePath());
 
         written_files.emplace_back(output_buffer_getter(*data_part_storage, file_name, file_size));
         HashingWriteBuffer hashing_out(*written_files.back());
@@ -840,6 +851,15 @@ MergeTreeData::MutableDataPartPtr Fetcher::downloadPartToDisk(
         {
             String projection_name;
             readStringBinary(projection_name, in);
+
+            /// Validate before getProjection()/createDirectories() so no attacker-named
+            /// directory is ever created from an untrusted replica's projection name.
+            if (!isProjectionNameSafe(projection_name))
+                throw Exception(ErrorCodes::INSECURE_PATH,
+                    "Projection name ({}) doesn't appear to be a valid name. "
+                    "This may happen if we are trying to download part from malicious replica or logical error.",
+                    projection_name);
+
             MergeTreeData::DataPart::Checksums projection_checksum;
 
             auto projection_part_storage = part_storage_for_loading->getProjection(projection_name + ".proj");


### PR DESCRIPTION
Two input-validation gaps in `Fetcher` (`DataPartsExchange.cpp`) let a malicious
source replica write files outside the destination part directory when a peer
downloads a part. The fetch path already treats the peer replica as untrusted;
these two fields were never given the same treatment.

- The projection name read from the wire was used to build a filesystem path
  without any `/` check, so a name such as `../../../../etc/...` could create
  directories outside the data directory. `isProjectionNameSafe` now rejects
  invalid names with `INSECURE_PATH` before `getProjection` and `createDirectories`.
- The per-file containment check used a raw string prefix compare without a
  trailing separator, so a sibling like `<dir>.proj.xml` passed the check against
  base `<dir>.proj`. It now uses `pathStartsWith` from `filesystemHelpers`, which
  compares whole path components and is not fooled by a shared string prefix. This
  guards the base part path as well as projections.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed two path-traversal issues in the replicated part fetch protocol that could let a malicious replica write files outside the part directory.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.968`
- Backported to: `26.5.3.48`, `26.4.5.54`, `26.3.14.44`, `25.8.25.27`
<!-- ch-version-info:end -->