### PR TITLE
Fix Azure DeltaKernel passing account name

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -171,6 +171,144 @@ private:
 };
 
 #if USE_AZURE_BLOB_STORAGE
+std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
+    const DB::AzureBlobStorage::ConnectionParams & connection_params)
+{
+    std::vector<std::pair<std::string, std::string>> options;
+    auto set_option = [&](const std::string & name, const std::string & value)
+    {
+        options.emplace_back(name, value);
+    };
+
+    const auto & endpoint = connection_params.endpoint;
+
+    /// Supported options
+    /// https://github.com/apache/arrow-rs-object-store/blob/main/src/azure/builder.rs#L390
+    set_option("azure_container_name", endpoint.container_name);
+
+    /// Extracts the storage account name from the hostname of storage_account_url.
+    /// Standard Azure Blob endpoints have the form https://<account>.blob.core.windows.net,
+    /// so the subdomain before the first '.' is the account name.
+    auto get_account_name = [&]() -> std::string
+    {
+        const auto & url = endpoint.storage_account_url;
+        auto scheme_end = url.find("://");
+        if (scheme_end == std::string::npos)
+            return {};
+
+        auto host_start = scheme_end + 3;
+        auto dot_pos = url.find('.', host_start);
+        if (dot_pos == std::string::npos)
+            return {};
+
+        return url.substr(host_start, dot_pos - host_start);
+    };
+
+    switch (connection_params.auth_method.index())
+    {
+        case 0: /// ConnectionString
+        {
+            const auto & auth = std::get<DB::AzureBlobStorage::ConnectionString>(connection_params.auth_method);
+
+            /// An empty ConnectionString is the default-constructed variant alternative used
+            /// by the vended-credentials / SAS path (e.g. a Delta table read through Unity
+            /// catalog). There is no connection string to parse: the account name lives in the
+            /// storage_account_url hostname and the SAS token is carried in endpoint.sas_auth,
+            /// which is applied after this switch. Without this branch we would parse an empty
+            /// connection string, leave azure_storage_account_name unset, and the object_store
+            /// Azure builder would fail with "Account must be specified (in builder_build)".
+            if (auth.toUnderType().empty())
+            {
+                const auto & name = endpoint.account_name.empty() ? get_account_name() : endpoint.account_name;
+                if (!name.empty())
+                    set_option("azure_storage_account_name", name);
+                break;
+            }
+
+            /// delta-kernel-rs does not support azure_storage_connection_string directly.
+            /// Parse the connection string into individual components instead.
+            /// Translate Azure SDK std::logic_error subtypes (e.g. std::invalid_argument
+            /// from std::stoi for malformed ports inside the connection string's
+            /// BlobEndpoint URL) to DB::Exception so they don't trigger
+            /// abortOnFailedAssertion in debug/sanitizer builds.
+            Azure::Storage::_internal::ConnectionStringParts parsed;
+            try
+            {
+                parsed = Azure::Storage::_internal::ParseConnectionString(auth.toUnderType());
+            }
+            catch (const std::logic_error & e)
+            {
+                throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
+                    "Failed to parse Azure connection string: {}", e.what());
+            }
+
+            if (!parsed.AccountName.empty())
+                set_option("azure_storage_account_name", parsed.AccountName);
+
+            if (!parsed.AccountKey.empty())
+            {
+                set_option("azure_storage_account_key", parsed.AccountKey);
+            }
+            else
+            {
+                /// SAS-based connection string: extract the SAS token from the
+                /// blob service URL query parameters (appended by ParseConnectionString).
+                auto query_params = parsed.BlobServiceUrl.GetQueryParameters();
+                if (!query_params.empty())
+                {
+                    std::string sas;
+                    for (const auto & [k, v] : query_params)
+                    {
+                        if (!sas.empty())
+                            sas += '&';
+                        sas += k + '=' + v;
+                    }
+                    set_option("azure_storage_sas_key", sas);
+                }
+            }
+
+            /// Set the blob service endpoint URL (without SAS query parameters).
+            const auto & blob_url = parsed.BlobServiceUrl;
+            const auto & scheme = blob_url.GetScheme();
+            set_option("azure_endpoint", connection_params.getConnectionURL());
+            if (!scheme.empty() && scheme == "http")
+                set_option("azure_allow_http", "true");
+            break;
+        }
+        case 2: /// StorageSharedKeyCredential
+        case 4: /// ManagedIdentityCredential
+        {
+            const auto & name = endpoint.account_name.empty() ? get_account_name() : endpoint.account_name;
+            if (!name.empty())
+                set_option("azure_storage_account_name", name);
+            if (!connection_params.endpoint.account_key.empty())
+                set_option("azure_storage_account_key", connection_params.endpoint.account_key);
+            break;
+        }
+        case 1: /// ClientSecretCredential
+        case 3: /// WorkloadIdentityCredential
+        case 5: /// StaticCredential
+        default:
+            /// Other variants are not supported yet
+            throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED,
+                            "Unsupported authentication type for azure: {}", connection_params.auth_method.index());
+    }
+
+    if (!endpoint.sas_auth.empty())
+        set_option("azure_storage_sas_key", endpoint.sas_auth);
+
+    /// For non-standard endpoints (e.g., Azurite emulator), set the endpoint explicitly.
+    /// Also allow plain HTTP connections when the endpoint uses http://, since the object-store
+    /// Azure builder defaults to https_only=true and would reject plain HTTP requests.
+    if (!endpoint.storage_account_url.empty() && endpoint.storage_account_url.starts_with("http://"))
+    {
+        set_option("azure_endpoint", connection_params.getConnectionURL());
+        set_option("azure_allow_http", "true");
+    }
+
+    return options;
+}
+
 /// A helper class to manage Azure Blob Storage.
 class AzureKernelHelper final : public IKernelHelper
 {
@@ -196,125 +334,13 @@ public:
             "get_engine_builder");
         BuilderGuard guard(builder);
 
-        auto set_option = [&](const std::string & name, const std::string & value)
-        {
+        for (const auto & [name, value] : getAzureBuilderOptions(connection_params))
             setBuilderOption(builder, name, value);
-        };
-
-        const auto & endpoint = connection_params.endpoint;
-
-        /// Supported options
-        /// https://github.com/apache/arrow-rs-object-store/blob/main/src/azure/builder.rs#L390
-        set_option("azure_container_name", endpoint.container_name);
-
-        /// Extracts the storage account name from the hostname of storage_account_url.
-        /// Standard Azure Blob endpoints have the form https://<account>.blob.core.windows.net,
-        /// so the subdomain before the first '.' is the account name.
-        auto get_account_name = [&]() -> std::string
-        {
-            const auto & url = endpoint.storage_account_url;
-            auto scheme_end = url.find("://");
-            if (scheme_end == std::string::npos)
-                return {};
-
-            auto host_start = scheme_end + 3;
-            auto dot_pos = url.find('.', host_start);
-            if (dot_pos == std::string::npos)
-                return {};
-
-            return url.substr(host_start, dot_pos - host_start);
-        };
-
-        switch (connection_params.auth_method.index())
-        {
-            case 0: /// ConnectionString
-            {
-                const auto & auth = std::get<DB::AzureBlobStorage::ConnectionString>(connection_params.auth_method);
-                /// delta-kernel-rs does not support azure_storage_connection_string directly.
-                /// Parse the connection string into individual components instead.
-                /// Translate Azure SDK std::logic_error subtypes (e.g. std::invalid_argument
-                /// from std::stoi for malformed ports inside the connection string's
-                /// BlobEndpoint URL) to DB::Exception so they don't trigger
-                /// abortOnFailedAssertion in debug/sanitizer builds.
-                Azure::Storage::_internal::ConnectionStringParts parsed;
-                try
-                {
-                    parsed = Azure::Storage::_internal::ParseConnectionString(auth.toUnderType());
-                }
-                catch (const std::logic_error & e)
-                {
-                    throw DB::Exception(DB::ErrorCodes::BAD_ARGUMENTS,
-                        "Failed to parse Azure connection string: {}", e.what());
-                }
-
-                if (!parsed.AccountName.empty())
-                    set_option("azure_storage_account_name", parsed.AccountName);
-
-                if (!parsed.AccountKey.empty())
-                {
-                    set_option("azure_storage_account_key", parsed.AccountKey);
-                }
-                else
-                {
-                    /// SAS-based connection string: extract the SAS token from the
-                    /// blob service URL query parameters (appended by ParseConnectionString).
-                    auto query_params = parsed.BlobServiceUrl.GetQueryParameters();
-                    if (!query_params.empty())
-                    {
-                        std::string sas;
-                        for (const auto & [k, v] : query_params)
-                        {
-                            if (!sas.empty())
-                                sas += '&';
-                            sas += k + '=' + v;
-                        }
-                        set_option("azure_storage_sas_key", sas);
-                    }
-                }
-
-                /// Set the blob service endpoint URL (without SAS query parameters).
-                const auto & blob_url = parsed.BlobServiceUrl;
-                const auto & scheme = blob_url.GetScheme();
-                set_option("azure_endpoint", connection_params.getConnectionURL());
-                if (!scheme.empty() && scheme == "http")
-                    set_option("azure_allow_http", "true");
-                break;
-            }
-            case 2: /// StorageSharedKeyCredential
-            case 4: /// ManagedIdentityCredential
-            {
-                const auto & name = endpoint.account_name.empty() ? get_account_name() : endpoint.account_name;
-                if (!name.empty())
-                    set_option("azure_storage_account_name", name);
-                if (!connection_params.endpoint.account_key.empty())
-                    set_option("azure_storage_account_key", connection_params.endpoint.account_key);
-                break;
-            }
-            case 1: /// ClientSecretCredential
-            case 3: /// WorkloadIdentityCredential
-            case 5: /// StaticCredential
-            default:
-                /// Other variants are not supported yet
-                throw DB::Exception(DB::ErrorCodes::NOT_IMPLEMENTED,
-                                "Unsupported authentication type for azure: {}", connection_params.auth_method.index());
-        }
-
-        if (!endpoint.sas_auth.empty())
-            set_option("azure_storage_sas_key", endpoint.sas_auth);
-
-        /// For non-standard endpoints (e.g., Azurite emulator), set the endpoint explicitly.
-        /// Also allow plain HTTP connections when the endpoint uses http://, since the object-store
-        /// Azure builder defaults to https_only=true and would reject plain HTTP requests.
-        if (!endpoint.storage_account_url.empty() && endpoint.storage_account_url.starts_with("http://"))
-        {
-            set_option("azure_endpoint", connection_params.getConnectionURL());
-            set_option("azure_allow_http", "true");
-        }
 
         LOG_TRACE(
             log,
             "Using azure container: {}, data_path: {}",
-            endpoint.container_name, data_path);
+            connection_params.endpoint.container_name, data_path);
 
         return guard.release();
     }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -4,10 +4,21 @@
 #if USE_DELTA_KERNEL_RS
 #include <Storages/ObjectStorage/StorageObjectStorage.h>
 
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace ffi
 {
 struct EngineBuilder;
 }
+
+#if USE_AZURE_BLOB_STORAGE
+namespace DB::AzureBlobStorage
+{
+struct ConnectionParams;
+}
+#endif
 
 namespace DeltaLake
 {
@@ -37,6 +48,17 @@ public:
 };
 
 using KernelHelperPtr = std::shared_ptr<IKernelHelper>;
+
+#if USE_AZURE_BLOB_STORAGE
+/// Computes the ordered list of delta-kernel-rs object_store builder options
+/// (the name/value pairs later passed to `ffi::set_builder_option`) for the given
+/// Azure connection params. Extracted from `AzureKernelHelper::createBuilder` so that
+/// the option-selection logic - in particular, that `azure_storage_account_name` is
+/// always emitted, including on the vended-credentials / SAS path used by Unity catalog -
+/// is unit-testable without the delta-kernel FFI.
+std::vector<std::pair<std::string, std::string>> getAzureBuilderOptions(
+    const DB::AzureBlobStorage::ConnectionParams & connection_params);
+#endif
 
 }
 

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -106,3 +106,82 @@ TEST(DeltaLakeMetadata, GetSimpleTypeByNameChar)
 }
 
 #endif
+
+#if USE_DELTA_KERNEL_RS && USE_AZURE_BLOB_STORAGE
+
+#include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
+
+#include <optional>
+
+namespace
+{
+std::optional<std::string> findBuilderOption(
+    const std::vector<std::pair<std::string, std::string>> & options, const std::string & name)
+{
+    for (const auto & [k, v] : options)
+        if (k == name)
+            return v;
+    return std::nullopt;
+}
+}
+
+/// Regression test for https://github.com/ClickHouse/support-escalation/issues/7917
+///
+/// Reading a Delta table via Unity catalog on Azure vends a SAS token, so the engine
+/// arguments become [abfss_url, sas_token]. That 2-argument path sets storage_account_url
+/// and sas_auth but never assigns auth_method, leaving it the default-constructed
+/// ConnectionString variant alternative (index 0, holding an empty string) - the user did
+/// not actually supply a connection string. The delta-kernel Azure builder must still emit
+/// azure_storage_account_name (derived from the storage_account_url hostname); otherwise
+/// object_store rejects the build with "Account must be specified (in builder_build)".
+TEST(DeltaLakeAzureKernelHelper, VendedSasTokenSetsAccountName)
+{
+    DB::AzureBlobStorage::ConnectionParams params;
+    params.endpoint.storage_account_url = "https://testaccount.blob.core.windows.net";
+    params.endpoint.container_name = "testcontainer";
+    params.endpoint.sas_auth = "sv=2021-06-08&sig=abcDEF123";
+    /// auth_method intentionally left default: the empty ConnectionString alternative that
+    /// the vended-credentials / Unity catalog path produces.
+    ASSERT_EQ(params.auth_method.index(), 0u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    const auto account = findBuilderOption(options, "azure_storage_account_name");
+    ASSERT_TRUE(account.has_value());
+    ASSERT_EQ(*account, "testaccount");
+
+    const auto sas = findBuilderOption(options, "azure_storage_sas_key");
+    ASSERT_TRUE(sas.has_value());
+    ASSERT_EQ(*sas, "sv=2021-06-08&sig=abcDEF123");
+
+    const auto container = findBuilderOption(options, "azure_container_name");
+    ASSERT_TRUE(container.has_value());
+    ASSERT_EQ(*container, "testcontainer");
+}
+
+/// A real connection string (non-empty ConnectionString alternative) must still be parsed
+/// into its components, including the account name.
+TEST(DeltaLakeAzureKernelHelper, ConnectionStringSetsAccountName)
+{
+    DB::AzureBlobStorage::ConnectionParams params;
+    const std::string connection_string =
+        "DefaultEndpointsProtocol=https;AccountName=testaccount;"
+        "AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net";
+    params.endpoint.storage_account_url = connection_string;
+    params.endpoint.container_name = "testcontainer";
+    params.auth_method = DB::AzureBlobStorage::ConnectionString{connection_string};
+    ASSERT_EQ(params.auth_method.index(), 0u);
+
+    const auto options = DeltaLake::getAzureBuilderOptions(params);
+
+    const auto account = findBuilderOption(options, "azure_storage_account_name");
+    ASSERT_TRUE(account.has_value());
+    ASSERT_EQ(*account, "testaccount");
+
+    const auto key = findBuilderOption(options, "azure_storage_account_key");
+    ASSERT_TRUE(key.has_value());
+    ASSERT_EQ(*key, "dGVzdGtleQ==");
+}
+
+#endif

--- a/src/Storages/tests/gtest_delta_kernel.cpp
+++ b/src/Storages/tests/gtest_delta_kernel.cpp
@@ -126,15 +126,7 @@ std::optional<std::string> findBuilderOption(
 }
 }
 
-/// Regression test for https://github.com/ClickHouse/support-escalation/issues/7917
-///
-/// Reading a Delta table via Unity catalog on Azure vends a SAS token, so the engine
-/// arguments become [abfss_url, sas_token]. That 2-argument path sets storage_account_url
-/// and sas_auth but never assigns auth_method, leaving it the default-constructed
-/// ConnectionString variant alternative (index 0, holding an empty string) - the user did
-/// not actually supply a connection string. The delta-kernel Azure builder must still emit
-/// azure_storage_account_name (derived from the storage_account_url hostname); otherwise
-/// object_store rejects the build with "Account must be specified (in builder_build)".
+/// Empty connection string
 TEST(DeltaLakeAzureKernelHelper, VendedSasTokenSetsAccountName)
 {
     DB::AzureBlobStorage::ConnectionParams params;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed 'Account must be specified error' when reading a Delta Lake table over Azure

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.939`
- Backported to: `26.5.3.52`, `26.4.5.59`
<!-- ch-version-info:end -->