### PR TITLE
check_ci: add PR auto-detection, --ci-only and --yes

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -451,10 +451,24 @@ class CommitStatusCheck:
                 return False
 
     @staticmethod
+    def abort_if_non_interactive_override(what):
+        """Fail closed: forcing a non-green merge gate to success is a deliberate
+        human decision and must never be taken automatically under --yes."""
+        if UserPrompt.assume_yes:
+            print(
+                f"ERROR: refusing to override {what} in non-interactive (--yes) mode. "
+                f"Re-run without --yes to decide this manually."
+            )
+            sys.exit(1)
+
+    @staticmethod
     def process_sync_status(
         commit_status_data: Optional[GH.CommitStatus], sha: str, repo: str = PUBLIC_REPO
     ):
         if not commit_status_data:
+            CommitStatusCheck.abort_if_non_interactive_override(
+                "a missing CH Inc sync status"
+            )
             if not UserPrompt.confirm(
                 "CH Inc sync status is missing. Override to success?"
             ):
@@ -474,6 +488,9 @@ class CommitStatusCheck:
             if commit_status_data.description == "tests failed":
                 print(
                     f"\nCH Sync failed for commit, description: {commit_status_data.description}"
+                )
+                CommitStatusCheck.abort_if_non_interactive_override(
+                    "a failed CH Inc sync (tests failed)"
                 )
                 if UserPrompt.confirm("You sure it can be ignored?"):
                     GH.post_commit_status(
@@ -495,6 +512,9 @@ class CommitStatusCheck:
             if commit_status_data.description == "tests started":
                 print(
                     f"\n{commit_status_data.context} is pending with description {commit_status_data.description}"
+                )
+                CommitStatusCheck.abort_if_non_interactive_override(
+                    "a pending CH Inc sync"
                 )
                 if UserPrompt.confirm("You sure it can be ignored?"):
                     GH.post_commit_status(
@@ -523,6 +543,9 @@ class CommitStatusCheck:
         elif not commit_status_data:
             override = True
         elif commit_status_data.state in (Result.GHStatus.FAILURE,):
+            CommitStatusCheck.abort_if_non_interactive_override(
+                "a failed Mergeable Check"
+            )
             if UserPrompt.confirm("Do you want to override mergeable check?"):
                 override = True
             else:
@@ -1045,7 +1068,9 @@ def main():
         )
         pr_data = json.loads(pr_data)
         head_sha = pr_data["headRefOid"]
-        if GH.pr_has_conflicts(pr_number, repo):
+        # Conflicts only matter for the merge-queue path; --ci-only never merges,
+        # so a conflicted PR can still be analyzed and have issues filed.
+        if not ci_only and GH.pr_has_conflicts(pr_number, repo):
             print("PR has conflicts, cannot merge")
             sys.exit(1)
     else:
@@ -1060,16 +1085,21 @@ def main():
         status_map = CommitStatusCheck.get_commit_statuses(head_sha, repo=repo)
         sync_status = status_map.get(CheckStatuses.CH_INC_SYNC)
         mergeable_check_status = status_map.get(CheckStatuses.MERGEABLE_CHECK)
+        pr_status = status_map.get(CheckStatuses.PR)
         if (
-            status_map[CheckStatuses.PR].state
-            not in (
-                Result.GHStatus.SUCCESS,
-                Result.GHStatus.FAILURE,
+            (
+                not pr_status
+                or pr_status.state
+                not in (
+                    Result.GHStatus.SUCCESS,
+                    Result.GHStatus.FAILURE,
+                )
             )
             and not FORCE_MERGE
         ):
             raise Exception(
-                f"Status for {commit_status_data.context} is not completed: {commit_status_data.state} - cannot proceed"
+                f"PR status is not completed: "
+                f"{pr_status.state if pr_status else 'missing'} - cannot proceed"
             )
     else:
         status_map = {}

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -758,10 +758,12 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
             print(
                 f"Loaded {len(public_catalog.active_test_issues)} active issues from {PUBLIC_REPO}\n"
             )
-            # Merge public issues into the catalog for matching
-            existing_numbers = {i.number for i in issue_catalog.active_test_issues}
+            # Merge public issues into the catalog for matching. Deduplicate by
+            # the globally unique issue URL: issue numbers are repo-local, so a
+            # private #123 must not shadow an unrelated public #123.
+            existing_urls = {i.url for i in issue_catalog.active_test_issues}
             for issue in public_catalog.active_test_issues:
-                if issue.number not in existing_numbers:
+                if issue.url not in existing_urls:
                     issue_catalog.active_test_issues.append(issue)
 
         print("Checking failures against open issues...\n")
@@ -1116,7 +1118,14 @@ def main():
     else:
         question = "All checks passed! Congratulations!\n"
 
-    if unknown_failures or known_failures:
+    if (unknown_failures or known_failures) and repo != PUBLIC_REPO:
+        # The summary builds job report links against the public reports bucket,
+        # which would be broken for a private PR. The private repo's own CI
+        # already maintains its summary comment, so skip updating it here.
+        print(
+            f"\nSkipping PR comment update for {repo}: cannot generate private report links"
+        )
+    elif unknown_failures or known_failures:
         question += "\nDo you want to update PR CI comment?"
         if not UserPrompt.confirm(question):
             sys.exit(0)

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -314,6 +314,13 @@ Test output:
         _pr = pr_num if pr_num is not None else pr_number
         _sha = sha if sha is not None else head_sha
 
+        if UserPrompt.assume_yes:
+            print(
+                "WARNING: infrastructure issues require manual classification - "
+                "cannot create in non-interactive (--yes) mode, skipping"
+            )
+            return ""
+
         print(CreateIssue.repr_result(result))
 
         failure_reason = UserPrompt.get_string(
@@ -610,13 +617,56 @@ class CommitStatusCheck:
         return Result.from_file("/tmp/result_sync_pr.json")
 
     @staticmethod
-    def detect_pr_repo(pr_number) -> Optional[str]:
-        """Find which repo a PR number belongs to: public first, then private."""
+    def find_pr_states(pr_number) -> dict:
+        """Map each repo (public, private) that has this PR number to its state.
+
+        PR numbers are repo-local, so the same number can exist in both repos.
+        State is one of OPEN/CLOSED/MERGED; repos without the PR are omitted.
+        """
+        states = {}
         for repo in (PUBLIC_REPO, SYNC_REPO):
-            if Shell.check(
-                f"gh pr view {pr_number} --json number --repo {repo} > /dev/null 2>&1"
-            ):
-                return repo
+            raw = Shell.get_output(
+                f"gh pr view {pr_number} --json state --jq '.state' --repo {repo} 2>/dev/null"
+            )
+            if raw and raw.strip():
+                states[repo] = raw.strip()
+        return states
+
+    @staticmethod
+    def resolve_pr_repo(pr_number, repo_override=None) -> Optional[str]:
+        """Pick the repo to operate on for a PR number.
+
+        Honors an explicit override; otherwise prefers the repo where the PR is
+        open. Returns None when the number is open in both repos (ambiguous) or
+        does not exist in either.
+        """
+        states = CommitStatusCheck.find_pr_states(pr_number)
+        if repo_override:
+            if repo_override not in states:
+                print(f"ERROR: PR #{pr_number} not found in {repo_override}")
+                return None
+            return repo_override
+        if not states:
+            print(
+                f"ERROR: PR #{pr_number} not found in {PUBLIC_REPO} or {SYNC_REPO}"
+            )
+            return None
+        open_repos = [r for r, s in states.items() if s == "OPEN"]
+        if len(open_repos) > 1:
+            print(
+                f"ERROR: PR #{pr_number} is open in both {PUBLIC_REPO} and "
+                f"{SYNC_REPO}. Disambiguate with --repo public|private."
+            )
+            return None
+        if len(open_repos) == 1:
+            return open_repos[0]
+        # Not open anywhere: fall back to the sole repo that has it, else fail.
+        if len(states) == 1:
+            return next(iter(states))
+        print(
+            f"ERROR: PR #{pr_number} exists in both {PUBLIC_REPO} and {SYNC_REPO} "
+            f"but is open in neither. Disambiguate with --repo public|private."
+        )
         return None
 
 
@@ -854,10 +904,17 @@ def main():
         action="store_true",
         help="Answer all prompts automatically (non-interactive)",
     )
+    parser.add_argument(
+        "--repo",
+        choices=["public", "private"],
+        help="Repo the PR number belongs to. Required to disambiguate when the "
+        "same number exists in both repos; auto-detected otherwise.",
+    )
     args = parser.parse_args()
     create_infrastructure_issue = args.create_infrastructure_issue
     ci_only = args.ci_only
     UserPrompt.assume_yes = args.yes
+    repo_override = {"public": PUBLIC_REPO, "private": SYNC_REPO}.get(args.repo)
 
     # Check gh CLI version
     gh_version_output = Shell.get_output("gh --version")
@@ -922,11 +979,8 @@ def main():
     repo = PUBLIC_REPO
 
     if not is_master_commit:
-        repo = CommitStatusCheck.detect_pr_repo(pr_number)
+        repo = CommitStatusCheck.resolve_pr_repo(pr_number, repo_override)
         if not repo:
-            print(
-                f"ERROR: PR #{pr_number} not found in {PUBLIC_REPO} or {SYNC_REPO}"
-            )
             sys.exit(1)
         if repo != PUBLIC_REPO and not CommitStatusCheck.ensure_s3_proxy_reachable():
             print(f"Cannot fetch results for private PR #{pr_number} - aborting")
@@ -1106,7 +1160,10 @@ def main():
         else:
             sys.exit(0)
 
-    CommitStatusCheck.process_sync_status(sync_status, sha=head_sha, repo=repo)
+    # `CH Inc sync` only flows from public to private, so it exists only on
+    # public PRs.
+    if repo == PUBLIC_REPO:
+        CommitStatusCheck.process_sync_status(sync_status, sha=head_sha, repo=repo)
     CommitStatusCheck.process_mergeable_check_status(
         mergeable_check_status, sha=head_sha, repo=repo
     )

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -616,36 +616,62 @@ class CommitStatusCheck:
             return None
         return Result.from_file("/tmp/result_sync_pr.json")
 
-    @staticmethod
-    def find_pr_states(pr_number) -> dict:
-        """Map each repo (public, private) that has this PR number to its state.
+    # gh emits this exact GraphQL message only when the PR genuinely does not
+    # exist. Any other failure (inaccessible repo, auth, network) is a lookup
+    # error, not a definitive "absent", and must fail closed.
+    PR_NOT_FOUND_MARKER = "Could not resolve to a PullRequest"
 
-        PR numbers are repo-local, so the same number can exist in both repos.
-        State is one of OPEN/CLOSED/MERGED; repos without the PR are omitted.
+    @classmethod
+    def get_pr_state(cls, pr_number, repo):
+        """Look up a PR's state in one repo.
+
+        Returns (state, error): state is OPEN/CLOSED/MERGED or None when the PR
+        is genuinely absent; error is a message when the lookup itself failed
+        (and state is then None and must not be treated as "absent").
         """
-        states = {}
-        for repo in (PUBLIC_REPO, SYNC_REPO):
-            raw = Shell.get_output(
-                f"gh pr view {pr_number} --json state --jq '.state' --repo {repo} 2>/dev/null"
-            )
-            if raw and raw.strip():
-                states[repo] = raw.strip()
-        return states
+        rc, out, err = Shell.get_res_stdout_stderr(
+            f"gh pr view {pr_number} --json state --jq '.state' --repo {repo}",
+            verbose=False,
+        )
+        if rc == 0 and out.strip():
+            return out.strip(), None
+        if cls.PR_NOT_FOUND_MARKER in err:
+            return None, None
+        return None, err or f"gh pr view exited with code {rc}"
 
-    @staticmethod
-    def resolve_pr_repo(pr_number, repo_override=None) -> Optional[str]:
+    @classmethod
+    def resolve_pr_repo(cls, pr_number, repo_override=None) -> Optional[str]:
         """Pick the repo to operate on for a PR number.
 
         Honors an explicit override; otherwise prefers the repo where the PR is
-        open. Returns None when the number is open in both repos (ambiguous) or
-        does not exist in either.
+        open. Fails closed (returns None) when a lookup errors, when the number
+        is open in both repos (ambiguous), or when it does not exist in either.
         """
-        states = CommitStatusCheck.find_pr_states(pr_number)
         if repo_override:
-            if repo_override not in states:
+            state, error = cls.get_pr_state(pr_number, repo_override)
+            if error:
+                print(
+                    f"ERROR: failed to look up PR #{pr_number} in {repo_override}: {error}"
+                )
+                return None
+            if not state:
                 print(f"ERROR: PR #{pr_number} not found in {repo_override}")
                 return None
             return repo_override
+
+        states = {}
+        for repo in (PUBLIC_REPO, SYNC_REPO):
+            state, error = cls.get_pr_state(pr_number, repo)
+            if error:
+                print(
+                    f"ERROR: failed to look up PR #{pr_number} in {repo}: {error}\n"
+                    f"Cannot safely auto-detect the repo; "
+                    f"rerun with --repo public|private."
+                )
+                return None
+            if state:
+                states[repo] = state
+
         if not states:
             print(
                 f"ERROR: PR #{pr_number} not found in {PUBLIC_REPO} or {SYNC_REPO}"

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -138,6 +138,11 @@ class CreateIssue:
             validator=lambda x: x in result.info,
             default=failure_reason_default,
         )
+        if failure_reason is None:
+            print(
+                "WARNING: no failure reason could be determined automatically - skipping issue creation"
+            )
+            return ""
         if result.name.startswith("test_"):
             # pytest case
             test_name = UserPrompt.get_string(
@@ -392,7 +397,20 @@ Test output example:
 class CommitStatusCheck:
 
     @staticmethod
-    def get_ci_praktika_result(pr_number, commit_sha):
+    def get_ci_praktika_result(pr_number, commit_sha, repo=PUBLIC_REPO):
+        if repo != PUBLIC_REPO:
+            # Private repo results are not public; fetch them via the S3 proxy.
+            report_url = (
+                f"{S3_PROXY_BASE_URL}/{S3_PRIVATE_REPORT_BUCKET}"
+                f"/PRs/{pr_number}/{commit_sha}/result_pr.json"
+            )
+            if not Shell.check(
+                f"curl -f {report_url} -o /tmp/result_pr.json > /dev/null 2>&1"
+            ):
+                raise Exception(
+                    f"Failed to fetch private PR result from {report_url}"
+                )
+            return Result.from_file("/tmp/result_pr.json")
         if pr_number != 0:
             report_url = f"https://s3.amazonaws.com/clickhouse-test-reports/PRs/{pr_number}/{commit_sha}/result_pr.json"
         else:
@@ -401,7 +419,34 @@ class CommitStatusCheck:
         return Result.from_file("/tmp/result_pr.json")
 
     @staticmethod
-    def process_sync_status(commit_status_data: Optional[GH.CommitStatus], sha: str):
+    def ensure_s3_proxy_reachable() -> bool:
+        """
+        Check that the private-reports S3 proxy is reachable, prompting the user
+        to connect to VPN/Tailscale and retry. Returns False if the user skips.
+        """
+        while True:
+            if Shell.check(
+                f"curl -sf --connect-timeout 5 {S3_PROXY_BASE_URL} -o /dev/null 2>&1"
+            ):
+                return True
+            print(
+                f"WARNING: S3 proxy at {S3_PROXY_BASE_URL} is not reachable. "
+                "Connect to VPN/Tailscale to access private repo results."
+            )
+            answer = UserPrompt.select_from_menu(
+                [
+                    ("Skip", "skip"),
+                    ("Retry (after connecting to VPN)", "retry"),
+                ],
+                question="S3 proxy is not available",
+            )
+            if answer[1] == "skip":
+                return False
+
+    @staticmethod
+    def process_sync_status(
+        commit_status_data: Optional[GH.CommitStatus], sha: str, repo: str = PUBLIC_REPO
+    ):
         if not commit_status_data:
             if not UserPrompt.confirm(
                 "CH Inc sync status is missing. Override to success?"
@@ -413,7 +458,7 @@ class CommitStatusCheck:
                 "Manually overridden",
                 "",
                 sha=sha,
-                repo="ClickHouse/ClickHouse",
+                repo=repo,
             )
             return
         if commit_status_data.state in (Result.GHStatus.SUCCESS,):
@@ -430,7 +475,7 @@ class CommitStatusCheck:
                         "Ignored",
                         commit_status_data.url,
                         sha=sha,
-                        repo="ClickHouse/ClickHouse",
+                        repo=repo,
                     )
                 else:
                     sys.exit(0)
@@ -451,7 +496,7 @@ class CommitStatusCheck:
                         "Ignored",
                         commit_status_data.url,
                         sha=sha,
-                        repo="ClickHouse/ClickHouse",
+                        repo=repo,
                     )
                 else:
                     sys.exit(0)
@@ -463,7 +508,7 @@ class CommitStatusCheck:
 
     @staticmethod
     def process_mergeable_check_status(
-        commit_status_data: Optional[GH.CommitStatus], sha: str
+        commit_status_data: Optional[GH.CommitStatus], sha: str, repo: str = PUBLIC_REPO
     ):
         override = False
         if commit_status_data and commit_status_data.state in (Result.GHStatus.SUCCESS,):
@@ -486,23 +531,24 @@ class CommitStatusCheck:
                 "Manually overridden",
                 "",
                 sha=sha,
-                repo="ClickHouse/ClickHouse",
+                repo=repo,
             )
 
     @classmethod
-    def get_commit_statuses(cls, head_sha: str) -> dict:
+    def get_commit_statuses(cls, head_sha: str, repo: str = PUBLIC_REPO) -> dict:
         """
         Fetch and filter commit statuses for the given commit SHA.
 
         Args:
             head_sha: The commit SHA to fetch statuses for
+            repo: GitHub repository to fetch statuses from
 
         Returns:
             Dictionary mapping status context names to GH.CommitStatus objects
         """
         # Get commit statuses with pagination
         statuses_list = Shell.get_output(
-            f"gh api repos/ClickHouse/ClickHouse/commits/{head_sha}/statuses --paginate"
+            f"gh api repos/{repo}/commits/{head_sha}/statuses --paginate"
         )
         statuses_list = json.loads(statuses_list)
 
@@ -562,6 +608,16 @@ class CommitStatusCheck:
             print(f"WARNING: Failed to fetch sync PR result from {report_url}")
             return None
         return Result.from_file("/tmp/result_sync_pr.json")
+
+    @staticmethod
+    def detect_pr_repo(pr_number) -> Optional[str]:
+        """Find which repo a PR number belongs to: public first, then private."""
+        for repo in (PUBLIC_REPO, SYNC_REPO):
+            if Shell.check(
+                f"gh pr view {pr_number} --json number --repo {repo} > /dev/null 2>&1"
+            ):
+                return repo
+        return None
 
 
 issues_created = 0
@@ -785,8 +841,23 @@ def main():
         action="store_true",
         help="Create infrastructure issues for failures",
     )
+    parser.add_argument(
+        "--ci-only",
+        "--no-merge",
+        action="store_true",
+        dest="ci_only",
+        help="Only analyze CI and create issues; do not override statuses or merge",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Answer all prompts automatically (non-interactive)",
+    )
     args = parser.parse_args()
     create_infrastructure_issue = args.create_infrastructure_issue
+    ci_only = args.ci_only
+    UserPrompt.assume_yes = args.yes
 
     # Check gh CLI version
     gh_version_output = Shell.get_output("gh --version")
@@ -847,14 +918,27 @@ def main():
         else:
             pr_number = selected_pr[1]
 
+    # Default repo for the master-commit path; PR path detects it below.
+    repo = PUBLIC_REPO
+
     if not is_master_commit:
-        pr_url = f"https://github.com/ClickHouse/ClickHouse/pull/{pr_number}"
+        repo = CommitStatusCheck.detect_pr_repo(pr_number)
+        if not repo:
+            print(
+                f"ERROR: PR #{pr_number} not found in {PUBLIC_REPO} or {SYNC_REPO}"
+            )
+            sys.exit(1)
+        if repo != PUBLIC_REPO and not CommitStatusCheck.ensure_s3_proxy_reachable():
+            print(f"Cannot fetch results for private PR #{pr_number} - aborting")
+            sys.exit(1)
+        print(f"PR #{pr_number} found in {repo}")
+        pr_url = f"https://github.com/{repo}/pull/{pr_number}"
         pr_data = Shell.get_output(
-            f"gh pr view {pr_number} --json headRefOid,headRefName --repo ClickHouse/ClickHouse"
+            f"gh pr view {pr_number} --json headRefOid,headRefName --repo {repo}"
         )
         pr_data = json.loads(pr_data)
         head_sha = pr_data["headRefOid"]
-        if GH.pr_has_conflicts(pr_number, "ClickHouse/ClickHouse"):
+        if GH.pr_has_conflicts(pr_number, repo):
             print("PR has conflicts, cannot merge")
             sys.exit(1)
     else:
@@ -866,7 +950,7 @@ def main():
     print(f"CI Report: {CreateIssue.get_job_report_url(pr_number, head_sha)}")
 
     if not is_master_commit:
-        status_map = CommitStatusCheck.get_commit_statuses(head_sha)
+        status_map = CommitStatusCheck.get_commit_statuses(head_sha, repo=repo)
         sync_status = status_map.get(CheckStatuses.CH_INC_SYNC)
         mergeable_check_status = status_map.get(CheckStatuses.MERGEABLE_CHECK)
         if (
@@ -886,7 +970,7 @@ def main():
         mergeable_check_status = None
 
     workflow_result = CommitStatusCheck.get_ci_praktika_result(
-        pr_number if not is_master_commit else 0, head_sha
+        pr_number if not is_master_commit else 0, head_sha, repo=repo
     ).to_failed_results_with_flat_leaves()
 
     global ci_start_time
@@ -895,7 +979,7 @@ def main():
     known_failures, unknown_failures, not_finished_jobs, new_issues_count = (
         process_workflow_failures(
             workflow_result,
-            PUBLIC_REPO,
+            repo,
             pr_number,
             head_sha,
             allow_infra_issues=create_infrastructure_issue,
@@ -914,34 +998,16 @@ def main():
     sync_known_failures = []
     sync_unknown_failures = []
     if (
-        sync_status
+        repo == PUBLIC_REPO
+        and sync_status
         and sync_status.state == Result.GHStatus.FAILURE
         and sync_status.description == "tests failed"
     ):
         print("\n=== Processing Sync PR (CH Inc sync) failures ===")
 
-        # Check proxy connectivity before proceeding
-        process_sync = False
-        while True:
-            if Shell.check(
-                f"curl -sf --connect-timeout 5 {S3_PROXY_BASE_URL} -o /dev/null 2>&1"
-            ):
-                process_sync = True
-                break
-            print(
-                f"WARNING: S3 proxy at {S3_PROXY_BASE_URL} is not reachable. "
-                "Connect to VPN/Tailscale to access sync PR results."
-            )
-            answer = UserPrompt.select_from_menu(
-                [
-                    ("Skip sync PR processing", "skip"),
-                    ("Retry (after connecting to VPN)", "retry"),
-                ],
-                question="S3 proxy is not available",
-            )
-            if answer[1] == "skip":
-                print("Skipping sync PR processing")
-                break
+        process_sync = CommitStatusCheck.ensure_s3_proxy_reachable()
+        if not process_sync:
+            print("Skipping sync PR processing")
 
         if process_sync:
             sync_pr_info = CommitStatusCheck.get_sync_pr_info(pr_number)
@@ -989,7 +1055,8 @@ def main():
         if known_failures:
             question += f" - {len(known_failures)} known failure{'s' if len(known_failures) != 1 else ''}\n"
         question += " - all other checks passed\n"
-        question += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
+        if sync_status:
+            question += f" - Sync status: {sync_status.state}, description: {sync_status.description}\n"
         if sync_known_failures or sync_unknown_failures:
             question += f" - Sync failures: {len(sync_known_failures)} known, {len(sync_unknown_failures)} unknown\n"
     else:
@@ -1009,7 +1076,7 @@ def main():
             if not GH.post_updateable_comment(
                 comment_tags_and_bodies={"summary": summary_body},
                 pr=pr_number,
-                repo="ClickHouse/ClickHouse",
+                repo=repo,
                 only_update=True,
                 verbose=False,
             ):
@@ -1018,26 +1085,30 @@ def main():
             print(f"ERROR: failed to post CI summary, ex: {e}")
             traceback.print_exc()
 
+    if ci_only:
+        print("\n--ci-only: skipping merge queue. Done.")
+        sys.exit(0)
+
     if not UserPrompt.confirm(
         f"Add PR #{pr_number} to the merge queue (y - continue, n - exit)?"
     ):
         sys.exit(0)
 
     if Shell.check(
-        f"gh pr view {pr_number} --json isDraft --jq '.isDraft' --repo ClickHouse/ClickHouse | grep -q true"
+        f"gh pr view {pr_number} --json isDraft --jq '.isDraft' --repo {repo} | grep -q true"
     ):
         if UserPrompt.confirm(f"It's a draft PR. Do you want to undraft it?"):
             Shell.check(
-                f"gh pr ready {pr_number} --repo ClickHouse/ClickHouse",
+                f"gh pr ready {pr_number} --repo {repo}",
                 strict=True,
                 verbose=True,
             )
         else:
             sys.exit(0)
 
-    CommitStatusCheck.process_sync_status(sync_status, sha=head_sha)
+    CommitStatusCheck.process_sync_status(sync_status, sha=head_sha, repo=repo)
     CommitStatusCheck.process_mergeable_check_status(
-        mergeable_check_status, sha=head_sha
+        mergeable_check_status, sha=head_sha, repo=repo
     )
 
     # `gh pr merge --auto` calls the `enablePullRequestAutoMerge` mutation,
@@ -1045,7 +1116,7 @@ def main():
     # `enqueuePullRequest` directly: it is the mutation the "Merge when ready"
     # button on github.com uses.
     pr_node_id = Shell.get_output(
-        f"gh pr view {pr_number} --json id --jq '.id' --repo ClickHouse/ClickHouse"
+        f"gh pr view {pr_number} --json id --jq '.id' --repo {repo}"
     ).strip()
     if not pr_node_id:
         print(f"ERROR: Failed to fetch node ID for PR #{pr_number}")
@@ -1072,7 +1143,7 @@ def main():
     # actually landed in the queue.
     time.sleep(5)
     merge_status = Shell.get_output(
-        f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo ClickHouse/ClickHouse"
+        f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo {repo}"
     )
     if merge_status == "QUEUED":
         print(f"OK: PR #{pr_number} added to the merge queue")

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -720,6 +720,9 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
     failures_to_process = []
     unknown_failures = []
     issues_created_count = 0
+    # Cleared if a catalog refresh fails, so we never auto-create issues against
+    # an untrustworthy (possibly empty) set of known issues.
+    catalog_trusted = True
 
     # Check if workflow has unknown failures before matching against open issues
     workflow_has_unknown_failures = False
@@ -758,9 +761,15 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
             not issue_catalog
             or issue_catalog.updated_at < datetime.now().timestamp() - 10 * 60
         ):
-            issue_catalog = TestCaseIssueCatalog.from_gh(verbose=False, repo=repo)
-            issue_catalog.name = catalog_name
-            issue_catalog.dump()
+            try:
+                issue_catalog = TestCaseIssueCatalog.from_gh(verbose=False, repo=repo)
+                issue_catalog.name = catalog_name
+                issue_catalog.dump()
+            except Exception as e:
+                print(f"ERROR: failed to load issue catalog from {repo}: {e}")
+                catalog_trusted = False
+                if not issue_catalog:
+                    issue_catalog = TestCaseIssueCatalog()
         print(f"Loaded {len(issue_catalog.active_test_issues)} active issues from {repo}\n")
 
         # For non-public repos, also load public repo issues since the same flaky
@@ -777,10 +786,18 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
                 or public_catalog.updated_at
                 < datetime.now().timestamp() - 10 * 60
             ):
-                public_catalog = TestCaseIssueCatalog.from_gh(
-                    verbose=False, repo=PUBLIC_REPO
-                )
-                public_catalog.dump()
+                try:
+                    public_catalog = TestCaseIssueCatalog.from_gh(
+                        verbose=False, repo=PUBLIC_REPO
+                    )
+                    public_catalog.dump()
+                except Exception as e:
+                    print(
+                        f"ERROR: failed to load issue catalog from {PUBLIC_REPO}: {e}"
+                    )
+                    catalog_trusted = False
+                    if not public_catalog:
+                        public_catalog = TestCaseIssueCatalog()
             print(
                 f"Loaded {len(public_catalog.active_test_issues)} active issues from {PUBLIC_REPO}\n"
             )
@@ -825,6 +842,14 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
                         unknown_failures.append((result.name, sub_result))
                         continue
                     failures_to_process.append((result.name, sub_result))
+
+    if failures_to_process and not catalog_trusted:
+        print(
+            "\nWARNING: the issue catalog could not be reliably loaded; "
+            "skipping automatic issue creation to avoid filing duplicates."
+        )
+        unknown_failures.extend(failures_to_process)
+        failures_to_process = []
 
     if not_finished_jobs:
         if not UserPrompt.confirm(

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -920,7 +920,8 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
                     print("WARNING: Issue has not been created - skipping this failure")
                     unknown_failures.append((job_name, failure_result))
                 # Let user read resolution before moving to the next failure
-                time.sleep(3)
+                if not UserPrompt.assume_yes:
+                    time.sleep(3)
             else:
                 unknown_failures.append((job_name, failure_result))
 
@@ -1233,6 +1234,17 @@ def main():
         print("\n--ci-only: skipping merge queue. Done.")
         sys.exit(0)
 
+    # Unknown failures are CI failures that were neither matched to an existing
+    # issue nor filed as a new one, so the PR is not triaged. Never enqueue past
+    # them in non-interactive mode; fail closed instead.
+    total_unknown = len(unknown_failures) + len(sync_unknown_failures)
+    if UserPrompt.assume_yes and total_unknown:
+        print(
+            f"\nERROR: {total_unknown} unknown failure(s) were not matched to or filed "
+            f"as an issue; refusing to enqueue in non-interactive (--yes) mode."
+        )
+        sys.exit(1)
+
     if not UserPrompt.confirm(
         f"Add PR #{pr_number} to the merge queue (y - continue, n - exit)?"
     ):
@@ -1241,6 +1253,14 @@ def main():
     if Shell.check(
         f"gh pr view {pr_number} --json isDraft --jq '.isDraft' --repo {repo} | grep -q true"
     ):
+        # A draft PR is explicitly marked not-ready by its author; undrafting and
+        # merging it is a deliberate decision, never something --yes should do.
+        if UserPrompt.assume_yes:
+            print(
+                "ERROR: PR is a draft; refusing to undraft and merge it in "
+                "non-interactive (--yes) mode."
+            )
+            sys.exit(1)
         if UserPrompt.confirm(f"It's a draft PR. Do you want to undraft it?"):
             Shell.check(
                 f"gh pr ready {pr_number} --repo {repo}",

--- a/ci/praktika/interactive.py
+++ b/ci/praktika/interactive.py
@@ -8,6 +8,11 @@ import sys
 class UserPrompt:
     """Provides interactive prompts for user input in terminal."""
 
+    # When set, prompts are answered automatically: confirmations return True,
+    # menus return their first item, and string prompts return their default
+    # (or None when no default is available).
+    assume_yes = False
+
     @staticmethod
     def _safe_input(prompt):
         try:
@@ -34,6 +39,12 @@ class UserPrompt:
             menu_map[i] = item
             val = item[0] if isinstance(item, tuple) else item
             print(f"{i}. {val}")
+
+        if UserPrompt.assume_yes:
+            selected_item = menuitems[0]
+            val = selected_item[0] if isinstance(selected_item, tuple) else selected_item
+            print(f"\n{question}: {val} [auto]")
+            return selected_item
 
         while True:
             try:
@@ -89,6 +100,9 @@ class UserPrompt:
         Returns:
             True for yes, False for no, None if cancelled.
         """
+        if UserPrompt.assume_yes:
+            print(f"\n{question} (y/n): y [auto]")
+            return True
         while True:
             choice = UserPrompt._safe_input(f"\n{question} (y/n): ")
             if choice.lower() in ("y", "yes"):
@@ -115,6 +129,13 @@ class UserPrompt:
         if default is not None:
             prompt += f" (default: {default})"
         prompt += ": "
+
+        if UserPrompt.assume_yes:
+            if default is not None and validator(default):
+                print(f"{prompt}{default} [auto]")
+                return default
+            print(f"{prompt}<no default available, skipping> [auto]")
+            return None
 
         while True:
             try:

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -56,34 +57,45 @@ def fetch_github_issues(
         base_cmd = f"gh issue list {repo_arg} {label_args} --state {state} --json number,title,body,closedAt,labels,url --limit {limit_per_request}"
         print(f"Fetching {state} issues with label '{label}'...")
 
-    try:
-        output = Shell.get_output(base_cmd, verbose=True)
+    # Fail closed: a failed lookup must raise rather than look like "no issues",
+    # otherwise callers would treat the catalog as empty and could create
+    # duplicate issues. A genuinely empty result (exit 0, empty/`[]` output) is
+    # distinct from a fetch error (non-zero exit).
+    last_error = ""
+    for attempt in range(3):
+        returncode, output, stderr = Shell.get_res_stdout_stderr(
+            base_cmd, verbose=(attempt == 0)
+        )
+        if returncode == 0:
+            break
+        last_error = stderr or f"exit code {returncode}"
+        print(f"WARNING: 'gh issue list' failed (attempt {attempt + 1}/3): {last_error}")
+        if attempt < 2:
+            time.sleep(2 * (attempt + 1))
+    else:
+        raise RuntimeError(
+            f"Failed to fetch issues for label '{label}' from GitHub: {last_error}"
+        )
 
-        if not output or not output.strip():
-            print(f"  No issues found for label '{label}' with state '{state}'")
-            return []
-
-        issues = json.loads(output)
-        if not issues:
-            print(f"  No issues found for label '{label}' with state '{state}'")
-            return []
-
-        all_issues.extend(issues)
-        print(f"  Found {len(all_issues)} issues")
-
-        # If the limit was hit, print a warning — there may be more issues to page
-        if len(issues) == limit_per_request:
-            print(
-                f"  WARNING: Reached limit of {limit_per_request} issues. There may be more issues not fetched."
-            )
-
-        return all_issues
-    except json.JSONDecodeError as e:
-        print(f"ERROR: Failed to parse JSON response for label '{label}': {e}")
+    if not output or not output.strip():
+        print(f"  No issues found for label '{label}' with state '{state}'")
         return []
-    except Exception as e:
-        print(f"ERROR: Failed to fetch issues with label '{label}': {e}")
+
+    issues = json.loads(output)
+    if not issues:
+        print(f"  No issues found for label '{label}' with state '{state}'")
         return []
+
+    all_issues.extend(issues)
+    print(f"  Found {len(all_issues)} issues")
+
+    # If the limit was hit, print a warning — there may be more issues to page
+    if len(issues) == limit_per_request:
+        print(
+            f"  WARNING: Reached limit of {limit_per_request} issues. There may be more issues not fetched."
+        )
+
+    return all_issues
 
 
 class IssueLabels:


### PR DESCRIPTION
Three improvements to the `check_ci.py` helper:

- Auto-detect whether a PR number belongs to `ClickHouse/ClickHouse` or `ClickHouse/clickhouse-private` and run the analysis against whichever repo it lives in. Private-PR results are fetched via the S3 proxy and matched against the private issue catalog; the `CH Inc sync` step is skipped (sync only flows public to private).
- `--ci-only` (alias `--no-merge`): run CI analysis, issue creation, and the PR CI-comment update, then stop before any merge action.
- `--yes`/`-y`: answer all prompts automatically. The flaky-test issue creator skips a failure when no reason can be determined automatically rather than filing a malformed issue.

Together, `check_ci.py <pr> --ci-only --yes` finds or files issues for a PR in either repo with no further input.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...