### PR TITLE
Fix REPLACE PARTITION resurrecting replaced parts after restart

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5656,7 +5656,7 @@ void MergeTreeData::removePartsFromWorkingSet(
 
 void MergeTreeData::removePartsInRangeFromWorkingSet(MergeTreeTransaction * txn, const MergeTreePartInfo & drop_range, DataPartsLock & lock)
 {
-    removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper(txn, drop_range, lock, /*create_empty_part*/ false);
+    removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper(txn, drop_range, lock, /*create_empty_part*/ true);
 }
 
 DataPartsVector MergeTreeData::grabActivePartsToRemoveForDropRange(
@@ -5771,11 +5771,15 @@ MergeTreeData::PartsToRemoveFromZooKeeper MergeTreeData::removePartsInRangeFromW
     /// if we remove a range from the middle when dropping a part).
     /// Maybe we could do it by incrementing mutation version to get a name for the empty covering part,
     /// but it's okay to simply avoid creating it for DROP PART (for a part in the middle).
-    /// NOTE: Block numbers in ReplicatedMergeTree start from 0. For MergeTree, is_new_syntax is always false.
-    chassert(!create_empty_part || supportsReplication());
+    /// NOTE: Both ReplicatedMergeTree DROP/REPLACE and plain MergeTree REPLACE PARTITION rely on this
+    /// empty covering part so that the removed parts are not resurrected as active after a restart.
+    /// It is gated on is_new_syntax (block numbers start from 0); old-format MergeTree tables are skipped.
     bool range_in_the_middle = drop_range.min_block;
     bool is_new_syntax = format_version >= MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING;
-    if (create_empty_part && !parts_to_remove.empty() && is_new_syntax && !range_in_the_middle)
+    /// Under a running MVCC transaction the removed parts keep their version metadata (creation/removal CSN
+    /// persisted on disk), which already prevents them from being resurrected on restart, so no covering part
+    /// is needed (mirrors plain MergeTree DROP PARTITION, which only covers parts in its non-transaction path).
+    if (create_empty_part && !txn && !parts_to_remove.empty() && is_new_syntax && !range_in_the_middle)
     {
         /// We are going to remove a lot of parts from zookeeper just after returning from this function.
         /// And we will remove parts from disk later (because some queries may use them).

--- a/tests/queries/0_stateless/04338_replace_partition_no_resurrect_after_restart.reference
+++ b/tests/queries/0_stateless/04338_replace_partition_no_resurrect_after_restart.reference
@@ -1,0 +1,4 @@
+before restart
+1	2
+after restart
+1	2

--- a/tests/queries/0_stateless/04338_replace_partition_no_resurrect_after_restart.sql
+++ b/tests/queries/0_stateless/04338_replace_partition_no_resurrect_after_restart.sql
@@ -1,0 +1,36 @@
+-- Tags: no-replicated-database, no-shared-merge-tree, no-parallel-replicas
+-- SharedMergeTree doesn't support replace partition from MergeTree engine
+
+-- REPLACE PARTITION must not resurrect the replaced-out parts after a restart.
+-- Before the fix the old parts were only deactivated in memory (no covering part on disk),
+-- so reloading parts from disk (here via DETACH/ATTACH, same code path as a server restart)
+-- made them active again and the table returned both the replacement and the stale rows.
+
+DROP TABLE IF EXISTS t_dst;
+DROP TABLE IF EXISTS t_src;
+
+CREATE TABLE t_dst (k UInt32, v UInt32) ENGINE = MergeTree ORDER BY k PARTITION BY k;
+CREATE TABLE t_src (k UInt32, v UInt32) ENGINE = MergeTree ORDER BY k PARTITION BY k;
+
+-- Keep the replaced-out part on disk until the simulated restart (otherwise background
+-- cleanup may remove it first and hide the bug, which is exactly the reported workaround).
+SYSTEM STOP CLEANUP t_dst;
+SYSTEM STOP MERGES t_dst;
+
+INSERT INTO t_dst VALUES (1, 1);
+INSERT INTO t_src VALUES (1, 2);
+
+ALTER TABLE t_dst REPLACE PARTITION ID '1' FROM t_src;
+
+SELECT 'before restart';
+SELECT * FROM t_dst ORDER BY v;
+
+-- DETACH + ATTACH rebuilds the active part set from disk, just like a server restart.
+DETACH TABLE t_dst;
+ATTACH TABLE t_dst;
+
+SELECT 'after restart';
+SELECT * FROM t_dst ORDER BY v;
+
+DROP TABLE t_dst;
+DROP TABLE t_src;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107605
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/107605

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ALTER TABLE ... REPLACE PARTITION` on a plain `MergeTree` table resurrecting the replaced-out parts after a server restart, which made the table return both the replacement rows and the stale replaced rows.

### Description

On a plain `MergeTree` table `REPLACE PARTITION` only deactivated the replaced-out parts in memory and did not leave a covering part on disk. If the server restarted before background cleanup removed those parts, they were loaded as active again, so the table silently returned both the replacement rows and the stale rows.

`DROP PARTITION` does not have this problem: it covers the removed parts with an empty part on disk, so on restart the removed parts are loaded as outdated. This fix makes `REPLACE PARTITION` reuse the same empty-covering-part mechanism that `ReplicatedMergeTree` DROP/REPLACE_RANGE already uses.

Change: `removePartsInRangeFromWorkingSet` (called only by `StorageMergeTree::replacePartitionFrom`) now passes `create_empty_part = true`. The empty-part creation in `removePartsInRangeFromWorkingSetAndGetPartsToRemoveFromZooKeeper` is gated on `!txn`, because under a running MVCC transaction the removed parts keep their persisted version metadata and are not resurrected. All `ReplicatedMergeTree` callers pass a null transaction, so their behavior is unchanged.

The empty covering part is named from the removed range only (for example `19700101_1_2_1`), so it covers the replaced-out parts but not the new replacement parts. The existing cleanup ordering (remove covered parts first, then the empty covering part) keeps it from leaking.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.962`
<!-- ch-version-info:end -->