### PR TITLE
Make server-side AST fuzzer respect KILL, timeout and shutdown

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1,4 +1,5 @@
 #include <Common/DateLUTImpl.h>
+#include <Common/CurrentMetrics.h>
 #include <Common/CurrentThread.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
@@ -115,6 +116,11 @@ namespace ProfileEvents
     extern const Event InsertQueryTimeMicroseconds;
     extern const Event OtherQueryTimeMicroseconds;
     extern const Event ASTFuzzerQueries;
+}
+
+namespace CurrentMetrics
+{
+    extern const Metric IsServerShuttingDown;
 }
 
 namespace DB
@@ -2054,19 +2060,28 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
     auto logger = getLogger("ASTFuzzer");
 
     /// The fuzzer runs as a query finish callback, after the outer query's pipeline executor
-    /// has stopped enforcing limits. Without this check the outer query keeps spawning fuzzed
-    /// queries while ignoring its own deadline, a KILL, or server shutdown (which kills all
-    /// queries), so it lingers in the processlist and can trip the stress test hung check.
-    /// checkTimeLimitSoft returns false on any of these without throwing.
+    /// has stopped enforcing limits. Without these checks the outer query keeps spawning fuzzed
+    /// queries while ignoring its own deadline, a KILL, or server shutdown, so it lingers in the
+    /// processlist and can trip the stress test hung check.
+    /// Some fuzzable queries (e.g. SHOW PROCESSLIST) are not inserted into the ProcessList, so
+    /// the deadline/KILL check via checkTimeLimitSoft is unavailable; the shutdown metric still
+    /// stops the loop in that case.
     QueryStatusPtr process_list_element = context->getProcessListElement();
 
     ASTPtr base_ast = ast;
 
     for (size_t i = 0; i < num_runs; ++i)
     {
+        if (CurrentMetrics::get(CurrentMetrics::IsServerShuttingDown))
+        {
+            LOG_TRACE(logger, "Stopping AST fuzzer: the server is shutting down");
+            break;
+        }
+
+        /// checkTimeLimitSoft returns false without throwing on a KILL or the outer deadline.
         if (process_list_element && !process_list_element->checkTimeLimitSoft())
         {
-            LOG_TRACE(logger, "Stopping AST fuzzer: outer query was killed, timed out, or the server is shutting down");
+            LOG_TRACE(logger, "Stopping AST fuzzer: outer query was killed or timed out");
             break;
         }
 

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -2053,10 +2053,23 @@ static void executeASTFuzzerQueries(const ASTPtr & ast, const ContextMutablePtr 
 
     auto logger = getLogger("ASTFuzzer");
 
+    /// The fuzzer runs as a query finish callback, after the outer query's pipeline executor
+    /// has stopped enforcing limits. Without this check the outer query keeps spawning fuzzed
+    /// queries while ignoring its own deadline, a KILL, or server shutdown (which kills all
+    /// queries), so it lingers in the processlist and can trip the stress test hung check.
+    /// checkTimeLimitSoft returns false on any of these without throwing.
+    QueryStatusPtr process_list_element = context->getProcessListElement();
+
     ASTPtr base_ast = ast;
 
     for (size_t i = 0; i < num_runs; ++i)
     {
+        if (process_list_element && !process_list_element->checkTimeLimitSoft())
+        {
+            LOG_TRACE(logger, "Stopping AST fuzzer: outer query was killed, timed out, or the server is shutting down");
+            break;
+        }
+
         ASTPtr fuzzed_ast;
         NameToNameMap fuzzed_query_params;
         {


### PR DESCRIPTION
The server-side AST fuzzer (`ast_fuzzer_runs`) runs as a query finish callback, after the outer query's pipeline executor has stopped enforcing limits. The fuzzing loop never consulted the outer query status, so it ignored a `KILL QUERY`, the outer `max_execution_time`, and server shutdown (which cancels all running queries). The outer query then kept spawning fuzzed queries and lingered in the processlist, which can trigger a false-positive stress test hung check.

Now `QueryStatus::checkTimeLimitSoft` is checked at the top of each fuzzing iteration. It returns false without throwing on a kill, on the outer query's time limit, or on shutdown (`ProcessList::killAllQueries` marks every query killed), so the loop stops promptly.

Observed in the stress test hung check of an unrelated PR (https://github.com/ClickHouse/ClickHouse/pull/107475):
https://s3.amazonaws.com/clickhouse-test-reports/PRs/107475/6271a231daa9d7adfda7f2c725b71ef672a3feb1/stress_test_arm_asan_ubsan_s3/hung_check.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
