### PR TITLE
Fix missing new line for stacktraces dump on hungs on CI

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -875,7 +875,7 @@ def get_processlist_with_stacktraces(args):
                 arrayStringConcat(groupArray('Thread ID ' || toString(s.thread_id) || '\n' || arrayStringConcat(arrayMap(
                     x -> concat(addressToLine(x), '::', demangle(addressToSymbol(x))),
                     s.trace), '\n') AS stacktrace
-                )) AS stacktraces
+                ), '\n') AS stacktraces
             FROM system.processes p
             JOIN system.stack_trace s USING (query_id)
             WHERE query NOT LIKE '%system.processes%'
@@ -901,7 +901,7 @@ def get_processlist_with_stacktraces(args):
                 arrayStringConcat(groupArray('Thread ID ' || toString(s.thread_id) || '\n' || arrayStringConcat(arrayMap(
                     x -> concat(addressToLine(x), '::', demangle(addressToSymbol(x))),
                     s.trace), '\n') AS stacktrace
-                )) AS stacktraces
+                ), '\n') AS stacktraces
             FROM system.processes p
             JOIN system.stack_trace s USING (query_id)
             WHERE query NOT LIKE '%system.processes%'
@@ -923,7 +923,7 @@ def get_processlist_with_stacktraces(args):
             arrayStringConcat(groupArray('Thread ID ' || toString(s.thread_id) || '\n' || arrayStringConcat(arrayMap(
                 x -> concat(addressToLine(x), '::', demangle(addressToSymbol(x))),
                 s.trace), '\n') AS stacktrace
-            )) AS stacktraces
+            ), '\n') AS stacktraces
         FROM system.processes p
         JOIN system.stack_trace s USING (query_id)
         WHERE query NOT LIKE '%system.processes%'


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.889`
<!-- ch-version-info:end -->