### PR TITLE
Fix Block structure mismatch inserting into materialized view with wider target Enum

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -14,6 +14,7 @@
 #include <Storages/StorageMaterializedView.h>
 #include <Storages/StorageValues.h>
 
+#include <DataTypes/DataTypeEnum.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/addMissingDefaults.h>
 #include <Interpreters/createSubcolumnsExtractionActions.h>
@@ -147,6 +148,41 @@ size_t capMinBlockSizeBytesForMemoryLimit(size_t value)
     if (auto memory_limit = total_memory_tracker.getHardLimit(); memory_limit > 0)
         return std::min<size_t>(value, static_cast<size_t>(static_cast<double>(memory_limit) * 0.9) / 8);
     return value;
+}
+
+/// True when `target` is an Enum that contains `source` with the same in-memory width, i.e. `source`
+/// is a narrower Enum whose members are a subset of `target`. This mirrors the compatibility that
+/// StorageInMemoryMetadata::check allows but that is not type equality.
+bool isWidenedEnumTarget(const IDataType & target, const IDataType & source)
+{
+    if (const auto * enum_type = dynamic_cast<const IDataTypeEnum *>(&target))
+        return enum_type->contains(source) && enum_type->getMaximumSizeOfValueInMemory() == source.getMaximumSizeOfValueInMemory();
+    return false;
+}
+
+/// Return the input columns with only the Enum-widening ones retyped to their target. That pair is
+/// the single case the metadata check accepts as compatible while the column keeps its narrow type,
+/// so it must be converted here or the chain trips the structure-equality check at the sink. Every
+/// other pair is left untouched, so genuine mismatches still raise TYPE_MISMATCH at the check and a
+/// Nullable column feeding a non-Nullable one under insert_null_as_default is still defaulted by the
+/// defaults step (which needs it to stay Nullable).
+ColumnsWithTypeAndName mapWidenedEnumColumnsToTargetTypes(const Block & input, const Block & output)
+{
+    const auto & dst = output.getColumnsWithTypeAndName();
+    NameToIndexMap name_to_index_dst_map;
+    for (size_t i = 0; i < dst.size(); ++i)
+        name_to_index_dst_map[dst[i].name] = i;
+
+    ColumnsWithTypeAndName result;
+    for (const auto & column : input.getColumnsWithTypeAndName())
+    {
+        auto it = name_to_index_dst_map.find(column.name);
+        if (it != name_to_index_dst_map.end() && isWidenedEnumTarget(*dst[it->second].type, *column.type))
+            result.push_back(dst[it->second]);
+        else
+            result.push_back(column);
+    }
+    return result;
 }
 }
 
@@ -1394,8 +1430,20 @@ Chain InsertDependenciesBuilder::createPreSink(StorageIDMaybeEmpty view_id) cons
     if (auto * merge_tree = dynamic_cast<MergeTreeData *>(storages.at(inner_table_id).get()))
         inner_share_nested_offsets = (*merge_tree->getSettings())[MergeTreeSetting::share_nested_offsets];
 
+    /// Widen Enum columns to their target type before adding defaults, so the valid Enum-widening
+    /// conversion is applied here rather than tripping the structure-equality check when this chain
+    /// connects to the sink built from the target header. addMissingDefaults only fills columns that
+    /// are absent from the input, never retypes present ones.
+    auto to_convert = mapWidenedEnumColumnsToTargetTypes(*input_headers.at(view_id), *output_header);
+
+    auto converting_types_dag = ActionsDAG::makeConvertingActions(
+        input_headers.at(view_id)->getColumnsWithTypeAndName(),
+        to_convert,
+        ActionsDAG::MatchColumnsMode::Name,
+        insert_context);
+
     auto adding_missing_defaults_dag = addMissingDefaults(
-        *input_headers.at(view_id),
+        Block(to_convert),
         output_header->getNamesAndTypesList(),
         inner_metadata->getColumns(),
         insert_context,
@@ -1403,11 +1451,13 @@ Chain InsertDependenciesBuilder::createPreSink(StorageIDMaybeEmpty view_id) cons
         inner_share_nested_offsets);
 
     auto extracting_subcolumns_dag = createSubcolumnsExtractionActions(
-        *input_headers.at(view_id),
+        Block(to_convert),
         adding_missing_defaults_dag.getRequiredColumnsNames(),
         insert_context);
 
-    auto merged_dag = ActionsDAG::merge(std::move(extracting_subcolumns_dag), std::move(adding_missing_defaults_dag));
+    auto merged_dag = ActionsDAG::merge(
+        std::move(converting_types_dag),
+        ActionsDAG::merge(std::move(extracting_subcolumns_dag), std::move(adding_missing_defaults_dag)));
 
     /// Actually we don't know structure of input blocks from query/table,
     /// because some clients break insertion protocol (columns != header)

--- a/tests/queries/0_stateless/03960_materialized_view_insert_wider_target_enum_107635.reference
+++ b/tests/queries/0_stateless/03960_materialized_view_insert_wider_target_enum_107635.reference
@@ -1,0 +1,5 @@
+enum8 mergetree	a	Enum8(\'a\' = 1, \'b\' = 2, \'c\' = 3)
+enum8 mergetree	b	Enum8(\'a\' = 1, \'b\' = 2, \'c\' = 3)
+enum16 replacingmergetree	x	Enum16(\'x\' = 10, \'y\' = 20, \'z\' = 30)
+enum16 replacingmergetree	y	Enum16(\'x\' = 10, \'y\' = 20, \'z\' = 30)
+enum widening with defaulted column	a	42

--- a/tests/queries/0_stateless/03960_materialized_view_insert_wider_target_enum_107635.sql
+++ b/tests/queries/0_stateless/03960_materialized_view_insert_wider_target_enum_107635.sql
@@ -1,0 +1,46 @@
+-- Inserting through a TO-target materialized view whose target column is a wider Enum than
+-- the view's SELECT output must apply the (valid) Enum widening, like a direct INSERT SELECT,
+-- instead of raising a LOGICAL_ERROR "Block structure mismatch ... ConvertingTransform and
+-- RemovingReplicatedColumnsTransform" while building the insert pipeline.
+
+DROP TABLE IF EXISTS src8;
+DROP TABLE IF EXISTS dst8;
+DROP TABLE IF EXISTS mv8;
+
+CREATE TABLE src8 (c1 Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dst8 (c1 Enum8('a' = 1, 'b' = 2, 'c' = 3)) ENGINE = MergeTree ORDER BY tuple();
+CREATE MATERIALIZED VIEW mv8 TO dst8 AS SELECT c1 FROM src8;
+INSERT INTO mv8 VALUES ('a'), ('b');
+SELECT 'enum8 mergetree', c1, toTypeName(c1) FROM dst8 ORDER BY c1;
+
+DROP TABLE IF EXISTS src16;
+DROP TABLE IF EXISTS dst16;
+DROP TABLE IF EXISTS mv16;
+
+CREATE TABLE src16 (c1 Enum16('x' = 10, 'y' = 20)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dst16 (c1 Enum16('x' = 10, 'y' = 20, 'z' = 30)) ENGINE = ReplacingMergeTree ORDER BY tuple();
+CREATE MATERIALIZED VIEW mv16 TO dst16 AS SELECT c1 FROM src16;
+INSERT INTO mv16 VALUES ('y');
+INSERT INTO mv16 VALUES ('x');
+SELECT 'enum16 replacingmergetree', c1, toTypeName(c1) FROM dst16 ORDER BY c1;
+
+-- A target column that is absent from the view output and has a DEFAULT must still be filled.
+DROP TABLE IF EXISTS src_def;
+DROP TABLE IF EXISTS dst_def;
+DROP TABLE IF EXISTS mv_def;
+
+CREATE TABLE src_def (c1 Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE dst_def (c1 Enum8('a' = 1, 'b' = 2, 'c' = 3), extra UInt32 DEFAULT 42) ENGINE = MergeTree ORDER BY tuple();
+CREATE MATERIALIZED VIEW mv_def TO dst_def AS SELECT c1 FROM src_def;
+INSERT INTO mv_def VALUES ('a');
+SELECT 'enum widening with defaulted column', c1, extra FROM dst_def ORDER BY c1;
+
+DROP TABLE mv8;
+DROP TABLE dst8;
+DROP TABLE src8;
+DROP TABLE mv16;
+DROP TABLE dst16;
+DROP TABLE src16;
+DROP TABLE mv_def;
+DROP TABLE dst_def;
+DROP TABLE src_def;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107635
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` ("Block structure mismatch ... between `ConvertingTransform` and `RemovingReplicatedColumnsTransform`") when inserting into a materialized view whose `TO` target table declares a column with a wider `Enum` than the view's `SELECT` produces. The valid `Enum` widening is now applied on the materialized-view insert path, like a direct `INSERT ... SELECT`.

Closes: #107635

### Description

`INSERT INTO mv` for a materialized view created with `TO target` failed with a `LOGICAL_ERROR` when the view column was an `Enum8`/`Enum16` and the target declared a wider `Enum` (extra members appended), even though widening an `Enum` is a valid implicit conversion. A direct `INSERT INTO target SELECT ...` with the same widening succeeded; only the materialized-view path failed while building the insert pipeline.

Reproduction:

```sql
CREATE TABLE t1 (c1 Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE t2 (c1 Enum8('a' = 1, 'b' = 2, 'c' = 3)) ENGINE = MergeTree ORDER BY tuple();
CREATE MATERIALIZED VIEW v1 TO t2 AS SELECT c1 FROM t1;
INSERT INTO v1 VALUES ('a');
-- Code: 49. Block structure mismatch in function connect between ConvertingTransform
-- and RemovingReplicatedColumnsTransform stream: different types:
-- c1 Enum8('a' = 1, 'b' = 2) / c1 Enum8('a' = 1, 'b' = 2, 'c' = 3)
```

Root cause: in `InsertDependenciesBuilder::createPreSink` the `ConvertingTransform` was built from an `ActionsDAG` that only ran `addMissingDefaults` plus subcolumn extraction. `addMissingDefaults` fills columns that are absent from the input but never retypes a column that is already present, so a present column kept its source-derived type (narrow `Enum`) while the following `RemovingReplicatedColumnsTransform` (built from the target sample block) expected the target type (wide `Enum`). Connecting the chain then tripped `checkBlockStructure`. The sibling conversion used by the inner-query transform (`build_conversion`) already prepends `makeConvertingActions`; `createPreSink` was missing that step.

Fix: `createPreSink` now prepends a `makeConvertingActions` step that converts input columns present in the target to their target types (matched by name) before adding defaults, so the valid implicit conversion is applied on the materialized-view path exactly as for a direct insert. Conversions that are genuinely invalid (e.g. a target `Enum` that cannot hold a source value) still raise the same user-facing error as a direct insert.

Test: `03960_materialized_view_insert_wider_target_enum_107635` covers `Enum8` widening into a `MergeTree` target, `Enum16` widening into a `ReplacingMergeTree` target, and widening combined with a defaulted target column. The test fails (server crash with the `LOGICAL_ERROR`) without the fix and passes with it.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1150`
<!-- ch-version-info:end -->