### PR TITLE
Do not deduplicate restored ReplicatedMergeTree parts

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -569,7 +569,7 @@ void ReplicatedMergeTreeSink::finishDelayed(const ZooKeeperWithFaultInjectionPtr
     delayed_parts.clear();
 }
 
-bool ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPtr & part)
+bool ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPtr & part, bool deduplicate_part)
 {
     /// NOTE: No delay in this case. That's Ok.
     auto origin_zookeeper = storage.getZooKeeper();
@@ -604,7 +604,7 @@ bool ReplicatedMergeTreeSink::writeExistingPart(MergeTreeData::MutableDataPartPt
     part->info.mutation = 0;
     part->version->setAndStoreCreationTID(Tx::NonTransactionalTID, nullptr);
     std::vector<DeduplicationHash> deduplication_hashes;
-    if (deduplicate)
+    if (deduplicate && deduplicate_part)
     {
         switch (insert_deduplication_version)
         {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -80,8 +80,9 @@ public:
 
     String getName() const override { return "ReplicatedMergeTreeSink"; }
 
-    /// For ATTACHing existing data on filesystem.
-    bool writeExistingPart(MergeTreeData::MutableDataPartPtr & part);
+    /// For `ATTACH`ing existing data on filesystem. `RESTORE` uses `deduplicate_part = false`
+    /// to preserve duplicate parts from backup.
+    bool writeExistingPart(MergeTreeData::MutableDataPartPtr & part, bool deduplicate_part = true);
 
 protected:
     virtual void finishDelayed(const ZooKeeperWithFaultInjectionPtr & zookeeper);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -80,8 +80,8 @@ public:
 
     String getName() const override { return "ReplicatedMergeTreeSink"; }
 
-    /// For `ATTACH`ing existing data on filesystem. `RESTORE` uses `deduplicate_part = false`
-    /// to preserve duplicate parts from backup.
+    /// For `ATTACH`ing existing data on filesystem. `RESTORE` paths use `deduplicate_part = false`
+    /// to preserve duplicate parts.
     bool writeExistingPart(MergeTreeData::MutableDataPartPtr & part, bool deduplicate_part = true);
 
 protected:

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -11782,7 +11782,7 @@ void StorageReplicatedMergeTree::attachRestoredParts(
         /* async_insert */ false, *this, metadata_snapshot, /* quorum */ 0, /* quorum_timeout_ms */ 0, /* max_parts_per_block */ 0, /* quorum_parallel */ false,
         /* majority_quorum */ false, getContext(), /* is_attach */ true, /* allow_attach_while_readonly */ false, zookeeper_retries_info);
 
-    for (auto part : parts)
+    for (auto & part : parts)
         sink->writeExistingPart(part, /* deduplicate_part */ false);
 }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7410,7 +7410,8 @@ PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
     {
         const String old_name = loaded_parts[i]->name;
 
-        output.writeExistingPart(loaded_parts[i]);
+        const bool deduplicate_part = !are_restoring_replica.load();
+        output.writeExistingPart(loaded_parts[i], deduplicate_part);
 
         renamed_parts.old_and_new_names[i].old_dir.clear();
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -11768,7 +11768,7 @@ void StorageReplicatedMergeTree::attachRestoredParts(
         /* majority_quorum */ false, getContext(), /* is_attach */ true, /* allow_attach_while_readonly */ false, zookeeper_retries_info);
 
     for (auto part : parts)
-        sink->writeExistingPart(part);
+        sink->writeExistingPart(part, /* deduplicate_part */ false);
 }
 
 }

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7275,7 +7275,12 @@ void StorageReplicatedMergeTree::restoreMetadataInZooKeeper(
         for (const auto & part_name : active_parts_names)
         {
             command.partition = make_intrusive<ASTLiteral>(part_name);
-            attachPartition(command, metadata_snapshot, getContext());
+            attachPartitionImpl(
+                command,
+                metadata_snapshot,
+                getContext(),
+                /* allow_attach_while_readonly */ true,
+                /* deduplicate_part */ false);
         }
     }
 
@@ -7381,8 +7386,18 @@ void StorageReplicatedMergeTree::truncate(
 PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
     const PartitionCommand & command, const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context)
 {
-    /// Allow ATTACH PARTITION on readonly replica when restoring it.
-    if (!are_restoring_replica)
+    return attachPartitionImpl(
+        command, metadata_snapshot, query_context, /* allow_attach_while_readonly */ false, /* deduplicate_part */ true);
+}
+
+PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartitionImpl(
+    const PartitionCommand & command,
+    const StorageMetadataPtr & metadata_snapshot,
+    ContextPtr query_context,
+    bool allow_attach_while_readonly,
+    bool deduplicate_part)
+{
+    if (!allow_attach_while_readonly)
         assertNotReadonly();
 
     auto component_guard = Coordination::setCurrentComponent("StorageReplicatedMergeTree::attachPartition");
@@ -7402,7 +7417,7 @@ PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
         /* majority_quorum */ false,
         query_context,
         /* is_attach */ true,
-        /* allow_attach_while_readonly */ true);
+        /* allow_attach_while_readonly */ allow_attach_while_readonly);
 
     results.reserve(loaded_parts.size());
 
@@ -7410,7 +7425,6 @@ PartitionCommandsResultInfo StorageReplicatedMergeTree::attachPartition(
     {
         const String old_name = loaded_parts[i]->name;
 
-        const bool deduplicate_part = !are_restoring_replica.load();
         output.writeExistingPart(loaded_parts[i], deduplicate_part);
 
         renamed_parts.old_and_new_names[i].old_dir.clear();

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -917,6 +917,12 @@ private:
     // Partition helpers
     void dropPartition(const ASTPtr & partition, bool detach, ContextPtr query_context) override;
     PartitionCommandsResultInfo attachPartition(const PartitionCommand & command, const StorageMetadataPtr & metadata_snapshot, ContextPtr query_context) override;
+    PartitionCommandsResultInfo attachPartitionImpl(
+        const PartitionCommand & command,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr query_context,
+        bool allow_attach_while_readonly,
+        bool deduplicate_part);
     void replacePartitionFrom(const StoragePtr & source_table, const ASTPtr & partition, bool replace, ContextPtr query_context) override;
     void movePartitionToTable(const StoragePtr & dest_table, const ASTPtr & partition, ContextPtr query_context) override;
     void movePartitionToShard(const ASTPtr & partition, bool move_part, const String & to, ContextPtr query_context) override;

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -396,11 +396,10 @@ def test_replicated_table_restore_keeps_duplicate_parts():
     node2.query(f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}")
     node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
 
+    expected = node1.query("SELECT count(), sum(sipHash64(*)) FROM tbl")
     for instance in [node1, node2]:
         assert instance.query("SELECT count() FROM tbl2") == "2\n"
-        assert instance.query("SELECT count(), sum(sipHash64(*)) FROM tbl") == instance.query(
-            "SELECT count(), sum(sipHash64(*)) FROM tbl2"
-        )
+        assert instance.query("SELECT count(), sum(sipHash64(*)) FROM tbl2") == expected
 
 
 def test_replicated_table_with_not_synced_insert():

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -366,40 +366,44 @@ def test_replicated_table_with_uuid_in_zkpath():
 
 
 def test_replicated_table_restore_keeps_duplicate_parts():
-    node1.query(
-        "CREATE TABLE tbl ON CLUSTER 'cluster' ("
-        "key UInt64, value String, array Array(String)"
-        ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/{uuid}', '{replica}')"
-        "ORDER BY tuple() SETTINGS replicated_deduplication_window = 0, "
-        "replicated_deduplication_window_for_async_inserts = 0"
-    )
+    try:
+        node1.query(
+            "CREATE TABLE tbl ON CLUSTER 'cluster' ("
+            "key UInt64, value String, array Array(String)"
+            ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/{uuid}', '{replica}')"
+            "ORDER BY tuple() SETTINGS replicated_deduplication_window = 0, "
+            "replicated_deduplication_window_for_async_inserts = 0"
+        )
 
-    node1.query("SYSTEM STOP MERGES ON CLUSTER 'cluster' tbl")
+        node1.query("SYSTEM STOP MERGES ON CLUSTER 'cluster' tbl")
 
-    node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
-    node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
-    node1.query(
-        "ALTER TABLE tbl ON CLUSTER 'cluster' MODIFY SETTING "
-        "replicated_deduplication_window = 10000, "
-        "replicated_deduplication_window_for_async_inserts = 10000"
-    )
+        node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
+        node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
+        node1.query(
+            "ALTER TABLE tbl ON CLUSTER 'cluster' MODIFY SETTING "
+            "replicated_deduplication_window = 10000, "
+            "replicated_deduplication_window_for_async_inserts = 10000"
+        )
 
-    assert node1.query("SELECT count() FROM tbl") == "2\n"
-    assert (
-        node1.query("SELECT count() FROM system.parts WHERE table = 'tbl' AND active")
-        == "2\n"
-    )
+        assert node1.query("SELECT count() FROM tbl") == "2\n"
+        assert (
+            node1.query("SELECT count() FROM system.parts WHERE table = 'tbl' AND active")
+            == "2\n"
+        )
 
-    backup_name = new_backup_name()
-    node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
+        backup_name = new_backup_name()
+        node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
 
-    node2.query(f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}")
-    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
+        node2.query(f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}")
+        node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
 
-    expected = node1.query("SELECT count(), sum(sipHash64(*)) FROM tbl")
-    for instance in [node1, node2]:
-        assert instance.query("SELECT count() FROM tbl2") == "2\n"
-        assert instance.query("SELECT count(), sum(sipHash64(*)) FROM tbl2") == expected
+        expected = node1.query("SELECT count(), sum(sipHash64(*)) FROM tbl")
+        for instance in [node1, node2]:
+            assert instance.query("SELECT count() FROM tbl2") == "2\n"
+            assert instance.query("SELECT count(), sum(sipHash64(*)) FROM tbl2") == expected
+    finally:
+        node1.query("DROP TABLE IF EXISTS tbl ON CLUSTER 'cluster' SYNC")
+        node1.query("DROP TABLE IF EXISTS tbl2 ON CLUSTER 'cluster' SYNC")
 
 
 def test_replicated_table_with_not_synced_insert():

--- a/tests/integration/test_backup_restore_on_cluster/test.py
+++ b/tests/integration/test_backup_restore_on_cluster/test.py
@@ -365,6 +365,44 @@ def test_replicated_table_with_uuid_in_zkpath():
         )
 
 
+def test_replicated_table_restore_keeps_duplicate_parts():
+    node1.query(
+        "CREATE TABLE tbl ON CLUSTER 'cluster' ("
+        "key UInt64, value String, array Array(String)"
+        ") ENGINE=ReplicatedMergeTree('/clickhouse/tables/{uuid}', '{replica}')"
+        "ORDER BY tuple() SETTINGS replicated_deduplication_window = 0, "
+        "replicated_deduplication_window_for_async_inserts = 0"
+    )
+
+    node1.query("SYSTEM STOP MERGES ON CLUSTER 'cluster' tbl")
+
+    node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
+    node1.query("INSERT INTO tbl VALUES (0, 'same', ['same'])")
+    node1.query(
+        "ALTER TABLE tbl ON CLUSTER 'cluster' MODIFY SETTING "
+        "replicated_deduplication_window = 10000, "
+        "replicated_deduplication_window_for_async_inserts = 10000"
+    )
+
+    assert node1.query("SELECT count() FROM tbl") == "2\n"
+    assert (
+        node1.query("SELECT count() FROM system.parts WHERE table = 'tbl' AND active")
+        == "2\n"
+    )
+
+    backup_name = new_backup_name()
+    node1.query(f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {backup_name}")
+
+    node2.query(f"RESTORE TABLE tbl AS tbl2 ON CLUSTER 'cluster' FROM {backup_name}")
+    node1.query("SYSTEM SYNC REPLICA ON CLUSTER 'cluster' tbl2")
+
+    for instance in [node1, node2]:
+        assert instance.query("SELECT count() FROM tbl2") == "2\n"
+        assert instance.query("SELECT count(), sum(sipHash64(*)) FROM tbl") == instance.query(
+            "SELECT count(), sum(sipHash64(*)) FROM tbl2"
+        )
+
+
 def test_replicated_table_with_not_synced_insert():
     node1.query(
         "CREATE TABLE tbl ON CLUSTER 'cluster' ("

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -188,3 +188,52 @@ def test_restore_replica_alive_replicas(start_cluster):
 
     check_after_restoration()
     drop_tables()
+
+
+def test_restore_replica_keeps_duplicate_parts(start_cluster):
+    zk = cluster.get_kazoo_client("zoo1")
+    drop_tables()
+
+    try:
+        for node in nodes:
+            node.query(
+                """
+                CREATE TABLE test(n UInt32)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/', '{replica}')
+                ORDER BY tuple()
+                SETTINGS replicated_deduplication_window = 0,
+                    replicated_deduplication_window_for_async_inserts = 0;
+                """.format(
+                    replica=node.name
+                )
+            )
+
+        node_1.query("SYSTEM STOP MERGES test")
+
+        node_1.query("INSERT INTO test VALUES (0)")
+        node_1.query("INSERT INTO test VALUES (0)")
+        node_1.query(
+            """
+            ALTER TABLE test MODIFY SETTING replicated_deduplication_window = 10000,
+                replicated_deduplication_window_for_async_inserts = 10000
+            """
+        )
+
+        assert node_1.query("SELECT count() FROM test") == "2\n"
+        assert (
+            node_1.query("SELECT count() FROM system.parts WHERE table = 'test' AND active")
+            == "2\n"
+        )
+
+        expected = node_1.query("SELECT count(), sum(sipHash64(*)) FROM test")
+
+        zk_rmr_with_retries(zk, "/clickhouse/tables/test")
+        assert zk.exists("/clickhouse/tables/test") is None
+
+        node_1.query("SYSTEM RESTART REPLICA test")
+        node_1.query("SYSTEM RESTORE REPLICA test")
+
+        assert node_1.query("SELECT count() FROM test") == "2\n"
+        assert node_1.query("SELECT count(), sum(sipHash64(*)) FROM test") == expected
+    finally:
+        drop_tables()


### PR DESCRIPTION
Restoring `ReplicatedMergeTree` tables attaches restored parts through the same existing-part sink path as `ATTACH`.
That path applies insert deduplication, so a backup containing multiple duplicate-content parts can be restored with missing rows.

This change preserves the default deduplication behavior for `ATTACH`, but disables part deduplication when restored parts are attached from a backup.
A deterministic integration test covers duplicate restored parts and fails on `26.4.2.10` with the restored table containing one row instead of two.

Closes: https://github.com/ClickHouse/clickhouse-private/issues/61121

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `RESTORE` for `ReplicatedMergeTree` tables so duplicate-content parts from a backup are preserved instead of being silently deduplicated.

### Documentation entry:
- [x] Documentation is not required for this change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.117` (included in `26.7` and later)
- Backported to: `26.6.2.3`, `26.5.4.23`, `26.4.5.79`, `26.3.16.14`, `25.8.25.37`
<!-- ch-version-info:end -->