### PR TITLE
Rename setting `enable_join_runtime_filter_shared_fixed_hash_table` to `join_runtime_filter_from_fixed_hash_table`

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7899,9 +7899,6 @@ Has effect only when `join_algorithm` is `hash`, `parallel_hash`, `default`, or 
     DECLARE(Bool, enable_join_fixed_hash_table_conversion, true, R"(
 Enable converting the hash table to a flat array for joins when the key is a single integer with a small value range.
 )", 0) \
-    DECLARE(Bool, enable_join_runtime_filter_shared_fixed_hash_table, true, R"(
-When the hash join build side has been converted to a FixedHashMap (see `enable_join_fixed_hash_table_conversion`), use that map directly as the runtime filter for the probe side, replacing the Set/BloomFilter that the runtime filter framework otherwise builds for the same join.
-)", 0) \
     \
     /* ####################################################### */ \
     /* ########### START OF EXPERIMENTAL FEATURES ############ */ \
@@ -8182,6 +8179,9 @@ Number of blocks that are skipped before trying to dynamically re-enable a runti
     DECLARE(Double, join_runtime_bloom_filter_max_ratio_of_set_bits, 0.7, R"(
 If the number of set bits in a runtime bloom filter exceeds this ratio the filter is completely disabled to reduce the overhead.
 )", EXPERIMENTAL) \
+    DECLARE(Bool, join_runtime_filter_from_fixed_hash_table, true, R"(
+When the hash join build side was converted to a FixedHashMap (see `enable_join_fixed_hash_table_conversion`), use that hash map directly as the runtime filter.
+)", 0) \
     DECLARE(Bool, rewrite_in_to_join, false, R"(
 Rewrite expressions like 'x IN subquery' to JOIN. This might be useful for optimizing the whole query with join reordering.
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -44,7 +44,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"output_format_image_width", 1024, 1024, "New setting controlling the width of the output image for image output formats such as PNG."},
             {"output_format_image_height", 1024, 1024, "New setting controlling the height of the output image for image output formats such as PNG."},
             {"output_format_image_terminal_mode", "", "", "New setting controlling whether image output formats such as PNG are rendered directly to the terminal using an inline image protocol."},
-            {"enable_join_runtime_filter_shared_fixed_hash_table", false, true, "New setting to share the hash join's FixedHashMap as the runtime filter for the probe side, replacing the Set/BloomFilter built upstream by the runtime filter framework."},
+            {"join_runtime_filter_from_fixed_hash_table", false, true, "New setting."},
             {"ai_function_embedding_max_batch_size", 100, 100, "New setting"},
             {"enable_sharding_aggregator", false, false, "New setting to enable sharded `GROUP BY` optimization that distributes rows across threads by hashing the grouping key, so each thread aggregates a disjoint subset of keys without a merge phase; this is efficient for high cardinality keys with evenly distributed data."},
             {"allow_experimental_text_index_lazy_apply", false, false, "New setting to gate experimental lazy posting list apply mode"},

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -2334,7 +2334,7 @@ void HashJoin::publishSharedRuntimeFilters()
         return;
     shared_runtime_filters_publish_attempted = true;
 
-    if (!table_join->enableJoinRuntimeFilterSharedFixedHashTable())
+    if (!table_join->joinRuntimeFilterFromFixedHashTable())
         return;
 
     const auto & descriptors = table_join->getSharedRuntimeFilterDescriptors();
@@ -2581,7 +2581,7 @@ bool HashJoin::hasPostBuildPhase() const
     const bool needs_shared_filter_publish =
         data && data->rows_to_join && data->maps.size() == 1
         && (data->type == Type::key8 || data->type == Type::key16)
-        && table_join->enableJoinRuntimeFilterSharedFixedHashTable()
+        && table_join->joinRuntimeFilterFromFixedHashTable()
         && !table_join->getSharedRuntimeFilterDescriptors().empty();
 
     return rightTableCanBeReranged() || canConvertToFixedHashMap() || needs_shared_filter_publish;

--- a/src/Interpreters/JoinOperator.cpp
+++ b/src/Interpreters/JoinOperator.cpp
@@ -75,7 +75,7 @@ namespace Setting
     extern const SettingsDouble max_bytes_ratio_before_external_join;
 
     extern const SettingsBool enable_join_fixed_hash_table_conversion;
-    extern const SettingsBool enable_join_runtime_filter_shared_fixed_hash_table;
+    extern const SettingsBool join_runtime_filter_from_fixed_hash_table;
 }
 
 namespace QueryPlanSerializationSetting
@@ -126,7 +126,7 @@ namespace QueryPlanSerializationSetting
     extern const QueryPlanSerializationSettingsBool use_hash_table_stats_for_join_reordering;
 
     extern const QueryPlanSerializationSettingsBool enable_join_fixed_hash_table_conversion;
-    extern const QueryPlanSerializationSettingsBool enable_join_runtime_filter_shared_fixed_hash_table;
+    extern const QueryPlanSerializationSettingsBool join_runtime_filter_from_fixed_hash_table;
 }
 
 JoinSettings::JoinSettings(const Settings & query_settings)
@@ -185,7 +185,7 @@ JoinSettings::JoinSettings(const Settings & query_settings)
     use_hash_table_stats_for_join_reordering = query_settings[Setting::use_hash_table_stats_for_join_reordering];
 
     enable_join_fixed_hash_table_conversion = query_settings[Setting::enable_join_fixed_hash_table_conversion];
-    enable_join_runtime_filter_shared_fixed_hash_table = query_settings[Setting::enable_join_runtime_filter_shared_fixed_hash_table];
+    join_runtime_filter_from_fixed_hash_table = query_settings[Setting::join_runtime_filter_from_fixed_hash_table];
 }
 
 JoinSettings::JoinSettings(const QueryPlanSerializationSettings & settings)
@@ -240,7 +240,7 @@ JoinSettings::JoinSettings(const QueryPlanSerializationSettings & settings)
     use_hash_table_stats_for_join_reordering = settings[QueryPlanSerializationSetting::use_hash_table_stats_for_join_reordering];
 
     enable_join_fixed_hash_table_conversion = settings[QueryPlanSerializationSetting::enable_join_fixed_hash_table_conversion];
-    enable_join_runtime_filter_shared_fixed_hash_table = settings[QueryPlanSerializationSetting::enable_join_runtime_filter_shared_fixed_hash_table];
+    join_runtime_filter_from_fixed_hash_table = settings[QueryPlanSerializationSetting::join_runtime_filter_from_fixed_hash_table];
 }
 
 void JoinSettings::updatePlanSettings(QueryPlanSerializationSettings & settings) const
@@ -295,7 +295,7 @@ void JoinSettings::updatePlanSettings(QueryPlanSerializationSettings & settings)
     settings[QueryPlanSerializationSetting::use_hash_table_stats_for_join_reordering] = use_hash_table_stats_for_join_reordering;
 
     settings[QueryPlanSerializationSetting::enable_join_fixed_hash_table_conversion] = enable_join_fixed_hash_table_conversion;
-    settings[QueryPlanSerializationSetting::enable_join_runtime_filter_shared_fixed_hash_table] = enable_join_runtime_filter_shared_fixed_hash_table;
+    settings[QueryPlanSerializationSetting::join_runtime_filter_from_fixed_hash_table] = join_runtime_filter_from_fixed_hash_table;
 }
 
 UInt64 JoinSettings::getMaxBytesBeforeExternalJoin(UInt64 max_bytes_before_external_join, double max_bytes_ratio_before_external_join)

--- a/src/Interpreters/JoinOperator.h
+++ b/src/Interpreters/JoinOperator.h
@@ -114,7 +114,7 @@ struct JoinSettings
     bool use_hash_table_stats_for_join_reordering;
 
     bool enable_join_fixed_hash_table_conversion;
-    bool enable_join_runtime_filter_shared_fixed_hash_table;
+    bool join_runtime_filter_from_fixed_hash_table;
 
     explicit JoinSettings(const Settings & query_settings);
     explicit JoinSettings(const QueryPlanSerializationSettings & settings);

--- a/src/Interpreters/TableJoin.cpp
+++ b/src/Interpreters/TableJoin.cpp
@@ -84,7 +84,7 @@ namespace Setting
     extern const SettingsUInt64 max_bytes_before_external_join;
     extern const SettingsDouble max_bytes_ratio_before_external_join;
     extern const SettingsBool enable_join_fixed_hash_table_conversion;
-    extern const SettingsBool enable_join_runtime_filter_shared_fixed_hash_table;
+    extern const SettingsBool join_runtime_filter_from_fixed_hash_table;
 }
 
 namespace ErrorCodes
@@ -230,7 +230,7 @@ TableJoin::TableJoin(const Settings & settings, VolumePtr tmp_volume_, Temporary
           settings[Setting::max_bytes_before_external_join],
           settings[Setting::max_bytes_ratio_before_external_join]))
     , enable_join_fixed_hash_table_conversion(settings[Setting::enable_join_fixed_hash_table_conversion])
-    , enable_join_runtime_filter_shared_fixed_hash_table(settings[Setting::enable_join_runtime_filter_shared_fixed_hash_table])
+    , join_runtime_filter_from_fixed_hash_table(settings[Setting::join_runtime_filter_from_fixed_hash_table])
     , max_memory_usage(settings[Setting::max_memory_usage])
     , tmp_volume(tmp_volume_)
     , tmp_data(tmp_data_)
@@ -263,7 +263,7 @@ TableJoin::TableJoin(const JoinSettings & settings, bool join_use_nulls_, Volume
     , enable_software_prefetch_in_join(settings.enable_software_prefetch_in_join)
     , max_bytes_before_external_join(settings.getEffectiveMaxBytesBeforeExternalJoin())
     , enable_join_fixed_hash_table_conversion(settings.enable_join_fixed_hash_table_conversion)
-    , enable_join_runtime_filter_shared_fixed_hash_table(settings.enable_join_runtime_filter_shared_fixed_hash_table)
+    , join_runtime_filter_from_fixed_hash_table(settings.join_runtime_filter_from_fixed_hash_table)
     , max_memory_usage(settings.max_bytes_in_join)
     , tmp_volume(tmp_volume_)
     , tmp_data(tmp_data_)

--- a/src/Interpreters/TableJoin.h
+++ b/src/Interpreters/TableJoin.h
@@ -168,7 +168,7 @@ private:
     const bool enable_software_prefetch_in_join = false;
     const size_t max_bytes_before_external_join = 0;
     const bool enable_join_fixed_hash_table_conversion = false;
-    const bool enable_join_runtime_filter_shared_fixed_hash_table = false;
+    const bool join_runtime_filter_from_fixed_hash_table = false;
 
     /// Value if setting max_memory_usage for query, can be used when max_bytes_in_join is not specified.
     size_t max_memory_usage = 0;
@@ -333,7 +333,7 @@ public:
     bool enableSoftwarePrefetchInJoin() const { return enable_software_prefetch_in_join; }
     size_t maxBytesBeforeExternalJoin() const { return max_bytes_before_external_join; }
     bool enableJoinFixedHashTableConversion() const { return enable_join_fixed_hash_table_conversion; }
-    bool enableJoinRuntimeFilterSharedFixedHashTable() const { return enable_join_runtime_filter_shared_fixed_hash_table; }
+    bool joinRuntimeFilterFromFixedHashTable() const { return join_runtime_filter_from_fixed_hash_table; }
 
     const std::vector<std::pair<String, String>> & getSharedRuntimeFilterDescriptors() const
     {

--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -446,11 +446,10 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
             /// otherwise the Set/BloomFilter stays as fallback. Carry the rendezvous key (`id.key`),
             /// NOT the stable display name: the filter is registered in the lookup under that key, so
             /// `HashJoin::publishSharedRuntimeFilters` must find/replace it under the same key.
-            if (join_step->getJoinSettings().enable_join_runtime_filter_shared_fixed_hash_table
+            if (join_step->getJoinSettings().join_runtime_filter_from_fixed_hash_table
                 && !check_left_does_not_contain)
             {
-                join_step->getJoinOperator().shared_runtime_filter_descriptors.emplace_back(
-                    id.key, join_key_build_side.name);
+                join_step->getJoinOperator().shared_runtime_filter_descriptors.emplace_back(id.key, join_key_build_side.name);
             }
         }
 

--- a/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
+++ b/src/Processors/QueryPlan/QueryPlanSerializationSettings.cpp
@@ -113,7 +113,7 @@ namespace DB
     DECLARE(Bool, serialize_string_in_memory_with_zero_byte, true, "Serialize String values during aggregation with zero byte at the end. Enable to keep compatibility when querying cluster of incompatible versions.", 0) \
     DECLARE(Bool, use_hash_table_stats_for_join_reordering, false, "Enable using collected hash table statistics for cardinality estimation during join reordering", 0) \
     DECLARE(Bool, enable_join_fixed_hash_table_conversion, true, R"(Enable converting the hash table to a flat array for joins when the key is a single integer with a small value range)", 0) \
-    DECLARE(Bool, enable_join_runtime_filter_shared_fixed_hash_table, true, R"(Use the hash join's FixedHashMap as the runtime filter for the probe side, replacing the Set/BloomFilter built upstream by the runtime filter framework)", 0) \
+    DECLARE(Bool, join_runtime_filter_from_fixed_hash_table, true, R"(When the hash join build side was converted to a FixedHashMap (see `enable_join_fixed_hash_table_conversion`), use that hash map directly as the runtime filter.)", 0) \
 
 
 // clang-format on

--- a/tests/queries/0_stateless/04241_join_runtime_filter_shared_fixed_hash_table.sql
+++ b/tests/queries/0_stateless/04241_join_runtime_filter_shared_fixed_hash_table.sql
@@ -12,24 +12,24 @@ INSERT INTO phjf_probe SELECT if(number % 50 = 0, NULL, toInt32(number % 250)) F
 SET join_algorithm = 'hash', max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0;
 
 -- INNER + dense range -> shared filter fires.
-SELECT 'inner_dense', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'inner_dense', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'inner_dense', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'inner_dense', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- build size = 1 -> guard skips, == const path stays.
-SELECT 'inner_size1', count() FROM phjf_probe p INNER JOIN (SELECT 42 AS k) b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'inner_size1', count() FROM phjf_probe p INNER JOIN (SELECT 42 AS k) b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'inner_size1', count() FROM phjf_probe p INNER JOIN (SELECT 42 AS k) b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'inner_size1', count() FROM phjf_probe p INNER JOIN (SELECT 42 AS k) b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- LEFT JOIN -> joinRuntimeFilter does not run, NULL rows preserved.
-SELECT 'left_dense', count(), sum(p.k IS NULL), sum(b.k IS NULL) FROM phjf_probe p LEFT JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'left_dense', count(), sum(p.k IS NULL), sum(b.k IS NULL) FROM phjf_probe p LEFT JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'left_dense', count(), sum(p.k IS NULL), sum(b.k IS NULL) FROM phjf_probe p LEFT JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'left_dense', count(), sum(p.k IS NULL), sum(b.k IS NULL) FROM phjf_probe p LEFT JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- LEFT SEMI -> filter fires, NULL probe never matches and is correctly dropped.
-SELECT 'left_semi', count() FROM phjf_probe p LEFT SEMI JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'left_semi', count() FROM phjf_probe p LEFT SEMI JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'left_semi', count() FROM phjf_probe p LEFT SEMI JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'left_semi', count() FROM phjf_probe p LEFT SEMI JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- LEFT ANTI -> guard skips publish (NOT IN semantics), OR isNull(key) keeps NULL probes.
-SELECT 'left_anti', count(), sum(p.k IS NULL) FROM phjf_probe p LEFT ANTI JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'left_anti', count(), sum(p.k IS NULL) FROM phjf_probe p LEFT ANTI JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'left_anti', count(), sum(p.k IS NULL) FROM phjf_probe p LEFT ANTI JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'left_anti', count(), sum(p.k IS NULL) FROM phjf_probe p LEFT ANTI JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Multi-equi-condition AND -> keys128 path (not range_type), filter does not publish.
 DROP TABLE phjf_build;
@@ -38,8 +38,8 @@ CREATE TABLE phjf_build (k1 Int16, k2 Int16) ENGINE = MergeTree ORDER BY tuple()
 CREATE TABLE phjf_probe (k1 Int16, k2 Int16) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt16(number % 50), toInt16(number % 50) FROM numbers(50);
 INSERT INTO phjf_probe SELECT toInt16(number % 100), toInt16(number % 100) FROM numbers(2000);
-SELECT 'multi_cond', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 AND p.k2 = b.k2 SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'multi_cond', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 AND p.k2 = b.k2 SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'multi_cond', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 AND p.k2 = b.k2 SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'multi_cond', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 AND p.k2 = b.k2 SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Signed Int32 with negative keys -> bit-cast correctness in probe loop.
 DROP TABLE phjf_build;
@@ -48,8 +48,8 @@ CREATE TABLE phjf_build (k Int32) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int32) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT number - 50 FROM numbers(100);                  -- range [-50, 49]
 INSERT INTO phjf_probe SELECT toInt32(number % 200 - 100) FROM numbers(20000);
-SELECT 'signed_neg', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'signed_neg', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'signed_neg', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'signed_neg', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Build has NULL keys -> HashJoin's FixedHashMap excludes them, baseline Set may include them; JOIN output stays identical.
 DROP TABLE phjf_build;
@@ -58,8 +58,8 @@ CREATE TABLE phjf_build (k Nullable(Int32)) ENGINE = MergeTree ORDER BY tuple() 
 CREATE TABLE phjf_probe (k Nullable(Int32)) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_nullable_key = 1;
 INSERT INTO phjf_build SELECT if(number % 20 = 0, NULL, toInt32(number)) FROM numbers(100);
 INSERT INTO phjf_probe SELECT if(number % 30 = 0, NULL, toInt32(number % 200)) FROM numbers(20000);
-SELECT 'null_in_build', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'null_in_build', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'null_in_build', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'null_in_build', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- UInt8 single-column join -> key8 path (FixedHashMap from build, no conversion needed).
 DROP TABLE phjf_build;
@@ -68,8 +68,8 @@ CREATE TABLE phjf_build (k UInt8) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k UInt8) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toUInt8(number) FROM numbers(50);
 INSERT INTO phjf_probe SELECT toUInt8(number % 100) FROM numbers(2000);
-SELECT 'key8', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'key8', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'key8', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'key8', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- UInt16 single-column join -> key16 path.
 DROP TABLE phjf_build;
@@ -78,8 +78,8 @@ CREATE TABLE phjf_build (k UInt16) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k UInt16) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toUInt16(number) FROM numbers(1000);
 INSERT INTO phjf_probe SELECT toUInt16(number % 2000) FROM numbers(20000);
-SELECT 'key16', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'key16', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'key16', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'key16', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Int8 with negative values -> key8 path with bit-cast through Int8.
 DROP TABLE phjf_build;
@@ -88,8 +88,8 @@ CREATE TABLE phjf_build (k Int8) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int8) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt8(number - 50) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt8(number % 200 - 100) FROM numbers(20000);
-SELECT 'key8_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'key8_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'key8_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'key8_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Range too wide for FixedHashMap conversion -> fallback to Set/BF.
 DROP TABLE phjf_build;
@@ -98,8 +98,8 @@ CREATE TABLE phjf_build (k Int32) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int32) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT number * 500000 FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt32(number * 500000) FROM numbers(50);
-SELECT 'inner_wide_range', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'inner_wide_range', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'inner_wide_range', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'inner_wide_range', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Cross-type: UInt8 build + Int32 probe -> bounds check must drop probe values outside [0, 255].
 DROP TABLE phjf_build;
@@ -108,8 +108,8 @@ CREATE TABLE phjf_build (k UInt8) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int32) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toUInt8(number) FROM numbers(50);
 INSERT INTO phjf_probe SELECT toInt32(number - 100) FROM numbers(2000);
-SELECT 'cross_uint8_int32', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'cross_uint8_int32', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'cross_uint8_int32', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'cross_uint8_int32', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Cross-type: Int8 build + Int64 probe -> signed narrow + reinterpret.
 DROP TABLE phjf_build;
@@ -118,8 +118,8 @@ CREATE TABLE phjf_build (k Int8) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int64) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt8(number - 50) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt64(number - 500) FROM numbers(2000);
-SELECT 'cross_int8_int64', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'cross_int8_int64', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'cross_int8_int64', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'cross_int8_int64', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Cross-type: Int32 build + Int128 probe -> exercises ColumnVector<Int128> dispatch.
 DROP TABLE phjf_build;
@@ -128,8 +128,8 @@ CREATE TABLE phjf_build (k Int32) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int128) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt32(number - 50) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt128(number - 100) FROM numbers(2000);
-SELECT 'cross_int32_int128', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'cross_int32_int128', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'cross_int32_int128', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'cross_int32_int128', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Int64 build -> range_*_key64 dispatch.
 DROP TABLE phjf_build;
@@ -138,8 +138,8 @@ CREATE TABLE phjf_build (k Int64) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Int64) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt64(number - 50) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt64(number % 200 - 100) FROM numbers(20000);
-SELECT 'key64_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'key64_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'key64_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'key64_signed', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- UInt64 build -> range_*_key64 dispatch (unsigned).
 DROP TABLE phjf_build;
@@ -148,8 +148,8 @@ CREATE TABLE phjf_build (k UInt64) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k UInt64) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toUInt64(number) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toUInt64(number % 200) FROM numbers(20000);
-SELECT 'key64_unsigned', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'key64_unsigned', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'key64_unsigned', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'key64_unsigned', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- OR clause -> maps.size() > 1 guard skips publish.
 DROP TABLE phjf_build;
@@ -158,8 +158,8 @@ CREATE TABLE phjf_build (k1 Int32, k2 Int32) ENGINE = MergeTree ORDER BY tuple()
 CREATE TABLE phjf_probe (k1 Int32, k2 Int32) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toInt32(number), toInt32(number + 1000) FROM numbers(100);
 INSERT INTO phjf_probe SELECT toInt32(number % 200), toInt32(number % 200 + 1000) FROM numbers(2000);
-SELECT 'or_clause', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 OR p.k2 = b.k2 SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'or_clause', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 OR p.k2 = b.k2 SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'or_clause', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 OR p.k2 = b.k2 SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'or_clause', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k1 = b.k1 OR p.k2 = b.k2 SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 -- Date build -> key16 path via isValueRepresentedByInteger generalization.
 DROP TABLE phjf_build;
@@ -168,8 +168,8 @@ CREATE TABLE phjf_build (k Date) ENGINE = MergeTree ORDER BY tuple();
 CREATE TABLE phjf_probe (k Date) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO phjf_build SELECT toDate('2024-01-01') + number FROM numbers(50);
 INSERT INTO phjf_probe SELECT toDate('2024-01-01') + (number % 100) FROM numbers(2000);
-SELECT 'date_key', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 0;
-SELECT 'date_key', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS enable_join_runtime_filter_shared_fixed_hash_table = 1;
+SELECT 'date_key', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 0;
+SELECT 'date_key', count() FROM phjf_probe p INNER JOIN phjf_build b ON p.k = b.k SETTINGS join_runtime_filter_from_fixed_hash_table = 1;
 
 DROP TABLE phjf_build;
 DROP TABLE phjf_probe;


### PR DESCRIPTION
Makes the name more consistent with the existing settings for runtime filters

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/105640

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.938`
<!-- ch-version-info:end -->