### PR TITLE
Fix CI reporting all gtest crashes as '-FunctionsStress'

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -775,11 +775,30 @@ class Result(MetaClasses.Serializable):
             result.set_status(Result.Status.FAIL)
         if result.is_error():
             # gtest.json is missing — the binary was killed before it could write results
-            # (e.g. by a sanitizer or OOM). Note: gdb returns 0 even when the inferior
-            # exits with a non-zero code, so we can't rely on binary_failed here.
-            # Extract the first meaningful error line from the log file if available.
-            # Covers sanitizer reports ("SUMMARY:") and ClickHouse logical errors.
-            _ERROR_PREFIXES = ("SUMMARY:", "Logical error:", "Code: ", "Signal description:")
+            # (e.g. by a sanitizer, OOM, an uncaught exception, or a logical error). Note: gdb
+            # returns 0 even when the inferior exits with a non-zero code, so we can't rely on
+            # binary_failed here.
+            #
+            # gtest prints "[ RUN      ] Suite.Test" before each test and a closing
+            # "[       OK ]"/"[  FAILED  ]" line after it. When the binary dies mid-test, the last
+            # "[ RUN      ]" line has no closing line and names the test that was running at the
+            # moment of the crash. Recover that name so the report shows the real test (instead of
+            # the gtest filter expression, e.g. "-FunctionsStress"), and scan only the lines after
+            # it for the crash message, so an unrelated error logged earlier by a test that
+            # finished normally (e.g. a deliberately-thrown-and-caught exception) is not mistaken
+            # for the cause.
+            # Covers sanitizer reports ("SUMMARY:"), ClickHouse logical errors, uncaught
+            # exceptions ("libc++abi:"/"terminate called") and fatal signals.
+            _ERROR_PREFIXES = (
+                "SUMMARY:",
+                "Logical error:",
+                "Code: ",
+                "Signal description:",
+                "libc++abi:",
+                "terminate called",
+            )
+            _ERROR_SUBSTRINGS = ("received signal SIG",)
+            crashed_test = ""
             crash_info = ""
             # Some gtests (e.g. the function property fuzzer, gtest_functions_stress) log the
             # offending call as a runnable SQL query right before crashing, via
@@ -789,9 +808,26 @@ class Result(MetaClasses.Serializable):
             _REPRO_MAX_LEN = 8192
             if result.files:
                 log_content = Shell.get_output(f"cat {result.files[0]}", verbose=False)
-                for line in log_content.splitlines():
-                    if not crash_info and any(line.startswith(p) for p in _ERROR_PREFIXES):
-                        crash_info = line
+                log_lines = log_content.splitlines()
+                # Index of the last test that started running. Everything before it belongs to
+                # tests that already finished, so the crash output must come after it. If no
+                # "[ RUN      ]" marker exists (the binary failed before any test ran), -1 makes
+                # the scan below cover the whole log.
+                last_run_idx = -1
+                for idx, line in enumerate(log_lines):
+                    if not line.startswith("[ RUN"):
+                        continue
+                    bracket_end = line.find("]")
+                    if bracket_end == -1:
+                        continue
+                    last_run_idx = idx
+                    crashed_test = line[bracket_end + 1 :].strip()
+                for line in log_lines[last_run_idx + 1 :]:
+                    if not crash_info and (
+                        any(line.startswith(p) for p in _ERROR_PREFIXES)
+                        or any(s in line for s in _ERROR_SUBSTRINGS)
+                    ):
+                        crash_info = line.strip()
                     if not repro_info and line.startswith("(while ") and "SELECT " in line:
                         repro_info = line
                         if len(repro_info) > _REPRO_MAX_LEN:
@@ -800,8 +836,10 @@ class Result(MetaClasses.Serializable):
                         break
             crash_info = "\n".join(p for p in (crash_info, repro_info) if p)
             result.info = crash_info or info
-            # Synthesize a failed sub-result so the job summary is not empty.
-            crashed_test = gtest_filter.rstrip(".*") or "unknown"
+            # Synthesize a failed sub-result so the job summary is not empty. Prefer the test that
+            # was running when the binary died; fall back to the filter expression only when the
+            # log had no "[ RUN      ]" marker at all.
+            crashed_test = crashed_test or gtest_filter.rstrip(".*") or "unknown"
             result.set_results(
                 [Result(name=crashed_test, status=Result.Status.FAIL, info=crash_info or info)]
             )


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106412&sha=98631ec372a5b804874ad9af1ff9d922cb35b953&name_0=PR

It shows test name as "-FunctionsStress", with no error message. The actual gtest output was:
```
...
[ RUN      ] KeeperMemorySnapshotApplyTest.CorruptSnapshotPrefixFailsBeforeDroppingStorage
libc++abi: terminating due to uncaught exception of type DB::Exception: Cannot read all data. Bytes read: 0. Bytes expected: 4.

Thread 1 "unit_tests_dbms" received signal SIGABRT, Aborted.

Program terminated with signal SIGABRT, Aborted.
The program no longer exists.
No stack.
```

I.e. `KeeperMemorySnapshotApplyTest.CorruptSnapshotPrefixFailsBeforeDroppingStorage` crashed. This PR makes it correctly show this as test "KeeperMemorySnapshotApplyTest.CorruptSnapshotPrefixFailsBeforeDroppingStorage" with the output.

Written by claude.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.931`
<!-- ch-version-info:end -->