### PR TITLE
Fix quadratic access entity cache recomputation during refresh (may lead to login hungs)

### DIFF
--- a/src/Access/AccessChangesNotifier.cpp
+++ b/src/Access/AccessChangesNotifier.cpp
@@ -83,17 +83,33 @@ scope_guard AccessChangesNotifier::subscribeForChanges(const std::vector<UUID> &
     return subscriptions;
 }
 
+scope_guard AccessChangesNotifier::subscribeForBatchFinished(const OnBatchFinishedHandler & handler)
+{
+    std::lock_guard lock{handlers->mutex};
+    auto & list = handlers->on_batch_finished;
+    list.push_back(handler);
+    auto handler_it = std::prev(list.end());
+
+    return [my_handlers = handlers, handler_it]
+    {
+        std::lock_guard lock2{my_handlers->mutex};
+        my_handlers->on_batch_finished.erase(handler_it);
+    };
+}
+
 void AccessChangesNotifier::sendNotifications()
 {
     /// Only one thread can send notification at any time.
     std::lock_guard sending_notifications_lock{sending_notifications};
 
+    bool sent_any = false;
     std::unique_lock queue_lock{queue_mutex};
     while (!queue.empty())
     {
         auto event = std::move(queue.front());
         queue.pop();
         queue_lock.unlock();
+        sent_any = true;
 
         std::vector<OnChangedHandler> current_handlers;
         {
@@ -117,6 +133,30 @@ void AccessChangesNotifier::sendNotifications()
         }
 
         queue_lock.lock();
+    }
+    queue_lock.unlock();
+
+    if (!sent_any)
+        return;
+
+    /// Queue drained (e.g. a full refresh); run the coalesced per-batch work. Copied out so handlers
+    /// run without `handlers->mutex` held.
+    std::vector<OnBatchFinishedHandler> batch_finished_handlers;
+    {
+        std::lock_guard handlers_lock{handlers->mutex};
+        boost::range::copy(handlers->on_batch_finished, std::back_inserter(batch_finished_handlers));
+    }
+
+    for (const auto & handler : batch_finished_handlers)
+    {
+        try
+        {
+            handler();
+        }
+        catch (...)
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
     }
 }
 

--- a/src/Access/AccessChangesNotifier.h
+++ b/src/Access/AccessChangesNotifier.h
@@ -36,6 +36,14 @@ public:
     scope_guard subscribeForChanges(const UUID & id, const OnChangedHandler & handler);
     scope_guard subscribeForChanges(const std::vector<UUID> & ids, const OnChangedHandler & handler);
 
+    using OnBatchFinishedHandler = std::function<void()>;
+
+    /// Subscribes for the end of a notification batch: the handler is called once after sendNotifications()
+    /// has dispatched all the per-entity notifications queued so far. Lets subscribers coalesce expensive
+    /// per-entity recomputations into a single one per batch (e.g. a full refresh delivers one notification
+    /// per entity, but the derived state only needs to be rebuilt once).
+    scope_guard subscribeForBatchFinished(const OnBatchFinishedHandler & handler);
+
     /// Called by access storages after a new access entity has been added.
     void onEntityAdded(const UUID & id, const AccessEntityPtr & new_entity);
 
@@ -54,6 +62,7 @@ private:
     {
         std::unordered_map<UUID, std::list<OnChangedHandler>> by_id;
         std::list<OnChangedHandler> by_type[static_cast<size_t>(AccessEntityType::MAX)];
+        std::list<OnBatchFinishedHandler> on_batch_finished;
         std::mutex mutex;
     };
 

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -559,6 +559,11 @@ scope_guard AccessControl::subscribeForChanges(const std::vector<UUID> & ids, co
     return changes_notifier->subscribeForChanges(ids, handler);
 }
 
+scope_guard AccessControl::subscribeForBatchFinished(const OnBatchFinishedHandler & handler) const
+{
+    return changes_notifier->subscribeForBatchFinished(handler);
+}
+
 bool AccessControl::insertImpl(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id)
 {
     if (MultipleAccessStorage::insertImpl(id, entity, replace_if_exists, throw_if_exists, conflicting_id))

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -128,6 +128,11 @@ public:
     scope_guard subscribeForChanges(const UUID & id, const OnChangedHandler & handler) const;
     scope_guard subscribeForChanges(const std::vector<UUID> & ids, const OnChangedHandler & handler) const;
 
+    using OnBatchFinishedHandler = std::function<void()>;
+
+    /// Subscribes for the end of a notification batch (see AccessChangesNotifier::subscribeForBatchFinished).
+    scope_guard subscribeForBatchFinished(const OnBatchFinishedHandler & handler) const;
+
     AuthResult authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ClientInfo & client_info) const;
 
     /// Makes a backup of access entities.

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -4,6 +4,9 @@
 #include <Access/QuotaUsage.h>
 #include <Access/AccessControl.h>
 #include <Common/Exception.h>
+#include <Common/Logger.h>
+#include <Common/Stopwatch.h>
+#include <Common/logger_useful.h>
 #include <base/range.h>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -331,6 +334,8 @@ void QuotaCache::chooseQuotaToConsume()
 {
     /// `mutex` is already locked.
 
+    Stopwatch watch;
+    size_t rechosen_sets = 0;
     for (auto i = enabled_quotas.begin(), e = enabled_quotas.end(); i != e;)
     {
         auto elem = i->second.lock();
@@ -339,9 +344,17 @@ void QuotaCache::chooseQuotaToConsume()
         else
         {
             chooseQuotaToConsumeFor(*elem, true);
+            ++rechosen_sets;
             ++i;
         }
     }
+
+    const auto elapsed_ms = watch.elapsedMilliseconds();
+    /// O(enabled sets * quotas), under `mutex` that the ContextAccess build path also takes.
+    if (elapsed_ms >= 1000)
+        LOG_WARNING(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", rechosen_sets, all_quotas.size(), elapsed_ms);
+    else
+        LOG_DEBUG(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", rechosen_sets, all_quotas.size(), elapsed_ms);
 }
 
 void QuotaCache::chooseQuotaToConsumeFor(EnabledQuota & enabled, bool throw_if_client_key_empty)

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -320,7 +320,7 @@ void QuotaCache::quotaAddedOrChanged(const UUID & quota_id, const std::shared_pt
 
     auto & info = it->second;
     info.setQuota(new_quota, quota_id);
-    need_rechoose_quotas = true;
+    need_choose_quota = true;
 }
 
 
@@ -328,18 +328,18 @@ void QuotaCache::quotaRemoved(const UUID & quota_id)
 {
     std::lock_guard lock{mutex};
     all_quotas.erase(quota_id);
-    need_rechoose_quotas = true;
+    need_choose_quota = true;
 }
 
 
 void QuotaCache::chooseQuotaToConsumeIfNeeded()
 {
     std::lock_guard lock{mutex};
-    if (!need_rechoose_quotas)
+    if (!need_choose_quota)
         return;
     /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     chooseQuotaToConsume();
-    need_rechoose_quotas = false;
+    need_choose_quota = false;
 }
 
 
@@ -348,7 +348,6 @@ void QuotaCache::chooseQuotaToConsume()
     /// `mutex` is already locked.
 
     Stopwatch watch;
-    size_t rechosen_sets = 0;
     for (auto i = enabled_quotas.begin(), e = enabled_quotas.end(); i != e;)
     {
         auto elem = i->second.lock();
@@ -357,7 +356,6 @@ void QuotaCache::chooseQuotaToConsume()
         else
         {
             chooseQuotaToConsumeFor(*elem, true);
-            ++rechosen_sets;
             ++i;
         }
     }
@@ -365,9 +363,9 @@ void QuotaCache::chooseQuotaToConsume()
     const auto elapsed_ms = watch.elapsedMilliseconds();
     /// O(enabled sets * quotas), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
-        LOG_WARNING(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", rechosen_sets, all_quotas.size(), elapsed_ms);
+        LOG_WARNING(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", enabled_quotas.size(), all_quotas.size(), elapsed_ms);
     else
-        LOG_DEBUG(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", rechosen_sets, all_quotas.size(), elapsed_ms);
+        LOG_DEBUG(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", enabled_quotas.size(), all_quotas.size(), elapsed_ms);
 }
 
 void QuotaCache::chooseQuotaToConsumeFor(EnabledQuota & enabled, bool throw_if_client_key_empty)

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -293,6 +293,8 @@ void QuotaCache::ensureAllQuotasRead()
                 quotaRemoved(id);
         });
 
+    batch_subscription = access_control.subscribeForBatchFinished([this] { chooseQuotaToConsumeIfNeeded(); });
+
     for (const UUID & quota_id : access_control.findAll<Quota>())
     {
         auto quota = access_control.tryRead<Quota>(quota_id);
@@ -318,7 +320,7 @@ void QuotaCache::quotaAddedOrChanged(const UUID & quota_id, const std::shared_pt
 
     auto & info = it->second;
     info.setQuota(new_quota, quota_id);
-    chooseQuotaToConsume();
+    need_rechoose_quotas = true;
 }
 
 
@@ -326,7 +328,18 @@ void QuotaCache::quotaRemoved(const UUID & quota_id)
 {
     std::lock_guard lock{mutex};
     all_quotas.erase(quota_id);
+    need_rechoose_quotas = true;
+}
+
+
+void QuotaCache::chooseQuotaToConsumeIfNeeded()
+{
+    std::lock_guard lock{mutex};
+    if (!need_rechoose_quotas)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     chooseQuotaToConsume();
+    need_rechoose_quotas = false;
 }
 
 

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -5,6 +5,7 @@
 #include <Access/AccessControl.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 #include <base/range.h>
@@ -14,6 +15,12 @@
 #include <boost/range/algorithm/stable_sort.hpp>
 #include <boost/smart_ptr/make_shared.hpp>
 
+
+namespace ProfileEvents
+{
+    extern const Event QuotaCacheRecalculations;
+    extern const Event QuotaCacheRecalculationMicroseconds;
+}
 
 namespace DB
 {
@@ -347,6 +354,7 @@ void QuotaCache::chooseQuotaToConsume()
 {
     /// `mutex` is already locked.
 
+    ProfileEvents::increment(ProfileEvents::QuotaCacheRecalculations);
     Stopwatch watch;
     for (auto i = enabled_quotas.begin(), e = enabled_quotas.end(); i != e;)
     {
@@ -361,6 +369,7 @@ void QuotaCache::chooseQuotaToConsume()
     }
 
     const auto elapsed_ms = watch.elapsedMilliseconds();
+    ProfileEvents::increment(ProfileEvents::QuotaCacheRecalculationMicroseconds, watch.elapsedMicroseconds());
     /// O(enabled sets * quotas), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
         LOG_WARNING(getLogger("QuotaCache"), "Re-chose quotas for {} enabled set(s) over {} quotas in {} ms", enabled_quotas.size(), all_quotas.size(), elapsed_ms);

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -57,13 +57,17 @@ private:
     void quotaAddedOrChanged(const UUID & quota_id, const std::shared_ptr<const Quota> & new_quota);
     void quotaRemoved(const UUID & quota_id);
     void chooseQuotaToConsume();
+    void chooseQuotaToConsumeIfNeeded();
     void chooseQuotaToConsumeFor(EnabledQuota & enabled_quota, bool throw_if_client_key_empty);
 
     const AccessControl & access_control;
     mutable std::mutex mutex;
     std::unordered_map<UUID /* quota id */, QuotaInfo> all_quotas;
     bool all_quotas_read = false;
+    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    bool need_rechoose_quotas = false;
     scope_guard subscription;
+    scope_guard batch_subscription;
     std::map<EnabledQuota::Params, std::weak_ptr<EnabledQuota>> enabled_quotas;
 };
 }

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -65,7 +65,7 @@ private:
     std::unordered_map<UUID /* quota id */, QuotaInfo> all_quotas;
     bool all_quotas_read = false;
     /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
-    bool need_rechoose_quotas = false;
+    bool need_choose_quota = false;
     scope_guard subscription;
     scope_guard batch_subscription;
     std::map<EnabledQuota::Params, std::weak_ptr<EnabledQuota>> enabled_quotas;

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -4,6 +4,9 @@
 #include <Access/AccessControl.h>
 #include <boost/container/flat_set.hpp>
 #include <base/FnTraits.h>
+#include <Common/Logger.h>
+#include <Common/Stopwatch.h>
+#include <Common/logger_useful.h>
 
 
 namespace DB
@@ -102,12 +105,15 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
+    Stopwatch watch;
+    size_t recalculated_sets = 0;
     for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
     {
         auto & item = i->second;
         if (auto enabled_roles = item.enabled_roles.lock())
         {
             collectEnabledRoles(*enabled_roles, item.subscriptions_on_roles, notifications);
+            ++recalculated_sets;
             ++i;
         }
         else
@@ -115,6 +121,13 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
             i = enabled_roles_by_params.erase(i);
         }
     }
+
+    const auto elapsed_ms = watch.elapsedMilliseconds();
+    /// O(enabled sets * roles), under `mutex` that the ContextAccess build path also takes.
+    if (elapsed_ms >= 1000)
+        LOG_WARNING(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", recalculated_sets, elapsed_ms);
+    else
+        LOG_DEBUG(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", recalculated_sets, elapsed_ms);
 }
 
 

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -5,9 +5,16 @@
 #include <boost/container/flat_set.hpp>
 #include <base/FnTraits.h>
 #include <Common/Logger.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 
+
+namespace ProfileEvents
+{
+    extern const Event RoleCacheRecalculations;
+    extern const Event RoleCacheRecalculationMicroseconds;
+}
 
 namespace DB
 {
@@ -106,6 +113,7 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
+    ProfileEvents::increment(ProfileEvents::RoleCacheRecalculations);
     Stopwatch watch;
     for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
     {
@@ -122,6 +130,7 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
     }
 
     const auto elapsed_ms = watch.elapsedMilliseconds();
+    ProfileEvents::increment(ProfileEvents::RoleCacheRecalculationMicroseconds, watch.elapsedMicroseconds());
     /// O(enabled sets * roles), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
         LOG_WARNING(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", enabled_roles_by_params.size(), elapsed_ms);

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -83,13 +83,6 @@ RoleCache::getEnabledRoles(boost::container::flat_set<UUID> roles, boost::contai
 {
     std::lock_guard lock{mutex};
 
-    /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
-    if (!batch_subscribed)
-    {
-        batch_subscription = access_control.subscribeForBatchFinished([this] { collectEnabledRolesIfNeeded(); });
-        batch_subscribed = true;
-    }
-
     EnabledRoles::Params params;
     params.current_roles = std::move(roles);
     params.current_roles_with_admin_option = std::move(roles_with_admin_option);
@@ -114,14 +107,12 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
     /// `mutex` is already locked.
 
     Stopwatch watch;
-    size_t recalculated_sets = 0;
     for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
     {
         auto & item = i->second;
         if (auto enabled_roles = item.enabled_roles.lock())
         {
             collectEnabledRoles(*enabled_roles, item.subscriptions_on_roles, notifications);
-            ++recalculated_sets;
             ++i;
         }
         else
@@ -133,9 +124,9 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
     const auto elapsed_ms = watch.elapsedMilliseconds();
     /// O(enabled sets * roles), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
-        LOG_WARNING(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", recalculated_sets, elapsed_ms);
+        LOG_WARNING(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", enabled_roles_by_params.size(), elapsed_ms);
     else
-        LOG_DEBUG(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", recalculated_sets, elapsed_ms);
+        LOG_DEBUG(getLogger("RoleCache"), "Recalculated enabled roles for {} enabled set(s) in {} ms", enabled_roles_by_params.size(), elapsed_ms);
 }
 
 
@@ -172,6 +163,13 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsO
 RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles)
 {
     /// `mutex` is already locked.
+
+    /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
+    if (!batch_subscribed)
+    {
+        batch_subscription = access_control.subscribeForBatchFinished([this] { collectEnabledRolesIfNeeded(); });
+        batch_subscribed = true;
+    }
 
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
@@ -218,7 +216,7 @@ void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
     }
 
     /// An enabled role for some users has been changed, we need to recalculate the access rights.
-    need_recalculate = true;
+    need_collect_enabled_roles = true;
 }
 
 
@@ -230,7 +228,7 @@ void RoleCache::roleRemoved(const UUID & role_id)
     cache.remove(role_id);
 
     /// An enabled role for some users has been removed, we need to recalculate the access rights.
-    need_recalculate = true;
+    need_collect_enabled_roles = true;
 }
 
 
@@ -240,11 +238,11 @@ void RoleCache::collectEnabledRolesIfNeeded()
     scope_guard notifications;
 
     std::lock_guard lock{mutex};
-    if (!need_recalculate)
+    if (!need_collect_enabled_roles)
         return;
     /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     collectEnabledRoles(&notifications); /// collectEnabledRoles() must be called with the `mutex` locked.
-    need_recalculate = false;
+    need_collect_enabled_roles = false;
 }
 
 }

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -82,6 +82,14 @@ std::shared_ptr<const EnabledRoles>
 RoleCache::getEnabledRoles(boost::container::flat_set<UUID> roles, boost::container::flat_set<UUID> roles_with_admin_option)
 {
     std::lock_guard lock{mutex};
+
+    /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
+    if (!batch_subscribed)
+    {
+        batch_subscription = access_control.subscribeForBatchFinished([this] { collectEnabledRolesIfNeeded(); });
+        batch_subscribed = true;
+    }
+
     EnabledRoles::Params params;
     params.current_roles = std::move(roles);
     params.current_roles_with_admin_option = std::move(roles_with_admin_option);
@@ -199,9 +207,6 @@ RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscrip
 
 void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
 {
-    /// Declared before `lock` to send notifications after the mutex will be unlocked.
-    scope_guard notifications;
-
     std::lock_guard lock{mutex};
 
     auto role_from_cache = cache.get(role_id);
@@ -213,22 +218,33 @@ void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
     }
 
     /// An enabled role for some users has been changed, we need to recalculate the access rights.
-    collectEnabledRoles(&notifications); /// collectEnabledRoles() must be called with the `mutex` locked.
+    need_recalculate = true;
 }
 
 
 void RoleCache::roleRemoved(const UUID & role_id)
 {
-    /// Declared before `lock` to send notifications after the mutex will be unlocked.
-    scope_guard notifications;
-
     std::lock_guard lock{mutex};
 
     /// If a cache entry with the role has expired already, that remove() will do nothing.
     cache.remove(role_id);
 
     /// An enabled role for some users has been removed, we need to recalculate the access rights.
+    need_recalculate = true;
+}
+
+
+void RoleCache::collectEnabledRolesIfNeeded()
+{
+    /// Declared before `lock` to send notifications after the mutex will be unlocked.
+    scope_guard notifications;
+
+    std::lock_guard lock{mutex};
+    if (!need_recalculate)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     collectEnabledRoles(&notifications); /// collectEnabledRoles() must be called with the `mutex` locked.
+    need_recalculate = false;
 }
 
 }

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -41,7 +41,7 @@ private:
     bool batch_subscribed TSA_GUARDED_BY(mutex) = false;
 
     /// Set by the per-entity handler; the recalculation is coalesced to once per notification batch.
-    bool need_recalculate TSA_GUARDED_BY(mutex) = false;
+    bool need_collect_enabled_roles TSA_GUARDED_BY(mutex) = false;
 
     Poco::AccessExpireCache<UUID, std::pair<RolePtr, std::shared_ptr<scope_guard>>> TSA_GUARDED_BY(mutex) cache;
 

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -31,11 +31,17 @@ private:
 
     void collectEnabledRoles(scope_guard * notifications) TSA_REQUIRES(mutex);
     void collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
+    void collectEnabledRolesIfNeeded();
     RolePtr getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles) TSA_REQUIRES(mutex);
     void roleChanged(const UUID & role_id, const RolePtr & changed_role);
     void roleRemoved(const UUID & role_id);
 
     const AccessControl & access_control;
+    scope_guard batch_subscription;
+    bool batch_subscribed TSA_GUARDED_BY(mutex) = false;
+
+    /// Set by the per-entity handler; the recalculation is coalesced to once per notification batch.
+    bool need_recalculate TSA_GUARDED_BY(mutex) = false;
 
     Poco::AccessExpireCache<UUID, std::pair<RolePtr, std::shared_ptr<scope_guard>>> TSA_GUARDED_BY(mutex) cache;
 

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -7,6 +7,7 @@
 #include <Parsers/makeASTForLogicalFunction.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
@@ -14,6 +15,12 @@
 #include <boost/smart_ptr/make_shared.hpp>
 #include <Core/Defines.h>
 
+
+namespace ProfileEvents
+{
+    extern const Event RowPolicyCacheRecalculations;
+    extern const Event RowPolicyCacheRecalculationMicroseconds;
+}
 
 namespace DB
 {
@@ -205,6 +212,7 @@ void RowPolicyCache::mixFiltersIfNeeded()
 void RowPolicyCache::mixFilters()
 {
     /// `mutex` is already locked.
+    ProfileEvents::increment(ProfileEvents::RowPolicyCacheRecalculations);
     Stopwatch watch;
     for (auto i = enabled_row_policies.begin(), e = enabled_row_policies.end(); i != e;)
     {
@@ -219,6 +227,7 @@ void RowPolicyCache::mixFilters()
     }
 
     const auto elapsed_ms = watch.elapsedMilliseconds();
+    ProfileEvents::increment(ProfileEvents::RowPolicyCacheRecalculationMicroseconds, watch.elapsedMicroseconds());
     /// O(enabled sets * policies), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
         LOG_WARNING(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", enabled_row_policies.size(), all_policies.size(), elapsed_ms);

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -150,6 +150,8 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
                 rowPolicyRemoved(id);
         });
 
+    batch_subscription = access_control.subscribeForBatchFinished([this] { mixFiltersIfNeeded(); });
+
     for (const UUID & id : access_control.findAll<RowPolicy>())
     {
         auto policy = access_control.tryRead<RowPolicy>(id);
@@ -177,7 +179,7 @@ void RowPolicyCache::rowPolicyAddedOrChanged(const UUID & policy_id, const RowPo
 
     auto & info = it->second;
     info.setPolicy(new_policy);
-    mixFilters();
+    need_mix_filters = true;
 }
 
 
@@ -185,7 +187,18 @@ void RowPolicyCache::rowPolicyRemoved(const UUID & policy_id)
 {
     std::lock_guard lock{mutex};
     all_policies.erase(policy_id);
+    need_mix_filters = true;
+}
+
+
+void RowPolicyCache::mixFiltersIfNeeded()
+{
+    std::lock_guard lock{mutex};
+    if (!need_mix_filters)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing mixFilters() is retried next batch.
     mixFilters();
+    need_mix_filters = false;
 }
 
 

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -206,7 +206,6 @@ void RowPolicyCache::mixFilters()
 {
     /// `mutex` is already locked.
     Stopwatch watch;
-    size_t mixed_sets = 0;
     for (auto i = enabled_row_policies.begin(), e = enabled_row_policies.end(); i != e;)
     {
         auto elem = i->second.lock();
@@ -215,7 +214,6 @@ void RowPolicyCache::mixFilters()
         else
         {
             mixFiltersFor(*elem);
-            ++mixed_sets;
             ++i;
         }
     }
@@ -223,9 +221,9 @@ void RowPolicyCache::mixFilters()
     const auto elapsed_ms = watch.elapsedMilliseconds();
     /// O(enabled sets * policies), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
-        LOG_WARNING(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", mixed_sets, all_policies.size(), elapsed_ms);
+        LOG_WARNING(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", enabled_row_policies.size(), all_policies.size(), elapsed_ms);
     else
-        LOG_DEBUG(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", mixed_sets, all_policies.size(), elapsed_ms);
+        LOG_DEBUG(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", enabled_row_policies.size(), all_policies.size(), elapsed_ms);
 }
 
 

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -7,6 +7,8 @@
 #include <Parsers/makeASTForLogicalFunction.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
+#include <Common/Stopwatch.h>
+#include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <base/range.h>
 #include <boost/smart_ptr/make_shared.hpp>
@@ -190,6 +192,8 @@ void RowPolicyCache::rowPolicyRemoved(const UUID & policy_id)
 void RowPolicyCache::mixFilters()
 {
     /// `mutex` is already locked.
+    Stopwatch watch;
+    size_t mixed_sets = 0;
     for (auto i = enabled_row_policies.begin(), e = enabled_row_policies.end(); i != e;)
     {
         auto elem = i->second.lock();
@@ -198,9 +202,17 @@ void RowPolicyCache::mixFilters()
         else
         {
             mixFiltersFor(*elem);
+            ++mixed_sets;
             ++i;
         }
     }
+
+    const auto elapsed_ms = watch.elapsedMilliseconds();
+    /// O(enabled sets * policies), under `mutex` that the ContextAccess build path also takes.
+    if (elapsed_ms >= 1000)
+        LOG_WARNING(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", mixed_sets, all_policies.size(), elapsed_ms);
+    else
+        LOG_DEBUG(getLogger("RowPolicyCache"), "Re-mixed row policy filters for {} enabled set(s) over {} policies in {} ms", mixed_sets, all_policies.size(), elapsed_ms);
 }
 
 

--- a/src/Access/RowPolicyCache.h
+++ b/src/Access/RowPolicyCache.h
@@ -40,12 +40,16 @@ private:
     void rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy);
     void rowPolicyRemoved(const UUID & policy_id);
     void mixFilters();
+    void mixFiltersIfNeeded();
     void mixFiltersFor(EnabledRowPolicies & enabled);
 
     const AccessControl & access_control;
     std::unordered_map<UUID, PolicyInfo> all_policies;
     bool all_policies_read = false;
+    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    bool need_mix_filters = false;
     scope_guard subscription;
+    scope_guard batch_subscription;
     std::map<EnabledRowPolicies::Params, std::weak_ptr<EnabledRowPolicies>> enabled_row_policies;
     std::mutex mutex;
 };

--- a/src/Access/RowPolicyCache.h
+++ b/src/Access/RowPolicyCache.h
@@ -39,15 +39,15 @@ private:
     void ensureAllRowPoliciesRead();
     void rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy);
     void rowPolicyRemoved(const UUID & policy_id);
-    void mixFilters();
     void mixFiltersIfNeeded();
+    void mixFilters();
     void mixFiltersFor(EnabledRowPolicies & enabled);
 
     const AccessControl & access_control;
     std::unordered_map<UUID, PolicyInfo> all_policies;
     bool all_policies_read = false;
     /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
-    bool need_mix_filters = false;
+    bool need_mix_filters TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
     scope_guard batch_subscription;
     std::map<EnabledRowPolicies::Params, std::weak_ptr<EnabledRowPolicies>> enabled_row_policies;

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -2,6 +2,9 @@
 #include <Access/AccessControl.h>
 #include <Access/SettingsProfile.h>
 #include <Access/SettingsProfilesInfo.h>
+#include <Common/Logger.h>
+#include <Common/Stopwatch.h>
+#include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 
 
@@ -103,6 +106,8 @@ void SettingsProfilesCache::setDefaultProfileName(const String & default_profile
 void SettingsProfilesCache::mergeSettingsAndConstraints()
 {
     /// `mutex` is already locked.
+    Stopwatch watch;
+    size_t merged_sets = 0;
     for (auto i = enabled_settings.begin(), e = enabled_settings.end(); i != e;)
     {
         auto enabled = i->second.lock();
@@ -111,9 +116,17 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
         else
         {
             mergeSettingsAndConstraintsFor(*enabled);
+            ++merged_sets;
             ++i;
         }
     }
+
+    const auto elapsed_ms = watch.elapsedMilliseconds();
+    /// O(enabled sets * profiles), under `mutex` that the ContextAccess build path also takes.
+    if (elapsed_ms >= 1000)
+        LOG_WARNING(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", merged_sets, all_profiles.size(), elapsed_ms);
+    else
+        LOG_DEBUG(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", merged_sets, all_profiles.size(), elapsed_ms);
 }
 
 

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -37,6 +37,8 @@ void SettingsProfilesCache::ensureAllProfilesRead()
                 profileRemoved(id);
         });
 
+    batch_subscription = access_control.subscribeForBatchFinished([this] { mergeSettingsAndConstraintsIfNeeded(); });
+
     for (const UUID & id : access_control.findAll<SettingsProfile>())
     {
         auto profile = access_control.tryRead<SettingsProfile>(id);
@@ -67,7 +69,7 @@ void SettingsProfilesCache::profileAddedOrChanged(const UUID & profile_id, const
         profiles_by_name[new_profile->getName()] = profile_id;
     }
     profile_infos_cache.clear();
-    mergeSettingsAndConstraints();
+    need_recalculate = true;
 }
 
 
@@ -80,7 +82,18 @@ void SettingsProfilesCache::profileRemoved(const UUID & profile_id)
     profiles_by_name.erase(it->second->getName());
     all_profiles.erase(it);
     profile_infos_cache.clear();
+    need_recalculate = true;
+}
+
+
+void SettingsProfilesCache::mergeSettingsAndConstraintsIfNeeded()
+{
+    std::lock_guard lock{mutex};
+    if (!need_recalculate)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     mergeSettingsAndConstraints();
+    need_recalculate = false;
 }
 
 

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -3,10 +3,17 @@
 #include <Access/SettingsProfile.h>
 #include <Access/SettingsProfilesInfo.h>
 #include <Common/Logger.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 
+
+namespace ProfileEvents
+{
+    extern const Event SettingsProfileCacheRecalculations;
+    extern const Event SettingsProfileCacheRecalculationMicroseconds;
+}
 
 namespace DB
 {
@@ -119,6 +126,7 @@ void SettingsProfilesCache::setDefaultProfileName(const String & default_profile
 void SettingsProfilesCache::mergeSettingsAndConstraints()
 {
     /// `mutex` is already locked.
+    ProfileEvents::increment(ProfileEvents::SettingsProfileCacheRecalculations);
     Stopwatch watch;
     for (auto i = enabled_settings.begin(), e = enabled_settings.end(); i != e;)
     {
@@ -133,6 +141,7 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
     }
 
     const auto elapsed_ms = watch.elapsedMilliseconds();
+    ProfileEvents::increment(ProfileEvents::SettingsProfileCacheRecalculationMicroseconds, watch.elapsedMicroseconds());
     /// O(enabled sets * profiles), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
         LOG_WARNING(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", enabled_settings.size(), all_profiles.size(), elapsed_ms);

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -11,8 +11,9 @@
 
 namespace ProfileEvents
 {
-    extern const Event SettingsProfileCacheRecalculations;
-    extern const Event SettingsProfileCacheRecalculationMicroseconds;
+    /// NOLINT: not settings; the names contain "Settings" so check-settings-style mistakes them for setting externs.
+    extern const Event SettingsProfileCacheRecalculations; // NOLINT
+    extern const Event SettingsProfileCacheRecalculationMicroseconds; // NOLINT
 }
 
 namespace DB

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -69,7 +69,7 @@ void SettingsProfilesCache::profileAddedOrChanged(const UUID & profile_id, const
         profiles_by_name[new_profile->getName()] = profile_id;
     }
     profile_infos_cache.clear();
-    need_recalculate = true;
+    need_merge_settings_and_constraints = true;
 }
 
 
@@ -82,18 +82,18 @@ void SettingsProfilesCache::profileRemoved(const UUID & profile_id)
     profiles_by_name.erase(it->second->getName());
     all_profiles.erase(it);
     profile_infos_cache.clear();
-    need_recalculate = true;
+    need_merge_settings_and_constraints = true;
 }
 
 
 void SettingsProfilesCache::mergeSettingsAndConstraintsIfNeeded()
 {
     std::lock_guard lock{mutex};
-    if (!need_recalculate)
+    if (!need_merge_settings_and_constraints)
         return;
     /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
     mergeSettingsAndConstraints();
-    need_recalculate = false;
+    need_merge_settings_and_constraints = false;
 }
 
 
@@ -120,7 +120,6 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
 {
     /// `mutex` is already locked.
     Stopwatch watch;
-    size_t merged_sets = 0;
     for (auto i = enabled_settings.begin(), e = enabled_settings.end(); i != e;)
     {
         auto enabled = i->second.lock();
@@ -129,7 +128,6 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
         else
         {
             mergeSettingsAndConstraintsFor(*enabled);
-            ++merged_sets;
             ++i;
         }
     }
@@ -137,9 +135,9 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
     const auto elapsed_ms = watch.elapsedMilliseconds();
     /// O(enabled sets * profiles), under `mutex` that the ContextAccess build path also takes.
     if (elapsed_ms >= 1000)
-        LOG_WARNING(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", merged_sets, all_profiles.size(), elapsed_ms);
+        LOG_WARNING(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", enabled_settings.size(), all_profiles.size(), elapsed_ms);
     else
-        LOG_DEBUG(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", merged_sets, all_profiles.size(), elapsed_ms);
+        LOG_DEBUG(getLogger("SettingsProfilesCache"), "Re-merged settings and constraints for {} enabled set(s) over {} profiles in {} ms", enabled_settings.size(), all_profiles.size(), elapsed_ms);
 }
 
 

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -49,7 +49,7 @@ private:
     std::unordered_map<String, UUID> profiles_by_name;
     bool all_profiles_read = false;
     /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
-    bool need_recalculate = false;
+    bool need_merge_settings_and_constraints = false;
     scope_guard subscription;
     scope_guard batch_subscription;
     std::map<EnabledSettings::Params, std::weak_ptr<EnabledSettings>> enabled_settings;

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -36,6 +36,7 @@ private:
     void profileAddedOrChanged(const UUID & profile_id, const SettingsProfilePtr & new_profile);
     void profileRemoved(const UUID & profile_id);
     void mergeSettingsAndConstraints();
+    void mergeSettingsAndConstraintsIfNeeded();
     void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const;
 
     void substituteProfiles(SettingsProfileElements & elements,
@@ -47,7 +48,10 @@ private:
     std::unordered_map<UUID, SettingsProfilePtr> all_profiles;
     std::unordered_map<String, UUID> profiles_by_name;
     bool all_profiles_read = false;
+    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    bool need_recalculate = false;
     scope_guard subscription;
+    scope_guard batch_subscription;
     std::map<EnabledSettings::Params, std::weak_ptr<EnabledSettings>> enabled_settings;
     std::optional<UUID> default_profile_id;
     Poco::LRUCache<UUID, std::shared_ptr<const SettingsProfilesInfo>> profile_infos_cache;

--- a/src/Access/tests/gtest_access_changes_notifier.cpp
+++ b/src/Access/tests/gtest_access_changes_notifier.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include <Access/AccessChangesNotifier.h>
+#include <Access/Common/AccessEntityType.h>
+#include <Core/UUID.h>
+
+using namespace DB;
+
+/// The per-entity caches (RowPolicyCache, RoleCache, SettingsProfilesCache, QuotaCache) rely on
+/// subscribeForBatchFinished firing exactly once after a whole notification batch is drained, so that
+/// they patch their per-entity maps in the cheap per-entity handlers and run the expensive O(enabled
+/// sets * entities) rebuild only once per batch (a full refresh delivers one notification per entity).
+TEST(AccessChangesNotifier, BatchFinishedCoalescesRecompute)
+{
+    AccessChangesNotifier notifier;
+
+    size_t per_entity_calls = 0;
+    size_t batch_calls = 0;
+    size_t per_entity_calls_seen_by_last_batch = 0;
+
+    auto entity_subscription = notifier.subscribeForChanges(
+        AccessEntityType::ROW_POLICY,
+        [&](const UUID &, const AccessEntityPtr &) { ++per_entity_calls; });
+
+    auto batch_subscription = notifier.subscribeForBatchFinished(
+        [&]
+        {
+            ++batch_calls;
+            per_entity_calls_seen_by_last_batch = per_entity_calls;
+        });
+
+    /// A refresh that touches many entities: one notification per entity, drained in a single batch.
+    static constexpr size_t num_entities = 16;
+    for (size_t i = 0; i < num_entities; ++i)
+        notifier.onEntityRemoved(UUIDHelpers::generateV4(), AccessEntityType::ROW_POLICY);
+
+    notifier.sendNotifications();
+
+    /// Every entity is dispatched, but the batch-finished hook runs exactly once - this is the
+    /// coalescing the caches depend on (without it the rebuild would run num_entities times).
+    EXPECT_EQ(per_entity_calls, num_entities);
+    EXPECT_EQ(batch_calls, 1u);
+    /// The batch hook runs after all per-entity notifications within the same sendNotifications() call,
+    /// so the derived state is current once sendNotifications() returns.
+    EXPECT_EQ(per_entity_calls_seen_by_last_batch, num_entities);
+
+    /// A single DDL still recomputes exactly once.
+    notifier.onEntityRemoved(UUIDHelpers::generateV4(), AccessEntityType::ROW_POLICY);
+    notifier.sendNotifications();
+    EXPECT_EQ(per_entity_calls, num_entities + 1);
+    EXPECT_EQ(batch_calls, 2u);
+
+    /// An empty queue must not invoke the batch hook (nothing changed, nothing to rebuild).
+    notifier.sendNotifications();
+    EXPECT_EQ(batch_calls, 2u);
+}

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -563,6 +563,14 @@
     \
     M(ContextLock, "Number of times the lock of Context was acquired or tried to acquire. This is global lock.", ValueType::Number) \
     M(ContextLockWaitMicroseconds, "Context lock wait time in microseconds", ValueType::Microseconds) \
+    M(RowPolicyCacheRecalculations, "Number of times the row policy cache re-mixed filters for all live enabled sets. Coalesced to once per access entity notification batch.", ValueType::Number) \
+    M(RowPolicyCacheRecalculationMicroseconds, "Total time spent re-mixing row policy filters for all live enabled sets (held under the cache mutex that the ContextAccess build path also takes).", ValueType::Microseconds) \
+    M(RoleCacheRecalculations, "Number of times the role cache recalculated all live enabled sets. Coalesced to once per access entity notification batch.", ValueType::Number) \
+    M(RoleCacheRecalculationMicroseconds, "Total time spent recalculating all live enabled role sets (held under the cache mutex that the ContextAccess build path also takes).", ValueType::Microseconds) \
+    M(SettingsProfileCacheRecalculations, "Number of times the settings profile cache re-merged settings and constraints for all live enabled sets. Coalesced to once per access entity notification batch.", ValueType::Number) \
+    M(SettingsProfileCacheRecalculationMicroseconds, "Total time spent re-merging settings and constraints for all live enabled sets (held under the cache mutex that the ContextAccess build path also takes).", ValueType::Microseconds) \
+    M(QuotaCacheRecalculations, "Number of times the quota cache re-chose quotas for all live enabled sets. Coalesced to once per access entity notification batch.", ValueType::Number) \
+    M(QuotaCacheRecalculationMicroseconds, "Total time spent re-choosing quotas for all live enabled sets (held under the cache mutex that the ContextAccess build path also takes).", ValueType::Microseconds) \
     M(FileProgressCallbackInvocations, "Number of times the per-query `FileProgressCallback` was invoked (counts each per-file `FileProgress` event delivered to the client over native TCP or via `clickhouse-local`).", ValueType::Number) \
     \
     M(StorageBufferFlush, "Number of times a buffer in a 'Buffer' table was flushed.", ValueType::Number) \

--- a/tests/integration/test_access_cache_recompute_coalescing/configs/config.xml
+++ b/tests/integration/test_access_cache_recompute_coalescing/configs/config.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <remote_servers>
+        <default>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+    <user_directories replace="replace">
+        <replicated>
+            <zookeeper_path>/clickhouse/access</zookeeper_path>
+        </replicated>
+    </user_directories>
+</clickhouse>

--- a/tests/integration/test_access_cache_recompute_coalescing/test.py
+++ b/tests/integration/test_access_cache_recompute_coalescing/test.py
@@ -1,0 +1,102 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.network import PartitionManager
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/config.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+)
+
+NUM_POLICIES = 50
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def get_row_policy_recalculations(node):
+    value = node.query(
+        "SELECT value FROM system.events WHERE event = 'RowPolicyCacheRecalculations'"
+    ).strip()
+    return int(value) if value else 0
+
+
+# A refresh that touches many entities at once (here: a ZooKeeper session loss that makes node2
+# reread everything) delivers one notification per entity. The row policy cache must coalesce the
+# expensive re-mix to once per batch instead of running it once per changed policy.
+def test_recompute_coalesced_on_reread(started_cluster):
+    node1.query(
+        "CREATE TABLE IF NOT EXISTS default.t (x Int32) ENGINE = Memory;"
+        "CREATE USER u IDENTIFIED WITH no_password;"
+        + "".join(
+            f"CREATE ROW POLICY p{i} ON default.t USING x = {i} TO u;"
+            for i in range(NUM_POLICIES)
+        )
+    )
+    node2.query("CREATE TABLE IF NOT EXISTS default.t (x Int32) ENGINE = Memory")
+
+    node2.query_with_retry(
+        "SELECT count() FROM system.row_policies WHERE short_name LIKE 'p%'",
+        check_callback=lambda r: r.strip() == str(NUM_POLICIES),
+    )
+
+    # Build a live EnabledRowPolicies set for u on node2 (this also subscribes RowPolicyCache).
+    node2.query("SELECT 1", user="u")
+
+    baseline = get_row_policy_recalculations(node2)
+
+    # All three steps are required and none can be dropped:
+    #  - PartitionManager makes node2 *miss* the changes, so they are not consumed one-by-one as
+    #    per-entity watches (each of which would be its own notification batch the coalescing can't
+    #    help with);
+    #  - SYSTEM RECONNECT ZOOKEEPER drops node2's session so the reconnect rereads everything in one
+    #    `all=true` pass (a surviving session would redeliver the missed changes as NUM_POLICIES
+    #    separate watch notifications);
+    #  - SYSTEM RELOAD USERS is the deterministic flush (reload + synchronous sendNotifications).
+    # SYSTEM RELOAD USERS on its own is not enough: on an up-to-date node `setAll` diffs to zero and
+    # emits nothing.
+    with PartitionManager() as pm:
+        pm.drop_instance_zk_connections(node2)
+        node1.query(
+            "".join(
+                f"ALTER ROW POLICY p{i} ON default.t USING x = {i} + 1000;"
+                for i in range(NUM_POLICIES)
+            )
+        )
+        node2.query("SYSTEM RECONNECT ZOOKEEPER")
+
+    node2.query_with_retry("SYSTEM RELOAD USERS")
+
+    delta = get_row_policy_recalculations(node2) - baseline
+
+    node1.query(
+        "DROP USER u;"
+        + "".join(f"DROP ROW POLICY p{i} ON default.t;" for i in range(NUM_POLICIES))
+        + "DROP TABLE default.t SYNC;"
+    )
+    node2.query("DROP TABLE default.t SYNC")
+
+    # Lower bound guards against a silently broken setup (cache not subscribed / batch never fired):
+    # the reread must recompute at least once. Upper bound is the coalescing guarantee: once per
+    # batch (allow 2 for the reconnect/reload reread overlapping), not once per changed policy (~50).
+    assert 1 <= delta <= 2, (
+        f"row policy cache recomputed {delta} times for a {NUM_POLICIES}-entity reread; "
+        f"expected 1 (coalesced); without coalescing it would be ~{NUM_POLICIES}"
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed long login and query-startup stalls with replicated access storage when many access entities (row policies, roles, quotas, settings profiles) change at once. Each per-entity cache now recomputes once per notification batch instead of once per changed entity, removing quadratic work that could hold the access lock for minutes.

With replicated (Keeper-backed) access storage, applying many access changes at once — row policies, roles, quotas, or settings profiles — could stall logins and query startup for a long time (minutes in production), even on replicas that only observe the change.

The notifier already delivers a whole change in one pass, so each cache now does only the cheap per-object bookkeeping on each notification and runs the single expensive rebuild **once per batch** instead of once per object. A batch changing N objects does ~1 rebuild instead of N; a single statement still rebuilds exactly once; and the rebuild completes before the call returns, so access stays current.

Also logs each rebuild's size and duration (DEBUG, raised to WARNING at ≥1s) so a slow rebuild is visible without enabling debug logging.

Refs: https://github.com/ClickHouse/ClickHouse/pull/107097

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1006`
- Backported to: `26.5.3.51`, `26.4.5.58`, `26.3.14.48`
<!-- ch-version-info:end -->