### PR TITLE
[Docs] Clarify FINAL placement relative to table aliases

### DIFF
--- a/docs/en/sql-reference/statements/select/from.md
+++ b/docs/en/sql-reference/statements/select/from.md
@@ -80,6 +80,18 @@ SET final = 1;
 SELECT x, y FROM mytable WHERE x > 1;
 ```
 
+### Aliases and FINAL {#aliases-and-final}
+
+When a table has an alias, `FINAL` comes after the alias. This is most visible in [`JOIN`](/sql-reference/statements/select/join) queries, where tables are usually aliased:
+
+```sql
+SELECT t1.id, t2.name
+FROM table1 AS t1 FINAL
+INNER JOIN table2 AS t2 FINAL ON t1.id = t2.id;
+```
+
+`FINAL` is a modifier on the table reference, so it must follow the full `table [AS alias]` expression. Placing it before the alias (`FROM table1 FINAL AS t1`) is a syntax error.
+
 ## Implementation Details {#implementation-details}
 
 If the `FROM` clause is omitted, data will be read from the `system.one` table.


### PR DESCRIPTION
FINAL is a modifier on the table reference, so it must follow the table [AS alias] expression. Document that the alias comes before FINAL (most visibly in JOINs, where every table is aliased) and that the reversed order is a syntax error. Verified against ClickHouse 26.1.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.936`
<!-- ch-version-info:end -->