### PR TITLE
Report fuzzer runner aborts instead of an opaque status.tsv FileNotFoundError

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -86,8 +86,10 @@ def _format_status_error(exc: Exception, log_paths) -> str:
             "clickhouse-server pid file is never created), a fuzzer-harness "
             "error, or an infrastructure problem (job timeout, out of memory, "
             "docker/orchestration). Inspect the log tails below to determine the "
-            "cause; a normal fuzzer finding instead writes status.tsv with a FAIL "
-            "status and a stack trace." + tails_str
+            "cause; a normal fuzzer finding instead writes a complete status.tsv "
+            "(the three numeric fields server_died, server_exit_code, "
+            "fuzzer_exit_code), which run_fuzz_job then reports as FAIL with a "
+            "stack trace parsed from the logs." + tails_str
         )
 
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -80,12 +80,14 @@ def _format_status_error(exc: Exception, log_paths) -> str:
 
     if isinstance(exc, FileNotFoundError):
         return (
-            "Fuzzer runner aborted before producing status.tsv. The fuzzer "
-            "process was killed (job timeout, out of memory, or a "
-            "docker/orchestration failure) before it could report its exit "
-            "status. This is a CI infrastructure issue, not a fuzzer finding (a "
-            "real finding writes status.tsv with a FAIL status and a stack "
-            "trace); re-running the job usually clears it." + tails_str
+            "Fuzzer runner aborted before writing status.tsv. run-fuzzer.sh runs "
+            "under 'set -e' and writes status.tsv only at the very end, so any "
+            "earlier failure lands here: a server startup failure (e.g. the "
+            "clickhouse-server pid file is never created), a fuzzer-harness "
+            "error, or an infrastructure problem (job timeout, out of memory, "
+            "docker/orchestration). Inspect the log tails below to determine the "
+            "cause; a normal fuzzer finding instead writes status.tsv with a FAIL "
+            "status and a stack trace." + tails_str
         )
 
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
@@ -302,11 +304,11 @@ def run_fuzz_job(check_name: str):
             WORKSPACE_PATH / "status.tsv"
         )
     except Exception as e:
-        # Missing/empty status.tsv -> runner aborted before reporting (infra);
-        # malformed status.tsv -> harness bug. _format_status_error explains
-        # which, and inlines the log tails so the abort cause is visible instead
-        # of an opaque FileNotFoundError traceback. Attach available artifacts
-        # (incl. sanitizer.log.*) so the report is not lost.
+        # Missing/empty status.tsv -> runner aborted before reporting (server
+        # start failure, harness error, or infra); malformed status.tsv ->
+        # harness bug. _format_status_error inlines the log tails so the abort
+        # cause is visible instead of an opaque FileNotFoundError traceback.
+        # Attach available artifacts (incl. sanitizer.log.*) so nothing is lost.
         error_info = _format_status_error(e, paths)
         early_result = Result.create_from(status=Result.Status.ERROR, info=error_info)
         for file in paths:

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -34,6 +34,67 @@ JOB_ARTIFACTS = (
 )
 
 
+def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
+    """Last `max_lines` lines of `path` (bounded read), or "" if absent/empty."""
+    try:
+        size = path.stat().st_size
+        if size == 0:
+            return ""
+        with open(path, "rb") as fh:
+            if size > max_bytes:
+                fh.seek(-max_bytes, os.SEEK_END)
+            data = fh.read()
+    except OSError:
+        return ""
+    return "\n".join(data.decode("utf-8", errors="replace").splitlines()[-max_lines:])
+
+
+def _read_fuzzer_status(status_path: Path) -> tuple[bool, int, int]:
+    """Parse (server_died, server_exit_code, fuzzer_exit_code) from status.tsv.
+
+    Raises FileNotFoundError when the file is missing or empty (the runner
+    aborted before writing it) and ValueError when its contents are malformed.
+    """
+    if not status_path.exists():
+        raise FileNotFoundError(f"{status_path} was not produced by the fuzzer runner")
+    first_line = status_path.read_text(encoding="utf-8").split("\n", 1)[0]
+    if not first_line.strip():
+        raise FileNotFoundError(f"{status_path} is empty")
+    fields = first_line.split("\t")
+    if len(fields) != 3:
+        raise ValueError(
+            f"expected 3 tab-separated fields, got {len(fields)}: {first_line!r}"
+        )
+    server_died, server_exit_code, fuzzer_exit_code = fields
+    return bool(int(server_died)), int(server_exit_code), int(fuzzer_exit_code)
+
+
+def _format_status_error(exc: Exception, log_paths) -> str:
+    """Actionable job-error text for a missing/malformed status.tsv, with log tails."""
+    tails = []
+    for path in log_paths:
+        tail = _log_tail(path)
+        if tail:
+            tails.append(f"--- {path.name} (last lines) ---\n{tail}")
+    tails_str = ("\n\n" + "\n\n".join(tails)) if tails else ""
+
+    if isinstance(exc, FileNotFoundError):
+        return (
+            "Fuzzer runner aborted before producing status.tsv. The fuzzer "
+            "process was killed (job timeout, out of memory, or a "
+            "docker/orchestration failure) before it could report its exit "
+            "status. This is a CI infrastructure issue, not a fuzzer finding (a "
+            "real finding writes status.tsv with a FAIL status and a stack "
+            "trace); re-running the job usually clears it." + tails_str
+        )
+
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    return (
+        f"Fuzzer runner wrote an unparseable status.tsv ({exc}). This is a "
+        f"fuzzer-harness bug. Traceback:\n{tb}" + tails_str
+    )
+
+
 def get_run_command(
     image: DockerImage,
     buzzhouse: bool,
@@ -237,18 +298,16 @@ def run_fuzz_job(check_name: str):
     server_exit_code = 0
     fuzzer_exit_code = 0
     try:
-        with open(WORKSPACE_PATH / "status.tsv", "r", encoding="utf-8") as status_f:
-            server_died, server_exit_code, fuzzer_exit_code = (
-                status_f.readline().rstrip("\n").split("\t")
-            )
-            server_died = bool(int(server_died))
-            server_exit_code = int(server_exit_code)
-            fuzzer_exit_code = int(fuzzer_exit_code)
-    except Exception:
-        error_info = f"Unknown error in fuzzer runner script. Traceback:\n{traceback.format_exc()}"
-        # Runner may have aborted before writing status.tsv (e.g. early server
-        # abort); attach available artifacts (incl. sanitizer.log.*) so the report
-        # is not lost.
+        server_died, server_exit_code, fuzzer_exit_code = _read_fuzzer_status(
+            WORKSPACE_PATH / "status.tsv"
+        )
+    except Exception as e:
+        # Missing/empty status.tsv -> runner aborted before reporting (infra);
+        # malformed status.tsv -> harness bug. _format_status_error explains
+        # which, and inlines the log tails so the abort cause is visible instead
+        # of an opaque FileNotFoundError traceback. Attach available artifacts
+        # (incl. sanitizer.log.*) so the report is not lost.
+        error_info = _format_status_error(e, paths)
         early_result = Result.create_from(status=Result.Status.ERROR, info=error_info)
         for file in paths:
             if file.exists() and file.stat().st_size > 0:

--- a/ci/tests/test_e2e.py
+++ b/ci/tests/test_e2e.py
@@ -15,11 +15,74 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from ci.jobs.ast_fuzzer_job import JOB_ARTIFACTS, WORKSPACE_PATH
+import tempfile
+
+import pytest
+
+from ci.jobs.ast_fuzzer_job import (
+    JOB_ARTIFACTS,
+    WORKSPACE_PATH,
+    _format_status_error,
+    _read_fuzzer_status,
+)
 from ci.praktika.utils import Utils
 
 FUZZER_JOB = "AST fuzzer (amd_debug)"
 STRESS_JOB = "Stress test (amd_debug)"
+
+
+def test_read_fuzzer_status_valid():
+    with tempfile.TemporaryDirectory() as d:
+        status = Path(d) / "status.tsv"
+        status.write_text("1\t0\t137\n")
+        assert _read_fuzzer_status(status) == (True, 0, 137)
+
+
+def test_read_fuzzer_status_missing_or_empty():
+    # The runner aborts (timeout / OOM / docker failure) before writing
+    # status.tsv. A missing or empty file must be reported as an early abort,
+    # not as an opaque parse crash.
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(FileNotFoundError):
+            _read_fuzzer_status(Path(d) / "status.tsv")
+        empty = Path(d) / "status.tsv"
+        empty.write_text("")
+        with pytest.raises(FileNotFoundError):
+            _read_fuzzer_status(empty)
+
+
+def test_read_fuzzer_status_malformed():
+    with tempfile.TemporaryDirectory() as d:
+        bad = Path(d) / "status.tsv"
+        bad.write_text("garbage line\n")
+        with pytest.raises(ValueError):
+            _read_fuzzer_status(bad)
+
+
+def test_format_status_error_missing_is_infra_with_log_tail():
+    # Missing status.tsv -> infra-flagged message, no traceback, with log tail.
+    with tempfile.TemporaryDirectory() as d:
+        fuzzer_log = Path(d) / "fuzzer.log"
+        fuzzer_log.write_text("\n".join(f"line{i}" for i in range(200)))
+        msg = _format_status_error(
+            FileNotFoundError("status.tsv was not produced"),
+            [fuzzer_log, Path(d) / "absent.log"],
+        )
+        assert "infrastructure" in msg
+        assert "Traceback" not in msg
+        assert "fuzzer.log (last lines)" in msg
+        assert "line199" in msg  # tail, not head
+        assert "line0\n" not in msg  # head bounded out
+
+
+def test_format_status_error_malformed_keeps_traceback():
+    # Malformed status.tsv -> harness bug; keep the traceback for debugging.
+    try:
+        raise ValueError("expected 3 tab-separated fields")
+    except ValueError as e:
+        msg = _format_status_error(e, [])
+    assert "harness bug" in msg
+    assert "Traceback" in msg
 
 
 def test_fuzzer():

--- a/ci/tests/test_e2e.py
+++ b/ci/tests/test_e2e.py
@@ -59,8 +59,10 @@ def test_read_fuzzer_status_malformed():
             _read_fuzzer_status(bad)
 
 
-def test_format_status_error_missing_is_infra_with_log_tail():
-    # Missing status.tsv -> infra-flagged message, no traceback, with log tail.
+def test_format_status_error_missing_is_neutral_with_log_tail():
+    # Missing status.tsv -> neutral early-abort message, no traceback, log tail.
+    # It must NOT assert infra / "re-run clears it": a missing file can also be
+    # a server-startup or harness regression, so we point at the logs instead.
     with tempfile.TemporaryDirectory() as d:
         fuzzer_log = Path(d) / "fuzzer.log"
         fuzzer_log.write_text("\n".join(f"line{i}" for i in range(200)))
@@ -68,7 +70,8 @@ def test_format_status_error_missing_is_infra_with_log_tail():
             FileNotFoundError("status.tsv was not produced"),
             [fuzzer_log, Path(d) / "absent.log"],
         )
-        assert "infrastructure" in msg
+        assert "aborted before writing status.tsv" in msg
+        assert "re-run" not in msg.lower()
         assert "Traceback" not in msg
         assert "fuzzer.log (last lines)" in msg
         assert "line199" in msg  # tail, not head


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

When the AST/BuzzHouse fuzzer process is killed before it writes `status.tsv` (job timeout, OOM, or a docker/orchestration failure), `run_fuzz_job` reported an opaque `Unknown error in fuzzer runner script` followed by a `FileNotFoundError` traceback. That gives no hint of the real abort cause and reads like a code crash, even though it is a CI-infrastructure flake that a re-run clears. Over the last 7 days this surfaced as spurious red `BuzzHouse (*)` / `AST fuzzer (*)` checks across ~18 unrelated PRs (and master), typically with only one of the four BuzzHouse builds failing on a given SHA while the other three pass on the identical commit.

This change distinguishes the two cases:

- **Missing or empty `status.tsv`** (the runner aborted before reporting): emit an actionable message that says the runner aborted before producing status, explains it is a CI-infrastructure issue rather than a fuzzer finding (a real finding writes `status.tsv` with a `FAIL` status and a stack trace), and inlines the tail of the `fuzzer.log` / `server.log` / `stderr.log` artifacts so the underlying abort cause is visible.
- **Malformed `status.tsv`** (a genuine harness bug): keep the traceback for debugging.

The status stays `ERROR` so the check is still red and a maintainer re-runs it; no auto-retry signal is invented (praktika has no retry path for python-callable jobs).

The parsing and message formatting are extracted into dependency-free helpers (`_read_fuzzer_status`, `_format_status_error`, `_log_tail`) and covered by unit tests in `ci/tests/test_e2e.py` (valid / missing / empty / malformed status, and the infra-vs-harness message shape).

No related open issue found (searched the `status.tsv` / `ast_fuzzer_job` signature on 2026-06-16).
