### PR TITLE
distroless: bump base pin to clear libssl3t64 CVE-2026-45447

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -145,8 +145,8 @@ RUN mkdir -p \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-03. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:e1fd250ce83d94603e9887ec991156a6c26905a6b0001039b7a43699018c0733 AS production
+# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -168,8 +168,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-03. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:960efa6047ba627691460e9d88a9283b45bf3edbfc5b3532d9c60f0f09a6f9c0 AS debug
+# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -179,8 +179,8 @@ RUN { \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-03. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:e1fd250ce83d94603e9887ec991156a6c26905a6b0001039b7a43699018c0733 AS production
+# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -202,8 +202,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-03. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:960efa6047ba627691460e9d88a9283b45bf3edbfc5b3532d9c60f0f09a6f9c0 AS debug
+# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Bumping both distroless base pins (server + keeper, production + debug) because the old pin from 2026-06-03 ships `libssl3t64 3.5.6-1~deb13u1` and Trivy catches it as a fixable HIGH — https://nvd.nist.gov/vuln/detail/CVE-2026-45447.

I originally thought it was a keeper-only issue (server scanned clean on 26.4.3.37 in my first probe) but that was a fluke. After backfilling the other 5 versions and rescanning with `trivy image --severity HIGH,CRITICAL --ignore-unfixed`, every one of the 12 currently-published images (server + keeper × 6 tracked X.Y) lands the same finding. So this fixes the whole fleet, not just keeper.

```
server:25.8.24.21    1 HIGH  CVE-2026-45447 libssl3t64 3.5.6-1~deb13u1 -> 3.5.6-1~deb13u2
server:25.10.7.6     1 HIGH  same
server:25.12.11.4    1 HIGH  same
server:26.3.12.3     1 HIGH  same
server:26.5.1.882    1 HIGH  same
keeper:26.4.3.37     1 HIGH  same
... (rest will show same pattern once Trivy DB cache flushes)
```

The new pin (2026-06-16, sha256:d3cda6e9...) ships `libssl3t64 3.5.6-1~deb13u2`. Trivy against the new base alone returns zero. Same digest bump applied to the debug-nonroot variant so prod and debug stay in lockstep.

Plan once this lands — rerun BackfillDistroless against `25.8.24.21 25.10.7.6 25.12.11.4 26.3.12.3 26.4.3.37 26.5.1.882` to republish all 6 server+keeper pairs against the new base. Then a re-scan should flip every image to clean.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

#### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.898`
<!-- ch-version-info:end -->