### PR TITLE
Add Cursor Cloud dev environment instructions to AGENTS.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -173,3 +173,13 @@ ARM machines in CI are not slow. They are similar to x86 in performance.
 
 Use `tmp` subdirectory in the current directory for temporary files (logs, downloads, scripts, etc.), do not use `/tmp`. Create the directory if needed.
 
+## Cursor Cloud specific instructions {#cursor-cloud-specific-instructions}
+
+The VM snapshot already has the full build toolchain installed: `clang-21`/`clang++-21`, `ld.lld-21`, `ninja`, `nasm`, `yasm`, `ccache`, plus the pinned Rust toolchain `nightly-2026-03-22` (with `rust-src`). The `contrib/` git submodules are already checked out (~9 GB), and the startup update script runs `git submodule update --init --jobs 8` to keep them in sync with the pulled code. Do not reinstall any of this.
+
+Build (Debug) is the configured dev build. It is pre-configured in `build/` using `clang-21`. Compile with `ninja -C build clickhouse` (a clean full build takes well over an hour on this VM and produces a ~6.6 GB debug binary; incremental rebuilds are fast). See `docs/en/development/build.md` for full reference; if `cmake` ever complains it cannot find the Rust toolchain, run `rustup toolchain install nightly-2026-03-22 && rustup component add rust-src --toolchain nightly-2026-03-22`. To reconfigure from scratch: `CC=clang-21 CXX=clang++-21 cmake -S . -B build -G Ninja -D CMAKE_BUILD_TYPE=Debug`.
+
+Non-obvious run caveat: `cmake` does not copy a `config.xml`/`users.xml` into `build/programs/server/`. Run the server against the source config with an explicit writable data path, e.g. from `build/programs`: `./clickhouse server --config-file=/workspace/programs/server/config.xml -- --path=/workspace/tmp/ch-data/ --logger.log=/workspace/tmp/ch-logs/server.log`. Everything (`server`, `client`, `local`, `keeper`) is the one multi-call `clickhouse` binary; Keeper is built in and starts embedded with the default config. Connect with `./clickhouse client --host 127.0.0.1` (HTTP on `8123`, native on `9000`), or run queries without a server via `./clickhouse local --query "..."`.
+
+Functional (stateless) tests: run `tests/clickhouse-test --binary /workspace/build/programs/clickhouse <test_names>` against a running server. Pass `--binary` (the harness derives the client as `<binary> client`); do not also pass `--client`. C++ style/lint check: `bash ci/jobs/scripts/check_style/check_cpp.sh` (no output and rc=0 means clean). Docker is not installed, so the `python -m ci.praktika run ...` containerized build/test flow and integration tests are unavailable unless Docker is set up first.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents how to build, run, and test ClickHouse inside the Cursor Cloud agent VM. The VM snapshot ships with the build toolchain (`clang-21`, `ninja`, `nasm`, `yasm`, `ccache`, `ld.lld-21`, Rust `nightly-2026-03-22`) and a pre-configured Debug build in `build/`, and the startup update script keeps `contrib/` submodules in sync via `git submodule update --init`. The added `## Cursor Cloud specific instructions` section in `AGENTS.md` (a symlink to `.claude/CLAUDE.md`) captures the non-obvious run caveat that `cmake` does not copy a `config.xml` into `build/programs/server/`, plus how to run the server/client/`local`, the stateless test harness, and the C++ style check.

No source code is changed.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1f1faf0-975f-44b5-a020-8f09dd927cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1f1faf0-975f-44b5-a020-8f09dd927cdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

