### PR TITLE
Reduce performance comparison test flakiness (raise change/unstable floors and slower-queries gate)

### DIFF
--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -297,9 +297,14 @@ def _build_base_cte(args, data_path):
         FROM file('{data_path}', 'TSV')
     ),
     filtered AS (
+        -- The 0.15 ('changed') and 0.25 ('unstable') floors mirror the
+        -- report_thresholds floors in ci/jobs/scripts/perf/compare.sh. Keep
+        -- them synchronized: anything below these is treated as run-to-run CI
+        -- noise (machine jitter, code-layout artifacts) rather than a real
+        -- change, so this helper and CI agree on which queries are flagged.
         SELECT *,
-            (abs(diff) >= stat_threshold AND abs(diff) > 0.1) AS is_changed,
-            (NOT (abs(diff) >= stat_threshold AND abs(diff) > 0.1) AND stat_threshold > 0.2) AS is_unstable,
+            (abs(diff) >= stat_threshold AND abs(diff) > 0.15) AS is_changed,
+            (NOT (abs(diff) >= stat_threshold AND abs(diff) > 0.15) AND stat_threshold > 0.25) AS is_unstable,
             if(diff > 0, 'slower', if(diff < 0, 'faster', 'same')) AS direction
         FROM data
         WHERE {where_clause}

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -261,13 +261,38 @@ def download_shard(shard, tmpdir):
 # SQL queries
 # ---------------------------------------------------------------------------
 
+# Number of (enriched) columns in all-query-metrics.tsv once it carries the
+# per-query changed_threshold/unstable_threshold columns. The two arch/shard
+# columns are prepended by download_shard, the report itself contributes the
+# rest, ending with changed_threshold (c12) and unstable_threshold (c13).
+COLUMNS_WITH_THRESHOLDS = 13
+
+
+def count_tsv_columns(path):
+    """Return the number of tab-separated columns in the first non-empty line."""
+    with open(path, "r") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if line:
+                return line.count("\t") + 1
+    return 0
+
+
 def _sql_escape(s):
     """Escape a string for use in SQL single-quoted literals."""
     return s.replace("\\", "\\\\").replace("'", "\\'")
 
 
-def _build_base_cte(args, data_path):
-    """Build the common CTE that reads, filters, and classifies data."""
+def _build_base_cte(args, data_path, has_thresholds):
+    """Build the common CTE that reads, filters, and classifies data.
+
+    When ``has_thresholds`` is true the report carries the per-query
+    changed_threshold/unstable_threshold columns (c12/c13) exported by
+    ci/jobs/scripts/perf/compare.sh, and we classify with them so this helper
+    matches the CI gate exactly. Older reports do not have those columns, so we
+    fall back to the floor constants (0.15/0.25); see count_tsv_columns and the
+    warning emitted in main().
+    """
     where_parts = [f"metric_name = '{_sql_escape(args.metric)}'"]
     if args.arch != "all":
         where_parts.append(f"arch = '{args.arch}'")
@@ -280,6 +305,15 @@ def _build_base_cte(args, data_path):
 
     where_clause = " AND ".join(where_parts)
 
+    if has_thresholds:
+        threshold_cols = """
+            toFloat64(c12) AS changed_threshold,
+            toFloat64(c13) AS unstable_threshold,"""
+    else:
+        threshold_cols = """
+            0.15 AS changed_threshold,
+            0.25 AS unstable_threshold,"""
+
     return f"""
     data AS (
         SELECT
@@ -290,30 +324,33 @@ def _build_base_cte(args, data_path):
             toFloat64(c5) AS `right`,
             toFloat64(c6) AS diff,
             toFloat64(c7) AS times_change,
-            toFloat64(c8) AS stat_threshold,
+            toFloat64(c8) AS stat_threshold,{threshold_cols}
             c9 AS test,
             toUInt32(c10) AS query_index,
             c11 AS query_display_name
         FROM file('{data_path}', 'TSV')
     ),
     filtered AS (
-        -- The 0.15 ('changed') and 0.25 ('unstable') floors mirror the
-        -- report_thresholds floors in ci/jobs/scripts/perf/compare.sh. Keep
-        -- them synchronized: anything below these is treated as run-to-run CI
-        -- noise (machine jitter, code-layout artifacts) rather than a real
-        -- change, so this helper and CI agree on which queries are flagged.
+        -- Classify each query exactly as ci/jobs/scripts/perf/compare.sh does:
+        --   changed_fail  = abs(diff) > changed_threshold  AND abs(diff) >= stat_threshold
+        --   unstable_fail = NOT changed_fail               AND stat_threshold > unstable_threshold
+        -- changed_threshold/unstable_threshold are the per-query thresholds
+        -- (the 0.15/0.25 floors raised by historical and per-test thresholds).
+        -- Using the exported per-query thresholds instead of only the floor
+        -- constants keeps this helper in agreement with the CI gate even when
+        -- the effective threshold for a query is above the floor.
         SELECT *,
-            (abs(diff) >= stat_threshold AND abs(diff) > 0.15) AS is_changed,
-            (NOT (abs(diff) >= stat_threshold AND abs(diff) > 0.15) AND stat_threshold > 0.25) AS is_unstable,
+            (abs(diff) >= stat_threshold AND abs(diff) > changed_threshold) AS is_changed,
+            (NOT (abs(diff) >= stat_threshold AND abs(diff) > changed_threshold) AND stat_threshold > unstable_threshold) AS is_unstable,
             if(diff > 0, 'slower', if(diff < 0, 'faster', 'same')) AS direction
         FROM data
         WHERE {where_clause}
     )"""
 
 
-def build_summary_sql(args, shard_meta, data_path):
+def build_summary_sql(args, shard_meta, data_path, has_thresholds):
     """Build SQL for per-shard summary."""
-    base_cte = _build_base_cte(args, data_path)
+    base_cte = _build_base_cte(args, data_path, has_thresholds)
     shard_values = ", ".join(
         f"('{_sql_escape(s['name'])}', '{s['arch']}', {s['shard_num']})"
         for s in shard_meta
@@ -350,9 +387,9 @@ def build_summary_sql(args, shard_meta, data_path):
     """
 
 
-def build_detail_sql(args, data_path, fmt="JSONEachRow"):
+def build_detail_sql(args, data_path, has_thresholds, fmt="JSONEachRow"):
     """Build SQL for per-query detail rows."""
-    base_cte = _build_base_cte(args, data_path)
+    base_cte = _build_base_cte(args, data_path, has_thresholds)
 
     sort_map = {
         "diff": "abs(diff) DESC",
@@ -465,9 +502,9 @@ def output_json(summary_rows, detail_rows, pr_number, sha, metric):
     print(json.dumps(output, indent=2))
 
 
-def output_tsv(args, data_path):
+def output_tsv(args, data_path, has_thresholds):
     """Run the detail query with TabSeparatedWithNames format and print."""
-    sql = build_detail_sql(args, data_path, fmt="TabSeparatedWithNames")
+    sql = build_detail_sql(args, data_path, has_thresholds, fmt="TabSeparatedWithNames")
     print(run_ch(sql), end="")
 
 
@@ -702,20 +739,34 @@ def main():
         ]
         multi_shard = len(downloaded) > 1
 
+        # Detect whether the report carries the per-query threshold columns.
+        # Reports generated before those columns were added to
+        # all-query-metrics.tsv lack them, so we classify with the floor
+        # constants instead and make that visible rather than silently
+        # reporting queries that CI would treat as noise.
+        has_thresholds = count_tsv_columns(merged_path) >= COLUMNS_WITH_THRESHOLDS
+        if not has_thresholds:
+            print(
+                "  Warning: this report predates the per-query threshold columns "
+                "in all-query-metrics.tsv; classifying with the 0.15/0.25 floor "
+                "constants, which may flag queries that CI treats as noise.",
+                file=sys.stderr,
+            )
+
         # Run summary query
-        summary_sql = build_summary_sql(args, shard_meta, merged_path)
+        summary_sql = build_summary_sql(args, shard_meta, merged_path, has_thresholds)
         summary_rows = parse_jsonl(run_ch(summary_sql))
 
         if args.tsv:
-            output_tsv(args, merged_path)
+            output_tsv(args, merged_path, has_thresholds)
         elif args.json:
-            detail_sql = build_detail_sql(args, merged_path)
+            detail_sql = build_detail_sql(args, merged_path, has_thresholds)
             detail_rows = parse_jsonl(run_ch(detail_sql))
             output_json(summary_rows, detail_rows, pr_number, sha, args.metric)
         elif args.summary:
             output_human(summary_rows, [], pr_number, args.metric, multi_shard)
         else:
-            detail_sql = build_detail_sql(args, merged_path)
+            detail_sql = build_detail_sql(args, merged_path, has_thresholds)
             detail_rows = parse_jsonl(run_ch(detail_sql))
             output_human(summary_rows, detail_rows, pr_number, args.metric, multi_shard)
 

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for the query classification in fetch_perf_report.py.
+
+These prove that the helper classifies queries with the same effective
+per-query thresholds as ci/jobs/scripts/perf/compare.sh, including the cases
+where the historical / per-test thresholds raise changed_threshold or
+unstable_threshold above the 0.15 / 0.25 floors. In those cases classifying
+with the floor constants alone would produce false "changed" / "unstable"
+findings that CI treats as noise.
+
+The test runs clickhouse-local through the same SQL builders the tool uses, so
+it exercises the real classification logic. It is skipped when the clickhouse
+binary is not available.
+
+Run directly:  python3 .claude/tools/test_fetch_perf_report.py
+"""
+
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import types
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "fetch_perf_report", os.path.join(_HERE, "fetch_perf_report.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+fpr = _load_module()
+
+
+def _args(**overrides):
+    defaults = dict(
+        metric="client_time",
+        arch="all",
+        shard=None,
+        test=None,
+        query=None,
+        sort="diff",
+        show_all=True,
+    )
+    defaults.update(overrides)
+    return types.SimpleNamespace(**defaults)
+
+
+# Each row mirrors one all-query-metrics.tsv record (after the arch/shard_num
+# columns are prepended by download_shard):
+#   arch shard metric left right diff times stat test qidx qname c_thr u_thr
+# The interesting rows are "noise_below_raised_changed" and
+# "stable_below_raised_unstable": with floor-only logic they would be flagged,
+# but their per-query thresholds are above the floor, so CI ignores them.
+ROWS = [
+    # name, diff, stat_threshold, changed_threshold, unstable_threshold
+    ("changed_slower", 0.30, 0.05, 0.20, 0.25),
+    ("noise_below_raised_changed", 0.18, 0.05, 0.20, 0.25),
+    ("unstable", 0.05, 0.30, 0.20, 0.25),
+    ("stable_below_raised_unstable", 0.05, 0.28, 0.20, 0.30),
+    ("changed_faster", -0.30, 0.05, 0.20, 0.25),
+]
+
+
+def _expected(diff, stat, changed_thr, unstable_thr):
+    """Replicate the compare.sh changed_fail / unstable_fail classification."""
+    is_changed = abs(diff) > changed_thr and abs(diff) >= stat
+    is_unstable = (not is_changed) and stat > unstable_thr
+    direction = "slower" if diff > 0 else ("faster" if diff < 0 else "same")
+    return is_changed, is_unstable, direction
+
+
+def _write_fixture(path):
+    with open(path, "w") as f:
+        for i, (name, diff, stat, c_thr, u_thr) in enumerate(ROWS):
+            left, right = 1.0, 1.0 + diff
+            times = abs(diff) + 1.0
+            fields = [
+                "amd", "1", "client_time",
+                f"{left}", f"{right}", f"{diff}", f"{times}", f"{stat}",
+                "test_a", str(i), name, f"{c_thr}", f"{u_thr}",
+            ]
+            f.write("\t".join(fields) + "\n")
+
+
+def test_classification_matches_compare_sh():
+    if shutil.which("clickhouse") is None:
+        print("SKIP: clickhouse binary not available")
+        return
+
+    tmpdir = tempfile.mkdtemp(prefix="test_perf_report_")
+    try:
+        data_path = os.path.join(tmpdir, "all.tsv")
+        _write_fixture(data_path)
+
+        assert fpr.count_tsv_columns(data_path) == fpr.COLUMNS_WITH_THRESHOLDS
+
+        args = _args()
+        sql = fpr.build_detail_sql(args, data_path, has_thresholds=True)
+        rows = {r["query"]: r for r in fpr.parse_jsonl(fpr.run_ch(sql))}
+
+        assert len(rows) == len(ROWS), rows
+
+        for name, diff, stat, c_thr, u_thr in ROWS:
+            exp_changed, exp_unstable, exp_dir = _expected(diff, stat, c_thr, u_thr)
+            row = rows[name]
+            assert bool(row["is_changed"]) == exp_changed, (name, row)
+            assert bool(row["is_unstable"]) == exp_unstable, (name, row)
+            assert row["direction"] == exp_dir, (name, row)
+
+        # The two rows whose thresholds were raised above the floors must NOT be
+        # flagged - this is exactly what the old floor-only logic got wrong.
+        assert not rows["noise_below_raised_changed"]["is_changed"]
+        assert not rows["noise_below_raised_changed"]["is_unstable"]
+        assert not rows["stable_below_raised_unstable"]["is_unstable"]
+        assert not rows["stable_below_raised_unstable"]["is_changed"]
+
+        # Sanity: floor-only classification (has_thresholds=False) WOULD flag
+        # them, which is the regression this change fixes.
+        floor_sql = fpr.build_detail_sql(args, data_path, has_thresholds=False)
+        floor_rows = {r["query"]: r for r in fpr.parse_jsonl(fpr.run_ch(floor_sql))}
+        assert floor_rows["noise_below_raised_changed"]["is_changed"]
+        assert floor_rows["stable_below_raised_unstable"]["is_unstable"]
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_summary_counts():
+    if shutil.which("clickhouse") is None:
+        print("SKIP: clickhouse binary not available")
+        return
+
+    tmpdir = tempfile.mkdtemp(prefix="test_perf_report_")
+    try:
+        data_path = os.path.join(tmpdir, "all.tsv")
+        _write_fixture(data_path)
+        shard_meta = [{"name": "amd 1/1", "arch": "amd", "shard_num": 1}]
+        sql = fpr.build_summary_sql(_args(), shard_meta, data_path, has_thresholds=True)
+        summary = fpr.parse_jsonl(fpr.run_ch(sql))
+        assert len(summary) == 1, summary
+        s = summary[0]
+        # changed_slower + changed_faster = 1 slower + 1 faster; 1 unstable.
+        assert s["faster"] == 1, s
+        assert s["slower"] == 1, s
+        assert s["unstable"] == 1, s
+        assert s["total"] == len(ROWS), s
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_classification_matches_compare_sh()
+    test_summary_counts()
+    print("All fetch_perf_report tests passed (or skipped).")

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -91,7 +91,9 @@ FROM input(
      stat_threshold Float64,
      test String,
      query_index Int32,
-     query_display_name String'
+     query_display_name String,
+     changed_threshold Float64,
+     unstable_threshold Float64'
 ) FORMAT TSV"""
 
 RAW_QUERY_METRICS_TABLE = "query_metric_runs_v1"
@@ -881,6 +883,28 @@ def find_base_release_build(info, build_type):
     return None
 
 
+# The number of distinct "slower" queries that fails the whole performance
+# check. This is the gate that actually decides the Praktika `Check Results`
+# status: `report.py` embeds a status into `report.html`, but `main` below
+# discards it ("always green mode") and recomputes the final status by
+# reparsing the "N slower" message, so the effective gate lives here. The value
+# must stay synchronized with the slower-queries threshold in
+# `ci/jobs/scripts/perf/report.py`. It is intentionally high: a handful of
+# "slower" queries is dominated by CI noise (a single bad shard run, frequency
+# scaling, or code-layout artifacts can push several unrelated micro benchmarks
+# over their per-query thresholds at once), while a genuine regression shows up
+# as a small cluster of related queries with large magnitudes that the
+# per-query thresholds catch on their own.
+SLOWER_QUERIES_FAIL_THRESHOLD = 10
+
+
+def too_many_slow(message):
+    match = re.search(r"(|.* )(\d+) slower.*", message)
+    return (
+        int(match.group(2).strip()) > SLOWER_QUERIES_FAIL_THRESHOLD if match else False
+    )
+
+
 def main():
 
     args = parse_args()
@@ -1433,11 +1457,6 @@ def main():
     # TODO: code to fetch status was taken from old script as is - status is to be correctly set in Test stage and this stage is to be removed!
     message = ""
     if res and JobStages.CHECK_RESULTS in stages:
-
-        def too_many_slow(msg):
-            match = re.search(r"(|.* )(\d+) slower.*", msg)
-            threshold = 5
-            return int(match.group(2).strip()) > threshold if match else False
 
         # Try to fetch status from the report.
         sw = Utils.Stopwatch()

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -667,9 +667,17 @@ create view query_metric_stats as
 create table report_thresholds engine File(TSVWithNamesAndTypes, 'report/thresholds.tsv')
     as select
         query_display_names.test test, query_display_names.query_index query_index,
-        ceil(greatest(0.1, historical_thresholds.max_diff,
+        -- The floors (0.15 for 'changed', 0.25 for 'unstable') are the minimum
+        -- relative difference we treat as a real change. They are intentionally
+        -- above the level of run-to-run noise observed on CI runners: micro
+        -- benchmarks routinely swing by 10-15% between two binaries because of
+        -- machine noise (noisy neighbours, frequency scaling) and code-layout
+        -- artifacts (function alignment/inlining shifts) unrelated to the tested
+        -- change. For historically noisier queries the learned thresholds
+        -- (1.5 * historical p99) are larger and take over.
+        ceil(greatest(0.15, historical_thresholds.max_diff,
             test_thresholds.report_threshold), 2) changed_threshold,
-        ceil(greatest(0.2, historical_thresholds.max_stat_threshold,
+        ceil(greatest(0.25, historical_thresholds.max_stat_threshold,
             test_thresholds.report_threshold + 0.1), 2) unstable_threshold,
         query_display_names.query_display_name query_display_name
     from query_display_names

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -927,14 +927,29 @@ create table queries_old_format engine File(TSVWithNamesAndTypes, 'queries.rep')
     ;
 
 -- new report for all queries with all metrics (no page yet)
+-- The trailing changed_threshold/unstable_threshold columns are the per-query
+-- thresholds computed in report_thresholds above (the 0.15/0.25 floors raised
+-- by historical and per-test thresholds). They are exported so downstream
+-- consumers (e.g. .claude/tools/fetch_perf_report.py) can classify queries
+-- with the same effective thresholds as the CI gate instead of only the floor
+-- constants. They are appended at the end to keep the existing column
+-- positions stable for older consumers.
 create table all_query_metrics_tsv engine File(TSV, 'report/all-query-metrics.tsv') as
     select metric_name, left, right, diff,
         floor(left > right ? left / right : right / left, 3),
-        stat_threshold, test, query_index, query_display_name
+        stat_threshold,
+        query_metric_stats.test test, query_metric_stats.query_index query_index,
+        query_display_names.query_display_name query_display_name,
+        report_thresholds.changed_threshold changed_threshold,
+        report_thresholds.unstable_threshold unstable_threshold
     from query_metric_stats
     left join query_display_names
         on query_metric_stats.test = query_display_names.test
             and query_metric_stats.query_index = query_display_names.query_index
+    left join report_thresholds
+        on query_display_names.test = report_thresholds.test
+            and query_display_names.query_index = report_thresholds.query_index
+            and query_display_names.query_display_name = report_thresholds.query_display_name
     order by test, query_index;
 " 2> >(tee -a report/errors.log 1>&2)
 

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -663,6 +663,11 @@ if args.report == "main":
         # as a small cluster of related queries with large magnitudes that the
         # per-query thresholds catch on their own. The false positive rate
         # should be kept < 1%.
+        #
+        # This threshold must stay synchronized with SLOWER_QUERIES_FAIL_THRESHOLD
+        # in ci/jobs/performance_tests.py: that script discards the status
+        # embedded here and recomputes the final Praktika status by reparsing the
+        # "N slower" message below, so the effective gate lives there.
         if slower_queries > 10:
             status = "failure"
         message_array.append(str(slower_queries) + " slower")

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -655,9 +655,15 @@ if args.report == "main":
         message_array.append(str(faster_queries) + " faster")
 
     if slower_queries:
-        # This threshold should be synchronized with the value in https://github.com/ClickHouse/ClickHouse/blob/master/tests/ci/performance_comparison_check.py#L225
-        # False positives rate should be < 1%: https://shorturl.at/CDEK8
-        if slower_queries > 5:
+        # Only fail the whole check when a large number of distinct queries
+        # regress at once. A handful of "slower" queries is dominated by CI
+        # noise: a single bad shard run (noisy neighbour, frequency scaling) or
+        # code-layout artifacts can push several unrelated micro benchmarks over
+        # the threshold simultaneously. A genuine, targeted regression shows up
+        # as a small cluster of related queries with large magnitudes that the
+        # per-query thresholds catch on their own. The false positive rate
+        # should be kept < 1%.
+        if slower_queries > 10:
             status = "failure"
         message_array.append(str(slower_queries) + " slower")
 

--- a/ci/tests/test_perf_slow_gate.py
+++ b/ci/tests/test_perf_slow_gate.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.performance_tests import (
+    INSERT_HISTORICAL_DATA,
+    SLOWER_QUERIES_FAIL_THRESHOLD,
+    too_many_slow,
+)
+
+
+def test_historical_insert_parses_threshold_columns():
+    # compare.sh appends changed_threshold/unstable_threshold to
+    # all-query-metrics.tsv. The historical-data CIDB insert reads that file
+    # with a fixed input() TSV schema; if the schema does not declare these two
+    # trailing columns, strict TSV parsing drops every row silently (0 rows
+    # inserted, no error). This guards that coupling.
+    assert "changed_threshold Float64" in INSERT_HISTORICAL_DATA
+    assert "unstable_threshold Float64" in INSERT_HISTORICAL_DATA
+
+
+def test_gate_threshold_value():
+    # The Praktika gate must stay aligned with report.py's "> 10" slower-query
+    # threshold. If this constant changes, report.py must change in lockstep.
+    assert SLOWER_QUERIES_FAIL_THRESHOLD == 10
+
+
+def test_no_slower_queries_does_not_fail():
+    assert too_many_slow("ok") is False
+    assert too_many_slow("3 faster") is False
+
+
+def test_slower_count_at_or_below_threshold_does_not_fail():
+    # 6-10 slower queries used to fail the check with the old threshold of 5.
+    # They must now pass, which is the whole point of the change.
+    for n in (1, 5, 6, 9, 10):
+        assert too_many_slow(f"{n} slower") is False, n
+        assert too_many_slow(f"2 faster, {n} slower") is False, n
+
+
+def test_slower_count_above_threshold_fails():
+    for n in (11, 12, 50):
+        assert too_many_slow(f"{n} slower") is True, n
+        assert too_many_slow(f"1 faster, {n} slower") is True, n
+
+
+if __name__ == "__main__":
+    test_historical_insert_parses_threshold_columns()
+    test_gate_threshold_value()
+    test_no_slower_queries_does_not_fail()
+    test_slower_count_at_or_below_threshold_does_not_fail()
+    test_slower_count_above_threshold_fails()
+    print("All perf slow-gate tests passed.")


### PR DESCRIPTION
Performance comparison checks frequently fail on unrelated PRs because of slowdowns in queries that have nothing to do with the change. These failures are dominated by CI noise rather than real regressions: a single bad shard run (noisy neighbour, frequency scaling) or code-layout artifacts (function alignment/inlining shifts between the two binaries) can push several unrelated micro benchmarks over the threshold at once.

This raises the noise floors so that run-to-run jitter no longer trips the check:

- In `compare.sh`, the `changed_threshold` floor goes from `0.1` to `0.15` and the `unstable_threshold` floor from `0.2` to `0.25`. These floors only bind for historically stable queries; for noisier queries the learned thresholds (`1.5 * historical p99`) are already larger and take over.
- The slower-queries gate that fails the whole check goes from more than `5` to more than `10` distinct slower queries, so a single noisy shard does not fail the job. This gate is enforced by `too_many_slow` in `ci/jobs/performance_tests.py`, which is the value that actually decides the Praktika `Check Results` status: `report.py` only embeds a status into `report.html`, but `performance_tests.py` recomputes the final status by reparsing the `N slower` message. Both the `report.py` threshold and the `performance_tests.py` gate are updated together and cross-referenced so they stay synchronized. The stale comment referencing the removed `tests/ci/performance_comparison_check.py` is dropped.

To keep all consumers in agreement with the raised thresholds, `compare.sh` now exports the per-query `changed_threshold` and `unstable_threshold` (the floors raised by historical and per-test thresholds) as trailing columns of `all-query-metrics.tsv`, and `.claude/tools/fetch_perf_report.py` classifies queries against those exported per-query thresholds instead of only the floor constants. The historical-data CIDB insert in `performance_tests.py` reads the same file with a fixed `input()` TSV schema, so that schema is extended with the two new columns (otherwise strict TSV parsing would silently drop every row).

Calibrated against the motivating case below: on that PR shard 3 reported `8 slower` (`if #0-5`, `join_reserve`, `codecs_int_select`) and shard 4 reported `6 slower`, with almost all flagged queries in the 10-15% range — pure noise for a change that only touches `formatReadableTimeDelta`. With the new floors each shard drops to a single flagged query (the genuinely large `+25.7%` and `+19.1%` outliers), and both shards pass. Large real swings (e.g. `hash_table_sizes_stats` at `+72%`/`+76%`) are still caught.

Tradeoff: this reduces sensitivity to small (10-15%) regressions on historically stable queries. On the current CI runners even stable micro benchmarks routinely swing by ~12% from machine/layout noise, so the previous 10% floor was below the noise level anyway.

Related: https://github.com/ClickHouse/ClickHouse/pull/64315
Related: https://github.com/ClickHouse/ClickHouse/issues/74661

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Reduce performance comparison test flakiness by raising the change/unstable thresholds and the slower-queries gate.

### Documentation entry for user-facing changes

- [ ] Documentation is written (not required for this change)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.945`
<!-- ch-version-info:end -->