### PR TITLE
Fix flaky test 03741_s3_glob_table_path_pushdown

### DIFF
--- a/tests/queries/0_stateless/03741_s3_glob_table_path_pushdown.sql
+++ b/tests/queries/0_stateless/03741_s3_glob_table_path_pushdown.sql
@@ -64,6 +64,9 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_databa
   AND log_comment like '%03741_s3_glob_table_path_pushdown%'
   AND query_kind = 'Select'
   AND type = 'QueryFinish'
+  -- Exclude the SELECT '' separators (they don't scan 03741_data). Backticks required:
+  -- tables[] stores the digit-prefixed name quoted as `03741_data`.
+  AND has(tables, currentDatabase() || '.`03741_data`')
 ORDER BY event_time_microseconds;
 
 -- Mutually exclusive filter uses glob iterator, and do some list ops, so


### PR DESCRIPTION
<!--
No related open issue found (the two historical flaky-test issues #92487 and #92890
were already closed by the earlier fix #92756, which addressed a different failure mode).
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The test reads `ProfileEvents['S3ListObjects']` and `ProfileEvents['EngineFileLikeReadFiles']` from `system.query_log` for all of its glob-table SELECTs. The filter matched any `Select`/`QueryFinish` row carrying the test's `log_comment`, which also matched the `SELECT ''` separator queries that print blank lines.

Those separators run after `SYSTEM FLUSH LOGS query_log` but before the ProfileEvents read. `query_log` flushes asynchronously, so a separator's own row (0 S3 ops) occasionally became visible to the immediately following ProfileEvents query, appearing as a spurious trailing `0\t0` row and failing against the reference.

The fix restricts the ProfileEvents query to rows that actually scanned `03741_data` via `has(tables, ...)`, which excludes the separators regardless of flush timing. Backticks are required in the literal because the digit-prefixed name is stored quoted as `` `03741_data` `` in `tables[]`.

Validated locally against MinIO S3 with the `s3_conn` named collection: 15/15 clean runs; and with the async-flush race forced deterministically, the test FAILS without the fix (spurious `0\t0` row) and PASSES with it.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.903`
<!-- ch-version-info:end -->