### PR TITLE
Make flaky test 03568_udf_memory_tracking lighter to avoid TSan timeout

### DIFF
--- a/tests/queries/0_stateless/03568_udf_memory_tracking.sql
+++ b/tests/queries/0_stateless/03568_udf_memory_tracking.sql
@@ -1,3 +1,5 @@
+-- Tags: long
+
 SET log_queries = 1;
 
 -- max_block_size = 1 makes each row its own block, exercising per-block executable-UDF memory tracking.

--- a/tests/queries/0_stateless/03568_udf_memory_tracking.sql
+++ b/tests/queries/0_stateless/03568_udf_memory_tracking.sql
@@ -1,7 +1,8 @@
 SET log_queries = 1;
 
-SELECT test_function(number, 0) FROM numbers(100) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
-SELECT test_function(number, 0) FROM numbers(200) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
+-- max_block_size = 1 makes each row its own block, exercising per-block executable-UDF memory tracking.
+SELECT test_function(number, 0) FROM numbers(40) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
+SELECT test_function(number, 0) FROM numbers(60) FORMAT Null SETTINGS max_threads = 1, max_block_size = 1;
 
 SYSTEM FLUSH LOGS query_log;
 
@@ -15,4 +16,3 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_databa
   AND query_kind = 'Select'
   AND query LIKE '%test_function(number, 0)%'
 FORMAT Vertical;
-


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/commit/fb79acefe3568a233ded50c28454d4b7fbce9f47
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03568_udf_memory_tracking` was flaky on `Stateless tests (amd_tsan, s3 storage, parallel)`: clean 600s per-test timeouts (CIDB: OK runs p50 247s / p90 303s / max 506s, plus 5 timeouts over 40 days). It streamed 300 single-row blocks (`numbers(100)` + `numbers(200)`, `max_block_size = 1`) through an executable UDF; each block forks `/bin/sh -c awk`, which is ~100x slower under TSan, and parallel CPU contention pushed it past the timeout.

Reduce the workload to `numbers(40)` + `numbers(60)` = 100 blocks (3x fewer fork/exec) and drop the (previously proposed) `no-parallel` tag.

The fix under test (fb79acefe35) attaches the data-sending threads to the query thread group, so query `memory_usage` stays flat regardless of block count. Without it, each block leaks ~1MB into the query tracker. Measured locally with a pre-fix vs current binary:

| blocks | without fix | with fix |
|---|---|---|
| 40 | 46.6 MB | 5.4 MB |
| 60 | 67.8 MB | 5.4 MB |

So both queries stay 2.3x-3.4x above the 20MB assertion without the fix (the test still fails on a regression) and ~3.7x below it with the fix. The two `< 20MB` assertions and the executable UDF are unchanged.

Verified via `clickhouse-test`: pre-fix binary FAILS (`min/max_less_then_20mb: 0`), current binary passes 20/20 with randomization in the parallel bucket.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.934`
<!-- ch-version-info:end -->