### PR TITLE
Fix missing symlinks for fasttest

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -184,9 +184,19 @@ def main():
 
             stages = [JobStages.CONFIG, JobStages.TEST]
             resolved_clickhouse_bin_path = clickhouse_bin_path.resolve()
-            Utils.link(resolved_clickhouse_bin_path, resolved_clickhouse_bin_path.parent / "clickhouse-server")
-            Utils.link(resolved_clickhouse_bin_path, resolved_clickhouse_bin_path.parent / "clickhouse-client")
-            Utils.link(resolved_clickhouse_bin_path, resolved_clickhouse_bin_path.parent / "clickhouse-local")
+            for tool in (
+                "clickhouse-server",
+                "clickhouse-client",
+                "clickhouse-local",
+                "clickhouse-benchmark",
+                "clickhouse-compressor",
+                "clickhouse-disks",
+                "clickhouse-extract-from-config",
+                "clickhouse-format",
+                "clickhouse-obfuscator",
+                "clickhouse-su",
+            ):
+                Utils.link(resolved_clickhouse_bin_path, resolved_clickhouse_bin_path.parent / tool)
             Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)
 
             break


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)



Spotted while working on #107131, that fasttest for Darwin [is missing clickhouse-disks](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107131&sha=3e33e745add43953b9e5beaaad4de9108dec5994&name_0=PR&name_1=Fast+test+%28arm_darwin%29), when fasttest for Linux [contains it and more importantly successfully runs the tests using it](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107131&sha=3e33e745add43953b9e5beaaad4de9108dec5994&name_0=PR&name_1=Fast+test). Check for test named `04327_disks_app_sed`.

The problem is that Linux suite builds from scratch and therefore contains all necessary symlinks. Darwin is started with a pre-built binary and initializes only three hardcoded symlinks - server, local, client. Such list seems outdated as well as the limitation is unnecessary. Updating the list of symlinks to its current state.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.906`
<!-- ch-version-info:end -->