### PR TITLE
ci: do not use very small index granularity values for slow builds

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1706,11 +1706,25 @@ class MergeTreeSettingsRandomizer:
     @staticmethod
     def get_random_settings(args):
         random_settings = {}
+        # Tiny granules multiply the number of marks per part (marks ~ rows /
+        # index_granularity), which is disproportionately expensive on slow
+        # builds and can turn a few-second test into minutes. Raise the lower
+        # bounds for index_granularity / index_granularity_bytes there.
+        slow_build = (
+            any(flag in args.build_flags for flag in BuildFlags.SANITIZERS)
+            or BuildFlags.DEBUG in args.build_flags
+            or BuildFlags.WITH_COVERAGE in args.build_flags
+        )
         for setting, generator in MergeTreeSettingsRandomizer.settings.items():
             if setting in args.changed_merge_tree_settings:
                 continue
 
-            value = generator()
+            if slow_build and setting == "index_granularity":
+                value = random.randint(100, 65536)
+            elif slow_build and setting == "index_granularity_bytes":
+                value = random.randint(100 * 1024, 30 * 1024 * 1024)
+            else:
+                value = generator()
             if type(value) == str and value == "":
                 continue
 


### PR DESCRIPTION
Some tests [1] may fail under MSan or debug build, and there can be just too much of them, let's simply increase the limit for slow builds

  [1]: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107678&sha=554f564face5193e65890ffc3fc9bb496a7e0370&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.926`
<!-- ch-version-info:end -->