### PR TITLE
Fix flaky CoordinationChangelogTest TestLogGap

### DIFF
--- a/src/Coordination/tests/gtest_coordination_changelog.cpp
+++ b/src/Coordination/tests/gtest_coordination_changelog.cpp
@@ -1444,6 +1444,11 @@ TYPED_TEST(CoordinationChangelogTest, TestLogGap)
         changelog.end_of_append_batch(0, 0);
     }
 
+    /// append/end_of_append_batch flush asynchronously on a background thread. Wait for the
+    /// log to be durable before opening a second store that reads the same file, otherwise
+    /// the reader races the writer.
+    waitDurableLogs(changelog);
+
     DB::KeeperLogStore changelog1(
         DB::LogFileSettings{.force_sync = true, .compress_logs = this->enable_compression, .rotate_interval = 100},
         DB::FlushSettings(),


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
No open issue tracks this failure.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a flaky failure of `CoordinationChangelogTest.TestLogGap` (compressed variant) that aborts in sanitizer/debug unit-test runs with:

```
Logical error: 'in->eof() || output.pos > 0 || in->position() < in->buffer().begin() + input.pos'.
  2. src/IO/ZstdInflatingReadBuffer.cpp:75 DB::ZstdInflatingReadBuffer::nextImpl()
  4. DB::ChangelogReader::readChangelog(...)
  5. DB::Changelog::readChangelogAndInitWriter(...)  src/Coordination/Changelog.cpp:1973
  7. CoordinationChangelogTest_TestLogGap_Test<ChangelogTestParam<true>>::TestBody()  :1451
```

The `test_name` recorded in CI for this is `-FunctionsStress`, which is the gtest *filter* string (`--gtest_filter=-FunctionsStress.*`, i.e. "run everything except FunctionsStress"), not the failing test. The failing test is `CoordinationChangelogTest/0.TestLogGap`.

Root cause: `TestLogGap` appends 54 entries with `append()` + `end_of_append_batch()` and then immediately constructs a second `KeeperLogStore` (`changelog1`) that reads the same changelog file, without waiting for durability. `end_of_append_batch()` calls `flushAsync()`, so the actual write happens on a background thread. The second store's `init()` -> `readChangelogAndInitWriter()` -> `ChangelogReader::readChangelog()` therefore reads the `.zstd` changelog while the first store's background writer is still flushing it. In that window `ZstdInflatingReadBuffer::nextImpl` can call `ZSTD_decompressStream` with no input available while the underlying file is not yet at eof, which returns no progress and trips the forward-progress assertion. The assertion was a plain `assert()` (a no-op under `NDEBUG` in release builds) until it was converted to `chassert`, so it only started aborting in sanitizer/debug CI; this is why the failure is new in CI without being a new bug.

Every other read-after-write test in `gtest_coordination_changelog.cpp` (for example `ChangelogTestStartNewLogAfterRead`) calls `waitDurableLogs()` before opening a reader store. `TestLogGap` was the only one missing it. The fix adds the same `waitDurableLogs(changelog)` call.

Reproduced and verified locally with an `address,undefined` sanitizer build of `unit_tests_dbms`: without the fix the assertion reproduces at about 1% (looping the compressed variant); with the fix it does not reproduce across 1300+ runs, and both the compressed and uncompressed variants pass.

No open issue found for this failure.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.933`
<!-- ch-version-info:end -->