### PR TITLE
don't apply compatibility setting if it's obsolete

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8650,6 +8650,9 @@ void SettingsImpl::applyCompatibilitySetting(const String & compatibility_value)
             /// In case the alias is being used (e.g. use enable_analyzer) we must change the original setting
             auto final_name = SettingsTraits::resolveName(change.name);
 
+            if (getTier(final_name) == SettingsTierType::OBSOLETE)
+                continue;
+
             /// If this setting was changed manually, we don't change it
             if (isChanged(final_name) && !settings_changed_by_compatibility_setting.contains(final_name))
                 continue;

--- a/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
+++ b/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
@@ -1,6 +1,6 @@
 -- { echo }
-SET compatibility = '24.8';
 
+SET compatibility = '24.8';
 SELECT value, changed FROM system.settings WHERE name = 'output_format_json_quote_64bit_integers';
 1	1
 SELECT count()

--- a/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
+++ b/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
@@ -1,0 +1,24 @@
+SET compatibility = '24.8';
+
+SELECT value, changed FROM system.settings WHERE name = 'output_format_json_quote_64bit_integers';
+1	1
+SELECT count()
+FROM system.settings
+WHERE changed AND is_obsolete AND name IN
+(
+    'allow_experimental_bfloat16_type',
+    'allow_experimental_refreshable_materialized_view',
+    'allow_experimental_vector_similarity_index',
+    'enable_vector_similarity_index'
+);
+0
+SELECT count()
+FROM system.warnings
+WHERE message LIKE '%Obsolete setting%'
+    AND (
+        message LIKE '%allow_experimental_bfloat16_type%'
+        OR message LIKE '%allow_experimental_refreshable_materialized_view%'
+        OR message LIKE '%allow_experimental_vector_similarity_index%'
+        OR message LIKE '%enable_vector_similarity_index%'
+    );
+0

--- a/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
+++ b/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.reference
@@ -1,3 +1,4 @@
+-- { echo }
 SET compatibility = '24.8';
 
 SELECT value, changed FROM system.settings WHERE name = 'output_format_json_quote_64bit_integers';

--- a/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.sql
+++ b/tests/queries/0_stateless/04356_compatibility_skips_obsolete_settings.sql
@@ -1,0 +1,25 @@
+-- { echo }
+
+SET compatibility = '24.8';
+
+SELECT value, changed FROM system.settings WHERE name = 'output_format_json_quote_64bit_integers';
+
+SELECT count()
+FROM system.settings
+WHERE changed AND is_obsolete AND name IN
+(
+    'allow_experimental_bfloat16_type',
+    'allow_experimental_refreshable_materialized_view',
+    'allow_experimental_vector_similarity_index',
+    'enable_vector_similarity_index'
+);
+
+SELECT count()
+FROM system.warnings
+WHERE message LIKE '%Obsolete setting%'
+    AND (
+        message LIKE '%allow_experimental_bfloat16_type%'
+        OR message LIKE '%allow_experimental_refreshable_materialized_view%'
+        OR message LIKE '%allow_experimental_vector_similarity_index%'
+        OR message LIKE '%enable_vector_similarity_index%'
+    );


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The compatibility setting no longer applies obsolete settings, so it does not mark them as changed or produce obsolete-setting warnings.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.971`
<!-- ch-version-info:end -->