### PR TITLE
CI: skip full functional suite for plain test-only changes

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -65,6 +65,31 @@ class Targeting:
     # Keep in sync with TEST_FILE_EXTENSIONS in tests/clickhouse-test.
     _TEST_FILE_EXTENSIONS = (".sql.j2", ".sql", ".sh", ".py", ".expect")
 
+    _STATELESS_DIR = Path("tests/queries/0_stateless")
+
+    @classmethod
+    def is_stateless_test_path(cls, fpath: str) -> bool:
+        """True if `fpath` is a numbered file under `tests/queries/0_stateless/`."""
+        return bool(re.match(r"tests/queries/0_stateless/\d{5}", fpath))
+
+    @classmethod
+    def read_test_tags(cls, test_base_name: str):
+        """Return the set of tags the stateless test declares (empty set if none),
+        or `None` if no source file is found or it can't be parsed. Tag parsing is
+        reused from `tests/test_tags.py`, shared with `tests/clickhouse-test`.
+        """
+        from tests.test_tags import read_test_tags as read_test_tags_from_file
+
+        for ext in cls._TEST_FILE_EXTENSIONS:
+            src = cls._STATELESS_DIR / f"{test_base_name}{ext}"
+            if not src.is_file():
+                continue
+            try:
+                return read_test_tags_from_file(str(src))
+            except (OSError, UnicodeDecodeError, ValueError):
+                return None
+        return None
+
     @classmethod
     def _derive_test_name(cls, fpath: str):
         """Map a changed file under `tests/queries/0_stateless/` to a test name.
@@ -86,7 +111,7 @@ class Targeting:
         # the same base name. This catches reference updates like
         # `00172_hits_joins.reference.j2` → `00172_hits_joins.sql.j2` while
         # rejecting orphan data files like `02995_settings_26_4_1.tsv`.
-        test_dir = Path("tests/queries/0_stateless")
+        test_dir = cls._STATELESS_DIR
         candidate = fname
         while "." in candidate:
             candidate = candidate.rsplit(".", 1)[0]
@@ -115,7 +140,7 @@ class Targeting:
             return result
 
         for fpath in changed_files:
-            if re.match(r"tests/queries/0_stateless/\d{5}", fpath):
+            if self.is_stateless_test_path(fpath):
                 if not Path(fpath).exists():
                     print(f"File '{fpath}' was removed — skipping")
                     continue

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -323,24 +323,26 @@ def should_skip_job(job_name):
             ):
                 return True, "Skipped: only CI scripts changed; running amd_asan_ubsan integration batch 1 only"
 
-    # Test-only changes: when every changed file is a stateless test that the
-    # flaky checks already run (across all sanitizer/debug/binary builds), the
-    # full functional suite only re-runs unchanged, unrelated tests. Skip the
-    # non-flaky Stateless/Stateful jobs and rely on the flaky checks. Coverage
-    # jobs are kept so the coverage report stays complete.
-    if (
-        _info_cache.pr_number
-        and (
+    # Test-only changes: the flaky checks already run these exact tests across
+    # all sanitizer/debug/binary builds, so the full functional suite only
+    # re-runs unchanged, unrelated tests. Skip the non-flaky Stateless/Stateful
+    # jobs and the whole LLVM coverage pipeline (its build, stateless/integration/
+    # unit coverage jobs, and the coverage merge), and rely on the flaky checks.
+    # The LLVM coverage merge is skipped too, so the master coverage number is
+    # not updated from a partial run.
+    if _info_cache.pr_number and only_changed_stateless_tests(changed_files):
+        is_full_functional_suite = (
             job_name.startswith(JobNames.STATELESS)
             or job_name.startswith(JobNames.STATEFUL)
+        ) and "flaky" not in job_name.lower()
+        is_llvm_coverage = (
+            "llvm_coverage" in job_name.lower()
+            or job_name == JobNames.LLVM_COVERAGE
         )
-        and "flaky" not in job_name.lower()
-        and "coverage" not in job_name.lower()
-        and only_changed_stateless_tests(changed_files)
-    ):
-        return (
-            True,
-            "Skipped, only stateless test files changed - covered by the flaky checks",
-        )
+        if is_full_functional_suite or is_llvm_coverage:
+            return (
+                True,
+                "Skipped, only stateless test files changed - covered by the flaky checks",
+            )
 
     return False, ""

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 from ci.defs.defs import JobNames
 from ci.defs.job_configs import JobConfigs
@@ -20,6 +21,49 @@ def only_docs(changed_files):
         ):
             continue
         else:
+            return False
+    return True
+
+
+# Cap the change set we treat as "test only". A larger change is a refactor or
+# a batch update where running the full suite is warranted, and the flaky check
+# (45 min budget, each test run many times) cannot meaningfully cover that many
+# tests anyway.
+MAX_TEST_ONLY_CHANGED_FILES = 10
+
+
+def only_changed_stateless_tests(changed_files):
+    """True if the change is a small set of plain stateless tests (or their
+    references) that the flaky checks will run repeatedly across all
+    sanitizer/debug/binary builds. When this holds, the full functional suite
+    would only re-run unchanged, unrelated tests, so it can be skipped in favor
+    of the flaky checks.
+
+    Returns False (keep the full suite) for an empty set, more than
+    `MAX_TEST_ONLY_CHANGED_FILES` files, deletions, any file that is not a
+    recognized `tests/queries/0_stateless` test (helpers, configs, orphan data
+    files, source code, etc.), or any tagged test. A tag such as `no-asan` /
+    `no-tsan` / `no-msan` / `no-debug` excludes the test from build configs the
+    flaky checks use, and `no-flaky-check` excludes it from the flaky check
+    entirely, so a tagged test may not be covered by the limited flaky matrix -
+    only untagged tests are guaranteed to run there.
+    """
+    from ci.jobs.scripts.find_tests import Targeting
+
+    if not changed_files or len(changed_files) > MAX_TEST_ONLY_CHANGED_FILES:
+        return False
+
+    for file in changed_files:
+        f = file.removeprefix(".").removeprefix("/")
+        if not Targeting.is_stateless_test_path(f) or not Path(f).is_file():
+            return False
+        test_base_name = Targeting._derive_test_name(f)
+        if test_base_name is None:
+            return False
+        tags = Targeting.read_test_tags(test_base_name)
+        # `None` means the source couldn't be read; any tag may restrict where
+        # the flaky checks run it. Either way, fall back to the full suite.
+        if tags is None or tags:
             return False
     return True
 
@@ -278,5 +322,25 @@ def should_skip_job(job_name):
                 or "_asan" not in job_name
             ):
                 return True, "Skipped: only CI scripts changed; running amd_asan_ubsan integration batch 1 only"
+
+    # Test-only changes: when every changed file is a stateless test that the
+    # flaky checks already run (across all sanitizer/debug/binary builds), the
+    # full functional suite only re-runs unchanged, unrelated tests. Skip the
+    # non-flaky Stateless/Stateful jobs and rely on the flaky checks. Coverage
+    # jobs are kept so the coverage report stays complete.
+    if (
+        _info_cache.pr_number
+        and (
+            job_name.startswith(JobNames.STATELESS)
+            or job_name.startswith(JobNames.STATEFUL)
+        )
+        and "flaky" not in job_name.lower()
+        and "coverage" not in job_name.lower()
+        and only_changed_stateless_tests(changed_files)
+    ):
+        return (
+            True,
+            "Skipped, only stateless test files changed - covered by the flaky checks",
+        )
 
     return False, ""

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -49,6 +49,8 @@ from subprocess import PIPE, Popen
 from time import sleep, time
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+from test_tags import find_tag_line, parse_tags_from_line
+
 try:
     import termcolor  # type: ignore
 except ImportError:
@@ -3815,23 +3817,6 @@ class TestSuite:
                 return "#"
             raise TestException(f"Unknown file_extension: {filename}")
 
-        def parse_tags_from_line(line, comment_sign) -> Set[str]:
-            if not line.startswith(comment_sign):
-                return set()
-            tags_str = line[len(comment_sign) :].lstrip()  # noqa: ignore E203
-            tags_prefix = "Tags:"
-            if not tags_str.startswith(tags_prefix):
-                return set()
-            tags_str = tags_str[len(tags_prefix) :]  # noqa: ignore E203
-            tags = tags_str.split(",")
-            tags = {tag.strip() for tag in tags}
-            if "no-stress" in tags:
-                raise ValueError(
-                    "The 'no-stress' tag is not supported: stress tests must be "
-                    "able to run every test. Remove it from the test."
-                )
-            return tags
-
         def parse_memory_limits_from_line(
             line, comment_sign
         ) -> Dict[str, Tuple[int, int]]:
@@ -3864,14 +3849,6 @@ class TestSuite:
                     setting_and_limit[1]
                 )
             return random_settings_limits
-
-        def find_tag_line(lines, comment_sign):
-            for line in lines:
-                if line.startswith(comment_sign) and line[
-                    len(comment_sign) :
-                ].lstrip().startswith("Tags:"):
-                    return line
-            return ""
 
         def find_random_settings_limits_line(lines, comment_sign):
             for line in lines:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -49,8 +49,6 @@ from subprocess import PIPE, Popen
 from time import sleep, time
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from test_tags import find_tag_line, parse_tags_from_line
-
 try:
     import termcolor  # type: ignore
 except ImportError:
@@ -3806,6 +3804,11 @@ class TestSuite:
     def read_test_tags_and_random_settings_limits(
         suite_dir: str, all_tests: List[str]
     ) -> (Dict[str, Set[str]], Dict[str, Dict[str, Tuple[int, int]]], Dict[str, int]):
+        # Imported here, not at module top, so loading this script via
+        # `runpy.run_path` (e.g. functional_tests_results.py grabbing exit codes)
+        # works without the script's directory on sys.path.
+        from test_tags import find_tag_line, parse_tags_from_line
+
         def get_comment_sign(filename):
             if filename.endswith(".sql") or filename.endswith(".sql.j2"):
                 return "--"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,54 @@
+"""Shared parsing of the ``-- Tags:`` / ``# Tags:`` line in functional tests.
+
+Imported by both ``tests/clickhouse-test`` (its own directory is on ``sys.path``)
+and the CI helper ``ci/jobs/scripts/find_tests.py`` (repo root on ``sys.path``) so
+tag detection has a single source of truth.
+"""
+from typing import List, Set
+
+
+def get_comment_sign(filename: str) -> str:
+    if filename.endswith(".sql") or filename.endswith(".sql.j2"):
+        return "--"
+    if (
+        filename.endswith(".sh")
+        or filename.endswith(".py")
+        or filename.endswith(".expect")
+    ):
+        return "#"
+    raise ValueError(f"Unknown file_extension: {filename}")
+
+
+def parse_tags_from_line(line: str, comment_sign: str) -> Set[str]:
+    if not line.startswith(comment_sign):
+        return set()
+    tags_str = line[len(comment_sign) :].lstrip()  # noqa: ignore E203
+    tags_prefix = "Tags:"
+    if not tags_str.startswith(tags_prefix):
+        return set()
+    tags_str = tags_str[len(tags_prefix) :]  # noqa: ignore E203
+    tags = {tag.strip() for tag in tags_str.split(",")}
+    if "no-stress" in tags:
+        raise ValueError(
+            "The 'no-stress' tag is not supported: stress tests must be "
+            "able to run every test. Remove it from the test."
+        )
+    return tags
+
+
+def find_tag_line(lines: List[str], comment_sign: str) -> str:
+    for line in lines:
+        if line.startswith(comment_sign) and line[
+            len(comment_sign) :
+        ].lstrip().startswith("Tags:"):
+            return line
+    return ""
+
+
+def read_test_tags(filepath: str) -> Set[str]:
+    """Return the tags declared on the test file's ``Tags:`` line (empty set if
+    none). Raises on an unknown extension; callers handle I/O errors."""
+    comment_sign = get_comment_sign(filepath)
+    with open(filepath, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    return parse_tags_from_line(find_tag_line(lines, comment_sign), comment_sign)


### PR DESCRIPTION
When every changed file is a small set (≤ `MAX_TEST_ONLY_CHANGED_FILES` = 10) of untagged `tests/queries/0_stateless` tests, the flaky checks already run those exact tests repeatedly across all sanitizer/debug/binary builds, so the full `Stateless`/`Stateful` suite only re-runs unchanged, unrelated tests. In that case the non-flaky, non-coverage `Stateless`/`Stateful` jobs are skipped and we rely on the flaky checks.

Only untagged tests qualify: a tag such as `no-asan`/`no-tsan`/`no-msan`/`no-debug` drops the test from build configs the flaky checks use, and `no-flaky-check` drops it from the flaky check entirely, so a tagged test may not be covered by the limited flaky matrix.

Tag parsing is extracted into a shared `tests/test_tags.py` module, now used by both `tests/clickhouse-test` and `ci/jobs/scripts/find_tests.py` instead of being duplicated.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...