### PR TITLE
CI: count integration test Docker image changes in the new-tests check

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -43,6 +43,24 @@ def has_new_unit_tests(changed_files):
     return False
 
 
+def has_new_integration_test_docker_images(changed_files):
+    for file in changed_files:
+        file = file.removeprefix(".").removeprefix("/")
+        # Docker images under `ci/docker/integration/` define the client/server
+        # environments that integration tests spin up (e.g. the MySQL and
+        # PostgreSQL client images). Changing one - for example bumping a client
+        # library version to exercise a fixed bug - is effectively a test change
+        # even when no `test_*.py` file is touched, so count it for this gate.
+        #
+        # Unlike `has_new_integration_tests`, this is intentionally NOT consulted by
+        # `filter_job.py` to enable the integration flaky/bugfix-validate jobs: those
+        # derive the test modules to run from changed `test_*.py` files and would
+        # have nothing to run for a Docker-image-only change.
+        if file.startswith("ci/docker/integration/") and Path(file).is_file():
+            return True
+    return False
+
+
 def has_ci_report_link(pr_body):
     return "s3.amazonaws.com/clickhouse-test-reports" in pr_body
 
@@ -65,6 +83,7 @@ def check():
         not has_new_unit_tests(changed_files)
         and not has_new_functional_tests(changed_files)
         and not has_new_integration_tests(changed_files)
+        and not has_new_integration_test_docker_images(changed_files)
     ):
         if has_ci_report_link(pr_body):
             print(


### PR DESCRIPTION
The "new tests" check (`ci/jobs/scripts/workflow_hooks/new_tests_check.py`) requires every bug-fix PR to add or modify a test. It previously recognized only changes to `tests/queries/0_stateless` (functional), `tests/integration/test_*` (integration), and `src/.../tests/` (unit) files.

Docker images under `ci/docker/integration/` define the client and server environments that integration tests spin up (e.g. the MySQL and PostgreSQL client images). Bumping a client library version there — to exercise a fixed bug through an existing integration test — is effectively a test change, even though no `test_*.py` file is touched. This change counts such Docker image changes for the new-tests gate.

It is added as a separate predicate (`has_new_integration_test_docker_images`) rather than extending `has_new_integration_tests`, because the latter is also consulted by `filter_job.py` to enable the integration flaky and `BUGFIX_VALIDATE_IT` jobs. Those jobs derive the test modules to run from changed `test_*.py` files and would have nothing to run for a Docker-image-only change.

Found via the failed "new tests" check in https://github.com/ClickHouse/ClickHouse/pull/107693

Related: https://github.com/ClickHouse/ClickHouse/pull/107693

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.925`
<!-- ch-version-info:end -->