### PR TITLE
Improve number of distinct values estimation for functions like toYear

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrder.h
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.h
@@ -107,4 +107,16 @@ struct QueryPlanOptimizationSettings;
 
 DPJoinEntryPtr optimizeJoinOrder(QueryGraph query_graph, const QueryPlanOptimizationSettings & optimization_settings);
 
+namespace QueryPlanOptimizations
+{
+
+/// Propagate per-column statistics from the inputs of `actions` to its outputs.
+/// An output column inherits an input's stats when it is the input itself, an alias of it,
+/// or a deterministic single-argument function of it (in which case the input's distinct
+/// count is an upper bound for the output's, since a function cannot increase the number of
+/// distinct values). The stats map is replaced in place with stats keyed by output names.
+void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const ActionsDAG & actions);
+
+}
+
 }

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.h
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.h
@@ -110,11 +110,9 @@ DPJoinEntryPtr optimizeJoinOrder(QueryGraph query_graph, const QueryPlanOptimiza
 namespace QueryPlanOptimizations
 {
 
-/// Propagate per-column statistics from the inputs of `actions` to its outputs.
-/// An output column inherits an input's stats when it is the input itself, an alias of it,
-/// or a deterministic single-argument function of it (in which case the input's distinct
-/// count is an upper bound for the output's, since a function cannot increase the number of
-/// distinct values). The stats map is replaced in place with stats keyed by output names.
+/// Propagate per-column statistics through `actions`, rekeying the map in place by output name.
+/// An output inherits an input's stats when it is that input, an alias of it, or a deterministic
+/// single-argument function of it (which cannot increase the distinct count).
 void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const ActionsDAG & actions);
 
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -82,52 +82,43 @@ namespace QueryPlanOptimizations
 const size_t MAX_ROWS = std::numeric_limits<size_t>::max();
 static String dumpStatsForLogs(const RelationStats & stats);
 
-/// Returns how many leading arguments of a known deterministic function carry through their source's
-/// distinct values. `firstNonDefault` (used to build JOIN USING keys) takes a value from any of its
-/// arguments, so all of them are sources.
-static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name, size_t num_args)
+/// Functions whose output value is taken directly from their first argument, so the output's
+/// distinct values are bounded by that argument's. These are all deterministic.
+static bool isValuePassThroughFunction(std::string_view function_name)
 {
-    if (function_name == "materialize" || function_name == "_CAST" || function_name == "CAST" || function_name == "toNullable")
-        return 1;
-    if (function_name == "firstNonDefault")
-        return num_args;
-    return 0;
+    return function_name == "materialize" || function_name == "_CAST"
+        || function_name == "CAST" || function_name == "toNullable";
 }
 
-/// Describes how a node relates the NDV of its output to the NDV of its source argument(s).
+/// How a node relates its output NDV to the NDV of its first child's source column.
 struct ValueHop
 {
-    size_t followed_children = 0;  /// number of leading children whose source the node inherits
-    UInt64 ndv_delta = 0;          /// extra distinct values this hop can introduce over the source
+    bool propagates = false;  /// output inherits the source NDV of children[0]
+    UInt64 ndv_delta = 0;     /// extra distinct values the hop can introduce over the source
 };
 
-/// A node propagates a source column's NDV when it just relabels or applies a value-preserving
-/// transform to it. `followed_children` is which leading children carry the source; `ndv_delta` is
-/// how much the output NDV can exceed the source NDV.
+/// A node propagates a source column's NDV when it just relabels (ALIAS) or applies a value-
+/// preserving transform to its first argument. `ndv_delta` is how much the output NDV can exceed it.
 static ValueHop describeValueHop(const ActionsDAG::Node & node)
 {
     if (node.type == ActionsDAG::ActionType::ALIAS && node.children.size() == 1)
-        return {.followed_children = 1, .ndv_delta = 0};
+        return {.propagates = true};
 
-    if (node.type != ActionsDAG::ActionType::FUNCTION || !node.function_base)
+    if (node.type != ActionsDAG::ActionType::FUNCTION || !node.function_base || node.children.empty())
         return {};
 
-    size_t followed_children = functionDoesNotChangeNumberOfValues(node.function_base->getName(), node.children.size());
-    /// A deterministic single-argument function has at most as many distinct values as its
-    /// argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
-    if (followed_children == 0 && node.children.size() == 1 && node.function_base->isDeterministic())
-        followed_children = 1;
+    /// A deterministic single-argument function has at most as many distinct values as its argument
+    /// (e.g. `toYear(date)`); the whitelisted functions pass their first argument's value through.
+    const bool propagates = isValuePassThroughFunction(node.function_base->getName())
+        || (node.children.size() == 1 && node.function_base->isDeterministic());
+    if (!propagates)
+        return {};
 
-    UInt64 ndv_delta = 0;
-    /// NDV counts only non-null values. A hop following a single source that turns a Nullable
-    /// argument into a non-Nullable result (e.g. `isNull`, or `CAST` dropping nullability) maps
-    /// NULL to one extra counted value, so add one to the bound.
-    if (followed_children == 1 && !node.children.empty()
-        && isNullableOrLowCardinalityNullable(node.children[0]->result_type)
-        && !isNullableOrLowCardinalityNullable(node.result_type))
-        ndv_delta = 1;
-
-    return {.followed_children = followed_children, .ndv_delta = ndv_delta};
+    /// NDV counts only non-null values. A hop turning a Nullable first argument into a non-Nullable
+    /// result (e.g. `isNull`, or `CAST` dropping nullability) maps NULL to one extra counted value.
+    const bool collapses_null = isNullableOrLowCardinalityNullable(node.children[0]->result_type)
+        && !isNullableOrLowCardinalityNullable(node.result_type);
+    return {.propagates = true, .ndv_delta = collapses_null ? 1u : 0u};
 }
 
 /// For each output column that traces back to `input_name`, return how much to add to the source
@@ -146,14 +137,14 @@ static std::unordered_map<String, UInt64> backTrackColumnsInDag(const String & i
     std::unordered_map<const ActionsDAG::Node *, std::optional<UInt64>> offset_to_input;
 
     /// Iterative post-order DFS (explicit stack to avoid deep recursion on long expression chains).
-    /// Each entry is a node paired with whether its children have already been pushed for processing.
+    /// Each entry is a node paired with whether its source child has already been pushed.
     for (const auto * out_node : actions.getOutputs())
     {
         std::stack<std::pair<const ActionsDAG::Node *, bool>> nodes_to_process;
         nodes_to_process.push({out_node, false});
         while (!nodes_to_process.empty())
         {
-            auto [node, children_pushed] = nodes_to_process.top();
+            auto [node, child_pushed] = nodes_to_process.top();
 
             if (offset_to_input.contains(node))
             {
@@ -168,23 +159,18 @@ static std::unordered_map<String, UInt64> backTrackColumnsInDag(const String & i
             }
 
             ValueHop hop = describeValueHop(*node);
-            if (!children_pushed)
+            if (hop.propagates && !child_pushed)
             {
                 nodes_to_process.top().second = true;
-                for (size_t i = 0; i < hop.followed_children && i < node->children.size(); ++i)
-                    nodes_to_process.push({node->children[i], false});
+                nodes_to_process.push({node->children[0], false});
                 continue;
             }
 
-            /// Children are resolved; inherit the source from the first followed child that traces back.
             std::optional<UInt64> result;
-            for (size_t i = 0; i < hop.followed_children && i < node->children.size(); ++i)
+            if (hop.propagates)
             {
-                if (auto child_offset = offset_to_input[node->children[i]])
-                {
-                    result = *child_offset + hop.ndv_delta;
-                    break;
-                }
+                if (auto source_offset = offset_to_input[node->children[0]])
+                    result = *source_offset + hop.ndv_delta;
             }
             offset_to_input[node] = result;
             nodes_to_process.pop();
@@ -213,12 +199,7 @@ void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const Ac
             /// Add the offset, guarding against overflow when the source NDV is near the maximum.
             if (stats.num_distinct_values <= std::numeric_limits<UInt64>::max() - ndv_offset)
                 stats.num_distinct_values += ndv_offset;
-            /// One output can trace back to several source columns (e.g. a JOIN USING key built with
-            /// `firstNonDefault(left, right)`). Keep the largest derived NDV so the result is an upper
-            /// bound and does not depend on the order source columns are processed in.
-            auto it = mapped.find(remapped);
-            if (it == mapped.end() || it->second.num_distinct_values < stats.num_distinct_values)
-                mapped[remapped] = stats;
+            mapped[remapped] = stats;
         }
     }
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -90,76 +91,72 @@ static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name
     return 0;
 }
 
+/// NDV offset from `node` down to a source input, or nullopt if `node` does not trace back to one.
+/// The offset counts null-collapsing hops (see below); a plain propagating hop adds zero. Results
+/// are memoized in `offset_to_input` so every node, including shared intermediates, is resolved once.
+static std::optional<UInt64> ndvOffsetToInput(
+    const ActionsDAG::Node * node,
+    const std::unordered_set<const ActionsDAG::Node *> & input_nodes,
+    std::unordered_map<const ActionsDAG::Node *, std::optional<UInt64>> & offset_to_input)
+{
+    if (auto it = offset_to_input.find(node); it != offset_to_input.end())
+        return it->second;
+
+    std::optional<UInt64> result;
+    if (input_nodes.contains(node))
+    {
+        result = 0;
+    }
+    else if (node->type == ActionsDAG::ActionType::ALIAS && node->children.size() == 1)
+    {
+        result = ndvOffsetToInput(node->children[0], input_nodes, offset_to_input);
+    }
+    else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
+    {
+        auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
+        UInt64 delta = 0;
+        /// A deterministic single-argument function has at most as many distinct values as its
+        /// argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
+        if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
+        {
+            number_of_args = 1;
+            /// NDV counts only non-null values. A function turning a Nullable argument into a
+            /// non-Nullable result (e.g. `isNull`) maps NULL to one extra counted value, so add one.
+            if (isNullableOrLowCardinalityNullable(node->children[0]->result_type)
+                && !isNullableOrLowCardinalityNullable(node->result_type))
+                delta = 1;
+        }
+        for (size_t i = 0; i < number_of_args && i < node->children.size(); ++i)
+        {
+            if (auto child_offset = ndvOffsetToInput(node->children[i], input_nodes, offset_to_input))
+            {
+                result = *child_offset + delta;
+                break;
+            }
+        }
+    }
+
+    offset_to_input[node] = result;
+    return result;
+}
+
 /// For each output column that traces back to `input_name`, return how much to add to the source
-/// NDV to bound the output NDV. The offset counts null-collapsing hops (see below); a plain
-/// propagating hop adds zero.
+/// NDV to bound the output NDV.
 static std::unordered_map<String, UInt64> backTrackColumnsInDag(const String & input_name, const ActionsDAG & actions)
 {
-    std::unordered_map<String, UInt64> output_offsets;
-
-    /// Nodes known to trace back to the source input, mapped to their offset to it. Seeded with the
-    /// source inputs (offset zero); resolved outputs are added so aliases inherit their offset.
-    std::unordered_map<const ActionsDAG::Node *, UInt64> resolved_offsets;
+    std::unordered_set<const ActionsDAG::Node *> input_nodes;
     for (const auto * node : actions.getInputs())
     {
         if (input_name == node->result_name)
-            resolved_offsets[node] = 0;
+            input_nodes.insert(node);
     }
 
-    std::unordered_set<const ActionsDAG::Node *> visited_nodes;
+    std::unordered_map<const ActionsDAG::Node *, std::optional<UInt64>> offset_to_input;
+    std::unordered_map<String, UInt64> output_offsets;
     for (const auto * out_node : actions.getOutputs())
     {
-        /// Each stack entry is a node paired with the offset accumulated from `out_node` to it.
-        std::stack<std::pair<const ActionsDAG::Node *, UInt64>> nodes_to_process;
-        nodes_to_process.push({out_node, 0});
-
-        while (!nodes_to_process.empty())
-        {
-            auto [node, offset_to_node] = nodes_to_process.top();
-            nodes_to_process.pop();
-
-            auto resolved_it = resolved_offsets.find(node);
-            if (resolved_it != resolved_offsets.end())
-            {
-                /// Reached the source input (or a node already remapped to it); sum both path segments.
-                UInt64 total_offset = offset_to_node + resolved_it->second;
-                output_offsets[out_node->result_name] = total_offset;
-                resolved_offsets[out_node] = total_offset;
-                break;
-            }
-
-            if (!visited_nodes.insert(node).second)
-                break;
-
-            if (node->type == ActionsDAG::ActionType::ALIAS && node->children.size() == 1)
-            {
-                nodes_to_process.push({node->children[0], offset_to_node});
-            }
-            else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
-            {
-                auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
-                UInt64 child_offset = offset_to_node;
-                /// A deterministic single-argument function has at most as many distinct values as
-                /// its argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
-                if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
-                {
-                    number_of_args = 1;
-                    /// NDV counts only non-null values. A function turning a Nullable argument into a
-                    /// non-Nullable result (e.g. `isNull`) maps NULL to one extra counted value, so
-                    /// add one to the bound.
-                    if (isNullableOrLowCardinalityNullable(node->children[0]->result_type)
-                        && !isNullableOrLowCardinalityNullable(node->result_type))
-                        child_offset += 1;
-                }
-                for (const auto * child : node->children)
-                {
-                    if (number_of_args == 0)
-                        break;
-                    number_of_args -= 1;
-                    nodes_to_process.push({child, child_offset});
-                }
-            }
-        }
+        if (auto offset = ndvOffsetToInput(out_node, input_nodes, offset_to_input))
+            output_offsets[out_node->result_name] = *offset;
     }
     return output_offsets;
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -136,6 +136,12 @@ static NameSet backTrackColumnsInDag(const String & input_name, const ActionsDAG
             else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
             {
                 auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
+                /// A deterministic single-argument function cannot produce more distinct values than
+                /// its argument, so the output column's NDV is bounded by the argument column's NDV.
+                /// Propagate the argument stats as that upper bound (e.g. `toYear(date)`) instead of
+                /// leaving the derived column without stats and defaulting to a fraction of rows.
+                if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
+                    number_of_args = 1;
                 for (const auto * child : node->children)
                 {
                     if (number_of_args == 0)
@@ -150,7 +156,7 @@ static NameSet backTrackColumnsInDag(const String & input_name, const ActionsDAG
 }
 
 /// If we have stats for column names for storage we need to find corresponding internal column names
-static void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const ActionsDAG & actions)
+void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const ActionsDAG & actions)
 {
     std::unordered_map<String, ColumnStats> original = std::move(mapped);
     mapped = {};

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -114,18 +114,20 @@ static std::optional<UInt64> ndvOffsetToInput(
     else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
     {
         auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
-        UInt64 delta = 0;
         /// A deterministic single-argument function has at most as many distinct values as its
         /// argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
         if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
-        {
             number_of_args = 1;
-            /// NDV counts only non-null values. A function turning a Nullable argument into a
-            /// non-Nullable result (e.g. `isNull`) maps NULL to one extra counted value, so add one.
-            if (isNullableOrLowCardinalityNullable(node->children[0]->result_type)
-                && !isNullableOrLowCardinalityNullable(node->result_type))
-                delta = 1;
-        }
+
+        UInt64 delta = 0;
+        /// NDV counts only non-null values. A hop following a single source that turns a Nullable
+        /// argument into a non-Nullable result (e.g. `isNull`, or `CAST` dropping nullability) maps
+        /// NULL to one extra counted value, so add one to the bound.
+        if (number_of_args == 1 && !node->children.empty()
+            && isNullableOrLowCardinalityNullable(node->children[0]->result_type)
+            && !isNullableOrLowCardinalityNullable(node->result_type))
+            delta = 1;
+
         for (size_t i = 0; i < number_of_args && i < node->children.size(); ++i)
         {
             if (auto child_offset = ndvOffsetToInput(node->children[i], input_nodes, offset_to_input))

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -5,6 +5,8 @@
 #include <Core/Joins.h>
 #include <Core/Settings.h>
 
+#include <DataTypes/IDataType.h>
+
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/HashJoin/HashJoin.h>
@@ -88,69 +90,78 @@ static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name
     return 0;
 }
 
-static NameSet backTrackColumnsInDag(const String & input_name, const ActionsDAG & actions)
+/// For each output column that traces back to `input_name`, return how much to add to the source
+/// NDV to bound the output NDV. The offset counts null-collapsing hops (see below); a plain
+/// propagating hop adds zero.
+static std::unordered_map<String, UInt64> backTrackColumnsInDag(const String & input_name, const ActionsDAG & actions)
 {
-    NameSet output_names;
+    std::unordered_map<String, UInt64> output_offsets;
 
-    std::unordered_set<const ActionsDAG::Node *> input_nodes;
+    /// Nodes known to trace back to the source input, mapped to their offset to it. Seeded with the
+    /// source inputs (offset zero); resolved outputs are added so aliases inherit their offset.
+    std::unordered_map<const ActionsDAG::Node *, UInt64> resolved_offsets;
     for (const auto * node : actions.getInputs())
     {
         if (input_name == node->result_name)
-            input_nodes.insert(node);
+            resolved_offsets[node] = 0;
     }
 
     std::unordered_set<const ActionsDAG::Node *> visited_nodes;
     for (const auto * out_node : actions.getOutputs())
     {
-
-        std::stack<const ActionsDAG::Node *> nodes_to_process;
-        nodes_to_process.push(out_node);
+        /// Each stack entry is a node paired with the offset accumulated from `out_node` to it.
+        std::stack<std::pair<const ActionsDAG::Node *, UInt64>> nodes_to_process;
+        nodes_to_process.push({out_node, 0});
 
         while (!nodes_to_process.empty())
         {
-            const auto * node = nodes_to_process.top();
+            auto [node, offset_to_node] = nodes_to_process.top();
             nodes_to_process.pop();
 
-            auto [_, inserted] = visited_nodes.insert(node);
-            if (!inserted)
+            auto resolved_it = resolved_offsets.find(node);
+            if (resolved_it != resolved_offsets.end())
             {
-                /// Node was already visited, check if it was an input or if it was already remapped to and input
-                if (input_nodes.contains(node))
-                    output_names.insert(out_node->result_name);
+                /// Reached the source input (or a node already remapped to it); sum both path segments.
+                UInt64 total_offset = offset_to_node + resolved_it->second;
+                output_offsets[out_node->result_name] = total_offset;
+                resolved_offsets[out_node] = total_offset;
                 break;
             }
 
-            if (input_nodes.contains(node))
-            {
-                /// We reached an input node so add the current output node name to list of remapped
-                output_names.insert(out_node->result_name);
-                /// Also add this output node to the list of inputs to handle more aliases pointing to it
-                input_nodes.insert(out_node);
+            if (!visited_nodes.insert(node).second)
                 break;
-            }
 
             if (node->type == ActionsDAG::ActionType::ALIAS && node->children.size() == 1)
             {
-                nodes_to_process.push(node->children[0]);
+                nodes_to_process.push({node->children[0], offset_to_node});
             }
             else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
             {
                 auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
-                /// A deterministic single-argument function cannot produce more distinct values than
-                /// its argument, so bound the output column's NDV by the argument's (e.g. `toYear(date)`).
+                UInt64 child_offset = offset_to_node;
+                /// A deterministic single-argument function has at most as many distinct values as
+                /// its argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
                 if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
+                {
                     number_of_args = 1;
+                    /// NDV counts only non-null values. A function turning a Nullable argument into a
+                    /// non-Nullable result (e.g. `isNull`) maps NULL to one extra counted value, so
+                    /// add one to the bound.
+                    if (isNullableOrLowCardinalityNullable(node->children[0]->result_type)
+                        && !isNullableOrLowCardinalityNullable(node->result_type))
+                        child_offset += 1;
+                }
                 for (const auto * child : node->children)
                 {
                     if (number_of_args == 0)
                         break;
                     number_of_args -= 1;
-                    nodes_to_process.push(child);
+                    nodes_to_process.push({child, child_offset});
                 }
             }
         }
     }
-    return output_names;
+    return output_offsets;
 }
 
 /// If we have stats for column names for storage we need to find corresponding internal column names
@@ -160,8 +171,14 @@ void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const Ac
     mapped = {};
     for (const auto & [name, value] : original)
     {
-        for (const auto & remapped : backTrackColumnsInDag(name, actions))
-            mapped[remapped] = value;
+        for (const auto & [remapped, ndv_offset] : backTrackColumnsInDag(name, actions))
+        {
+            ColumnStats stats = value;
+            /// Add the offset, guarding against overflow when the source NDV is near the maximum.
+            if (stats.num_distinct_values <= std::numeric_limits<UInt64>::max() - ndv_offset)
+                stats.num_distinct_values += ndv_offset;
+            mapped[remapped] = stats;
+        }
     }
 }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -82,6 +82,9 @@ namespace QueryPlanOptimizations
 const size_t MAX_ROWS = std::numeric_limits<size_t>::max();
 static String dumpStatsForLogs(const RelationStats & stats);
 
+/// Returns how many leading arguments of a known deterministic function carry through their source's
+/// distinct values. `firstNonDefault` (used to build JOIN USING keys) takes a value from any of its
+/// arguments, so all of them are sources.
 static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name, size_t num_args)
 {
     if (function_name == "materialize" || function_name == "_CAST" || function_name == "CAST" || function_name == "toNullable")
@@ -91,55 +94,40 @@ static size_t functionDoesNotChangeNumberOfValues(std::string_view function_name
     return 0;
 }
 
-/// NDV offset from `node` down to a source input, or nullopt if `node` does not trace back to one.
-/// The offset counts null-collapsing hops (see below); a plain propagating hop adds zero. Results
-/// are memoized in `offset_to_input` so every node, including shared intermediates, is resolved once.
-static std::optional<UInt64> ndvOffsetToInput(
-    const ActionsDAG::Node * node,
-    const std::unordered_set<const ActionsDAG::Node *> & input_nodes,
-    std::unordered_map<const ActionsDAG::Node *, std::optional<UInt64>> & offset_to_input)
+/// Describes how a node relates the NDV of its output to the NDV of its source argument(s).
+struct ValueHop
 {
-    if (auto it = offset_to_input.find(node); it != offset_to_input.end())
-        return it->second;
+    size_t followed_children = 0;  /// number of leading children whose source the node inherits
+    UInt64 ndv_delta = 0;          /// extra distinct values this hop can introduce over the source
+};
 
-    std::optional<UInt64> result;
-    if (input_nodes.contains(node))
-    {
-        result = 0;
-    }
-    else if (node->type == ActionsDAG::ActionType::ALIAS && node->children.size() == 1)
-    {
-        result = ndvOffsetToInput(node->children[0], input_nodes, offset_to_input);
-    }
-    else if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base)
-    {
-        auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
-        /// A deterministic single-argument function has at most as many distinct values as its
-        /// argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
-        if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
-            number_of_args = 1;
+/// A node propagates a source column's NDV when it just relabels or applies a value-preserving
+/// transform to it. `followed_children` is which leading children carry the source; `ndv_delta` is
+/// how much the output NDV can exceed the source NDV.
+static ValueHop describeValueHop(const ActionsDAG::Node & node)
+{
+    if (node.type == ActionsDAG::ActionType::ALIAS && node.children.size() == 1)
+        return {.followed_children = 1, .ndv_delta = 0};
 
-        UInt64 delta = 0;
-        /// NDV counts only non-null values. A hop following a single source that turns a Nullable
-        /// argument into a non-Nullable result (e.g. `isNull`, or `CAST` dropping nullability) maps
-        /// NULL to one extra counted value, so add one to the bound.
-        if (number_of_args == 1 && !node->children.empty()
-            && isNullableOrLowCardinalityNullable(node->children[0]->result_type)
-            && !isNullableOrLowCardinalityNullable(node->result_type))
-            delta = 1;
+    if (node.type != ActionsDAG::ActionType::FUNCTION || !node.function_base)
+        return {};
 
-        for (size_t i = 0; i < number_of_args && i < node->children.size(); ++i)
-        {
-            if (auto child_offset = ndvOffsetToInput(node->children[i], input_nodes, offset_to_input))
-            {
-                result = *child_offset + delta;
-                break;
-            }
-        }
-    }
+    size_t followed_children = functionDoesNotChangeNumberOfValues(node.function_base->getName(), node.children.size());
+    /// A deterministic single-argument function has at most as many distinct values as its
+    /// argument, so bound the output NDV by the argument's (e.g. `toYear(date)`).
+    if (followed_children == 0 && node.children.size() == 1 && node.function_base->isDeterministic())
+        followed_children = 1;
 
-    offset_to_input[node] = result;
-    return result;
+    UInt64 ndv_delta = 0;
+    /// NDV counts only non-null values. A hop following a single source that turns a Nullable
+    /// argument into a non-Nullable result (e.g. `isNull`, or `CAST` dropping nullability) maps
+    /// NULL to one extra counted value, so add one to the bound.
+    if (followed_children == 1 && !node.children.empty()
+        && isNullableOrLowCardinalityNullable(node.children[0]->result_type)
+        && !isNullableOrLowCardinalityNullable(node.result_type))
+        ndv_delta = 1;
+
+    return {.followed_children = followed_children, .ndv_delta = ndv_delta};
 }
 
 /// For each output column that traces back to `input_name`, return how much to add to the source
@@ -153,11 +141,60 @@ static std::unordered_map<String, UInt64> backTrackColumnsInDag(const String & i
             input_nodes.insert(node);
     }
 
+    /// Offset from a node down to a source input, or nullopt if it does not trace back to one.
+    /// Memoized so every node, including shared intermediates, is resolved once regardless of order.
     std::unordered_map<const ActionsDAG::Node *, std::optional<UInt64>> offset_to_input;
+
+    /// Iterative post-order DFS (explicit stack to avoid deep recursion on long expression chains).
+    /// Each entry is a node paired with whether its children have already been pushed for processing.
+    for (const auto * out_node : actions.getOutputs())
+    {
+        std::stack<std::pair<const ActionsDAG::Node *, bool>> nodes_to_process;
+        nodes_to_process.push({out_node, false});
+        while (!nodes_to_process.empty())
+        {
+            auto [node, children_pushed] = nodes_to_process.top();
+
+            if (offset_to_input.contains(node))
+            {
+                nodes_to_process.pop();
+                continue;
+            }
+            if (input_nodes.contains(node))
+            {
+                offset_to_input[node] = 0;
+                nodes_to_process.pop();
+                continue;
+            }
+
+            ValueHop hop = describeValueHop(*node);
+            if (!children_pushed)
+            {
+                nodes_to_process.top().second = true;
+                for (size_t i = 0; i < hop.followed_children && i < node->children.size(); ++i)
+                    nodes_to_process.push({node->children[i], false});
+                continue;
+            }
+
+            /// Children are resolved; inherit the source from the first followed child that traces back.
+            std::optional<UInt64> result;
+            for (size_t i = 0; i < hop.followed_children && i < node->children.size(); ++i)
+            {
+                if (auto child_offset = offset_to_input[node->children[i]])
+                {
+                    result = *child_offset + hop.ndv_delta;
+                    break;
+                }
+            }
+            offset_to_input[node] = result;
+            nodes_to_process.pop();
+        }
+    }
+
     std::unordered_map<String, UInt64> output_offsets;
     for (const auto * out_node : actions.getOutputs())
     {
-        if (auto offset = ndvOffsetToInput(out_node, input_nodes, offset_to_input))
+        if (auto offset = offset_to_input[out_node])
             output_offsets[out_node->result_name] = *offset;
     }
     return output_offsets;
@@ -176,7 +213,12 @@ void remapColumnStats(std::unordered_map<String, ColumnStats> & mapped, const Ac
             /// Add the offset, guarding against overflow when the source NDV is near the maximum.
             if (stats.num_distinct_values <= std::numeric_limits<UInt64>::max() - ndv_offset)
                 stats.num_distinct_values += ndv_offset;
-            mapped[remapped] = stats;
+            /// One output can trace back to several source columns (e.g. a JOIN USING key built with
+            /// `firstNonDefault(left, right)`). Keep the largest derived NDV so the result is an upper
+            /// bound and does not depend on the order source columns are processed in.
+            auto it = mapped.find(remapped);
+            if (it == mapped.end() || it->second.num_distinct_values < stats.num_distinct_values)
+                mapped[remapped] = stats;
         }
     }
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -137,9 +137,7 @@ static NameSet backTrackColumnsInDag(const String & input_name, const ActionsDAG
             {
                 auto number_of_args = functionDoesNotChangeNumberOfValues(node->function_base->getName(), node->children.size());
                 /// A deterministic single-argument function cannot produce more distinct values than
-                /// its argument, so the output column's NDV is bounded by the argument column's NDV.
-                /// Propagate the argument stats as that upper bound (e.g. `toYear(date)`) instead of
-                /// leaving the derived column without stats and defaulting to a fraction of rows.
+                /// its argument, so bound the output column's NDV by the argument's (e.g. `toYear(date)`).
                 if (number_of_args == 0 && node->children.size() == 1 && node->function_base->isDeterministic())
                     number_of_args = 1;
                 for (const auto * child : node->children)

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -193,6 +193,33 @@ TEST(ColumnStatsDerivation, NullAwareFunctionInChainCarriesOffset)
     EXPECT_EQ(stats["month_is_null"].num_distinct_values, distinct_dates + 1);
 }
 
+/// A `CAST` that drops nullability collapses NULL into a counted value, like a null-aware function,
+/// so its bound is the source NDV plus one even though `CAST` is a pass-through hop.
+TEST(ColumnStatsDerivation, CastDroppingNullabilityAddsOneToBound)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_values = 1000;
+
+    auto nullable_int_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>());
+    ActionsDAG dag;
+    const auto & int_input = dag.addInput("n", nullable_int_type);
+
+    /// Nullable(Int32) -> Int32: NULL maps to the default value, gaining one distinct value.
+    const auto & casted = dag.addCast(int_input, std::make_shared<DataTypeInt32>(), "n_int32", getContext().context);
+    dag.addOrReplaceInOutputs(casted);
+
+    /// Casting to Nullable(Int32) preserves nulls, so the exact bound holds.
+    const auto & casted_nullable = dag.addCast(int_input, nullable_int_type, "n_nullable", getContext().context);
+    dag.addOrReplaceInOutputs(casted_nullable);
+
+    auto stats = statsOf("n", distinct_values);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["n_int32"].num_distinct_values, distinct_values + 1);
+    EXPECT_EQ(stats["n_nullable"].num_distinct_values, distinct_values);
+}
+
 /// Two outputs consuming the same internal node both inherit the source bound: resolving one output
 /// must not stop the other from resolving through the shared node, regardless of output order.
 TEST(ColumnStatsDerivation, SharedIntermediateNodeResolvesForAllOutputs)

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -4,6 +4,7 @@
 #include <Common/tests/gtest_global_register.h>
 
 #include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Functions/FunctionFactory.h>
@@ -134,6 +135,62 @@ TEST(ColumnStatsDerivation, AttributesDerivedColumnToCorrectSource)
 
     EXPECT_EQ(stats["year"].num_distinct_values, 2556u);
     EXPECT_EQ(stats["neg"].num_distinct_values, 1000u);
+}
+
+/// NDV counts only non-null values. A null-aware function such as `isNull` maps NULL to one extra
+/// counted value, so its bound is the argument's NDV plus one. A null-preserving function over the
+/// same Nullable argument keeps the exact bound, since NULL stays NULL and is uncounted on both sides.
+TEST(ColumnStatsDerivation, NullAwareFunctionAddsOneToBound)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_dates = 2556;
+
+    auto nullable_date_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDate>());
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", nullable_date_type);
+
+    /// Nullable -> non-Nullable UInt8: NULL maps to one counted value, so the bound gains one.
+    addOutputFunction(dag, "isNull", {&date_input}, "is_null");
+    addOutputFunction(dag, "isNotNull", {&date_input}, "is_not_null");
+    /// Nullable -> Nullable: NULL stays NULL, so the exact bound still holds.
+    addOutputFunction(dag, "toYear", {&date_input}, "year");
+
+    auto stats = statsOf("d", distinct_dates);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["is_null"].num_distinct_values, distinct_dates + 1);
+    EXPECT_EQ(stats["is_not_null"].num_distinct_values, distinct_dates + 1);
+    EXPECT_EQ(stats["year"].num_distinct_values, distinct_dates);
+}
+
+/// The +1 from a null-aware hop is carried along the rest of the chain, regardless of its position:
+/// a downstream null-preserving function keeps it, and an upstream one does not consume it.
+TEST(ColumnStatsDerivation, NullAwareFunctionInChainCarriesOffset)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_dates = 2556;
+
+    auto nullable_date_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeDate>());
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", nullable_date_type);
+
+    /// toString(isNull(d)): isNull adds one, the downstream toString preserves it.
+    const auto & is_null = dag.addFunction(
+        FunctionFactory::instance().get("isNull", getContext().context), {&date_input}, "is_null");
+    addOutputFunction(dag, "toString", {&is_null}, "is_null_string");
+
+    /// isNull(toStartOfMonth(d)): the upstream null-preserving hop keeps the bound exact, then isNull adds one.
+    const auto & start_of_month = dag.addFunction(
+        FunctionFactory::instance().get("toStartOfMonth", getContext().context), {&date_input}, "start_of_month");
+    addOutputFunction(dag, "isNull", {&start_of_month}, "month_is_null");
+
+    auto stats = statsOf("d", distinct_dates);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["is_null_string"].num_distinct_values, distinct_dates + 1);
+    EXPECT_EQ(stats["month_is_null"].num_distinct_values, distinct_dates + 1);
 }
 
 /// The bound propagates through a chain of deterministic single-argument functions: no link can

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -245,6 +245,53 @@ TEST(ColumnStatsDerivation, SharedIntermediateNodeResolvesForAllOutputs)
     EXPECT_EQ(stats["year_uint"].num_distinct_values, distinct_dates);
 }
 
+/// `firstNonDefault(a, b)` (the JOIN USING merged key) draws values from both arguments, so its
+/// derived NDV must be an upper bound over both sources and must not depend on the order the source
+/// columns are processed in. The largest source bound is kept.
+TEST(ColumnStatsDerivation, FirstNonDefaultTakesUpperBoundOverSources)
+{
+    tryRegisterFunctions();
+
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & left = dag.addInput("a", int_type);
+    const auto & right = dag.addInput("b", int_type);
+
+    addOutputFunction(dag, "firstNonDefault", {&left, &right}, "merged");
+
+    std::unordered_map<String, ColumnStats> stats;
+    stats["a"] = ColumnStats{.num_distinct_values = 10};
+    stats["b"] = ColumnStats{.num_distinct_values = 1000};
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["merged"].num_distinct_values, 1000u);
+}
+
+/// A very long chain of single-argument functions resolves without hitting a recursion-depth limit,
+/// and the source bound still reaches the final output.
+TEST(ColumnStatsDerivation, DeepChainOfFunctionsResolves)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_values = 1000;
+    const size_t chain_length = 20000;
+
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & int_input = dag.addInput("n", int_type);
+
+    const ActionsDAG::Node * current = &int_input;
+    for (size_t i = 0; i < chain_length; ++i)
+        current = &dag.addFunction(
+            FunctionFactory::instance().get("negate", getContext().context), {current}, "v" + std::to_string(i));
+    dag.addOrReplaceInOutputs(*current);
+
+    auto stats = statsOf("n", distinct_values);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats[current->result_name].num_distinct_values, distinct_values);
+}
+
 /// The bound propagates through a chain of deterministic single-argument functions: no link can
 /// increase the distinct count, so the final output is still bounded by the source column. A
 /// multi-argument link anywhere in the chain breaks the propagation.

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+
+#include <DataTypes/DataTypeDate.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/ActionsDAG.h>
+#include <Processors/QueryPlan/Optimizations/joinOrder.h>
+
+using namespace DB;
+using namespace DB::QueryPlanOptimizations;
+
+namespace
+{
+
+/// Build statistics for a single column with the given distinct-value count.
+std::unordered_map<String, ColumnStats> statsOf(const String & name, UInt64 num_distinct_values)
+{
+    std::unordered_map<String, ColumnStats> stats;
+    stats[name] = ColumnStats{.num_distinct_values = num_distinct_values};
+    return stats;
+}
+
+/// Add `function(children)` to the DAG as an output named `result_name` and return its node.
+const ActionsDAG::Node & addOutputFunction(
+    ActionsDAG & dag,
+    const String & function_name,
+    ActionsDAG::NodeRawConstPtrs children,
+    const String & result_name)
+{
+    auto resolver = FunctionFactory::instance().get(function_name, getContext().context);
+    const auto & node = dag.addFunction(resolver, std::move(children), result_name);
+    dag.addOrReplaceInOutputs(node);
+    return node;
+}
+
+}
+
+/// `remapColumnStats` must carry an input column's distinct-value count to every output that is a
+/// deterministic single-argument function of it. A function cannot produce more distinct values
+/// than its argument, so the argument's count is a valid upper bound for the derived column.
+TEST(ColumnStatsDerivation, DeterministicSingleArgFunctionBoundsDistinctValues)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_dates = 2556;
+
+    auto date_type = std::make_shared<DataTypeDate>();
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", date_type);
+
+    /// Common single-argument deterministic functions of a date column. Each output column's
+    /// distinct count is bounded by the date column's distinct count.
+    addOutputFunction(dag, "toYear", {&date_input}, "year");
+    addOutputFunction(dag, "toMonth", {&date_input}, "month");
+    addOutputFunction(dag, "toDayOfWeek", {&date_input}, "day_of_week");
+    addOutputFunction(dag, "toStartOfMonth", {&date_input}, "start_of_month");
+    addOutputFunction(dag, "toString", {&date_input}, "as_string");
+    /// `materialize` is in the explicit pass-through list and must keep working.
+    addOutputFunction(dag, "materialize", {&date_input}, "materialized");
+    /// The column itself passed through as an output keeps its stats.
+    dag.addOrReplaceInOutputs(date_input);
+
+    auto stats = statsOf("d", distinct_dates);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["year"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["month"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["day_of_week"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["start_of_month"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["as_string"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["materialized"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["d"].num_distinct_values, distinct_dates);
+}
+
+/// Single-argument functions of a numeric column behave the same way.
+TEST(ColumnStatsDerivation, SingleArgFunctionOfNumericColumn)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_values = 1000;
+
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & int_input = dag.addInput("n", int_type);
+
+    addOutputFunction(dag, "negate", {&int_input}, "neg");
+    addOutputFunction(dag, "abs", {&int_input}, "magnitude");
+    addOutputFunction(dag, "toString", {&int_input}, "as_string");
+
+    auto stats = statsOf("n", distinct_values);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["neg"].num_distinct_values, distinct_values);
+    EXPECT_EQ(stats["magnitude"].num_distinct_values, distinct_values);
+    EXPECT_EQ(stats["as_string"].num_distinct_values, distinct_values);
+}
+
+/// A multi-argument function is not bounded by a single argument's distinct count, so the bound
+/// is not propagated: the derived column gets no stats.
+TEST(ColumnStatsDerivation, MultiArgFunctionDoesNotPropagateBound)
+{
+    tryRegisterFunctions();
+
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & int_input = dag.addInput("n", int_type);
+
+    addOutputFunction(dag, "plus", {&int_input, &int_input}, "doubled");
+
+    auto stats = statsOf("n", 1000);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats.count("doubled"), 0u);
+}
+
+/// A derived column is attributed to the right source column when several inputs carry stats.
+TEST(ColumnStatsDerivation, AttributesDerivedColumnToCorrectSource)
+{
+    tryRegisterFunctions();
+
+    auto date_type = std::make_shared<DataTypeDate>();
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", date_type);
+    const auto & int_input = dag.addInput("n", int_type);
+
+    addOutputFunction(dag, "toYear", {&date_input}, "year");
+    addOutputFunction(dag, "negate", {&int_input}, "neg");
+
+    std::unordered_map<String, ColumnStats> stats;
+    stats["d"] = ColumnStats{.num_distinct_values = 2556};
+    stats["n"] = ColumnStats{.num_distinct_values = 1000};
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["year"].num_distinct_values, 2556u);
+    EXPECT_EQ(stats["neg"].num_distinct_values, 1000u);
+}

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -193,6 +193,31 @@ TEST(ColumnStatsDerivation, NullAwareFunctionInChainCarriesOffset)
     EXPECT_EQ(stats["month_is_null"].num_distinct_values, distinct_dates + 1);
 }
 
+/// Two outputs consuming the same internal node both inherit the source bound: resolving one output
+/// must not stop the other from resolving through the shared node, regardless of output order.
+TEST(ColumnStatsDerivation, SharedIntermediateNodeResolvesForAllOutputs)
+{
+    tryRegisterFunctions();
+
+    const UInt64 distinct_dates = 2556;
+
+    auto date_type = std::make_shared<DataTypeDate>();
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", date_type);
+
+    /// Internal node year = toYear(d), consumed by two separate outputs but not an output itself.
+    const auto & year = dag.addFunction(
+        FunctionFactory::instance().get("toYear", getContext().context), {&date_input}, "year");
+    addOutputFunction(dag, "toString", {&year}, "year_string");
+    addOutputFunction(dag, "toUInt32", {&year}, "year_uint");
+
+    auto stats = statsOf("d", distinct_dates);
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["year_string"].num_distinct_values, distinct_dates);
+    EXPECT_EQ(stats["year_uint"].num_distinct_values, distinct_dates);
+}
+
 /// The bound propagates through a chain of deterministic single-argument functions: no link can
 /// increase the distinct count, so the final output is still bounded by the source column. A
 /// multi-argument link anywhere in the chain breaks the propagation.

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -51,10 +51,10 @@ TEST(ColumnStatsDerivation, DeterministicSingleArgFunctionBoundsDistinctValues)
     ActionsDAG dag;
     const auto & date_input = dag.addInput("d", date_type);
 
-    /// Single-argument deterministic functions of a date column, each bounded by the date's NDV.
+    /// Single-argument deterministic functions whose distinct count is genuinely bounded by the
+    /// date's NDV, with no smaller fixed codomain (unlike `toMonth`, which is always <= 12 and would
+    /// warrant a tighter constant bound instead).
     addOutputFunction(dag, "toYear", {&date_input}, "year");
-    addOutputFunction(dag, "toMonth", {&date_input}, "month");
-    addOutputFunction(dag, "toDayOfWeek", {&date_input}, "day_of_week");
     addOutputFunction(dag, "toStartOfMonth", {&date_input}, "start_of_month");
     addOutputFunction(dag, "toString", {&date_input}, "as_string");
     /// `materialize` is in the explicit pass-through list and must keep working.
@@ -66,8 +66,6 @@ TEST(ColumnStatsDerivation, DeterministicSingleArgFunctionBoundsDistinctValues)
     remapColumnStats(stats, dag);
 
     EXPECT_EQ(stats["year"].num_distinct_values, distinct_dates);
-    EXPECT_EQ(stats["month"].num_distinct_values, distinct_dates);
-    EXPECT_EQ(stats["day_of_week"].num_distinct_values, distinct_dates);
     EXPECT_EQ(stats["start_of_month"].num_distinct_values, distinct_dates);
     EXPECT_EQ(stats["as_string"].num_distinct_values, distinct_dates);
     EXPECT_EQ(stats["materialized"].num_distinct_values, distinct_dates);
@@ -136,4 +134,44 @@ TEST(ColumnStatsDerivation, AttributesDerivedColumnToCorrectSource)
 
     EXPECT_EQ(stats["year"].num_distinct_values, 2556u);
     EXPECT_EQ(stats["neg"].num_distinct_values, 1000u);
+}
+
+/// The bound propagates through a chain of deterministic single-argument functions: no link can
+/// increase the distinct count, so the final output is still bounded by the source column. A
+/// multi-argument link anywhere in the chain breaks the propagation.
+TEST(ColumnStatsDerivation, ChainOfFunctionsPropagatesBound)
+{
+    tryRegisterFunctions();
+
+    auto date_type = std::make_shared<DataTypeDate>();
+    auto int_type = std::make_shared<DataTypeInt64>();
+    ActionsDAG dag;
+    const auto & date_input = dag.addInput("d", date_type);
+    const auto & int_input = dag.addInput("n", int_type);
+
+    /// toString(toStartOfMonth(d)) -- two single-argument functions in a row.
+    const auto & start_of_month = dag.addFunction(
+        FunctionFactory::instance().get("toStartOfMonth", getContext().context), {&date_input}, "start_of_month");
+    addOutputFunction(dag, "toString", {&start_of_month}, "formatted_month");
+
+    /// toString(abs(negate(n))) -- three single-argument functions in a row.
+    const auto & neg = dag.addFunction(
+        FunctionFactory::instance().get("negate", getContext().context), {&int_input}, "neg");
+    const auto & magnitude = dag.addFunction(
+        FunctionFactory::instance().get("abs", getContext().context), {&neg}, "magnitude");
+    addOutputFunction(dag, "toString", {&magnitude}, "formatted_magnitude");
+
+    /// negate(plus(n, n)) -- a multi-argument link breaks the chain, so the bound stops there.
+    const auto & doubled = dag.addFunction(
+        FunctionFactory::instance().get("plus", getContext().context), {&int_input, &int_input}, "doubled");
+    addOutputFunction(dag, "negate", {&doubled}, "neg_doubled");
+
+    std::unordered_map<String, ColumnStats> stats;
+    stats["d"] = ColumnStats{.num_distinct_values = 2556};
+    stats["n"] = ColumnStats{.num_distinct_values = 1000};
+    remapColumnStats(stats, dag);
+
+    EXPECT_EQ(stats["formatted_month"].num_distinct_values, 2556u);
+    EXPECT_EQ(stats["formatted_magnitude"].num_distinct_values, 1000u);
+    EXPECT_EQ(stats.count("neg_doubled"), 0u);
 }

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -245,10 +245,9 @@ TEST(ColumnStatsDerivation, SharedIntermediateNodeResolvesForAllOutputs)
     EXPECT_EQ(stats["year_uint"].num_distinct_values, distinct_dates);
 }
 
-/// `firstNonDefault(a, b)` (the JOIN USING merged key) draws values from both arguments, so its
-/// derived NDV must be an upper bound over both sources and must not depend on the order the source
-/// columns are processed in. The largest source bound is kept.
-TEST(ColumnStatsDerivation, FirstNonDefaultTakesUpperBoundOverSources)
+/// `firstNonDefault(a, b)` (the JOIN USING merged key) draws values from both arguments, so a single
+/// source's NDV is not a valid upper bound for it. No stats are propagated for such multi-source hops.
+TEST(ColumnStatsDerivation, FirstNonDefaultDoesNotPropagateBound)
 {
     tryRegisterFunctions();
 
@@ -264,7 +263,7 @@ TEST(ColumnStatsDerivation, FirstNonDefaultTakesUpperBoundOverSources)
     stats["b"] = ColumnStats{.num_distinct_values = 1000};
     remapColumnStats(stats, dag);
 
-    EXPECT_EQ(stats["merged"].num_distinct_values, 1000u);
+    EXPECT_EQ(stats.count("merged"), 0u);
 }
 
 /// A very long chain of single-argument functions resolves without hitting a recursion-depth limit,

--- a/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
+++ b/src/Processors/QueryPlan/tests/gtest_column_stats_derivation.cpp
@@ -39,9 +39,8 @@ const ActionsDAG::Node & addOutputFunction(
 
 }
 
-/// `remapColumnStats` must carry an input column's distinct-value count to every output that is a
-/// deterministic single-argument function of it. A function cannot produce more distinct values
-/// than its argument, so the argument's count is a valid upper bound for the derived column.
+/// A deterministic single-argument function inherits its argument's distinct count as an upper
+/// bound, since it cannot produce more distinct values than its argument.
 TEST(ColumnStatsDerivation, DeterministicSingleArgFunctionBoundsDistinctValues)
 {
     tryRegisterFunctions();
@@ -52,8 +51,7 @@ TEST(ColumnStatsDerivation, DeterministicSingleArgFunctionBoundsDistinctValues)
     ActionsDAG dag;
     const auto & date_input = dag.addInput("d", date_type);
 
-    /// Common single-argument deterministic functions of a date column. Each output column's
-    /// distinct count is bounded by the date column's distinct count.
+    /// Single-argument deterministic functions of a date column, each bounded by the date's NDV.
     addOutputFunction(dag, "toYear", {&date_input}, "year");
     addOutputFunction(dag, "toMonth", {&date_input}, "month");
     addOutputFunction(dag, "toDayOfWeek", {&date_input}, "day_of_week");


### PR DESCRIPTION
The query-plan statistics derivation propagates per-column distinct-value counts (NDV)
through expressions so the join-order optimizer can estimate cardinalities. Previously a
column produced by a function inherited its argument's stats only for a small hard-coded
whitelist (`materialize`, `CAST`, `toNullable`, `firstNonDefault`); a column produced by any
other function was left without statistics, so its NDV fell back to a fraction of the row
count — a large overestimate for low-cardinality derived keys such as `toYear(date)`.

A deterministic single-argument function cannot produce more distinct values than its
argument, so this PR propagates the argument's NDV to the derived column as an upper bound.
This gives the cardinality estimator a realistic bound for common derived expressions (e.g.
`toYear(d)`, `toStartOfMonth(d)`, `toString(d)`, and chains of such functions), improving
join-reordering estimates. The bound is an upper bound, not an exact count; functions with a
small fixed codomain (e.g. `toMonth` is always <= 12) are not given a tighter constant bound
here — that is left as a possible follow-up.

A `ColumnStatsDerivation` gtest is added covering single-argument functions of date and
numeric columns, source attribution across multiple stat-carrying inputs, function chains,
and the negative case where a multi-argument link does not propagate the bound.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Improve cardinality estimation in the query plan optimizer: a column produced by a deterministic single-argument function (e.g. `toYear(date)`) now inherits its argument's number of distinct values as an upper bound instead of being left without statistics, leading to more accurate join reordering.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1116`
<!-- ch-version-info:end -->