### PR TITLE
Don't handle `timeout_overflow_mode='break'` in `ReplicatedMergeTreeSink::waitForQuorum`

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -1283,13 +1283,12 @@ void ReplicatedMergeTreeSink::waitForQuorum(
 
         /// Wait for the quorum watch to fire, but in bounded steps so that a cancelled query stops waiting
         /// promptly instead of blocking for the whole quorum_timeout_ms. The watch is only signalled when the
-        /// quorum node changes, so on a `KILL QUERY` (or once max_execution_time is exceeded) nothing would wake
-        /// us up: without this a cancelled quorum INSERT can stay in the processlist for the entire (possibly very
-        /// large) insert_quorum_timeout and trip the hung-check. checkTimeLimit() throws QUERY_WAS_CANCELLED on a
-        /// kill and TIMEOUT_EXCEEDED on max_execution_time when timeout_overflow_mode = 'throw'; with
-        /// timeout_overflow_mode = 'break' it returns false instead. A quorum INSERT cannot return a partial
-        /// success while the quorum status is unknown, so we treat a false return as a timeout too (rather than
-        /// silently continuing to wait). This matches the check ZooKeeperRetriesControl performs between retries.
+        /// quorum node changes, so on a `KILL QUERY` (or once max_execution_time is exceeded with
+        /// timeout_overflow_mode = 'throw') nothing would wake us up: without this a cancelled quorum INSERT can
+        /// stay in the processlist for the entire (possibly very large) insert_quorum_timeout and trip the
+        /// hung-check. checkTimeLimit() throws QUERY_WAS_CANCELLED on a kill and TIMEOUT_EXCEEDED on
+        /// max_execution_time when timeout_overflow_mode = 'throw'. This matches the check ZooKeeperRetriesControl
+        /// performs between retries.
         auto process_list_element = context->getProcessListElement();
         Stopwatch quorum_watch;
         bool quorum_updated = false;
@@ -1305,16 +1304,14 @@ void ReplicatedMergeTreeSink::waitForQuorum(
                 break;
             }
 
-            /// checkTimeLimit() throws on a kill or on a 'throw'-mode timeout. A false return means a 'break'-mode
-            /// timeout was reached: the framework would normally let such a query finish gracefully (as a
-            /// successful "break"), but a quorum INSERT must not report success while the quorum status is unknown.
-            /// Escalate to a hard cancellation (the same call CancellationChecker uses for 'throw' mode) so the
-            /// query fails with TIMEOUT_EXCEEDED instead of being silently completed.
-            if (process_list_element && !process_list_element->checkTimeLimit())
-            {
-                process_list_element->cancelQuery(DB::CancelReason::TIMEOUT);
+            /// checkTimeLimit() throws on a kill (QUERY_WAS_CANCELLED) or on a 'throw'-mode max_execution_time
+            /// timeout (TIMEOUT_EXCEEDED), which is what we need to stop waiting promptly. With
+            /// timeout_overflow_mode = 'break' it returns false instead of throwing: there is nothing to "break"
+            /// to here (a quorum INSERT cannot report a partial success), so we deliberately ignore the false and
+            /// keep waiting until the quorum is satisfied or quorum_timeout_ms elapses (the wait's own bound,
+            /// reported as UNKNOWN_STATUS_OF_INSERT). A kill is still honored every step regardless of the mode.
+            if (process_list_element)
                 process_list_element->checkTimeLimit();
-            }
         }
 
         if (!quorum_updated)

--- a/tests/queries/0_stateless/04337_quorum_insert_honors_time_limit.sql
+++ b/tests/queries/0_stateless/04337_quorum_insert_honors_time_limit.sql
@@ -5,17 +5,21 @@
 
 -- A quorum INSERT must honor the query time limit / cancellation while waiting for quorum, instead of blocking
 -- for the whole insert_quorum_timeout. See ReplicatedMergeTreeSink::waitForQuorum: the quorum watch is only
--- signalled when the quorum node changes, so a killed query (or one that exceeded max_execution_time) would never
--- be woken up. Before the fix such an INSERT lingered in the processlist for the entire (possibly very large)
--- insert_quorum_timeout, tripping the hung-check.
+-- signalled when the quorum node changes, so a killed query (or one that exceeded max_execution_time with
+-- timeout_overflow_mode = 'throw') would never be woken up. Before the fix such an INSERT lingered in the
+-- processlist for the entire (possibly very large) insert_quorum_timeout, tripping the hung-check.
 --
 -- The second replica never fetches the part (SYSTEM STOP FETCHES), so insert_quorum = 2 can never be satisfied.
--- insert_quorum_timeout is set very large while max_execution_time is small, so the INSERT must be interrupted
--- promptly with TIMEOUT_EXCEEDED rather than hanging for insert_quorum_timeout. Both timeout_overflow_mode values
--- are covered: checkTimeLimit() throws for 'throw' and only returns false for 'break', but a quorum INSERT cannot
--- report a partial success while the quorum status is unknown, so 'break' must error out too (it is escalated to a
--- hard timeout). Each mode uses its own table because a finished-but-unsatisfied quorum write would otherwise make
--- the next INSERT fail early with UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE before it ever waits for quorum.
+-- Two timeout_overflow_mode values are covered, each on its own table (a finished-but-unsatisfied quorum write
+-- would otherwise make the next INSERT fail early with UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE before it ever waits
+-- for quorum):
+--   - 'throw' (default): checkTimeLimit() throws directly, so insert_quorum_timeout is set very large while
+--     max_execution_time is small and the INSERT must be interrupted promptly with TIMEOUT_EXCEEDED rather than
+--     hanging for insert_quorum_timeout.
+--   - 'break': checkTimeLimit() returns false instead of throwing. A quorum INSERT cannot report a partial
+--     success, so waitForQuorum ignores the 'break'-mode timeout and the wait is bounded by insert_quorum_timeout
+--     instead, ending with UNKNOWN_STATUS_OF_INSERT. (A 'KILL QUERY' is still honored every step regardless of the
+--     mode -- see 04338_kill_quorum_insert.)
 
 DROP TABLE IF EXISTS quorum_throw_r1 SYNC;
 DROP TABLE IF EXISTS quorum_throw_r2 SYNC;
@@ -37,11 +41,14 @@ INSERT INTO quorum_throw_r1
 SETTINGS insert_quorum = 2, insert_quorum_parallel = 0, insert_quorum_timeout = 6000000, max_execution_time = 3, timeout_overflow_mode = 'throw', async_insert = 0, insert_keeper_fault_injection_probability = 0
 VALUES (1); -- { serverError TIMEOUT_EXCEEDED }
 
--- timeout_overflow_mode = 'break': checkTimeLimit() returns false; the wait must still stop and fail rather than
--- hang until insert_quorum_timeout or report a successful "break" with unknown quorum status.
+-- timeout_overflow_mode = 'break': checkTimeLimit() returns false instead of throwing, so the 'break'-mode
+-- max_execution_time is ignored in the quorum wait and the INSERT is bounded by insert_quorum_timeout (set small
+-- here), failing with UNKNOWN_STATUS_OF_INSERT. max_execution_time is set much larger than insert_quorum_timeout
+-- so the quorum timeout fires first and the result is deterministic: a small 'break'-mode max_execution_time could
+-- otherwise be consumed during pipeline setup and let the executor stop gracefully before reaching waitForQuorum.
 INSERT INTO quorum_break_r1
-SETTINGS insert_quorum = 2, insert_quorum_parallel = 0, insert_quorum_timeout = 6000000, max_execution_time = 3, timeout_overflow_mode = 'break', async_insert = 0, insert_keeper_fault_injection_probability = 0
-VALUES (1); -- { serverError TIMEOUT_EXCEEDED }
+SETTINGS insert_quorum = 2, insert_quorum_parallel = 0, insert_quorum_timeout = 3000, max_execution_time = 300, timeout_overflow_mode = 'break', async_insert = 0, insert_keeper_fault_injection_probability = 0
+VALUES (1); -- { serverError UNKNOWN_STATUS_OF_INSERT }
 
 DROP TABLE quorum_throw_r1 SYNC;
 DROP TABLE quorum_throw_r2 SYNC;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

https://github.com/ClickHouse/ClickHouse/pull/107513 caused failures in CI, and we decided to reconsider the behaviour with `timeout_overflow_mode='break'`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.976`
<!-- ch-version-info:end -->