### PR TITLE
Fix OOM during linking in private builds

### DIFF
--- a/cmake/limit_jobs.cmake
+++ b/cmake/limit_jobs.cmake
@@ -48,9 +48,22 @@ endif ()
 # But use 2 parallel jobs, since:
 # - this is what llvm does
 # - and I've verfied that lld-11 does not use all available CPU time (in peak) while linking one binary
-if (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" AND ENABLE_THINLTO AND PARALLEL_LINK_JOBS GREATER 2)
-    message(STATUS "ThinLTO provides its own parallel linking - limiting parallel link jobs to 2.")
-    set (PARALLEL_LINK_JOBS 2)
+#
+# Each ThinLTO link of a large binary (clickhouse, standalone keeper) can use
+# ~100 GB RAM when debug info is kept (-g), so don't run more concurrent LTO
+# links than physically fit in memory - otherwise the linker is OOM-killed.
+if (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" AND ENABLE_THINLTO AND PARALLEL_LINK_JOBS GREATER 1)
+    set (MAX_THINLTO_LINK_MEMORY 102400) # megabytes per concurrent ThinLTO link
+    math (EXPR THINLTO_LINK_JOBS "${TOTAL_PHYSICAL_MEMORY} / ${MAX_THINLTO_LINK_MEMORY}")
+    if (THINLTO_LINK_JOBS LESS 1)
+        set (THINLTO_LINK_JOBS 1)
+    elseif (THINLTO_LINK_JOBS GREATER 2)
+        set (THINLTO_LINK_JOBS 2) # 2 is plenty; ThinLTO is already internally parallel
+    endif ()
+    if (THINLTO_LINK_JOBS LESS PARALLEL_LINK_JOBS)
+        message(STATUS "ThinLTO provides its own parallel linking - limiting parallel link jobs to ${THINLTO_LINK_JOBS} (system has ${TOTAL_PHYSICAL_MEMORY} MB RAM).")
+        set (PARALLEL_LINK_JOBS ${THINLTO_LINK_JOBS})
+    endif ()
 endif()
 
 message(STATUS "Building sub-tree with ${PARALLEL_COMPILE_JOBS} compile jobs and ${PARALLEL_LINK_JOBS} linker jobs (system: ${NUMBER_OF_LOGICAL_CORES} cores, ${TOTAL_PHYSICAL_MEMORY} MB RAM, 'OFF' means the native core count).")

--- a/cmake/limit_jobs.cmake
+++ b/cmake/limit_jobs.cmake
@@ -52,8 +52,14 @@ endif ()
 # Each ThinLTO link of a large binary (clickhouse, standalone keeper) can use
 # ~100 GB RAM when debug info is kept (-g), so don't run more concurrent LTO
 # links than physically fit in memory - otherwise the linker is OOM-killed.
+# With debug info disabled (-g0, DISABLE_ALL_DEBUG_SYMBOLS) a link needs only
+# ~50 GB, so two still fit and we keep them parallel.
 if (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" AND ENABLE_THINLTO AND PARALLEL_LINK_JOBS GREATER 1)
-    set (MAX_THINLTO_LINK_MEMORY 102400) # megabytes per concurrent ThinLTO link
+    if (DISABLE_ALL_DEBUG_SYMBOLS)
+        set (MAX_THINLTO_LINK_MEMORY 51200)  # megabytes per concurrent ThinLTO link, measured ~49 GB with -g0
+    else ()
+        set (MAX_THINLTO_LINK_MEMORY 102400) # megabytes per concurrent ThinLTO link, measured ~100 GB with -g
+    endif ()
     math (EXPR THINLTO_LINK_JOBS "${TOTAL_PHYSICAL_MEMORY} / ${MAX_THINLTO_LINK_MEMORY}")
     if (THINLTO_LINK_JOBS LESS 1)
         set (THINLTO_LINK_JOBS 1)
@@ -61,7 +67,7 @@ if (CMAKE_BUILD_TYPE_UC STREQUAL "RELWITHDEBINFO" AND ENABLE_THINLTO AND PARALLE
         set (THINLTO_LINK_JOBS 2) # 2 is plenty; ThinLTO is already internally parallel
     endif ()
     if (THINLTO_LINK_JOBS LESS PARALLEL_LINK_JOBS)
-        message(STATUS "ThinLTO provides its own parallel linking - limiting parallel link jobs to ${THINLTO_LINK_JOBS} (system has ${TOTAL_PHYSICAL_MEMORY} MB RAM).")
+        message(STATUS "ThinLTO provides its own parallel linking - limiting parallel link jobs to ${THINLTO_LINK_JOBS} (system has ${TOTAL_PHYSICAL_MEMORY} MB RAM, ~${MAX_THINLTO_LINK_MEMORY} MB per link).")
         set (PARALLEL_LINK_JOBS ${THINLTO_LINK_JOBS})
     endif ()
 endif()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

---

Problematic runs: https://github.com/ClickHouse/clickhouse-private/actions/runs/27638162799/job/81860926233?pr=60561

Supposedly fixed by this patch: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=60561&sha=latest&name_0=PR

```
Root cause

The release build is ThinLTO (ENABLE_THINLTO=1) with BUILD_STANDALONE_KEEPER=1, so clickhouse and clickhouse-keeper are two separate full-LTO executables linked near the end. cmake/limit_jobs.cmake capped concurrent link jobs at a hard-coded 2 for ThinLTO RelWithDebInfo, so Ninja runs both heavy links concurrently (log steps 17141 + 17142). On the standard CI runner (32 cores, ~126.5 GB RAM, no swap), a single LTO link with full debug info already peaks at ~100 GiB, so two at once exceed physical RAM → OOM.

Measured peak RSS (ru_maxrss, i.e. the largest single process):

┌────────────────────────────────────────────┬──────────────────────┬────────────────────────────┬─────────┐
│                   Build                    │ Effective debug flag │   Peak RSS (one ld.lld)    │ Result  │
├────────────────────────────────────────────┼──────────────────────┼────────────────────────────┼─────────┤
│ Public CI                                  │ -O3 -g0              │ 51,798,536 KB ≈ 49.4 GiB   │ ✅ pass │
├────────────────────────────────────────────┼──────────────────────┼────────────────────────────┼─────────┤
│ Private CI                                 │ -O3 -g               │ 106,048,140 KB ≈ 101.2 GiB │ ❌ OOM  │
├────────────────────────────────────────────┼──────────────────────┼────────────────────────────┼─────────┤
│ Local repro (public src, -g, serial links) │ -O3 -g               │ 91.5 GiB                   │ ✅ pass │
└────────────────────────────────────────────┴──────────────────────┴────────────────────────────┴─────────┘

Why public passes but private fails (same branch, same runner class)

The single difference is one flag. ci/jobs/build_clickhouse.py adds -DDISABLE_ALL_DEBUG_SYMBOLS=1 (→ -g0, CMakeLists.txt:374-376) only for non-private builds:

if not is_private and info.pr_number != 0 and "ENABLE_THINLTO=1" in cmake_cmd:
    cmake_cmd += " -DDISABLE_ALL_DEBUG_SYMBOLS=1"

Private builds keep full debug info on purpose (comment: "We keep them in private to allow deploying to staging from PRs"). Full DWARF roughly doubles ThinLTO link-time memory (the linker merges debug info during LTO codegen), which is what pushes a single private link to ~100 GiB and makes two concurrent links OOM.

Regression

The not is_private carve-out was introduced 2025-12-01 in commit 761628b3015 ("Apply DISABLE_ALL_DEBUG_SYMBOLS to any PR build with LTO"). Before it, private PR release builds also compiled -g0 and didn't OOM. The OOM became deterministic as the binary grew past the point where a single -g link leaves room for the concurrent keeper link.
- Caused by: https://github.com/ClickHouse/ClickHouse/commit/761628b3015 (aggravated by binary-size growth)

Why a build-config change, not "fix the new code on the branch"

Measured on a CI-class instance (32 cores, 126.5 GB, no swap; master 5670bbaaf1d):

┌──────────────────────────┬───────┬───────┬──────────────────────────────────────────────┬──────────┬──────────────────┐
│         Scenario         │ Debug │ Links │                 Peak memory                  │ Headroom │      Result      │
├──────────────────────────┼───────┼───────┼──────────────────────────────────────────────┼──────────┼──────────────────┤
│ Private CI (failing job) │ -g    │ =2    │ single ld.lld 101.2 GiB                      │ none     │ ❌ OOM           │
├──────────────────────────┼───────┼───────┼──────────────────────────────────────────────┼──────────┼──────────────────┤
│ Master, old policy       │ -g    │ =2    │ combined ~101 GiB committed, avail ~24.6 GiB │ ~25 GiB  │ ✅ pass (barely) │
├──────────────────────────┼───────┼───────┼──────────────────────────────────────────────┼──────────┼──────────────────┤
│ Master, fix              │ -g    │ =1    │ single link 91.5 GiB                         │ ~35 GiB  │ ✅ pass          │
├──────────────────────────┼───────┼───────┼──────────────────────────────────────────────┼──────────┼──────────────────┤
│ Public CI (same branch)  │ -g0   │ =2    │ single ld.lld 49.4 GiB                       │ ~77 GiB  │ ✅ pass          │
└──────────────────────────┴───────┴───────┴──────────────────────────────────────────────┴──────────┴──────────────────┘

```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.948`
<!-- ch-version-info:end -->