### PR TITLE
Add regression test for IMDSv2-only availability-zone detection

### DIFF
--- a/tests/integration/test_placement_info/metadata_servers/imdsv2_server.py
+++ b/tests/integration/test_placement_info/metadata_servers/imdsv2_server.py
@@ -1,0 +1,83 @@
+import http.server
+import sys
+import uuid
+
+
+# Mocks an IMDSv2-only EC2 instance metadata service:
+#   * PUT /latest/api/token returns a fresh token when the
+#     x-aws-ec2-metadata-token-ttl-seconds header is present;
+#   * GET on metadata resources requires a matching x-aws-ec2-metadata-token
+#     header and otherwise returns 401 (matching the AWS contract for
+#     "IMDSv2 only (token required)" instances). Used to verify #81402.
+
+ISSUED_TOKENS = set()
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_PUT(self):
+        if self.path != "/latest/api/token":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        ttl = self.headers.get("x-aws-ec2-metadata-token-ttl-seconds")
+        if ttl is None:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        # Drain any request body before responding.
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+
+        token = uuid.uuid4().hex
+        ISSUED_TOKENS.add(token)
+        body = token.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_HEAD(self):
+        return self._serve_get_or_head(write_body=False)
+
+    def do_GET(self):
+        self._serve_get_or_head(write_body=True)
+
+    def _serve_get_or_head(self, write_body):
+        if self.path == "/":
+            body = b"OK"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if write_body:
+                self.wfile.write(body)
+            return
+
+        token = self.headers.get("x-aws-ec2-metadata-token")
+        if not token or token not in ISSUED_TOKENS:
+            self.send_response(401)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        if self.path == "/latest/meta-data/placement/availability-zone":
+            body = b"ci-test-1a"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if write_body:
+                self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+httpd = http.server.HTTPServer(("0.0.0.0", int(sys.argv[1])), RequestHandler)
+httpd.serve_forever()

--- a/tests/integration/test_placement_info/test.py
+++ b/tests/integration/test_placement_info/test.py
@@ -7,6 +7,8 @@ from helpers.mock_servers import start_mock_servers
 
 METADATA_SERVER_HOSTNAME = "node_imds"
 METADATA_SERVER_PORT = 8080
+METADATA_SERVER_V2_HOSTNAME = "node_imds_v2"
+METADATA_SERVER_V2_PORT = 8081
 
 cluster = ClickHouseCluster(__file__)
 node_imds = cluster.add_instance(
@@ -14,6 +16,14 @@ node_imds = cluster.add_instance(
     main_configs=["configs/imds_bootstrap.xml"],
     env_variables={
         "AWS_EC2_METADATA_SERVICE_ENDPOINT": f"http://{METADATA_SERVER_HOSTNAME}:{METADATA_SERVER_PORT}",
+    },
+    stay_alive=True,
+)
+node_imds_v2 = cluster.add_instance(
+    "node_imds_v2",
+    main_configs=["configs/imds_bootstrap.xml"],
+    env_variables={
+        "AWS_EC2_METADATA_SERVICE_ENDPOINT": f"http://{METADATA_SERVER_V2_HOSTNAME}:{METADATA_SERVER_V2_PORT}",
     },
     stay_alive=True,
 )
@@ -42,7 +52,12 @@ def start_metadata_server(started_cluster):
                 "simple_server.py",
                 METADATA_SERVER_HOSTNAME,
                 METADATA_SERVER_PORT,
-            )
+            ),
+            (
+                "imdsv2_server.py",
+                METADATA_SERVER_V2_HOSTNAME,
+                METADATA_SERVER_V2_PORT,
+            ),
         ],
     )
 
@@ -67,6 +82,24 @@ def test_placement_info_from_imds():
 
     node_imds.query("SYSTEM FLUSH LOGS")
     assert node_imds.contains_in_log(
+        "CloudPlacementInfo: Loaded info: availability_zone: ci-test-1a"
+    )
+
+
+def test_placement_info_from_imdsv2_only():
+    # Regression test for #81402: an EC2 instance configured with
+    # "IMDSv2 only (token required)" rejects unauthenticated GETs
+    # against the metadata service. The mock server here only honors
+    # GETs that present a freshly-issued IMDSv2 session token.
+    with open(os.path.join(os.path.dirname(__file__), "configs/imds.xml"), "r") as f:
+        node_imds_v2.replace_config(
+            "/etc/clickhouse-server/config.d/imds_bootstrap.xml", f.read()
+        )
+    node_imds_v2.stop_clickhouse(kill=True)
+    node_imds_v2.start_clickhouse()
+
+    node_imds_v2.query("SYSTEM FLUSH LOGS")
+    assert node_imds_v2.contains_in_log(
         "CloudPlacementInfo: Loaded info: availability_zone: ci-test-1a"
     )
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/81402
Related: https://github.com/ClickHouse/ClickHouse/pull/81323
Related: https://github.com/ClickHouse/ClickHouse/pull/103549

Issue #81402 reported that availability-zone detection failed on EC2 instances configured for "IMDSv2 only (token required)": `getAvailabilityZoneOrException` issued a plain unauthenticated `GET` against the instance metadata service, which such instances reject with `401 Unauthorized`, so `tryGetRunningAvailabilityZone` failed.

The behavior was already fixed in master by #81323 (`kafka_aws_az_aware`), which makes `getAvailabilityZoneOrException` acquire an IMDSv2 session token via `PUT /latest/api/token` and send it with the availability-zone `GET`, falling back to the token-less IMDSv1 request when the metadata service does not implement the token endpoint. That change did not, however, add a test covering the IMDSv2-only scenario in `test_placement_info`.

This PR adds that missing regression coverage:
- a new mock metadata server `imdsv2_server.py` that issues tokens on `PUT /latest/api/token` and rejects `GET` requests without a valid `x-aws-ec2-metadata-token` header (`401`);
- a `node_imds_v2` instance and a `test_placement_info_from_imdsv2_only` case asserting the availability zone is still loaded against such an endpoint.

The test originates from #103549, which proposed an equivalent production fix before #81323 was merged; that pull request is now superseded for the code change, so only its regression test is kept here (credit retained via `Co-authored-by`).

Verified locally: `test_placement_info_from_imdsv2_only` and the existing `test_placement_info_from_imds` both pass (`2 passed`).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is not required (test-only change).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.942`
<!-- ch-version-info:end -->