### PR TITLE
Speed up clickhouse startup on macOS by not exporting dynamic symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,13 @@ if (OS_DARWIN)
     # use dlopen, so it does not need to export any dynamic symbols. By default the Mach-O
     # linker puts every global symbol into the export trie (hundreds of thousands of them for
     # clickhouse), which dyld walks for weak-symbol coalescing on every launch, adding ~0.15s
-    # of startup latency. Suppressing the export trie keeps the LC_SYMTAB used for backtraces
-    # intact.
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_exported_symbols")
+    # of startup latency. An empty `-exported_symbols_list` suppresses the export trie while
+    # keeping the LC_SYMTAB used for backtraces intact. We use it instead of the simpler
+    # `-no_exported_symbols` because the latter is not understood by the cctools `ld` used for
+    # cross-compilation in CI, while `-exported_symbols_list` is supported by both it and lld.
+    set (EMPTY_EXPORTED_SYMBOLS_LIST "${CMAKE_BINARY_DIR}/empty_exported_symbols.txt")
+    file (WRITE "${EMPTY_EXPORTED_SYMBOLS_LIST}" "")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-exported_symbols_list,${EMPTY_EXPORTED_SYMBOLS_LIST}")
 
     # Remove unreachable functions/data (Darwin equivalent of --gc-sections).
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,14 @@ if (OS_LINUX)
 endif ()
 
 if (OS_DARWIN)
+    # Same reasoning as `--no-export-dynamic` on Linux: the main clickhouse binary does not
+    # use dlopen, so it does not need to export any dynamic symbols. By default the Mach-O
+    # linker puts every global symbol into the export trie (hundreds of thousands of them for
+    # clickhouse), which dyld walks for weak-symbol coalescing on every launch, adding ~0.15s
+    # of startup latency. Suppressing the export trie keeps the LC_SYMTAB used for backtraces
+    # intact.
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_exported_symbols")
+
     # Remove unreachable functions/data (Darwin equivalent of --gc-sections).
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,9 +181,17 @@ if (OS_DARWIN)
     # keeping the LC_SYMTAB used for backtraces intact. We use it instead of the simpler
     # `-no_exported_symbols` because the latter is not understood by the cctools `ld` used for
     # cross-compilation in CI, while `-exported_symbols_list` is supported by both it and lld.
-    set (EMPTY_EXPORTED_SYMBOLS_LIST "${CMAKE_BINARY_DIR}/empty_exported_symbols.txt")
-    file (WRITE "${EMPTY_EXPORTED_SYMBOLS_LIST}" "")
-    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-exported_symbols_list,${EMPTY_EXPORTED_SYMBOLS_LIST}")
+    #
+    # Skip this for sanitizer builds: on Darwin we rely on Apple's bundled sanitizer runtime,
+    # which resolves hooks such as `__asan_default_options` / `__lsan_default_suppressions`
+    # (see base/base/sanitizer_options.h) by symbol name via dyld weak-symbol coalescing.
+    # Hiding the executable's exports would silently drop those options. Sanitizer builds are
+    # for testing and do not need the startup optimization anyway.
+    if (NOT SANITIZE)
+        set (EMPTY_EXPORTED_SYMBOLS_LIST "${CMAKE_BINARY_DIR}/empty_exported_symbols.txt")
+        file (WRITE "${EMPTY_EXPORTED_SYMBOLS_LIST}" "")
+        set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-exported_symbols_list,${EMPTY_EXPORTED_SYMBOLS_LIST}")
+    endif ()
 
     # Remove unreachable functions/data (Darwin equivalent of --gc-sections).
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")


### PR DESCRIPTION
On macOS, `clickhouse local "SELECT 1"` took ~0.24s to start, far more than on Linux. Profiling with `sample` showed the time is spent in `dyld` before `main`: the binary exports ~450k dynamic symbols (mostly statically-linked internals such as BoringSSL `AES_*`/`ASN1_*`), and `dyld` walks that export trie for weak-symbol coalescing on every launch.

`CMakeLists.txt` already passes `-Wl,--no-export-dynamic` on Linux (the main binary does not use `dlopen`, so it does not need to export anything), but there was no Darwin equivalent. This adds `-Wl,-no_exported_symbols` for Darwin. It only drops the dynamic export trie; the `LC_SYMTAB` used for backtraces stays intact, and stack traces still symbolize correctly.

Measurements on otherwise identical binaries (same objects, only the linker flag differs):

| | Exported symbols | `SELECT 1` (12 runs) | `--version` (5 runs) |
|---|---|---|---|
| Without change | 450,449 | 0.241s | 0.18s |
| With change | 0 | 0.081s | 0.03s |

~3x faster for a query, ~6x for pure startup.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up `clickhouse` startup on macOS by about 3x by not exporting dynamic symbols, which the dynamic linker would otherwise process on every launch.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.988`
<!-- ch-version-info:end -->