### PR TITLE
Avoid per-column-reference allocations in FunctionToSubcolumnsPass

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -22,7 +22,6 @@
 #include <Analyzer/ColumnNode.h>
 #include <Analyzer/ConstantNode.h>
 #include <Analyzer/FunctionNode.h>
-#include <Analyzer/Identifier.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/JoinNode.h>
 #include <Analyzer/QueryNode.h>
@@ -55,15 +54,32 @@ struct ColumnContext
     ContextPtr context;
 };
 
+/// A column identity used as the key of the counting containers in both passes.
+/// It is an opaque token: the source `TableNode *` (stable across both passes,
+/// since the tree is not cloned and table nodes are never replaced) plus the
+/// owned column name. Keying on the pointer avoids recomputing the table's full
+/// name (and the associated allocations) for every column reference.
+using ColumnIdentifier = std::pair<const TableNode *, String>;
+
+struct ColumnIdentifierHash
+{
+    size_t operator()(const ColumnIdentifier & key) const
+    {
+        size_t h1 = std::hash<const TableNode *>{}(key.first);
+        size_t h2 = std::hash<std::string>{}(key.second);
+        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+    }
+};
+
 struct IdentifiersToOptimize
 {
     /// Identifiers where ALL uses are optimizable (count matches).
     /// Rewritten unconditionally in every clause.
-    std::unordered_set<Identifier> everywhere;
+    std::unordered_set<ColumnIdentifier, ColumnIdentifierHash> everywhere;
 
     /// Identifiers that also have plain column references, but have at least one
     /// transformable use in WHERE/PREWHERE. Rewritten ONLY inside WHERE/PREWHERE.
-    std::unordered_set<Identifier> filter_only;
+    std::unordered_set<ColumnIdentifier, ColumnIdentifierHash> filter_only;
 
     bool empty() const { return everywhere.empty() && filter_only.empty(); }
 };
@@ -972,21 +988,21 @@ public:
     }
 
 private:
-    std::unordered_set<Identifier> all_key_columns;
-    std::unordered_map<Identifier, UInt64> identifiers_count;
-    std::unordered_map<Identifier, UInt64> optimized_identifiers_count;
+    std::unordered_set<ColumnIdentifier, ColumnIdentifierHash> all_key_columns;
+    std::unordered_map<ColumnIdentifier, UInt64, ColumnIdentifierHash> identifiers_count;
+    std::unordered_map<ColumnIdentifier, UInt64, ColumnIdentifierHash> optimized_identifiers_count;
     /// Counts only uses of transformers from `transformers_safe_with_indexes`.
-    std::unordered_map<Identifier, UInt64> optimized_identifiers_index_safe_count;
+    std::unordered_map<ColumnIdentifier, UInt64, ColumnIdentifierHash> optimized_identifiers_index_safe_count;
     /// Identifiers that have at least one use of a transformer from
     /// `transformers_optimize_in_filter_with_full_column` inside WHERE or PREWHERE.
     /// These are optimized even when the column is also read as a full column elsewhere.
-    std::unordered_set<Identifier> identifiers_with_filter_optimization;
+    std::unordered_set<ColumnIdentifier, ColumnIdentifierHash> identifiers_with_filter_optimization;
 
     /// Stack tracking whether the current node is inside a WHERE or PREWHERE clause.
     /// One entry per QueryNode depth; true means we are inside WHERE/PREWHERE.
     std::vector<bool> in_where_prewhere_stack;
 
-    NameSet processed_tables;
+    std::unordered_set<const TableNode *> processed_tables;
     bool can_wrap_result_columns_with_nullable = false;
     bool has_where_prewhere_or_group_by = false;
 
@@ -997,20 +1013,17 @@ private:
 
     void enterImpl(const TableNode & table_node)
     {
-        auto table_name = table_node.getStorage()->getStorageID().getFullTableName();
-
-        /// If table occurs in query several times (e.g., in subquery), process only once
-        /// because we collect only static properties of the table, which are the same for each occurrence.
-        if (!processed_tables.emplace(table_name).second)
+        /// Each distinct TableNode is processed once. We key on the node pointer because
+        /// the static properties we collect are recorded under that pointer; a second
+        /// occurrence of the same physical table is a different TableNode and must register
+        /// its own key columns under its own pointer.
+        if (!processed_tables.emplace(&table_node).second)
             return;
 
         auto add_key_columns = [&](const auto & key_columns)
         {
             for (const auto & column_name : key_columns)
-            {
-                Identifier identifier({table_name, column_name});
-                all_key_columns.insert(identifier);
-            }
+                all_key_columns.emplace(&table_node, column_name);
         };
 
         const auto & metadata_snapshot = table_node.getStorageSnapshot()->metadata;
@@ -1037,10 +1050,7 @@ private:
         if (!table_node)
             return;
 
-        auto table_name = table_node->getStorage()->getStorageID().getFullTableName();
-        Identifier qualified_name({table_name, column_node.getColumnName()});
-
-        ++identifiers_count[qualified_name];
+        ++identifiers_count[ColumnIdentifier{table_node, column_node.getColumnName()}];
     }
 
     void enterImpl(const FunctionNode & function_node, const ColumnNode & first_argument_column_node, const TableNode & table_node)
@@ -1051,8 +1061,7 @@ private:
             return;
 
         const auto & column = first_argument_column_node.getColumn();
-        auto table_name = table_node.getStorage()->getStorageID().getFullTableName();
-        Identifier qualified_name({table_name, column.name});
+        ColumnIdentifier qualified_name{&table_node, column.name};
 
         if (has_where_prewhere_or_group_by && !canOptimizeWithWherePrewhereOrGroupBy(function_node.getFunctionName()))
             return;
@@ -1077,14 +1086,13 @@ private:
             return;
 
         const auto & column = first_argument_column_node.getColumn();
-        auto table_name = table_node.getStorage()->getStorageID().getFullTableName();
 
         if (has_where_prewhere_or_group_by && !canOptimizeWithWherePrewhereOrGroupBy(function_node.getFunctionName()))
             return;
 
         if (chained_node_transformers.contains({column.type->getTypeId(), function_node.getFunctionName()}))
         {
-            Identifier qualified_name({table_name, column.name});
+            ColumnIdentifier qualified_name{&table_node, column.name};
             ++optimized_identifiers_count[qualified_name];
 
             /// Mark intermediate nodes to prevent double-counting.
@@ -1153,9 +1161,7 @@ public:
         if (function_node && first_argument_column_node && table_node)
         {
             auto column = first_argument_column_node->getColumn();
-            auto table_name = table_node->getStorage()->getStorageID().getFullTableName();
-
-            Identifier qualified_name({table_name, column.name});
+            ColumnIdentifier qualified_name{table_node, column.name};
 
             /// For "filter_only" identifiers, only optimize when inside WHERE/PREWHERE.
             bool should_optimize = identifiers_to_optimize.everywhere.contains(qualified_name);
@@ -1187,8 +1193,7 @@ public:
         if (chain_func && chain_col && chain_table)
         {
             auto column = chain_col->getColumn();
-            auto table_name = chain_table->getStorage()->getStorageID().getFullTableName();
-            Identifier qualified_name({table_name, column.name});
+            ColumnIdentifier qualified_name{chain_table, column.name};
 
             if (!identifiers_to_optimize.everywhere.contains(qualified_name))
                 return;

--- a/tests/performance/function_to_subcolumns_alias_chain.xml
+++ b/tests/performance/function_to_subcolumns_alias_chain.xml
@@ -1,0 +1,50 @@
+<test>
+    <!--
+        Targets FunctionToSubcolumnsPass (setting `optimize_functions_to_subcolumns`, default on).
+
+        A chain of WITH-clause aliases, each a nested `if` referencing the previous alias several
+        times, so the analyzer clones the aliased subtree at every use and the resolved query tree
+        grows exponentially in the chain depth. `FunctionToSubcolumnsVisitorFirstPass` visits every
+        column reference in that tree.
+
+        The important detail is `FROM t_fts_alias_chain` (a real table), NOT a subquery. The pass's
+        per-column work in `enterImpl(const ColumnNode &)` is guarded by `if (!table_node) return;`
+        and only runs when the column's source is a `TableNode`. Wrapping the source in a subquery
+        (e.g. `FROM (SELECT value FROM t_fts_alias_chain)`) makes `value` a subquery/`QueryNode`
+        column, so every reference early-exits before the `getFullTableName()` + `Identifier`
+        construction that dominates the pass, and no improvement to that path is observable.
+        Keep the FROM a plain table.
+
+        No data is needed: the query is analysis-bound (the table has a handful of rows and the
+        result is discarded with FORMAT Null), so `client_time` reflects analyzer/planner time.
+    -->
+    <settings>
+        <enable_analyzer>1</enable_analyzer>
+        <max_expanded_ast_elements>5000000000</max_expanded_ast_elements>
+    </settings>
+
+    <create_query>
+        CREATE TABLE t_fts_alias_chain (value UInt64) ENGINE = MergeTree ORDER BY tuple()
+    </create_query>
+    <fill_query>
+        INSERT INTO t_fts_alias_chain SELECT number FROM numbers(100)
+    </fill_query>
+
+    <query><![CDATA[
+        WITH
+            if(value = 10, 'A', if(value = 20, 'B', if(value = 30, 'C', if(value = 40, 'D', if(value = 50, 'E', 'F'))))) AS col1,
+            if(col1 = 'A', 'Alpha', if(col1 = 'B', 'Beta', if(col1 = 'C', 'Gamma', if(col1 = 'D', 'Delta', if(col1 = 'E', 'Epsilon', 'Other'))))) AS col2,
+            if(col2 = 'A', 'Alpha', if(col2 = 'B', 'Beta', if(col2 = 'C', 'Gamma', if(col2 = 'D', 'Delta', if(col2 = 'E', 'Epsilon', 'Other'))))) AS col3,
+            if(col3 = 'A', 'Alpha', if(col3 = 'B', 'Beta', if(col3 = 'C', 'Gamma', if(col3 = 'D', 'Delta', if(col3 = 'E', 'Epsilon', 'Other'))))) AS col4,
+            if(col4 = 'A', 'Alpha', if(col4 = 'B', 'Beta', if(col4 = 'C', 'Gamma', if(col4 = 'D', 'Delta', if(col4 = 'E', 'Epsilon', 'Other'))))) AS col5,
+            if(col5 = 'A', 'Alpha', if(col5 = 'B', 'Beta', if(col5 = 'C', 'Gamma', if(col5 = 'D', 'Delta', if(col5 = 'E', 'Epsilon', 'Other'))))) AS col6,
+            if(col6 = 'A', 'Alpha', if(col6 = 'B', 'Beta', if(col6 = 'C', 'Gamma', if(col6 = 'D', 'Delta', if(col6 = 'E', 'Epsilon', 'Other'))))) AS col7,
+            if(col7 = 'A', 'Alpha', if(col7 = 'B', 'Beta', if(col7 = 'C', 'Gamma', if(col7 = 'D', 'Delta', if(col7 = 'E', 'Epsilon', 'Other'))))) AS col8,
+            if(col8 = 'Alpha', if(col1 = 'A', 'A-One', 'Other'), 'Zero') AS col9
+        SELECT col1, col2, col3, col4, col5, col6, col7, col8, col9
+        FROM t_fts_alias_chain
+        FORMAT Null
+    ]]></query>
+
+    <drop_query>DROP TABLE IF EXISTS t_fts_alias_chain</drop_query>
+</test>


### PR DESCRIPTION
`FunctionToSubcolumnsPass` runs for every query, because the setting
`optimize_functions_to_subcolumns` defaults to true. Its first pass visits every
column reference and, per column, built a fully-qualified key: it called
`getFullTableName` (two `backQuoteIfNeed` strings plus a concatenation) and
constructed an `Identifier` (a two-element parts vector plus a
`boost::algorithm::join`) — roughly six heap allocations per column reference,
only to increment a counter. On wide tables and column-heavy queries this
dominates the cost of the pass.

This change keys the counting containers on the column's source `TableNode`
pointer plus the column name (`std::pair<const TableNode *, String>`) instead of
a synthesized full-name `Identifier`. The key is only ever used as an opaque
identity token (counting and set membership), and both passes traverse the same
query tree without cloning it, so the pointer is stable across them. This removes
`getFullTableName` and `Identifier` construction from the per-column path
entirely.

Identifiers are now distinguished by `TableNode` instance rather than by table
name. Within a single query scope this is identical, because one `FROM` clause
resolves to one `TableNode`; the same physical table referenced in separate
scopes is now counted independently, which is more aggressive but
result-preserving, since those are independent table scans.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reduce query analysis overhead by removing per-column-reference heap allocations in the `optimize_functions_to_subcolumns` optimization pass. This speeds up analysis of queries over wide tables and queries with large column lists.

### Documentation entry for user-facing changes
- [x] Documentation is not needed (internal optimization, no user-facing behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)