### PR TITLE
Play UI: deactivate the selected cell on Escape

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2021,6 +2021,13 @@ class QueryResultElement extends HTMLElement
         let cell = this._current_selected_cell;
         if (!cell) { return; }
 
+        if (e.key === 'Escape')
+        {
+            e.preventDefault();
+            this.clearSelection();
+            return;
+        }
+
         const row = cell.parentElement;
         const table = row.parentElement;
         let cell_index = cell.cellIndex;


### PR DESCRIPTION
In the Web UI (`play.html`), clicking a result-table cell makes it active (selected) and enables keyboard navigation between cells with the arrow keys. There was previously no way to deactivate a cell from the keyboard.

Now pressing `Escape` while a cell is active clears the selection (reusing the existing `clearSelection` method). When no cell is active, `Escape` is a no-op, so other behavior is unaffected.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In the Web UI (`play.html`), pressing `Escape` now deactivates the currently selected result-table cell.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.995`
<!-- ch-version-info:end -->