### PR TITLE
Add agent instruction: do not create stacked pull requests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,8 @@ When working with a branch, do not use rebase or amend - add new commits instead
 
 Do not commit to the master branch. Create a new branch for every task.
 
+Do not create stacked pull requests. Every pull request must target `master` directly (or, in rare cases, a release branch), not another feature branch. CI only runs for pull requests whose base is `master` or a release branch, so a pull request stacked on another feature branch gets no checks. If a change depends on unmerged work, wait for that work to merge into `master` first, or include all the changes in a single pull request.
+
 When writing text such as documentation, comments, or commit messages, wrap literal names from ClickHouse SQL language, classes and functions, or literal excerpts from log messages inside inline code blocks, such as: `MergeTree`.
 
 When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels. New documentation files must also include a frontmatter block at the top (before the first heading) with `description`, `sidebar_label`, `sidebar_position`, `slug`, `title`, and `doc_type` fields, modelled on existing files such as `docs/en/development/continuous-integration.md`.


### PR DESCRIPTION
Adds a rule to `.claude/CLAUDE.md` instructing the agent not to create stacked pull requests. Every pull request must target `master` directly (or, in rare cases, a release branch), never another feature branch.

Motivation: the PR CI workflow (`.github/workflows/pull_request.yml`) only triggers for pull requests whose base is `master`, and release branches are covered by their own workflows. A pull request stacked on top of another feature branch therefore receives no checks at all, which is easy to do by accident and confusing to diagnose.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.994`
<!-- ch-version-info:end -->