### PR TITLE
Fix BAD_GET in countmin statistics estimation on type mismatch

### DIFF
--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -32,13 +32,12 @@ StatisticsCountMinSketch::StatisticsCountMinSketch(const SingleStatisticsDescrip
 
 Float64 StatisticsCountMinSketch::estimateEqual(const Field & val) const
 {
-    /// Try to convert field to data_type. Converting string to proper data types such as: number, date, datetime, IPv4, Decimal etc.
-    /// Return null if val larger than the range of data_type
-    ///
-    /// For example: if data_type is Int32:
-    ///     1. For 1.0, 1, '1', return Field(1)
-    ///     2. For 1.1, max_value_int64, return null
-    Field val_converted = convertFieldToType(val, *data_type, data_type.get());
+    /// Coerce the comparison field to data_type (e.g. parse '5' into a number). `val` may have an
+    /// unrelated type on paths that do not pre-coerce it, such as `col IN (subquery)`.
+    /// No from_type_hint: a hint equal to data_type short-circuits convertFieldToType into a no-op.
+    /// The try-variant returns null (-> zero selectivity) instead of throwing on an out-of-range or
+    /// unconvertible field, mirroring how TDigest/MinMax guard via tryConvertToFloat64.
+    Field val_converted = tryConvertFieldToType(val, *data_type);
     if (val_converted.isNull())
         return 0;
 
@@ -54,7 +53,7 @@ Float64 StatisticsCountMinSketch::estimateEqual(const Field & val) const
     }
 
     if (isStringOrFixedString(data_type))
-        return static_cast<Float64>(sketch.get_estimate(val.safeGet<String>()));
+        return static_cast<Float64>(sketch.get_estimate(val_converted.safeGet<String>()));
 
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Statistics 'countmin' does not support estimate data type of {}", data_type->getName());
 }

--- a/tests/queries/0_stateless/04338_statistics_countmin_estimate_type_mismatch.reference
+++ b/tests/queries/0_stateless/04338_statistics_countmin_estimate_type_mismatch.reference
@@ -1,0 +1,7 @@
+numeric column, string set element
+5
+numeric column, non-numeric string set element
+numeric column, numeric set element
+5
+string column, numeric set element
+5

--- a/tests/queries/0_stateless/04338_statistics_countmin_estimate_type_mismatch.sql
+++ b/tests/queries/0_stateless/04338_statistics_countmin_estimate_type_mismatch.sql
@@ -1,0 +1,32 @@
+-- Tags: no-fasttest
+-- no-fasttest: 'countmin' sketches need a 3rd party library
+
+SET allow_statistics = 1;
+SET use_statistics = 1;
+SET materialize_statistics_on_insert = 1;
+
+-- A numeric column estimated against a string set element (from `IN (subquery)`, which does not
+-- pre-coerce the literal) must not crash the countmin estimator with BAD_GET.
+DROP TABLE IF EXISTS t_countmin_num;
+CREATE TABLE t_countmin_num (id UInt64, value UInt64)
+    ENGINE = MergeTree ORDER BY (id, value) SETTINGS auto_statistics_types = 'countmin';
+INSERT INTO t_countmin_num SELECT number, number FROM numbers(10);
+
+SELECT 'numeric column, string set element';
+SELECT id FROM t_countmin_num WHERE id <= 10 AND value IN (SELECT '5') ORDER BY id;
+SELECT 'numeric column, non-numeric string set element';
+SELECT id FROM t_countmin_num WHERE id <= 10 AND value IN (SELECT 'abc') ORDER BY id;
+SELECT 'numeric column, numeric set element';
+SELECT id FROM t_countmin_num WHERE id <= 10 AND value IN (SELECT 5) ORDER BY id;
+
+-- Mirror case: a string column estimated against a numeric set element.
+DROP TABLE IF EXISTS t_countmin_str;
+CREATE TABLE t_countmin_str (id UInt64, s String)
+    ENGINE = MergeTree ORDER BY id SETTINGS auto_statistics_types = 'countmin';
+INSERT INTO t_countmin_str SELECT number, toString(number) FROM numbers(10);
+
+SELECT 'string column, numeric set element';
+SELECT id FROM t_countmin_str WHERE id <= 10 AND s IN (SELECT 5) ORDER BY id;
+
+DROP TABLE t_countmin_num;
+DROP TABLE t_countmin_str;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106868
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/106868

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `BAD_GET` exception ("Bad get: has String, requested UInt64") from `countmin` column statistics estimation when a query compares a column against a literal of a different type that is not pre-coerced, such as `numeric_col IN (SELECT '5')` or `string_col IN (SELECT 5)`.


### Description

`StatisticsCountMinSketch::estimateEqual` crashed with `Bad get: has String, requested UInt64` (BAD_GET) on a valid query like:

```sql
CREATE TABLE t0 (id UInt64, value UInt64) ENGINE=MergeTree ORDER BY (id, value)
  SETTINGS auto_statistics_types = 'countmin';
SET materialize_statistics_on_insert = 1;
INSERT INTO t0 SELECT number, number FROM numbers(10);
SELECT id FROM t0 WHERE id <= 10 AND value IN (SELECT '5');  -- BAD_GET
```

Root cause: the `IN (subquery)` path in `ConditionSelectivityEstimator` does not set the literal's type, so the estimator's literal-coercion block is skipped and the raw set element (a `String`) reaches `estimateEqual` against a `UInt64` sketch. The conversion in `estimateEqual` that should have coerced it was a no-op: it passed `data_type` as the `from_type_hint` argument, and a hint equal to the target type makes `convertFieldToType` return the field unchanged. The unconverted `String` was then fed to `safeGet<UInt64>` -> BAD_GET. The mirror case (`String` column `IN (SELECT 5)`) failed the same way, and the `String` branch additionally used the original `val` rather than the converted value.

Fix: use `tryConvertFieldToType(val, *data_type)` (no `from_type_hint`, so the conversion actually runs; exception-safe so an out-of-range or unconvertible field yields zero selectivity instead of throwing, matching how TDigest/MinMax guard via `tryConvertToFloat64`), and read the converted value in the `String` branch.

The crash surfaced after the temp-column insert path was added, which turned the previously silently-wrong conversion into a hard exception.

Added regression test `04338_statistics_countmin_estimate_type_mismatch` covering numeric-vs-string and string-vs-numeric set elements; it fails on the current code with BAD_GET and passes with the fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.972`
<!-- ch-version-info:end -->