### PR TITLE
Fix flaky test test_azure_glob_scheherazade

### DIFF
--- a/tests/integration/test_storage_azure_blob_storage/test.py
+++ b/tests/integration/test_storage_azure_blob_storage/test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import functools
 import gzip
 import io
 import json
@@ -20,6 +21,7 @@ from azure.storage.blob import (
 
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 from helpers.test_tools import TSV, assert_logs_contain_with_retry
+from helpers.utility import SafeThread
 
 
 @pytest.fixture(scope="module")
@@ -472,8 +474,27 @@ def test_azure_glob_scheherazade(cluster):
     query = "select count(), sum(column1), sum(column2), sum(column3) from test_glob_select_scheherazade"
     assert azure_query(node, query).splitlines() == ["1001\t1001\t1001\t1001"]
     azure_query(node, "DROP TABLE test_glob_select_scheherazade")
-    for name in used_names:
-        azure_query(node, f"DROP TABLE {name}")
+
+    drop_jobs = []
+
+    def drop_tales(names):
+        for name in names:
+            azure_query(node, f"DROP TABLE {name}")
+
+    # SafeThread re-raises a worker's exception on join(); a raw threading.Thread
+    # would swallow it, letting cleanup fail silently and leak the table.
+    for start in range(0, len(used_names), nights_per_job):
+        drop_jobs.append(
+            SafeThread(
+                target=functools.partial(
+                    drop_tales, used_names[start : start + nights_per_job]
+                )
+            )
+        )
+        drop_jobs[-1].start()
+
+    for job in drop_jobs:
+        job.join()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/101143
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky integration test `test_storage_azure_blob_storage/test.py::test_azure_glob_scheherazade`, which times out (>900s pytest-timeout) under sanitizer builds with concurrent xdist workers.

The test creates 1001 AzureBlobStorage tables across ~31 threads to verify glob selection beyond the 1000-blob pagination boundary, then dropped all 1001 tables serially during cleanup. The serial cleanup is 1001 sequential `DROP TABLE` round-trips, each of which can enter `azure_query`'s retriable-error backoff (`time.sleep(i)`, up to 10 tries). Under ASan plus contention from concurrent workers the cleanup wall-clock crossed the per-test timeout.

The fix parallelizes the cleanup using the same chunked-thread pattern the test already uses for creation. The creation phase runs ~31 concurrent threads doing heavier CREATE + INSERT work without timing out, so the lighter parallel DROP stays well within the concurrency the test already exercises. Test intent is unchanged: still 1001 tables, still asserts the glob count beyond the 1000-blob boundary.

Surfaced on PR #101143 ("Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)"), whose clickhouse-local SYSTEM LISTEN changes do not touch AzureBlobStorage code. Pre-existing chronic flake, fixed here in a separate PR.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.965`
<!-- ch-version-info:end -->