### PR TITLE
Fix false-positive TSan data race in WASM by forcing rustix libc backend under sanitizers

### DIFF
--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -150,6 +150,21 @@ elseif (SANITIZE STREQUAL "address")
     list(APPEND RUSTFLAGS "-Zsanitizer=address")
 endif()
 
+# Force `rustix` to use its libc backend under sanitizers.
+# On Linux `rustix` defaults to the `linux_raw` backend, which issues `mmap`, `munmap` and
+# other syscalls directly via the `syscall` instruction, bypassing libc. The sanitizers
+# intercept these operations at the libc symbol boundary, so with the raw backend they never
+# observe `rustix`'s memory mappings. For ThreadSanitizer this means the shadow memory of a
+# region is not reset when `rustix` (used by `wasmtime` for compiled-code `mmap` allocations)
+# maps or unmaps it, so a freshly mapped region inherits the stale shadow of whatever
+# previously occupied that virtual address, producing false-positive data races. The same gap
+# affects MemorySanitizer (freshly mapped memory looks uninitialized) and AddressSanitizer.
+# `--cfg=rustix_use_libc` is the mechanism `rustix` provides for transitive consumers to select
+# the libc backend; it also activates the `libc` dependency (already pinned in `Cargo.lock`).
+if (NOT SANITIZE STREQUAL "")
+    list(APPEND RUSTFLAGS "--cfg" "rustix_use_libc")
+endif()
+
 # Set metadata flag to force different hashes for different sanitizers
 if (SANITIZE STREQUAL "")
     list(APPEND RUSTFLAGS "-C" "metadata=no-sanitizer")


### PR DESCRIPTION
Fixes a false-positive ThreadSanitizer data race reported on master CI for `Stateless tests (amd_tsan)`.

ThreadSanitizer reported a race between `wasmtime` writing compiled WASM code into an `mmap`-backed buffer (during `CREATE FUNCTION ... LANGUAGE WASM`) and an unrelated MergeTree marks decompression reading at the same virtual address. The two accesses are in completely unrelated subsystems but hit the identical virtual address — the signature of memory-address reuse rather than a logic race. `WasmModuleManager::getModule` already serializes compilation under a mutex, so the WASM code itself is correctly locked.

Root cause: Rust contribs are built with `-Zsanitizer=thread`, so `wasmtime`'s `memcpy` is instrumented, but `wasmtime` allocates its compiled-code memory through `rustix`, which on Linux defaults to the `linux_raw` backend and issues `mmap`/`munmap` via raw syscalls, bypassing libc. The sanitizer interceptors hook libc symbols, so they never observe these mappings and do not reset shadow memory on map/unmap. A freshly mapped region then inherits the stale shadow of whatever previously occupied that virtual address, producing the false-positive race.

The fix forces `rustix` onto its libc backend with `--cfg=rustix_use_libc` (the mechanism `rustix` documents for transitive consumers), routing those syscalls through interceptable libc symbols so the shadow is reset correctly. The flag also activates the `libc`/`errno` dependencies, which are already vendored and pinned in `Cargo.lock`. The same interceptor gap also affects MemorySanitizer and AddressSanitizer, so the flag is applied to all sanitizer builds.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bcb49a5280a3b0a1ae223e5ce7bf3df7c3807d60&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (CI fix).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.966`
<!-- ch-version-info:end -->