### PR TITLE
Always print parentheses for no-argument window functions

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -783,7 +783,10 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
     /// If the function has a NULLS modifier (IGNORE NULLS / RESPECT NULLS), we must always print
     /// parentheses, otherwise the modifier cannot be parsed back (e.g. `count IGNORE NULLS` is not parseable).
     bool has_nulls_action = getNullsAction() != NullsAction::EMPTY;
-    bool need_parens = (arguments && !arguments->children.empty()) || !noEmptyArgs() || has_nulls_action;
+    /// A window function must always print parentheses too: the grammar requires `f() OVER (...)`,
+    /// so a no-argument one like `cume_dist() OVER (...)` re-parses as a bare identifier `cume_dist`
+    /// followed by `OVER` if the `()` is dropped, breaking the format-parse round-trip.
+    bool need_parens = (arguments && !arguments->children.empty()) || !noEmptyArgs() || has_nulls_action || isWindowFunction();
 
     if (need_parens)
         ostr << '(';

--- a/tests/queries/0_stateless/04338_inconsistent_ast_codec_window_func_parens_1941_26fa.reference
+++ b/tests/queries/0_stateless/04338_inconsistent_ast_codec_window_func_parens_1941_26fa.reference
@@ -1,0 +1,8 @@
+CREATE TABLE t (`c0` Int CODEC(cume_dist() OVER (ORDER BY x ASC, b DESC), NONE)) ENGINE = MergeTree ORDER BY c0
+CREATE TABLE t (`c0` Int CODEC(rank() OVER (ORDER BY x ASC), NONE)) ENGINE = MergeTree ORDER BY c0
+CREATE TABLE t (`c0` Int CODEC(row_number() OVER (PARTITION BY y), NONE)) ENGINE = MergeTree ORDER BY c0
+CREATE TABLE t (`c0` Int CODEC(dense_rank() OVER w, NONE)) ENGINE = MergeTree ORDER BY c0
+CREATE TABLE t (`c0` Int CODEC(lagInFrame(c0) OVER (ORDER BY x ASC), NONE)) ENGINE = MergeTree ORDER BY c0
+CREATE TABLE t (`c0` Int CODEC(Delta, NONE)) ENGINE = MergeTree ORDER BY c0
+SELECT cume_dist() OVER (ORDER BY number ASC) FROM numbers(3)
+SELECT count() OVER (ORDER BY number ASC) FROM numbers(3)

--- a/tests/queries/0_stateless/04338_inconsistent_ast_codec_window_func_parens_1941_26fa.sql
+++ b/tests/queries/0_stateless/04338_inconsistent_ast_codec_window_func_parens_1941_26fa.sql
@@ -1,0 +1,28 @@
+-- STID 1941-26fa: a no-argument window function inside a CODEC, e.g.
+-- CODEC(cume_dist() OVER (...), NONE), was formatted back as cume_dist OVER (...)
+-- (the () dropped), so the format-parse-format round-trip diverged and the
+-- server aborted with the Inconsistent AST formatting LOGICAL_ERROR in
+-- debug / sanitizer builds. See the commit message for the full root cause.
+
+-- Original reproducer. We do not care which error fires, only that the server
+-- does not abort with LOGICAL_ERROR. cume_dist is not a valid codec family, so
+-- the parser returns UNKNOWN_CODEC once the round-trip check passes cleanly.
+CREATE TABLE base32__fuzz_6 (`i` Int16 CODEC(cume_dist() OVER (ORDER BY toDateTime64OrZero('2017-06-15') ASC, b DESC), NONE), `f` Nullable(Float32) CODEC(NONE)) ENGINE = MergeTree ORDER BY i; -- { serverError UNKNOWN_CODEC }
+
+-- The formatted output must keep the () of every no-argument window function.
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(cume_dist() OVER (ORDER BY x ASC, b DESC), NONE)) ENGINE = MergeTree ORDER BY c0');
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(rank() OVER (ORDER BY x), NONE)) ENGINE = MergeTree ORDER BY c0');
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(row_number() OVER (PARTITION BY y), NONE)) ENGINE = MergeTree ORDER BY c0');
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(dense_rank() OVER w, NONE)) ENGINE = MergeTree ORDER BY c0');
+
+-- A window function that has arguments was always fine; assert no regression.
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(lagInFrame(c0) OVER (ORDER BY x), NONE)) ENGINE = MergeTree ORDER BY c0');
+
+-- The fix is gated on isWindowFunction(): a plain no-argument codec family
+-- (Delta) must NOT gain parentheses.
+SELECT formatQuerySingleLine('CREATE TABLE t (c0 Int CODEC(Delta, NONE)) ENGINE = MergeTree ORDER BY c0');
+
+-- Window functions in normal expression context already round-tripped; assert
+-- the fix did not change them.
+SELECT formatQuerySingleLine('SELECT cume_dist() OVER (ORDER BY number) FROM numbers(3)');
+SELECT formatQuerySingleLine('SELECT count() OVER (ORDER BY number) FROM numbers(3)');


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/issues/101173
-->

Related: #101173

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`Inconsistent AST formatting`) when a no-argument window function such as `cume_dist() OVER (...)` is used inside a column `CODEC(...)` expression. The formatter dropped the empty `()`, producing `cume_dist OVER (...)` which does not re-parse as a window function.


### Description

`ASTFunction::formatImplWithoutAlias` decides whether to print `()` for a function from `arguments`, `noEmptyArgs()` and the NULLS modifier. A no-argument window function inside `CODEC` / `STATISTICS` / `BACKUP_NAME` is parsed via `ParserIdentifierWithOptionalParameters`, which sets `no_empty_args = true`, so `need_parens` was `false` and the `()` was omitted. The window `OVER (...)` clause was still appended, yielding `cume_dist OVER (...)`. That does not round-trip: re-parsing reads `cume_dist` as a bare identifier, so the debug/sanitizer format-parse-format consistency check aborts with the `Inconsistent AST formatting` `LOGICAL_ERROR`.

The grammar requires `f() OVER (...)`, so a window function must always print its parentheses. The fix adds `isWindowFunction()` to the `need_parens` condition, mirroring the existing rule for the NULLS modifier on the same line. It applies to every no-argument window function (`cume_dist`, `rank`, `dense_rank`, `row_number`, `percent_rank`) and only changes formatting when `isWindowFunction()` is true, so non-window no-argument codec families (e.g. `Delta`) are unaffected.

Found by the AST fuzzer (STID 1941-26fa), reported on the `Stress test (amd_debug)` run of PR #106522:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106522&sha=095d6c6a9efbfb32fbb3233307115a6e42d16755&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

Reproducer (aborts the server with `Inconsistent AST formatting` on a debug build before this change):

```sql
CREATE TABLE base32__fuzz_6 (`i` Int16 CODEC(cume_dist() OVER (ORDER BY toDateTime64OrZero('2017-06-15') ASC, b DESC), NONE), `f` Nullable(Float32) CODEC(NONE)) ENGINE = MergeTree ORDER BY i;
```
