### PR TITLE
Fix flaky test 03001_consider_lwd_when_merge

### DIFF
--- a/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
+++ b/tests/queries/0_stateless/03001_consider_lwd_when_merge.sql
@@ -2,7 +2,8 @@ DROP TABLE IF EXISTS lwd_merge;
 
 CREATE TABLE lwd_merge (id UInt64 CODEC(NONE))
     ENGINE = MergeTree ORDER BY id
-SETTINGS max_bytes_to_merge_at_min_space_in_pool = 80000, max_bytes_to_merge_at_max_space_in_pool = 80000, exclude_deleted_rows_for_part_size_in_merge = 0;
+-- index_granularity pinned: the 80000-byte thresholds are calibrated against bytes_on_disk, which a small granularity inflates via per-granule marks/primary.idx.
+SETTINGS index_granularity = 8192, max_bytes_to_merge_at_min_space_in_pool = 80000, max_bytes_to_merge_at_max_space_in_pool = 80000, exclude_deleted_rows_for_part_size_in_merge = 0;
 
 INSERT INTO lwd_merge SELECT number FROM numbers(10000);
 INSERT INTO lwd_merge SELECT number FROM numbers(10000, 10000);


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107457
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flakiness of `03001_consider_lwd_when_merge` under randomized MergeTree settings. Requested by @ alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/107457#issuecomment-4736700167.

The test calibrates the `80000`-byte `max_bytes_to_merge_at_{min,max}_space_in_pool` thresholds against the on-disk size of a 10000-row `UInt64 CODEC(NONE)` part (`10000 * 8 = 80000` bytes of column data). It relies on `exclude_deleted_rows_for_part_size_in_merge` scaling that size down by `existing_rows / total_rows` so the final `OPTIMIZE` can merge two otherwise too-large parts into one.

The CI test runner randomizes MergeTree settings, including `index_granularity` over `[1, 65536]`. A small granularity multiplies the number of granules, so the per-granule overhead (marks files + `primary.idx`) inflates `bytes_on_disk` far beyond the 80000-byte data size: at `index_granularity = 1` a 10000-row part is ~690 KB on disk instead of ~85 KB. The deletion-scaled size then stays above the threshold, and the final `OPTIMIZE` (which must succeed) fails with `CANNOT_ASSIGN_OPTIMIZE`.

Fix: pin `index_granularity = 8192` (the default) in the `CREATE TABLE` SETTINGS so the part size matches what the byte thresholds were calibrated for. Explicit CREATE-level settings override the runner's randomized values, so the rest of the randomization is preserved.

CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107457&sha=77b6e9e71f92036d5855dedcf83435d1507431eb&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29 (`Stateless tests (amd_tsan, s3 storage, parallel, 2/2)`, culprit setting `--index_granularity 1`). Reproduced locally; with the pin the test passes 50/50 over randomized `index_granularity` drawn from `[1, 65536]`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.992`
<!-- ch-version-info:end -->