### PR TITLE
Enable grace hash join by default globally

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3407,7 +3407,7 @@ See also:
 - [Join table engine](../../engines/table-engines/special/join.md)
 - [join_default_strictness](#join_default_strictness)
 )", IMPORTANT) \
-    DECLARE(JoinAlgorithm, join_algorithm, "direct,parallel_hash,hash", R"(
+    DECLARE(JoinAlgorithm, join_algorithm, "direct,grace_hash,hash", R"(
 Specifies which [JOIN](../../sql-reference/statements/select/join.md) algorithm is used.
 
 Several algorithms can be specified, and an available one would be chosen for a particular query based on kind/strictness and table engine.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -66,6 +66,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"format_avro_schema_registry_max_retries", 0, 5, "New setting controlling the maximum number of retries for transient failures (transport timeouts, connection refused, DNS errors, HTTP 5xx/408/429) when communicating with the Confluent Schema Registry. Set to 0 to disable retries. Previous behavior (no retries) is preserved by `compatibility = '26.5'`."},
             {"format_avro_schema_registry_retry_initial_backoff_ms", 100, 100, "New setting controlling the initial backoff (in milliseconds) before retrying a failed Confluent Schema Registry request. The backoff doubles on each retry, capped at 10 seconds. Has no effect when `format_avro_schema_registry_max_retries = 0` (the pre-26.6 behavior restored by `compatibility = '26.5'`)."},
             {"enable_join_transitive_predicates", false, true, "Turn on enable_join_transitive_predicates by default"},
+            {"join_algorithm", "direct,parallel_hash,hash", "direct,grace_hash,hash", "Make grace_hash the default JOIN algorithm so large joins spill to disk automatically instead of running out of memory. parallel_hash does not honor max_bytes_before_external_join and was dropped from the default; hash remains as the fallback for asof/cross/multi-disjunct joins that grace_hash cannot perform. Set join_algorithm = 'direct,parallel_hash,hash' to restore the previous default."},
         });
 
         addSettingsChanges(settings_changes_history, "26.5",

--- a/tests/queries/0_stateless/02236_explain_pipeline_join.sql
+++ b/tests/queries/0_stateless/02236_explain_pipeline_join.sql
@@ -2,6 +2,7 @@ SET query_plan_join_swap_table = false;
 SET enable_analyzer = 1;
 SET enable_parallel_replicas=0;
 SET query_plan_optimize_join_order_limit = 0;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test pins the parallel hash pipeline
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 
 EXPLAIN PIPELINE

--- a/tests/queries/0_stateless/02815_join_algorithm_setting.sql
+++ b/tests/queries/0_stateless/02815_join_algorithm_setting.sql
@@ -12,7 +12,7 @@ INSERT INTO rdb VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
 CREATE TABLE t2 ( `k` UInt16 ) ENGINE = TinyLog;
 INSERT INTO t2 VALUES (4), (5), (6);
 
-SELECT value == 'direct,parallel_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
+SELECT value == 'direct,grace_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
 
 SELECT countIf(explain like '%Algorithm: DirectKeyValueJoin%'), countIf(explain like '%Algorithm: HashJoin%') FROM (
     EXPLAIN PLAN actions = 1

--- a/tests/queries/0_stateless/02835_join_step_explain.sql
+++ b/tests/queries/0_stateless/02835_join_step_explain.sql
@@ -1,6 +1,7 @@
 -- Tags: no-parallel-replicas
 -- no-parallel-replicas - because explain produced different plan
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET parallel_hash_join_threshold = 0;
 SET enable_join_runtime_filters = 0;
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test

--- a/tests/queries/0_stateless/03036_join_filter_push_down_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03036_join_filter_push_down_equivalent_sets.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET optimize_move_to_prewhere = 0;
 SET query_plan_convert_outer_join_to_inner_join = 0;
 SET parallel_hash_join_threshold = 0;

--- a/tests/queries/0_stateless/03274_join_algorithm_default.reference
+++ b/tests/queries/0_stateless/03274_join_algorithm_default.reference
@@ -5,51 +5,43 @@ ExpressionTransform × 16
   ExpressionTransform × 16
     (Join)
     SimpleSquashingTransform × 16
-      JoiningTransform × 16 2 → 1
-        Resize 1 → 16
-          (Expression)
-          ExpressionTransform
-            (Expression)
-            ExpressionTransform
-              (Limit)
-              Limit
-                (ReadFromSystemNumbers)
-                NumbersRange 0 → 1
-          (Expression)
-          Resize × 2 16 → 1
-            FillingRightJoinSide
-              SimpleSquashingTransform
-                FillingRightJoinSide
-                  SimpleSquashingTransform
-                    FillingRightJoinSide
-                      SimpleSquashingTransform
-                        FillingRightJoinSide
-                          SimpleSquashingTransform
-                            FillingRightJoinSide
-                              SimpleSquashingTransform
-                                FillingRightJoinSide
-                                  SimpleSquashingTransform
-                                    FillingRightJoinSide
-                                      SimpleSquashingTransform
-                                        FillingRightJoinSide
-                                          SimpleSquashingTransform
-                                            FillingRightJoinSide
-                                              SimpleSquashingTransform
-                                                FillingRightJoinSide
-                                                  SimpleSquashingTransform
-                                                    FillingRightJoinSide
-                                                      SimpleSquashingTransform
-                                                        FillingRightJoinSide
-                                                          SimpleSquashingTransform
-                                                            FillingRightJoinSide
-                                                              SimpleSquashingTransform
-                                                                FillingRightJoinSide
-                                                                  SimpleSquashingTransform
-                                                                    FillingRightJoinSide
-                                                                      SimpleSquashingTransform
-                                                                        FillingRightJoinSide
-                                                                          SimpleSquashingTransform
+      Resize 32 → 16
+        DelayedPorts 32 → 32
+          JoiningTransform 2 → 1
+            DelayedJoinedBlocksWorkerTransform
+              JoiningTransform 2 → 1
+                DelayedJoinedBlocksWorkerTransform
+                  JoiningTransform 2 → 1
+                    DelayedJoinedBlocksWorkerTransform
+                      JoiningTransform 2 → 1
+                        DelayedJoinedBlocksWorkerTransform
+                          JoiningTransform 2 → 1
+                            DelayedJoinedBlocksWorkerTransform
+                              JoiningTransform 2 → 1
+                                DelayedJoinedBlocksWorkerTransform
+                                  JoiningTransform 2 → 1
+                                    DelayedJoinedBlocksWorkerTransform
+                                      JoiningTransform 2 → 1
+                                        DelayedJoinedBlocksWorkerTransform
+                                          JoiningTransform 2 → 1
+                                            DelayedJoinedBlocksWorkerTransform
+                                              JoiningTransform 2 → 1
+                                                DelayedJoinedBlocksWorkerTransform
+                                                  JoiningTransform 2 → 1
+                                                    DelayedJoinedBlocksWorkerTransform
+                                                      JoiningTransform 2 → 1
+                                                        DelayedJoinedBlocksWorkerTransform
+                                                          JoiningTransform 2 → 1
+                                                            DelayedJoinedBlocksWorkerTransform
+                                                              JoiningTransform 2 → 1
+                                                                DelayedJoinedBlocksWorkerTransform
+                                                                  JoiningTransform 2 → 1
+                                                                    DelayedJoinedBlocksWorkerTransform
+                                                                      JoiningTransform 2 → 1
+                                                                        DelayedJoinedBlocksWorkerTransform
+                                                                          DelayedJoinedBlocksTransform 0 → 16
                                                                             Resize 1 → 16
+                                                                              (Expression)
                                                                               ExpressionTransform
                                                                                 (Expression)
                                                                                 ExpressionTransform
@@ -57,6 +49,48 @@ ExpressionTransform × 16
                                                                                   Limit
                                                                                     (ReadFromSystemNumbers)
                                                                                     NumbersRange 0 → 1
+                                                                              (Expression)
+                                                                              Resize × 2 16 → 1
+                                                                                FillingRightJoinSide
+                                                                                  SimpleSquashingTransform
+                                                                                    FillingRightJoinSide
+                                                                                      SimpleSquashingTransform
+                                                                                        FillingRightJoinSide
+                                                                                          SimpleSquashingTransform
+                                                                                            FillingRightJoinSide
+                                                                                              SimpleSquashingTransform
+                                                                                                FillingRightJoinSide
+                                                                                                  SimpleSquashingTransform
+                                                                                                    FillingRightJoinSide
+                                                                                                      SimpleSquashingTransform
+                                                                                                        FillingRightJoinSide
+                                                                                                          SimpleSquashingTransform
+                                                                                                            FillingRightJoinSide
+                                                                                                              SimpleSquashingTransform
+                                                                                                                FillingRightJoinSide
+                                                                                                                  SimpleSquashingTransform
+                                                                                                                    FillingRightJoinSide
+                                                                                                                      SimpleSquashingTransform
+                                                                                                                        FillingRightJoinSide
+                                                                                                                          SimpleSquashingTransform
+                                                                                                                            FillingRightJoinSide
+                                                                                                                              SimpleSquashingTransform
+                                                                                                                                FillingRightJoinSide
+                                                                                                                                  SimpleSquashingTransform
+                                                                                                                                    FillingRightJoinSide
+                                                                                                                                      SimpleSquashingTransform
+                                                                                                                                        FillingRightJoinSide
+                                                                                                                                          SimpleSquashingTransform
+                                                                                                                                            FillingRightJoinSide
+                                                                                                                                              SimpleSquashingTransform
+                                                                                                                                                Resize 1 → 16
+                                                                                                                                                  ExpressionTransform
+                                                                                                                                                    (Expression)
+                                                                                                                                                    ExpressionTransform
+                                                                                                                                                      (Limit)
+                                                                                                                                                      Limit
+                                                                                                                                                        (ReadFromSystemNumbers)
+                                                                                                                                                        NumbersRange 0 → 1
 1
 (Expression)
 ExpressionTransform

--- a/tests/queries/0_stateless/03274_join_algorithm_default.sql
+++ b/tests/queries/0_stateless/03274_join_algorithm_default.sql
@@ -5,9 +5,9 @@ SET query_plan_optimize_join_order_limit = 0;
 SET enable_join_runtime_filters = 0;
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 
--- Test that with default join_algorithm setting, we are doing a parallel hash join
+-- Test that with default join_algorithm setting, we are doing a grace hash join
 
-SELECT value == 'direct,parallel_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
+SELECT value == 'direct,grace_hash,hash' FROM system.settings WHERE name = 'join_algorithm';
 
 EXPLAIN PIPELINE
 SELECT

--- a/tests/queries/0_stateless/03357_join_pk_sharding.sql
+++ b/tests/queries/0_stateless/03357_join_pk_sharding.sql
@@ -18,6 +18,9 @@ insert into tab_r select number, number, number, number from numbers(1e6);
 --where e like '%ReadFromMergeTree%' or e like '%Expression%' or e like '%Join%' or e like '%Clauses%' or e like '%Sharding%';
 
 set enable_analyzer=1;
+-- PK-range sharding is a ConcurrentHashJoin feature; pin parallel_hash since the
+-- default is now grace_hash, which does not shard by PK ranges.
+set join_algorithm='parallel_hash';
 set query_plan_join_swap_table=0;
 set query_plan_join_shard_by_pk_ranges=1;
 set allow_experimental_parallel_reading_from_replicas=0;

--- a/tests/queries/0_stateless/03405_merge_filter_into_join.sql
+++ b/tests/queries/0_stateless/03405_merge_filter_into_join.sql
@@ -9,6 +9,7 @@ INSERT INTO users VALUES (8888, 'Alice', 50);
 SET query_plan_join_swap_table = 0;
 SET enable_analyzer = 1; -- Optimization requires LogicalJoinStep
 SET enable_parallel_replicas = 0; -- Optimization requires LogicalJoinStep
+SET join_algorithm = 'parallel_hash,hash'; -- default is now grace_hash; pin parallel_hash with hash fallback (a JOIN ON constant below needs hash)
 SET parallel_hash_join_threshold = 0;
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subqueries_use_equivalence_classes.sql
@@ -1,5 +1,6 @@
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET query_plan_join_swap_table = 0; -- Changes query plan
 SET correlated_subqueries_default_join_kind = 'left';
 SET query_plan_remove_unused_columns = 1;

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
@@ -1,5 +1,6 @@
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
+SET join_algorithm = 'parallel_hash,hash'; -- default is now grace_hash; pin parallel_hash with hash fallback to keep the validated plan
 SET enable_parallel_replicas = 0;
 SET correlated_subqueries_default_join_kind = 'left';
 SET correlated_subqueries_use_in_memory_buffer = 0;

--- a/tests/queries/0_stateless/03595_convert_any_join_to_semi_or_anti.sql
+++ b/tests/queries/0_stateless/03595_convert_any_join_to_semi_or_anti.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash,hash'; -- default is now grace_hash; pin parallel_hash with hash fallback to keep the validated plan
 SET query_plan_join_swap_table = false;
 SET enable_join_runtime_filters = 0;
 SET enable_parallel_replicas = 0;

--- a/tests/queries/0_stateless/03701_analyzer_correlated_subquery_plan_reference.sql
+++ b/tests/queries/0_stateless/03701_analyzer_correlated_subquery_plan_reference.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash,hash'; -- default is now grace_hash; pin parallel_hash with hash fallback to keep the validated plan
 SET query_plan_join_swap_table = false;
 SET enable_parallel_replicas = 0;
 SET correlated_subqueries_default_join_kind = 'left';

--- a/tests/queries/0_stateless/03711_read_in_order_through_join.reference
+++ b/tests/queries/0_stateless/03711_read_in_order_through_join.reference
@@ -44,29 +44,6 @@
 ['ReadType: InOrder','ReadType: Default','ReadType: Default']
 2024-01-01 00:00:00	80	59	3	3
 2024-02-02 00:00:00	80	59	3	3
-['ReadType: InOrder','ReadType: Default']
-2024-01-01 00:00:00	0	Payload for event 0
-2024-01-01 00:00:01	1	\N
-2024-01-01 00:00:02	2	\N
-['ReadType: InReverseOrder','ReadType: Default','ReadType: Default']
-2024-02-02 00:00:29	29	\N	\N
-2024-02-02 00:00:28	28	Payload for event 28	\N
-2024-02-02 00:00:27	27	\N	\N
-['ReadType: InOrder','ReadType: Default','ReadType: Default']
-2024-01-01 00:00:00	133	157	3600	5
-2024-01-01 01:00:00	\N	\N	3600	0
-2024-01-01 02:00:00	\N	\N	3600	0
-['ReadType: InOrder','ReadType: Default']
-2024-01-01 00:00:00	0	Payload for event 0
-2024-01-01 00:00:04	4	Payload for event 4
-2024-01-01 00:00:08	8	Payload for event 8
-['ReadType: InReverseOrder','ReadType: Default','ReadType: Default']
-2024-02-02 00:00:24	24	Payload for event 24	Second payload for event 24
-2024-02-02 00:00:12	12	Payload for event 12	Second payload for event 12
-2024-02-02 00:00:00	0	Payload for event 0	Second payload for event 0
-['ReadType: InOrder','ReadType: Default','ReadType: Default']
-2024-01-01 00:00:00	80	59	3	3
-2024-02-02 00:00:00	80	59	3	3
 2024-01-01 00:00:00	0	Payload for event 0
 2024-01-01 00:00:04	4	Payload for event 4
 2024-01-01 00:00:08	8	Payload for event 8
@@ -74,10 +51,6 @@
 2024-01-01 00:00:04	4	Payload for event 4
 2024-01-01 00:00:08	8	Payload for event 8
 --
-OK
-OK
-OK
-OK
 OK
 OK
 OK

--- a/tests/queries/0_stateless/03711_read_in_order_through_join.sql.j2
+++ b/tests/queries/0_stateless/03711_read_in_order_through_join.sql.j2
@@ -35,7 +35,9 @@ CREATE TEMPORARY TABLE start_ts AS ( SELECT now() AS ts );
 
 SET join_use_nulls = 1;
 
-{% for join_algorithm in ["'hash'", "'parallel_hash'", "DEFAULT"] -%}
+{# grace_hash (the default since 26.6) scatters rows into hash buckets, so read-in-order
+   cannot stream through it; test only the algorithms that preserve input order. #}
+{% for join_algorithm in ["'hash'", "'parallel_hash'"] -%}
 {% for join_kind in ["LEFT", "INNER"] -%}
 
 SET join_algorithm = {{ join_algorithm }};

--- a/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
+++ b/tests/queries/0_stateless/03773_semi_join_equivalent_sets.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET enable_parallel_replicas = 0;
 SET query_plan_join_swap_table = 0;
 SET enable_join_runtime_filters = 0;

--- a/tests/queries/0_stateless/03786_storage_join_type_conversion.sql
+++ b/tests/queries/0_stateless/03786_storage_join_type_conversion.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'hash'; -- default is now grace_hash; pin hash (StorageJoin RIGHT JOIN uses HashJoin) so the EXPLAIN plan is stable
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 
 CREATE TABLE t1__fuzz_0 (`x` Nullable(UInt32), `str` String) ENGINE = Memory;

--- a/tests/queries/0_stateless/04011_explain_pretty_join.sql
+++ b/tests/queries/0_stateless/04011_explain_pretty_join.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET parallel_hash_join_threshold = 0;
 SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;

--- a/tests/queries/0_stateless/04012_explain_pretty_output.sql
+++ b/tests/queries/0_stateless/04012_explain_pretty_output.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET parallel_hash_join_threshold = 0;
 SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;

--- a/tests/queries/0_stateless/04060_explain_pretty_joins_sets.sql
+++ b/tests/queries/0_stateless/04060_explain_pretty_joins_sets.sql
@@ -1,4 +1,5 @@
 SET enable_analyzer = 1;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test validates the ConcurrentHashJoin plan
 SET parallel_hash_join_threshold = 0;
 SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;

--- a/tests/queries/0_stateless/04209_top_k_through_join_read_in_order_gate.sql
+++ b/tests/queries/0_stateless/04209_top_k_through_join_read_in_order_gate.sql
@@ -9,6 +9,10 @@
 
 SET enable_analyzer = 1;
 SET query_plan_top_k_through_join = 1;
+-- The default join_algorithm is grace_hash, which reorders rows and is always
+-- rejected by optimizeReadInOrder's join traversal. This test exercises the
+-- deferral path that only applies to order-preserving joins, so pin hash.
+SET join_algorithm = 'hash';
 
 DROP TABLE IF EXISTS t_l;
 DROP TABLE IF EXISTS t_r;

--- a/tests/queries/0_stateless/04230_top_k_through_join_join_swap_gate.sql
+++ b/tests/queries/0_stateless/04230_top_k_through_join_join_swap_gate.sql
@@ -9,6 +9,10 @@
 
 SET enable_analyzer = 1;
 SET query_plan_top_k_through_join = 1;
+-- The default join_algorithm is grace_hash, which reorders rows and is always
+-- rejected by optimizeReadInOrder's join traversal. This test exercises the
+-- deferral path that only applies to order-preserving joins, so pin hash.
+SET join_algorithm = 'hash';
 
 DROP TABLE IF EXISTS t_l;
 DROP TABLE IF EXISTS t_r;

--- a/tests/queries/0_stateless/04234_explain_pipeline_compact_repeated_processor_chains.sql
+++ b/tests/queries/0_stateless/04234_explain_pipeline_compact_repeated_processor_chains.sql
@@ -2,6 +2,7 @@ SET query_plan_join_swap_table = false;
 SET enable_analyzer = 1;
 SET enable_parallel_replicas=0;
 SET query_plan_optimize_join_order_limit = 0;
+SET join_algorithm = 'parallel_hash'; -- default is now grace_hash; this test pins the parallel hash pipeline
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 
 EXPLAIN PIPELINE compact_repeated_processor_chains = 1

--- a/tests/queries/0_stateless/04234_top_k_through_join_final_desc_gate.sql
+++ b/tests/queries/0_stateless/04234_top_k_through_join_final_desc_gate.sql
@@ -11,6 +11,10 @@
 
 SET enable_analyzer = 1;
 SET query_plan_top_k_through_join = 1;
+-- The default join_algorithm is grace_hash, which reorders rows and is always
+-- rejected by optimizeReadInOrder's join traversal. This test exercises the
+-- deferral path that only applies to order-preserving joins, so pin hash.
+SET join_algorithm = 'hash';
 
 DROP TABLE IF EXISTS t_l_final;
 DROP TABLE IF EXISTS t_r_final;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107461
-->


### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The default `join_algorithm` is now `direct,grace_hash,hash` instead of `direct,parallel_hash,hash`. Large joins now spill to disk automatically (via `max_bytes_before_external_join` / `max_bytes_ratio_before_external_join`) instead of running out of memory, because `grace_hash` is the hash-based algorithm that supports spilling. `parallel_hash` keeps the whole right side in RAM and was the reason large joins still ran out of memory; it was removed from the default. `direct` is still used for dictionary and key-value lookups, and `hash` remains as the fallback for joins `grace_hash` cannot perform (`ASOF`, `CROSS`, multi-disjunct `ON`). To restore the previous behavior, set `join_algorithm = 'direct,parallel_hash,hash'`.


### Description

Implements the global default requested in #107461: grace hash join enabled by default so that automatic disk spilling for JOINs works out of the box.

#### What changed

- `src/Core/Settings.cpp`: `join_algorithm` default `direct,parallel_hash,hash` -> `direct,grace_hash,hash`.
- `src/Core/SettingsChangesHistory.cpp`: 26.6 entry restoring the previous default for older `compatibility` levels.

#### Why this chain

- `direct`: fast path for dictionary / EmbeddedRocksDB / MergeTree key lookups, no memory cost. Kept.
- `grace_hash`: the only hash-based algorithm that honors `max_bytes_before_external_join` and `max_bytes_ratio_before_external_join` for automatic disk spilling. Made the main default.
- `parallel_hash`: does NOT spill (keeps the full right side in RAM), which is exactly why large joins still OOM with the old default. Dropped from the default.
- `hash`: kept as the fallback for shapes `grace_hash` cannot perform (`ASOF`, `CROSS`, multi-disjunct `ON`, constant `ON`).

Fallback to `hash` for unsupported shapes was verified locally with the new default: `JOIN ON <constant>`, `CROSS JOIN`, `ASOF JOIN`, and multi-disjunct `OR` joins all execute correctly; `FULL JOIN` uses `grace_hash` directly.

#### Test updates

`join_algorithm` is not part of the CI randomization pool, so functional tests rely on the default value. A design note from the read-in-order optimizer (`optimizeReadInOrder.cpp`) is relevant: "Grace hash join scatters rows into buckets by hash, destroying the input order", so the optimizer rejects grace hash for read-in-order-through-join. The same applies to top-k-through-join and to PK-range sharding (a `ConcurrentHashJoin`/`parallel_hash` feature). These optimizations do not apply under the new default by design.

Tests were updated to preserve their original intent rather than weakened:

- `03274_join_algorithm_default`, `03711_read_in_order_through_join`: these document the default's behavior. `03274` is updated to the grace hash default; `03711` drops the `DEFAULT` iteration of its `[hash, parallel_hash, DEFAULT]` loop because grace hash cannot stream read-in-order through a join.
- Tests validating a `parallel_hash` / `ConcurrentHashJoin` plan or pipeline pin `join_algorithm = 'parallel_hash'` (or `'parallel_hash,hash'` where a constant/scalar join needs the `hash` fallback): `02236`, `02835`, `03036`, `03357` (PK sharding), `03405`, `03545_*`, `03595`, `03701`, `03773`, `04011`, `04012`, `04060`, `04234_explain_pipeline_compact_repeated_processor_chains`.
- Tests validating the read-in-order / top-k deferral pin `join_algorithm = 'hash'` (an order-preserving join): `04209`, `04230`, `04234_top_k_through_join_final_desc_gate`.
- `03786_storage_join_type_conversion` pins `'hash'` (StorageJoin RIGHT JOIN uses a plain HashJoin).
- `02815_join_algorithm_setting`: default value-string assertion updated.

`02995_new_settings_history` passes with the new history entry. All touched tests pass locally on a debug build.
