### PR TITLE
Fix build-ordering race in self-extracting stripped binary

### DIFF
--- a/programs/self-extracting/CMakeLists.txt
+++ b/programs/self-extracting/CMakeLists.txt
@@ -23,7 +23,7 @@ if (BUILD_STRIPPED_BINARY)
     add_custom_target (clickhouse-self-extracting-stripped ALL
         ${CMAKE_COMMAND} -E remove clickhouse-stripped
         COMMAND ${COMPRESSOR} ${DECOMPRESSOR} clickhouse-stripped ../clickhouse-stripped
-        DEPENDS clickhouse clickhouse-stripped
+        DEPENDS clickhouse clickhouse-stripped compressor
     )
     list(APPEND self_extracting_deps clickhouse-self-extracting-stripped)
 endif()

--- a/programs/self-extracting/CMakeLists.txt
+++ b/programs/self-extracting/CMakeLists.txt
@@ -23,7 +23,7 @@ if (BUILD_STRIPPED_BINARY)
     add_custom_target (clickhouse-self-extracting-stripped ALL
         ${CMAKE_COMMAND} -E remove clickhouse-stripped
         COMMAND ${COMPRESSOR} ${DECOMPRESSOR} clickhouse-stripped ../clickhouse-stripped
-        DEPENDS clickhouse clickhouse-stripped compressor
+        DEPENDS clickhouse-stripped compressor
     )
     list(APPEND self_extracting_deps clickhouse-self-extracting-stripped)
 endif()


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/83158
-->

The `clickhouse-self-extracting-stripped` target runs `pre_compressor --decompressor=.../decompressor` to produce the self-extracting stripped binary, but its `DEPENDS` list contained only `clickhouse clickhouse-stripped` and not `compressor`. The `decompressor` executable is built only transitively through the `compressor` target (`add_dependencies(compressor pre_compressor decompressor)`), so without that dependency edge `ninja` is free to run the compression step before `decompressor` has been linked.

This is an intermittent build failure that only affects builds with `BUILD_STRIPPED_BINARY` enabled (the release builds that publish the stripped binary). In most builds `decompressor` happens to be linked first, but occasionally the compression step wins the race and fails with:

```
Error: decompressor file [.../decompressor].
stat: No such file or directory
```

In the failing CI run the compression step (ninja step 16128) ran before the `decompressor` link (step 16129). The two `Post Hooks` failures in that report are downstream consequences (no self-extracting `clickhouse` produced, hence no `binary_symbols.txt`).

The regression was introduced in #83158, which split the combined `self-extracting-server` target (`DEPENDS clickhouse clickhouse-stripped compressor`) into separate targets; the new stripped target dropped the `compressor` dependency, while `clickhouse-self-extracting` and `self-extracting-keeper` kept it. This restores it.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3c16008600a521022628277f57d956d5cc560eb2&name_0=MasterCI&name_1=Build%20%28amd_release%29&name_1=Build%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.980`
<!-- ch-version-info:end -->