### PR TITLE
Fix flaky 04257_intersect_empty_input / 04258_except_empty_left_input

### DIFF
--- a/tests/queries/0_stateless/04257_intersect_empty_input.sql
+++ b/tests/queries/0_stateless/04257_intersect_empty_input.sql
@@ -1,3 +1,4 @@
+-- max_rows_to_read is the guard: a regressed short-circuit reads the unbounded side and trips it.
 SELECT count()
 FROM
 (
@@ -5,7 +6,7 @@ FROM
     INTERSECT
     SELECT number FROM system.numbers
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
 
 SELECT count()
 FROM
@@ -14,7 +15,7 @@ FROM
     INTERSECT
     SELECT number FROM numbers(0)
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
 
 SELECT count()
 FROM
@@ -23,7 +24,7 @@ FROM
     INTERSECT DISTINCT
     SELECT number FROM system.numbers
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
 
 SELECT count()
 FROM
@@ -32,4 +33,4 @@ FROM
     INTERSECT DISTINCT
     SELECT number FROM numbers(0)
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;

--- a/tests/queries/0_stateless/04258_except_empty_left_input.sql
+++ b/tests/queries/0_stateless/04258_except_empty_left_input.sql
@@ -1,3 +1,4 @@
+-- max_rows_to_read is the guard: a regressed short-circuit reads the unbounded side and trips it.
 SELECT count()
 FROM
 (
@@ -5,7 +6,7 @@ FROM
     EXCEPT
     SELECT number FROM system.numbers
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
 
 SELECT count()
 FROM
@@ -14,4 +15,4 @@ FROM
     EXCEPT DISTINCT
     SELECT number FROM system.numbers
 )
-SETTINGS max_execution_time = 2, timeout_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;
+SETTINGS max_rows_to_read = 10000000, read_overflow_mode = 'throw', max_memory_usage = 50000000, max_untracked_memory = 1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/80392
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/80392

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04257_intersect_empty_input` and `04258_except_empty_left_input` guard the empty-input short-circuit for `INTERSECT` / `EXCEPT` (introduced in f6e3ba2810d, issue #80392). Each query pairs an empty side with the unbounded `system.numbers`, so a regressed short-circuit would read an unbounded input.

The guard was `max_execution_time = 2` plus `timeout_overflow_mode = 'throw'`, a wall-clock limit. On the ~20x-slower sanitizer builds under parallel load this is flaky: the query does correct, minimal work but the wall clock alone exceeds 2s, raising `TIMEOUT_EXCEEDED`. Example failure on `Stateless tests (amd_tsan, parallel, 1/2)`, where CI's own rerun loop passed the test 54/54 (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107654&sha=a15fc15cc1f3e152935aa4e5ae366b1a91a57353&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29).

This replaces the wall-clock guard with a deterministic read-volume guard: `max_rows_to_read = 10000000, read_overflow_mode = 'throw'`. A regressed short-circuit reads the unbounded side and trips the row limit on any machine, while the working short-circuit reads at most a few hundred thousand rows (verified locally up to 300k with `max_block_size = 100000`), leaving a >30x margin. `max_memory_usage = 50000000` is kept.

This also strengthens the tests. The retained memory limit only catches the unbounded-right-input direction (`numbers(0) INTERSECT system.numbers`), which builds a set. The unbounded-left-input direction (`system.numbers INTERSECT numbers(0)`) filters against an empty set and keeps memory low, so previously only the wall-clock timer could catch a regression there; `max_rows_to_read` now catches both directions. Verified by reverting the short-circuit locally: all queries throw (`MEMORY_LIMIT_EXCEEDED` for the set-build direction, `TOO_MANY_ROWS` for the unbounded-left direction), and all pass with the short-circuit in place.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.997`
<!-- ch-version-info:end -->