### PR TITLE
Fix client data race on std_out cancellation hook with parallel formatting

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1434,8 +1434,10 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
             /// Without this, a write to a slow or stuck sink (e.g. a slow terminal) blocks the
             /// client, so the first Ctrl+C appears to have no effect until the whole block is
             /// written. The hook lets the output buffer stop waiting and discard the rest.
+            /// The hook is removed in resetOutput() after the output format (and its background
+            /// parallel-formatting threads, which write through std_out) have been finished and
+            /// joined, so that std_out's hook is never mutated while a collector thread reads it.
             std_out->setCancellationHook([this]() { return query_interrupt_handler.cancelled(); });
-            SCOPE_EXIT({ std_out->setCancellationHook({}); });
 
             /// Allow cancellation during query analysis (e.g. scalar subqueries).
             /// For TCP connections this is handled by receivePacketsExpectCancel;
@@ -1863,6 +1865,16 @@ void ClientBase::resetOutput()
 
     output_format.reset();
     pending_progress.reset();
+
+    /// Remove the per-query cancellation hook now that the output format has been finished and
+    /// its background parallel-formatting threads joined (in output_format.reset() above). Those
+    /// threads write through std_out and read its cancellation hook, so clearing it here - rather
+    /// than from a scope guard in processOrdinaryQuery that can fire while they are still running -
+    /// avoids a data race on std_out's hook. std_out outlives a single query, so the stale hook
+    /// must be cleared; the per-query pager / "INTO OUTFILE AND STDOUT" buffers are destroyed
+    /// below instead.
+    if (std_out)
+        std_out->setCancellationHook({});
 
     /// out_file_buf wraps std_out_wrapper (via a raw pointer), so it must be finalized
     /// first to flush remaining data (e.g. the gzip footer) into std_out_wrapper.

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1434,9 +1434,8 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
             /// Without this, a write to a slow or stuck sink (e.g. a slow terminal) blocks the
             /// client, so the first Ctrl+C appears to have no effect until the whole block is
             /// written. The hook lets the output buffer stop waiting and discard the rest.
-            /// The hook is removed in resetOutput() after the output format (and its background
-            /// parallel-formatting threads, which write through std_out) have been finished and
-            /// joined, so that std_out's hook is never mutated while a collector thread reads it.
+            /// Cleared in resetOutput() after the parallel-formatting threads are joined, so it is
+            /// never mutated while a collector thread reads it.
             std_out->setCancellationHook([this]() { return query_interrupt_handler.cancelled(); });
 
             /// Allow cancellation during query analysis (e.g. scalar subqueries).
@@ -1866,15 +1865,15 @@ void ClientBase::resetOutput()
     output_format.reset();
     pending_progress.reset();
 
-    /// Remove the per-query cancellation hook now that the output format has been finished and
-    /// its background parallel-formatting threads joined (in output_format.reset() above). Those
-    /// threads write through std_out and read its cancellation hook, so clearing it here - rather
-    /// than from a scope guard in processOrdinaryQuery that can fire while they are still running -
-    /// avoids a data race on std_out's hook. std_out outlives a single query, so the stale hook
-    /// must be cleared; the per-query pager / "INTO OUTFILE AND STDOUT" buffers are destroyed
-    /// below instead.
-    if (std_out)
-        std_out->setCancellationHook({});
+    /// Clear std_out's per-query cancellation hook. The placement matters in two directions:
+    /// registered here (after output_format.reset() joined the parallel-formatting threads that
+    /// read the hook in WriteBufferFromFileDescriptor::nextImpl) it cannot race with a collector;
+    /// firing at function end (a SCOPE_EXIT, after the final teardown flushes below) it keeps
+    /// Ctrl+C able to interrupt those flushes to a slow/stuck stdout. std_out outlives the query.
+    SCOPE_EXIT({
+        if (std_out)
+            std_out->setCancellationHook({});
+    });
 
     /// out_file_buf wraps std_out_wrapper (via a raw pointer), so it must be finalized
     /// first to flush remaining data (e.g. the gzip footer) into std_out_wrapper.

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1433,9 +1433,10 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
             /// Abort writing the result set to the output promptly when the query is cancelled.
             /// Without this, a write to a slow or stuck sink (e.g. a slow terminal) blocks the
             /// client, so the first Ctrl+C appears to have no effect until the whole block is
-            /// written. The hook lets the output buffer stop waiting and discard the rest.
-            /// Cleared in resetOutput() after the parallel-formatting threads are joined, so it is
-            /// never mutated while a collector thread reads it.
+            /// written. The hook lets the output buffer stop waiting and discard the rest. It is
+            /// re-pointed and then cleared in resetOutput(), after the parallel-formatting collector
+            /// that also reads it has been joined, so the hook is never mutated while that thread
+            /// reads it.
             std_out->setCancellationHook([this]() { return query_interrupt_handler.cancelled(); });
 
             /// Allow cancellation during query analysis (e.g. scalar subqueries).
@@ -1865,11 +1866,18 @@ void ClientBase::resetOutput()
     output_format.reset();
     pending_progress.reset();
 
-    /// Clear std_out's per-query cancellation hook. The placement matters in two directions:
-    /// registered here (after output_format.reset() joined the parallel-formatting threads that
-    /// read the hook in WriteBufferFromFileDescriptor::nextImpl) it cannot race with a collector;
-    /// firing at function end (a SCOPE_EXIT, after the final teardown flushes below) it keeps
-    /// Ctrl+C able to interrupt those flushes to a slow/stuck stdout. std_out outlives the query.
+    /// output_format.reset() above joined the parallel-formatting collector, the only other reader of
+    /// std_out's cancellation hook (WriteBufferFromFileDescriptor::nextImpl), so the hook can now be
+    /// re-pointed for the teardown flushes below and cleared at function end without racing it.
+    /// On exception paths the interrupt handler is already stopped here (its cancelled() is then
+    /// unconditionally true), so fall back to the genuine cancellation flag to avoid discarding
+    /// already-produced output; on normal completion the handler is still armed and is honored so a
+    /// fresh Ctrl+C keeps interrupting a flush to a slow/stuck stdout.
+    const bool interrupt_handler_armed = !query_interrupt_handler.cancelled();
+    if (std_out)
+        std_out->setCancellationHook(
+            [this, interrupt_handler_armed]
+            { return interrupt_handler_armed ? query_interrupt_handler.cancelled() : cancelled.load(); });
     SCOPE_EXIT({
         if (std_out)
             std_out->setCancellationHook({});


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106430
Related: https://github.com/ClickHouse/ClickHouse/issues/22426
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a data race in the client/local on the result-output buffer's cancellation hook (introduced by the interruptible Ctrl+C output feature) when the result set is written with parallel formatting and a query ends by an exception.

### Description

A ThreadSanitizer data race was reported on master by `BuzzHouse (amd_tsan)`:
- Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=73e97deb9abbc3258e75d297aabfc3fbe7c3ca5e&name_0=MasterCI&name_1=BuzzHouse%20%28amd_tsan%29
- STID: 5296-4b74

Both racing stacks reference the same long-lived heap object, the client's persistent stdout `AutoCanceledWriteBuffer<WriteBufferFromFileDescriptor>` (`std_out`, allocated once in `ClientBase::ClientBase`):

- WRITE (main thread): `WriteBufferFromFileDescriptor::setCancellationHook` resetting `cancellation_hook`, from the scope guard at the end of `ClientBase::processOrdinaryQuery`.
- READ (collector thread): `WriteBufferFromFileDescriptor::nextImpl` reading `cancellation_hook`, via `FlushCallbackWriteBuffer::nextImpl` from `ParallelFormattingOutputFormat::collectorThreadFunction`.

Root cause: the interruptible client output feature (PR #106430, issue #22426) installs a cancellation hook on `std_out` at the start of `processOrdinaryQuery` and removed it via `SCOPE_EXIT({ std_out->setCancellationHook({}); })` at the end of the same scope. When the result set is written with parallel formatting, `ParallelFormattingOutputFormat` runs a background collector thread that writes through `std_out` and reads its cancellation hook. On the normal end-of-stream path the collector is joined by `output_format->finalize()` before the scope guard runs, so the clear is safe. But on paths that leave `processOrdinaryQuery` by an exception without first finalizing the output (e.g. a `NetException`, or a `LocalFormatError` rethrown from `receiveResult`), the scope guard cleared the hook while the collector thread was still alive and reading it: a data race on the `std::function`.

Fix: clear the hook in `resetOutput()` right after `output_format.reset()`. `output_format.reset()` destroys the parallel formatter and joins its collector thread (`~ParallelFormattingOutputFormat` -> `finishAndWait` -> `collector_thread.join()`), so afterwards no other thread can read `std_out`'s hook and the clear is single-threaded. `resetOutput()` runs on every exit path of `processParsedSingleQuery` (including the `SCOPE_EXIT_SAFE` that already parks the formatting threads) and at the start of the next query, so the hook is still always removed and `std_out` (which outlives a single query) never carries a stale hook into the next query. The pager and `INTO OUTFILE ... AND STDOUT` buffers are per-query and destroyed in `resetOutput()` after the collector join, so they were never affected.

The change is confined to `src/Client/ClientBase.cpp` and does not touch the low-level `WriteBufferFromFileDescriptor` (which is used server-wide on a hot single-threaded write path).
