### PR TITLE
Support parallel replicas read for Alias engine

### DIFF
--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -305,14 +305,36 @@ void StorageAlias::setMutationCSN(const String & mutation_id, UInt64 csn)
     getTargetTable()->setMutationCSN(mutation_id, csn);
 }
 
+namespace
+{
+
+/// Holds the resolved target StoragePtr alongside its task list
+struct AliasCheckTasks : IStorage::DataValidationTasksBase
+{
+    StoragePtr target;
+    IStorage::DataValidationTasksPtr inner;
+
+    AliasCheckTasks(StoragePtr target_, IStorage::DataValidationTasksPtr inner_)
+        : target(std::move(target_)), inner(std::move(inner_))
+    {
+    }
+
+    size_t size() const override { return inner->size(); }
+};
+
+}
+
 IStorage::DataValidationTasksPtr StorageAlias::getCheckTaskList(const CheckTaskFilter & filter, ContextPtr query_context)
 {
-    return getTargetTable(TargetAccess{query_context, AccessType::CHECK})->getCheckTaskList(filter, query_context);
+    auto target = getTargetTable(TargetAccess{query_context, AccessType::CHECK});
+    auto inner = target->getCheckTaskList(filter, query_context);
+    return std::make_shared<AliasCheckTasks>(std::move(target), std::move(inner));
 }
 
 std::optional<CheckResult> StorageAlias::checkDataNext(DataValidationTasksPtr & check_task_list)
 {
-    return getTargetTable()->checkDataNext(check_task_list);
+    auto & tasks = dynamic_cast<AliasCheckTasks &>(*check_task_list);
+    return tasks.target->checkDataNext(tasks.inner);
 }
 
 CancellationCode StorageAlias::killPartMoveToShard(const UUID & task_uuid)

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -305,6 +305,16 @@ void StorageAlias::setMutationCSN(const String & mutation_id, UInt64 csn)
     getTargetTable()->setMutationCSN(mutation_id, csn);
 }
 
+IStorage::DataValidationTasksPtr StorageAlias::getCheckTaskList(const CheckTaskFilter & filter, ContextPtr query_context)
+{
+    return getTargetTable(TargetAccess{query_context, AccessType::CHECK})->getCheckTaskList(filter, query_context);
+}
+
+std::optional<CheckResult> StorageAlias::checkDataNext(DataValidationTasksPtr & check_task_list)
+{
+    return getTargetTable()->checkDataNext(check_task_list);
+}
+
 CancellationCode StorageAlias::killPartMoveToShard(const UUID & task_uuid)
 {
     return getTargetTable()->killPartMoveToShard(task_uuid);

--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -14,6 +14,7 @@
 #include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Core/Settings.h>
 #include <Access/Common/AccessFlags.h>
+#include <Common/assert_cast.h>
 
 
 namespace DB
@@ -317,6 +318,7 @@ struct AliasCheckTasks : IStorage::DataValidationTasksBase
     AliasCheckTasks(StoragePtr target_, IStorage::DataValidationTasksPtr inner_)
         : target(std::move(target_)), inner(std::move(inner_))
     {
+        chassert(inner);
     }
 
     size_t size() const override { return inner->size(); }
@@ -333,8 +335,8 @@ IStorage::DataValidationTasksPtr StorageAlias::getCheckTaskList(const CheckTaskF
 
 std::optional<CheckResult> StorageAlias::checkDataNext(DataValidationTasksPtr & check_task_list)
 {
-    auto & tasks = dynamic_cast<AliasCheckTasks &>(*check_task_list);
-    return tasks.target->checkDataNext(tasks.inner);
+    auto * tasks = assert_cast<AliasCheckTasks *>(check_task_list.get());
+    return tasks->target->checkDataNext(tasks->inner);
 }
 
 CancellationCode StorageAlias::killPartMoveToShard(const UUID & task_uuid)

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -27,6 +27,12 @@ public:
 
     std::string getName() const override { return "Alias"; }
 
+    bool isMergeTree() const override
+    {
+        auto target = tryGetTargetTable();
+        return target && target->isMergeTree();
+    }
+
     /// Get the target storage this alias points to
     StoragePtr getTargetTable(std::optional<TargetAccess> access_check = std::nullopt) const;
     StoragePtr tryGetTargetTable() const { return DatabaseCatalog::instance().tryGetTable(StorageID(target_database, target_table), getContext()); }
@@ -271,6 +277,16 @@ public:
     }
 
     IndexSizeByName getSecondaryIndexSizes() const override { auto target = tryGetTargetTable(); return target ? target->getSecondaryIndexSizes() : IndexSizeByName{}; }
+
+    DataValidationTasksPtr getCheckTaskList(const CheckTaskFilter & filter, ContextPtr query_context) override
+    {
+        return getTargetTable()->getCheckTaskList(filter, query_context);
+    }
+
+    std::optional<CheckResult> checkDataNext(DataValidationTasksPtr & check_task_list) override
+    {
+        return getTargetTable()->checkDataNext(check_task_list);
+    }
 
     CancellationCode killPartMoveToShard(const UUID & task_uuid) override;
 

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -278,15 +278,8 @@ public:
 
     IndexSizeByName getSecondaryIndexSizes() const override { auto target = tryGetTargetTable(); return target ? target->getSecondaryIndexSizes() : IndexSizeByName{}; }
 
-    DataValidationTasksPtr getCheckTaskList(const CheckTaskFilter & filter, ContextPtr query_context) override
-    {
-        return getTargetTable()->getCheckTaskList(filter, query_context);
-    }
-
-    std::optional<CheckResult> checkDataNext(DataValidationTasksPtr & check_task_list) override
-    {
-        return getTargetTable()->checkDataNext(check_task_list);
-    }
+    DataValidationTasksPtr getCheckTaskList(const CheckTaskFilter & filter, ContextPtr query_context) override;
+    std::optional<CheckResult> checkDataNext(DataValidationTasksPtr & check_task_list) override;
 
     CancellationCode killPartMoveToShard(const UUID & task_uuid) override;
 

--- a/tests/integration/test_storage_alias_replicated/test.py
+++ b/tests/integration/test_storage_alias_replicated/test.py
@@ -101,6 +101,7 @@ def test_alias_with_parallel_replicas(started_cluster):
             "max_parallel_replicas": 2,
             "cluster_for_parallel_replicas": "test_cluster",
             "prefer_localhost_replica": 0,
+            "parallel_replicas_prefer_local_replica": 0,
             "parallel_replicas_mark_segment_size": 128,
             "log_comment": "test_alias_parallel_replicas",
         },

--- a/tests/integration/test_storage_alias_replicated/test.py
+++ b/tests/integration/test_storage_alias_replicated/test.py
@@ -69,3 +69,80 @@ def test_alias_empty_args_with_replicated(started_cluster):
     assert node1.query("SELECT * FROM d0.alias_table") == "1\n"
     
     node1.query("DROP DATABASE d0 SYNC")
+
+
+def test_alias_with_parallel_replicas(started_cluster):
+    """Verify that an Alias support parallel replicas read."""
+    node1.query(
+        "CREATE DATABASE test_pr ENGINE = Replicated('/clickhouse/databases/test_pr', '{shard}', '{replica}')"
+    )
+    node2.query(
+        "CREATE DATABASE test_pr ENGINE = Replicated('/clickhouse/databases/test_pr', '{shard}', '{replica}')"
+    )
+
+    node1.query(
+        "CREATE TABLE test_pr.base_table (id UInt32, value String) "
+        "ENGINE = ReplicatedMergeTree ORDER BY id "
+        "SETTINGS index_granularity = 1"
+    )
+    node1.query("CREATE TABLE test_pr.alias_table ENGINE = Alias('base_table')")
+    # Ensure alias_table DDL has replicated to node2 before we send it work.
+    node2.query("SYSTEM SYNC DATABASE REPLICA test_pr")
+
+    node1.query(
+        "INSERT INTO test_pr.base_table SELECT number, toString(number) FROM numbers(1000)"
+    )
+    node2.query("SYSTEM SYNC REPLICA test_pr.base_table")
+
+    result = node1.query(
+        "SELECT sum(id) FROM test_pr.alias_table",
+        settings={
+            "enable_parallel_replicas": 1,
+            "max_parallel_replicas": 2,
+            "cluster_for_parallel_replicas": "test_cluster",
+            "prefer_localhost_replica": 0,
+            "parallel_replicas_mark_segment_size": 128,
+            "log_comment": "test_alias_parallel_replicas",
+        },
+    )
+
+    assert result.strip() == "499500"
+
+    # Verify parallel replicas were actually used
+    node1.query("SYSTEM FLUSH LOGS")
+    used_count = node1.query(
+        "SELECT ProfileEvents['ParallelReplicasUsedCount'] "
+        "FROM system.query_log "
+        "WHERE log_comment = 'test_alias_parallel_replicas' "
+        "  AND is_initial_query = 1 "
+        "  AND type = 'QueryFinish' "
+        "ORDER BY query_start_time DESC LIMIT 1"
+    )
+    assert int(used_count.strip()) >= 2, (
+        f"Expected ParallelReplicasUsedCount >= 2, got {used_count.strip()}"
+    )
+
+    node1.query("DROP DATABASE test_pr SYNC")
+    node2.query("DROP DATABASE test_pr SYNC")
+
+
+def test_alias_check_table(started_cluster):
+    """Verify that CHECK TABLE and CHECK DATABASE correctly delegate to the target table when the database contains an Alias table."""
+    node1.query("CREATE DATABASE check_db")
+    node1.query(
+        "CREATE TABLE check_db.base_table (id UInt32) ENGINE = MergeTree ORDER BY id"
+    )
+    node1.query("CREATE TABLE check_db.alias_table ENGINE = Alias('base_table')")
+    node1.query("INSERT INTO check_db.base_table VALUES (1), (2), (3)")
+
+    # CHECK TABLE on alias must delegate to the target and report success.
+    result = node1.query(
+        "CHECK TABLE check_db.alias_table",
+        settings={"check_query_single_value_result": 1},
+    )
+    assert result.strip() == "1", f"Expected 1, got: {result.strip()}"
+
+    # CHECK DATABASE must not abort when the database contains alias tables.
+    node1.query("CHECK DATABASE check_db")
+
+    node1.query("DROP DATABASE check_db SYNC")

--- a/tests/integration/test_storage_alias_replicated/test.py
+++ b/tests/integration/test_storage_alias_replicated/test.py
@@ -100,9 +100,6 @@ def test_alias_with_parallel_replicas(started_cluster):
             "enable_parallel_replicas": 1,
             "max_parallel_replicas": 2,
             "cluster_for_parallel_replicas": "test_cluster",
-            "prefer_localhost_replica": 0,
-            "parallel_replicas_prefer_local_replica": 0,
-            "parallel_replicas_mark_segment_size": 128,
             "log_comment": "test_alias_parallel_replicas",
         },
     )
@@ -119,8 +116,8 @@ def test_alias_with_parallel_replicas(started_cluster):
         "  AND type = 'QueryFinish' "
         "ORDER BY query_start_time DESC LIMIT 1"
     )
-    assert int(used_count.strip()) >= 2, (
-        f"Expected ParallelReplicasUsedCount >= 2, got {used_count.strip()}"
+    assert int(used_count.strip()) > 0, (
+        f"Expected ParallelReplicasUsedCount > 0, got {used_count.strip()}"
     )
 
     node1.query("DROP DATABASE test_pr SYNC")

--- a/tests/queries/0_stateless/03636_storage_alias_access_rights.reference
+++ b/tests/queries/0_stateless/03636_storage_alias_access_rights.reference
@@ -15,6 +15,12 @@ Test TRUNCATE with permission
 Test OPTIMIZE without permission
 ACCESS_DENIED
 Test OPTIMIZE with permission
+Test CHECK TABLE without permission
+ACCESS_DENIED
+Test CHECK TABLE with alias permission only
+ACCESS_DENIED
+Test CHECK TABLE with both alias and target permission
+1
 Test ALTER without permission
 ACCESS_DENIED
 Test ALTER with permission

--- a/tests/queries/0_stateless/03636_storage_alias_access_rights.sh
+++ b/tests/queries/0_stateless/03636_storage_alias_access_rights.sh
@@ -71,6 +71,18 @@ ${CLICKHOUSE_CLIENT} --query "
 echo "Test OPTIMIZE with permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "OPTIMIZE TABLE test_alias FINAL;"
 
+# Test: CHECK TABLE requires CHECK on both the alias and the target table.
+echo "Test CHECK TABLE without permission"
+${CLICKHOUSE_CLIENT} --user="${username}" --query "CHECK TABLE test_alias;" 2>&1 | grep -o "ACCESS_DENIED" | uniq
+
+${CLICKHOUSE_CLIENT} --query "GRANT CHECK ON test_alias TO ${username};"
+echo "Test CHECK TABLE with alias permission only"
+${CLICKHOUSE_CLIENT} --user="${username}" --query "CHECK TABLE test_alias;" 2>&1 | grep -o "ACCESS_DENIED" | uniq
+
+${CLICKHOUSE_CLIENT} --query "GRANT CHECK ON test_table TO ${username};"
+echo "Test CHECK TABLE with both alias and target permission"
+${CLICKHOUSE_CLIENT} --user="${username}" --query "SET check_query_single_value_result = 1; CHECK TABLE test_alias;"
+
 # Test: ALTER
 echo "Test ALTER without permission"
 ${CLICKHOUSE_CLIENT} --user="${username}" --query "ALTER TABLE test_alias ADD COLUMN status String DEFAULT 'active';" 2>&1 | grep -o "ACCESS_DENIED" | uniq


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`Alias` engine now supports parallel replicas read when the target table is a `MergeTree` family engine.

As a consequence of the `isMergeTree` proxy, `getCheckTaskList` and `checkDataNext` are also proxied to the target, so `CHECK TABLE` and `CHECK DATABASE` work correctly on `Alias` tables.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.22`
<!-- ch-version-info:end -->