### PR TITLE
Fix flaky 04117_max_threads_min_free_memory_per_thread under memory pressure

### DIFF
--- a/tests/queries/0_stateless/04117_max_threads_min_free_memory_per_thread.sh
+++ b/tests/queries/0_stateless/04117_max_threads_min_free_memory_per_thread.sh
@@ -14,9 +14,18 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG_FILE=$(mktemp -p "${CLICKHOUSE_TMP:-.}" 04117_config.XXXXXX.xml)
 trap 'rm -f "$CONFIG_FILE"' EXIT
 
+# `max_server_memory_usage` gives the free-memory limiter a deterministic budget.
+# `memory_worker_use_cgroup` is disabled so `clickhouse-local` tracks its own
+# process memory instead of the (shared) cgroup: in CI the cgroup spans the whole
+# container, and under load the worker would seed `total_memory_tracker` with the
+# container-wide usage (e.g. ~8 GiB), tripping the 4G hard limit on the first
+# allocation of any query. `memory_worker_dynamic_hard_limit` is disabled so the
+# 4G hard limit (and thus the limiter's budget) stays fixed regardless of host load.
 cat > "$CONFIG_FILE" <<'EOF'
 <clickhouse>
     <max_server_memory_usage>4G</max_server_memory_usage>
+    <memory_worker_use_cgroup>false</memory_worker_use_cgroup>
+    <memory_worker_dynamic_hard_limit>false</memory_worker_dynamic_hard_limit>
 </clickhouse>
 EOF
 


### PR DESCRIPTION
`04117_max_threads_min_free_memory_per_thread` is flaky in CI and fails under load with:

```
Code: 241. DB::Exception: (total) memory limit exceeded: would use 7.85 GiB
(attempt to allocate chunk of 4.00 MiB), current RSS: 7.84 GiB, maximum: 3.73 GiB.
(MEMORY_LIMIT_EXCEEDED)
```

The test sets a small `max_server_memory_usage` (4G) on purpose, so the `max_threads_min_free_memory_per_thread` limiter has a deterministic budget to work against. The catch is that `clickhouse-local` runs inside the CI container's shared cgroup, and its `MemoryWorker` seeds `total_memory_tracker` from the cgroup's memory usage on the first tick. On a busy runner that cgroup already accounts for several gigabytes of unrelated work, so the tracker starts out above the 4G limit and the next allocation throws, even for a no-op `EXPLAIN`. It has nothing to do with the feature being tested, which is why it only shows up under load.

The fix stays inside the test: make `clickhouse-local` account for its own process memory instead of the shared cgroup (`memory_worker_use_cgroup = false`), and pin the limit so it doesn't drift with host pressure (`memory_worker_dynamic_hard_limit = false`). The limiter still sees the intended 4G budget, so the expected output is unchanged.

I reproduced the failure in a memory-constrained Linux cgroup with a sibling process holding a few GiB of anonymous memory: before the change the no-op `EXPLAIN` fails exactly as above, and after it the queries return the expected thread counts (8 and 1).

recent failures on [CI](http://cidb.clickhouse-staging.com:8123/play?user=play#c2VsZWN0IERJU1RJTkNUIHB1bGxfcmVxdWVzdF9udW1iZXIgZnJvbSBjaGVja3Mgd2hlcmUgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDggREFZIGFuZCB0ZXN0X25hbWU9JzA0MTE3X21heF90aHJlYWRzX21pbl9mcmVlX21lbW9yeV9wZXJfdGhyZWFkJyBhbmQgdGVzdF9zdGF0dXM9J0ZBSUwnIE9SREVSIEJZIGNoZWNrX3N0YXJ0X3RpbWUgREVTQwo=)

eg. of a recent failure [here](https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=60876&sha=2a4095165798098199b04dcf6d3d4be6692310df&name_0=PR&name_1=Stateless%20tests%20%28amd_fips_release%2C%20meta%20in%20keeper%2C%20s3%20storage%2C%20OpenSSL%20FIPS%2C%20parallel%29&name_1=Stateless%20tests%20%28amd_fips_release%2C%20meta%20in%20keeper%2C%20s3%20storage%2C%20OpenSSL%20FIPS%2C%20parallel%29)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.981`
<!-- ch-version-info:end -->