### PR TITLE
Limit random index_granularity in 03927_sharded_aggregation

### DIFF
--- a/tests/queries/0_stateless/03927_sharded_aggregation.sql
+++ b/tests/queries/0_stateless/03927_sharded_aggregation.sql
@@ -1,4 +1,7 @@
 -- Tags: long
+-- Random settings limits: index_granularity=(8192, None)
+-- A tiny index_granularity over S3 storage explodes the per-granule read count
+-- (one S3 GET per granule for multi-column reads), making this long test time out.
 
 SET max_rows_to_group_by = 0;
 


### PR DESCRIPTION
`03927_sharded_aggregation` (tagged `long`) timed out at 600s on `Stateless tests (amd_tsan, s3 storage)`. The stateless randomizer picked a tiny `index_granularity` (19), producing ~31578 marks for the test tables. On object storage a multi-column read issues roughly one S3 GET per granule (single-column reads coalesce into a couple of large GETs; multi-column reads do not), so each string-key `GROUP BY a` plus aggregate-of-`b` query made ~15792 S3 GET requests and spent ~70s in S3 read initialization. Eight such queries pushed the test past the limit.

Clamp the randomized `index_granularity` to a floor of 8192 (still randomized up to 65536) via the `Random settings limits` directive, keeping coverage while bounding the per-granule read amplification.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106349&sha=1035d9f91c950f79da75fd6429d6c56dfe7999b4&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29

Related: https://github.com/ClickHouse/ClickHouse/pull/106349

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.984`
<!-- ch-version-info:end -->