### PR TITLE
distroless: swap base to base-nossl-debian13

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init --keeper` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/base-nossl-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/base-nossl-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-keeper:distroless .
@@ -145,8 +145,8 @@ RUN mkdir -p \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -168,8 +168,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/base-nossl-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/base-nossl-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-server:distroless .
@@ -179,8 +179,8 @@ RUN { \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -202,8 +202,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-16. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Followup to #107677. clickhouse already statically links its own openssl/libstdc++/zlib/zstd/gomp — only 5 glibc libs in `DT_NEEDED` (librt, libpthread, libc, libm, libdl). So the 7 packages `cc-debian13` ships on top of glibc (`gcc-14-base libgcc-s1 libgomp1 libssl3t64 libstdc++6 libzstd1 zlib1g`) are dead weight we chase CVEs on every few weeks. `libssl3t64` was the latest one. Swap to `base-nossl-debian13:nonroot` drops them all. Base goes 13 -> 6 packages.

i wanted to be sure the binary really doesn't need any of that before flipping, so i ran a broad smoke on 26.5.2.39 across both arches:

- `--version` on server + keeper, prod + debug targets, amd64 + arm64. all clean, dynamic linker happy.
- server starts, takes HTTP queries, native TCP on 9000 via clickhouse-client (incl. LZ4), and inbound HTTPS with a self-signed cert (TLSv1.3 / AEAD-AES256-GCM-SHA384).
- outbound HTTPS via `url('https://api.github.com/zen')` and `url('https://...s3.amazonaws.com/...')` — handshakes complete, bodies returned. statically-linked openssl client doesn't need `libssl3t64`.
- SQL crypto: SHA224/256/384/512, MD5, AES-256-CTR and AES-256-GCM encrypt+decrypt round-trip, `randomString`/`randomPrintableASCII` length + entropy. byte-identical hashes between amd64 and arm64.
- ZSTD column codec ALTER + OPTIMIZE FINAL round-trips rows. GZIP HTTP `Content-Encoding: gzip` works both directions. statically-linked zstd + zlib OK.
- 2-server ReplicatedMergeTree on a 3-node Keeper quorum: insert on srv-1 replicates to srv-2 in ~1s, bit-identical SHA256 over the id set. killed the Keeper leader mid-flight, re-election in ~1s, data preserved.
- inter-server replication over HTTPS *only* (`interserver_http_port` removed entirely, `interserver_https_port=9010`, mounted cert): 3000 rows fetched srv-1 -> srv-2 in 2s, bit-identical. that's the inter-server TLS data plane proven, not just the listener.
- Trivy `--severity HIGH,CRITICAL --ignore-unfixed` on all four prod images (server/keeper × amd64/arm64): 0 findings.
- no `<Error>` or `<Fatal>` log lines in any container during any of the above.

CA bundle `/etc/ssl/certs/ca-certificates.crt` still ships in `base-nossl`, outbound verification unchanged. `/busybox/pgrep` story is identical to `cc-debian13` — present in `debug-nonroot`, absent in `nonroot`. operator probe path is unaffected either way.

Prod image sizes: 790 MB amd64, 755 MB arm64.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Switch the distroless server and keeper images to `gcr.io/distroless/base-nossl-debian13` so they only ship the libraries ClickHouse actually links against and stop pulling in ones we statically link ourselves.

#### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1088`
<!-- ch-version-info:end -->