### PR TITLE
Stop bugfix validation from flipping clean log checks into failures

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -185,6 +185,15 @@ def invert_bugfix_validation_status(test_result: Result) -> None:
     masking the `ERROR` and flipping the job to green. Treat any per-row
     `ERROR` the same as an aggregate `ERROR`. Mirrors the `has_error`
     dominant guard in `integration_test_job.py`.
+
+    Rows produced by `check_fatal_messages_in_logs` (labelled `LOG_CHECK`:
+    "Lost s3 keys", "OOM in dmesg", "Exception in test runner", etc.) are
+    server-log / runner health checks, not test cases. A LOG_CHECK *failure*
+    on the validated binary is itself evidence the bug reproduced (a crash /
+    sanitizer assert / lost key triggered by the regression test), so it is
+    flipped like a test failure. But a *clean* LOG_CHECK must stay `OK`: the
+    absence of a fatal is not "failed to reproduce", and flipping it to
+    `FAIL` is what produced the spurious xfail rows.
     """
     if test_result.status == Result.Status.ERROR or any(
         r.status == Result.Status.ERROR for r in test_result.results
@@ -200,8 +209,14 @@ def invert_bugfix_validation_status(test_result: Result) -> None:
 
     has_failure = False
     for r in test_result.results:
+        if r.status == Result.Status.OK and r.has_label(Result.Label.LOG_CHECK):
+            # A clean health check is not a test that "failed to reproduce";
+            # leave it untouched so it does not become a spurious failure.
+            continue
         r.set_label(Result.Label.XFAIL)
         if r.status == Result.Status.FAIL:
+            # A failing test, or a fatal / sanitizer assert / lost key on the
+            # validated binary, both mean the bug was reproduced.
             r.status = Result.Status.OK
             has_failure = True
         elif r.status == Result.Status.OK:

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1132,6 +1132,12 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 result.set_status(Result.Status.OK)
             else:
                 result.set_status(Result.Status.FAIL)
+            # These are server-log / runner health checks, not test cases.
+            # The bugfix-validation inverter uses this label so a clean check
+            # (OK) is left as-is instead of being flipped into a spurious
+            # failure. A failing check still flips like a test (a fatal on the
+            # validated binary is the bug reproducing).
+            result.set_label(Result.Label.LOG_CHECK)
         return results
 
     def dump_system_tables(self):

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -89,6 +89,7 @@ class Result(MetaClasses.Serializable):
         SETTING_VALUE = "setting"
         FLAKY = "flaky"
         REPRODUCIBLE = "reproducible"
+        LOG_CHECK = "log_check"
 
     # Default hints rendered as a hover tooltip in json.html.
     # Looked up automatically when set_label is called without an explicit hint.
@@ -103,6 +104,7 @@ class Result(MetaClasses.Serializable):
         Label.SETTING_VALUE: "Failure caused by a specific randomized setting value",
         Label.FLAKY: "Failure is reproducible in less than 100% of reruns",
         Label.REPRODUCIBLE: "Failure is reproducible in 100% of reruns",
+        Label.LOG_CHECK: "Server-log / runner health check, not a test case (excluded from bugfix-validation inversion)",
     }
 
     name: str

--- a/ci/tests/test_bugfix_validation_inverter.py
+++ b/ci/tests/test_bugfix_validation_inverter.py
@@ -27,6 +27,21 @@ def _make_leaf(name, status, info=""):
     return Result(name=name, status=status, info=info)
 
 
+def _make_log_check(name, status):
+    """A server-log / runner health-check row, as produced by
+    `check_fatal_messages_in_logs` and labelled `LOG_CHECK`."""
+    leaf = Result(name=name, status=status)
+    leaf.set_label(Result.Label.LOG_CHECK)
+    return leaf
+
+
+def _labels(leaf):
+    return [
+        lbl.get("name") if isinstance(lbl, dict) else lbl
+        for lbl in leaf.ext.get("labels", [])
+    ]
+
+
 def _make_outer(status, results=None, info=""):
     return Result(
         name="Tests",
@@ -168,6 +183,66 @@ def test_empty_results_with_ok_outer_still_reports_failed_to_reproduce():
 
     assert outer.status == Result.Status.FAIL
     assert "Failed to reproduce the bug" in outer.info
+
+
+def test_clean_log_checks_are_not_flipped_to_failures():
+    """Clean health checks ("Lost s3 keys", "OOM in dmesg", ...) are OK and
+    must stay OK: they are not test cases and must not become spurious xfail
+    failures when the bug is not reproduced.
+    """
+    test_ok = _make_leaf("01234_regression_test", Result.Status.OK)
+    log_checks = [
+        _make_log_check("Exception in test runner", Result.Status.OK),
+        _make_log_check("Lost s3 keys", Result.Status.OK),
+        _make_log_check("OOM in dmesg", Result.Status.OK),
+    ]
+    outer = _make_outer(Result.Status.OK, [test_ok, *log_checks])
+
+    invert_bugfix_validation_status(outer)
+
+    # The real test row is flipped (bug not reproduced).
+    assert test_ok.status == Result.Status.FAIL
+    # The health checks stay OK and are not labelled XFAIL.
+    for leaf in log_checks:
+        assert leaf.status == Result.Status.OK
+        assert Result.Label.XFAIL not in _labels(leaf)
+    assert outer.status == Result.Status.FAIL
+    assert "Failed to reproduce the bug" in outer.info
+
+
+def test_clean_log_checks_do_not_mask_a_reproduced_bug():
+    """A reproduced bug (test FAIL on master) is still reported even when
+    health-check rows are present and clean.
+    """
+    test_fail = _make_leaf("01234_regression_test", Result.Status.FAIL)
+    log_check = _make_log_check("Lost s3 keys", Result.Status.OK)
+    outer = _make_outer(Result.Status.FAIL, [test_fail, log_check])
+
+    invert_bugfix_validation_status(outer)
+
+    assert test_fail.status == Result.Status.OK
+    assert log_check.status == Result.Status.OK
+    assert outer.status == Result.Status.OK
+
+
+def test_log_check_failure_counts_as_reproduced_bug():
+    """A fatal / sanitizer assert / lost key on the validated binary is the
+    bug reproducing, so it is flipped to OK and the job passes, even when no
+    plain test row failed.
+    """
+    test_ok = _make_leaf("01234_regression_test", Result.Status.OK)
+    log_fail = _make_log_check(
+        "Sanitizer assert or Fatal messages in server logs", Result.Status.FAIL
+    )
+    outer = _make_outer(Result.Status.FAIL, [test_ok, log_fail])
+
+    invert_bugfix_validation_status(outer)
+
+    # The fatal is treated as a reproduction: flipped to OK and labelled XFAIL.
+    assert log_fail.status == Result.Status.OK
+    assert Result.Label.XFAIL in _labels(log_fail)
+    assert outer.status == Result.Status.OK
+    assert "Failed to reproduce" not in outer.info
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bugfix validation inverts each per-test `FAIL`/`OK` so a regression test that
fails on the validated binary reads as "bug reproduced". The inverter also
flipped the server-log / runner health-check rows produced by
`check_fatal_messages_in_logs` (`Lost s3 keys`, `OOM in dmesg`, `Exception in
test runner`, `Lost forever for SharedMergeTree`, `S3_ERROR No such key`). When
the bug was not reproduced those checks were `OK` and got flipped to `FAIL`, so
the report showed several spurious xfail failures on top of the legitimate
"Failed to reproduce the bug".

These rows are now labelled `LOG_CHECK` and excluded from the `OK`->`FAIL` flip:
a clean health check stays `OK` instead of becoming noise. A failing health
check still flips like a test failure, since a fatal / sanitizer assert / lost
key on the validated binary is itself the bug reproducing.

On the report below, 6 of the 7 reported failures were these clean checks. With
this change only the single regression-test row (`04356_sqlite_open_error_leak`)
remains, and the stage reports "Failed to reproduce the bug".

With this change, that same run would have reported:

```
[FAIL] Bugfix validation (functional tests)
  [OK]   Install ClickHouse
  [OK]   Start ClickHouse Server
  [FAIL] Tests   info="Failed to reproduce the bug"
    [FAIL] 04356_sqlite_open_error_leak                      labels=[amd_debug, xfail]
    [OK]   Exception in test runner                          labels=[amd_debug, log_check]
    [OK]   Lost s3 keys                                      labels=[amd_debug, log_check]
    [OK]   Lost forever for SharedMergeTree                  labels=[amd_debug, log_check]
    [OK]   Lost forever for SharedMergeTree                  labels=[amd_debug, log_check]
    [OK]   S3_ERROR No such key thrown (...)                 labels=[amd_debug, log_check]
    [OK]   OOM in dmesg                                      labels=[amd_debug, log_check]
  [OK]   Collect logs
```

Previously all 7 child rows were reported as `FAIL` (xfail).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107807&sha=16be5f5638e8f155f60f445f3dfa88b450a24b7c&name_0=PR&name_1=Bugfix+validation+%28functional+tests%29&name_2=Tests

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1005`
<!-- ch-version-info:end -->