### PR TITLE
Fix exception leak in PNG writer libpng callbacks

### DIFF
--- a/src/Formats/PNGWriter.cpp
+++ b/src/Formats/PNGWriter.cpp
@@ -114,12 +114,15 @@ void PNGWriter::writeDataCallback(png_struct_def * png_ptr_, unsigned char * dat
     try
     {
         writer->out.write(reinterpret_cast<const char *>(data), length);
+        return;
     }
     catch (...) /// Ok: a C++ exception must not propagate through libpng's C frames; save it and longjmp instead.
     {
         writer->saved_exception = std::current_exception();
-        png_longjmp(png_ptr_, 1);
     }
+    /// `png_longjmp` must run after leaving the `catch` block: jumping out of an active handler skips the
+    /// runtime's end-of-catch cleanup, leaving the in-flight exception object permanently referenced and leaked.
+    png_longjmp(png_ptr_, 1);
 }
 
 void PNGWriter::flushDataCallback(png_struct_def * png_ptr_)
@@ -128,12 +131,14 @@ void PNGWriter::flushDataCallback(png_struct_def * png_ptr_)
     try
     {
         writer->out.next();
+        return;
     }
     catch (...) /// Ok: a C++ exception must not propagate through libpng's C frames; save it and longjmp instead.
     {
         writer->saved_exception = std::current_exception();
-        png_longjmp(png_ptr_, 1);
     }
+    /// See `writeDataCallback`: `png_longjmp` only after leaving the `catch` block to avoid leaking the exception.
+    png_longjmp(png_ptr_, 1);
 }
 
 void PNGWriter::saveMessage(png_const_charp message)


### PR DESCRIPTION
`PNGWriter`'s libpng write/flush callbacks called `png_longjmp` from inside their `catch` block. Jumping out of an active handler skips the C++ runtime's end-of-catch cleanup (`__cxa_end_catch`), which is what removes the exception from the thread's caught-exception list and performs the balancing reference-count decrement set up by the throw. As a result the in-flight `DB::Exception` (for example the `MEMORY_LIMIT_EXCEEDED` raised while growing the memory-tracked encode buffer) stays referenced forever and leaks.

The fix moves `png_longjmp` out of the `catch` so the handler exits normally before the jump. `errorCallback`/`warningCallback` do not catch a C++ exception, so they were already correct.

Found by `arm_asan_ubsan` MasterCI: `840 byte(s) leaked in 3 allocation(s)` (the exception object plus its message members). Reproduced and verified with an Address Sanitizer build: the leak is gone, the exception is still raised, the encoded PNG/iTerm output is unchanged, and the `04326`/`04327`/`04328`/`04339` PNG tests pass.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1a0bea9bc8fdfd12f6af4ba36fde2b5fcbdd0df9&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: the `PNG` output format is not part of any released version.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1071`
<!-- ch-version-info:end -->