### PR TITLE
Fix flaky test_iceberg_s3_cluster_read_task_failpoint

### DIFF
--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -734,6 +734,11 @@ def test_iceberg_s3_cluster_read_task_failpoint(started_cluster):
                 "SYSTEM ENABLE FAILPOINT storage_cluster_read_sleep"
             )
 
+        # The failpoint sleeps 10s uninterruptibly before max_execution_time can
+        # fire, so the server's legitimate abort lands well after 5s. The client
+        # timeout must outlast that abort (plus sanitizer/runner slowdown), not
+        # the 5s execution limit, otherwise a slow runner raises a false
+        # "Client timed out!".
         _, error = node.query_and_get_answer_with_error(
             f"""
             INSERT INTO {dst_table}
@@ -743,7 +748,7 @@ def test_iceberg_s3_cluster_read_task_failpoint(started_cluster):
                 '{minio_access_key}', '{minio_secret_key}')
             SETTINGS max_execution_time = 5
             """,
-            timeout=30,
+            timeout=120,
         )
 
         assert error, (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/98165
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Stabilizes the flaky integration test `test_s3_cluster/test.py::test_iceberg_s3_cluster_read_task_failpoint`, which intermittently fails with `Client timed out!` on slow sanitizer runners (~3 FAIL / 2623 OK, ~0.1%; observed on `amd_asan_ubsan` and `amd_msan`; 0 post-merge `master` failures). Reported by @ alexey-milovidov on PR #79091, which is unrelated to and inert for this test.

CI report (one of the failures): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=79091&sha=8a9432d6dab7dcf74575717a9e2f82211e8188d3&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29

Root cause: the test enables the `storage_cluster_read_sleep` failpoint, which sleeps 10s uninterruptibly in the task-distribution callback, then runs an `icebergS3Cluster` read with `max_execution_time = 5` and a 30s client timeout. `max_execution_time` can only be enforced between the failpoint sleeps (the worker `ReadTaskIterator` checks the time limit in `next()`, after each 10s callback returns), so the server's legitimate abort lands at ~10s, not 5s. Measured locally: the server aborts at `elapsed 10033 ms` via `QueryStatus::checkTimeLimit()`. The 30s client timeout leaves only ~20s of headroom over that floor, which the sanitizer slowdown plus 6-way batch parallelism, 3-node cluster startup, S3, and cancellation/teardown occasionally consume, raising a false `Client timed out!` before the server's abort reaches the client.

Fix: raise the test's client timeout from 30s to 120s so it comfortably outlasts the server's legitimate abort even on a heavily loaded sanitizer runner. The test's intent is preserved: the regression it guards (#98165, an infinite unkillable initiator query) is still detected, because that produces no error at all (the `assert error` fails regardless of the timeout value), and any finite client timeout still catches a true hang.

Verified locally (debug build, integration runner):
- timeout=8 (below the ~10s abort floor): reproduces `QueryTimeoutExceedException: Client timed out!` (1 failed) - confirms the failure mode.
- timeout=120 (this fix): passes (1 passed).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1053`
<!-- ch-version-info:end -->