### PR TITLE
Fix list with data and stat extention for `TestKeeper`

### DIFF
--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -1170,7 +1170,7 @@ void TestKeeper::list(
     request.with_data = with_data;
 
     RequestInfo request_info;
-    request_info.request = std::make_shared<TestKeeperListRequest>(std::move(request));
+    request_info.request = std::make_shared<TestKeeperFilteredListWithStatsAndDataRequest>(std::move(request));
     request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const ListResponse &>(response)); };
     request_info.watch = watch;
     pushRequest(std::move(request_info));

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -626,16 +626,21 @@ std::pair<ResponsePtr, Undo> TestKeeperListRequest::process(TestKeeper::Containe
                     with_data = filtered_list_with_stat_and_data->with_data;
                 }
 
-                const auto is_ephemeral = child_it->second.stat.ephemeralOwner != 0;
-                if (list_request_type == ALL || (is_ephemeral && list_request_type == EPHEMERAL_ONLY)
-                    || (!is_ephemeral && list_request_type == PERSISTENT_ONLY))
+                const bool is_ephemeral = child_it->second.stat.ephemeralOwner != 0;
+                const bool should_return = list_request_type == ALL
+                    || (is_ephemeral && list_request_type == EPHEMERAL_ONLY)
+                    || (!is_ephemeral && list_request_type == PERSISTENT_ONLY);
+
+                if (should_return)
+                {
                     response.names.emplace_back(baseName(child_it->first));
 
-                if (with_data)
-                    response.data.emplace_back(child_it->second.data);
+                    if (with_data)
+                        response.data.emplace_back(child_it->second.data);
 
-                if (with_stat)
-                    response.stats.emplace_back(child_it->second.stat);
+                    if (with_stat)
+                        response.stats.emplace_back(child_it->second.stat);
+                }
             }
         }
 

--- a/src/Common/ZooKeeper/tests/gtest_testkeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_testkeeper.cpp
@@ -1,0 +1,112 @@
+#include <Common/ZooKeeper/IKeeper.h>
+#include <Common/ZooKeeper/TestKeeper.h>
+#include <Common/ZooKeeper/Types.h>
+#include <Common/ZooKeeper/ZooKeeperArgs.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
+
+#include <gtest/gtest.h>
+
+#include <future>
+
+using namespace Coordination;
+using namespace DB;
+
+namespace
+{
+
+Coordination::TestKeeper makeKeeper(int32_t operation_timeout_ms = DEFAULT_OPERATION_TIMEOUT_MS, std::string chroot = "")
+{
+    zkutil::ZooKeeperArgs args;
+    args.operation_timeout_ms = operation_timeout_ms;
+    args.chroot = chroot;
+
+    return Coordination::TestKeeper(args);
+}
+
+void create(TestKeeper & keeper, const String & path, const String & data, bool is_ephemeral)
+{
+    std::promise<CreateResponse> sink;
+    std::future<CreateResponse> future = sink.get_future();
+    keeper.create(path, data, is_ephemeral, /* is_sequential */ false, {},
+        [&](const auto & response) { sink.set_value(std::move(response)); });
+
+    CreateResponse response = future.get();
+    ASSERT_EQ(response.error, Error::ZOK);
+}
+
+bool exists(TestKeeper & keeper, const String & path)
+{
+    std::promise<ExistsResponse> sink;
+    std::future<ExistsResponse> future = sink.get_future();
+    keeper.exists(path, [&](const auto & response) { sink.set_value(std::move(response)); }, WatchCallbackPtrOrEventPtr());
+
+    return future.get().error == Coordination::Error::ZOK;
+}
+
+ListResponse list(TestKeeper & keeper, const String & path, ListRequestType list_request_type, bool with_stat, bool with_data)
+{
+    std::promise<ListResponse> sink;
+    std::future<ListResponse> future = sink.get_future();
+    keeper.list(path, list_request_type,
+        [&](const auto & response) { sink.set_value(std::move(response)); },
+        WatchCallbackPtrOrEventPtr(), with_stat, with_data);
+
+    return future.get();
+}
+
+}
+
+TEST(TestKeeperTest, JustWorks)
+{
+    TestKeeper keeper = makeKeeper();
+
+    ASSERT_TRUE(exists(keeper, "/"));
+    ASSERT_FALSE(exists(keeper, "/A"));
+
+    create(keeper, "/A", "hello", /*is_ephemeral=*/false);
+    ASSERT_TRUE(exists(keeper, "/A"));
+}
+
+TEST(TestKeeperTest, FilteredListWithStatsAndDataIsAligned)
+{
+    TestKeeper keeper = makeKeeper();
+
+    create(keeper, "/parent", "", /* is_ephemeral */ false);
+    create(keeper, "/parent/ephemeral", "ephemeral_data", /* is_ephemeral */ true);
+    create(keeper, "/parent/persistent", "persistent_data", /* is_ephemeral */ false);
+
+    {
+        ListResponse response = list(keeper, "/parent", ListRequestType::PERSISTENT_ONLY, /* with_stat */ true, /* with_data */ true);
+
+        ASSERT_EQ(response.error, Error::ZOK);
+        ASSERT_EQ(response.names, std::vector<std::string>({"persistent"}));
+
+        ASSERT_EQ(response.data.size(), 1u);
+        EXPECT_EQ(response.data[0], "persistent_data");
+
+        ASSERT_EQ(response.stats.size(), 1u);
+        EXPECT_EQ(response.stats[0].ephemeralOwner, 0);
+    }
+
+    {
+        ListResponse response = list(keeper, "/parent", ListRequestType::EPHEMERAL_ONLY, /* with_stat */ true, /* with_data */ true);
+
+        ASSERT_EQ(response.error, Error::ZOK);
+        EXPECT_EQ(response.names, std::vector<std::string>({"ephemeral"}));
+
+        ASSERT_EQ(response.data.size(), 1u);
+        EXPECT_EQ(response.data[0], "ephemeral_data");
+
+        ASSERT_EQ(response.stats.size(), 1u);
+        EXPECT_NE(response.stats[0].ephemeralOwner, 0);
+    }
+
+    {
+        ListResponse response = list(keeper, "/parent", ListRequestType::ALL, /* with_stat */ true, /* with_data */ true);
+
+        ASSERT_EQ(response.error, Error::ZOK);
+        ASSERT_EQ(response.names.size(), 2u);
+        ASSERT_EQ(response.data.size(), 2u);
+        ASSERT_EQ(response.stats.size(), 2u);
+    }
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes a misalignment in `TestKeeperFilteredListWithStatsAndDataRequest` processing, where filtered children are still used to populate data and stats.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1022`
<!-- ch-version-info:end -->