### PR TITLE
Remove useless mutex

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2992,12 +2992,12 @@ bool IMergeTreeDataPart::hasBrokenProjection(const String & projection_name) con
 
 void IMergeTreeDataPart::setBrokenReason(const String & message, int code) const
 {
-    std::lock_guard lock(broken_reason_mutex);
     if (is_broken)
         return;
-    is_broken = true;
+
     exception = message;
     exception_code = code;
+    is_broken = true;
 }
 
 ColumnPtr IMergeTreeDataPart::getColumnSample(const NameAndTypePair & column) const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -300,7 +300,6 @@ public:
     mutable std::atomic<bool> is_broken {false};
     mutable std::string exception;
     mutable int exception_code = 0;
-    mutable std::mutex broken_reason_mutex;
 
     /// Indicates that the part was marked Outdated by PartCheckThread because the part was not committed to ZooKeeper
     mutable bool is_unexpected_local_part = false;

--- a/src/Storages/System/StorageSystemProjectionParts.cpp
+++ b/src/Storages/System/StorageSystemProjectionParts.cpp
@@ -277,7 +277,6 @@ void StorageSystemProjectionParts::processNextStorage(
 
             if (part->is_broken)
             {
-                std::lock_guard lock(part->broken_reason_mutex);
                 if (columns_mask[src_index++])
                     columns[res_index++]->insert(part->exception_code);
                 if (columns_mask[src_index++])


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Use message passing instead
