### PR TITLE
Limit random index_granularity in `03633_negative_limit_offset`

### DIFF
--- a/tests/queries/0_stateless/03633_negative_limit_offset.sql
+++ b/tests/queries/0_stateless/03633_negative_limit_offset.sql
@@ -1,4 +1,5 @@
 -- Random settings limits: index_granularity=(8192, None)
+-- Reason: a tiny index_granularity (e.g. 4) creates ~250k granules per 1M-row MergeTree table, which slows the test down enough to time out.
 
 SET enable_analyzer=0;
 SELECT 'Old Analyzer:';

--- a/tests/queries/0_stateless/03633_negative_limit_offset.sql
+++ b/tests/queries/0_stateless/03633_negative_limit_offset.sql
@@ -1,3 +1,5 @@
+-- Random settings limits: index_granularity=(8192, None)
+
 SET enable_analyzer=0;
 SELECT 'Old Analyzer:';
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107535&sha=c833c2d21be11e6450fe268f1bdf5aef3e9aff39&name_0=PR&name_1=Stateless+tests+%28amd_msan%2C+WasmEdge%2C+parallel%2C+2%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1021`
<!-- ch-version-info:end -->