### PR TITLE
validate array sizes in analysisOfVariance and lttb aggregate states

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
+++ b/src/AggregateFunctions/AggregateFunctionLargestTriangleThreeBuckets.cpp
@@ -26,6 +26,7 @@ namespace ErrorCodes
     extern const int TOO_LARGE_ARRAY_SIZE;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int INCORRECT_DATA;
 }
 
 struct Settings;
@@ -52,8 +53,15 @@ struct LargestTriangleThreeBucketsData : public StatisticalSample<Float64, Float
         if (size >= MAX_ARRAY_SIZE)
             throw Exception(ErrorCodes::TOO_LARGE_ARRAY_SIZE, "Too large array size in largestTriangleThreeBuckets, max: {}", MAX_ARRAY_SIZE);
 
-        /// Sort the data
-        chassert(size == this->y.size());
+        /// x and y are filled together by add, so they are equal in length for any state built
+        /// by aggregation. A state deserialized from raw bytes can break that, and the loops below
+        /// index y by positions taken from the x permutation, so unequal lengths read out of bounds.
+        if (size != this->y.size())
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "Sizes of nested arrays in largestTriangleThreeBuckets state do not match: {} (x) vs {} (y)",
+                size,
+                this->y.size());
 
         // sort the this->x and this->y in ascending order of this->x using index
         PODArray<UInt32> index(size);

--- a/src/AggregateFunctions/Moments.h
+++ b/src/AggregateFunctions/Moments.h
@@ -19,6 +19,7 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
+    extern const int INCORRECT_DATA;
 }
 
 
@@ -590,6 +591,17 @@ struct AnalysisOfVarianceMoments
         readVectorBinary(xs1, buf);
         readVectorBinary(xs2, buf);
         readVectorBinary(ns, buf);
+
+        /// The three vectors hold one entry per group and must stay equal in length.
+        /// The finalize path iterates up to xs1.size() and indexes xs2 and ns with the
+        /// same position, so a state with mismatched lengths reads out of bounds.
+        if (xs1.size() != xs2.size() || xs1.size() != ns.size())
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "Sizes of nested arrays in analysisOfVariance state do not match: {}, {}, {}",
+                xs1.size(),
+                xs2.size(),
+                ns.size());
     }
 
     Float64 getMeanAll() const

--- a/tests/queries/0_stateless/04357_analysisOfVariance_lttb_deserialize_size.sql
+++ b/tests/queries/0_stateless/04357_analysisOfVariance_lttb_deserialize_size.sql
@@ -1,0 +1,15 @@
+-- analysisOfVariance and largestTriangleThreeBuckets keep parallel arrays in their
+-- aggregate state (one entry per group / one (x, y) point). The finalize path iterates
+-- one array and indexes the others at the same position, so a state deserialized from
+-- raw bytes with mismatched array lengths reads out of bounds. Such a state is reachable
+-- from any user via CAST of a String to AggregateFunction.
+
+-- Normal aggregation builds equal-length arrays and must keep working.
+SELECT analysisOfVariance(number, number % 3) FROM numbers(30) FORMAT Null;
+SELECT largestTriangleThreeBuckets(5)(number, number * 2) FROM numbers(30) FORMAT Null;
+
+-- analysisOfVariance: xs1 and xs2 have two groups, ns has one -> ns is read past its end.
+SELECT finalizeAggregation(CAST(unhex('02000000000000f03f000000000000f03f02000000000000f03f000000000000f03f010500000000000000') AS AggregateFunction(analysisOfVariance, Float64, UInt8))); -- { serverError INCORRECT_DATA }
+
+-- largestTriangleThreeBuckets: x holds two points, y holds one -> y is read past its end.
+SELECT finalizeAggregation(CAST(unhex('0201000000000000f03f00000000000000400000000000000840') AS AggregateFunction(largestTriangleThreeBuckets(100), Float64, Float64))); -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
Repro: `finalizeAggregation(CAST(unhex('...') AS AggregateFunction(analysisOfVariance, Float64, UInt8)))` on a state whose nested arrays have different lengths.
Cause: `analysisOfVariance` reads `xs1`/`xs2`/`ns` as independent vectors, then finalization walks one array's length and indexes the siblings at the same position, so a shorter sibling is read past its end. `read` also trusted the serialized lengths, unlike `add`/`merge` which cap groups at `MAX_GROUPS_NUMBER`.
Fix: `read` now caps each vector at `MAX_GROUPS_NUMBER` before resizing (via a new `max_size` argument on `readVectorBinary`) and rejects mismatched lengths with `INCORRECT_DATA` before indexing. Before, a crafted state caused an out-of-bounds heap read (release builds returned garbage instead of throwing); after, a clean exception, with states built by normal aggregation unaffected.

The `largestTriangleThreeBuckets` hunk was dropped: `deserialize` already rejects mismatched `x`/`y` (a2ee9cb619a), so the extra `getResult` check was unreachable.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed an out-of-bounds read when finalizing a crafted `analysisOfVariance` aggregate state whose internal arrays have mismatched lengths.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=107860&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/107860](https://github.com/search?q=head%3Async-upstream%2Fpr%2F107860+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.10.1.349` (included in `26.10` and later)
- Backported to: `26.9.1.1629`, `26.8.11.6`, `26.7.14.10`, `26.3.33.126`
<!-- ch-version-info:end -->