### PR TITLE
Fix UBSan null-pointer in MsgPack schema inference for empty fields

### DIFF
--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -593,6 +593,14 @@ MsgPackSchemaReader::MsgPackSchemaReader(ReadBuffer & in_, const FormatSettings 
 }
 
 
+/// Reference (don't copy) zero-length STR/BIN payloads: msgpack copies them via
+/// memcpy(dst, null, 0), which is UB under the nonnull attribute. The empty payload
+/// is never dereferenced during schema inference.
+static bool msgpackReferenceEmptyData(msgpack::type::object_type, size_t size, void *)
+{
+    return size == 0;
+}
+
 msgpack::object_handle MsgPackSchemaReader::readObject()
 {
     if (buf.eof())
@@ -607,7 +615,9 @@ msgpack::object_handle MsgPackSchemaReader::readObject()
         offset = 0;
         try
         {
-            object_handle = msgpack::unpack(buf.position(), buf.buffer().end() - buf.position(), offset);
+            object_handle = msgpack::unpack(
+                buf.position(), buf.buffer().end() - buf.position(), offset,
+                msgpackReferenceEmptyData, nullptr, msgpack::unpack_limit());
             need_more_data = false;
         }
         catch (msgpack::insufficient_bytes &)

--- a/tests/queries/0_stateless/04338_msgpack_schema_inference_empty_field.reference
+++ b/tests/queries/0_stateless/04338_msgpack_schema_inference_empty_field.reference
@@ -1,0 +1,4 @@
+Nullable(String)	
+Nullable(String)	
+
+abc

--- a/tests/queries/0_stateless/04338_msgpack_schema_inference_empty_field.sh
+++ b/tests/queries/0_stateless/04338_msgpack_schema_inference_empty_field.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: MsgPack format is not supported in fast test
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Schema inference over a MsgPack value with an empty string/bin field passed a
+# null data pointer to memcpy in msgpack create_object_visitor, which is UB under
+# the nonnull attribute (caught by UBSan) even when the size is 0. Raw bytes are
+# piped through stdin so the test is safe to run in parallel with itself.
+
+# Empty string field (0xa0 = fixstr of length 0): the data pointer is null.
+printf '\xa0' \
+  | $CLICKHOUSE_LOCAL --input-format MsgPack --input_format_msgpack_number_of_columns=1 \
+      -q "SELECT toTypeName(c1), c1 FROM table"
+
+# Empty binary field (0xc4 0x00 = bin8 of length 0).
+printf '\xc4\x00' \
+  | $CLICKHOUSE_LOCAL --input-format MsgPack --input_format_msgpack_number_of_columns=1 \
+      -q "SELECT toTypeName(c1), c1 FROM table"
+
+# Empty string followed by a non-empty one (the copy path must still work):
+# 0xa0 = "", 0xa3 0x61 0x62 0x63 = "abc".
+printf '\xa0\xa3\x61\x62\x63' \
+  | $CLICKHOUSE_LOCAL --input-format MsgPack --input_format_msgpack_number_of_columns=1 \
+      -q "SELECT c1 FROM table ORDER BY c1"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a UBSan finding in MsgPack schema inference. `MsgPackSchemaReader::readObject()` calls `msgpack::unpack()` without a reference function, so msgpack-c copies every STR/BIN payload into its zone with `memcpy(dst, src, size)`. For an empty field (`size == 0`) the source pointer is null, and `memcpy` is declared `nonnull`, so this is undefined behavior:

```
contrib/msgpack-c/include/msgpack/v2/create_object_visitor.hpp:118:30
runtime error: null pointer passed as argument 2, which is declared to never be null
(note: nonnull attribute specified at string.h:43:28 — memcpy)
```

The data path is unaffected: it uses ClickHouse's own `MsgPackVisitor` (`insertString`), not msgpack `create_object_visitor`. Only schema inference (`input_format_msgpack_number_of_columns`) reaches the affected path. On release builds `memcpy(dst, null, 0)` is benign, so there is no user-visible misbehavior; the only impact is the sanitizer abort in the `arm_ubsan` jobs — hence the CI Fix category (happy to bump to Bug Fix if preferred).

Fix: pass a reference function that returns true for zero-length payloads so msgpack references the empty range instead of copying it. Non-empty payloads are still copied into the zone as before, and the referenced empty payload is never dereferenced during schema inference.

Reproduced and verified both directions with an ASAN+UBSan build of `clickhouse` (`-fno-sanitize-recover=all`):
- Without the fix, feeding a single empty MsgPack string (`0xa0`) through schema inference aborts at `create_object_visitor.hpp:118:30` with the exact error above.
- With the fix, the same input returns `Nullable(String)` cleanly. The new test `04338_msgpack_schema_inference_empty_field` fails on the unfixed binary and passes on the fixed one.

No related open issue found.

CI provenance: caught by `Stress test (arm_ubsan)`. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97312&sha=1a521e93cb88a2a206d5f9aef428877eeb887e4a&name_0=PR&name_1=Stress%20test%20%28arm_ubsan%29 (the carrier PR is unrelated — it is an AVX2 string-search change; this is a pre-existing latent bug in the MsgPack reader).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1155`
<!-- ch-version-info:end -->