### PR TITLE
Avoid cluster-wide refresh for access updates that change nothing

### DIFF
--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -389,6 +389,12 @@ bool ZooKeeperReplicator::updateZooKeeper(const zkutil::ZooKeeperPtr & zookeeper
         throw Exception(ErrorCodes::LOGICAL_ERROR, "{}: {} expected to be of type {}",
             toString(id), formatEntityNameWithType(new_entity->getType(), new_entity->getName()), toString(old_entity->getType()));
 
+    /// No-op update: setting the znode would still bump its version and fire the CHANGED watch on
+    /// every replica, which rereads and re-publishes the entity for nothing. Matches the early-out
+    /// in MemoryAccessStorage::updateNoLock.
+    if (*new_entity == *old_entity)
+        return true;
+
     const AccessEntityTypeInfo type_info = AccessEntityTypeInfo::get(new_entity->getType());
 
     Coordination::Requests ops;

--- a/tests/integration/test_replicated_access/test.py
+++ b/tests/integration/test_replicated_access/test.py
@@ -46,6 +46,31 @@ def prepare_test():
         node1.query("DROP TABLE IF EXISTS secret ON CLUSTER default")
 
 
+def test_noop_update_does_not_bump_znode(started_cluster):
+    node1.query("GRANT SELECT ON *.* TO test")
+
+    user_id = node1.query("SELECT id FROM system.users WHERE name = 'test'").strip()
+    znode = f"/clickhouse/access/uuid/{user_id}"
+
+    zk = started_cluster.get_kazoo_client("zoo1")
+    try:
+        _, stat_before = zk.get(znode)
+
+        # Re-granting an already granted privilege leaves the entity identical, so it
+        # must not write to ZooKeeper (and thus must not refresh the entity cluster-wide).
+        node1.query("GRANT SELECT ON *.* TO test")
+        _, stat_noop = zk.get(znode)
+        assert stat_noop.version == stat_before.version
+
+        # A privilege change that actually modifies the entity must still bump the version.
+        node1.query("GRANT INSERT ON *.* TO test")
+        _, stat_changed = zk.get(znode)
+        assert stat_changed.version > stat_before.version
+    finally:
+        zk.stop()
+        zk.close()
+
+
 def test_initiator_user_in_ddl(started_cluster):
     node1.query("INSERT INTO secret VALUES ('super_secret')")
 


### PR DESCRIPTION
With access control replicated via ZooKeeper, an `ALTER`/`GRANT`/`REVOKE` that leaves a user, role or other access entity exactly as it was still triggered a ZooKeeper write and a refresh of that entity on every replica in the cluster.

This is common with idempotent reconcilers, e.g. a periodic `REVOKE <role> FROM <user>` for a role that is already not granted: the entity ends up identical, yet every such statement caused a ZooKeeper write plus a reread on each replica for no actual change.

Now an update that produces an identical entity is skipped entirely, so repeated no-op access management statements no longer generate ZooKeeper traffic or wake up the rest of the cluster.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid cluster-wide refresh for access updates that change nothing