### PR TITLE
Bump WasmEdge contrib to speed up startup

### DIFF
--- a/src/Interpreters/WebAssembly/WasmEdgeRuntime.cpp
+++ b/src/Interpreters/WebAssembly/WasmEdgeRuntime.cpp
@@ -425,7 +425,7 @@ std::span<uint8_t> WasmEdgeCompartment::getMemory(WasmPtr ptr, WasmSizeT size)
     auto * data = WasmEdge_MemoryInstanceGetPointer(memory_ctx, ptr, size);
     if (data == nullptr)
     {
-        uint32_t total_memory = WasmEdge_MemoryInstanceGetPageSize(memory_ctx) * WASMEDGE_PAGE_SIZE;
+        uint64_t total_memory = WasmEdge_MemoryInstanceGetPageSize(memory_ctx) * WASMEDGE_PAGE_SIZE;
         throw Exception(
             ErrorCodes::WASM_ERROR, "Cannot get memory at offset {} and size {} from wasm module with size {}", ptr, size, total_memory);
     }


### PR DESCRIPTION
Bumps the `wasmedge` contrib from `ee0b1c2` to upstream master `fba982b`.

WasmEdge's `rapidHash` previously computed a per-process randomized hash secret in a load-time global initializer (a `std::random_device` read plus a Miller-Rabin prime rejection-sampling loop), which ran on every `clickhouse` invocation — including those that never use WASM UDFs. Upstream's rapidhash v3 "Nano" rewrite replaces it with `constexpr` compile-time constants, removing the work.

### Measurement

Same ClickHouse source, only the `wasmedge` submodule changed (local `RelWithDebInfo` build, `clickhouse --version`):

| metric | before (eager) | after (bump) | Δ |
|---|---|---|---|
| instructions (deterministic) | 133.4 M | 117.9 M | −15.6 M (−11.7%) |
| cycles | 106.8 M | 92.9 M | −13% |
| wall-clock median (150 runs, interleaved) | 24.45 ms | 22.42 ms | −2.0 ms (−8.3%) |
| page-faults | 8,515 | 8,527 | ~0 |

The −15.6 M instructions is the removed Miller-Rabin loop (unchanged page-fault count confirms it is CPU work, not paging). On a release build, this initializer was the single most expensive C++ global constructor at startup (~15% of `--version` wall time); the dev number above is smaller because PIE relocations dilute it.

### Notes

No ClickHouse cmake changes are required: the source glob picks up the new Component-Model files automatically, and the new `aot`/`driver`/`wasi_nn_rpc` directories are correctly excluded (wasmedge is built without LLVM/CLI here). The WASM UDF stateless tests (`03206`, `03207`, `03208`, `03668`, `03925`) pass with the `wasmedge` engine.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduced `clickhouse` process startup overhead by updating the bundled WasmEdge library, which no longer generates a random hash secret in a global initializer at every startup.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1092`
<!-- ch-version-info:end -->