### PR TITLE
Support per-replica ports for distributed query plan workers

### DIFF
--- a/programs/server/config.xml
+++ b/programs/server/config.xml
@@ -1030,6 +1030,13 @@
                     <!-- <secure>0</secure> -->
                     <!-- Optional. Bind to specific host before connecting to use a specific network. -->
                     <!-- <bind_host>10.0.0.1</bind_host> -->
+                    <!-- Optional. Per-node ports for the multi-stage distributed query engine
+                         (make_distributed_plan): the interserver port the initiator dispatches
+                         tasks to, and the streaming-exchange listener port. When unset, the
+                         initiator falls back to its stateless_worker_client.port /
+                         distributed_query.streaming_exchange_port. -->
+                    <!-- <stateless_worker_port>9009</stateless_worker_port> -->
+                    <!-- <streaming_exchange_port>9223</streaming_exchange_port> -->
                 </replica>
             </shard>
         </default>

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -56,7 +56,8 @@ static constexpr auto DBMS_MERGE_TREE_PART_INFO_VERSION = 1;
 
 static constexpr auto DBMS_QUERY_PLAN_SERIALIZATION_VERSION = 1;
 /// Version 1 added the initiator's settings changes to the task.
-static constexpr auto DBMS_DISTRIBUTED_TASK_SERIALIZATION_VERSION = 1;
+/// Version 2 added per-stream streaming-exchange ports to exchange_stream_sources.
+static constexpr auto DBMS_DISTRIBUTED_TASK_SERIALIZATION_VERSION = 2;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET = 54441;
 

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -42,6 +42,7 @@ namespace ErrorCodes
     extern const int INVALID_SHARD_ID;
     extern const int NO_SUCH_REPLICA;
     extern const int BAD_ARGUMENTS;
+    extern const int INVALID_CONFIG_PARAMETER;
 }
 
 namespace
@@ -134,8 +135,17 @@ Cluster::Address::Address(
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Port is not specified in cluster configuration: {}.port", config_prefix);
 
     /// Optional per-node ports for the distributed-plan engine; zero means "not configured".
-    stateless_worker_port = static_cast<UInt16>(config.getInt(config_prefix + ".stateless_worker_port", 0));
-    streaming_exchange_port = static_cast<UInt16>(config.getInt(config_prefix + ".streaming_exchange_port", 0));
+    /// Range-checked before narrowing so an out-of-range value errors instead of wrapping.
+    auto read_optional_port = [&](const String & key)
+    {
+        Int64 value = config.getInt64(config_prefix + key, 0);
+        if (value < 0 || value > 65535)
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+                "{}{} must be 0 or in range 1..65535, got {}", config_prefix, key, value);
+        return static_cast<UInt16>(value);
+    };
+    stateless_worker_port = read_optional_port(".stateless_worker_port");
+    streaming_exchange_port = read_optional_port(".streaming_exchange_port");
 
     is_local = isLocal(static_cast<UInt16>(config.getInt(port_type, 0)));
 

--- a/src/Interpreters/Cluster.cpp
+++ b/src/Interpreters/Cluster.cpp
@@ -133,6 +133,10 @@ Cluster::Address::Address(
     if (!port)
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Port is not specified in cluster configuration: {}.port", config_prefix);
 
+    /// Optional per-node ports for the distributed-plan engine; zero means "not configured".
+    stateless_worker_port = static_cast<UInt16>(config.getInt(config_prefix + ".stateless_worker_port", 0));
+    streaming_exchange_port = static_cast<UInt16>(config.getInt(config_prefix + ".streaming_exchange_port", 0));
+
     is_local = isLocal(static_cast<UInt16>(config.getInt(port_type, 0)));
 
     /// By default compression is disabled if address looks like localhost.

--- a/src/Interpreters/Cluster.h
+++ b/src/Interpreters/Cluster.h
@@ -122,6 +122,11 @@ public:
         String database_shard_name;
         String database_replica_name;
         UInt16 port{0};
+        /// Optional per-node ports for the distributed-plan engine: the interserver port the
+        /// initiator dispatches tasks to, and the streaming-exchange listener port. Zero means
+        /// "not configured" (the initiator then falls back to the server-level ports).
+        UInt16 stateless_worker_port{0};
+        UInt16 streaming_exchange_port{0};
         String user;
         String password;
         String proto_send_chunked = "notchunked";

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -571,10 +571,15 @@ ExchangeLookupPtr createExchangeLookup(
             "set it, force `distributed_plan_force_exchange_kind = 'Persisted'`, or enable "
             "`distributed_plan_execute_locally` for in-process testing");
 
-    /// The gate above validates this node's own listener config; the port used to dial a producer
-    /// comes per-stream from exchange_stream_sources, so none is passed here.
+    /// A task from an older initiator (version 1) ships no per-stream ports; fall back to this
+    /// node's configured exchange port to preserve the previous single-port behavior.
+    ExchangeStreamSources sources_with_ports = exchange_stream_sources;
+    for (auto & [stream, address] : sources_with_ports.stream_hosts)
+        if (address.port == 0)
+            address.port = static_cast<UInt16>(streaming_exchange_port);
+
     auto streaming_exchanges = createStreamingExchangeLookup(
-        query_id, ExchangeConnections::instance(), exchange_stream_sources);
+        query_id, ExchangeConnections::instance(), sources_with_ports);
     return std::make_shared<AllKindsExchangeLookup>(exchanges_, persisted_exchanges, streaming_exchanges);
 #else
     UNUSED(exchange_stream_sources);

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -935,6 +935,10 @@ static WorkerAddress resolveWorkerAddress(
     address.host = host;
 
     auto server_level_exchange_port = context->getConfigRef().getUInt("distributed_query.streaming_exchange_port", 0);
+    /// Reject out-of-range values instead of silently narrowing them to a different or unset port.
+    if (server_level_exchange_port > 65535)
+        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+            "`distributed_query.streaming_exchange_port` must be in range 0..65535, got {}", server_level_exchange_port);
     address.streaming_exchange_port = cluster_streaming_exchange_port != 0
         ? cluster_streaming_exchange_port
         : static_cast<UInt16>(server_level_exchange_port);

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -571,8 +571,10 @@ ExchangeLookupPtr createExchangeLookup(
             "set it, force `distributed_plan_force_exchange_kind = 'Persisted'`, or enable "
             "`distributed_plan_execute_locally` for in-process testing");
 
+    /// The gate above validates this node's own listener config; the port used to dial a producer
+    /// comes per-stream from exchange_stream_sources, so none is passed here.
     auto streaming_exchanges = createStreamingExchangeLookup(
-        query_id, ExchangeConnections::instance(), exchange_stream_sources, static_cast<UInt16>(streaming_exchange_port));
+        query_id, ExchangeConnections::instance(), exchange_stream_sources);
     return std::make_shared<AllKindsExchangeLookup>(exchanges_, persisted_exchanges, streaming_exchanges);
 #else
     UNUSED(exchange_stream_sources);
@@ -919,18 +921,45 @@ private:
 };
 
 
+/// Resolve a worker's endpoint on the initiator from the cluster config (with server-level
+/// fallbacks). The single place a future port source would plug in.
+static WorkerAddress resolveWorkerAddress(
+    const String & host, UInt16 cluster_stateless_worker_port, UInt16 cluster_streaming_exchange_port, ContextPtr context)
+{
+    WorkerAddress address;
+    address.host = host;
+
+    auto server_level_exchange_port = context->getConfigRef().getUInt("distributed_query.streaming_exchange_port", 0);
+    address.streaming_exchange_port = cluster_streaming_exchange_port != 0
+        ? cluster_streaming_exchange_port
+        : static_cast<UInt16>(server_level_exchange_port);
+
+    /// Fall back to the global client port, then the interserver port (read lazily, since
+    /// getInterserverIOAddress throws when unconfigured, so an explicit per-node port avoids it).
+    UInt64 dispatch_port = cluster_stateless_worker_port;
+    if (dispatch_port == 0)
+        dispatch_port = context->getConfigRef().getUInt("stateless_worker_client.port", 0);
+    if (dispatch_port == 0)
+        dispatch_port = context->getInterserverIOAddress().second;
+    if (dispatch_port == 0 || dispatch_port > 65535)
+        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+            "Resolved stateless worker port for host '{}' must be in range 1..65535, got {}", host, dispatch_port);
+    address.stateless_worker_port = static_cast<UInt16>(dispatch_port);
+
+    return address;
+}
+
 TaskToHostMap::TaskToHostMap(const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_)
 {
-    fillHostnames(context_);
+    fillWorkerAddresses(context_);
     assignHostsForTasks(distributed_query_plan_);
 }
 
-void TaskToHostMap::fillHostnames(ContextPtr context)
+void TaskToHostMap::fillWorkerAddresses(ContextPtr context)
 {
     if (!context->getConfigRef().getBool("stateless_worker_client.enabled", false))
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Stateless worker client is not enabled in configuration");
 
-    String host;
     String cluster_name = context->getConfigRef().getString("stateless_worker_client.cluster", "");
     if (!cluster_name.empty())
     {
@@ -946,16 +975,17 @@ void TaskToHostMap::fillHostnames(ContextPtr context)
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                 "Stateless worker cluster '{}' must have a single shard, got {}", cluster_name, shard_addresses.size());
         for (const auto & replica : shard_addresses[0])
-            hostnames.push_back(replica.host_name);
+            worker_addresses.push_back(
+                resolveWorkerAddress(replica.host_name, replica.stateless_worker_port, replica.streaming_exchange_port, context));
     }
     else
     {
-        host = context->getConfigRef().getString("stateless_worker_client.host");
+        String host = context->getConfigRef().getString("stateless_worker_client.host");
         if (!host.empty())
-            hostnames.push_back(host);
+            worker_addresses.push_back(resolveWorkerAddress(host, 0, 0, context));
     }
 
-    if (hostnames.empty())
+    if (worker_addresses.empty())
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "No hosts specified for stateless worker client");
 }
 
@@ -966,11 +996,11 @@ void TaskToHostMap::assignHostsForTasks(const DistributedQueryPlan & distributed
     {
         for (const auto & task : stage.tasks)
         {
-            const auto & assigned_host = hostnames[current_host];
-            current_host = (current_host + 1) % hostnames.size();
-            task_hosts[task.task_id] = assigned_host;
+            const auto & assigned_worker = worker_addresses[current_host];
+            current_host = (current_host + 1) % worker_addresses.size();
+            task_hosts[task.task_id] = assigned_worker;
             for (const auto & output_stream : task.output_exchange_streams)
-                exchange_stream_source_hosts[output_stream.toString()] = assigned_host;
+                exchange_stream_source_hosts[output_stream.toString()] = {assigned_worker.host, assigned_worker.streaming_exchange_port};
         }
     }
 }
@@ -991,7 +1021,10 @@ public:
         , running_tasks(8, context, is_cancelled, logger)
     {
         QueryStatusPtr query_status = context->getProcessListElement();
-        LOG_DEBUG(logger, "Hosts for running distributed query: [{}]", fmt::join(task_to_host_map->getHostnames(), ", "));
+        Strings worker_hosts;
+        for (const auto & worker : task_to_host_map->getWorkerAddresses())
+            worker_hosts.push_back(worker.host);
+        LOG_DEBUG(logger, "Hosts for running distributed query: [{}]", fmt::join(worker_hosts, ", "));
     }
 
     void cleanup() override
@@ -1413,21 +1446,16 @@ protected:
 
     RunningTaskInfo buildTaskInfo(const DistributedQueryTaskDescription & task_description) const
     {
-        const String host = task_to_host_map->getTaskHosts().at(task_description.task.task_id);
+        const auto & worker = task_to_host_map->getTaskHosts().at(task_description.task.task_id);
         String stateless_worker_endpoint_uri;
         {
-            auto default_port = context->getInterserverIOAddress().second;
-            auto port = context->getConfigRef().getUInt("stateless_worker_client.port", default_port);
-            if (port == 0 || port > 65535)
-                throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
-                    "`stateless_worker_client.port` must be in range 1..65535, got {}", port);
             String default_endpoint = context->getConfigRef().getString("stateless_worker_server.endpoint", "localhost");
             auto endpoint = context->getConfigRef().getString("stateless_worker_client.endpoint", "stateless_worker/" + default_endpoint);
             Poco::URI stateless_worker_uri;
             /// Match the interserver scheme so a server with interserver_https_port is not sent plaintext.
             stateless_worker_uri.setScheme(context->getInterserverScheme());
-            stateless_worker_uri.setHost(host);
-            stateless_worker_uri.setPort(static_cast<UInt16>(port));
+            stateless_worker_uri.setHost(worker.host);
+            stateless_worker_uri.setPort(worker.stateless_worker_port);
             stateless_worker_uri.addQueryParameter("endpoint", endpoint);
             stateless_worker_endpoint_uri = stateless_worker_uri.toString();
         }

--- a/src/QueryPipeline/DistributedPlanExecutor.cpp
+++ b/src/QueryPipeline/DistributedPlanExecutor.cpp
@@ -958,6 +958,14 @@ static WorkerAddress resolveWorkerAddress(
     return address;
 }
 
+UInt64 chooseTaskSerializationVersion(const ExchangeStreamSources & exchange_stream_sources, UInt64 server_exchange_port)
+{
+    for (const auto & stream : exchange_stream_sources.stream_hosts)
+        if (stream.second.port != server_exchange_port)
+            return 2;
+    return 1;
+}
+
 TaskToHostMap::TaskToHostMap(const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_)
 {
     fillWorkerAddresses(context_);
@@ -1482,6 +1490,7 @@ protected:
         task_description.settings_changes = context->getSettingsRef().changes();
 
         const String unique_temp_file_path = toString(unique_query_id);
+        const auto server_exchange_port = context->getConfigRef().getUInt("distributed_query.streaming_exchange_port", 0);
 
         for (const auto & task : stage.tasks)
         {
@@ -1496,6 +1505,7 @@ protected:
                 String input_stream_name = input_stream.toString();
                 task_description.exchange_stream_sources.stream_hosts[input_stream_name] = task_to_host_map->getExchangeStreamSourceHosts().at(input_stream_name);
             }
+            task_description.serialization_version = chooseTaskSerializationVersion(task_description.exchange_stream_sources, server_exchange_port);
 
             /// Send the task before registering it: status polling does not tolerate
             /// UnknownTaskId, so a tracker poll racing the start would abort the query.

--- a/src/QueryPipeline/DistributedPlanExecutor.h
+++ b/src/QueryPipeline/DistributedPlanExecutor.h
@@ -10,6 +10,7 @@
 #include <Common/SettingsChanges.h>
 #include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/UnorderedSetWithMemoryTracking.h>
+#include <Common/VectorWithMemoryTracking.h>
 
 namespace DB
 {
@@ -36,7 +37,7 @@ class TaskToHostMap : public boost::noncopyable
 public:
     TaskToHostMap(const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_);
 
-    const std::vector<WorkerAddress> & getWorkerAddresses() const { return worker_addresses; }
+    const VectorWithMemoryTracking<WorkerAddress> & getWorkerAddresses() const { return worker_addresses; }
     const UnorderedMapWithMemoryTracking<String, WorkerAddress> & getTaskHosts() const { return task_hosts; }
     const UnorderedMapWithMemoryTracking<String, StreamSourceAddress> & getExchangeStreamSourceHosts() const { return exchange_stream_source_hosts; }
 
@@ -44,7 +45,7 @@ private:
     void fillWorkerAddresses(ContextPtr context);
     void assignHostsForTasks(const DistributedQueryPlan & distributed_query_plan);
 
-    std::vector<WorkerAddress> worker_addresses;
+    VectorWithMemoryTracking<WorkerAddress> worker_addresses;
     UnorderedMapWithMemoryTracking<String, WorkerAddress> task_hosts;
     UnorderedMapWithMemoryTracking<String, StreamSourceAddress> exchange_stream_source_hosts;
 };

--- a/src/QueryPipeline/DistributedPlanExecutor.h
+++ b/src/QueryPipeline/DistributedPlanExecutor.h
@@ -11,6 +11,7 @@
 #include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/UnorderedSetWithMemoryTracking.h>
 #include <Common/VectorWithMemoryTracking.h>
+#include <Core/ProtocolDefines.h>
 
 namespace DB
 {
@@ -106,6 +107,10 @@ struct ExchangeStreamSources
     UnorderedMapWithMemoryTracking<String, StreamSourceAddress> stream_hosts;
 };
 
+/// Minimal serialization version: v1 if every producer uses the server-level exchange port (a v1 worker
+/// derives it locally), else v2.
+UInt64 chooseTaskSerializationVersion(const ExchangeStreamSources & exchange_stream_sources, UInt64 server_exchange_port);
+
 /// Contains all info to send a task to remote worker
 struct DistributedQueryTaskDescription
 {
@@ -117,6 +122,8 @@ struct DistributedQueryTaskDescription
     /// The initiator's changed settings, applied on the worker so query limits and execution-affecting
     /// settings (e.g. max_memory_usage) are honored remotely.
     SettingsChanges settings_changes;
+    /// Wire-format version to emit, lowered to v1 for legacy-port-only tasks (rolling-upgrade safe).
+    UInt64 serialization_version = DBMS_DISTRIBUTED_TASK_SERIALIZATION_VERSION;
 };
 
 /// Executes a task locally. `distributed_query_id` is the node-independent identifier of the whole

--- a/src/QueryPipeline/DistributedPlanExecutor.h
+++ b/src/QueryPipeline/DistributedPlanExecutor.h
@@ -14,22 +14,39 @@
 namespace DB
 {
 
+/// Network endpoint of a worker, resolved on the initiator from the cluster config (and
+/// server-level defaults). Both ports may differ per node so several workers can share a host.
+struct WorkerAddress
+{
+    String host;
+    UInt16 stateless_worker_port = 0;    /// interserver HTTP port the initiator dispatches tasks to
+    UInt16 streaming_exchange_port = 0;  /// port this node accepts streaming-exchange peer connections on
+};
+
+/// Producer endpoint of an exchange stream, shipped to consumers so they dial the producer's
+/// actual streaming-exchange port.
+struct StreamSourceAddress
+{
+    String host;
+    UInt16 port = 0;
+};
+
 class TaskToHostMap : public boost::noncopyable
 {
 public:
     TaskToHostMap(const DistributedQueryPlan & distributed_query_plan_, ContextPtr context_);
 
-    const Strings & getHostnames() const { return hostnames; }
-    const UnorderedMapWithMemoryTracking<String, String> & getTaskHosts() const { return task_hosts; }
-    const UnorderedMapWithMemoryTracking<String, String> & getExchangeStreamSourceHosts() const { return exchange_stream_source_hosts; }
+    const std::vector<WorkerAddress> & getWorkerAddresses() const { return worker_addresses; }
+    const UnorderedMapWithMemoryTracking<String, WorkerAddress> & getTaskHosts() const { return task_hosts; }
+    const UnorderedMapWithMemoryTracking<String, StreamSourceAddress> & getExchangeStreamSourceHosts() const { return exchange_stream_source_hosts; }
 
 private:
-    void fillHostnames(ContextPtr context);
+    void fillWorkerAddresses(ContextPtr context);
     void assignHostsForTasks(const DistributedQueryPlan & distributed_query_plan);
 
-    Strings hostnames;
-    UnorderedMapWithMemoryTracking<String, String> task_hosts;
-    UnorderedMapWithMemoryTracking<String, String> exchange_stream_source_hosts;
+    std::vector<WorkerAddress> worker_addresses;
+    UnorderedMapWithMemoryTracking<String, WorkerAddress> task_hosts;
+    UnorderedMapWithMemoryTracking<String, StreamSourceAddress> exchange_stream_source_hosts;
 };
 
 using TaskToHostMapPtr = std::shared_ptr<const TaskToHostMap>;
@@ -84,8 +101,8 @@ void cancelDistributedQueryInMemoryExchanges(const UUID & unique_query_id);
 /// Contains info about hosts assigned to exchange buckets
 struct ExchangeStreamSources
 {
-    /// Exchange stream id -> source host
-    UnorderedMapWithMemoryTracking<String, String> stream_hosts;
+    /// Exchange stream id -> producer endpoint (host + that producer's streaming-exchange port)
+    UnorderedMapWithMemoryTracking<String, StreamSourceAddress> stream_hosts;
 };
 
 /// Contains all info to send a task to remote worker

--- a/src/Server/DistributedQuery/StreamingExchangeLookup.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeLookup.cpp
@@ -23,12 +23,10 @@ public:
     explicit StreamingExchangeLookup(
         const String & query_id_,
         ExchangeConnectionsPtr connections_,
-        const ExchangeStreamSources & exchange_stream_sources_,
-        UInt16 streaming_exchange_port_)
+        const ExchangeStreamSources & exchange_stream_sources_)
         : query_id(query_id_)
         , connections(connections_)
         , exchange_stream_sources(exchange_stream_sources_)
-        , streaming_exchange_port(streaming_exchange_port_)
     {
     }
 
@@ -45,23 +43,24 @@ public:
         auto it = exchange_stream_sources.stream_hosts.find(stream_name);
         if (it == exchange_stream_sources.stream_hosts.end())
             throw Exception(ErrorCodes::LOGICAL_ERROR, "No host found for exchange stream {}", stream_name);
-        return std::make_shared<StreamingExchangeSource>(output_header, query_id, stream_name, it->second, streaming_exchange_port);
+        if (it->second.port == 0)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "No streaming exchange port for exchange stream {} on host {}", stream_name, it->second.host);
+        return std::make_shared<StreamingExchangeSource>(output_header, query_id, stream_name, it->second.host, it->second.port);
     }
 
 private:
     const String query_id;
     const ExchangeConnectionsPtr connections;
     const ExchangeStreamSources exchange_stream_sources;
-    const UInt16 streaming_exchange_port;
 };
 
 ExchangeLookupPtr createStreamingExchangeLookup(
     const String & query_id,
     ExchangeConnectionsPtr connections,
-    const ExchangeStreamSources & exchange_stream_sources,
-    UInt16 streaming_exchange_port)
+    const ExchangeStreamSources & exchange_stream_sources)
 {
-    return std::make_shared<StreamingExchangeLookup>(query_id, connections, exchange_stream_sources, streaming_exchange_port);
+    return std::make_shared<StreamingExchangeLookup>(query_id, connections, exchange_stream_sources);
 }
 
 }

--- a/src/Server/DistributedQuery/StreamingExchangeLookup.h
+++ b/src/Server/DistributedQuery/StreamingExchangeLookup.h
@@ -12,8 +12,7 @@ namespace DB
 ExchangeLookupPtr createStreamingExchangeLookup(
     const String & query_id,
     ExchangeConnectionsPtr connections,
-    const ExchangeStreamSources & exchange_stream_sources,
-    UInt16 streaming_exchange_port);
+    const ExchangeStreamSources & exchange_stream_sources);
 
 }
 

--- a/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_distributed_query.cpp
@@ -571,3 +571,19 @@ TEST_F(DistributedQueryTest, ShuffleHashJoin)
     executeTestWithExchangeKind("Persisted");
     executeTestWithExchangeKind("Streaming");
 }
+
+/// v1 for legacy-port-only sources (rolling-upgrade safe); v2 once a per-replica port appears.
+TEST(DistributedTaskSerializationVersion, LowersToV1ForLegacyPorts)
+{
+    const UInt64 server_exchange_port = 9000;
+
+    ExchangeStreamSources sources;
+    EXPECT_EQ(chooseTaskSerializationVersion(sources, server_exchange_port), UInt64(1));
+
+    sources.stream_hosts["s1"] = {"host1", 9000};
+    sources.stream_hosts["s2"] = {"host2", 9000};
+    EXPECT_EQ(chooseTaskSerializationVersion(sources, server_exchange_port), UInt64(1));
+
+    sources.stream_hosts["s3"] = {"host3", 9224};
+    EXPECT_EQ(chooseTaskSerializationVersion(sources, server_exchange_port), UInt64(2));
+}

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
@@ -39,7 +39,7 @@ std::string StatelessWorkerEndpoint::getId(const std::string & path) const
 void serializeTask(const DistributedQueryTaskDescription & task_description, WriteBuffer & out);
 void serializeTask(const DistributedQueryTaskDescription & task_description, WriteBuffer & out)
 {
-    writeVarUInt(DBMS_DISTRIBUTED_TASK_SERIALIZATION_VERSION, out);
+    writeVarUInt(task_description.serialization_version, out);
 
     writeStringBinary(task_description.initial_query_id, out);
 
@@ -86,7 +86,8 @@ void serializeTask(const DistributedQueryTaskDescription & task_description, Wri
     {
         writeStringBinary(stream, out);
         writeStringBinary(address.host, out);
-        writeVarUInt(address.port, out);
+        if (task_description.serialization_version >= 2)
+            writeVarUInt(address.port, out);
     }
 
     writeVarUInt(task_description.settings_changes.size(), out);

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
@@ -82,10 +82,11 @@ void serializeTask(const DistributedQueryTaskDescription & task_description, Wri
     }
 
     writeVarUInt(task_description.exchange_stream_sources.stream_hosts.size(), out);
-    for (const auto & [stream, host] : task_description.exchange_stream_sources.stream_hosts)
+    for (const auto & [stream, address] : task_description.exchange_stream_sources.stream_hosts)
     {
         writeStringBinary(stream, out);
-        writeStringBinary(host, out);
+        writeStringBinary(address.host, out);
+        writeVarUInt(address.port, out);
     }
 
     writeVarUInt(task_description.settings_changes.size(), out);
@@ -166,9 +167,15 @@ void deserializeTask(DistributedQueryTaskDescription & task_description, ReadBuf
     {
         String stream;
         readStringBinary(stream, in);
-        String host;
-        readStringBinary(host, in);
-        task_description.exchange_stream_sources.stream_hosts[stream] = host;
+        StreamSourceAddress address;
+        readStringBinary(address.host, in);
+        if (version >= 2)
+        {
+            UInt64 port = 0;
+            readVarUInt(port, in);
+            address.port = static_cast<UInt16>(port);
+        }
+        task_description.exchange_stream_sources.stream_hosts[stream] = address;
     }
 
     if (version >= 1)

--- a/tests/integration/test_distributed_plan_worker_exchange_port/configs/cluster.xml
+++ b/tests/integration/test_distributed_plan_worker_exchange_port/configs/cluster.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <stateless_worker_server>
+        <enabled>1</enabled>
+        <endpoint>localhost</endpoint>
+    </stateless_worker_server>
+
+    <stateless_worker_client>
+        <enabled>1</enabled>
+        <cluster>default</cluster>
+    </stateless_worker_client>
+
+    <!-- Single-shard worker cluster (replicas hold the same data). Each replica declares its own
+         interserver (stateless_worker_port) and streaming exchange port, so the initiator
+         dispatches tasks to, and dials, each node on its own ports. -->
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                    <stateless_worker_port>9009</stateless_worker_port>
+                    <streaming_exchange_port>9223</streaming_exchange_port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                    <stateless_worker_port>9010</stateless_worker_port>
+                    <streaming_exchange_port>9224</streaming_exchange_port>
+                </replica>
+                <replica>
+                    <host>node3</host>
+                    <port>9000</port>
+                    <stateless_worker_port>9011</stateless_worker_port>
+                    <streaming_exchange_port>9225</streaming_exchange_port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_distributed_plan_worker_exchange_port/configs/node1.xml
+++ b/tests/integration/test_distributed_plan_worker_exchange_port/configs/node1.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <!-- This node's task-dispatch (interserver) port; matches its stateless_worker_port in the cluster. -->
+    <interserver_http_port>9009</interserver_http_port>
+    <distributed_query>
+        <!-- This node's own streaming-exchange listener; matches its streaming_exchange_port in the cluster. -->
+        <streaming_exchange_port>9223</streaming_exchange_port>
+        <streaming_exchange_listen_host>0.0.0.0</streaming_exchange_listen_host>
+        <temporary_files_storage>
+            <type>local</type>
+            <path>./local_object_storage/</path>
+            <endpoint_subpath>tmp_sub_path/</endpoint_subpath>
+        </temporary_files_storage>
+    </distributed_query>
+</clickhouse>

--- a/tests/integration/test_distributed_plan_worker_exchange_port/configs/node2.xml
+++ b/tests/integration/test_distributed_plan_worker_exchange_port/configs/node2.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <!-- This node's task-dispatch (interserver) port; matches its stateless_worker_port in the cluster. -->
+    <interserver_http_port>9010</interserver_http_port>
+    <distributed_query>
+        <!-- This node's own streaming-exchange listener; matches its streaming_exchange_port in the cluster. -->
+        <streaming_exchange_port>9224</streaming_exchange_port>
+        <streaming_exchange_listen_host>0.0.0.0</streaming_exchange_listen_host>
+        <temporary_files_storage>
+            <type>local</type>
+            <path>./local_object_storage/</path>
+            <endpoint_subpath>tmp_sub_path/</endpoint_subpath>
+        </temporary_files_storage>
+    </distributed_query>
+</clickhouse>

--- a/tests/integration/test_distributed_plan_worker_exchange_port/configs/node3.xml
+++ b/tests/integration/test_distributed_plan_worker_exchange_port/configs/node3.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <!-- This node's task-dispatch (interserver) port; matches its stateless_worker_port in the cluster. -->
+    <interserver_http_port>9011</interserver_http_port>
+    <distributed_query>
+        <!-- This node's own streaming-exchange listener; matches its streaming_exchange_port in the cluster. -->
+        <streaming_exchange_port>9225</streaming_exchange_port>
+        <streaming_exchange_listen_host>0.0.0.0</streaming_exchange_listen_host>
+        <temporary_files_storage>
+            <type>local</type>
+            <path>./local_object_storage/</path>
+            <endpoint_subpath>tmp_sub_path/</endpoint_subpath>
+        </temporary_files_storage>
+    </distributed_query>
+</clickhouse>

--- a/tests/integration/test_distributed_plan_worker_exchange_port/test.py
+++ b/tests/integration/test_distributed_plan_worker_exchange_port/test.py
@@ -1,0 +1,172 @@
+"""
+Per-node ports for the distributed-plan engine (`make_distributed_plan`).
+
+The 3 worker nodes use different task-dispatch (interserver) and streaming-exchange
+ports, declared per replica (`stateless_worker_port` / `streaming_exchange_port`):
+
+    node1  interserver 9009  exchange 9223
+    node2  interserver 9010  exchange 9224
+    node3  interserver 9011  exchange 9225
+
+Streaming queries dispatch each task to its node's interserver port and dial each
+producer on its own exchange port, so they succeed only when the per-node ports are
+honored; the pre-fix single-port assumption cannot reach node2/node3.
+"""
+
+import pytest
+
+from helpers.client import QueryRuntimeException
+from helpers.cluster import ClickHouseCluster
+
+CLUSTER_CONFIG_PATH = "/etc/clickhouse-server/config.d/cluster.xml"
+
+pytestmark = pytest.mark.timeout(300)
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/cluster.xml", "configs/node1.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 1},
+)
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/cluster.xml", "configs/node2.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 2},
+)
+node3 = cluster.add_instance(
+    "node3",
+    main_configs=["configs/cluster.xml", "configs/node3.xml"],
+    with_zookeeper=True,
+    stay_alive=True,
+    macros={"shard": 1, "replica": 3},
+)
+
+NODES = [node1, node2, node3]
+INITIATOR = node1
+
+# Streaming exchange exercises both per-node ports: task dispatch (interserver)
+# and worker-to-worker exchange connections. 3 buckets match the 3-node cluster.
+STREAMING_SETTINGS = ", ".join(
+    [
+        "make_distributed_plan = 1",
+        "enable_parallel_replicas = 0",
+        "distributed_plan_default_shuffle_join_bucket_count = 3",
+        "distributed_plan_default_reader_bucket_count = 3",
+        "distributed_plan_force_exchange_kind = 'Streaming'",
+        "query_plan_use_new_logical_join_step = 1",
+        "enable_join_runtime_filters = 0",
+    ]
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        _create_table_and_load_data()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _create_table_and_load_data():
+    """Create a ReplicatedMergeTree table on every node so all replicas hold an
+    identical set of parts (required by the bucketed distributed read), and load
+    several parts."""
+    for node in NODES:
+        node.query(
+            """
+            CREATE TABLE big (id UInt64, group_key UInt32, payload String)
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/big', '{replica}')
+            ORDER BY id
+            """
+        )
+        node.query("SYSTEM STOP MERGES big")
+
+    # Load on a single replica; replication propagates to the others. Multiple
+    # inserts produce multiple parts so the parallel read splits real work per bucket.
+    for batch in range(4):
+        offset = batch * 25_000
+        INITIATOR.query(
+            f"""
+            INSERT INTO big
+            SELECT number + {offset} AS id,
+                   (number + {offset}) % 100 AS group_key,
+                   concat('p_', toString(number + {offset})) AS payload
+            FROM numbers(25000)
+            """
+        )
+
+    for node in NODES:
+        node.query("SYSTEM SYNC REPLICA big")
+        assert int(node.query("SELECT count() FROM big").strip()) == 100_000
+
+
+def _assert_distributed_matches_baseline(query: str, extra_settings: str = ""):
+    settings = STREAMING_SETTINGS
+    if extra_settings:
+        settings += ", " + extra_settings
+    distributed = INITIATOR.query(f"{query} SETTINGS {settings}")
+    baseline = INITIATOR.query(f"{query} SETTINGS make_distributed_plan = 0")
+    assert distributed == baseline
+
+
+def test_parallel_read(started_cluster):
+    """Bucketed scan across the 3 nodes, gathered to the initiator; each task is
+    dispatched to its node's own interserver port."""
+    _assert_distributed_matches_baseline(
+        "SELECT count(), sum(id), sum(group_key) FROM big"
+    )
+
+
+def test_shuffle_aggregation(started_cluster):
+    """GROUP BY shuffled by hash across the 3 nodes: every node both produces and
+    consumes streams, so every node is dialed on its own exchange port."""
+    _assert_distributed_matches_baseline(
+        "SELECT group_key, count(), sum(id) FROM big GROUP BY group_key ORDER BY group_key",
+        extra_settings="distributed_plan_force_shuffle_aggregation = 1",
+    )
+
+
+def test_shuffle_hash_join(started_cluster):
+    """Self-join on a non-key expression forces a shuffle of both inputs by the
+    join key, fanning streams across all per-node exchange ports."""
+    _assert_distributed_matches_baseline(
+        """
+        SELECT count()
+        FROM big AS a
+        INNER JOIN big AS b ON a.id = b.id + 1
+        WHERE a.group_key < 5
+        """
+    )
+
+
+def test_wrong_per_node_exchange_port_fails(started_cluster):
+    """Break node2's declared exchange port in the initiator's cluster view: consumers
+    are then told to dial a dead port and the streaming query fails. Confirms the
+    per-node exchange port is actually consulted (the pre-fix single-port assumption
+    ignores it). Runs last and restores the config in `finally`."""
+    INITIATOR.replace_in_config(
+        CLUSTER_CONFIG_PATH,
+        "<streaming_exchange_port>9224</streaming_exchange_port>",
+        "<streaming_exchange_port>9999</streaming_exchange_port>",
+    )
+    INITIATOR.query("SYSTEM RELOAD CONFIG")
+    try:
+        with pytest.raises(QueryRuntimeException):
+            INITIATOR.query(
+                "SELECT group_key, count(), sum(id) FROM big GROUP BY group_key ORDER BY group_key"
+                f" SETTINGS {STREAMING_SETTINGS}, distributed_plan_force_shuffle_aggregation = 1"
+            )
+    finally:
+        INITIATOR.replace_in_config(
+            CLUSTER_CONFIG_PATH,
+            "<streaming_exchange_port>9999</streaming_exchange_port>",
+            "<streaming_exchange_port>9224</streaming_exchange_port>",
+        )
+        INITIATOR.query("SYSTEM RELOAD CONFIG")


### PR DESCRIPTION
The experimental distributed query plan engine (`make_distributed_plan`) assumed
every worker uses the same task-dispatch (interserver) and streaming-exchange ports,
which prevents running more than one worker on a host.

Each `<replica>` in `<remote_servers>` now takes two optional ports,
`stateless_worker_port` and `streaming_exchange_port`; the initiator dispatches each
task to, and dials each producer on, that worker's own ports. When unset, the
server-level `stateless_worker_client.port` / `distributed_query.streaming_exchange_port`
are used, so existing setups are unaffected. The distributed-task serialization
version is bumped to carry the per-stream exchange port.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry:
The experimental distributed query plan engine (`make_distributed_plan`) can now use a different task-dispatch and streaming-exchange port per worker, configured per replica in `<remote_servers>` with `stateless_worker_port` and `streaming_exchange_port`. When unset, the previous server-level ports (`stateless_worker_client.port` and `distributed_query.streaming_exchange_port`) are used. This makes it possible to run several workers on one host.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1046`
<!-- ch-version-info:end -->