### PR TITLE
Fix flaky test_checking_s3_blobs_paranoid

### DIFF
--- a/tests/integration/helpers/s3_mocks/broken_s3.py
+++ b/tests/integration/helpers/s3_mocks/broken_s3.py
@@ -23,17 +23,22 @@ class MockControl:
         self._container = container
         self._port = port
 
-    def reset(self):
-        response = self._cluster.exec_in_container(
-            self._cluster.get_container_id(self._container),
-            [
-                "curl",
-                "-s",
-                f"http://localhost:{self._port}/mock_settings/reset",
-            ],
-            nothrow=True,
-        )
+    def _apply(self, url):
+        # The mock is briefly unreachable when these tests flood it, so retry until it answers.
+        response = ""
+        for _ in range(20):
+            response = self._cluster.exec_in_container(
+                self._cluster.get_container_id(self._container),
+                ["curl", "-s", "--max-time", "10", url],
+                nothrow=True,
+            )
+            if response == "OK":
+                return
+            time.sleep(0.5)
         assert response == "OK", response
+
+    def reset(self):
+        self._apply(f"http://localhost:{self._port}/mock_settings/reset")
 
     def setup_action(self, when, count=None, after=None, action=None, action_args=None):
         url = f"http://localhost:{self._port}/mock_settings/{when}?nothing=1"
@@ -51,16 +56,7 @@ class MockControl:
             for x in action_args:
                 url += f"&action_args={x}"
 
-        response = self._cluster.exec_in_container(
-            self._cluster.get_container_id(self._container),
-            [
-                "curl",
-                "-s",
-                url,
-            ],
-            nothrow=True,
-        )
-        assert response == "OK", response
+        self._apply(url)
 
     def setup_at_object_upload(self, **kwargs):
         self.setup_action("at_object_upload", **kwargs)
@@ -75,28 +71,14 @@ class MockControl:
         self.setup_action("at_create_multi_part_upload", **kwargs)
 
     def setup_fake_puts(self, part_length):
-        response = self._cluster.exec_in_container(
-            self._cluster.get_container_id(self._container),
-            [
-                "curl",
-                "-s",
-                f"http://localhost:{self._port}/mock_settings/fake_puts?when_length_bigger={part_length}",
-            ],
-            nothrow=True,
+        self._apply(
+            f"http://localhost:{self._port}/mock_settings/fake_puts?when_length_bigger={part_length}"
         )
-        assert response == "OK", response
 
     def setup_fake_multpartuploads(self):
-        response = self._cluster.exec_in_container(
-            self._cluster.get_container_id(self._container),
-            [
-                "curl",
-                "-s",
-                f"http://localhost:{self._port}/mock_settings/setup_fake_multpartuploads?",
-            ],
-            nothrow=True,
+        self._apply(
+            f"http://localhost:{self._port}/mock_settings/setup_fake_multpartuploads?"
         )
-        assert response == "OK", response
 
     def setup_slow_answers(
         self, minimal_length=0, timeout=None, probability=None, count=None
@@ -116,12 +98,7 @@ class MockControl:
         if count is not None:
             url += f"&count={count}"
 
-        response = self._cluster.exec_in_container(
-            self._cluster.get_container_id(self._container),
-            ["curl", "-s", url],
-            nothrow=True,
-        )
-        assert response == "OK", response
+        self._apply(url)
 
 
 class Throttler:

--- a/tests/integration/helpers/s3_mocks/broken_s3.py
+++ b/tests/integration/helpers/s3_mocks/broken_s3.py
@@ -24,12 +24,15 @@ class MockControl:
         self._port = port
 
     def _apply(self, url):
-        # The mock is briefly unreachable when these tests flood it, so retry until it answers.
+        # Retry while the flooded mock is briefly unreachable. Each attempt is short
+        # and the total wait is capped, so a wedged mock that accepts the connection
+        # but never replies fails within the window instead of stalling for minutes.
         response = ""
-        for _ in range(20):
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
             response = self._cluster.exec_in_container(
                 self._cluster.get_container_id(self._container),
-                ["curl", "-s", "--max-time", "10", url],
+                ["curl", "-s", "--connect-timeout", "1", "--max-time", "1", url],
                 nothrow=True,
             )
             if response == "OK":


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/68921
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/68921

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky `test_checking_s3_blobs_paranoid` by retrying the `broken_s3` mock control channel.

### Description

These tests deliberately flood the `broken_s3` Python mock with thousands of retried and slow S3 requests. On heavily instrumented CI builds (coverage, MSan, TSan) the mock briefly stops accepting new connections while it drains that backlog. `MockControl` issued each control request (`reset` / `setup_*`) as a single `curl` with no retry and asserted the body equals `"OK"`, so one transient empty response made the function-scoped `broken_s3` fixture error out, cascading into ERROR for every remaining test in the file (whole-file failure).

This routes every `MockControl` request through a small retry helper that polls the mock for up to ~10s before failing. A momentary backlog stall no longer aborts the suite; a genuinely dead mock still fails the assert (no infinite wait, test intent preserved).

Found via CI on PR #68921, `Integration tests (amd_llvm_coverage, 3/5)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=68921&sha=3eeec3bd885760eb005d87314ec5d3b31cafcbcc&name_0=PR&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%203%2F5%29

The mock's `broken_s3.err.log` stops logging mid-flood right after `test_when_error_is_retried[connection_refused]` (which sets `count=1000`), and the next test errors at `MockControl.reset()` -> `assert response == "OK"`. The test never fails on master and only on the heaviest builds, consistent with a load/timing stall rather than a product regression.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.132`
<!-- ch-version-info:end -->