### PR TITLE
Fix fuzzer status.tsv write aborting on "server_died: unbound variable"

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -284,6 +284,11 @@ function fuzz
     # the process is still present while the server is terminating and not
     # accepting the connections anymore.
 
+    # Default: the loop leaves this unset if it exhausts all retries via the
+    # "alive but busy" branches (TOO_MANY_SIMULTANEOUS_QUERIES /
+    # MEMORY_LIMIT_EXCEEDED); a dead server sets server_died=1 and breaks.
+    server_died=0
+
     for _ in {1..100}
     do
         if clickhouse-client --receive_timeout=5 --query "SELECT 1" 2> err

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -300,8 +300,11 @@ function fuzz
             # SELECT * FROM remote('127.0.0.{1..255}', system, one)
             if grep -F 'TOO_MANY_SIMULTANEOUS_QUERIES' err
             then
-                # Give it some time to cool down
-                clickhouse-client --query "SHOW PROCESSLIST"
+                # Give it some time to cool down. The SHOW PROCESSLIST is only a
+                # diagnostic and runs under `set -e`; if the same overload rejects
+                # it, do not abort the script (that would skip the status.tsv
+                # write below and surface as a missing-status job ERROR).
+                clickhouse-client --query "SHOW PROCESSLIST" ||:
                 sleep 1
             elif grep -F 'MEMORY_LIMIT_EXCEEDED' err
             then


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (CI fix).


### Description

`ci/jobs/scripts/fuzzer/run-fuzzer.sh` writes the run outcome to `status.tsv`
with `echo -e "$server_died\t$server_exit_code\t$fuzzer_exit_code"`. Of the
three variables, `server_died` is the only one never initialized before use:
it is assigned solely inside the post-fuzz server-liveness loop, either
`server_died=0` (`SELECT 1` succeeds, then `break`) or `server_died=1` (server
unreachable, then `break`).

Two branches of that loop, `TOO_MANY_SIMULTANEOUS_QUERIES` and
`MEMORY_LIMIT_EXCEEDED`, `sleep` and continue without assigning `server_died`
or breaking. When `SELECT 1` keeps returning one of these for all 100
iterations (e.g. the `tcp_handler_fail_connection_setup` failpoint returns
`MEMORY_LIMIT_EXCEEDED`, or the server is under sustained memory pressure),
the loop exhausts with `server_died` still unset. Under `set -u` the
`status.tsv` write then aborts with `server_died: unbound variable`, so the
file is never created and `ast_fuzzer_job.py:240` reports the job as ERROR:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../ci/tmp/workspace/status.tsv'
```

even though the server shut down cleanly (signal 15, graceful teardown, no
crash, no sanitizer report, no core dump).

Fix: initialize `server_died=0` before the loop, matching the existing
pre-loop defaults of its two siblings (`fuzzer_exit_code=0`,
`server_exit_code=0`). A truly dead server still sets `server_died=1` in the
`else` branch; defaulting to `0` only covers loop exhaustion via the "alive
but busy" branches, which means the server survived.

Observed over the last 30 days across 112 distinct unrelated PRs and 17 master
runs, on all fuzzer variants (BuzzHouse `amd_debug` / `arm_asan_ubsan` /
`amd_msan` / `amd_tsan` and AST fuzzer).

Example CI report (BuzzHouse arm_asan_ubsan):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107817&sha=7cae758e10f60706ccc862b31386f5447c67e324&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29

No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1008`
<!-- ch-version-info:end -->