### PR TITLE
Fix flaky test 04033_iceberg_mismatched_location

### DIFF
--- a/tests/queries/0_stateless/04033_iceberg_mismatched_location.sh
+++ b/tests/queries/0_stateless/04033_iceberg_mismatched_location.sh
@@ -23,8 +23,10 @@ ${CLICKHOUSE_CLIENT} --allow_experimental_insert_into_iceberg 1 -q "
 # Before the fix this caused std::out_of_range exception in IcebergPathResolver::resolve
 # because table_location is longer than data_path (the manifest filename),
 # causing unsigned underflow and out-of-range substr.
+# input_format_parallel_parsing=0: the metadata file is pretty-printed, and parallel
+# parsing returns its lines out of order, which breaks the downstream json.load.
 ${CLICKHOUSE_CLIENT} -q "
-    SELECT * FROM s3(s3_conn, filename='${TABLE_PATH}/metadata/v2.metadata.json', structure='line String', format='LineAsString')
+    SELECT * FROM s3(s3_conn, filename='${TABLE_PATH}/metadata/v2.metadata.json', structure='line String', format='LineAsString') SETTINGS input_format_parallel_parsing = 0
 " | python3 -c "
 import json, sys
 m = json.load(sys.stdin)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/92348
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Flaky test fix. The test reads ClickHouse's own pretty-printed (multi-line) `v2.metadata.json` back via `SELECT * FROM s3(..., format='LineAsString')` and pipes it to python `json.load`. `SELECT *` has no `ORDER BY`, so when the randomized setting `input_format_parallel_parsing=1` splits the single file into chunks, the rows (lines) are emitted out of order. `json.load` then sees an interior line first and fails with `Extra data: line 1 column N`, leaving the next `INSERT ... SELECT * FROM input()` with empty stdin (`NO_DATA_TO_INSERT`).

Fix: pin `input_format_parallel_parsing = 0` on that read so the lines keep file order.

Reproduced locally (debug build, MinIO) with `input_format_parallel_parsing=1` + small `min_chunk_bytes_for_parallel_parsing`: 9/300 reordered reads, 20/20 test failures. After the fix: 0 anomalies over 300 reads / 100 json.load runs, 40/40 test runs under the forced settings, and 60/60 under full randomization.

Recent CI failure (json.load mode), `Stateless tests (arm_binary, parallel)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107707&sha=2ac10954bc29986227802007d6c04f829bbc80f4&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1014`
<!-- ch-version-info:end -->