### PR TITLE
FileCache: stop invalidated priority entries from pinning KeyMetadata

### DIFF
--- a/src/Interpreters/FileCache/FileCache_fwd_internal.h
+++ b/src/Interpreters/FileCache/FileCache_fwd_internal.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <list>
+#include <memory>
 
 namespace DB
 {
@@ -22,5 +23,6 @@ using LockedKeyPtr = std::shared_ptr<LockedKey>;
 
 struct KeyMetadata;
 using KeyMetadataPtr = std::shared_ptr<KeyMetadata>;
+using KeyMetadataWeakPtr = std::weak_ptr<KeyMetadata>;
 
 }

--- a/src/Interpreters/FileCache/IFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/IFileCachePriority.cpp
@@ -47,7 +47,6 @@ IFileCachePriority::Entry::Entry(const Entry & other)
     , offset(other.offset)
     , key_metadata(other.key_metadata)
     , size(other.size.load())
-    , hits(other.hits.load())
 {
 }
 
@@ -57,6 +56,14 @@ std::string IFileCachePriority::Entry::toString(const std::string & prefix) cons
         "{}{}:{}:{} (state: {})",
         prefix, key, offset, size.load(),
         magic_enum::enum_name(state.load(std::memory_order_relaxed)));
+}
+
+KeyMetadataPtr IFileCachePriority::Entry::getKeyMetadata() const
+{
+    auto locked = key_metadata.lock();
+    if (!locked)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Key metadata is expired for entry {}", toString());
+    return locked;
 }
 
 void IFileCachePriority::check(const CacheStateGuard::Lock & lock) const

--- a/src/Interpreters/FileCache/IFileCachePriority.h
+++ b/src/Interpreters/FileCache/IFileCachePriority.h
@@ -58,12 +58,16 @@ public:
     {
         const Key key;
         const size_t offset;
-        const KeyMetadataPtr key_metadata;
+        /// Weak so invalidated entries awaiting lazy removal do not pin KeyMetadata.
+        /// While Active it is kept alive by the metadata bucket.
+        const KeyMetadataWeakPtr key_metadata;
 
         std::atomic<size_t> size;
-        std::atomic<size_t> hits = 0;
 
         std::string toString(const std::string & prefix = "") const;
+
+        /// Locks `key_metadata`, throwing if it expired.
+        KeyMetadataPtr getKeyMetadata() const;
 
         enum class State
         {

--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -396,7 +396,8 @@ LRUFileCachePriority::iterateImpl(
             continue;
         }
 
-        auto locked_key = entry.key_metadata->tryLock();
+        auto key_metadata = entry.key_metadata.lock();
+        auto locked_key = key_metadata ? key_metadata->tryLock() : nullptr;
         if (!locked_key)
         {
             /// locked_key == nullptr means that the cache key of
@@ -716,7 +717,6 @@ bool LRUFileCachePriority::tryIncreasePriority(
     auto lock = queue_guard.writeLock();
     const auto & entry = iterator.getEntry();
     chassert(entry->getState() == Entry::State::Active);
-    entry->hits += 1;
 
     auto it = dynamic_cast<const LRUFileCachePriority::LRUIterator &>(iterator).get();
     moveEvictionPosIfEqual(it, lock);

--- a/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
@@ -564,7 +564,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
                 /// and reset size for the old entry,
                 /// thus size will be transferred from one entry to another.
                 /// PreActive: iterateImpl skips this entry until setIterator atomically transitions it to Active.
-                auto empty_entry = std::make_shared<Entry>(entry->key, entry->offset, /* size */0, entry->key_metadata, Entry::State::PreActive);
+                auto empty_entry = std::make_shared<Entry>(entry->key, entry->offset, /* size */0, entry->getKeyMetadata(), Entry::State::PreActive);
                 auto new_iterator = probationary_queue.add(std::move(empty_entry), lk, /* state_lock */nullptr);
                 downgraded_entries->add(DowngradedEntryInfo{
                     .slru_iterator = iterator,
@@ -660,7 +660,7 @@ bool SLRUFileCachePriority::tryIncreasePriority(
     EntryPtr prev_entry = iterator.getEntry();
 
     {
-        auto locked_key = prev_entry->key_metadata->lock();
+        auto locked_key = prev_entry->getKeyMetadata()->lock();
         const auto entry_state = prev_entry->getState();
         chassert(entry_state == Entry::State::Active || entry_state == Entry::State::Evicting);
         if (entry_state != Entry::State::Active)
@@ -737,11 +737,12 @@ bool SLRUFileCachePriority::tryIncreasePriority(
         removeEntries(invalidated_entries, lock);
 
         /// PreActive: iterateImpl skips this entry until setIterator atomically transitions it to Active.
+        /// prev_entry is in Moving state here, so its KeyMetadata is still alive.
         auto empty_entry = std::make_shared<Entry>(
             prev_entry->key,
             prev_entry->offset,
             /* size */0,
-            prev_entry->key_metadata,
+            prev_entry->getKeyMetadata(),
             Entry::State::PreActive);
 
         return protected_queue.add(
@@ -790,13 +791,14 @@ LRUFileCachePriority::LRUIterator SLRUFileCachePriority::addOrThrow(
             /// there is no corresponding entry in priority queue for it,
             /// because it will mean that cache became inconsistent.
             /// So let's try to fix the situation.
-            auto metadata = entry->key_metadata->tryLock();
-            chassert(metadata);
-            if (metadata)
-            {
-                auto segment_metadata = metadata->tryGetByOffset(entry->offset);
-                metadata->removeFileSegment(entry->offset, segment_metadata->file_segment->lock());
-            }
+            auto metadata = entry->getKeyMetadata()->tryLock();
+            if (!metadata)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Cannot lock key metadata to clean up file segment {}:{}", entry->key, entry->offset);
+
+            auto segment_metadata = metadata->tryGetByOffset(entry->offset);
+            metadata->removeFileSegment(entry->offset, segment_metadata->file_segment->lock());
         }
         catch (...)
         {

--- a/src/Interpreters/FileCache/SplitFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SplitFileCachePriority.cpp
@@ -312,7 +312,7 @@ bool SplitFileCachePriority::tryIncreasePriority(
     CachePriorityGuard & queue_guard,
     CacheStateGuard & state_guard)
 {
-    const auto type = getPriorityType(iterator.getEntry()->key_metadata->origin.segment_type);
+    const auto type = getPriorityType(iterator.getEntry()->getKeyMetadata()->origin.segment_type);
     return getPriority(type).tryIncreasePriority(iterator, is_space_reservation_complete, queue_guard, state_guard);
 }
 


### PR DESCRIPTION



### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Filesystem cache improvement: stop invalidated priority entries from pinning `KeyMetadata`. Follow up to https://github.com/ClickHouse/ClickHouse/pull/106387.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1122`
- Backported to: `26.5.4.5`
<!-- ch-version-info:end -->