### PR TITLE
Fix position-dependent column-wise insert deduplication hash

### DIFF
--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -307,10 +307,7 @@ void ColumnArray::updateHashWithValueRange(size_t begin, size_t end, SipHash & h
     size_t nested_begin = offsetAt(begin);
     size_t nested_end = offsetAt(end);
     getData().updateHashWithValueRange(nested_begin, nested_end, hash);
-    /// Hash the array boundaries relative to the start of the range — see the comment in
-    /// ColumnString::updateHashWithValueRange. Absolute offsets would make the hash position-dependent
-    /// and break deduplication of equal rows located at different offsets. The raw bytes are fed (not
-    /// SipHash::update(UInt64)) to keep the byte stream identical on big-endian targets.
+    /// Relative offsets as raw bytes, see ColumnString::updateHashWithValueRange.
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = getOffsets()[i] - nested_begin;

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -307,7 +307,7 @@ void ColumnArray::updateHashWithValueRange(size_t begin, size_t end, SipHash & h
     size_t nested_begin = offsetAt(begin);
     size_t nested_end = offsetAt(end);
     getData().updateHashWithValueRange(nested_begin, nested_end, hash);
-    /// Relative offsets, see ColumnString::updateHashWithValueRange.
+    /// Relative offsets so equal data hashes equally regardless of position (insert deduplication).
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = getOffsets()[i] - nested_begin;

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -307,11 +307,11 @@ void ColumnArray::updateHashWithValueRange(size_t begin, size_t end, SipHash & h
     size_t nested_begin = offsetAt(begin);
     size_t nested_end = offsetAt(end);
     getData().updateHashWithValueRange(nested_begin, nested_end, hash);
-    /// Relative offsets as raw bytes, see ColumnString::updateHashWithValueRange.
+    /// Relative offsets, see ColumnString::updateHashWithValueRange.
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = getOffsets()[i] - nested_begin;
-        hash.update(reinterpret_cast<const char *>(&relative_offset), sizeof(relative_offset));
+        hash.update(relative_offset);
     }
 }
 

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -307,7 +307,14 @@ void ColumnArray::updateHashWithValueRange(size_t begin, size_t end, SipHash & h
     size_t nested_begin = offsetAt(begin);
     size_t nested_end = offsetAt(end);
     getData().updateHashWithValueRange(nested_begin, nested_end, hash);
-    hash.update(reinterpret_cast<const char *>(&getOffsets()[begin]), (end - begin) * sizeof(getOffsets()[0]));
+    /// Hash the array boundaries relative to the start of the range — see the comment in
+    /// ColumnString::updateHashWithValueRange. Absolute offsets would make the hash position-dependent
+    /// and break deduplication of equal rows located at different offsets.
+    for (size_t i = begin; i < end; ++i)
+    {
+        UInt64 relative_offset = getOffsets()[i] - nested_begin;
+        hash.update(relative_offset);
+    }
 }
 
 void ColumnArray::computeHashInto(size_t row_begin, size_t row_end, UInt32 * hash_out, bool initial) const

--- a/src/Columns/ColumnArray.cpp
+++ b/src/Columns/ColumnArray.cpp
@@ -309,11 +309,12 @@ void ColumnArray::updateHashWithValueRange(size_t begin, size_t end, SipHash & h
     getData().updateHashWithValueRange(nested_begin, nested_end, hash);
     /// Hash the array boundaries relative to the start of the range — see the comment in
     /// ColumnString::updateHashWithValueRange. Absolute offsets would make the hash position-dependent
-    /// and break deduplication of equal rows located at different offsets.
+    /// and break deduplication of equal rows located at different offsets. The raw bytes are fed (not
+    /// SipHash::update(UInt64)) to keep the byte stream identical on big-endian targets.
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = getOffsets()[i] - nested_begin;
-        hash.update(relative_offset);
+        hash.update(reinterpret_cast<const char *>(&relative_offset), sizeof(relative_offset));
     }
 }
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -832,14 +832,8 @@ void ColumnString::updateHashWithValueRange(size_t begin, size_t end, SipHash & 
     size_t chars_begin = offsetAt(begin);
     size_t chars_end = offsetAt(end);
     hash.update(reinterpret_cast<const char *>(&chars[chars_begin]), chars_end - chars_begin);
-    /// Hash the string boundaries relative to the start of the range. Hashing the absolute offsets
-    /// would make the result depend on the position of the range inside the column, so two equal rows
-    /// located at different offsets (e.g. repeated blocks combined into one async insert) would hash
-    /// differently and fail to deduplicate. For begin == 0 this is byte-identical to hashing the raw
-    /// offsets, so already-persisted deduplication hashes stay valid.
-    /// Feed the raw bytes (not SipHash::update(UInt64)) so the byte stream is the same on big-endian
-    /// targets too — the scalar overload endian-normalizes the value, which would change the begin == 0
-    /// stream on s390x.
+    /// Relative offsets: equal data must hash equally at any position in the column (deduplication).
+    /// Raw bytes, not the integer overload that normalizes byte order on big-endian.
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = offsets[i] - chars_begin;

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -837,10 +837,13 @@ void ColumnString::updateHashWithValueRange(size_t begin, size_t end, SipHash & 
     /// located at different offsets (e.g. repeated blocks combined into one async insert) would hash
     /// differently and fail to deduplicate. For begin == 0 this is byte-identical to hashing the raw
     /// offsets, so already-persisted deduplication hashes stay valid.
+    /// Feed the raw bytes (not SipHash::update(UInt64)) so the byte stream is the same on big-endian
+    /// targets too — the scalar overload endian-normalizes the value, which would change the begin == 0
+    /// stream on s390x.
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = offsets[i] - chars_begin;
-        hash.update(relative_offset);
+        hash.update(reinterpret_cast<const char *>(&relative_offset), sizeof(relative_offset));
     }
 }
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -832,7 +832,16 @@ void ColumnString::updateHashWithValueRange(size_t begin, size_t end, SipHash & 
     size_t chars_begin = offsetAt(begin);
     size_t chars_end = offsetAt(end);
     hash.update(reinterpret_cast<const char *>(&chars[chars_begin]), chars_end - chars_begin);
-    hash.update(reinterpret_cast<const char *>(&offsets[begin]), (end - begin) * sizeof(offsets[0]));
+    /// Hash the string boundaries relative to the start of the range. Hashing the absolute offsets
+    /// would make the result depend on the position of the range inside the column, so two equal rows
+    /// located at different offsets (e.g. repeated blocks combined into one async insert) would hash
+    /// differently and fail to deduplicate. For begin == 0 this is byte-identical to hashing the raw
+    /// offsets, so already-persisted deduplication hashes stay valid.
+    for (size_t i = begin; i < end; ++i)
+    {
+        UInt64 relative_offset = offsets[i] - chars_begin;
+        hash.update(relative_offset);
+    }
 }
 
 void ColumnString::updateHashFast(SipHash & hash) const

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -832,12 +832,11 @@ void ColumnString::updateHashWithValueRange(size_t begin, size_t end, SipHash & 
     size_t chars_begin = offsetAt(begin);
     size_t chars_end = offsetAt(end);
     hash.update(reinterpret_cast<const char *>(&chars[chars_begin]), chars_end - chars_begin);
-    /// Relative offsets: equal data must hash equally at any position in the column (deduplication).
-    /// Raw bytes, not the integer overload that normalizes byte order on big-endian.
+    /// Relative offsets so equal data hashes equally regardless of position (insert deduplication).
     for (size_t i = begin; i < end; ++i)
     {
         UInt64 relative_offset = offsets[i] - chars_begin;
-        hash.update(reinterpret_cast<const char *>(&relative_offset), sizeof(relative_offset));
+        hash.update(relative_offset);
     }
 }
 

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -67,6 +67,7 @@ protected:
     friend class InsertDependenciesBuilder;
     /// src/Storages/MergeTree/tests/gtest_async_inserts.cpp
     friend std::vector<Int64> testSelfDeduplicate(std::vector<Int64> data, std::vector<size_t> offsets, std::vector<String> hashes);
+    friend std::vector<String> testSelfDeduplicateStrings(std::vector<String> data, std::vector<size_t> offsets, std::vector<String> hashes);
 
 public:
     using Ptr = std::shared_ptr<DeduplicationInfo>;

--- a/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
+++ b/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
@@ -3,6 +3,7 @@
 #include <Processors/Chunk.h>
 #include <Columns/IColumn.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeString.h>
 #include <Common/PODArray.h>
 #include <base/defines.h>
 
@@ -69,6 +70,70 @@ TEST(AsyncInsertsTest, testSelfDeduplicate)
     test_impl({1,2,3,1,2,3,1,2,3,1,2,3},{2,3,5,6,8,9,11,12},{"a","b","a","b","a","b","a","b"},{1,2,3});
     test_impl({1,2,3,1,2,4,1,2,5,1,2},{2,3,5,6,8,9,11},{"a","b","a","c","a","d","a"},{1,2,3,4,5});
     test_impl({1,2,1,2,1,2,1,2,1,2},{2,4,6,8,10},{"a","a","a","a","a"},{1,2});
+}
+
+
+/// Self-deduplication must be position-invariant for variable-length columns. With the unified hash
+/// (NEW_UNIFIED_HASHES) the data hash is computed column-wise over a row range; if it folded in
+/// absolute string/array offsets, two equal rows located at different offsets would get different
+/// block ids and fail to deduplicate (e.g. repeated rows combined into one async insert).
+std::vector<String> testSelfDeduplicateStrings(std::vector<String> data, std::vector<size_t> offsets, std::vector<String> hashes)
+{
+    MutableColumnPtr column = DataTypeString().createColumn();
+    for (const auto & datum : data)
+    {
+        column->insert(datum);
+    }
+    Block block({ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "a")});
+
+    auto deduplication_info = DeduplicationInfo::create(true, InsertDeduplicationVersions::NEW_UNIFIED_HASHES);
+    deduplication_info->setRootViewID({});
+    deduplication_info->disabled = false; // there is no insert dependencies instance in this test
+    deduplication_info->updateOriginalBlock(Chunk(block.getColumns(), block.rows()), std::make_shared<const Block>(block.cloneEmpty()));
+
+    chassert(offsets.size() == hashes.size());
+    chassert(!offsets.empty());
+
+    deduplication_info->setUserToken(hashes[0], offsets[0]);
+
+    for (size_t i = 1; i < offsets.size(); ++i)
+        deduplication_info->setUserToken(hashes[i], offsets[i] - offsets[i-1]);
+
+    chassert(offsets.size() == deduplication_info->getCount());
+    chassert(offsets.back() == deduplication_info->getRows());
+
+    auto filtered = deduplication_info->filterImpl(deduplication_info->filterSelf("all"));
+
+    /// Nothing was deduplicated — all rows survive in their original order.
+    if (filtered.removed_rows == 0 || !filtered.filtered_block)
+        return data;
+
+    ColumnPtr col = filtered.filtered_block->getColumns()[0];
+
+    std::vector<String> result;
+    result.reserve(col->size());
+
+    for (size_t i = 0; i < col->size(); i++)
+    {
+        result.push_back(String(col->getDataAt(i)));
+    }
+
+    return result;
+}
+
+TEST(AsyncInsertsTest, testSelfDeduplicateStrings)
+{
+    auto test_impl = [](std::vector<String> data, std::vector<size_t> offsets, std::vector<String> hashes, std::vector<String> answer)
+    {
+        auto result = testSelfDeduplicateStrings(data, offsets, hashes);
+        ASSERT_EQ(answer, result);
+    };
+    /// Two equal single-row blocks with no user token must collapse to one row.
+    test_impl({"one line","one line"},{1,2},{"",""},{"one line"});
+    /// Equal multi-row blocks with no user token must collapse, keeping the first occurrence.
+    test_impl({"a","bb","a","bb","ccc"},{2,4,5},{"","",""},{"a","bb","ccc"});
+    /// Distinct blocks must survive (no false deduplication from relative offsets).
+    test_impl({"ab","c","a","bc"},{2,4},{"",""},{"ab","c","a","bc"});
 }
 
 }

--- a/tests/integration/test_migration_deduplication_hash/test.py
+++ b/tests/integration/test_migration_deduplication_hash/test.py
@@ -270,3 +270,44 @@ def test_sync_async_deduplicated_with_2512(cluster, insert_type):
 
         for node in nodes:
             node.query("SYSTEM SYNC REPLICA test_sync_async_deduplicated_with_2512")
+
+
+def test_new_unified_hash_self_deduplication_variable_length(cluster):
+    # Regression test for a deduplication hash bug with new_unified_hash.
+    # ColumnString/ColumnArray::updateHashWithValueRange hashed absolute offsets, so equal rows
+    # located at different offsets within one async-insert flush produced different unified
+    # deduplication ids and were not self-deduplicated. Fixed-width columns (e.g. UInt32) are
+    # position-invariant and did not expose the bug, hence the String/Array columns here.
+    node_new = cluster.instances["node_new"]
+
+    create_table_query = \
+"""
+    DROP TABLE IF EXISTS test_unified_self_dedup;
+
+    CREATE TABLE test_unified_self_dedup (key UInt32, s String, a Array(UInt32))
+    ENGINE=ReplicatedMergeTree('/clickhouse/tables/test_unified_self_dedup/', '{replica}')
+    ORDER BY key
+"""
+
+    drop_table_query = "DROP TABLE IF EXISTS test_unified_self_dedup SYNC"
+
+    # Keep the busy timeout high and do not wait for the flush, so both inserts accumulate in the
+    # queue and are combined into a single flush (one block with two offsets) by SYSTEM FLUSH.
+    async_settings = (
+        "async_insert=1, wait_for_async_insert=0, async_insert_use_adaptive_busy_timeout=0, "
+        "async_insert_busy_timeout_min_ms=10000, async_insert_busy_timeout_max_ms=50000, "
+        "deduplicate_insert='enable'"
+    )
+
+    with with_tables(
+        nodes=[node_new],
+        create_query=create_table_query,
+        drop_query=drop_table_query,
+    ):
+        node_new.query(f"INSERT INTO test_unified_self_dedup SETTINGS {async_settings} VALUES (1, 'one line', [10, 20])")
+        node_new.query(f"INSERT INTO test_unified_self_dedup SETTINGS {async_settings} VALUES (1, 'one line', [10, 20])")
+        node_new.query("SYSTEM FLUSH ASYNC INSERT QUEUE")
+
+        # Two identical inserts combined in one flush must self-deduplicate to a single row.
+        result = node_new.query("SELECT key, s, a FROM test_unified_self_dedup ORDER BY key")
+        assert result == "1\tone line\t[10,20]\n"


### PR DESCRIPTION
`ColumnString::updateHashWithValueRange` and `ColumnArray::updateHashWithValueRange` hashed the absolute cumulative offsets of the `[begin, end)` row range. Because the offsets are cumulative, the same value at a different position has a different offset, so the hash depended on the row's position in the column rather than only on its content.

These methods are used only by the column-wise data hash of the unified insert deduplication path (server setting `insert_deduplication_version = new_unified_hash` and `compatible_double_hashes`). As a result, two identical blocks located at different offsets — e.g. repeated rows combined into one asynchronous insert flush — produced different deduplication block ids and were not deduplicated. Fixed-width columns (`UInt32`, …) are position-invariant and did not expose the bug.

The fix hashes the boundaries relative to the start of the range, so equal data hashes equally regardless of its position.

This changes the unified deduplication hashes, which needs no backward compatibility: under the default `compatible_double_hashes`, deduplication correctness comes from the legacy id (unchanged here), so the unified id only becomes authoritative once `new_unified_hash` is the default — and the previously-broken unified hashes are not worth preserving.

Tests (both fail before the fix, pass after):
- a unit test deduplicating equal `String` blocks located at different offsets (`gtest_async_inserts`);
- an integration test doing async self-deduplication under `new_unified_hash` with `String` and `Array` columns (`test_migration_deduplication_hash`).

Related: https://github.com/ClickHouse/ClickHouse/pull/95409
Related: https://github.com/ClickHouse/ClickHouse/pull/107886

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed insert deduplication computing wrong hashes for `String` and `Array` columns with the server setting `insert_deduplication_version = new_unified_hash`: identical inserts could fail to deduplicate because the deduplication hash depended on the row's position within the inserted block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1028`
- Backported to: `26.5.3.49`, `26.4.5.56`, `26.3.14.46`
<!-- ch-version-info:end -->