### PR TITLE
Make previous-release package downloads resilient to infrastructure flakes

### DIFF
--- a/ci/tests/test_download_build_with_progress.py
+++ b/ci/tests/test_download_build_with_progress.py
@@ -1,0 +1,143 @@
+"""
+Tests for `build_download_helper.download_build_with_progress`.
+
+The upgrade check downloads the previous release `.deb` packages during setup.
+A transient hiccup that exhausted the (small) retry budget there used to waste
+the whole job in the setup phase, recorded only as a generic failure. These
+tests pin the resilience and diagnostics behaviour the download path now
+guarantees:
+
+  * a genuine 404 (the artifact was never uploaded) fails fast instead of
+    burning the entire retry budget;
+  * transient errors are retried `retries` times with a capped backoff;
+  * a truncated response is treated as a transient failure rather than silently
+    producing a corrupt file.
+
+See https://github.com/ClickHouse/ClickHouse/pull/102817#issuecomment-4726000791
+"""
+
+import importlib.util
+import os
+import types
+
+import pytest
+
+# Load the module directly from its file so we do not have to put the whole
+# `tests/ci` directory on `sys.path` for the entire pytest session (which would
+# risk shadowing equally-named modules in other tests).
+_BDH_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "tests", "ci", "build_download_helper.py"
+)
+_spec = importlib.util.spec_from_file_location("build_download_helper", _BDH_PATH)
+bdh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bdh)
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, content_length=None):
+        self.body = body
+        length = len(body) if content_length is None else content_length
+        self.headers = {"content-length": str(length)}
+
+    @property
+    def content(self) -> bytes:
+        return self.body
+
+    def iter_content(self, chunk_size=4096):
+        for i in range(0, len(self.body), chunk_size):
+            yield self.body[i : i + chunk_size]
+
+
+def _http_error(status_code: int) -> Exception:
+    err = Exception(f"HTTP {status_code}")
+    err.response = types.SimpleNamespace(status_code=status_code)
+    return err
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Record backoff durations without actually sleeping."""
+    sleeps = []
+    monkeypatch.setattr(bdh.time, "sleep", sleeps.append)
+    return sleeps
+
+
+def _patch_get(monkeypatch, side_effects):
+    """`get_with_retries` returns/raises the next item from `side_effects`."""
+    calls = {"count": 0}
+
+    def fake_get_with_retries(*_args, **_kwargs):
+        effect = side_effects[calls["count"]]
+        calls["count"] += 1
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
+
+    monkeypatch.setattr(bdh, "get_with_retries", fake_get_with_retries)
+    return calls
+
+
+def test_success_writes_file(tmp_path, monkeypatch, no_sleep):
+    body = b"hello clickhouse" * 1000
+    calls = _patch_get(monkeypatch, [FakeResponse(body)])
+    dst = tmp_path / "pkg.deb"
+
+    bdh.download_build_with_progress("http://example/pkg.deb", dst)
+
+    assert dst.read_bytes() == body
+    assert calls["count"] == 1
+    assert no_sleep == []
+
+
+def test_404_fails_fast(tmp_path, monkeypatch, no_sleep):
+    calls = _patch_get(monkeypatch, [_http_error(404)] * 10)
+    dst = tmp_path / "missing.deb"
+
+    with pytest.raises(bdh.DownloadException, match="does not exist"):
+        bdh.download_build_with_progress("http://example/missing.deb", dst, retries=10)
+
+    # A 404 must not be retried and must not leave a partial file behind.
+    assert calls["count"] == 1
+    assert no_sleep == []
+    assert not dst.exists()
+
+
+def test_transient_error_retries_then_fails(tmp_path, monkeypatch, no_sleep):
+    retries = 4
+    calls = _patch_get(monkeypatch, [ConnectionError("boom")] * retries)
+    dst = tmp_path / "pkg.deb"
+
+    with pytest.raises(bdh.DownloadException, match="all 4 retries exceeded"):
+        bdh.download_build_with_progress("http://example/pkg.deb", dst, retries=retries)
+
+    assert calls["count"] == retries
+    # One sleep between each pair of attempts.
+    assert len(no_sleep) == retries - 1
+
+
+def test_backoff_is_capped(tmp_path, monkeypatch, no_sleep):
+    retries = 10
+    _patch_get(monkeypatch, [ConnectionError("boom")] * retries)
+    dst = tmp_path / "pkg.deb"
+
+    with pytest.raises(bdh.DownloadException):
+        bdh.download_build_with_progress("http://example/pkg.deb", dst, retries=retries)
+
+    assert max(no_sleep) == bdh.DOWNLOAD_RETRY_MAX_BACKOFF
+    assert all(s <= bdh.DOWNLOAD_RETRY_MAX_BACKOFF for s in no_sleep)
+
+
+def test_truncated_download_retries_then_succeeds(tmp_path, monkeypatch, no_sleep):
+    body = b"x" * 4096
+    # First response claims more bytes than it delivers (short read), the retry
+    # delivers the full body.
+    truncated = FakeResponse(body[:100], content_length=len(body))
+    complete = FakeResponse(body)
+    calls = _patch_get(monkeypatch, [truncated, complete])
+    dst = tmp_path / "pkg.deb"
+
+    bdh.download_build_with_progress("http://example/pkg.deb", dst)
+
+    assert dst.read_bytes() == body
+    assert calls["count"] == 2
+    assert len(no_sleep) == 1

--- a/ci/tests/test_download_release_packages.py
+++ b/ci/tests/test_download_release_packages.py
@@ -1,0 +1,100 @@
+"""
+Tests for `download_release_packages.download_packages`.
+
+The upgrade check downloads the previous release `.deb` packages before it can
+install and start the old server. These tests pin two properties:
+
+  * a failure of an *essential* package (one that `install_packages` installs)
+    is reported as a hard, attributable error instead of being silently skipped;
+  * a failure of a non-essential asset (e.g. `clickhouse-keeper`) is tolerated,
+    so an unrelated hiccup does not waste the whole job.
+
+See https://github.com/ClickHouse/ClickHouse/pull/102817#issuecomment-4726000791
+"""
+
+import os
+import sys
+
+import pytest
+
+# `download_release_packages` imports sibling modules from `tests/ci` by bare
+# name, so put that directory on `sys.path` only while importing it and remove
+# it again afterwards to avoid leaking it into the rest of the pytest session.
+_CI_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
+)
+sys.path.insert(0, _CI_DIR)
+try:
+    # pylint: disable=import-error
+    import download_release_packages as drp
+    from build_download_helper import DownloadException
+finally:
+    sys.path.remove(_CI_DIR)
+
+
+class FakeRelease:
+    def __init__(self, *package_names):
+        self.assets = {name: f"http://example/{name}" for name in package_names}
+
+    def __str__(self):
+        return "v1.2.3.4-stable"
+
+
+def _make_fake_download(fail_substrings=()):
+    calls = []
+
+    def fake(url, path, retries=None):
+        calls.append({"url": url, "path": str(path), "retries": retries})
+        for sub in fail_substrings:
+            if sub in str(path):
+                raise DownloadException(f"simulated failure (HTTP 404) for {sub}")
+
+    return fake, calls
+
+
+def test_all_packages_succeed(tmp_path, monkeypatch):
+    fake, calls = _make_fake_download()
+    monkeypatch.setattr(drp, "download_build_with_progress", fake)
+    release = FakeRelease(
+        "clickhouse-common-static_1_amd64.deb",
+        "clickhouse-server_1_amd64.deb",
+        "clickhouse-client_1_amd64.deb",
+    )
+
+    drp.download_packages(release, dest_path=tmp_path)
+
+    assert len(calls) == 3
+    # The essential packages are retried with the larger, dedicated budget.
+    assert all(c["retries"] == drp.RELEASE_PACKAGE_DOWNLOAD_RETRIES for c in calls)
+
+
+def test_non_essential_failure_is_tolerated(tmp_path, monkeypatch):
+    fake, _ = _make_fake_download(fail_substrings=("clickhouse-keeper",))
+    monkeypatch.setattr(drp, "download_build_with_progress", fake)
+    release = FakeRelease(
+        "clickhouse-common-static_1_amd64.deb",
+        "clickhouse-server_1_amd64.deb",
+        "clickhouse-client_1_amd64.deb",
+        "clickhouse-keeper_1_amd64.deb",
+    )
+
+    # Only an unused extra package failed - the job can still run.
+    drp.download_packages(release, dest_path=tmp_path)
+
+
+def test_essential_failure_raises_with_reason(tmp_path, monkeypatch):
+    fake, _ = _make_fake_download(fail_substrings=("clickhouse-server",))
+    monkeypatch.setattr(drp, "download_build_with_progress", fake)
+    release = FakeRelease(
+        "clickhouse-common-static_1_amd64.deb",
+        "clickhouse-server_1_amd64.deb",
+    )
+
+    with pytest.raises(DownloadException) as excinfo:
+        drp.download_packages(release, dest_path=tmp_path)
+
+    message = str(excinfo.value)
+    assert "required release package" in message
+    # The original per-package reason is preserved for diagnostics.
+    assert "clickhouse-server_1_amd64.deb" in message
+    assert "HTTP 404" in message

--- a/ci/tests/test_download_release_packages.py
+++ b/ci/tests/test_download_release_packages.py
@@ -88,6 +88,7 @@ def test_essential_failure_raises_with_reason(tmp_path, monkeypatch):
     release = FakeRelease(
         "clickhouse-common-static_1_amd64.deb",
         "clickhouse-server_1_amd64.deb",
+        "clickhouse-client_1_amd64.deb",
     )
 
     with pytest.raises(DownloadException) as excinfo:
@@ -98,3 +99,52 @@ def test_essential_failure_raises_with_reason(tmp_path, monkeypatch):
     # The original per-package reason is preserved for diagnostics.
     assert "clickhouse-server_1_amd64.deb" in message
     assert "HTTP 404" in message
+
+
+def test_missing_required_package_raises(tmp_path, monkeypatch):
+    # A partially published release: every published asset downloads fine, but a
+    # required package is absent from the release metadata entirely, so it never
+    # enters the download loop. This must still fail loudly instead of letting a
+    # later `install_packages` die with an opaque `dpkg` glob error.
+    fake, calls = _make_fake_download()
+    monkeypatch.setattr(drp, "download_build_with_progress", fake)
+    release = FakeRelease(
+        "clickhouse-common-static_1_amd64.deb",
+        "clickhouse-server_1_amd64.deb",
+        # `clickhouse-client_..._amd64.deb` is missing.
+    )
+
+    with pytest.raises(DownloadException) as excinfo:
+        drp.download_packages(release, dest_path=tmp_path)
+
+    message = str(excinfo.value)
+    assert "required release package" in message
+    assert "clickhouse-client_" in message
+    assert "not found in the release assets" in message
+    # The packages that were present still got downloaded.
+    assert len(calls) == 2
+
+
+def test_missing_dbg_is_required_only_in_debug_mode(tmp_path, monkeypatch):
+    # The debug-symbols package is only installed (and thus required) in debug
+    # mode, so a release without it is fine for a non-debug run but must fail a
+    # debug run.
+    fake, _ = _make_fake_download()
+    monkeypatch.setattr(drp, "download_build_with_progress", fake)
+    release = FakeRelease(
+        "clickhouse-common-static_1_amd64.deb",
+        "clickhouse-server_1_amd64.deb",
+        "clickhouse-client_1_amd64.deb",
+        # `clickhouse-common-static-dbg_..._amd64.deb` is missing.
+    )
+
+    # Non-debug run: the debug package is not needed.
+    drp.download_packages(release, dest_path=tmp_path, debug=False)
+
+    # Debug run: the missing debug package is now a required, attributable error.
+    with pytest.raises(DownloadException) as excinfo:
+        drp.download_packages(release, dest_path=tmp_path, debug=True)
+
+    message = str(excinfo.value)
+    assert "clickhouse-common-static-dbg_" in message
+    assert "not found in the release assets" in message

--- a/ci/tests/test_upgrade_runner_download_boundary.py
+++ b/ci/tests/test_upgrade_runner_download_boundary.py
@@ -1,0 +1,111 @@
+"""
+Shell-level contract test for the previous-release download boundary in
+`tests/docker_scripts/upgrade_runner.sh`.
+
+`download_release_packages` (see `tests/ci/download_release_packages.py`) exits
+nonzero when a required previous-release package is missing or fails to download.
+The runner must stop at that boundary instead of recording success and reaching
+`install_packages`, which would otherwise die later with an opaque `dpkg` glob
+error.
+
+The Python unit tests in `test_download_release_packages.py` prove the exit code;
+this test proves the shell caller honours it. It extracts the real download block
+from the runner (between stable anchor comments) and runs it under bash with a
+stub `download_release_packages`, so the test cannot drift from the script it
+guards.
+
+See https://github.com/ClickHouse/ClickHouse/pull/107916
+"""
+
+import os
+import subprocess
+
+_RUNNER = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "tests",
+        "docker_scripts",
+        "upgrade_runner.sh",
+    )
+)
+
+_BEGIN = (
+    "# --- download previous release packages: "
+    "fail closed on a missing required one ---"
+)
+_END = "# --- end download previous release packages ---"
+
+# Mirrors the `OK`/`FAIL` status columns defined in `stress_tests.lib`. A raw
+# string keeps the backslashes literal so the bash harness sees exactly what the
+# library defines.
+_PREAMBLE = r"""set -ex
+OK="\tOK\t\\N\t"
+FAIL="\tFAIL\t\\N\t"
+previous_release_tag=v1.2.3.4-stable
+"""
+
+
+def _extract_download_block():
+    with open(_RUNNER, encoding="utf-8") as f:
+        text = f.read()
+    begin = text.index(_BEGIN)
+    end = text.index(_END, begin)
+    # Keep the BEGIN anchor, drop the END marker line.
+    return text[begin:end]
+
+
+def _run_block(tmp_path, download_exit_code):
+    block = _extract_download_block()
+
+    # The runner writes to the absolute path /test_output; redirect it into the
+    # test's temporary directory.
+    test_output = tmp_path / "test_output"
+    test_output.mkdir()
+    block = block.replace("/test_output", str(test_output))
+
+    # Stub `download_release_packages` (a PATH command in the real job, symlinked
+    # to the Python script) so the block's only moving part is its own control
+    # flow. It drains stdin (the piped release tag) and exits with the given code.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "download_release_packages"
+    stub.write_text(f"#!/bin/bash\ncat >/dev/null\nexit {download_exit_code}\n")
+    stub.chmod(0o755)
+
+    # `REACHED_INSTALL` stands in for the `install_packages` call that follows the
+    # block in the real runner: it must be reached on success and skipped on
+    # failure.
+    script = _PREAMBLE + block + "\necho REACHED_INSTALL\n"
+
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}")
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+        check=False,
+    )
+    return proc, test_output
+
+
+def test_runner_stops_when_download_fails(tmp_path):
+    proc, test_output = _run_block(tmp_path, download_exit_code=1)
+
+    # The runner must exit before reaching `install_packages`.
+    assert proc.returncode != 0
+    assert "REACHED_INSTALL" not in proc.stdout
+    assert (test_output / "check_status.tsv").read_text().startswith("failure")
+    assert "FAIL" in (test_output / "test_results.tsv").read_text()
+
+
+def test_runner_continues_when_download_succeeds(tmp_path):
+    proc, test_output = _run_block(tmp_path, download_exit_code=0)
+
+    # A successful download records the OK row and proceeds to `install_packages`.
+    assert proc.returncode == 0, proc.stderr
+    assert "REACHED_INSTALL" in proc.stdout
+    assert not (test_output / "check_status.tsv").exists()
+    assert "OK" in (test_output / "test_results.tsv").read_text()

--- a/tests/ci/build_download_helper.py
+++ b/tests/ci/build_download_helper.py
@@ -21,6 +21,10 @@ except ImportError:
 
 
 DOWNLOAD_RETRIES_COUNT = 5
+# Cap the exponential backoff so that increasing the number of retries extends
+# the total time we keep trying through a transient outage instead of exploding
+# the per-attempt sleep.
+DOWNLOAD_RETRY_MAX_BACKOFF = 60
 
 logger = logging.getLogger(__name__)
 
@@ -117,9 +121,11 @@ def get_gh_api(
     raise APIException(f"Unable to request data from GH API: {url}") from exc
 
 
-def download_build_with_progress(url: str, path: Path) -> None:
+def download_build_with_progress(
+    url: str, path: Path, retries: int = DOWNLOAD_RETRIES_COUNT
+) -> None:
     logger.info("Downloading from %s to temp path %s", url, path)
-    for i in range(DOWNLOAD_RETRIES_COUNT):
+    for i in range(retries):
         try:
             response = get_with_retries(url, retries=1, stream=True)
             total_length = int(response.headers.get("content-length", 0))
@@ -132,14 +138,15 @@ def download_build_with_progress(url: str, path: Path) -> None:
                 return
 
             with open(path, "wb") as f:
+                dl = 0
                 if total_length == 0:
                     logger.info(
                         "No content-length, will download file without progress"
                     )
-                    f.write(response.content)
+                    content = response.content
+                    dl = len(content)
+                    f.write(content)
                 else:
-                    dl = 0
-
                     logger.info("Content length is %ld bytes", total_length)
                     for data in response.iter_content(chunk_size=4096):
                         dl += len(data)
@@ -151,6 +158,14 @@ def download_build_with_progress(url: str, path: Path) -> None:
                             space_str = " " * (50 - done)
                             sys.stdout.write(f"\r[{eq_str}{space_str}] {percent}%")
                             sys.stdout.flush()
+
+            # A truncated response is a transient failure too: without this check a
+            # short read produces a corrupt file that only fails much later (e.g. as
+            # an opaque `dpkg` error), hiding the real download problem.
+            if total_length and dl != total_length:
+                raise DownloadException(
+                    f"Downloaded {dl} of {total_length} bytes from {url}"
+                )
             break
         except Exception as e:
             if sys.stdout.isatty():
@@ -158,17 +173,30 @@ def download_build_with_progress(url: str, path: Path) -> None:
             if path.exists():
                 path.unlink()
 
-            if i + 1 < DOWNLOAD_RETRIES_COUNT:
-                sleep_time = 3 * (2**i)
-                logger.info(
-                    "Download attempt %i failed, retrying in %i seconds",
+            # A 404 means the artifact genuinely does not exist (e.g. packages were
+            # not uploaded for this tag yet). Retrying cannot help, so fail fast with
+            # a clear, attributable message instead of burning the whole retry budget.
+            status_code = getattr(getattr(e, "response", None), "status_code", None)
+            if status_code == 404:
+                raise DownloadException(
+                    f"Cannot download {url}: the file does not exist (HTTP 404)"
+                ) from e
+
+            if i + 1 < retries:
+                sleep_time = min(3 * (2**i), DOWNLOAD_RETRY_MAX_BACKOFF)
+                logger.warning(
+                    "Download attempt %i of %i for %s failed (%s), retrying in %i seconds",
                     i + 1,
+                    retries,
+                    url,
+                    e,
                     sleep_time,
                 )
                 time.sleep(sleep_time)
             else:
                 raise DownloadException(
-                    f"Cannot download dataset from {url}, all retries exceeded"
+                    f"Cannot download {url}, all {retries} retries exceeded; "
+                    f"last error: {e}"
                 ) from e
 
     if sys.stdout.isatty():

--- a/tests/ci/download_release_packages.py
+++ b/tests/ci/download_release_packages.py
@@ -37,6 +37,12 @@ def download_packages(
 
     logging.info("Will download %s", release)
 
+    # The debug-symbols package is only downloaded (and installed) in debug mode,
+    # so it is only required there.
+    required_prefixes = tuple(
+        prefix for prefix in REQUIRED_PACKAGE_PREFIXES if debug or "-dbg_" not in prefix
+    )
+
     failed = {}
     for pkg, url in release.assets.items():
         if not pkg.endswith("_amd64.deb") or (not debug and "-dbg_" in pkg):
@@ -50,20 +56,27 @@ def download_packages(
             failed[pkg] = str(e)
             logging.error("Failed to download %s: %s", pkg, e)
 
-    # Do not silently skip a missing essential package: an incomplete set always
-    # breaks the subsequent install, so fail with a clear, attributable reason
-    # (the per-package message distinguishes a genuine 404 from a transient error).
-    required_failed = {
+    # A required package can be unusable for two reasons, and both must fail the
+    # job loudly with a clear, attributable reason instead of letting a later
+    # `install_packages` die with an opaque `dpkg` glob error:
+    #   1. it was published but failed to download (recorded in `failed`; the
+    #      per-package message distinguishes a genuine 404 from a transient error);
+    #   2. it is absent from the release metadata entirely - a partially published
+    #      release - so it never even entered the download loop above.
+    errors = {
         pkg: reason
         for pkg, reason in failed.items()
-        if pkg.startswith(REQUIRED_PACKAGE_PREFIXES)
+        if pkg.startswith(required_prefixes)
     }
-    if required_failed:
-        details = "; ".join(
-            f"{pkg}: {reason}" for pkg, reason in required_failed.items()
-        )
+    available = [pkg for pkg in release.assets if pkg.endswith("_amd64.deb")]
+    for prefix in required_prefixes:
+        if not any(pkg.startswith(prefix) for pkg in available):
+            errors[prefix] = "not found in the release assets"
+
+    if errors:
+        details = "; ".join(f"{pkg}: {reason}" for pkg, reason in errors.items())
         raise DownloadException(
-            f"Failed to download {len(required_failed)} required release package(s) "
+            f"Failed to obtain {len(errors)} required release package(s) "
             f"for {release}: {details}"
         )
     if failed:

--- a/tests/ci/download_release_packages.py
+++ b/tests/ci/download_release_packages.py
@@ -12,6 +12,23 @@ from get_previous_release_tag import (
 
 PACKAGES_DIR = Path("previous_release_package_folder")
 
+# The release packages are a hard prerequisite for the upgrade check: if any of
+# them is missing the whole job is wasted on setup. Retry more persistently than
+# the generic default to ride out transient GitHub/CDN hiccups (the per-attempt
+# backoff is capped, so this extends the total time window rather than the sleep).
+RELEASE_PACKAGE_DOWNLOAD_RETRIES = 10
+
+# Packages that the upgrade check actually installs (see `install_packages` in
+# `tests/docker_scripts/stress_tests.lib`). Only these are essential; a hiccup
+# while downloading any of the other assets (e.g. `clickhouse-keeper`) must not
+# fail the job.
+REQUIRED_PACKAGE_PREFIXES = (
+    "clickhouse-common-static_",
+    "clickhouse-common-static-dbg_",
+    "clickhouse-server_",
+    "clickhouse-client_",
+)
+
 
 def download_packages(
     release: ReleaseInfo, dest_path: Path = PACKAGES_DIR, debug: bool = False
@@ -20,19 +37,39 @@ def download_packages(
 
     logging.info("Will download %s", release)
 
-    failed = []
+    failed = {}
     for pkg, url in release.assets.items():
         if not pkg.endswith("_amd64.deb") or (not debug and "-dbg_" in pkg):
             continue
         pkg_name = dest_path / pkg
         try:
-            download_build_with_progress(url, pkg_name)
-        except DownloadException:
-            failed.append(pkg)
-            logging.warning("Failed to download %s, will skip", pkg)
+            download_build_with_progress(
+                url, pkg_name, retries=RELEASE_PACKAGE_DOWNLOAD_RETRIES
+            )
+        except DownloadException as e:
+            failed[pkg] = str(e)
+            logging.error("Failed to download %s: %s", pkg, e)
 
+    # Do not silently skip a missing essential package: an incomplete set always
+    # breaks the subsequent install, so fail with a clear, attributable reason
+    # (the per-package message distinguishes a genuine 404 from a transient error).
+    required_failed = {
+        pkg: reason
+        for pkg, reason in failed.items()
+        if pkg.startswith(REQUIRED_PACKAGE_PREFIXES)
+    }
+    if required_failed:
+        details = "; ".join(
+            f"{pkg}: {reason}" for pkg, reason in required_failed.items()
+        )
+        raise DownloadException(
+            f"Failed to download {len(required_failed)} required release package(s) "
+            f"for {release}: {details}"
+        )
     if failed:
-        logging.warning("Some packages failed to download: %s", ", ".join(failed))
+        logging.warning(
+            "Some non-essential packages failed to download: %s", ", ".join(failed)
+        )
 
 
 def download_last_release(dest_path: Path, debug: bool = False) -> None:

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -40,8 +40,20 @@ git clone https://github.com/ClickHouse/ClickHouse.git --no-tags --progress --br
 echo "Download clickhouse-server from the previous release"
 mkdir previous_release_package_folder
 
-echo $previous_release_tag | download_release_packages && echo -e "Download script exit code$OK" >> /test_output/test_results.tsv \
-    || echo -e "Download script failed$FAIL" >> /test_output/test_results.tsv
+# --- download previous release packages: fail closed on a missing required one ---
+# `download_release_packages` exits nonzero when a required previous-release
+# package is missing or fails to download. Stop here at the download boundary
+# with a clear, attributable status instead of letting the later `install_packages`
+# die with an opaque `dpkg` glob error. (`set -e` does not fire inside an
+# `&& ... || ...` list, so the nonzero status must be handled explicitly.)
+if echo $previous_release_tag | download_release_packages; then
+    echo -e "Download script exit code$OK" >> /test_output/test_results.tsv
+else
+    echo -e "Download script failed$FAIL" >> /test_output/test_results.tsv
+    echo -e 'failure\tFailed to download previous release packages' > /test_output/check_status.tsv
+    exit 1
+fi
+# --- end download previous release packages ---
 
 # Check if we cloned previous release repository successfully
 if ! [ "$(ls -A previous_release_repository/tests/queries)" ]


### PR DESCRIPTION
The Upgrade check downloads the previous stable release `.deb` packages during the setup phase. A transient hiccup that exhausted the small retry budget there (5 attempts, ~45s of total backoff) used to abort the whole job before the actual test ran, and was recorded only as a generic `Download script exit code` row with an `OK` status — making it hard to recognize as infrastructure noise.

Reported here: https://github.com/ClickHouse/ClickHouse/pull/102817#issuecomment-4726000791 (job log: https://github.com/ClickHouse/ClickHouse/actions/runs/27117485031/job/80044635535).

This makes the package download path resilient and self-diagnosing.

`download_build_with_progress`:
- configurable `retries` count;
- capped exponential backoff (`DOWNLOAD_RETRY_MAX_BACKOFF`), so raising the retry count extends the total retry *window* instead of exploding the per-attempt sleep;
- fail fast on a genuine `404` (the artifact was never uploaded) instead of burning the whole retry budget;
- treat a truncated response (short read vs. `content-length`) as a transient failure rather than producing a corrupt file that only surfaces later as an opaque `dpkg` error;
- log the HTTP status / error and attempt number on each retry.

`download_packages` (`download_release_packages`):
- retry the release packages more persistently (`RELEASE_PACKAGE_DOWNLOAD_RETRIES`);
- stop silently skipping a missing *essential* package (the ones `install_packages` installs) — raise a clear, attributable error that distinguishes a genuine `404` from a transient failure, while still tolerating a hiccup on unused extra assets such as `clickhouse-keeper`.

Unit tests added in `ci/tests/`.

Related: https://github.com/ClickHouse/ClickHouse/pull/102817

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (CI improvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1057`
<!-- ch-version-info:end -->