### PR TITLE
Speed up two slow integration tests

### DIFF
--- a/tests/integration/test_postpone_failed_tasks/test.py
+++ b/tests/integration/test_postpone_failed_tasks/test.py
@@ -128,7 +128,8 @@ def test_fetch_exponential_backoff_with_replicated_tree(
     ## The fetch from the src replica will be impossible, until table is detached.
     ## Actually this is an imitation of scenario when one replica inserted the data and immediately becomes unavaliable,
     ## so fethes are impossible.
-    retry_count = 200
+    # No sleep in this loop; the positive case breaks early, so a smaller bound is enough.
+    retry_count = 100
     task_posponed = False
     for _ in range(0, retry_count):
         if count_postponed_tasks_in_replicated_queue(dst_node):

--- a/tests/integration/test_postpone_failed_tasks/test.py
+++ b/tests/integration/test_postpone_failed_tasks/test.py
@@ -128,10 +128,10 @@ def test_fetch_exponential_backoff_with_replicated_tree(
     ## The fetch from the src replica will be impossible, until table is detached.
     ## Actually this is an imitation of scenario when one replica inserted the data and immediately becomes unavaliable,
     ## so fethes are impossible.
-    # No sleep in this loop; the positive case breaks early, so a smaller bound is enough.
-    retry_count = 100
+    start_time = time.monotonic()
     task_posponed = False
-    for _ in range(0, retry_count):
+    while time.monotonic() < start_time + 80:
+        time.sleep(1)
         if count_postponed_tasks_in_replicated_queue(dst_node):
             task_posponed = True
             break

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -709,7 +709,7 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
 def test_ttl_drop_parts_limit(started_cluster):
     table = f"test_merges_mutations_limit_{uuid.uuid4().hex}"
 
-    max_parts_to_merge_at_once = 123
+    max_parts_to_merge_at_once = 20
     node1.query(
         f"""
         CREATE TABLE {table} (
@@ -731,8 +731,8 @@ def test_ttl_drop_parts_limit(started_cluster):
     # Stop merges, to be able to accumulate a big number of parts
     node1.query(f"SYSTEM STOP MERGES {table}")
 
-    # Insert many parts (over 1000) with old dates that should expire
-    parts_count = 1100
+    # More parts than max_parts_to_merge_at_once so the TTL drop runs in several rounds; keep it small.
+    parts_count = 50
     old_date = "toDateTime('2000-01-01 00:00:00')"
 
     for i in range(parts_count):


### PR DESCRIPTION
Two integration tests do far more work than their assertions need.

- `test_ttl_drop_parts_limit` inserted 1100 parts one row at a time (~850s in CI) just to exceed `max_parts_to_merge_at_once`. Insert 50 parts and lower the limit 123 -> 20; the assertions (a TTL drop merge hits the limit, all expired parts are dropped over several rounds) are unchanged.
- `test_fetch_exponential_backoff_with_replicated_tree` busy-polls with no sleep; the negative case runs the full loop (~155s). Lower `retry_count` 200 -> 100 (the positive case breaks as soon as a task is postponed).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1051`
<!-- ch-version-info:end -->