### PR TITLE
MergeTreeSink: honor query cancellation while writing many parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -5,6 +5,7 @@
 #include <Interpreters/InsertDeduplication.h>
 #include <Interpreters/PartLog.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
 #include <Common/logger_useful.h>
 #include <Common/ProfileEventsScope.h>
@@ -115,8 +116,15 @@ void MergeTreeSink::consume(Chunk & chunk)
     std::vector<UInt128> all_partwriter_hashes;
     all_partwriter_hashes.reserve(part_blocks.size());
 
+    auto process_list_element = context->getProcessListElement();
+
     for (auto & current_block : part_blocks)
     {
+        /// A single INSERT can split into very many parts (e.g. high-cardinality partition key with
+        /// max_partitions_per_insert_block); honor cancellation/timeout between them.
+        if (process_list_element)
+            process_list_element->checkTimeLimit();
+
         ProfileEvents::Counters part_counters;
         auto partition_scope = std::make_unique<ProfileEventsScope>(&part_counters);
 
@@ -240,8 +248,15 @@ void MergeTreeSink::finishDelayedChunk()
     if (!delayed_chunk)
         return;
 
+    auto process_list_element = context->getProcessListElement();
+
     for (auto & partition : delayed_chunk->partitions)
     {
+        /// Honor cancellation/timeout between parts; finalizing each can be slow on object storage.
+        /// onFinish() skips finishDelayedChunk() when cancelled, so a normal finish never throws here.
+        if (process_list_element)
+            process_list_element->checkTimeLimit();
+
         Stopwatch watch;
         auto profile_events_scope = std::make_unique<ProfileEventsScope>(&partition.part_counters);
 


### PR DESCRIPTION
A single `INSERT` can split into a very large number of parts (e.g. a high-cardinality partition key together with `max_partitions_per_insert_block`), and writing/finalizing each part can be slow on object storage with the filesystem cache. The per-part loops in `MergeTreeSink::consume` and `MergeTreeSink::finishDelayedChunk` had no cancellation point, so a killed or timed-out `INSERT` kept grinding through all remaining parts — which could keep the query (and server shutdown) stuck for a long time, surfacing as "Hung check failed" in stress tests.

Call `process_list_element->checkTimeLimit()` between parts in both loops, the same idiom `ReplicatedMergeTreeSink` already uses. It throws `QUERY_WAS_CANCELLED` on a kill or `TIMEOUT_EXCEEDED` on a 'throw'-mode `max_execution_time` timeout. `onFinish` already skips `finishDelayedChunk` when cancelled, so a normal finish never throws.

Related: https://github.com/ClickHouse/ClickHouse/issues/107477

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
`INSERT` into a `MergeTree` table now honors query cancellation and `max_execution_time` while writing many parts, instead of potentially running long after being killed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.187` (included in `26.7` and later)
<!-- ch-version-info:end -->