### PR TITLE
arrayFold: sanity-check the array argument against malformed input

### DIFF
--- a/src/Functions/array/arrayFold.cpp
+++ b/src/Functions/array/arrayFold.cpp
@@ -18,6 +18,7 @@ namespace ErrorCodes
     extern const int TOO_FEW_ARGUMENTS_FOR_FUNCTION;
     extern const int SIZES_OF_ARRAYS_DONT_MATCH;
     extern const int TYPE_MISMATCH;
+    extern const int LOGICAL_ERROR;
 }
 
 /**
@@ -154,6 +155,13 @@ public:
 
         const auto & offsets = first_array_col_concrete->getOffsets(); /// the internal offsets column of the first array argument (other array arguments have the same offsets)
 
+        /// A malformed array whose data column size disagrees with its offsets would desync the
+        /// selector loop below and blow up max_array_size (observed as a multi-GB ~uncancellable hang).
+        if (offsets[num_rows - 1] != static_cast<ColumnArray::Offset>(num_elements_in_array_col))
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Malformed array argument of function {}: nested data column has {} elements but offsets describe {}",
+                getName(), num_elements_in_array_col, offsets[num_rows - 1]);
+
         /// Find the first row which contains a non-empty array
         ssize_t first_row_with_non_empty_array = 0;
         if (num_elements_in_array_col)
@@ -181,6 +189,13 @@ public:
                 cur_element_in_cur_array = 0;
             }
         }
+
+        /// max_array_size cannot exceed the total number of array elements; if it does, the selector
+        /// computation above is corrupt - bail out before scatter() allocates that many slices.
+        if (max_array_size > static_cast<size_t>(num_elements_in_array_col))
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "Function {}: computed max_array_size {} exceeds total array elements {}",
+                getName(), max_array_size, num_elements_in_array_col);
 
         /// Based on the selector, scatter elements of the arrays on all rows into vertical slices
         /// Example:


### PR DESCRIPTION
A fuzzer-found query (`arrayFold(acc,x -> arrayPushFront(acc,x), range(number), emptyArrayUInt64()) FROM system.numbers LIMIT 5`) spent ~6 GB and ~1500s stuck in `scatter`, on only 5 rows. Add two cheap checks that turn such a malformed input into an immediate exception instead of a huge, ~uncancellable allocation: the first array's nested data column size must equal its offsets, and `max_array_size` must not exceed the total number of array elements.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1042`
<!-- ch-version-info:end -->