### PR TITLE
clickhouse-format: add --align-column-types option

### DIFF
--- a/programs/format/Format.cpp
+++ b/programs/format/Format.cpp
@@ -90,6 +90,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
             ("seed", po::value<std::string>(), "seed (arbitrary string) that determines the result of obfuscation")
             ("show_secrets", po::bool_switch()->default_value(false), "show secret values like passwords, API keys, etc.")
             ("semicolons_inline", "In multiquery mode put semicolon on last line of query instead of a new line")
+            ("align_column_types", "align type declarations in CREATE TABLE column lists")
         ;
 
         Settings cmd_settings;
@@ -118,6 +119,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
         bool allow_settings_after_format_in_insert = options.contains("allow_settings_after_format_in_insert");
         bool show_secrets = options["show_secrets"].as<bool>();
         bool semicolon_inline = options.contains("semicolons_inline");
+        bool align_column_types = options.contains("align_column_types");
 
         std::function<void(std::string_view)> comments_callback;
         if (options.contains("comments"))
@@ -300,6 +302,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                         IAST::FormatSettings settings(oneline_current_query);
                         settings.show_secrets = show_secrets;
                         settings.print_pretty_type_names = !oneline_current_query;
+                        settings.align_column_types = align_column_types && !oneline_current_query;
                         res->format(query_buf, settings);
                         String formatted_query = query_buf.str();
 #if USE_REPLXX
@@ -353,6 +356,7 @@ int mainEntryClickHouseFormat(int argc, char ** argv)
                         IAST::FormatSettings settings(oneline_current_query);
                         settings.show_secrets = show_secrets;
                         settings.print_pretty_type_names = !oneline_current_query;
+                        settings.align_column_types = align_column_types && !oneline_current_query;
                         res->format(str_buf, settings);
 
                         if (insert_query_payload)

--- a/src/Parsers/ASTColumnDeclaration.cpp
+++ b/src/Parsers/ASTColumnDeclaration.cpp
@@ -104,7 +104,15 @@ void ASTColumnDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings &
 
     if (auto type = getType())
     {
-        ostr << ' ';
+        if (frame.column_name_max_width > 0)
+        {
+            /// Quoted length of this column name = raw length + 2 backticks (see ASTColumns::formatImpl).
+            size_t quoted_len = name.size() + 2;
+            size_t pad = (frame.column_name_max_width >= quoted_len) ? frame.column_name_max_width - quoted_len + 1 : 1;
+            ostr << std::string(pad, ' ');
+        }
+        else
+            ostr << ' ';
         type->format(ostr, format_settings, state, frame);
     }
 

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -229,6 +229,18 @@ void ASTColumns::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Format
 
     if (columns)
     {
+        if (s.align_column_types && !s.one_line)
+        {
+            for (const auto & column : columns->children)
+            {
+                if (const auto * col = column->as<ASTColumnDeclaration>())
+                    /// Quoted length = raw name length + 2 backticks.
+                    /// Valid SQL identifiers consist of [A-Za-z0-9_] only, so no escape
+                    /// expansion occurs inside the backticks and this formula is exact.
+                    frame.column_name_max_width = std::max(frame.column_name_max_width, col->name.size() + 2);
+            }
+        }
+
         for (const auto & column : columns->children)
         {
             auto elem = make_intrusive<ASTColumnsElement>();

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -335,6 +335,8 @@ public:
         bool enforce_strict_identifier_format;
         /// This is needed for distributed queries with the old analyzer. Remove it after removing the old analyzer.
         bool collapse_identical_nodes_to_aliases;
+        /// Align type declarations in CREATE TABLE column lists so all type tokens start at the same column.
+        bool align_column_types;
 
         explicit FormatSettings(
             bool one_line_,
@@ -344,7 +346,8 @@ public:
             LiteralEscapingStyle literal_escaping_style_ = LiteralEscapingStyle::Regular,
             bool print_pretty_type_names_ = false,
             bool enforce_strict_identifier_format_ = false,
-            bool collapse_identical_nodes_to_aliases_ = false)
+            bool collapse_identical_nodes_to_aliases_ = false,
+            bool align_column_types_ = false)
             : one_line(one_line_)
             , identifier_quoting_rule(identifier_quoting_rule_)
             , identifier_quoting_style(identifier_quoting_style_)
@@ -354,6 +357,7 @@ public:
             , print_pretty_type_names(print_pretty_type_names_)
             , enforce_strict_identifier_format(enforce_strict_identifier_format_)
             , collapse_identical_nodes_to_aliases(collapse_identical_nodes_to_aliases_)
+            , align_column_types(align_column_types_)
         {
         }
 
@@ -389,6 +393,10 @@ public:
         /// This keeps the format-parse-format round-trip stable: `(expr) AS alias` re-parses with
         /// `parenthesized=true` on the aliased node, which formats back to `(expr) AS alias`.
         bool parenthesize_alias_inner_only = false;
+        /// Set by ASTColumns::formatImpl when align_column_types is enabled.
+        /// Holds the maximum quoted column-name width across all columns in the current CREATE TABLE,
+        /// so ASTColumnDeclaration can pad the gap between name and type to align all types.
+        size_t column_name_max_width = 0;
     };
 
     void format(WriteBuffer & ostr, const FormatSettings & settings) const;

--- a/tests/queries/0_stateless/04341_clickhouse_format_align_column_types.reference
+++ b/tests/queries/0_stateless/04341_clickhouse_format_align_column_types.reference
@@ -1,0 +1,29 @@
+CREATE TABLE t
+(
+    `id`                       UInt64,
+    `customer_booking_number`  String,
+    `amount`                   Decimal(18, 2),
+    `has_flag`                 Bool,
+    `created_at`               DateTime
+)
+ENGINE = MergeTree
+ORDER BY id
+;
+CREATE TABLE metrics
+(
+    `ts`     DateTime,
+    `count`  UInt64,
+    `ratio`  Float64,
+    `name`   String
+)
+ENGINE = MergeTree
+ORDER BY ts
+;
+CREATE TABLE t
+(
+    `id` UInt64,
+    `customer_booking_number` String
+)
+ENGINE = MergeTree
+ORDER BY id
+;

--- a/tests/queries/0_stateless/04341_clickhouse_format_align_column_types.sh
+++ b/tests/queries/0_stateless/04341_clickhouse_format_align_column_types.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# --align-column-types aligns type tokens in CREATE TABLE column lists
+echo "CREATE TABLE t (id UInt64, customer_booking_number String, amount Decimal(18, 2), has_flag Bool, created_at DateTime) ENGINE = MergeTree ORDER BY id;" | $CLICKHOUSE_FORMAT --align-column-types
+
+# Mix of short and long names
+echo "CREATE TABLE metrics (ts DateTime, count UInt64, ratio Float64, name String) ENGINE = MergeTree ORDER BY ts;" | $CLICKHOUSE_FORMAT --align-column-types
+
+# Without the flag the output is unchanged (single space between name and type)
+echo "CREATE TABLE t (id UInt64, customer_booking_number String) ENGINE = MergeTree ORDER BY id;" | $CLICKHOUSE_FORMAT


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/107959

### Changelog category (leave one):
- New Feature

### Changelog entry:
Added `--align-column-types` option to `clickhouse-format` that aligns type declarations in `CREATE TABLE` column lists so all type tokens start at the same column position.

---

## Summary

Adds a new `--align-column-types` option to `clickhouse-format` that aligns type declarations in `CREATE TABLE` column lists so all type tokens start at the same column position.

## Example

**With `--align-column-types`:**
```sql
CREATE TABLE bookings
(
    `booking_key`              UUID,
    `customer_booking_number`  String,
    `gross_weight`             String,
    `has_64`                   Bool,
    `timestamp`                DateTime
)
ENGINE = ReplacingMergeTree
ORDER BY booking_key
```

**Without (existing behaviour, unchanged):**
```sql
CREATE TABLE bookings
(
    `booking_key` UUID,
    `customer_booking_number` String,
    `gross_weight` String,
    `has_64` Bool,
    `timestamp` DateTime
)
ENGINE = ReplacingMergeTree
ORDER BY booking_key
```

## Implementation

- `FormatSettings` gets a `bool align_column_types` field (default `false`) — the user-facing on/off switch
- `FormatStateStacked` gets a `size_t column_name_max_width` field — the max quoted column-name width computed per `CREATE TABLE`, passed down to descendant nodes via the existing frame-copy mechanism
- `ASTColumns::formatImpl` computes the max quoted column-name width across all columns in the block when `align_column_types` is enabled and stores it in `frame.column_name_max_width`
- `ASTColumnDeclaration::formatImpl` uses `frame.column_name_max_width` to pad the gap between the backtick-quoted identifier and the type token; falls back to a single space when the field is zero (flag off) or when the name is the longest one in the block
- `Format.cpp` exposes the flag as `--align-column-types`; the flag is silently ignored in one-line mode since alignment is meaningless there

## Why the quoted-length formula is exact

Under `clickhouse-format`'s default settings (`WhenNecessary` + `Backticks`), column names are always backtick-quoted because `ASTColumnDeclaration` always passes `ambiguous=true` to `writeIdentifier`. Valid SQL identifiers consist only of `[A-Za-z0-9_]`, none of which trigger backslash-escape expansion inside backticks. Therefore quoted length = `name.size() + 2` exactly, with no `WriteBuffer` pass needed at the width-computation step.
