### PR TITLE
Fix flaky test 04146_iceberg_orc_row_policy_prewhere on release branches

### DIFF
--- a/tests/queries/0_stateless/04146_iceberg_orc_row_policy_prewhere.sh
+++ b/tests/queries/0_stateless/04146_iceberg_orc_row_policy_prewhere.sh
@@ -36,6 +36,9 @@ rm -rf "${ICEBERG_PATH}"
 # passes) but write a mix of ORC and Parquet data files into it.
 ${CLICKHOUSE_CLIENT} --query "
     SET allow_experimental_insert_into_iceberg = 1;
+    -- StorageObjectStorage caches supportsPrewhere() at CREATE time from this
+    -- session setting; pinning it only on the SELECTs below is too late.
+    SET input_format_parquet_use_native_reader_v3 = 1;
 
     CREATE TABLE ${TEST_TABLE} (c0 Int64, c1 String)
         ENGINE = IcebergLocal('${ICEBERG_PATH}', 'Parquet');


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/101206
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/101206

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04146_iceberg_orc_row_policy_prewhere` fails deterministically (~1 in 6 runs)
on the `26.3` and `26.4` release branches, breaking `ReleaseBranchCI` and every
backport PR's stateless suite. It is clean on master.

Root cause: `StorageObjectStorage` caches `supportsPrewhere()` at
table-construction time. For format `Parquet` the prewhere-support checker
returns the value of `input_format_parquet_use_native_reader_v3`. The test
creates an Iceberg table with format `Parquet` and uses `PREWHERE`, but the
`CREATE TABLE` block did not pin that setting. A randomized session with
`input_format_parquet_use_native_reader_v3 = 0` therefore baked
`supports_prewhere = false` into the storage object, and the later
`SELECT ... PREWHERE` failed at analysis time with `ILLEGAL_PREWHERE` (Code
182) — even though those SELECTs pin `= 1`, which is too late because the
storage was already constructed.

On master `input_format_parquet_use_native_reader_v3` is obsolete and was
removed from `clickhouse-test` randomization (commit 80f3bb84403, "Remove old
Parquet writer and reader implementations"), so the failing value never
occurs there. On `26.3`/`26.4` the setting is still live and still randomized,
so the table is sometimes built with the old reader and the test fails.

Fix: pin `input_format_parquet_use_native_reader_v3 = 1` in the `CREATE TABLE`
block, matching the sibling test
`04147_iceberg_orc_schema_evolution_row_policy`. This is a no-op on master
(the setting is already effectively always 1 there).

Verification (debug build, branch base `backport/26.4/106349`, commit
a47777551e2c):

- Without the fix, forcing `input_format_parquet_use_native_reader_v3=0` via
  the runner: 206 FAIL / 17 OK (`ILLEGAL_PREWHERE`).
- With the fix, randomization on, `clickhouse-test --test-runs 40`: 40/40 OK.
- Direct repro: `CREATE` under session v3=0 throws `ILLEGAL_PREWHERE`; with the
  pin the three queries return the reference values 139 / 144 / 11120.

Report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=26.4&sha=d4d44a390d59339d45f76829011eedc123ddcf5b&name_0=ReleaseBranchCI


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.960` (included in `26.7` and later)
- Backported to: `26.6.2.70`, `26.5.6.42`, `26.4.5.130`, `26.3.17.47`
<!-- ch-version-info:end -->