### PR TITLE
Make `set` skip index gate on `canBeUsedInBooleanContext` instead of integer-only

### DIFF
--- a/src/Functions/bitWrapperFunc.cpp
+++ b/src/Functions/bitWrapperFunc.cpp
@@ -24,10 +24,14 @@ struct BitWrapperFuncImpl
 
     static ResultType NO_SANITIZE_UNDEFINED apply(A a [[maybe_unused]])
     {
-        // Should be a logical error, but this function is callable from SQL.
-        // Need to investigate this.
-        if constexpr (!is_integer<A>)
-            throw DB::Exception(ErrorCodes::BAD_ARGUMENTS, "It's a bug! Only integer types are supported by __bitWrapperFunc.");
+        /// `__bitWrapperFunc` maps a value to a `BoolMask` purely by truthiness (zero -> "can be false",
+        /// non-zero -> "can be true"), which is well-defined for every number. `FunctionUnaryArithmetic`
+        /// only resolves this function for native integers and `Float32`/`Float64` (`BFloat16` and
+        /// `Decimal` are not in its `castType` list), which is exactly the set the set skip index gates on
+        /// via `canBeUsedInBooleanContext`. Accept integers and floating-point here so float atoms wrap
+        /// (and the index prunes) instead of throwing; non-numeric types cannot reach this code.
+        if constexpr (!is_integer<A> && !is_floating_point<A>)
+            throw DB::Exception(ErrorCodes::BAD_ARGUMENTS, "It's a bug! Only numeric types are supported by __bitWrapperFunc.");
         return a == 0 ? static_cast<ResultType>(0b10) : static_cast<ResultType>(0b01);
     }
 

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -4,6 +4,7 @@
 #include <Common/FieldAccurateComparison.h>
 #include <Common/quoteString.h>
 
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/IDataType.h>
 
@@ -579,12 +580,13 @@ const ActionsDAG::Node & MergeTreeIndexConditionSet::traverseDAG(const ActionsDA
             atom_node_ptr->type == ActionsDAG::ActionType::FUNCTION ||
             (atom_node_ptr->type == ActionsDAG::ActionType::COLUMN && !WhichDataType(atom_node_ptr->result_type).isSet()))
         {
-            /// `__bitWrapperFunc` is defined only for integer arguments. If the atom result type
-            /// is not integer (e.g. `Float`, `BFloat16`), wrapping it would throw the internal
-            /// "It's a bug!" exception from `__bitWrapperFunc` at execution time. Fall back to
-            /// `UNKNOWN_FIELD` so that the index does not prune granules and the query goes
-            /// through the regular filter path.
-            if (WhichDataType(removeNullable(atom_node_ptr->result_type)).isInteger())
+            /// Wrap the atom in `__bitWrapperFunc` to turn its truthiness into a `BoolMask`. The set of
+            /// types this is valid for is exactly the set query analysis admits for a WHERE filter, so we
+            /// gate on the same predicate (`canBeUsedInBooleanContext`, which sees through `Nullable` and
+            /// `LowCardinality`). This keeps the index in sync with the filter contract: any atom that is
+            /// legal in WHERE can be pruned on. Anything else falls back to `UNKNOWN_FIELD`, so the index
+            /// does not prune and the query goes through the regular filter path.
+            if (atom_node_ptr->result_type->canBeUsedInBooleanContext())
             {
                 auto bit_wrapper_function = FunctionFactory::instance().get("__bitWrapperFunc", context);
                 result_node = &result_dag.addFunction(bit_wrapper_function, {atom_node_ptr}, {});

--- a/tests/queries/0_stateless/04357_set_skip_index_lowcardinality_hastoken_like.reference
+++ b/tests/queries/0_stateless/04357_set_skip_index_lowcardinality_hastoken_like.reference
@@ -1,0 +1,4 @@
+Granules: 1/16
+Granules: 1/16
+1
+1

--- a/tests/queries/0_stateless/04357_set_skip_index_lowcardinality_hastoken_like.sql
+++ b/tests/queries/0_stateless/04357_set_skip_index_lowcardinality_hastoken_like.sql
@@ -1,0 +1,63 @@
+-- Regression test for a `set` skip index that stops pruning granules for
+-- function predicates (`hasToken`, `LIKE`, ...) over a non-nullable
+-- `LowCardinality(String)` column.
+--
+-- Caused by https://github.com/ClickHouse/ClickHouse/pull/105384 . That PR
+-- guards the `__bitWrapperFunc` wrapping in
+-- `MergeTreeIndexConditionSet::traverseDAG` with
+-- `WhichDataType(removeNullable(atom->result_type)).isInteger()`, falling back
+-- to `UNKNOWN_FIELD` (no pruning) otherwise. The check strips `Nullable` but
+-- not `LowCardinality`: for a `LowCardinality(String)` column, `hasToken` and
+-- `LIKE` produce `LowCardinality(UInt8)`, which is not "integer", so every atom
+-- becomes `UNKNOWN_FIELD` and the `set` index prunes nothing -- turning an
+-- index lookup into a full scan. A plain `String` column returns `UInt8` and is
+-- unaffected, which is why the regression is specific to `LowCardinality`.
+--
+-- The index lookup is correct (the wrapped `LowCardinality(UInt8)` atom matches
+-- the granule's stored values), so results are unchanged -- only pruning is
+-- lost. Hence this test asserts on the number of granules the index keeps, via
+-- `EXPLAIN indexes = 1`, rather than on query results.
+
+DROP TABLE IF EXISTS t_set_lc;
+
+CREATE TABLE t_set_lc
+(
+    s LowCardinality(String),
+    INDEX idx_set s TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS index_granularity = 1;
+
+-- 16 rows, one distinct value per granule (GRANULARITY 1, index_granularity 1),
+-- so a predicate matching a single value must leave exactly one granule.
+INSERT INTO t_set_lc SELECT 'svc' || leftPad(toString(number), 4, '0') FROM numbers(16);
+
+-- Pin the settings that gate skip-index analysis so the stateless runner's
+-- setting randomization cannot mask the regression.
+
+-- `hasToken`: the set index must prune to a single granule (expect `1/16`).
+SELECT trimLeft(explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT count() FROM t_set_lc WHERE hasToken(s, 'svc0003')
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, use_query_condition_cache = 0
+)
+WHERE explain LIKE '%Granules:%';
+
+-- `LIKE`: same expectation.
+SELECT trimLeft(explain)
+FROM
+(
+    EXPLAIN indexes = 1
+    SELECT count() FROM t_set_lc WHERE s LIKE '%svc0003%'
+    SETTINGS use_skip_indexes = 1, use_skip_indexes_on_data_read = 0, use_query_condition_cache = 0
+)
+WHERE explain LIKE '%Granules:%';
+
+-- Results stay correct regardless of pruning (sanity check).
+SELECT count() FROM t_set_lc WHERE hasToken(s, 'svc0003');
+SELECT count() FROM t_set_lc WHERE s LIKE '%svc0003%';
+
+DROP TABLE t_set_lc;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix set skip index not pruning granules over LowCardinality columns.
