### PR TITLE
Fix data race on the packed skip-indices archive reader

### DIFF
--- a/src/IO/PackedFilesReader.cpp
+++ b/src/IO/PackedFilesReader.cpp
@@ -14,17 +14,13 @@ namespace ErrorCodes
 }
 
 PackedFilesReader::PackedFilesReader(
-    DiskPtr disk_, const String & data_file_name_, const ReadSettings & read_settings_)
-    : disk(std::move(disk_)), data_file_name(data_file_name_)
+    const DiskPtr & disk, const String & data_file_name, const ReadSettings & read_settings)
+    : index(readIndex(*disk->readFile(data_file_name, read_settings.adjustBufferSize(4096))))
 {
-    auto in = disk->readFile(data_file_name, read_settings_.adjustBufferSize(4096));
-
-    index = readIndex(*in);
 }
 
-PackedFilesReader::PackedFilesReader(
-    DiskPtr disk_, const String & data_file_name_, const PackedFilesIO::Index & index_)
-    : disk(std::move(disk_)), data_file_name(data_file_name_), index(index_)
+PackedFilesReader::PackedFilesReader(PackedFilesIO::Index index_)
+    : index(std::move(index_))
 {
 }
 
@@ -87,6 +83,8 @@ static ReadSettings patchSettings(ReadSettings settings)
 }
 
 std::unique_ptr<ReadBufferFromFileBase> PackedFilesReader::readFile(
+    const DiskPtr & disk,
+    const String & data_file_name,
     const String & file_name,
     const ReadSettings & settings,
     std::optional<size_t> read_hint) const

--- a/src/IO/PackedFilesReader.h
+++ b/src/IO/PackedFilesReader.h
@@ -14,22 +14,33 @@ class ReadBufferFromFileBase;
 using DiskPtr = std::shared_ptr<IDisk>;
 
 /// Class that allows to read files from archive written by PackedFilesWriter.
+///
+/// Holds only the archive index (file name -> offset+size within the archive). The index is
+/// path-independent: it stays valid when the part is renamed or moved, because the offsets inside
+/// the archive do not change. The disk and the archive's current path are supplied by the caller
+/// to readFile, never cached here, so a concurrent rename cannot leave the reader pointing at a
+/// stale location, and the reader can be shared without locking.
 class PackedFilesReader
 {
 public:
-    /// Constructor that loads index from disk.
-    PackedFilesReader(DiskPtr disk_, const String & data_file_name_, const ReadSettings & read_settings_);
+    /// Constructor that loads the index from an archive file on disk. The disk and path are used
+    /// only to read the index here; they are not retained.
+    PackedFilesReader(const DiskPtr & disk, const String & data_file_name, const ReadSettings & read_settings);
 
-    /// Constructor that initializes index by provided one.
-    PackedFilesReader(DiskPtr disk_, const String & data_file_name_, const PackedFilesIO::Index & index_);
+    /// Constructor that initializes the index by the provided one.
+    explicit PackedFilesReader(PackedFilesIO::Index index_);
 
     /// Common read operations which return data from index.
     bool exists(const std::string & file_name) const;
     size_t getFileSize(const String & file_name) const;
     Names getFileNames() const;
 
-    /// Returns read buffer to read requested file as a part of archive file.
+    /// Returns read buffer to read requested file as a part of the archive file. The archive's
+    /// current location (disk + path) is supplied by the caller, so a relocated part reads from
+    /// the right place without the reader caching a path.
     std::unique_ptr<ReadBufferFromFileBase> readFile(
+        const DiskPtr & disk,
+        const String & data_file_name,
         const String & file_name,
         const ReadSettings & settings,
         std::optional<size_t> read_hint) const;
@@ -39,12 +50,8 @@ public:
     static PackedFilesIO::Index readIndex(ReadBuffer & in);
 
 private:
-    /// Disk of file with archive.
-    const DiskPtr disk;
-    /// Path of file with archive.
-    const String data_file_name;
-    /// Index of archive.
-    PackedFilesIO::Index index;
+    /// Index of archive: immutable and path-independent.
+    const PackedFilesIO::Index index;
 };
 
 }

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -5,6 +5,7 @@
 #include <Disks/IDiskTransaction.h>
 #include <Disks/SingleDiskVolume.h>
 #include <Disks/TemporaryFileOnDisk.h>
+#include <IO/Expect404ResponseScope.h>
 #include <IO/HashingWriteBuffer.h>
 #include <IO/PackedFilesReader.h>
 #include <IO/PackedFilesWriter.h>
@@ -12,6 +13,7 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadPipeline.h>
 #include <IO/ReadHelpers.h>
+#include <IO/S3Common.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/copyData.h>
 #include <Interpreters/Context.h>
@@ -1034,7 +1036,22 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndic
     const String packed_path = fs::path(root_path) / part_dir / String(SKIP_INDICES_PACKED_FILENAME);
     auto disk = volume->getDisk();
     if (disk->existsFile(packed_path))
-        skip_indices_packed_reader = std::make_shared<PackedFilesReader>(disk, packed_path, ReadSettings{});
+    {
+        /// On shared storage another replica may delete skp_idx.packed between the existence check
+        /// above and the open below. A NO_SUCH_KEY then means the archive is gone, not an error, so
+        /// treat the part as having no overlay. Expect404ResponseScope keeps it from being logged or
+        /// counted as a DiskS3NoSuchKeyError (which fails stress tests); catching alone is not enough.
+        Expect404ResponseScope scope;
+        try
+        {
+            skip_indices_packed_reader = std::make_shared<PackedFilesReader>(disk, packed_path, ReadSettings{});
+        }
+        catch (const S3Exception & e)
+        {
+            if (e.getS3ErrorCode() != Aws::S3::S3Errors::NO_SUCH_KEY)
+                throw;
+        }
+    }
 
     skip_indices_packed_probed = true;
     return skip_indices_packed_reader;

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -1036,11 +1036,15 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndic
     auto disk = volume->getDisk();
     if (disk->existsFile(packed_path))
     {
-        /// On shared storage another replica may delete skp_idx.packed between the existence check
-        /// above and the open below, so the open fails with a "no such key" error. Expect404ResponseScope
-        /// keeps that 404 from being logged or counted as a DiskS3NoSuchKeyError (which fails stress
-        /// tests); catching alone is not enough. If the archive is indeed gone after the failure, treat
-        /// the part as having no overlay; otherwise rethrow a genuine read error.
+        /// On shared storage another replica may delete or relocate skp_idx.packed between the
+        /// existence check above and the open below, so the open fails with a "no such key" error.
+        /// Expect404ResponseScope keeps that 404 from being logged or counted as a DiskS3NoSuchKeyError
+        /// (which fails stress tests); catching alone is not enough. If the archive is still present
+        /// it is a genuine read error -> rethrow. Otherwise it was removed or moved: do NOT cache a
+        /// miss (return without setting probed), so the next access re-probes against the current
+        /// path -- after a rename the archive lives at the new path and must not be lost. A part that
+        /// genuinely has no archive is cached as a miss via the existsFile-false branch above, so this
+        /// does not loop.
         Expect404ResponseScope scope;
         try
         {
@@ -1050,6 +1054,7 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndic
         {
             if (disk->existsFile(packed_path))
                 throw;
+            return nullptr;
         }
     }
 

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -208,6 +208,10 @@ bool DataPartStorageOnDiskBase::looksLikeBrokenDetachedPartHasTheSameContent(con
 void DataPartStorageOnDiskBase::setRelativePath(const std::string & path)
 {
     part_dir = path;
+    /// Unlike rename/changeRootPath, this can repoint the storage at an unrelated directory whose
+    /// archive has a different index, so the cached reader must be dropped. The reset is safe for
+    /// concurrent readers because the reader is shared-owned: a reader still using it keeps it
+    /// alive until done.
     {
         std::lock_guard lock(skip_indices_packed_mutex);
         skip_indices_packed_probed = false;
@@ -693,14 +697,10 @@ void DataPartStorageOnDiskBase::rename(
     part_dir = new_part_dir;
     root_path = new_root_path;
 
-    /// The cached skp_idx.packed reader (if any) was constructed with the old absolute path and
-    /// would keep reading from there even after the directory move. Drop it so the next access
-    /// reloads from the new location.
-    {
-        std::lock_guard lock(skip_indices_packed_mutex);
-        skip_indices_packed_probed = false;
-        skip_indices_packed_reader.reset();
-    }
+    /// The cached skp_idx.packed reader keeps serving the same archive index: a directory move
+    /// does not change the offsets inside the archive, and reads resolve the archive's current
+    /// location through readFile. So there is nothing to invalidate here, and not touching the
+    /// reader avoids freeing it while a concurrent query is reading the index.
 }
 
 void DataPartStorageOnDiskBase::remove(
@@ -983,11 +983,9 @@ void DataPartStorageOnDiskBase::changeRootPath(const std::string & from_root, co
 
     root_path = to_root.substr(0, dst_size) + root_path.substr(prefix_size);
 
-    {
-        std::lock_guard lock(skip_indices_packed_mutex);
-        skip_indices_packed_probed = false;
-        skip_indices_packed_reader.reset();
-    }
+    /// See rename: the cached skp_idx.packed index is path-independent, so a root-path change
+    /// does not invalidate it. Leaving the reader in place avoids freeing it under a concurrent
+    /// reader.
 }
 
 SyncGuardPtr DataPartStorageOnDiskBase::getDirectorySyncGuard() const
@@ -1025,28 +1023,27 @@ bool DataPartStorageOnDiskBase::isCaseInsensitive() const
     return getDisk()->isCaseInsensitive();
 }
 
-const PackedFilesReader * DataPartStorageOnDiskBase::getSkipIndicesPackedReader() const
+std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndicesPackedReader() const
 {
     std::lock_guard lock(skip_indices_packed_mutex);
     if (skip_indices_packed_probed)
-        return skip_indices_packed_reader.get();
+        return skip_indices_packed_reader;
 
     auto component_guard = Coordination::setCurrentComponent("DataPartStorageOnDiskBase::getSkipIndicesPackedReader");
 
     const String packed_path = fs::path(root_path) / part_dir / String(SKIP_INDICES_PACKED_FILENAME);
     auto disk = volume->getDisk();
     if (disk->existsFile(packed_path))
-        skip_indices_packed_reader = std::make_unique<PackedFilesReader>(disk, packed_path, ReadSettings{});
+        skip_indices_packed_reader = std::make_shared<PackedFilesReader>(disk, packed_path, ReadSettings{});
 
     skip_indices_packed_probed = true;
-    return skip_indices_packed_reader.get();
+    return skip_indices_packed_reader;
 }
 
 void DataPartStorageOnDiskBase::seedSkipIndicesPackedReader(const PackedFilesIO::Index & index) const
 {
     std::lock_guard lock(skip_indices_packed_mutex);
-    const String packed_path = fs::path(root_path) / part_dir / String(SKIP_INDICES_PACKED_FILENAME);
-    skip_indices_packed_reader = std::make_unique<PackedFilesReader>(volume->getDisk(), packed_path, index);
+    skip_indices_packed_reader = std::make_shared<PackedFilesReader>(index);
     skip_indices_packed_probed = true;
 }
 
@@ -1058,7 +1055,7 @@ void DataPartStorageOnDiskBase::seedSkipIndicesPackedReaderFrom(const IDataPartS
 
     /// Same-class access to the protected probe is allowed; this also triggers the source's lazy
     /// load if it hasn't been read yet.
-    const auto * source_archive = source_disk->getSkipIndicesPackedReader();
+    auto source_archive = source_disk->getSkipIndicesPackedReader();
     if (!source_archive)
         return;
 
@@ -1067,7 +1064,7 @@ void DataPartStorageOnDiskBase::seedSkipIndicesPackedReaderFrom(const IDataPartS
 
 bool DataPartStorageOnDiskBase::isFileInPackedSkipIndicesArchive(const std::string & name) const
 {
-    const auto * reader = getSkipIndicesPackedReader();
+    auto reader = getSkipIndicesPackedReader();
     return reader != nullptr && reader->exists(name);
 }
 
@@ -1085,7 +1082,7 @@ void DataPartStorageOnDiskBase::copyPackedSkipIndicesFilesInto(
     if (file_names.empty())
         return;
 
-    const auto * source_archive = getSkipIndicesPackedReader();
+    auto source_archive = getSkipIndicesPackedReader();
     if (!source_archive)
         return;
 
@@ -1115,7 +1112,7 @@ void DataPartStorageOnDiskBase::filterPackedSkipIndicesArchiveTo(
     MergeTreeDataPartChecksums & checksums,
     bool sync) const
 {
-    const auto * source_archive = getSkipIndicesPackedReader();
+    auto source_archive = getSkipIndicesPackedReader();
     if (!source_archive)
         return;
 

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -698,10 +698,17 @@ void DataPartStorageOnDiskBase::rename(
     part_dir = new_part_dir;
     root_path = new_root_path;
 
-    /// The cached skp_idx.packed reader keeps serving the same archive index: a directory move
-    /// does not change the offsets inside the archive, and reads resolve the archive's current
-    /// location through readFile. So there is nothing to invalidate here, and not touching the
-    /// reader avoids freeing it while a concurrent query is reading the index.
+    /// A successfully-loaded reader stays valid: its archive index is path-independent and reads
+    /// resolve the archive's current location through readFile, so keep it (dropping it could also
+    /// race a concurrent query holding it). But a cached *miss* may be stale: a probe that ran while
+    /// this rename was in progress could have built packed_path from the old location and found no
+    /// file. Clear that stale miss (only when there is no reader) so the next access re-probes the
+    /// new path.
+    {
+        std::lock_guard lock(skip_indices_packed_mutex);
+        if (!skip_indices_packed_reader)
+            skip_indices_packed_probed = false;
+    }
 }
 
 void DataPartStorageOnDiskBase::remove(
@@ -984,9 +991,13 @@ void DataPartStorageOnDiskBase::changeRootPath(const std::string & from_root, co
 
     root_path = to_root.substr(0, dst_size) + root_path.substr(prefix_size);
 
-    /// See rename: the cached skp_idx.packed index is path-independent, so a root-path change
-    /// does not invalidate it. Leaving the reader in place avoids freeing it under a concurrent
-    /// reader.
+    /// See rename: keep a successfully-loaded (path-independent) reader, but clear a stale cached
+    /// miss so the next access re-probes the new path.
+    {
+        std::lock_guard lock(skip_indices_packed_mutex);
+        if (!skip_indices_packed_reader)
+            skip_indices_packed_probed = false;
+    }
 }
 
 SyncGuardPtr DataPartStorageOnDiskBase::getDirectorySyncGuard() const

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp
@@ -13,7 +13,6 @@
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadPipeline.h>
 #include <IO/ReadHelpers.h>
-#include <IO/S3Common.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/copyData.h>
 #include <Interpreters/Context.h>
@@ -1038,17 +1037,18 @@ std::shared_ptr<const PackedFilesReader> DataPartStorageOnDiskBase::getSkipIndic
     if (disk->existsFile(packed_path))
     {
         /// On shared storage another replica may delete skp_idx.packed between the existence check
-        /// above and the open below. A NO_SUCH_KEY then means the archive is gone, not an error, so
-        /// treat the part as having no overlay. Expect404ResponseScope keeps it from being logged or
-        /// counted as a DiskS3NoSuchKeyError (which fails stress tests); catching alone is not enough.
+        /// above and the open below, so the open fails with a "no such key" error. Expect404ResponseScope
+        /// keeps that 404 from being logged or counted as a DiskS3NoSuchKeyError (which fails stress
+        /// tests); catching alone is not enough. If the archive is indeed gone after the failure, treat
+        /// the part as having no overlay; otherwise rethrow a genuine read error.
         Expect404ResponseScope scope;
         try
         {
             skip_indices_packed_reader = std::make_shared<PackedFilesReader>(disk, packed_path, ReadSettings{});
         }
-        catch (const S3Exception & e)
+        catch (const Exception &)
         {
-            if (e.getS3ErrorCode() != Aws::S3::S3Errors::NO_SUCH_KEY)
+            if (disk->existsFile(packed_path))
                 throw;
         }
     }

--- a/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskBase.h
@@ -170,7 +170,12 @@ protected:
     /// Virtual so storage subclasses where skp_idx.packed isn't a standalone file on disk can
     /// override the probe path. The default implementation does a disk->existsFile against the
     /// part-relative path and constructs a PackedFilesReader from there if it exists.
-    virtual const PackedFilesReader * getSkipIndicesPackedReader() const;
+    ///
+    /// Returns a shared owning handle, not a raw pointer: callers dereference the reader after the
+    /// internal mutex is released, while a concurrent resetReader/seed can replace or drop the
+    /// cached reader. Holding a shared_ptr for the duration of use keeps the object alive and
+    /// avoids a use-after-free on the cached archive index.
+    virtual std::shared_ptr<const PackedFilesReader> getSkipIndicesPackedReader() const;
 
 public:
     /// Pre-populate the cached PackedFilesReader from an in-memory index produced by the
@@ -199,7 +204,7 @@ protected:
     /// probed=true with reader=null means we checked and the archive isn't present.
     mutable std::mutex skip_indices_packed_mutex;
     mutable bool skip_indices_packed_probed TSA_GUARDED_BY(skip_indices_packed_mutex) = false;
-    mutable std::unique_ptr<PackedFilesReader> skip_indices_packed_reader TSA_GUARDED_BY(skip_indices_packed_mutex);
+    mutable std::shared_ptr<const PackedFilesReader> skip_indices_packed_reader TSA_GUARDED_BY(skip_indices_packed_mutex);
 
     template <typename Op>
     void executeWriteOperation(Op && op)

--- a/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
+++ b/src/Storages/MergeTree/DataPartStorageOnDiskFull.cpp
@@ -55,7 +55,7 @@ bool DataPartStorageOnDiskFull::existsFile(const std::string & name) const
 {
     if (looksLikePackedSkipIndexFile(name))
     {
-        if (const auto * reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
+        if (auto reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
             return true;
     }
     return volume->getDisk()->existsFile(fs::path(root_path) / part_dir / name);
@@ -101,7 +101,7 @@ size_t DataPartStorageOnDiskFull::getFileSize(const String & file_name) const
 {
     if (looksLikePackedSkipIndexFile(file_name))
     {
-        if (const auto * reader = getSkipIndicesPackedReader(); reader && reader->exists(file_name))
+        if (auto reader = getSkipIndicesPackedReader(); reader && reader->exists(file_name))
             return reader->getFileSize(file_name);
     }
     return volume->getDisk()->getFileSize(fs::path(root_path) / part_dir / file_name);
@@ -143,16 +143,19 @@ void DataPartStorageOnDiskFull::prepareRead(
 {
     if (looksLikePackedSkipIndexFile(name))
     {
-        if (const auto * reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
+        if (auto reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
         {
             /// Packed substreams skip the disk's normal pipeline (filesystem cache,
             /// async prefetch, etc.) and read through PackedFilesReader::readFile, which
-            /// already opens the archive via the underlying disk and wraps the result with
-            /// ReadBufferFromFileView at the right offset.
+            /// opens the archive via the underlying disk and wraps the result with
+            /// ReadBufferFromFileView at the right offset. The archive's current location is
+            /// captured here and passed in, so the reader holds no path of its own.
+            auto disk = volume->getDisk();
+            String archive_path = fs::path(root_path) / part_dir / String(SKIP_INDICES_PACKED_FILENAME);
             ReadPipeline::BufferCreator creator =
-                [reader, name, read_hint](const StoredObject &, const ReadSettings & s, bool, bool)
+                [reader, disk, archive_path, name, read_hint](const StoredObject &, const ReadSettings & s, bool, bool)
                 {
-                    return reader->readFile(name, s, read_hint);
+                    return reader->readFile(disk, archive_path, name, s, read_hint);
                 };
             pipeline.setSource(std::move(creator), StoredObjects{StoredObject{}}, settings);
             return;
@@ -168,8 +171,11 @@ std::unique_ptr<ReadBufferFromFileBase> DataPartStorageOnDiskFull::readFileIfExi
 {
     if (looksLikePackedSkipIndexFile(name))
     {
-        if (const auto * reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
-            return reader->readFile(name, settings, read_hint);
+        if (auto reader = getSkipIndicesPackedReader(); reader && reader->exists(name))
+            return reader->readFile(
+                volume->getDisk(),
+                fs::path(root_path) / part_dir / String(SKIP_INDICES_PACKED_FILENAME),
+                name, settings, read_hint);
     }
     return volume->getDisk()->readFileIfExists(fs::path(root_path) / part_dir / name, settings, read_hint);
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1138,6 +1138,14 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
     ColumnsStatistics result;
     auto read_settings = storage.getContext()->getReadSettings();
 
+    /// The reader holds only the index; resolve the archive's current location here so a part
+    /// that has since been renamed or moved still reads from the right place.
+    const auto * disk_storage = dynamic_cast<const DataPartStorageOnDiskBase *>(&getDataPartStorage());
+    if (!disk_storage)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Statistics packed reader requires on-disk part storage");
+    const auto disk = disk_storage->getDisk();
+    const String packed_file = fs::path(getDataPartStorage().getRelativePath()) / String(ColumnsStatistics::FILENAME);
+
     for (const auto & filename : reader.getFileNames())
     {
         if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
@@ -1148,7 +1156,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
             continue;
 
         size_t file_size = reader.getFileSize(filename);
-        auto file_buf = reader.readFile(filename, read_settings, file_size);
+        auto file_buf = reader.readFile(disk, packed_file, filename, read_settings, file_size);
 
         CompressedReadBuffer compressed_buf(*file_buf);
         try


### PR DESCRIPTION
Fixes a rare data race and use-after-free on the cached per-part `skp_idx.packed` archive reader.

A query reading packed skip-index substreams (for example during `ReadFromMergeTree::buildIndexes`) obtains the cached `PackedFilesReader` via `getSkipIndicesPackedReader` and then dereferences it after the internal mutex has already been released. Concurrently, relocating the part (`rename` / `changeRootPath`) reset and freed that cached reader, so the reading thread could access a freed archive index. ThreadSanitizer reports this as a data race in `free`.

The archive index is path-independent: moving the part's directory does not change the offsets inside the archive. So `PackedFilesReader` now holds only the immutable index, `readFile` takes the archive's current `(disk, path)` from the caller, and the cached reader is handed out as a shared owning handle. Relocation no longer needs to free or rebuild the reader, which removes the race at its source. `setRelativePath`, which can repoint the storage at unrelated content, still drops the cached reader (now safely, since callers co-own it).

Not for changelog since this isn't released

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed a rare data race and possible use-after-free on the cached skip-index archive reader of a `MergeTree` part, which could happen when a query read skip indices while the part was being moved or renamed.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1104`
<!-- ch-version-info:end -->