### PR TITLE
Fix performance regression when reading `Dynamic` columns with multiple threads

### DIFF
--- a/src/DataTypes/DataTypesCache.cpp
+++ b/src/DataTypes/DataTypesCache.cpp
@@ -100,21 +100,16 @@ SerializationPtr SimpleDataTypesCache::getSerialization(const String & type_name
     return type->getDefaultSerialization();
 }
 
-const SimpleDataTypesCache & SimpleDataTypesCache::instance()
-{
-    static SimpleDataTypesCache cache;
-    return cache;
-}
-
 const SimpleDataTypesCache & getSimpleDataTypesCache()
 {
-    return SimpleDataTypesCache::instance();
+    thread_local SimpleDataTypesCache cache;
+    return cache;
 }
 
 DataTypePtr DataTypesCache::getType(const String & type_name)
 {
-    /// Check the global immutable cache of simple types first.
-    if (const auto * elem = SimpleDataTypesCache::instance().findByName(type_name))
+    /// Check the thread-local cache of simple types first.
+    if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->type;
 
     return getCacheElement(type_name).type;
@@ -122,8 +117,8 @@ DataTypePtr DataTypesCache::getType(const String & type_name)
 
 SerializationPtr DataTypesCache::getSerialization(const String & type_name)
 {
-    /// Check the global immutable cache of simple types first.
-    if (const auto * elem = SimpleDataTypesCache::instance().findByName(type_name))
+    /// Check the thread-local cache of simple types first.
+    if (const auto * elem = getSimpleDataTypesCache().findByName(type_name))
         return elem->serialization;
 
     return getCacheElement(type_name).serialization;

--- a/src/DataTypes/DataTypesCache.h
+++ b/src/DataTypes/DataTypesCache.h
@@ -12,7 +12,8 @@ namespace DB
 /// Cache of simple (parameterless) data types and their serializations,
 /// pre-filled at construction time. Avoids repeated DataTypeFactory lookups
 /// and shared_ptr allocations for commonly used types.
-/// Thread-safe: immutable after construction.
+/// Thread-local to avoid atomic refcount contention on shared_ptr
+/// when multiple threads return copies of the same DataTypePtr.
 class SimpleDataTypesCache
 {
 public:
@@ -22,8 +23,6 @@ public:
         DataTypePtr type;
         SerializationPtr serialization;
     };
-
-    static const SimpleDataTypesCache & instance();
 
     bool hasElement(BinaryTypeIndex index) const;
 
@@ -47,19 +46,20 @@ public:
     /// for simple types, falls back to DataTypeFactory for others.
     SerializationPtr getSerialization(const String & type_name) const;
 
-private:
     SimpleDataTypesCache();
+
+private:
     void addSimpleType(BinaryTypeIndex index, const String & type_name);
 
     std::array<Element, BINARY_TYPE_INDEX_SIZE> by_index{};
     std::unordered_map<String, Element> by_name;
 };
 
-/// Return the singleton instance of the simple data type cache.
+/// Return a thread-local instance of the simple data type cache.
 const SimpleDataTypesCache & getSimpleDataTypesCache();
 
 /// Thread-local cache for data type lookups by name.
-/// Checks the global SimpleDataTypesCache first; only caches
+/// Checks the thread-local SimpleDataTypesCache first; only caches
 /// non-simple types (e.g. DateTime64(9), Variant types) in its own map.
 class DataTypesCache
 {

--- a/tests/performance/dynamic_compact_read.xml
+++ b/tests/performance/dynamic_compact_read.xml
@@ -1,0 +1,43 @@
+<test>
+
+    <create_query>
+        CREATE TABLE dynamic_compact_read
+        (
+            key Dynamic,
+            blob1 Dynamic,
+            blob2 Dynamic,
+            grp_kind String,
+            tenant String,
+            flag_a Bool,
+            flag_b Bool,
+            rid String
+        )
+        ENGINE = MergeTree
+        ORDER BY (flag_a, flag_b, grp_kind, tenant, rid)
+        SETTINGS min_bytes_for_wide_part = 9223372036854775807
+    </create_query>
+
+    <fill_query>
+        INSERT INTO dynamic_compact_read SELECT
+            concat('k-', toString(number))::Dynamic AS key,
+            concat(repeat('x', 100), '-', toString(number))::Dynamic AS blob1,
+            concat(repeat('y', 100), '-', toString(number % 500))::Dynamic AS blob2,
+            concat('K', toString(number % 20)) AS grp_kind,
+            concat('t', toString(number % 200)) AS tenant,
+            false AS flag_a,
+            true AS flag_b,
+            concat('r-', toString(number)) AS rid
+        FROM numbers(2000000)
+    </fill_query>
+
+    <query>
+<![CDATA[SELECT T.key, T.blob1, T.blob2
+FROM dynamic_compact_read AS T
+WHERE ((has(_CAST(['k-0'], 'Array(String)'), T.key) AND (T.grp_kind = 'K0')) AND (T.tenant = 't0')) OR ((has(_CAST(['k-1'], 'Array(String)'), T.key) AND (T.grp_kind = 'K1')) AND (T.tenant = 't1')) OR ((has(_CAST(['k-2'], 'Array(String)'), T.key) AND (T.grp_kind = 'K2')) AND (T.tenant = 't2')) OR ((has(_CAST(['k-3'], 'Array(String)'), T.key) AND (T.grp_kind = 'K3')) AND (T.tenant = 't3')) OR ((has(_CAST(['k-4'], 'Array(String)'), T.key) AND (T.grp_kind = 'K4')) AND (T.tenant = 't4')) OR ((has(_CAST(['k-5'], 'Array(String)'), T.key) AND (T.grp_kind = 'K5')) AND (T.tenant = 't5')) OR ((has(_CAST(['k-6'], 'Array(String)'), T.key) AND (T.grp_kind = 'K6')) AND (T.tenant = 't6')) OR ((has(_CAST(['k-7'], 'Array(String)'), T.key) AND (T.grp_kind = 'K7')) AND (T.tenant = 't7')) OR ((has(_CAST(['k-8'], 'Array(String)'), T.key) AND (T.grp_kind = 'K8')) AND (T.tenant = 't8')) OR ((has(_CAST(['k-9'], 'Array(String)'), T.key) AND (T.grp_kind = 'K9')) AND (T.tenant = 't9')) OR ((has(_CAST(['k-10'], 'Array(String)'), T.key) AND (T.grp_kind = 'K10')) AND (T.tenant = 't10')) OR ((has(_CAST(['k-11'], 'Array(String)'), T.key) AND (T.grp_kind = 'K11')) AND (T.tenant = 't11')) OR ((has(_CAST(['k-12'], 'Array(String)'), T.key) AND (T.grp_kind = 'K12')) AND (T.tenant = 't12')) OR ((has(_CAST(['k-13'], 'Array(String)'), T.key) AND (T.grp_kind = 'K13')) AND (T.tenant = 't13')) OR ((has(_CAST(['k-14'], 'Array(String)'), T.key) AND (T.grp_kind = 'K14')) AND (T.tenant = 't14')) OR ((has(_CAST(['k-15'], 'Array(String)'), T.key) AND (T.grp_kind = 'K15')) AND (T.tenant = 't15')) OR ((has(_CAST(['k-16'], 'Array(String)'), T.key) AND (T.grp_kind = 'K16')) AND (T.tenant = 't16')) OR ((has(_CAST(['k-17'], 'Array(String)'), T.key) AND (T.grp_kind = 'K17')) AND (T.tenant = 't17')) OR ((has(_CAST(['k-18'], 'Array(String)'), T.key) AND (T.grp_kind = 'K18')) AND (T.tenant = 't18')) OR ((has(_CAST(['k-19'], 'Array(String)'), T.key) AND (T.grp_kind = 'K19')) AND (T.tenant = 't19')) OR ((has(_CAST(['k-20'], 'Array(String)'), T.key) AND (T.grp_kind = 'K0')) AND (T.tenant = 't20')) OR ((has(_CAST(['k-21'], 'Array(String)'), T.key) AND (T.grp_kind = 'K1')) AND (T.tenant = 't21')) OR ((has(_CAST(['k-22'], 'Array(String)'), T.key) AND (T.grp_kind = 'K2')) AND (T.tenant = 't22')) OR ((has(_CAST(['k-23'], 'Array(String)'), T.key) AND (T.grp_kind = 'K3')) AND (T.tenant = 't23')) OR ((has(_CAST(['k-24'], 'Array(String)'), T.key) AND (T.grp_kind = 'K4')) AND (T.tenant = 't24')) OR ((has(_CAST(['k-25'], 'Array(String)'), T.key) AND (T.grp_kind = 'K5')) AND (T.tenant = 't25')) OR ((has(_CAST(['k-26'], 'Array(String)'), T.key) AND (T.grp_kind = 'K6')) AND (T.tenant = 't26')) OR ((has(_CAST(['k-27'], 'Array(String)'), T.key) AND (T.grp_kind = 'K7')) AND (T.tenant = 't27')) OR ((has(_CAST(['k-28'], 'Array(String)'), T.key) AND (T.grp_kind = 'K8')) AND (T.tenant = 't28')) OR ((has(_CAST(['k-29'], 'Array(String)'), T.key) AND (T.grp_kind = 'K9')) AND (T.tenant = 't29')) OR ((has(_CAST(['k-30'], 'Array(String)'), T.key) AND (T.grp_kind = 'K10')) AND (T.tenant = 't30')) OR ((has(_CAST(['k-31'], 'Array(String)'), T.key) AND (T.grp_kind = 'K11')) AND (T.tenant = 't31')) OR ((has(_CAST(['k-32'], 'Array(String)'), T.key) AND (T.grp_kind = 'K12')) AND (T.tenant = 't32')) OR ((has(_CAST(['k-33'], 'Array(String)'), T.key) AND (T.grp_kind = 'K13')) AND (T.tenant = 't33')) OR ((has(_CAST(['k-34'], 'Array(String)'), T.key) AND (T.grp_kind = 'K14')) AND (T.tenant = 't34')) OR ((has(_CAST(['k-35'], 'Array(String)'), T.key) AND (T.grp_kind = 'K15')) AND (T.tenant = 't35')) OR ((has(_CAST(['k-36'], 'Array(String)'), T.key) AND (T.grp_kind = 'K16')) AND (T.tenant = 't36')) OR ((has(_CAST(['k-37'], 'Array(String)'), T.key) AND (T.grp_kind = 'K17')) AND (T.tenant = 't37')) OR ((has(_CAST(['k-38'], 'Array(String)'), T.key) AND (T.grp_kind = 'K18')) AND (T.tenant = 't38')) OR ((has(_CAST(['k-39'], 'Array(String)'), T.key) AND (T.grp_kind = 'K19')) AND (T.tenant = 't39')) OR ((has(_CAST(['k-40'], 'Array(String)'), T.key) AND (T.grp_kind = 'K0')) AND (T.tenant = 't40')) OR ((has(_CAST(['k-41'], 'Array(String)'), T.key) AND (T.grp_kind = 'K1')) AND (T.tenant = 't41')) OR ((has(_CAST(['k-42'], 'Array(String)'), T.key) AND (T.grp_kind = 'K2')) AND (T.tenant = 't42')) OR ((has(_CAST(['k-43'], 'Array(String)'), T.key) AND (T.grp_kind = 'K3')) AND (T.tenant = 't43')) OR ((has(_CAST(['k-44'], 'Array(String)'), T.key) AND (T.grp_kind = 'K4')) AND (T.tenant = 't44')) OR ((has(_CAST(['k-45'], 'Array(String)'), T.key) AND (T.grp_kind = 'K5')) AND (T.tenant = 't45')) OR ((has(_CAST(['k-46'], 'Array(String)'), T.key) AND (T.grp_kind = 'K6')) AND (T.tenant = 't46')) OR ((has(_CAST(['k-47'], 'Array(String)'), T.key) AND (T.grp_kind = 'K7')) AND (T.tenant = 't47')) OR ((has(_CAST(['k-48'], 'Array(String)'), T.key) AND (T.grp_kind = 'K8')) AND (T.tenant = 't48')) OR ((has(_CAST(['k-49'], 'Array(String)'), T.key) AND (T.grp_kind = 'K9')) AND (T.tenant = 't49'))
+FORMAT Null
+SETTINGS max_threads = 16;]]>
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS dynamic_compact_read</drop_query>
+
+</test>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix performance regression when reading `Dynamic` columns with multiple threads. Caused by https://github.com/ClickHouse/ClickHouse/pull/100730. Closes https://github.com/ClickHouse/ClickHouse/issues/107942

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1117`
- Backported to: `26.5.4.6`, `26.4.5.63`
<!-- ch-version-info:end -->