### PR TITLE
Stop test_ttl_replicated fixture from swallowing cluster startup errors

### DIFF
--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -56,12 +56,7 @@ node6 = cluster.add_instance(
 def started_cluster():
     try:
         cluster.start()
-
         yield cluster
-
-    except Exception as ex:
-        print(ex)
-
     finally:
         cluster.shutdown()
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The module-scoped `started_cluster` fixture caught any exception from `cluster.start()` and only `print()`ed it, between the `yield` and the `finally`. A generator fixture that catches the pre-yield exception returns without yielding, so pytest raises `ValueError: started_cluster did not yield a value` for every dependent test.

Effect: one cluster startup failure was reported as 15 identical `did not yield a value` rows across all subtests, with the real cause (e.g. an old-version node timing out during start) hidden in lost stdout. This made each recurrence un-triageable and caused the failure to be repeatedly misattributed as test flakiness across unrelated PRs.

Dropping the `except` branch lets the real startup error propagate; the `finally` still guarantees `cluster.shutdown()`. This matches the sibling `test_ttl_move` fixture and the common pattern used by the other ~412 integration fixtures.

No related open issue found (checked by test name, error text, and STID).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1066`
<!-- ch-version-info:end -->