### PR TITLE
backfill_distroless: also update :latest-distroless on the highest version

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -122,6 +122,7 @@ jobs:
 
           SEEN_MINOR=""
           SEEN_MAJOR=""
+          SEEN_LATEST=""
 
           for VERSION in $SORTED_VERSIONS; do
             echo "============================================"
@@ -134,7 +135,11 @@ jobs:
             # Decide which floating tags THIS version is allowed to write.
             # First time we see a given X.Y.Z or X.Y in this run, we let
             # this build update that floating ref. Subsequent (lower)
-            # versions in the same group skip it.
+            # versions in the same group skip it. The :latest-distroless
+            # ref is only ever a candidate for the very first (highest)
+            # version in the run; the cross-run version_ge check below
+            # then refuses to actually overwrite :latest if a newer
+            # version is already published there.
             FLOATING_TAGS=""
             case " $SEEN_MINOR " in
               *" $VERSION_MINOR "*)
@@ -150,6 +155,12 @@ jobs:
                 FLOATING_TAGS="$FLOATING_TAGS:${VERSION_MAJOR}"
                 SEEN_MAJOR="$SEEN_MAJOR $VERSION_MAJOR" ;;
             esac
+            if [ -z "$SEEN_LATEST" ]; then
+              FLOATING_TAGS="$FLOATING_TAGS:latest"
+              SEEN_LATEST=1
+            else
+              echo "skipping :latest-distroless — already considered for a higher patch in this run"
+            fi
 
             for image_config in \
               "clickhouse/clickhouse-server:docker/server/Dockerfile.distroless:docker/server" \


### PR DESCRIPTION
BackfillDistroless writes X.Y.Z.N, X.Y, and X floating tags, but not \`:latest-distroless\`. So when we re-publish the fleet on a base bump (the libssl3t64 chase, the upcoming base-nossl swap in #107837, etc) the version-specific tags refresh correctly but \`:latest-distroless\` stays frozen at whatever the last \`create_release.yml\` run with \`is_latest=true\` pointed at. Right now that's 2026-05-22 — a month stale.

Fix: add \`:latest\` as a third candidate floating tag, owned by the first (highest semver) version in the run only. Reuse the existing cross-run \`version_ge\` check so an out-of-order backfill of an older patch refuses to silently move \`:latest\` backwards — same protection \`:X.Y-distroless\` and \`:X-distroless\` already have.

Test cases the existing protection covers:

- \`versions=\"26.5.2.39 26.4.3.37 26.3.12.3 ...\"\` — \`26.5.2.39\` wins \`:latest\` if it's \`>=\` the currently published \`:latest-distroless\`.
- \`versions=\"26.4.3.37\"\` — \`26.4.3.37\` is the highest in this run, becomes the \`:latest\` candidate, but the cross-run check sees the published \`:latest\` is at \`26.5.x\` and skips.

Related: #107837 (will trigger the BackfillDistroless re-publish that this fix lets correctly update \`:latest-distroless\`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

#### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1105`
<!-- ch-version-info:end -->