### PR TITLE
Play: database panel hide button, full-width clickable rows, and width-jitter fix

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -410,6 +410,11 @@
             right: 0.25rem;
             color: var(--misc-text-color);
             animation: hourglass-animation 2s linear infinite;
+            /* The hourglass overlays the right edge of the full-width database button.
+               Let clicks pass through to the button underneath, so the row stays fully
+               clickable while tables load (otherwise a click here is treated as a menu
+               background click and would close the whole panel). */
+            pointer-events: none;
         }
 
         .no-tables

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -199,7 +199,7 @@
         #menu.databases-opened
         {
             grid-template-columns: auto 1fr;
-            grid-template-areas: "databases-icon databases-icon" "contents contents" "terminal-icon github-icon";
+            grid-template-areas: "databases-icon databases-hide" "contents contents" "terminal-icon github-icon";
         }
 
         #menu.databases-opened #github-icon
@@ -236,6 +236,51 @@
             display: block;
         }
 
+        /* Drop the inline-SVG baseline gap so the icon's box hugs the glyph and the
+           "hide panel" button can be centered against it. */
+        #databases-icon svg
+        {
+            display: block;
+        }
+
+        /* Small "hide panel" button shown at the top-right corner of the menu, vertically
+           aligned with the database icon. Only visible while the database panel is open. */
+        #databases-hide
+        {
+            grid-area: databases-hide;
+            display: none;
+            justify-self: end;
+            /* Center against the database icon: same row, aligned by vertical midpoint.
+               The icon's bars span y=0..8 of a 9-unit viewBox, so their visual midpoint sits
+               (0.5/9) * 2.25em = 0.125em above the row center; nudge the arrow up to match.
+               font-size: inherit makes the button's em equal the icon's (buttons default to a
+               smaller font), so the offset is exact and scales with zoom. */
+            align-self: center;
+            align-items: center;
+            justify-content: center;
+            background: none;
+            border: none;
+            padding: 0 0.25rem;
+            cursor: pointer;
+            font-size: inherit;
+            transform: translateY(-0.125em);
+            /* Faint color, with no change on hover. */
+            color: var(--menu-toggle-color);
+            opacity: 0.25;
+        }
+
+        #databases-hide svg
+        {
+            width: 1.25em;
+            display: block;
+        }
+
+        /* Shown only while the database panel is open. */
+        #menu.databases-opened #databases-hide
+        {
+            display: flex;
+        }
+
         #databases
         {
             grid-area: contents;
@@ -243,6 +288,10 @@
             overflow-y: auto;
             scrollbar-width: thin;
             scrollbar-color: var(--border-color) transparent;
+            /* The menu column is auto-sized (max-content), so the appearance of the vertical
+               scrollbar (e.g. when expanding tables) would otherwise widen the whole panel by
+               the scrollbar width. Reserve the gutter permanently to avoid that layout shift. */
+            scrollbar-gutter: stable;
         }
 
         .tables:not(:empty)
@@ -316,11 +365,22 @@
             display: block;
         }
 
+        .database
+        {
+            /* Anchor the loading hourglass, which is absolutely positioned (see below). */
+            position: relative;
+        }
+
         .database button
         {
             cursor: pointer;
             background: transparent;
             font-size: 100%;
+            /* Span the full panel width so the whole row is a click target. */
+            display: block;
+            width: 100%;
+            text-align: left;
+            border: none;
             padding: 0;
             user-select: none;
             color: var(--text-color);
@@ -343,12 +403,13 @@
 
         .loading-hourglass
         {
-            display: inline-block;
-            margin-left: 0.5em;
+            /* Pinned to the top-right of the database row so the full-width name
+               button does not push it onto a new line while tables load. */
+            position: absolute;
+            top: 0;
+            right: 0.25rem;
             color: var(--misc-text-color);
             animation: hourglass-animation 2s linear infinite;
-            line-height: 0;
-            vertical-align: middle;
         }
 
         .no-tables
@@ -368,12 +429,26 @@
 
         .table button
         {
-            display: inline-block;
-            max-width: 100%;
+            /* Span the full panel width so the whole row is a click target. */
+            display: block;
+            width: 100%;
+            text-align: left;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
-            vertical-align: middle;
+            cursor: pointer;
+            background: transparent;
+            border: none;
+            padding: 0;
+            font-size: 100%;
+            user-select: none;
+            color: var(--text-color);
+        }
+
+        .table button:hover, .table button:focus
+        {
+            color: var(--button-text-color);
+            background-color: var(--button-color);
         }
 
         .table-icon
@@ -397,7 +472,7 @@
             backdrop-filter: blur(4px);
             border-radius: 0.5rem;
             padding: 0.25rem;
-            margin-left: 0.25rem;
+            margin-left: 0.5rem;
             opacity: 0;
             pointer-events: none;
             transition: opacity 0s 0.1s;
@@ -414,7 +489,7 @@
             border-color: transparent color-mix(in srgb, var(--text-color) 50%, var(--background-color)) transparent transparent;
         }
 
-        .table button:hover + .table-addendum,
+        .table-name:hover ~ .table-addendum,
         .table .table-addendum:hover
         {
             opacity: 1;
@@ -426,7 +501,7 @@
            next mousemove), no balloon may appear from a :hover state. This prevents
            a different table button from scrolling under a stationary cursor and
            revealing its balloon without `mouseenter` having fired to position it. */
-        body.suppress-balloons .table button:hover + .table-addendum,
+        body.suppress-balloons .table-name:hover ~ .table-addendum,
         body.suppress-balloons .table .table-addendum:hover
         {
             opacity: 0;
@@ -884,9 +959,12 @@
 
 <body>
     <div id="menu">
-        <a id="databases-icon" class="menu-icon" href="">
+        <a id="databases-icon" class="menu-icon" href="" title="Databases and tables">
             <svg id="databases-toggle" viewBox="0 0 9 9"><path d="M0,0 h1 v8 h-1 z"/><path d="M2,0 h1 v8 h-1 z"/><path d="M4,0 h1 v8 h-1 z"/><path d="M6,0 h1 v8 h-1 z"/><path d="M8,3.25 h1 v1.5 h-1 z"/></svg>
         </a>
+        <button id="databases-hide" type="button" title="Hide the database panel">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><line x1="3" y1="12" x2="15" y2="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><polyline points="9,6 3,12 9,18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="20" y1="4" x2="20" y2="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        </button>
         <div id="databases"></div>
         <div id="terminal-icon" class="menu-icon" title="Web Terminal (~)">
             <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="22" height="22" rx="3" fill="none" stroke="currentColor" stroke-width="2"/><path d="M6 8l4 4-4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><line x1="13" y1="16" x2="18" y2="16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
@@ -2645,7 +2723,12 @@ async function loadTables(server_address, user, password, database, container) {
         let table = document.createElement('div');
         table.className = 'table';
         let table_link = document.createElement('button');
-        table_link.append(getTableIcon(elem.engine), elem.table);
+        /// Wrap the icon+name so the balloon opens only when hovering the name, not the
+        /// empty right part of the full-width button.
+        let table_name = document.createElement('span');
+        table_name.className = 'table-name';
+        table_name.append(getTableIcon(elem.engine), elem.table);
+        table_link.appendChild(table_name);
 
         if (max_total_bytes && +elem.total_bytes) {
             const percent = Number(100 * +elem.total_bytes / max_total_bytes).toFixed(2);
@@ -2693,16 +2776,21 @@ async function loadTables(server_address, user, password, database, container) {
         engine_elem.addEventListener('click', e => set_query_or_run(e, `SHOW TABLE "${database}"."${elem.table}"`));
         table_addendum.append(engine_elem);
 
-        table_link.addEventListener('mouseenter', function() {
+        table_name.addEventListener('mouseenter', function() {
+            /// Anchor the balloon to the end of the name (clamped to the button when the name
+            /// is truncated), so it stays next to the text rather than the far-right edge.
             const rect = this.getBoundingClientRect();
-            table_addendum.style.left = rect.right + 'px';
+            const btn = table_link.getBoundingClientRect();
+            table_addendum.style.left = Math.min(rect.right, btn.right) + 'px';
             table_addendum.style.top = (rect.top + rect.height / 2) + 'px';
             table_addendum.style.visibility = '';
             visible_balloon = table_addendum;
         });
 
+        /// Keep the addendum inside the button so the `.table-name ~ .table-addendum` hover
+        /// selector works; it is position:fixed, so it is not clipped by the button overflow.
+        table_link.appendChild(table_addendum);
         table.appendChild(table_link);
-        table.appendChild(table_addendum);
         table.addEventListener('click', e => set_query_or_run(e, `SELECT * FROM "${database}"."${elem.table}" LIMIT 100`));
         tables_elem.appendChild(table);
     }
@@ -2776,6 +2864,12 @@ databases_toggle.addEventListener('click', e => {
     if (e.ctrlKey || e.metaKey || e.shiftKey) return;
     /// Normal click: toggle the databases panel instead of following the link.
     e.preventDefault();
+    toggleDatabases();
+});
+
+/// The "hide panel" button is only visible while the panel is open, so it always closes it.
+document.getElementById('databases-hide').addEventListener('click', e => {
+    e.stopPropagation();
     toggleDatabases();
 });
 


### PR DESCRIPTION
Several usability improvements to the database panel in the Web SQL UI (Play):

- **Tooltip on the database icon** — added a `title` so a tooltip shows on hover.
- **Hide-panel button** — a small, faint SVG button (a `<-|` "collapse left" glyph) at the top-right corner of the menu, vertically aligned with the middle of the database icon. It is shown only while the panel is open and closes the panel when clicked.
- **Full-width clickable rows** — the clickable area of database and table names now spans the full width of the panel, with a full-width hover highlight (previously only the text itself was clickable). The table size/rows/engine balloon now opens only when the cursor is over the name (not the empty space to its right) and is anchored just to the right of the name.
- **No more width jitter** — the menu column is auto-sized (max-content), so the appearance of the vertical scrollbar (e.g. when expanding a database's tables) was widening the whole panel by the scrollbar width. The scrollbar gutter is now reserved permanently (`scrollbar-gutter: stable`), so the panel width no longer shifts.

All changes are confined to `programs/server/play.html` (frontend HTML/CSS/JS), so no build is required; they can be verified by loading `/play`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improvements to the database panel in the Web SQL UI (Play): a tooltip on the database icon, a button to hide the panel, full-width clickable database/table names, and a fix for the panel width shifting when the scrollbar appears.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1129`
<!-- ch-version-info:end -->