### PR TITLE
Client AI: do not send `temperature` unless explicitly configured

### DIFF
--- a/docs/en/interfaces/client.md
+++ b/docs/en/interfaces/client.md
@@ -450,7 +450,9 @@ For more control over AI settings, configure them in your ClickHouse Client conf
             <enable_schema_access>true</enable_schema_access>
 
             <!-- Generation parameters -->
-            <temperature>0.0</temperature>
+            <!-- Optional: temperature is only sent to the model when set here.
+                 It is omitted by default because some models reject this parameter. -->
+            <!-- <temperature>0.0</temperature> -->
             <max_tokens>1000</max_tokens>
             <timeout_seconds>30</timeout_seconds>
             <max_steps>10</max_steps>
@@ -480,7 +482,9 @@ For more control over AI settings, configure them in your ClickHouse Client conf
       enable_schema_access: true
 
       # Generation parameters
-      temperature: 0.0      # Controls randomness (0.0 = deterministic)
+      # temperature is only sent to the model when set here; omitted by default
+      # because some models reject this parameter.
+      # temperature: 0.0    # Controls randomness (0.0 = deterministic)
       max_tokens: 1000      # Maximum response length
       timeout_seconds: 30   # Request timeout
       max_steps: 10         # Maximum schema exploration steps
@@ -565,7 +569,7 @@ ai:
 <details>
 <summary>Generation parameters</summary>
 
-- `temperature` - Controls randomness, 0.0 = deterministic, 1.0 = creative (default: `0.0`)
+- `temperature` - Controls randomness, 0.0 = deterministic, 1.0 = creative. Omitted by default and only sent to the model when explicitly set, because some models reject this parameter.
 - `max_tokens` - Maximum response length in tokens (default: `1000`)
 - `system_prompt` - Custom instructions for the AI (optional)
 

--- a/src/Client/AI/AIConfiguration.h
+++ b/src/Client/AI/AIConfiguration.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace DB
@@ -20,8 +21,11 @@ struct AIConfiguration
     /// Model to use (e.g., "gpt-4", "claude-3-opus-20240229")
     std::string model;
 
-    /// Temperature for generation (0.0 = deterministic, higher = more creative)
-    double temperature = 0.0;
+    /// Temperature for generation (0.0 = deterministic, higher = more creative).
+    /// Left unset by default: some models (e.g. reasoning models served behind
+    /// OpenAI-compatible gateways) reject the `temperature` parameter, so it is
+    /// only sent when explicitly configured via `ai.temperature`.
+    std::optional<double> temperature;
 
     /// Maximum tokens to generate
     size_t max_tokens = 1000;

--- a/src/Client/AI/tests/gtest_ai_client_factory.cpp
+++ b/src/Client/AI/tests/gtest_ai_client_factory.cpp
@@ -128,7 +128,8 @@ TEST(AIClientFactory, MalformedConfigurationValues)
     config->setDouble("ai.temperature", 2.5); // This is accepted without validation
     
     AIConfiguration ai_config = AIClientFactory::loadConfiguration(*config);
-    EXPECT_EQ(2.5, ai_config.temperature); // It's loaded as-is
+    ASSERT_TRUE(ai_config.temperature.has_value());
+    EXPECT_EQ(2.5, *ai_config.temperature); // It's loaded as-is
     
     // Test negative max_tokens - Poco throws exception on negative integer for unsigned type
     config->setDouble("ai.temperature", 0.5);
@@ -149,6 +150,23 @@ TEST(AIClientFactory, MalformedConfigurationValues)
         ai_config = AIClientFactory::loadConfiguration(*config);
     });
     EXPECT_EQ(0, ai_config.timeout_seconds);
+}
+
+/// Temperature must be left unset unless explicitly configured, so that it is
+/// not sent to models that reject the `temperature` parameter.
+TEST(AIClientFactory, TemperatureUnsetByDefault)
+{
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration();
+    config->setString("ai.provider", "openai");
+    config->setString("ai.api_key", "test_key");
+
+    AIConfiguration without_temperature = AIClientFactory::loadConfiguration(*config);
+    EXPECT_FALSE(without_temperature.temperature.has_value());
+
+    config->setDouble("ai.temperature", 0.0);
+    AIConfiguration with_temperature = AIClientFactory::loadConfiguration(*config);
+    ASSERT_TRUE(with_temperature.temperature.has_value());
+    EXPECT_EQ(0.0, *with_temperature.temperature);
 }
 
 /// Test handling of special characters in API keys


### PR DESCRIPTION
The AI SQL generation feature in `clickhouse-client` / `clickhouse-local` (the `??` prompt) always sent a `temperature` parameter to the model, because `AIConfiguration::temperature` defaulted to `0.0` and was unconditionally copied into the request options.

Some models reject the `temperature` parameter outright — for example, reasoning models served behind OpenAI-compatible gateways respond with `temperature is deprecated for this model` — which made AI SQL generation fail for those models regardless of configuration.

This makes `temperature` a `std::optional<double>` that is left unset by default and only sent to the model when the user explicitly configures `ai.temperature`. The request builder already omits the field when the option has no value, so there is no behavior change for users who do set a temperature.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

AI SQL generation in the client no longer sends the `temperature` parameter unless it is explicitly set via `ai.temperature` in the configuration. This fixes AI SQL generation for models that reject the `temperature` parameter.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)