### PR TITLE
Fix dictGetAll documentation

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.cpp
+++ b/src/Functions/FunctionsExternalDictionaries.cpp
@@ -1046,12 +1046,26 @@ R"(
 
     /// dictGetAll
     {
-        const String type_name = "All";
+        FunctionDocumentation::Description description = R"(
+Retrieves the attribute values of all the nodes that matched each key in a [regular expression tree dictionary](/docs/sql-reference/statements/create/dictionary/layouts/regexp-tree).
 
-        FunctionDocumentation::Description description = getDictGetDescription(type_name);
-        FunctionDocumentation::Syntax syntax = getDictGetSyntax(type_name);
-        FunctionDocumentation::Arguments arguments = getDictGetArguments();
-        FunctionDocumentation::ReturnedValue returned_value = getDictGetReturnedValue();
+Besides returning values of type `Array(T)` instead of `T`, this function behaves similarly to [`dictGet`](#dictGet).
+)";
+        FunctionDocumentation::Syntax syntax = "dictGetAll(dict_name, attr_names, id_expr[, limit])";
+        FunctionDocumentation::Arguments arguments = {
+            {"dict_name", "Name of the dictionary.", {"String"}},
+            {"attr_names", "Name of the column of the dictionary, or tuple of column names.", {"String", "Tuple(String)"}},
+            {"id_expr", "Key value. An expression returning a dictionary key-type value or tuple value (dictionary configuration dependent).", {"Expression", "Tuple(T)"}},
+            {"limit", "Optional. Maximum length for each value array returned. When truncating, child nodes are given precedence over parent nodes, and otherwise the defined list order for the regexp tree dictionary is respected. If unspecified, the array length is unlimited.", {"UInt*"}}
+        };
+        FunctionDocumentation::ReturnedValue returned_value = {R"(
+Returns an array of the dictionary attribute values that correspond to `id_expr` for each attribute specified by `attr_names`.
+If there is no key corresponding to `id_expr` in the dictionary, an empty array is returned.
+
+:::note
+ClickHouse throws an exception if it cannot parse the value of the attribute or the value does not match the attribute data type.
+:::
+)", {"Array(T)"}};
         FunctionDocumentation::Examples examples = {
             {"Usage example",
 R"(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/108015


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Description

`dictGetAll` reused the generic `dictGet<T>` documentation helpers with `type_name = "All"`, so the rendered docs page made no sense:

- Description: "Converts a dictionary attribute value to `All` data type regardless of the dictionary configuration." (there is no "All" data type)
- Syntax: `dictGetAll(dict_name, attr_name, id_expr)` (missing the optional `limit` argument)
- Returned value: described a scalar value with a `<null_value>` fallback, but `dictGetAll` returns an `Array(T)` of all matching values from a regexp tree dictionary

This gives `dictGetAll` its own documentation: it retrieves the attribute values of all matched nodes in a [regexp tree dictionary](https://clickhouse.com/docs/sql-reference/statements/create/dictionary/layouts/regexp-tree), documents the optional `limit` argument, and states that it returns an `Array(T)` (empty when no key matches).

Verified locally by building and reading the regenerated `system.functions` row for `dictGetAll` (the docs page is autogenerated from it).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1073`
<!-- ch-version-info:end -->