### PR TITLE
Accept Operation timeout in Keeper max_request_size tests

### DIFF
--- a/tests/integration/test_keeper_dynamic_settings/test.py
+++ b/tests/integration/test_keeper_dynamic_settings/test.py
@@ -118,8 +118,9 @@ def test_max_request_size_hot_reload(started_cluster):
                 f"current value: {settings.get('max_request_size')}"
             )
 
-        # 3. A large write should now be rejected.
-        with pytest.raises(Exception, match=r"Connection loss"):
+        # 3. A large write should now be rejected. Connection loss and Operation
+        # timeout are both valid client surfaces of the connection-level rejection.
+        with pytest.raises(Exception, match=r"Connection loss|Operation timeout"):
             node.query(
                 "INSERT INTO system.zookeeper (name, path, value) "
                 "SELECT number::String, '/test_max_req', repeat('x', 3000) "

--- a/tests/integration/test_keeper_max_request_size/test.py
+++ b/tests/integration/test_keeper_max_request_size/test.py
@@ -23,5 +23,7 @@ def started_cluster():
 
 def test_max_request_size(started_cluster):
     node.query("insert into system.zookeeper (name, path, value) select number::String, '/test_soft_limit', repeat('a', 3000) from numbers(100)")
-    with pytest.raises(Exception, match=r"Connection loss"):
+    # Connection loss and Operation timeout are both valid client surfaces of the
+    # connection-level rejection; do not narrow this back to a single code.
+    with pytest.raises(Exception, match=r"Connection loss|Operation timeout"):
         node.query("insert into system.zookeeper (name, path, value) select number::String, '/test_soft_limit', repeat('a', 3000) from numbers(10000)")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_keeper_max_request_size::test_max_request_size` and `test_keeper_dynamic_settings::test_max_request_size_hot_reload` assert that an oversized write to `system.zookeeper` is rejected, matching only `Connection loss`. Under load (ASan + db-disk shard) the rejection occasionally surfaces as `Operation timeout` instead, failing the assertion.

Both codes describe the same connection-level rejection:

- The server rejects the oversized request at the framing layer in `KeeperTCPHandler::receiveRequest` (`LIMIT_EXCEEDED`) before any xid is parsed. The exception propagates to `runImpl`'s catch, which cancels the write buffer and closes the socket without sending an error response.
- The client's `zkutil::ZooKeeper` then surfaces a hardware error whose exact form depends on a thread race: `ZCONNECTIONLOSS` when the receive thread observes the socket close first (`finalize` sets `probably_sent ? ZCONNECTIONLOSS`), or `ZOPERATIONTIMEOUT` when `waitForFutureWithProgress` gives up first. `isHardwareError()` classifies both as connection-level errors, so either is a valid outcome of the same rejection.

Both assertions are broadened to accept `Connection loss` or `Operation timeout`. A wrongly-accepted oversized write still fails the test (`pytest.raises` reports `DID NOT RAISE` regardless of the regex), so the regression these tests guard is preserved.

CI sighting (Integration tests, amd_asan_ubsan, db disk, old analyzer, 5/6): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107150&sha=f723193b4a20faf83ac5955cb4d79d6858dbb2c6&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29

No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.133`
<!-- ch-version-info:end -->