### PR TITLE
Fix MULTIPLE_EXPRESSIONS_FOR_ALIAS for distributed JOIN with same-named ALIAS columns

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -757,33 +757,6 @@ std::optional<QueryProcessingStage::Enum> StorageDistributed::getOptimizedQueryP
 namespace
 {
 
-class ReplaseAliasColumnsVisitor : public InDepthQueryTreeVisitor<ReplaseAliasColumnsVisitor>
-{
-    static QueryTreeNodePtr getColumnNodeAliasExpression(const QueryTreeNodePtr & node)
-    {
-        const auto * column_node = node->as<ColumnNode>();
-        if (!column_node || !column_node->hasExpression())
-            return nullptr;
-
-        const auto & column_source = column_node->getColumnSourceOrNull();
-        if (!column_source || column_source->getNodeType() == QueryTreeNodeType::JOIN
-                           || column_source->getNodeType() == QueryTreeNodeType::CROSS_JOIN
-                           || column_source->getNodeType() == QueryTreeNodeType::ARRAY_JOIN)
-            return nullptr;
-
-        auto column_expression = column_node->getExpression();
-        column_expression->setAlias(column_node->getColumnName());
-        return column_expression;
-    }
-
-public:
-    void visitImpl(QueryTreeNodePtr & node)
-    {
-        if (auto column_expression = getColumnNodeAliasExpression(node))
-            node = column_expression;
-    }
-};
-
 class RewriteInToGlobalInVisitor : public InDepthQueryTreeVisitorWithContext<RewriteInToGlobalInVisitor>
 {
 public:
@@ -933,8 +906,7 @@ QueryTreeNodePtr buildQueryTreeDistributed(SelectQueryInfo & query_info,
     replacement_table_expression->setAlias(query_info.table_expression->getAlias());
 
     auto query_tree_to_modify = query_info.query_tree->cloneAndReplace(query_info.table_expression, std::move(replacement_table_expression));
-    ReplaseAliasColumnsVisitor replace_alias_columns_visitor;
-    replace_alias_columns_visitor.visit(query_tree_to_modify);
+    inlineAliasColumnsForDistributed(query_tree_to_modify);
 
     const auto & settings = query_context->getSettingsRef();
 

--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -7,6 +7,7 @@
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/IQueryTreeNode.h>
 #include <Analyzer/JoinNode.h>
+#include <Analyzer/ListNode.h>
 #include <Analyzer/QueryNode.h>
 #include <Core/Block.h>
 #include <Planner/PlannerActionsVisitor.h>
@@ -596,6 +597,91 @@ QueryTreeNodePtr getSubqueryFromTableExpression(
     return subquery_node;
 }
 
+/// Return a clone of the defining expression of an inlineable ALIAS column node, or nullptr otherwise.
+/// The expression is cloned so each occurrence gets its own copy: this lets us alias one occurrence
+/// (a projection output) without mutating another occurrence (a reference in WHERE/GROUP BY/...).
+QueryTreeNodePtr getInlineableAliasColumnExpression(const QueryTreeNodePtr & node)
+{
+    const auto * column_node = node->as<ColumnNode>();
+    if (!column_node || !column_node->hasExpression())
+        return nullptr;
+
+    const auto & column_source = column_node->getColumnSourceOrNull();
+    if (!column_source || column_source->getNodeType() == QueryTreeNodeType::JOIN
+                       || column_source->getNodeType() == QueryTreeNodeType::CROSS_JOIN
+                       || column_source->getNodeType() == QueryTreeNodeType::ARRAY_JOIN)
+        return nullptr;
+
+    return column_node->getExpression()->clone();
+}
+
+void inlineAliasColumnsForDistributedImpl(QueryTreeNodePtr & node);
+
+/// Inline ALIAS columns inside an expression subtree without assigning any alias. Nested subqueries are
+/// handed back to inlineAliasColumnsForDistributedImpl so their own projection columns keep their names.
+void inlineAliasColumnsInExpression(QueryTreeNodePtr & node)
+{
+    if (node->as<QueryNode>() || node->as<UnionNode>())
+    {
+        inlineAliasColumnsForDistributedImpl(node);
+        return;
+    }
+
+    while (auto expression = getInlineableAliasColumnExpression(node))
+        node = expression;
+
+    for (auto & child : node->getChildren())
+        if (child)
+            inlineAliasColumnsInExpression(child);
+}
+
+/// Inline ALIAS columns for shard transport. The defining expression keeps the column's logical name as
+/// an alias only when the ALIAS column is a top-level projection item, so the mergeable-state output column
+/// keeps its name. Inside expression clauses (WHERE/GROUP BY/ORDER BY/HAVING/JOIN ON) and nested expressions
+/// no alias is set; otherwise several same-named ALIAS columns from different JOIN sources would land in one
+/// scope and trigger MULTIPLE_EXPRESSIONS_FOR_ALIAS (https://github.com/ClickHouse/ClickHouse/issues/107990).
+void inlineAliasColumnsForDistributedImpl(QueryTreeNodePtr & node)
+{
+    if (auto * union_node = node->as<UnionNode>())
+    {
+        for (auto & query : union_node->getQueries().getNodes())
+            inlineAliasColumnsForDistributedImpl(query);
+        return;
+    }
+
+    auto * query_node = node->as<QueryNode>();
+    if (!query_node)
+    {
+        inlineAliasColumnsInExpression(node);
+        return;
+    }
+
+    for (auto & projection_item : query_node->getProjection().getNodes())
+    {
+        const auto * column_node = projection_item->as<ColumnNode>();
+        if (auto expression = getInlineableAliasColumnExpression(projection_item))
+        {
+            const String output_alias = column_node->getColumnName();
+            inlineAliasColumnsInExpression(expression);
+            expression->setAlias(output_alias);
+            projection_item = expression;
+        }
+        else
+        {
+            inlineAliasColumnsInExpression(projection_item);
+        }
+    }
+
+    for (auto & child : query_node->getChildren())
+        if (child && child != query_node->getProjectionNode())
+            inlineAliasColumnsInExpression(child);
+}
+
+}
+
+void inlineAliasColumnsForDistributed(QueryTreeNodePtr & query_tree)
+{
+    inlineAliasColumnsForDistributedImpl(query_tree);
 }
 
 QueryTreeNodePtr buildQueryTreeForShard(const PlannerContextPtr & planner_context, QueryTreeNodePtr query_tree_to_modify, bool allow_global_join_for_right_table)
@@ -802,40 +888,13 @@ void rewriteJoinToGlobalJoin(QueryTreeNodePtr query_tree_to_modify, ContextPtr c
 namespace
 {
 
-/// Replace ALIAS column nodes with their defining expression. The action name computed afterwards then matches the name
-/// the shard's ActionsDAG assigns (the shard works on the inlined query tree).
-class InlineAliasColumnsForNamingVisitor : public InDepthQueryTreeVisitor<InlineAliasColumnsForNamingVisitor>
-{
-    static QueryTreeNodePtr getColumnNodeAliasExpression(const QueryTreeNodePtr & node)
-    {
-        const auto * column_node = node->as<ColumnNode>();
-        if (!column_node || !column_node->hasExpression())
-            return nullptr;
-
-        const auto & column_source = column_node->getColumnSourceOrNull();
-        if (!column_source || column_source->getNodeType() == QueryTreeNodeType::JOIN
-                           || column_source->getNodeType() == QueryTreeNodeType::CROSS_JOIN
-                           || column_source->getNodeType() == QueryTreeNodeType::ARRAY_JOIN)
-            return nullptr;
-
-        auto column_expression = column_node->getExpression();
-        column_expression->setAlias(column_node->getColumnName());
-        return column_expression;
-    }
-
-public:
-    void visitImpl(QueryTreeNodePtr & node)
-    {
-        if (auto column_expression = getColumnNodeAliasExpression(node))
-            node = column_expression;
-    }
-};
-
 String actionNameAfterAliasInlining(const QueryTreeNodePtr & node, const PlannerContext & planner_context)
 {
     auto node_clone = node->clone();
-    InlineAliasColumnsForNamingVisitor visitor;
-    visitor.visit(node_clone);
+    /// Inline ALIAS columns exactly as the shard does. Aliasing is irrelevant here: action node names are
+    /// computed from the column identifier / expression, not from the SQL alias, so the no-alias inliner
+    /// yields the same name the shard assigns.
+    inlineAliasColumnsInExpression(node_clone);
 
     /// `buildQueryTreeForShard` performs one more naming-relevant rewrite after inlining ALIAS columns:
     /// `ReplaceLongConstWithScalarVisitor` turns over-threshold constants into `__getScalar('<hash>')` calls

--- a/src/Storages/buildQueryTreeForShard.h
+++ b/src/Storages/buildQueryTreeForShard.h
@@ -25,6 +25,16 @@ QueryTreeNodePtr buildQueryTreeForShard(const PlannerContextPtr & planner_contex
 
 void rewriteJoinToGlobalJoin(QueryTreeNodePtr query_tree_to_modify, ContextPtr context);
 
+/** Inline `ALIAS` columns into their defining expressions for distributed/shard transport.
+  *
+  * The defining expression keeps the column's logical name as an alias only for top-level projection items
+  * (so the mergeable-state output column keeps its name). Inside expression clauses (`WHERE`/`GROUP BY`/
+  * `ORDER BY`/`HAVING`/`JOIN ON`) and nested expressions no alias is set, so that several same-named `ALIAS`
+  * columns from different `JOIN` sources do not collide as duplicate scope aliases
+  * (`MULTIPLE_EXPRESSIONS_FOR_ALIAS`).
+  */
+void inlineAliasColumnsForDistributed(QueryTreeNodePtr & query_tree);
+
 /** When a Distributed/parallel-replicas query is executed up to `WithMergeableState`, the shard's query tree has its
   * `ALIAS` columns inlined into their defining expressions. If several projection (or sort/group/...) items expand to the
   * same expression, the shard's `ActionsDAG` deduplicates them into a single output column, so the shard header can have

--- a/tests/queries/0_stateless/04401_distributed_alias_name_collision.reference
+++ b/tests/queries/0_stateless/04401_distributed_alias_name_collision.reference
@@ -1,0 +1,27 @@
+where
+1
+1
+2
+2
+group_by
+5	50	2
+7	70	2
+order_by
+1
+1
+2
+2
+projection_expr
+55
+55
+77
+77
+global_join_subquery
+1	5	50
+1	5	50
+1	5	50
+1	5	50
+2	7	70
+2	7	70
+2	7	70
+2	7	70

--- a/tests/queries/0_stateless/04401_distributed_alias_name_collision.sql
+++ b/tests/queries/0_stateless/04401_distributed_alias_name_collision.sql
@@ -1,0 +1,58 @@
+-- Tags: distributed
+
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/107990
+-- A distributed JOIN where both tables define an ALIAS column with the SAME name, referenced in an
+-- expression clause (WHERE / GROUP BY / ORDER BY / JOIN ON), used to fail with
+-- MULTIPLE_EXPRESSIONS_FOR_ALIAS: inlining each ALIAS column re-applied the bare column name as an
+-- alias, so two different expressions ended up sharing one alias in the same scope. The inlined
+-- expression must keep its alias only as a top-level projection output, not inside expression clauses.
+
+DROP TABLE IF EXISTS na_local;
+DROP TABLE IF EXISTS nb_local;
+DROP TABLE IF EXISTS na_dist;
+DROP TABLE IF EXISTS nb_dist;
+
+CREATE TABLE na_local (id UInt64, x UInt64, foo UInt64 ALIAS x) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE nb_local (id UInt64, x UInt64, foo UInt64 ALIAS x) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE na_dist AS na_local ENGINE = Distributed('test_cluster_two_shards_localhost', currentDatabase(), na_local, rand());
+CREATE TABLE nb_dist AS nb_local ENGINE = Distributed('test_cluster_two_shards_localhost', currentDatabase(), nb_local, rand());
+
+INSERT INTO na_local VALUES (1, 5), (2, 7);
+INSERT INTO nb_local VALUES (1, 50), (2, 70);
+
+SET enable_analyzer = 1, distributed_product_mode = 'local';
+
+-- WHERE references the same-named alias column on both JOIN sides.
+SELECT 'where';
+SELECT l.id FROM na_dist AS l INNER JOIN nb_dist AS r ON l.id = r.id WHERE l.foo > 0 AND r.foo > 0 ORDER BY l.id;
+
+-- GROUP BY on the same-named alias columns from both sides.
+SELECT 'group_by';
+SELECT l.foo AS lf, r.foo AS rf, count() AS c FROM na_dist AS l INNER JOIN nb_dist AS r ON l.id = r.id GROUP BY l.foo, r.foo ORDER BY lf, rf;
+
+-- ORDER BY on the same-named alias columns from both sides.
+SELECT 'order_by';
+SELECT l.id FROM na_dist AS l INNER JOIN nb_dist AS r ON l.id = r.id ORDER BY l.foo, r.foo, l.id;
+
+-- A projection expression combining the same-named alias columns from both sides.
+SELECT 'projection_expr';
+SELECT l.foo + r.foo AS s FROM na_dist AS l INNER JOIN nb_dist AS r ON l.id = r.id ORDER BY s;
+
+-- GLOBAL JOIN wrapping a subquery that references the same-named alias columns (the original report).
+SELECT 'global_join_subquery';
+SELECT a.id, j.left_foo, j.right_foo
+FROM na_dist AS a
+GLOBAL INNER JOIN
+(
+    SELECT l.id, l.foo AS left_foo, r.foo AS right_foo
+    FROM na_dist AS l
+    INNER JOIN nb_dist AS r ON l.id = r.id
+    WHERE l.foo + r.foo > 0
+) AS j
+ON a.id = j.id
+ORDER BY a.id, j.left_foo, j.right_foo;
+
+DROP TABLE na_dist;
+DROP TABLE nb_dist;
+DROP TABLE na_local;
+DROP TABLE nb_local;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: https://github.com/ClickHouse/ClickHouse/issues/107990

> Stacked on #107913 — the base of this PR is that branch, so review the incremental diff. It will retarget to `master` automatically once #107913 merges.

When a `Distributed` query JOINs two tables that each define an `ALIAS` column with the **same name**, and that name is referenced in an expression clause (`WHERE`/`GROUP BY`/`ORDER BY`/`HAVING`/`JOIN ON`), the query failed during analysis with `MULTIPLE_EXPRESSIONS_FOR_ALIAS`:

```sql
CREATE TABLE a_local (id UInt64, x UInt64, foo UInt64 ALIAS x) ENGINE = MergeTree ORDER BY id;
CREATE TABLE b_local (id UInt64, x UInt64, foo UInt64 ALIAS x) ENGINE = MergeTree ORDER BY id;
CREATE TABLE a_dist AS a_local ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), a_local, rand());
CREATE TABLE b_dist AS b_local ENGINE = Distributed(test_cluster_two_shards_localhost, currentDatabase(), b_local, rand());

SELECT l.id FROM a_dist AS l INNER JOIN b_dist AS r ON l.id = r.id
WHERE l.foo > 0 AND r.foo > 0
SETTINGS distributed_product_mode = 'local';
-- Multiple expressions __table2.x AS foo and __table1.x AS foo for alias foo. (MULTIPLE_EXPRESSIONS_FOR_ALIAS)
```

### Root cause

For shard transport, `ALIAS` columns are inlined into their defining expressions and the **bare column name** was re-applied as an alias on every inlined expression. After `createUniqueAliasesIfNecessary` qualifies the table sources, the two structurally different expressions `__table1.x` and `__table2.x` both carry the alias `foo` in one scope, which the analyzer rejects.

### Fix

The inlined alias only needs to preserve the logical column name for **top-level projection items** (so the mergeable-state output column keeps its name). Inside expression clauses and nested expressions the alias is redundant and only creates the conflicting scope entry, so the inliner now sets the alias **only for top-level projection items**. Grouping/sorting/filtering still match the projection by expression (action node name), independent of the SQL alias.

This is **new-analyzer only** and is **orthogonal to the column-count fix** (#107913): action node names — and therefore the mergeable header names the reconciliation relies on — are computed from the column identifier / expression, not from the SQL alias, so dropping the redundant alias does not change them.

While here, the two copies of the inliner are **consolidated** into one shared implementation in `buildQueryTreeForShard` (the shard-transport inliner, previously `ReplaseAliasColumnsVisitor` in `StorageDistributed`, and the name-computation inliner introduced by #107913). Each inlined expression is cloned so per-occurrence aliasing does not mutate shared nodes.

A new stateless test `04401_distributed_alias_name_collision` covers the same-named `ALIAS` columns referenced in `WHERE`, `GROUP BY`, `ORDER BY`, a projection expression, and a `GLOBAL JOIN` subquery (the original report), each checked for correct results.

Related: https://github.com/ClickHouse/ClickHouse/pull/107913
Related: https://github.com/ClickHouse/ClickHouse/issues/79916

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `MULTIPLE_EXPRESSIONS_FOR_ALIAS` error when querying a `Distributed` table with a `JOIN` where both tables have an `ALIAS` column of the same name referenced in `WHERE`/`GROUP BY`/`ORDER BY`/`JOIN ON`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74d42b7b-948c-484c-9c17-5078798b3628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74d42b7b-948c-484c-9c17-5078798b3628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

