### PR TITLE
Mark getClientHTTPHeader as non-deterministic

### DIFF
--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -36,6 +36,8 @@ public:
 
     String getName() const override { return "getClientHTTPHeader"; }
 
+    bool isDeterministic() const override { return false; }
+
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return false; }
 

--- a/tests/queries/0_stateless/04404_get_client_http_header_non_deterministic.sql
+++ b/tests/queries/0_stateless/04404_get_client_http_header_non_deterministic.sql
@@ -1,0 +1,4 @@
+-- getClientHTTPHeader returns a per-request value, so it must be treated as non-deterministic and
+-- therefore rejected by the query result cache (which throws by default for non-deterministic functions).
+SET allow_get_client_http_header = 1;
+SELECT getClientHTTPHeader('X-Test-04404') SETTINGS use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS }


### PR DESCRIPTION
`getClientHTTPHeader` returns a per-request value (it reads the HTTP headers of the current request), so it is non-deterministic. It did not override `isDeterministic`, so it inherited the default `true`. As a consequence the query result cache treated queries using it as cacheable, which could return a stale header value for a later request. Other runtime-dependent functions (`queryID`, `currentDatabase`, `connectionId`, `initialQueryID`) already override `isDeterministic` to return `false`.

This revives the change from the closed PR #102766 (closed for process reasons), adds a regression test, and rebases it onto current `master`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/101120
Related: https://github.com/ClickHouse/ClickHouse/pull/102766

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`getClientHTTPHeader` is now correctly treated as non-deterministic, so its result is no longer incorrectly reused by the query result cache.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1198`
<!-- ch-version-info:end -->