### PR TITLE
Fix garbled error message in the nested function

### DIFF
--- a/src/Functions/nested.cpp
+++ b/src/Functions/nested.cpp
@@ -131,10 +131,10 @@ private:
 
             if (!type)
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "Argument {} for function {} must be {}-dimentional array. Actual {}",
+                    "Argument {} for function {} must be {}-dimensional array. Actual {}",
                     i + 1,
-                    array_depth,
                     getName(),
+                    array_depth,
                     argument.type->getName());
 
             names.push_back(std::string{column.getDataAt(i)});
@@ -161,7 +161,7 @@ private:
 
         if (array_col->size() != 1)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "First argument for function {} must be constant column with N-dimentional array of strings, "
+                "First argument for function {} must be constant column with N-dimensional array of strings, "
                 "where the all arrays except the most inner one must have size = 1. "
                 "The size of array at depth {} is {}",
                 getName(), array_depth, array_col->size());

--- a/tests/queries/0_stateless/04406_nested_error_message_dimensional.reference
+++ b/tests/queries/0_stateless/04406_nested_error_message_dimensional.reference
@@ -1,0 +1,1 @@
+must be 2-dimensional array

--- a/tests/queries/0_stateless/04406_nested_error_message_dimensional.sh
+++ b/tests/queries/0_stateless/04406_nested_error_message_dimensional.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# The error message for the `nested` function used to interleave the dimension and the function name
+# (e.g. "for function 2 must be nested-dimentional array") and misspelled "dimensional". Verify the
+# message now substitutes the arguments in the right order and is spelled correctly.
+$CLICKHOUSE_CLIENT --query "SELECT nested([['a']], [1, 2, 3])" 2>&1 | grep -o -m1 "must be 2-dimensional array"


### PR DESCRIPTION
The error message raised by the `nested` function for an argument of the wrong type interleaved its format arguments: the dimension and the function name were swapped, producing messages like `Argument 1 for function 2 must be nested-dimentional array`. The word "dimensional" was also misspelled as "dimentional" in two messages.

This revives the change from the closed PR #102745 (closed for process reasons), adds a regression test, and rebases it onto current `master`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/102441
Related: https://github.com/ClickHouse/ClickHouse/pull/102745

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a garbled error message (swapped arguments) and a typo ("dimentional") in the `nested` function.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1179`
<!-- ch-version-info:end -->