### PR TITLE
Add test: `alterRefreshParams` empty-database dependency resolution untested for temp-table-shadowed `DEPENDS ON`

### DIFF
--- a/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.reference
+++ b/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.reference
@@ -1,0 +1,4 @@
+1. ALTER MODIFY REFRESH DEPENDS ON temp-shadowed name, settled status and empty exception:
+MissingDependencies	1
+2. server alive:
+1

--- a/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.sh
+++ b/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tags: atomic-database, memory-engine
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Exercises ALTER ... MODIFY REFRESH ... DEPENDS ON where the bare dependency name is shadowed by a
+# TEMPORARY table, so the StorageID reaches alterRefreshParams with an empty database. The view must
+# settle at MissingDependencies with an empty exception, not abort scheduling.
+
+DB2="${CLICKHOUSE_DATABASE}_mv"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS \`$DB2\` SYNC"
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE \`$DB2\`"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE \`$DB2\`.t (a UInt64) ENGINE = MergeTree ORDER BY a"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE \`$DB2\`.dst1 (a UInt64) ENGINE = MergeTree ORDER BY a"
+
+report_refresh_state() {
+    local view="$1"
+    local status=""
+    local i
+    for i in $(seq 1 120); do
+        status=$(${CLICKHOUSE_CLIENT} -q "SELECT status FROM system.view_refreshes WHERE database = '$DB2' AND view = '$view'")
+        if [ -n "$status" ] && [ "$status" != "Scheduling" ]; then
+            break
+        fi
+        sleep 0.5
+    done
+    ${CLICKHOUSE_CLIENT} -q "
+        SELECT status, exception = '' AS no_exception
+        FROM system.view_refreshes WHERE database = '$DB2' AND view = '$view' FORMAT TSV"
+}
+
+# Temp table and ALTER must run in the SAME session so AddDefaultDatabaseVisitor leaves bare `t` unqualified.
+${CLICKHOUSE_CLIENT} --multiquery -q "
+    CREATE TEMPORARY TABLE t (a UInt64) ENGINE = Memory;
+    CREATE MATERIALIZED VIEW \`$DB2\`.mv_alt REFRESH EVERY 1 SECOND TO \`$DB2\`.dst1 AS SELECT a FROM \`$DB2\`.t;
+    ALTER TABLE \`$DB2\`.mv_alt MODIFY REFRESH EVERY 1 SECOND DEPENDS ON t;
+"
+echo "1. ALTER MODIFY REFRESH DEPENDS ON temp-shadowed name, settled status and empty exception:"
+report_refresh_state mv_alt
+
+echo "2. server alive:"
+${CLICKHOUSE_CLIENT} -q "SELECT 1"
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE \`$DB2\` SYNC"

--- a/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.sh
+++ b/tests/queries/0_stateless/04401_refreshable_mv_alter_depends_on_temp_shadow.sh
@@ -32,9 +32,11 @@ report_refresh_state() {
 }
 
 # Temp table and ALTER must run in the SAME session so AddDefaultDatabaseVisitor leaves bare `t` unqualified.
+# Create with a qualified DEPENDS ON so the view cannot run before the ALTER (first timeslot is otherwise
+# immediately due and the scheduler could flip to Running, masking the expected MissingDependencies status).
 ${CLICKHOUSE_CLIENT} --multiquery -q "
     CREATE TEMPORARY TABLE t (a UInt64) ENGINE = Memory;
-    CREATE MATERIALIZED VIEW \`$DB2\`.mv_alt REFRESH EVERY 1 SECOND TO \`$DB2\`.dst1 AS SELECT a FROM \`$DB2\`.t;
+    CREATE MATERIALIZED VIEW \`$DB2\`.mv_alt REFRESH EVERY 1 SECOND DEPENDS ON \`$DB2\`.t TO \`$DB2\`.dst1 AS SELECT a FROM \`$DB2\`.t;
     ALTER TABLE \`$DB2\`.mv_alt MODIFY REFRESH EVERY 1 SECOND DEPENDS ON t;
 "
 echo "1. ALTER MODIFY REFRESH DEPENDS ON temp-shadowed name, settled status and empty exception:"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #107156](https://github.com/ClickHouse/ClickHouse/pull/107156).
That PR The PR fixes a server abort/crash-loop in refreshable materialized views: a `REFRESH ... DEPENDS ON <name>` whose unqualified name is shadowed by a temporary table or CTE is left with an empty database by `AddDefaultDatabaseVisitor`, so `StorageID::getFullTableName` throws `UNKNOWN_DATABASE` during 

**1. `alterRefreshParams` empty-database dependency resolution untested for temp-table-shadowed `DEPENDS ON`**
  `src/Storages/MaterializedView/RefreshTask.cpp:402`
  **Risk:** InterpreterAlterQuery.cpp:475 runs `AddDefaultDatabaseVisitor` over MODIFY REFRESH; with `t` shadowed by a temporary table the dependency stays unqualified and arrives at `alterRefreshParams` (RefreshTask.cpp:402-403) with empty database. Without resolution against `view->getStorageID().database_name`, `StorageID::getFullTableName` throws `UNKNOWN_DATABASE` on the first scheduling pass, re-raised as `LOGICAL_ERROR` (server abort in debug/sanitizer builds, persisted bad definition causing …
  **What's unique vs PR tests:** The PR's test 04329 covers only the `create` call site (CREATE MATERIALIZED VIEW ... DEPENDS ON t plus detach/attach). This test covers the second, independently-wired `alterRefreshParams` call site (RefreshTask.cpp:402-403) via ALTER ... MODIFY REFRESH ... DEPENDS ON with a temp-table shadow — a distinct mutation guard (the alter call site's default_database argument) that the create test does not protect.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1083`
<!-- ch-version-info:end -->