### PR TITLE
Reject deprecated storage_catalog_url in the data lake catalog guard

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -355,8 +355,11 @@ public:
     std::shared_ptr<DataLake::ICatalog> getCatalog([[maybe_unused]] ContextPtr context, [[maybe_unused]] const StorageID & table_id) const override
     {
 #if USE_AVRO && USE_PARQUET
-        if ((*settings)[DataLakeStorageSetting::storage_catalog_type].changed || (*settings)[DataLakeStorageSetting::storage_aws_access_key_id].changed)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Don't use deprecated settings storage_catalog_type and storage_catalog_url");
+        if ((*settings)[DataLakeStorageSetting::storage_catalog_type].changed
+            || (*settings)[DataLakeStorageSetting::storage_catalog_url].changed
+            || (*settings)[DataLakeStorageSetting::storage_aws_access_key_id].changed)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Don't use deprecated settings storage_catalog_type, storage_catalog_url, storage_aws_access_key_id");
         const String db_name = table_id.hasDatabase() ? table_id.database_name : context->getCurrentDatabase();
         /// Having no associated `DataLakeDatabase` is a valid state (e.g. an `Iceberg` table in a
         /// regular `Atomic`/`Ordinary` database, or a database not currently registered during

--- a/tests/queries/0_stateless/04407_datalake_getcatalog_deprecated_settings_guard.sql
+++ b/tests/queries/0_stateless/04407_datalake_getcatalog_deprecated_settings_guard.sql
@@ -1,0 +1,7 @@
+-- Tags: no-fasttest
+
+-- The deprecated data-lake setting `storage_catalog_url` must be rejected by the catalog guard.
+-- Before the fix, the guard checked `storage_catalog_type` and `storage_aws_access_key_id` but not
+-- `storage_catalog_url`, so this setting silently slipped through. `IcebergLocal` is used so the guard
+-- (in DataLakeConfiguration::getCatalog) is reached during CREATE without any network/storage access.
+CREATE TABLE t_04407 (x Int) ENGINE = IcebergLocal('/tmp/clickhouse_04407_does_not_exist') SETTINGS storage_catalog_url = 'http://example.invalid'; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
`DataLakeConfiguration::getCatalog` rejects deprecated data-lake settings, but the guard condition only checked `storage_catalog_type` and `storage_aws_access_key_id` — while the error message named `storage_catalog_type` and `storage_catalog_url`. So setting only the deprecated `storage_catalog_url` silently slipped through the guard. This adds `storage_catalog_url` to the condition and lists all three deprecated settings in the message.

A stateless regression test was added and verified locally: with `storage_catalog_url` set, `CREATE TABLE ... ENGINE = IcebergLocal(...)` now throws `BAD_ARGUMENTS` from the guard (it reaches `getCatalog` during `CREATE` before any storage access); without the setting it proceeds past the guard.

This revives the data-lake portion of the closed PR #102755 (closed for process reasons), adds a regression test, and rebases it onto current `master`. (The unrelated `nested.cpp` change that the original PR also bundled is handled separately in the `nested` error-message PR.)

Closes: https://github.com/ClickHouse/ClickHouse/issues/102459
Related: https://github.com/ClickHouse/ClickHouse/pull/102755

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The deprecated data lake setting `storage_catalog_url` is now correctly rejected by the catalog guard (previously only `storage_catalog_type` and `storage_aws_access_key_id` were checked), and the error message lists all deprecated settings.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1121`
<!-- ch-version-info:end -->