### PR TITLE
Fix per-test coverage export tripping `max_rows_to_read`

### DIFF
--- a/ci/jobs/scripts/functional_tests/export_coverage.py
+++ b/ci/jobs/scripts/functional_tests/export_coverage.py
@@ -6,7 +6,7 @@ temp_dir = f"{Utils.cwd()}/ci/tmp"
 
 
 class CoverageExporter:
-    LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_result_rows 0 --max_result_bytes 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
+    LOGS_SAVER_CLIENT_OPTIONS = "--max_memory_usage 10G --max_threads 1 --max_result_rows 0 --max_result_bytes 0 --max_rows_to_read 0 --max_rows_to_read_leaf 0 --max_bytes_to_read 0 --max_execution_time 0 --max_execution_time_leaf 0 --max_estimated_execution_time 0"
 
     def __init__(
         self,


### PR DESCRIPTION
The per-test coverage export (`ci/jobs/scripts/functional_tests/export_coverage.py`) reads `system.coverage_log FINAL` (and `system.coverage_indirect_calls FINAL`) via `clickhouse local` started with `--config-file=/etc/clickhouse-server/config.xml`, so it inherits the server default profile's `max_rows_to_read` / `max_rows_to_read_leaf` limits. After a full shard the coverage log is large, so the stats query fails with `TOO_MANY_ROWS` in `SizeLimits::check` (`MergeTreeDataSelectExecutor`), failing the `Collect coverage` step of the `NightlyCoverage` job.

`LOGS_SAVER_CLIENT_OPTIONS` already zeroes `max_bytes_to_read`, `max_result_rows`, `max_result_bytes` and the time limits so the export reads everything without limits, but it omitted the row-count counterpart. This adds `--max_rows_to_read 0 --max_rows_to_read_leaf 0`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d7da366c9b182d6e05a64f422ae563298995c55e&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_llvm_coverage_per_test%2C%20per_test_coverage%2C%205%2F8%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1082`
<!-- ch-version-info:end -->