### PR TITLE
Pin coverage fault-injection seeds server-side to fix readonly tests

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -301,6 +301,13 @@ def main():
         if "ParallelReplicas" in to:
             is_parallel_replicas = True
 
+    if is_llvm_coverage:
+        # Pin random-by-default fault injection seeds server-side (in the default
+        # profile) so coverage is deterministic, instead of injecting them as
+        # per-query client settings (which broke tests that switch to readonly
+        # mode mid-session). See tests/config/users.d/coverage_fault_injection_seeds.xml.
+        config_installs_args += " --llvm-coverage"
+
     if is_shared_catalog or is_parallel_replicas:
         pass
     else:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6769,36 +6769,17 @@ if __name__ == "__main__":
     else:
         args.client_options_query_str = ""
 
-    if args.llvm_coverage:
-        # Pin the seeds of random-by-default mechanisms so the set of branches
-        # exercised inside the server is stable run-to-run. Without this the
-        # LLVM coverage report flickers on files reachable from these injection
-        # points (keeper fault injection, etc.).
-        # `--allow_repeated_settings` is already appended later by the per-test
-        # composition, so a test that explicitly sets one of these still wins.
-        coverage_pinned_settings = {
-            "backup_restore_keeper_fault_injection_seed": 1,
-            "insert_keeper_fault_injection_seed": 1,
-        }
-        coverage_pinned_cli = " ".join(
-            f"--{k}={v}" for k, v in coverage_pinned_settings.items()
-        )
-        coverage_pinned_url = "&".join(
-            f"{k}={v}" for k, v in coverage_pinned_settings.items()
-        )
-
-        existing_client_opt = os.environ.get("CLICKHOUSE_CLIENT_OPT", "").rstrip()
-        os.environ["CLICKHOUSE_CLIENT_OPT"] = (
-            f"{existing_client_opt} {coverage_pinned_cli} ".lstrip()
-        )
-
-        existing_url_params = os.environ.get("CLICKHOUSE_URL_PARAMS", "").rstrip("&")
-        if existing_url_params:
-            os.environ["CLICKHOUSE_URL_PARAMS"] = (
-                f"{existing_url_params}&{coverage_pinned_url}"
-            )
-        else:
-            os.environ["CLICKHOUSE_URL_PARAMS"] = coverage_pinned_url
+    # NOTE: The seeds of random-by-default mechanisms (keeper fault injection,
+    # etc.) are pinned under LLVM coverage so the set of branches exercised
+    # inside the server is stable run-to-run. They are pinned server-side, in
+    # the `default` profile (see `tests/config/users.d/coverage_fault_injection_seeds.xml`,
+    # installed by `tests/config/install.sh --llvm-coverage`), rather than as
+    # per-query client/URL settings. Injecting them per query made every
+    # statement re-apply them, which broke tests that switch to readonly mode
+    # mid-session (e.g. `01187_set_profile_as_setting`, `00543_...`): the
+    # follow-up statement failed with "Cannot modify '...' setting in readonly
+    # mode" instead of the expected behaviour. As session defaults they are not
+    # re-applied per statement, so readonly tests are unaffected.
 
     if args.jobs is None:
         args.jobs = multiprocessing.cpu_count()

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -22,6 +22,7 @@ NO_AZURE=0
 KEEPER_INJECT_AUTH=1
 WASM_ENGINE=""
 REMOTE_DATABASE_DISK=0
+LLVM_COVERAGE=0
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -48,6 +49,7 @@ while [[ "$#" -gt 0 ]]; do
         --no-remote-database-disk) REMOTE_DATABASE_DISK=0 ;;
 
         --encrypted-storage) USE_ENCRYPTED_STORAGE=1 ;;
+        --llvm-coverage) LLVM_COVERAGE=1 ;;
         *) echo "Unknown option: $1" ; exit 1 ;;
     esac
     shift
@@ -239,6 +241,12 @@ fi
 
 if [[ -n "$USE_DISTRIBUTED_PLAN" ]] && [[ "$USE_DISTRIBUTED_PLAN" -eq 1 ]]; then
     ln -sf $SRC_PATH/users.d/distributed_plan.xml $DEST_SERVER_PATH/users.d/
+fi
+
+if [[ -n "$LLVM_COVERAGE" ]] && [[ "$LLVM_COVERAGE" -eq 1 ]]; then
+    # Pin random-by-default fault injection seeds in the default profile so coverage
+    # is deterministic without injecting per-query settings (which break readonly tests).
+    ln -sf $SRC_PATH/users.d/coverage_fault_injection_seeds.xml $DEST_SERVER_PATH/users.d/
 fi
 
 # FIXME DataPartsExchange may hang for http_send_timeout seconds

--- a/tests/config/users.d/coverage_fault_injection_seeds.xml
+++ b/tests/config/users.d/coverage_fault_injection_seeds.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!--
+                Pin the seeds of random-by-default fault injection mechanisms so the set
+                of branches exercised inside the server is stable run-to-run under LLVM
+                coverage (without this the coverage report flickers on files reachable
+                from these injection points).
+
+                These are set in the `default` profile (server side) rather than injected
+                as per-query client/URL settings on purpose: as per-query settings they
+                were re-applied on every statement, so a statement issued after switching
+                to readonly mode (e.g. `SET profile = 'readonly'` / `SET readonly = 1`)
+                failed with "Cannot modify '...' setting in readonly mode". As session
+                defaults they are not re-applied per statement, so tests that exercise
+                readonly mode (01187_set_profile_as_setting, 00543_..., etc.) are
+                unaffected. Installed only for coverage runs by install.sh, gated on
+                its llvm-coverage flag.
+            -->
+            <backup_restore_keeper_fault_injection_seed>1</backup_restore_keeper_fault_injection_seed>
+            <insert_keeper_fault_injection_seed>1</insert_keeper_fault_injection_seed>
+        </default>
+    </profiles>
+</clickhouse>


### PR DESCRIPTION
Under LLVM coverage, `clickhouse-test` pins `insert_keeper_fault_injection_seed` and `backup_restore_keeper_fault_injection_seed` so the set of branches exercised inside the server is stable run-to-run. It did so by injecting them as per-query settings via `CLICKHOUSE_CLIENT_OPT` / `CLICKHOUSE_URL_PARAMS`.

Because the client re-applies these settings on **every** statement, a statement issued after the session switched to readonly mode failed with `Cannot modify '...' setting in readonly mode. (READONLY)`. This broke tests that exercise readonly mode, e.g.:
- `01187_set_profile_as_setting` — `set profile='readonly'; select ...`
- `00543_access_to_temporary_table_in_readonly_mode` — `SET readonly = 1; CREATE TEMPORARY TABLE ...`

The follow-up statement got the seed-modification error instead of the expected behaviour. Only the per-test coverage job hit this because the seed injection is gated on `--llvm-coverage`.

This pins the seeds **server-side** instead, in the `default` profile via `tests/config/users.d/coverage_fault_injection_seeds.xml`, installed only for coverage runs by `install.sh` (new `--llvm-coverage` flag, passed from `functional_tests.py`). As session defaults the seeds are not re-applied per statement, so switching to readonly mode does not try to modify them, while coverage stays deterministic. A test that explicitly sets these settings still overrides the profile default.

Verified locally against a running server that, when the seeds are session defaults (not per-query settings), `SET profile='readonly'` neither errors nor resets them, matching the expected behaviour of the affected tests.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d7da366c9b182d6e05a64f422ae563298995c55e&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_llvm_coverage_per_test%2C%20per_test_coverage%2C%205%2F8%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1090`
<!-- ch-version-info:end -->