### PR TITLE
Allow DateTime64 and Decimal range arguments in range_hashed dictionaries

### DIFF
--- a/src/Dictionaries/RangeHashedDictionary.h
+++ b/src/Dictionaries/RangeHashedDictionary.h
@@ -323,6 +323,28 @@ namespace impl
                             range_type->getName());
         }
     }
+
+    /// `std::numeric_limits` is not specialized for `Decimal` (which is the storage type of
+    /// `DateTime64`, `Time64` and `Decimal*` range columns), so it would value-initialize to zero.
+    /// That turns an open-ended (NULL bound) interval into an empty one, so a lookup falling into it
+    /// returns the default value. Use the limits of the underlying native type for such ranges.
+    template <typename RangeStorageType>
+    constexpr RangeStorageType rangeStorageTypeMin()
+    {
+        if constexpr (is_decimal<RangeStorageType>)
+            return RangeStorageType{std::numeric_limits<typename RangeStorageType::NativeType>::min()};
+        else
+            return std::numeric_limits<RangeStorageType>::min();
+    }
+
+    template <typename RangeStorageType>
+    constexpr RangeStorageType rangeStorageTypeMax()
+    {
+        if constexpr (is_decimal<RangeStorageType>)
+            return RangeStorageType{std::numeric_limits<typename RangeStorageType::NativeType>::max()};
+        else
+            return std::numeric_limits<RangeStorageType>::max();
+    }
 }
 
 template <DictionaryKeyType dictionary_key_type>
@@ -872,13 +894,13 @@ void RangeHashedDictionary<dictionary_key_type>::blockToAttributes(const Block &
 
             if (unlikely(min_range_null_map && (*min_range_null_map)[key_index]))
             {
-                lower_bound = std::numeric_limits<RangeStorageType>::min();
+                lower_bound = impl::rangeStorageTypeMin<RangeStorageType>();
                 invalid_range = true;
             }
 
             if (unlikely(max_range_null_map && (*max_range_null_map)[key_index]))
             {
-                upper_bound = std::numeric_limits<RangeStorageType>::max();
+                upper_bound = impl::rangeStorageTypeMax<RangeStorageType>();
                 invalid_range = true;
             }
 

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -48,6 +48,19 @@ namespace ErrorCodes
     extern const int TYPE_MISMATCH;
 }
 
+/// The range value passed to `dictGet`/`dictHas` for a `range_hashed` dictionary is cast to the
+/// dictionary's range type before the lookup (see `RangeHashedDictionary::getColumn`). The range
+/// type may be an integer, `Enum`, `Date`/`DateTime`/`DateTime64` or `Decimal` whose value fits
+/// into `Int64` (see `impl::callOnRangeType`). `DateTime64` and `Decimal` are not "represented by
+/// integer", so they must be checked explicitly; otherwise a `DateTime64` range argument would be
+/// rejected even though it is a valid range type.
+inline bool isValidRangeArgumentType(const DataTypePtr & range_col_type)
+{
+    if (range_col_type->getSizeOfValueInMemory() > sizeof(Int64))
+        return false;
+    return range_col_type->isValueRepresentedByInteger() || isDateTime64(range_col_type) || isDecimal(range_col_type);
+}
+
 
 /** Functions that use plug-ins (external) dictionaries_loader.
   *
@@ -243,7 +256,7 @@ public:
             range_col = arguments[2].column;
             range_col_type = arguments[2].type;
 
-            if (!(range_col_type->isValueRepresentedByInteger() && range_col_type->getSizeOfValueInMemory() <= sizeof(Int64)))
+            if (!isValidRangeArgumentType(range_col_type))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                     "Illegal type {} of fourth argument of function {} must be convertible to Int64.",
                     range_col_type->getName(),
@@ -452,7 +465,7 @@ public:
             range_col = arguments[current_arguments_index].column;
             range_col_type = arguments[current_arguments_index].type;
 
-            if (!(range_col_type->isValueRepresentedByInteger() && range_col_type->getSizeOfValueInMemory() <= sizeof(Int64)))
+            if (!isValidRangeArgumentType(range_col_type))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                     "Illegal type {} of fourth argument of function {} must be convertible to Int64.",
                     range_col_type->getName(),

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -49,16 +49,26 @@ namespace ErrorCodes
 }
 
 /// The range value passed to `dictGet`/`dictHas` for a `range_hashed` dictionary is cast to the
-/// dictionary's range type before the lookup (see `RangeHashedDictionary::getColumn`). The range
-/// type may be an integer, `Enum`, `Date`/`DateTime`/`DateTime64` or `Decimal` whose value fits
-/// into `Int64` (see `impl::callOnRangeType`). `DateTime64` and `Decimal` are not "represented by
-/// integer", so they must be checked explicitly; otherwise a `DateTime64` range argument would be
-/// rejected even though it is a valid range type.
+/// dictionary's range type before the lookup (see `RangeHashedDictionary::getColumn`). The accepted
+/// classes mirror the range types that `range_hashed`/`complex_key_range_hashed` itself accepts (see
+/// `impl::callOnRangeType`): integer-represented types (integers, `Date`/`DateTime`, `Enum`),
+/// floating point, `DateTime64` and `Decimal`. `DateTime64` and `Decimal` are not "represented by
+/// integer", so they must be checked explicitly; otherwise such an argument would be rejected even
+/// though it is a valid range type.
 inline bool isValidRangeArgumentType(const DataTypePtr & range_col_type)
 {
-    if (range_col_type->getSizeOfValueInMemory() > sizeof(Int64))
+    /// The type class must be checked before the in-memory size: variable-size types such as
+    /// `String` have no fixed value size and would make `getSizeOfValueInMemory` throw a
+    /// `LOGICAL_ERROR` instead of producing the intended `ILLEGAL_COLUMN` message below.
+    if (!(range_col_type->isValueRepresentedByInteger()
+          || isFloat(range_col_type)
+          || isDateTime64(range_col_type)
+          || isDecimal(range_col_type)))
         return false;
-    return range_col_type->isValueRepresentedByInteger() || isDateTime64(range_col_type) || isDecimal(range_col_type);
+
+    /// The range value is compared as a 64-bit quantity, so wider types (e.g. `Int128`,
+    /// `Decimal128`) are rejected with `ILLEGAL_COLUMN`.
+    return range_col_type->getSizeOfValueInMemory() <= sizeof(Int64);
 }
 
 

--- a/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.reference
+++ b/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.reference
@@ -1,0 +1,18 @@
+DateTime64 range argument, open-ended (NULL) interval
+250
+250
+DateTime64 range argument, sub-second precision
+100
+50
+0
+100
+dictHas with DateTime64 range argument
+1
+0
+Simple key with DateTime64 range
+first
+open
+none
+Decimal range argument
+low
+high

--- a/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.reference
+++ b/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.reference
@@ -16,3 +16,7 @@ none
 Decimal range argument
 low
 high
+Float range argument
+low
+high
+Unsupported range argument types are rejected with a clean error

--- a/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.sql
+++ b/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.sql
@@ -1,0 +1,133 @@
+-- Tests that a range_hashed / complex_key_range_hashed dictionary can be queried with a
+-- DateTime64 range argument (and that sub-second precision is preserved), as well as with a
+-- Decimal range argument. Previously dictGet/dictHas rejected such arguments with
+-- "must be convertible to Int64", even though DateTime64/Decimal are valid range column types.
+-- https://github.com/ClickHouse/ClickHouse/issues/46060
+
+DROP TABLE IF EXISTS 04401_range_source;
+CREATE TABLE 04401_range_source
+(
+    offer_id UInt64,
+    postback_status UInt64,
+    date_start DateTime64(6, 'UTC'),
+    date_end Nullable(DateTime64(6, 'UTC')),
+    amount Decimal(12, 2)
+)
+ENGINE = TinyLog;
+
+INSERT INTO 04401_range_source VALUES
+    (4, 5, '2018-11-28 16:10:05.636720', '2019-04-01 00:00:00.451254', 50),
+    (4, 5, '2019-04-01 00:00:00.451254', '2019-11-30 23:59:59.000000', 100),
+    (4, 4, '2019-11-30 23:59:59.000000', NULL, 250);
+
+DROP DICTIONARY IF EXISTS 04401_range_dict;
+CREATE DICTIONARY 04401_range_dict
+(
+    offer_id UInt64,
+    postback_status UInt64,
+    date_start DateTime64(6, 'UTC'),
+    date_end Nullable(DateTime64(6, 'UTC')),
+    amount Decimal(12, 2)
+)
+PRIMARY KEY offer_id, postback_status
+SOURCE(CLICKHOUSE(TABLE '04401_range_source'))
+LAYOUT(COMPLEX_KEY_RANGE_HASHED(range_lookup_strategy 'max'))
+RANGE(MIN date_start MAX date_end)
+LIFETIME(0);
+
+SELECT 'DateTime64 range argument, open-ended (NULL) interval';
+-- A point far in the future falls into the open-ended interval of (4, 4) -> 250.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(4)), toDateTime64('2025-01-01 00:00:00.000000', 6, 'UTC'));
+-- The open interval starts exactly at its lower bound -> 250.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(4)), toDateTime64('2019-11-30 23:59:59.000000', 6, 'UTC'));
+
+SELECT 'DateTime64 range argument, sub-second precision';
+-- Inside the second closed interval of (4, 5) -> 100.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(5)), toDateTime64('2019-08-08 23:59:59.636720', 6, 'UTC'));
+-- Exactly at the lower bound of the first interval of (4, 5) -> 50.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(5)), toDateTime64('2018-11-28 16:10:05.636720', 6, 'UTC'));
+-- One microsecond before that lower bound -> outside any interval -> default 0.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(5)), toDateTime64('2018-11-28 16:10:05.636719', 6, 'UTC'));
+-- Overlapping point shared by both (4, 5) intervals: range_lookup_strategy 'max' picks the
+-- interval with the larger range_min -> the second one -> 100.
+SELECT dictGet('04401_range_dict', 'amount', (toUInt64(4), toUInt64(5)), toDateTime64('2019-04-01 00:00:00.451254', 6, 'UTC'));
+
+SELECT 'dictHas with DateTime64 range argument';
+SELECT dictHas('04401_range_dict', (toUInt64(4), toUInt64(4)), toDateTime64('2025-01-01 00:00:00.000000', 6, 'UTC'));
+SELECT dictHas('04401_range_dict', (toUInt64(4), toUInt64(5)), toDateTime64('2018-11-28 16:10:05.636719', 6, 'UTC'));
+
+DROP DICTIONARY 04401_range_dict;
+DROP TABLE 04401_range_source;
+
+SELECT 'Simple key with DateTime64 range';
+
+DROP TABLE IF EXISTS 04401_range_source_simple;
+CREATE TABLE 04401_range_source_simple
+(
+    id UInt64,
+    date_start DateTime64(3, 'UTC'),
+    date_end Nullable(DateTime64(3, 'UTC')),
+    value String
+)
+ENGINE = TinyLog;
+
+INSERT INTO 04401_range_source_simple VALUES
+    (1, '2020-01-01 00:00:00.100', '2020-06-01 00:00:00.500', 'first'),
+    (1, '2020-06-01 00:00:00.500', NULL, 'open');
+
+DROP DICTIONARY IF EXISTS 04401_range_dict_simple;
+CREATE DICTIONARY 04401_range_dict_simple
+(
+    id UInt64,
+    date_start DateTime64(3, 'UTC'),
+    date_end Nullable(DateTime64(3, 'UTC')),
+    value String DEFAULT 'none'
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '04401_range_source_simple'))
+LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))
+RANGE(MIN date_start MAX date_end)
+LIFETIME(0);
+
+SELECT dictGet('04401_range_dict_simple', 'value', toUInt64(1), toDateTime64('2020-03-01 00:00:00.000', 3, 'UTC'));
+SELECT dictGet('04401_range_dict_simple', 'value', toUInt64(1), toDateTime64('2030-01-01 00:00:00.000', 3, 'UTC'));
+SELECT dictGet('04401_range_dict_simple', 'value', toUInt64(1), toDateTime64('2020-01-01 00:00:00.099', 3, 'UTC'));
+
+DROP DICTIONARY 04401_range_dict_simple;
+DROP TABLE 04401_range_source_simple;
+
+SELECT 'Decimal range argument';
+
+DROP TABLE IF EXISTS 04401_range_source_decimal;
+CREATE TABLE 04401_range_source_decimal
+(
+    id UInt64,
+    range_start Decimal(18, 6),
+    range_end Decimal(18, 6),
+    value String
+)
+ENGINE = TinyLog;
+
+INSERT INTO 04401_range_source_decimal VALUES
+    (1, 0.000000, 10.500000, 'low'),
+    (1, 10.500000, 100.000000, 'high');
+
+DROP DICTIONARY IF EXISTS 04401_range_dict_decimal;
+CREATE DICTIONARY 04401_range_dict_decimal
+(
+    id UInt64,
+    range_start Decimal(18, 6),
+    range_end Decimal(18, 6),
+    value String DEFAULT 'none'
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '04401_range_source_decimal'))
+LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))
+RANGE(MIN range_start MAX range_end)
+LIFETIME(0);
+
+SELECT dictGet('04401_range_dict_decimal', 'value', toUInt64(1), toDecimal64(5.25, 6));
+SELECT dictGet('04401_range_dict_decimal', 'value', toUInt64(1), toDecimal64(50.0, 6));
+
+DROP DICTIONARY 04401_range_dict_decimal;
+DROP TABLE 04401_range_source_decimal;

--- a/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.sql
+++ b/tests/queries/0_stateless/04401_datetime64_range_hashed_dictionary.sql
@@ -131,3 +131,48 @@ SELECT dictGet('04401_range_dict_decimal', 'value', toUInt64(1), toDecimal64(50.
 
 DROP DICTIONARY 04401_range_dict_decimal;
 DROP TABLE 04401_range_source_decimal;
+
+SELECT 'Float range argument';
+
+DROP TABLE IF EXISTS 04401_range_source_float;
+CREATE TABLE 04401_range_source_float
+(
+    id UInt64,
+    range_start Float64,
+    range_end Nullable(Float64),
+    value String
+)
+ENGINE = TinyLog;
+
+INSERT INTO 04401_range_source_float VALUES
+    (1, 0.0, 10.5, 'low'),
+    (1, 10.5, NULL, 'high');
+
+DROP DICTIONARY IF EXISTS 04401_range_dict_float;
+CREATE DICTIONARY 04401_range_dict_float
+(
+    id UInt64,
+    range_start Float64,
+    range_end Nullable(Float64),
+    value String DEFAULT 'none'
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE '04401_range_source_float'))
+LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))
+RANGE(MIN range_start MAX range_end)
+LIFETIME(0);
+
+-- A Float64 range column is accepted by range_hashed, so a fractional Float64 argument must be
+-- accepted by dictGet as well (it is cast to the dictionary's range type before the lookup).
+SELECT dictGet('04401_range_dict_float', 'value', toUInt64(1), toFloat64(5.25));
+-- A point far in the future falls into the open-ended (NULL max) interval.
+SELECT dictGet('04401_range_dict_float', 'value', toUInt64(1), toFloat64(1000.0));
+
+SELECT 'Unsupported range argument types are rejected with a clean error';
+-- A variable-size type such as String must produce ILLEGAL_COLUMN, not a LOGICAL_ERROR.
+SELECT dictGet('04401_range_dict_float', 'value', toUInt64(1), 'not a number'); -- { serverError ILLEGAL_COLUMN }
+-- A wider-than-Int64 numeric argument is rejected, since the range value is compared as Int64.
+SELECT dictGet('04401_range_dict_float', 'value', toUInt64(1), toInt128(5)); -- { serverError ILLEGAL_COLUMN }
+
+DROP DICTIONARY 04401_range_dict_float;
+DROP TABLE 04401_range_source_float;


### PR DESCRIPTION
A `range_hashed` / `complex_key_range_hashed` dictionary already accepts `DateTime64` and `Decimal` columns as its range key (see `impl::callOnRangeType`), but `dictGet` and `dictHas` rejected a `DateTime64` or `Decimal` range argument with `Illegal type ... must be convertible to Int64`. The guard relied on `isValueRepresentedByInteger`, which is `false` for `DateTime64` and `Decimal`, even though the range argument is cast to the dictionary's range type before the lookup.

As a result, a `DateTime64`-range dictionary could not be queried directly with a `DateTime64` value. The only suggested workaround — passing a raw `Int64` produced by `toUnixTimestamp64Micro` — is silently wrong, because that integer is cast to the range type as a number of *seconds* and overflows, so every lookup returns the default value.

This change accepts `DateTime64`, `Decimal` and floating-point arguments (whose value fits into `Int64`) in addition to integer-represented types, so such dictionaries can be queried directly, preserving sub-second precision. The accepted argument types now mirror the range types that `range_hashed` itself stores, and unsupported types (e.g. `String`, or numeric types wider than `Int64`) are rejected with a clean `ILLEGAL_COLUMN` error instead of a `LOGICAL_ERROR`.

It also fixes a latent bug in `RangeHashedDictionary` where an open-ended (`NULL` bound) interval of a `Decimal`/`DateTime64` range was stored as an empty interval — because `std::numeric_limits` is not specialized for `Decimal` and value-initialized the bound to zero — so lookups falling inside such an interval returned the default value.

Closes: https://github.com/ClickHouse/ClickHouse/issues/46060

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow querying a `range_hashed` or `complex_key_range_hashed` dictionary that uses a `DateTime64`, `Decimal` or floating-point range with a matching argument to `dictGet`/`dictHas`. Previously such queries failed with `must be convertible to Int64`, and open-ended intervals of `Decimal`/`DateTime64` ranges incorrectly returned the default value.
