### PR TITLE
Fix SELECT count() with a grant on only an ALIAS column

### DIFF
--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -265,13 +265,28 @@ NameAndTypePair chooseSmallestColumnToReadFromStorage(const StoragePtr & storage
 
     if (!column_names_allowed_to_select.empty())
     {
-        auto it = column_names_and_types.begin();
-        while (it != column_names_and_types.end())
+        /// Keep only the columns the user is allowed to read, so that a trivial query reads a column
+        /// it has access to. But if none of the allowed columns is a physical column (e.g. the user is
+        /// granted access only to ALIAS columns, which are not physical and therefore never appear in
+        /// `column_names_and_types`), the filter below would remove everything. In that case we keep all
+        /// physical columns: reading any of them just to determine the number of rows for a trivial query
+        /// (such as `SELECT count()`) is allowed, because computing an accessible ALIAS column requires
+        /// reading its physical source columns anyway and no column values are exposed to the user.
+        bool has_allowed_physical_column = std::any_of(
+            column_names_and_types.begin(),
+            column_names_and_types.end(),
+            [&](const auto & column) { return column_names_allowed_to_select.contains(column.name); });
+
+        if (has_allowed_physical_column)
         {
-            if (!column_names_allowed_to_select.contains(it->name))
-                it = column_names_and_types.erase(it);
-            else
-                ++it;
+            auto it = column_names_and_types.begin();
+            while (it != column_names_and_types.end())
+            {
+                if (!column_names_allowed_to_select.contains(it->name))
+                    it = column_names_and_types.erase(it);
+                else
+                    ++it;
+            }
         }
     }
 

--- a/tests/queries/0_stateless/04402_grant_select_alias_column.reference
+++ b/tests/queries/0_stateless/04402_grant_select_alias_column.reference
@@ -1,0 +1,15 @@
+-- read alias column
+012
+-- read alias column with always-false WHERE
+-- read alias column with always-true WHERE
+012
+-- read alias column with WHERE on the alias itself
+012
+-- count() with a grant on only the alias column
+1
+-- count() with always-false WHERE
+0
+-- reading the underlying physical column directly is still denied
+ACCESS_DENIED
+-- referencing the physical column in WHERE is still denied
+ACCESS_DENIED

--- a/tests/queries/0_stateless/04402_grant_select_alias_column.sh
+++ b/tests/queries/0_stateless/04402_grant_select_alias_column.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-old-analyzer
+
+# Tests for column-level SELECT grants on ALIAS columns.
+#
+# 1. A user granted SELECT only on an ALIAS column must be able to read it,
+#    including with a WHERE clause (regression test for the bug from
+#    https://github.com/ClickHouse/ClickHouse/issues/31912 where a WHERE clause
+#    turned the read into ACCESS_DENIED).
+# 2. SELECT count() with a grant on only an ALIAS column must work and not throw
+#    a "No available columns" LOGICAL_ERROR (the count reads the alias' physical
+#    source columns, which is allowed even though the user cannot read them directly).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+USER="user_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${USER}"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE test_alias (str String, sub_str String ALIAS substring(str, 1, 3)) ENGINE = Memory"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO test_alias(str) VALUES ('0123456')"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${USER}"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT(sub_str) ON ${CLICKHOUSE_DATABASE}.test_alias TO ${USER}"
+
+run() { ${CLICKHOUSE_CLIENT} --user "${USER}" --query "$1"; }
+denied() { ${CLICKHOUSE_CLIENT} --user "${USER}" --query "$1" 2>&1 | grep -o 'ACCESS_DENIED' | head -1; }
+
+echo "-- read alias column"
+run "SELECT sub_str FROM test_alias"
+echo "-- read alias column with always-false WHERE"
+run "SELECT sub_str FROM test_alias WHERE 1 = 0"
+echo "-- read alias column with always-true WHERE"
+run "SELECT sub_str FROM test_alias WHERE 1 = 1"
+echo "-- read alias column with WHERE on the alias itself"
+run "SELECT sub_str FROM test_alias WHERE sub_str = '012'"
+echo "-- count() with a grant on only the alias column"
+run "SELECT count() FROM test_alias"
+echo "-- count() with always-false WHERE"
+run "SELECT count() FROM test_alias WHERE 1 = 0"
+
+echo "-- reading the underlying physical column directly is still denied"
+denied "SELECT str FROM test_alias"
+echo "-- referencing the physical column in WHERE is still denied"
+denied "SELECT sub_str FROM test_alias WHERE str = '0123456'"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE test_alias"
+${CLICKHOUSE_CLIENT} --query "DROP USER ${USER}"


### PR DESCRIPTION
When a user is granted `SELECT` on only an `ALIAS` column, a trivial query such as `SELECT count() FROM table` threw a `No available columns` `LOGICAL_ERROR` (an exception) in the analyzer.

`checkAccessRights` correctly returns the set of accessible columns (the `ALIAS` column), but `chooseSmallestColumnToReadFromStorage` then filters the physical columns of the table down to that set in order to read the cheapest column. An `ALIAS` column is not physical, so it never appears among the physical columns, the filtered list becomes empty, and `ExpressionActions::getSmallestColumn` throws on the empty list.

Reading a physical column just to determine the number of rows for a trivial query is allowed even when the user can only access an `ALIAS` column, because computing that `ALIAS` requires reading its physical source columns anyway and no column values are exposed to the user (this is the behavior already documented in `PlannerJoinTree`). So when none of the allowed columns is physical, we keep all physical columns instead of emptying the list.

This also adds a regression test for the original report, reading an `ALIAS` column under a column-level grant together with a `WHERE` clause. That scenario used to fail with `ACCESS_DENIED` and is already fixed in the analyzer, but was not covered by a test. The test is tagged `no-old-analyzer` because the old analyzer is not fixed.

Closes: https://github.com/ClickHouse/ClickHouse/issues/31912

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `LOGICAL_ERROR` (`No available columns`) when executing `SELECT count()` (or other trivial queries) on a table where the user is granted `SELECT` access only on an `ALIAS` column.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.169` (included in `26.7` and later)
<!-- ch-version-info:end -->