### PR TITLE
Preserve LowCardinality in mapFilter, mapSort and mapConcat

### DIFF
--- a/src/Functions/array/FunctionsMapMiscellaneous.cpp
+++ b/src/Functions/array/FunctionsMapMiscellaneous.cpp
@@ -6,6 +6,7 @@
 
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeFunction.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeTuple.h>
 
@@ -52,10 +53,28 @@ public:
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionMapToArrayAdapter>(); }
     String getName() const override { return name; }
 
+    /// Functions that return a Map by selecting or reordering the original key-value pairs
+    /// (`mapFilter`, `mapSort` and its variants, `mapConcat`) must keep the exact key and value
+    /// types of the input Map, including `LowCardinality`. The generic
+    /// `useDefaultImplementationForLowCardinalityColumns` machinery strips nested `LowCardinality`
+    /// recursively (as it does for arrays), which would silently turn `Map(LowCardinality(String), String)`
+    /// into `Map(String, String)` and corrupt the metadata of a table created from such an expression.
+    /// `mapApply` is excluded because it rebuilds the elements from the lambda result, so its element
+    /// types follow the lambda (just like `arrayMap`).
+    static constexpr bool preserve_nested_low_cardinality = Adapter::preserve_low_cardinality && !std::is_same_v<Impl, FunctionArrayMap>;
+
     bool isVariadic() const override { return impl.isVariadic(); }
     size_t getNumberOfArguments() const override { return impl.getNumberOfArguments(); }
     bool useDefaultImplementationForNulls() const override { return impl.useDefaultImplementationForNulls(); }
-    bool useDefaultImplementationForLowCardinalityColumns() const override { return impl.useDefaultImplementationForLowCardinalityColumns(); }
+
+    bool useDefaultImplementationForLowCardinalityColumns() const override
+    {
+        if constexpr (preserve_nested_low_cardinality)
+            return false;
+        else
+            return impl.useDefaultImplementationForLowCardinalityColumns();
+    }
+
     bool useDefaultImplementationForConstants() const override { return impl.useDefaultImplementationForConstants(); }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override  { return false; }
 
@@ -128,7 +147,29 @@ public:
     {
         auto nested_arguments = arguments;
         Adapter::extractNestedTypesAndColumns(nested_arguments);
-        return Adapter::wrapColumn(impl.executeImpl(nested_arguments, Adapter::extractResultType(result_type), input_rows_count));
+
+        if constexpr (preserve_nested_low_cardinality)
+        {
+            /// We disabled the default LowCardinality implementation to keep the key/value types in
+            /// the result type, so the framework no longer strips LowCardinality from the arguments.
+            /// The nested `impl` (e.g. `arrayFilter`) operates on full columns and its lambda argument
+            /// types were declared without LowCardinality, so we strip it here and restore it on the
+            /// result to match the declared result type.
+            const auto nested_result_type = Adapter::extractResultType(result_type);
+            const auto nested_result_type_no_lc = recursiveRemoveLowCardinality(nested_result_type);
+
+            for (auto & argument : nested_arguments)
+            {
+                argument.column = recursiveRemoveLowCardinality(argument.column);
+                argument.type = recursiveRemoveLowCardinality(argument.type);
+            }
+
+            auto nested_result = impl.executeImpl(nested_arguments, nested_result_type_no_lc, input_rows_count);
+            nested_result = recursiveLowCardinalityTypeConversion(nested_result, nested_result_type_no_lc, nested_result_type);
+            return Adapter::wrapColumn(std::move(nested_result));
+        }
+        else
+            return Adapter::wrapColumn(impl.executeImpl(nested_arguments, Adapter::extractResultType(result_type), input_rows_count));
     }
 
 private:
@@ -189,6 +230,9 @@ struct MapToNestedAdapter : public MapAdapterBase<MapToNestedAdapter<Name, retur
     using MapAdapterBase<MapToNestedAdapter, Name>::extractNestedTypes;
     using MapAdapterBase<MapToNestedAdapter, Name>::extractNestedTypesAndColumns;
 
+    /// Functions returning a Map should keep the key/value types (including LowCardinality) of the input.
+    static constexpr bool preserve_low_cardinality = returns_map;
+
     static DataTypePtr extractNestedType(const DataTypeMap & type_map)
     {
         return type_map.getNestedType();
@@ -226,6 +270,9 @@ template <typename Name, size_t position>
 struct MapToSubcolumnAdapter
 {
     static_assert(position <= 1, "position of Map subcolumn must be 0 or 1");
+
+    /// These functions return an Array or a scalar, not a Map (the array convention strips nested LowCardinality).
+    static constexpr bool preserve_low_cardinality = false;
 
     static void extractNestedTypes(DataTypes & types)
     {
@@ -343,6 +390,10 @@ struct MapLikeAdapter
     /// The SQL-level signature is `(Map, String pattern)`; the lambda is constructed internally,
     /// so the first user-facing argument is not a lambda.
     static constexpr bool first_argument_is_lambda = false;
+
+    /// These functions match keys/values with `LIKE`, which is defined only for String/FixedString.
+    /// Their LowCardinality handling is left to the generic machinery (nested LowCardinality is not preserved).
+    static constexpr bool preserve_low_cardinality = false;
 
     static void checkTypes(const DataTypes & types)
     {

--- a/tests/queries/0_stateless/04402_map_functions_lowcardinality.reference
+++ b/tests/queries/0_stateless/04402_map_functions_lowcardinality.reference
@@ -1,0 +1,28 @@
+-- mapFilter preserves LowCardinality of key and value
+Map(LowCardinality(String), String)
+Map(String, LowCardinality(String))
+{'b':'y'}
+-- mapSort and variants preserve LowCardinality
+Map(LowCardinality(String), String)
+{'a':'x','b':'y'}
+Map(LowCardinality(String), String)
+Map(LowCardinality(String), String)
+-- mapConcat preserves LowCardinality when all inputs agree, otherwise falls back
+Map(LowCardinality(String), String)
+{'a':'x','b':'y'}
+Map(String, String)
+-- mapApply follows the lambda (just like arrayMap)
+Map(String, String)
+Map(LowCardinality(String), String)
+-- subcolumn/scalar functions keep their existing behavior
+Array(String)
+Array(String)
+UInt8
+UInt8
+-- plain Map (no LowCardinality) is unaffected
+Map(String, String)
+-- the reproducer from the issue: CREATE TABLE AS keeps the column type and passes CHECK
+attributes_map	Map(LowCardinality(String), String)
+key	String
+key_1	{'attr_2':'value_2','attr_3':'value_3'}
+1

--- a/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
+++ b/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
@@ -1,0 +1,59 @@
+-- Map functions that return a Map by selecting or reordering the original key-value pairs
+-- must preserve the key and value types of the input Map, including LowCardinality.
+-- Previously mapFilter, mapSort and mapConcat silently dropped LowCardinality, which corrupted
+-- the metadata of a table created from such an expression.
+
+SELECT '-- mapFilter preserves LowCardinality of key and value';
+SELECT toTypeName(mapFilter((k, v) -> k != 'a', map('a'::LowCardinality(String), 'x', 'b'::LowCardinality(String), 'y')));
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a', 'x'::LowCardinality(String))));
+SELECT mapFilter((k, v) -> k != 'a', map('a'::LowCardinality(String), 'x', 'b'::LowCardinality(String), 'y'));
+
+SELECT '-- mapSort and variants preserve LowCardinality';
+SELECT toTypeName(mapSort(map('b'::LowCardinality(String), 'y', 'a'::LowCardinality(String), 'x')));
+SELECT mapSort(map('b'::LowCardinality(String), 'y', 'a'::LowCardinality(String), 'x'));
+SELECT toTypeName(mapReverseSort(map('a'::LowCardinality(String), 'x', 'b'::LowCardinality(String), 'y')));
+SELECT toTypeName(mapPartialSort((k, v) -> k, 1, map('b'::LowCardinality(String), 'y', 'a'::LowCardinality(String), 'x')));
+
+SELECT '-- mapConcat preserves LowCardinality when all inputs agree, otherwise falls back';
+SELECT toTypeName(mapConcat(map('a'::LowCardinality(String), 'x'), map('b'::LowCardinality(String), 'y')));
+SELECT mapConcat(map('a'::LowCardinality(String), 'x'), map('b'::LowCardinality(String), 'y'));
+SELECT toTypeName(mapConcat(map('a'::LowCardinality(String), 'x'), map('b', 'y')));
+
+SELECT '-- mapApply follows the lambda (just like arrayMap)';
+SELECT toTypeName(mapApply((k, v) -> (k, v), map('a'::LowCardinality(String), 'x')));
+SELECT toTypeName(mapApply((k, v) -> (k::LowCardinality(String), v), map('a', 'x')));
+
+SELECT '-- subcolumn/scalar functions keep their existing behavior';
+SELECT toTypeName(mapKeys(map('a'::LowCardinality(String), 'x')));
+SELECT toTypeName(mapValues(map('a', 'x'::LowCardinality(String))));
+SELECT toTypeName(mapContains(map('a'::LowCardinality(String), 'x'), 'a'));
+SELECT toTypeName(mapExists((k, v) -> 1, map('a'::LowCardinality(String), 'x')));
+
+SELECT '-- plain Map (no LowCardinality) is unaffected';
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a', 'x')));
+
+SELECT '-- the reproducer from the issue: CREATE TABLE AS keeps the column type and passes CHECK';
+DROP TABLE IF EXISTS t_map_lc_src;
+DROP TABLE IF EXISTS t_map_lc_dst;
+
+CREATE TABLE t_map_lc_src
+(
+    key String,
+    attributes_map Map(LowCardinality(String), String)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO t_map_lc_src VALUES ('key_1', {'attr_1': 'value_1', 'attr_2': 'value_2', 'attr_3': 'value_3'});
+
+CREATE TABLE t_map_lc_dst
+ENGINE = MergeTree
+ORDER BY tuple()
+AS SELECT key, mapFilter((k, v) -> k != 'attr_1', attributes_map) AS attributes_map FROM t_map_lc_src;
+
+SELECT name, type FROM system.columns WHERE database = currentDatabase() AND table = 't_map_lc_dst' ORDER BY name;
+SELECT key, attributes_map FROM t_map_lc_dst;
+CHECK TABLE t_map_lc_dst SETTINGS check_query_single_value_result = 1;
+
+DROP TABLE t_map_lc_src;
+DROP TABLE t_map_lc_dst;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/64453

Map functions that return a `Map` by selecting or reordering the original key-value pairs (`mapFilter`, `mapSort` and its variants, `mapConcat`) silently dropped `LowCardinality` from the key and value types, turning `Map(LowCardinality(String), String)` into `Map(String, String)`.

When such an expression was used in `CREATE TABLE ... AS SELECT`, the created table's declared type no longer matched the data on disk, so `CHECK TABLE` reported `CORRUPTED_DATA`.

These functions are implemented as adapters over the array higher-order functions, and the generic `useDefaultImplementationForLowCardinalityColumns` machinery recursively strips nested `LowCardinality` from the arguments (the same convention arrays use) before the return type is derived. For the structure-preserving `Map` functions, this change disables that machinery and handles `LowCardinality` in the adapter instead: it is kept in the result type, stripped from the columns before running the nested array function, and restored on the result.

`mapApply` is unchanged and keeps following the lambda result (like `arrayMap`), and the `*Like` functions, which are defined only for String keys/values, are left as they were.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `mapFilter`, `mapSort` (and its variants) and `mapConcat` dropping `LowCardinality` from the key and value types of a `Map`. Previously `mapFilter` over a `Map(LowCardinality(String), String)` column returned `Map(String, String)`, which could corrupt the metadata of a table created via `CREATE TABLE ... AS SELECT` and make `CHECK TABLE` fail.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.38`
<!-- ch-version-info:end -->