### PR TITLE
Run test_huge_concurrent_restore sequentially to avoid integration-test host overload

### DIFF
--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -40,6 +40,11 @@ TEST_CONFIGS = [
         False,
         "10-node cluster; fully isolated per test module",
     ),
+    TC(
+        "test_backup_restore_on_cluster/test_huge_concurrent_restore.py",
+        True,
+        "20-node cluster; under ASan its concurrent startup saturates the host and overloads Keeper (KEEPER_EXCEPTION on ON CLUSTER queries), timing out co-scheduled tests",
+    ),
     TC("test_storage_iceberg_no_spark/", False, "minio/azurite per cluster; fully isolated"),
     TC("test_storage_iceberg_with_spark_cache/", False, "package-scoped Spark session; each xdist worker gets its own instance"),
     TC("test_storage_iceberg_concurrent/", False, "package-scoped Spark session; each xdist worker gets its own instance"),


### PR DESCRIPTION
Several `amd_asan_ubsan` integration test batches on `master` fail as a *group*: multiple unrelated tests (`test_huge_concurrent_restore`, `test_cross_replication`, `test_config_xml_yaml_mix`) all time out at the same wall-clock moment with `Timeout (>900.0s) from pytest-timeout`, or fail with `Code: 999 ... Keeper server rejected the connection during the handshake. Possibly it's overloaded` on `ON CLUSTER` queries.

This is host overload, not a test bug. The parallel phase runs three modules concurrently (`-n 3 --dist=loadfile`). `test_backup_restore_on_cluster/test_huge_concurrent_restore.py` starts a 20-node cluster (`num_nodes = 20`); when its nodes start simultaneously with two other multi-node cluster tests on one `m7i.4xlarge`, the runner saturates under ASan, Keeper stops answering handshakes in time, and in the worst case the Docker daemon itself stalls for minutes (its own debug logging goes silent), so every co-scheduled worker hits the 900s `pytest-timeout`.

The per-test failure rate is ~0.01% (these tests are essentially never flaky on their own), yet this same trio fails together repeatedly — observed on 2026-05-25, 2026-06-14 and twice on 2026-06-20 — confirming host-overload collateral rather than individual test defects. No tracking issue exists (the rate is too low for the flaky-test bot to have filed one).

Fix: mark the 20-node test `is_sequential=True` in `ci/jobs/scripts/integration_tests_configs.py` so it runs alone in the sequential phase (`-n 1`) with the whole host to itself, instead of competing in the parallel phase. This mirrors the existing `test_server_overload/` entry ("sensitive to concurrent CPU load"), adds ~2 minutes to the sequential phase, and loses no test coverage. The 10-node `test_concurrency.py` stays parallel as before.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=23049df43a7bd91cb18e8949a776a38c0270ef05&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1084`
<!-- ch-version-info:end -->