### PR TITLE
Add autocompletion to the Web UI (play.html)

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -548,6 +548,83 @@
         #query-backdrop .q-op  { color: var(--syntax-operator); }
         #query-backdrop .q-err { color: var(--syntax-error); text-decoration: underline wavy; }
 
+        /* Off-screen mirror used to measure the pixel coordinates of the caret inside the
+           textarea. Its typography and box model MUST match the textarea exactly (same as
+           the backdrop) so that wrapping is identical. */
+        #completion-mirror
+        {
+            position: absolute;
+            inset: 0;
+            visibility: hidden;
+            overflow: hidden;
+            pointer-events: none;
+            z-index: -1;
+            font-family: DejaVu Sans Mono, Liberation Mono, MonoLisa, Consolas, monospace;
+            font-size: 11pt;
+            line-height: normal;
+            padding: 0.25rem;
+            border: 1px solid transparent;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+            box-sizing: border-box;
+        }
+
+        /* The completion overlay sits above the textarea and shows the "ghost" completion
+           candidates. The container itself does not capture clicks (so the user can keep
+           interacting with the textarea), only its entries do. Its inner-border (padding box)
+           origin coincides with the textarea's, so entry offsets line up with the caret. */
+        #completion-overlay
+        {
+            display: none;
+            position: absolute;
+            inset: 0;
+            overflow: hidden;
+            pointer-events: none;
+            z-index: 2;
+            border: 1px solid transparent;
+            box-sizing: border-box;
+        }
+
+        /* A hidden, zero-visibility span injected into the backdrop at the cursor. It occupies
+           exactly the width (and wrapping) of the selected completion's suffix, so the text to
+           the right shifts as if the completion had already been typed. */
+        #query-backdrop .completion-spacer
+        {
+            visibility: hidden;
+        }
+
+        .completion-entry
+        {
+            position: absolute;
+            white-space: pre;
+            pointer-events: auto;
+            cursor: pointer;
+            font-family: DejaVu Sans Mono, Liberation Mono, MonoLisa, Consolas, monospace;
+            font-size: 11pt;
+            line-height: normal;
+            /* Faint text (a muted version of the backdrop's default token color). The
+               faintness lives in the color, not in `opacity`, so the background can stay
+               fully opaque and cover any existing text underneath. Inactive candidates are
+               a 30% mix; the selected one is brighter (see below). */
+            color: color-mix(in srgb, var(--syntax-default) 30%, var(--element-background-color));
+            /* Opaque background so the entry fully covers any existing text underneath. */
+            background-color: var(--element-background-color);
+            border-radius: 0.2rem;
+        }
+
+        /* The selected entry is distinguished only by being a little brighter: a 50% mix of
+           the default color (vs 30% for the inactive ones). */
+        .completion-entry.completion-selected
+        {
+            color: color-mix(in srgb, var(--syntax-default) 50%, var(--element-background-color));
+        }
+
+        /* The "…" marker shown when more candidates exist below the visible window. */
+        .completion-entry.completion-more
+        {
+            cursor: default;
+        }
 
         #inputs
         {
@@ -907,7 +984,7 @@
             <div id="inputs">
                 <input name="url" spellcheck="false" class="monospace shadow" id="url" type="url" value="" placeholder="url" /><span id="url_status"><span id="server_info"></span>●</span><input name="user" spellcheck="false" class="monospace shadow" id="user" type="text" value="" placeholder="user" /><input name="password" class="monospace shadow" id="password" type="password" placeholder="password" />
             </div>
-            <div id="query_div"><div id="query-backdrop"></div><textarea autofocus spellcheck="false" autocorrect="false" autocomplete="false" data-gramm="false" class="monospace shadow" id="query"></textarea></div>
+            <div id="query_div"><div id="query-backdrop"></div><div id="completion-mirror"></div><textarea autofocus spellcheck="false" autocorrect="false" autocomplete="false" data-gramm="false" class="monospace shadow" id="query"></textarea><div id="completion-overlay"></div></div>
             <div id="query-params"></div>
             <div id="run_div">
                 <button type="submit" class="shadow" id="run">Run</button>
@@ -3401,6 +3478,8 @@ function beginFlight() {
     setFavicon(favicon_running);
     document.getElementById('run').innerText = 'Stop';
     document.getElementById('run-all').style.display = 'none';
+    /// Hide any open autocompletion when a query starts running.
+    closeCompletions();
 }
 
 function endFlight() {
@@ -4097,6 +4176,9 @@ function tokenClass(tokens, i) {
 let currentTokens = [];
 let currentBoundaries = [];
 let currentBackdropText = '';
+/// Guard so that the backdrop re-renders triggered by the completion code (to update the
+/// reserved spacer) do not recurse back into `updateCompletions`.
+let inRenderBackdrop = false;
 
 function updateQueryBackdrop(text, tokens, boundaries) {
     currentTokens = tokens || [];
@@ -4117,8 +4199,16 @@ function renderQueryBackdrop() {
     if (!text || tokens.length === 0) {
         queryBackdrop.style.display = 'none';
         query_area.classList.remove('has-backdrop');
+        if (!inRenderBackdrop) updateCompletions();
         return;
     }
+
+    /// When the completion list is open, reserve blank space at the cursor for the selected
+    /// candidate's suffix, so the text to the right shifts as if it had been typed.
+    const spacerText = completionCandidates.length
+        ? completionCandidates[completionSelected].substring(completionPrefix.length)
+        : null;
+    const spacerOffset = completionPrefixStart + completionPrefix.length;
 
     const cursor = query_area.selectionStart;
     const focused = document.activeElement === query_area;
@@ -4163,6 +4253,12 @@ function renderQueryBackdrop() {
         } else {
             html += escaped;
         }
+
+        /// The cursor sits at the end of the prefix identifier (a token boundary); insert the
+        /// reserved spacer right there.
+        if (spacerText !== null && offset === spacerOffset) {
+            html += '<span class="completion-spacer">' + escapeHTML(spacerText) + '</span>';
+        }
     }
     if (activeOpen) {
         html += '</span>';
@@ -4189,6 +4285,10 @@ function renderQueryBackdrop() {
 
     queryBackdrop.scrollTop = query_area.scrollTop;
     queryBackdrop.scrollLeft = query_area.scrollLeft;
+
+    /// Keep autocompletion in sync with the freshly rendered text/cursor (unless this render
+    /// was itself triggered by the completion code, which would recurse).
+    if (!inRenderBackdrop) updateCompletions();
 }
 
 /// Re-render backdrop when cursor moves or selection changes.
@@ -4197,12 +4297,505 @@ query_area.addEventListener('keyup', renderQueryBackdrop);
 query_area.addEventListener('select', renderQueryBackdrop);
 query_area.addEventListener('focus', renderQueryBackdrop);
 query_area.addEventListener('blur', renderQueryBackdrop);
+/// Hide autocompletion when the textarea loses focus.
+query_area.addEventListener('blur', closeCompletions);
 
 /// Keep backdrop scroll in sync with textarea.
 query_area.addEventListener('scroll', () => {
     queryBackdrop.scrollTop = query_area.scrollTop;
     queryBackdrop.scrollLeft = query_area.scrollLeft;
+    /// Reposition the completion overlay to follow the scrolled caret.
+    renderCompletionOverlay();
 });
+
+/// ----------------------------------------------------------------------------
+/// Autocompletion.
+///
+/// Completions are loaded lazily from `system.completions` the first time the user
+/// focuses the textarea (mirroring how `clickhouse-client` loads its suggestions).
+/// The feature only activates when the WASM lexer is available, because we reuse the
+/// token stream to find the identifier under the cursor and the backdrop/mirror
+/// machinery to position the ghost text.
+/// ----------------------------------------------------------------------------
+
+/// The visible window around the selected candidate: up to this many above and below (so up to
+/// 1 + 4 + 4 entries are shown at once). The rest are reachable by navigating; a "…" marks more.
+const MAX_COMPLETIONS_ABOVE = 4;
+const MAX_COMPLETIONS_BELOW = 4;
+const MAX_COMPLETION_CANDIDATES = 100; /// Upper bound on the full candidate list we keep.
+const MIN_COMPLETION_PREFIX = 1;
+
+const completionMirror = document.getElementById('completion-mirror');
+const completionOverlay = document.getElementById('completion-overlay');
+
+/// Sorted (by lowercased word) array of { w, lw } for prefix lookup.
+let completionWords = [];
+let completionsLoadStarted = false;
+/// How many times each completion was accepted in this session — accepted completions
+/// bubble to the top of the candidate list on subsequent uses.
+let completionUsage = new Map();
+
+/// Currently displayed candidates and which one is selected.
+let completionCandidates = [];
+let completionSelected = 0;
+let completionPrefix = '';
+let completionPrefixStart = -1;
+/// When the user dismisses with Esc, suppress re-opening for the exact same caret state.
+let completionSuppressedKey = null;
+/// Set when the user types a word character; gates *opening* the completion list so that
+/// clicks, focus, and cursor navigation do not pop it up on their own.
+let completionOpenRequested = false;
+
+function wasmAvailable() {
+    return typeof WebAssembly === 'object' && typeof WebAssembly.instantiate === 'function';
+}
+
+/// Build the request URL the same way `postImpl` does, but for the completion query.
+function buildCompletionUrl() {
+    const user = user_elem.value;
+    const password = password_elem.value;
+    const server_address = url_elem.value;
+    let url = server_address + (server_address.indexOf('?') >= 0 ? '&' : '?') + 'add_http_cors_header=1';
+    if (user) url += '&user=' + encodeURIComponent(user);
+    if (password) url += '&password=' + encodeURIComponent(password);
+    url += '&default_format=TSVRaw';
+    return url;
+}
+
+/// The completion query mirrors `getLoadSuggestionQueryUsingSystemCompletionsTable` in
+/// `src/Client/Suggest.cpp`: it extracts identifier-like words from every completion entry.
+const COMPLETION_QUERY =
+    "SELECT DISTINCT arrayJoin(extractAll(word, '[\\\\w]{2,}')) AS res FROM system.completions WHERE notEmpty(res)";
+
+async function loadCompletions() {
+    if (completionsLoadStarted || !wasmAvailable()) {
+        return;
+    }
+    completionsLoadStarted = true;
+
+    try {
+        const response = await fetch(buildCompletionUrl(), {
+            method: "POST",
+            body: COMPLETION_QUERY,
+            headers: { 'Authorization': 'never' },
+        });
+        if (!response.ok) {
+            /// Older servers without `system.completions`, or no connection — the feature
+            /// simply stays inactive. This is an optional enhancement, not a fallback that
+            /// hides an error from a primary operation. Allow a retry on a later focus (e.g.
+            /// once the user has filled in the connection details).
+            completionsLoadStarted = false;
+            return;
+        }
+        const text = await response.text();
+        const seen = new Set();
+        const words = [];
+        for (const line of text.split('\n')) {
+            const w = line.trim();
+            if (w && !seen.has(w)) {
+                seen.add(w);
+                words.push({ w, lw: w.toLowerCase() });
+            }
+        }
+        words.sort((a, b) => (a.lw < b.lw ? -1 : a.lw > b.lw ? 1 : 0));
+        completionWords = words;
+
+        /// The user may have already typed something — show completions right away.
+        updateCompletions();
+    } catch (e) {
+        /// Network error or aborted — allow a retry on a later focus.
+        completionsLoadStarted = false;
+        console.error('Failed to load completions:', e);
+    }
+}
+
+/// Lower-bound binary search for the first word whose lowercased form is >= `key`.
+function completionLowerBound(key) {
+    let lo = 0;
+    let hi = completionWords.length;
+    while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (completionWords[mid].lw < key) lo = mid + 1;
+        else hi = mid;
+    }
+    return lo;
+}
+
+/// Find the bare-word identifier that ends exactly at the cursor (so the cursor is at the
+/// end of the identifier), using the cached lexer tokens. Returns { prefix, start } or null.
+function getIdentifierBeforeCursor() {
+    /// Only valid when the cached tokens describe the current textarea contents.
+    if (currentBackdropText !== query_area.value) {
+        return null;
+    }
+    const cursor = query_area.selectionStart;
+    let offset = 0;
+    for (let i = 0; i < currentTokens.length; ++i) {
+        const elem = currentTokens[i];
+        const start = offset;
+        const end = offset + elem.token.length;
+        offset = end;
+        if (elem.type === TT.BareWord && end === cursor && start < cursor) {
+            return { prefix: elem.token, start };
+        }
+    }
+    return null;
+}
+
+/// Collect the identifier-like words already present in the query (aliases, column/table names,
+/// etc.), excluding the identifier currently being typed at `excludeStart`. These are both a
+/// priority signal and a source of candidates, so a word introduced in the query can be
+/// completed even if it is not in `system.completions`. Returns unique words in original case.
+function queryIdentifierWords(excludeStart) {
+    const words = [];
+    const seen = new Set();
+    let offset = 0;
+    for (const elem of currentTokens) {
+        const start = offset;
+        offset += elem.token.length;
+        if (elem.type !== TT.BareWord) continue;
+        if (start === excludeStart) continue; /// The identifier being typed is not a suggestion.
+        if (elem.token.length < 2) continue;  /// Match the `{2,}` convention used for completions.
+        if (seen.has(elem.token)) continue;
+        seen.add(elem.token);
+        words.push(elem.token);
+    }
+    return words;
+}
+
+/// Compute the candidate list for the given prefix (up to MAX_COMPLETION_CANDIDATES), applying priorities:
+///   1. an exact match (a word equal to what was typed) — shown as an empty completion, always first
+///   2. previously accepted completions (usage count, desc)
+///   3. identifier-like words already present in the query
+///   4. case-exact prefix match (so the ghost text continues the typed casing)
+///   5. shorter words first, then alphabetical
+function findCandidates(prefix, prefixStart) {
+    const lprefix = prefix.toLowerCase();
+    const queryWords = queryIdentifierWords(prefixStart);
+    const present = new Set(queryWords.map(w => w.toLowerCase()));
+    const matches = [];
+    for (let i = completionLowerBound(lprefix); i < completionWords.length; ++i) {
+        const entry = completionWords[i];
+        if (!entry.lw.startsWith(lprefix)) break;
+        /// A word equal to the prefix is kept as an "empty completion" (its suffix is empty),
+        /// rather than skipped, so the user sees their typed word is a recognized one.
+        matches.push(entry.w);
+    }
+
+    /// Also offer identifier-like words from the query itself (deduplicated by suffix below).
+    for (const w of queryWords) {
+        if (w.toLowerCase().startsWith(lprefix)) {
+            matches.push(w);
+        }
+    }
+
+    /// Do not open a popup that would only offer the already-typed word (an empty completion
+    /// on its own has nothing to show and would needlessly capture Tab/Enter). The empty
+    /// completion is shown only alongside at least one real extension.
+    if (!matches.some(w => w.length > prefix.length)) {
+        return [];
+    }
+
+    const score = (w) => ({
+        exact: w.length === prefix.length ? 1 : 0,
+        usage: completionUsage.get(w) || 0,
+        present: present.has(w.toLowerCase()) ? 1 : 0,
+        caseExact: w.startsWith(prefix) ? 1 : 0,
+    });
+
+    matches.sort((a, b) => {
+        const sa = score(a);
+        const sb = score(b);
+        if (sa.exact !== sb.exact) return sb.exact - sa.exact;
+        if (sa.usage !== sb.usage) return sb.usage - sa.usage;
+        if (sa.present !== sb.present) return sb.present - sa.present;
+        if (sa.caseExact !== sb.caseExact) return sb.caseExact - sa.caseExact;
+        if (a.length !== b.length) return a.length - b.length;
+        return a < b ? -1 : a > b ? 1 : 0;
+    });
+
+    /// Deduplicate by the displayed suffix so that, e.g., case variants of the exact match
+    /// (`array`/`ARRAY`/`Array`, all an empty completion) collapse into a single entry and do
+    /// not crowd out the real extensions.
+    const result = [];
+    const seenSuffix = new Set();
+    for (const w of matches) {
+        const suffix = w.substring(prefix.length);
+        if (seenSuffix.has(suffix)) continue;
+        seenSuffix.add(suffix);
+        result.push(w);
+        if (result.length >= MAX_COMPLETION_CANDIDATES) break;
+    }
+    return result;
+}
+
+/// Pixel coordinates (relative to the overlay's padding box) of the caret at `pos`.
+function getCaretCoordinates(pos) {
+    const text = query_area.value;
+    completionMirror.textContent = text.substring(0, pos);
+    const marker = document.createElement('span');
+    marker.textContent = '​';
+    completionMirror.appendChild(marker);
+    completionMirror.appendChild(document.createTextNode(text.substring(pos)));
+
+    /// Match the scrollbar reservation the backdrop uses, so wrapping is identical.
+    const scrollbarWidth = query_area.offsetWidth - query_area.clientWidth - 2;
+    completionMirror.style.paddingRight = scrollbarWidth > 0 ? 'calc(0.25rem + ' + scrollbarWidth + 'px)' : '';
+
+    const top = marker.offsetTop;
+    const left = marker.offsetLeft;
+    const height = marker.offsetHeight;
+    return { top, left, height };
+}
+
+/// Recompute whether completions should be shown and update the overlay.
+///
+/// Completions only *open* right after the user types a word character (tracked by
+/// `completionOpenRequested`). Cursor-only events — clicks, focus, arrow navigation — may
+/// reposition or close an already-open list, but never open a new one.
+function updateCompletions() {
+    if (!completionWords.length
+        || document.activeElement !== query_area
+        || query_area.selectionStart !== query_area.selectionEnd) {
+        completionOpenRequested = false;
+        closeCompletions();
+        return;
+    }
+
+    /// The cached tokens do not yet describe the current text (tokenization is still in
+    /// flight after an edit). Leave any pending open request intact so the follow-up call,
+    /// made once tokens are fresh, can act on it.
+    if (currentBackdropText !== query_area.value) {
+        return;
+    }
+
+    /// Consume the "just typed a word character" request now that we have fresh tokens.
+    const allowOpen = completionOpenRequested;
+    completionOpenRequested = false;
+
+    const id = getIdentifierBeforeCursor();
+    if (!id || id.prefix.length < MIN_COMPLETION_PREFIX) {
+        closeCompletions();
+        return;
+    }
+
+    /// Respect an Esc dismissal for this exact caret state.
+    const key = id.start + ':' + id.prefix;
+    if (completionSuppressedKey === key) {
+        closeCompletions();
+        return;
+    }
+    completionSuppressedKey = null;
+
+    const candidates = findCandidates(id.prefix, id.start);
+    if (!candidates.length) {
+        closeCompletions();
+        return;
+    }
+
+    /// Do not pop up the list on a mere cursor move; only open after a typed word character.
+    if (!completionCandidates.length && !allowOpen) {
+        return;
+    }
+
+    /// Preserve the selection if the candidate list is unchanged (e.g. on a cursor-only event).
+    const sameList = candidates.length === completionCandidates.length
+        && candidates.every((c, i) => c === completionCandidates[i]);
+    if (!sameList || id.prefix !== completionPrefix || id.start !== completionPrefixStart) {
+        completionSelected = 0;
+    }
+
+    completionCandidates = candidates;
+    completionPrefix = id.prefix;
+    completionPrefixStart = id.start;
+    renderCompletions();
+}
+
+/// Redraw both the backdrop (to refresh the reserved spacer for the selected candidate) and
+/// the overlay. The backdrop render is guarded so it does not recurse into `updateCompletions`.
+function renderCompletions() {
+    inRenderBackdrop = true;
+    renderQueryBackdrop();
+    inRenderBackdrop = false;
+    renderCompletionOverlay();
+}
+
+function renderCompletionOverlay() {
+    if (!completionCandidates.length) {
+        completionOverlay.style.display = 'none';
+        return;
+    }
+
+    /// `caretEnd` is the cursor (end of the typed prefix); `caretStart` is the start of the
+    /// identifier. The selected candidate shows only its suffix at the cursor (its prefix is
+    /// the real typed text). The other candidates show the full word aligned at the identifier
+    /// start, so their shared prefix lines up with the typed prefix and their suffixes line up
+    /// at the cursor column.
+    const caretEnd = getCaretCoordinates(completionPrefixStart + completionPrefix.length);
+    const caretStart = getCaretCoordinates(completionPrefixStart);
+    const scrollTop = query_area.scrollTop;
+    const scrollLeft = query_area.scrollLeft;
+    const total = completionCandidates.length;
+
+    /// A window around the selection: up to MAX_COMPLETIONS_ABOVE items above and
+    /// MAX_COMPLETIONS_BELOW below. Navigating moves the selection (and the window) through the
+    /// full list; the selected item always stays on the cursor line.
+    const winStart = Math.max(0, completionSelected - MAX_COMPLETIONS_ABOVE);
+    const winEnd = Math.min(total - 1, completionSelected + MAX_COMPLETIONS_BELOW);
+
+    const rowTop = (row) => (caretEnd.top + row * caretEnd.height - scrollTop) + 'px';
+
+    completionOverlay.innerHTML = '';
+    for (let i = winStart; i <= winEnd; ++i) {
+        const word = completionCandidates[i];
+        const selected = i === completionSelected;
+
+        const entry = document.createElement('div');
+        entry.className = 'completion-entry' + (selected ? ' completion-selected' : '');
+        entry.textContent = selected ? word.substring(completionPrefix.length) : word;
+        /// The selected candidate is always shown right at the cursor; the others are placed
+        /// above/below by their distance from the selection, so navigating moves the whole
+        /// block vertically while the selected one stays on the cursor line.
+        entry.style.top = rowTop(i - completionSelected);
+        entry.style.left = ((selected ? caretEnd.left : caretStart.left) - scrollLeft) + 'px';
+        entry.dataset.index = i;
+
+        /// Use mousedown (not click) and preventDefault so the textarea keeps focus.
+        entry.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            acceptCompletion(i);
+        });
+
+        completionOverlay.appendChild(entry);
+    }
+
+    /// "…" at the bottom when there are more candidates below the visible window.
+    if (winEnd < total - 1) {
+        const more = document.createElement('div');
+        more.className = 'completion-entry completion-more';
+        more.textContent = '…';
+        more.style.top = rowTop(winEnd - completionSelected + 1);
+        more.style.left = (caretStart.left - scrollLeft) + 'px';
+        completionOverlay.appendChild(more);
+    }
+
+    completionOverlay.style.display = 'block';
+}
+
+function closeCompletions() {
+    if (completionCandidates.length) {
+        completionCandidates = [];
+        completionSelected = 0;
+        completionPrefix = '';
+        completionPrefixStart = -1;
+        completionOverlay.style.display = 'none';
+        completionOverlay.innerHTML = '';
+        /// Redraw the backdrop to drop the reserved spacer (unless we are already inside a
+        /// backdrop render).
+        if (!inRenderBackdrop) {
+            inRenderBackdrop = true;
+            renderQueryBackdrop();
+            inRenderBackdrop = false;
+        }
+    }
+}
+
+function acceptCompletion(index) {
+    if (index === undefined) index = completionSelected;
+    if (index < 0 || index >= completionCandidates.length) return;
+
+    const word = completionCandidates[index];
+    /// Capture the prefix and its position before closeCompletions() resets them.
+    const prefix = completionPrefix;
+    const start = completionPrefixStart;
+    completionUsage.set(word, (completionUsage.get(word) || 0) + 1);
+
+    closeCompletions();
+
+    /// Nothing to do when the word is exactly what was already typed (same text, same case).
+    if (word === prefix) {
+        return;
+    }
+
+    /// Replace the whole typed identifier with the canonical-cased completion word, so the
+    /// already-typed prefix also takes the suggestion's case (e.g. "se" + accept -> "SELECT").
+    /// Done via a selection + execCommand so it participates in the undo history and fires an
+    /// `input` event (which refreshes the backdrop and recomputes completions).
+    query_area.focus();
+    query_area.setSelectionRange(start, start + prefix.length);
+    document.execCommand('insertText', false, word);
+}
+
+/// Force the completion list to open at the current cursor (used as a manual Tab trigger),
+/// bypassing the "only open after typing a word character" and Esc-dismissal gates. Returns
+/// true if it opened.
+function tryOpenCompletions() {
+    completionSuppressedKey = null;
+    completionOpenRequested = true;
+    updateCompletions();
+    if (!completionCandidates.length) {
+        completionOpenRequested = false;
+        return false;
+    }
+    return true;
+}
+
+/// Capture-phase key handling so it runs before the textarea's own `onkeydown` (which would
+/// otherwise treat Tab as "insert spaces").
+query_area.addEventListener('keydown', (e) => {
+    if (!completionCandidates.length) {
+        /// Completions are closed: Tab at the end of a word manually opens them if a
+        /// continuation is possible; otherwise let the default Tab (indentation) happen.
+        if (e.key === 'Tab' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            if (tryOpenCompletions()) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+            }
+        }
+        return;
+    }
+    /// Plain Enter accepts the completion; Ctrl/Cmd+Enter is left alone so it still runs the query.
+    if (e.key === 'Tab' || e.key === 'ArrowRight' || (e.key === 'Enter' && !e.ctrlKey && !e.metaKey)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        acceptCompletion(completionSelected);
+    } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        completionSelected = (completionSelected + 1) % completionCandidates.length;
+        renderCompletions();
+    } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        completionSelected = (completionSelected - 1 + completionCandidates.length) % completionCandidates.length;
+        renderCompletions();
+    } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        completionSuppressedKey = completionPrefixStart + ':' + completionPrefix;
+        closeCompletions();
+    }
+}, true);
+
+/// Arm the completion list to open only when the user actually types word characters.
+/// This listener is registered before the one that drives tokenization, so the flag is set
+/// by the time the post-tokenize `updateCompletions` runs. `e.data` holds the inserted text
+/// (null for deletions); composition input also carries the composed text.
+query_area.addEventListener('input', (e) => {
+    const typed = e.data;
+    completionOpenRequested = typeof typed === 'string' && /^\w+$/.test(typed);
+});
+
+/// Clicking outside the completion entries closes the list.
+document.addEventListener('mousedown', (e) => {
+    if (completionCandidates.length && !e.target.closest('.completion-entry')) {
+        closeCompletions();
+    }
+});
+
+/// Load completions the first time the textarea is focused.
+query_area.addEventListener('focus', loadCompletions);
 
 /// Query parameters support: detect {name:Type} placeholders and show input fields.
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -4331,6 +4331,10 @@ const completionOverlay = document.getElementById('completion-overlay');
 /// Sorted (by lowercased word) array of { w, lw } for prefix lookup.
 let completionWords = [];
 let completionsLoadStarted = false;
+/// Bumped whenever the connection settings change, to invalidate a cached or in-flight load.
+/// `system.completions` is filtered by the connected user's privileges, so suggestions must not
+/// outlive the connection they were loaded for.
+let completionsLoadGeneration = 0;
 /// How many times each completion was accepted in this session — accepted completions
 /// bubble to the top of the candidate list on subsequent uses.
 let completionUsage = new Map();
@@ -4363,15 +4367,29 @@ function buildCompletionUrl() {
 }
 
 /// The completion query mirrors `getLoadSuggestionQueryUsingSystemCompletionsTable` in
-/// `src/Client/Suggest.cpp`: it extracts identifier-like words from every completion entry.
+/// `src/Client/Suggest.cpp`: static contexts are loaded in full, while the catalog-sized
+/// contexts (database/table/column/dictionary) are capped per context so that focusing the
+/// editor does not enumerate and transfer the whole catalog on large installations. Then it
+/// extracts identifier-like words from the resulting completion entries.
+const COMPLETION_SUGGESTION_LIMIT = 10000;
 const COMPLETION_QUERY =
-    "SELECT DISTINCT arrayJoin(extractAll(word, '[\\\\w]{2,}')) AS res FROM system.completions WHERE notEmpty(res)";
+    "SELECT DISTINCT arrayJoin(extractAll(word, '[\\\\w]{2,}')) AS res FROM (" +
+        "SELECT word FROM system.completions WHERE context IN " +
+        "('function', 'table engine', 'format', 'table function', 'data type', 'merge tree setting', " +
+        "'setting', 'aggregate function combinator pair', 'keyword', 'cluster', 'macro', 'policy') " +
+        "UNION ALL SELECT word FROM (" +
+            "SELECT word, ROW_NUMBER() OVER (PARTITION BY context ORDER BY word) AS rn FROM " +
+            "(SELECT DISTINCT word, context FROM system.completions WHERE context IN " +
+            "('database', 'table', 'column', 'dictionary'))" +
+        ") WHERE rn <= " + COMPLETION_SUGGESTION_LIMIT +
+    ") WHERE notEmpty(res)";
 
 async function loadCompletions() {
     if (completionsLoadStarted || !wasmAvailable()) {
         return;
     }
     completionsLoadStarted = true;
+    const generation = completionsLoadGeneration;
 
     try {
         const response = await fetch(buildCompletionUrl(), {
@@ -4379,6 +4397,10 @@ async function loadCompletions() {
             body: COMPLETION_QUERY,
             headers: { 'Authorization': 'never' },
         });
+        /// The connection settings changed while loading — discard this stale result.
+        if (generation !== completionsLoadGeneration) {
+            return;
+        }
         if (!response.ok) {
             /// Older servers without `system.completions`, or no connection — the feature
             /// simply stays inactive. This is an optional enhancement, not a fallback that
@@ -4388,6 +4410,9 @@ async function loadCompletions() {
             return;
         }
         const text = await response.text();
+        if (generation !== completionsLoadGeneration) {
+            return;
+        }
         const seen = new Set();
         const words = [];
         for (const line of text.split('\n')) {
@@ -4404,10 +4429,23 @@ async function loadCompletions() {
         updateCompletions();
     } catch (e) {
         /// Network error or aborted — allow a retry on a later focus.
-        completionsLoadStarted = false;
+        if (generation === completionsLoadGeneration) {
+            completionsLoadStarted = false;
+        }
         console.error('Failed to load completions:', e);
     }
 }
+
+/// Invalidate the cached completions when the connection settings change, so suggestions are
+/// reloaded (with the new privileges) on the next focus and any in-flight load is discarded.
+function resetCompletions() {
+    completionsLoadGeneration++;
+    completionsLoadStarted = false;
+    completionWords = [];
+    closeCompletions();
+}
+
+[url_elem, user_elem, password_elem].forEach(el => el.addEventListener('input', resetCompletions));
 
 /// Lower-bound binary search for the first word whose lowercased form is >= `key`.
 function completionLowerBound(key) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -4349,6 +4349,9 @@ let completionSuppressedKey = null;
 /// Set when the user types a word character; gates *opening* the completion list so that
 /// clicks, focus, and cursor navigation do not pop it up on their own.
 let completionOpenRequested = false;
+/// True while `acceptCompletion` is inserting text, so the resulting `input` event is not
+/// mistaken for the user typing a new word (which would reopen the list on the accepted word).
+let completionAccepting = false;
 
 function wasmAvailable() {
     return typeof WebAssembly === 'object' && typeof WebAssembly.instantiate === 'function';
@@ -4592,8 +4595,14 @@ function getCaretCoordinates(pos) {
 /// `completionOpenRequested`). Cursor-only events — clicks, focus, arrow navigation — may
 /// reposition or close an already-open list, but never open a new one.
 function updateCompletions() {
-    if (!completionWords.length
-        || document.activeElement !== query_area
+    /// Completions are not loaded yet (the lazy `system.completions` load may still be in
+    /// flight). Keep any pending "just typed a word" request so it can fire once
+    /// `loadCompletions` finishes and calls back here — otherwise the first word typed during
+    /// the initial load would get no suggestions.
+    if (!completionWords.length) {
+        return;
+    }
+    if (document.activeElement !== query_area
         || query_area.selectionStart !== query_area.selectionEnd) {
         completionOpenRequested = false;
         closeCompletions();
@@ -4760,9 +4769,15 @@ function acceptCompletion(index) {
     /// already-typed prefix also takes the suggestion's case (e.g. "se" + accept -> "SELECT").
     /// Done via a selection + execCommand so it participates in the undo history and fires an
     /// `input` event (which refreshes the backdrop and recomputes completions).
+    ///
+    /// The `input` event from this programmatic insertion carries the inserted word as
+    /// `e.data`, which would otherwise re-arm the open request and reopen the list (e.g.
+    /// accepting `count` would reopen on `countIf`). Suppress that for the duration of the edit.
+    completionAccepting = true;
     query_area.focus();
     query_area.setSelectionRange(start, start + prefix.length);
     document.execCommand('insertText', false, word);
+    completionAccepting = false;
 }
 
 /// Force the completion list to open at the current cursor (used as a manual Tab trigger),
@@ -4821,6 +4836,11 @@ query_area.addEventListener('keydown', (e) => {
 /// by the time the post-tokenize `updateCompletions` runs. `e.data` holds the inserted text
 /// (null for deletions); composition input also carries the composed text.
 query_area.addEventListener('input', (e) => {
+    if (completionAccepting) {
+        /// Programmatic insertion from accepting a completion — do not treat as typing.
+        completionOpenRequested = false;
+        return;
+    }
     const typed = e.data;
     completionOpenRequested = typeof typed === 'string' && /^\w+$/.test(typed);
 });


### PR DESCRIPTION
Implements query autocompletion in the embedded Web UI (`play.html`), reusing the WASM lexer and the syntax-highlighting backdrop that are already used for highlighting. Completions are loaded lazily from `system.completions` the first time the query editor is focused (mirroring how `clickhouse-client` loads suggestions), and the feature only activates when the WASM lexer is available.

Behavior:
- Suggestions appear after typing a word character at the end of an identifier (not inside strings/comments, not mid-word). `Tab` at the end of a word also opens them when a continuation is possible.
- The selected candidate is shown as ghost text right at the cursor, with blank space reserved in the text so the tail shifts as if it had been typed. Other candidates are shown in full, aligned at the identifier start.
- Up/Down move the whole block vertically (the selected one stays on the cursor line); up to 4 above + selected + 4 below are shown, with a `…` marker when more candidates exist.
- `Tab`/`Right`/`Enter` accept (`Ctrl`/`Cmd+Enter` still runs the query); `Esc` dismisses; clicking an entry accepts it; clicking outside, losing focus, or running a query hides the list.
- Accepting replaces the whole typed identifier with the suggestion's canonical case (e.g. `sele` → `SELECT`).
- Priorities: an empty completion for the already-typed word, then previously accepted completions, then identifier-like words already present in the query (also suggestible on their own), then the rest.

The change is confined to `programs/server/play.html`. It was verified end-to-end by driving the page with a headless browser against a local server (gating, navigation/windowing, accept via keyboard/mouse, Tab-to-open, hide on blur/run, case replacement, and string/comment/mid-word edge cases).

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added autocompletion to the Web UI (`play.html`), based on `system.completions` and the WASM-based SQL lexer.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.158` (included in `26.7` and later)
<!-- ch-version-info:end -->