### PR TITLE
Fix logical error casting Dynamic/Variant inside Tuple with accurateCastOrNull

### DIFF
--- a/src/Functions/FunctionsConversion.cpp
+++ b/src/Functions/FunctionsConversion.cpp
@@ -56,6 +56,21 @@ ColumnUInt8::MutablePtr copyNullMap(ColumnPtr col)
 namespace detail
 {
 
+/// When assembling the result of a Variant/Dynamic-to-column conversion, the result column must have
+/// the exact type of the converted columns it is filled from, otherwise `insertFrom` fails the column
+/// type check. Under `accurateCastOrNull` a per-variant conversion may return a `Nullable` column even
+/// when `result_type` is not `Nullable` (a NULL marks a value that could not be converted), so the
+/// result column cannot always be created from `result_type` directly. All convertible variants share
+/// the same target type, so the type of any non-empty converted column is a valid template. Returns
+/// `nullptr` when there is no converted column to copy the type from.
+static MutableColumnPtr cloneEmptyFromFirstConvertedColumn(const VectorWithMemoryTracking<ColumnPtr> & cast_columns)
+{
+    for (const auto & column : cast_columns)
+        if (column)
+            return column->cloneEmpty();
+    return nullptr;
+}
+
 ColumnPtr ConvertImplFromDynamicToColumn::execute(
     const ColumnsWithTypeAndName & arguments,
     const DataTypePtr & result_type,
@@ -152,7 +167,11 @@ ColumnPtr ConvertImplFromDynamicToColumn::execute(
     }
 
     /// Construct result column from all cast variants.
-    auto res = result_type->createColumn();
+    auto res = cloneEmptyFromFirstConvertedColumn(cast_variant_columns);
+    if (!res)
+        res = cloneEmptyFromFirstConvertedColumn(cast_shared_variant_columns);
+    if (!res)
+        res = result_type->createColumn();
     res->reserve(input_rows_count);
     for (size_t i = 0; i != input_rows_count; ++i)
     {
@@ -304,7 +323,9 @@ ColumnPtr ConvertImplFromVariantToColumn::execute(
         }
     }
 
-    auto res = result_type->createColumn();
+    auto res = cloneEmptyFromFirstConvertedColumn(cast_variant_columns);
+    if (!res)
+        res = result_type->createColumn();
     res->reserve(input_rows_count);
     for (size_t i = 0; i != input_rows_count; ++i)
     {
@@ -1540,7 +1561,9 @@ FunctionCast::WrapperType FunctionCast::createVariantToColumnWrapper(const DataT
 
         /// Second, construct resulting column from cast variant columns according to discriminators.
         const auto & local_discriminators = column_variant.getLocalDiscriminators();
-        auto res = result_type->createColumn();
+        auto res = cloneEmptyFromFirstConvertedColumn(cast_variant_columns);
+        if (!res)
+            res = result_type->createColumn();
         res->reserve(input_rows_count);
         for (size_t i = 0; i != input_rows_count; ++i)
         {

--- a/tests/queries/0_stateless/04404_accurate_cast_or_null_dynamic_variant_in_tuple.reference
+++ b/tests/queries/0_stateless/04404_accurate_cast_or_null_dynamic_variant_in_tuple.reference
@@ -1,0 +1,40 @@
+-- { echo }
+
+-- Dynamic inside a Tuple, accurateCastOrNull to a non-Nullable element type.
+SELECT accurateCastOrNull(CAST(tuple(1), 'Tuple(Dynamic)'), 'Tuple(Float32)') AS r, toTypeName(r);
+(1)	Nullable(Tuple(Float32))
+-- A value that does not fit makes the whole Tuple NULL.
+SELECT accurateCastOrNull(CAST(tuple(256), 'Tuple(Dynamic)'), 'Tuple(UInt8)') AS r, toTypeName(r);
+\N	Nullable(Tuple(UInt8))
+-- accurateCastOrDefault goes through the same accurateOrNull path internally.
+SELECT accurateCastOrDefault(CAST(tuple(1), 'Tuple(Dynamic)'), 'Tuple(Float32)') AS r, toTypeName(r);
+(1)	Tuple(Float32)
+SELECT accurateCastOrDefault(CAST(tuple(256), 'Tuple(Dynamic)'), 'Tuple(UInt8)') AS r, toTypeName(r);
+(0)	Tuple(UInt8)
+-- Variant inside a Tuple, multiple variant types across rows (assembles the result row by row).
+SELECT accurateCastOrNull(tuple(v), 'Tuple(Float32)') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number)) AS v FROM numbers(6)) ORDER BY number;
+(0)
+\N
+\N
+(3)
+\N
+\N
+-- Dynamic inside a Tuple, multiple variant types across rows.
+SELECT accurateCastOrNull(tuple(d), 'Tuple(Float32)') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number))::Dynamic AS d FROM numbers(6)) ORDER BY number;
+(0)
+\N
+\N
+(3)
+\N
+\N
+-- Standalone Variant conversion still works (target type is already Nullable here).
+SELECT accurateCastOrNull(v, 'Float32') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number)) AS v FROM numbers(6)) ORDER BY number;
+0
+\N
+\N
+3
+\N
+\N

--- a/tests/queries/0_stateless/04404_accurate_cast_or_null_dynamic_variant_in_tuple.sql
+++ b/tests/queries/0_stateless/04404_accurate_cast_or_null_dynamic_variant_in_tuple.sql
@@ -1,0 +1,32 @@
+-- Tests that accurateCastOrNull / accurateCastOrDefault do not produce a logical error when a
+-- Dynamic or Variant column is nested inside a container (Tuple) and the target element type is
+-- not Nullable. The conversion of the inner Dynamic/Variant returns a Nullable column to signal
+-- values that could not be converted, while the result column used to be built from the bare
+-- (non-Nullable) element type, causing a column type mismatch in insertFrom.
+
+SET allow_experimental_dynamic_type = 1;
+SET allow_experimental_variant_type = 1;
+SET use_variant_as_common_type = 1;
+
+-- { echo }
+
+-- Dynamic inside a Tuple, accurateCastOrNull to a non-Nullable element type.
+SELECT accurateCastOrNull(CAST(tuple(1), 'Tuple(Dynamic)'), 'Tuple(Float32)') AS r, toTypeName(r);
+-- A value that does not fit makes the whole Tuple NULL.
+SELECT accurateCastOrNull(CAST(tuple(256), 'Tuple(Dynamic)'), 'Tuple(UInt8)') AS r, toTypeName(r);
+
+-- accurateCastOrDefault goes through the same accurateOrNull path internally.
+SELECT accurateCastOrDefault(CAST(tuple(1), 'Tuple(Dynamic)'), 'Tuple(Float32)') AS r, toTypeName(r);
+SELECT accurateCastOrDefault(CAST(tuple(256), 'Tuple(Dynamic)'), 'Tuple(UInt8)') AS r, toTypeName(r);
+
+-- Variant inside a Tuple, multiple variant types across rows (assembles the result row by row).
+SELECT accurateCastOrNull(tuple(v), 'Tuple(Float32)') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number)) AS v FROM numbers(6)) ORDER BY number;
+
+-- Dynamic inside a Tuple, multiple variant types across rows.
+SELECT accurateCastOrNull(tuple(d), 'Tuple(Float32)') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number))::Dynamic AS d FROM numbers(6)) ORDER BY number;
+
+-- Standalone Variant conversion still works (target type is already Nullable here).
+SELECT accurateCastOrNull(v, 'Float32') AS r
+FROM (SELECT number, multiIf(number % 3 = 0, number, number % 3 = 1, 'str_' || toString(number), range(number)) AS v FROM numbers(6)) ORDER BY number;


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/100942
Related: https://github.com/ClickHouse/ClickHouse/issues/107951

When `accurateCastOrNull` (or `accurateCastOrDefault`, which uses it internally) converts a `Dynamic` or `Variant` column nested inside a container such as `Tuple` to a non-`Nullable` element type, the per-variant conversion returns a `Nullable` column to mark values that could not be converted. The assembled result column, however, was built from the bare (non-`Nullable`) element type (e.g. `Float32`), so filling it row by row with `insertFrom` tripped the column type check in `IColumn::assertTypeEquality` and raised a logical error.

Unlike the fuzzer-only sites in #107951, this reproduces with plain SQL — it is a real bug in a valid conversion:

```sql
SELECT accurateCastOrNull(CAST(tuple(1), 'Tuple(Dynamic)'), 'Tuple(Float32)');
```

The fix builds the result column from the type of the actually converted variant columns instead of the nominal `result_type`, in all three assembly paths: `ConvertImplFromDynamicToColumn::execute`, `ConvertImplFromVariantToColumn::execute`, and `createVariantToColumnWrapper`. The standalone (non-container) path is unaffected because it already receives the full `Nullable(...)` result type.

Found by the AST fuzzer in the `Stress test (arm_ubsan)` job on master.
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ccd31d5ceb80278da5eca0c5db15791b5e4ade40&name_0=MasterCI&name_1=Stress%20test%20%28arm_ubsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error when casting a `Dynamic` or `Variant` column nested inside a `Tuple` to a non-`Nullable` element type with `accurateCastOrNull` or `accurateCastOrDefault`.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.37` (included in `26.7` and later)
- Backported to: `26.6.1.1189`, `26.5.5.9`, `26.4.5.87`
<!-- ch-version-info:end -->