### PR TITLE
Make INSERT responsive to cancellation when a block creates many partitions

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -5,6 +5,7 @@
 #include <Interpreters/InsertDeduplication.h>
 #include <Interpreters/PartLog.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
 #include <Common/logger_useful.h>
 #include <Common/ProfileEventsScope.h>
@@ -117,6 +118,15 @@ void MergeTreeSink::consume(Chunk & chunk)
 
     for (auto & current_block : part_blocks)
     {
+        /// A single INSERT block can be scattered into a huge number of single-partition blocks
+        /// (for example, a high-cardinality `partition by` expression together with
+        /// `throw_on_max_partitions_per_insert_block = false`). Writing all of them happens in this
+        /// loop without returning to the pipeline executor, which otherwise enforces time limits and
+        /// cancellation only between `consume` calls. Check it here so such a query stays responsive
+        /// to `max_execution_time` and `KILL QUERY` instead of running an uninterruptible loop.
+        if (auto process_list_element = context->getProcessListElement())
+            process_list_element->checkTimeLimit();
+
         ProfileEvents::Counters part_counters;
         auto partition_scope = std::make_unique<ProfileEventsScope>(&part_counters);
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/InsertDeduplication.h>
 #include <Interpreters/PartLog.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/MergeTreeTransaction/VersionMetadata.h>
 #include <IO/Operators.h>
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
@@ -305,6 +306,15 @@ void ReplicatedMergeTreeSink::consume(Chunk & chunk)
 
     for (auto & current_block : part_blocks)
     {
+        /// A single INSERT block can be scattered into a huge number of single-partition blocks
+        /// (for example, a high-cardinality `partition by` expression together with
+        /// `throw_on_max_partitions_per_insert_block = false`). Writing all of them happens in this
+        /// loop without returning to the pipeline executor, which otherwise enforces time limits and
+        /// cancellation only between `consume` calls. Check it here so such a query stays responsive
+        /// to `max_execution_time` and `KILL QUERY` instead of running an uninterruptible loop.
+        if (auto process_list_element = context->getProcessListElement())
+            process_list_element->checkTimeLimit();
+
         Stopwatch watch;
 
         ProfileEvents::Counters part_counters;

--- a/tests/queries/0_stateless/04358_insert_many_partitions_cancellable.sql
+++ b/tests/queries/0_stateless/04358_insert_many_partitions_cancellable.sql
@@ -1,0 +1,17 @@
+-- Tags: long, no-fasttest
+
+-- An INSERT that scatters a single block into a huge number of single-partition parts must stay
+-- responsive to `max_execution_time` (and `KILL QUERY`) instead of running an uninterruptible loop
+-- inside `MergeTreeSink::consume`. This reproduces a stress-test hung check found by the AST fuzzer:
+-- an INSERT into a table with a high-cardinality `partition by` and
+-- `throw_on_max_partitions_per_insert_block = 0` used to write all the parts without ever checking
+-- the time limit, hanging the query (and the server shutdown) for many minutes.
+
+drop table if exists t_many_partitions_cancel;
+create table t_many_partitions_cancel (key Int) engine = MergeTree order by key partition by key;
+
+insert into t_many_partitions_cancel select * from numbers(1000000)
+settings max_insert_block_size = 1000000, max_partitions_per_insert_block = 1,
+    throw_on_max_partitions_per_insert_block = 0, max_execution_time = 1, timeout_overflow_mode = 'throw'; -- { serverError TIMEOUT_EXCEEDED }
+
+drop table t_many_partitions_cancel;


### PR DESCRIPTION
A single `INSERT` block can be scattered into a very large number of single-partition parts — for example, a high-cardinality `partition by` expression together with `throw_on_max_partitions_per_insert_block = 0`. In that case `MergeTreeSink::consume` and `ReplicatedMergeTreeSink::consume` wrote every part in one loop without ever returning to the pipeline executor. Because the executor enforces `max_execution_time` and `KILL QUERY` only between `consume` calls, such an `INSERT` could not be interrupted and ran until all parts were written.

This was found by the AST fuzzer in the stress test: it turned `numbers_mt(10)` into roughly `numbers_mt(1048577)` for an insert into a `partition by key` table, producing about 1048577 single-row parts on object storage. The query ran for over 1400 seconds, the hung check failed, the server could not shut down (the thread was stuck inside `consume`), and the subsequent restart failed with `Address already in use` — surfacing as `Hung check failed, possible deadlock found`, `Cannot start clickhouse-server`, and `Check failed`.

The fix checks the query time limit via `QueryStatus::checkTimeLimit` at the start of each per-partition iteration, so the `INSERT` honors `max_execution_time` and `KILL QUERY` instead of running an uninterruptible loop. This mirrors the pattern already used in `StorageMergeTree` and `StorageReplicatedMergeTree`. Normal inserts (one or a few partitions) are unaffected: it is a single cheap check per partition that only throws when a limit is actually reached.

Added a regression test `04358_insert_many_partitions_cancellable` that asserts such an `INSERT` returns `TIMEOUT_EXCEEDED` instead of hanging.

CI report (master): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a006dbd8a1e92a14b7404c4bfdcd90b6345ab6ee&name_0=MasterCI&name_1=Stress%20test%20%28amd_tsan%29

Related: https://github.com/ClickHouse/ClickHouse/issues/107941

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed an `INSERT` that creates a large number of partitions in a single block (for example, a high-cardinality `partition by` together with `throw_on_max_partitions_per_insert_block = 0`) being uninterruptible: it now respects `max_execution_time` and `KILL QUERY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
