### PR TITLE
Fix flaky test_storage_iceberg_concurrent (thread-pool oversubscription)

### DIFF
--- a/tests/integration/test_storage_iceberg_concurrent/test_concurrent_reads.py
+++ b/tests/integration/test_storage_iceberg_concurrent/test_concurrent_reads.py
@@ -39,8 +39,10 @@ def test_concurrent_reads(started_cluster_iceberg):
 
     def run_concurrent_queries(i):
         def select(_):
+            # Bound per-query fan-out so the concurrent readers don't exhaust the global thread pool.
             instance.query(
                 f"SELECT * FROM {TABLE_NAME}",
+                settings={"max_threads": 4},
             )
                 
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108049
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @ alexey-milovidov on #108049 (the failure surfaced there; the ZSTD PR is unrelated).

`test_storage_iceberg_concurrent::test_concurrent_reads` runs 25 concurrent `SELECT *` queries against one accumulating Iceberg table while 15 Spark writers commit in parallel, for 10 rounds. By default each `SELECT` fans out to ~`max_threads` (number of CPU cores) internal read threads, so 25 simultaneous readers request hundreds of threads at once. On a loaded CI shard this oversubscribes the global thread pool and a single `SELECT` gets starved past the 300s client `receive_timeout`:

```
QueryRuntimeException: Return code: 159 ... Timeout exceeded while receiving data from server.
Waited for 312 seconds, timeout is 300 seconds. (query: SELECT * FROM test_concurrent_reads_s3_...)
```

Timeout-class failures (30d), all on the loaded `amd_asan_ubsan, db disk, old analyzer, 5/6` shard:
- PR #108049 — report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108049&sha=4007e1ae67c0d725cafe30faaa669b50326445cc&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29
- PR #100651 — same shard, `Waited for 333 seconds`
- master — same shard

**Fix:** pin `max_threads=4` on the concurrent `SELECT` so the readers' aggregate thread demand stays bounded. This does not change what the test verifies: all 25 readers still race all 15 writers across every round and the exact row-count assertion is unchanged. Only the per-query intra-read parallelism is capped, which is irrelevant to concurrent-read snapshot consistency.

**Local validation (debug build, both directions):**
- Pristine test: FAILS at round 2 with `Code 439 CANNOT_SCHEDULE_TASK (threads=1000, jobs=1000)` (the same oversubscription, manifesting as outright thread-pool exhaustion on my 96-core box).
- With `max_threads=4`: PASSES all 10 rounds, twice (147s, 152s).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1096`
<!-- ch-version-info:end -->