### PR TITLE
Document that complex single-key dictionaries accept a bare key

### DIFF
--- a/docs/en/sql-reference/functions/ext-dict-functions.md
+++ b/docs/en/sql-reference/functions/ext-dict-functions.md
@@ -290,6 +290,35 @@ LIFETIME(MIN 300 MAX 600);
 ```
 </details>
 
+## Passing keys to dictionary functions {#passing-keys}
+
+The key argument (`id_expr`) of functions such as `dictGet`, `dictGetOrDefault`, `dictGetOrNull` and `dictHas` depends on the dictionary's key:
+
+- For a dictionary with a **simple key** (`UInt64`), pass the key value directly:
+
+```sql
+SELECT dictGet('simple_key_dictionary', 'attr_name', toUInt64(1));
+```
+
+- For a dictionary with a **composite (complex) key** of more than one attribute, pass the key values as a tuple:
+
+```sql
+SELECT dictGet('complex_key_dictionary', 'attr_name', ('value_for_field1', 42));
+```
+
+- When the **composite key consists of a single attribute**, the key value can be passed directly, without wrapping it in `tuple`. Both of the following are valid and equivalent:
+
+```sql
+SELECT dictGet('complex_key_dictionary', 'attr_name', 'key');
+SELECT dictGet('complex_key_dictionary', 'attr_name', tuple('key'));
+```
+
+This also applies to `ip_trie` dictionaries, whose key is a single attribute. The IP address to look up can be passed directly:
+
+```sql
+SELECT dictGet('ip_trie_dictionary', 'attr_name', toIPv4('202.79.32.10'));
+```
+
 <!-- 
 The inner content of the tags below are replaced at doc framework build time with 
 docs generated from system.functions. Please do not modify or remove the tags.

--- a/docs/en/sql-reference/statements/create/dictionary/attributes.md
+++ b/docs/en/sql-reference/statements/create/dictionary/attributes.md
@@ -135,6 +135,8 @@ PRIMARY KEY field1, field2
 
 For a query to the `dictGet*` function, a tuple is passed as the key. Example: `dictGetString('dict_name', 'attr_name', tuple('string for field1', num_for_field2))`.
 
+When the composite key consists of a single attribute, the key value can be passed directly, without wrapping it in `tuple`. For example, both `dictGetString('dict_name', 'attr_name', 'key')` and `dictGetString('dict_name', 'attr_name', tuple('key'))` are valid.
+
 ## Attributes {#attributes}
 
 Configuration example:

--- a/src/Functions/FunctionsExternalDictionaries.cpp
+++ b/src/Functions/FunctionsExternalDictionaries.cpp
@@ -85,7 +85,7 @@ REGISTER_FUNCTION(ExternalDictionaries)
         FunctionDocumentation::Arguments arguments = {
             {"dict_name", "Name of the dictionary.", {"String"}},
             {"attr_names", "Name of the column of the dictionary, or tuple of column names.", {"String", "Tuple(String)"}},
-            {"id_expr", "Key value. An expression returning UInt64/Tuple(T).", {"UInt64", "Tuple(T)"}}
+            {"id_expr", "Key value. For a dictionary with a simple key, an expression returning a `UInt64` value. For a dictionary with a composite (complex) key, an expression returning a tuple of the key values. If the composite key consists of a single attribute, its value may be passed directly, without wrapping it in `tuple`.", {"UInt64", "Tuple(T)"}}
         };
         FunctionDocumentation::ReturnedValue returned_value =
 {R"(
@@ -135,7 +135,7 @@ R"(
         FunctionDocumentation::Arguments arguments = {
             {"dict_name", "Name of the dictionary.", {"String"}},
             {"attr_names", "Name of the column of the dictionary, or tuple of column names.", {"String", "Tuple(String)"}},
-            {"id_expr", "Key value. An expression returning UInt64/Tuple(T).", {"UInt64", "Tuple(T)"}},
+            {"id_expr", "Key value. For a dictionary with a simple key, an expression returning a `UInt64` value. For a dictionary with a composite (complex) key, an expression returning a tuple of the key values. If the composite key consists of a single attribute, its value may be passed directly, without wrapping it in `tuple`.", {"UInt64", "Tuple(T)"}},
             {"default_value", "Default value to return if the key is not found. Type must match the attribute's data type.", {}}
         };
         FunctionDocumentation::ReturnedValue returned_value = {R"(

--- a/tests/queries/0_stateless/04402_ip_trie_dict_get_single_key_no_tuple.reference
+++ b/tests/queries/0_stateless/04402_ip_trie_dict_get_single_key_no_tuple.reference
@@ -1,0 +1,13 @@
+dictGet IPv4
+NP
+NP
+17501
+dictGet IPv6
+ZZ
+ZZ
+dictGet multiple attributes
+(17501,'NP')
+dictHas
+1
+1
+0

--- a/tests/queries/0_stateless/04402_ip_trie_dict_get_single_key_no_tuple.sql
+++ b/tests/queries/0_stateless/04402_ip_trie_dict_get_single_key_no_tuple.sql
@@ -1,0 +1,34 @@
+-- An ip_trie dictionary has a single-attribute (complex) key, so the key value
+-- can be passed to dictGet / dictHas directly, without wrapping it in tuple.
+
+DROP DICTIONARY IF EXISTS ip_trie_dict;
+DROP TABLE IF EXISTS ip_trie_src;
+
+CREATE TABLE ip_trie_src (prefix String, asn UInt32, cca2 String) ENGINE = TinyLog;
+INSERT INTO ip_trie_src VALUES ('202.79.32.0/20', 17501, 'NP'), ('2001:db8::/32', 65536, 'ZZ');
+
+CREATE DICTIONARY ip_trie_dict (prefix String, asn UInt32, cca2 String)
+PRIMARY KEY prefix
+SOURCE(CLICKHOUSE(TABLE 'ip_trie_src'))
+LAYOUT(IP_TRIE)
+LIFETIME(0);
+
+SELECT 'dictGet IPv4';
+SELECT dictGet('ip_trie_dict', 'cca2', toIPv4('202.79.32.10'));
+SELECT dictGet('ip_trie_dict', 'cca2', tuple(toIPv4('202.79.32.10')));
+SELECT dictGet('ip_trie_dict', 'asn', materialize(toIPv4('202.79.32.10')));
+
+SELECT 'dictGet IPv6';
+SELECT dictGet('ip_trie_dict', 'cca2', toIPv6('2001:db8::1'));
+SELECT dictGet('ip_trie_dict', 'cca2', tuple(toIPv6('2001:db8::1')));
+
+SELECT 'dictGet multiple attributes';
+SELECT dictGet('ip_trie_dict', ('asn', 'cca2'), toIPv4('202.79.32.10'));
+
+SELECT 'dictHas';
+SELECT dictHas('ip_trie_dict', toIPv4('202.79.32.10'));
+SELECT dictHas('ip_trie_dict', tuple(toIPv4('202.79.32.10')));
+SELECT dictHas('ip_trie_dict', toIPv4('8.8.8.8'));
+
+DROP DICTIONARY ip_trie_dict;
+DROP TABLE ip_trie_src;


### PR DESCRIPTION
Functions such as `dictGet`, `dictGetOrDefault`, `dictHas` and related functions have accepted a bare key value (without a `tuple` wrapper) for complex (composite) key dictionaries with a single key attribute since 2021 (commit `03c4853`, "Functions `dictGet`, `dictHas` complex key dictionary key argument tuple fix"). However, the documentation still implied that a `tuple` is always required for complex key dictionaries — which is exactly what the issue complains about: `dictGet('dict', 'attr', tuple(key))` "looks stupid" when there is a single key.

This change updates the documentation so the bare-key form is discoverable:
- Clarifies the `id_expr` argument description of `dictGet` and `dictGetOrDefault`.
- Adds a "Passing keys to dictionary functions" section to the dictionary functions reference page.
- Notes the single-attribute case in the composite key documentation.

It also adds a stateless test that locks in the bare-key form for an `ip_trie` dictionary (the layout used by the blog post referenced in the issue), whose key is a single attribute and was previously only exercised with the `tuple` form. The behavior is otherwise already covered by `01941_dict_get_has_complex_single_key`.

Note: the blog post https://clickhouse.com/blog/geolocating-ips-in-clickhouse-and-grafana mentioned in the issue lives in a separate repository and is not changed here.

Closes: https://github.com/ClickHouse/ClickHouse/issues/50165

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Documentation: clarify that `dictGet` and related functions accept a bare key (without `tuple`) for complex key dictionaries that have a single key attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1176`
<!-- ch-version-info:end -->