### PR TITLE
Fix flaky test test_kafka_commit_on_block_write

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1596,17 +1596,44 @@ def test_kafka_commit_on_block_write(kafka_cluster, create_query_generator):
         check_callback=lambda res: int(res) >= 100,
     )
 
+    # Stop the producer and join it first, so i[0] is the final message count
+    # and no new messages arrive during the drop/recreate below.
     cancel.set()
-
-    instance.query(f"DROP TABLE test.{kafka_table} SYNC")
-
-    instance.query(create_query)
     kafka_thread.join()
 
+    # Wait until every produced message has reached the view.
     instance.query_with_retry(
         f"SELECT uniqExact(key) FROM test.{kafka_table}_view",
         sleep_time=1,
+        retry_count=60,
         check_callback=lambda res: int(res) >= i[0],
+    )
+
+    # Wait for one full streaming cycle to finish after consumption. The
+    # "stalled. Rescheduling" line is logged by threadFunc only after
+    # streamToViews() returns, i.e. after offsets have been committed.
+    stalled_count = int(
+        instance.count_in_log(f"{kafka_table}.*stalled.*Rescheduling").strip()
+    )
+    instance.wait_for_log_line(
+        f"{kafka_table}.*stalled.*Rescheduling",
+        timeout=60,
+        repetitions=stalled_count + 1,
+    )
+
+    # Offsets are now committed: dropping and recreating must not re-consume.
+    instance.query(f"DROP TABLE test.{kafka_table} SYNC")
+    instance.query(create_query)
+
+    # Let the recreated consumer poll and stall, so any wrong offset would
+    # show up as re-consumed duplicates in the view.
+    stalled_count = int(
+        instance.count_in_log(f"{kafka_table}.*stalled.*Rescheduling").strip()
+    )
+    instance.wait_for_log_line(
+        f"{kafka_table}.*stalled.*Rescheduling",
+        timeout=60,
+        repetitions=stalled_count + 1,
     )
 
     result = int(instance.query(f"SELECT count() == uniqExact(key) FROM test.{kafka_table}_view"))
@@ -1615,8 +1642,6 @@ def test_kafka_commit_on_block_write(kafka_cluster, create_query_generator):
         DROP TABLE test.{kafka_table}_consumer;
         DROP TABLE test.{kafka_table}_view;
     """)
-
-    kafka_thread.join()
 
     assert result == 1, "Messages from kafka get duplicated!"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/101463
Related: https://github.com/ClickHouse/ClickHouse/pull/102167
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/101463
Related: https://github.com/ClickHouse/ClickHouse/pull/102167

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Reimplements the closed PR #102167 on current master, as suggested by @alexey-milovidov in the issue.

The test produced messages to a Kafka table with a materialized view, then dropped and recreated the table and asserted the view had no duplicates. It dropped immediately after the view reached >=100 rows, without confirming the streaming cycle had committed offsets, and read `i[0]` (the produced count) while the producer was still running.

Under load (TSan), `DROP TABLE SYNC` can cancel a streaming cycle after its rows reached the view but before the offset commit, so the recreated consumer (same group) re-reads those messages and the view ends up with duplicates ("Messages from kafka get duplicated!", `assert 0 == 1`).

The fix makes the test deterministic:
- Join the producer before dropping, so `i[0]` is final and no new messages arrive during drop/recreate.
- Wait until all produced messages are in the view.
- Wait for the post-consumption `stalled. Rescheduling` log line, which `threadFunc` emits only after `streamToViews()` returns (i.e. after offsets are committed), before dropping.
- After recreate, wait for another stall so a wrong offset would surface as duplicates.
- Remove the redundant second `kafka_thread.join()`.

Test-only change; no engine code is modified.
