### PR TITLE
distroless: auto-trigger BackfillDistroless on base-pin changes

### DIFF
--- a/.github/workflows/distroless_auto_rebuild.yml
+++ b/.github/workflows/distroless_auto_rebuild.yml
@@ -1,0 +1,99 @@
+name: DistrolessAutoRebuild
+
+# Auto-trigger BackfillDistroless when a base-pin change lands on master.
+# Closes the manual "click Run workflow" step that previously followed every
+# libssl3t64-style digest bump — without this, a freshly-merged base PR only
+# affects future official releases, leaving the historical X.Y fleet on the
+# old base until someone remembers to backfill.
+#
+# How it picks the versions: queries Docker Hub for every published
+# `X.Y-distroless` floating tag on `clickhouse/clickhouse-server`, reads each
+# one's `com.clickhouse.build.version` label, and feeds the recovered
+# `X.Y.Z.N` list to `BackfillDistroless`. That keeps the tracked set in lockstep
+# with whatever the previous BackfillDistroless run published, no manifest file
+# to maintain.
+
+"on":
+  push:
+    branches: [master]
+    paths:
+      - 'docker/server/Dockerfile.distroless'
+      - 'docker/keeper/Dockerfile.distroless'
+
+concurrency:
+  group: distroless-auto-rebuild
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  TriggerBackfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discover currently-tracked X.Y.Z.N patches
+        id: versions
+        env:
+          IMAGE: clickhouse/clickhouse-server
+        run: |
+          set -euo pipefail
+
+          # Page through Docker Hub tags, keep only X.Y-distroless floats.
+          XY_TAGS=$(mktemp)
+          : > "$XY_TAGS"
+          PAGE=1
+          while :; do
+            URL="https://hub.docker.com/v2/repositories/${IMAGE}/tags/?page_size=100&page=${PAGE}&name=-distroless"
+            JSON=$(curl -sf "$URL") || break
+            echo "$JSON" | jq -r '.results[].name' \
+              | grep -E '^[0-9]+\.[0-9]+-distroless$' >> "$XY_TAGS" || true
+            NEXT=$(echo "$JSON" | jq -r '.next // empty')
+            [ -z "$NEXT" ] && break
+            PAGE=$((PAGE + 1))
+          done
+
+          XY_LIST=$(sort -ru "$XY_TAGS")
+          echo "X.Y-distroless floating tags discovered on Docker Hub:"
+          echo "$XY_LIST"
+
+          # Resolve each X.Y float to its X.Y.Z.N patch via the canonical
+          # `com.clickhouse.build.version` label (with the historical
+          # `com.clickhoghuse.build.version` typo fallback that some old
+          # backfills wrote — same fallback BackfillDistroless itself accepts).
+          VERSIONS=""
+          for XY_TAG in $XY_LIST; do
+            LABEL=$(docker buildx imagetools inspect "${IMAGE}:${XY_TAG}" --format '{{json .}}' 2>/dev/null \
+              | jq -r '
+                  (.image // {}) as $img |
+                  (if ($img | has("config")) then $img.config.Labels
+                   else ($img | to_entries[0]?.value.config.Labels) end) as $lbl |
+                  ($lbl["com.clickhouse.build.version"] //
+                   $lbl["com.clickhoghuse.build.version"] // "")') || LABEL=""
+            VERSION="${LABEL%-distroless}"
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              VERSIONS="$VERSIONS $VERSION"
+            else
+              echo "WARN: ${IMAGE}:${XY_TAG} has no valid X.Y.Z.N label (got '$LABEL'), skipping"
+            fi
+          done
+
+          VERSIONS=$(echo "$VERSIONS" | xargs)
+          if [ -z "$VERSIONS" ]; then
+            echo "ERROR: no tracked patches discovered — refusing to dispatch with empty list"
+            exit 1
+          fi
+          echo "Discovered tracked versions: $VERSIONS"
+          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch BackfillDistroless
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSIONS: ${{ steps.versions.outputs.versions }}
+        run: |
+          set -euo pipefail
+          gh workflow run backfill_distroless.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref master \
+            --field versions="${VERSIONS}" \
+            --field dry-run=false
+          echo "Dispatched BackfillDistroless with versions=${VERSIONS}"


### PR DESCRIPTION
Followup to #107677, #107837, #108001. Closes the manual "click Run workflow on BackfillDistroless" step that historically followed every base-pin bump. Without this, a freshly-merged base change only affects future official releases and the historical `X.Y` fleet stays on the old base until someone remembers to backfill. That's exactly what happened after #107677 merged.

When a push to master touches `docker/server/Dockerfile.distroless` or `docker/keeper/Dockerfile.distroless`, the new workflow auto-dispatches `BackfillDistroless` against the currently-tracked `X.Y.Z.N` patches.

How the versions list gets built (no manifest file to maintain):
- Query Docker Hub for every `X.Y-distroless` floating tag on `clickhouse/clickhouse-server`.
- Read each one's `com.clickhouse.build.version` label via `docker buildx imagetools inspect`, with the historical `com.clickhoghuse` typo fallback that some old backfills wrote (same fallback BackfillDistroless itself accepts).
- Both sides regex-validate the format (`X.Y-distroless` on discovery, `X.Y.Z.N` on dispatch).
- If discovery finds zero versions, exit non-zero rather than dispatch an empty run.

Also patches `BackfillDistroless` itself with two fixes that came out of debugging this:
- Cross-run check so `:latest-distroless` stops getting moved backwards by a stale partial backfill.
- `:latest-distroless` actually gets refreshed properly now. It was stuck at 2026-05-22 before this; fleet just refreshed to 26.5.1.882 at 19:50Z on 2026-06-22 once this logic ran end-to-end.

Only fires on push, not `pull_request`. Concurrency-grouped, `actions: write` scoped to just this workflow's `GITHUB_TOKEN`, no `pull_request_target`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

#### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.120`
<!-- ch-version-info:end -->