### PR TITLE
Set Keeper component for MergeTreeTextIndexSource index reads

### DIFF
--- a/src/Storages/StorageMergeTreeTextIndex.cpp
+++ b/src/Storages/StorageMergeTreeTextIndex.cpp
@@ -4,6 +4,7 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnsNumber.h>
 #include <Columns/ColumnConst.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Compression/CompressedReadBufferFromFile.h>
 #include <Core/Range.h>
 #include <DataTypes/DataTypeEnum.h>
@@ -65,6 +66,8 @@ public:
 protected:
     Chunk generate() override
     {
+        Coordination::ComponentGuard component_guard = Coordination::setCurrentComponent("MergeTreeTextIndexSource::generate");
+
         using enum PostingsSerialization::Flags;
 
         size_t total_rows = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
