### PR TITLE
Use precise float parsing where long double has no extra precision

### DIFF
--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -1,4 +1,3 @@
-00558_parse_floats
 00564_versioned_collapsing_merge_tree
 00565_enum_order
 00573_shard_aggregation_by_empty_set
@@ -962,7 +961,6 @@
 02898_input_format_values_allow_data_after_semicolon
 02898_parallel_replicas_progress_bar
 02900_clickhouse_local_drop_current_database
-02900_issue_55858
 02901_parallel_replicas_rollup
 02902_show_databases_limit
 02903_parameterized_view_explain_ast

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1532,7 +1532,9 @@ Possible values:
 -   1 — Enabled.
 )", IMPORTANT) \
     DECLARE(Bool, precise_float_parsing, false, R"(
-Prefer more precise (but slower) float parsing algorithm
+Prefer more precise (but slower) float parsing algorithm.
+
+Note: this setting has no effect on platforms where `long double` is no wider than `double` (e.g. Apple silicon). There the fast algorithm is neither faster nor more precise, so the precise algorithm is always used regardless of this setting.
 )", 0) \
     DECLARE(DateTimeOverflowBehavior, date_time_overflow_behavior, "ignore", R"(
 Defines the behavior when [Date](../../sql-reference/data-types/date.md), [Date32](../../sql-reference/data-types/date32.md), [DateTime](../../sql-reference/data-types/datetime.md), [DateTime64](../../sql-reference/data-types/datetime64.md) or integers are converted into Date, Date32, DateTime or DateTime64 but the value cannot be represented in the result type.

--- a/src/IO/readFloatText.h
+++ b/src/IO/readFloatText.h
@@ -624,8 +624,21 @@ template <typename T> bool tryReadFloatTextPrecise(T & x, ReadBuffer & in)
         return readFloatTextPreciseImpl<T, bool>(x, in);
 }
 
+/// The fast float parser relies on `long double` being wider than `double` for its precision.
+/// On platforms where it is not (e.g. Apple arm64, where `long double == double`), the fast parser
+/// is less precise, and making it correctly rounded (e.g. with a double-double powers-of-ten table)
+/// was measured to be both slower and no more precise than the precise (fast_float) parser. So the
+/// fast path has nothing to offer there - neither speed nor accuracy - and we defer to precise.
+inline constexpr bool fast_float_parsing_is_useful = std::numeric_limits<long double>::digits > std::numeric_limits<double>::digits;
+
 template <typename T> void readFloatTextFast(T & x, ReadBuffer & in)
 {
+    if constexpr (!fast_float_parsing_is_useful)
+    {
+        readFloatTextPrecise(x, in);
+        return;
+    }
+
     bool has_fractional = false;
     if constexpr (std::is_same_v<T, BFloat16>)
     {
@@ -639,6 +652,9 @@ template <typename T> void readFloatTextFast(T & x, ReadBuffer & in)
 
 template <typename T> bool tryReadFloatTextFast(T & x, ReadBuffer & in)
 {
+    if constexpr (!fast_float_parsing_is_useful)
+        return tryReadFloatTextPrecise(x, in);
+
     bool has_fractional = false;
     if constexpr (std::is_same_v<T, BFloat16>)
     {

--- a/tests/queries/0_stateless/04075_float_to_string_format.reference
+++ b/tests/queries/0_stateless/04075_float_to_string_format.reference
@@ -59,7 +59,7 @@ inf
 -inf
 0
 --- Float32 small values ---
-1.1754941e-38
+1.1754942e-38
 3.14
 --- BFloat16 ---
 3.125

--- a/tests/queries/0_stateless/04075_float_to_string_format.sql
+++ b/tests/queries/0_stateless/04075_float_to_string_format.sql
@@ -3,6 +3,10 @@
 --   Scientific notation: no '+' on positive exponent, no zero-padding.
 --   NaN never has a sign. Inf preserves sign.
 
+-- This test is about float-to-string formatting, so parse the input literals precisely to get the
+-- same values on every platform (the fast parser may round a literal differently between archs).
+SET precise_float_parsing = 1;
+
 -- Float64: Fixed notation boundaries
 SELECT '--- Float64 fixed/scientific boundaries ---';
 SELECT 0.000001;             -- dec_exp = -6 → fixed


### PR DESCRIPTION
On platforms where `long double` has the same width as `double` (notably Apple silicon / ARM macOS), the "fast" float parser cannot use `long double` for the extra precision it relies on, so it parsed `Float64` values less accurately than elsewhere (off by one ULP, e.g. `toFloat64('0.000005')`).

Benchmarks on such a platform show the fast parser is also *slower* than the precise (`fast_float`) parser for real floats, and an attempt to make it correctly rounded (a double-double powers-of-ten table) was both slower and no more precise. So the fast path has nothing to offer there - neither speed nor accuracy - and float parsing now defers to the precise implementation when `long double == double`. Other platforms are unaffected.

This also un-skips the macOS tests it fixes (`00558_parse_floats`) and a stale skip (`02900_issue_55858`), and makes `04075_float_to_string_format` parse its input literals precisely so it is deterministic across platforms.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed less accurate parsing of `Float64` values from text on platforms where `long double` is no wider than `double` (such as Apple silicon): such values could be off by one unit in the last place. These platforms now always use the precise float parser, which is also faster there.
