### PR TITLE
Docs: Raise MongoDB minimum required version

### DIFF
--- a/src/Storages/StorageMongoDB.cpp
+++ b/src/Storages/StorageMongoDB.cpp
@@ -656,7 +656,7 @@ void registerStorageMongoDB(StorageFactory & factory)
         .description = R"DOCS_MD(
 MongoDB engine is read-only table engine which allows to read data from a remote [MongoDB](https://www.mongodb.com/) collection.
 
-Only MongoDB v3.6+ servers are supported.
+Only MongoDB >=7 is supported.
 [Seed list(`mongodb+srv`)](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-seed-list) is not yet supported.
 
 ## Creating a table {#creating-a-table}


### PR DESCRIPTION
`master` references the Mongo C driver 2.3

1.2.8 raised the minimum wire protocol to 7: https://www.mongodb.com/docs/languages/c/c-driver/current/reference/upgrade/#libmongoc-breaking-changes-in-v1280

This PR updates ClickHouse's docs.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1147`
<!-- ch-version-info:end -->