### PR TITLE
Always run access cache batch-finished handlers, even on empty batch

### DIFF
--- a/src/Access/AccessChangesNotifier.cpp
+++ b/src/Access/AccessChangesNotifier.cpp
@@ -102,14 +102,12 @@ void AccessChangesNotifier::sendNotifications()
     /// Only one thread can send notification at any time.
     std::lock_guard sending_notifications_lock{sending_notifications};
 
-    bool sent_any = false;
     std::unique_lock queue_lock{queue_mutex};
     while (!queue.empty())
     {
         auto event = std::move(queue.front());
         queue.pop();
         queue_lock.unlock();
-        sent_any = true;
 
         std::vector<OnChangedHandler> current_handlers;
         {
@@ -136,10 +134,11 @@ void AccessChangesNotifier::sendNotifications()
     }
     queue_lock.unlock();
 
-    if (!sent_any)
-        return;
-
-    /// Queue drained (e.g. a full refresh); run the coalesced per-batch work. Copied out so handlers
+    /// Run the coalesced per-batch work unconditionally, even when this call drained nothing: a
+    /// per-batch handler whose previous rebuild threw left its work pending, and the per-entity flag
+    /// guarding that rebuild is only cleared on success, so the retry must not depend on a fresh event
+    /// being queued (an up-to-date `SYSTEM RELOAD USERS` diffs to zero and would otherwise never retry).
+    /// Each handler is cheap when nothing is pending (a mutex + a flag check). Copied out so handlers
     /// run without `handlers->mutex` held.
     std::vector<OnBatchFinishedHandler> batch_finished_handlers;
     {

--- a/src/Access/AccessChangesNotifier.h
+++ b/src/Access/AccessChangesNotifier.h
@@ -38,10 +38,12 @@ public:
 
     using OnBatchFinishedHandler = std::function<void()>;
 
-    /// Subscribes for the end of a notification batch: the handler is called once after sendNotifications()
-    /// has dispatched all the per-entity notifications queued so far. Lets subscribers coalesce expensive
-    /// per-entity recomputations into a single one per batch (e.g. a full refresh delivers one notification
-    /// per entity, but the derived state only needs to be rebuilt once).
+    /// Subscribes for the end of a notification batch: the handler is called once per sendNotifications()
+    /// after all the per-entity notifications queued so far have been dispatched. Lets subscribers coalesce
+    /// expensive per-entity recomputations into a single one per batch (e.g. a full refresh delivers one
+    /// notification per entity, but the derived state only needs to be rebuilt once). The handler is also
+    /// called when the batch was empty, so a recomputation that threw (and left its work pending) is retried
+    /// on the next call without waiting for a fresh access change; it must therefore be cheap when idle.
     scope_guard subscribeForBatchFinished(const OnBatchFinishedHandler & handler);
 
     /// Called by access storages after a new access entity has been added.

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -65,7 +65,7 @@ private:
     std::unordered_map<UUID /* quota id */, QuotaInfo> all_quotas;
     bool all_quotas_read = false;
     /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
-    bool need_choose_quota = false;
+    bool need_choose_quota TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
     scope_guard batch_subscription;
     std::map<EnabledQuota::Params, std::weak_ptr<EnabledQuota>> enabled_quotas;

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -49,7 +49,7 @@ private:
     std::unordered_map<String, UUID> profiles_by_name;
     bool all_profiles_read = false;
     /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
-    bool need_merge_settings_and_constraints = false;
+    bool need_merge_settings_and_constraints TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
     scope_guard batch_subscription;
     std::map<EnabledSettings::Params, std::weak_ptr<EnabledSettings>> enabled_settings;

--- a/src/Access/tests/gtest_access_changes_notifier.cpp
+++ b/src/Access/tests/gtest_access_changes_notifier.cpp
@@ -50,7 +50,53 @@ TEST(AccessChangesNotifier, BatchFinishedCoalescesRecompute)
     EXPECT_EQ(per_entity_calls, num_entities + 1);
     EXPECT_EQ(batch_calls, 2u);
 
-    /// An empty queue must not invoke the batch hook (nothing changed, nothing to rebuild).
+    /// An empty queue still invokes the batch hook: real handlers early-return on their per-entity
+    /// flag, so this is cheap, and it must keep firing so a rebuild that previously threw is retried
+    /// without waiting for a fresh access change (see BatchFinishedRetriedAfterThrow).
     notifier.sendNotifications();
-    EXPECT_EQ(batch_calls, 2u);
+    EXPECT_EQ(batch_calls, 3u);
+}
+
+/// A per-batch rebuild that throws must not lose the pending work: the caches clear their "needs
+/// rebuild" flag only on success, so the notifier has to keep invoking batch-finished handlers on
+/// later sendNotifications() calls - including ones that drain no events - otherwise the derived
+/// state stays stale until some unrelated access change happens to queue a notification (and an
+/// up-to-date SYSTEM RELOAD USERS, which diffs to zero, would never trigger the retry).
+TEST(AccessChangesNotifier, BatchFinishedRetriedAfterThrow)
+{
+    AccessChangesNotifier notifier;
+
+    bool need_rebuild = false; /// mirrors RowPolicyCache::need_mix_filters and friends
+    size_t rebuilds = 0;
+    bool fail_next_rebuild = true;
+
+    auto entity_subscription = notifier.subscribeForChanges(
+        AccessEntityType::ROW_POLICY,
+        [&](const UUID &, const AccessEntityPtr &) { need_rebuild = true; });
+
+    auto batch_subscription = notifier.subscribeForBatchFinished(
+        [&]
+        {
+            if (!need_rebuild)
+                return;
+            if (fail_next_rebuild)
+            {
+                fail_next_rebuild = false;
+                throw std::runtime_error("rebuild failed"); /// caught and logged by sendNotifications()
+            }
+            ++rebuilds;
+            need_rebuild = false; /// cleared only after a successful rebuild
+        });
+
+    notifier.onEntityRemoved(UUIDHelpers::generateV4(), AccessEntityType::ROW_POLICY);
+    notifier.sendNotifications(); /// first attempt throws; the work stays pending
+    EXPECT_EQ(rebuilds, 0u);
+
+    /// No new event is queued, yet the pending rebuild must still be retried and now succeed.
+    notifier.sendNotifications();
+    EXPECT_EQ(rebuilds, 1u);
+
+    /// Once it has succeeded an empty flush is a no-op, guarded by the handler's own flag.
+    notifier.sendNotifications();
+    EXPECT_EQ(rebuilds, 1u);
 }


### PR DESCRIPTION
After PR #107672 a coalesced rebuild that threw left its need_* flag set, but the retry was gated on `sent_any`, so sendNotifications re-ran batch handlers only on batches that delivered an event. Stale quota/role/row-policy/ settings state then persisted until an unrelated change queued a notification (an up-to-date `SYSTEM RELOAD USERS` diffs to zero and never retried). Run the handlers unconditionally; they early-return when idle.

Refs: https://github.com/ClickHouse/ClickHouse/pull/107672

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Always run access cache batch-finished handlers, even on empty batch

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1127`
- Backported to: `26.5.4.11`, `26.4.5.72`, `26.3.16.12`
<!-- ch-version-info:end -->