### PR TITLE
Collect runtime stats from hash join to enable switching to parallel_hash join

### DIFF
--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -154,7 +154,8 @@ HashJoin::HashJoin(
     bool any_take_last_row_,
     size_t reserve_num_,
     const String & instance_id_,
-    bool use_two_level_maps)
+    bool use_two_level_maps,
+    const StatsCollectingParams & stats_collecting_params_)
     : table_join(table_join_)
     , kind(table_join->kind())
     , strictness(table_join->strictness())
@@ -170,6 +171,7 @@ HashJoin::HashJoin(
     , joined_block_split_single_row(table_join->joinedBlockAllowSplitSingleRow())
     , enable_lazy_columns_replication(table_join->enableColumnsLazyReplication())
     , enable_prefetch(table_join->enableSoftwarePrefetchInJoin())
+    , stats_collecting_params(stats_collecting_params_)
     , instance_log_id(!instance_id_.empty() ? "(" + instance_id_ + ") " : "")
     , log(getLogger("HashJoin"))
 {
@@ -1347,6 +1349,21 @@ HashJoin::~HashJoin()
         LOG_TEST(log, "{}Join data has been already released", instance_log_id);
         return;
     }
+
+    try
+    {
+        if (build_phase_finished && stats_collecting_params.isCollectionAndUseEnabled())
+        {
+            if (const auto ht_size = getTotalRowCount())
+                getHashTablesStatistics<HashJoinEntry>().update(
+                    {.ht_size = ht_size, .source_rows = data->rows_to_join}, stats_collecting_params);
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(__PRETTY_FUNCTION__);
+    }
+
     LOG_TEST(
         log,
         "{}Join data is being destroyed, {} bytes and {} rows in hash table",
@@ -2570,6 +2587,8 @@ void HashJoin::onBuildPhaseFinish()
         LOG_DEBUG(log, "Promoting join strictness to RightAny, because all values in the right table are unique");
     }
     updateNonJoinedRowsStatus();
+
+    build_phase_finished = true;
 
     LOG_TRACE(log, "{}Join data is built, {} and {} rows in hash table", instance_log_id, ReadableSize(getTotalByteCount()), getTotalRowCount());
 }

--- a/src/Interpreters/HashJoin/HashJoin.h
+++ b/src/Interpreters/HashJoin/HashJoin.h
@@ -6,6 +6,7 @@
 #include <variant>
 #include <vector>
 
+#include <Interpreters/HashTablesStatistics.h>
 #include <Interpreters/IJoin.h>
 #include <Interpreters/RowRefs.h>
 
@@ -114,7 +115,8 @@ public:
         bool any_take_last_row_ = false,
         size_t reserve_num_ = 0,
         const String & instance_id_ = "",
-        bool use_two_level_maps_ = false);
+        bool use_two_level_maps_ = false,
+        const StatsCollectingParams & stats_collecting_params_ = {});
 
     ~HashJoin() override;
 
@@ -574,6 +576,9 @@ private:
 
     /// Track if shared runtime filters were already published to keep publication one-shot.
     bool shared_runtime_filters_publish_attempted = false;
+
+    const StatsCollectingParams stats_collecting_params;
+    bool build_phase_finished = false;
 
     /// Identifier to distinguish different HashJoin instances in logs
     /// Several instances can be created, for example, in GraceHashJoin to handle different buckets

--- a/src/Interpreters/HashTablesStatistics.h
+++ b/src/Interpreters/HashTablesStatistics.h
@@ -53,11 +53,7 @@ struct AggregationEntry
 
 struct HashJoinEntry
 {
-    bool shouldBeUpdated(const HashJoinEntry & new_entry) const
-    {
-        return new_entry.ht_size < ht_size / 2 || ht_size < new_entry.ht_size
-            || new_entry.source_rows < source_rows / 2 || source_rows < new_entry.source_rows;
-    }
+    bool shouldBeUpdated(const HashJoinEntry & new_entry) const { return new_entry.ht_size < ht_size / 2 || ht_size < new_entry.ht_size; }
 
     std::string dump() const { return fmt::format("ht_size={}", ht_size); }
 

--- a/src/Interpreters/HashTablesStatistics.h
+++ b/src/Interpreters/HashTablesStatistics.h
@@ -54,7 +54,7 @@ struct AggregationEntry
 struct HashJoinEntry
 {
     bool shouldBeUpdated(const HashJoinEntry & new_entry) const
-    { 
+    {
         return new_entry.ht_size < ht_size / 2 || ht_size < new_entry.ht_size
             || new_entry.source_rows < source_rows / 2 || source_rows < new_entry.source_rows;
     }

--- a/src/Interpreters/HashTablesStatistics.h
+++ b/src/Interpreters/HashTablesStatistics.h
@@ -53,7 +53,11 @@ struct AggregationEntry
 
 struct HashJoinEntry
 {
-    bool shouldBeUpdated(const HashJoinEntry & new_entry) const { return new_entry.ht_size < ht_size / 2 || ht_size < new_entry.ht_size; }
+    bool shouldBeUpdated(const HashJoinEntry & new_entry) const
+    { 
+        return new_entry.ht_size < ht_size / 2 || ht_size < new_entry.ht_size
+            || new_entry.source_rows < source_rows / 2 || source_rows < new_entry.source_rows;
+    }
 
     std::string dump() const { return fmt::format("ht_size={}", ht_size); }
 

--- a/src/Interpreters/JoinSwitcher.cpp
+++ b/src/Interpreters/JoinSwitcher.cpp
@@ -7,13 +7,18 @@
 namespace DB
 {
 
-JoinSwitcher::JoinSwitcher(std::shared_ptr<TableJoin> table_join_, SharedHeader right_sample_block_)
+JoinSwitcher::JoinSwitcher(
+    std::shared_ptr<TableJoin> table_join_,
+    SharedHeader right_sample_block_,
+    const StatsCollectingParams & stats_collecting_params_)
     : limits(table_join_->sizeLimits())
     , switched(false)
     , table_join(table_join_)
     , right_sample_block(right_sample_block_->cloneEmpty())
 {
-    join = std::make_shared<HashJoin>(table_join, right_sample_block_);
+    join = std::make_shared<HashJoin>(
+        table_join, right_sample_block_, /*any_take_last_row_=*/false, /*reserve_num_=*/0, /*instance_id_=*/"",
+        /*use_two_level_maps_=*/false, stats_collecting_params_);
 
     if (!limits.hasLimits())
         limits.max_bytes = table_join->defaultMaxBytes();

--- a/src/Interpreters/JoinSwitcher.h
+++ b/src/Interpreters/JoinSwitcher.h
@@ -3,6 +3,7 @@
 #include <mutex>
 
 #include <Core/Block.h>
+#include <Interpreters/HashTablesStatistics.h>
 #include <Interpreters/IJoin.h>
 #include <Interpreters/TableJoin.h>
 
@@ -16,7 +17,10 @@ namespace DB
 class JoinSwitcher : public IJoin
 {
 public:
-    JoinSwitcher(std::shared_ptr<TableJoin> table_join_, SharedHeader right_sample_block_);
+    JoinSwitcher(
+        std::shared_ptr<TableJoin> table_join_,
+        SharedHeader right_sample_block_,
+        const StatsCollectingParams & stats_collecting_params_ = {});
 
     std::string getName() const override { return "JoinSwitcher"; }
     const TableJoin & getTableJoin() const override { return *table_join; }

--- a/src/Interpreters/SpillingHashJoin.cpp
+++ b/src/Interpreters/SpillingHashJoin.cpp
@@ -21,7 +21,8 @@ SpillingHashJoin::SpillingHashJoin(
     SharedHeader right_sample_block_,
     TemporaryDataOnDiskScopePtr tmp_data_,
     size_t initial_num_buckets_,
-    size_t max_num_buckets_)
+    size_t max_num_buckets_,
+    const StatsCollectingParams & stats_collecting_params_)
     : log(getLogger("SpillingHashJoin"))
     , table_join(std::move(table_join_))
     , left_sample_block(std::move(left_sample_block_))
@@ -31,7 +32,9 @@ SpillingHashJoin::SpillingHashJoin(
     , max_num_buckets(max_num_buckets_)
     , max_bytes_before_external_join(table_join->maxBytesBeforeExternalJoin())
 {
-    hash_join = std::make_shared<HashJoin>(table_join, right_sample_block_);
+    hash_join = std::make_shared<HashJoin>(
+        table_join, right_sample_block_, /*any_take_last_row_=*/false, /*reserve_num_=*/0, /*instance_id_=*/"",
+        /*use_two_level_maps_=*/false, stats_collecting_params_);
 }
 
 SpillingHashJoin::SpillingHashJoin(

--- a/src/Interpreters/SpillingHashJoin.h
+++ b/src/Interpreters/SpillingHashJoin.h
@@ -53,7 +53,8 @@ public:
         SharedHeader right_sample_block_,
         TemporaryDataOnDiskScopePtr tmp_data_,
         size_t initial_num_buckets_,
-        size_t max_num_buckets_);
+        size_t max_num_buckets_,
+        const StatsCollectingParams & stats_collecting_params_ = {});
 
     /// Concurrent mode: wraps a ConcurrentHashJoin.
     SpillingHashJoin(

--- a/src/Planner/PlannerJoins.cpp
+++ b/src/Planner/PlannerJoins.cpp
@@ -1193,6 +1193,12 @@ static std::shared_ptr<IJoin> tryCreateJoin(
         algorithm == JoinAlgorithm::PARALLEL_HASH ||
         algorithm == JoinAlgorithm::DEFAULT)
     {
+        StatsCollectingParams stats_collecting_params{
+            params.hash_table_key_hash,
+            params.collect_hash_table_stats_during_joins,
+            params.max_entries_for_hash_table_stats,
+            params.max_size_to_preallocate_for_joins};
+
         if (params.max_bytes_before_external_join > 0 && table_join->getTempDataOnDisk() && GraceHashJoin::isSupported(table_join))
         {
             if (table_join->allowParallelHashJoin())
@@ -1201,11 +1207,6 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                     || (*params.rhs_size_estimation >= params.parallel_hash_join_threshold);
                 if (use_parallel_hash)
                 {
-                    StatsCollectingParams stats_collecting_params{
-                        params.hash_table_key_hash,
-                        params.collect_hash_table_stats_during_joins,
-                        params.max_entries_for_hash_table_stats,
-                        params.max_size_to_preallocate_for_joins};
                     return std::make_shared<SpillingHashJoin>(
                         table_join,
                         left_table_expression_header,
@@ -1224,7 +1225,8 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                 right_table_expression_header,
                 table_join->getTempDataOnDisk(),
                 params.grace_hash_join_initial_buckets,
-                params.grace_hash_join_max_buckets);
+                params.grace_hash_join_max_buckets,
+                stats_collecting_params);
         }
 
         if (table_join->allowParallelHashJoin())
@@ -1233,17 +1235,13 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                 || (*params.rhs_size_estimation >= params.parallel_hash_join_threshold);
             if (use_parallel_hash)
             {
-                StatsCollectingParams stats_collecting_params{
-                    params.hash_table_key_hash,
-                    params.collect_hash_table_stats_during_joins,
-                    params.max_entries_for_hash_table_stats,
-                    params.max_size_to_preallocate_for_joins};
                 return std::make_shared<ConcurrentHashJoin>(table_join, params.max_threads, right_table_expression_header, stats_collecting_params);
             }
         }
 
         return std::make_shared<HashJoin>(
-            table_join, right_table_expression_header, params.join_any_take_last_row);
+            table_join, right_table_expression_header, params.join_any_take_last_row, /*reserve_num_=*/0, /*instance_id_=*/"",
+            /*use_two_level_maps_=*/false, stats_collecting_params);
     }
 
     if (algorithm == JoinAlgorithm::FULL_SORTING_MERGE)
@@ -1273,15 +1271,16 @@ static std::shared_ptr<IJoin> tryCreateJoin(
 
     if (algorithm == JoinAlgorithm::AUTO)
     {
+        StatsCollectingParams stats_collecting_params{
+            params.hash_table_key_hash,
+            params.collect_hash_table_stats_during_joins,
+            params.max_entries_for_hash_table_stats,
+            params.max_size_to_preallocate_for_joins};
+
         if (params.max_bytes_before_external_join > 0 && table_join->getTempDataOnDisk() && GraceHashJoin::isSupported(table_join))
         {
             if (table_join->allowParallelHashJoin())
             {
-                StatsCollectingParams stats_collecting_params{
-                    params.hash_table_key_hash,
-                    params.collect_hash_table_stats_during_joins,
-                    params.max_entries_for_hash_table_stats,
-                    params.max_size_to_preallocate_for_joins};
                 return std::make_shared<SpillingHashJoin>(
                     table_join,
                     left_table_expression_header,
@@ -1299,12 +1298,15 @@ static std::shared_ptr<IJoin> tryCreateJoin(
                 right_table_expression_header,
                 table_join->getTempDataOnDisk(),
                 params.grace_hash_join_initial_buckets,
-                params.grace_hash_join_max_buckets);
+                params.grace_hash_join_max_buckets,
+                stats_collecting_params);
         }
 
         if (MergeJoin::isSupported(table_join))
-            return std::make_shared<JoinSwitcher>(table_join, right_table_expression_header);
-        return std::make_shared<HashJoin>(table_join, right_table_expression_header);
+            return std::make_shared<JoinSwitcher>(table_join, right_table_expression_header, stats_collecting_params);
+        return std::make_shared<HashJoin>(
+            table_join, right_table_expression_header, /*any_take_last_row_=*/false, /*reserve_num_=*/0, /*instance_id_=*/"",
+            /*use_two_level_maps_=*/false, stats_collecting_params);
     }
 
     return nullptr;

--- a/tests/performance/hash_join_stats_update.xml
+++ b/tests/performance/hash_join_stats_update.xml
@@ -1,0 +1,19 @@
+<test>
+    <!--
+        The build size underestimation that leads to selecting hash join instead of concurrent hash join
+        should be corrected with runtime statistics.
+    -->
+    <create_query>CREATE TABLE build (k UInt64, s String) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE probe (k UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+
+    <fill_query>INSERT INTO build SELECT number, toString(number) FROM numbers_mt(5000000)</fill_query>
+    <fill_query>INSERT INTO probe SELECT number FROM numbers_mt(10000000)</fill_query>
+
+    <fill_query>ALTER TABLE build MATERIALIZE STATISTICS ALL SETTINGS mutations_sync=1</fill_query>
+    <fill_query>ALTER TABLE probe MATERIALIZE STATISTICS ALL SETTINGS mutations_sync=1</fill_query>
+
+    <query>SELECT l.k FROM probe AS l INNER JOIN build r ON l.k = r.k WHERE substring(r.s, 1, 1) IN ('1', '2', '3', '4', '5', '6', '7', '8', '9') FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS build</drop_query>
+    <drop_query>DROP TABLE IF EXISTS probe</drop_query>
+</test>

--- a/tests/queries/0_stateless/03835_join_transitive_predicates_edge_cases.sql
+++ b/tests/queries/0_stateless/03835_join_transitive_predicates_edge_cases.sql
@@ -6,6 +6,7 @@ SET enable_join_runtime_filters = 0;
 SET enable_parallel_replicas = 0;
 SET enable_join_transitive_predicates = 1;
 SET materialize_statistics_on_insert = 1;
+SET collect_hash_table_stats_during_joins = 0;
 
 DROP TABLE IF EXISTS e1;
 DROP TABLE IF EXISTS e2;

--- a/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.reference
+++ b/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.reference
@@ -1,0 +1,2 @@
+Algorithm: HashJoin
+Algorithm: ConcurrentHashJoin

--- a/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.sql
+++ b/tests/queries/0_stateless/04356_threshold_for_parallel_hash_2.sql
@@ -1,0 +1,37 @@
+-- The opposite direction of 03356_threshold_for_parallel_hash:
+-- switching from `HashJoin` to `ConcurrentHashJoin` based on runtime statistics.
+
+SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
+
+create table lhs(a UInt64) Engine=MergeTree order by ();
+create table rhs(a UInt64) Engine=MergeTree order by ();
+
+insert into lhs select * from numbers_mt(1e5);
+insert into rhs select * from numbers_mt(1e6);
+
+set enable_parallel_replicas = 0; -- join optimization (and table size estimation) disabled with parallel replicas
+set enable_analyzer = 1, use_query_condition_cache = 0;
+set query_plan_optimize_join_order_limit = 10; -- CI may inject 0; chooseJoinOrder skipped → estimation does not run
+
+set join_algorithm = 'direct,parallel_hash,hash'; -- default
+set parallel_hash_join_threshold = 100001;
+
+-- Pretend the right table is small so the first run is planned as `HashJoin`, even though it actually has 1e6 rows.
+set param__internal_join_table_stat_hints = '{ "rhs": { "cardinality": 50000 } }';
+
+-- First run: the estimate comes from the hint (below the threshold) - use `HashJoin`.
+select trimBoth(explain)
+from (
+  explain actions=1 select * from lhs t0 join rhs t1 on t0.a = t1.a settings query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 10
+)
+where explain ilike '%Algorithm%';
+
+-- Execute the query so the `HashJoin` records the real right-side size into the statistics cache.
+select * from lhs t0 join rhs t1 on t0.a = t1.a settings query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 10 format Null;
+
+-- Second run: the cached size (1e6) overrides the hint - use `ConcurrentHashJoin`.
+select trimBoth(explain)
+from (
+  explain actions=1 select * from lhs t0 join rhs t1 on t0.a = t1.a settings query_plan_join_swap_table = false, query_plan_optimize_join_order_limit = 10
+)
+where explain ilike '%Algorithm%';


### PR DESCRIPTION
Runtime statistics about the join build size are only collected in `ConcurrentHashJoin`, which means underestimations about the build size that lead to using HashJoin for a large build are never corrected.
This change adds runtime statistics collection in `HashJoin` too.

<img width="3250" height="882" alt="image" src="https://github.com/user-attachments/assets/74c657d1-96c0-46b6-b75b-434a4fc7eaa0" />
<img width="3250" height="1584" alt="image" src="https://github.com/user-attachments/assets/9397a71b-27d0-48e1-932c-a23479f94579" />
<img width="3250" height="570" alt="image" src="https://github.com/user-attachments/assets/df357509-b477-437c-99d7-e967af0c35d2" />


<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Enabling switching for `hash` join in the first query run to `parallel_hash` in subsequent runs based on runtime statistics collected in the first run.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.106`
<!-- ch-version-info:end -->