### PR TITLE
Add perf comparison Claude skill

### DIFF
--- a/.claude/skills/perf-comparison/SKILL.md
+++ b/.claude/skills/perf-comparison/SKILL.md
@@ -62,7 +62,8 @@ python3 scripts/perf_api.py pr-query-history \
   --arch arm
 
 # Parse local tests/performance/scripts/perf.py output.
-python3 scripts/parse_perf_py.py /tmp/perf-output.tsv
+mkdir -p tmp
+python3 scripts/parse_perf_py.py tmp/perf-output.tsv
 ```
 
 References:
@@ -218,28 +219,30 @@ tests/performance/scripts/perf.py --print-queries tests/performance/$TEST.xml
 Compare two already-running servers:
 
 ```bash
+mkdir -p tmp
 tests/performance/scripts/perf.py \
   --host 127.0.0.1 127.0.0.1 \
   --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
   --runs 7 \
-  tests/performance/$TEST.xml | tee /tmp/${TEST}.perf.tsv
+  tests/performance/$TEST.xml | tee tmp/${TEST}.perf.tsv
 ```
 
 Run one query index:
 
 ```bash
+mkdir -p tmp
 tests/performance/scripts/perf.py \
   --host 127.0.0.1 127.0.0.1 \
   --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
   --runs 7 \
   --queries-to-run "$QUERY_INDEX" \
-  tests/performance/$TEST.xml | tee /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+  tests/performance/$TEST.xml | tee tmp/${TEST}_${QUERY_INDEX}.perf.tsv
 ```
 
 Parse output:
 
 ```bash
-python3 scripts/parse_perf_py.py /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+python3 scripts/parse_perf_py.py tmp/${TEST}_${QUERY_INDEX}.perf.tsv
 ```
 
 If servers are not running and the user wants help, use `references/local-perf.md` and optionally `scripts/local_servers.sh`. Prefer release/static builds. Do not compare debug/sanitizer builds unless the user explicitly wants that.

--- a/.claude/skills/perf-comparison/SKILL.md
+++ b/.claude/skills/perf-comparison/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: perf-comparison
+description: Evaluate ClickHouse performance test results from existing CI/dashboard data or local perf.py runs. Use to check PR performance changes, run local performance tests, compare with history, assess flakiness, inspect coverage/PR relevance, and summarize whether a result is actionable.
+argument-hint: "<PR number | performance.ci URL | runId | tests/performance/*.xml> [test/query/metric/arch]"
+disable-model-invocation: false
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+---
+
+# ClickHouse Performance Comparison
+
+Use this skill whenever the goal is to answer:
+
+> Is this ClickHouse performance result real, flaky/noisy, already known from history, or worth deeper investigation?
+
+The evidence may come from existing performance CI/dashboard data, a local `perf.py` run, or both. Do not treat this as two separate modes; use whichever evidence is available and add missing evidence only when it changes the decision.
+
+## Core principles
+
+1. **Keep the current accepted evidence separate from stale exploratory data.** If a newer rerun/confidence/history check supersedes an older table, say so and show the newer numbers.
+2. **Do not call a regression real from one changed row.** Check repeated PR runs, confidence, master/history trend, and test stability.
+3. **Do not dismiss a regression as flaky without evidence.** Show the history/trend or repeated-run data that justifies the verdict.
+4. **Do not emit opaque dashboard internals as evidence.** Raw strings like `M1:downgrade, M2:neutral` are not report-ready; translate confidence into tier/reason and named evidence checks.
+5. **Metric, arch, query index, and run identity must match.** Do not mix ARM with AMD or `client_time` with CPU/real/memory metrics.
+6. **Coverage/PR-diff overlap is supporting evidence, not proof.** It raises or lowers plausibility but does not replace measurements.
+7. **Local runs are validation evidence, not a substitute for CI history.** Local setup differences must be reported.
+8. **Never file issues, comment on PRs, or edit source unless explicitly asked.**
+
+## Useful helper scripts in this skill
+
+```bash
+# List performance.ci runs for a PR.
+python3 scripts/perf_api.py runs --pr 104350
+
+# Inventory a PR first. This prints a small summary layer, then separates changed slowdowns,
+# changed speedups, and high-noise rows.
+python3 scripts/perf_api.py pr-inventory --pr 104350 --limit 20 --with-confidence
+
+# 30-day master status classification via play.clickhouse.com default.checks.
+python3 scripts/perf_api.py master-checks --pr 104350 --limit 50
+
+# Inspect raw CI metric TSVs only when dashboard/API cannot provide required artifact-level data.
+python3 scripts/perf_api.py tsv-inventory --tsv pr_104350_amd.tsv pr_104350_arm.tsv --limit 20
+
+# Summarize a run's changed metrics.
+python3 scripts/perf_api.py changes --run-id "$RUN_ID" --with-confidence
+
+# Inspect one query with trend/history/coverage/flamegraph diff.
+python3 scripts/perf_api.py query \
+  --run-id "$RUN_ID" \
+  --test aggregation_in_order_2 \
+  --query-index 4 \
+  --metric client_time \
+  --arch arm \
+  --with-confidence --with-trend --with-history --with-coverage --with-flamegraph-diff
+
+# Compare one test/query/metric across all dashboard runs for a PR.
+python3 scripts/perf_api.py pr-query-history \
+  --pr 104350 \
+  --test aggregation_in_order_2 \
+  --query-index 4 \
+  --metric client_time \
+  --arch arm
+
+# Parse local tests/performance/scripts/perf.py output.
+python3 scripts/parse_perf_py.py /tmp/perf-output.tsv
+```
+
+References:
+
+- `references/ci-api.md` — performance.ci API and dashboard workflow.
+- `references/local-perf.md` — local `perf.py`, optional server startup, datasets, and profiling.
+- `references/verdict-rules.md` — classification rules and reporting checklist.
+
+## Data source priority
+
+Use the richest reliable source for each question:
+
+1. **performance.ci API/dashboard first** for current PR runs, full changed-row inventory, confidence, query details, trend/history charts, coverage overlap, and flamegraph-diff links.
+2. **ClickHouse Play HTTP (`default.checks`)** for 30-day master status counts: how often the same test/query appeared `slower`, `faster`, or `unstable` on master. Use `master-checks` for this.
+3. **CI artifacts/logs** when dashboard/API cannot provide root-cause data: server logs, job logs, raw trace logs, raw profile-event TSVs, exact binary revision/build ID, or complete artifact-manifest details.
+4. **Local `perf.py`** only when explicit old/new binaries are provided and local validation is useful; report it as non-CI-equivalent.
+
+## Standard performance.ci API
+
+```bash
+BASE="https://performance.ci.clickhouse.com/api/v1"
+```
+
+Find PR runs:
+
+```bash
+PR=104350
+curl -fsS "$BASE/runs?q=$PR" | jq .
+```
+
+Get run overview:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Get query detail:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Get trend/history:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/trend?metric=$METRIC&queryIndex=$QUERY_INDEX&arch=$ARCH" | jq .
+curl -fsS "$BASE/history/$TEST/$QUERY_INDEX?metric=$METRIC&arch=$ARCH" | jq .
+```
+
+Get PR coverage overlap for a test:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/coverage?fileSet=intersecting" | jq .
+```
+
+Open the UI flamegraph page first:
+
+```text
+https://performance.ci.clickhouse.com/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX
+```
+
+Use the raw flamegraph-diff API only for machine-readable sample deltas:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX/flamegraph-diff?metric=$METRIC&arch=$ARCH&traceType=CPU" | jq .
+```
+
+API caveats observed in live testing:
+
+- `unstableQueries[]` can contain high-noise/below-threshold rows even when the summary card says `Unstable queries: 0`; do not treat them as actionable changed rows unless they are over threshold.
+- `trend.selectedRunPoint.value` may be a zero marker; use query-detail old/new values for the measurement.
+- `coverage?fileSet=intersecting` may omit `totals.intersectingFiles` when there are zero intersecting files; use `len(files)` as the fallback.
+- Flamegraph endpoints can return 404 or no frames; missing flamegraph data is absence of evidence, not proof of noise.
+
+## Evidence ladder
+
+For each suspicious change, collect as much of this ladder as needed:
+
+1. **Complete changed-row inventory, including improvements**: before picking representative examples, list changed slowdowns, changed improvements/speedups, and high-noise/unstable-threshold rows separately for the relevant PR/run/arch. Start with `python3 scripts/perf_api.py pr-inventory --pr <PR> --with-confidence`. The inventory must begin with a small generated summary layer: **Top likely signal**, **Top likely noise**, and **Top improvements**. Changed-row tables must separate signal evidence from noise/uncertain evidence. Do not mix high-noise rows into changed slowdown/speedup tables. Use CI artifacts only when dashboard/API cannot provide required raw data.
+2. **Changed row details**: test, query, metric, arch, old/new, diff, threshold.
+3. **Repeated PR runs**: did the same query/metric/arch change repeatedly over several dashboard runs?
+4. **Confidence data**: report confidence tier/reason and named checks (`Raw Sample Evidence`, `History Adaptive Threshold`, `Recent Master Variation`, etc.). Never leave raw `M1/M2/...` codes unexplained.
+5. **Master/history trend**: report period, all-history p05/p25/p50/p75/p95, recent-window p05/p50/p95, and selected old/new values versus p50/p95. Do not use only min/max/median/last.
+6. **Master status counts when needed**: run `python3 scripts/perf_api.py master-checks --pr <PR>` to query `play.clickhouse.com default.checks` over master-only runs and classify rows as new/rare/flaky/unstable/fixes-known-regression. The output should be grouped by signal vs noise/uncertain evidence and link to the test page with the query selected.
+7. **Related metrics**: do CPU/real/client/memory move consistently or contradict each other?
+8. **Coverage/PR relation**: did the PR touch code covered by this test? does the query text match the changed subsystem?
+9. **Flamegraph/profile**: if available, does a stack/function explain the changed metric?
+10. **Artifacts/logs for root cause**: if dashboard/API cannot answer why, download CI artifacts for server logs, trace logs, raw profile events, SVG flamegraphs, and exact binary/build metadata.
+11. **Local reproduction**: if needed, run `perf.py` against old/new binaries with isolated servers.
+
+Stop when the verdict is clear; do not gather expensive evidence just to decorate a report. Exceptions: always inventory improvements as well as regressions; for large PRs or many changed rows, do not stop after a few representative examples; produce a portfolio/ranking summary first. Avoid repetitive all-run top tables unless the caller asks for verbose output or rerun history is central to the conclusion.
+
+## Dashboard run stability over multiple days
+
+For a PR, inspect all runs returned by:
+
+```bash
+curl -fsS "$BASE/runs?q=$PR" | jq '.items[] | {runId: .identity.runId, time: .identity.runTime, changed: .changedQueries, slowdowns: .slowdownQueries, speedups: .speedupQueries}'
+```
+
+For a specific query:
+
+```bash
+python3 scripts/perf_api.py pr-query-history --pr "$PR" --test "$TEST" --query-index "$QUERY_INDEX" --metric "$METRIC" --arch "$ARCH"
+```
+
+The output must include performance.ci UI links and an oldest→newest diff chart. A missing old run endpoint is `not available`; do not turn an HTTP status into an investigation conclusion.
+
+Interpretation:
+
+- Appears in every/most PR runs with similar direction: stronger signal.
+- Appears once, disappears later: likely noise or needs rerun.
+- Flips direction: unstable or measurement-sensitive.
+- Appears only on one architecture: still can be real, but must be reported as arch-specific.
+
+## Coverage and PR-diff relevance
+
+Fetch coverage overlap:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/coverage?fileSet=intersecting" | jq .
+```
+
+Use:
+
+- `totals.intersectingFiles > 0`: PR touched files executed by the perf test.
+- `files[].path`, `files[].patch`, `coverageRanges`: identify touched covered lines.
+
+If coverage is unavailable, fall back to:
+
+```bash
+gh pr diff "$PR" --name-only
+gh pr diff "$PR"
+```
+
+Relate query to changes:
+
+- aggregation query + aggregate/Aggregator pipeline changes: plausible.
+- join query + analyzer/join/filter changes: plausible.
+- formatting/parsing query + IO/read/write helper changes: plausible.
+- no overlap and unrelated files: lower confidence, but not automatic dismissal.
+
+## Local performance tests
+
+If the user wants to run a test locally or validate a patch, use ClickHouse `perf.py`.
+
+Print queries first:
+
+```bash
+tests/performance/scripts/perf.py --print-queries tests/performance/$TEST.xml
+```
+
+Compare two already-running servers:
+
+```bash
+tests/performance/scripts/perf.py \
+  --host 127.0.0.1 127.0.0.1 \
+  --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
+  --runs 7 \
+  tests/performance/$TEST.xml | tee /tmp/${TEST}.perf.tsv
+```
+
+Run one query index:
+
+```bash
+tests/performance/scripts/perf.py \
+  --host 127.0.0.1 127.0.0.1 \
+  --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
+  --runs 7 \
+  --queries-to-run "$QUERY_INDEX" \
+  tests/performance/$TEST.xml | tee /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+```
+
+Parse output:
+
+```bash
+python3 scripts/parse_perf_py.py /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+```
+
+If servers are not running and the user wants help, use `references/local-perf.md` and optionally `scripts/local_servers.sh`. Prefer release/static builds. Do not compare debug/sanitizer builds unless the user explicitly wants that.
+
+Local binary contract:
+
+- `scripts/local_servers.sh` requires explicit local paths: `OLD_CLICKHOUSE NEW_CLICKHOUSE [WORKDIR]`.
+- If default ports are busy, set `OLD_TCP_PORT`, `NEW_TCP_PORT`, `OLD_HTTP_PORT`, `NEW_HTTP_PORT`.
+- If paths are missing, ask the user/caller for the old/base and new/candidate binary paths. A skill invocation is just an instruction context; there is no magic binary provider, so ask the human or calling agent rather than guessing.
+- Do not silently download or build binaries.
+- If the user does not have binaries, suggest exact Praktika CI artifacts and ask for approval before downloading.
+
+Praktika CI artifact lookup for performance-style release binaries:
+
+```bash
+# First get PR/run identity. Use identity.newSha for candidate and identity.oldSha for base/reference.
+python3 scripts/perf_api.py runs --pr "$PR"
+
+# Candidate PR binary from Praktika artifact report.
+PR=<pr-number>
+SHA=<candidate-sha>
+ARCH=arm        # arm or amd, matching the run/result being reproduced
+JOB="build_${ARCH}_release"
+REPORT="https://clickhouse-builds.s3.amazonaws.com/PRs/${PR}/${SHA}/${JOB}/artifact_report_${JOB}.json"
+curl -fsS "$REPORT" | jq -r '.build_urls[] | select(endswith("/clickhouse"))'
+
+# Exact master/reference binary.
+SHA=<reference-sha>
+URL="https://clickhouse-builds.s3.amazonaws.com/REFs/master/${SHA}/${JOB}/clickhouse"
+curl -sfI "$URL"
+```
+
+If the user approves a URL, download it to a named path and `chmod +x`; then pass those paths to `local_servers.sh`. Record binary path, SHA, architecture, build job, source URL, and `version()/buildId()` output in the report. Avoid non-SHA-pinned `master/amd64/clickhouse` or `master/aarch64/clickhouse` fallbacks for validation unless the user explicitly accepts them.
+
+## Local result interpretation
+
+`perf.py` prints important lines like:
+
+```text
+report-threshold <relative_threshold>
+diff <query_index> <old_median> <new_median> <relative_diff> <pvalue>
+```
+
+Treat a local result as meaningful when:
+
+- `abs(relative_diff)` exceeds the report threshold.
+- `pvalue <= 0.05`.
+- enough runs were collected.
+- repeat runs agree if the result is borderline.
+- machine load/config/dataset differences are not obvious confounders.
+
+## Verdict labels
+
+Use one of:
+
+- `real regression`
+- `likely noise`
+- `needs rerun`
+- `unstable test`
+- `real improvement`
+- `local-only evidence`
+- `not enough evidence`
+
+## Required report format
+
+```md
+## Performance verdict
+
+Short verdict: <label>
+Confidence: <high | medium | low>
+
+## Evidence checked
+
+- Run/API URLs:
+- Test/query/metric/arch:
+- Old/new/diff/threshold:
+- Repeated PR runs:
+- Confidence:
+- History/trend:
+- Coverage/PR relation:
+- Flamegraph/profile: exact UI query-page link plus top sample deltas; raw API link only as backup, or explicit `not available` / `no frames returned`.
+- Local perf.py, if any:
+
+## Changed metrics
+
+<table>
+
+## Why this verdict
+
+Short explanation that distinguishes current accepted evidence from stale/exploratory measurements.
+
+## Recommended next step
+
+- no action
+- rerun performance CI
+- run local perf.py
+- inspect flamegraph hotspot
+- inspect PR code around covered files
+- bisect / targeted local validation
+```
+
+## Common mistakes to avoid
+
+- Showing stale candidate measurements under a newer rerun/history verdict.
+- Calling a PR regression real without checking repeated PR runs and history.
+- Dismissing as flaky without dashboard/history evidence.
+- Mixing metrics or architectures.
+- Treating coverage overlap as proof of causality.
+- Treating local-only results as CI-confirmed.
+- Hiding changed rows that CI marked as changed.

--- a/.claude/skills/perf-comparison/references/ci-api.md
+++ b/.claude/skills/perf-comparison/references/ci-api.md
@@ -1,0 +1,289 @@
+# performance.ci API reference for the skill
+
+Base URL:
+
+```bash
+BASE="https://performance.ci.clickhouse.com/api/v1"
+```
+
+## Run discovery
+
+Find runs for a PR:
+
+```bash
+PR=104350
+curl -fsS "$BASE/runs?q=$PR" | jq .
+```
+
+Important fields in `items[]`:
+
+- `identity.runId`
+- `identity.prNumber`
+- `identity.oldSha`
+- `identity.newSha`
+- `identity.runTime`
+- `arches`
+- `changedQueries`
+- `slowdownQueries`
+- `speedupQueries`
+- `unstableQueries`
+
+Always filter by `identity.prNumber == PR`; search can return more than intended.
+
+
+Caveats observed during testing:
+
+- `unstableQueries[]` can contain high-noise/high-threshold rows even when the summary card says `Unstable queries: 0`. Treat them as flakiness/noise context, not as changed rows unless they are also over threshold.
+- `totals.intersectingFiles` may be omitted when `fileSet=intersecting` has no files; use `len(files)` as the zero-intersection fallback.
+- `selectedRunPoint.value` in trend responses can be `0` as a marker; use query detail old/new values for the actual PR measurement.
+- Flamegraph endpoints may return 404 even when a query is changed; absence of flamegraph data is not evidence either way.
+
+## Master status counts through ClickHouse Play
+
+Use this when you need 30-day master status counts for every changed row: how often the same test/query appeared `slower`, `faster`, or `unstable` on master. The dashboard history API is richer for charts/trends; `default.checks` gives direct status counts.
+
+Helper:
+
+```bash
+python3 scripts/perf_api.py master-checks --pr "$PR" --limit 50
+```
+
+Equivalent HTTP query pattern:
+
+```bash
+curl -fsS 'https://play.clickhouse.com/?user=explorer' --data-binary @- <<'SQL'
+SELECT
+    replaceRegexpOne(test_name, '::(new|old)$', '') AS test,
+    countIf(test_status = 'slower') AS slower_count,
+    countIf(test_status = 'faster') AS faster_count,
+    countIf(test_status = 'unstable') AS unstable_count,
+    count() AS total_runs
+FROM default.checks
+WHERE pull_request_number = 0
+  AND check_name LIKE '%Performance%arm%'
+  AND check_start_time >= now() - INTERVAL 30 DAY
+  AND test_name IN ('fixed_hash_table_parallel_merge #1::new')
+GROUP BY test
+FORMAT JSONEachRow
+SQL
+```
+
+Use these counts for classifications: `new in PR`, `rarely on master`, `flaky/slower on master`, `unstable on master`, `new improvement`, or `fixes known master regression`.
+
+## TSV/raw artifact inventory
+
+When available, raw `all-query-metrics.tsv` / `fetch_perf_report.py --tsv` output gives per-shard rows with:
+
+- `old`/`new` (`left`/`right` in raw files),
+- `diff`,
+- `times_change`,
+- `stat_threshold`,
+- `test`,
+- `query_index`,
+- query display text,
+- and, in `fetch_perf_report.py --tsv`, `arch`, `shard`, `is_changed`, `is_unstable`, `direction`.
+
+Use this helper only when dashboard/API cannot provide required artifact-level data:
+
+```bash
+python3 scripts/perf_api.py tsv-inventory --tsv pr_${PR}_amd.tsv pr_${PR}_arm.tsv --limit 20
+```
+
+TSV rows are artifact fallback evidence; do not use them to override dashboard classification.
+
+## Artifact/log fallback
+
+Use artifacts when dashboard/API cannot provide root-cause data:
+
+- `logs.tar.zst` / `job.log.zst`: job context, server configs, warnings/errors, machine contention.
+- `left/server.log` and `right/server.log`: exact old/new binary revision, build ID, startup settings, query execution timing, background activity.
+- `left-trace-log.tsv` / `right-trace-log.tsv`: raw `system.trace_log` samples by query id for CPU/Real/Memory stacks.
+- `analyze/tmp/{test}_{queryN}.tsv`: per-run raw profile events, useful when dashboard only shows summary metrics.
+- prebuilt `.svg` flamegraphs: useful if the dashboard flamegraph-diff endpoint is missing or incomplete.
+
+Prefer dashboard flamegraph/query APIs first. Fall back to artifacts when you need raw logs, raw traces, exact build metadata, or a query/run that dashboard did not profile.
+
+## Run overview
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Use:
+
+- `slowdowns[]`
+- `speedups[]`
+- `unstableQueries[]`
+- `testSummaries[]`
+- `assets[]`
+- `reports[]`
+
+`ComparisonRow` fields:
+
+- `test`
+- `queryIndex`
+- `queryDisplayName`
+- `metric`
+- `arch`
+- `oldValue`
+- `newValue`
+- `diffPercent`
+- `statThreshold`
+- `direction`
+- `severity`
+- `confidence`
+
+Note: current API represents `diffPercent` and `statThreshold` as fractions in observed examples (`0.232` means about `+23.2%`). Display both safely if uncertain.
+
+## Confidence
+
+Run-level confidence:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/confidence?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Test-level confidence:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/confidence?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Use confidence as human-readable evidence, not raw module codes:
+
+- Always report `confidence.tier` and `confidence.reason` when present.
+- For module details, use `modules[].title`, `modules[].status`, `modules[].interpretation`, and useful `modules[].rows[]` facts.
+- Do **not** write unexplained strings like `M1:downgrade, M2:neutral`; that is dashboard-internal shorthand, not a reviewer-facing conclusion.
+- Be careful with speedups: current tier names/reasons can be slowdown-oriented. Do not print `confirmed_regression` for a speedup row; call it a stable speedup/change only if the surrounding evidence supports that.
+- Example useful wording: `tier=noise; reason=change is smaller than recent-history adaptive threshold; History Adaptive Threshold downgraded because observed 47.2% < adaptive 94.8%.`
+
+## Test and query detail
+
+Test detail:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Query detail:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX?metrics=client_time,real_time,cpu_time,memory" | jq .
+```
+
+Use query detail to collect:
+
+- `queryText`
+- all metric rows for the query
+- `flamegraphAssets`
+- report links
+
+## Trend and history
+
+Trend near selected run:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/trend?metric=$METRIC&queryIndex=$QUERY_INDEX&arch=$ARCH" | jq .
+```
+
+Longer history:
+
+```bash
+curl -fsS "$BASE/history/$TEST/$QUERY_INDEX?metric=$METRIC&arch=$ARCH" | jq .
+```
+
+Use:
+
+- `points[]` / `centerTrend[]`: normal spread and selected run context.
+- `changePoints[]`: known historical jumps.
+- `periodComparisons[]`: large historical changes.
+
+Required summary shape:
+
+- state the time period covered by the points;
+- show percentiles, not only min/max: p05/p25/p50/p75/p95;
+- show a recent-window spread, e.g. last 30 points with its own time span;
+- compare selected old/new values to p50 and p95;
+- de-duplicate change points and list date/direction/sha for the latest relevant entries.
+
+Interpretation:
+
+- selected run far outside recent p95 + repeated PR runs: stronger evidence.
+- selected run inside recent spread: likely noise/unstable.
+- known recent master change point: PR may be inheriting master movement, not causing it.
+
+## Coverage / PR overlap
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/coverage?fileSet=intersecting" | jq .
+```
+
+Other useful `fileSet` values:
+
+```bash
+fileSet=pr
+fileSet=covered
+fileSet=all
+```
+
+Use:
+
+- `coverageAvailable`
+- `message`
+- `totals.touchedFiles`
+- `totals.coveredFiles`
+- `totals.intersectingFiles`
+- `files[].path`
+- `files[].status`
+- `files[].patch`
+- `files[].coverageRanges`
+
+Do not require coverage to prove causality. Use it to decide if a PR/test relation is plausible.
+
+## Flamegraphs
+
+Reviewer-facing links should point to the UI query page, which contains the Flamegraphs card:
+
+```text
+https://performance.ci.clickhouse.com/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX
+```
+
+Use raw APIs only when you need machine-readable stacks/deltas.
+
+Collapsed stacks for one side:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX/flamegraph?metric=$METRIC&arch=$ARCH&side=candidate&traceType=CPU" | jq -r .collapsed
+```
+
+Differential flamegraph data:
+
+```bash
+curl -fsS "$BASE/runs/$RUN_ID/tests/$TEST/queries/$QUERY_INDEX/flamegraph-diff?metric=$METRIC&arch=$ARCH&traceType=CPU" | jq .
+```
+
+Trace types:
+
+- `CPU`: compute time.
+- `REAL_TIME`: wall-clock time; useful for waits, locks, I/O, scheduler noise.
+- `MEMORY`: memory-related samples if available.
+
+Flamegraph diff fields:
+
+- `stack`
+- `baselineSamples`
+- `candidateSamples`
+
+Suggested summary:
+
+| Leaf/subsystem | Baseline samples | Candidate samples | Delta | Interpretation |
+|---|---:|---:|---:|---|
+
+Do not claim root cause solely because a frame has samples. It must match the metric/query and PR change plausibility.
+
+Reviewer-facing flamegraph evidence must include:
+
+- exact UI query-page link first;
+- raw API link only as backup if useful;
+- top sample deltas in a table;
+- a short interpretation tied to the query, or `no frames returned` / `not available` if absent.

--- a/.claude/skills/perf-comparison/references/ci-api.md
+++ b/.claude/skills/perf-comparison/references/ci-api.md
@@ -83,7 +83,7 @@ When available, raw `all-query-metrics.tsv` / `fetch_perf_report.py --tsv` outpu
 - query display text,
 - and, in `fetch_perf_report.py --tsv`, `arch`, `shard`, `is_changed`, `is_unstable`, `direction`.
 
-Use this helper only when dashboard/API cannot provide required artifact-level data:
+Use this helper only when dashboard/API cannot provide required artifact-level data. It supports both named TSV output from `fetch_perf_report.py --tsv` and headerless raw `all-query-metrics.tsv` rows with the current CI column order.
 
 ```bash
 python3 scripts/perf_api.py tsv-inventory --tsv pr_${PR}_amd.tsv pr_${PR}_arm.tsv --limit 20

--- a/.claude/skills/perf-comparison/references/local-perf.md
+++ b/.claude/skills/perf-comparison/references/local-perf.md
@@ -37,7 +37,8 @@ Local comparison requires two executable `clickhouse` binary paths:
 The helper does **not** download or build ClickHouse:
 
 ```bash
-scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+mkdir -p tmp
+scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse tmp/ch-perf-local
 ```
 
 If either path is missing, ask the user/caller for it before starting servers. Do not silently guess a binary, build from source, or download artifacts without confirmation.
@@ -90,9 +91,9 @@ curl -sfI "$URL"
 If the URL exists and the user approves:
 
 ```bash
-mkdir -p /tmp/ch-binaries
-curl -fL "$URL" -o "/tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
-chmod +x "/tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
+mkdir -p tmp/ch-binaries
+curl -fL "$URL" -o "tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
+chmod +x "tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
 ```
 
 For PR artifacts, prefer the URL returned by `artifact_report_${JOB}.json`; for master/reference artifacts, verify the exact `REFs/<branch>/<sha>/<job>/clickhouse` URL with `curl -sfI`. Avoid non-exact `master/amd64/clickhouse` or `master/aarch64/clickhouse` fallbacks for validation unless the user explicitly accepts that they are not SHA-pinned.
@@ -104,7 +105,8 @@ If the user already has two servers, use them.
 If not, this skill includes an optional helper:
 
 ```bash
-scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+mkdir -p tmp
+scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse tmp/ch-perf-local
 ```
 
 It starts by default:
@@ -115,8 +117,9 @@ It starts by default:
 Override ports if defaults are busy:
 
 ```bash
+mkdir -p tmp
 OLD_TCP_PORT=9100 NEW_TCP_PORT=9101 OLD_HTTP_PORT=8223 NEW_HTTP_PORT=8224 \
-  scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+  scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse tmp/ch-perf-local
 ```
 
 Verify:
@@ -129,7 +132,7 @@ clickhouse-client --port ${NEW_TCP_PORT:-9001} -q "SELECT version(), buildId()"
 Stop using the printed PID files or:
 
 ```bash
-kill "$(cat /tmp/ch-perf-local/old/clickhouse.pid)" "$(cat /tmp/ch-perf-local/new/clickhouse.pid)"
+kill "$(cat tmp/ch-perf-local/old/clickhouse.pid)" "$(cat tmp/ch-perf-local/new/clickhouse.pid)"
 ```
 
 The helper is intentionally minimal. If a test requires special config, use an existing project config instead.
@@ -172,22 +175,24 @@ tests/performance/scripts/perf.py --print-settings tests/performance/$TEST.xml
 ## Run one test
 
 ```bash
+mkdir -p tmp
 tests/performance/scripts/perf.py \
   --host 127.0.0.1 127.0.0.1 \
   --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
   --runs 7 \
-  tests/performance/$TEST.xml | tee /tmp/${TEST}.perf.tsv
+  tests/performance/$TEST.xml | tee tmp/${TEST}.perf.tsv
 ```
 
 Run one query index:
 
 ```bash
+mkdir -p tmp
 tests/performance/scripts/perf.py \
   --host 127.0.0.1 127.0.0.1 \
   --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
   --runs 7 \
   --queries-to-run "$QUERY_INDEX" \
-  tests/performance/$TEST.xml | tee /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+  tests/performance/$TEST.xml | tee tmp/${TEST}_${QUERY_INDEX}.perf.tsv
 ```
 
 Allow long tests only when expected:
@@ -207,7 +212,7 @@ Profiling can perturb measurements; do not mix profiled timings with normal timi
 ## Parse perf.py output
 
 ```bash
-python3 scripts/parse_perf_py.py /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+python3 scripts/parse_perf_py.py tmp/${TEST}_${QUERY_INDEX}.perf.tsv
 ```
 
 Important output lines:

--- a/.claude/skills/perf-comparison/references/local-perf.md
+++ b/.claude/skills/perf-comparison/references/local-perf.md
@@ -1,0 +1,272 @@
+# Local ClickHouse performance testing reference
+
+Use local testing when:
+
+- the user wants to validate a patch before/after CI;
+- performance.ci is ambiguous and a controlled local pair can help;
+- the user is writing or modifying `tests/performance/*.xml`;
+- CI artifacts are unavailable.
+
+Local results are not automatically CI-equivalent. Always report machine, build type, settings, dataset, server ports, run count, and whether the result repeats.
+
+## Requirements
+
+Prefer:
+
+- release or release-like static builds;
+- same compiler/build options for old and new binaries;
+- isolated server data dirs;
+- same ClickHouse config except ports/paths;
+- same datasets and settings;
+- idle machine.
+
+Avoid unless explicitly requested:
+
+- debug builds;
+- sanitizer builds;
+- comparing a local build against a public CI binary without noting toolchain bias;
+- reusing dirty server data dirs.
+
+## Binary sourcing
+
+Local comparison requires two executable `clickhouse` binary paths:
+
+- `OLD_CLICKHOUSE`: old/base/reference binary.
+- `NEW_CLICKHOUSE`: new/candidate binary.
+
+The helper does **not** download or build ClickHouse:
+
+```bash
+scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+```
+
+If either path is missing, ask the user/caller for it before starting servers. Do not silently guess a binary, build from source, or download artifacts without confirmation.
+
+Record, at minimum:
+
+- old and new binary paths;
+- `clickhouse local -q "SELECT version(), buildId()"` or server `SELECT version(), buildId()` output for each side;
+- source SHA/build URL if known;
+- architecture and build type.
+
+### Suggesting Praktika CI downloads
+
+If the user does not already have binaries, suggest exact Praktika CI artifacts and ask whether to download them. Derive the inputs from the performance.ci run identity:
+
+```bash
+python3 scripts/perf_api.py runs --pr "$PR"
+# Use identity.newSha for the candidate, identity.oldSha for the reference/base,
+# and the run's arch (`amd` or `arm`) for ARCH.
+```
+
+Performance comparison jobs normally use release artifacts:
+
+- AMD: `build_amd_release`
+- ARM: `build_arm_release`
+
+For a PR candidate build:
+
+```bash
+PR=<pr-number>
+SHA=<candidate-sha>
+ARCH=arm        # arm or amd
+JOB="build_${ARCH}_release"
+REPORT="https://clickhouse-builds.s3.amazonaws.com/PRs/${PR}/${SHA}/${JOB}/artifact_report_${JOB}.json"
+
+curl -fsS "$REPORT" | jq -r '.build_urls[] | select(endswith("/clickhouse"))'
+```
+
+For an exact master/reference build:
+
+```bash
+SHA=<reference-sha>
+ARCH=arm        # arm or amd
+JOB="build_${ARCH}_release"
+URL="https://clickhouse-builds.s3.amazonaws.com/REFs/master/${SHA}/${JOB}/clickhouse"
+
+curl -sfI "$URL"
+```
+
+If the URL exists and the user approves:
+
+```bash
+mkdir -p /tmp/ch-binaries
+curl -fL "$URL" -o "/tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
+chmod +x "/tmp/ch-binaries/clickhouse-${SHA}-${ARCH}"
+```
+
+For PR artifacts, prefer the URL returned by `artifact_report_${JOB}.json`; for master/reference artifacts, verify the exact `REFs/<branch>/<sha>/<job>/clickhouse` URL with `curl -sfI`. Avoid non-exact `master/amd64/clickhouse` or `master/aarch64/clickhouse` fallbacks for validation unless the user explicitly accepts that they are not SHA-pinned.
+
+## Starting servers
+
+If the user already has two servers, use them.
+
+If not, this skill includes an optional helper:
+
+```bash
+scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+```
+
+It starts by default:
+
+- old/base: TCP `9000`, HTTP `8123`
+- new/candidate: TCP `9001`, HTTP `8124`
+
+Override ports if defaults are busy:
+
+```bash
+OLD_TCP_PORT=9100 NEW_TCP_PORT=9101 OLD_HTTP_PORT=8223 NEW_HTTP_PORT=8224 \
+  scripts/local_servers.sh /path/to/old/clickhouse /path/to/new/clickhouse /tmp/ch-perf-local
+```
+
+Verify:
+
+```bash
+clickhouse-client --port ${OLD_TCP_PORT:-9000} -q "SELECT version(), buildId()"
+clickhouse-client --port ${NEW_TCP_PORT:-9001} -q "SELECT version(), buildId()"
+```
+
+Stop using the printed PID files or:
+
+```bash
+kill "$(cat /tmp/ch-perf-local/old/clickhouse.pid)" "$(cat /tmp/ch-perf-local/new/clickhouse.pid)"
+```
+
+The helper is intentionally minimal. If a test requires special config, use an existing project config instead.
+
+## Dataset setup
+
+Some performance tests create/fill their own tables via XML `create_query` and `fill_query`.
+
+For shared datasets such as hits, visits, TPC-H, TPC-DS, use the repository scripts and verify row counts. Do not overwrite existing user data silently.
+
+Useful checks:
+
+```bash
+clickhouse-client --port ${OLD_TCP_PORT:-9000} -q "SHOW DATABASES"
+clickhouse-client --port ${NEW_TCP_PORT:-9001} -q "SHOW DATABASES"
+```
+
+If using existing tables:
+
+```bash
+--use-existing-tables
+```
+
+Only use this when both servers have identical datasets.
+
+## Inspect a performance test
+
+Print expanded query texts:
+
+```bash
+tests/performance/scripts/perf.py --print-queries tests/performance/$TEST.xml
+```
+
+Print ClickHouse settings from the XML:
+
+```bash
+tests/performance/scripts/perf.py --print-settings tests/performance/$TEST.xml
+```
+
+## Run one test
+
+```bash
+tests/performance/scripts/perf.py \
+  --host 127.0.0.1 127.0.0.1 \
+  --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
+  --runs 7 \
+  tests/performance/$TEST.xml | tee /tmp/${TEST}.perf.tsv
+```
+
+Run one query index:
+
+```bash
+tests/performance/scripts/perf.py \
+  --host 127.0.0.1 127.0.0.1 \
+  --port ${OLD_TCP_PORT:-9000} ${NEW_TCP_PORT:-9001} \
+  --runs 7 \
+  --queries-to-run "$QUERY_INDEX" \
+  tests/performance/$TEST.xml | tee /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+```
+
+Allow long tests only when expected:
+
+```bash
+--long
+```
+
+Use profiling only after a meaningful difference appears:
+
+```bash
+--profile-seconds 30
+```
+
+Profiling can perturb measurements; do not mix profiled timings with normal timings.
+
+## Parse perf.py output
+
+```bash
+python3 scripts/parse_perf_py.py /tmp/${TEST}_${QUERY_INDEX}.perf.tsv
+```
+
+Important output lines:
+
+```text
+report-threshold <relative_threshold>
+query <query_index> <run_id> <server_index> <elapsed>
+client-time <query_index> <client_seconds> <server_seconds>
+median <query_index> <median_server_0>
+diff <query_index> <old_median> <new_median> <relative_diff> <pvalue>
+```
+
+`relative_diff` is `(new_median - old_median) / old_median`:
+
+- positive: new/candidate slower;
+- negative: new/candidate faster.
+
+Meaningful local signal:
+
+- `abs(relative_diff) >= report-threshold`;
+- `pvalue <= 0.05`;
+- enough samples;
+- repeat agrees if borderline;
+- server self-comparison or rerun is stable if the result is surprising.
+
+## Optional trace analysis on local servers
+
+If a query ID is known, inspect `system.trace_log`:
+
+```sql
+SELECT
+    count() AS samples,
+    demangle(addressToSymbol(trace[1])) AS function
+FROM system.trace_log
+WHERE query_id = '<query_id>'
+  AND trace_type = 'CPU'
+GROUP BY function
+ORDER BY samples DESC
+LIMIT 30
+SETTINGS allow_introspection_functions = 1
+```
+
+Collapsed stacks:
+
+```sql
+SELECT concat(
+    arrayStringConcat(arrayReverse(arrayMap(x -> demangle(addressToSymbol(x)), trace)), ';'),
+    ' ',
+    toString(count())
+)
+FROM system.trace_log
+WHERE query_id = '<query_id>'
+  AND trace_type = 'CPU'
+GROUP BY trace
+FORMAT TSVRaw
+```
+
+Compare `CPU` and `Real`:
+
+- CPU up with runtime up: compute regression likely.
+- Real up with CPU flat: wait, lock, I/O, scheduler, or background work likely.
+- Memory up with time up: allocation pressure or changed algorithm likely.

--- a/.claude/skills/perf-comparison/references/local-perf.md
+++ b/.claude/skills/perf-comparison/references/local-perf.md
@@ -232,11 +232,13 @@ diff <query_index> <old_median> <new_median> <relative_diff> <pvalue>
 
 Meaningful local signal:
 
+- use at least `--runs 3`; prefer `--runs 7` or more for noisy queries;
 - `abs(relative_diff) >= report-threshold`;
 - `pvalue <= 0.05`;
-- enough samples;
-- repeat agrees if borderline;
+- repeat the local comparison before calling a regression real, especially if local data is the only evidence;
 - server self-comparison or rerun is stable if the result is surprising.
+
+Do not use a single local run as a standalone verdict. If the result has not repeated, report it as `needs rerun` or `local-only evidence`, not a real regression.
 
 ## Optional trace analysis on local servers
 

--- a/.claude/skills/perf-comparison/references/verdict-rules.md
+++ b/.claude/skills/perf-comparison/references/verdict-rules.md
@@ -1,0 +1,224 @@
+# Verdict rules
+
+The skill's job is to decide whether a performance result is actionable, not merely to restate a dashboard row.
+
+## Evidence checklist
+
+For every suspicious change, try to fill this table:
+
+| Evidence | Question | Strong signal | Weak/noisy signal |
+|---|---|---|---|
+| Changed metric | Is the raw diff above threshold? | large diff, consistent direction | barely above threshold |
+| Repeated PR runs | Does it recur over days/runs? | same query/metric/arch repeats | appears once/disappears/flips |
+| Confidence | Does confidence keep or downgrade? | tier/reason supports raw change; named checks explain why | tier says noise/suspect; adaptive threshold or raw samples downgrade |
+| Trend/history | Is selected run outside normal spread? | outside p95/recent band, stable history | inside recent p95, frequent spikes/change points |
+| Related metrics | Do CPU/real/client/memory agree? | consistent metrics | contradictory metrics |
+| Coverage/PR diff | Did PR touch executed code? | intersecting covered changed files | no overlap/unrelated files |
+| Flamegraph | Does stack delta explain metric? | hotspot aligns with PR/query | absent/unrelated/mixed |
+| Local run | Does controlled local pair reproduce? | repeatable, significant p-value | one-off or toolchain-biased |
+
+## Verdict labels
+
+### `real regression`
+
+Use when most of the following hold:
+
+- CI diff is above threshold.
+- Same query/metric/arch repeats across PR runs or confidence supports it.
+- History does not show the same random movement frequently.
+- Related metrics are consistent.
+- PR/coverage relation is plausible, or flamegraph points at changed behavior.
+
+Do not require every item; explain missing evidence.
+
+### `likely noise`
+
+Use when:
+
+- changed row appears once and disappears in later PR runs;
+- selected value sits inside normal trend/history spread;
+- confidence downgrades raw evidence;
+- related metrics contradict the headline;
+- no plausible PR/test relation and no profile support.
+
+Still show the data that proves this.
+
+### `needs rerun`
+
+Use when:
+
+- raw diff is large but confidence/history/repeated runs disagree;
+- only one run exists;
+- result is near threshold;
+- setup or infrastructure may have distorted measurements;
+- local and CI disagree.
+
+Recommended action: rerun performance CI or run a focused local pair.
+
+### `unstable test`
+
+Use when:
+
+- trend/history shows frequent comparable spikes;
+- same query flips slowdown/speedup across runs;
+- dashboard marks unstable metrics;
+- self-comparisons or repeated runs are noisy.
+
+Do not use this label just because a result is inconvenient.
+
+### `real improvement`
+
+Use when:
+
+- speedup is above threshold;
+- repeated runs/confidence/history support it;
+- it is not simply a reversal of random instability.
+
+### `local-only evidence`
+
+Use when local `perf.py` shows a meaningful result but CI/dashboard evidence is absent or not checked.
+
+### `not enough evidence`
+
+Use when required identity is missing:
+
+- unknown run;
+- unknown query index;
+- wrong metric/arch;
+- unavailable history and no repeated/local evidence.
+
+## Repeated PR run rules
+
+When checking a PR, list all performance.ci runs returned by:
+
+```bash
+curl -fsS "$BASE/runs?q=$PR" | jq .
+```
+
+Then compare the same test/query/metric/arch across runs.
+
+Interpretation:
+
+- `N/N` repeated with similar diff: strong.
+- `1/N` only: weak; likely rerun/noise unless diff is huge and profile explains it.
+- direction flips: unstable.
+- only old run has it and latest run is clean: likely resolved/noise.
+- latest run newly has it after earlier clean runs: investigate; could be new PR changes or master movement.
+
+## Master/history rules
+
+Use dashboard trend/history instead of guessing.
+
+Evidence for flakiness/noise:
+
+- selected point lies in the recent normal band, e.g. below/near p95;
+- comparable spikes appear without the PR;
+- confidence adaptive threshold is larger than the raw effect;
+- `changePoints` show a master change before/after the PR run;
+- `periodComparisons` show frequent similar movements.
+
+Evidence for new PR effect:
+
+- selected point is outside recent p95 by a meaningful factor;
+- no comparable historical spikes;
+- repeated PR runs show same movement;
+- PR touched covered relevant code.
+
+Required history wording:
+
+> History center trend: 976 points over 2026-04-24 → 2026-06-15; all p05/p50/p95 = ..., recent 30 points over 22.7h p05/p50/p95 = ...; candidate is 3.06x p95.
+
+Forbidden history wording:
+
+> min=..., median-ish=..., max=..., last=... .
+
+## Coverage/PR relation rules
+
+Coverage answers: did this test execute code touched by the PR?
+
+It does not answer: did the PR cause the slowdown?
+
+Use coverage to phrase plausibility:
+
+- `intersectingFiles > 0`: plausible relation; inspect changed hunks.
+- touched-only files but no coverage overlap: relation less direct.
+- covered-only files but PR did not touch them: maybe indirect behavior change.
+- coverage unavailable: say unavailable; use PR diff and query text manually.
+
+## Flamegraph rules
+
+Use flamegraph only for the matching:
+
+- run id;
+- test;
+- query index;
+- metric;
+- arch;
+- trace type.
+
+Interpretation:
+
+- CPU diff stack grows in candidate: compute hotspot candidate.
+- Real grows but CPU does not: wait/I/O/lock/scheduler likely.
+- Memory trace grows: allocation pressure likely.
+
+Do not claim root cause if stack delta does not connect to query/PR changes.
+
+Required flamegraph wording:
+
+- include the UI query-page link first (`/runs/<runId>/tests/<test>/queries/<queryIndex>`), because that opens the Flamegraphs card;
+- include raw API link only as supporting machine-readable evidence;
+- list top sample deltas;
+- say whether frames are absent.
+
+Forbidden flamegraph wording:
+
+> flamegraph diff exists and contains relevant samples.
+
+That is too vague to review.
+
+## Local perf.py rules
+
+Meaningful local result requires:
+
+- enough runs;
+- p-value <= 0.05;
+- diff above test threshold;
+- repeat stability when result is important;
+- identical datasets and comparable server settings.
+
+Local-only result should be reported as local-only until checked against CI/history.
+
+## Report wording
+
+Good:
+
+> The latest PR run shows `aggregation_in_order_2/4` `client_time/arm` at `+23.2%`, above a `21.7%` threshold. The same query appears in 3/4 PR runs, history does not show comparable spikes, and coverage intersects `src/AggregateFunctions/...`; verdict: real regression, medium confidence.
+
+Bad:
+
+> This is a regression because the table says slower.
+
+Bad:
+
+> Confidence: `M1:downgrade, M2:neutral, M3:downgrade`.
+
+Good:
+
+> Confidence tier is `noise`: History Adaptive Threshold downgraded because observed 47.2% is below the 94.8% threshold from recent master noise; Raw Sample Evidence also downgraded.
+
+Bad:
+
+> Cross-run behavior is unstable.
+
+Good:
+
+> Cross-run chart oldest→newest: -15.3%, +19.8%, +6.6%, -10.7%, +15.3%, -15.6%, -3.1%, +22.5%; direction flips repeatedly, so verdict: unstable.
+
+Good:
+
+> The latest rerun no longer reproduces the earlier `+24%` row: the same test/query/metric/arch is now `+1.2%`, below threshold. The older row is superseded, so verdict: likely noise or resolved.
+
+Bad:
+
+> Shows an old `+24%` measurement table after a newer clean rerun with no explanation.

--- a/.claude/skills/perf-comparison/scripts/local_servers.sh
+++ b/.claude/skills/perf-comparison/scripts/local_servers.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Start two minimal isolated ClickHouse servers for local performance comparison.
+# This is a convenience helper, not a CI-equivalent environment.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  cat >&2 <<'USAGE'
+Usage:
+  scripts/local_servers.sh OLD_CLICKHOUSE NEW_CLICKHOUSE [WORKDIR]
+
+Starts by default:
+  old/base server:      TCP 9000, HTTP 8123
+  new/candidate server: TCP 9001, HTTP 8124
+
+Override ports with OLD_TCP_PORT, NEW_TCP_PORT, OLD_HTTP_PORT, NEW_HTTP_PORT.
+
+Then run:
+  tests/performance/scripts/perf.py --host 127.0.0.1 127.0.0.1 --port "$OLD_TCP_PORT" "$NEW_TCP_PORT" --runs 7 tests/performance/<test>.xml
+
+Stop:
+  kill "$(cat WORKDIR/old/clickhouse.pid)" "$(cat WORKDIR/new/clickhouse.pid)"
+USAGE
+  exit 2
+fi
+
+OLD_BIN="$1"
+NEW_BIN="$2"
+ROOT="${3:-$PWD/ch-perf-local}"
+OLD_TCP_PORT="${OLD_TCP_PORT:-9000}"
+NEW_TCP_PORT="${NEW_TCP_PORT:-9001}"
+OLD_HTTP_PORT="${OLD_HTTP_PORT:-8123}"
+NEW_HTTP_PORT="${NEW_HTTP_PORT:-8124}"
+
+if [[ ! -x "$OLD_BIN" ]]; then
+  echo "OLD_CLICKHOUSE is not executable: $OLD_BIN" >&2
+  exit 1
+fi
+if [[ ! -x "$NEW_BIN" ]]; then
+  echo "NEW_CLICKHOUSE is not executable: $NEW_BIN" >&2
+  exit 1
+fi
+
+write_config() {
+  local dir="$1"
+  local tcp_port="$2"
+  local http_port="$3"
+  mkdir -p "$dir" "$dir/data" "$dir/tmp" "$dir/user_files" "$dir/format_schemas" "$dir/log"
+  cat > "$dir/config.xml" <<XML
+<clickhouse>
+    <logger>
+        <level>warning</level>
+        <log>${dir}/log/server.log</log>
+        <errorlog>${dir}/log/server.err.log</errorlog>
+        <console>false</console>
+    </logger>
+    <listen_host>127.0.0.1</listen_host>
+    <tcp_port>${tcp_port}</tcp_port>
+    <http_port>${http_port}</http_port>
+    <interserver_http_port>0</interserver_http_port>
+    <path>${dir}/data/</path>
+    <tmp_path>${dir}/tmp/</tmp_path>
+    <user_files_path>${dir}/user_files/</user_files_path>
+    <format_schema_path>${dir}/format_schemas/</format_schema_path>
+    <users_config>${dir}/users.xml</users_config>
+    <mark_cache_size>536870912</mark_cache_size>
+    <uncompressed_cache_size>0</uncompressed_cache_size>
+    <timezone>UTC</timezone>
+</clickhouse>
+XML
+  cat > "$dir/users.xml" <<XML
+<clickhouse>
+    <profiles>
+        <default>
+            <max_memory_usage>0</max_memory_usage>
+            <load_balancing>random</load_balancing>
+        </default>
+    </profiles>
+    <users>
+        <default>
+            <password></password>
+            <networks><ip>::/0</ip></networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </default>
+    </users>
+    <quotas><default><interval><duration>3600</duration><queries>0</queries><errors>0</errors><result_rows>0</result_rows><read_rows>0</read_rows><execution_time>0</execution_time></interval></default></quotas>
+</clickhouse>
+XML
+}
+
+start_server() {
+  local bin="$1"
+  local dir="$2"
+  local port="$3"
+  echo "Starting $bin on TCP $port in $dir"
+  "$bin" server --config-file="$dir/config.xml" --daemon --pid-file="$dir/clickhouse.pid"
+  for _ in {1..60}; do
+    if "$bin" client --port "$port" --query "SELECT 1" >/dev/null 2>&1; then
+      "$bin" client --port "$port" --query "SELECT version(), buildId()"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Server on port $port did not become ready. Logs: $dir/log/server.log $dir/log/server.err.log" >&2
+  return 1
+}
+
+mkdir -p "$ROOT"
+write_config "$ROOT/old" "$OLD_TCP_PORT" "$OLD_HTTP_PORT"
+write_config "$ROOT/new" "$NEW_TCP_PORT" "$NEW_HTTP_PORT"
+start_server "$OLD_BIN" "$ROOT/old" "$OLD_TCP_PORT"
+start_server "$NEW_BIN" "$ROOT/new" "$NEW_TCP_PORT"
+
+cat <<EOF
+
+Servers are running.
+
+Old/base:
+  TCP: $OLD_TCP_PORT
+  PID: $ROOT/old/clickhouse.pid
+  Log: $ROOT/old/log/server.log
+
+New/candidate:
+  TCP: $NEW_TCP_PORT
+  PID: $ROOT/new/clickhouse.pid
+  Log: $ROOT/new/log/server.log
+
+Run a performance test:
+  tests/performance/scripts/perf.py --host 127.0.0.1 127.0.0.1 --port $OLD_TCP_PORT $NEW_TCP_PORT --runs 7 tests/performance/<test>.xml
+
+Stop:
+  kill "\$(cat '$ROOT/old/clickhouse.pid')" "\$(cat '$ROOT/new/clickhouse.pid')"
+EOF

--- a/.claude/skills/perf-comparison/scripts/local_servers.sh
+++ b/.claude/skills/perf-comparison/scripts/local_servers.sh
@@ -2,7 +2,7 @@
 # Start two minimal isolated ClickHouse servers for local performance comparison.
 # This is a convenience helper, not a CI-equivalent environment.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 if [[ $# -lt 2 ]]; then
   cat >&2 <<'USAGE'
@@ -16,7 +16,8 @@ Starts by default:
 Override ports with OLD_TCP_PORT, NEW_TCP_PORT, OLD_HTTP_PORT, NEW_HTTP_PORT.
 
 Then run:
-  tests/performance/scripts/perf.py --host 127.0.0.1 127.0.0.1 --port "$OLD_TCP_PORT" "$NEW_TCP_PORT" --runs 7 tests/performance/<test>.xml
+  mkdir -p tmp
+  tests/performance/scripts/perf.py --host 127.0.0.1 127.0.0.1 --port "$OLD_TCP_PORT" "$NEW_TCP_PORT" --runs 7 tests/performance/<test>.xml | tee tmp/<test>.perf.tsv
 
 Stop:
   kill "$(cat WORKDIR/old/clickhouse.pid)" "$(cat WORKDIR/new/clickhouse.pid)"
@@ -26,7 +27,7 @@ fi
 
 OLD_BIN="$1"
 NEW_BIN="$2"
-ROOT="${3:-$PWD/ch-perf-local}"
+ROOT="${3:-$PWD/tmp/ch-perf-local}"
 OLD_TCP_PORT="${OLD_TCP_PORT:-9000}"
 NEW_TCP_PORT="${NEW_TCP_PORT:-9001}"
 OLD_HTTP_PORT="${OLD_HTTP_PORT:-8123}"
@@ -90,12 +91,37 @@ XML
 XML
 }
 
+STARTED_DIRS=()
+
+cleanup_started() {
+  local status="${1:-1}"
+  trap - ERR INT TERM
+  if [[ ${#STARTED_DIRS[@]} -gt 0 ]]; then
+    echo "Cleaning up partially started ClickHouse servers..." >&2
+  fi
+  for dir in "${STARTED_DIRS[@]}"; do
+    if [[ -s "$dir/clickhouse.pid" ]]; then
+      local pid
+      pid="$(cat "$dir/clickhouse.pid" 2>/dev/null || true)"
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        kill "$pid" 2>/dev/null || true
+      fi
+    fi
+  done
+  exit "$status"
+}
+
+trap 'cleanup_started $?' ERR
+trap 'cleanup_started 130' INT
+trap 'cleanup_started 143' TERM
+
 start_server() {
   local bin="$1"
   local dir="$2"
   local port="$3"
   echo "Starting $bin on TCP $port in $dir"
   "$bin" server --config-file="$dir/config.xml" --daemon --pid-file="$dir/clickhouse.pid"
+  STARTED_DIRS+=("$dir")
   for _ in {1..60}; do
     if "$bin" client --port "$port" --query "SELECT 1" >/dev/null 2>&1; then
       "$bin" client --port "$port" --query "SELECT version(), buildId()"
@@ -112,6 +138,7 @@ write_config "$ROOT/old" "$OLD_TCP_PORT" "$OLD_HTTP_PORT"
 write_config "$ROOT/new" "$NEW_TCP_PORT" "$NEW_HTTP_PORT"
 start_server "$OLD_BIN" "$ROOT/old" "$OLD_TCP_PORT"
 start_server "$NEW_BIN" "$ROOT/new" "$NEW_TCP_PORT"
+trap - ERR INT TERM
 
 cat <<EOF
 

--- a/.claude/skills/perf-comparison/scripts/parse_perf_py.py
+++ b/.claude/skills/perf-comparison/scripts/parse_perf_py.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import statistics
 from collections import defaultdict
 from pathlib import Path
 from typing import Any

--- a/.claude/skills/perf-comparison/scripts/parse_perf_py.py
+++ b/.claude/skills/perf-comparison/scripts/parse_perf_py.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Parse ClickHouse tests/performance/scripts/perf.py TSV-ish output."""
+from __future__ import annotations
+
+import argparse
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def pct(x: float) -> str:
+    return f"{x * 100:+.2f}%"
+
+
+def sec(x: Any) -> str:
+    try:
+        return f"{float(x):.6g}s"
+    except Exception:
+        return "—"
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    xs = sorted(values)
+    if len(xs) == 1:
+        return xs[0]
+    pos = (len(xs) - 1) * p
+    lo = int(pos)
+    hi = min(lo + 1, len(xs) - 1)
+    frac = pos - lo
+    return xs[lo] * (1 - frac) + xs[hi] * frac
+
+
+def verdict(diff: float, pvalue: float, threshold: float) -> str:
+    if abs(diff) < threshold:
+        return "within threshold"
+    if pvalue > 0.05:
+        return "not statistically significant"
+    return "candidate slower" if diff > 0 else "candidate faster"
+
+
+def parse(path: Path) -> dict[str, Any]:
+    threshold = 0.05
+    display: dict[int, str] = {}
+    query_runs: dict[int, dict[int, list[float]]] = defaultdict(lambda: defaultdict(list))
+    diffs = []
+    medians = {}
+    servers = []
+    stages = []
+    skipped = []
+    partial = []
+    profile_total = None
+
+    for raw in path.read_text(errors="replace").splitlines():
+        if not raw.strip():
+            continue
+        parts = raw.rstrip("\n").split("\t")
+        tag = parts[0]
+        try:
+            if tag == "report-threshold" and len(parts) >= 2:
+                threshold = float(parts[1])
+            elif tag == "display-name" and len(parts) >= 3:
+                display[int(parts[1])] = parts[2].replace("\\n", "\n").replace("\\t", "\t")
+            elif tag == "server" and len(parts) >= 6:
+                servers.append(parts[1:])
+            elif tag == "stage":
+                stages.append(parts[1:])
+            elif tag == "skipped":
+                skipped.append("\t".join(parts[1:]))
+            elif tag == "partial" and len(parts) >= 3:
+                partial.append((int(parts[1]), parts[2]))
+            elif tag == "query" and len(parts) >= 5:
+                qidx = int(parts[1])
+                conn = int(parts[3])
+                elapsed = float(parts[4])
+                query_runs[qidx][conn].append(elapsed)
+            elif tag == "median" and len(parts) >= 3:
+                medians[int(parts[1])] = float(parts[2])
+            elif tag == "diff" and len(parts) >= 6:
+                qidx = int(parts[1])
+                old = float(parts[2])
+                new = float(parts[3])
+                rel = float(parts[4])
+                pvalue = float(parts[5])
+                diffs.append({"query": qidx, "old": old, "new": new, "diff": rel, "pvalue": pvalue})
+            elif tag == "profile-total" and len(parts) >= 2:
+                profile_total = float(parts[1])
+        except Exception:
+            # Keep parser forgiving; malformed lines are ignored.
+            pass
+
+    return {
+        "threshold": threshold,
+        "display": display,
+        "query_runs": query_runs,
+        "diffs": diffs,
+        "medians": medians,
+        "servers": servers,
+        "stages": stages,
+        "skipped": skipped,
+        "partial": partial,
+        "profile_total": profile_total,
+    }
+
+
+def print_report(path: Path, data: dict[str, Any]) -> None:
+    print(f"# perf.py result: `{path}`\n")
+    print(f"Report threshold: `{pct(data['threshold'])}`\n")
+    if data["servers"]:
+        print("## Servers\n")
+        print("| Index | Host | Port | User | TLS |")
+        print("|---:|---|---:|---|---|")
+        for s in data["servers"]:
+            # perf.py: server idx host port user ssl_status
+            print(f"| {s[0]} | `{s[1]}` | {s[2]} | `{s[3]}` | {s[4]} |")
+        print()
+
+    if data["skipped"]:
+        print("## Skipped\n")
+        for s in data["skipped"]:
+            print(f"- {s}")
+        print()
+
+    print("## Diff rows\n")
+    if not data["diffs"]:
+        print("No `diff` rows. Either only one server was used, too few samples were collected, or no query passed perf.py's diff/p-value gate.\n")
+    else:
+        print("| Query | Old median | New median | Diff | p-value | Verdict | Query preview |")
+        print("|---:|---:|---:|---:|---:|---|---|")
+        for d in sorted(data["diffs"], key=lambda x: abs(x["diff"]), reverse=True):
+            qidx = d["query"]
+            preview = (data["display"].get(qidx) or "").replace("\n", " ")[:160]
+            print(
+                f"| {qidx} | {sec(d['old'])} | {sec(d['new'])} | {pct(d['diff'])} | "
+                f"{d['pvalue']:.4g} | {verdict(d['diff'], d['pvalue'], data['threshold'])} | `{preview}` |"
+            )
+        print()
+
+    print("## Per-query sample summary\n")
+    print("| Query | Server | Runs | p05 | p50 | p95 | Min | Max |")
+    print("|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for qidx in sorted(data["query_runs"]):
+        for conn in sorted(data["query_runs"][qidx]):
+            vals = data["query_runs"][qidx][conn]
+            print(
+                f"| {qidx} | {conn} | {len(vals)} | {sec(percentile(vals, 0.05))} | "
+                f"{sec(percentile(vals, 0.50))} | {sec(percentile(vals, 0.95))} | {sec(min(vals))} | {sec(max(vals))} |"
+            )
+    print()
+
+    if data["partial"]:
+        print("## Partial queries\n")
+        for qidx, conns in data["partial"]:
+            print(f"- query {qidx}: ran only on connections `{conns}`")
+        print()
+
+    if data["profile_total"] is not None:
+        print(f"Profile total seconds: `{data['profile_total']:.3f}`\n")
+
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("path", type=Path)
+    args = ap.parse_args()
+    print_report(args.path, parse(args.path))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/perf-comparison/scripts/perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/perf_api.py
@@ -713,6 +713,15 @@ def tsv_bool(value: Any) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes"}
 
 
+def float_or(value: Any, default: float) -> float:
+    try:
+        if value is None or value == "":
+            return default
+        return float(value)
+    except Exception:
+        return default
+
+
 RAW_ALL_QUERY_METRICS_COLUMNS = [
     "metric_name",
     "left",
@@ -726,6 +735,8 @@ RAW_ALL_QUERY_METRICS_COLUMNS = [
     "changed_threshold",
     "unstable_threshold",
 ]
+DEFAULT_CHANGED_THRESHOLD = 0.15
+DEFAULT_UNSTABLE_THRESHOLD = 0.25
 
 
 def iter_tsv_dicts(path: str) -> list[dict[str, str]]:
@@ -766,22 +777,20 @@ def parse_perf_tsv(paths: list[str], metric_filter: str = "client_time", arch_fi
                 threshold = float(src.get("stat_threshold") or src.get("threshold") or 0)
             except Exception:
                 continue
+            changed_threshold = float_or(src.get("changed_threshold"), DEFAULT_CHANGED_THRESHOLD)
+            unstable_threshold = float_or(src.get("unstable_threshold"), DEFAULT_UNSTABLE_THRESHOLD)
             if "is_changed" in src:
                 is_changed = tsv_bool(src.get("is_changed"))
             else:
-                changed_threshold = src.get("changed_threshold") or src.get("stat_threshold") or src.get("threshold") or 0
-                try:
-                    is_changed = abs(diff) >= float(changed_threshold) and abs(diff) > 0
-                except Exception:
-                    is_changed = abs(diff) >= threshold and abs(diff) > 0
+                # Match ci/jobs/scripts/perf/compare.sh changed_fail:
+                # abs(diff) > changed_threshold AND abs(diff) >= stat_threshold
+                is_changed = abs(diff) > changed_threshold and abs(diff) >= threshold
             if "is_unstable" in src:
                 is_unstable = tsv_bool(src.get("is_unstable"))
             else:
-                unstable_threshold = src.get("unstable_threshold")
-                try:
-                    is_unstable = (not is_changed) and abs(diff) >= float(unstable_threshold or 0) and abs(diff) > 0
-                except Exception:
-                    is_unstable = (not is_changed) and threshold > 0.2
+                # Match compare.sh unstable_fail:
+                # NOT changed_fail AND stat_threshold > unstable_threshold
+                is_unstable = (not is_changed) and threshold > unstable_threshold
             direction_raw = (src.get("direction") or "").lower()
             if direction_raw in {"slower", "slowdown"}:
                 direction = "slowdown"

--- a/.claude/skills/perf-comparison/scripts/perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/perf_api.py
@@ -1,0 +1,1302 @@
+#!/usr/bin/env python3
+"""Small helper for the ClickHouse performance.ci API.
+
+This is intentionally dependency-free: Python stdlib only.
+It prints markdown-ish summaries for agents/humans.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from datetime import datetime, timezone
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from typing import Any
+
+BASE_DEFAULT = "https://performance.ci.clickhouse.com/api/v1"
+PLAY_DEFAULT = "https://play.clickhouse.com/"
+DEFAULT_METRICS = "client_time,real_time,cpu_time,memory"
+
+
+def q(s: Any) -> str:
+    return urllib.parse.quote(str(s), safe="")
+
+
+def fetch_json(base: str, path: str, params: dict[str, Any] | None = None) -> Any:
+    url = base.rstrip("/") + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean, doseq=True)
+    req = urllib.request.Request(url, headers={"Accept": "application/json", "User-Agent": "clickhouse-performance-analysis-skill"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def api_url(base: str, path: str, params: dict[str, Any] | None = None) -> str:
+    url = base.rstrip("/") + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean, doseq=True)
+    return url
+
+
+def change_pct(x: Any) -> str:
+    if x is None:
+        return "—"
+    try:
+        v = float(x)
+    except Exception:
+        return str(x)
+    # Observed API values are fractional: 0.232 means +23.2%.
+    if abs(v) <= 10:
+        return f"{v * 100:+.2f}%"
+    return f"{v:+.2f}%"
+
+
+def num(x: Any) -> str:
+    if x is None:
+        return "—"
+    try:
+        v = float(x)
+    except Exception:
+        return str(x)
+    if abs(v) >= 1000:
+        return f"{v:.0f}"
+    if abs(v) >= 10:
+        return f"{v:.3f}"
+    return f"{v:.6g}"
+
+
+def over_threshold(row: dict[str, Any]) -> str:
+    if row.get("diffPercent") is None or row.get("statThreshold") is None:
+        return "—"
+    try:
+        diff = abs(float(row.get("diffPercent")))
+        threshold = abs(float(row.get("statThreshold")))
+    except Exception:
+        return "—"
+    # API floats are often rounded in display but differ by tiny binary/decimal error.
+    return "yes" if diff + 1e-6 >= threshold else "no"
+
+
+def optional_fetch_json(base: str, path: str, params: dict[str, Any] | None = None) -> tuple[Any | None, str | None]:
+    try:
+        return fetch_json(base, path, params), None
+    except Exception as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def sql_quote(value: Any) -> str:
+    return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def clickhouse_play_json_each_row(sql: str, play_url: str = PLAY_DEFAULT, user: str = "explorer") -> list[dict[str, Any]]:
+    url = play_url.rstrip("/") + "/?" + urllib.parse.urlencode({"user": user})
+    req = urllib.request.Request(
+        url,
+        data=sql.encode(),
+        method="POST",
+        headers={"User-Agent": "clickhouse-performance-analysis-skill"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        text = r.read().decode()
+    rows = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            rows.append(json.loads(line))
+    return rows
+
+
+def shorten(text: Any, max_len: int = 170) -> str:
+    if text is None:
+        return "—"
+    value = " ".join(str(text).split())
+    if len(value) <= max_len:
+        return value
+    return value[: max_len - 1].rstrip() + "…"
+
+
+def module_fact_summary(module: dict[str, Any], max_items: int = 4) -> str:
+    facts = []
+    for item in module.get("rows") or []:
+        label = item.get("label") or ""
+        value = item.get("value")
+        if not label or label.lower() == "status":
+            continue
+        facts.append(f"{label}: {value}")
+    if not facts:
+        return "—"
+    return "; ".join(facts[:max_items])
+
+
+def confidence_overall(row: dict[str, Any]) -> tuple[str, str]:
+    conf = row.get("confidence") or {}
+    tier = conf.get("tier") or "scored"
+    reason = conf.get("reason") or "no overall reason returned"
+    # The current dashboard confidence vocabulary is slowdown/regression-oriented.
+    # Do not print slowdown/regression wording on a speedup row in a run summary.
+    if row.get("direction") == "speedup":
+        if "regression" in tier:
+            tier = "stable_speedup"
+        reason = reason.replace("slowdown", "change").replace("regression", "change")
+    return tier, reason
+
+
+def evidence_class(row: dict[str, Any]) -> str:
+    conf = row.get("confidence") or {}
+    raw_tier = str(conf.get("tier") or "").lower()
+    raw_reason = str(conf.get("reason") or "").lower()
+    if row.get("bucket") == "high-noise/unstable-threshold":
+        return "HIGH-NOISE"
+    tier, reason = confidence_overall(row) if conf else ("", "")
+    tier_l = tier.lower()
+    reason_l = reason.lower() or raw_reason
+    # Tier is authoritative. Reasons can mention "history noise" even for confirmed rows.
+    if "noise" in tier_l:
+        return "NOISE"
+    if row.get("direction") == "speedup" and ("stable" in tier_l or "confirmed" in tier_l or "stable" in raw_tier or "confirmed" in raw_tier):
+        return "STABLE SPEEDUP"
+    if row.get("direction") == "slowdown" and ("confirmed" in tier_l or "regression" in tier_l or "confirmed" in raw_tier or "regression" in raw_tier):
+        return "SLOWDOWN SIGNAL"
+    if tier_l or raw_tier:
+        return "SUSPECT"
+    if "noise" in reason_l:
+        return "NOISE"
+    return "UNSCORED"
+
+
+def is_noise_or_uncertain(row: dict[str, Any]) -> bool:
+    return evidence_class(row) in {"NOISE", "HIGH-NOISE", "UNSCORED"}
+
+
+def display_confidence_tier(row: dict[str, Any], tier: str) -> str:
+    tier_l = str(tier or "").lower()
+    if row.get("direction") == "slowdown" and ("confirmed" in tier_l or "regression" in tier_l):
+        return "supported slowdown"
+    if row.get("direction") == "speedup" and ("stable" in tier_l or "confirmed" in tier_l):
+        return "supported speedup"
+    return str(tier or "scored")
+
+
+def confidence_status(row: dict[str, Any]) -> str:
+    conf = row.get("confidence") or {}
+    prefix = evidence_class(row)
+    if conf.get("tier") or conf.get("reason"):
+        tier, reason = confidence_overall(row)
+        return f"**{prefix}** — {display_confidence_tier(row, tier)}: {shorten(reason, 95)}"
+    modules = conf.get("modules") or []
+    if not modules:
+        return "—"
+    useful = []
+    for m in modules:
+        status = m.get("status")
+        if status and status != "neutral":
+            title = m.get("title") or m.get("code") or "module"
+            useful.append(f"{title}: {status}")
+    return f"**{prefix}** — {shorten('; '.join(useful) if useful else 'scored, no decisive module', 120)}"
+
+
+def print_confidence_details(rows: list[dict[str, Any]]) -> None:
+    seen = set()
+    any_conf = False
+    for r in rows:
+        conf = r.get("confidence") or {}
+        modules = conf.get("modules") or []
+        if not conf:
+            continue
+        key = row_key(r)
+        if key in seen:
+            continue
+        seen.add(key)
+        any_conf = True
+        tier, reason = confidence_overall(r)
+        print(f"\n### Confidence explanation: `{r.get('test','—')}/{r.get('queryIndex','—')}` `{r.get('metric','—')}/{r.get('arch','—')}`\n")
+        print(f"Overall: **{display_confidence_tier(r, tier)}** — {reason}\n")
+        if modules:
+            print("| Evidence check | Status | Useful facts | Interpretation |")
+            print("|---|---|---|---|")
+            for m in modules:
+                title = m.get("title") or m.get("code") or "module"
+                print(f"| {title} | {m.get('status','—')} | {shorten(module_fact_summary(m), 180)} | {shorten(m.get('interpretation'), 220)} |")
+    if not any_conf:
+        print("\nNo confidence details returned for the selected row(s).")
+
+def row_key(row: dict[str, Any]) -> tuple:
+    query_index = row.get("queryIndex")
+    if query_index is None:
+        query_index = -1
+    return (row.get("arch") or "", row.get("test") or "", query_index, row.get("metric") or "")
+
+
+def rows_for_display(rows: list[dict[str, Any]], limit: int | None = None) -> list[dict[str, Any]]:
+    rows = sorted(rows, key=lambda r: abs(float(r.get("diffPercent") or 0)), reverse=True)
+    return rows[:limit] if limit else rows
+
+
+def dashboard_link_for_row(run_id: str | None, row: dict[str, Any]) -> str:
+    if not run_id:
+        return "—"
+    test = row.get("test")
+    query_index = row.get("queryIndex")
+    if test is None or query_index is None:
+        return "—"
+    return f"[open]({dashboard_query_url(run_id, test, query_index, row.get('metric'))})"
+
+
+def dashboard_test_query_link_for_row(run_id: str | None, row: dict[str, Any]) -> str:
+    if not run_id:
+        return "—"
+    test = row.get("test")
+    query_index = row.get("queryIndex")
+    if test is None or query_index is None:
+        return "—"
+    return f"[test page]({dashboard_test_url(run_id, test, query_index, row.get('metric'))})"
+
+
+def print_rows(title: str, rows: list[dict[str, Any]], limit: int | None = None, run_id: str | None = None) -> None:
+    print(f"\n## {title}\n")
+    if not rows:
+        print("No rows.\n")
+        return
+    rows = rows_for_display(rows, limit)
+    if run_id:
+        print("| Direction | Arch | Test | Query | Dashboard | Metric | Old | New | Diff | Threshold | Over threshold | Confidence |")
+        print("|---|---|---|---:|---|---|---:|---:|---:|---:|---|---|")
+    else:
+        print("| Direction | Arch | Test | Query | Metric | Old | New | Diff | Threshold | Over threshold | Confidence |")
+        print("|---|---|---|---:|---|---:|---:|---:|---:|---|---|")
+    for r in rows:
+        common = (
+            f"| {r.get('direction','—')} | {r.get('arch','—')} | `{r.get('test','—')}` | {r.get('queryIndex','—')} | "
+        )
+        if run_id:
+            common += f"{dashboard_link_for_row(run_id, r)} | "
+        print(
+            common
+            + f"`{r.get('metric','—')}` | {num(r.get('oldValue'))} | {num(r.get('newValue'))} | "
+            f"{change_pct(r.get('diffPercent'))} | {change_pct(r.get('statThreshold'))} | {over_threshold(r)} | {confidence_status(r)} |"
+        )
+    print()
+
+
+def cmd_runs(args: argparse.Namespace) -> None:
+    search = args.pr if args.pr is not None else args.q
+    data = fetch_json(args.base, "/runs", {"q": search, "metrics": args.metrics})
+    items = data.get("items") or []
+    if args.pr is not None:
+        try:
+            pr = int(args.pr)
+            items = [x for x in items if (x.get("identity") or {}).get("prNumber") == pr]
+        except Exception:
+            pass
+    print(f"API: {api_url(args.base, '/runs', {'q': search, 'metrics': args.metrics})}\n")
+    print("| Time | Run ID | Dashboard | PR | Old | New | Arches | Changed | Slowdowns | Speedups | Reports |")
+    print("|---|---|---|---:|---|---|---|---:|---:|---:|---:|")
+    for item in items:
+        ident = item.get("identity") or {}
+        run_id = ident.get('runId', '—')
+        print(
+            f"| {ident.get('runTime','—')} | `{run_id}` | [open]({dashboard_run_url(run_id)}) | {ident.get('prNumber','—')} | "
+            f"`{str(ident.get('oldSha',''))[:12]}` | `{str(ident.get('newSha',''))[:12]}` | "
+            f"{','.join(item.get('arches') or [])} | {item.get('changedQueries','—')} | "
+            f"{item.get('slowdownQueries','—')} | {item.get('speedupQueries','—')} | {item.get('reportCount','—')} |"
+        )
+
+
+
+def attach_confidence_for_display(args: argparse.Namespace, row_groups: list[list[dict[str, Any]]]) -> list[str]:
+    if not getattr(args, "with_confidence", False):
+        return []
+    rows: list[dict[str, Any]] = []
+    for group in row_groups:
+        rows.extend(rows_for_display(group, args.limit))
+    tests = sorted({r.get("test") for r in rows if r.get("test")})
+    confidence_by_key: dict[tuple, dict[str, Any]] = {}
+    errors: list[str] = []
+    for test in tests:
+        conf_path = f"/runs/{q(args.run_id)}/tests/{q(test)}/confidence"
+        conf, err = optional_fetch_json(args.base, conf_path, {"metrics": args.metrics})
+        if err:
+            errors.append(f"{test}: {err}")
+            continue
+        for cr in (conf.get("changedMetrics") or []) + (conf.get("unstableMetrics") or []):
+            if cr.get("confidence"):
+                confidence_by_key[row_key(cr)] = cr.get("confidence")
+    for r in rows:
+        conf = confidence_by_key.get(row_key(r))
+        if conf:
+            r["confidence"] = conf
+    return errors
+
+
+def cmd_run(args: argparse.Namespace) -> None:
+    data = fetch_json(args.base, f"/runs/{q(args.run_id)}", {"metrics": args.metrics})
+    slowdowns = data.get("slowdowns") or []
+    speedups = data.get("speedups") or []
+    unstable = data.get("unstableQueries") or []
+    confidence_errors = attach_confidence_for_display(args, [slowdowns, speedups, unstable])
+    print(f"API: {api_url(args.base, f'/runs/{q(args.run_id)}', {'metrics': args.metrics})}\n")
+    print(f"Dashboard: {dashboard_run_url(args.run_id)}\n")
+    run = data.get("run") or {}
+    print(f"# Run `{run.get('runId', args.run_id)}`\n")
+    for card in data.get("summaryCards") or []:
+        print(f"- {card.get('label')}: **{card.get('value')}** {card.get('detail') or ''}")
+    if getattr(args, "with_confidence", False):
+        print("\n_Confidence requested: fetched per-test confidence for displayed rows where available._")
+        for err in confidence_errors[:5]:
+            print(f"- confidence unavailable for {err}")
+    print_rows("Slowdowns", slowdowns, args.limit, run_id=args.run_id)
+    print_rows("Speedups", speedups, args.limit, run_id=args.run_id)
+    if unstable:
+        print("\n_Note: `unstableQueries` from the API are high-noise/high-threshold rows. They are useful for flakiness context, but many are not over the reporting threshold and may not be counted in the run summary cards._")
+    print_rows("High-noise / unstable-threshold rows", unstable, args.limit, run_id=args.run_id)
+
+
+
+def cmd_changes(args: argparse.Namespace) -> None:
+    cmd_run(args)
+
+
+
+def parse_time(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    xs = sorted(values)
+    if len(xs) == 1:
+        return xs[0]
+    pos = (len(xs) - 1) * p
+    lo = int(pos)
+    hi = min(lo + 1, len(xs) - 1)
+    frac = pos - lo
+    return xs[lo] * (1 - frac) + xs[hi] * frac
+
+
+def period_text(times: list[datetime]) -> str:
+    if not times:
+        return "unknown period"
+    start = min(times)
+    end = max(times)
+    delta = end - start
+    if delta.days >= 2:
+        span = f"{delta.days}d"
+    else:
+        span = f"{delta.total_seconds() / 3600:.1f}h"
+    return f"{start.date()} → {end.date()} ({span})"
+
+
+def point_pairs(points: list[dict[str, Any]]) -> list[tuple[datetime | None, float]]:
+    out = []
+    for p in points:
+        value = p.get("value")
+        if isinstance(value, (int, float)):
+            out.append((parse_time(p.get("time")), float(value)))
+    return out
+
+
+def pct_summary(values: list[float]) -> str:
+    if not values:
+        return "no numeric values"
+    return (
+        f"p05={num(percentile(values, 0.05))}, "
+        f"p25={num(percentile(values, 0.25))}, "
+        f"p50={num(percentile(values, 0.50))}, "
+        f"p75={num(percentile(values, 0.75))}, "
+        f"p95={num(percentile(values, 0.95))}"
+    )
+
+
+def summarize_points(points: list[dict[str, Any]], recent_n: int = 30) -> str:
+    pairs = point_pairs(points)
+    if not pairs:
+        return "No numeric points."
+    pairs.sort(key=lambda x: x[0] or datetime.min.replace(tzinfo=timezone.utc))
+    vals = [v for _, v in pairs]
+    times = [t for t, _ in pairs if t is not None]
+    recent = pairs[-min(recent_n, len(pairs)) :]
+    recent_vals = [v for _, v in recent]
+    recent_times = [t for t, _ in recent if t is not None]
+    return (
+        f"{len(vals)} points over {period_text(times)}; "
+        f"all: {pct_summary(vals)}; "
+        f"recent {len(recent_vals)} points over {period_text(recent_times)}: {pct_summary(recent_vals)}"
+    )
+
+
+def selected_value_context(rows: list[dict[str, Any]], points: list[dict[str, Any]], label: str) -> str:
+    pairs = point_pairs(points)
+    vals = [v for _, v in pairs]
+    if not vals or not rows:
+        return ""
+    row = rows[0]
+    old = row.get("oldValue")
+    new = row.get("newValue")
+    try:
+        old_f = float(old)
+        new_f = float(new)
+    except Exception:
+        return ""
+    p50 = percentile(vals, 0.50)
+    p95 = percentile(vals, 0.95)
+    p05 = percentile(vals, 0.05)
+    def ratio(v: float, denom: float) -> str:
+        return "—" if not denom else f"{v / denom:.2f}x"
+    return (
+        f"Selected row vs {label}: old={num(old_f)} ({ratio(old_f, p50)} p50), "
+        f"new={num(new_f)} ({ratio(new_f, p50)} p50, {ratio(new_f, p95)} p95; p05={num(p05)}, p95={num(p95)})."
+    )
+
+
+def change_points_summary(change_points: list[dict[str, Any]], limit: int = 8) -> str:
+    if not change_points:
+        return "No change points returned."
+    seen = set()
+    deduped = []
+    for cp in change_points:
+        key = (cp.get("time"), cp.get("direction"), cp.get("causalSha"), cp.get("magnitude"), cp.get("disparity"))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(cp)
+    deduped.sort(key=lambda cp: parse_time(cp.get("time")) or datetime.min.replace(tzinfo=timezone.utc))
+    times = [parse_time(cp.get("time")) for cp in deduped if parse_time(cp.get("time"))]
+    lines = [f"{len(deduped)} unique change points over {period_text(times)}; latest {min(limit, len(deduped))}:"]
+    for cp in deduped[-limit:]:
+        lines.append(
+            f"- {cp.get('time','—')} {cp.get('direction','—')} "
+            f"magnitude={num(cp.get('magnitude'))} disparity={num(cp.get('disparity'))} "
+            f"sha={str(cp.get('causalSha') or '')[:12] or '—'} trust={cp.get('trustLabel') or '—'}"
+        )
+    return "\n".join(lines)
+
+
+def dashboard_run_url(run_id: str) -> str:
+    return f"https://performance.ci.clickhouse.com/runs/{q(run_id)}"
+
+
+def dashboard_test_url(run_id: str, test: str, query_index: int | str | None = None, metric: str | None = None) -> str:
+    params = {}
+    if query_index is not None:
+        params["query_index"] = query_index
+    if metric:
+        params["metrics"] = metric
+    search = ("?" + urllib.parse.urlencode(params)) if params else ""
+    return f"https://performance.ci.clickhouse.com/runs/{q(run_id)}/tests/{q(test)}{search}"
+
+
+def dashboard_query_url(run_id: str, test: str, query_index: int | str, metric: str | None = None) -> str:
+    params = {}
+    if metric:
+        params["metrics"] = metric
+    search = ("?" + urllib.parse.urlencode(params)) if params else ""
+    return f"https://performance.ci.clickhouse.com/runs/{q(run_id)}/tests/{q(test)}/queries/{query_index}{search}"
+
+
+def ascii_diff_chart(points: list[tuple[str, str, dict[str, Any] | None]]) -> str:
+    numeric = []
+    for time_text, run_id, row in points:
+        if not row:
+            continue
+        try:
+            numeric.append((time_text, run_id, float(row.get("diffPercent")), over_threshold(row)))
+        except Exception:
+            continue
+    if not numeric:
+        return "No numeric changed rows for chart."
+    max_abs = max(abs(v) for _, _, v, _ in numeric) or 1.0
+    lines = ["Diff chart, oldest → newest (`*` = over threshold):"]
+    for time_text, run_id, diff, over in numeric:
+        width = max(1, int(abs(diff) / max_abs * 24))
+        bar = ("+" if diff >= 0 else "-") * width
+        star = "*" if over == "yes" else " "
+        lines.append(f"{time_text[:10]} {change_pct(diff):>9} {star} {bar} {run_id[:18]}…")
+    return "\n".join(lines)
+
+def leaf(stack: str) -> str:
+    if not stack:
+        return "—"
+    return stack.split(";")[-1][:160]
+
+
+def cmd_query(args: argparse.Namespace) -> None:
+    params = {"metrics": args.metrics}
+    path = f"/runs/{q(args.run_id)}/tests/{q(args.test)}/queries/{args.query_index}"
+    data = fetch_json(args.base, path, params)
+    print(f"API: {api_url(args.base, path, params)}\n")
+    print(f"Dashboard: {dashboard_query_url(args.run_id, args.test, args.query_index, args.metric)}\n")
+    print(f"# `{args.test}/{args.query_index}`\n")
+    print(f"Query display: {data.get('queryDisplayName') or '—'}\n")
+    if data.get("queryText"):
+        print("```sql")
+        print(data["queryText"].strip())
+        print("```\n")
+    rows = data.get("metrics") or []
+    if args.metric:
+        rows = [r for r in rows if r.get("metric") == args.metric]
+    if args.arch:
+        rows = [r for r in rows if r.get("arch") == args.arch]
+    print_rows("Matching metric rows", rows, None, run_id=args.run_id)
+
+    if args.with_confidence:
+        conf_path = f"/runs/{q(args.run_id)}/tests/{q(args.test)}/confidence"
+        conf, err = optional_fetch_json(args.base, conf_path, {"metrics": args.metrics})
+        print(f"\n## Confidence\n\nAPI: {api_url(args.base, conf_path, {'metrics': args.metrics})}\n")
+        if err:
+            print(f"Not available: `{err}`\n")
+        else:
+            conf_rows = (conf.get("changedMetrics") or []) + (conf.get("unstableMetrics") or [])
+            conf_rows = [r for r in conf_rows if r.get("queryIndex") == args.query_index]
+            if args.metric:
+                conf_rows = [r for r in conf_rows if r.get("metric") == args.metric]
+            if args.arch:
+                conf_rows = [r for r in conf_rows if r.get("arch") == args.arch]
+            print_rows("Matching confidence rows", conf_rows, None, run_id=args.run_id)
+            print_confidence_details(conf_rows)
+
+    if args.with_trend:
+        trend_path = f"/runs/{q(args.run_id)}/tests/{q(args.test)}/trend"
+        trend_params = {"metric": args.metric, "queryIndex": args.query_index, "arch": args.arch}
+        trend, err = optional_fetch_json(args.base, trend_path, trend_params)
+        print(f"\n## Trend\n\nAPI: {api_url(args.base, trend_path, trend_params)}\n")
+        if err:
+            print(f"Not available: `{err}`")
+        else:
+            trend_points = trend.get("points") or []
+            print(summarize_points(trend_points))
+            ctx = selected_value_context(rows, trend_points, "trend distribution")
+            if ctx:
+                print(ctx)
+            selected = trend.get("selectedRunPoint")
+            if selected:
+                print(f"Selected run marker: `{selected.get('time')}` sha={str(selected.get('label') or '')[:12]} (marker only; measured values are in the table above)")
+
+    if args.with_history:
+        hist_path = f"/history/{q(args.test)}/{args.query_index}"
+        hist_params = {"metric": args.metric, "arch": args.arch}
+        hist, err = optional_fetch_json(args.base, hist_path, hist_params)
+        print(f"\n## History\n\nAPI: {api_url(args.base, hist_path, hist_params)}\n")
+        if err:
+            print(f"Not available: `{err}`")
+        else:
+            center = hist.get("centerTrend") or []
+            print("Center trend:", summarize_points(center))
+            ctx = selected_value_context(rows, center, "history center trend")
+            if ctx:
+                print(ctx)
+            print(change_points_summary(hist.get("changePoints") or []))
+            period = hist.get("periodComparisons") or []
+            if period:
+                print("\nPeriod comparisons returned by API:")
+                for pc in period[:8]:
+                    print(f"- {pc.get('direction','—')} magnitude={num(pc.get('magnitude'))} disparity={num(pc.get('disparity'))} leadingSha={str(pc.get('leadingSha') or '')[:12]} trust={pc.get('trustLabel') or '—'}")
+
+    if args.with_coverage:
+        cov_path = f"/runs/{q(args.run_id)}/tests/{q(args.test)}/coverage"
+        cov_params = {"fileSet": "intersecting"}
+        cov, err = optional_fetch_json(args.base, cov_path, cov_params)
+        print(f"\n## Coverage / PR overlap\n\nAPI: {api_url(args.base, cov_path, cov_params)}\n")
+        if err:
+            print(f"Not available: `{err}`")
+        else:
+            totals = cov.get("totals") or {}
+            files = cov.get("files") or []
+            intersecting = totals.get('intersectingFiles')
+            if intersecting is None:
+                intersecting = len(files)
+            print(f"coverageAvailable={cov.get('coverageAvailable')} source={cov.get('coverageSource') or '—'} message={cov.get('message') or '—'}")
+            print(f"touched={totals.get('touchedFiles','—')} covered={totals.get('coveredFiles','—')} intersecting={intersecting}")
+            for f in files[:20]:
+                ranges = f.get("coverageRanges") or []
+                print(f"- `{f.get('path')}` status={f.get('status')} changes={f.get('changes')} ranges={len(ranges)}")
+
+    if args.with_flamegraph_diff:
+        fg_path = f"/runs/{q(args.run_id)}/tests/{q(args.test)}/queries/{args.query_index}/flamegraph-diff"
+        fg_params = {"metric": args.metric, "arch": args.arch, "traceType": args.trace_type}
+        fg, err = optional_fetch_json(args.base, fg_path, fg_params)
+        fg_url = api_url(args.base, fg_path, fg_params)
+        ui_url = dashboard_query_url(args.run_id, args.test, args.query_index, args.metric)
+        print(f"\n## Flamegraph diff ({args.trace_type})\n\nUI (query page, Flamegraphs card): {ui_url}\n")
+        print(f"Raw API: {fg_url}\n")
+        if err:
+            print(f"Not available: `{err}`")
+        else:
+            frames = fg.get("frames") or []
+            frames = sorted(frames, key=lambda f: abs(float(f.get("candidateSamples") or 0) - float(f.get("baselineSamples") or 0)), reverse=True)
+            if not frames:
+                print("No diff frames returned.")
+            else:
+                print("| Leaf | Baseline | Candidate | Delta |")
+                print("|---|---:|---:|---:|")
+                for f in frames[:20]:
+                    b = float(f.get("baselineSamples") or 0)
+                    c = float(f.get("candidateSamples") or 0)
+                    print(f"| `{leaf(f.get('stack') or '')}` | {b:.0f} | {c:.0f} | {c-b:+.0f} |")
+
+
+
+def fetch_pr_runs(base: str, pr: str, metrics: str) -> list[dict[str, Any]]:
+    runs = fetch_json(base, "/runs", {"q": pr, "metrics": metrics}).get("items") or []
+    try:
+        pr_int = int(pr)
+        runs = [x for x in runs if (x.get("identity") or {}).get("prNumber") == pr_int]
+    except Exception:
+        pass
+    return runs
+
+
+def collect_run_rows(base: str, items: list[dict[str, Any]], metrics: str, metric_filter: str = "client_time", arch_filter: str = "") -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in items:
+        ident = item.get("identity") or {}
+        run_id = ident.get("runId")
+        if not run_id:
+            continue
+        detail = fetch_json(base, f"/runs/{q(run_id)}", {"metrics": metrics})
+        for bucket, label in (("slowdowns", "slowdown"), ("speedups", "speedup"), ("unstableQueries", "high-noise/unstable-threshold")):
+            for r in detail.get(bucket) or []:
+                if metric_filter and r.get("metric") != metric_filter:
+                    continue
+                if arch_filter and r.get("arch") != arch_filter:
+                    continue
+                row = dict(r)
+                row["runId"] = run_id
+                row["runTime"] = ident.get("runTime")
+                row["oldSha"] = ident.get("oldSha")
+                row["newSha"] = ident.get("newSha")
+                row["bucket"] = label
+                # unstableQueries still carry a real direction; keep it for sorting/counts.
+                row["direction"] = row.get("direction") or label
+                rows.append(row)
+    return rows
+
+
+def attach_confidence_to_rows(base: str, metrics: str, rows: list[dict[str, Any]]) -> list[str]:
+    """Attach dashboard confidence to API inventory rows in-place, grouped by run/test."""
+    by_run_test: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        run_id = r.get("runId")
+        test = r.get("test")
+        if run_id and test:
+            by_run_test[(run_id, test)].append(r)
+    errors: list[str] = []
+    for (run_id, test), group in sorted(by_run_test.items()):
+        conf_path = f"/runs/{q(run_id)}/tests/{q(test)}/confidence"
+        conf, err = optional_fetch_json(base, conf_path, {"metrics": metrics})
+        if err:
+            errors.append(f"{run_id} {test}: {err}")
+            continue
+        confidence_by_key: dict[tuple, dict[str, Any]] = {}
+        for cr in (conf.get("changedMetrics") or []) + (conf.get("unstableMetrics") or []):
+            if cr.get("confidence"):
+                confidence_by_key[row_key(cr)] = cr.get("confidence")
+        for r in group:
+            row_conf = confidence_by_key.get(row_key(r))
+            if row_conf:
+                r["confidence"] = row_conf
+    return errors
+
+
+def tsv_bool(value: Any) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def parse_perf_tsv(paths: list[str], metric_filter: str = "client_time", arch_filter: str = "") -> list[dict[str, Any]]:
+    """Parse fetch_perf_report.py --tsv output or raw all-query-metrics.tsv-like files."""
+    rows: list[dict[str, Any]] = []
+    for path in paths:
+        with open(path, newline="") as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for src in reader:
+                metric = src.get("metric") or src.get("metric_name") or metric_filter
+                if metric_filter and metric != metric_filter:
+                    continue
+                arch = src.get("arch") or arch_filter or ""
+                if arch_filter and arch != arch_filter:
+                    continue
+                try:
+                    diff = float(src.get("diff") or 0)
+                    threshold = float(src.get("stat_threshold") or src.get("threshold") or 0)
+                except Exception:
+                    continue
+                is_changed = tsv_bool(src.get("is_changed")) if "is_changed" in src else (abs(diff) >= threshold and abs(diff) > 0.1)
+                is_unstable = tsv_bool(src.get("is_unstable")) if "is_unstable" in src else ((not is_changed) and threshold > 0.2)
+                direction_raw = (src.get("direction") or "").lower()
+                if direction_raw in {"slower", "slowdown"}:
+                    direction = "slowdown"
+                elif direction_raw in {"faster", "speedup"}:
+                    direction = "speedup"
+                elif diff > 0:
+                    direction = "slowdown"
+                elif diff < 0:
+                    direction = "speedup"
+                else:
+                    direction = "same"
+                try:
+                    query_index: int | str = int(src.get("query_index") or src.get("queryIndex") or 0)
+                except Exception:
+                    query_index = src.get("query_index") or src.get("queryIndex") or "—"
+                rows.append({
+                    "source": path,
+                    "bucket": "changed" if is_changed else ("unstable" if is_unstable else "unchanged"),
+                    "metric": metric,
+                    "arch": arch,
+                    "shard": src.get("shard") or src.get("shard_num") or "",
+                    "test": src.get("test") or "",
+                    "queryIndex": query_index,
+                    "queryDisplayName": src.get("query") or src.get("query_display_name") or "",
+                    "oldValue": src.get("old") or src.get("left"),
+                    "newValue": src.get("new") or src.get("right"),
+                    "diffPercent": diff,
+                    "timesChange": src.get("times_change"),
+                    "statThreshold": threshold,
+                    "isChanged": is_changed,
+                    "isUnstable": is_unstable,
+                    "direction": direction,
+                })
+    return rows
+
+
+def compare_key(row: dict[str, Any]) -> tuple:
+    query_index = row.get("queryIndex")
+    if query_index is None:
+        query_index = -1
+    return (row.get("arch") or "", row.get("test") or "", query_index, row.get("metric") or "")
+
+
+def row_abs_diff(row: dict[str, Any]) -> float:
+    try:
+        return abs(float(row.get("diffPercent") or 0))
+    except Exception:
+        return 0.0
+
+
+def row_evidence(row: dict[str, Any]) -> str:
+    conf = confidence_status(row)
+    if conf != "—":
+        return conf
+    if row.get("bucket") == "high-noise/unstable-threshold":
+        if over_threshold(row) == "yes":
+            return "**HIGH-NOISE** — raw diff is at/above threshold; confidence not returned"
+        return "**HIGH-NOISE** — below adaptive/stat threshold; confidence not returned"
+    return "**UNSCORED** — confidence not returned"
+
+
+def print_inventory_table(rows: list[dict[str, Any]], limit: int | None = None) -> None:
+    rows = sorted(rows, key=row_abs_diff, reverse=True)
+    if limit:
+        rows = rows[:limit]
+    print("| Time | Direction | Arch | Test | Query | Dashboard | Old | New | Diff | Threshold | Over threshold | Evidence / next action |")
+    print("|---|---|---|---|---:|---|---:|---:|---:|---:|---|---|")
+    for r in rows:
+        print(
+            f"| {r.get('runTime','—')} | {r.get('direction','—')} | {r.get('arch','—')} | `{r.get('test','—')}` | {r.get('queryIndex','—')} | "
+            f"{dashboard_test_query_link_for_row(r.get('runId'), r)} | {num(r.get('oldValue'))} | {num(r.get('newValue'))} | "
+            f"{change_pct(r.get('diffPercent'))} | {change_pct(r.get('statThreshold'))} | {over_threshold(r)} | {row_evidence(r)} |"
+        )
+    print()
+
+
+def print_inventory_rows(title: str, rows: list[dict[str, Any]], limit: int | None, note: str = "", group_evidence: bool = False) -> None:
+    print(f"\n## {title}\n")
+    if note:
+        print(f"_{note}_\n")
+    if not rows:
+        print("No rows.\n")
+        return
+    if not group_evidence:
+        print_inventory_table(rows, limit)
+        return
+    signal = [r for r in rows if not is_noise_or_uncertain(r)]
+    rest = [r for r in rows if is_noise_or_uncertain(r)]
+    if signal:
+        print(f"### Signal evidence ({len(signal)})\n")
+        print_inventory_table(signal, limit)
+    if rest:
+        print(f"### Noise / uncertain evidence ({len(rest)})\n")
+        print_inventory_table(rest, limit)
+
+
+def summary_rank(row: dict[str, Any]) -> tuple[int, float]:
+    klass = evidence_class(row)
+    weight = {
+        "SLOWDOWN SIGNAL": 5,
+        "STABLE SPEEDUP": 5,
+        "SUSPECT": 3,
+        "UNSCORED": 1,
+        "NOISE": 0,
+        "HIGH-NOISE": -1,
+    }.get(klass, 0)
+    return (weight, row_abs_diff(row))
+
+
+def print_summary_bullets(title: str, rows: list[dict[str, Any]], limit: int = 5) -> None:
+    print(f"\n### {title}\n")
+    if not rows:
+        print("- None in the current candidate.\n")
+        return
+    for r in sorted(rows, key=summary_rank, reverse=True)[:limit]:
+        print(
+            f"- {row_evidence(r)} — {r.get('direction','—')} `{r.get('arch','—')}` "
+            f"`{r.get('test','—')}` q{r.get('queryIndex','—')} "
+            f"{change_pct(r.get('diffPercent'))}; {dashboard_test_query_link_for_row(r.get('runId'), r)}"
+        )
+    print()
+
+
+def print_inventory_summary(current_slow: list[dict[str, Any]], current_fast: list[dict[str, Any]], current_high_noise: list[dict[str, Any]]) -> None:
+    likely_signal = [r for r in current_slow if not is_noise_or_uncertain(r)]
+    likely_improvements = [r for r in current_fast if not is_noise_or_uncertain(r)]
+    likely_noise = [r for r in current_slow + current_fast + current_high_noise if is_noise_or_uncertain(r)]
+    print("\n## Summary layer\n")
+    print("_Small generated shortlist before the full tables. Use this to decide what to read first; the full tables below remain the source of detail._")
+    print_summary_bullets("Top likely signal", likely_signal)
+    print_summary_bullets("Top likely noise", likely_noise)
+    print_summary_bullets("Top improvements", likely_improvements)
+
+
+def aggregate_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_key: dict[tuple, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        query_index = r.get("queryIndex")
+        if query_index is None:
+            query_index = -1
+        by_key[(r.get("arch") or "", r.get("test") or "", query_index, r.get("metric") or "")].append(r)
+    out = []
+    for (arch, test, query_index, metric), vals in by_key.items():
+        vals = sorted(vals, key=lambda r: r.get("runTime") or "")
+        slow = [r for r in vals if r.get("direction") == "slowdown"]
+        fast = [r for r in vals if r.get("direction") == "speedup"]
+        high_noise = [r for r in vals if r.get("bucket") == "high-noise/unstable-threshold"]
+        latest = vals[-1]
+        max_slow = max([float(r.get("diffPercent") or 0) for r in slow], default=0.0)
+        max_fast = min([float(r.get("diffPercent") or 0) for r in fast], default=0.0)
+        out.append({
+            "arch": arch,
+            "test": test,
+            "queryIndex": query_index,
+            "metric": metric,
+            "runs": len(vals),
+            "slowdowns": len(slow),
+            "speedups": len(fast),
+            "max_slowdown": max_slow,
+            "max_speedup": max_fast,
+            "high_noise": len(high_noise),
+            "flip": bool(slow and fast),
+            "latest": latest,
+            "max_abs": max(row_abs_diff(r) for r in vals),
+        })
+    return sorted(out, key=lambda x: (x["flip"], x["runs"], x["max_abs"]), reverse=True)
+
+
+def print_aggregate_rows(title: str, aggs: list[dict[str, Any]], limit: int | None) -> None:
+    print(f"\n## {title}\n")
+    if not aggs:
+        print("No rows.\n")
+        return
+    if limit:
+        aggs = aggs[:limit]
+    print("| Arch | Test | Query | Runs | Slowdowns | Speedups | High-noise rows | Direction flip | Max slowdown | Max speedup | Latest test page |")
+    print("|---|---|---:|---:|---:|---:|---:|---|---:|---:|---|")
+    for a in aggs:
+        latest = a["latest"]
+        print(
+            f"| {a['arch'] or '—'} | `{a['test']}` | {a['queryIndex']} | {a['runs']} | {a['slowdowns']} | {a['speedups']} | {a['high_noise']} | "
+            f"{'yes' if a['flip'] else 'no'} | {change_pct(a['max_slowdown']) if a['slowdowns'] else '—'} | "
+            f"{change_pct(a['max_speedup']) if a['speedups'] else '—'} | {dashboard_test_query_link_for_row(latest.get('runId'), latest)} |"
+        )
+    print()
+
+
+def print_tsv_rows(title: str, rows: list[dict[str, Any]], limit: int | None) -> None:
+    print(f"\n## {title}\n")
+    rows = sorted(rows, key=row_abs_diff, reverse=True)
+    if limit:
+        rows = rows[:limit]
+    if not rows:
+        print("No rows.\n")
+        return
+    print("| Bucket | Direction | Arch | Shard | Test | Query | Old | New | Diff | Times | Threshold | Changed | Unstable | Query text |")
+    print("|---|---|---|---:|---|---:|---:|---:|---:|---:|---:|---|---|---|")
+    for r in rows:
+        print(
+            f"| {r.get('bucket','—')} | {r.get('direction','—')} | {r.get('arch','—')} | {r.get('shard','—')} | `{r.get('test','—')}` | {r.get('queryIndex','—')} | "
+            f"{num(r.get('oldValue'))} | {num(r.get('newValue'))} | {change_pct(r.get('diffPercent'))} | {num(r.get('timesChange'))} | "
+            f"{change_pct(r.get('statThreshold'))} | {'yes' if r.get('isChanged') else 'no'} | {'yes' if r.get('isUnstable') else 'no'} | {shorten(r.get('queryDisplayName'), 110)} |"
+        )
+    print()
+
+
+def cmd_tsv_inventory(args: argparse.Namespace) -> None:
+    rows = parse_perf_tsv(args.tsv, args.metric, args.arch)
+    if not args.show_all:
+        rows = [r for r in rows if r.get("isChanged") or r.get("isUnstable")]
+    slow = [r for r in rows if r.get("isChanged") and r.get("direction") == "slowdown"]
+    fast = [r for r in rows if r.get("isChanged") and r.get("direction") == "speedup"]
+    unstable = [r for r in rows if r.get("isUnstable") and not r.get("isChanged")]
+    print("# TSV/raw-artifact performance inventory\n")
+    print("Input TSVs:")
+    for path in args.tsv:
+        print(f"- `{path}`")
+    print("\n## Counts\n")
+    print(f"- Rows considered: **{len(rows)}**")
+    print(f"- Changed slowdowns: **{len(slow)}**")
+    print(f"- Changed improvements/speedups: **{len(fast)}**")
+    print(f"- Unstable/non-changed rows: **{len(unstable)}**")
+    print_tsv_rows("Changed slowdowns from TSV/raw artifacts", slow, args.limit)
+    print_tsv_rows("Changed improvements / speedups from TSV/raw artifacts", fast, args.limit)
+    print_tsv_rows("Unstable/non-changed rows from TSV/raw artifacts", unstable, args.limit)
+
+
+
+def cmd_pr_inventory(args: argparse.Namespace) -> None:
+    items = fetch_pr_runs(args.base, args.pr, args.metrics)
+    if not items:
+        print(f"No runs found for PR {args.pr}.")
+        return
+    print(f"# PR {args.pr} performance inventory\n")
+    print(f"API: {api_url(args.base, '/runs', {'q': args.pr, 'metrics': args.metrics})}\n")
+    print("| Time | Run | Old | New | Arches | Changed | Slowdowns | Speedups |")
+    print("|---|---|---|---|---|---:|---:|---:|")
+    for item in items:
+        ident = item.get("identity") or {}
+        run_id = ident.get("runId", "")
+        print(
+            f"| {ident.get('runTime','—')} | [open]({dashboard_run_url(run_id)}) | `{str(ident.get('oldSha',''))[:12]}` | `{str(ident.get('newSha',''))[:12]}` | "
+            f"{','.join(item.get('arches') or [])} | {item.get('changedQueries','—')} | {item.get('slowdownQueries','—')} | {item.get('speedupQueries','—')} |"
+        )
+    newest_sha = (items[0].get("identity") or {}).get("newSha")
+    current_items = [it for it in items if (it.get("identity") or {}).get("newSha") == newest_sha]
+    all_rows = collect_run_rows(args.base, items, args.metrics, args.metric, args.arch)
+    confidence_errors: list[str] = []
+    if getattr(args, "with_confidence", False):
+        confidence_errors = attach_confidence_to_rows(args.base, args.metrics, all_rows)
+    current_rows = [r for r in all_rows if r.get("runId") in {(it.get("identity") or {}).get("runId") for it in current_items}]
+    current_slow = [r for r in current_rows if r.get("bucket") == "slowdown"]
+    current_fast = [r for r in current_rows if r.get("bucket") == "speedup"]
+    current_high_noise = [r for r in current_rows if r.get("bucket") == "high-noise/unstable-threshold"]
+    all_slow = [r for r in all_rows if r.get("bucket") == "slowdown"]
+    all_fast = [r for r in all_rows if r.get("bucket") == "speedup"]
+    all_high_noise = [r for r in all_rows if r.get("bucket") == "high-noise/unstable-threshold"]
+    print("\n## Counts\n")
+    print(f"- Runs found: **{len(items)}**")
+    print(f"- Current candidate SHA: `{str(newest_sha or '')[:12]}`; current run(s): **{len(current_items)}**")
+    print(f"- Current candidate: changed slowdowns **{len(current_slow)}**, changed improvements/speedups **{len(current_fast)}**, high-noise/unstable-threshold rows **{len(current_high_noise)}**")
+    print(f"- All PR runs: changed slowdowns **{len(all_slow)}**, changed improvements/speedups **{len(all_fast)}**, high-noise/unstable-threshold rows **{len(all_high_noise)}**")
+    if getattr(args, "with_confidence", False):
+        attached = sum(1 for r in all_rows if r.get("confidence"))
+        print(f"- Confidence attached: **{attached}/{len(all_rows)}** rows")
+        for err in confidence_errors[:5]:
+            print(f"  - confidence unavailable for {err}")
+    print_inventory_summary(current_slow, current_fast, current_high_noise)
+    print_inventory_rows("Current changed slowdowns", current_slow, args.limit, "Raw changed rows with slowdown direction. Evidence can still downgrade a raw change to noise/flaky.", group_evidence=True)
+    print_inventory_rows("Current changed improvements / speedups", current_fast, args.limit, "Raw changed rows with speedup direction. Evidence can still downgrade a raw change to noise/flaky.", group_evidence=True)
+    print_inventory_rows("Current high-noise / unstable-threshold rows", current_high_noise, args.limit, "Separate from changed slowdowns/speedups. Inspect only if magnitude/context makes them relevant.")
+    if not args.current_only and len(items) > 1:
+        aggs = aggregate_rows(all_rows)
+        flips = [a for a in aggs if a["flip"]]
+        repeated = [a for a in aggs if a["runs"] > 1]
+        if repeated:
+            print_aggregate_rows("Rows repeated across PR runs", repeated, args.aggregate_limit)
+        if flips:
+            print_aggregate_rows("Direction flips across PR runs", flips, args.aggregate_limit)
+        if args.show_all_run_tables:
+            print_inventory_rows("All PR-run changed slowdowns", all_slow, args.limit)
+            print_inventory_rows("All PR-run changed improvements / speedups", all_fast, args.limit)
+            print_inventory_rows("All PR-run high-noise / unstable-threshold rows", all_high_noise, args.limit)
+
+
+def master_test_name(row: dict[str, Any]) -> str:
+    return f"{row.get('test')} #{row.get('queryIndex')}"
+
+
+def fetch_master_check_counts(rows: list[dict[str, Any]], days: int, play_url: str, play_user: str) -> dict[tuple[str, str], dict[str, Any]]:
+    by_arch: dict[str, set[str]] = defaultdict(set)
+    for r in rows:
+        arch = r.get("arch") or ""
+        test = r.get("test")
+        query_index = r.get("queryIndex")
+        if arch in {"amd", "arm"} and test is not None and query_index is not None:
+            by_arch[arch].add(master_test_name(r))
+    out: dict[tuple[str, str], dict[str, Any]] = {}
+    for arch, tests in sorted(by_arch.items()):
+        if not tests:
+            continue
+        names = ",\n    ".join(sql_quote(t + "::new") for t in sorted(tests))
+        sql = f"""
+SELECT
+    replaceRegexpOne(test_name, '::(new|old)$', '') AS test,
+    countIf(test_status = 'slower') AS slower_count,
+    countIf(test_status = 'faster') AS faster_count,
+    countIf(test_status = 'unstable') AS unstable_count,
+    count() AS total_runs
+FROM default.checks
+WHERE pull_request_number = 0
+  AND check_name LIKE '%Performance%{arch}%'
+  AND check_start_time >= now() - INTERVAL {int(days)} DAY
+  AND test_name IN (
+    {names}
+  )
+GROUP BY test
+FORMAT JSONEachRow
+"""
+        for row in clickhouse_play_json_each_row(sql, play_url=play_url, user=play_user):
+            out[(arch, row.get("test") or "")] = row
+    return out
+
+
+def master_counts_text(hist: dict[str, Any] | None) -> str:
+    if not hist:
+        return "0/0/0/0"
+    return f"{hist.get('slower_count',0)}/{hist.get('faster_count',0)}/{hist.get('unstable_count',0)}/{hist.get('total_runs',0)}"
+
+
+def classify_with_master_counts(row: dict[str, Any], hist: dict[str, Any] | None) -> str:
+    if not hist:
+        return "no master data"
+    slower = int(hist.get("slower_count") or 0)
+    faster = int(hist.get("faster_count") or 0)
+    unstable = int(hist.get("unstable_count") or 0)
+    total = int(hist.get("total_runs") or 0)
+    if total <= 0:
+        return "no master data"
+    slower_rate = slower / total
+    faster_rate = faster / total
+    unstable_rate = unstable / total
+    direction = row.get("direction")
+    if unstable >= 5 or unstable_rate > 0.01:
+        return "unstable on master"
+    if direction == "slowdown":
+        if slower_rate > 0.01 or slower >= 3:
+            return "flaky/slower on master"
+        if 1 <= slower <= 2:
+            return "rarely slower on master"
+        if total >= 50:
+            return "new in PR — investigate"
+        return "insufficient master history"
+    if direction == "speedup":
+        if slower_rate > 0.01 or slower >= 3:
+            return "fixes known master regression"
+        if faster_rate > 0.01 or faster >= 3:
+            return "flaky/faster on master"
+        if 1 <= faster <= 2:
+            return "rarely faster on master"
+        if total >= 50:
+            return "new in PR — improvement"
+        return "insufficient master history"
+    return "unknown direction"
+
+
+def cmd_master_checks(args: argparse.Namespace) -> None:
+    if not args.tsv and not args.pr:
+        raise SystemExit("master-checks requires either --pr or --tsv")
+    rows: list[dict[str, Any]] = []
+    source_note = ""
+    if args.tsv:
+        rows = [r for r in parse_perf_tsv(args.tsv, args.metric, args.arch) if r.get("isChanged")]
+        source_note = "TSV/raw artifact rows"
+    else:
+        items = fetch_pr_runs(args.base, args.pr, args.metrics)
+        if not args.all_runs:
+            newest_sha = (items[0].get("identity") or {}).get("newSha") if items else None
+            items = [it for it in items if (it.get("identity") or {}).get("newSha") == newest_sha]
+        rows = collect_run_rows(args.base, items, args.metrics, args.metric, args.arch)
+        rows = [r for r in rows if r.get("bucket") in {"slowdown", "speedup"}]
+        source_note = "performance.ci API changed rows"
+    if not rows:
+        print("No changed rows found for master-check classification.")
+        return
+    # Attach dashboard confidence by default when rows came from performance.ci.
+    # This lets the report separate likely signal from noise/uncertain rows.
+    confidence_errors: list[str] = []
+    if not args.tsv:
+        confidence_errors = attach_confidence_to_rows(args.base, args.metrics, rows)
+    counts = fetch_master_check_counts(rows, args.days, args.play_url, args.play_user)
+    rows = rows_for_display(rows, args.limit)
+    grouped: dict[tuple[str, str, str, str], list[tuple[dict[str, Any], dict[str, Any] | None]]] = defaultdict(list)
+    for r in rows:
+        key = (r.get("arch") or "", master_test_name(r))
+        hist = counts.get(key)
+        verdict = classify_with_master_counts(r, hist)
+        signal_group = "noise / uncertain evidence" if is_noise_or_uncertain(r) else "not-noise evidence"
+        grouped[(signal_group, r.get("arch") or "—", r.get("direction") or "—", verdict)].append((r, hist))
+
+    verdict_order = {
+        "new in PR — investigate": 0,
+        "new in PR — improvement": 0,
+        "fixes known master regression": 1,
+        "rarely slower on master": 2,
+        "rarely faster on master": 2,
+        "flaky/slower on master": 3,
+        "flaky/faster on master": 3,
+        "unstable on master": 4,
+        "insufficient master history": 5,
+        "no master data": 6,
+    }
+    signal_order = {"not-noise evidence": 0, "noise / uncertain evidence": 1}
+    direction_order = {"slowdown": 0, "speedup": 1}
+
+    print(f"# Master-check classification ({args.days}d)\n")
+    print(f"Source: {source_note}\n")
+    print("Counts column is `master slower/faster/unstable/total` from `play.clickhouse.com default.checks` over master-only runs.\n")
+    if confidence_errors:
+        print(f"Confidence unavailable for {len(confidence_errors)} test/run groups; those rows may appear under noise / uncertain evidence.\n")
+
+    current_signal_group = None
+    for (signal_group, arch, direction, verdict), group in sorted(grouped.items(), key=lambda kv: (signal_order.get(kv[0][0], 9), kv[0][1], direction_order.get(kv[0][2], 9), verdict_order.get(kv[0][3], 9), -len(kv[1]))):
+        if signal_group != current_signal_group:
+            print(f"\n## {signal_group} ({sum(len(v) for k, v in grouped.items() if k[0] == signal_group)})\n")
+            current_signal_group = signal_group
+        print(f"\n### {arch} {direction} — {verdict} ({len(group)})\n")
+        print("| Test | Query | Diff | Test page | Master s/f/u/total | Evidence |")
+        print("|---|---:|---:|---|---:|---|")
+        for r, hist in sorted(group, key=lambda item: row_abs_diff(item[0]), reverse=True):
+            print(
+                f"| `{r.get('test','—')}` | {r.get('queryIndex','—')} | {change_pct(r.get('diffPercent'))} | "
+                f"{dashboard_test_query_link_for_row(r.get('runId'), r)} | {master_counts_text(hist)} | {row_evidence(r)} |"
+            )
+
+
+def cmd_pr_query_history(args: argparse.Namespace) -> None:
+    runs = fetch_json(args.base, "/runs", {"q": args.pr, "metrics": args.metrics}).get("items") or []
+    try:
+        pr_int = int(args.pr)
+        runs = [x for x in runs if (x.get("identity") or {}).get("prNumber") == pr_int]
+    except Exception:
+        pass
+    print(f"# PR {args.pr}: `{args.test}/{args.query_index}` `{args.metric}/{args.arch}` across dashboard runs\n")
+    print("| Time | Dashboard | Old | New | Diff | Threshold | Over threshold | Direction | Severity |")
+    print("|---|---|---:|---:|---:|---:|---|---|---|")
+    seen = 0
+    chart_points: list[tuple[str, str, dict[str, Any] | None]] = []
+    for item in runs:
+        ident = item.get("identity") or {}
+        run_id = ident.get("runId")
+        if not run_id:
+            continue
+        try:
+            detail = fetch_json(args.base, f"/runs/{q(run_id)}/tests/{q(args.test)}/queries/{args.query_index}", {"metrics": args.metrics})
+        except Exception:
+            dash = dashboard_query_url(run_id, args.test, args.query_index, args.metric)
+            print(f"| {ident.get('runTime','—')} | [open]({dash}) | — | — | — | — | — | not available | — |")
+            chart_points.append((ident.get('runTime','—'), run_id, None))
+            continue
+        rows = detail.get("metrics") or []
+        match = [r for r in rows if r.get("metric") == args.metric and (not args.arch or r.get("arch") == args.arch)]
+        dash = dashboard_query_url(run_id, args.test, args.query_index, args.metric)
+        if not match:
+            print(f"| {ident.get('runTime','—')} | [open]({dash}) | — | — | — | — | — | not listed | — |")
+            chart_points.append((ident.get('runTime','—'), run_id, None))
+            continue
+        for r in match:
+            seen += 1
+            chart_points.append((ident.get('runTime','—'), run_id, r))
+            print(
+                f"| {ident.get('runTime','—')} | [open]({dash}) | {num(r.get('oldValue'))} | {num(r.get('newValue'))} | "
+                f"{change_pct(r.get('diffPercent'))} | {change_pct(r.get('statThreshold'))} | {over_threshold(r)} | {r.get('direction','—')} | {r.get('severity','—')} |"
+            )
+    print(f"\nMatched rows: {seen}/{len(runs)} runs.\n")
+    chronological = list(reversed(chart_points))
+    print("```text")
+    print(ascii_diff_chart(chronological))
+    print("```\n")
+
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--base", default=BASE_DEFAULT)
+    p.add_argument("--metrics", default=DEFAULT_METRICS)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("runs", help="List performance.ci runs for a PR/search query")
+    sp.add_argument("--pr")
+    sp.add_argument("--q")
+    sp.set_defaults(func=cmd_runs)
+
+    sp = sub.add_parser("run", help="Summarize one run")
+    sp.add_argument("--run-id", required=True)
+    sp.add_argument("--limit", type=int)
+    sp.add_argument("--with-confidence", action="store_true")
+    sp.set_defaults(func=cmd_run)
+
+    sp = sub.add_parser("changes", help="Alias for run summary")
+    sp.add_argument("--run-id", required=True)
+    sp.add_argument("--limit", type=int)
+    sp.add_argument("--with-confidence", action="store_true")
+    sp.set_defaults(func=cmd_changes)
+
+    sp = sub.add_parser("query", help="Inspect one run/test/query")
+    sp.add_argument("--run-id", required=True)
+    sp.add_argument("--test", required=True)
+    sp.add_argument("--query-index", required=True, type=int)
+    sp.add_argument("--metric", default="client_time")
+    sp.add_argument("--arch", default="")
+    sp.add_argument("--with-confidence", action="store_true")
+    sp.add_argument("--with-trend", action="store_true")
+    sp.add_argument("--with-history", action="store_true")
+    sp.add_argument("--with-coverage", action="store_true")
+    sp.add_argument("--with-flamegraph-diff", action="store_true")
+    sp.add_argument("--trace-type", default="CPU", choices=["CPU", "REAL_TIME", "MEMORY"])
+    sp.set_defaults(func=cmd_query)
+
+    sp = sub.add_parser("pr-inventory", help="Inventory slowdowns and improvements for all performance.ci runs of a PR")
+    sp.add_argument("--pr", required=True)
+    sp.add_argument("--metric", default="client_time")
+    sp.add_argument("--arch", default="")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.add_argument("--aggregate-limit", type=int, default=20)
+    sp.add_argument("--current-only", action="store_true")
+    sp.add_argument("--show-all-run-tables", action="store_true", help="Also print full all-run top slowdown/speedup/high-noise tables")
+    sp.add_argument("--with-confidence", action="store_true", help="Fetch per-test confidence for inventory rows")
+    sp.set_defaults(func=cmd_pr_inventory)
+
+    sp = sub.add_parser("tsv-inventory", help="Inventory rows from fetch_perf_report.py --tsv or raw all-query-metrics TSV files")
+    sp.add_argument("--tsv", nargs="+", required=True)
+    sp.add_argument("--metric", default="client_time")
+    sp.add_argument("--arch", default="")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.add_argument("--show-all", action="store_true")
+    sp.set_defaults(func=cmd_tsv_inventory)
+
+    sp = sub.add_parser("master-checks", help="Classify changed rows using 30-day master status counts from play.clickhouse.com default.checks")
+    sp.add_argument("--pr", help="PR number; uses performance.ci API changed rows")
+    sp.add_argument("--tsv", nargs="+", help="Optional fetch_perf_report.py --tsv / raw artifact TSV input instead of API rows")
+    sp.add_argument("--metric", default="client_time")
+    sp.add_argument("--arch", default="")
+    sp.add_argument("--limit", type=int)
+    sp.add_argument("--days", type=int, default=30)
+    sp.add_argument("--all-runs", action="store_true", help="Use all PR dashboard runs instead of current candidate SHA only")
+    sp.add_argument("--play-url", default=PLAY_DEFAULT)
+    sp.add_argument("--play-user", default="explorer")
+    sp.set_defaults(func=cmd_master_checks)
+
+    sp = sub.add_parser("pr-query-history", help="Compare one query across all PR dashboard runs")
+    sp.add_argument("--pr", required=True)
+    sp.add_argument("--test", required=True)
+    sp.add_argument("--query-index", required=True, type=int)
+    sp.add_argument("--metric", default="client_time")
+    sp.add_argument("--arch", default="")
+    sp.set_defaults(func=cmd_pr_query_history)
+
+    args = p.parse_args()
+    if getattr(args, "pr", None) is None and getattr(args, "q", None) is None and args.cmd == "runs":
+        p.error("runs requires --pr or --q")
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/perf-comparison/scripts/perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/perf_api.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import sys
 from datetime import datetime, timezone
 import urllib.parse
 import urllib.request
@@ -714,59 +713,108 @@ def tsv_bool(value: Any) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes"}
 
 
+RAW_ALL_QUERY_METRICS_COLUMNS = [
+    "metric_name",
+    "left",
+    "right",
+    "diff",
+    "times_change",
+    "stat_threshold",
+    "test",
+    "query_index",
+    "query_display_name",
+    "changed_threshold",
+    "unstable_threshold",
+]
+
+
+def iter_tsv_dicts(path: str) -> list[dict[str, str]]:
+    """Read named TSV or headerless raw all-query-metrics.tsv rows."""
+    with open(path, newline="") as f:
+        reader = csv.reader(f, delimiter="\t")
+        raw_rows = [row for row in reader if row]
+    if not raw_rows:
+        return []
+    first = raw_rows[0]
+    header_names = {"metric", "metric_name", "test", "query_index", "queryIndex", "diff"}
+    if header_names.intersection(first):
+        header = first
+        data_rows = raw_rows[1:]
+    else:
+        header = RAW_ALL_QUERY_METRICS_COLUMNS
+        data_rows = raw_rows
+    out: list[dict[str, str]] = []
+    for row in data_rows:
+        padded = row + [""] * max(0, len(header) - len(row))
+        out.append(dict(zip(header, padded)))
+    return out
+
+
 def parse_perf_tsv(paths: list[str], metric_filter: str = "client_time", arch_filter: str = "") -> list[dict[str, Any]]:
     """Parse fetch_perf_report.py --tsv output or raw all-query-metrics.tsv-like files."""
     rows: list[dict[str, Any]] = []
     for path in paths:
-        with open(path, newline="") as f:
-            reader = csv.DictReader(f, delimiter="\t")
-            for src in reader:
-                metric = src.get("metric") or src.get("metric_name") or metric_filter
-                if metric_filter and metric != metric_filter:
-                    continue
-                arch = src.get("arch") or arch_filter or ""
-                if arch_filter and arch != arch_filter:
-                    continue
+        for src in iter_tsv_dicts(path):
+            metric = src.get("metric") or src.get("metric_name") or metric_filter
+            if metric_filter and metric != metric_filter:
+                continue
+            arch = src.get("arch") or arch_filter or ""
+            if arch_filter and arch != arch_filter:
+                continue
+            try:
+                diff = float(src.get("diff") or 0)
+                threshold = float(src.get("stat_threshold") or src.get("threshold") or 0)
+            except Exception:
+                continue
+            if "is_changed" in src:
+                is_changed = tsv_bool(src.get("is_changed"))
+            else:
+                changed_threshold = src.get("changed_threshold") or src.get("stat_threshold") or src.get("threshold") or 0
                 try:
-                    diff = float(src.get("diff") or 0)
-                    threshold = float(src.get("stat_threshold") or src.get("threshold") or 0)
+                    is_changed = abs(diff) >= float(changed_threshold) and abs(diff) > 0
                 except Exception:
-                    continue
-                is_changed = tsv_bool(src.get("is_changed")) if "is_changed" in src else (abs(diff) >= threshold and abs(diff) > 0.1)
-                is_unstable = tsv_bool(src.get("is_unstable")) if "is_unstable" in src else ((not is_changed) and threshold > 0.2)
-                direction_raw = (src.get("direction") or "").lower()
-                if direction_raw in {"slower", "slowdown"}:
-                    direction = "slowdown"
-                elif direction_raw in {"faster", "speedup"}:
-                    direction = "speedup"
-                elif diff > 0:
-                    direction = "slowdown"
-                elif diff < 0:
-                    direction = "speedup"
-                else:
-                    direction = "same"
+                    is_changed = abs(diff) >= threshold and abs(diff) > 0
+            if "is_unstable" in src:
+                is_unstable = tsv_bool(src.get("is_unstable"))
+            else:
+                unstable_threshold = src.get("unstable_threshold")
                 try:
-                    query_index: int | str = int(src.get("query_index") or src.get("queryIndex") or 0)
+                    is_unstable = (not is_changed) and abs(diff) >= float(unstable_threshold or 0) and abs(diff) > 0
                 except Exception:
-                    query_index = src.get("query_index") or src.get("queryIndex") or "—"
-                rows.append({
-                    "source": path,
-                    "bucket": "changed" if is_changed else ("unstable" if is_unstable else "unchanged"),
-                    "metric": metric,
-                    "arch": arch,
-                    "shard": src.get("shard") or src.get("shard_num") or "",
-                    "test": src.get("test") or "",
-                    "queryIndex": query_index,
-                    "queryDisplayName": src.get("query") or src.get("query_display_name") or "",
-                    "oldValue": src.get("old") or src.get("left"),
-                    "newValue": src.get("new") or src.get("right"),
-                    "diffPercent": diff,
-                    "timesChange": src.get("times_change"),
-                    "statThreshold": threshold,
-                    "isChanged": is_changed,
-                    "isUnstable": is_unstable,
-                    "direction": direction,
-                })
+                    is_unstable = (not is_changed) and threshold > 0.2
+            direction_raw = (src.get("direction") or "").lower()
+            if direction_raw in {"slower", "slowdown"}:
+                direction = "slowdown"
+            elif direction_raw in {"faster", "speedup"}:
+                direction = "speedup"
+            elif diff > 0:
+                direction = "slowdown"
+            elif diff < 0:
+                direction = "speedup"
+            else:
+                direction = "same"
+            try:
+                query_index: int | str = int(src.get("query_index") or src.get("queryIndex") or 0)
+            except Exception:
+                query_index = src.get("query_index") or src.get("queryIndex") or "—"
+            rows.append({
+                "source": path,
+                "bucket": "changed" if is_changed else ("unstable" if is_unstable else "unchanged"),
+                "metric": metric,
+                "arch": arch,
+                "shard": src.get("shard") or src.get("shard_num") or "",
+                "test": src.get("test") or "",
+                "queryIndex": query_index,
+                "queryDisplayName": src.get("query") or src.get("query_display_name") or "",
+                "oldValue": src.get("old") or src.get("left"),
+                "newValue": src.get("new") or src.get("right"),
+                "diffPercent": diff,
+                "timesChange": src.get("times_change"),
+                "statThreshold": threshold,
+                "isChanged": is_changed,
+                "isUnstable": is_unstable,
+                "direction": direction,
+            })
     return rows
 
 

--- a/.claude/skills/perf-comparison/scripts/test_perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/test_perf_api.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Focused tests for perf_api.py artifact parsing."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import perf_api
+
+
+RAW_ROWS = [
+    # test name, diff, stat_threshold, changed_threshold, unstable_threshold
+    ("changed_slower", 0.30, 0.05, 0.20, 0.25),
+    ("boundary_equal_changed", 0.20, 0.05, 0.20, 0.25),
+    ("ci_unstable_low_diff", 0.01, 0.40, 0.20, 0.25),
+    ("stable_below_unstable", 0.01, 0.20, 0.20, 0.25),
+    ("changed_faster", -0.30, 0.05, 0.20, 0.25),
+]
+
+
+def expected(diff: float, stat_threshold: float, changed_threshold: float, unstable_threshold: float) -> tuple[bool, bool, str]:
+    """Replicate ci/jobs/scripts/perf/compare.sh changed_fail / unstable_fail."""
+    is_changed = abs(diff) > changed_threshold and abs(diff) >= stat_threshold
+    is_unstable = (not is_changed) and stat_threshold > unstable_threshold
+    direction = "slowdown" if diff > 0 else ("speedup" if diff < 0 else "same")
+    return is_changed, is_unstable, direction
+
+
+def write_raw_fixture(path: Path) -> None:
+    with path.open("w") as f:
+        for i, (name, diff, stat, changed_threshold, unstable_threshold) in enumerate(RAW_ROWS):
+            left = 1.0
+            right = left + diff
+            times_change = abs(diff) + 1.0
+            fields = [
+                "client_time",
+                f"{left}",
+                f"{right}",
+                f"{diff}",
+                f"{times_change}",
+                f"{stat}",
+                "test_a",
+                str(i),
+                name,
+                f"{changed_threshold}",
+                f"{unstable_threshold}",
+            ]
+            f.write("\t".join(fields) + "\n")
+
+
+def test_raw_all_query_metrics_classification() -> None:
+    root = Path.cwd() / "tmp" / "perf-comparison-parser-test"
+    shutil.rmtree(root, ignore_errors=True)
+    root.mkdir(parents=True)
+    try:
+        fixture = root / "all-query-metrics.tsv"
+        write_raw_fixture(fixture)
+        parsed = {row["queryDisplayName"]: row for row in perf_api.parse_perf_tsv([str(fixture)], metric_filter="client_time")}
+        assert set(parsed) == {row[0] for row in RAW_ROWS}
+        for name, diff, stat, changed_threshold, unstable_threshold in RAW_ROWS:
+            exp_changed, exp_unstable, exp_direction = expected(diff, stat, changed_threshold, unstable_threshold)
+            row = parsed[name]
+            assert row["isChanged"] is exp_changed, (name, row)
+            assert row["isUnstable"] is exp_unstable, (name, row)
+            assert row["direction"] == exp_direction, (name, row)
+
+        # Boundary/regression cases from review feedback.
+        assert parsed["boundary_equal_changed"]["bucket"] == "unchanged"
+        assert parsed["ci_unstable_low_diff"]["bucket"] == "unstable"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_raw_all_query_metrics_classification()
+    print("ok")


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes
- Adds a Claude skill for ClickHouse performance comparison analysis.

### Summary
Adds `.claude/skills/perf-comparison`, a Claude skill for reviewing ClickHouse performance.ci results and optional local `perf.py` runs.

Included files only:
- `SKILL.md`
- `scripts/perf_api.py`
- `scripts/parse_perf_py.py`
- `scripts/local_servers.sh`
- `references/ci-api.md`
- `references/local-perf.md`
- `references/verdict-rules.md`

No README, generated reports, HTML artifacts, or PR-specific test reports are included.

### Validation
- `python3 -m py_compile .claude/skills/perf-comparison/scripts/perf_api.py .claude/skills/perf-comparison/scripts/parse_perf_py.py`
- `bash -n .claude/skills/perf-comparison/scripts/local_servers.sh`
- `python3 .claude/skills/perf-comparison/scripts/perf_api.py --help`
- Checked the added files for local paths, private hosts, tokens/private-key patterns, and test-specific report artifacts.
