### PR TITLE
Fix flaky test_database_glue/test.py::test_show_tables_optimization

### DIFF
--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -291,6 +291,21 @@ def started_cluster():
         cluster.shutdown()
 
 
+@pytest.fixture(autouse=True)
+def clean_catalog(started_cluster):
+    # All tests share one module-scoped Glue catalog. Listing operations such as
+    # SHOW TABLES enumerate every namespace and make one sequential Glue call per
+    # namespace, so leftover namespaces from earlier tests make these calls grow
+    # unbounded and eventually exceed query timeouts. Drop everything each test
+    # created so the catalog stays bounded to the running test.
+    yield
+    catalog = load_catalog_impl(started_cluster)
+    for namespace in catalog.list_namespaces():
+        for table in catalog.list_tables(namespace):
+            catalog.drop_table(table)
+        catalog.drop_namespace(namespace)
+
+
 def test_no_secrets_in_logs(started_cluster):
     node = started_cluster.instances["node1"]
 


### PR DESCRIPTION
The `test_database_glue` tests share one module-scoped Glue catalog but never drop the namespaces and tables they create. By the time `test_show_tables_optimization` runs, the catalog has accumulated dozens of namespaces, so `SHOW TABLES` (one sequential Glue call per namespace) grows slow enough to exceed the test's client timeout on slow builds (observed on `amd_msan`).

Add an autouse fixture that drops all namespaces and tables after each test, keeping the catalog bounded to the running test.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108122

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1144`
<!-- ch-version-info:end -->