### PR TITLE
Avoid mispredicted `offset < copy_amount` branch in `decompressImpl` (LZ4)

### DIFF
--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -418,31 +418,33 @@ template <size_t copy_amount>
 inline constexpr BootMasks<copy_amount> boot_masks{};
 
 /// The 16-byte small-offset overlap fill, via one unconditional table-lookup shuffle using the
-/// constexpr `boot_masks` table. `idx` is the table index: callers on the branchless path pass
-/// `min(real_offset, 16)`, so an index of 16 selects the identity shuffle (a plain copy). That is
-/// what lets the caller drop the highly mispredicted `offset < 16` branch and call this
+/// constexpr `boot_masks` table. Here `offset` is the table index: callers on the branchless path
+/// pass `min(real_offset, 16)`, so an index of 16 selects the identity shuffle (a plain copy).
+/// That is what lets the caller drop the highly mispredicted `offset < 16` branch and call this
 /// unconditionally — the only difference from a plain `copyOverlap` is that clamp (one `cmov`),
 /// computed at the call site. `copyOverlap<8>` and `copyOverlap<32>` are the branched-only
 /// variants and index by the real `offset` directly.
+/// (The parameter is named `offset` to match the primary template; on the branchless path it
+/// carries the clamped index `min(real_offset, 16)`.)
 template <>
-[[maybe_unused]] void ALWAYS_INLINE copyOverlap<16>(UInt8 * op, UInt8 *& match, size_t idx)
+[[maybe_unused]] void ALWAYS_INLINE copyOverlap<16>(UInt8 * op, UInt8 *& match, size_t offset)
 {
 #if defined(__SSSE3__)
     _mm_storeu_si128(reinterpret_cast<__m128i *>(op),
         _mm_shuffle_epi8(
             _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
-            _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<16>.boot[idx]))));
+            _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<16>.boot[offset]))));
     __msan_unpoison(op, 16);
-    match += boot_masks<16>.shift[idx];
+    match += boot_masks<16>.shift[offset];
 #elif defined(__aarch64__) && defined(__ARM_NEON)
     vst1q_u8(reinterpret_cast<uint8_t *>(op),
         vqtbl1q_u8(
             vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
-            vld1q_u8(boot_masks<16>.boot[idx])));
+            vld1q_u8(boot_masks<16>.boot[offset])));
     __msan_unpoison(op, 16);
-    match += boot_masks<16>.shift[idx];
+    match += boot_masks<16>.shift[offset];
 #else
-    /// Scalar fallback (no SSSE3/NEON): reached only via the branched call path, where `idx` is
+    /// Scalar fallback (no SSSE3/NEON): reached only via the branched call path, where `offset` is
     /// the real offset < 16.
     static constexpr UInt8 shift1[] = {0, 1, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
     static constexpr UInt8 shift2[] = {0, 1, 2, 2, 4, 3, 2, 1, 0, 8, 8, 8, 8, 8, 8, 8};
@@ -451,9 +453,9 @@ template <>
     op[1] = match[1];
     op[2] = match[2];
     op[3] = match[3];
-    memcpy(op + 4, match + shift1[idx], 4);
-    memcpy(op + 8, match + shift2[idx], 8);
-    match += shift3[idx];
+    memcpy(op + 4, match + shift1[offset], 4);
+    memcpy(op + 8, match + shift2[offset], 8);
+    match += shift3[offset];
 #endif
 }
 

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -397,6 +397,11 @@ template <>
 template <size_t copy_amount>
 struct BootMasks
 {
+    /// The inner dimension and the `pshufb` / `vqtbl1q_u8` shuffle it feeds are 16 bytes wide, so the
+    /// generated masks are only correct for a 16-byte copy. Only `boot_masks<16>` is ever used; guard
+    /// against a future `boot_masks<8>` / `<32>` silently getting wrong masks.
+    static_assert(copy_amount == 16, "BootMasks is only valid for a 16-byte copy amount");
+
     alignas(16) UInt8 boot[copy_amount + 1][16];
     UInt8 shift[copy_amount + 1];
     constexpr BootMasks() : boot{}, shift{}
@@ -429,6 +434,11 @@ template <>
     __msan_unpoison(op, 16);
     match += boot_masks<16>.shift[offset];
 #elif defined(__aarch64__) && defined(__ARM_NEON)
+    /// A non-branchless `vqtbl1q_u8` copyOverlap<16> was previously measured on Graviton 4 to be no
+    /// better than the scalar fallback (geo mean 1.0000x on test.hits): the `offset < 16` branch it
+    /// still carried was the bottleneck, not the copy. This branchless variant removes that branch, so
+    /// the table lookup finally pays off — forced-variant-1 on Graviton 4 (armv8.2-a) vs the scalar
+    /// 16-byte path: RegionID +27%, ResolutionWidth +28%, UserID +9%.
     unalignedStore<uint8x16_t>(op,
         vqtbl1q_u8(unalignedLoad<uint8x16_t>(match), unalignedLoad<uint8x16_t>(boot_masks<16>.boot[offset])));
     __msan_unpoison(op, 16);

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -549,7 +549,13 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
         ip += 2;
         UInt8 * match = op - offset;
 
-        if (unlikely(match < output_begin))
+        /// Reject a zero offset (invalid in LZ4 — the minimum match distance is 1) together with an
+        /// offset that reaches before the start of the output, in a single unsigned comparison that
+        /// adds no branch to the hot loop. For any `offset >= 1` this is exactly `match < output_begin`
+        /// (`match = op - offset`); for `offset == 0`, `offset - 1` wraps to `SIZE_MAX` and also fails,
+        /// so the overlap copy can no longer synthesize output from the destination and wrongly report
+        /// success. We fail closed here (the reference decoder is more lenient and returns garbage).
+        if (unlikely(offset - 1 >= static_cast<size_t>(op - output_begin)))
             return false;
 
         /// Get match length.

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -618,13 +618,27 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
                 _mm_shuffle_epi8(
                     _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
                     _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<copy_amount>.boot[idx]))));
-#else
-            vst1q_u8(reinterpret_cast<uint8_t *>(op),
-                vqtbl1q_u8(
-                    vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
-                    vld1q_u8(boot_masks<copy_amount>.boot[idx])));
-#endif
             __msan_unpoison(op, 16);
+#else
+            if constexpr (copy_amount == 8)
+            {
+                /// 8-byte D-register `vtbl1_u8`: a native 8-byte op on AArch64, avoiding the
+                /// wasted half of a 16-byte Q-register shuffle (the better branchless width on ARM).
+                vst1_u8(reinterpret_cast<uint8_t *>(op),
+                    vtbl1_u8(
+                        vld1_u8(reinterpret_cast<const uint8_t *>(match)),
+                        vld1_u8(boot_masks<copy_amount>.boot[idx])));
+                __msan_unpoison(op, 8);
+            }
+            else
+            {
+                vst1q_u8(reinterpret_cast<uint8_t *>(op),
+                    vqtbl1q_u8(
+                        vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
+                        vld1q_u8(boot_masks<copy_amount>.boot[idx])));
+                __msan_unpoison(op, 16);
+            }
+#endif
             match += boot_masks<copy_amount>.shift[idx];
         }
         else if (offset < copy_amount)
@@ -700,33 +714,26 @@ bool decompress(
     /// where timing very small blocks would add too much noise.
     if (statistics.choose_method >= 0 || dest_size >= 32768)
     {
-        /// The branchless small-offset variant (the last one) only helps blocks that contain
-        /// many small-offset matches, which is strongly correlated with a higher compression
-        /// ratio. For near-incompressible blocks it cannot help, so drop it from the candidate
-        /// set — the bandit keeps exploring forever (to adapt to shifting data), so leaving an
-        /// option that can never win for this block just wastes that exploration. The
-        /// compression ratio is free: both sizes are already in the block header.
-        size_t variant_size = (dest_size >= source_size * 2)
-            ? PerformanceStatistics::NUM_ELEMENTS
-            : PerformanceStatistics::NUM_ELEMENTS - 1;
+        size_t variant_size = PerformanceStatistics::NUM_ELEMENTS;
         size_t best_variant = statistics.select(variant_size);
 
         Stopwatch watch;
         bool success = false;
-        /// Variant 3 is the branchless small-offset match copy (16-byte). It is added as an
-        /// extra bandit option rather than replacing a variant: on low-cardinality
-        /// (small-offset) columns it is ~+20-25% faster on x86 and a win on ARM, while on
-        /// large-offset / incompressible columns the bandit keeps selecting the branched
-        /// variants. Adding (not replacing) guarantees no regression on any architecture —
-        /// the bandit can always fall back to the original best variant.
+        /// Variants 0 and 1 use the branchless small-offset match copy (8- and 16-byte). It
+        /// removes the `offset < copy_amount` branch, which is highly mispredicted on
+        /// low-cardinality (small-offset) columns. The best branchless width is architecture
+        /// dependent — 16-byte (`pshufb`) tends to win on x86, 8-byte (NEON D-register
+        /// `vtbl1_u8`) on AArch64 — so both are offered and the bandit picks per column
+        /// (e.g. small-offset integers -> branchless 8/16, large-offset/string -> 32). The
+        /// branchless variants only change the match-copy step, so on near-incompressible
+        /// blocks (almost no matches) they behave like the branched ones — no regression and
+        /// no need to special-case them.
         if (best_variant == 0)
-            success = decompressImpl<8>(source, dest, source_size, dest_size);
+            success = decompressImpl<8, true>(source, dest, source_size, dest_size);
         else if (best_variant == 1)
-            success = decompressImpl<16>(source, dest, source_size, dest_size);
-        else if (best_variant == 2)
-            success = decompressImpl<32>(source, dest, source_size, dest_size);
-        else
             success = decompressImpl<16, true>(source, dest, source_size, dest_size);
+        else
+            success = decompressImpl<32>(source, dest, source_size, dest_size);
 
         watch.stop();
         statistics.data[best_variant].update(watch.elapsedSeconds(), static_cast<double>(dest_size));  // NOLINT(clang-analyzer-security.ArrayBound)
@@ -742,7 +749,7 @@ bool decompress(
     /// (AMD 7950X3D), sweeping it from 0 to 32K changes the oracle total by only 0.003%,
     /// because variant 0 is available in the bandit anyway and would be selected for
     /// the same files. The threshold is purely a noise-reduction measure.
-    return decompressImpl<8>(source, dest, source_size, dest_size);
+    return decompressImpl<8, true>(source, dest, source_size, dest_size);
 }
 
 }

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -452,7 +452,34 @@ template <>
 }
 
 
+/// Branchless small-offset bootstrap masks (SSSE3), indexed by min(offset, copy_amount).
+/// One unconditional `pshufb` writes the first `copy_amount` bytes correctly for ANY
+/// offset (identity for offset >= copy_amount), and advancing `match` by `shift[idx]`
+/// makes the effective offset >= copy_amount, so the remaining copies are non-overlapping.
+/// This removes the `offset < copy_amount` data-dependent branch that dominates
+/// mispredicts on small-offset (low-cardinality) columns.
 template <size_t copy_amount>
+struct BootMasks
+{
+    alignas(16) uint8_t boot[copy_amount + 1][16];
+    uint8_t shift[copy_amount + 1];
+    constexpr BootMasks() : boot{}, shift{}
+    {
+        for (size_t idx = 1; idx <= copy_amount; ++idx)
+        {
+            for (size_t i = 0; i < 16; ++i)
+                boot[idx][i] = (idx == copy_amount) ? static_cast<uint8_t>(i) : static_cast<uint8_t>(i % idx);
+            shift[idx] = (idx == copy_amount)
+                ? static_cast<uint8_t>(copy_amount)
+                : static_cast<uint8_t>((copy_amount % idx) ? (copy_amount % idx) : idx);
+        }
+    }
+};
+
+template <size_t copy_amount>
+inline constexpr BootMasks<copy_amount> boot_masks{};
+
+template <size_t copy_amount, bool branchless = false>
 bool NO_INLINE decompressImpl(const char * const source, char * const dest, size_t source_size, size_t dest_size)
 {
     const UInt8 * ip = reinterpret_cast<const UInt8 *>(source);
@@ -577,6 +604,31 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
           * The worst case when offset = 1 and length = 4
           */
 
+#if defined(__SSSE3__) || (defined(__aarch64__) && defined(__ARM_NEON))
+        if constexpr (branchless && copy_amount != 32)
+        {
+            /// Branchless: one unconditional 16-byte table-lookup shuffle + cmov index,
+            /// removing the `offset < copy_amount` data-dependent branch. The shuffle builds
+            /// the first `copy_amount` output bytes correctly for any offset (identity when
+            /// offset >= copy_amount), and `match += shift[idx]` makes the effective offset
+            /// >= copy_amount so the remaining copies are non-overlapping.
+            unsigned idx = offset < copy_amount ? static_cast<unsigned>(offset) : copy_amount;
+#if defined(__SSSE3__)
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(op),
+                _mm_shuffle_epi8(
+                    _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
+                    _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<copy_amount>.boot[idx]))));
+#else
+            vst1q_u8(reinterpret_cast<uint8_t *>(op),
+                vqtbl1q_u8(
+                    vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
+                    vld1q_u8(boot_masks<copy_amount>.boot[idx])));
+#endif
+            __msan_unpoison(op, 16);
+            match += boot_masks<copy_amount>.shift[idx];
+        }
+        else
+#endif
         if (offset < copy_amount)
         {
             /// output: Hello
@@ -647,17 +699,25 @@ bool decompress(
     /// where timing very small blocks would add too much noise.
     if (statistics.choose_method >= 0 || dest_size >= 32768)
     {
-        size_t variant_size = 3;
+        size_t variant_size = PerformanceStatistics::NUM_ELEMENTS;
         size_t best_variant = statistics.select(variant_size);
 
         Stopwatch watch;
         bool success = false;
+        /// Variant 3 is the branchless small-offset match copy (16-byte). It is added as an
+        /// extra bandit option rather than replacing a variant: on low-cardinality
+        /// (small-offset) columns it is ~+20-25% faster on x86 and a win on ARM, while on
+        /// large-offset / incompressible columns the bandit keeps selecting the branched
+        /// variants. Adding (not replacing) guarantees no regression on any architecture —
+        /// the bandit can always fall back to the original best variant.
         if (best_variant == 0)
             success = decompressImpl<8>(source, dest, source_size, dest_size);
         else if (best_variant == 1)
             success = decompressImpl<16>(source, dest, source_size, dest_size);
-        else
+        else if (best_variant == 2)
             success = decompressImpl<32>(source, dest, source_size, dest_size);
+        else
+            success = decompressImpl<16, true>(source, dest, source_size, dest_size);
 
         watch.stop();
         statistics.data[best_variant].update(watch.elapsedSeconds(), static_cast<double>(dest_size));  // NOLINT(clang-analyzer-security.ArrayBound)

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -699,7 +699,15 @@ bool decompress(
     /// where timing very small blocks would add too much noise.
     if (statistics.choose_method >= 0 || dest_size >= 32768)
     {
-        size_t variant_size = PerformanceStatistics::NUM_ELEMENTS;
+        /// The branchless small-offset variant (the last one) only helps blocks that contain
+        /// many small-offset matches, which is strongly correlated with a higher compression
+        /// ratio. For near-incompressible blocks it cannot help, so drop it from the candidate
+        /// set — the bandit keeps exploring forever (to adapt to shifting data), so leaving an
+        /// option that can never win for this block just wastes that exploration. The
+        /// compression ratio is free: both sizes are already in the block header.
+        size_t variant_size = (dest_size >= source_size * 2)
+            ? PerformanceStatistics::NUM_ELEMENTS
+            : PerformanceStatistics::NUM_ELEMENTS - 1;
         size_t best_variant = statistics.select(variant_size);
 
         Stopwatch watch;

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -627,9 +627,10 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
             __msan_unpoison(op, 16);
             match += boot_masks<copy_amount>.shift[idx];
         }
-        else
-#endif
+        else if (offset < copy_amount)
+#else
         if (offset < copy_amount)
+#endif
         {
             /// output: Hello
             ///              ^-op

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -397,17 +397,17 @@ template <>
 template <size_t copy_amount>
 struct BootMasks
 {
-    alignas(16) uint8_t boot[copy_amount + 1][16];
-    uint8_t shift[copy_amount + 1];
+    alignas(16) UInt8 boot[copy_amount + 1][16];
+    UInt8 shift[copy_amount + 1];
     constexpr BootMasks() : boot{}, shift{}
     {
         for (size_t idx = 1; idx <= copy_amount; ++idx)
         {
             for (size_t i = 0; i < 16; ++i)
-                boot[idx][i] = (idx == copy_amount) ? static_cast<uint8_t>(i) : static_cast<uint8_t>(i % idx);
+                boot[idx][i] = (idx == copy_amount) ? static_cast<UInt8>(i) : static_cast<UInt8>(i % idx);
             shift[idx] = (idx == copy_amount)
-                ? static_cast<uint8_t>(copy_amount)
-                : static_cast<uint8_t>((copy_amount % idx) ? (copy_amount % idx) : idx);
+                ? static_cast<UInt8>(copy_amount)
+                : static_cast<UInt8>((copy_amount % idx) ? (copy_amount % idx) : idx);
         }
     }
 };
@@ -429,10 +429,8 @@ template <>
     __msan_unpoison(op, 16);
     match += boot_masks<16>.shift[offset];
 #elif defined(__aarch64__) && defined(__ARM_NEON)
-    vst1q_u8(reinterpret_cast<uint8_t *>(op),
-        vqtbl1q_u8(
-            vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
-            vld1q_u8(boot_masks<16>.boot[offset])));
+    unalignedStore<uint8x16_t>(op,
+        vqtbl1q_u8(unalignedLoad<uint8x16_t>(match), unalignedLoad<uint8x16_t>(boot_masks<16>.boot[offset])));
     __msan_unpoison(op, 16);
     match += boot_masks<16>.shift[offset];
 #else

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -394,8 +394,6 @@ template <>
 /// One unconditional `pshufb` writes the first `copy_amount` bytes correctly for ANY
 /// offset (identity for offset >= copy_amount), and advancing `match` by `shift[idx]`
 /// makes the effective offset >= copy_amount, so the remaining copies are non-overlapping.
-/// This removes the `offset < copy_amount` data-dependent branch that dominates
-/// mispredicts on small-offset (low-cardinality) columns.
 template <size_t copy_amount>
 struct BootMasks
 {
@@ -420,12 +418,6 @@ inline constexpr BootMasks<copy_amount> boot_masks{};
 /// The 16-byte small-offset overlap fill, via one unconditional table-lookup shuffle using the
 /// constexpr `boot_masks` table. Here `offset` is the table index: callers on the branchless path
 /// pass `min(real_offset, 16)`, so an index of 16 selects the identity shuffle (a plain copy).
-/// That is what lets the caller drop the highly mispredicted `offset < 16` branch and call this
-/// unconditionally — the only difference from a plain `copyOverlap` is that clamp (one `cmov`),
-/// computed at the call site. `copyOverlap<8>` and `copyOverlap<32>` are the branched-only
-/// variants and index by the real `offset` directly.
-/// (The parameter is named `offset` to match the primary template; on the branchless path it
-/// carries the clamped index `min(real_offset, 16)`.)
 template <>
 [[maybe_unused]] void ALWAYS_INLINE copyOverlap<16>(UInt8 * op, UInt8 *& match, size_t offset)
 {
@@ -668,16 +660,6 @@ bool decompress(
 
         Stopwatch watch;
         bool success = false;
-        /// Variant 1 (16-byte) uses the branchless small-offset match copy: it removes the
-        /// `offset < copy_amount` branch via one unconditional `pshufb` (x86) / `vqtbl1q_u8`
-        /// (NEON), which is highly mispredicted on low-cardinality (small-offset) columns where
-        /// 16-byte copies are optimal (e.g. RegionID). Only the 16-byte variant is made
-        /// branchless: at 8 bytes the unconditional shuffle is pure overhead on the many
-        /// columns whose offsets are regular and well-predicted (RLE / structured states), so
-        /// variant 0 stays branched; columns that want the 8-byte copy keep it branch-free of
-        /// extra work. The bandit routes each column to its best variant; the branchless step
-        /// only changes the match copy, so near-incompressible blocks behave like the branched
-        /// variants — no regression, no special-casing.
         if (best_variant == 0)
             success = decompressImpl<8>(source, dest, source_size, dest_size);
         else if (best_variant == 1)

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -25,8 +25,7 @@ namespace
 
 ALWAYS_INLINE UInt16 LZ4_readLE16(const void * mem_ptr)
 {
-    const UInt8* p = reinterpret_cast<const UInt8*>(mem_ptr);
-    return static_cast<UInt16>(p[0] + (p[1] << 8));
+    return unalignedLoadLittleEndian<UInt16>(mem_ptr);
 }
 
 template <size_t block_size>
@@ -235,67 +234,6 @@ template <>
 }
 
 template <>
-[[maybe_unused]] void ALWAYS_INLINE copyOverlap<16>(UInt8 * op, UInt8 *& match, size_t offset)
-{
-#if defined(__SSSE3__)
-
-    static constexpr UInt8 __attribute__((__aligned__(16))) masks[] =
-    {
-        0,  1,  2,  1,  4,  1,  4,  2,  8,  7,  6,  5,  4,  3,  2,  1, /* offset = 0, not used as mask, but for shift amount instead */
-        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, /* offset = 1 */
-        0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,  0,  1,
-        0,  1,  2,  0,  1,  2,  0,  1,  2,  0,  1,  2,  0,  1,  2,  0,
-        0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,  1,  2,  3,  4,  0,
-        0,  1,  2,  3,  4,  5,  0,  1,  2,  3,  4,  5,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  5,  6,  0,  1,  2,  3,  4,  5,  6,  0,  1,
-        0,  1,  2,  3,  4,  5,  6,  7,  0,  1,  2,  3,  4,  5,  6,  7,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  0,  1,  2,  3,  4,  5,  6,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  0,  1,  2,  3,  4,  5,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,  0,  1,  2,  3,  4,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11,  0,  1,  2,  3,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12,  0,  1,  2,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13,  0,  1,
-        0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  0,
-    };
-
-    _mm_storeu_si128(reinterpret_cast<__m128i *>(op),
-        _mm_shuffle_epi8(
-            _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
-            _mm_load_si128(reinterpret_cast<const __m128i *>(masks) + offset)));
-
-    match += masks[offset];
-
-    /// MSAN does not recognize the store as initializing the memory
-    __msan_unpoison(op, 16);
-
-    /// Note: an ARM NEON path using `vqtbl1q_u8` (Q-register 16-byte table lookup) was tested
-    /// on Graviton 4 but showed no improvement over the scalar fallback (geo mean 1.0000x across
-    /// test.hits columns). The previous `vtbl2_u8` (D-register) path was actively slower.
-
-#else
-    /// 4 % n.
-    static constexpr UInt8 shift1[] = {0, 1, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-
-    /// 8 % n
-    static constexpr UInt8 shift2[] = {0, 1, 2, 2, 4, 3, 2, 1, 0, 8, 8, 8, 8, 8, 8, 8};
-
-    /// 16 % n
-    static constexpr UInt8 shift3[] = {0, 1, 2, 1, 4, 1, 4, 2, 8, 7, 6, 5, 4, 3, 2, 1};
-
-    op[0] = match[0];
-    op[1] = match[1];
-    op[2] = match[2];
-    op[3] = match[3];
-
-    memcpy(op + 4, match + shift1[offset], 4);
-    memcpy(op + 8, match + shift2[offset], 8);
-    match += shift3[offset];
-#endif
-}
-
-
-template <>
 [[maybe_unused]] void ALWAYS_INLINE copyOverlap<32>(UInt8 * op, UInt8 *& match, size_t offset)
 {
 #if defined(__SSSE3__)
@@ -479,6 +417,46 @@ struct BootMasks
 template <size_t copy_amount>
 inline constexpr BootMasks<copy_amount> boot_masks{};
 
+/// The 16-byte small-offset overlap fill, via one unconditional table-lookup shuffle using the
+/// constexpr `boot_masks` table. `idx` is the table index: callers on the branchless path pass
+/// `min(real_offset, 16)`, so an index of 16 selects the identity shuffle (a plain copy). That is
+/// what lets the caller drop the highly mispredicted `offset < 16` branch and call this
+/// unconditionally — the only difference from a plain `copyOverlap` is that clamp (one `cmov`),
+/// computed at the call site. `copyOverlap<8>` and `copyOverlap<32>` are the branched-only
+/// variants and index by the real `offset` directly.
+template <>
+[[maybe_unused]] void ALWAYS_INLINE copyOverlap<16>(UInt8 * op, UInt8 *& match, size_t idx)
+{
+#if defined(__SSSE3__)
+    _mm_storeu_si128(reinterpret_cast<__m128i *>(op),
+        _mm_shuffle_epi8(
+            _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
+            _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<16>.boot[idx]))));
+    __msan_unpoison(op, 16);
+    match += boot_masks<16>.shift[idx];
+#elif defined(__aarch64__) && defined(__ARM_NEON)
+    vst1q_u8(reinterpret_cast<uint8_t *>(op),
+        vqtbl1q_u8(
+            vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
+            vld1q_u8(boot_masks<16>.boot[idx])));
+    __msan_unpoison(op, 16);
+    match += boot_masks<16>.shift[idx];
+#else
+    /// Scalar fallback (no SSSE3/NEON): reached only via the branched call path, where `idx` is
+    /// the real offset < 16.
+    static constexpr UInt8 shift1[] = {0, 1, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+    static constexpr UInt8 shift2[] = {0, 1, 2, 2, 4, 3, 2, 1, 0, 8, 8, 8, 8, 8, 8, 8};
+    static constexpr UInt8 shift3[] = {0, 1, 2, 1, 4, 1, 4, 2, 8, 7, 6, 5, 4, 3, 2, 1};
+    op[0] = match[0];
+    op[1] = match[1];
+    op[2] = match[2];
+    op[3] = match[3];
+    memcpy(op + 4, match + shift1[idx], 4);
+    memcpy(op + 8, match + shift2[idx], 8);
+    match += shift3[idx];
+#endif
+}
+
 template <size_t copy_amount, bool branchless = false>
 bool NO_INLINE decompressImpl(const char * const source, char * const dest, size_t source_size, size_t dest_size)
 {
@@ -605,42 +583,11 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
           */
 
 #if defined(__SSSE3__) || (defined(__aarch64__) && defined(__ARM_NEON))
-        if constexpr (branchless && copy_amount != 32)
-        {
-            /// Branchless: one unconditional 16-byte table-lookup shuffle + cmov index,
-            /// removing the `offset < copy_amount` data-dependent branch. The shuffle builds
-            /// the first `copy_amount` output bytes correctly for any offset (identity when
-            /// offset >= copy_amount), and `match += shift[idx]` makes the effective offset
-            /// >= copy_amount so the remaining copies are non-overlapping.
-            unsigned idx = offset < copy_amount ? static_cast<unsigned>(offset) : copy_amount;
-#if defined(__SSSE3__)
-            _mm_storeu_si128(reinterpret_cast<__m128i *>(op),
-                _mm_shuffle_epi8(
-                    _mm_loadu_si128(reinterpret_cast<const __m128i *>(match)),
-                    _mm_load_si128(reinterpret_cast<const __m128i *>(boot_masks<copy_amount>.boot[idx]))));
-            __msan_unpoison(op, 16);
-#else
-            if constexpr (copy_amount == 8)
-            {
-                /// 8-byte D-register `vtbl1_u8`: a native 8-byte op on AArch64, avoiding the
-                /// wasted half of a 16-byte Q-register shuffle (the better branchless width on ARM).
-                vst1_u8(reinterpret_cast<uint8_t *>(op),
-                    vtbl1_u8(
-                        vld1_u8(reinterpret_cast<const uint8_t *>(match)),
-                        vld1_u8(boot_masks<copy_amount>.boot[idx])));
-                __msan_unpoison(op, 8);
-            }
-            else
-            {
-                vst1q_u8(reinterpret_cast<uint8_t *>(op),
-                    vqtbl1q_u8(
-                        vld1q_u8(reinterpret_cast<const uint8_t *>(match)),
-                        vld1q_u8(boot_masks<copy_amount>.boot[idx])));
-                __msan_unpoison(op, 16);
-            }
-#endif
-            match += boot_masks<copy_amount>.shift[idx];
-        }
+        if constexpr (branchless && copy_amount == 16)
+            /// Unconditional branchless overlap copy: clamp the index here (one `cmov`) so that
+            /// `copyOverlap<16>` selects the identity shuffle for offset >= 16, dropping the
+            /// highly mispredicted `offset < 16` branch.
+            copyOverlap<copy_amount>(op, match, offset < copy_amount ? offset : copy_amount);
         else if (offset < copy_amount)
 #else
         if (offset < copy_amount)

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -545,9 +545,8 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
 
         /// Get match offset.
 
-        size_t offset = LZ4_readLE16(ip);
+        const size_t offset = LZ4_readLE16(ip);
         ip += 2;
-        UInt8 * match = op - offset;
 
         /// Reject a zero offset (invalid in LZ4 — the minimum match distance is 1) together with an
         /// offset that reaches before the start of the output, in a single unsigned comparison that
@@ -555,8 +554,13 @@ bool NO_INLINE decompressImpl(const char * const source, char * const dest, size
         /// (`match = op - offset`); for `offset == 0`, `offset - 1` wraps to `SIZE_MAX` and also fails,
         /// so the overlap copy can no longer synthesize output from the destination and wrongly report
         /// success. We fail closed here (the reference decoder is more lenient and returns garbage).
-        if (unlikely(offset - 1 >= static_cast<size_t>(op - output_begin)))
+        /// The check is done before forming `match`, so `op - offset` is never computed for a malformed
+        /// offset that would point before `output_begin` (which would be out-of-range pointer arithmetic).
+        const size_t produced = static_cast<size_t>(op - output_begin);
+        if (unlikely(offset - 1 >= produced))
             return false;
+
+        UInt8 * match = op - offset;
 
         /// Get match length.
 

--- a/src/Compression/LZ4_decompress_faster.cpp
+++ b/src/Compression/LZ4_decompress_faster.cpp
@@ -719,17 +719,18 @@ bool decompress(
 
         Stopwatch watch;
         bool success = false;
-        /// Variants 0 and 1 use the branchless small-offset match copy (8- and 16-byte). It
-        /// removes the `offset < copy_amount` branch, which is highly mispredicted on
-        /// low-cardinality (small-offset) columns. The best branchless width is architecture
-        /// dependent — 16-byte (`pshufb`) tends to win on x86, 8-byte (NEON D-register
-        /// `vtbl1_u8`) on AArch64 — so both are offered and the bandit picks per column
-        /// (e.g. small-offset integers -> branchless 8/16, large-offset/string -> 32). The
-        /// branchless variants only change the match-copy step, so on near-incompressible
-        /// blocks (almost no matches) they behave like the branched ones — no regression and
-        /// no need to special-case them.
+        /// Variant 1 (16-byte) uses the branchless small-offset match copy: it removes the
+        /// `offset < copy_amount` branch via one unconditional `pshufb` (x86) / `vqtbl1q_u8`
+        /// (NEON), which is highly mispredicted on low-cardinality (small-offset) columns where
+        /// 16-byte copies are optimal (e.g. RegionID). Only the 16-byte variant is made
+        /// branchless: at 8 bytes the unconditional shuffle is pure overhead on the many
+        /// columns whose offsets are regular and well-predicted (RLE / structured states), so
+        /// variant 0 stays branched; columns that want the 8-byte copy keep it branch-free of
+        /// extra work. The bandit routes each column to its best variant; the branchless step
+        /// only changes the match copy, so near-incompressible blocks behave like the branched
+        /// variants — no regression, no special-casing.
         if (best_variant == 0)
-            success = decompressImpl<8, true>(source, dest, source_size, dest_size);
+            success = decompressImpl<8>(source, dest, source_size, dest_size);
         else if (best_variant == 1)
             success = decompressImpl<16, true>(source, dest, source_size, dest_size);
         else
@@ -749,7 +750,7 @@ bool decompress(
     /// (AMD 7950X3D), sweeping it from 0 to 32K changes the oracle total by only 0.003%,
     /// because variant 0 is available in the bandit anyway and would be selected for
     /// the same files. The threshold is purely a noise-reduction measure.
-    return decompressImpl<8, true>(source, dest, source_size, dest_size);
+    return decompressImpl<8>(source, dest, source_size, dest_size);
 }
 
 }

--- a/src/Compression/LZ4_decompress_faster.h
+++ b/src/Compression/LZ4_decompress_faster.h
@@ -88,7 +88,8 @@ struct PerformanceStatistics
     };
 
     /// Number of different algorithms to select from.
-    static constexpr size_t NUM_ELEMENTS = 3;
+    /// 0: 8-byte copies, 1: 16-byte, 2: 32-byte, 3: 16-byte with branchless small-offset match copy.
+    static constexpr size_t NUM_ELEMENTS = 4;
 
     /// Cold invocations may be affected by additional memory latencies. Don't take first invocations into account.
     static constexpr double NUM_INVOCATIONS_TO_THROW_OFF = 1;

--- a/src/Compression/LZ4_decompress_faster.h
+++ b/src/Compression/LZ4_decompress_faster.h
@@ -88,8 +88,8 @@ struct PerformanceStatistics
     };
 
     /// Number of different algorithms to select from.
-    /// 0: 8-byte copies, 1: 16-byte, 2: 32-byte, 3: 16-byte with branchless small-offset match copy.
-    static constexpr size_t NUM_ELEMENTS = 4;
+    /// 0: 8-byte and 1: 16-byte copies with the branchless small-offset match copy; 2: 32-byte.
+    static constexpr size_t NUM_ELEMENTS = 3;
 
     /// Cold invocations may be affected by additional memory latencies. Don't take first invocations into account.
     static constexpr double NUM_INVOCATIONS_TO_THROW_OFF = 1;

--- a/src/Compression/LZ4_decompress_faster.h
+++ b/src/Compression/LZ4_decompress_faster.h
@@ -88,7 +88,7 @@ struct PerformanceStatistics
     };
 
     /// Number of different algorithms to select from.
-    /// 0: 8-byte and 1: 16-byte copies with the branchless small-offset match copy; 2: 32-byte.
+    /// 0: 8-byte copies; 1: 16-byte copies with branchless small-offset match copy; 2: 32-byte copies.
     static constexpr size_t NUM_ELEMENTS = 3;
 
     /// Cold invocations may be affected by additional memory latencies. Don't take first invocations into account.

--- a/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
+++ b/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
@@ -1,10 +1,11 @@
 #include <Compression/LZ4_decompress_faster.h>
 
+#include <base/types.h>
+
 #include <lz4.h>
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -27,14 +28,14 @@ namespace
 
 /// Append the LZ4 length-extension bytes for the part of a length that exceeds the
 /// 15 already encoded in the token nibble.
-void appendLengthExtension(std::vector<uint8_t> & out, size_t remainder)
+void appendLengthExtension(std::vector<UInt8> & out, size_t remainder)
 {
     while (remainder >= 255)
     {
         out.push_back(255);
         remainder -= 255;
     }
-    out.push_back(static_cast<uint8_t>(remainder));
+    out.push_back(static_cast<UInt8>(remainder));
 }
 
 /** Hand-encode a raw LZ4 block (no ClickHouse frame, no checksum) consisting of:
@@ -43,32 +44,32 @@ void appendLengthExtension(std::vector<uint8_t> & out, size_t remainder)
   *
   * Decoding it yields exactly `seed` ++ (match replicated from `offset` back) ++ `trailing`.
   */
-std::vector<uint8_t> encodeBlock(
-    const std::vector<uint8_t> & seed,
-    uint16_t offset,
+std::vector<UInt8> encodeBlock(
+    const std::vector<UInt8> & seed,
+    UInt16 offset,
     size_t match_length,
-    const std::vector<uint8_t> & trailing)
+    const std::vector<UInt8> & trailing)
 {
-    std::vector<uint8_t> b;
+    std::vector<UInt8> b;
 
     const size_t lit = seed.size();
     const size_t ml = match_length - 4; /// LZ4 minMatch is 4.
 
-    const uint8_t lit_nibble = static_cast<uint8_t>(std::min<size_t>(lit, 15));
-    const uint8_t ml_nibble = static_cast<uint8_t>(std::min<size_t>(ml, 15));
-    b.push_back(static_cast<uint8_t>((lit_nibble << 4) | ml_nibble));
+    const UInt8 lit_nibble = static_cast<UInt8>(std::min<size_t>(lit, 15));
+    const UInt8 ml_nibble = static_cast<UInt8>(std::min<size_t>(ml, 15));
+    b.push_back(static_cast<UInt8>((lit_nibble << 4) | ml_nibble));
     if (lit >= 15)
         appendLengthExtension(b, lit - 15);
     b.insert(b.end(), seed.begin(), seed.end());
 
-    b.push_back(static_cast<uint8_t>(offset & 0xFF));
-    b.push_back(static_cast<uint8_t>((offset >> 8) & 0xFF));
+    b.push_back(static_cast<UInt8>(offset & 0xFF));
+    b.push_back(static_cast<UInt8>((offset >> 8) & 0xFF));
     if (ml >= 15)
         appendLengthExtension(b, ml - 15);
 
     const size_t tl = trailing.size();
-    const uint8_t tl_nibble = static_cast<uint8_t>(std::min<size_t>(tl, 15));
-    b.push_back(static_cast<uint8_t>(tl_nibble << 4));
+    const UInt8 tl_nibble = static_cast<UInt8>(std::min<size_t>(tl, 15));
+    b.push_back(static_cast<UInt8>(tl_nibble << 4));
     if (tl >= 15)
         appendLengthExtension(b, tl - 15);
     b.insert(b.end(), trailing.begin(), trailing.end());
@@ -78,13 +79,13 @@ std::vector<uint8_t> encodeBlock(
 
 /// The bytes that decoding `encodeBlock(seed, offset, match_length, trailing)` must produce,
 /// derived independently from the LZ4 overlap semantics.
-std::vector<uint8_t> expectedOutput(
-    const std::vector<uint8_t> & seed,
-    uint16_t offset,
+std::vector<UInt8> expectedOutput(
+    const std::vector<UInt8> & seed,
+    UInt16 offset,
     size_t match_length,
-    const std::vector<uint8_t> & trailing)
+    const std::vector<UInt8> & trailing)
 {
-    std::vector<uint8_t> out = seed;
+    std::vector<UInt8> out = seed;
     for (size_t i = 0; i < match_length; ++i)
         out.push_back(out[out.size() - offset]);
     out.insert(out.end(), trailing.begin(), trailing.end());
@@ -95,11 +96,11 @@ std::vector<uint8_t> expectedOutput(
 /// Both buffers carry the mandatory `ADDITIONAL_BYTES_AT_END_OF_BUFFER` slack so the
 /// wild copies never read or write out of bounds.
 bool decodeWithForcedVariant(
-    const std::vector<uint8_t> & block,
+    const std::vector<UInt8> & block,
     size_t dest_size,
-    std::vector<uint8_t> & out)
+    std::vector<UInt8> & out)
 {
-    std::vector<uint8_t> source(block.size() + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER, 0);
+    std::vector<UInt8> source(block.size() + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER, 0);
     std::copy(block.begin(), block.end(), source.begin());
 
     out.assign(dest_size + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER, 0);
@@ -128,31 +129,31 @@ const std::vector<size_t> match_lengths = {4, 15, 16, 17, 31, 32};
 TEST(LZ4DecompressBranchless, ForcedMethod1MatchesReferenceForSmallOffsets)
 {
     /// Non-trivial literal payloads so a wrong copy cannot accidentally pass.
-    std::vector<uint8_t> trailing(18);
+    std::vector<UInt8> trailing(18);
     for (size_t i = 0; i < trailing.size(); ++i)
-        trailing[i] = static_cast<uint8_t>(0x80 + i);
+        trailing[i] = static_cast<UInt8>(0x80 + i);
 
-    for (uint16_t offset = 1; offset <= 15; ++offset)
+    for (UInt16 offset = 1; offset <= 15; ++offset)
     {
-        std::vector<uint8_t> seed(offset);
+        std::vector<UInt8> seed(offset);
         for (size_t i = 0; i < seed.size(); ++i)
-            seed[i] = static_cast<uint8_t>(0x10 + i);
+            seed[i] = static_cast<UInt8>(0x10 + i);
 
         for (size_t match_length : match_lengths)
         {
             SCOPED_TRACE("offset=" + std::to_string(offset) + " match_length=" + std::to_string(match_length));
 
-            const std::vector<uint8_t> block = encodeBlock(seed, offset, match_length, trailing);
-            const std::vector<uint8_t> expected = expectedOutput(seed, offset, match_length, trailing);
+            const std::vector<UInt8> block = encodeBlock(seed, offset, match_length, trailing);
+            const std::vector<UInt8> expected = expectedOutput(seed, offset, match_length, trailing);
             const size_t dest_size = expected.size();
 
             /// Forced branchless variant.
-            std::vector<uint8_t> got;
+            std::vector<UInt8> got;
             ASSERT_TRUE(decodeWithForcedVariant(block, dest_size, got));
             ASSERT_EQ(got, expected);
 
             /// Canonical reference decoder.
-            std::vector<uint8_t> reference(dest_size);
+            std::vector<UInt8> reference(dest_size);
             const int ref_size = LZ4_decompress_safe(
                 reinterpret_cast<const char *>(block.data()),
                 reinterpret_cast<char *>(reference.data()),
@@ -171,12 +172,12 @@ TEST(LZ4DecompressBranchless, ForcedMethod1MatchesReferenceForSmallOffsets)
 /// not silently reported as a successful decode. The reference decoder rejects it too.
 TEST(LZ4DecompressBranchless, ForcedMethod1RejectsTruncatedInput)
 {
-    std::vector<uint8_t> trailing(18, 0x55);
-    std::vector<uint8_t> seed = {0x10, 0x11, 0x12};
-    const uint16_t offset = 3;
+    std::vector<UInt8> trailing(18, 0x55);
+    std::vector<UInt8> seed = {0x10, 0x11, 0x12};
+    const UInt16 offset = 3;
     const size_t match_length = 32;
 
-    const std::vector<uint8_t> block = encodeBlock(seed, offset, match_length, trailing);
+    const std::vector<UInt8> block = encodeBlock(seed, offset, match_length, trailing);
     const size_t dest_size = expectedOutput(seed, offset, match_length, trailing).size();
 
     /// Cut the block off in the middle of the 2-byte match offset, so the stream is
@@ -184,14 +185,14 @@ TEST(LZ4DecompressBranchless, ForcedMethod1RejectsTruncatedInput)
     /// Layout up to here: token (1) + literals (seed) + first offset byte (1).
     const size_t truncated = 1 + seed.size() + 1;
     ASSERT_LT(truncated, block.size());
-    const std::vector<uint8_t> truncated_block(block.begin(), block.begin() + truncated);
+    const std::vector<UInt8> truncated_block(block.begin(), block.begin() + truncated);
 
     /// The forced variant must signal failure, never claim a successful decode.
-    std::vector<uint8_t> got;
+    std::vector<UInt8> got;
     ASSERT_FALSE(decodeWithForcedVariant(truncated_block, dest_size, got));
 
     /// The reference decoder cannot reconstruct the full intended output either.
-    std::vector<uint8_t> reference(dest_size);
+    std::vector<UInt8> reference(dest_size);
     const int ref_size = LZ4_decompress_safe(
         reinterpret_cast<const char *>(truncated_block.data()),
         reinterpret_cast<char *>(reference.data()),
@@ -203,21 +204,21 @@ TEST(LZ4DecompressBranchless, ForcedMethod1RejectsTruncatedInput)
 /// A block whose match offset points before the start of the output must be rejected.
 TEST(LZ4DecompressBranchless, ForcedMethod1RejectsOutOfRangeOffset)
 {
-    std::vector<uint8_t> trailing(18, 0x66);
-    std::vector<uint8_t> seed = {0x10, 0x11, 0x12};
+    std::vector<UInt8> trailing(18, 0x66);
+    std::vector<UInt8> seed = {0x10, 0x11, 0x12};
 
     /// Offset 100 is far larger than the 3 bytes of output produced so far.
-    const uint16_t bad_offset = 100;
+    const UInt16 bad_offset = 100;
     const size_t match_length = 16;
-    const std::vector<uint8_t> block = encodeBlock(seed, bad_offset, match_length, trailing);
+    const std::vector<UInt8> block = encodeBlock(seed, bad_offset, match_length, trailing);
 
     /// dest_size as if the (impossible) match had been decoded.
     const size_t dest_size = seed.size() + match_length + trailing.size();
 
-    std::vector<uint8_t> got;
+    std::vector<UInt8> got;
     ASSERT_FALSE(decodeWithForcedVariant(block, dest_size, got));
 
-    std::vector<uint8_t> reference(dest_size);
+    std::vector<UInt8> reference(dest_size);
     const int ref_size = LZ4_decompress_safe(
         reinterpret_cast<const char *>(block.data()),
         reinterpret_cast<char *>(reference.data()),

--- a/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
+++ b/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
@@ -1,0 +1,227 @@
+#include <Compression/LZ4_decompress_faster.h>
+
+#include <lz4.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/** These tests pin down the behavioural contract of LZ4 decode method 1
+  * (`decompressImpl<16, true>` — 16-byte copies with the branchless small-offset
+  *  match copy through `copyOverlap<16>`).
+  *
+  * The variant is reached only when `PerformanceStatistics::choose_method >= 0`,
+  * because a fresh `PerformanceStatistics` first samples method 0 and small blocks
+  * (< 32 KiB) bypass the bandit straight into `decompressImpl<8>`. So none of the
+  * existing codec tests or the fuzzer exercise it. Here we force the variant with
+  * `LZ4::PerformanceStatistics{1}` and compare it against the canonical reference
+  * decoder (`LZ4_decompress_safe`) for every small offset 1..15 (the branchless
+  * `copyOverlap<16>` overlap path) crossed with match lengths that straddle the
+  * 16-byte copy granularity, plus truncated and corrupted inputs.
+  */
+
+namespace
+{
+
+/// Append the LZ4 length-extension bytes for the part of a length that exceeds the
+/// 15 already encoded in the token nibble.
+void appendLengthExtension(std::vector<uint8_t> & out, size_t remainder)
+{
+    while (remainder >= 255)
+    {
+        out.push_back(255);
+        remainder -= 255;
+    }
+    out.push_back(static_cast<uint8_t>(remainder));
+}
+
+/** Hand-encode a raw LZ4 block (no ClickHouse frame, no checksum) consisting of:
+  *   sequence 1: `seed` literals, then a match of `match_length` at `offset`;
+  *   final sequence: `trailing` literals only (LZ4 blocks always end with literals).
+  *
+  * Decoding it yields exactly `seed` ++ (match replicated from `offset` back) ++ `trailing`.
+  */
+std::vector<uint8_t> encodeBlock(
+    const std::vector<uint8_t> & seed,
+    uint16_t offset,
+    size_t match_length,
+    const std::vector<uint8_t> & trailing)
+{
+    std::vector<uint8_t> b;
+
+    const size_t lit = seed.size();
+    const size_t ml = match_length - 4; /// LZ4 minMatch is 4.
+
+    const uint8_t lit_nibble = static_cast<uint8_t>(std::min<size_t>(lit, 15));
+    const uint8_t ml_nibble = static_cast<uint8_t>(std::min<size_t>(ml, 15));
+    b.push_back(static_cast<uint8_t>((lit_nibble << 4) | ml_nibble));
+    if (lit >= 15)
+        appendLengthExtension(b, lit - 15);
+    b.insert(b.end(), seed.begin(), seed.end());
+
+    b.push_back(static_cast<uint8_t>(offset & 0xFF));
+    b.push_back(static_cast<uint8_t>((offset >> 8) & 0xFF));
+    if (ml >= 15)
+        appendLengthExtension(b, ml - 15);
+
+    const size_t tl = trailing.size();
+    const uint8_t tl_nibble = static_cast<uint8_t>(std::min<size_t>(tl, 15));
+    b.push_back(static_cast<uint8_t>(tl_nibble << 4));
+    if (tl >= 15)
+        appendLengthExtension(b, tl - 15);
+    b.insert(b.end(), trailing.begin(), trailing.end());
+
+    return b;
+}
+
+/// The bytes that decoding `encodeBlock(seed, offset, match_length, trailing)` must produce,
+/// derived independently from the LZ4 overlap semantics.
+std::vector<uint8_t> expectedOutput(
+    const std::vector<uint8_t> & seed,
+    uint16_t offset,
+    size_t match_length,
+    const std::vector<uint8_t> & trailing)
+{
+    std::vector<uint8_t> out = seed;
+    for (size_t i = 0; i < match_length; ++i)
+        out.push_back(out[out.size() - offset]);
+    out.insert(out.end(), trailing.begin(), trailing.end());
+    return out;
+}
+
+/// Decode through the forced branchless variant (method 1 = `decompressImpl<16, true>`).
+/// Both buffers carry the mandatory `ADDITIONAL_BYTES_AT_END_OF_BUFFER` slack so the
+/// wild copies never read or write out of bounds.
+bool decodeWithForcedVariant(
+    const std::vector<uint8_t> & block,
+    size_t dest_size,
+    std::vector<uint8_t> & out)
+{
+    std::vector<uint8_t> source(block.size() + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER, 0);
+    std::copy(block.begin(), block.end(), source.begin());
+
+    out.assign(dest_size + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER, 0);
+
+    LZ4::PerformanceStatistics stat{1}; /// Force method 1 regardless of block size.
+    EXPECT_EQ(stat.choose_method, 1);
+
+    const bool ok = LZ4::decompress(
+        reinterpret_cast<const char *>(source.data()),
+        reinterpret_cast<char *>(out.data()),
+        block.size(),
+        dest_size,
+        stat);
+
+    out.resize(dest_size);
+    return ok;
+}
+
+const std::vector<size_t> match_lengths = {4, 15, 16, 17, 31, 32};
+
+}
+
+/// For every small offset and a set of match lengths straddling the 16-byte copy
+/// granularity, the forced branchless variant must agree byte-for-byte with both an
+/// independent reference computation and the canonical `LZ4_decompress_safe` decoder.
+TEST(LZ4DecompressBranchless, ForcedMethod1MatchesReferenceForSmallOffsets)
+{
+    /// Non-trivial literal payloads so a wrong copy cannot accidentally pass.
+    std::vector<uint8_t> trailing(18);
+    for (size_t i = 0; i < trailing.size(); ++i)
+        trailing[i] = static_cast<uint8_t>(0x80 + i);
+
+    for (uint16_t offset = 1; offset <= 15; ++offset)
+    {
+        std::vector<uint8_t> seed(offset);
+        for (size_t i = 0; i < seed.size(); ++i)
+            seed[i] = static_cast<uint8_t>(0x10 + i);
+
+        for (size_t match_length : match_lengths)
+        {
+            SCOPED_TRACE("offset=" + std::to_string(offset) + " match_length=" + std::to_string(match_length));
+
+            const std::vector<uint8_t> block = encodeBlock(seed, offset, match_length, trailing);
+            const std::vector<uint8_t> expected = expectedOutput(seed, offset, match_length, trailing);
+            const size_t dest_size = expected.size();
+
+            /// Forced branchless variant.
+            std::vector<uint8_t> got;
+            ASSERT_TRUE(decodeWithForcedVariant(block, dest_size, got));
+            ASSERT_EQ(got, expected);
+
+            /// Canonical reference decoder.
+            std::vector<uint8_t> reference(dest_size);
+            const int ref_size = LZ4_decompress_safe(
+                reinterpret_cast<const char *>(block.data()),
+                reinterpret_cast<char *>(reference.data()),
+                static_cast<int>(block.size()),
+                static_cast<int>(dest_size));
+            ASSERT_EQ(ref_size, static_cast<int>(dest_size));
+            ASSERT_EQ(reference, expected);
+
+            /// The whole point: forced variant == reference decoder.
+            ASSERT_EQ(got, reference);
+        }
+    }
+}
+
+/// A block that is truncated before the match offset must be rejected (return false),
+/// not silently reported as a successful decode. The reference decoder rejects it too.
+TEST(LZ4DecompressBranchless, ForcedMethod1RejectsTruncatedInput)
+{
+    std::vector<uint8_t> trailing(18, 0x55);
+    std::vector<uint8_t> seed = {0x10, 0x11, 0x12};
+    const uint16_t offset = 3;
+    const size_t match_length = 32;
+
+    const std::vector<uint8_t> block = encodeBlock(seed, offset, match_length, trailing);
+    const size_t dest_size = expectedOutput(seed, offset, match_length, trailing).size();
+
+    /// Cut the block off in the middle of the 2-byte match offset, so the stream is
+    /// unambiguously malformed: the decoder runs out of input while reading the match.
+    /// Layout up to here: token (1) + literals (seed) + first offset byte (1).
+    const size_t truncated = 1 + seed.size() + 1;
+    ASSERT_LT(truncated, block.size());
+    const std::vector<uint8_t> truncated_block(block.begin(), block.begin() + truncated);
+
+    /// The forced variant must signal failure, never claim a successful decode.
+    std::vector<uint8_t> got;
+    ASSERT_FALSE(decodeWithForcedVariant(truncated_block, dest_size, got));
+
+    /// The reference decoder cannot reconstruct the full intended output either.
+    std::vector<uint8_t> reference(dest_size);
+    const int ref_size = LZ4_decompress_safe(
+        reinterpret_cast<const char *>(truncated_block.data()),
+        reinterpret_cast<char *>(reference.data()),
+        static_cast<int>(truncated_block.size()),
+        static_cast<int>(dest_size));
+    ASSERT_LT(ref_size, static_cast<int>(dest_size));
+}
+
+/// A block whose match offset points before the start of the output must be rejected.
+TEST(LZ4DecompressBranchless, ForcedMethod1RejectsOutOfRangeOffset)
+{
+    std::vector<uint8_t> trailing(18, 0x66);
+    std::vector<uint8_t> seed = {0x10, 0x11, 0x12};
+
+    /// Offset 100 is far larger than the 3 bytes of output produced so far.
+    const uint16_t bad_offset = 100;
+    const size_t match_length = 16;
+    const std::vector<uint8_t> block = encodeBlock(seed, bad_offset, match_length, trailing);
+
+    /// dest_size as if the (impossible) match had been decoded.
+    const size_t dest_size = seed.size() + match_length + trailing.size();
+
+    std::vector<uint8_t> got;
+    ASSERT_FALSE(decodeWithForcedVariant(block, dest_size, got));
+
+    std::vector<uint8_t> reference(dest_size);
+    const int ref_size = LZ4_decompress_safe(
+        reinterpret_cast<const char *>(block.data()),
+        reinterpret_cast<char *>(reference.data()),
+        static_cast<int>(block.size()),
+        static_cast<int>(dest_size));
+    ASSERT_LT(ref_size, 0);
+}

--- a/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
+++ b/src/Compression/tests/gtest_lz4_decompress_branchless.cpp
@@ -226,3 +226,26 @@ TEST(LZ4DecompressBranchless, ForcedMethod1RejectsOutOfRangeOffset)
         static_cast<int>(dest_size));
     ASSERT_LT(ref_size, 0);
 }
+
+/// A zero match offset is invalid in LZ4 (minimum match distance is 1). With `offset == 0` the
+/// match pointer equals `op`, which slips past the `match < output_begin` guard, so the decoder
+/// must reject it explicitly rather than synthesize output from the destination and report success.
+///
+/// Note the reference `LZ4_decompress_safe` is lenient here: it does not reject `offset == 0`, it
+/// copies `op` onto itself and reports success with garbage output. Our decoder is deliberately
+/// stricter (fail-closed) — the contract this test pins down is that it never claims success.
+TEST(LZ4DecompressBranchless, ForcedMethod1RejectsZeroOffset)
+{
+    std::vector<UInt8> trailing(18, 0x77);
+    std::vector<UInt8> seed = {0x10, 0x11, 0x12};
+
+    const UInt16 zero_offset = 0;
+    const size_t match_length = 16;
+    const std::vector<UInt8> block = encodeBlock(seed, zero_offset, match_length, trailing);
+
+    /// dest_size as if the (invalid) match had been decoded.
+    const size_t dest_size = seed.size() + match_length + trailing.size();
+
+    std::vector<UInt8> got;
+    ASSERT_FALSE(decodeWithForcedVariant(block, dest_size, got));
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
LZ4 decompression speed was improved for fixed-size, low-cardinality columns.

---

Not too big for the end-to-end queries in CI perf tests:

```
  AMD/x86 — consistently faster, but all sub-threshold:

  ┌───────────────────────────────────────────────┬───────────────┐
  │                     query                     │       Δ       │
  ├───────────────────────────────────────────────┼───────────────┤
  │ RegionID                                      │ −9.4%         │
  ├───────────────────────────────────────────────┼───────────────┤
  │ EventDate                                     │ −6.8%         │
  ├───────────────────────────────────────────────┼───────────────┤
  │ GoodEvent                                     │ −5.7%         │
  ├───────────────────────────────────────────────┼───────────────┤
  │ ParamPrice                                    │ −4.8%         │
  ├───────────────────────────────────────────────┼───────────────┤
  │ URLCategoryID                                 │ −4.4%         │
  ├───────────────────────────────────────────────┼───────────────┤
  │ JavaEnable/HitColor/WindowName/ClientTimeZone │ −3.6 to −4.1% │
  ├───────────────────────────────────────────────┼───────────────┤
  │ synthetic t_lz4_uncomp                        │ −4.5%         │
  └───────────────────────────────────────────────┴───────────────┘
```

Scoped LZ4 benchmarks (only decode without query execution) look better, of course. E.g. up to 25% on `RegionID` and `ResolutionWidth`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.441` (included in `26.7` and later)
<!-- ch-version-info:end -->