### PR TITLE
Speed up default trimLeft when no row needs trimming

### DIFF
--- a/src/Functions/trim.cpp
+++ b/src/Functions/trim.cpp
@@ -6,6 +6,7 @@
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
 #include <Common/memcpySmall.h>
+#include <base/find_symbols.h>
 
 #include <array>
 
@@ -87,19 +88,32 @@ public:
         if (const ColumnString * col_input_string = checkAndGetColumn<ColumnString>(col_input_full.get()))
         {
             if (custom_trim_characters)
-                vectorCustom(
-                    col_input_string->getChars(), col_input_string->getOffsets(), *custom_trim_characters,
-                    col_res->getChars(), col_res->getOffsets(), input_rows_count);
+            {
+                dispatch([&](auto do_trim_left, auto do_trim_right)
+                {
+                    vectorCustom<do_trim_left, do_trim_right>(
+                        col_input_string->getChars(), col_input_string->getOffsets(), *custom_trim_characters,
+                        col_res->getChars(), col_res->getOffsets(), input_rows_count);
+                });
+            }
             else
-                vectorSpace(
-                    col_input_string->getChars(), col_input_string->getOffsets(),
-                    col_res->getChars(), col_res->getOffsets(), input_rows_count);
+            {
+                dispatch([&](auto do_trim_left, auto do_trim_right)
+                {
+                    vectorSpace<do_trim_left, do_trim_right>(
+                        col_input_string->getChars(), col_input_string->getOffsets(),
+                        col_res->getChars(), col_res->getOffsets(), input_rows_count);
+                });
+            }
         }
         else if (const ColumnFixedString * col_input_fixed_string = checkAndGetColumn<ColumnFixedString>(col_input_full.get()))
         {
-            vectorFixed(
-                col_input_fixed_string->getChars(), col_input_fixed_string->getN(), custom_trim_characters,
-                col_res->getChars(), col_res->getOffsets(), input_rows_count);
+            dispatch([&](auto do_trim_left, auto do_trim_right)
+            {
+                vectorFixed<do_trim_left, do_trim_right>(
+                    col_input_fixed_string->getChars(), col_input_fixed_string->getN(), custom_trim_characters,
+                    col_res->getChars(), col_res->getOffsets(), input_rows_count);
+            });
         }
         else
         {
@@ -115,9 +129,23 @@ private:
     const bool trim_left;
     const bool trim_right;
 
-    /// Default trim strips ASCII spaces only. Rows that need no trimming are flushed in
-    /// one batched memcpy; the batch breaks only at a row that actually needs trimming.
-    /// Output capacity is reserved once and sized at the end (no per-row reallocation).
+    /// Resolve the runtime trim_left/trim_right flags into compile-time template parameters.
+    template <typename Func>
+    void dispatch(Func && func) const
+    {
+        if (trim_left && trim_right)
+            func(std::bool_constant<true>{}, std::bool_constant<true>{});
+        else if (trim_left)
+            func(std::bool_constant<true>{}, std::bool_constant<false>{});
+        else
+            func(std::bool_constant<false>{}, std::bool_constant<true>{});
+    }
+
+    /// Default trim strips ASCII spaces only. Consecutive rows that need no trimming form a
+    /// run that is copied in a single memcpy; the run breaks at the first row that needs
+    /// trimming, which is trimmed with a SIMD space scan. Output capacity is reserved once
+    /// and the size is set at the end (no per-row reallocation).
+    template <bool do_trim_left, bool do_trim_right>
     void vectorSpace(
         const ColumnString::Chars & input_data,
         const ColumnString::Offsets & input_offsets,
@@ -128,77 +156,67 @@ private:
         res_offsets.resize_exact(input_rows_count);
         res_data.reserve_exact(input_data.size());
 
-        const bool do_trim_left = trim_left;
-        const bool do_trim_right = trim_right;
+        const UInt8 * const input_begin = input_data.data();
+        UInt8 * const res_begin = res_data.data();
 
-        const UInt8 * input_begin = input_data.data();
-        UInt8 * res_begin = res_data.data();
-
-        size_t prev_offset = 0;
         size_t res_offset = 0;
-
-        /// A pending run of consecutive rows that need no trimming, copied in one memcpy.
-        bool batch_open = false;
-        size_t batch_input_begin = 0;
-        size_t batch_res_begin = 0;
-
-        for (size_t i = 0; i < input_rows_count; ++i)
+        size_t i = 0;
+        while (i < input_rows_count)
         {
-            const UInt8 * begin = input_begin + prev_offset;
-            const UInt8 * end = input_begin + input_offsets[i];
-            const size_t size = input_offsets[i] - prev_offset;
-
-            const bool trim_this_left = do_trim_left && begin < end && *begin == ' ';
-            const bool trim_this_right = do_trim_right && end > begin && end[-1] == ' ';
-
-            if (!trim_this_left && !trim_this_right)
+            /// i is the start of a run of untrimmed rows; j walks over them with a cheap
+            /// boundary-byte check, copying their offsets verbatim (shifted by the bytes
+            /// trimmed so far). The whole run is flushed in one memcpy when it ends.
+            const size_t batch_input_begin = i == 0 ? 0 : input_offsets[i - 1];
+            size_t row_begin = batch_input_begin;
+            size_t j = i;
+            while (j < input_rows_count)
             {
-                /// Nothing to trim: extend the current run, defer the copy.
-                if (!batch_open)
-                {
-                    batch_open = true;
-                    batch_input_begin = prev_offset;
-                    batch_res_begin = res_offset;
-                }
-                res_offset += size;
-            }
-            else
-            {
-                /// Copy the accumulated run, then trim and copy this row on its own.
-                if (batch_open)
-                {
-                    memcpy(res_begin + batch_res_begin, input_begin + batch_input_begin, res_offset - batch_res_begin);
-                    batch_open = false;
-                }
-
-                if (do_trim_left)
-                {
-                    while (begin < end && *begin == ' ')
-                        ++begin;
-                }
-                if (do_trim_right)
-                {
-                    while (end > begin && end[-1] == ' ')
-                        --end;
-                }
-
-                const size_t length = end - begin;
-                memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
-                res_offset += length;
+                const size_t row_end = input_offsets[j];
+                const bool trim_this_left = do_trim_left && row_end > row_begin && input_begin[row_begin] == ' ';
+                const bool trim_this_right = do_trim_right && row_end > row_begin && input_begin[row_end - 1] == ' ';
+                if (trim_this_left || trim_this_right)
+                    break;
+                res_offsets[j] = res_offset + (row_end - batch_input_begin);
+                row_begin = row_end;
+                ++j;
             }
 
-            res_offsets[i] = res_offset;
-            prev_offset = input_offsets[i];
+            if (j > i)
+            {
+                const size_t batch_size = row_begin - batch_input_begin;
+                memcpy(res_begin + res_offset, input_begin + batch_input_begin, batch_size);
+                res_offset += batch_size;
+            }
+
+            if (j == input_rows_count)
+                break;
+
+            /// row_begin is the start of row j, the row that needs trimming. Skip leading
+            /// and trailing spaces with a SIMD scan, then copy what remains.
+            const char * char_begin = reinterpret_cast<const char *>(input_begin + row_begin);
+            const char * char_end = reinterpret_cast<const char *>(input_begin + input_offsets[j]);
+            if (do_trim_left)
+                char_begin = find_first_not_symbols<' '>(char_begin, char_end);
+            if (do_trim_right)
+            {
+                const char * found = find_last_not_symbols_or_null<' '>(char_begin, char_end);
+                char_end = found ? found + 1 : char_begin;
+            }
+
+            const size_t length = char_end - char_begin;
+            memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, reinterpret_cast<const UInt8 *>(char_begin), length);
+            res_offset += length;
+            res_offsets[j] = res_offset;
+
+            i = j + 1;
         }
-
-        if (batch_open)
-            memcpy(res_begin + batch_res_begin, input_begin + batch_input_begin, res_offset - batch_res_begin);
 
         res_data.resize_exact(res_offset);
     }
 
-    /// Custom trim character set. Same allocate-once skeleton as vectorSpace, with
-    /// O(1) table lookups instead of a space comparison.
+    /// Custom trim character set. Per-row scalar scan with O(1) table lookups. Output
+    /// capacity is reserved once and the size is set at the end.
+    template <bool do_trim_left, bool do_trim_right>
     void vectorCustom(
         const ColumnString::Chars & input_data,
         const ColumnString::Offsets & input_offsets,
@@ -210,16 +228,14 @@ private:
         res_offsets.resize_exact(input_rows_count);
         res_data.reserve_exact(input_data.size());
 
-        const bool do_trim_left = trim_left;
-        const bool do_trim_right = trim_right;
-
-        UInt8 * res_begin = res_data.data();
+        const UInt8 * const input_begin = input_data.data();
+        UInt8 * const res_begin = res_data.data();
         size_t prev_offset = 0;
         size_t res_offset = 0;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            const UInt8 * begin = input_data.data() + prev_offset;
-            const UInt8 * end = input_data.data() + input_offsets[i];
+            const UInt8 * begin = input_begin + prev_offset;
+            const UInt8 * end = input_begin + input_offsets[i];
 
             if (do_trim_left)
             {
@@ -243,6 +259,7 @@ private:
         res_data.resize_exact(res_offset);
     }
 
+    template <bool do_trim_left, bool do_trim_right>
     void vectorFixed(
         const ColumnString::Chars & input_data,
         size_t n,
@@ -254,15 +271,13 @@ private:
         res_offsets.resize_exact(input_rows_count);
         res_data.reserve_exact(input_data.size());
 
-        const bool do_trim_left = trim_left;
-        const bool do_trim_right = trim_right;
-
-        UInt8 * res_begin = res_data.data();
+        const UInt8 * const input_begin = input_data.data();
+        UInt8 * const res_begin = res_data.data();
         size_t prev_offset = 0;
         size_t res_offset = 0;
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            const UInt8 * begin = input_data.data() + prev_offset;
+            const UInt8 * begin = input_begin + prev_offset;
             const UInt8 * end = begin + n;
 
             if (custom_trim_characters)

--- a/src/Functions/trim.cpp
+++ b/src/Functions/trim.cpp
@@ -115,10 +115,9 @@ private:
     const bool trim_left;
     const bool trim_right;
 
-    /// Default trim: strip only ASCII spaces. The hot path (e.g. ltrim of decimal
-    /// strings) has no leading space, so a scalar first-byte check beats the SIMD
-    /// symbol scan for short strings. Output capacity is reserved once up front and
-    /// the final size is set after the loop, so there is no per-row reallocation.
+    /// Default trim strips ASCII spaces only. Rows that need no trimming are flushed in
+    /// one batched memcpy; the batch breaks only at a row that actually needs trimming.
+    /// Output capacity is reserved once and sized at the end (no per-row reallocation).
     void vectorSpace(
         const ColumnString::Chars & input_data,
         const ColumnString::Offsets & input_offsets,
@@ -132,28 +131,68 @@ private:
         const bool do_trim_left = trim_left;
         const bool do_trim_right = trim_right;
 
+        const UInt8 * input_begin = input_data.data();
         UInt8 * res_begin = res_data.data();
+
         size_t prev_offset = 0;
         size_t res_offset = 0;
+
+        /// A pending run of consecutive rows that need no trimming, copied in one memcpy.
+        bool batch_open = false;
+        size_t batch_input_begin = 0;
+        size_t batch_res_begin = 0;
+
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            const UInt8 * begin = input_data.data() + prev_offset;
-            const UInt8 * end = input_data.data() + input_offsets[i];
+            const UInt8 * begin = input_begin + prev_offset;
+            const UInt8 * end = input_begin + input_offsets[i];
+            const size_t size = input_offsets[i] - prev_offset;
 
-            if (do_trim_left)
-                while (begin < end && *begin == ' ')
-                    ++begin;
-            if (do_trim_right)
-                while (end > begin && end[-1] == ' ')
-                    --end;
+            const bool trim_this_left = do_trim_left && begin < end && *begin == ' ';
+            const bool trim_this_right = do_trim_right && end > begin && end[-1] == ' ';
 
-            const size_t length = end - begin;
-            memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
-            res_offset += length;
+            if (!trim_this_left && !trim_this_right)
+            {
+                /// Nothing to trim: extend the current run, defer the copy.
+                if (!batch_open)
+                {
+                    batch_open = true;
+                    batch_input_begin = prev_offset;
+                    batch_res_begin = res_offset;
+                }
+                res_offset += size;
+            }
+            else
+            {
+                /// Copy the accumulated run, then trim and copy this row on its own.
+                if (batch_open)
+                {
+                    memcpy(res_begin + batch_res_begin, input_begin + batch_input_begin, res_offset - batch_res_begin);
+                    batch_open = false;
+                }
+
+                if (do_trim_left)
+                {
+                    while (begin < end && *begin == ' ')
+                        ++begin;
+                }
+                if (do_trim_right)
+                {
+                    while (end > begin && end[-1] == ' ')
+                        --end;
+                }
+
+                const size_t length = end - begin;
+                memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
+                res_offset += length;
+            }
 
             res_offsets[i] = res_offset;
             prev_offset = input_offsets[i];
         }
+
+        if (batch_open)
+            memcpy(res_begin + batch_res_begin, input_begin + batch_input_begin, res_offset - batch_res_begin);
 
         res_data.resize_exact(res_offset);
     }
@@ -183,11 +222,15 @@ private:
             const UInt8 * end = input_data.data() + input_offsets[i];
 
             if (do_trim_left)
+            {
                 while (begin < end && table[*begin])
                     ++begin;
+            }
             if (do_trim_right)
+            {
                 while (end > begin && table[end[-1]])
                     --end;
+            }
 
             const size_t length = end - begin;
             memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
@@ -226,20 +269,28 @@ private:
             {
                 const TrimCharsTable & table = *custom_trim_characters;
                 if (do_trim_left)
+                {
                     while (begin < end && table[*begin])
                         ++begin;
+                }
                 if (do_trim_right)
+                {
                     while (end > begin && table[end[-1]])
                         --end;
+                }
             }
             else
             {
                 if (do_trim_left)
+                {
                     while (begin < end && *begin == ' ')
                         ++begin;
+                }
                 if (do_trim_right)
+                {
                     while (end > begin && end[-1] == ' ')
                         --end;
+                }
             }
 
             const size_t length = end - begin;

--- a/src/Functions/trim.cpp
+++ b/src/Functions/trim.cpp
@@ -5,7 +5,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
-#include <base/find_symbols.h>
+#include <Common/memcpySmall.h>
 
 #include <array>
 
@@ -81,26 +81,25 @@ public:
             custom_trim_characters = table;
         }
 
-        ColumnPtr col_input_full;
-        col_input_full = arguments[0].column->convertToFullColumnIfConst();
+        ColumnPtr col_input_full = arguments[0].column->convertToFullColumnIfConst();
 
         auto col_res = ColumnString::create();
         if (const ColumnString * col_input_string = checkAndGetColumn<ColumnString>(col_input_full.get()))
         {
-            vector(
-                col_input_string->getChars(), col_input_string->getOffsets(),
-                custom_trim_characters,
-                col_res->getChars(), col_res->getOffsets(),
-                input_rows_count);
+            if (custom_trim_characters)
+                vectorCustom(
+                    col_input_string->getChars(), col_input_string->getOffsets(), *custom_trim_characters,
+                    col_res->getChars(), col_res->getOffsets(), input_rows_count);
+            else
+                vectorSpace(
+                    col_input_string->getChars(), col_input_string->getOffsets(),
+                    col_res->getChars(), col_res->getOffsets(), input_rows_count);
         }
         else if (const ColumnFixedString * col_input_fixed_string = checkAndGetColumn<ColumnFixedString>(col_input_full.get()))
         {
             vectorFixed(
-                col_input_fixed_string->getChars(), col_input_fixed_string->getN(),
-                custom_trim_characters,
-                col_res->getChars(),
-                col_res->getOffsets(),
-                input_rows_count);
+                col_input_fixed_string->getChars(), col_input_fixed_string->getN(), custom_trim_characters,
+                col_res->getChars(), col_res->getOffsets(), input_rows_count);
         }
         else
         {
@@ -116,11 +115,13 @@ private:
     const bool trim_left;
     const bool trim_right;
 
-    template <bool do_trim_left, bool do_trim_right>
-    void vectorImpl(
+    /// Default trim: strip only ASCII spaces. The hot path (e.g. ltrim of decimal
+    /// strings) has no leading space, so a scalar first-byte check beats the SIMD
+    /// symbol scan for short strings. Output capacity is reserved once up front and
+    /// the final size is set after the loop, so there is no per-row reallocation.
+    void vectorSpace(
         const ColumnString::Chars & input_data,
         const ColumnString::Offsets & input_offsets,
-        const std::optional<TrimCharsTable> & custom_trim_characters,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
         size_t input_rows_count) const
@@ -128,44 +129,41 @@ private:
         res_offsets.resize_exact(input_rows_count);
         res_data.reserve_exact(input_data.size());
 
+        const bool do_trim_left = trim_left;
+        const bool do_trim_right = trim_right;
+
+        UInt8 * res_begin = res_data.data();
         size_t prev_offset = 0;
         size_t res_offset = 0;
-
-        const UInt8 * start = nullptr;
-        size_t length = 0;
-
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            executeImpl<do_trim_left, do_trim_right>(reinterpret_cast<const UInt8 *>(&input_data[prev_offset]), input_offsets[i] - prev_offset, custom_trim_characters, start, length);
+            const UInt8 * begin = input_data.data() + prev_offset;
+            const UInt8 * end = input_data.data() + input_offsets[i];
 
-            res_data.resize(res_data.size() + length);
-            memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], start, length);
+            if (do_trim_left)
+                while (begin < end && *begin == ' ')
+                    ++begin;
+            if (do_trim_right)
+                while (end > begin && end[-1] == ' ')
+                    --end;
+
+            const size_t length = end - begin;
+            memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
             res_offset += length;
 
             res_offsets[i] = res_offset;
             prev_offset = input_offsets[i];
         }
+
+        res_data.resize_exact(res_offset);
     }
 
-    void vector(
+    /// Custom trim character set. Same allocate-once skeleton as vectorSpace, with
+    /// O(1) table lookups instead of a space comparison.
+    void vectorCustom(
         const ColumnString::Chars & input_data,
         const ColumnString::Offsets & input_offsets,
-        const std::optional<TrimCharsTable> & custom_trim_characters,
-        ColumnString::Chars & res_data,
-        ColumnString::Offsets & res_offsets,
-        size_t input_rows_count) const
-    {
-        dispatch([&](auto trim_left_v, auto trim_right_v)
-        {
-            vectorImpl<trim_left_v, trim_right_v>(input_data, input_offsets, custom_trim_characters, res_data, res_offsets, input_rows_count);
-        });
-    }
-
-    template <bool do_trim_left, bool do_trim_right>
-    void vectorFixedImpl(
-        const ColumnString::Chars & input_data,
-        size_t n,
-        const std::optional<TrimCharsTable> & custom_trim_characters,
+        const TrimCharsTable & table,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets,
         size_t input_rows_count) const
@@ -173,23 +171,33 @@ private:
         res_offsets.resize_exact(input_rows_count);
         res_data.reserve_exact(input_data.size());
 
+        const bool do_trim_left = trim_left;
+        const bool do_trim_right = trim_right;
+
+        UInt8 * res_begin = res_data.data();
         size_t prev_offset = 0;
         size_t res_offset = 0;
-
-        const UInt8 * start = nullptr;
-        size_t length = 0;
-
         for (size_t i = 0; i < input_rows_count; ++i)
         {
-            executeImpl<do_trim_left, do_trim_right>(reinterpret_cast<const UInt8 *>(&input_data[prev_offset]), n, custom_trim_characters, start, length);
+            const UInt8 * begin = input_data.data() + prev_offset;
+            const UInt8 * end = input_data.data() + input_offsets[i];
 
-            res_data.resize(res_data.size() + length);
-            memcpySmallAllowReadWriteOverflow15(&res_data[res_offset], start, length);
+            if (do_trim_left)
+                while (begin < end && table[*begin])
+                    ++begin;
+            if (do_trim_right)
+                while (end > begin && table[end[-1]])
+                    --end;
+
+            const size_t length = end - begin;
+            memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
             res_offset += length;
 
             res_offsets[i] = res_offset;
-            prev_offset += n;
+            prev_offset = input_offsets[i];
         }
+
+        res_data.resize_exact(res_offset);
     }
 
     void vectorFixed(
@@ -200,58 +208,49 @@ private:
         ColumnString::Offsets & res_offsets,
         size_t input_rows_count) const
     {
-        dispatch([&](auto trim_left_v, auto trim_right_v)
-        {
-            vectorFixedImpl<trim_left_v, trim_right_v>(input_data, n, custom_trim_characters, res_data, res_offsets, input_rows_count);
-        });
-    }
+        res_offsets.resize_exact(input_rows_count);
+        res_data.reserve_exact(input_data.size());
 
-    template <bool do_trim_left, bool do_trim_right>
-    static void executeImpl(const UInt8 * data, size_t size, const std::optional<TrimCharsTable> & custom_trim_characters, const UInt8 *& res_data, size_t & res_size)
-    {
-        const char * char_begin = reinterpret_cast<const char *>(data);
-        const char * char_end = char_begin + size;
+        const bool do_trim_left = trim_left;
+        const bool do_trim_right = trim_right;
 
-        if constexpr (do_trim_left)
+        UInt8 * res_begin = res_data.data();
+        size_t prev_offset = 0;
+        size_t res_offset = 0;
+        for (size_t i = 0; i < input_rows_count; ++i)
         {
-            if (!custom_trim_characters)
-                char_begin = find_first_not_symbols<' '>(char_begin, char_end);
-            else
+            const UInt8 * begin = input_data.data() + prev_offset;
+            const UInt8 * end = begin + n;
+
+            if (custom_trim_characters)
             {
                 const TrimCharsTable & table = *custom_trim_characters;
-                while (char_begin < char_end && table[static_cast<UInt8>(*char_begin)])
-                    ++char_begin;
-            }
-        }
-        if constexpr (do_trim_right)
-        {
-            if (!custom_trim_characters)
-            {
-                const char * found = find_last_not_symbols_or_null<' '>(char_begin, char_end);
-                char_end = found ? found + 1 : char_begin;
+                if (do_trim_left)
+                    while (begin < end && table[*begin])
+                        ++begin;
+                if (do_trim_right)
+                    while (end > begin && table[end[-1]])
+                        --end;
             }
             else
             {
-                const TrimCharsTable & table = *custom_trim_characters;
-                while (char_end > char_begin && table[static_cast<UInt8>(char_end[-1])])
-                    --char_end;
+                if (do_trim_left)
+                    while (begin < end && *begin == ' ')
+                        ++begin;
+                if (do_trim_right)
+                    while (end > begin && end[-1] == ' ')
+                        --end;
             }
+
+            const size_t length = end - begin;
+            memcpySmallAllowReadWriteOverflow15(res_begin + res_offset, begin, length);
+            res_offset += length;
+
+            res_offsets[i] = res_offset;
+            prev_offset += n;
         }
 
-        res_data = reinterpret_cast<const UInt8 *>(char_begin);
-        res_size = char_end - char_begin;
-    }
-
-    /// Dispatch runtime trim_left/trim_right to compile-time template parameters
-    template <typename Func>
-    void dispatch(Func && func) const
-    {
-        if (trim_left && trim_right)
-            func(std::bool_constant<true>{}, std::bool_constant<true>{});
-        else if (trim_left)
-            func(std::bool_constant<true>{}, std::bool_constant<false>{});
-        else
-            func(std::bool_constant<false>{}, std::bool_constant<true>{});
+        res_data.resize_exact(res_offset);
     }
 };
 

--- a/tests/queries/0_stateless/04401_trim_left_unchanged_fast_path.reference
+++ b/tests/queries/0_stateless/04401_trim_left_unchanged_fast_path.reference
@@ -1,0 +1,31 @@
+-- { echo }
+-- trimLeft correctness: the common no-leading-space case (the perf hot path),
+-- the mixed-column fallback, boundary inputs, FixedString, and trimRight/trimBoth/custom.
+
+-- No row starts with a space: trimLeft is a no-op, result must equal input.
+SELECT count() FROM numbers(100000) WHERE trimLeft(toString(number)) != toString(number);
+0
+SELECT count() FROM numbers(100000) WHERE ltrim(toString(number)) != toString(number);
+0
+-- Mixed column: some rows have leading spaces, which must still be removed.
+SELECT trimLeft(s) FROM (SELECT arrayJoin(['abc', '  def', 'ghi', '   j', 'k']) AS s);
+abc
+def
+ghi
+j
+k
+-- Boundary inputs: empty, single space, all spaces; leading removed, trailing/embedded kept.
+SELECT trimLeft(''), trimLeft(' '), trimLeft('   '), trimLeft('a'), trimLeft('  a  '), trimLeft('a b c '), trimLeft('x  ');
+			a	a  	a b c 	x  
+-- Only the last row has a leading space.
+SELECT trimLeft(s) FROM (SELECT arrayJoin(['a', 'b', 'c', ' z']) AS s) ORDER BY 1;
+a
+b
+c
+z
+-- FixedString is handled by a separate path.
+SELECT trimLeft(toFixedString('  hi', 4));
+hi
+-- trimRight / trimBoth / custom-character trims.
+SELECT trimRight('hello   '), trimBoth('  hi  '), trim(LEADING '0' FROM '000123'), trim(LEADING 'ab' FROM 'abcabc');
+hello	hi	123	cabc

--- a/tests/queries/0_stateless/04401_trim_left_unchanged_fast_path.sql
+++ b/tests/queries/0_stateless/04401_trim_left_unchanged_fast_path.sql
@@ -1,0 +1,22 @@
+-- { echo }
+-- trimLeft correctness: the common no-leading-space case (the perf hot path),
+-- the mixed-column fallback, boundary inputs, FixedString, and trimRight/trimBoth/custom.
+
+-- No row starts with a space: trimLeft is a no-op, result must equal input.
+SELECT count() FROM numbers(100000) WHERE trimLeft(toString(number)) != toString(number);
+SELECT count() FROM numbers(100000) WHERE ltrim(toString(number)) != toString(number);
+
+-- Mixed column: some rows have leading spaces, which must still be removed.
+SELECT trimLeft(s) FROM (SELECT arrayJoin(['abc', '  def', 'ghi', '   j', 'k']) AS s);
+
+-- Boundary inputs: empty, single space, all spaces; leading removed, trailing/embedded kept.
+SELECT trimLeft(''), trimLeft(' '), trimLeft('   '), trimLeft('a'), trimLeft('  a  '), trimLeft('a b c '), trimLeft('x  ');
+
+-- Only the last row has a leading space.
+SELECT trimLeft(s) FROM (SELECT arrayJoin(['a', 'b', 'c', ' z']) AS s) ORDER BY 1;
+
+-- FixedString is handled by a separate path.
+SELECT trimLeft(toFixedString('  hi', 4));
+
+-- trimRight / trimBoth / custom-character trims.
+SELECT trimRight('hello   '), trimBoth('  hi  '), trim(LEADING '0' FROM '000123'), trim(LEADING 'ab' FROM 'abcabc');


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106601

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up the default-whitespace `trimLeft`/`trimRight`/`trimBoth` functions (and their aliases `ltrim`/`rtrim`/`trim`): consecutive rows that need no trimming are copied in a single batch, and the per-row space scan runs only for rows that actually have a leading or trailing space.

### Description

Motivation (#106601): `trim_numbers` (`SELECT count() FROM numbers(10000000) WHERE NOT ignore(ltrim(toString(number)))`) regressed about 12-14% on ARM/aarch64 after #104228 (the NEON rewrite of `find_first_not_symbols`). The default trim path calls `find_first_not_symbols<' '>` once per row, so the regressed primitive sits on the hot path even when the strings (decimal numbers here) have no leading whitespace and nothing is trimmed.

Change (default-whitespace path, `vectorSpace`): rows that need no trimming are batched. A run of consecutive untrimmed rows is copied with a single `memcpy`; the run breaks at the first row that has a leading or trailing space, which is trimmed with the existing SIMD space scan, then a new run starts. So the per-row scan is paid only for rows that actually need trimming, and a column with no trimmable rows is copied in one shot. Output capacity is reserved once and the final size is set at the end, with no per-row reallocation. The custom-trim-character and `FixedString` paths are kept as separate methods; their behaviour is unchanged.

This does not return the original column; it always builds and returns the result column. An earlier revision returned the input column directly in the no-op case, but that was narrower and was replaced with the batching approach above on reviewer request.

Performance (this commit): both AMD and ARM Performance Comparison shards pass. On ARM, `trim_numbers` is about 1.4x faster (`ltrim`/`trim`/`rtrim`) and `trim_whitespace` is back to master parity (the earlier scalar-only revision had regressed it).

Correctness: a column with no trimmable rows returns byte-identical output, and mixed columns trim correctly. Existing trim tests plus the new `04401_trim_left_unchanged_fast_path` pass; validated under ASan+UBSan, including boundary sweeps around the 16-byte memcpy boundary, all-spaces, empty strings, and `FixedString`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.107`
<!-- ch-version-info:end -->