### PR TITLE
Restore O(1) reserve in MergeSorter::mergeBatchImpl (fix ORDER BY perf regression)

### DIFF
--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -101,13 +101,9 @@ Chunk MergeSorter::mergeBatchImpl(TSortingQueue & queue)
     /// Reserve
     if (queue.isValid())
     {
-        size_t size_to_reserve = 0;
-        for (auto & chunk : chunks)
-            size_to_reserve += chunk.getNumRows();
-
-        /// The size of output block will not be larger than the `max_merged_block_size`.
-        /// If redundant memory space is reserved, `MemoryTracker` will count more memory usage than actual usage.
-        size_to_reserve = std::min(size_to_reserve, max_merged_block_size);
+        /// chunks[0] is one input chunk, so this never exceeds the rows the merge
+        /// emits, and it stays O(1) per output block (no walk over chunks).
+        size_t size_to_reserve = std::min(static_cast<size_t>(chunks[0].getNumRows()), max_merged_block_size);
         for (auto & column : merged_columns)
             column->reserve(size_to_reserve);
     }


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106599
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a performance regression in `ORDER BY` (merge sort) introduced in #100963. Queries with a sort followed by `LIMIT` were slower because of redundant per-output-block work in the result-block reservation.


### Description

Reported by egor-click in #106599: `jit_sort` query `12` regressed on ARM Neoverse-V2 by about +18% `client_time` (`SELECT WatchID FROM hits_100m_single ORDER BY WatchID ASC, CounterID DESC, ClientIP ASC LIMIT 2000000`). History: https://performance.ci.clickhouse.com/history/jit_sort/12?metric=client_time&arch=arm

**Root cause.** Bisecting the issue's controlled window (`bd123fed28c5` -> `d8dd2c3a1a82`) leaves one functional change: #100963 in `MergeSorter::mergeBatchImpl`, which replaced the O(1) reservation `min(chunks[0].getNumRows(), max_merged_block_size)` with a sum over all input chunks capped at `max_merged_block_size`. That walks the whole `chunks` vector on every output block, in front of the hot k-way merge loop, and reserves a larger, cap-saturated size. It matches the issue's profile (`MergeSortingTransform` +10.88%).

**Fix.** Restore the pre-#100963 O(1) reservation. `min(chunks[0] rows, cap)` is never larger than `min(sum of all chunk rows, cap)`, so for every input shape this reserves at most what master reserves today, and `reserve()` is a capacity hint, so results are unchanged and the columns grow as needed.

egor-click validated this exact form on Neoverse-V2 at about -14.55% against the affected revision. His data also shows the win needs the smaller reserve, not only dropping the per-block walk: an O(1) variant reserving the full input-row sum, which saturates the cap, recovered nothing (+0.59%).

Refreshed onto current master, where `mergeBatchImpl` is now templated on `MergeSorter::Mode`. The refactor did not change the reservation, and master's comment on the cap is kept as it is.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=108179&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/108179](https://github.com/search?q=head%3Async-upstream%2Fpr%2F108179+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
