### PR TITLE
Out-of-line AllocatorWithMemoryTracking allocate/deallocate to fix FPC codec ARM regression

### DIFF
--- a/src/Common/AllocatorWithMemoryTracking.cpp
+++ b/src/Common/AllocatorWithMemoryTracking.cpp
@@ -1,0 +1,41 @@
+#include <Common/AllocatorWithMemoryTracking.h>
+
+#include <cstdlib>
+
+#include <Common/AllocationInterceptors.h>
+#include <Common/CurrentMemoryTracker.h>
+
+
+void * allocateWithMemoryTracking(size_t bytes, size_t alignment)
+{
+    auto trace = CurrentMemoryTracker::alloc(static_cast<Int64>(bytes));
+
+    void * p = nullptr;
+    if (alignment != 0)
+    {
+        const int res = __real_posix_memalign(&p, alignment, bytes);
+        if (res != 0)
+            // We don't have to, but to be sure
+            p = nullptr;
+    }
+    else
+    {
+        p = __real_malloc(bytes);
+    }
+
+    if (!p) [[unlikely]]
+    {
+        [[maybe_unused]] auto rollback_trace = CurrentMemoryTracker::free(static_cast<Int64>(bytes));
+        throwBadAllocFromAllocatorWithMemoryTracking();
+    }
+
+    trace.onAlloc(p, bytes);
+    return p;
+}
+
+void deallocateWithMemoryTracking(void * p, size_t bytes) noexcept
+{
+    __real_free(p);
+    auto trace = CurrentMemoryTracker::free(static_cast<Int64>(bytes));
+    trace.onFree(p, bytes);
+}

--- a/src/Common/AllocatorWithMemoryTracking.h
+++ b/src/Common/AllocatorWithMemoryTracking.h
@@ -1,11 +1,34 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdlib>
+#include <limits>
+#include <new>
 #include <type_traits>
 
+#include <base/defines.h>
+
+/// Not used directly anymore (the allocation machinery moved to the .cpp), but kept so
+/// the set of symbols this widely-included header transitively provides (e.g. config.h
+/// macros) does not change for downstream translation units.
 #include <Common/AllocationInterceptors.h>
 #include <Common/CurrentMemoryTracker.h>
+
+
+/// The throw is kept in a cold, never-inlined helper so that allocate() (which is
+/// inlined into hot allocation sites) does not carry exception-handling machinery.
+[[noreturn]] [[gnu::cold]] NO_INLINE inline void throwBadAllocFromAllocatorWithMemoryTracking()
+{
+    throw std::bad_alloc();
+}
+
+/// Out-of-line allocation primitives. Keeping the tracker + malloc + onAlloc/onFree
+/// machinery in the .cpp lets allocate()/deallocate() inline to a single call, the same
+/// shape std::allocator has (operator new/delete are also out-of-line calls). With the
+/// machinery inlined, the container's fill-constructor became too large to inline into
+/// callers and turned into an out-of-line call, which perturbed register allocation in
+/// hot functions. `alignment == 0` selects the default (max_align_t) path.
+[[nodiscard]] void * allocateWithMemoryTracking(size_t bytes, size_t alignment);
+void deallocateWithMemoryTracking(void * p, size_t bytes) noexcept;
 
 
 /// Implementation of std::allocator interface that tracks memory with MemoryTracker.
@@ -37,42 +60,16 @@ struct AllocatorWithMemoryTracking
 
     [[nodiscard]] T * allocate(size_t n)
     {
-        if (n > std::numeric_limits<size_t>::max() / sizeof(T))
-            throw std::bad_alloc();
+        if (n > std::numeric_limits<size_t>::max() / sizeof(T)) [[unlikely]]
+            throwBadAllocFromAllocatorWithMemoryTracking();
 
-        size_t bytes = n * sizeof(T);
-        auto trace = CurrentMemoryTracker::alloc(bytes);
-
-        T * p = nullptr;
-        if constexpr (alignof(T) > alignof(std::max_align_t))
-        {
-            const int res = __real_posix_memalign(reinterpret_cast<void **>(&p), alignof(T), bytes);
-            if (res != 0)
-                // We don't have to, but to be sure
-                p = nullptr;
-        }
-        else
-        {
-            p = static_cast<T *>(__real_malloc(bytes));
-        }
-        if (!p)
-        {
-            [[maybe_unused]] auto rollback_trace = CurrentMemoryTracker::free(bytes);
-            throw std::bad_alloc();
-        }
-
-        trace.onAlloc(p, bytes);
-
-        return p;
+        constexpr size_t alignment = alignof(T) > alignof(std::max_align_t) ? alignof(T) : 0;
+        return static_cast<T *>(allocateWithMemoryTracking(n * sizeof(T), alignment));
     }
 
     void deallocate(T * p, size_t n) noexcept
     {
-        size_t bytes = n * sizeof(T);
-
-        __real_free(p);
-        auto trace = CurrentMemoryTracker::free(bytes);
-        trace.onFree(p, bytes);
+        deallocateWithMemoryTracking(p, n * sizeof(T));
     }
 };
 


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106606
Related: https://github.com/ClickHouse/ClickHouse/pull/105580
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a ~16% throughput regression of the `FPC` floating-point codec on ARM that was introduced when its predictor tables started using `VectorWithMemoryTracking`.

### Description

PR #105580 switched the `FPC` codec predictor tables from `std::vector` to `VectorWithMemoryTracking`, which caused a ~16% regression on the ARM `codecs_float_insert` performance test (query #12, `FPC` Float64 insert). The regression is ARM-only.

Root cause, confirmed by disassembling the real `CompressionCodecFPC.cpp` translation unit cross-compiled to `aarch64 -O3` with the production ARM target (`armv8.2-a+...`, no `-mtune`):

- `std::vector<T, std::allocator>` inlines its fill-constructor into `doCompressData`: 4 inline `bl operator new` plus an inline zero-fill loop, dtor inlines to `operator delete`.
- With the tracking allocator, `allocate()`/`deallocate()` were header-inlined and carried the entire tracker + malloc + `onAlloc`/`onFree` (+ exception) body. That made the container fill-constructor too large for the inliner, so it became an out-of-line call. `doCompressData` then makes 4 out-of-line vector-ctor calls plus out-of-line predictor destructor calls. Those calls clobber caller-saved registers and force spills/reloads, shifting register allocation across the whole hot function. The generic-scheduled ARM target is layout-sensitive and loses throughput; x86 absorbs it, which is why only ARM flagged it.

This also explains why the earlier cold-throw-helper attempt did not move the number: the helper lives inside that out-of-line constructor, so `doCompressData` kept making the same perturbing calls.

Fix: move the tracker + malloc + `onAlloc`/`onFree` machinery into `AllocatorWithMemoryTracking.cpp` so `allocate()`/`deallocate()` inline to a single call, matching `std::allocator`'s shape (`operator new`/`delete` are also out-of-line calls). The container fill-constructor then inlines back into `doCompressData` and the out-of-line vector-ctor calls disappear. Tracking behavior is unchanged: every allocation still goes through `CurrentMemoryTracker`. The change is in the shared allocator, so it benefits every `*WithMemoryTracking` container, not just the FPC codec.

The arm_release `Performance Comparison` job on this PR is the measurement of record for the actual recovery.

Closes https://github.com/ClickHouse/ClickHouse/issues/106606

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1167`
<!-- ch-version-info:end -->