### PR TITLE
Skip predicate statistics counters on the read path when the feature is disabled

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -34,6 +34,7 @@ namespace Setting
     extern const SettingsBool secondary_indices_enable_bulk_filtering;
     extern const SettingsUInt64 merge_tree_min_bytes_for_seek;
     extern const SettingsUInt64 merge_tree_min_rows_for_seek;
+    extern const SettingsUInt64 predicate_statistics_sample_rate;
 }
 
 namespace MergeTreeSetting
@@ -129,6 +130,7 @@ MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const Context
     result.filesystem_prefetches_limit = settings[Setting::filesystem_prefetches_limit];
     result.enable_analyzer = settings[Setting::allow_experimental_analyzer];
     result.load_marks_asynchronously = settings[Setting::load_marks_asynchronously];
+    result.collect_predicate_statistics = settings[Setting::predicate_statistics_sample_rate] > 0;
     return result;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -77,6 +77,10 @@ struct MergeTreeReaderSettings
     /// This information can be used for more optimal reading of
     /// columns prefixes.
     bool read_only_column_sample = false;
+    /// True when predicate_statistics_sample_rate > 0, i.e. the read steps must
+    /// maintain selectivity counters for system.predicate_statistics_log. When
+    /// false (the default), the readers skip the per-granule counter work.
+    bool collect_predicate_statistics = false;
 
     static MergeTreeReaderSettings createFromContext(const ContextPtr & context);
     /// Note storage_settings used only in private, do not remove

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -1434,7 +1434,9 @@ void MergeTreeRangeReader::updatePerformanceCounters(size_t num_rows_read)
 {
     ProfileEvents::increment(ProfileEvents::RowsReadByMainReader, main_reader * num_rows_read);
     ProfileEvents::increment(ProfileEvents::RowsReadByPrewhereReaders, (!main_reader) * num_rows_read);
-    performance_counters->rows_read += num_rows_read;
+    /// Null when predicate_statistics_sample_rate = 0 (default): skip the counter work.
+    if (performance_counters)
+        performance_counters->rows_read += num_rows_read;
 }
 
 static void checkCombinedFiltersSize(size_t bytes_in_first_filter, size_t second_filter_size)
@@ -1701,7 +1703,11 @@ void MergeTreeRangeReader::executePrewhereActionsAndFilterColumns(ReadResult & r
             result.columns.erase(result.columns.begin() + filter_column_pos);
 
         FilterWithCachedCount current_filter(current_step_filter);
-        performance_counters->rows_passed_filter += current_filter.countBytesInFilter();
+        /// Null when predicate_statistics_sample_rate = 0 (default). countBytesInFilter()
+        /// is an O(rows) scan that the following optimize() does not otherwise need, so
+        /// keep it behind the guard.
+        if (performance_counters)
+            performance_counters->rows_passed_filter += current_filter.countBytesInFilter();
         result.optimize(current_filter, can_read_incomplete_granules, false);
 
         if (prewhere_info->need_filter && !result.filterWasApplied())

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -226,7 +226,8 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
 MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
     const Readers & task_readers,
     const PrewhereExprInfo & prewhere_actions,
-    const ReadStepsPerformanceCounters & read_steps_performance_counters)
+    const ReadStepsPerformanceCounters & read_steps_performance_counters,
+    bool collect_predicate_statistics)
 {
     if (prewhere_actions.steps.size() != task_readers.prewhere.size())
     {
@@ -250,13 +251,22 @@ MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
             return reader->canReadIncompleteGranules();
         });
 
+    /// Only hand counters to the readers when system.predicate_statistics_log collection is on.
+    /// Otherwise the per-granule counter updates are dead work (see MergeTreeRangeReader).
+    auto index_counter = collect_predicate_statistics
+        ? read_steps_performance_counters.getCounterForIndexStep() : nullptr;
+    auto step_counter = [&](size_t step) -> ReadStepPerformanceCountersPtr
+    {
+        return collect_predicate_statistics ? read_steps_performance_counters.getCountersForStep(step) : nullptr;
+    };
+
     if (task_readers.prepared_index)
     {
         range_readers.emplace_back(
             task_readers.prepared_index.get(),
             Block{},
             /*prewhere_info_=*/ nullptr,
-            read_steps_performance_counters.getCounterForIndexStep(),
+            index_counter,
             /*main_reader_=*/ false,
             can_read_incomplete_granules);
     }
@@ -268,7 +278,7 @@ MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
             task_readers.prewhere[i].get(),
             range_readers.empty() ? Block{} : range_readers.back().getSampleBlock(),
             prewhere_actions.steps[i].get(),
-            read_steps_performance_counters.getCountersForStep(counter_idx++),
+            step_counter(counter_idx++),
             /*main_reader_=*/ false,
             can_read_incomplete_granules);
     }
@@ -279,7 +289,7 @@ MergeTreeReadersChain MergeTreeReadTask::createReadersChain(
             task_readers.main.get(),
             range_readers.empty() ? Block{} : range_readers.back().getSampleBlock(),
             /*prewhere_info_=*/ nullptr,
-            read_steps_performance_counters.getCountersForStep(counter_idx),
+            step_counter(counter_idx),
             /*main_reader_=*/ true,
             can_read_incomplete_granules);
     }
@@ -291,7 +301,8 @@ void MergeTreeReadTask::initializeReadersChain(
     const PrewhereExprInfo & prewhere_actions,
     MergeTreeIndexBuildContextPtr index_build_context,
     LazyMaterializingRowsPtr lazy_materializing_rows,
-    const ReadStepsPerformanceCounters & read_steps_performance_counters)
+    const ReadStepsPerformanceCounters & read_steps_performance_counters,
+    bool collect_predicate_statistics)
 {
     if (readers_chain.isInitialized())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Range readers chain is already initialized");
@@ -307,7 +318,9 @@ void MergeTreeReadTask::initializeReadersChain(
     for (const auto & step : prewhere_actions.steps)
         all_prewhere_actions.steps.push_back(step);
 
-    readers_chain = createReadersChain(readers, all_prewhere_actions, read_steps_performance_counters);
+    readers_chain = createReadersChain(
+        readers, all_prewhere_actions, read_steps_performance_counters,
+        collect_predicate_statistics);
 }
 
 void MergeTreeReadTask::initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows)

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -193,7 +193,8 @@ public:
         const PrewhereExprInfo & prewhere_actions,
         MergeTreeIndexBuildContextPtr index_build_context,
         LazyMaterializingRowsPtr lazy_materializing_rows,
-        const ReadStepsPerformanceCounters & read_steps_performance_counters);
+        const ReadStepsPerformanceCounters & read_steps_performance_counters,
+        bool collect_predicate_statistics);
 
     void initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows);
 
@@ -233,7 +234,8 @@ public:
     static MergeTreeReadersChain createReadersChain(
         const Readers & readers,
         const PrewhereExprInfo & prewhere_actions,
-        const ReadStepsPerformanceCounters & read_steps_performance_counters);
+        const ReadStepsPerformanceCounters & read_steps_performance_counters,
+        bool collect_predicate_statistics);
 
 private:
     using DataflowCacheUpdateCallback

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -248,7 +248,9 @@ ChunkAndProgress
 MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMergeTreeSelectAlgorithm & task_algorithm) const
 {
     if (!current_task.getReadersChain().isInitialized())
-        current_task.initializeReadersChain(prewhere_actions, merge_tree_index_build_context, lazy_materializing_rows, read_steps_performance_counters);
+        current_task.initializeReadersChain(
+            prewhere_actions, merge_tree_index_build_context, lazy_materializing_rows,
+            read_steps_performance_counters, reader_settings.collect_predicate_statistics);
 
     auto res = task_algorithm.readFromTask(current_task);
 


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106600
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/106600

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid maintaining `system.predicate_statistics_log` selectivity counters on the MergeTree read path when the feature is disabled (`predicate_statistics_sample_rate = 0`, the default). This removes a per-granule atomic update and an `O(rows)` filter popcount from every read, recovering a performance regression that was most visible on aarch64.

### Description

The `predicate_statistics_log` feature added two per-granule counter updates on the MergeTree read path in `MergeTreeRangeReader`, both running unconditionally even with `predicate_statistics_sample_rate = 0` (the default, feature off):

- `updatePerformanceCounters()`: `performance_counters->rows_read += num_rows_read`
- `executePrewhereActionsAndFilterColumns()`: `performance_counters->rows_passed_filter += current_filter.countBytesInFilter()`

The second one is the expensive part: `countBytesInFilter()` is an `O(rows)` scan that the following `ReadResult::optimize()` does not otherwise need on its common paths (it short-circuits via `clear()` for fully filtered granules). Combined with the atomic read-modify-write per granule, this is pure overhead when the feature is off. On aarch64 (weaker memory model, costlier atomics) it surfaced as a ~36% `client_time` regression on the `lightweight_delete` performance test query `0`; on x86 it is a few percent.

The regressing change is in the bisect window reported on the issue (commit `577ecf35cd9`, NOT an ancestor of the reported baseline `bc538c8`, IS an ancestor of the affected `a949f49`).

Fix: compute `collect_predicate_statistics` once per query from `predicate_statistics_sample_rate` in `MergeTreeReaderSettings`, thread it to the readers chain, and only allocate/update the counters when it is on. When the feature is enabled the behavior is unchanged.

Reproduction (issue #106600): `lightweight_delete` perf test, query `0`:
`SELECT id, length(value) FROM lwd_test ORDER BY id LIMIT 1` after `DELETE FROM lwd_test WHERE id < 9999999` on a 10M-row table.

Performance public history: https://performance.ci.clickhouse.com/history/lightweight_delete/0?metric=client_time&arch=arm

Verification: `04011_predicate_statistics_log` still passes (feature ON records identical selectivity: 0.1 / 0.999 / 0.0333 for the equality / prewhere / conjunction cases; feature OFF logs nothing). Query results identical across serial, parallel, PREWHERE, WHERE, lightweight-delete, and mutation read paths.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.143`
<!-- ch-version-info:end -->