### PR TITLE
Docs: mark Executable UDFs as beta in ClickHouse Cloud

### DIFF
--- a/docs/en/sql-reference/functions/udf.md
+++ b/docs/en/sql-reference/functions/udf.md
@@ -6,7 +6,7 @@ title: 'User Defined Functions (UDFs)'
 doc_type: 'reference'
 ---
 
-import PrivatePreviewBadge from '@theme/badges/PrivatePreviewBadge';
+import BetaBadge from '@theme/badges/BetaBadge';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CloudNotSupportedBadge from '@theme/badges/CloudNotSupportedBadge';
@@ -22,11 +22,10 @@ ClickHouse supports several types of user defined functions (UDFs):
 
 ## Executable User Defined Functions {#executable-user-defined-functions}
 
-<PrivatePreviewBadge/>
+<BetaBadge/>
 
 :::note
-This feature is supported in private preview in ClickHouse Cloud.
-Please contact ClickHouse Support at https://clickhouse.cloud/support to access.
+This feature is supported in beta in ClickHouse Cloud
 :::
 
 ClickHouse can call any external executable program or script to process data.


### PR DESCRIPTION
Update the **Executable User Defined Functions** section of `udf.md` to reflect that the feature is now supported in **beta** in ClickHouse Cloud rather than private preview.

- Replace the `PrivatePreviewBadge` with the `BetaBadge` component (and update the corresponding import).
- Update the accompanying note from "supported in private preview" (with the support-contact instruction) to "supported in beta in ClickHouse Cloud".

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1152`
<!-- ch-version-info:end -->