### PR TITLE
Fix refreshable materialized view failing to add keeper watch and getting stuck

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -129,6 +129,7 @@ static struct InitFiu
     ONCE(column_aggregate_function_ensureOwnership_exception) \
     ONCE(space_saving_copy_arena_throw) \
     REGULAR(keepermap_fail_drop_data) \
+    REGULAR(keeper_fault_on_watch_request) \
     REGULAR(lazy_pipe_fds_fail_close) \
     PAUSEABLE(infinite_sleep) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -8,6 +8,7 @@
 
 #include <Core/Settings.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/StringUtils.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/ZooKeeper/ShuffleHost.h>
@@ -54,6 +55,11 @@ namespace Setting
     extern const SettingsFloat opentelemetry_start_trace_probability;
     extern const SettingsFloatAuto opentelemetry_start_keeper_trace_probability;
 }
+
+namespace FailPoints
+{
+    extern const char keeper_fault_on_watch_request[];
+}
 }
 
 
@@ -62,6 +68,16 @@ namespace zkutil
 
 namespace
 {
+    /// Fail point that fails all requests with watches but allows requests without watches.
+    bool shouldInjectWatchFault(const Coordination::WatchCallbackPtrOrEventPtr & watch_callback)
+    {
+        if (!watch_callback)
+            return false;
+        bool inject = false;
+        fiu_do_on(DB::FailPoints::keeper_fault_on_watch_request, { inject = true; });
+        return inject;
+    }
+
     float calculateOpenTelemetryProbability()
     {
         const auto global_context = DB::Context::getGlobalContextInstance();
@@ -392,6 +408,9 @@ Coordination::Error ZooKeeper::getChildrenImpl(const std::string & path, Strings
                                    bool with_stat,
                                    bool with_data)
 {
+    if (shouldInjectWatchFault(watch_callback))
+        return Coordination::Error::ZCONNECTIONLOSS;
+
     std::optional<DB::OpenTelemetry::SpanHolder> maybe_span;
     if (sampleForOpenTelemetryTracing())
     {
@@ -690,6 +709,9 @@ Coordination::Error ZooKeeper::tryRemove(const std::string & path, int32_t versi
 
 Coordination::Error ZooKeeper::existsImpl(const std::string & path, Coordination::Stat * stat, Coordination::WatchCallbackPtrOrEventPtr watch_callback)
 {
+    if (shouldInjectWatchFault(watch_callback))
+        return Coordination::Error::ZCONNECTIONLOSS;
+
     std::optional<DB::OpenTelemetry::SpanHolder> maybe_span;
     if (sampleForOpenTelemetryTracing())
     {
@@ -752,6 +774,9 @@ bool ZooKeeper::existsWatch(const std::string & path, Coordination::Stat * stat,
 Coordination::Error ZooKeeper::getImpl(
     const std::string & path, std::string & res, Coordination::Stat * stat, Coordination::WatchCallbackPtrOrEventPtr watch_callback)
 {
+    if (shouldInjectWatchFault(watch_callback))
+        return Coordination::Error::ZCONNECTIONLOSS;
+
     std::optional<DB::OpenTelemetry::SpanHolder> maybe_span;
     if (sampleForOpenTelemetryTracing())
     {

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -226,8 +226,6 @@ OwnedRefreshTask RefreshTask::create(
 
     task->watch_callback = std::make_shared<Coordination::WatchCallback>([w = task->coordination.watches, task_waker = task->scheduling_task->getWatchCallback()](const Coordination::WatchResponse & response)
     {
-        w->root_watch_active.store(false);
-        w->children_watch_active.store(false);
         w->should_reread_znodes.store(true);
         (*task_waker)(response);
     });
@@ -1377,20 +1375,13 @@ void RefreshTask::readZnodesIfNeeded(std::shared_ptr<zkutil::ZooKeeper> zookeepe
     if (!zookeeper->isFeatureEnabled(KeeperFeatureFlag::MULTI_READ))
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Keeper server doesn't support multi-reads. Refreshable materialized views won't work.");
 
-    /// Set watches. (This is a lot of code, is there a better way?)
+    /// Do separate requests just to add watches.
     Coordination::WatchCallbackPtrOrEventPtr labelled_watch{
         watch_callback, ProfileEvents::ZooKeeperWatchTriggeredMaterializedViewRefresh};
-    if (!coordination.watches->root_watch_active.load())
-    {
-        coordination.watches->root_watch_active.store(true);
-        zookeeper->existsWatch(coordination.path, nullptr, labelled_watch);
-    }
-    if (!coordination.watches->children_watch_active.load())
-    {
-        coordination.watches->children_watch_active.store(true);
-        zookeeper->getChildrenWatch(coordination.path, nullptr, labelled_watch);
-    }
+    zookeeper->existsWatch(coordination.path, nullptr, labelled_watch);
+    zookeeper->getChildrenWatch(coordination.path, nullptr, labelled_watch);
 
+    /// Do an atomic multi-read.
     Strings paths {coordination.path, coordination.path + "/running", coordination.path + "/paused"};
     auto responses = zookeeper->tryGet(paths.begin(), paths.end());
 

--- a/src/Storages/MaterializedView/RefreshTask.h
+++ b/src/Storages/MaterializedView/RefreshTask.h
@@ -235,8 +235,6 @@ private:
         struct WatchState
         {
             std::atomic_bool should_reread_znodes {true};
-            std::atomic_bool root_watch_active {false};
-            std::atomic_bool children_watch_active {false};
         };
 
         CoordinationZnode root_znode;

--- a/tests/integration/test_refreshable_mv_watch_fault/configs/remote_servers.xml
+++ b/tests/integration/test_refreshable_mv_watch_fault/configs/remote_servers.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <remote_servers>
+        <default>
+            <shard>
+                <replica>
+                    <host>node1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>node2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </default>
+    </remote_servers>
+</clickhouse>

--- a/tests/integration/test_refreshable_mv_watch_fault/test.py
+++ b/tests/integration/test_refreshable_mv_watch_fault/test.py
@@ -50,6 +50,21 @@ def wait_for_status(node, table, expected, timeout=60):
     )
 
 
+def count_keeper_errors(node):
+    return int(node.count_in_log("RefreshTask.re.a.*Keeper error").strip())
+
+
+def wait_for_keeper_errors(node, at_least, timeout=60):
+    deadline = time.time() + timeout
+    while count_keeper_errors(node) < at_least:
+        if time.time() >= deadline:
+            raise AssertionError(
+                f"{node.name}: got {count_keeper_errors(node)} RMV keeper errors, "
+                f"expected >= {at_least} within {timeout}s"
+            )
+        time.sleep(0.5)
+
+
 def test_watch_registration_failure_recovers(started_cluster):
     """
     A coordinated RMV relies on keeper watches to wake up when another replica changes the
@@ -94,6 +109,7 @@ def test_watch_registration_failure_recovers(started_cluster):
 
     # Break node1's watch requests. Process-local and only affects watch-carrying reads, so node1's
     # session stays healthy. No DDL is issued on node1 while it is enabled.
+    errors_before = count_keeper_errors(node1)
     node1.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
 
     # node2 starts a refresh and creates the 'running' ephemeral child. That fires node1's existing
@@ -101,11 +117,11 @@ def test_watch_registration_failure_recovers(started_cluster):
     node2.query("SYSTEM REFRESH VIEW re.a")
     wait_for_status(node2, "a", "Running", timeout=30)
 
-    # Wait for two watch-add failures: the exists-watch on the first scheduling iteration and the
-    # children-watch on the second (5s retry apart). Both flags would be left stuck by the bug.
-    node1.wait_for_log_line(
-        "RefreshTask.re.a.*Keeper error", timeout=60, repetitions=2
-    )
+    # Wait for two new watch-add failures: the exists-watch on the first scheduling iteration and
+    # the children-watch on the second (5s retry apart). Both flags would be left stuck by the bug.
+    # Counting the delta (rather than wait_for_log_line, which scans old log lines) keeps this robust
+    # when the module-scoped cluster's log is reused across repeated runs.
+    wait_for_keeper_errors(node1, errors_before + 2)
 
     # Stop injecting faults. With the fix node1 re-adds both watches; with the bug the flags are
     # stuck and it never tries again.

--- a/tests/integration/test_refreshable_mv_watch_fault/test.py
+++ b/tests/integration/test_refreshable_mv_watch_fault/test.py
@@ -50,21 +50,6 @@ def wait_for_status(node, table, expected, timeout=60):
     )
 
 
-def count_keeper_errors(node):
-    return int(node.count_in_log("RefreshTask.re.a.*Keeper error").strip())
-
-
-def wait_for_keeper_errors(node, at_least, timeout=60):
-    deadline = time.time() + timeout
-    while count_keeper_errors(node) < at_least:
-        if time.time() >= deadline:
-            raise AssertionError(
-                f"{node.name}: got {count_keeper_errors(node)} RMV keeper errors, "
-                f"expected >= {at_least} within {timeout}s"
-            )
-        time.sleep(0.5)
-
-
 def test_watch_registration_failure_recovers(started_cluster):
     """
     A coordinated RMV relies on keeper watches to wake up when another replica changes the
@@ -109,7 +94,9 @@ def test_watch_registration_failure_recovers(started_cluster):
 
     # Break node1's watch requests. Process-local and only affects watch-carrying reads, so node1's
     # session stays healthy. No DDL is issued on node1 while it is enabled.
-    errors_before = count_keeper_errors(node1)
+    # Anchor the log search at the current line so it ignores any matches from a previous run sharing
+    # this module-scoped cluster (wait_for_log_line's default scans backwards over old lines).
+    log_anchor = node1.count_log_lines()
     node1.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
 
     # node2 starts a refresh and creates the 'running' ephemeral child. That fires node1's existing
@@ -117,11 +104,14 @@ def test_watch_registration_failure_recovers(started_cluster):
     node2.query("SYSTEM REFRESH VIEW re.a")
     wait_for_status(node2, "a", "Running", timeout=30)
 
-    # Wait for two new watch-add failures: the exists-watch on the first scheduling iteration and
-    # the children-watch on the second (5s retry apart). Both flags would be left stuck by the bug.
-    # Counting the delta (rather than wait_for_log_line, which scans old log lines) keeps this robust
-    # when the module-scoped cluster's log is reused across repeated runs.
-    wait_for_keeper_errors(node1, errors_before + 2)
+    # Wait for two watch-add failures: the exists-watch on the first scheduling iteration and the
+    # children-watch on the second (5s retry apart). Both flags would be left stuck by the bug.
+    node1.wait_for_log_line(
+        "RefreshTask.re.a.*Keeper error",
+        timeout=60,
+        repetitions=2,
+        look_behind_lines=f"+{log_anchor}",
+    )
 
     # Stop injecting faults. With the fix node1 re-adds both watches; with the bug the flags are
     # stuck and it never tries again.

--- a/tests/integration/test_refreshable_mv_watch_fault/test.py
+++ b/tests/integration/test_refreshable_mv_watch_fault/test.py
@@ -1,0 +1,123 @@
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": 1, "replica": 1},
+)
+
+node2 = cluster.add_instance(
+    "node2",
+    main_configs=["configs/remote_servers.xml"],
+    with_zookeeper=True,
+    keeper_required_feature_flags=["multi_read", "create_if_not_exists"],
+    macros={"shard": 1, "replica": 2},
+)
+
+FAILPOINT = "keeper_fault_on_watch_request"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def wait_for_status(node, table, expected, timeout=60):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = node.query(
+            f"SELECT status FROM system.view_refreshes WHERE view = '{table}'"
+        ).strip()
+        if last == expected:
+            return
+        time.sleep(0.2)
+    raise AssertionError(
+        f"{node.name}: view '{table}' did not reach status '{expected}' within {timeout}s "
+        f"(last: '{last}')"
+    )
+
+
+def test_watch_registration_failure_recovers(started_cluster):
+    """
+    A coordinated RMV relies on keeper watches to wake up when another replica changes the
+    shared state - the `RunningOnAnotherReplica` state schedules no timer. The bug: the
+    "watch active" flag in `RefreshTask::readZnodesIfNeeded` was set before the watch request
+    was sent and not reset on failure, so after one failed request the watch was never re-added
+    and the replica stayed blind.
+
+    Repro: break node1's watch requests via the failpoint, start a refresh on node2 (which fires
+    node1's watches and makes it try - and fail - to re-add them), then disable the failpoint and
+    check node1 still notices when node2 finishes. With the fix node1 re-adds its watches and
+    returns to Scheduled; with the bug it stays stuck in RunningOnAnotherReplica.
+    """
+    # Replicated database is the only flavor that supports coordinated RMVs.
+    node1.query("DROP DATABASE IF EXISTS re ON CLUSTER default SYNC")
+    node1.query(
+        "CREATE DATABASE re ON CLUSTER default "
+        "ENGINE = Replicated('/clickhouse/databases/re', '{shard}', '{replica}')"
+    )
+    node1.query(
+        "CREATE TABLE re.tgt (t DateTime, i UInt64) "
+        "ENGINE = ReplicatedMergeTree() ORDER BY tuple()"
+    )
+
+    # EVERY 1 YEAR so neither replica refreshes on its own (no periodic wakeup to mask the missing
+    # watch); EMPTY skips the initial refresh; the ~60s SELECT keeps node2's refresh running long
+    # enough for the failpoint dance to finish before node2 completes.
+    node1.query(
+        """
+        CREATE MATERIALIZED VIEW re.a
+        REFRESH EVERY 1 YEAR APPEND
+        TO re.tgt
+        EMPTY
+        AS SELECT now() AS t, sum(sleepEachRow(1) + 1) AS i
+           FROM numbers(60) SETTINGS max_block_size = 1
+        """
+    )
+
+    # Both replicas idle in Scheduled, each with its watches registered (failpoint off).
+    wait_for_status(node1, "a", "Scheduled")
+    wait_for_status(node2, "a", "Scheduled")
+
+    # Break node1's watch requests. Process-local and only affects watch-carrying reads, so node1's
+    # session stays healthy. No DDL is issued on node1 while it is enabled.
+    node1.query(f"SYSTEM ENABLE FAILPOINT {FAILPOINT}")
+
+    # node2 starts a refresh and creates the 'running' ephemeral child. That fires node1's existing
+    # watches, so node1 wakes and tries to re-add them - which now fails.
+    node2.query("SYSTEM REFRESH VIEW re.a")
+    wait_for_status(node2, "a", "Running", timeout=30)
+
+    # Wait for two watch-add failures: the exists-watch on the first scheduling iteration and the
+    # children-watch on the second (5s retry apart). Both flags would be left stuck by the bug.
+    node1.wait_for_log_line(
+        "RefreshTask.re.a.*Keeper error", timeout=60, repetitions=2
+    )
+
+    # Stop injecting faults. With the fix node1 re-adds both watches; with the bug the flags are
+    # stuck and it never tries again.
+    node1.query(f"SYSTEM DISABLE FAILPOINT {FAILPOINT}")
+
+    # node1 has read the state and seen node2's refresh. Both bug and fix reach this; the difference
+    # is whether node1 holds a working watch here.
+    wait_for_status(node1, "a", "RunningOnAnotherReplica", timeout=60)
+
+    # node2 finishes and clears the 'running' znode - the change node1 must be woken by.
+    wait_for_status(node2, "a", "Scheduled", timeout=120)
+
+    # The crux: node1 must notice node2 finished, via its watch, and return to Scheduled. With the
+    # bug it has no watch and stays in RunningOnAnotherReplica until this times out.
+    wait_for_status(node1, "a", "Scheduled", timeout=60)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed refreshable materialized view getting stuck if zookeeper connection is lost at the wrong moment.

---

An obvious bug that seems to have been there from the start (https://github.com/ClickHouse/ClickHouse/pull/60669) :/ . "Watch was added" flag is set before watch is actually added, then not unset if adding the watch fails. Then we never re-read the state from zookeeper and get stuck. Not sure how the reviewer and I both missed it.

(Why didn't https://github.com/ClickHouse/ClickHouse/pull/60669 just set the flag *after* adding the watch? Because then there would be a race condition: the watch may fire and deactivate itself immediately after being added, before we set the flag.)

Trivial fix that just removes the "watch was added" flags. (They made some limited amount of sense initially, but then became useless when watch callbacks were moved from inline lambdas to a reused `watch_callback` field. Zookeeper client deduplicates watches, so watches don't accumulate if we add the same callback multiple times without it firing.)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1163`
- Backported to: `26.5.4.10`, `26.4.5.66`, `26.3.16.6`
<!-- ch-version-info:end -->