### PR TITLE
Fix noise warning, warn only if Kerberos is used in `Kafka` engine

### DIFF
--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -419,14 +419,14 @@ void updateConfigurationFromConfig(
     }
 
 #if USE_KRB5
-    if (kafka_config.has_property("sasl.kerberos.kinit.cmd"))
-        LOG_WARNING(params.log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
-
-    kafka_config.set("sasl.kerberos.kinit.cmd", "");
-    kafka_config.set("sasl.kerberos.min.time.before.relogin", "0");
-
     if (kafka_config.has_property("sasl.kerberos.keytab") && kafka_config.has_property("sasl.kerberos.principal"))
     {
+        if (kafka_config.has_property("sasl.kerberos.kinit.cmd"))
+            LOG_WARNING(params.log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
+
+        kafka_config.set("sasl.kerberos.kinit.cmd", "");
+        kafka_config.set("sasl.kerberos.min.time.before.relogin", "0");
+
         String keytab = kafka_config.get("sasl.kerberos.keytab");
         String principal = kafka_config.get("sasl.kerberos.principal");
         LOG_DEBUG(params.log, "Running KerberosInit");

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -419,14 +419,15 @@ void updateConfigurationFromConfig(
     }
 
 #if USE_KRB5
+    static const String default_kinit_cmd = cppkafka::Configuration{}.get("sasl.kerberos.kinit.cmd");
+    if (kafka_config.get("sasl.kerberos.kinit.cmd") != default_kinit_cmd)
+        LOG_WARNING(params.log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
+
+    kafka_config.set("sasl.kerberos.kinit.cmd", "");
+    kafka_config.set("sasl.kerberos.min.time.before.relogin", "0");
+
     if (kafka_config.has_property("sasl.kerberos.keytab") && kafka_config.has_property("sasl.kerberos.principal"))
     {
-        if (kafka_config.has_property("sasl.kerberos.kinit.cmd"))
-            LOG_WARNING(params.log, "sasl.kerberos.kinit.cmd configuration parameter is ignored.");
-
-        kafka_config.set("sasl.kerberos.kinit.cmd", "");
-        kafka_config.set("sasl.kerberos.min.time.before.relogin", "0");
-
         String keytab = kafka_config.get("sasl.kerberos.keytab");
         String principal = kafka_config.get("sasl.kerberos.principal");
         LOG_DEBUG(params.log, "Running KerberosInit");

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -82,6 +82,37 @@ def kafka_setup_teardown():
 
 
 # Tests
+def test_kafka_no_kerberos_kinit_warning(kafka_cluster):
+    suffix = k.random_string(6)
+    kafka_table = f"kafka_{suffix}"
+
+    instance.rotate_logs()
+    instance.query(f"""
+        CREATE TABLE test.{kafka_table} (key UInt64)
+            ENGINE = Kafka()
+            SETTINGS kafka_broker_list = 'kafka1:19092',
+                     kafka_topic_list = 'no_kerberos_kinit_warning_{suffix}',
+                     kafka_group_name = 'no_kerberos_kinit_warning_{suffix}',
+                     kafka_format = 'JSONEachRow';
+    """)
+
+    instance.query(f"""
+        CREATE MATERIALIZED VIEW test.{kafka_table}_view
+        ENGINE = MergeTree
+        ORDER BY tuple()
+        AS SELECT * FROM test.{kafka_table}
+    """)
+    instance.wait_for_log_line(f"{kafka_table}.*Created #0 consumer")
+
+    instance.query(f"DROP TABLE test.{kafka_table}_view")
+    instance.query(f"INSERT INTO test.{kafka_table} VALUES (1)")
+
+    assert instance.contains_in_log(f"{kafka_table}.*Kafka producer created")
+    assert not instance.contains_in_log(
+        f"{kafka_table}.*sasl.kerberos.kinit.cmd configuration parameter is ignored."
+    )
+
+
 @pytest.mark.parametrize(
     "create_query_generator",
     [


### PR DESCRIPTION
Avoid logging `sasl.kerberos.kinit.cmd configuration parameter is ignored.` for `Kafka` engine configurations that do not use Kerberos keytab authentication.

I think it makes sense to warn users only when Kerberos-related parameters are provided.

The warning is now emitted only when `sasl.kerberos.kinit.cmd` was actually configured, i.e. its value differs from librdkafka's built-in default. `cppkafka::Configuration::has_property` returns true for every property that has a librdkafka default, which is why the old check fired for every `Kafka` table.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid logging `sasl.kerberos.kinit.cmd configuration parameter is ignored.` for `Kafka` engine configurations that do not use Kerberos keytab authentication.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1163` (included in `26.8` and later)
<!-- ch-version-info:end -->