### PR TITLE
Promoters for streaming enrichment must be constructed after local parts snapshot

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -11115,11 +11115,11 @@ bool MergeTreeData::scheduleStreamingJob(BackgroundJobsAssignee & assignee)
     if (subscription_manager.isEmpty())
         return false;
 
-    auto promoters = buildPromoters();
-
     LocalPartsByPartition local_parts;
     for (const auto & part : getDataPartsVectorForInternalUsage())
         local_parts[part->info.getPartitionId()].push_back(part->info);
+
+    auto promoters = buildPromoters();
 
     bool any_enriched = false;
     subscription_manager.executeOnEachSubscription([&](StreamSubscriptionPtr & subscription)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes a race where, after promoters were constructed, 2 parts were inserted into the table, and the second was fetched and became visible in the local parts snapshot. In this case, we should not enrich subscriptions, as this will cause cursors to pass the second part, skipping the first.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1145`
<!-- ch-version-info:end -->