### PR TITLE
Fix LOGICAL_ERROR in normal projection optimization with correlated subqueries

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -428,6 +428,14 @@ std::optional<String> optimizeUseNormalProjections(
         reading->isParallelReadingEnabled(),
         reading->getParallelReadingExtension());
 
+    /// filterPartsByProjection mutates parent_reading_select_result in place. When it is the analyzed
+    /// result held by the parent ReadFromMergeTree, that mutation is visible to the regular read. If
+    /// the structure check below makes us skip the projection, the regular read must still see every
+    /// part, so remember the pre-filter result and restore it on that path.
+    ReadFromMergeTree::AnalysisResultPtr analyzed_result_to_restore_on_skip;
+    if (reading->getAnalyzedResult() == parent_reading_select_result)
+        analyzed_result_to_restore_on_skip = std::make_shared<ReadFromMergeTree::AnalysisResult>(*parent_reading_select_result);
+
     /// Filter out parts in parent_ranges that overlap with those already read by the best candidate projection
     filterPartsByProjection(*parent_reading_select_result, best_candidate->parent_parts);
 
@@ -497,7 +505,13 @@ std::optional<String> optimizeUseNormalProjections(
     }
 
     if (!blocksHaveEqualStructure(*main_stream, **proj_stream))
+    {
+        /// Skipping the projection: undo the filterPartsByProjection mutation so the regular read,
+        /// which stays in the plan, still sees all parts instead of silently returning too few rows.
+        if (analyzed_result_to_restore_on_skip)
+            reading->setAnalyzedResult(std::move(analyzed_result_to_restore_on_skip));
         return {};
+    }
 
     if (parent_reading_select_result->parts_with_ranges.empty())
     {

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -479,6 +479,26 @@ std::optional<String> optimizeUseNormalProjections(
         next_node = &expr_or_filter_node;
     }
 
+    /// The rewritten projection stream must keep the same structure as the subplan it replaces:
+    /// columns from `required_columns` that `query.dag` does not consume survive as pass-throughs
+    /// and would otherwise widen the output header, breaking the parent step's header contract.
+    /// Materialize constants if needed and require equal structure, else skip (regular read stays correct).
+    const auto & main_stream = iter->node->children[iter->next_child - 1]->step->getOutputHeader();
+    const auto * proj_stream = &next_node->step->getOutputHeader();
+
+    if (auto materializing = makeMaterializingDAG(**proj_stream, *main_stream))
+    {
+        auto converting = std::make_unique<ExpressionStep>(*proj_stream, std::move(*materializing));
+        proj_stream = &converting->getOutputHeader();
+        auto & expr_node = nodes.emplace_back();
+        expr_node.step = std::move(converting);
+        expr_node.children.push_back(next_node);
+        next_node = &expr_node;
+    }
+
+    if (!blocksHaveEqualStructure(*main_stream, **proj_stream))
+        return {};
+
     if (parent_reading_select_result->parts_with_ranges.empty())
     {
         /// All parts are taken from projection
@@ -486,25 +506,6 @@ std::optional<String> optimizeUseNormalProjections(
     }
     else
     {
-        const auto & main_stream = iter->node->children[iter->next_child - 1]->step->getOutputHeader();
-        const auto * proj_stream = &next_node->step->getOutputHeader();
-
-        if (auto materializing = makeMaterializingDAG(**proj_stream, *main_stream))
-        {
-            auto converting = std::make_unique<ExpressionStep>(*proj_stream, std::move(*materializing));
-            proj_stream = &converting->getOutputHeader();
-            auto & expr_node = nodes.emplace_back();
-            expr_node.step = std::move(converting);
-            expr_node.children.push_back(next_node);
-            next_node = &expr_node;
-        }
-
-        /// Verify headers are compatible before creating the Union.
-        /// If they differ (e.g., different columns due to different query DAGs being applied),
-        /// skip this optimization to avoid "Block structure mismatch" errors.
-        if (!blocksHaveEqualStructure(*main_stream, **proj_stream))
-            return {};
-
         auto & union_node = nodes.emplace_back();
         SharedHeaders input_headers = {main_stream, *proj_stream};
         union_node.step = std::make_unique<UnionStep>(std::move(input_headers));

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
@@ -1,0 +1,18 @@
+-- { echo ON }
+SET allow_suspicious_low_cardinality_types = 1;
+DROP TABLE IF EXISTS t_proj_corr;
+-- Normal projection that materializes the _part_offset virtual column; disable merges to keep 5 parts.
+CREATE TABLE t_proj_corr (i LowCardinality(Int32), j LowCardinality(Int32), PROJECTION p (SELECT *, _part_offset ORDER BY j) WITH SETTINGS (index_granularity = 64)) ENGINE = MergeTree ORDER BY i SETTINGS index_granularity = 1, max_bytes_to_merge_at_max_space_in_pool = 1;
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+-- A correlated scalar subquery decorrelates into a CROSS JOIN whose input reads via the normal
+-- projection (forced by PREWHERE on _part_offset). With join kind 'left' the projection-rewritten
+-- read used to leak the unused i/j columns past the join's declared header, aborting the server with
+-- "Invalid number of columns in chunk pushed to OutputPort". Both queries must run without crashing.
+SELECT count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+20
+SELECT i, j FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) = 8 ORDER BY ALL SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+DROP TABLE t_proj_corr;

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
@@ -11,8 +11,17 @@ INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
 -- A correlated scalar subquery decorrelates into a CROSS JOIN whose input reads via the normal
 -- projection (forced by PREWHERE on _part_offset). With join kind 'left' the projection-rewritten
 -- read used to leak the unused i/j columns past the join's declared header, aborting the server with
--- "Invalid number of columns in chunk pushed to OutputPort". Both queries must run without crashing.
+-- "Invalid number of columns in chunk pushed to OutputPort". Must run without crashing.
 SELECT count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
 20
 SELECT i, j FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) = 8 ORDER BY ALL SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+3	7
+-- The fix must skip the projection when its rewritten stream cannot match the replaced read's
+-- structure, WITHOUT silently dropping rows: the skip path may not leave the regular read with the
+-- parts already filtered out. Assert the projection-on result equals the projection-off result. A
+-- regression returns fewer rows (e.g. 0) only with optimize_use_projections = 1.
+SELECT sum(i), sum(j), count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left', optimize_use_projections = 1;
+40	160	20
+SELECT sum(i), sum(j), count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left', optimize_use_projections = 0;
+40	160	20
 DROP TABLE t_proj_corr;

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.reference
@@ -1,4 +1,6 @@
 -- { echo ON }
+-- Correlated subqueries require the new analyzer.
+SET enable_analyzer = 1;
 SET allow_suspicious_low_cardinality_types = 1;
 DROP TABLE IF EXISTS t_proj_corr;
 -- Normal projection that materializes the _part_offset virtual column; disable merges to keep 5 parts.

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
@@ -1,4 +1,6 @@
 -- { echo ON }
+-- Correlated subqueries require the new analyzer.
+SET enable_analyzer = 1;
 SET allow_suspicious_low_cardinality_types = 1;
 
 DROP TABLE IF EXISTS t_proj_corr;

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
@@ -15,9 +15,16 @@ INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
 -- A correlated scalar subquery decorrelates into a CROSS JOIN whose input reads via the normal
 -- projection (forced by PREWHERE on _part_offset). With join kind 'left' the projection-rewritten
 -- read used to leak the unused i/j columns past the join's declared header, aborting the server with
--- "Invalid number of columns in chunk pushed to OutputPort". Both queries must run without crashing.
+-- "Invalid number of columns in chunk pushed to OutputPort". Must run without crashing.
 SELECT count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
 
 SELECT i, j FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) = 8 ORDER BY ALL SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+
+-- The fix must skip the projection when its rewritten stream cannot match the replaced read's
+-- structure, WITHOUT silently dropping rows: the skip path may not leave the regular read with the
+-- parts already filtered out. Assert the projection-on result equals the projection-off result. A
+-- regression returns fewer rows (e.g. 0) only with optimize_use_projections = 1.
+SELECT sum(i), sum(j), count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left', optimize_use_projections = 1;
+SELECT sum(i), sum(j), count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left', optimize_use_projections = 0;
 
 DROP TABLE t_proj_corr;

--- a/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
+++ b/tests/queries/0_stateless/04410_normal_projection_correlated_subquery_part_offset.sql
@@ -1,0 +1,23 @@
+-- { echo ON }
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS t_proj_corr;
+
+-- Normal projection that materializes the _part_offset virtual column; disable merges to keep 5 parts.
+CREATE TABLE t_proj_corr (i LowCardinality(Int32), j LowCardinality(Int32), PROJECTION p (SELECT *, _part_offset ORDER BY j) WITH SETTINGS (index_granularity = 64)) ENGINE = MergeTree ORDER BY i SETTINGS index_granularity = 1, max_bytes_to_merge_at_max_space_in_pool = 1;
+
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+INSERT INTO t_proj_corr SELECT number, 10 - number FROM numbers(5);
+
+-- A correlated scalar subquery decorrelates into a CROSS JOIN whose input reads via the normal
+-- projection (forced by PREWHERE on _part_offset). With join kind 'left' the projection-rewritten
+-- read used to leak the unused i/j columns past the join's declared header, aborting the server with
+-- "Invalid number of columns in chunk pushed to OutputPort". Both queries must run without crashing.
+SELECT count() FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) >= 0 SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+
+SELECT i, j FROM t_proj_corr PREWHERE _part_offset < (_part_offset + _part_starting_offset) WHERE ((SELECT _part_starting_offset) + _part_offset) = 8 ORDER BY ALL SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0, correlated_subqueries_default_join_kind = 'left';
+
+DROP TABLE t_proj_corr;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/103695
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` ("Invalid number of columns in chunk pushed to OutputPort") that could crash the server when a normal projection that materializes a virtual column (e.g. `PROJECTION p (SELECT *, _part_offset ORDER BY j)`) was used to read the input of a correlated subquery.


### Description

CI report: [AST fuzzer (arm_asan_ubsan), master](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d31a0396e975fe945840fad3750aa7b0904fffa8&name_0=MasterCI&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29) (STID 2270-3452, same family as the umbrella issue #103695).

Found by the AST fuzzer. Minimal deterministic reproducer:

```sql
SET allow_suspicious_low_cardinality_types = 1;
CREATE TABLE t (i LowCardinality(Int32), j LowCardinality(Int32),
  PROJECTION p (SELECT *, _part_offset ORDER BY j) WITH SETTINGS (index_granularity = 64))
ENGINE = MergeTree ORDER BY i SETTINGS index_granularity = 1, max_bytes_to_merge_at_max_space_in_pool = 1;
-- insert several parts
SELECT i, j FROM t
PREWHERE _part_offset < (_part_offset + _part_starting_offset)
WHERE ((SELECT _part_starting_offset) + _part_offset) = 8
SETTINGS correlated_subqueries_substitute_equivalent_expressions = 0,
         correlated_subqueries_default_join_kind = 'left';
```

Root cause: `optimizeUseNormalProjections` reads the projection with `required_columns = reading->getAllColumnNames()`. Columns in that set that the rebuilt `query.dag` does not consume survive as pass-throughs (`ActionsDAG::updateHeader` appends every un-consumed input column). When the subplan being replaced produced fewer columns - here a "Project only used columns" step inserted while decorrelating the correlated scalar subquery `(SELECT _part_starting_offset)` had pruned `i`/`j` away - those extra pass-through columns silently widened the rewritten read's output header.

The all-parts-from-projection branch then spliced the widened node into the plan **without** the `blocksHaveEqualStructure` check that the Union branch already had. At execution the decorrelation CROSS `JoiningTransform` pushed a 4-column chunk into a port whose header declared 2 columns, aborting the server.

Fix: hoist the existing materialize-constants + equal-structure guard so it protects both replacement branches; if the projection-rewritten stream does not match the structure of the subplan it replaces, the projection is skipped and the regular read (which is correct) is kept.

Verified: the reproducer aborts the server before the change and runs cleanly after it; results match the non-projection plan. Added a regression test (`04410_normal_projection_correlated_subquery_part_offset`). Existing projection / `_part_offset` / correlated-subquery tests still pass.
