### PR TITLE
Fix Bad cast LowCardinality to Nullable in primary-key range pruning

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1436,6 +1436,8 @@ bool KeyCondition::hasOnlyConjunctions() const
 }
 
 
+DataTypePtr getArgumentTypeOfMonotonicFunction(const IFunctionBase & func);
+
 static Field applyFunctionForField(
     const FunctionBasePtr & func,
     const DataTypePtr & arg_type,
@@ -1479,14 +1481,36 @@ static FieldRef applyFunction(const FunctionBasePtr & func, const DataTypePtr & 
     {
         /// When cache is missed, we calculate the whole column where the field comes from. This will avoid repeated calculation.
         ColumnsWithTypeAndName args{(*columns)[field.column_idx]};
+        /// Coerce the cached column to the outer-`LowCardinality` shape the function was actually built
+        /// for, instead of blindly stripping the wrapper. The chain builder strips `LowCardinality` only
+        /// from the initial key type, so after a step like `CAST(s, 'LowCardinality(String)')` the next
+        /// function's declared argument type is itself `LowCardinality(...)`. `FunctionCast` keeps LC
+        /// dictionaries (`useDefaultImplementationForLowCardinalityColumns = false`) and `typeid_cast`-es
+        /// the column to the declared shape, so the column wrapper must match. Mirrors
+        /// `applyFunctionChainToColumn`; touches only the outer level, preserving inner LowCardinality.
+        if (args[0].type && func)
+        {
+            auto argument_type = getArgumentTypeOfMonotonicFunction(*func);
+            if (argument_type && argument_type->lowCardinality() && !args[0].column->lowCardinality())
+            {
+                auto lc_col = argument_type->createColumn();
+                auto full_col = args[0].column->convertToFullColumnIfConst();
+                assert_cast<ColumnLowCardinality &>(*lc_col).insertRangeFromFullColumn(*full_col, 0, full_col->size());
+                args[0].column = std::move(lc_col);
+                args[0].type = argument_type;
+            }
+            else if (argument_type && !argument_type->lowCardinality() && args[0].column->lowCardinality())
+            {
+                args[0].column = args[0].column->convertToFullColumnIfLowCardinality();
+                args[0].type = removeLowCardinality(args[0].type);
+            }
+        }
         field.columns->emplace_back(ColumnWithTypeAndName {nullptr, func->getResultType(), result_name});
         (*columns)[result_idx].column = func->execute(args, (*columns)[result_idx].type, columns->front().column->size(), /* dry_run = */ false);
     }
 
     return {field.columns, field.row_idx, result_idx};
 }
-
-DataTypePtr getArgumentTypeOfMonotonicFunction(const IFunctionBase & func);
 
 /// Sequentially applies functions to the column, returns `true`
 /// if all function arguments are compatible with functions

--- a/tests/queries/0_stateless/04365_keycondition_lc_cast_sparse_pk.reference
+++ b/tests/queries/0_stateless/04365_keycondition_lc_cast_sparse_pk.reference
@@ -1,0 +1,10 @@
+-- fuzzer crash shape (lightweight PK analysis)
+0
+-- CAST chain pruning matches full scan (lightweight vs regular)
+35	35	35
+-- another comparison shape
+38	38	38
+-- nested CAST chain crash shape (lightweight PK analysis)
+35
+-- nested CAST chain pruning matches full scan (lightweight vs regular)
+35	35	35

--- a/tests/queries/0_stateless/04365_keycondition_lc_cast_sparse_pk.sql
+++ b/tests/queries/0_stateless/04365_keycondition_lc_cast_sparse_pk.sql
@@ -1,0 +1,58 @@
+-- Regression test for a `Bad cast from type DB::ColumnLowCardinality to DB::ColumnNullable`
+-- LOGICAL_ERROR in primary-key range pruning. A `LowCardinality(...)` key column with an
+-- executing monotonic CAST chain (e.g. `CAST(s, 'LowCardinality(String)')`) made
+-- `applyFunction` feed the raw dictionary column to a `FunctionCast` wrapper that was built
+-- for a `LowCardinality`-stripped source, which then `assert_cast`-ed it to `ColumnNullable`.
+-- Both the lightweight (sparse) and the regular primary-key analysis paths are exercised.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS t_lc_cast_pk;
+
+-- Two non-overlapping parts and a small granule so the index has single-value granules
+-- (single_point), which is what makes the non-monotonic CAST-to-String chain actually execute.
+CREATE TABLE t_lc_cast_pk (s LowCardinality(Nullable(Int32)))
+ENGINE = MergeTree ORDER BY s SETTINGS index_granularity = 8, allow_nullable_key = 1;
+INSERT INTO t_lc_cast_pk SELECT number FROM numbers(20);
+INSERT INTO t_lc_cast_pk SELECT number + 1000 FROM numbers(20);
+
+-- The original AST-fuzzer crash shape. Just running it must not abort.
+SELECT '-- fuzzer crash shape (lightweight PK analysis)';
+SELECT count() FROM t_lc_cast_pk
+WHERE CAST(s, 'LowCardinality(String)') < toLowCardinality('(')
+SETTINGS use_lightweight_primary_key_index_analysis = 1;
+
+-- Correctness: the CAST-chain pruning result must match a full scan, on both PK-analysis paths.
+-- toString(int) is lexicographic, so the answers below are non-trivial (neither 0 nor all rows).
+SELECT '-- CAST chain pruning matches full scan (lightweight vs regular)';
+SELECT
+    countIf(CAST(s, 'String') < '5')  AS full_scan,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(s, 'String') < '5' SETTINGS use_lightweight_primary_key_index_analysis = 1) AS sparse,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(s, 'String') < '5' SETTINGS use_lightweight_primary_key_index_analysis = 0) AS regular
+FROM t_lc_cast_pk;
+
+SELECT '-- another comparison shape';
+SELECT
+    countIf(CAST(s, 'String') >= '10') AS full_scan,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(s, 'String') >= '10' SETTINGS use_lightweight_primary_key_index_analysis = 1) AS sparse,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(s, 'String') >= '10' SETTINGS use_lightweight_primary_key_index_analysis = 0) AS regular
+FROM t_lc_cast_pk;
+
+-- Nested CAST chain: the first CAST re-introduces a `LowCardinality(String)` argument type for the
+-- second CAST, so a fix that just strips the wrapper would feed a full `ColumnString` to a function
+-- built for an LC source, hitting the mirror `Bad cast ColumnString -> ColumnLowCardinality`. The
+-- chain must coerce each cached column to its function's declared argument type. Just running it
+-- must not abort, on both PK-analysis paths.
+SELECT '-- nested CAST chain crash shape (lightweight PK analysis)';
+SELECT count() FROM t_lc_cast_pk
+WHERE CAST(CAST(s, 'LowCardinality(String)'), 'String') < '5'
+SETTINGS use_lightweight_primary_key_index_analysis = 1;
+
+SELECT '-- nested CAST chain pruning matches full scan (lightweight vs regular)';
+SELECT
+    countIf(CAST(CAST(s, 'LowCardinality(String)'), 'String') < '5') AS full_scan,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(CAST(s, 'LowCardinality(String)'), 'String') < '5' SETTINGS use_lightweight_primary_key_index_analysis = 1) AS sparse,
+    (SELECT count() FROM t_lc_cast_pk WHERE CAST(CAST(s, 'LowCardinality(String)'), 'String') < '5' SETTINGS use_lightweight_primary_key_index_analysis = 0) AS regular
+FROM t_lc_cast_pk;
+
+DROP TABLE t_lc_cast_pk;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `Logical error: 'Bad cast from type DB::ColumnLowCardinality to DB::ColumnNullable'` (server abort in debug/sanitizer builds) when a query has a `LowCardinality` primary-key column wrapped in an executing monotonic `CAST` chain, for example `CAST(s, 'LowCardinality(String)')` over a `LowCardinality(Nullable(Int32))` primary key.

### Description

The monotonic-functions chain is built in `isKeyPossiblyWrappedByMonotonicFunctions` against an outer-`LowCardinality`-stripped key type (`recursiveRemoveLowCardinality`), so the chain's `FunctionCast` wrapper is prepared for a non-`LowCardinality` source and unconditionally `assert_cast`s its argument to `ColumnNullable`. The range path `KeyCondition::applyMonotonicFunctionsChainToRange` -> `applyFunction`, however, fed the raw primary-index column (still a `ColumnLowCardinality`) to `func->execute`, so the wrapper cast a `ColumnLowCardinality` to `ColumnNullable` and aborted in `FunctionsConversion.cpp`.

The constant path (`applyFunctionChainToColumn`) already strips the outer `LowCardinality` from its column before executing the chain; the range path did not. The fix strips the outer wrapper symmetrically on the cached column and its type in `applyFunction`, mirroring `applyFunctionChainToColumn` (outer-level only, preserving `LowCardinality` nested inside container types). The strip is a no-op for normal non-`LowCardinality` key columns, so existing tests are unaffected.

This covers both the regular and the lightweight (sparse) primary-key analysis paths (`use_lightweight_primary_key_index_analysis`), since both reach `applyFunction`. #106793 fixed the same `Bad cast` class for the non-sparse `checkInHyperrectangle` monotonicity argument but did not address the column fed to `func->execute`, so this shape still crashed on both paths.

Found by the server-side AST fuzzer (`AST fuzzer (arm_asan_ubsan)`), report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108212&sha=baeec9c2aa908877563e854b8ffd8647cb2c826c&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
