### PR TITLE
Fix flaky test_kafka_formats_with_broken_message integration test

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -398,9 +398,17 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
         )
         errors_text = instance.query_with_retry(
             errors_query,
-            retry_count=30,
+            retry_count=60,
             sleep_time=1,
             check_callback=lambda res: len(res) > 0,
+        )
+        # query_with_retry returns the last result even if check_callback never
+        # passed, so guard against an empty error MV before json.loads (which
+        # would otherwise raise an opaque "Expecting value" JSONDecodeError).
+        assert (
+            len(errors_text) > 0
+        ), "Error row for format {} did not appear in kafka_errors_{}_mv".format(
+            format_name, format_name
         )
         errors_result = json.loads(errors_text)
         # print(errors_result.strip())


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Stabilizes the flaky integration test
`test_storage_kafka/test_batch_slow_0.py::test_kafka_formats_with_broken_message`.

**Root cause.** The error row written into `kafka_errors_<format>_mv` can lag
behind the data rows on slow builds. The test polls for it with
`query_with_retry(retry_count=30, sleep_time=1, check_callback=lambda res: len(res) > 0)`,
but `query_with_retry` returns its last result even when `check_callback` never
passed (`if result is not None: return result`). So when the error MV has not
flushed within the 30s budget, the call returns an empty string and
`json.loads("")` raises the opaque `JSONDecodeError: Expecting value: line 1
column 1 (char 0)` at line 405.

**Slow-build only.** Over the last 60 days, every `json.loads`-mode failure of
this test was on a slow build: `amd_asan_ubsan` (x10), `amd_tsan` (x1),
`amd_msan` (x1), `amd_llvm_coverage` (x1). Zero on fast/release builds. 30 days:
~15 hits across 11 distinct PRs plus 2 on master, all `amd_asan_ubsan`. This is
the classic "30s wait calibrated for fast builds" timing race; the same class was
fixed for sibling Kafka tests in #100286 and #105138.

**Fix.** Double the error-MV poll budget (30s -> 60s) to give slow builds headroom,
and assert the polled result is non-empty before `json.loads` so any genuine
residual failure surfaces with a clear message instead of an opaque JSON decode
error. Test-only change; the test's assertions on `raw_message`/`error` are
unchanged.

CI report (latest, PR #108182, commit 17b519a0248e):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108182&sha=17b519a0248e&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.144` (included in `26.7` and later)
- Backported to: `26.6.2.11`, `26.3.33.65`
<!-- ch-version-info:end -->