### PR TITLE
Fix flaky test_rabbitmq_csv_with_delimiter

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -299,6 +299,7 @@ def test_rabbitmq_csv_with_delimiter(rabbitmq_cluster, db, unique):
     time.sleep(1)
 
     result = ""
+    prev_len = 0
     deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result += instance.query(
@@ -306,7 +307,10 @@ def test_rabbitmq_csv_with_delimiter(rabbitmq_cluster, db, unique):
         )
         if rabbitmq_check_result(result):
             break
-
+        # Fail only on a genuine stall: while rows keep arriving, reset the deadline.
+        if len(result) > prev_len:
+            deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
+        prev_len = len(result)
         time.sleep(0.05)
     else:
         pytest.fail(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fix the flaky integration test `test_storage_rabbitmq/test.py::test_rabbitmq_csv_with_delimiter`.

The test publishes 50 CSV messages and polls `SELECT * FROM rabbitmq` against a fixed `DEFAULT_TIMEOUT_SEC` (60s) wall-clock deadline that is never extended. On a contended sanitizer runner the 50 rows can take longer than 60s to fully arrive, so the loop hits its deadline mid-consumption and calls `pytest.fail`, even though it is still steadily consuming and would have passed shortly after. The CI run that prompted this fix reran the single test in isolation and it passed in 65.27s, just past the 60s budget.

CIDB shows 14 such timeouts (`test.py:312`) in 30 days across 11 unrelated PRs and 3 master runs, spanning `amd_asan_ubsan`, `amd_msan`, `arm_binary` and `amd_llvm_coverage` builds. A recent example: `Integration tests (amd_asan_ubsan, db disk, old analyzer, 6/6)`, https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2a3a502d2ed&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Fix: reset the no-progress deadline to `now + DEFAULT_TIMEOUT_SEC` whenever the accumulated result grows, so the loop waits as long as rows keep arriving and fails only after a genuine `DEFAULT_TIMEOUT_SEC`-long stall. This mirrors the progress-based deadline already used by `check_expected_result_polling` for the same class of flakiness, and preserves the test's ability to detect a stalled consumer.

Validation (timing flake, so the failing direction is shown via a virtual-clock simulation of a slow runner): old loop FAILs at ~60s, new loop passes at 65s/120s, and a never-delivering consumer still FAILs at ~60s (genuine-stall detection intact). The real integration test passes locally (`1 passed in 137.27s`).
