### PR TITLE
Remove unused curl dependency from AWS, Azure, and Arrow contribs

### DIFF
--- a/contrib/arrow-cmake/CMakeLists.txt
+++ b/contrib/arrow-cmake/CMakeLists.txt
@@ -529,7 +529,6 @@ target_link_libraries(_arrow PRIVATE
     ch_contrib::zstd
     ch_contrib::brotli
     ch_contrib::bzip2
-    ch_contrib::curl
 )
 target_link_libraries(_arrow PUBLIC _orc)
 # PUBLIC so the xsimd headers are visible to _parquet too (it links _arrow PUBLIC).

--- a/contrib/azure-cmake/CMakeLists.txt
+++ b/contrib/azure-cmake/CMakeLists.txt
@@ -13,7 +13,6 @@ file(GLOB AZURE_SDK_SRC
     "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/credentials/*.cpp"
     "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/cryptography/*.cpp"
     "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/http/*.cpp"
-    "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/http/curl/*.cpp"
     "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/io/*.cpp"
     "${AZURE_SDK_LIBRARY_DIR}/core/azure-core/src/tracing/*.cpp"
     "${AZURE_SDK_LIBRARY_DIR}/identity/azure-identity/src/*.cpp"
@@ -48,16 +47,13 @@ file(GLOB AZURE_SDK_UNIFIED_SRC
 )
 
 add_library(_azure_sdk ${AZURE_SDK_UNIFIED_SRC})
-target_compile_definitions(_azure_sdk PRIVATE BUILD_CURL_HTTP_TRANSPORT_ADAPTER)
+
+# ClickHouse supplies its own HTTP transport (PocoAzureHTTPClient), so neither the
+# libcurl nor the WinHTTP transport adapters of the Azure SDK are built or linked.
 
 # Originally, on Windows azure-core is built with bcrypt and crypt32 by default
 if (TARGET OpenSSL::SSL)
     target_link_libraries(_azure_sdk PRIVATE OpenSSL::Crypto OpenSSL::SSL)
-endif()
-
-# Originally, on Windows azure-core is built with winhttp by default
-if (TARGET ch_contrib::curl)
-    target_link_libraries(_azure_sdk PRIVATE ch_contrib::curl)
 endif()
 
 target_link_libraries(_azure_sdk PRIVATE ch_contrib::libxml2)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureObjectStorage.h
@@ -9,7 +9,6 @@
 #include <Common/MultiVersion.h>
 #include <azure/storage/blobs.hpp>
 #include <azure/storage/files/datalake/datalake_file_client.hpp>
-#include <azure/core/http/curl_transport.hpp>
 #include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
 
 namespace Poco

--- a/src/Disks/tests/gtest_azure_sdk.cpp
+++ b/src/Disks/tests/gtest_azure_sdk.cpp
@@ -1,15 +1,11 @@
 #include <string>
-#include <vector>
 #include <Common/logger_useful.h>
 
 #include "config.h"
 
 #if USE_AZURE_BLOB_STORAGE
 
-#include <azure/storage/blobs.hpp>
 #include <azure/storage/common/internal/xml_wrapper.hpp>
-#include <azure/storage/blobs/blob_container_client.hpp>
-#include <azure/storage/blobs/blob_options.hpp>
 
 #include <gtest/gtest.h>
 
@@ -21,21 +17,6 @@ TEST(AzureXMLWrapper, TestLeak)
     Azure::Storage::_internal::XmlReader reader2(std::move(reader));
     Azure::Storage::_internal::XmlReader reader3 = std::move(reader2);
     reader3.Read();
-}
-
-TEST(AzureBlobContainerClient, CurlMemoryLeak)
-{
-    using Azure::Storage::Blobs::BlobContainerClient;
-    using Azure::Storage::Blobs::BlobClientOptions;
-
-    static constexpr auto unavailable_url = "http://unavailable:19999/bucket";
-    static constexpr auto container = "container";
-
-    BlobClientOptions options;
-    options.Retry.MaxRetries = 0;
-
-    auto client = std::make_unique<BlobContainerClient>(BlobContainerClient::CreateFromConnectionString(unavailable_url, container, options));
-    EXPECT_THROW({ client->ListBlobs(); }, Azure::Core::RequestFailedException);
 }
 
 #endif


### PR DESCRIPTION
ClickHouse does not use `libcurl` through the AWS SDK, the Azure SDK, or Arrow. In all three cases the curl-based code is either already excluded from the build or installed as a custom transport, leaving the curl link/sources as dead weight. This removes them so the dependency surface reflects what is actually used.

- **AWS**: the `aws-cmake` wrapper already builds only the `standard` and `crt` HTTP clients (never `http/curl`), and `lib_aws.a` contains no curl symbols. No change was required.
- **Azure**: ClickHouse installs its own `PocoAzureHTTPClient` transport (`client_options.Transport.Transport`), so the SDK's `libcurl` transport adapter was dead code. This stops compiling `http/curl/curl.cpp`, drops the `BUILD_CURL_HTTP_TRANSPORT_ADAPTER` definition and the `ch_contrib::curl` link, and removes the vestigial `<azure/core/http/curl_transport.hpp>` include. The `CurlMemoryLeak` unit test relied on the default `libcurl` transport and is removed together with it.
- **Arrow**: curl is only needed by Arrow's S3/GCS filesystem layer, which is excluded from the build, so `lib_arrow.a` referenced no curl symbols. This drops the `ch_contrib::curl` link.

`librdkafka` still links `ch_contrib::curl` (it genuinely uses it for the SASL/OAUTHBEARER OIDC token endpoint) and is left untouched.

Verified by building `clickhouse` and `unit_tests_dbms` and confirming `nm` reports zero undefined curl symbols in `lib_azure_sdk.a`, `lib_arrow.a`, and `lib_aws.a` (and 15 in `lib_rdkafka.a`, unchanged). All `Azure*` unit tests pass.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not build or link `libcurl` into the Azure SDK and Arrow contribs, which never used it (ClickHouse uses its own HTTP transport for Azure and excludes Arrow's filesystem layer).

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)