### PR TITLE
Do not use projections for distributed reads in make_distributed_plan

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -48,6 +48,14 @@ bool canUseProjectionForReadingStep(ReadFromMergeTree * reading)
     if (reading->getAnalyzedResult() && reading->getAnalyzedResult()->readFromProjection())
         return false;
 
+    /// A distributed read (make_distributed_plan) was already turned into a sharded read by an
+    /// earlier optimization pass. A projection match would replace this single read with a Union of
+    /// the surviving-parts read and the projection read, and only one branch carries the sharded
+    /// flag -> the branches expose different shard lists and makeDistributedPlan asserts on the
+    /// mismatch. Keep the read whole; the projection optimization is a no-op for distributed reads.
+    if (reading->getDistributedReadBucketCount() > 0)
+        return false;
+
     if (reading->isQueryWithFinal())
         return false;
 

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
@@ -1,4 +1,4 @@
 -- distributed read over a projected table does not abort
-200099
+20099
 -- matches the single-node result
-200099
+20099

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
@@ -1,4 +1,4 @@
 -- distributed read over a projected table does not abort
-20099
+499
 -- matches the single-node result
-20099
+499

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.reference
@@ -1,0 +1,4 @@
+-- distributed read over a projected table does not abort
+200099
+-- matches the single-node result
+200099

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
@@ -15,21 +15,26 @@ CREATE TABLE t1 (id UInt32, s String) ENGINE = MergeTree ORDER BY id;
 CREATE TABLE t2 (id1 UInt32, id2 UInt32) ENGINE = MergeTree ORDER BY id1 SETTINGS index_granularity = 1;
 
 -- Two inserts so some parts are served by the projection and some by the surviving parts; the
--- projection ADD between them leaves the first batch's parts without the projection.
-INSERT INTO t2 SELECT number, number % 10 FROM numbers(1000000);
+-- projection ADD between them leaves the first batch's parts without the projection. This mix of
+-- projection / non-projection parts is what reproduces the shard-list mismatch, so keep it.
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(100000);
 ALTER TABLE t2 ADD PROJECTION proj (SELECT id2 ORDER BY id2);
-INSERT INTO t2 SELECT number, number % 10 FROM numbers(1000000);
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(100000);
 
 INSERT INTO t1 SELECT number, toString(number) FROM numbers(100);
 
--- distributed aggregation rejects a nonzero max_rows_to_group_by; some configs (e.g. the Fast test
--- profile) set it nonzero by default, which would make the count() below throw before the read path.
+-- Pin max_rows_to_group_by = 0: the outer count() is an AggregatingStep and a nonzero limit (which
+-- randomized settings can set) makes make_distributed_plan reject the query before it reaches the
+-- projection regression this test targets.
 SET max_rows_to_group_by = 0;
-
+-- Pin distributed_plan_max_rows_to_broadcast low so t2's read is sharded (the bug path) without a
+-- huge fixture; t1 stays under the threshold and is broadcast, as in the original bug. Otherwise
+-- randomized settings could raise it above the selected row count and skip the sharded read.
 SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
-    distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3;
+    distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3,
+    distributed_plan_max_rows_to_broadcast = 1000;
 
--- The big read of t2 is turned into a sharded read; the projection match would split it into a Union.
+-- t2's read is sharded; the projection match would split it into a Union. t1 is broadcast.
 SELECT '-- distributed read over a projected table does not abort';
 SELECT count() FROM (
     SELECT s FROM t1 AS lhs LEFT JOIN (SELECT * FROM t2 PREWHERE id2 = 2 WHERE id2 = 2) AS rhs ON lhs.id = rhs.id2

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
@@ -1,0 +1,41 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- Regression test: a distributed read (make_distributed_plan) over a table with a normal projection
+-- used to abort with LOGICAL_ERROR 'Different list of shards in child plans'. The projection
+-- optimization replaced the single read with a Union of (surviving-parts read, projection read), but
+-- only the surviving-parts branch carried the distributed (sharded) flag, so the two Union branches
+-- exposed different shard lists and makeDistributedPlan asserted on the mismatch. The projection
+-- optimization now declines for distributed reads, keeping the read whole.
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+
+CREATE TABLE t1 (id UInt32, s String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t2 (id1 UInt32, id2 UInt32) ENGINE = MergeTree ORDER BY id1 SETTINGS index_granularity = 1;
+
+-- Two inserts so some parts are served by the projection and some by the surviving parts; the
+-- projection ADD between them leaves the first batch's parts without the projection.
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(1000000);
+ALTER TABLE t2 ADD PROJECTION proj (SELECT id2 ORDER BY id2);
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(1000000);
+
+INSERT INTO t1 SELECT number, toString(number) FROM numbers(100);
+
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3;
+
+-- The big read of t2 is turned into a sharded read; the projection match would split it into a Union.
+SELECT '-- distributed read over a projected table does not abort';
+SELECT count() FROM (
+    SELECT s FROM t1 AS lhs LEFT JOIN (SELECT * FROM t2 PREWHERE id2 = 2 WHERE id2 = 2) AS rhs ON lhs.id = rhs.id2
+);
+
+-- Same query single-node, for an explicit value to compare against.
+SELECT '-- matches the single-node result';
+SELECT count() FROM (
+    SELECT s FROM t1 AS lhs LEFT JOIN (SELECT * FROM t2 PREWHERE id2 = 2 WHERE id2 = 2) AS rhs ON lhs.id = rhs.id2
+) SETTINGS make_distributed_plan = 0;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
@@ -12,14 +12,17 @@ DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 
 CREATE TABLE t1 (id UInt32, s String) ENGINE = MergeTree ORDER BY id;
-CREATE TABLE t2 (id1 UInt32, id2 UInt32) ENGINE = MergeTree ORDER BY id1 SETTINGS index_granularity = 1;
+-- Small granularity so the read spans several granules; the projection split must produce a
+-- non-trivial read on both Union branches to reach the sharded-read decision (a single-granule read
+-- does not reproduce). A few hundred granules is plenty and keeps the fixture cheap.
+CREATE TABLE t2 (id1 UInt32, id2 UInt32) ENGINE = MergeTree ORDER BY id1 SETTINGS index_granularity = 16;
 
 -- Two inserts so some parts are served by the projection and some by the surviving parts; the
 -- projection ADD between them leaves the first batch's parts without the projection. This mix of
 -- projection / non-projection parts is what reproduces the shard-list mismatch, so keep it.
-INSERT INTO t2 SELECT number, number % 10 FROM numbers(100000);
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(2000);
 ALTER TABLE t2 ADD PROJECTION proj (SELECT id2 ORDER BY id2);
-INSERT INTO t2 SELECT number, number % 10 FROM numbers(100000);
+INSERT INTO t2 SELECT number, number % 10 FROM numbers(2000);
 
 INSERT INTO t1 SELECT number, toString(number) FROM numbers(100);
 
@@ -32,7 +35,7 @@ SET max_rows_to_group_by = 0;
 -- randomized settings could raise it above the selected row count and skip the sharded read.
 SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
     distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3,
-    distributed_plan_max_rows_to_broadcast = 1000;
+    distributed_plan_max_rows_to_broadcast = 10;
 
 -- t2's read is sharded; the projection match would split it into a Union. t1 is broadcast.
 SELECT '-- distributed read over a projected table does not abort';

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
@@ -22,6 +22,10 @@ INSERT INTO t2 SELECT number, number % 10 FROM numbers(1000000);
 
 INSERT INTO t1 SELECT number, toString(number) FROM numbers(100);
 
+-- distributed aggregation rejects a nonzero max_rows_to_group_by; some configs (e.g. the Fast test
+-- profile) set it nonzero by default, which would make the count() below throw before the read path.
+SET max_rows_to_group_by = 0;
+
 SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
     distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3;
 

--- a/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
+++ b/tests/queries/0_stateless/04342_distributed_plan_read_with_projection.sql
@@ -30,6 +30,10 @@ INSERT INTO t1 SELECT number, toString(number) FROM numbers(100);
 -- randomized settings can set) makes make_distributed_plan reject the query before it reaches the
 -- projection regression this test targets.
 SET max_rows_to_group_by = 0;
+-- Pin optimize_use_projections = 1. Without it, randomized settings can disable projection
+-- optimization, so optimizeUseNormalProjections never runs, no Union split happens, and neither the
+-- fixed nor the unfixed binary aborts, so the test would pass trivially and prove nothing.
+SET optimize_use_projections = 1;
 -- Pin distributed_plan_max_rows_to_broadcast low so t2's read is sharded (the bug path) without a
 -- huge fixture; t1 stays under the threshold and is broadcast, as in the original bug. Otherwise
 -- randomized settings could raise it above the selected row count and skip the sharded read.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/107946
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/107946

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`Different list of shards in child plans`) when running a query with `make_distributed_plan = 1` over a `MergeTree` table that has a normal/aggregate projection.

### Description

Found by the AST fuzzer: `AST fuzzer (amd_debug, targeted, old_compatibility)`, STID 4661-51c1.
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107667&sha=d31425ae6691d8bf9e83f8dcd6cf217bbabdbc85&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29

```
Logical error: 'Different list of shards in child plans 3 and 1,
last child plan: ReadFromMergeTree (default.t2)'
```
at `src/Processors/QueryPlan/Optimizations/makeDistributed.cpp:900`, on the
`buildQueryPipeline -> convertToDistributed -> makeDistributedPlan` path.

Root cause: in `optimizeTreeSecondPass` the distributed pass runs first and
`tryMakeDistributedRead` turns a large `ReadFromMergeTree` into a sharded read
(`distributed_read_bucket_count > 0`). The projection pass runs afterwards; when a
normal/aggregate projection matches, it replaces that single read with a
`Union(surviving-parts read, projection read)`. The sharded flag stays only on the
surviving-parts branch, so the two `Union` branches expose different shard lists, and
`makeDistributedPlan` aborts on the shard-list consistency check when uniting them.

Fix: decline the projection optimization for a read that is already a distributed read.
`canUseProjectionForReadingStep` is the single guard shared by both
`optimizeUseNormalProjections` and `optimizeUseAggregateProjections`, alongside the other
reading modes already incompatible with projections (FINAL, sampling, in-order, parallel
replicas without support, ...). Keeping the read whole means any later split exposes one
consistent shard list. Projection use for non-distributed reads (`make_distributed_plan = 0`)
is unaffected.

`make_distributed_plan` is an experimental, off-by-default feature. The bug is not
JOIN-specific: any distributed read over a projected table where some parts are served by
the projection can trip it.

Regression test `04342_distributed_plan_read_with_projection` reproduces the abort on
master (verified: crashes without the fix, passes with it) and checks the distributed result
matches the single-node result.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.90` (included in `26.7` and later)
- Backported to: `26.6.4.41`
<!-- ch-version-info:end -->