### PR TITLE
Fix null AST in remote() named-collection database override

### DIFF
--- a/src/TableFunctions/TableFunctionFactory.cpp
+++ b/src/TableFunctions/TableFunctionFactory.cpp
@@ -42,6 +42,10 @@ TableFunctionPtr TableFunctionFactory::get(
     ContextPtr context) const
 {
     const auto * table_function = ast_function->as<ASTFunction>();
+    if (!table_function)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Expected a table function (ASTFunction) but got '{}'", ast_function->formatForErrorMessage());
+
     auto res = tryGet(table_function->name, context);
     if (!res)
     {

--- a/src/TableFunctions/TableFunctionRemote.cpp
+++ b/src/TableFunctions/TableFunctionRemote.cpp
@@ -75,7 +75,17 @@ void TableFunctionRemote::parseArguments(const ASTPtr & ast_function, ContextPtr
             for (const auto & [arg_name, arg_ast] : complex_args)
             {
                 if (arg_name == "database" || arg_name == "db")
-                    remote_table_function_ptr = arg_ast;
+                {
+                    /// A table function is allowed here (remote(nc, database = mysql(...))), mirroring the
+                    /// positional signature remote('addr', table_function()). Any other expression is a
+                    /// database name, so a non-function node never reaches TableFunctionFactory::get().
+                    const auto * function = arg_ast->as<ASTFunction>();
+                    if (function && TableFunctionFactory::instance().isTableFunctionName(function->name))
+                        remote_table_function_ptr = arg_ast;
+                    else
+                        database = checkAndGetLiteralArgument<String>(
+                            evaluateConstantExpressionForDatabaseName(arg_ast, context), "database");
+                }
                 else if (arg_name == "sharding_key")
                     sharding_key = arg_ast;
                 else

--- a/tests/queries/0_stateless/04408_remote_named_collection_database_override.reference
+++ b/tests/queries/0_stateless/04408_remote_named_collection_database_override.reference
@@ -1,0 +1,4 @@
+BAD_GET
+BAD_GET
+BAD_GET
+1

--- a/tests/queries/0_stateless/04408_remote_named_collection_database_override.sh
+++ b/tests/queries/0_stateless/04408_remote_named_collection_database_override.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A non-table-function expression in the database/db override of a named collection must be
+# rejected while parsing the arguments, not reach TableFunctionFactory::get() as a null AST.
+
+nc="${CLICKHOUSE_TEST_UNIQUE_NAME}_nc"
+
+${CLICKHOUSE_CLIENT} --query "DROP NAMED COLLECTION IF EXISTS \`${nc}\`"
+${CLICKHOUSE_CLIENT} --query "CREATE NAMED COLLECTION \`${nc}\` AS host = '127.0.0.1', port = 9000, table = 'one'"
+
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM remote(\`${nc}\`, database = (SELECT 1))" 2>&1 | grep -o -m1 "BAD_GET"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM remote(\`${nc}\`, db = (SELECT 1))" 2>&1 | grep -o -m1 "BAD_GET"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM remote(\`${nc}\`, database = 1)" 2>&1 | grep -o -m1 "BAD_GET"
+
+# The server is still responsive after the rejected queries.
+${CLICKHOUSE_CLIENT} --query "SELECT 1"
+
+${CLICKHOUSE_CLIENT} --query "DROP NAMED COLLECTION \`${nc}\`"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107189
-->

Related: #107189

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a possible crash (null pointer dereference) when the `database`/`db` override of a named collection passed to `remote()`/`remoteSecure()` is not a constant database name, e.g. `remote(nc, database = (SELECT 1))`. The query now fails with a clear error instead of crashing.


### Description

`remote()`/`remoteSecure()` with a named collection accepts a `database`/`db` override, e.g. `remote(nc, database = ...)`. `TableFunctionRemote::parseArguments` stored that override expression directly as the remote table function without checking it is an `ASTFunction`, unlike the positional signature `remote('addr', table_function())` which validates the node and otherwise treats it as a database name.

So `remote(nc, database = (SELECT 1))` stored a non-function node as the table function. When the shard is local it reached `TableFunctionFactory::get()`, where `ast_function->as<ASTFunction>()` returns `nullptr` and `table_function->name` dereferenced it: UBSan reported a member access within a null pointer, and a release build would read from a null base pointer. This is reachable from plain SQL, no fuzzer needed.

UBSan report (`Stress test (arm_ubsan)`):
```
src/TableFunctions/TableFunctionFactory.cpp:45:39: runtime error: member access within null pointer of type 'const DB::ASTFunction'
```
CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107189&sha=ee127aeb85205b0eec364f557f260bf3e1e6ab38&name_0=PR&name_1=Stress%20test%20%28arm_ubsan%29

Fix: the `database`/`db` override is now handled like the positional argument. A table function is stored as the remote table function; anything else is evaluated as a constant database name, so a non-constant or wrong-typed expression fails at argument-parsing time (before any connection) with a clean error and the server stays up. `TableFunctionFactory::get()` can no longer receive a non-`ASTFunction` node from this path or from the analyzer's `TableFunctionNode::toAST()`, so the guard there is now an internal invariant and throws `LOGICAL_ERROR`.

A stateless test (`04408_remote_named_collection_database_override`) reproduces the bug from SQL and replaces the previous unit test.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1168`
<!-- ch-version-info:end -->