### PR TITLE
Cap 04299_move_assignment_memory_limit loop at 60 seconds

### DIFF
--- a/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
+++ b/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
@@ -26,5 +26,9 @@ query="SELECT DISTINCT 1025, toFixedString('%', 1048576), 100 UNION ALL SELECT 9
 start=$SECONDS
 for _ in {1..500}; do
     $CLICKHOUSE_CLIENT --memory_tracker_fault_probability=0.001 --max_untracked_memory=0 --query="$query" >/dev/null 2>&1 ||:
-    (( SECONDS - start >= 60 )) && break
+    (( SECONDS - start < 60 )) || break
 done
+
+# The loop's last evaluated command is the arithmetic test above, which is false (status 1) when the
+# time budget is not yet reached. Exit explicitly so the script's status does not depend on it.
+exit 0

--- a/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
+++ b/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
@@ -20,6 +20,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 query="SELECT DISTINCT 1025, toFixedString('%', 1048576), 100 UNION ALL SELECT 9223372036854775807, '\0', materialize(toLowCardinality(1025)) SETTINGS extremes = 1 FORMAT Null"
 
+# Loop up to 500 times, but stop after 60 seconds. A buggy build crashes within a few dozen
+# iterations, so this is plenty; the cap keeps slow configs (TSan, s3) under the run timeout, as
+# each iteration spawns a fresh client and process startup dominates there.
+start=$SECONDS
 for _ in {1..500}; do
     $CLICKHOUSE_CLIENT --memory_tracker_fault_probability=0.001 --max_untracked_memory=0 --query="$query" >/dev/null 2>&1 ||:
+    (( SECONDS - start >= 60 )) && break
 done


### PR DESCRIPTION
The test spawns a fresh `clickhouse-client` 500 times. The query is trivial (constants, `FORMAT Null`, no storage), so per-iteration process startup dominates. Under TSan it takes ~1.5s/iteration, so 500 iterations exceed the 600s run timeout and the test is killed.

A buggy build terminates within a few dozen iterations, so the full 500 are never needed to catch the regression. Cap the loop at 500 iterations or 60 seconds, whichever comes first, using the bash `SECONDS` builtin.

Observed in MasterCI Stateless tests (amd_tsan, s3 storage, parallel, 2/2):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=be3417e5cb5428775e9586b2b453ad8b07aee237&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1199`
<!-- ch-version-info:end -->