### PR TITLE
Fix flaky test_executable_udf_async_metrics by resetting the metric baseline

### DIFF
--- a/tests/integration/test_executable_udf_async_metrics/test.py
+++ b/tests/integration/test_executable_udf_async_metrics/test.py
@@ -159,6 +159,10 @@ def test_descendant_processes_are_counted(started_cluster):
 
 def test_inflight_executable_invocation_is_visible(started_cluster):
     _skip_msan()
+    # Restart for a clean 0/0 baseline: earlier tests leave idle pool workers
+    # whose resident memory would otherwise contaminate this non-pool delta.
+    node.restart_clickhouse()
+    assert _wait_for(lambda: _memory_resident() is not None)
     mem_before = _memory_resident()
     procs_before = _processes()
 
@@ -198,6 +202,10 @@ def test_timed_out_executable_is_killed_and_leaves_metrics(started_cluster):
     # Covers cleanup after a FAILED invocation: the script hangs after
     # allocating, command_read_timeout (10 s) fails the query, and the error
     # path must tear the stuck process down and release its registry entry.
+    # Restart for a clean 0/0 baseline: earlier tests leave idle pool workers
+    # whose resident memory would otherwise contaminate this non-pool delta.
+    node.restart_clickhouse()
+    assert _wait_for(lambda: _memory_resident() is not None)
     mem_before = _memory_resident()
     procs_before = _processes()
 
@@ -269,6 +277,10 @@ def test_killed_pool_worker_leaves_metrics(started_cluster):
 
 def test_non_udf_shell_commands_are_not_counted(started_cluster):
     _skip_msan()
+    # Restart for a clean 0/0 baseline: earlier tests leave idle pool workers
+    # whose resident memory would otherwise contaminate this delta.
+    node.restart_clickhouse()
+    assert _wait_for(lambda: _memory_resident() is not None)
     mem_before = _memory_resident()
     procs_before = _processes()
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/107300
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky integration test `test_executable_udf_async_metrics`, whose
subtests `test_inflight_executable_invocation_is_visible` and
`test_timed_out_executable_is_killed_and_leaves_metrics` fail on master and
across unrelated PRs (`Integration tests (arm_binary, distributed plan, 3/4)`).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3dc5a77be297fb233e527e3e09e9f4c7ee53716e&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

The tests added in #107300 measure async-metric deltas against `mem_before` /
`procs_before` snapshots. Six of the eight subtests call `restart_clickhouse()`
first, so they start from a clean 0/0 baseline. Three did not.

The three preceding pool tests run `executable_pool` UDFs and never restart
afterwards, leaving idle pool workers (each ~128 MiB) registered in the metrics.
The no-restart subtests therefore captured `mem_before` while that residual was
live (observed ~275 MiB across three idle workers in a local repro). Because
`asynchronous_metrics` refresh once per second and idle pool workers are reaped
on `max_command_execution_time`, the residual also shifted during the subtest's
own 25 s measurement window: when it stayed, the measured delta overshot the
one-worker band (CI saw +170..187 MiB); when a worker was reaped mid-window, the
delta went negative (CI saw -137 MiB). Both match the arm_binary failures.

Fix: have the three no-restart subtests restart and wait for the metric to
settle, matching the clean baseline the other six already establish. No
assertion is weakened.

Verified locally with the master debug binary: the full file passes 8/8 three
times with the fix; a no-restart replica of the in-flight subtest, run after the
residual is established, deterministically falls outside its band
(`mem_before=275 MiB`, delta=287.7 MiB).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1166`
<!-- ch-version-info:end -->