### PR TITLE
CI: collect Build profile telemetry for a subset of builds

### DIFF
--- a/ci/jobs/scripts/job_hooks/build_profile_hook.py
+++ b/ci/jobs/scripts/job_hooks/build_profile_hook.py
@@ -10,6 +10,37 @@ from ci.praktika.utils import Shell, Utils
 temp_dir = "./ci/tmp"
 build_dir = "./ci/tmp/build"
 
+# Build profile telemetry is collected only for this explicit subset of builds.
+# The analytics DB is shared by every Build variant; on a master push ~25
+# variants finish and upload near-simultaneously, and the combined load crosses
+# the cluster's per-user memory limit (Code 241 MEMORY_LIMIT_EXCEEDED). Two
+# representative release builds keep the profile we actually look at (the
+# production binaries) while removing that contention at the source. Uncomment a
+# build below to profile it too; the full set of build names is BuildTypes in
+# ci/defs/defs.py.
+_PROFILED_BUILDS = (
+    "amd_release",
+    "arm_release",
+    # "amd_debug",
+    # "arm_debug",
+    # "amd_binary",
+    # "arm_binary",
+    # "amd_asan_ubsan",
+    # "arm_asan_ubsan",
+    # "amd_tsan",
+    # "arm_tsan",
+    # "amd_msan",
+    # "arm_msan",
+    # "arm_ubsan",
+    # "amd_darwin",
+    # "arm_darwin",
+)
+
+
+def _should_profile(build_type):
+    """Whether build profile telemetry is collected for this build variant."""
+    return build_type in _PROFILED_BUILDS
+
 
 def _has_data(file):
     """Whether prepare-time-trace.sh actually produced this artifact.
@@ -26,29 +57,25 @@ def _has_data(file):
 
 
 def _upload_profile_artifacts(build_type, start_time, artifacts):
-    """No-op for builds without profile data; upload it for builds that have it.
+    """Upload the profile artifacts this build produced.
 
-    Skips artifacts that are genuinely empty (no data for this build). Uploading
-    is best-effort: it ships data to a remote analytics DB purely for build
-    observability and has no bearing on the produced binaries. That DB is shared
-    by every Build variant and routinely rejects an INSERT (e.g. Code 241
-    MEMORY_LIMIT_EXCEEDED, or transient connectivity) when the variants finish
-    and upload at once; a successful build must not be reported as failed for
-    that. Genuine build/producer errors surface earlier (prepare-time-trace.sh
-    under strict Shell.check, local file assembly), not here.
+    Skips artifacts that are genuinely empty (no data for this build, see
+    _has_data). Upload failures are NOT swallowed: an INSERT rejection
+    propagates so the lost telemetry stays visible and the hook fails loudly.
     """
     for insert, file in artifacts:
         if not _has_data(file):
             print(f"No build profile data in [{file}], skipping upload")
             continue
-        try:
-            insert(build_name=build_type, start_time=start_time, file=file)
-        except Exception:
-            print(f"WARNING: failed to upload build profile data [{file}]:")
-            traceback.print_exc()
+        insert(build_name=build_type, start_time=start_time, file=file)
 
 
 def check():
+    build_type = Info().job_name.split("(")[1].rstrip(")")
+    assert build_type
+    if not _should_profile(build_type):
+        print(f"Build profile telemetry not collected for [{build_type}]")
+        return
     print("Prepare build profile data")
     profiles_dir = Path("./ci/tmp") / "profiles_source"
     profiles_dir.mkdir(parents=True, exist_ok=True)
@@ -73,8 +100,6 @@ def check():
         check_start_time = Utils.timestamp_to_str(
             Result.from_fs(Info().job_name).start_time
         )
-        build_type = Info().job_name.split("(")[1].rstrip(")")
-        assert build_type
         queries = LogClusterBuildProfileQueries()
         _upload_profile_artifacts(
             build_type,
@@ -86,11 +111,9 @@ def check():
             ],
         )
     except Exception:
-        # Fail loudly on a genuine error in producing the profile data
-        # (prepare-time-trace.sh crashed, local assembly failed): never let the
-        # post-hook pass silently. Remote upload rejections are handled best
-        # effort in _upload_profile_artifacts and do not reach here.
-        print("ERROR: Failed to prepare build profile data:")
+        # Fail loudly on any error producing, assembling, or uploading the
+        # profile data: never let the post-hook pass silently.
+        print("ERROR: Failed to collect build profile data:")
         traceback.print_exc()
         sys.exit(1)
 

--- a/ci/jobs/scripts/job_hooks/build_profile_hook.py
+++ b/ci/jobs/scripts/job_hooks/build_profile_hook.py
@@ -28,15 +28,24 @@ def _has_data(file):
 def _upload_profile_artifacts(build_type, start_time, artifacts):
     """No-op for builds without profile data; upload it for builds that have it.
 
-    Skips only artifacts that are genuinely empty (no data for this build).
-    A non-empty artifact is always uploaded, and any failure uploading it
-    propagates so the caller can fail loudly: we never swallow a real error.
+    Skips artifacts that are genuinely empty (no data for this build). Uploading
+    is best-effort: it ships data to a remote analytics DB purely for build
+    observability and has no bearing on the produced binaries. That DB is shared
+    by every Build variant and routinely rejects an INSERT (e.g. Code 241
+    MEMORY_LIMIT_EXCEEDED, or transient connectivity) when the variants finish
+    and upload at once; a successful build must not be reported as failed for
+    that. Genuine build/producer errors surface earlier (prepare-time-trace.sh
+    under strict Shell.check, local file assembly), not here.
     """
     for insert, file in artifacts:
         if not _has_data(file):
             print(f"No build profile data in [{file}], skipping upload")
             continue
-        insert(build_name=build_type, start_time=start_time, file=file)
+        try:
+            insert(build_name=build_type, start_time=start_time, file=file)
+        except Exception:
+            print(f"WARNING: failed to upload build profile data [{file}]:")
+            traceback.print_exc()
 
 
 def check():
@@ -77,9 +86,11 @@ def check():
             ],
         )
     except Exception:
-        # Fail loudly on any genuine error (producer crashed, upload rejected,
-        # malformed data): never let the post-hook pass silently.
-        print("ERROR: Failed to upload build profile data:")
+        # Fail loudly on a genuine error in producing the profile data
+        # (prepare-time-trace.sh crashed, local assembly failed): never let the
+        # post-hook pass silently. Remote upload rejections are handled best
+        # effort in _upload_profile_artifacts and do not reach here.
+        print("ERROR: Failed to prepare build profile data:")
         traceback.print_exc()
         sys.exit(1)
 

--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -82,6 +82,10 @@ class LogCluster:
             # profile, which otherwise aborts large INSERTs with
             # "User memory limit exceeded" via the OvercommitTracker.
             "max_memory_usage_for_user": 0,
+            # Parse the input on a single thread: parallel parsing buffers many
+            # chunks at once, and that peak is what crosses the shared cluster's
+            # per-user memory limit when all Build variants upload at once.
+            "input_format_parallel_parsing": 0,
         }
         if db_name:
             params["database"] = db_name

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -2,17 +2,19 @@
 
 See ClickHouse/ClickHouse#84159.
 
-Two layers are covered:
+Layers covered:
 
 * The producer (``utils/prepare-time-trace/prepare-time-trace.sh``): for a build
   with no readable objects (cross-arch/non-Linux) it must leave
   ``binary_sizes.txt`` empty, not write a junk ``0`` row that no consumer can
   parse.
+* The build subset gate (``_should_profile``): telemetry is collected only for
+  an explicit subset of builds (amd_release, arm_release) so that ~25 Build
+  variants do not upload at once and cross the shared cluster's per-user memory
+  limit.
 * The hook artifact selection (``_has_data`` / ``_upload_profile_artifacts``):
   no-op for builds without profile data, upload for builds that have it, and
-  treat a remote-upload rejection as best-effort (logged, never fatal) so a
-  successful build is not reported as failed when the shared analytics DB
-  rejects the telemetry INSERT.
+  propagate (not swallow) an upload rejection so lost telemetry stays visible.
 * The upload transport (``LogCluster.do_query``): the telemetry INSERT runs
   with parallel parsing disabled so its peak parse memory stays under the
   shared cluster's per-user limit.
@@ -23,10 +25,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.job_hooks.build_profile_hook import (
     _has_data,
+    _should_profile,
     _upload_profile_artifacts,
 )
 from ci.jobs.scripts.log_cluster import LogCluster
@@ -66,6 +71,19 @@ def test_producer_no_objects_leaves_binary_sizes_empty(tmp_path):
     binary_sizes = out_dir / "binary_sizes.txt"
     assert binary_sizes.exists()
     assert binary_sizes.read_bytes() == b""
+
+
+# --- build subset gate ----------------------------------------------------
+
+
+def test_should_profile_only_release_builds():
+    """Telemetry is collected only for the explicit release-build subset."""
+    assert _should_profile("amd_release")
+    assert _should_profile("arm_release")
+    assert not _should_profile("amd_debug")
+    assert not _should_profile("amd_asan_ubsan")
+    assert not _should_profile("arm_tsan")
+    assert not _should_profile("amd_darwin")
 
 
 # --- hook artifact selection ----------------------------------------------
@@ -122,7 +140,7 @@ def test_cross_arch_build_no_data_is_noop(tmp_path):
     recorded = []
     insert = _record_inserts(recorded)
     _upload_profile_artifacts(
-        "amd_darwin",
+        "arm_release",
         "2026-06-11 00:00:00",
         [
             (insert, tmp_path / "profile.json"),
@@ -145,7 +163,7 @@ def test_native_build_uploads_all(tmp_path):
     recorded = []
     insert = _record_inserts(recorded)
     _upload_profile_artifacts(
-        "amd_debug",
+        "amd_release",
         "2026-06-11 00:00:00",
         [(insert, f) for f in files],
     )
@@ -153,12 +171,13 @@ def test_native_build_uploads_all(tmp_path):
     assert recorded == [str(f) for f in files]
 
 
-def test_remote_upload_rejection_is_best_effort(tmp_path):
-    """A remote-upload rejection must not fail the build post-hook.
+def test_upload_rejection_propagates(tmp_path):
+    """An upload rejection must NOT be swallowed: it propagates to the caller.
 
-    insert_* raises AssertionError when the shared analytics DB rejects the
-    INSERT (e.g. Code 241 MEMORY_LIMIT_EXCEEDED when all Build variants upload
-    at once). That is telemetry-only and must be swallowed, not propagated.
+    With the upload restricted to a small build subset the per-user-limit
+    contention is gone, so a genuine INSERT rejection now means a real lost
+    upload. It must surface (the hook fails loudly) rather than be reported as
+    success.
     """
     f = tmp_path / "binary_sizes.txt"
     f.write_text("1 a.o")
@@ -166,31 +185,10 @@ def test_remote_upload_rejection_is_best_effort(tmp_path):
     def failing_insert(build_name, start_time, file):
         raise AssertionError("upload rejected")
 
-    # Must not raise.
-    _upload_profile_artifacts(
-        "amd_debug", "2026-06-11 00:00:00", [(failing_insert, f)]
-    )
-
-
-def test_one_artifact_rejection_does_not_block_the_rest(tmp_path):
-    """One rejected artifact must not stop the remaining uploads."""
-    a = tmp_path / "profile.json"
-    a.write_text("[]")
-    b = tmp_path / "binary_sizes.txt"
-    b.write_text("1 a.o")
-
-    recorded = []
-
-    def insert(build_name, start_time, file):
-        if str(file).endswith("profile.json"):
-            raise AssertionError("upload rejected")
-        recorded.append(str(file))
-
-    _upload_profile_artifacts(
-        "amd_debug", "2026-06-11 00:00:00", [(insert, a), (insert, b)]
-    )
-
-    assert recorded == [str(b)]
+    with pytest.raises(AssertionError):
+        _upload_profile_artifacts(
+            "amd_release", "2026-06-11 00:00:00", [(failing_insert, f)]
+        )
 
 
 # --- upload transport: parallel parsing disabled --------------------------

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -10,7 +10,9 @@ Two layers are covered:
   parse.
 * The hook artifact selection (``_has_data`` / ``_upload_profile_artifacts``):
   no-op for builds without profile data, upload for builds that have it, and
-  propagate any genuine upload error so the caller fails loudly.
+  treat a remote-upload rejection as best-effort (logged, never fatal) so a
+  successful build is not reported as failed when the shared analytics DB
+  rejects the telemetry INSERT.
 """
 
 import os
@@ -147,18 +149,41 @@ def test_native_build_uploads_all(tmp_path):
     assert recorded == [str(f) for f in files]
 
 
-def test_upload_error_propagates(tmp_path):
-    """A genuine upload failure must not be swallowed by the selector."""
+def test_remote_upload_rejection_is_best_effort(tmp_path):
+    """A remote-upload rejection must not fail the build post-hook.
+
+    insert_* raises AssertionError when the shared analytics DB rejects the
+    INSERT (e.g. Code 241 MEMORY_LIMIT_EXCEEDED when all Build variants upload
+    at once). That is telemetry-only and must be swallowed, not propagated.
+    """
     f = tmp_path / "binary_sizes.txt"
     f.write_text("1 a.o")
 
     def failing_insert(build_name, start_time, file):
         raise AssertionError("upload rejected")
 
-    try:
-        _upload_profile_artifacts(
-            "amd_debug", "2026-06-11 00:00:00", [(failing_insert, f)]
-        )
-    except AssertionError:
-        return
-    raise AssertionError("expected the upload error to propagate")
+    # Must not raise.
+    _upload_profile_artifacts(
+        "amd_debug", "2026-06-11 00:00:00", [(failing_insert, f)]
+    )
+
+
+def test_one_artifact_rejection_does_not_block_the_rest(tmp_path):
+    """One rejected artifact must not stop the remaining uploads."""
+    a = tmp_path / "profile.json"
+    a.write_text("[]")
+    b = tmp_path / "binary_sizes.txt"
+    b.write_text("1 a.o")
+
+    recorded = []
+
+    def insert(build_name, start_time, file):
+        if str(file).endswith("profile.json"):
+            raise AssertionError("upload rejected")
+        recorded.append(str(file))
+
+    _upload_profile_artifacts(
+        "amd_debug", "2026-06-11 00:00:00", [(insert, a), (insert, b)]
+    )
+
+    assert recorded == [str(b)]

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -13,6 +13,9 @@ Two layers are covered:
   treat a remote-upload rejection as best-effort (logged, never fatal) so a
   successful build is not reported as failed when the shared analytics DB
   rejects the telemetry INSERT.
+* The upload transport (``LogCluster.do_query``): the telemetry INSERT runs
+  with parallel parsing disabled so its peak parse memory stays under the
+  shared cluster's per-user limit.
 """
 
 import os
@@ -26,6 +29,7 @@ from ci.jobs.scripts.job_hooks.build_profile_hook import (
     _has_data,
     _upload_profile_artifacts,
 )
+from ci.jobs.scripts.log_cluster import LogCluster
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _PRODUCER = _REPO_ROOT / "utils" / "prepare-time-trace" / "prepare-time-trace.sh"
@@ -187,3 +191,38 @@ def test_one_artifact_rejection_does_not_block_the_rest(tmp_path):
     )
 
     assert recorded == [str(b)]
+
+
+# --- upload transport: parallel parsing disabled --------------------------
+
+
+def test_do_query_disables_parallel_parsing():
+    """The telemetry INSERT must run with parallel parsing off.
+
+    Parallel parsing buffers many chunks at once; that peak is what crosses the
+    shared cluster's per-user memory limit when all Build variants upload at
+    once (Code 241 MEMORY_LIMIT_EXCEEDED While executing
+    ParallelParsingBlockInputFormat). do_query must send
+    input_format_parallel_parsing=0 so the INSERT is accepted and the telemetry
+    is kept.
+    """
+
+    class _Resp:
+        ok = True
+
+    class _Session:
+        def __init__(self):
+            self.params = None
+
+        def post(self, url, params, data, headers, timeout):
+            self.params = params
+            return _Resp()
+
+    cluster = LogCluster()
+    cluster.is_ready = lambda: True
+    cluster.url = "https://example"
+    cluster._auth = {}
+    cluster._session = _Session()
+
+    assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
+    assert cluster._session.params["input_format_parallel_parsing"] == 0


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/84159
Related: https://github.com/ClickHouse/ClickHouse/pull/107117
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/84159

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`build_profile_hook` runs on every master Build variant and uploads compile-time-trace telemetry to a shared remote analytics DB. The ~25 variants of a master push finish and upload at roughly the same time, so the per-user INSERTs cross that DB's memory limit and one is killed with `Code: 241 MEMORY_LIMIT_EXCEEDED` (`While executing ParallelParsingBlockInputFormat`). The hook treated that rejection as fatal (`sys.exit(1)`), so a successful build was reported as a failed `Post Hooks` check (~600/day, all variants, build-content-independent).

Reduce the workload at the source: collect build profile telemetry only for an explicit subset of two representative release builds (`amd_release`, `arm_release`) instead of all ~25 variants, so they no longer upload at once and cross the per-user limit. The other build names are listed commented-out, so re-enabling one is a one-line change.

Keep `input_format_parallel_parsing=0` on the INSERT (per @nikitamikhaylov): the kill happens in `ParallelParsingBlockInputFormat`, whose chunk buffering is the memory peak, and single-threaded parsing keeps a single upload's peak parse memory low.

Upload errors are no longer swallowed. With the workload reduced, a genuine INSERT rejection means a real lost upload and now fails the hook loudly instead of being reported as success. The empty-artifact skip (#84159, builds that produce no profile data) is unrelated to error handling and stays.

Example failure (master `Build (amd_release)`, 2026-06-23): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4dde9a6abaa86ed9c3897525f053b02a284f6a67&name_0=MasterCI&name_1=Build%20%28amd_release%29

Regression tests in `ci/tests/test_build_profile_hook.py`: telemetry is collected only for the allow-listed release builds; the INSERT runs with `input_format_parallel_parsing=0`; an upload rejection propagates rather than being swallowed. Each fails against the un-fixed code and passes with this change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.156` (included in `26.7` and later)
<!-- ch-version-info:end -->