### PR TITLE
Fix exception in predefined HTTP handler on absent header

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -963,7 +963,10 @@ void PredefinedQueryHandler::customizeContext(HTTPServerRequest & request, Conte
 
     for (const auto & [header_name, regex] : header_name_with_capture_regexp)
     {
-        const auto & header_value = request.get(header_name);
+        /// Use a defaulted lookup like `headersFilter` does: a missing header is treated as an empty string.
+        /// A header regex can match the empty string, so the rule may match a request without that header,
+        /// and reading it here without a default would raise an exception after the rule has already matched.
+        const auto header_value = request.get(header_name, "");
         set_query_params(header_value.data(), header_value.data() + header_value.size(), regex);
     }
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -223,6 +223,39 @@ def test_predefined_query_handler():
         )
 
 
+def test_predefined_handler_absent_header():
+    with contextlib.closing(
+        SimpleCluster(
+            ClickHouseCluster(__file__),
+            "predefined_handler_absent_header",
+            "test_predefined_handler_absent_header",
+        )
+    ) as cluster:
+
+        def get(headers):
+            return cluster.instance.http_request(
+                "test_predefined_handler_absent_header", method="GET", headers=headers
+            )
+
+        # The header regex (?P<value_from_header>.*) matches any value, including the empty string, so
+        # the rule matches even when header XXX is absent. The captured value is passed to the query as
+        # the parameter value_from_header. A missing header must be treated as an empty string instead
+        # of raising an exception after the rule has already matched.
+        response = get({"XXX": "hello"})
+        assert response.status_code == 200, response.content
+        assert response.content == b"hello\n"
+
+        # Header absent: the rule still matches and the captured parameter is empty.
+        response = get({})
+        assert response.status_code == 200, response.content
+        assert response.content == b"\n"
+
+        # Header present but empty: same as absent.
+        response = get({"XXX": ""})
+        assert response.status_code == 200, response.content
+        assert response.content == b"\n"
+
+
 def test_fixed_static_handler():
     with contextlib.closing(
         SimpleCluster(

--- a/tests/integration/test_http_handlers_config/test_predefined_handler_absent_header/config.xml
+++ b/tests/integration/test_http_handlers_config/test_predefined_handler_absent_header/config.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <http_handlers>
+        <rule>
+            <methods>GET</methods>
+            <url>/test_predefined_handler_absent_header</url>
+            <headers_regexp><XXX><![CDATA[(?P<value_from_header>.*)]]></XXX></headers_regexp>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>SELECT {value_from_header:String}</query>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception in predefined HTTP handler on absent header

The problem was found in PR [#107492](https://github.com/ClickHouse/ClickHouse/pull/107492#discussion_r3428726558), it's that when a regular expression for a HTTP header allows empty string:

```
<clickhouse>
    <http_handlers>
        <rule>
            <methods>GET</methods>
            <url>/test_predefined_handler_absent_header</url>
            <headers_regexp><XXX><![CDATA[(?P<value_from_header>.*)]]></XXX></headers_regexp>
            <handler>
                <type>predefined_query_handler</type>
                <query>SELECT {value_from_header:String}</query>
            </handler>
        </rule>
    </http_handlers>
</clickhouse>
```

then it matches if a request doesn't have this header at all, but before this PR then it threw an exception trying to extract the value of a named capturing group from this header.