### PR TITLE
Bump `libssh` to 0.12.0

### DIFF
--- a/contrib/libssh-cmake/CMakeLists.txt
+++ b/contrib/libssh-cmake/CMakeLists.txt
@@ -7,8 +7,8 @@ endif()
 
 # CMake variables needed by libssh_version.h.cmake, update them when you update libssh
 set(libssh_VERSION_MAJOR 0)
-set(libssh_VERSION_MINOR 9)
-set(libssh_VERSION_PATCH 8)
+set(libssh_VERSION_MINOR 12)
+set(libssh_VERSION_PATCH 0)
 
 set(LIB_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/libssh")
 set(LIB_BINARY_DIR "${ClickHouse_BINARY_DIR}/contrib/libssh")
@@ -37,6 +37,7 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/external/poly1305.c
     ${LIB_SOURCE_DIR}/src/external/sntrup761.c
     ${LIB_SOURCE_DIR}/src/getpass.c
+    ${LIB_SOURCE_DIR}/src/hybrid_mlkem.c
     ${LIB_SOURCE_DIR}/src/init.c
     ${LIB_SOURCE_DIR}/src/kdf.c
     ${LIB_SOURCE_DIR}/src/kex.c
@@ -47,6 +48,7 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/match.c
     ${LIB_SOURCE_DIR}/src/messages.c
     ${LIB_SOURCE_DIR}/src/misc.c
+    ${LIB_SOURCE_DIR}/src/mlkem.c
     ${LIB_SOURCE_DIR}/src/options.c
     ${LIB_SOURCE_DIR}/src/packet.c
     ${LIB_SOURCE_DIR}/src/packet_cb.c
@@ -79,6 +81,7 @@ set(libssh_SRCS
     ${LIB_SOURCE_DIR}/src/gzip.c
     ${LIB_SOURCE_DIR}/src/libcrypto.c
     ${LIB_SOURCE_DIR}/src/md_crypto.c
+    ${LIB_SOURCE_DIR}/src/mlkem_crypto.c
     ${LIB_SOURCE_DIR}/src/pki_crypto.c
     ${LIB_SOURCE_DIR}/src/pki_context.c
     ${LIB_SOURCE_DIR}/src/sntrup761.c

--- a/contrib/libssh-cmake/darwin/config.h
+++ b/contrib/libssh-cmake/darwin/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/freebsd/config.h
+++ b/contrib/libssh-cmake/freebsd/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/aarch64-musl/config.h
+++ b/contrib/libssh-cmake/linux/aarch64-musl/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/aarch64/config.h
+++ b/contrib/libssh-cmake/linux/aarch64/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/loongarch64/config.h
+++ b/contrib/libssh-cmake/linux/loongarch64/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/ppc64le/config.h
+++ b/contrib/libssh-cmake/linux/ppc64le/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/riscv64/config.h
+++ b/contrib/libssh-cmake/linux/riscv64/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/s390x/config.h
+++ b/contrib/libssh-cmake/linux/s390x/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/x86-64-musl/config.h
+++ b/contrib/libssh-cmake/linux/x86-64-musl/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */

--- a/contrib/libssh-cmake/linux/x86-64/config.h
+++ b/contrib/libssh-cmake/linux/x86-64/config.h
@@ -14,6 +14,18 @@
 /* Global client configuration file path */
 #define GLOBAL_CLIENT_CONFIG "/etc/ssh/ssh_config"
 
+/* Global configuration directory (libssh >= 0.12 uses it unconditionally) */
+#define GLOBAL_CONF_DIR "/etc/ssh"
+
+/* Define to 1 if we have support for ML-KEM in libgcrypt */
+/* #undef HAVE_GCRYPT_MLKEM */
+
+/* Define to 1 if we have support for ML-KEM in OpenSSL */
+#define HAVE_OPENSSL_MLKEM 1
+
+/* Define to 1 if we have support for ML-KEM1024 in either backend */
+#define HAVE_MLKEM1024 1
+
 /************************** HEADER FILES *************************/
 
 /* Define to 1 if you have the <argp.h> header file. */
@@ -188,8 +200,6 @@
 /* Define to 1 if we have support for blowfish */
 /* #undef HAVE_BLOWFISH */
 
-/* Define to 1 if we have support for ML-KEM */
-/* #undef HAVE_MLKEM */
 
 /*************************** LIBRARIES ***************************/
 

--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -66,6 +66,12 @@ if(NOT OS_DARWIN)
     )
 endif()
 
+if(OS_DARWIN OR ARCH_PPC64LE)
+    set(SRCS ${SRCS}
+        "${POSTGRES_SOURCE_DIR}/src/port/explicit_bzero.c"
+    )
+endif()
+
 add_library(_libpq ${SRCS})
 
 add_definitions(-DFRONTEND)


### PR DESCRIPTION
Update the `contrib/libssh` submodule to the upstream release `libssh-0.12.0` (from an upstream master snapshot, `libssh-0.11.0-368-g47305a2f`), tracked via the `ClickHouse/libssh-0.12.0` branch of the fork mirror. Both the old and new pins are clean upstream commits, so no ClickHouse patches needed to be carried forward.

Build integration changes in `contrib/libssh-cmake`:
- Bump the `libssh_VERSION_*` variables to 0.12.0.
- Add the new ML-KEM sources. In 0.12.0, `kex.c` references `ssh_client_hybrid_mlkem_remove_callbacks` from an unguarded switch case, so `hybrid_mlkem.c` and `mlkem.c` are now mandatory. ClickHouse bundles OpenSSL 3.5, which provides the EVP ML-KEM API, so the OpenSSL backend `mlkem_crypto.c` is used (matching upstream's `OPENSSL_VERSION >= 3.5.0` logic).
- In every per-platform `config.h`: define `GLOBAL_CONF_DIR` (now used unconditionally via string concatenation in `options.c`), and enable `HAVE_OPENSSL_MLKEM` / `HAVE_MLKEM1024` to select the OpenSSL ML-KEM backend and the ML-KEM-1024 variants.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Update `libssh` to 0.12.0.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.24` (included in `26.7` and later)
- Backported to: `26.6.3.62`, `26.5.7.63`, `26.3.20.4`, `25.8.31.9`
<!-- ch-version-info:end -->