### PR TITLE
Fix false `lock-order-inversion` in parallel prefix reading of nested JSON

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <set>
 
 namespace DB
@@ -457,6 +458,11 @@ public:
         StreamCallback prefixes_prefetch_callback;
         /// ThreadPool that can be used to read prefixes of subcolumns in parallel.
         ThreadPool * prefixes_deserialization_thread_pool = nullptr;
+        /// Mutex serializing the (non-thread-safe) prefix callbacks during parallel deserialization.
+        /// Set by the outermost Object; when non-null a nested Object reuses the already-installed
+        /// thread-safe callbacks and must not wrap again, so the whole subtree shares one mutex
+        /// (a second per-level mutex is what makes TSan's deadlock detector report a false cycle).
+        std::mutex * prefix_callbacks_mutex = nullptr;
 
         /// If set to true, all prefixes and suffixes should be read from separate specialized substreams.
         /// For example prefix for discriminators in Variant column should be read from a separate

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -18,6 +18,8 @@
 #include <Common/setThreadName.h>
 #include <Common/ThreadGroupSwitcher.h>
 
+#include <optional>
+
 namespace DB
 {
 
@@ -526,41 +528,51 @@ void SerializationObject::deserializeBinaryBulkStatePrefix(
         for (const auto & path : *structure_state_concrete->sorted_dynamic_paths)
             object_state->dynamic_path_states[path] = nullptr;
 
-        /// All threads will use the same callbacks that are not thread safe.
-        std::mutex callbacks_mutex;
+        /// The callbacks are not thread safe, so parallel tasks must funnel through a single mutex.
+        /// Only the outermost parallel Object installs the locking wrappers; a nested Object inherits
+        /// the already-thread-safe callbacks (via settings.prefix_callbacks_mutex) and must not wrap
+        /// again, otherwise the whole subtree would hold one callbacks_mutex per level. Those per-level
+        /// stack mutexes are what let TSan's deadlock detector report a (false) lock-order inversion
+        /// across nesting levels. With a single mutex per subtree there is nothing to invert, while
+        /// nested fan-out still runs in parallel.
+        const bool install_wrappers = !settings.prefix_callbacks_mutex;
+        std::optional<std::mutex> own_callbacks_mutex;
+        if (install_wrappers)
+            own_callbacks_mutex.emplace();
+        std::mutex * callbacks_mutex = install_wrappers ? &*own_callbacks_mutex : settings.prefix_callbacks_mutex;
         auto safe_getter = [&](const SubstreamPath & path)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             return settings.getter(path);
         };
 
         auto safe_dynamic_subcolumns_callback = [&](const SubstreamPath & path)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             settings.dynamic_subcolumns_callback(path);
         };
 
         auto safe_prefixes_prefetch_callback = [&](const SubstreamPath & path)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             settings.prefixes_prefetch_callback(path);
         };
 
         auto safe_release_stream_callback = [&](const SubstreamPath & path)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             settings.release_stream_callback(path);
         };
 
         auto safe_seek_to_start_callback = [&](const SubstreamPath & path)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             settings.seek_to_start_callback(path);
         };
 
         auto safe_has_uniform_marks_callback = [&](const SubstreamPath & path, size_t max_transitions)
         {
-            std::unique_lock lock(callbacks_mutex);
+            std::unique_lock lock(*callbacks_mutex);
             return settings.has_uniform_marks_callback(path, max_transitions);
         };
 
@@ -583,14 +595,21 @@ void SerializationObject::deserializeBinaryBulkStatePrefix(
             auto deserialize = [&, batch_start, batch_end, cache_ptr = cache_copy.get()]()
             {
                 auto settings_copy = settings;
-                settings_copy.getter = safe_getter;
-                settings_copy.dynamic_subcolumns_callback = settings.dynamic_subcolumns_callback ? safe_dynamic_subcolumns_callback : StreamCallback{};
-                settings_copy.prefixes_prefetch_callback = settings.prefixes_prefetch_callback ? safe_prefixes_prefetch_callback : StreamCallback{};
-                settings_copy.release_stream_callback = settings.release_stream_callback ? safe_release_stream_callback : StreamCallback{};
-                settings_copy.seek_to_start_callback = settings.seek_to_start_callback ? safe_seek_to_start_callback : StreamCallback{};
-                settings_copy.has_uniform_marks_callback = settings.has_uniform_marks_callback
-                    ? safe_has_uniform_marks_callback
-                    : decltype(settings.has_uniform_marks_callback){};
+                /// Install the locking wrappers only at the outermost level; nested Objects inherit them
+                /// (and the flag) and keep the thread pool, so nested prefixes are still read in parallel
+                /// but through this single callbacks_mutex.
+                if (install_wrappers)
+                {
+                    settings_copy.getter = safe_getter;
+                    settings_copy.dynamic_subcolumns_callback = settings.dynamic_subcolumns_callback ? safe_dynamic_subcolumns_callback : StreamCallback{};
+                    settings_copy.prefixes_prefetch_callback = settings.prefixes_prefetch_callback ? safe_prefixes_prefetch_callback : StreamCallback{};
+                    settings_copy.release_stream_callback = settings.release_stream_callback ? safe_release_stream_callback : StreamCallback{};
+                    settings_copy.seek_to_start_callback = settings.seek_to_start_callback ? safe_seek_to_start_callback : StreamCallback{};
+                    settings_copy.has_uniform_marks_callback = settings.has_uniform_marks_callback
+                        ? safe_has_uniform_marks_callback
+                        : decltype(settings.has_uniform_marks_callback){};
+                    settings_copy.prefix_callbacks_mutex = callbacks_mutex;
+                }
                 for (size_t j = batch_start; j != batch_end; ++j)
                 {
                     settings_copy.path.push_back(Substream::ObjectDynamicPath);

--- a/tests/integration/test_object_nested_prefixes_lock_inversion/configs/prefixes_pool.xml
+++ b/tests/integration/test_object_nested_prefixes_lock_inversion/configs/prefixes_pool.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <!--
+        Keep the prefixes deserialization thread pool small and, crucially, warm
+        (free_size > 0). With the default free_size = 0 the pool stays cold: idle
+        workers exit immediately, so the scheduling thread work-steals every nested
+        task onto its own stack and the per-level `callbacks_mutex` objects always sit
+        at strictly decreasing stack addresses (deep -> shallow), which can never form
+        a lock-order cycle. With warm idle workers the nested Object levels land on
+        different pool threads at the same stack frame offset, and reused stack
+        addresses let TSan see both lock orders - the false `lock-order-inversion`
+        this test guards against. A small pool concentrates the addresses so the
+        report shows up quickly.
+    -->
+    <max_prefixes_deserialization_thread_pool_size>8</max_prefixes_deserialization_thread_pool_size>
+    <max_prefixes_deserialization_thread_pool_free_size>8</max_prefixes_deserialization_thread_pool_free_size>
+</clickhouse>

--- a/tests/integration/test_object_nested_prefixes_lock_inversion/test.py
+++ b/tests/integration/test_object_nested_prefixes_lock_inversion/test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prefixes_pool.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# Reading a JSON column whose values nest an Array(JSON) inside another Array(JSON)
+# makes prefix deserialization recurse into nested `SerializationObject`s while it is
+# parallelized over the prefixes deserialization thread pool. Each nesting level used
+# to create its own stack `callbacks_mutex`; with warm pool threads (see the config)
+# the levels land on different threads at the same stack frame offset, and TSan keys
+# mutexes by address and keeps lock-order edges past destruction, so reused stack
+# addresses formed a phantom `M0 => M1 => M0` cycle reported as `lock-order-inversion`.
+# Under the thread sanitizer that aborts the server; here we just read the table many
+# times and check it stays alive. See google/sanitizers#1717.
+def test_nested_json_prefixes_no_lock_inversion(start_cluster):
+    node.query("DROP TABLE IF EXISTS t_object_nested_prefixes SYNC")
+    node.query(
+        """
+        CREATE TABLE t_object_nested_prefixes (c JSON)
+        ENGINE = MergeTree ORDER BY tuple()
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0
+        """,
+        settings={"allow_experimental_json_type": 1},
+    )
+    # Many small wide parts, each with three nested Object levels (top object, `arr`
+    # and `arr2`), so a single read fans many nested prefix tasks into the pool.
+    node.query("SYSTEM STOP MERGES t_object_nested_prefixes")
+    insert = """
+        INSERT INTO t_object_nested_prefixes
+        SELECT concat('{',
+            arrayStringConcat(arrayMap(i -> concat('"a', toString(i), '":', toString(number + i)), range(40)), ','),
+            ',"arr":[{', arrayStringConcat(arrayMap(i -> concat('"b', toString(i), '":', toString(number + i)), range(40)), ','),
+            ',"arr2":[{', arrayStringConcat(arrayMap(i -> concat('"d', toString(i), '":', toString(number + i)), range(40)), ','),
+            '}]}]}')::JSON
+        FROM numbers(5)
+    """
+    for _ in range(50):
+        node.query(insert, settings={"allow_experimental_json_type": 1})
+
+    # Low max_threads keeps few concurrent outer tasks, leaving warm pool threads idle
+    # to pick up the nested tasks directly (instead of being work-stolen by the parent).
+    for _ in range(20):
+        node.query(
+            "SELECT count() FROM t_object_nested_prefixes WHERE NOT ignore(c)",
+            settings={
+                "merge_tree_use_prefixes_deserialization_thread_pool": 1,
+                "max_threads": 2,
+                "allow_experimental_json_type": 1,
+            },
+        )
+
+    assert node.query("SELECT count() FROM t_object_nested_prefixes") == "250\n"
+
+    node.query("DROP TABLE t_object_nested_prefixes SYNC")


### PR DESCRIPTION
`SerializationObject` guards its non-thread-safe stream callbacks with a per-call stack `callbacks_mutex` for parallel prefix reading; recursing into a nested `Object` made every level create its own. TSan keys mutexes by address and keeps lock-order edges past destruction, so reused stack addresses formed a phantom `M0 => M1 => M0` cycle (real order is deep to shallow; google/sanitizers#1717). Now only the outermost `Object` installs the wrappers and shares its mutex via `prefix_callbacks_mutex`, so the subtree shares one mutex and stays parallel.

CI report: https://pastila.nl/?0002a102/73a0817799760e7738dd8acccdbdda12#onl6eWQomSaqPVL/cJ4A5g==GCM
Related: https://github.com/ClickHouse/ClickHouse/pull/106898

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix false `lock-order-inversion` in parallel prefix reading of nested JSON