### PR TITLE
Fix flaky test_system_kafka_consumers (DROP-view-vs-streamer race)

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -3293,6 +3293,7 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
             f"""
             DROP TABLE IF EXISTS test.{kafka_table} SYNC;
             DROP TABLE IF EXISTS test.{kafka_table}_view SYNC;
+            DROP TABLE IF EXISTS test.{kafka_table}_target SYNC;
 
             {create_query_generator(
                 kafka_table,
@@ -3306,15 +3307,18 @@ def test_system_kafka_consumers(kafka_cluster, create_query_generator, consumer_
                 }
             )};
 
-            CREATE MATERIALIZED VIEW test.{kafka_table}_view ENGINE=MergeTree ORDER BY tuple() AS SELECT * FROM test.{kafka_table};
+            CREATE TABLE test.{kafka_table}_target (a UInt64, b String) ENGINE=MergeTree ORDER BY tuple();
+            CREATE MATERIALIZED VIEW test.{kafka_table}_view TO test.{kafka_table}_target AS SELECT * FROM test.{kafka_table};
             """
         )
         count = instance.query_with_retry(
-            f"SELECT count() FROM test.{kafka_table}_view",
+            f"SELECT count() FROM test.{kafka_table}_target",
             check_callback=lambda res: int(res) == 6,
         )
         assert int(count) == 6
 
+        # Drop only the materialized view (the explicit target table survives) so the
+        # background Kafka streamer can never observe a missing inner table mid-push.
         instance.query_with_retry(f"DROP TABLE test.{kafka_table}_view SYNC")
 
         check_query = f"""
@@ -3364,6 +3368,7 @@ last_used_and_last_poll_time: equal
         )
 
         instance.query(f"DROP TABLE test.{kafka_table}")
+        instance.query(f"DROP TABLE IF EXISTS test.{kafka_table}_target SYNC")
 
 
 def test_system_kafka_consumers_rebalance(kafka_cluster, max_retries=15):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a flaky integration test, `test_storage_kafka/test_batch_fast.py::test_system_kafka_consumers`.

Failure signature (sanitizer/coverage builds):
`Code: 60. DB::Exception: Target table 'test.`.inner_id.<uuid>`' of view '...' doesn't exists. (UNKNOWN_TABLE)`
surfacing as an `assert_eq_with_retry` on `system.kafka_consumers` that never converges to `last_exception_: no exception`.

Root cause: the test created the MV with an implicit inner table (`CREATE MATERIALIZED VIEW ... ENGINE=MergeTree AS SELECT`) and then ran `DROP TABLE ..._view SYNC` while the Kafka table kept streaming. `DROP ... SYNC` removes the implicit inner table (`.inner_id.<uuid>`) before the view itself (`StorageMaterializedView::drop`). A background `streamToViews()` cycle that has locked the view but not yet resolved its inner table then resolves a now-missing inner table, and `InsertDependenciesBuilder::observePath` throws `UNKNOWN_TABLE`. `StorageKafka` propagates that to every consumer's append-only `exceptions_buffer` (never cleared on success), so the retry can never see "no exception". The window is widened under sanitizer slowness, matching the observed sanitizer-only distribution.

Fix: use an explicit target table (`CREATE TABLE ..._target; CREATE MATERIALIZED VIEW ... TO ..._target`) and drop only the view. The target table always exists, so the streamer can never observe a missing inner table, and dropping the view alone takes the graceful no-dependencies path. Test intent and the `system.kafka_consumers` assertion are unchanged. This matches the explicit-target idiom already used by the sibling `test_system_kafka_consumers_rebalance_mv`.

Validation: reproduced the exact `UNKNOWN_TABLE` signature deterministically by injecting a temporary sleep in the `checkDependencies -> resolve inner table` window (reverted; not in this PR); with the explicit-target shape the race no longer occurs under the same injection. With a clean build the fixed test passed 10/10 runs (5x both parametrizations), and all three `test_system_kafka_consumers*` siblings pass.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.48`
<!-- ch-version-info:end -->