### PR TITLE
Add `explicit_bzero` to `postgres` CMake explicitly

### DIFF
--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -66,6 +66,12 @@ if(NOT OS_DARWIN)
     )
 endif()
 
+if(OS_DARWIN OR ARCH_PPC64LE)
+    set(SRCS ${SRCS}
+        "${POSTGRES_SOURCE_DIR}/src/port/explicit_bzero.c"
+    )
+endif()
+
 add_library(_libpq ${SRCS})
 
 add_definitions(-DFRONTEND)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Noticed during [`libssh` update](https://github.com/ClickHouse/ClickHouse/pull/108329) that linking on ppcle64 and darwin failed referencing `explicit_bzero` symbol.
Apparently it got to `postgres` via `libssh` until it got removed from the latter.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108329&sha=2040e0cbe5005736dfc2af87b17f89de8e0161b7&name_0=PR