### PR TITLE
Fix flaky test 04365_cancel_insert_when_client_dies_distributed

### DIFF
--- a/tests/queries/0_stateless/04365_cancel_insert_when_client_dies_distributed.sh
+++ b/tests/queries/0_stateless/04365_cancel_insert_when_client_dies_distributed.sh
@@ -87,8 +87,12 @@ $CLICKHOUSE_CLIENT -q 'select count() from dedup_test'
 
 $CLICKHOUSE_CLIENT -q 'system flush logs text_log'
 
-# Ensure that thread_cancel actually did something
+# Ensure that thread_cancel actually did something. Native-protocol SIGINT sends a graceful
+# 'Cancel' packet (connection preserved) rather than dropping the socket, so match the
+# QUERY_WAS_CANCELLED_BY_CLIENT messages too; the socket-drop messages only fire on SIGKILL.
 $CLICKHOUSE_CLIENT -q "select count() > 0 from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 and query_id like '$TEST_MARK%' and (
   message_format_string in ('Unexpected end of file while reading chunk header of HTTP chunked data', 'Unexpected EOF, got {} of {} bytes',
-  'Query was cancelled or a client has unexpectedly dropped the connection') or
+  'Query was cancelled or a client has unexpectedly dropped the connection',
+  'Received ''Cancel'' packet from the client, canceling the query.',
+  'Packet ''Cancel'' has been received from the client, canceling the query.') or
   message like '%Connection reset by peer%' or message like '%Broken pipe, while writing to socket%') SETTINGS max_rows_to_read = 0"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found (searched issues + PRs for the test name; none exist).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `04365_cancel_insert_when_client_dies_distributed` (failed flakily in two unrelated PRs, 0 master hits; 2 FAIL / 59 OK in 30 days).

The test cancels an INSERT into a `Distributed` table over the native protocol only (the HTTP variants live in the siblings `02434` / `04366`). Its final "ensure that thread_cancel actually did something" assertion was inherited from the HTTP-heavy `02434` and matches only HTTP-chunked / socket-drop messages (plus the predicate `'Query was cancelled or a client has unexpectedly dropped the connection'`, which exists only in the test files, never in the server source).

On the native protocol a `SIGINT` makes the client send a graceful `Cancel` packet and keep the connection open, so the server logs `QUERY_WAS_CANCELLED_BY_CLIENT` (`Received 'Cancel' packet from the client, canceling the query.`) rather than a broken pipe / connection reset. The socket-drop messages only fire when a `SIGKILL` lands while the server happens to be writing back to the client. `thread_cancel` picks `INT` or `KILL` with equal probability, so roughly half the cancellations produce no message the assertion recognizes, and the `SIGKILL` half matches only when the kill races a server-side write. Over the 40s run the margin is thin and the assertion occasionally observes zero matching messages, printing `0` instead of `1`.

Fix: add the native-protocol cancellation messages to the matcher. Verified locally against a debug build with the test's cluster pointed at a single capped server:

- A `SIGINT` interrupting an in-flight native distributed insert logs the cancel-packet message 11/12 times while matching the old filter 0/12 (directional proof: old assertion -> 0, the flaky failure; new assertion -> 1).
- A normal uncancelled insert never logs it, so the assertion still requires a real cancellation.
- The full `.sh` test passes 3/3 end-to-end (output `500000 / 500000 / 1`).

Only the assertion's message list changes; the test's behavior and `.reference` are unchanged.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1200`
<!-- ch-version-info:end -->