### PR TITLE
Skip out-of-order release check on recovery runs

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -102,15 +102,6 @@ jobs:
             echo "DOCKER_TAG_TYPE=release" >> "$GITHUB_ENV"
             echo "IS_LATEST=0" >> "$GITHUB_ENV"
           fi
-          # A recovery run (only-repo/only-docker) rebuilds an already-released
-          # tag, which may no longer be the current release on its branch. The
-          # floating docker tags (minor/major/latest) must keep pointing at the
-          # current release, so they are not (re)published on a recovery run.
-          if [ "${{ inputs.only-repo }}" == "true" ] || [ "${{ inputs.only-docker }}" == "true" ]; then
-            echo "IS_RECOVERY=1" >> "$GITHUB_ENV"
-          else
-            echo "IS_RECOVERY=0" >> "$GITHUB_ENV"
-          fi
       - name: Download All Release Artifacts
         if: ${{ inputs.type == 'patch' && ! inputs.only-docker }}
         shell: bash
@@ -270,13 +261,13 @@ jobs:
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
             # minor/major/latest tags track the current release, so they are
-            # skipped on a recovery run to avoid moving them back to an older
-            # image (IS_RECOVERY is set in "Prepare Release Info").
+            # skipped on a recovery run (only-repo/only-docker) to avoid moving
+            # them back to an older image.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "$IS_RECOVERY" != "1" ]; then
+            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
@@ -348,13 +339,13 @@ jobs:
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
             # minor/major/latest tags track the current release, so they are
-            # skipped on a recovery run to avoid moving them back to an older
-            # image (IS_RECOVERY is set in "Prepare Release Info").
+            # skipped on a recovery run (only-repo/only-docker) to avoid moving
+            # them back to an older image.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "$IS_RECOVERY" != "1" ]; then
+            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -85,7 +85,7 @@ jobs:
           python3 ./tests/ci/create_release.py --prepare-release-info \
             --ref ${{ inputs.ref }} --release-type ${{ inputs.type }} \
             ${{ inputs.dry-run == true && '--dry-run' || '' }} \
-            ${{ (inputs.only-repo == true || inputs.only-docker == true) && '--skip-tag-check --recovery' || '' }}
+            ${{ (inputs.only-repo == true || inputs.only-docker == true) && '--skip-tag-check --skip-out-of-order-check' || '' }}
           echo "::group::Release Info"
           python3 -m json.tool /tmp/release_info.json
           echo "::endgroup::"
@@ -101,6 +101,15 @@ jobs:
           else
             echo "DOCKER_TAG_TYPE=release" >> "$GITHUB_ENV"
             echo "IS_LATEST=0" >> "$GITHUB_ENV"
+          fi
+          # A recovery run (only-repo/only-docker) rebuilds an already-released
+          # tag, which may no longer be the current release on its branch. The
+          # floating docker tags (minor/major/latest) must keep pointing at the
+          # current release, so they are not (re)published on a recovery run.
+          if [ "${{ inputs.only-repo }}" == "true" ] || [ "${{ inputs.only-docker }}" == "true" ]; then
+            echo "IS_RECOVERY=1" >> "$GITHUB_ENV"
+          else
+            echo "IS_RECOVERY=0" >> "$GITHUB_ENV"
           fi
       - name: Download All Release Artifacts
         if: ${{ inputs.type == 'patch' && ! inputs.only-docker }}
@@ -259,14 +268,22 @@ jobs:
 
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
+            # The exact version tag is always (re)built. The floating
+            # minor/major/latest tags track the current release, so they are
+            # skipped on a recovery run to avoid moving them back to an older
+            # image (IS_RECOVERY is set in "Prepare Release Info").
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
-              "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
-              "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
             )
 
-            if [ "$IS_LATEST" = "1" ]; then
-              TAGS+=("--tag=${DOCKER_IMAGE}:latest${VERSION_SUFFIX}")
+            if [ "$IS_RECOVERY" != "1" ]; then
+              TAGS+=(
+                "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
+                "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
+              )
+              if [ "$IS_LATEST" = "1" ]; then
+                TAGS+=("--tag=${DOCKER_IMAGE}:latest${VERSION_SUFFIX}")
+              fi
             fi
 
             echo "Following tags will be created: ${TAGS[*]}"
@@ -329,14 +346,22 @@ jobs:
 
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
+            # The exact version tag is always (re)built. The floating
+            # minor/major/latest tags track the current release, so they are
+            # skipped on a recovery run to avoid moving them back to an older
+            # image (IS_RECOVERY is set in "Prepare Release Info").
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
-              "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
-              "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
             )
 
-            if [ "$IS_LATEST" = "1" ]; then
-              TAGS+=("--tag=${DOCKER_IMAGE}:latest${VERSION_SUFFIX}")
+            if [ "$IS_RECOVERY" != "1" ]; then
+              TAGS+=(
+                "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
+                "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
+              )
+              if [ "$IS_LATEST" = "1" ]; then
+                TAGS+=("--tag=${DOCKER_IMAGE}:latest${VERSION_SUFFIX}")
+              fi
             fi
 
             echo "Following tags will be created: ${TAGS[*]}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -260,14 +260,17 @@ jobs:
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
-            # minor/major/latest tags track the current release, so they are
-            # skipped on a recovery run (only-repo/only-docker) to avoid moving
-            # them back to an older image.
+            # minor/major/latest tags track the current release. A docker-only
+            # recovery rebuilds docker for an already-released, possibly older
+            # tag, so it must not move the floating tags back to an older image;
+            # skip them in that case. A repo-only recovery instead repairs the
+            # current release (its docker images were never built), so it still
+            # publishes the floating tags.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
+            if [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
@@ -338,14 +341,17 @@ jobs:
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
-            # minor/major/latest tags track the current release, so they are
-            # skipped on a recovery run (only-repo/only-docker) to avoid moving
-            # them back to an older image.
+            # minor/major/latest tags track the current release. A docker-only
+            # recovery rebuilds docker for an already-released, possibly older
+            # tag, so it must not move the floating tags back to an older image;
+            # skip them in that case. A repo-only recovery instead repairs the
+            # current release (its docker images were never built), so it still
+            # publishes the floating tags.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
+            if [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -85,7 +85,7 @@ jobs:
           python3 ./tests/ci/create_release.py --prepare-release-info \
             --ref ${{ inputs.ref }} --release-type ${{ inputs.type }} \
             ${{ inputs.dry-run == true && '--dry-run' || '' }} \
-            ${{ (inputs.only-repo == true || inputs.only-docker == true) && '--skip-tag-check' || '' }}
+            ${{ (inputs.only-repo == true || inputs.only-docker == true) && '--skip-tag-check --recovery' || '' }}
           echo "::group::Release Info"
           python3 -m json.tool /tmp/release_info.json
           echo "::endgroup::"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -260,17 +260,14 @@ jobs:
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
-            # minor/major/latest tags track the current release. A docker-only
-            # recovery rebuilds docker for an already-released, possibly older
-            # tag, so it must not move the floating tags back to an older image;
-            # skip them in that case. A repo-only recovery instead repairs the
-            # current release (its docker images were never built), so it still
-            # publishes the floating tags.
+            # minor/major/latest tags track the current release, so they are
+            # skipped on a recovery run (only-repo/only-docker) to avoid moving
+            # them back to an older image.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "${{ inputs.only-docker }}" != "true" ]; then
+            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"
@@ -341,17 +338,14 @@ jobs:
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             # The exact version tag is always (re)built. The floating
-            # minor/major/latest tags track the current release. A docker-only
-            # recovery rebuilds docker for an already-released, possibly older
-            # tag, so it must not move the floating tags back to an older image;
-            # skip them in that case. A repo-only recovery instead repairs the
-            # current release (its docker images were never built), so it still
-            # publishes the floating tags.
+            # minor/major/latest tags track the current release, so they are
+            # skipped on a recovery run (only-repo/only-docker) to avoid moving
+            # them back to an older image.
             TAGS=(
               "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             )
 
-            if [ "${{ inputs.only-docker }}" != "true" ]; then
+            if [ "${{ inputs.only-repo }}" != "true" ] && [ "${{ inputs.only-docker }}" != "true" ]; then
               TAGS+=(
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MINOR}${VERSION_SUFFIX}"
                 "--tag=${DOCKER_IMAGE}:${CLICKHOUSE_VERSION_MAJOR}${VERSION_SUFFIX}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -80,7 +80,13 @@ jobs:
         shell: bash
         run: |
           if [ ${{ inputs.only-repo }} == "true" ] || [ ${{ inputs.only-docker }} == "true" ]; then
-              git tag -l ${{ inputs.ref }} || { echo "With only-repo/docker option ref must be a valid release tag"; exit 1; }
+              # `git tag -l <ref>` lists matching tags and exits 0 even when none
+              # match, so it does not actually validate the ref. Resolve the ref
+              # as a tag instead and fail closed when it is not one — otherwise an
+              # arbitrary commit could be released to repos/docker, especially now
+              # that recovery runs skip the out-of-order check.
+              git rev-parse --verify --quiet "refs/tags/${{ inputs.ref }}^{commit}" > /dev/null \
+                  || { echo "With only-repo/only-docker option ref must be a valid release tag"; exit 1; }
           fi
           python3 ./tests/ci/create_release.py --prepare-release-info \
             --ref ${{ inputs.ref }} --release-type ${{ inputs.type }} \

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -241,7 +241,7 @@ class ReleaseInfo:
         commit_ref: str,
         release_type: str,
         _skip_tag_check: bool,
-        recovery: bool = False,
+        _skip_out_of_order_check: bool = False,
     ) -> "ReleaseInfo":
         version = None
         release_branch = None
@@ -309,7 +309,7 @@ class ReleaseInfo:
             # we only rebuild repos/docker for an already-released tag, so an
             # out-of-order check is irrelevant and would always trip once a later
             # release exists on the branch. Skip it in that case.
-            if not recovery:
+            if not _skip_out_of_order_check:
                 ref_cmake = Shell.get_output_or_raise(
                     f"git show {commit_ref}:{FILE_WITH_VERSION_PATH}"
                 )
@@ -930,10 +930,11 @@ def parse_args() -> argparse.Namespace:
         help="To skip check against latest git tag on a release branch",
     )
     parser.add_argument(
-        "--recovery",
+        "--skip-out-of-order-check",
         action="store_true",
-        help="Recovery run (only-repo/only-docker): rebuild repos/docker for an "
-        "already-released tag without tagging, so skip the out-of-order release check",
+        help="Skip the out-of-order release check. Used by recovery runs "
+        "(only-repo/only-docker) that rebuild repos/docker for an "
+        "already-released tag without tagging",
     )
     parser.add_argument(
         "--push-release-tag",
@@ -1028,7 +1029,7 @@ if __name__ == "__main__":
                 commit_ref=args.ref,
                 release_type=args.release_type,
                 _skip_tag_check=args.skip_tag_check,
-                recovery=args.recovery,
+                _skip_out_of_order_check=args.skip_out_of_order_check,
             )
 
     if args.download_packages:

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -237,7 +237,11 @@ class ReleaseInfo:
         return self
 
     def prepare(
-        self, commit_ref: str, release_type: str, _skip_tag_check: bool
+        self,
+        commit_ref: str,
+        release_type: str,
+        _skip_tag_check: bool,
+        recovery: bool = False,
     ) -> "ReleaseInfo":
         version = None
         release_branch = None
@@ -300,19 +304,25 @@ class ReleaseInfo:
             # file at `origin/<release_branch>` HEAD, a release has been made on
             # a later commit — tagging `commit_ref` now would create an
             # out-of-order release.
-            ref_cmake = Shell.get_output_or_raise(
-                f"git show {commit_ref}:{FILE_WITH_VERSION_PATH}"
-            )
-            branch_cmake = Shell.get_output_or_raise(
-                f"git show origin/{release_branch}:{FILE_WITH_VERSION_PATH}"
-            )
-            if ref_cmake != branch_cmake:
-                raise RuntimeError(
-                    f"Refusing to release ref [{commit_ref}]: "
-                    f"{FILE_WITH_VERSION_PATH} differs from origin/{release_branch} "
-                    f"HEAD, which means a release has already been made on a "
-                    f"later commit. Tagging would create an out-of-order release."
+            #
+            # On a recovery run (`only-repo`/`only-docker`) we do not tag at all,
+            # we only rebuild repos/docker for an already-released tag, so an
+            # out-of-order check is irrelevant and would always trip once a later
+            # release exists on the branch. Skip it in that case.
+            if not recovery:
+                ref_cmake = Shell.get_output_or_raise(
+                    f"git show {commit_ref}:{FILE_WITH_VERSION_PATH}"
                 )
+                branch_cmake = Shell.get_output_or_raise(
+                    f"git show origin/{release_branch}:{FILE_WITH_VERSION_PATH}"
+                )
+                if ref_cmake != branch_cmake:
+                    raise RuntimeError(
+                        f"Refusing to release ref [{commit_ref}]: "
+                        f"{FILE_WITH_VERSION_PATH} differs from origin/{release_branch} "
+                        f"HEAD, which means a release has already been made on a "
+                        f"later commit. Tagging would create an out-of-order release."
+                    )
             if version.patch == 1:
                 expected_version = copy(version)
                 previous_release_tag = f"v{version.major}.{version.minor}.1.1-new"
@@ -920,6 +930,12 @@ def parse_args() -> argparse.Namespace:
         help="To skip check against latest git tag on a release branch",
     )
     parser.add_argument(
+        "--recovery",
+        action="store_true",
+        help="Recovery run (only-repo/only-docker): rebuild repos/docker for an "
+        "already-released tag without tagging, so skip the out-of-order release check",
+    )
+    parser.add_argument(
         "--push-release-tag",
         action="store_true",
         help="Creates and pushes git tag",
@@ -1012,6 +1028,7 @@ if __name__ == "__main__":
                 commit_ref=args.ref,
                 release_type=args.release_type,
                 _skip_tag_check=args.skip_tag_check,
+                recovery=args.recovery,
             )
 
     if args.download_packages:


### PR DESCRIPTION
The `CreateRelease` workflow has `only-repo` and `only-docker` dispatch options that turn a run into a *recovery* run: instead of cutting a new release, they re-export the apt/rpm/tgz repositories and rebuild the docker images for a tag that was already released. These are exactly the steps that have to be re-run when a release was left in an inconsistent state — for example when the `createrepo_c` step timed out (https://github.com/ClickHouse/ClickHouse/actions/runs/27142009612/job/80117345079, `v26.3.13.31-lts`) or published incomplete RPM metadata (https://github.com/ClickHouse/ClickHouse/actions/runs/27970913207/job/82776581872, `v26.5.3.52`).

However, `ReleaseInfo.prepare` runs an out-of-order release guard for patch releases: it compares `cmake/autogenerated_versions.txt` at the requested ref against `origin/<release_branch>` HEAD and refuses with a `RuntimeError` when they differ, on the assumption that a later release has already been made and tagging now would produce an out-of-order release. On a recovery run for an older tag this is guaranteed to trip as soon as any newer patch has shipped on the branch, so the recovery is blocked before it can rebuild anything:

```
RuntimeError: Refusing to release ref [v26.3.13.31-lts]:
cmake/autogenerated_versions.txt differs from origin/26.3 HEAD, which means a
release has already been made on a later commit. Tagging would create an
out-of-order release.
```

A recovery run never creates a tag, so the out-of-order check does not apply to it. This adds a `--skip-out-of-order-check` flag to `tests/ci/create_release.py` (named for consistency with the existing `--skip-tag-check`), passed by the workflow's `Prepare Release Info` step alongside `--skip-tag-check` whenever `only-repo` or `only-docker` is set, which skips the out-of-order check.

Skipping the check also means a recovery may rebuild an older tag that is no longer the current release on its branch. The docker steps publish floating tags (`${CLICKHOUSE_VERSION_MINOR}`, `${CLICKHOUSE_VERSION_MAJOR}`, and `latest` when `IS_LATEST=1`) that must keep pointing at the current release, so re-pushing them from a recovery could move them back onto an older image. To prevent this, a recovery run (`only-repo`/`only-docker`) now rebuilds only the exact version tag and skips the floating tags entirely; floating tags are published only by a normal (non-recovery) release.

Validated end-to-end by re-running the `v26.3.13.31-lts` recovery from this branch (https://github.com/ClickHouse/ClickHouse/actions/runs/28094640279): the run is fully green — `Prepare Release Info` now passes, and the recovery proceeds through repo export/tests and the docker image builds to completion. (Two unrelated failures surfaced first on the release-maker runner and were fixed in the runner environment, not here: the default `buildx` builder had flipped from the `docker-container` builder to the `docker` driver, and the host had lost its `qemu`/`binfmt` `arm64` registration — neither is a code issue.)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.95`
<!-- ch-version-info:end -->