### PR TITLE
Fix flaky test_s3_plain_rewritable: opt in to legacy REPLACE PARTITION from empty source

### DIFF
--- a/tests/integration/test_s3_plain_rewritable/test.py
+++ b/tests/integration/test_s3_plain_rewritable/test.py
@@ -122,7 +122,11 @@ def test(storage_policy, key_prefix):
         node.query("ALTER TABLE test MOVE PARTITION 0 TO TABLE test_dst")
 
         count_part_1 = int(node.query("SELECT count(*) FROM test WHERE id % 10 = 1"))
-        node.query("ALTER TABLE test_dst REPLACE PARTITION 1 FROM test")
+        # Source partition 1 is empty when this node's random row count was 1 (only id=0).
+        # Opt in to the legacy no-op semantics; #23727 made empty-source REPLACE PARTITION throw by default.
+        node.query(
+            "ALTER TABLE test_dst REPLACE PARTITION 1 FROM test SETTINGS allow_replace_partition_from_empty_source = 1"
+        )
 
         count_dst = int(node.query("SELECT count(*) FROM test_dst"))
         assert count_dst > 0

--- a/tests/integration/test_s3_plain_rewritable/test.py
+++ b/tests/integration/test_s3_plain_rewritable/test.py
@@ -123,7 +123,7 @@ def test(storage_policy, key_prefix):
 
         count_part_1 = int(node.query("SELECT count(*) FROM test WHERE id % 10 = 1"))
         # Source partition 1 is empty when this node's random row count was 1 (only id=0).
-        # Opt in to the legacy no-op semantics; #23727 made empty-source REPLACE PARTITION throw by default.
+        # Opt in to the legacy no-op semantics; #104939 (fix for #23727) made empty-source REPLACE PARTITION throw by default.
         node.query(
             "ALTER TABLE test_dst REPLACE PARTITION 1 FROM test SETTINGS allow_replace_partition_from_empty_source = 1"
         )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104939
Related: https://github.com/ClickHouse/ClickHouse/issues/23727
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `test_s3_plain_rewritable/test.py::test`.

#104939 (fixing the silent data loss in #23727) made `ALTER TABLE ... REPLACE PARTITION ... FROM ...` from a source that has no parts in the requested partition throw `BAD_ARGUMENTS` by default, gated behind the new `allow_replace_partition_from_empty_source` setting. It updated the affected stateless tests but missed this integration test.

The test inserts `random.randint(1, MAX_ROWS)` rows with consecutive ids (`PARTITION BY id % 10`). When a node draws a row count of 1, only `id=0` exists, so partition 1 of `test` is empty. The test then does `MOVE PARTITION 0 TO test_dst` (emptying `test`) followed by `REPLACE PARTITION 1 FROM test`, which now reads an empty source partition and throws.

This surfaced as a low-rate flake (~0.05% of master runs) across the asan/tsan/msan integration builds within hours of #104939 merging.

Fix: pin `allow_replace_partition_from_empty_source = 1` on the `REPLACE PARTITION` query to restore the legacy no-op semantics the test relies on, matching the fix applied to the stateless tests in #104939. The destination partition 1 is also empty at that point, so no data is lost and the existing assertions (`count_dst > 0`, `count_dst == count_part_0 + count_part_1`) still hold.

CI report (one of the failures): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105387&sha=fb91a686249e35a738fd3be8f2fb480dc39ddc95&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.85` (included in `26.7` and later)
- Backported to: `26.6.2.10`
<!-- ch-version-info:end -->