### PR TITLE
Fix a cancelled INSERT not stopping while building a skip index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterOnDisk.cpp
@@ -6,6 +6,9 @@
 #include <Storages/MergeTree/MergeTreeIndicesSerialization.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/ParallelSyncFiles.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+#include <Common/CurrentThread.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
 #include <Common/StringUtils.h>
@@ -261,6 +264,15 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializePrimaryIndex(const Bloc
 
 void MergeTreeDataPartWriterOnDisk::calculateAndSerializeSkipIndices(const Block & skip_indexes_block, const Granules & granules_to_write)
 {
+    /// Building a skip index over many granules (e.g. an unbounded `set(0)` index on a
+    /// high-cardinality column) can run for minutes. The INSERT pipeline only enforces query limits
+    /// between blocks, so without a check here a KILLed INSERT keeps building the index to completion.
+    /// checkTimeLimit throws on a cancelled query and on an exceeded max_execution_time in throw mode;
+    /// it is cheap (an atomic flag plus an elapsed-timer read).
+    QueryStatusPtr query_status;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        query_status = query_context->getProcessListElementSafe();
+
     /// Filling and writing skip indices like in MergeTreeDataPartWriterWide::writeColumn
     for (size_t i = 0; i < skip_indices.size(); ++i)
     {
@@ -269,6 +281,9 @@ void MergeTreeDataPartWriterOnDisk::calculateAndSerializeSkipIndices(const Block
 
         for (const auto & granule : granules_to_write)
         {
+            if (query_status)
+                query_status->checkTimeLimit();
+
             if (skip_index_accumulated_marks[i] == index_helper->index.granularity)
             {
                 auto index_granule = skip_indices_aggregators[i]->getGranuleAndReset();

--- a/tests/queries/0_stateless/04409_skip_index_build_cancellation.reference
+++ b/tests/queries/0_stateless/04409_skip_index_build_cancellation.reference
@@ -1,0 +1,1 @@
+killed promptly

--- a/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
+++ b/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tags: long, no-random-merge-tree-settings
+#
+# A KILLed INSERT must abort an in-progress skip-index build promptly, instead of
+# finishing the whole build first. We start a single-block INSERT that spends many
+# seconds building an unbounded set(0) index, cancel it, and require KILL QUERY ... SYNC
+# to return quickly. Without the per-granule cancellation check the KILL blocks until the
+# whole block's build completes and the timeout below trips.
+#
+# no-random-merge-tree-settings: a randomized index_granularity changes the granule count
+# and can make the build pathologically slow or memory-heavy; the timing/memory assumptions
+# here need the pinned granularity below.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_skip_index_cancel"
+${CLICKHOUSE_CLIENT} -q "
+CREATE TABLE t_skip_index_cancel
+(
+    x UInt64,
+    INDEX idx x TYPE set(0) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 8192
+"
+
+query_id="skip_index_cancel_${CLICKHOUSE_DATABASE}_$$"
+insert_err="${CLICKHOUSE_TMP}/04409_insert_err.txt"
+
+# Single large block of low-cardinality values: the set stays tiny (low memory) but the
+# per-granule build loop runs for many seconds, and is the active phase when we cancel.
+${CLICKHOUSE_CLIENT} --query_id "$query_id" \
+    --max_block_size 30000000 --max_insert_block_size 30000000 \
+    --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
+    -q "INSERT INTO t_skip_index_cancel SELECT number % 1000 FROM numbers(30000000)" >/dev/null 2>"$insert_err" &
+insert_pid=$!
+
+# Wait until the INSERT is actually building skip indices (past source generation), so the
+# cancellation has to be observed inside the build loop rather than between blocks.
+building=0
+for _ in $(seq 1 600); do
+    building=$(${CLICKHOUSE_CLIENT} -q "
+        SELECT ProfileEvents['MergeTreeDataWriterSkipIndicesCalculationMicroseconds'] > 0
+        FROM system.processes WHERE query_id = '$query_id'")
+    [ "$building" = "1" ] && break
+    sleep 0.1
+done
+
+if [ "$building" != "1" ]; then
+    # Fail loudly instead of cancelling a query that never reached the skip-index build.
+    echo "did not observe the skip-index build phase"
+    echo "--- INSERT client output ---"
+    cat "$insert_err"
+# On the fixed server the cancel is observed at the next granule and KILL returns in well under a
+# second; bound it so a regression (KILL ignored until the build finishes) fails instead of hanging.
+elif timeout 10 ${CLICKHOUSE_CLIENT} -q "KILL QUERY WHERE query_id = '$query_id' SYNC FORMAT Null"
+then
+    echo "killed promptly"
+else
+    echo "KILL QUERY SYNC did not return in time"
+fi
+
+wait "$insert_pid" 2>/dev/null
+
+rm -f "$insert_err"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_skip_index_cancel"

--- a/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
+++ b/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
@@ -7,14 +7,17 @@
 # to return quickly. Without the per-granule cancellation check the KILL blocks until the
 # whole block's build completes and the timeout below trips.
 #
-# no-random-settings: the test reads 30M rows in a single large INSERT and controls
-# termination itself via KILL QUERY. Randomized query limits break that contract -- e.g.
-# an injected 'max_rows_to_read' aborts the INSERT with TOO_MANY_ROWS before the build even
-# starts, and a random 'max_execution_time' / 'max_memory_usage' would terminate it instead
-# of our KILL. We need the read/time/memory limits left at their (unlimited) defaults.
-# no-random-merge-tree-settings: a randomized index_granularity changes the granule count
-# and can make the build pathologically slow or memory-heavy; the timing/memory assumptions
-# here need the pinned granularity below.
+# The test reads 30M rows in a single large INSERT and controls termination itself via
+# KILL QUERY, so the read/time limits must be left out of its way:
+# * The CI 'default' test profile (tests/config/users.d/limits.yaml) caps 'max_rows_to_read'
+#   at 20M, which aborts the 30M-row INSERT with TOO_MANY_ROWS before the build even starts.
+#   We override it with --max_rows_to_read 0 on the INSERT below (this is a fixed profile
+#   limit, not a randomized one, so no-random-settings alone does not relax it).
+# * no-random-settings: a random 'max_execution_time' / 'max_memory_usage' would terminate
+#   the long INSERT instead of our KILL.
+# * no-random-merge-tree-settings: a randomized index_granularity changes the granule count
+#   and can make the build pathologically slow or memory-heavy; the timing/memory assumptions
+#   here need the pinned granularity below.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -39,6 +42,7 @@ insert_err="${CLICKHOUSE_TMP}/04409_insert_err.txt"
 ${CLICKHOUSE_CLIENT} --query_id "$query_id" \
     --max_block_size 30000000 --max_insert_block_size 30000000 \
     --min_insert_block_size_rows 0 --min_insert_block_size_bytes 0 \
+    --max_rows_to_read 0 \
     -q "INSERT INTO t_skip_index_cancel SELECT number % 1000 FROM numbers(30000000)" >/dev/null 2>"$insert_err" &
 insert_pid=$!
 

--- a/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
+++ b/tests/queries/0_stateless/04409_skip_index_build_cancellation.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-random-merge-tree-settings
+# Tags: long, no-random-settings, no-random-merge-tree-settings
 #
 # A KILLed INSERT must abort an in-progress skip-index build promptly, instead of
 # finishing the whole build first. We start a single-block INSERT that spends many
@@ -7,6 +7,11 @@
 # to return quickly. Without the per-granule cancellation check the KILL blocks until the
 # whole block's build completes and the timeout below trips.
 #
+# no-random-settings: the test reads 30M rows in a single large INSERT and controls
+# termination itself via KILL QUERY. Randomized query limits break that contract -- e.g.
+# an injected 'max_rows_to_read' aborts the INSERT with TOO_MANY_ROWS before the build even
+# starts, and a random 'max_execution_time' / 'max_memory_usage' would terminate it instead
+# of our KILL. We need the read/time/memory limits left at their (unlimited) defaults.
 # no-random-merge-tree-settings: a randomized index_granularity changes the granule count
 # and can make the build pathologically slow or memory-heavy; the timing/memory assumptions
 # here need the pinned granularity below.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107971
-->

## Problem

A cancelled `INSERT` can keep running for a long time while it is building a secondary (skip) index. In `Stress test (arm_tsan)` an AST-fuzzer-mutated `INSERT` building a `set` skip index stayed in `system.processes` with `is_cancelled = 1` for ~19 minutes (`MergeTreeDataWriterSkipIndicesCalculationMicroseconds` ≈ 1145 s), which tripped the 60 s hung-check ("possible deadlock found"). This is not a deadlock — the thread is making forward progress — and a user `KILL QUERY` cannot abort the build either.

The originating scenario (from `03374_indexes_with_trivial_cast.sql`) is a `set(0)` index with `index_granularity = 1`:

```sql
CREATE TABLE test (`x` String, INDEX idx1 x TYPE set(0) GRANULARITY 1)
ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
INSERT INTO test SELECT number FROM numbers(1000);
```

With `index_granularity = 1`, the 1000-row block produces 1000 single-row granules; under `arm_tsan` each granule's index work is slow enough that the whole build takes ~1145 s. So the long runtime is spread across many granules, not one giant granule.

## Root cause

The per-granule skip-index build loop in `MergeTreeDataPartWriterOnDisk::calculateAndSerializeSkipIndices` has no cancellation point. The INSERT pipeline only enforces query limits *between* blocks (`MergeTreeSink::consume` checks `isCancelled` per block), so once execution is inside `MergeTreeDataWriter::writeTempPart` → writer → `calculateAndSerializeSkipIndices` → `IMergeTreeIndexAggregator::update`, neither cancellation nor `max_execution_time` is observed until the whole block's index build finishes.

This is not a regression of #107971, which only touches the read side (`MergeTreeIndexConditionSet::atomFromDAG`); the hang is on the write side (`MergeTreeIndexAggregatorSet::update`), a pre-existing behavior the fuzzer exposed.

## Fix

Fetch the query status once and call `checkTimeLimit` once per granule inside `calculateAndSerializeSkipIndices`, mirroring the existing precedent in `MergeTreeIndexVectorSimilarity` (and the read-side `MergeTreeDataSelectExecutor`). The check is cheap (an atomic flag plus an elapsed-timer read), lives in the shared writer path so it covers every skip-index type and both wide and compact part writers, and honors both cancellation and `max_execution_time` in throw mode. `set(0)` semantics are unchanged.

Per-granule placement is sufficient for the failing scenario: with `index_granularity = 1` the build is 1000 single-row granules, so the check effectively runs per row and a cancelled query is observed after at most one granule (~1.1 s under `arm_tsan`) instead of after the full ~1145 s build. The only case it would not cover is a single pathologically large granule, but that build would be fast and could not produce the multi-minute hang seen here.

Regression test `04409_skip_index_build_cancellation.sh`: a single-block `INSERT` is driven into the skip-index build phase (confirmed via the `MergeTreeDataWriterSkipIndicesCalculationMicroseconds` profile event), then cancelled; the test requires `KILL QUERY ... SYNC` to return within a bound. With the fix it returns in ~1 s; without it the `KILL` blocks until the whole block's build completes. The test is a deterministic reproduction of the underlying defect, not a 1:1 replay of the arm_tsan stress run.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a cancelled or `KILL`ed `INSERT` continuing to run for a long time while building a skip index (for example an unbounded `set(0)` index on a high-cardinality column). The index build now stops promptly when the query is cancelled.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.206` (included in `26.7` and later)
<!-- ch-version-info:end -->