### PR TITLE
Speed up PR version-info search with GraphQL and parallel fetches

### DIFF
--- a/.github/workflows/pr_version_info.yml
+++ b/.github/workflows/pr_version_info.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: 0 * * * *
   workflow_dispatch:
+    inputs:
+      days:
+        description: Lookback window in days; overrides the default for a manual run (e.g. 100 to backfill). Leave empty for the scheduled 1-day window.
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}
@@ -35,7 +40,9 @@ jobs:
           mkdir -p ./ci/tmp
           cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
           export PYTHONPATH=./ci:.:
-
+          cat > ./ci/tmp/workflow_inputs.json << 'EOF'
+          ${{ toJson(github.event.inputs) }}
+          EOF
           cat > ./ci/tmp/workflow_job.json << 'EOF'
           ${{ toJson(job) }}
           EOF
@@ -69,7 +76,9 @@ jobs:
           mkdir -p ./ci/tmp
           cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
           export PYTHONPATH=./ci:.:
-
+          cat > ./ci/tmp/workflow_inputs.json << 'EOF'
+          ${{ toJson(github.event.inputs) }}
+          EOF
           cat > ./ci/tmp/workflow_job.json << 'EOF'
           ${{ toJson(job) }}
           EOF

--- a/ci/praktika/yaml_generator.py
+++ b/ci/praktika/yaml_generator.py
@@ -72,7 +72,7 @@ permissions: write-all\
 name: {NAME}
 on:
   schedule:{CRON_TEMPLATES}
-  workflow_dispatch:
+  workflow_dispatch:{DISPATCH_INPUTS_BLOCK}
 
 concurrency:
   group: ${{{{{{{{ github.workflow }}}}}}}}
@@ -284,9 +284,7 @@ class PullRequestPushYamlGen:
         job_items = []
         for i, job in enumerate(self.workflow_config.jobs):
             job_name_normalized = Utils.normalize_string(job.name)
-            needs = ", ".join(
-                sorted(map(Utils.normalize_string, _all_needs(job.name)))
-            )
+            needs = ", ".join(sorted(map(Utils.normalize_string, _all_needs(job.name))))
             job_name = job.name
             job_addons = []
             for addon in job.addons:
@@ -343,13 +341,18 @@ class PullRequestPushYamlGen:
             # Emit timeout-minutes for any job whose configured timeout exceeds GitHub's 6h default.
             # JobYaml has no timeout; get it from the original Job.Config in workflow config.
             timeout_minutes = ""
-            orig_job = next((j for j in self.workflow_config.config.jobs if j.name == job.name), None)
+            orig_job = next(
+                (j for j in self.workflow_config.config.jobs if j.name == job.name),
+                None,
+            )
             if (
                 orig_job
                 and getattr(orig_job, "timeout", None)
                 and orig_job.timeout > 360 * 60
             ):
-                timeout_minutes = f"\n    timeout-minutes: {math.ceil(orig_job.timeout / 60) + 5}"
+                timeout_minutes = (
+                    f"\n    timeout-minutes: {math.ceil(orig_job.timeout / 60) + 5}"
+                )
 
             secrets_envs = []
             for secret in job.secret_names_gh:
@@ -362,7 +365,10 @@ class PullRequestPushYamlGen:
                 secrets_envs.append(
                     YamlGenerator.Templates.TEMPLATE_SETUP_ENV_VARS.format(VAR_NAME=var)
                 )
-            if self.workflow_config.event == Workflow.Event.DISPATCH:
+            if (
+                self.workflow_config.event == Workflow.Event.DISPATCH
+                or self.workflow_config.dispatch_inputs
+            ):
                 secrets_envs.append(
                     YamlGenerator.Templates.TEMPLATE_SETUP_ENVS_INPUTS.format(
                         WORKFLOW_INPUTS_FILE=Settings.WORKFLOW_INPUTS_FILE
@@ -449,7 +455,15 @@ class PullRequestPushYamlGen:
                 )
         elif self.workflow_config.event in (Workflow.Event.SCHEDULE,):
             base_template = YamlGenerator.Templates.TEMPLATE_SCHEDULE
-            format_kwargs = {"CRON_TEMPLATES": cron_items}
+            format_kwargs = {
+                "CRON_TEMPLATES": cron_items,
+                # Allow a scheduled workflow to also declare workflow_dispatch
+                # inputs for manual runs; empty when none are declared, so the
+                # generated YAML is unchanged for inputs-less schedules.
+                "DISPATCH_INPUTS_BLOCK": (
+                    f"\n    inputs:{dispatch_inputs}" if dispatch_inputs else ""
+                ),
+            }
             ENV_CHECKOUT_REFERENCE = (
                 YamlGenerator.Templates.TEMPLATE_ENV_CHECKOUT_REF_DEFAULT
             )

--- a/ci/workflows/pr_version_info.py
+++ b/ci/workflows/pr_version_info.py
@@ -7,12 +7,23 @@ from ci.defs.defs import BASE_BRANCH, SECRETS, RunnerLabels
 # tests/ci/pr_version_info.py for details.
 #
 # Runs hourly with a 1-day lookback: each run reconciles PRs merged in the last
-# day, plus any original pulled in by a backport merged in that window.
+# day, plus any original pulled in by a backport merged in that window. A manual
+# run can widen the lookback via the `days` input (e.g. 100 to backfill).
 
 workflow = Workflow.Config(
     name="PRVersionInfo",
     event=Workflow.Event.SCHEDULE,
     branches=[BASE_BRANCH],
+    inputs=[
+        Workflow.Config.InputConfig(
+            name="days",
+            description="Lookback window in days; overrides the default for a "
+            "manual run (e.g. 100 to backfill). Leave empty for the scheduled "
+            "1-day window.",
+            is_required=False,
+            default_value="",
+        ),
+    ],
     jobs=[
         Job.Config(
             name="Update PR version info",

--- a/ci/workflows/pr_version_info.py
+++ b/ci/workflows/pr_version_info.py
@@ -6,8 +6,8 @@ from ci.defs.defs import BASE_BRANCH, SECRETS, RunnerLabels
 # release version a PR shipped in from the CIDB `version_history` table. See
 # tests/ci/pr_version_info.py for details.
 #
-# Runs in `--dry-run` for now: it logs the intended edits without touching any
-# PR. Drop `--dry-run` once the output has been validated.
+# Runs hourly with a 1-day lookback: each run reconciles PRs merged in the last
+# day, plus any original pulled in by a backport merged in that window.
 
 workflow = Workflow.Config(
     name="PRVersionInfo",
@@ -16,7 +16,7 @@ workflow = Workflow.Config(
     jobs=[
         Job.Config(
             name="Update PR version info",
-            command="python3 ./tests/ci/pr_version_info.py --dry-run",
+            command="python3 ./tests/ci/pr_version_info.py --days 1",
             runs_on=RunnerLabels.STYLE_CHECK_ARM,
             enable_gh_auth=True,
         ),

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -228,10 +228,25 @@ class GitHub(github.Github):
                     "POST", url, input={"query": query, "variables": variables}
                 )
                 # GraphQL reports query errors with HTTP 200 and an `errors` key,
-                # so `requestJsonAndCheck` does not raise on them.
-                if data.get("errors"):
-                    raise GithubException(200, data["errors"], None)
-                return data["data"]
+                # so `requestJsonAndCheck` does not raise on them. A query can be
+                # partially successful: e.g. a `pullRequest(number: N)` alias for
+                # a number that does not exist in this repo returns `null` for
+                # that field plus a NOT_FOUND error, while the other aliases
+                # resolve. Use whatever `data` resolved; only raise when nothing
+                # came back at all (malformed query, auth failure, ...).
+                payload = data.get("data")
+                errors = data.get("errors")
+                if payload is None:
+                    raise GithubException(
+                        200, errors or "GraphQL query returned no data", None
+                    )
+                if errors:
+                    logger.warning(
+                        "GraphQL returned %s error(s); using partial data: %s",
+                        len(errors),
+                        errors[0].get("message", errors[0]),
+                    )
+                return payload
             except RateLimitExceededException:
                 if i == self.retries - 1:
                     raise
@@ -315,6 +330,44 @@ class GitHub(github.Github):
                 node = (repository or {}).get(f"pr{n}")
                 if node:
                     result[n] = self._pr_info_from_node(node)
+        return result
+
+    def get_backport_merge_commits(
+        self, repo_name: str, head_refs: List[str]
+    ) -> Dict[str, Optional[str]]:
+        """For each backport branch name, return the merge commit SHA of the
+        merged PR opened from it (or ``None`` if there is none), batching many
+        head refs per GraphQL request.
+
+        Replaces one REST `get_pulls(head=...)` request per backport branch --
+        which at a large lookback fans out into thousands of calls and trips
+        GitHub's secondary rate limit -- with a handful of GraphQL queries.
+        """
+        owner, name = repo_name.split("/")
+        result = {}  # type: Dict[str, Optional[str]]
+        batch_size = 50
+        for start in range(0, len(head_refs), batch_size):
+            batch = head_refs[start : start + batch_size]
+            aliases = " ".join(
+                f'b{i}: pullRequests(headRefName: "{head}", states: MERGED, '
+                "first: 1) { nodes { mergeCommit { oid } } }"
+                for i, head in enumerate(batch)
+            )
+            gql = (
+                "query($owner:String!, $name:String!) {"
+                f"  repository(owner:$owner, name:$name) {{ {aliases} }}"
+                "}"
+            )
+            repository = (
+                self._graphql(gql, {"owner": owner, "name": name})["repository"] or {}
+            )
+            for i, head in enumerate(batch):
+                node = repository.get(f"b{i}")
+                oid = None
+                if node and node["nodes"]:
+                    merge_commit = node["nodes"][0].get("mergeCommit")
+                    oid = merge_commit.get("oid") if merge_commit else None
+                result[head] = oid
         return result
 
     def sleep_on_rate_limit(self) -> None:

--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -2,11 +2,13 @@
 """Helper for GitHub API requests"""
 import logging
 import re
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from os import path as p
 from pathlib import Path
 from time import sleep
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import github
 import requests
@@ -15,6 +17,7 @@ import requests
 # pylint: disable=useless-import-alias
 from github.AuthenticatedUser import AuthenticatedUser
 from github.GithubException import (
+    GithubException as GithubException,
     RateLimitExceededException as RateLimitExceededException,
 )
 from github.Issue import Issue as Issue
@@ -30,6 +33,34 @@ logger = logging.getLogger(__name__)
 
 PullRequests = List[PullRequest]
 Issues = List[Issue]
+
+# How many PRs to fetch concurrently in `get_pulls_from_search`. The GitHub
+# search API returns issues, and each one still needs a `get_pull` request; those
+# requests are independent, so fetching them in parallel turns an O(N) sequence
+# of round-trips into a handful of waves.
+DEFAULT_FETCH_THREADS = 12
+
+
+@dataclass
+class PullRequestInfo:
+    """Lightweight, read-only view of a pull request fetched via GraphQL.
+
+    Carries only the fields needed for bulk classification and body edits, so a
+    whole search result set can be retrieved in a few batched GraphQL requests
+    instead of one REST request per PR. To mutate a PR (e.g. `PullRequest.edit`)
+    fetch the full object via `GitHub.get_pull_cached` for the few that change.
+    """
+
+    number: int
+    head_ref: str
+    base_ref: str
+    label_names: List[str]
+    merged: bool
+    merge_commit_sha: Optional[str]
+    body: str
+    node_id: str
+    html_url: str
+    repo: str
 
 
 class GitHub(github.Github):
@@ -115,20 +146,33 @@ class GitHub(github.Github):
         progress_func = kwargs.pop(
             "progress_func", lambda x: x
         )  # type: Callable[[Issues], Issues]
+        threads = kwargs.pop("threads", DEFAULT_FETCH_THREADS)
         issues = self.search_issues(*args, **kwargs)
-        repos = {}
-        prs = []  # type: PullRequests
-        for issue in progress_func(issues):
-            # See https://github.com/PyGithub/PyGithub/issues/2202,
-            # obj._rawData doesn't spend additional API requests
-            # pylint: disable=protected-access
+
+        # See https://github.com/PyGithub/PyGithub/issues/2202,
+        # obj._rawData doesn't spend additional API requests
+        # pylint: disable=protected-access
+        repos = {}  # type: Dict[str, Repository]
+        # Resolve the repository objects up front (cheap, usually a single repo)
+        # so the parallel fetch below neither races to populate `repos` nor
+        # triggers a lazy `issue.repository` API call from a worker thread.
+        for issue in issues:
             repo_url = issue._rawData["repository_url"]
             if repo_url not in repos:
                 repos[repo_url] = issue.repository
-            prs.append(
-                self.get_pull_cached(repos[repo_url], issue.number, issue.updated_at)
-            )
-        return prs
+
+        def _fetch(issue: Issue) -> PullRequest:
+            repo_url = issue._rawData["repository_url"]
+            return self.get_pull_cached(repos[repo_url], issue.number, issue.updated_at)
+
+        if threads <= 1 or len(issues) <= 1:
+            return [_fetch(issue) for issue in progress_func(issues)]
+
+        # Each `get_pull` is an independent request and each PR is cached to its
+        # own file, so the fetches parallelize without shared mutable state.
+        # `executor.map` preserves input order, keeping the result deterministic.
+        with ThreadPoolExecutor(max_workers=threads) as executor:
+            return list(progress_func(executor.map(_fetch, issues)))
 
     def get_release_pulls(self, repo_name: str) -> PullRequests:
         prs = self.get_pulls_from_search(
@@ -142,6 +186,136 @@ class GitHub(github.Github):
         # Ensure that the answer from GitHub is correct (we should always have some releases)
         assert prs
         return prs
+
+    # The exact set of fields `PullRequestInfo` needs, shared by both GraphQL
+    # entry points below.
+    _GRAPHQL_PR_FIELDS = """
+        number
+        headRefName
+        baseRefName
+        merged
+        body
+        id
+        url
+        mergeCommit { oid }
+        labels(first: 100) { nodes { name } }
+        baseRepository { nameWithOwner }
+    """
+
+    @staticmethod
+    def _pr_info_from_node(node: dict) -> PullRequestInfo:
+        merge_commit = node["mergeCommit"] or {}
+        return PullRequestInfo(
+            number=node["number"],
+            head_ref=node["headRefName"],
+            base_ref=node["baseRefName"],
+            label_names=[label["name"] for label in node["labels"]["nodes"]],
+            merged=node["merged"],
+            merge_commit_sha=merge_commit.get("oid"),
+            body=node["body"] or "",
+            node_id=node["id"],
+            html_url=node["url"],
+            repo=node["baseRepository"]["nameWithOwner"],
+        )
+
+    def _graphql(self, query: str, variables: dict) -> dict:
+        # pylint: disable=protected-access
+        requester = self._Github__requester  # type: ignore
+        url = f"{requester.base_url}/graphql"
+        for i in range(self.retries):
+            try:
+                _, data = requester.requestJsonAndCheck(
+                    "POST", url, input={"query": query, "variables": variables}
+                )
+                # GraphQL reports query errors with HTTP 200 and an `errors` key,
+                # so `requestJsonAndCheck` does not raise on them.
+                if data.get("errors"):
+                    raise GithubException(200, data["errors"], None)
+                return data["data"]
+            except RateLimitExceededException:
+                if i == self.retries - 1:
+                    raise
+                self.sleep_on_rate_limit()
+        raise RuntimeError("Unreachable: GraphQL retry loop exited without result")
+
+    def get_pulls_lightweight(
+        self, query: str, merged: Optional[List[datetime]] = None
+    ) -> List[PullRequestInfo]:
+        """Fetch lightweight PR records matching a search `query` via GraphQL.
+
+        A single GraphQL request returns up to 100 PRs, versus one REST request
+        per PR in `get_pulls_from_search`. The GitHub search index caps any one
+        query at 1000 results, so when `merged=[since, until]` is given and a
+        sub-range would exceed that, the range is split in half and re-queried --
+        mirroring `search_issues`. Results are de-duplicated by PR number.
+        """
+        gql = (
+            "query($q:String!, $after:String) {"
+            "  search(query:$q, type:ISSUE, first:100, after:$after) {"
+            "    issueCount pageInfo { hasNextPage endCursor }"
+            "    nodes { ... on PullRequest {" + self._GRAPHQL_PR_FIELDS + "} }"
+            "  }"
+            "}"
+        )
+        found = {}  # type: Dict[int, PullRequestInfo]
+
+        def run(since: Optional[datetime], until: Optional[datetime]) -> None:
+            q = query
+            if since is not None:
+                q = f"{query} merged:{since.isoformat()}..{until.isoformat()}"
+            after = None
+            first_page = True
+            while True:
+                search = self._graphql(gql, {"q": q, "after": after})["search"]
+                if first_page and since is not None and search["issueCount"] > 1000:
+                    middle = since + (until - since) / 2
+                    if since < middle < until:
+                        run(since, middle)
+                        run(middle, until)
+                        return
+                first_page = False
+                for node in search["nodes"]:
+                    if node:  # search also returns plain issues -> empty fragment
+                        info = self._pr_info_from_node(node)
+                        found[info.number] = info
+                if not search["pageInfo"]["hasNextPage"]:
+                    return
+                after = search["pageInfo"]["endCursor"]
+
+        if merged is not None:
+            assert len(merged) == 2
+            run(merged[0], merged[1])
+        else:
+            run(None, None)
+        return list(found.values())
+
+    def get_pulls_lightweight_by_numbers(
+        self, repo_name: str, numbers: List[int]
+    ) -> Dict[int, PullRequestInfo]:
+        """Fetch lightweight PR records for explicit PR numbers via GraphQL,
+        batching many PRs per request using field aliases."""
+        owner, name = repo_name.split("/")
+        result = {}  # type: Dict[int, PullRequestInfo]
+        batch_size = 50
+        for start in range(0, len(numbers), batch_size):
+            batch = numbers[start : start + batch_size]
+            aliases = " ".join(
+                f"pr{n}: pullRequest(number: {n}) {{{self._GRAPHQL_PR_FIELDS}}}"
+                for n in batch
+            )
+            gql = (
+                "query($owner:String!, $name:String!) {"
+                f"  repository(owner:$owner, name:$name) {{ {aliases} }}"
+                "}"
+            )
+            repository = self._graphql(gql, {"owner": owner, "name": name})[
+                "repository"
+            ]
+            for n in batch:
+                node = (repository or {}).get(f"pr{n}")
+                if node:
+                    result[n] = self._pr_info_from_node(node)
+        return result
 
     def sleep_on_rate_limit(self) -> None:
         for limit, data in self.get_rate_limit().raw_data.items():

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -334,7 +334,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> None:
+def main() -> int:
     from clickhouse_helper import ClickHouseHelper
     from get_robot_token import get_best_robot_token
     from github_helper import GitHub
@@ -409,8 +409,23 @@ def main() -> None:
             logging.error("Failed to process PR #%s: %s", number, ex)
 
     logging.info("Done. Updated %s PR(s)", updated)
+    return updated
 
 
 if __name__ == "__main__":
     logging.getLogger().setLevel(level=logging.INFO)
-    main()
+    # Imported here (not at module top) so the pure helpers stay importable for
+    # unit tests without the praktika package on the path.
+    from ci.praktika.result import Result
+
+    status = Result.Status.OK
+    info = ""
+    try:
+        info = f"Updated {main()} PR(s)"
+    except Exception as error:  # pylint: disable=broad-except
+        status = Result.Status.FAIL
+        info = f"ERROR: {error}"
+        logging.exception("pr_version_info failed")
+    # Emit a praktika Result so the job is reported as completed; a plain
+    # command that exits 0 without a Result is otherwise treated as killed.
+    Result.create_from(status=status, info=info).complete_job()

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -379,12 +379,21 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     from ci.jobs.scripts.cidb_cluster import CIDBCluster
+    from ci.praktika.info import Info
     from get_robot_token import get_best_robot_token
     from github_helper import GitHub
 
     args = parse_args()
     token = args.token or get_best_robot_token()
     owner = args.repo.split("/")[0]
+
+    # A manual run can widen the lookback via the `days` workflow_dispatch input;
+    # it overrides the command's --days. Absent/empty (scheduled runs) -> --days.
+    days = args.days
+    dispatch_days = Info.get_workflow_input_value("days")
+    if dispatch_days and dispatch_days.strip().isdigit():
+        days = int(dispatch_days)
+        logging.info("Using lookback from workflow input: %s days", days)
 
     gh = GitHub(token, per_page=100)
     repo = gh.get_repo(args.repo)
@@ -393,16 +402,14 @@ def main() -> int:
     logging.info("Active release branches: %s", release_branches)
 
     now = datetime.now()
-    since = now - timedelta(days=args.days)
+    since = now - timedelta(days=days)
     # Lightweight GraphQL fetch: a few batched requests for the whole window,
     # instead of one REST request per merged PR.
     merged_infos = gh.get_pulls_lightweight(
         query=f"type:pr repo:{args.repo} is:merged",
         merged=[since, now],
     )
-    logging.info(
-        "Found %s merged PRs in the last %s days", len(merged_infos), args.days
-    )
+    logging.info("Found %s merged PRs in the last %s days", len(merged_infos), days)
 
     infos_by_number = {info.number: info for info in merged_infos}
     backport_numbers, original_numbers, need_scan = partition_merged_prs(

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -50,7 +50,6 @@ import argparse
 import logging
 import re
 import threading
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
@@ -256,34 +255,48 @@ def scan_backport_versions(
     release_branches: List[str],
     version_history: VersionHistory,
     threads: int,
-) -> Dict[int, List[str]]:
+) -> Tuple[Dict[int, List[str]], Set[int]]:
     """Resolve, for each original PR number, the versions its merged backports
     shipped in by scanning every active release branch.
 
-    Each ``(number, release)`` pair is an independent REST lookup, so they run
-    concurrently. Returns ``{number: [versions, newest first]}``.
+    Each original is scanned by its own worker, so the scans run concurrently
+    while keeping failures isolated per original: if any release-branch lookup
+    for an original fails, that original is reported in the returned ``failed``
+    set and left out of the versions map. The caller must skip those originals
+    rather than write a partial `Backported to` list (fail closed). Returns
+    ``({number: [versions, newest first]}, failed_numbers)``.
     """
-    tasks = [(number, release) for number in numbers for release in release_branches]
-    by_number: Dict[int, List[str]] = defaultdict(list)
-    if not tasks:
-        return {}
+    by_number: Dict[int, List[str]] = {}
+    failed: Set[int] = set()
+    if not numbers:
+        return by_number, failed
 
-    def work(task: Tuple[int, str]) -> Tuple[int, Optional[str]]:
-        number, release = task
-        backport_pr = get_backport_pr(repo, owner, release, number)
-        if backport_pr is None or backport_pr.merged_at is None:
-            return number, None
-        return number, version_history.version_for_commit(backport_pr.merge_commit_sha)
+    def scan_one(number: int) -> List[str]:
+        versions: List[str] = []
+        for release in release_branches:
+            backport_pr = get_backport_pr(repo, owner, release, number)
+            if backport_pr is None or backport_pr.merged_at is None:
+                continue
+            version = version_history.version_for_commit(backport_pr.merge_commit_sha)
+            if version:
+                versions.append(version)
+        return sorted(set(versions), key=version_key, reverse=True)
+
+    def work(number: int) -> Tuple[int, Optional[List[str]], Optional[Exception]]:
+        try:
+            return number, scan_one(number), None
+        except Exception as ex:  # pylint: disable=broad-except
+            return number, None, ex
 
     with ThreadPoolExecutor(max_workers=max(1, threads)) as executor:
-        for number, version in executor.map(work, tasks):
-            if version:
-                by_number[number].append(version)
+        for number, versions, error in executor.map(work, numbers):
+            if error is not None:
+                logging.error("Failed to scan backports for PR #%s: %s", number, error)
+                failed.add(number)
+            else:
+                by_number[number] = versions
 
-    return {
-        number: sorted(set(versions), key=version_key, reverse=True)
-        for number, versions in by_number.items()
-    }
+    return by_number, failed
 
 
 def update_original_pr(
@@ -372,14 +385,26 @@ def main() -> int:
 
     # Originals referenced only by a backport (merged later, after the original
     # left the lookback window) are not in the window result; fetch them in one
-    # batched GraphQL request.
+    # batched GraphQL request. A failure here must not abort the run -- any
+    # original we could not fetch simply stays absent and is skipped below.
     missing = [n for n in original_numbers if n not in infos_by_number]
     if missing:
-        infos_by_number.update(gh.get_pulls_lightweight_by_numbers(args.repo, missing))
+        try:
+            infos_by_number.update(
+                gh.get_pulls_lightweight_by_numbers(args.repo, missing)
+            )
+        except Exception as ex:  # pylint: disable=broad-except
+            logging.error(
+                "Failed to fetch %s referenced original PR(s); they will be "
+                "skipped and reconciled next run: %s",
+                len(missing),
+                ex,
+            )
 
     # Resolve every scanned original's backports up front, in parallel -- the
-    # only remaining per-PR REST traffic.
-    backported_by_number = scan_backport_versions(
+    # only remaining per-PR REST traffic. `scan_failed` holds originals whose
+    # scan errored; they are skipped below so we never write a partial list.
+    backported_by_number, scan_failed = scan_backport_versions(
         repo, owner, sorted(need_scan), release_branches, version_history, args.threads
     )
 
@@ -395,6 +420,9 @@ def main() -> int:
         info = infos_by_number.get(number)
         if info is None:
             logging.error("Could not fetch PR #%s, skipping", number)
+            continue
+        if number in scan_failed:
+            logging.error("Skipping PR #%s: backport scan incomplete", number)
             continue
         try:
             updated += update_original_pr(

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -40,8 +40,10 @@ the private repo's `release/<x.y>` head refs (and the resulting
 `backport/release/<x.y>/<number>` branches) are matched the same way as the
 public repo's bare `<x.y>` names. Versions are matched by `commit_sha`, which is
 unique per merge commit per repo, so there is no cross-repo mismatch. It does
-require that the repo's CI populates `version_history` in the CIDB reachable via
-the `clickhouse-test-stat-*` SSM parameters.
+require that the repo's CI populates `version_history` in the CIDB; reads use
+`CIDBCluster`, which resolves the same `Settings.SECRET_CI_DB_*` credentials
+that `version_log.py` writes with (the public `clickhouse-test-stat-*` params
+or the private `PRIVATE_CI_DB_*` secrets), so the workflow must declare them.
 """
 
 from __future__ import annotations
@@ -180,14 +182,21 @@ def partition_merged_prs(
 class VersionHistory:
     """Reads versions from the CIDB `version_history` table, with a SHA cache."""
 
-    def __init__(self, ch_helper) -> None:
-        self.ch = ch_helper
+    def __init__(self, cidb) -> None:
+        # `cidb` is a CIDBCluster; it resolves the CIDB credentials from the
+        # workflow secrets (Settings.SECRET_CI_DB_*), which map to the public
+        # `clickhouse-test-stat-*` params or the private `PRIVATE_CI_DB_*`
+        # secrets -- the same cluster `version_log.py` writes `version_history`
+        # to, so reads and writes always agree.
+        self.cidb = cidb
         self._cache: Dict[str, Optional[str]] = {}
         # Guards `_cache` so the lookup can be shared by parallel backport scans.
         self._lock = threading.Lock()
 
     def version_for_commit(self, sha: Optional[str]) -> Optional[str]:
-        if not sha:
+        # `do_select_query` does not bind parameters, so only a real git oid
+        # (hex) is ever interpolated into the query text.
+        if not sha or not re.fullmatch(r"[0-9a-fA-F]+", sha):
             return None
         with self._lock:
             if sha in self._cache:
@@ -195,14 +204,14 @@ class VersionHistory:
         # The query runs outside the lock so concurrent lookups for different
         # commits do not serialize; a duplicate query for the same sha is rare
         # and harmless.
-        rows = self.ch.select_json_each_row(
-            CIDB_DATABASE,
+        text = self.cidb.do_select_query(
             "SELECT version FROM version_history "
-            "WHERE commit_sha = {sha:String} "
-            "ORDER BY check_start_time DESC LIMIT 1",
-            query_params={"sha": sha},
+            f"WHERE commit_sha = '{sha}' "
+            "ORDER BY check_start_time DESC LIMIT 1 "
+            "FORMAT TabSeparated",
+            db_name=CIDB_DATABASE,
         )
-        version = rows[0]["version"] if rows else None
+        version = (text or "").strip() or None
         with self._lock:
             self._cache[sha] = version
         return version
@@ -348,7 +357,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
-    from clickhouse_helper import ClickHouseHelper
+    from ci.jobs.scripts.cidb_cluster import CIDBCluster
     from get_robot_token import get_best_robot_token
     from github_helper import GitHub
 
@@ -358,7 +367,7 @@ def main() -> int:
 
     gh = GitHub(token, per_page=100)
     repo = gh.get_repo(args.repo)
-    version_history = VersionHistory(ClickHouseHelper())
+    version_history = VersionHistory(CIDBCluster())
     release_branches = [pr.head.ref for pr in gh.get_release_pulls(args.repo)]
     logging.info("Active release branches: %s", release_branches)
 

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -52,13 +52,9 @@ import argparse
 import logging
 import re
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
-
-# How many release-branch backport lookups to run concurrently. These are the
-# only per-PR REST requests left after the lightweight GraphQL window fetch.
-DEFAULT_SCAN_THREADS = 12
 
 # Heavy imports (github, clickhouse_helper, ...) are done lazily inside main() so
 # that the pure helpers below stay importable for unit tests without PyGithub.
@@ -238,16 +234,6 @@ class VersionHistory:
         return version
 
 
-def get_backport_pr(repo, owner: str, release: str, number: int):
-    """Return the (merged, if any) backport PR for ``number`` on ``release``."""
-    head = f"{owner}:backport/{release}/{number}"
-    candidates = list(repo.get_pulls(state="all", head=head))
-    merged = [pr for pr in candidates if pr.merged_at is not None]
-    if merged:
-        return merged[0]
-    return candidates[0] if candidates else None
-
-
 def apply_section(gh, repo, info, section_body: str, dry_run: bool) -> bool:
     """Write the section into the PR if it changed. Returns True if changed.
 
@@ -279,54 +265,53 @@ def update_backport_pr(
 
 
 def scan_backport_versions(
-    repo,
-    owner: str,
+    gh,
+    repo_name: str,
     numbers: List[int],
     release_branches: List[str],
     version_history: VersionHistory,
-    threads: int,
 ) -> Tuple[Dict[int, List[str]], Set[int]]:
     """Resolve, for each original PR number, the versions its merged backports
-    shipped in by scanning every active release branch.
+    shipped in by looking up `backport/<release>/<number>` on every release.
 
-    Each original is scanned by its own worker, so the scans run concurrently
-    while keeping failures isolated per original: if any release-branch lookup
-    for an original fails, that original is reported in the returned ``failed``
-    set and left out of the versions map. The caller must skip those originals
-    rather than write a partial `Backported to` list (fail closed). Returns
-    ``({number: [versions, newest first]}, failed_numbers)``.
+    The lookups for all ``(number, release)`` pairs are resolved with a few
+    batched GraphQL requests rather than one REST request per pair, which keeps
+    a wide lookback from tripping GitHub's secondary rate limit. Returns
+    ``({number: [versions, newest first]}, failed_numbers)``; on a hard query
+    failure every scanned original is reported failed so the caller skips it
+    (fail closed -- never write a partial `Backported to` list).
     """
-    by_number: Dict[int, List[str]] = {}
-    failed: Set[int] = set()
-    if not numbers:
-        return by_number, failed
+    if not numbers or not release_branches:
+        return {}, set()
 
-    def scan_one(number: int) -> List[str]:
-        versions: List[str] = []
-        for release in release_branches:
-            backport_pr = get_backport_pr(repo, owner, release, number)
-            if backport_pr is None or backport_pr.merged_at is None:
-                continue
-            version = version_history.version_for_commit(backport_pr.merge_commit_sha)
-            if version:
-                versions.append(version)
-        return sorted(set(versions), key=version_key, reverse=True)
+    pairs = [(number, release) for number in numbers for release in release_branches]
+    head_refs = [f"backport/{release}/{number}" for number, release in pairs]
+    try:
+        merge_commits = gh.get_backport_merge_commits(repo_name, head_refs)
+    except Exception as ex:  # pylint: disable=broad-except
+        logging.error(
+            "Backport scan failed; %s originals will be reconciled next run: %s",
+            len(numbers),
+            ex,
+        )
+        return {}, set(numbers)
 
-    def work(number: int) -> Tuple[int, Optional[List[str]], Optional[Exception]]:
-        try:
-            return number, scan_one(number), None
-        except Exception as ex:  # pylint: disable=broad-except
-            return number, None, ex
+    by_number: Dict[int, List[str]] = defaultdict(list)
+    for number, release in pairs:
+        oid = merge_commits.get(f"backport/{release}/{number}")
+        if not oid:
+            continue
+        version = version_history.version_for_commit(oid)
+        if version:
+            by_number[number].append(version)
 
-    with ThreadPoolExecutor(max_workers=max(1, threads)) as executor:
-        for number, versions, error in executor.map(work, numbers):
-            if error is not None:
-                logging.error("Failed to scan backports for PR #%s: %s", number, error)
-                failed.add(number)
-            else:
-                by_number[number] = versions
-
-    return by_number, failed
+    return (
+        {
+            number: sorted(set(versions), key=version_key, reverse=True)
+            for number, versions in by_number.items()
+        },
+        set(),
+    )
 
 
 def update_original_pr(
@@ -368,12 +353,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dry-run", action="store_true", help="do not edit any PR, only print"
     )
-    parser.add_argument(
-        "--threads",
-        type=int,
-        default=DEFAULT_SCAN_THREADS,
-        help="concurrent backport-branch lookups",
-    )
     return parser.parse_args()
 
 
@@ -385,7 +364,6 @@ def main() -> int:
 
     args = parse_args()
     token = args.token or get_best_robot_token()
-    owner = args.repo.split("/")[0]
 
     # A manual run can widen the lookback via the `days` workflow_dispatch input;
     # it overrides the command's --days. Absent/empty (scheduled runs) -> --days.
@@ -449,16 +427,15 @@ def main() -> int:
         if release:
             scan_release_branches.add(release)
 
-    # Resolve every scanned original's backports up front, in parallel -- the
-    # only remaining per-PR REST traffic. `scan_failed` holds originals whose
-    # scan errored; they are skipped below so we never write a partial list.
+    # Resolve every scanned original's backports up front via batched GraphQL.
+    # `scan_failed` holds originals whose scan errored; they are skipped below so
+    # we never write a partial list.
     backported_by_number, scan_failed = scan_backport_versions(
-        repo,
-        owner,
+        gh,
+        args.repo,
         sorted(need_scan),
         sorted(scan_release_branches),
         version_history,
-        args.threads,
     )
 
     updated = 0

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -49,8 +49,15 @@ from __future__ import annotations
 import argparse
 import logging
 import re
+import threading
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
+
+# How many release-branch backport lookups to run concurrently. These are the
+# only per-PR REST requests left after the lightweight GraphQL window fetch.
+DEFAULT_SCAN_THREADS = 12
 
 # Heavy imports (github, clickhouse_helper, ...) are done lazily inside main() so
 # that the pure helpers below stay importable for unit tests without PyGithub.
@@ -177,12 +184,18 @@ class VersionHistory:
     def __init__(self, ch_helper) -> None:
         self.ch = ch_helper
         self._cache: Dict[str, Optional[str]] = {}
+        # Guards `_cache` so the lookup can be shared by parallel backport scans.
+        self._lock = threading.Lock()
 
     def version_for_commit(self, sha: Optional[str]) -> Optional[str]:
         if not sha:
             return None
-        if sha in self._cache:
-            return self._cache[sha]
+        with self._lock:
+            if sha in self._cache:
+                return self._cache[sha]
+        # The query runs outside the lock so concurrent lookups for different
+        # commits do not serialize; a duplicate query for the same sha is rare
+        # and harmless.
         rows = self.ch.select_json_each_row(
             CIDB_DATABASE,
             "SELECT version FROM version_history "
@@ -191,7 +204,8 @@ class VersionHistory:
             query_params={"sha": sha},
         )
         version = rows[0]["version"] if rows else None
-        self._cache[sha] = version
+        with self._lock:
+            self._cache[sha] = version
         return version
 
 
@@ -205,56 +219,92 @@ def get_backport_pr(repo, owner: str, release: str, number: int):
     return candidates[0] if candidates else None
 
 
-def apply_section(pr, section_body: str, dry_run: bool) -> bool:
-    """Write the section into ``pr`` if it changed. Returns True if changed."""
-    new_body = upsert_section(pr.body, section_body)
-    if new_body == (pr.body or ""):
+def apply_section(gh, repo, info, section_body: str, dry_run: bool) -> bool:
+    """Write the section into the PR if it changed. Returns True if changed.
+
+    ``info`` is the lightweight GraphQL record; a full ``PullRequest`` (needed to
+    call ``edit``) is fetched only when an edit is actually performed.
+    """
+    new_body = upsert_section(info.body, section_body)
+    if new_body == (info.body or ""):
         return False
     if dry_run:
-        print(f"DRY RUN: would update PR #{pr.number} version info:\n{section_body}\n")
+        print(
+            f"DRY RUN: would update PR #{info.number} version info:\n{section_body}\n"
+        )
         return True
+    pr = gh.get_pull_cached(repo, info.number)
     pr.edit(body=new_body)
-    logging.info("Updated PR #%s version info", pr.number)
+    logging.info("Updated PR #%s version info", info.number)
     return True
 
 
-def update_backport_pr(pr, version_history: VersionHistory, dry_run: bool) -> bool:
+def update_backport_pr(
+    gh, repo, info, version_history: VersionHistory, dry_run: bool
+) -> bool:
     """Set the `Merged into` line on a merged backport PR."""
-    version = version_history.version_for_commit(pr.merge_commit_sha)
+    version = version_history.version_for_commit(info.merge_commit_sha)
     if not version:
         return False
-    return apply_section(pr, render_section(version, []), dry_run)
+    return apply_section(gh, repo, info, render_section(version, []), dry_run)
+
+
+def scan_backport_versions(
+    repo,
+    owner: str,
+    numbers: List[int],
+    release_branches: List[str],
+    version_history: VersionHistory,
+    threads: int,
+) -> Dict[int, List[str]]:
+    """Resolve, for each original PR number, the versions its merged backports
+    shipped in by scanning every active release branch.
+
+    Each ``(number, release)`` pair is an independent REST lookup, so they run
+    concurrently. Returns ``{number: [versions, newest first]}``.
+    """
+    tasks = [(number, release) for number in numbers for release in release_branches]
+    by_number: Dict[int, List[str]] = defaultdict(list)
+    if not tasks:
+        return {}
+
+    def work(task: Tuple[int, str]) -> Tuple[int, Optional[str]]:
+        number, release = task
+        backport_pr = get_backport_pr(repo, owner, release, number)
+        if backport_pr is None or backport_pr.merged_at is None:
+            return number, None
+        return number, version_history.version_for_commit(backport_pr.merge_commit_sha)
+
+    with ThreadPoolExecutor(max_workers=max(1, threads)) as executor:
+        for number, version in executor.map(work, tasks):
+            if version:
+                by_number[number].append(version)
+
+    return {
+        number: sorted(set(versions), key=version_key, reverse=True)
+        for number, versions in by_number.items()
+    }
 
 
 def update_original_pr(
-    pr,
+    gh,
     repo,
-    owner: str,
+    info,
     version_history: VersionHistory,
-    release_branches: List[str],
-    scan_backports: bool,
+    backported: List[str],
     dry_run: bool,
 ) -> bool:
     """Set `Merged into` and `Backported to` on a merged original PR."""
-    if pr.merged_at is None:
+    if not info.merged:
         return False
-    merged_into = version_history.version_for_commit(pr.merge_commit_sha)
-
-    backported: List[str] = []
-    if scan_backports:
-        for release in release_branches:
-            backport_pr = get_backport_pr(repo, owner, release, pr.number)
-            if backport_pr is None or backport_pr.merged_at is None:
-                continue
-            version = version_history.version_for_commit(backport_pr.merge_commit_sha)
-            if version:
-                backported.append(version)
-        backported = sorted(set(backported), key=version_key, reverse=True)
+    merged_into = version_history.version_for_commit(info.merge_commit_sha)
 
     if not merged_into and not backported:
         # Nothing known yet -- the post-merge build has likely not finished.
         return False
-    return apply_section(pr, render_section(merged_into, backported), dry_run)
+    return apply_section(
+        gh, repo, info, render_section(merged_into, backported), dry_run
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -274,6 +324,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="do not edit any PR, only print"
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=DEFAULT_SCAN_THREADS,
+        help="concurrent backport-branch lookups",
     )
     return parser.parse_args()
 
@@ -295,46 +351,58 @@ def main() -> None:
 
     now = datetime.now()
     since = now - timedelta(days=args.days)
-    merged_prs = gh.get_pulls_from_search(
+    # Lightweight GraphQL fetch: a few batched requests for the whole window,
+    # instead of one REST request per merged PR.
+    merged_infos = gh.get_pulls_lightweight(
         query=f"type:pr repo:{args.repo} is:merged",
         merged=[since, now],
     )
-    logging.info("Found %s merged PRs in the last %s days", len(merged_prs), args.days)
+    logging.info(
+        "Found %s merged PRs in the last %s days", len(merged_infos), args.days
+    )
 
-    prs_by_number = {pr.number: pr for pr in merged_prs}
+    infos_by_number = {info.number: info for info in merged_infos}
     backport_numbers, original_numbers, need_scan = partition_merged_prs(
         (
-            MergedPR(
-                pr.number,
-                pr.head.ref,
-                pr.base.ref,
-                [label.name for label in pr.labels],
-            )
-            for pr in merged_prs
+            MergedPR(info.number, info.head_ref, info.base_ref, info.label_names)
+            for info in merged_infos
         ),
         repo.default_branch,
     )
 
+    # Originals referenced only by a backport (merged later, after the original
+    # left the lookback window) are not in the window result; fetch them in one
+    # batched GraphQL request.
+    missing = [n for n in original_numbers if n not in infos_by_number]
+    if missing:
+        infos_by_number.update(gh.get_pulls_lightweight_by_numbers(args.repo, missing))
+
+    # Resolve every scanned original's backports up front, in parallel -- the
+    # only remaining per-PR REST traffic.
+    backported_by_number = scan_backport_versions(
+        repo, owner, sorted(need_scan), release_branches, version_history, args.threads
+    )
+
     updated = 0
     for number in sorted(backport_numbers):
-        pr = prs_by_number[number]
+        info = infos_by_number[number]
         try:
-            updated += update_backport_pr(pr, version_history, args.dry_run)
+            updated += update_backport_pr(gh, repo, info, version_history, args.dry_run)
         except Exception as ex:  # pylint: disable=broad-except
             logging.error("Failed to process backport PR #%s: %s", number, ex)
 
     for number in sorted(original_numbers):
+        info = infos_by_number.get(number)
+        if info is None:
+            logging.error("Could not fetch PR #%s, skipping", number)
+            continue
         try:
-            # An original referenced only by a backport (merged later, after the
-            # original left the lookback window) is fetched on demand.
-            pr = prs_by_number.get(number) or gh.get_pull_cached(repo, number)
             updated += update_original_pr(
-                pr,
+                gh,
                 repo,
-                owner,
+                info,
                 version_history,
-                release_branches,
-                number in need_scan,
+                backported_by_number.get(number, []),
                 args.dry_run,
             )
         except Exception as ex:  # pylint: disable=broad-except

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -77,8 +77,9 @@ CIDB_DATABASE = "default"
 DEFAULT_LOOKBACK_DAYS = 30
 
 # Backport branches are named `backport/<release>/<original_pr_number>`; this
-# mirrors cherry_pick.py:ReleaseBranch.bp_branch.
-BACKPORT_BRANCH_RE = re.compile(r"^backport/.+/(\d+)$")
+# mirrors cherry_pick.py:ReleaseBranch.bp_branch. Group 1 is the release (which
+# may itself contain slashes, e.g. `release/26.5`), group 2 the original number.
+BACKPORT_BRANCH_RE = re.compile(r"^backport/(.+)/(\d+)$")
 
 # Mirrors tests/ci/pr_info.py:Labels -- a PR carrying any of these has (or is
 # meant to have) backports, so it is worth scanning release branches for them.
@@ -139,7 +140,13 @@ def upsert_section(body: Optional[str], section_body: str) -> str:
 def original_pr_number_from_backport_ref(head_ref: str) -> Optional[int]:
     """Extract the original PR number from a `backport/<release>/<number>` ref."""
     match = BACKPORT_BRANCH_RE.match(head_ref)
-    return int(match.group(1)) if match else None
+    return int(match.group(2)) if match else None
+
+
+def release_from_backport_ref(head_ref: str) -> Optional[str]:
+    """Extract the release branch from a `backport/<release>/<number>` ref."""
+    match = BACKPORT_BRANCH_RE.match(head_ref)
+    return match.group(1) if match else None
 
 
 def has_backport_label(label_names: List[str]) -> bool:
@@ -424,11 +431,27 @@ def main() -> int:
                 ex,
             )
 
+    # Release branches to scan = the currently-open releases plus any release a
+    # backport merged into this window. The latter catches releases whose
+    # `release` PR is already closed (so they are not in `release_branches`) but
+    # that still receive backports -- otherwise the original's `Backported to`
+    # would miss those versions.
+    scan_release_branches = set(release_branches)
+    for number in backport_numbers:
+        release = release_from_backport_ref(infos_by_number[number].head_ref)
+        if release:
+            scan_release_branches.add(release)
+
     # Resolve every scanned original's backports up front, in parallel -- the
     # only remaining per-PR REST traffic. `scan_failed` holds originals whose
     # scan errored; they are skipped below so we never write a partial list.
     backported_by_number, scan_failed = scan_backport_versions(
-        repo, owner, sorted(need_scan), release_branches, version_history, args.threads
+        repo,
+        owner,
+        sorted(need_scan),
+        sorted(scan_release_branches),
+        version_history,
+        args.threads,
     )
 
     updated = 0

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -90,6 +90,16 @@ BACKPORT_LABELS = {
 }
 VERSION_BACKPORT_LABEL_RE = re.compile(r"^v\d+\.\d+-must-backport$")
 
+# PRs carrying any of these labels are skipped entirely. These are the
+# automated periodic upstream-sync PRs in the private fork ("Automatic
+# synchronization with upstream"); they are not real changes that ship in a
+# release, so they get no version-info section.
+IGNORE_LABELS = {"pr-periodic-sync-upstream"}
+
+
+def has_ignore_label(label_names: List[str]) -> bool:
+    return any(name in IGNORE_LABELS for name in label_names)
+
 
 def version_key(version: str) -> Tuple[int, ...]:
     """Sort key for version strings like ``26.6.1.1``."""
@@ -162,11 +172,15 @@ def partition_merged_prs(
       * ``need_scan`` -- originals worth scanning the release branches for
         backports: any original referenced by a backport, plus originals that
         carry a backport label.
+
+    PRs carrying an ignore label (see ``IGNORE_LABELS``) are dropped entirely.
     """
     backport_numbers: Set[int] = set()
     original_numbers: Set[int] = set()
     need_scan: Set[int] = set()
     for pr in prs:
+        if has_ignore_label(pr.label_names):
+            continue
         original_number = original_pr_number_from_backport_ref(pr.head_ref)
         if original_number is not None:
             backport_numbers.add(pr.number)
@@ -429,6 +443,10 @@ def main() -> int:
         info = infos_by_number.get(number)
         if info is None:
             logging.error("Could not fetch PR #%s, skipping", number)
+            continue
+        if has_ignore_label(info.label_names):
+            # An on-demand original (pulled in by a backport) may still carry an
+            # ignore label; `partition_merged_prs` only saw the in-window PRs.
             continue
         if number in scan_failed:
             logging.error("Skipping PR #%s: backport scan incomplete", number)

--- a/tests/ci/test_pr_version_info.py
+++ b/tests/ci/test_pr_version_info.py
@@ -18,6 +18,7 @@ from pr_version_info import (
     has_ignore_label,
     original_pr_number_from_backport_ref,
     partition_merged_prs,
+    release_from_backport_ref,
     render_section,
     upsert_section,
     version_key,
@@ -112,6 +113,13 @@ class TestBackportRefParsing(unittest.TestCase):
     def test_non_backport_ref(self):
         self.assertIsNone(original_pr_number_from_backport_ref("my-feature-branch"))
         self.assertIsNone(original_pr_number_from_backport_ref("cherrypick/25.12/1"))
+
+    def test_release_extraction(self):
+        self.assertEqual(release_from_backport_ref("backport/25.12/92538"), "25.12")
+        self.assertEqual(
+            release_from_backport_ref("backport/release/26.5/58548"), "release/26.5"
+        )
+        self.assertIsNone(release_from_backport_ref("my-feature-branch"))
 
 
 class TestHasBackportLabel(unittest.TestCase):

--- a/tests/ci/test_pr_version_info.py
+++ b/tests/ci/test_pr_version_info.py
@@ -15,6 +15,7 @@ from pr_version_info import (
     SECTION_START,
     MergedPR,
     has_backport_label,
+    has_ignore_label,
     original_pr_number_from_backport_ref,
     partition_merged_prs,
     render_section,
@@ -159,6 +160,31 @@ class TestPartitionMergedPRs(unittest.TestCase):
         prs = [MergedPR(300, "some-fix", "25.12", [])]
         backports, originals, need_scan = partition_merged_prs(prs, "master")
         self.assertEqual((backports, originals, need_scan), (set(), set(), set()))
+
+    def test_ignore_label_pr_is_dropped(self):
+        # The automated periodic upstream-sync PR merges to master but must not
+        # get a version-info section.
+        prs = [
+            MergedPR(
+                400, "sync-upstream/master", "master", ["pr-periodic-sync-upstream"]
+            ),
+            MergedPR(401, "feature-branch", "master", ["pr-must-backport"]),
+        ]
+        backports, originals, need_scan = partition_merged_prs(prs, "master")
+        self.assertEqual(backports, set())
+        self.assertEqual(originals, {401})
+        self.assertEqual(need_scan, {401})
+
+
+class TestHasIgnoreLabel(unittest.TestCase):
+    def test_periodic_sync_label(self):
+        self.assertTrue(has_ignore_label(["pr-periodic-sync-upstream"]))
+
+    def test_other_labels(self):
+        self.assertFalse(has_ignore_label(["pr-sync-upstream", "pr-backport"]))
+
+    def test_no_labels(self):
+        self.assertFalse(has_ignore_label([]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The scheduled `PRVersionInfo` job (added in #108064) spends ~20 minutes per run fetching the merged-PR window. `get_pulls_from_search` issues the GitHub search query (cheap) and then one `get_pull` REST request **per result** — with ~1500 PRs merged in the 30-day window that is ~1500 sequential round-trips, and the on-disk PR cache is empty on the ephemeral CI runner so every run pays the full cost. See the ~28-minute run: https://github.com/ClickHouse/ClickHouse/actions/runs/28029878313

This PR makes two improvements in `tests/ci/github_helper.py`:

- **Parallelize** the per-PR fetch in `get_pulls_from_search` with a thread pool (`threads` kwarg, default 12). Each `get_pull` is an independent request and each PR is cached to its own file, so the fetches parallelize without shared mutable state; `executor.map` preserves input order. This speeds up every caller (`cherry_pick`, `changelog`, the synchronizers, ...).
- **GraphQL batch fetch**: add `PullRequestInfo` plus `get_pulls_lightweight` and `get_pulls_lightweight_by_numbers`. One GraphQL request returns up to 100 PRs with only the fields needed for classification and body edits, versus one REST request per PR. The 1000-result search cap is handled by splitting the date range, mirroring `search_issues`.

`tests/ci/pr_version_info.py` now uses the GraphQL path for the merged-PR window and batches the on-demand originals; the per-original release-branch backport scan runs in parallel (`scan_backport_versions`, `--threads`), and `VersionHistory` is made thread-safe. The full `PullRequest` object is fetched only for the few PRs whose body actually changes.

Validated end-to-end against the live API (dry-run): over a 30-day window the GraphQL window fetch returns ~1700 unique PRs in ~40s (vs ~20 min via REST), de-duplicated, with the range-split path exercised; the parallel backport scan and `Backported to` assembly were verified against known backport sets. Existing unit tests in `tests/ci/test_pr_version_info.py` pass (the pure helpers are unchanged).

Related: https://github.com/ClickHouse/ClickHouse/pull/108064

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.61`
<!-- ch-version-info:end -->