### PR TITLE
Make RabbitMQ direct selects tolerate slow consumption

### DIFF
--- a/tests/integration/test_storage_rabbitmq/__init__.py
+++ b/tests/integration/test_storage_rabbitmq/__init__.py
@@ -8,18 +8,19 @@ def poll_direct_select_result(
     instance, query, is_result_complete, timeout, ignore_error=True, sleep_time=0.05
 ):
     result = ""
-    previous_rows = 0
+    rows = 0
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         # Direct SELECT from RabbitMQ consumes rows, so accumulate all returned batches.
-        result += instance.query(query, ignore_error=ignore_error)
+        batch = instance.query(query, ignore_error=ignore_error)
+        result += batch
         if is_result_complete(result):
             return result
 
-        rows = len([line for line in result.splitlines() if line.strip()])
-        if rows > previous_rows:
+        new_rows = sum(1 for line in batch.splitlines() if line.strip())
+        if new_rows:
+            rows += new_rows
             deadline = time.monotonic() + timeout
-        previous_rows = rows
         logging.debug(f"Collected rows: {rows}. Now {time.monotonic()}, deadline {deadline}")
         time.sleep(sleep_time)
 

--- a/tests/integration/test_storage_rabbitmq/__init__.py
+++ b/tests/integration/test_storage_rabbitmq/__init__.py
@@ -1,0 +1,29 @@
+import logging
+import time
+
+import pytest
+
+
+def poll_direct_select_result(
+    instance, query, is_result_complete, timeout, ignore_error=True, sleep_time=0.05
+):
+    result = ""
+    previous_rows = 0
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        # Direct SELECT from RabbitMQ consumes rows, so accumulate all returned batches.
+        result += instance.query(query, ignore_error=ignore_error)
+        if is_result_complete(result):
+            return result
+
+        rows = len([line for line in result.splitlines() if line.strip()])
+        if rows > previous_rows:
+            deadline = time.monotonic() + timeout
+        previous_rows = rows
+        logging.debug(f"Collected rows: {rows}. Now {time.monotonic()}, deadline {deadline}")
+        time.sleep(sleep_time)
+
+    pytest.fail(
+        f"Time limit of {timeout} seconds reached without RabbitMQ consumption progress. "
+        "The result did not match the expected value."
+    )

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -13,6 +13,7 @@ import pytest
 from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
+from . import poll_direct_select_result
 
 pytestmark = pytest.mark.timeout(1200)
 
@@ -61,6 +62,19 @@ def rabbitmq_check_result(result, check=False, reference=None):
         assert TSV(result) == TSV(reference)
     else:
         return TSV(result) == TSV(reference)
+
+
+def check_direct_select_result_polling(query, reference=None, timeout=DEFAULT_TIMEOUT_SEC):
+    if reference is None:
+        reference = "\n".join([f"{i}\t{i}" for i in range(50)])
+
+    result = poll_direct_select_result(
+        instance,
+        query,
+        lambda current_result: rabbitmq_check_result(current_result, reference=reference),
+        timeout,
+    )
+    rabbitmq_check_result(result, True, reference=reference)
 
 
 # Fixtures
@@ -175,21 +189,7 @@ def test_rabbitmq_select(rabbitmq_cluster, secure, db, unique):
     # The order of messages in select * from {db}.rabbitmq is not guaranteed, so sleep to collect everything in one select
     time.sleep(1)
 
-    result = ""
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
-    while time.monotonic() < deadline:
-        result += instance.query(
-            f"SELECT * FROM {db}.rabbitmq ORDER BY key", ignore_error=True
-        )
-        if rabbitmq_check_result(result):
-            break
-        time.sleep(0.05)
-    else:
-        pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
-        )
-
-    rabbitmq_check_result(result, True)
+    check_direct_select_result_polling(f"SELECT * FROM {db}.rabbitmq ORDER BY key")
 
 
 def test_rabbitmq_select_empty(rabbitmq_cluster, db, unique):
@@ -248,22 +248,7 @@ def test_rabbitmq_json_without_delimiter(rabbitmq_cluster, db, unique):
     connection.close()
     time.sleep(1)
 
-    result = ""
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
-    while time.monotonic() < deadline:
-        result += instance.query(
-            f"SELECT * FROM {db}.rabbitmq ORDER BY key", ignore_error=True
-        )
-        if rabbitmq_check_result(result):
-            break
-
-        time.sleep(0.05)
-    else:
-        pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
-        )
-
-    rabbitmq_check_result(result, True)
+    check_direct_select_result_polling(f"SELECT * FROM {db}.rabbitmq ORDER BY key")
 
 
 def test_rabbitmq_csv_with_delimiter(rabbitmq_cluster, db, unique):
@@ -298,22 +283,7 @@ def test_rabbitmq_csv_with_delimiter(rabbitmq_cluster, db, unique):
     connection.close()
     time.sleep(1)
 
-    result = ""
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
-    while time.monotonic() < deadline:
-        result += instance.query(
-            f"SELECT * FROM {db}.rabbitmq ORDER BY key", ignore_error=True
-        )
-        if rabbitmq_check_result(result):
-            break
-
-        time.sleep(0.05)
-    else:
-        pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
-        )
-
-    rabbitmq_check_result(result, True)
+    check_direct_select_result_polling(f"SELECT * FROM {db}.rabbitmq ORDER BY key")
 
 
 def test_rabbitmq_tsv_with_delimiter(rabbitmq_cluster, db, unique):
@@ -398,21 +368,7 @@ def test_rabbitmq_macros(rabbitmq_cluster, db, unique):
     connection.close()
     time.sleep(1)
 
-    result = ""
-    deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
-    while time.monotonic() < deadline:
-        result += instance.query(
-            f"SELECT * FROM {db}.rabbitmq ORDER BY key", ignore_error=True
-        )
-        if rabbitmq_check_result(result):
-            break
-        time.sleep(0.05)
-    else:
-        pytest.fail(
-            f"Time limit of {DEFAULT_TIMEOUT_SEC} seconds reached. The result did not match the expected value."
-        )
-
-    rabbitmq_check_result(result, True)
+    check_direct_select_result_polling(f"SELECT * FROM {db}.rabbitmq ORDER BY key")
 
 
 def test_rabbitmq_materialized_view(rabbitmq_cluster, db, unique):
@@ -585,6 +541,9 @@ def test_rabbitmq_many_materialized_views(rabbitmq_cluster, db, unique):
         channel.basic_publish(exchange=f"{unique}_mmv", routing_key="", body=message)
 
     is_check_passed = False
+    result1 = ""
+    result2 = ""
+    result3 = ""
     deadline = time.monotonic() + DEFAULT_TIMEOUT_SEC
     while time.monotonic() < deadline:
         result1 = instance.query(f"SELECT * FROM {db}.view1 ORDER BY key")

--- a/tests/integration/test_storage_rabbitmq/test_shutdown.py
+++ b/tests/integration/test_storage_rabbitmq/test_shutdown.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import time
 from helpers.cluster import ClickHouseCluster
+from . import poll_direct_select_result
 
 cluster = ClickHouseCluster(__file__)
 
@@ -389,19 +390,20 @@ def test_rabbitmq_virtual_column_table(started_cluster):
         """
     )
 
-    result = ""
-    for _ in range(100):
-        result += instance.query(
-            """
-            SELECT key, value, _exchange_name, _table
-            FROM test_virt.rabbitmq_source
-            SETTINGS stream_like_engine_allow_direct_select=1
-            """
-        )
-        lines = [l for l in result.strip().split("\n") if l]
-        if len(lines) == 10:
-            break
-        time.sleep(0.5)
+    result = poll_direct_select_result(
+        instance,
+        """
+        SELECT key, value, _exchange_name, _table
+        FROM test_virt.rabbitmq_source
+        SETTINGS stream_like_engine_allow_direct_select=1
+        """,
+        lambda current_result: len(
+            [l for l in current_result.strip().split("\n") if l]
+        ) == 10,
+        timeout=50,
+        ignore_error=False,
+        sleep_time=0.5,
+    )
 
     lines = [l for l in result.strip().split("\n") if l]
     assert len(lines) == 10, f"Expected 10 rows, got {len(lines)}"


### PR DESCRIPTION
Make direct `RabbitMQ` select tests resilient to slow sanitizer/db-disk runs by resetting the polling deadline whenever accumulated rows increase. Direct selects consume rows from `RabbitMQ`, so the tests still accumulate returned batches rather than replacing the result.

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108014&sha=ca91c12b238e033b5dc8c7453295e4e7017ac997&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Related: https://github.com/ClickHouse/ClickHouse/pull/108014

No existing open tracking issue was found for `test_rabbitmq_csv_with_delimiter` or the `RabbitMQ` timeout.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry:
- [x] Documentation is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.33`
<!-- ch-version-info:end -->