### PR TITLE
Optimize `DISTINCT` when all keys in chunk are distinct

### DIFF
--- a/src/Processors/Transforms/DistinctSortedStreamTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedStreamTransform.cpp
@@ -249,11 +249,19 @@ void DistinctSortedStreamTransform::transform(Chunk & chunk)
 
     saveLatestKey(chunk_rows - 1);
 
-    /// apply the built filter
-    for (auto & input_column : input_columns)
-        input_column = input_column->filter(filter, output_rows);
+    if (output_rows == chunk_rows)
+    {
+        /// Every row is a new distinct value: keep the chunk unchanged, without copying it.
+        chunk.setColumns(std::move(input_columns), chunk_rows);
+    }
+    else
+    {
+        /// apply the built filter
+        for (auto & input_column : input_columns)
+            input_column = input_column->filter(filter, output_rows);
 
-    chunk.setColumns(std::move(input_columns), output_rows);
+        chunk.setColumns(std::move(input_columns), output_rows);
+    }
 
     /// Update total output rows and check limits
     total_output_rows += output_rows;

--- a/src/Processors/Transforms/DistinctTransform.cpp
+++ b/src/Processors/Transforms/DistinctTransform.cpp
@@ -241,25 +241,32 @@ void DistinctTransform::transform(Chunk & chunk)
 #undef M
     }
 
+    const auto new_set_size = data.getTotalRowCount();
+    const size_t num_selected = new_set_size - old_set_size;
+
     /// Just go to the next chunk if there isn't any new record in the current one.
-    size_t new_set_size = data.getTotalRowCount();
-    if (new_set_size == old_set_size)
+    if (num_selected == 0)
         return;
 
     if (!set_size_limits.check(new_set_size, data.getTotalByteCount(), "DISTINCT", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED))
         return;
 
-    for (auto & column : columns)
-        column = column->filter(filter, -1);
+    if (num_selected == num_rows)
+    {
+        /// Every row is a new distinct value: keep the chunk unchanged, without copying it.
+        chunk.setColumns(std::move(columns), num_rows);
+    }
+    else
+    {
+        for (auto & column : columns)
+            column = column->filter(filter, -1);
 
-    chunk.setColumns(std::move(columns), new_set_size - old_set_size);
+        chunk.setColumns(std::move(columns), num_selected);
+    }
 
     /// Stop reading if we already reach the limit
     if (limit_hint && new_set_size >= limit_hint)
-    {
         stopReading();
-        return;
-    }
 }
 
 }

--- a/tests/performance/distinct_high_cardinality.xml
+++ b/tests/performance/distinct_high_cardinality.xml
@@ -1,0 +1,11 @@
+<test>
+    <query>SELECT DISTINCT leftPad(toString(number), 2000, 'x') FROM numbers_mt(1000000) FORMAT Null</query>
+    <query>SELECT DISTINCT leftPad(toString(number), 1000, 'x') FROM numbers_mt(2000000) FORMAT Null</query>
+    <query>SELECT DISTINCT leftPad(toString(number), 500, 'x') FROM numbers_mt(4000000) FORMAT Null</query>
+    <query>SELECT DISTINCT leftPad(toString(number), 2000, 'x') as col FROM numbers_mt(1000000) ORDER BY col FORMAT Null</query>
+    <query>SELECT DISTINCT leftPad(toString(number), 1000, 'x') as col FROM numbers_mt(2000000) ORDER BY col FORMAT Null</query>
+    <query>SELECT DISTINCT leftPad(toString(number), 500, 'x') as col FROM numbers_mt(4000000) ORDER BY col FORMAT Null</query>
+    <query>SELECT DISTINCT toFixedString(leftPad(toString(number), 128, '0'), 128) FROM numbers_mt(8000000) FORMAT Null</query>
+    <query>SELECT DISTINCT arrayWithConstant(30, number) FROM numbers_mt(3000000) FORMAT Null</query>
+    <query>SELECT DISTINCT number FROM numbers_mt(40000000) FORMAT Null</query>
+</test>


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

When every row in an input chunk is a new distinct value, we still call `IColumn::filter`, which copies the surviving rows into fresh columns. We can instead detect that all rows survived and pass the chunk through unchanged, avoiding the copy. This is especially important for the final `DISTINCT` since the preliminary `DISTINCT` has already removed within-stream duplicates, for high-cardinality inputs its chunks are frequently all-distinct.

<img width="2964" height="986" alt="image" src="https://github.com/user-attachments/assets/42e642ec-79ee-429d-b692-5ddb8b444b3b" />


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimize `DISTINCT` for expensive high cardinality keys.
