### PR TITLE
Reduce 03274_squashing_transform_sparse_bug size

### DIFF
--- a/tests/queries/0_stateless/03274_squashing_transform_sparse_bug.sql
+++ b/tests/queries/0_stateless/03274_squashing_transform_sparse_bug.sql
@@ -9,7 +9,7 @@ SET max_execution_time = 300;
 
 CREATE TABLE t0 (x UInt64, y Tuple(UInt64, UInt64) ) ENGINE = MergeTree ORDER BY x SETTINGS ratio_of_defaults_for_sparse_serialization = 0.5;
 SYSTEM STOP MERGES t0;
-INSERT INTO t0 SELECT if(number % 2 = 0, 0, number) as x, (x, 0) from numbers(200) SETTINGS max_block_size = 1;
+INSERT INTO t0 SELECT if(number % 2 = 0, 0, number) as x, (x, 0) from numbers(20) SETTINGS max_block_size = 1;
 
 CREATE TABLE t1 (x UInt64, y Tuple(UInt64, UInt64) ) ENGINE = MergeTree ORDER BY x;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.34` (included in `26.7` and later)
- Backported to: `26.6.2.44`
<!-- ch-version-info:end -->