### PR TITLE
Add Iceberg pruning details to `EXPLAIN` indexes

### DIFF
--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.cpp
@@ -1,5 +1,7 @@
 #include <Processors/QueryPlan/ReadFromObjectStorageStep.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/JSONBuilder.h>
+#include <Processors/QueryPlan/QueryPlanFormat.h>
 #include <Core/Settings.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSource.h>
 #include <Interpreters/ActionsDAG.h>
@@ -23,6 +25,97 @@
 
 namespace DB
 {
+
+namespace
+{
+
+void formatExplainIndexes(
+    IQueryPlanStep::FormatSettings & explain_settings,
+    const std::vector<IDataLakeMetadata::ExplainIndexDescription> & indexes)
+{
+    if (indexes.empty())
+        return;
+
+    const std::string & prefix = explain_settings.detail_prefix;
+    std::string indent(explain_settings.base_indent, explain_settings.indent_char);
+    explain_settings.out << prefix << "Indexes:\n";
+
+    for (const auto & stat : indexes)
+    {
+        explain_settings.out << prefix << indent << stat.type << '\n';
+
+        if (!stat.description.empty())
+            explain_settings.out << prefix << indent << indent << "Description: " << stat.description << '\n';
+
+        if (!stat.used_keys.empty())
+        {
+            explain_settings.out << prefix << indent << indent << "Keys:" << '\n';
+            for (const auto & used_key : stat.used_keys)
+                explain_settings.out << prefix << indent << indent << indent << used_key << '\n';
+        }
+
+        if (!stat.condition.empty())
+            explain_settings.out << prefix << indent << indent << "Condition: " << stat.condition << '\n';
+
+        explain_settings.out << prefix << indent << indent << "Partitions: " << stat.selected_partitions << '/' << stat.initial_partitions << '\n';
+        explain_settings.out << prefix << indent << indent << "Files: " << stat.selected_files << '/' << stat.initial_files << '\n';
+    }
+}
+
+void formatExplainIndexes(
+    JSONBuilder::JSONMap & map,
+    const std::vector<IDataLakeMetadata::ExplainIndexDescription> & indexes)
+{
+    if (indexes.empty())
+        return;
+
+    auto indexes_array = std::make_unique<JSONBuilder::JSONArray>();
+    for (const auto & stat : indexes)
+    {
+        auto index_map = std::make_unique<JSONBuilder::JSONMap>();
+        index_map->add("Type", stat.type);
+
+        if (!stat.description.empty())
+            index_map->add("Description", stat.description);
+
+        if (!stat.used_keys.empty())
+        {
+            auto keys_array = std::make_unique<JSONBuilder::JSONArray>();
+            for (const auto & used_key : stat.used_keys)
+                keys_array->add(used_key);
+            index_map->add("Keys", std::move(keys_array));
+        }
+
+        if (!stat.condition.empty())
+            index_map->add("Condition", stat.condition);
+
+        index_map->add("Initial Partitions", stat.initial_partitions);
+        index_map->add("Selected Partitions", stat.selected_partitions);
+        index_map->add("Initial Files", stat.initial_files);
+        index_map->add("Selected Files", stat.selected_files);
+        indexes_array->add(std::move(index_map));
+    }
+
+    map.add("Indexes", std::move(indexes_array));
+}
+
+std::vector<IDataLakeMetadata::ExplainIndexDescription> getExplainIndexes(
+    const StorageObjectStorageConfigurationPtr & configuration,
+    const std::shared_ptr<const ActionsDAG> & filter_actions_dag,
+    StorageMetadataPtr storage_metadata,
+    ContextPtr context)
+{
+    if (!filter_actions_dag)
+        return {};
+
+    const auto * metadata = configuration->getExternalMetadata();
+    if (!metadata)
+        return {};
+
+    return metadata->getExplainIndexDescriptions(filter_actions_dag.get(), storage_metadata, context);
+}
+
+}
 
 namespace Setting
 {
@@ -154,6 +247,16 @@ void ReadFromObjectStorageStep::initializePipeline(QueryPipelineBuilder & pipeli
         processors.emplace_back(processor);
 
     pipeline.init(std::move(pipe));
+}
+
+void ReadFromObjectStorageStep::describeIndexes(FormatSettings & explain_settings) const
+{
+    formatExplainIndexes(explain_settings, getExplainIndexes(configuration, filter_actions_dag, storage_snapshot->metadata, getContext()));
+}
+
+void ReadFromObjectStorageStep::describeIndexes(JSONBuilder::JSONMap & map) const
+{
+    formatExplainIndexes(map, getExplainIndexes(configuration, filter_actions_dag, storage_snapshot->metadata, getContext()));
 }
 
 void ReadFromObjectStorageStep::createIterator()

--- a/src/Processors/QueryPlan/ReadFromObjectStorageStep.h
+++ b/src/Processors/QueryPlan/ReadFromObjectStorageStep.h
@@ -39,6 +39,8 @@ public:
     bool canUpdatePrewhereInfoMultipleTimes() const override { return false; }
 
     void initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &) override;
+    void describeIndexes(FormatSettings & format_settings) const override;
+    void describeIndexes(JSONBuilder::JSONMap & map) const override;
     QueryPlanStepPtr clone() const override;
 #if CLICKHOUSE_CLOUD
     /// In distributed query plan, this step will be executed in a distributed manner - shards will be read in parallel.

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -275,6 +275,12 @@ public:
         return current_metadata.get();
     }
 
+    const IDataLakeMetadata * getExternalMetadata() const override
+    {
+        assertInitialized();
+        return current_metadata.get();
+    }
+
     bool supportsFileIterator() const override { return true; }
 
     bool supportsWrites() const override

--- a/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h
@@ -52,6 +52,18 @@ using FormatParserSharedResourcesPtr = std::shared_ptr<FormatParserSharedResourc
 class IDataLakeMetadata : boost::noncopyable
 {
 public:
+    struct ExplainIndexDescription
+    {
+        String type;
+        String description;
+        std::vector<String> used_keys;
+        String condition;
+        size_t initial_partitions = 0;
+        size_t selected_partitions = 0;
+        size_t initial_files = 0;
+        size_t selected_files = 0;
+    };
+
     virtual ~IDataLakeMetadata() = default;
 
     virtual bool operator==(const IDataLakeMetadata & other) const = 0;
@@ -117,6 +129,12 @@ public:
     /// not be rewritten and will be left unsorted or with previous sort order.
     /// In this case we shouldn't use read in order optimization.
     virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
+
+    virtual std::vector<ExplainIndexDescription> getExplainIndexDescriptions(
+        const ActionsDAG * /* filter_dag */, StorageMetadataPtr /* storage_metadata */, ContextPtr /* context */) const
+    {
+        return {};
+    }
 
     /// Some data lakes specify information for reading files from disks.
     /// For example, Iceberg has Parquet schema field ids in its metadata for reading files.

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -1031,6 +1031,102 @@ bool IcebergMetadata::isDataSortedBySortingKey(StorageMetadataPtr storage_metada
     return true;
 }
 
+std::vector<IDataLakeMetadata::ExplainIndexDescription> IcebergMetadata::getExplainIndexDescriptions(
+    const ActionsDAG * filter_dag,
+    StorageMetadataPtr storage_metadata,
+    ContextPtr context) const
+{
+    if (!filter_dag || !context->getSettingsRef()[Setting::use_iceberg_partition_pruning].value)
+        return {};
+
+    auto iceberg_table_state = extractIcebergSnapshotIdFromMetadataObject(storage_metadata);
+    if (iceberg_table_state == nullptr)
+    {
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Can't extract iceberg table state from storage snapshot for table location {}",
+            persistent_components.table_location);
+    }
+
+    auto data_snapshot = getRelevantDataSnapshotFromTableStateSnapshot(*iceberg_table_state, context);
+    if (!data_snapshot)
+        return {};
+
+    std::shared_ptr<const ActionsDAG> filter_dag_copy = std::make_shared<ActionsDAG>(filter_dag->clone());
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> partition_description;
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> minmax_description;
+
+    size_t initial_partitions = 0;
+    size_t partition_selected_partitions = 0;
+    size_t minmax_selected_partitions = 0;
+    size_t initial_files = 0;
+    size_t partition_selected_files = 0;
+    size_t minmax_selected_files = 0;
+
+    for (const auto & manifest_list_entry : data_snapshot->manifest_list_entries)
+    {
+        if (manifest_list_entry.content_type != Iceberg::ManifestFileContentType::DATA)
+            continue;
+
+        auto manifest_file_cacheable_part = Iceberg::getManifestFile(
+            object_storage,
+            persistent_components,
+            context,
+            log,
+            manifest_list_entry.manifest_file_path,
+            manifest_list_entry.manifest_file_byte_size);
+
+        auto iterator = Iceberg::ManifestFileIterator::create(
+            manifest_file_cacheable_part.deserializer,
+            manifest_list_entry.manifest_file_path,
+            persistent_components.path_resolver,
+            *persistent_components.schema_processor,
+            manifest_list_entry.added_sequence_number,
+            manifest_list_entry.added_snapshot_id,
+            context,
+            filter_dag_copy,
+            iceberg_table_state->schema_id);
+
+        while (iterator->next())
+        {
+        }
+
+        auto stats = iterator->getExplainPruningStatistics();
+        initial_partitions += stats.initial_partitions;
+        partition_selected_partitions += stats.partition_selected_partitions;
+        minmax_selected_partitions += stats.minmax_selected_partitions;
+        initial_files += stats.initial_data_files;
+        partition_selected_files += stats.partition_selected_data_files;
+        minmax_selected_files += stats.minmax_selected_data_files;
+
+        if (!partition_description)
+            partition_description = iterator->getPartitionExplainIndexDescription();
+        if (!minmax_description)
+            minmax_description = iterator->getMinMaxExplainIndexDescription();
+    }
+
+    std::vector<IDataLakeMetadata::ExplainIndexDescription> result;
+    if (partition_description)
+    {
+        partition_description->initial_partitions = initial_partitions;
+        partition_description->selected_partitions = partition_selected_partitions;
+        partition_description->initial_files = initial_files;
+        partition_description->selected_files = partition_selected_files;
+        result.push_back(*partition_description);
+    }
+
+    if (minmax_description)
+    {
+        minmax_description->initial_partitions = partition_selected_partitions;
+        minmax_description->selected_partitions = minmax_selected_partitions;
+        minmax_description->initial_files = partition_selected_files;
+        minmax_description->selected_files = minmax_selected_files;
+        result.push_back(*minmax_description);
+    }
+
+    return result;
+}
+
 std::optional<size_t> IcebergMetadata::totalRows(ContextPtr local_context) const
 {
     auto [actual_data_snapshot, actual_table_state_snapshot] = getRelevantState(local_context);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h
@@ -124,6 +124,9 @@ public:
 
     bool isDataSortedBySortingKey(StorageMetadataPtr storage_metadata_snapshot, ContextPtr context) const override;
 
+    std::vector<ExplainIndexDescription> getExplainIndexDescriptions(
+        const ActionsDAG * filter_dag, StorageMetadataPtr storage_metadata, ContextPtr context) const override;
+
     ColumnMapperPtr getColumnMapperForObject(ObjectInfoPtr object_info) const override;
 
     ColumnMapperPtr getColumnMapperForCurrentSchema(StorageMetadataPtr storage_metadata_snapshot, ContextPtr context) const override;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -9,6 +9,7 @@
 #include <Interpreters/IcebergMetadataLog.h>
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergDataObjectInfo.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h>
@@ -125,6 +126,20 @@ namespace
             column->get(0, result);
             return result;
         }
+    }
+
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> makeExplainIndexDescription(
+        String type,
+        const std::optional<ManifestFilesPruner::ExplainDescription> & explain_description)
+    {
+        if (!explain_description)
+            return std::nullopt;
+
+        IDataLakeMetadata::ExplainIndexDescription result;
+        result.type = std::move(type);
+        result.used_keys = explain_description->used_keys;
+        result.condition = explain_description->condition;
+        return result;
     }
 
 }
@@ -496,6 +511,27 @@ ProcessedManifestFileEntryPtr ManifestFileIterator::processRow(size_t row_index)
         const ManifestFilesPruner * current_pruner = getOrCreatePruner(entry->resolved_schema_id);
         pruning_status = current_pruner->canBePruned(entry, hyperrectangles);
     }
+    if (parsed_entry->content_type == FileContentType::DATA)
+    {
+        std::lock_guard lock(explain_stats_mutex);
+        ++explain_initial_data_files;
+
+        String partition_id = Iceberg::computePartitionId(parsed_entry->partition_key_value);
+        explain_initial_partitions.insert(partition_id);
+
+        if (pruning_status != PruningReturnStatus::PARTITION_PRUNED)
+        {
+            ++explain_partition_selected_data_files;
+            explain_partition_selected_partitions.insert(partition_id);
+        }
+
+        if (pruning_status == PruningReturnStatus::NOT_PRUNED)
+        {
+            ++explain_minmax_selected_data_files;
+            explain_minmax_selected_partitions.insert(partition_id);
+        }
+    }
+
     insertRowToLogTable(
         context,
         manifest_file_deserializer->getContent(row_index),
@@ -546,6 +582,24 @@ const ManifestFilesPruner * ManifestFileIterator::getOrCreatePruner(Int32 schema
 
     auto pruner = std::make_unique<ManifestFilesPruner>(
         *schema_processor_ptr, table_snapshot_schema_id, schema_id, filter_dag.get(), *this, context);
+
+    {
+        std::lock_guard explain_lock(explain_stats_mutex);
+        if (!partition_explain_index_description)
+        {
+            partition_explain_index_description = makeExplainIndexDescription(
+                "Partition",
+                pruner->getPartitionExplainDescription());
+        }
+
+        if (!minmax_explain_index_description)
+        {
+            minmax_explain_index_description = makeExplainIndexDescription(
+                "MinMax",
+                pruner->getMinMaxExplainDescription());
+        }
+    }
+
     auto * raw_ptr = pruner.get();
     pruners_by_schema_id.emplace(schema_id, std::move(pruner));
     return raw_ptr;
@@ -626,6 +680,47 @@ std::optional<Int64> ManifestFileIterator::getBytesCountInAllDataFilesExcludingD
         if (!found)
             return std::nullopt;
     }
+    return result;
+}
+
+ManifestFileIterator::ExplainPruningStatistics ManifestFileIterator::getExplainPruningStatistics() const
+{
+    std::lock_guard lock(explain_stats_mutex);
+    return {
+        .initial_data_files = explain_initial_data_files,
+        .partition_selected_data_files = explain_partition_selected_data_files,
+        .minmax_selected_data_files = explain_minmax_selected_data_files,
+        .initial_partitions = explain_initial_partitions.size(),
+        .partition_selected_partitions = explain_partition_selected_partitions.size(),
+        .minmax_selected_partitions = explain_minmax_selected_partitions.size(),
+    };
+}
+
+std::optional<IDataLakeMetadata::ExplainIndexDescription> ManifestFileIterator::getPartitionExplainIndexDescription() const
+{
+    std::lock_guard lock(explain_stats_mutex);
+    if (!partition_explain_index_description)
+        return std::nullopt;
+
+    auto result = *partition_explain_index_description;
+    result.initial_partitions = explain_initial_partitions.size();
+    result.selected_partitions = explain_partition_selected_partitions.size();
+    result.initial_files = explain_initial_data_files;
+    result.selected_files = explain_partition_selected_data_files;
+    return result;
+}
+
+std::optional<IDataLakeMetadata::ExplainIndexDescription> ManifestFileIterator::getMinMaxExplainIndexDescription() const
+{
+    std::lock_guard lock(explain_stats_mutex);
+    if (!minmax_explain_index_description)
+        return std::nullopt;
+
+    auto result = *minmax_explain_index_description;
+    result.initial_partitions = explain_partition_selected_partitions.size();
+    result.selected_partitions = explain_minmax_selected_partitions.size();
+    result.initial_files = explain_partition_selected_data_files;
+    result.selected_files = explain_minmax_selected_data_files;
     return result;
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.h
@@ -6,12 +6,14 @@
 #if USE_AVRO
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergPath.h>
+#include <Storages/ObjectStorage/DataLakes/IDataLakeMetadata.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/ManifestFile.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h>
 #include <Storages/ObjectStorage/DataLakes/Common/AvroForIcebergDeserializer.h>
 #include <Storages/KeyDescription.h>
 
 #include <mutex>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace DB::Iceberg
@@ -48,6 +50,16 @@ class ManifestFilesPruner;
 class ManifestFileIterator : public boost::noncopyable
 {
 public:
+    struct ExplainPruningStatistics
+    {
+        size_t initial_data_files = 0;
+        size_t partition_selected_data_files = 0;
+        size_t minmax_selected_data_files = 0;
+        size_t initial_partitions = 0;
+        size_t partition_selected_partitions = 0;
+        size_t minmax_selected_partitions = 0;
+    };
+
     struct ManifestFileEntriesHandle
     {
         using FilesPtr = std::shared_ptr<const std::vector<ProcessedManifestFileEntryPtr>>;
@@ -96,6 +108,9 @@ public:
     std::optional<Int64> getBytesCountInAllDataFilesExcludingDeleted() const;
 
     bool areAllDataFilesSortedBySortOrderID(Int32 sort_order_id) const;
+    ExplainPruningStatistics getExplainPruningStatistics() const;
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> getPartitionExplainIndexDescription() const;
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> getMinMaxExplainIndexDescription() const;
 
     /// Returns true if all manifest file entries have been processed
     bool isInitialized() const;
@@ -161,6 +176,16 @@ private:
     mutable std::mutex pruners_mutex;
     std::unordered_map<Int32, std::unique_ptr<ManifestFilesPruner>> pruners_by_schema_id;
     const ManifestFilesPruner * getOrCreatePruner(Int32 schema_id);
+
+    mutable std::mutex explain_stats_mutex;
+    size_t explain_initial_data_files TSA_GUARDED_BY(explain_stats_mutex) = 0;
+    size_t explain_partition_selected_data_files TSA_GUARDED_BY(explain_stats_mutex) = 0;
+    size_t explain_minmax_selected_data_files TSA_GUARDED_BY(explain_stats_mutex) = 0;
+    std::unordered_set<String> explain_initial_partitions TSA_GUARDED_BY(explain_stats_mutex);
+    std::unordered_set<String> explain_partition_selected_partitions TSA_GUARDED_BY(explain_stats_mutex);
+    std::unordered_set<String> explain_minmax_selected_partitions TSA_GUARDED_BY(explain_stats_mutex);
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> partition_explain_index_description TSA_GUARDED_BY(explain_stats_mutex);
+    std::optional<IDataLakeMetadata::ExplainIndexDescription> minmax_explain_index_description TSA_GUARDED_BY(explain_stats_mutex);
 };
 
 using ManifestIteratorPtr = std::shared_ptr<ManifestFileIterator>;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
@@ -14,6 +14,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <IO/ReadHelpers.h>
 #include <Common/quoteString.h>
+#include <boost/algorithm/string/replace.hpp>
 #include <fmt/ranges.h>
 
 #include <Interpreters/ExpressionActions.h>
@@ -26,6 +27,70 @@ using namespace DB;
 
 namespace DB::Iceberg
 {
+
+namespace
+{
+
+std::optional<Int32> tryParseIcebergFieldIdName(const String & key_name)
+{
+    Int32 field_id{};
+    if (tryParse(field_id, key_name))
+        return field_id;
+
+    if (key_name.size() >= 2 && key_name.front() == '`' && key_name.back() == '`')
+    {
+        auto unquoted_key_name = key_name.substr(1, key_name.size() - 2);
+        if (tryParse(field_id, unquoted_key_name))
+            return field_id;
+    }
+
+    return std::nullopt;
+}
+
+String normalizeExplainKeyName(
+    const IcebergSchemaProcessor & schema_processor,
+    Int32 current_schema_id,
+    const String & key_name)
+{
+    if (auto field_id = tryParseIcebergFieldIdName(key_name))
+    {
+        if (auto field = schema_processor.tryGetFieldCharacteristics(current_schema_id, *field_id))
+            return field->name;
+    }
+
+    return key_name;
+}
+
+ManifestFilesPruner::ExplainDescription buildExplainDescription(
+    const IcebergSchemaProcessor & schema_processor,
+    Int32 current_schema_id,
+    const std::vector<String> & key_names,
+    const KeyCondition::Description & key_condition_description)
+{
+    ManifestFilesPruner::ExplainDescription result;
+
+    for (const auto & key_name : key_names)
+    {
+        String current_name = normalizeExplainKeyName(schema_processor, current_schema_id, key_name);
+
+        if (std::find(result.used_keys.begin(), result.used_keys.end(), current_name) == result.used_keys.end())
+            result.used_keys.push_back(current_name);
+    }
+
+    result.condition = key_condition_description.condition;
+    for (const auto & used_key : key_condition_description.used_keys)
+    {
+        if (auto field_id = tryParseIcebergFieldIdName(used_key))
+        {
+            if (auto field = schema_processor.tryGetFieldCharacteristics(current_schema_id, *field_id))
+                boost::replace_all(result.condition, backQuote(DB::toString(*field_id)), backQuote(field->name));
+        }
+    }
+
+    return result;
+}
+
+}
 
 DB::ASTPtr getASTFromTransform(const String & transform_name_src, const String & column_name)
 {
@@ -119,21 +184,67 @@ ManifestFilesPruner::ManifestFilesPruner(
         ActionsDAGWithInversionPushDown inverted_dag(transformed_dag->getOutputs().front(), context);
         partition_key_condition.emplace(
             inverted_dag, context, partition_key->column_names, partition_key->expression, true /* single_point */);
+
+        auto description = partition_key_condition->getDescription();
+        if (!description.used_keys.empty() || !description.condition.empty())
+            partition_explain_description = buildExplainDescription(schema_processor, current_schema_id, partition_key->column_names, description);
     }
 
+    std::vector<String> minmax_conditions;
     for (Int32 used_column_id : used_columns_in_filter)
     {
+        auto current_name_and_type = schema_processor.tryGetFieldCharacteristics(current_schema_id, used_column_id);
+        /// Build the pruning `KeyCondition` in the manifest namespace, using the
+        /// field/type from `initial_schema_id`. Manifest file statistics are keyed
+        /// by stable Iceberg field ids and may come from an older schema version.
         auto name_and_type = schema_processor.tryGetFieldCharacteristics(initial_schema_id, used_column_id);
-        if (!name_and_type.has_value())
+        if (!current_name_and_type.has_value() || !name_and_type.has_value())
             continue;
 
+        /// Use the Iceberg field id as the key name in the pruning expression.
+        /// This keeps pruning correct across column renames.
         name_and_type->name = DB::backQuote(DB::toString(used_column_id));
 
         ExpressionActionsPtr expression
             = std::make_shared<ExpressionActions>(ActionsDAG({name_and_type.value()}), ExpressionActionsSettings(context));
 
         ActionsDAGWithInversionPushDown inverted_dag(transformed_dag->getOutputs().front(), context);
-        min_max_key_conditions.emplace(used_column_id, KeyCondition(inverted_dag, context, {name_and_type->name}, expression));
+        auto [it, inserted]
+            = min_max_key_conditions.emplace(used_column_id, KeyCondition(inverted_dag, context, {name_and_type->name}, expression));
+
+        if (inserted)
+        {
+            if (!minmax_explain_description)
+                minmax_explain_description.emplace();
+
+            auto description = it->second.getDescription();
+            /// `buildExplainDescription` is responsible for converting internal
+            /// field-id-based key names into current user-facing column names for
+            /// `EXPLAIN`, so we pass the current schema id here even though pruning
+            /// itself is built over the manifest namespace above.
+            auto explain_description = buildExplainDescription(
+                schema_processor,
+                current_schema_id,
+                {current_name_and_type->name},
+                description);
+            for (const auto & used_key : explain_description.used_keys)
+            {
+                if (std::find(minmax_explain_description->used_keys.begin(), minmax_explain_description->used_keys.end(), used_key)
+                    == minmax_explain_description->used_keys.end())
+                    minmax_explain_description->used_keys.push_back(used_key);
+            }
+
+            if (!explain_description.condition.empty())
+                minmax_conditions.push_back(explain_description.condition);
+        }
+    }
+
+    if (!min_max_key_conditions.empty())
+    {
+        if (!minmax_explain_description)
+            minmax_explain_description.emplace();
+        if (!minmax_conditions.empty())
+            minmax_explain_description->condition = fmt::format("({})", fmt::join(minmax_conditions, ") AND ("));
     }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.h
@@ -35,7 +35,15 @@ DB::ASTPtr getASTFromTransform(const String & transform_name_src, const String &
 /// Prune specific data files based on manifest content
 class ManifestFilesPruner
 {
+public:
+    struct ExplainDescription
+    {
+        std::vector<String> used_keys;
+        String condition;
+    };
+
 private:
+
     const IcebergSchemaProcessor & schema_processor;
     Int32 current_schema_id;
     Int32 initial_schema_id;
@@ -43,6 +51,8 @@ private:
     std::optional<DB::KeyCondition> partition_key_condition;
 
     std::unordered_map<Int32, DB::KeyCondition> min_max_key_conditions;
+    std::optional<ExplainDescription> partition_explain_description;
+    std::optional<ExplainDescription> minmax_explain_description;
     /// NOTE: tricky part to support RENAME column.
     /// Takes ActionDAG representation of user's WHERE expression and
     /// rename columns to the their origina numeric ID's in iceberg
@@ -58,6 +68,9 @@ public:
         DB::ContextPtr context);
 
     PruningReturnStatus canBePruned(const ProcessedManifestFileEntryPtr & entry, const std::unordered_map<Int32, DB::Range> & entry_hyperrectangles) const;
+
+    const std::optional<ExplainDescription> & getPartitionExplainDescription() const { return partition_explain_description; }
+    const std::optional<ExplainDescription> & getMinMaxExplainDescription() const { return minmax_explain_description; }
 };
 
 }

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -161,6 +161,7 @@ public:
     virtual bool isDataSortedBySortingKey(StorageMetadataPtr, ContextPtr) const { return false; }
 
     virtual IDataLakeMetadata * getExternalMetadata() { return nullptr; }
+    virtual const IDataLakeMetadata * getExternalMetadata() const { return nullptr; }
 
     virtual std::shared_ptr<NamesAndTypesList> getInitialSchemaByPath(ContextPtr, ObjectInfoPtr) const { return {}; }
 

--- a/tests/queries/0_stateless/04357_iceberg_explain_pruning.reference
+++ b/tests/queries/0_stateless/04357_iceberg_explain_pruning.reference
@@ -1,0 +1,13 @@
+combined
+Partition
+Partitions: 2/3
+Files: 2/3
+MinMax
+Partitions: 1/2
+Files: 1/2
+minmax_only
+MinMax
+Partitions: 1/1
+Files: 1/3
+disabled
+NoIndexes

--- a/tests/queries/0_stateless/04357_iceberg_explain_pruning.sh
+++ b/tests/queries/0_stateless/04357_iceberg_explain_pruning.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+PARTITIONED_TABLE="t_iceberg_explain_partitioned_${CLICKHOUSE_DATABASE}_${RANDOM}"
+UNPARTITIONED_TABLE="t_iceberg_explain_unpartitioned_${CLICKHOUSE_DATABASE}_${RANDOM}"
+PARTITIONED_PATH="${USER_FILES_PATH}/${PARTITIONED_TABLE}/"
+UNPARTITIONED_PATH="${USER_FILES_PATH}/${UNPARTITIONED_TABLE}/"
+
+cleanup()
+{
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${PARTITIONED_TABLE}"
+    ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${UNPARTITIONED_TABLE}"
+    rm -rf "${PARTITIONED_PATH}" "${UNPARTITIONED_PATH}"
+}
+trap cleanup EXIT
+
+normalize_explain()
+{
+    local query="$1"
+    local output
+    output=$(${CLICKHOUSE_CLIENT} --query "
+        SELECT trimLeft(explain)
+        FROM ($query)
+        WHERE startsWith(trimLeft(explain), 'Partition')
+           OR startsWith(trimLeft(explain), 'MinMax')
+           OR startsWith(trimLeft(explain), 'Partitions:')
+           OR startsWith(trimLeft(explain), 'Files:')
+    ")
+
+    if [[ -z "$output" ]]; then
+        echo "NoIndexes"
+    else
+        printf '%s\n' "$output"
+    fi
+}
+
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${PARTITIONED_TABLE} (part Int32, value Int32)
+    ENGINE = IcebergLocal('${PARTITIONED_PATH}', 'Parquet')
+    PARTITION BY (part)
+"
+
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${PARTITIONED_TABLE} VALUES (1, 10)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${PARTITIONED_TABLE} VALUES (2, 20)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${PARTITIONED_TABLE} VALUES (3, 30)"
+
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${UNPARTITIONED_TABLE} (value Int32)
+    ENGINE = IcebergLocal('${UNPARTITIONED_PATH}', 'Parquet')
+"
+
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${UNPARTITIONED_TABLE} VALUES (10)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${UNPARTITIONED_TABLE} VALUES (20)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "INSERT INTO ${UNPARTITIONED_TABLE} VALUES (30)"
+
+echo "combined"
+normalize_explain "EXPLAIN indexes = 1 SELECT * FROM ${PARTITIONED_TABLE} WHERE part IN (2, 3) AND value = 30"
+
+echo "minmax_only"
+normalize_explain "EXPLAIN indexes = 1 SELECT * FROM ${UNPARTITIONED_TABLE} WHERE value = 20"
+
+echo "disabled"
+normalize_explain "EXPLAIN indexes = 1 SELECT * FROM ${PARTITIONED_TABLE} WHERE part IN (2, 3) AND value = 30 SETTINGS use_iceberg_partition_pruning = 0"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add Iceberg pruning details to `EXPLAIN` indexes


Show Iceberg partition and min-max pruning in EXPLAIN indexes.

```
EXPLAIN indexes = 1
SELECT *
FROM iceberg_part
WHERE (part IN (2, 3)) AND (value = 30)

Query id: 5ed65fb7-b99a-4999-9ecc-7a24413392e2

    ┌─explain────────────────────────────────────────────────────────────────────┐
 1. │ Expression ((Project names + Projection))                                  │
 2. │   Expression ((WHERE + Change column names to column identifiers))         │
 3. │     ReadFromObjectStorage                                                  │
 4. │     Indexes:                                                               │
 5. │       Partition                                                            │
 6. │         Keys:                                                              │
 7. │           part                                                             │
 8. │         Condition: (`part` in 2-element set)                               │
 9. │         Partitions: 2/3                                                    │
10. │         Files: 2/3                                                         │
11. │       MinMax                                                               │
12. │         Keys:                                                              │
13. │           value                                                            │
15. │         Condition: ((`value` in [30, 30])) AND ((`part` in 2-element set)) │
16. │         Partitions: 1/2                                                    │
17. │         Files: 1/2                                                         │
    └────────────────────────────────────────────────────────────────────────────┘

17 rows in set. Elapsed: 0.003 sec.
```