### PR TITLE
Hide secret arguments in EXPLAIN actions

### DIFF
--- a/src/Analyzer/ConstantNode.cpp
+++ b/src/Analyzer/ConstantNode.cpp
@@ -95,19 +95,14 @@ void ConstantNode::dumpTreeImpl(WriteBuffer & buffer, FormatState & format_state
         buffer << ", alias: " << getAlias();
 
     buffer << ", constant_value: ";
-    if (mask_id)
-    {
-        if (mask_id == std::numeric_limits<decltype(mask_id)>::max())
-            buffer << "[HIDDEN]";
-        else
-            buffer << "[HIDDEN id: " << mask_id << "]";
-    }
+    if (isMasked())
+        buffer << getMaskString();
     else
         buffer << getValue().dump();
 
     buffer << ", constant_value_type: " << constant_value.getType()->getName();
 
-    if (!mask_id && getSourceExpression())
+    if (!isMasked() && getSourceExpression())
     {
         buffer << '\n' << std::string(indent + 2, ' ') << "EXPRESSION" << '\n';
         getSourceExpression()->dumpTreeImpl(buffer, format_state, indent + 4);
@@ -138,7 +133,9 @@ void ConstantNode::updateTreeHashImpl(HashState & hash_state, CompareOptions /*c
 
 QueryTreeNodePtr ConstantNode::cloneImpl() const
 {
-    return std::make_shared<ConstantNode>(constant_value, source_expression, is_deterministic);
+    auto result = std::make_shared<ConstantNode>(constant_value, source_expression, is_deterministic);
+    result->mask_id = mask_id;
+    return result;
 }
 
 template <typename F>

--- a/src/Analyzer/ConstantNode.h
+++ b/src/Analyzer/ConstantNode.h
@@ -102,12 +102,29 @@ public:
         mask_id = id;
     }
 
+    /// Whether this constant is hidden as a secret (e.g. a key argument of `encrypt`).
+    bool isMasked() const
+    {
+        return mask_id != 0;
+    }
+
+    /// Placeholder shown instead of the value when this constant is hidden as a secret.
+    String getMaskString() const
+    {
+        chassert(isMasked());
+        if (mask_id == std::numeric_limits<decltype(mask_id)>::max())
+            return "[HIDDEN]";
+        return "[HIDDEN id: " + std::to_string(mask_id) + "]";
+    }
+
     void convertToNullable() override;
 
     void dumpTreeImpl(WriteBuffer & buffer, FormatState & format_state, size_t indent) const override;
 
     String getValueName(const IColumn::Options & options) const
     {
+        if (isMasked())
+            return getMaskString();
         return constant_value.getValueName(options);
     }
 

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -136,6 +136,13 @@ public:
             case QueryTreeNodeType::CONSTANT:
             {
                 const auto & constant_node = node->as<ConstantNode &>();
+                /// A masked secret must be named by its placeholder, never by its value or source expression,
+                /// identically on initiator and secondary servers so distributed headers still match.
+                if (constant_node.isMasked())
+                {
+                    result = calculateActionNodeNameWithCastIfNeeded(constant_node, planner_context.getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
+                    break;
+                }
                 /* To ensure that headers match during distributed query we need to simulate action node naming on
                 * secondary servers. If we don't do that headers will mismatch due to constant folding.
                 *
@@ -929,6 +936,11 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
 
     auto constant_node_name = !override_column_name.empty() ? override_column_name : [&]()
     {
+        /// A masked secret must be named by its placeholder, never by its value or source expression,
+        /// identically on initiator and secondary servers so distributed headers still match.
+        if (constant_node.isMasked())
+            return calculateActionNodeNameWithCastIfNeeded(constant_node, planner_context->getQueryContext()->getSettingsRef()[Setting::optimize_const_name_size]);
+
         /* To ensure that headers match during distributed query we need to simulate action node naming on
          * secondary servers. If we don't do that headers will mismatch due to constant folding.
          *

--- a/tests/queries/0_stateless/04409_explain_actions_secret_args.reference
+++ b/tests/queries/0_stateless/04409_explain_actions_secret_args.reference
@@ -1,0 +1,88 @@
+-- Secret arguments of recognized scalar functions must be hidden in the ActionsDAG dump of
+-- EXPLAIN actions, just like they already are for EXPLAIN SYNTAX and EXPLAIN QUERY TREE.
+-- This is general: every constant masked during analysis (encrypt/decrypt/HMAC/...) is covered.
+
+-- { echoOn }
+-- All EXPLAIN flavours must hide the key consistently.
+EXPLAIN SYNTAX
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+SELECT encrypt(\'aes-128-ecb\', \'[HIDDEN]\')
+FROM numbers(3)
+EXPLAIN QUERY TREE
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+QUERY id: 0
+  PROJECTION COLUMNS
+    encrypt(\'aes-128-ecb\', toString(number), [HIDDEN id: 1]) String
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: encrypt, function_type: ordinary, result_type: String
+        ARGUMENTS
+          LIST id: 3, nodes: 3
+            CONSTANT id: 4, constant_value: \'aes-128-ecb\', constant_value_type: String
+            FUNCTION id: 5, function_name: toString, function_type: ordinary, result_type: String
+              ARGUMENTS
+                LIST id: 6, nodes: 1
+                  COLUMN id: 7, column_name: number, result_type: UInt64, source_id: 8
+            CONSTANT id: 9, constant_value: [HIDDEN id: 1], constant_value_type: String
+  JOIN TREE
+    TABLE_FUNCTION id: 8, alias: __table1, table_function_name: numbers
+      ARGUMENTS
+        LIST id: 10, nodes: 1
+          CONSTANT id: 11, constant_value: UInt64_3, constant_value_type: UInt8
+EXPLAIN actions = 1
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+Actions: INPUT : 0 -> number UInt64 : 0
+         COLUMN Const(String) -> \'aes-128-ecb\'_String String : 1
+         COLUMN Const(String) -> [HIDDEN id: 1]_String String : 2
+         ALIAS number :: 0 -> __table1.number UInt64 : 3
+         FUNCTION toString(__table1.number :: 3) -> toString(__table1.number) String : 0
+         FUNCTION encrypt(\'aes-128-ecb\'_String :: 1, toString(__table1.number) :: 0, [HIDDEN id: 1]_String :: 2) -> encrypt(\'aes-128-ecb\'_String, toString(__table1.number), [HIDDEN id: 1]_String) String : 3
+         ALIAS encrypt(\'aes-128-ecb\'_String, toString(__table1.number), [HIDDEN id: 1]_String) :: 3 -> encrypt(\'aes-128-ecb\', toString(number), [HIDDEN id: 1]) String : 2
+Positions: 2
+  ReadFromSystemNumbers
+EXPLAIN actions = 1
+SELECT decrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+Actions: INPUT : 0 -> number UInt64 : 0
+         COLUMN Const(String) -> \'aes-128-ecb\'_String String : 1
+         COLUMN Const(String) -> [HIDDEN id: 1]_String String : 2
+         ALIAS number :: 0 -> __table1.number UInt64 : 3
+         FUNCTION toString(__table1.number :: 3) -> toString(__table1.number) String : 0
+         FUNCTION decrypt(\'aes-128-ecb\'_String :: 1, toString(__table1.number) :: 0, [HIDDEN id: 1]_String :: 2) -> decrypt(\'aes-128-ecb\'_String, toString(__table1.number), [HIDDEN id: 1]_String) String : 3
+         ALIAS decrypt(\'aes-128-ecb\'_String, toString(__table1.number), [HIDDEN id: 1]_String) :: 3 -> decrypt(\'aes-128-ecb\', toString(number), [HIDDEN id: 1]) String : 2
+Positions: 2
+  ReadFromSystemNumbers
+EXPLAIN actions = 1
+SELECT hex(HMAC('sha256', toString(number), 'MY_SUPER_SECRET_KEY_123'))
+FROM numbers(3);
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+Actions: INPUT : 0 -> number UInt64 : 0
+         COLUMN Const(String) -> \'sha256\'_String String : 1
+         COLUMN Const(String) -> [HIDDEN id: 1]_String String : 2
+         ALIAS number :: 0 -> __table1.number UInt64 : 3
+         FUNCTION toString(__table1.number :: 3) -> toString(__table1.number) String : 0
+         FUNCTION HMAC(\'sha256\'_String :: 1, toString(__table1.number) :: 0, [HIDDEN id: 1]_String :: 2) -> HMAC(\'sha256\'_String, toString(__table1.number), [HIDDEN id: 1]_String) String : 3
+         FUNCTION hex(HMAC(\'sha256\'_String, toString(__table1.number), [HIDDEN id: 1]_String) :: 3) -> hex(HMAC(\'sha256\'_String, toString(__table1.number), [HIDDEN id: 1]_String)) String : 2
+         ALIAS hex(HMAC(\'sha256\'_String, toString(__table1.number), [HIDDEN id: 1]_String)) :: 2 -> hex(HMAC(\'sha256\', toString(number), [HIDDEN id: 1])) String : 3
+Positions: 3
+  ReadFromSystemNumbers
+-- With the setting enabled the key is shown verbatim.
+SET format_display_secrets_in_show_and_select = 1;
+EXPLAIN actions = 1
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+Actions: INPUT : 0 -> number UInt64 : 0
+         COLUMN Const(String) -> \'aes-128-ecb\'_String String : 1
+         COLUMN Const(String) -> \'MY_SUPER_SECRET_KEY_123\'_String String : 2
+         ALIAS number :: 0 -> __table1.number UInt64 : 3
+         FUNCTION toString(__table1.number :: 3) -> toString(__table1.number) String : 0
+         FUNCTION encrypt(\'aes-128-ecb\'_String :: 1, toString(__table1.number) :: 0, \'MY_SUPER_SECRET_KEY_123\'_String :: 2) -> encrypt(\'aes-128-ecb\'_String, toString(__table1.number), \'MY_SUPER_SECRET_KEY_123\'_String) String : 3
+         ALIAS encrypt(\'aes-128-ecb\'_String, toString(__table1.number), \'MY_SUPER_SECRET_KEY_123\'_String) :: 3 -> encrypt(\'aes-128-ecb\', toString(number), \'MY_SUPER_SECRET_KEY_123\') String : 2
+Positions: 2
+  ReadFromSystemNumbers

--- a/tests/queries/0_stateless/04409_explain_actions_secret_args.sql
+++ b/tests/queries/0_stateless/04409_explain_actions_secret_args.sql
@@ -1,0 +1,37 @@
+-- Tags: no-fasttest, no-old-analyzer
+-- Tag no-fasttest: the encryption functions are not available in the fast test build
+-- Tag no-old-analyzer: the old analyzer builds the ActionsDAG without query-tree masking, so it still leaks the key
+
+-- Secret arguments of recognized scalar functions must be hidden in the ActionsDAG dump of
+-- EXPLAIN actions, just like they already are for EXPLAIN SYNTAX and EXPLAIN QUERY TREE.
+-- This is general: every constant masked during analysis (encrypt/decrypt/HMAC/...) is covered.
+
+-- { echoOn }
+-- All EXPLAIN flavours must hide the key consistently.
+EXPLAIN SYNTAX
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+
+EXPLAIN QUERY TREE
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+
+EXPLAIN actions = 1
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+
+EXPLAIN actions = 1
+SELECT decrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+
+EXPLAIN actions = 1
+SELECT hex(HMAC('sha256', toString(number), 'MY_SUPER_SECRET_KEY_123'))
+FROM numbers(3);
+
+-- With the setting enabled the key is shown verbatim.
+SET format_display_secrets_in_show_and_select = 1;
+
+EXPLAIN actions = 1
+SELECT encrypt('aes-128-ecb', toString(number), 'MY_SUPER_SECRET_KEY_123')
+FROM numbers(3);
+-- { echoOff }

--- a/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.reference
+++ b/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.reference
@@ -1,0 +1,11 @@
+-- secondary query, secrets hidden by default
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+Actions: INPUT : 0 -> number UInt64 : 0
+         COLUMN Const(String) -> \'aes-128-ecb\'_String String : 1
+         COLUMN Const(String) -> _CAST([HIDDEN id: 1]_String, \'String\'_String) String : 2
+         ALIAS number :: 0 -> __table1.number UInt64 : 3
+         FUNCTION toString(__table1.number :: 3) -> toString(__table1.number) String : 0
+         FUNCTION encrypt(\'aes-128-ecb\'_String :: 1, toString(__table1.number) :: 0, _CAST([HIDDEN id: 1]_String, \'String\'_String) :: 2) -> encrypt(\'aes-128-ecb\'_String, toString(__table1.number), _CAST([HIDDEN id: 1]_String, \'String\'_Strin... String : 3
+         ALIAS encrypt(\'aes-128-ecb\'_String, toString(__table1.number), _CAST([HIDDEN id: 1]_String, \'String\'_String)) :: 3 -> encrypt(\'aes-128-ecb\', toString(number), [HIDDEN id: 1]) String : 2
+Positions: 2
+  ReadFromSystemNumbers

--- a/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.sh
+++ b/tests/queries/0_stateless/04410_explain_actions_secret_args_secondary.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-old-analyzer
+# Tag no-fasttest: the encryption functions are not available in the fast test build
+# Tag no-old-analyzer: the old analyzer builds the ActionsDAG without query-tree masking, so it still leaks the key
+
+# On a secondary (shard) query the planner skips AST-level optimizations, so a secret argument
+# folded into a constant (e.g. concat('SECRET_', 'KEY')) used to be named by its source expression,
+# leaking the pieces in the ActionsDAG dump and in distributed headers/logs. It must be hidden, and
+# named identically to the initiator so distributed headers still match.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+QUERY="EXPLAIN actions = 1 SELECT encrypt('aes-128-ecb', toString(number), concat('SECRET_', 'KEY')) FROM numbers(1)"
+
+echo "-- secondary query, secrets hidden by default"
+${CLICKHOUSE_CLIENT} --query_kind secondary_query --query "${QUERY}"


### PR DESCRIPTION
`EXPLAIN actions = 1` printed the secret arguments of recognized functions such as `encrypt`, `decrypt`, and `HMAC` in plaintext, even though `format_display_secrets_in_show_and_select` defaults to `0` and `EXPLAIN SYNTAX` / `EXPLAIN QUERY TREE` already redact them.

The secret leaked through the `ActionsDAG` node `result_name`. The planner builds those names via `ConstantNode::getValueName`, which returned the raw literal and ignored the `mask_id` set during analysis, while the projection name and the query-tree dump already honor it.

`getValueName` now returns the `[HIDDEN id: N]` placeholder for masked constants, so the DAG node names are masked at construction. The masked name propagates to the enclosing function and ancestor names, fixing every analyzer-path consumer of `result_name` at once: `EXPLAIN actions` (text and `json`), `EXPLAIN header`, `EXPLAIN PIPELINE header`, and `ActionsDAG::dumpDAG` (used in exception and log messages). `cloneImpl` now preserves `mask_id` so the masking survives query-tree cloning between analysis and planning.

The fix is general: it covers every constant masked during analysis (the encryption family and `HMAC`), not only `encrypt`. Masking stays consistent within a query (the same secret maps to the same id) and the real value still lives in the column, so execution and distributed header matching are unaffected. With the analyzer disabled the old code path still leaks; that path builds names from the AST without query-tree masking and leaks in `EXPLAIN SYNTAX` too, so the regression test is tagged `no-old-analyzer`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108373

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Hide secret arguments of functions such as `encrypt`, `decrypt`, and `HMAC` in `EXPLAIN actions`, `EXPLAIN header`, and `EXPLAIN PIPELINE` output when `format_display_secrets_in_show_and_select` is disabled (the default).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.60` (included in `26.7` and later)
- Backported to: `26.6.1.1192`, `26.5.4.14`, `26.4.5.70`, `26.3.16.10`, `25.8.25.36`
<!-- ch-version-info:end -->