### PR TITLE
Fix data race on query MemoryReservation during normal query finish

### DIFF
--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -60,7 +60,6 @@ BlockIO::~BlockIO()
 
 void BlockIO::onFinish(std::chrono::system_clock::time_point finish_time)
 {
-    releaseWorkloadResources();
     if (finalize_query_pipeline)
     {
         /// Keep the same teardown order as in resetPipeline:
@@ -71,6 +70,10 @@ void BlockIO::onFinish(std::chrono::system_clock::time_point finish_time)
     }
     else
         resetPipeline(/*cancel=*/false);
+
+    /// Release workload resources AFTER the pipeline is down
+    /// Pipeline threads hold raw pointers to `MemoryReservation`.
+    releaseWorkloadResources();
 }
 
 void BlockIO::onException(bool log_as_error)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/108393


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a data race and possible use-after-free of a query's memory reservation when a query finishes while its pipeline executor threads are still running (workload memory scheduling).