### PR TITLE
Make ProfileEvents.h less hot

### DIFF
--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -133,9 +133,12 @@ EXTERN_TYPES_EXCLUDES=(
 # and this matches with zkutil::CreateMode
 grep -v -e 'src/Common/ZooKeeper/Types.h' -e 'src/Coordination/KeeperConstants.cpp' "$STYLE_TMPDIR/all_excluded" > "$STYLE_TMPDIR/extern_files"
 
-# Extract declarations: "filepath:D TYPE NAME"
+# Extract declarations: "filepath:D TYPE NAME [NOLINT]"
+# A trailing NOLINT comment marks the declaration as used elsewhere: it still counts as a
+# declaration (so same-file usages and duplicates are checked), but is exempt from the
+# "defined but not used" check below.
 xargs < "$STYLE_TMPDIR/extern_files" rg -o --no-line-number \
-    'extern const (int|Event|Metric) ([_A-Za-z0-9]+);' -r 'D $1 $2' > "$STYLE_TMPDIR/extern_combined"
+    'extern const (int|Event|Metric) ([_A-Za-z0-9]+);(?:.*?(NOLINT))?' -r 'D $1 $2 $3' > "$STYLE_TMPDIR/extern_combined"
 
 # Extract usages (skipping comment lines): "filepath:U NS NAME"
 xargs < "$STYLE_TMPDIR/extern_files" rg --no-line-number \
@@ -172,6 +175,7 @@ BEGIN {
         ns = type_to_ns[p[2]]
         key = file SUBSEP ns SUBSEP p[3]
         decl[key]++
+        if (p[4] == "NOLINT") used[key] = 1
     } else {
         key = file SUBSEP p[2] SUBSEP p[3]
         used[key] = 1

--- a/src/AggregateFunctions/examples/group_array_sorted.cpp
+++ b/src/AggregateFunctions/examples/group_array_sorted.cpp
@@ -1,6 +1,4 @@
 #include <algorithm>
-#include <type_traits>
-#include <utility>
 #include <iostream>
 
 #include <pcg_random.hpp>
@@ -8,6 +6,7 @@
 #include <Columns/ColumnVector.h>
 #include <Common/ArenaAllocator.h>
 #include <Common/RadixSort.h>
+#include <Common/Stopwatch.h>
 #include <Columns/ColumnArray.h>
 #include <Examples/clickhouse_examples.h>
 

--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -25,6 +25,7 @@
 #include <Interpreters/ProcessorsProfileLog.h>
 #include <Storages/IStorage.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/ProfileEvents.h>
 
 namespace ProfileEvents
 {

--- a/src/Backups/BackupEntryWithChecksumCalculation.cpp
+++ b/src/Backups/BackupEntryWithChecksumCalculation.cpp
@@ -1,5 +1,6 @@
 #include <Backups/BackupEntryWithChecksumCalculation.h>
 #include <IO/HashingReadBuffer.h>
+#include <Common/ProfileEvents.h>
 
 
 namespace ProfileEvents

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -6,6 +6,7 @@
 #include <Backups/IBackupCoordination.h>
 #include <Backups/BackupInfo.h>
 #include <Common/Logger_fwd.h>
+#include <atomic>
 #include <map>
 #include <mutex>
 

--- a/src/Client/ProgressTable.h
+++ b/src/Client/ProgressTable.h
@@ -2,13 +2,10 @@
 
 #include <Interpreters/ProfileEventsExt.h>
 #include <base/types.h>
-#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 
-#include <list>
 #include <map>
 #include <mutex>
-#include <ostream>
 #include <string_view>
 #include <unordered_map>
 #include <unistd.h>

--- a/src/Common/Arena.cpp
+++ b/src/Common/Arena.cpp
@@ -1,0 +1,25 @@
+#include <Common/Arena.h>
+#include <Common/ProfileEvents.h>
+
+namespace ProfileEvents
+{
+    extern const Event ArenaAllocChunks;
+    extern const Event ArenaAllocBytes;
+}
+
+namespace DB
+{
+
+Arena::MemoryChunk::MemoryChunk(size_t size_)
+{
+    ProfileEvents::increment(ProfileEvents::ArenaAllocChunks);
+    ProfileEvents::increment(ProfileEvents::ArenaAllocBytes, size_);
+
+    begin = reinterpret_cast<char *>(Allocator<false>::alloc(size_));
+    pos = begin;
+    end = begin + size_ - pad_right;
+
+    ASAN_POISON_MEMORY_REGION(begin, size_);
+}
+
+}

--- a/src/Common/Arena.h
+++ b/src/Common/Arena.h
@@ -6,7 +6,6 @@
 #include <Core/Defines.h>
 #include <boost/noncopyable.hpp>
 #include <Common/Allocator.h>
-#include <Common/ProfileEvents.h>
 #include <Common/memcpySmall.h>
 #include <base/getPageSize.h>
 
@@ -14,12 +13,6 @@
 #   include <sanitizer/asan_interface.h>
 #endif
 
-
-namespace ProfileEvents
-{
-    extern const Event ArenaAllocChunks;
-    extern const Event ArenaAllocBytes;
-}
 
 namespace DB
 {
@@ -68,17 +61,7 @@ private:
             return *this;
         }
 
-        explicit MemoryChunk(size_t size_)
-        {
-            ProfileEvents::increment(ProfileEvents::ArenaAllocChunks);
-            ProfileEvents::increment(ProfileEvents::ArenaAllocBytes, size_);
-
-            begin = reinterpret_cast<char *>(Allocator<false>::alloc(size_));
-            pos = begin;
-            end = begin + size_ - pad_right;
-
-            ASAN_POISON_MEMORY_REGION(begin, size_);
-        }
+        explicit MemoryChunk(size_t size_);
 
         ~MemoryChunk()
         {

--- a/src/Common/IThrottler.h
+++ b/src/Common/IThrottler.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Poco/Net/Throttler.h>
-#include <Common/ProfileEvents.h>
 #include <base/types.h>
 #include <boost/core/noncopyable.hpp>
 #include <memory>

--- a/src/Common/PageCache.h
+++ b/src/Common/PageCache.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <IO/BufferWithOwnMemory.h>
 #include <Common/CacheBase.h>
 #include <Common/CacheLine.h>
 #include <Common/HashTable/Hash.h>

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1778,26 +1778,6 @@ void Counters::incrementNoTrace(Event event, Count amount)
     } while (current != nullptr);
 }
 
-void incrementForLogMessage(Poco::Message::Priority priority)
-{
-    switch (priority)
-    {
-        case Poco::Message::PRIO_TEST: increment(LogTest); break;
-        case Poco::Message::PRIO_TRACE: increment(LogTrace); break;
-        case Poco::Message::PRIO_DEBUG: increment(LogDebug); break;
-        case Poco::Message::PRIO_INFORMATION: increment(LogInfo); break;
-        case Poco::Message::PRIO_WARNING: increment(LogWarning); break;
-        case Poco::Message::PRIO_ERROR: increment(LogError); break;
-        case Poco::Message::PRIO_FATAL: increment(LogFatal); break;
-        default: break;
-    }
-}
-
-void incrementLoggerElapsedNanoseconds(UInt64 ns)
-{
-    increment(LoggerElapsedNanoseconds, ns);
-}
-
 CountersIncrement::CountersIncrement(Counters::Snapshot const & snapshot)
 {
     init();

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -5,7 +5,6 @@
 #include <Interpreters/Context_fwd.h>
 #include <base/types.h>
 #include <base/strong_typedef.h>
-#include <Poco/Message.h>
 #include <atomic>
 #include <memory>
 #include <cstddef>
@@ -201,12 +200,6 @@ namespace ProfileEvents
     /// The same as above but ignores value of setting 'trace_profile_events'
     /// and never sends profile event to trace log.
     void incrementNoTrace(Event event, Count amount = 1);
-
-    /// Increment a counter for log messages.
-    void incrementForLogMessage(Poco::Message::Priority priority);
-
-    /// Increment time consumed by logging.
-    void incrementLoggerElapsedNanoseconds(UInt64 ns);
 
     /// Get name of event by identifier. Returns statically allocated string.
     const std::string_view & getName(Event event);

--- a/src/Common/ProfileEventsLogger.cpp
+++ b/src/Common/ProfileEventsLogger.cpp
@@ -1,0 +1,36 @@
+#include <Common/ProfileEventsLogger.h>
+#include <Common/ProfileEvents.h>
+
+namespace ProfileEvents
+{
+
+extern const Event LoggerElapsedNanoseconds; /// NOLINT(used here)
+extern const Event LogTest; /// NOLINT(used here)
+extern const Event LogTrace; /// NOLINT(used here)
+extern const Event LogDebug; /// NOLINT(used here)
+extern const Event LogInfo; /// NOLINT(used here)
+extern const Event LogWarning; /// NOLINT(used here)
+extern const Event LogError; /// NOLINT(used here)
+extern const Event LogFatal; /// NOLINT(used here)
+
+void incrementForLogMessage(Poco::Message::Priority priority)
+{
+    switch (priority)
+    {
+        case Poco::Message::PRIO_TEST: increment(LogTest); break;
+        case Poco::Message::PRIO_TRACE: increment(LogTrace); break;
+        case Poco::Message::PRIO_DEBUG: increment(LogDebug); break;
+        case Poco::Message::PRIO_INFORMATION: increment(LogInfo); break;
+        case Poco::Message::PRIO_WARNING: increment(LogWarning); break;
+        case Poco::Message::PRIO_ERROR: increment(LogError); break;
+        case Poco::Message::PRIO_FATAL: increment(LogFatal); break;
+        default: break;
+    }
+}
+
+void incrementLoggerElapsedNanoseconds(UInt64 ns)
+{
+    increment(LoggerElapsedNanoseconds, ns);
+}
+
+}

--- a/src/Common/ProfileEventsLogger.h
+++ b/src/Common/ProfileEventsLogger.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Poco/Message.h>
+#include <base/types.h>
+
+namespace ProfileEvents
+{
+    /// Increment a counter for log messages.
+    void incrementForLogMessage(Poco::Message::Priority priority);
+
+    /// Increment time consumed by logging.
+    void incrementLoggerElapsedNanoseconds(UInt64 ns);
+}

--- a/src/Common/Scheduler/CPUSlotsAllocation.h
+++ b/src/Common/Scheduler/CPUSlotsAllocation.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <vector>
 
 namespace DB
 {

--- a/src/Common/ThreadPoolTaskTracker.cpp
+++ b/src/Common/ThreadPoolTaskTracker.cpp
@@ -1,7 +1,6 @@
-#include "config.h"
-
 #include <Common/MemoryTracker.h>
 #include <Common/ThreadPoolTaskTracker.h>
+#include <Common/ProfileEvents.h>
 
 namespace ProfileEvents
 {

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -17,6 +17,7 @@
 #include <functional>
 #include <mutex>
 #include <unordered_set>
+#include <vector>
 
 
 template <class T>

--- a/src/Common/logger_useful.h
+++ b/src/Common/logger_useful.h
@@ -12,7 +12,7 @@
 #include <Common/LoggingFormatStringHelpers.h>
 #include <Common/LoggingHelpers.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
-#include <Common/ProfileEvents.h>
+#include <Common/ProfileEventsLogger.h>
 #include <Common/Stopwatch.h>
 
 

--- a/src/Dictionaries/SSDCacheDictionaryStorage.h
+++ b/src/Dictionaries/SSDCacheDictionaryStorage.h
@@ -11,6 +11,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <Common/ErrnoException.h>
+#include <Common/ProfileEvents.h>
 
 #    include <base/MemorySanitizer.h>
 #    include <Dictionaries/DictionaryHelpers.h>

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -9,6 +9,7 @@
 #include <IO/ParallelReadBuffer.h>
 #include <IO/SharedThreadPools.h>
 #include <IO/WriteHelpers.h>
+#include <IO/BufferWithOwnMemory.h>
 #include <Processors/Formats/IRowInputFormat.h>
 #include <Processors/Formats/IRowOutputFormat.h>
 #include <Processors/Formats/Impl/MySQLOutputFormat.h>

--- a/src/Formats/FormatFactory.h
+++ b/src/Formats/FormatFactory.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <Formats/FormatSettings.h>
-#include <IO/BufferWithOwnMemory.h>
 #include <IO/CompressionMethod.h>
 #include <Interpreters/Context_fwd.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <base/types.h>
-#include <Common/Allocator.h>
+#include <Common/Allocator_fwd.h>
 #include <Common/Documentation.h>
 #include <Common/NamePrompter.h>
 

--- a/src/IO/BufferWithOwnMemory.cpp
+++ b/src/IO/BufferWithOwnMemory.cpp
@@ -1,0 +1,23 @@
+#include "config.h"
+
+#include <IO/BufferWithOwnMemoryImpl.h>
+
+#include <Common/JemallocCacheAllocator.h>
+
+
+namespace DB
+{
+
+template void Memory<Allocator<false>>::alloc(size_t);
+template void Memory<Allocator<false>>::resize(size_t, bool);
+
+template void Memory<Allocator<true>>::alloc(size_t);
+template void Memory<Allocator<true>>::resize(size_t, bool);
+
+/// When jemalloc is disabled JemallocCacheAllocator is an alias for Allocator<false>, already instantiated above.
+#if USE_JEMALLOC
+template void Memory<JemallocCacheAllocator>::alloc(size_t);
+template void Memory<JemallocCacheAllocator>::resize(size_t, bool);
+#endif
+
+}

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -3,19 +3,11 @@
 #include <boost/noncopyable.hpp>
 
 #include <Common/Allocator.h>
-#include <Common/ProfileEvents.h>
 
 #include <Common/Exception.h>
 #include <Core/Defines.h>
 
 #include <base/arithmeticOverflow.h>
-
-
-namespace ProfileEvents
-{
-    extern const Event IOBufferAllocs;
-    extern const Event IOBufferAllocBytes;
-}
 
 
 namespace DB
@@ -77,36 +69,7 @@ struct Memory : boost::noncopyable, Allocator
     const char * data() const { return m_data; }
     char * data() { return m_data; }
 
-    void resize(size_t new_size, bool deallocate_if_empty = false)
-    {
-        if (!m_data)
-        {
-            alloc(new_size);
-            return;
-        }
-
-        if (new_size == 0 && deallocate_if_empty)
-        {
-            dealloc();
-            m_size = m_capacity = 0;
-            return;
-        }
-
-        if (new_size <= m_capacity - pad_right)
-        {
-            m_size = new_size;
-            return;
-        }
-
-        size_t new_capacity = withPadding(new_size);
-
-        size_t diff = new_capacity - m_capacity;
-        ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
-
-        m_data = static_cast<char *>(Allocator::realloc(m_data, m_capacity, new_capacity, alignment));
-        m_capacity = new_capacity;
-        m_size = new_size;
-    }
+    void resize(size_t new_size, bool deallocate_if_empty = false);
 
 private:
     static size_t withPadding(size_t value)
@@ -119,23 +82,7 @@ private:
         return res;
     }
 
-    void alloc(size_t new_size)
-    {
-        if (!new_size)
-        {
-            m_data = nullptr;
-            return;
-        }
-
-        size_t new_capacity = withPadding(new_size);
-
-        ProfileEvents::increment(ProfileEvents::IOBufferAllocs);
-        ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);
-
-        m_data = static_cast<char *>(Allocator::alloc(new_capacity, alignment));
-        m_capacity = new_capacity;
-        m_size = new_size;
-    }
+    void alloc(size_t new_size);
 
     void dealloc()
     {

--- a/src/IO/BufferWithOwnMemoryImpl.h
+++ b/src/IO/BufferWithOwnMemoryImpl.h
@@ -1,0 +1,76 @@
+#pragma once
+
+/// Definitions of Memory<Allocator>::alloc and Memory<Allocator>::resize.
+///
+/// Kept out of BufferWithOwnMemory.h so that the heavily included declaration header does not pull
+/// in ProfileEvents.h. Include this header only from the translation unit that instantiates Memory
+/// for a given allocator (BufferWithOwnMemory.cpp for the production allocators, or a test that uses
+/// its own allocator type).
+
+#include <IO/BufferWithOwnMemory.h>
+
+#include <Common/ProfileEvents.h>
+
+
+namespace ProfileEvents
+{
+    extern const Event IOBufferAllocs;
+    extern const Event IOBufferAllocBytes;
+}
+
+
+namespace DB
+{
+
+template <typename Allocator>
+void Memory<Allocator>::alloc(size_t new_size)
+{
+    if (!new_size)
+    {
+        m_data = nullptr;
+        return;
+    }
+
+    size_t new_capacity = withPadding(new_size);
+
+    ProfileEvents::increment(ProfileEvents::IOBufferAllocs);
+    ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, new_capacity);
+
+    m_data = static_cast<char *>(Allocator::alloc(new_capacity, alignment));
+    m_capacity = new_capacity;
+    m_size = new_size;
+}
+
+template <typename Allocator>
+void Memory<Allocator>::resize(size_t new_size, bool deallocate_if_empty)
+{
+    if (!m_data)
+    {
+        alloc(new_size);
+        return;
+    }
+
+    if (new_size == 0 && deallocate_if_empty)
+    {
+        dealloc();
+        m_size = m_capacity = 0;
+        return;
+    }
+
+    if (new_size <= m_capacity - pad_right)
+    {
+        m_size = new_size;
+        return;
+    }
+
+    size_t new_capacity = withPadding(new_size);
+
+    size_t diff = new_capacity - m_capacity;
+    ProfileEvents::increment(ProfileEvents::IOBufferAllocBytes, diff);
+
+    m_data = static_cast<char *>(Allocator::realloc(m_data, m_capacity, new_capacity, alignment));
+    m_capacity = new_capacity;
+    m_size = new_size;
+}
+
+}

--- a/src/IO/ReadBufferFromPocoSocket.h
+++ b/src/IO/ReadBufferFromPocoSocket.h
@@ -4,6 +4,7 @@
 #include <IO/ReadBuffer.h>
 #include <Common/AsyncTaskExecutor.h>
 #include <Common/Stopwatch.h>
+#include <Common/ProfileEvents.h>
 #include <Poco/Net/Socket.h>
 
 namespace DB

--- a/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
+++ b/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
@@ -1,4 +1,5 @@
 #include <IO/WriteBufferFromFileDescriptorDiscardOnFailure.h>
+#include <Common/ProfileEvents.h>
 
 namespace ProfileEvents
 {

--- a/src/IO/WriteBufferFromPocoSocket.h
+++ b/src/IO/WriteBufferFromPocoSocket.h
@@ -5,6 +5,7 @@
 #include <IO/WriteBuffer.h>
 #include <IO/BufferWithOwnMemory.h>
 #include <Common/AsyncTaskExecutor.h>
+#include <Common/ProfileEvents.h>
 
 namespace DB
 {

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -1,6 +1,6 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
-#include <IO/BufferWithOwnMemory.h>
+#include <IO/BufferWithOwnMemoryImpl.h>
 #include <gtest/gtest.h>
 #include <Common/ErrnoException.h>
 

--- a/src/Interpreters/DirectJoinMergeTreeEntity.cpp
+++ b/src/Interpreters/DirectJoinMergeTreeEntity.cpp
@@ -27,6 +27,7 @@
 #include <Planner/Utils.h>
 #include <Common/AllocatorWithMemoryTracking.h>
 #include <Common/ArenaAllocator.h>
+#include <Common/ProfileEvents.h>
 #include <Functions/CastOverloadResolver.h>
 
 

--- a/src/Interpreters/PartLog.h
+++ b/src/Interpreters/PartLog.h
@@ -10,11 +10,6 @@
 #include <Storages/MergeTree/MergeType.h>
 
 
-namespace ProfileEvents
-{
-    class Counters;
-}
-
 namespace DB
 {
 

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -7,6 +7,7 @@
 #include <Columns/FilterDescription.h>
 #include <Common/FieldAccurateComparison.h>
 #include <Common/checkStackSize.h>
+#include <Common/ProfileEvents.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Interpreters/castColumn.h>
 #include <IO/CompressionMethod.h>

--- a/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.cpp
@@ -7,6 +7,7 @@
 #include <Common/SharedMutex.h>
 #include <Common/typeid_cast.h>
 #include <Common/logger_useful.h>
+#include <Common/ProfileEvents.h>
 #include <algorithm>
 #include <vector>
 

--- a/src/Server/PostgreSQLHandler.h
+++ b/src/Server/PostgreSQLHandler.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <Common/CurrentMetrics.h>
-#include "config.h"
+#include <Common/ProfileEvents.h>
 #include <Core/PostgreSQLProtocol.h>
 #include <Poco/Net/TCPServerConnection.h>
 #include <Server/IServer.h>
+
+#include "config.h"
 
 #if USE_SSL
 #    include <Poco/Net/SSLManager.h>

--- a/src/Storages/MergeTree/IDataPartStorage.h
+++ b/src/Storages/MergeTree/IDataPartStorage.h
@@ -13,6 +13,7 @@
 #include <optional>
 
 #include <boost/core/noncopyable.hpp>
+#include <Poco/Timestamp.h>
 
 namespace DB
 {

--- a/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.cpp
+++ b/src/Storages/ObjectStorage/HDFS/AsynchronousReadBufferFromHDFS.cpp
@@ -4,6 +4,7 @@
 #include <Storages/ObjectStorage/HDFS/ReadBufferFromHDFS.h>
 #include <mutex>
 #include <Common/logger_useful.h>
+#include <Common/ProfileEvents.h>
 #include <Disks/IO/ThreadPoolRemoteFSReader.h>
 #include <IO/AsynchronousReader.h>
 #include <IO/ReadSettings.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Before: 2700TUs on ProfileEvents.h changes
After (as of now): 1200TUs

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.54`
<!-- ch-version-info:end -->