### PR TITLE
Simplify access-change notifications: replace two-tier notifications

### DIFF
--- a/src/Access/AccessChangesNotifier.cpp
+++ b/src/Access/AccessChangesNotifier.cpp
@@ -60,14 +60,18 @@ scope_guard AccessChangesNotifier::subscribeForChanges(AccessEntityType type, co
 scope_guard AccessChangesNotifier::subscribeForChanges(const UUID & id, const OnChangedHandler & handler)
 {
     std::lock_guard lock{handlers->mutex};
-    auto it = handlers->by_id.emplace(id, std::list<OnChangedHandler>{}).first;
-    auto & list = it->second;
+    auto & list = handlers->by_id[id];
     list.push_back(handler);
     auto handler_it = std::prev(list.end());
 
-    return [my_handlers = handlers, it, handler_it]
+    /// Capture `id`, not the map iterator: inserting another by-id subscription can rehash `by_id` and
+    /// invalidate the iterator (the `std::list` iterator `handler_it` stays valid across rehashes).
+    return [my_handlers = handlers, id, handler_it]
     {
         std::lock_guard lock2{my_handlers->mutex};
+        auto it = my_handlers->by_id.find(id);
+        if (it == my_handlers->by_id.end())
+            return;
         auto & list2 = it->second;
         list2.erase(handler_it);
         if (list2.empty())

--- a/src/Access/AccessChangesNotifier.cpp
+++ b/src/Access/AccessChangesNotifier.cpp
@@ -89,62 +89,78 @@ void AccessChangesNotifier::sendNotifications()
     /// Only one thread can send notifications at any time.
     std::lock_guard sending_notifications_lock{sending_notifications};
 
-    /// Drain the whole queue into a single batch.
-    std::vector<Change> batch;
+    /// Deliver in batches until the queue is empty.
+    ///
+    /// A handler may enqueue more changes while it runs (for example LDAP role mapping reacts to a Role change
+    /// by updating the mapped users), and those must be delivered before this call returns -
+    /// otherwise sessions keep stale access until some unrelated change flushes the queue.
+    ///
+    /// We always run at least one pass, even when the queue is empty,
+    /// so by-type handlers fire and a recomputation that previously threw is retried (see subscribeForChanges).
+    for (;;)
     {
+        /// Drain the whole queue into a single batch.
+        std::vector<Change> batch;
+        {
+            std::lock_guard queue_lock{queue_mutex};
+            batch = std::exchange(queue, {});
+        }
+
+        /// Group the batch by entity type (one copy of each change).
+        std::vector<Change> changes_by_type[static_cast<size_t>(AccessEntityType::MAX)];
+        for (const auto & change : batch)
+            changes_by_type[static_cast<size_t>(change.type)].push_back(change);
+
+        /// Snapshot the handlers and the changes to deliver to each of them, then call them without
+        /// `handlers->mutex` held (a handler may add or remove subscriptions, which takes that mutex).
+        const std::vector<Change> no_changes;
+        std::unordered_map<UUID, std::vector<Change>> changes_by_id; /// built only for subscribed ids
+        std::vector<std::pair<OnChangedHandler, const std::vector<Change> *>> calls;
+        {
+            std::lock_guard handlers_lock{handlers->mutex};
+
+            /// Every by-type handler is called even when nothing of its type changed (with an empty batch)
+            /// so a recomputation that threw is retried on the next call.
+            for (size_t type = 0; type != static_cast<size_t>(AccessEntityType::MAX); ++type)
+            {
+                const auto & changes = changes_by_type[type];
+                for (const auto & handler : handlers->by_type[type])
+                    calls.emplace_back(handler, changes.empty() ? &no_changes : &changes);
+            }
+
+            /// By-id handlers are called only for ids that actually changed.
+            /// Collect per-id changes only for ids someone subscribed to.
+            if (!handlers->by_id.empty())
+            {
+                for (const auto & change : batch)
+                {
+                    if (handlers->by_id.contains(change.id))
+                        changes_by_id[change.id].push_back(change);
+                }
+                for (const auto & [id, changes] : changes_by_id)
+                {
+                    for (const auto & handler : handlers->by_id.at(id))
+                        calls.emplace_back(handler, &changes);
+                }
+            }
+        }
+
+        for (const auto & [handler, changes] : calls)
+        {
+            try
+            {
+                handler(*changes);
+            }
+            catch (...)
+            {
+                tryLogCurrentException(__PRETTY_FUNCTION__);
+            }
+        }
+
+        /// Stop once a pass produced no new changes.
         std::lock_guard queue_lock{queue_mutex};
-        batch = std::exchange(queue, {});
-    }
-
-    /// Group the batch by entity type (one copy of each change).
-    std::vector<Change> changes_by_type[static_cast<size_t>(AccessEntityType::MAX)];
-    for (const auto & change : batch)
-        changes_by_type[static_cast<size_t>(change.type)].push_back(change);
-
-    /// Snapshot the handlers and the changes to deliver to each of them, then call them without
-    /// `handlers->mutex` held (a handler may add or remove subscriptions, which takes that mutex).
-    const std::vector<Change> no_changes;
-    std::unordered_map<UUID, std::vector<Change>> changes_by_id; /// built only for subscribed ids
-    std::vector<std::pair<OnChangedHandler, const std::vector<Change> *>> calls;
-    {
-        std::lock_guard handlers_lock{handlers->mutex};
-
-        /// Every by-type handler is called even when nothing of its type changed (with an empty batch)
-        /// so a recomputation that threw is retried on the next call.
-        for (size_t type = 0; type != static_cast<size_t>(AccessEntityType::MAX); ++type)
-        {
-            const auto & changes = changes_by_type[type];
-            for (const auto & handler : handlers->by_type[type])
-                calls.emplace_back(handler, changes.empty() ? &no_changes : &changes);
-        }
-
-        /// By-id handlers are called only for ids that actually changed.
-        /// Collect per-id changes only for ids someone subscribed to.
-        if (!handlers->by_id.empty())
-        {
-            for (const auto & change : batch)
-            {
-                if (handlers->by_id.contains(change.id))
-                    changes_by_id[change.id].push_back(change);
-            }
-            for (const auto & [id, changes] : changes_by_id)
-            {
-                for (const auto & handler : handlers->by_id.at(id))
-                    calls.emplace_back(handler, &changes);
-            }
-        }
-    }
-
-    for (const auto & [handler, changes] : calls)
-    {
-        try
-        {
-            handler(*changes);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
+        if (queue.empty())
+            break;
     }
 }
 

--- a/src/Access/AccessChangesNotifier.cpp
+++ b/src/Access/AccessChangesNotifier.cpp
@@ -1,6 +1,7 @@
 #include <Access/AccessChangesNotifier.h>
 #include <Common/Exception.h>
-#include <boost/range/algorithm/copy.hpp>
+
+#include <utility>
 
 
 namespace DB
@@ -15,30 +16,30 @@ AccessChangesNotifier::~AccessChangesNotifier() = default;
 void AccessChangesNotifier::onEntityAdded(const UUID & id, const AccessEntityPtr & new_entity)
 {
     std::lock_guard lock{queue_mutex};
-    Event event;
-    event.id = id;
-    event.entity = new_entity;
-    event.type = new_entity->getType();
-    queue.push(std::move(event));
+    Change change;
+    change.id = id;
+    change.entity = new_entity;
+    change.type = new_entity->getType();
+    queue.push_back(std::move(change));
 }
 
 void AccessChangesNotifier::onEntityUpdated(const UUID & id, const AccessEntityPtr & changed_entity)
 {
     std::lock_guard lock{queue_mutex};
-    Event event;
-    event.id = id;
-    event.entity = changed_entity;
-    event.type = changed_entity->getType();
-    queue.push(std::move(event));
+    Change change;
+    change.id = id;
+    change.entity = changed_entity;
+    change.type = changed_entity->getType();
+    queue.push_back(std::move(change));
 }
 
 void AccessChangesNotifier::onEntityRemoved(const UUID & id, AccessEntityType type)
 {
     std::lock_guard lock{queue_mutex};
-    Event event;
-    event.id = id;
-    event.type = type;
-    queue.push(std::move(event));
+    Change change;
+    change.id = id;
+    change.type = type;
+    queue.push_back(std::move(change));
 }
 
 scope_guard AccessChangesNotifier::subscribeForChanges(AccessEntityType type, const OnChangedHandler & handler)
@@ -83,74 +84,62 @@ scope_guard AccessChangesNotifier::subscribeForChanges(const std::vector<UUID> &
     return subscriptions;
 }
 
-scope_guard AccessChangesNotifier::subscribeForBatchFinished(const OnBatchFinishedHandler & handler)
-{
-    std::lock_guard lock{handlers->mutex};
-    auto & list = handlers->on_batch_finished;
-    list.push_back(handler);
-    auto handler_it = std::prev(list.end());
-
-    return [my_handlers = handlers, handler_it]
-    {
-        std::lock_guard lock2{my_handlers->mutex};
-        my_handlers->on_batch_finished.erase(handler_it);
-    };
-}
-
 void AccessChangesNotifier::sendNotifications()
 {
-    /// Only one thread can send notification at any time.
+    /// Only one thread can send notifications at any time.
     std::lock_guard sending_notifications_lock{sending_notifications};
 
-    std::unique_lock queue_lock{queue_mutex};
-    while (!queue.empty())
+    /// Drain the whole queue into a single batch.
+    std::vector<Change> batch;
     {
-        auto event = std::move(queue.front());
-        queue.pop();
-        queue_lock.unlock();
-
-        std::vector<OnChangedHandler> current_handlers;
-        {
-            std::lock_guard handlers_lock{handlers->mutex};
-            boost::range::copy(handlers->by_type[static_cast<size_t>(event.type)], std::back_inserter(current_handlers));
-            auto it = handlers->by_id.find(event.id);
-            if (it != handlers->by_id.end())
-                boost::range::copy(it->second, std::back_inserter(current_handlers));
-        }
-
-        for (const auto & handler : current_handlers)
-        {
-            try
-            {
-                handler(event.id, event.entity);
-            }
-            catch (...)
-            {
-                tryLogCurrentException(__PRETTY_FUNCTION__);
-            }
-        }
-
-        queue_lock.lock();
+        std::lock_guard queue_lock{queue_mutex};
+        batch = std::exchange(queue, {});
     }
-    queue_lock.unlock();
 
-    /// Run the coalesced per-batch work unconditionally, even when this call drained nothing: a
-    /// per-batch handler whose previous rebuild threw left its work pending, and the per-entity flag
-    /// guarding that rebuild is only cleared on success, so the retry must not depend on a fresh event
-    /// being queued (an up-to-date `SYSTEM RELOAD USERS` diffs to zero and would otherwise never retry).
-    /// Each handler is cheap when nothing is pending (a mutex + a flag check). Copied out so handlers
-    /// run without `handlers->mutex` held.
-    std::vector<OnBatchFinishedHandler> batch_finished_handlers;
+    /// Group the batch by entity type (one copy of each change).
+    std::vector<Change> changes_by_type[static_cast<size_t>(AccessEntityType::MAX)];
+    for (const auto & change : batch)
+        changes_by_type[static_cast<size_t>(change.type)].push_back(change);
+
+    /// Snapshot the handlers and the changes to deliver to each of them, then call them without
+    /// `handlers->mutex` held (a handler may add or remove subscriptions, which takes that mutex).
+    const std::vector<Change> no_changes;
+    std::unordered_map<UUID, std::vector<Change>> changes_by_id; /// built only for subscribed ids
+    std::vector<std::pair<OnChangedHandler, const std::vector<Change> *>> calls;
     {
         std::lock_guard handlers_lock{handlers->mutex};
-        boost::range::copy(handlers->on_batch_finished, std::back_inserter(batch_finished_handlers));
+
+        /// Every by-type handler is called even when nothing of its type changed (with an empty batch)
+        /// so a recomputation that threw is retried on the next call.
+        for (size_t type = 0; type != static_cast<size_t>(AccessEntityType::MAX); ++type)
+        {
+            const auto & changes = changes_by_type[type];
+            for (const auto & handler : handlers->by_type[type])
+                calls.emplace_back(handler, changes.empty() ? &no_changes : &changes);
+        }
+
+        /// By-id handlers are called only for ids that actually changed.
+        /// Collect per-id changes only for ids someone subscribed to.
+        if (!handlers->by_id.empty())
+        {
+            for (const auto & change : batch)
+            {
+                if (handlers->by_id.contains(change.id))
+                    changes_by_id[change.id].push_back(change);
+            }
+            for (const auto & [id, changes] : changes_by_id)
+            {
+                for (const auto & handler : handlers->by_id.at(id))
+                    calls.emplace_back(handler, &changes);
+            }
+        }
     }
 
-    for (const auto & handler : batch_finished_handlers)
+    for (const auto & [handler, changes] : calls)
     {
         try
         {
-            handler();
+            handler(*changes);
         }
         catch (...)
         {

--- a/src/Access/AccessChangesNotifier.h
+++ b/src/Access/AccessChangesNotifier.h
@@ -4,8 +4,8 @@
 #include <base/scope_guard.h>
 #include <list>
 #include <mutex>
-#include <queue>
 #include <unordered_map>
+#include <vector>
 
 
 namespace DB
@@ -18,11 +18,24 @@ public:
     AccessChangesNotifier();
     ~AccessChangesNotifier();
 
-    using OnChangedHandler
-        = std::function<void(const UUID & /* id */, const AccessEntityPtr & /* new or changed entity, null if removed */)>;
+    /// A single access entity change. `entity` is the new or changed entity, or null if the entity was removed.
+    struct Change
+    {
+        UUID id;
+        AccessEntityPtr entity;
+        AccessEntityType type{};
+    };
 
-    /// Subscribes for all changes.
-    /// Can return nullptr if cannot subscribe (identifier not found) or if it doesn't make sense (the storage is read-only).
+    /// A handler is called once per sendNotifications() with the changes of that batch that match the
+    /// subscription. sendNotifications() drains the whole queue in one pass, so a refresh that touches many
+    /// entities arrives as a single call: the subscriber updates its bookkeeping for each change and runs
+    /// any expensive recomputation just once per batch (a single rebuild instead of one per changed entity).
+    using OnChangedHandler = std::function<void(const std::vector<Change> & changes)>;
+
+    /// Subscribes for all changes of entities of a given type.
+    /// A by-type handler is called on every sendNotifications(), even when no entity of that type changed
+    /// (with an empty `changes`), so a recomputation that threw (and left its work pending) is retried on
+    /// the next call without waiting for a fresh access change; it must therefore be cheap when idle.
     scope_guard subscribeForChanges(AccessEntityType type, const OnChangedHandler & handler);
 
     template <typename EntityClassT>
@@ -32,19 +45,9 @@ public:
     }
 
     /// Subscribes for changes of a specific entry.
-    /// Can return nullptr if cannot subscribe (identifier not found) or if it doesn't make sense (the storage is read-only).
+    /// A by-id handler is called only when its entity actually changed in the batch.
     scope_guard subscribeForChanges(const UUID & id, const OnChangedHandler & handler);
     scope_guard subscribeForChanges(const std::vector<UUID> & ids, const OnChangedHandler & handler);
-
-    using OnBatchFinishedHandler = std::function<void()>;
-
-    /// Subscribes for the end of a notification batch: the handler is called once per sendNotifications()
-    /// after all the per-entity notifications queued so far have been dispatched. Lets subscribers coalesce
-    /// expensive per-entity recomputations into a single one per batch (e.g. a full refresh delivers one
-    /// notification per entity, but the derived state only needs to be rebuilt once). The handler is also
-    /// called when the batch was empty, so a recomputation that threw (and left its work pending) is retried
-    /// on the next call without waiting for a fresh access change; it must therefore be cheap when idle.
-    scope_guard subscribeForBatchFinished(const OnBatchFinishedHandler & handler);
 
     /// Called by access storages after a new access entity has been added.
     void onEntityAdded(const UUID & id, const AccessEntityPtr & new_entity);
@@ -64,20 +67,13 @@ private:
     {
         std::unordered_map<UUID, std::list<OnChangedHandler>> by_id;
         std::list<OnChangedHandler> by_type[static_cast<size_t>(AccessEntityType::MAX)];
-        std::list<OnBatchFinishedHandler> on_batch_finished;
         std::mutex mutex;
     };
 
     /// shared_ptr is here for safety because AccessChangesNotifier can be destroyed before all subscriptions are removed.
     std::shared_ptr<Handlers> handlers;
 
-    struct Event
-    {
-        UUID id;
-        AccessEntityPtr entity;
-        AccessEntityType type{};
-    };
-    std::queue<Event> queue;
+    std::vector<Change> queue;
     std::mutex queue_mutex;
     std::mutex sending_notifications;
 };

--- a/src/Access/AccessChangesNotifier.h
+++ b/src/Access/AccessChangesNotifier.h
@@ -26,10 +26,10 @@ public:
         AccessEntityType type{};
     };
 
-    /// A handler is called once per sendNotifications() with the changes of that batch that match the
-    /// subscription. sendNotifications() drains the whole queue in one pass, so a refresh that touches many
-    /// entities arrives as a single call: the subscriber updates its bookkeeping for each change and runs
-    /// any expensive recomputation just once per batch (a single rebuild instead of one per changed entity).
+    /// A handler is called once per delivered batch with the changes of that batch that match the subscription.
+    /// sendNotifications drains the current queue into a batch, delivers it, and repeats until the queue is empty.
+    /// A refresh that touches many entities therefore arrives as a single call, and handler-enqueued changes are
+    /// also delivered before sendNotifications returns (as additional batches).
     using OnChangedHandler = std::function<void(const std::vector<Change> & changes)>;
 
     /// Subscribes for all changes of entities of a given type.

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -559,11 +559,6 @@ scope_guard AccessControl::subscribeForChanges(const std::vector<UUID> & ids, co
     return changes_notifier->subscribeForChanges(ids, handler);
 }
 
-scope_guard AccessControl::subscribeForBatchFinished(const OnBatchFinishedHandler & handler) const
-{
-    return changes_notifier->subscribeForBatchFinished(handler);
-}
-
 bool AccessControl::insertImpl(const UUID & id, const AccessEntityPtr & entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id)
 {
     if (MultipleAccessStorage::insertImpl(id, entity, replace_if_exists, throw_if_exists, conflicting_id))

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include <Access/AccessChangesNotifier.h>
 #include <Access/MultipleAccessStorage.h>
 #include <Access/Common/AuthenticationType.h>
 #include <Common/SettingsChanges.h>
@@ -49,7 +50,6 @@ class SettingsProfilesCache;
 class SettingsProfileElements;
 class ClientInfo;
 class ExternalAuthenticators;
-class AccessChangesNotifier;
 struct Settings;
 
 
@@ -114,24 +114,17 @@ public:
     /// Reloads and updates all access entities.
     void reload(ReloadMode reload_mode) override;
 
-    using OnChangedHandler = std::function<void(const UUID & /* id */, const AccessEntityPtr & /* new or changed entity, null if removed */)>;
+    using OnChangedHandler = AccessChangesNotifier::OnChangedHandler;
 
-    /// Subscribes for all changes.
-    /// Can return nullptr if cannot subscribe (identifier not found) or if it doesn't make sense (the storage is read-only).
+    /// Subscribes for all changes of entities of a given type (see AccessChangesNotifier::subscribeForChanges).
     scope_guard subscribeForChanges(AccessEntityType type, const OnChangedHandler & handler) const;
 
     template <typename EntityClassT>
     scope_guard subscribeForChanges(OnChangedHandler handler) const { return subscribeForChanges(EntityClassT::TYPE, handler); }
 
     /// Subscribes for changes of a specific entry.
-    /// Can return nullptr if cannot subscribe (identifier not found) or if it doesn't make sense (the storage is read-only).
     scope_guard subscribeForChanges(const UUID & id, const OnChangedHandler & handler) const;
     scope_guard subscribeForChanges(const std::vector<UUID> & ids, const OnChangedHandler & handler) const;
-
-    using OnBatchFinishedHandler = std::function<void()>;
-
-    /// Subscribes for the end of a notification batch (see AccessChangesNotifier::subscribeForBatchFinished).
-    scope_guard subscribeForBatchFinished(const OnBatchFinishedHandler & handler) const;
 
     AuthResult authenticate(const Credentials & credentials, const Poco::Net::IPAddress & address, const ClientInfo & client_info) const;
 

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -344,11 +344,13 @@ void ContextAccess::initialize()
 
     subscription_for_user_change = access_control->subscribeForChanges(
         *params.user_id,
-        [weak_ptr = weak_from_this()](const UUID &, const AccessEntityPtr & entity)
+        [weak_ptr = weak_from_this()](const std::vector<AccessChangesNotifier::Change> & changes)
         {
             auto ptr = weak_ptr.lock();
             if (!ptr)
                 return;
+            /// All changes are for the same user id; the last one reflects its current state.
+            const auto & entity = changes.back().entity;
             UserPtr changed_user = entity ? typeid_cast<UserPtr>(entity) : nullptr;
             std::lock_guard lock2{ptr->mutex};
             ptr->setUser(changed_user);
@@ -427,7 +429,7 @@ void ContextAccess::setUser(const UserPtr & user_) const
     {
         subscription_for_initial_user_change = access_control->subscribeForChanges(
             *params.initial_user_id,
-            [weak_ptr = weak_from_this()](const UUID &, const AccessEntityPtr &)
+            [weak_ptr = weak_from_this()](const std::vector<AccessChangesNotifier::Change> &)
             {
                 if (auto ptr = weak_ptr.lock())
                 {

--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -86,9 +86,10 @@ void LDAPAccessStorage::setConfiguration(const Poco::Util::AbstractConfiguration
     granted_role_ids.clear();
 
     role_change_subscription = access_control.subscribeForChanges<Role>(
-        [this] (const UUID & id, const AccessEntityPtr & entity)
+        [this] (const std::vector<AccessChangesNotifier::Change> & changes)
         {
-            this->processRoleChange(id, entity);
+            for (const auto & change : changes)
+                this->processRoleChange(change.id, change.entity);
         }
     );
 }

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -289,7 +289,6 @@ void QuotaCache::ensureAllQuotasRead()
     /// `mutex` is already locked.
     if (all_quotas_read)
         return;
-    all_quotas_read = true;
 
     subscription = access_control.subscribeForChanges<Quota>(
         [this](const std::vector<AccessChangesNotifier::Change> & changes)
@@ -305,12 +304,17 @@ void QuotaCache::ensureAllQuotasRead()
             chooseQuotaToConsumeIfNeeded();
         });
 
+    /// Start clean: a previous attempt may have thrown mid-scan.
+    all_quotas.clear();
     for (const UUID & quota_id : access_control.findAll<Quota>())
     {
         auto quota = access_control.tryRead<Quota>(quota_id);
         if (quota)
             all_quotas.emplace(quota_id, QuotaInfo(quota, quota_id));
     }
+
+    /// Set only after the subscription and the initial read succeed.
+    all_quotas_read = true;
 }
 
 

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -292,15 +292,23 @@ void QuotaCache::ensureAllQuotasRead()
     all_quotas_read = true;
 
     subscription = access_control.subscribeForChanges<Quota>(
-        [&](const UUID & id, const AccessEntityPtr & entity)
+        [this](const std::vector<AccessChangesNotifier::Change> & changes)
         {
-            if (entity)
-                quotaAddedOrChanged(id, typeid_cast<QuotaPtr>(entity));
-            else
-                quotaRemoved(id);
+            std::lock_guard lock{mutex};
+            for (const auto & change : changes)
+            {
+                if (change.entity)
+                    quotaAddedOrChanged(change.id, typeid_cast<QuotaPtr>(change.entity));
+                else
+                    quotaRemoved(change.id);
+            }
+            if (need_choose_quota)
+            {
+                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+                chooseQuotaToConsume();
+                need_choose_quota = false;
+            }
         });
-
-    batch_subscription = access_control.subscribeForBatchFinished([this] { chooseQuotaToConsumeIfNeeded(); });
 
     for (const UUID & quota_id : access_control.findAll<Quota>())
     {
@@ -313,7 +321,7 @@ void QuotaCache::ensureAllQuotasRead()
 
 void QuotaCache::quotaAddedOrChanged(const UUID & quota_id, const std::shared_ptr<const Quota> & new_quota)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     auto it = all_quotas.find(quota_id);
     if (it == all_quotas.end())
     {
@@ -333,20 +341,9 @@ void QuotaCache::quotaAddedOrChanged(const UUID & quota_id, const std::shared_pt
 
 void QuotaCache::quotaRemoved(const UUID & quota_id)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     all_quotas.erase(quota_id);
     need_choose_quota = true;
-}
-
-
-void QuotaCache::chooseQuotaToConsumeIfNeeded()
-{
-    std::lock_guard lock{mutex};
-    if (!need_choose_quota)
-        return;
-    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-    chooseQuotaToConsume();
-    need_choose_quota = false;
 }
 
 

--- a/src/Access/QuotaCache.cpp
+++ b/src/Access/QuotaCache.cpp
@@ -302,12 +302,7 @@ void QuotaCache::ensureAllQuotasRead()
                 else
                     quotaRemoved(change.id);
             }
-            if (need_choose_quota)
-            {
-                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-                chooseQuotaToConsume();
-                need_choose_quota = false;
-            }
+            chooseQuotaToConsumeIfNeeded();
         });
 
     for (const UUID & quota_id : access_control.findAll<Quota>())
@@ -344,6 +339,17 @@ void QuotaCache::quotaRemoved(const UUID & quota_id)
     /// `mutex` is already locked.
     all_quotas.erase(quota_id);
     need_choose_quota = true;
+}
+
+
+void QuotaCache::chooseQuotaToConsumeIfNeeded()
+{
+    /// `mutex` is already locked.
+    if (!need_choose_quota)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+    chooseQuotaToConsume();
+    need_choose_quota = false;
 }
 
 

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -58,8 +58,9 @@ private:
     void ensureAllQuotasRead();
     void quotaAddedOrChanged(const UUID & quota_id, const std::shared_ptr<const Quota> & new_quota) TSA_REQUIRES(mutex);
     void quotaRemoved(const UUID & quota_id) TSA_REQUIRES(mutex);
-    void chooseQuotaToConsume();
-    void chooseQuotaToConsumeFor(EnabledQuota & enabled_quota, bool throw_if_client_key_empty);
+    void chooseQuotaToConsumeIfNeeded() TSA_REQUIRES(mutex);
+    void chooseQuotaToConsume() TSA_REQUIRES(mutex);
+    void chooseQuotaToConsumeFor(EnabledQuota & enabled_quota, bool throw_if_client_key_empty) TSA_REQUIRES(mutex);
 
     const AccessControl & access_control;
     mutable std::mutex mutex;

--- a/src/Access/QuotaCache.h
+++ b/src/Access/QuotaCache.h
@@ -56,20 +56,18 @@ private:
     };
 
     void ensureAllQuotasRead();
-    void quotaAddedOrChanged(const UUID & quota_id, const std::shared_ptr<const Quota> & new_quota);
-    void quotaRemoved(const UUID & quota_id);
+    void quotaAddedOrChanged(const UUID & quota_id, const std::shared_ptr<const Quota> & new_quota) TSA_REQUIRES(mutex);
+    void quotaRemoved(const UUID & quota_id) TSA_REQUIRES(mutex);
     void chooseQuotaToConsume();
-    void chooseQuotaToConsumeIfNeeded();
     void chooseQuotaToConsumeFor(EnabledQuota & enabled_quota, bool throw_if_client_key_empty);
 
     const AccessControl & access_control;
     mutable std::mutex mutex;
     std::unordered_map<UUID /* quota id */, QuotaInfo> all_quotas;
     bool all_quotas_read = false;
-    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    /// Set while applying a batch of changes; the rebuild is coalesced to once per notification batch.
     bool need_choose_quota TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
-    scope_guard batch_subscription;
     std::map<EnabledQuota::Params, std::weak_ptr<EnabledQuota>> enabled_quotas;
 };
 }

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -89,6 +89,7 @@ std::shared_ptr<const EnabledRoles>
 RoleCache::getEnabledRoles(boost::container::flat_set<UUID> roles, boost::container::flat_set<UUID> roles_with_admin_option)
 {
     std::lock_guard lock{mutex};
+    ensureSubscribed();
 
     EnabledRoles::Params params;
     params.current_roles = std::move(roles);
@@ -96,16 +97,50 @@ RoleCache::getEnabledRoles(boost::container::flat_set<UUID> roles, boost::contai
     auto it = enabled_roles_by_params.find(params);
     if (it != enabled_roles_by_params.end())
     {
-        if (auto enabled_roles = it->second.enabled_roles.lock())
+        if (auto enabled_roles = it->second.lock())
             return enabled_roles;
         enabled_roles_by_params.erase(it);
     }
 
     auto res = std::shared_ptr<EnabledRoles>(new EnabledRoles(params));
-    SubscriptionsOnRoles subscriptions_on_roles;
-    collectEnabledRoles(*res, subscriptions_on_roles, nullptr);
-    enabled_roles_by_params.emplace(std::move(params), EnabledRolesWithSubscriptions{res, std::move(subscriptions_on_roles)});
+    collectEnabledRoles(*res, nullptr);
+    enabled_roles_by_params.emplace(std::move(params), res);
     return res;
+}
+
+
+void RoleCache::ensureSubscribed()
+{
+    /// `mutex` is already locked.
+
+    /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
+    if (subscribed)
+        return;
+    subscribed = true;
+
+    /// A single subscription for all roles: each batch updates the cached roles and runs one coalesced
+    /// recalculation, instead of one subscription (and one recalculation) per role.
+    subscription = access_control.subscribeForChanges<Role>(
+        [this](const std::vector<AccessChangesNotifier::Change> & changes)
+        {
+            /// Declared before `lock` to send notifications after the mutex will be unlocked.
+            scope_guard notifications;
+
+            std::lock_guard lock{mutex};
+            for (const auto & change : changes)
+            {
+                if (auto changed_role = change.entity ? typeid_cast<RolePtr>(change.entity) : nullptr)
+                    roleChanged(change.id, changed_role);
+                else
+                    roleRemoved(change.id);
+            }
+            if (need_collect_enabled_roles)
+            {
+                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+                collectEnabledRoles(&notifications);
+                need_collect_enabled_roles = false;
+            }
+        });
 }
 
 
@@ -115,12 +150,14 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 
     ProfileEvents::increment(ProfileEvents::RoleCacheRecalculations);
     Stopwatch watch;
+    /// Recompute the set of roles that take part in some enabled set from scratch (it also drops roles
+    /// that are only referenced by enabled sets that have expired by now).
+    referenced_roles.clear();
     for (auto i = enabled_roles_by_params.begin(), e = enabled_roles_by_params.end(); i != e;)
     {
-        auto & item = i->second;
-        if (auto enabled_roles = item.enabled_roles.lock())
+        if (auto enabled_roles = i->second.lock())
         {
-            collectEnabledRoles(*enabled_roles, item.subscriptions_on_roles, notifications);
+            collectEnabledRoles(*enabled_roles, notifications);
             ++i;
         }
         else
@@ -139,7 +176,7 @@ void RoleCache::collectEnabledRoles(scope_guard * notifications)
 }
 
 
-void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications)
+void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, scope_guard * notifications)
 {
     /// `mutex` is already locked.
 
@@ -147,11 +184,7 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsO
     auto new_info = std::make_shared<EnabledRolesInfo>();
     boost::container::flat_set<UUID> skip_ids;
 
-    /// We need to collect and keep not only enabled roles but also subscriptions for them to be able to recalculate EnabledRolesInfo when some of the roles change.
-    SubscriptionsOnRoles new_subscriptions_on_roles;
-    new_subscriptions_on_roles.reserve(subscriptions_on_roles.size());
-
-    auto get_role_function = [this, &new_subscriptions_on_roles](const UUID & id) TSA_NO_THREAD_SAFETY_ANALYSIS { return getRole(id, new_subscriptions_on_roles); };
+    auto get_role_function = [this](const UUID & id) TSA_NO_THREAD_SAFETY_ANALYSIS { return getRole(id); };
 
     for (const auto & current_role : enabled_roles.params.current_roles)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, false);
@@ -159,52 +192,27 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsO
     for (const auto & current_role : enabled_roles.params.current_roles_with_admin_option)
         collectRoles(*new_info, skip_ids, get_role_function, current_role, true, true);
 
-    /// Remove duplicates from `subscriptions_on_roles`.
-    std::sort(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end());
-    new_subscriptions_on_roles.erase(std::unique(new_subscriptions_on_roles.begin(), new_subscriptions_on_roles.end()), new_subscriptions_on_roles.end());
-    subscriptions_on_roles = std::move(new_subscriptions_on_roles);
+    /// Remember which roles take part in this enabled set, so that a later change to one of them triggers
+    /// a recalculation (and a change to a role nobody uses does not).
+    referenced_roles.insert(new_info->enabled_roles.begin(), new_info->enabled_roles.end());
 
     /// Collect data from the collected roles.
     enabled_roles.setRolesInfo(new_info, notifications);
 }
 
 
-RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles)
+RolePtr RoleCache::getRole(const UUID & role_id)
 {
     /// `mutex` is already locked.
 
-    /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
-    if (!batch_subscribed)
-    {
-        batch_subscription = access_control.subscribeForBatchFinished([this] { collectEnabledRolesIfNeeded(); });
-        batch_subscribed = true;
-    }
-
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
-    {
-        subscriptions_on_roles.emplace_back(role_from_cache->second);
-        return role_from_cache->first;
-    }
-
-    auto on_role_changed_or_removed = [this, role_id](const UUID &, const AccessEntityPtr & entity)
-    {
-        auto changed_role = entity ? typeid_cast<RolePtr>(entity) : nullptr;
-        if (changed_role)
-            roleChanged(role_id, changed_role);
-        else
-            roleRemoved(role_id);
-    };
-
-    auto subscription_on_role = std::make_shared<scope_guard>(access_control.subscribeForChanges(role_id, on_role_changed_or_removed));
+        return *role_from_cache;
 
     auto role = access_control.tryRead<Role>(role_id);
     if (role)
     {
-        auto cache_value = Poco::SharedPtr<std::pair<RolePtr, std::shared_ptr<scope_guard>>>(
-            new std::pair<RolePtr, std::shared_ptr<scope_guard>>{role, subscription_on_role});
-        cache.add(role_id, cache_value);
-        subscriptions_on_roles.emplace_back(subscription_on_role);
+        cache.add(role_id, role);
         return role;
     }
 
@@ -214,44 +222,32 @@ RolePtr RoleCache::getRole(const UUID & role_id, SubscriptionsOnRoles & subscrip
 
 void RoleCache::roleChanged(const UUID & role_id, const RolePtr & changed_role)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
 
     auto role_from_cache = cache.get(role_id);
     if (role_from_cache)
     {
         /// We update the role stored in a cache entry only if that entry has not expired yet.
-        role_from_cache->first = changed_role;
+        *role_from_cache = changed_role;
         cache.update(role_id, role_from_cache);
     }
 
-    /// An enabled role for some users has been changed, we need to recalculate the access rights.
-    need_collect_enabled_roles = true;
+    /// Recalculate the access rights only if this role takes part in some enabled set.
+    if (referenced_roles.contains(role_id))
+        need_collect_enabled_roles = true;
 }
 
 
 void RoleCache::roleRemoved(const UUID & role_id)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
 
     /// If a cache entry with the role has expired already, that remove() will do nothing.
     cache.remove(role_id);
 
-    /// An enabled role for some users has been removed, we need to recalculate the access rights.
-    need_collect_enabled_roles = true;
-}
-
-
-void RoleCache::collectEnabledRolesIfNeeded()
-{
-    /// Declared before `lock` to send notifications after the mutex will be unlocked.
-    scope_guard notifications;
-
-    std::lock_guard lock{mutex};
-    if (!need_collect_enabled_roles)
-        return;
-    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-    collectEnabledRoles(&notifications); /// collectEnabledRoles() must be called with the `mutex` locked.
-    need_collect_enabled_roles = false;
+    /// Recalculate the access rights only if this role takes part in some enabled set.
+    if (referenced_roles.contains(role_id))
+        need_collect_enabled_roles = true;
 }
 
 }

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -194,7 +194,10 @@ void RoleCache::collectEnabledRoles(EnabledRoles & enabled_roles, scope_guard * 
 
     /// Remember which roles take part in this enabled set, so that a later change to one of them triggers
     /// a recalculation (and a change to a role nobody uses does not).
+    /// We need to remember `skip_ids` too in order to trigger a recalculation if they appear later
+    /// (for example if a role with a granted role is replicated before that granted role);
     referenced_roles.insert(new_info->enabled_roles.begin(), new_info->enabled_roles.end());
+    referenced_roles.insert(skip_ids.begin(), skip_ids.end());
 
     /// Collect data from the collected roles.
     enabled_roles.setRolesInfo(new_info, notifications);

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -116,7 +116,6 @@ void RoleCache::ensureSubscribed()
     /// Lazy (not in the ctor): `changes_notifier` is constructed after the caches in `AccessControl`.
     if (subscribed)
         return;
-    subscribed = true;
 
     /// A single subscription for all roles: each batch updates the cached roles and runs one coalesced
     /// recalculation, instead of one subscription (and one recalculation) per role.
@@ -136,6 +135,9 @@ void RoleCache::ensureSubscribed()
             }
             collectEnabledRolesIfNeeded(&notifications);
         });
+
+    /// Set after the subscription is established.
+    subscribed = true;
 }
 
 

--- a/src/Access/RoleCache.cpp
+++ b/src/Access/RoleCache.cpp
@@ -134,13 +134,19 @@ void RoleCache::ensureSubscribed()
                 else
                     roleRemoved(change.id);
             }
-            if (need_collect_enabled_roles)
-            {
-                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-                collectEnabledRoles(&notifications);
-                need_collect_enabled_roles = false;
-            }
+            collectEnabledRolesIfNeeded(&notifications);
         });
+}
+
+
+void RoleCache::collectEnabledRolesIfNeeded(scope_guard * notifications)
+{
+    /// `mutex` is already locked.
+    if (!need_collect_enabled_roles)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+    collectEnabledRoles(notifications);
+    need_collect_enabled_roles = false;
 }
 
 

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <mutex>
+#include <unordered_set>
 #include <Access/EnabledRoles.h>
 #include <Poco/AccessExpireCache.h>
 
@@ -27,34 +28,26 @@ public:
         boost::container::flat_set<UUID> current_roles_with_admin_option);
 
 private:
-    using SubscriptionsOnRoles = std::vector<std::shared_ptr<scope_guard>>;
-
+    void ensureSubscribed() TSA_REQUIRES(mutex);
     void collectEnabledRoles(scope_guard * notifications) TSA_REQUIRES(mutex);
-    void collectEnabledRoles(EnabledRoles & enabled_roles, SubscriptionsOnRoles & subscriptions_on_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
-    void collectEnabledRolesIfNeeded();
-    RolePtr getRole(const UUID & role_id, SubscriptionsOnRoles & subscriptions_on_roles) TSA_REQUIRES(mutex);
-    void roleChanged(const UUID & role_id, const RolePtr & changed_role);
-    void roleRemoved(const UUID & role_id);
+    void collectEnabledRoles(EnabledRoles & enabled_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
+    RolePtr getRole(const UUID & role_id) TSA_REQUIRES(mutex);
+    void roleChanged(const UUID & role_id, const RolePtr & changed_role) TSA_REQUIRES(mutex);
+    void roleRemoved(const UUID & role_id) TSA_REQUIRES(mutex);
 
     const AccessControl & access_control;
-    scope_guard batch_subscription;
-    bool batch_subscribed TSA_GUARDED_BY(mutex) = false;
+    scope_guard subscription;
+    bool subscribed TSA_GUARDED_BY(mutex) = false;
 
-    /// Set by the per-entity handler; the recalculation is coalesced to once per notification batch.
+    /// Set while applying a batch of changes; the recalculation is coalesced to once per notification batch.
     bool need_collect_enabled_roles TSA_GUARDED_BY(mutex) = false;
 
-    Poco::AccessExpireCache<UUID, std::pair<RolePtr, std::shared_ptr<scope_guard>>> TSA_GUARDED_BY(mutex) cache;
+    Poco::AccessExpireCache<UUID, RolePtr> TSA_GUARDED_BY(mutex) cache;
 
-    struct EnabledRolesWithSubscriptions
-    {
-        std::weak_ptr<EnabledRoles> enabled_roles;
+    std::map<EnabledRoles::Params, std::weak_ptr<EnabledRoles>> TSA_GUARDED_BY(mutex) enabled_roles_by_params;
 
-        /// We need to keep subscriptions for all enabled roles to be able to recalculate EnabledRolesInfo when some of the roles change.
-        /// `cache` also keeps subscriptions but that's not enough because values can be purged from the `cache` anytime.
-        SubscriptionsOnRoles subscriptions_on_roles;
-    };
-
-    std::map<EnabledRoles::Params, EnabledRolesWithSubscriptions> TSA_GUARDED_BY(mutex) enabled_roles_by_params;
+    /// Roles that take part in some live enabled set: a change to a role outside this set needs no recalculation.
+    std::unordered_set<UUID> TSA_GUARDED_BY(mutex) referenced_roles;
 
     mutable std::mutex mutex;
 };

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -46,7 +46,7 @@ private:
 
     std::map<EnabledRoles::Params, std::weak_ptr<EnabledRoles>> TSA_GUARDED_BY(mutex) enabled_roles_by_params;
 
-    /// Roles that take part in some live enabled set: a change to a role outside this set needs no recalculation.
+    /// Roles that take part in some enabled set: a change to a role outside this set needs no recalculation.
     std::unordered_set<UUID> TSA_GUARDED_BY(mutex) referenced_roles;
 
     mutable std::mutex mutex;

--- a/src/Access/RoleCache.h
+++ b/src/Access/RoleCache.h
@@ -29,6 +29,7 @@ public:
 
 private:
     void ensureSubscribed() TSA_REQUIRES(mutex);
+    void collectEnabledRolesIfNeeded(scope_guard * notifications) TSA_REQUIRES(mutex);
     void collectEnabledRoles(scope_guard * notifications) TSA_REQUIRES(mutex);
     void collectEnabledRoles(EnabledRoles & enabled_roles, scope_guard * notifications) TSA_REQUIRES(mutex);
     RolePtr getRole(const UUID & role_id) TSA_REQUIRES(mutex);

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -159,12 +159,7 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
                 else
                     rowPolicyRemoved(change.id);
             }
-            if (need_mix_filters)
-            {
-                /// Clear the flag only after a successful rebuild, so a throwing mixFilters() is retried next batch.
-                mixFilters();
-                need_mix_filters = false;
-            }
+            mixFiltersIfNeeded();
         });
 
     for (const UUID & id : access_control.findAll<RowPolicy>())
@@ -203,6 +198,17 @@ void RowPolicyCache::rowPolicyRemoved(const UUID & policy_id)
     /// `mutex` is already locked.
     all_policies.erase(policy_id);
     need_mix_filters = true;
+}
+
+
+void RowPolicyCache::mixFiltersIfNeeded()
+{
+    /// `mutex` is already locked.
+    if (!need_mix_filters)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing mixFilters() is retried next batch.
+    mixFilters();
+    need_mix_filters = false;
 }
 
 

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -146,7 +146,6 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
     /// `mutex` is already locked.
     if (all_policies_read)
         return;
-    all_policies_read = true;
 
     subscription = access_control.subscribeForChanges<RowPolicy>(
         [this](const std::vector<AccessChangesNotifier::Change> & changes)
@@ -162,6 +161,8 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
             mixFiltersIfNeeded();
         });
 
+    /// Start clean: a previous attempt may have thrown mid-scan.
+    all_policies.clear();
     for (const UUID & id : access_control.findAll<RowPolicy>())
     {
         auto policy = access_control.tryRead<RowPolicy>(id);
@@ -170,6 +171,9 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
             all_policies.emplace(id, PolicyInfo(policy));
         }
     }
+
+    /// Set only after the subscription and the initial read succeed.
+    all_policies_read = true;
 }
 
 

--- a/src/Access/RowPolicyCache.cpp
+++ b/src/Access/RowPolicyCache.cpp
@@ -149,15 +149,23 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
     all_policies_read = true;
 
     subscription = access_control.subscribeForChanges<RowPolicy>(
-        [&](const UUID & id, const AccessEntityPtr & entity)
+        [this](const std::vector<AccessChangesNotifier::Change> & changes)
         {
-            if (entity)
-                rowPolicyAddedOrChanged(id, typeid_cast<RowPolicyPtr>(entity));
-            else
-                rowPolicyRemoved(id);
+            std::lock_guard lock{mutex};
+            for (const auto & change : changes)
+            {
+                if (change.entity)
+                    rowPolicyAddedOrChanged(change.id, typeid_cast<RowPolicyPtr>(change.entity));
+                else
+                    rowPolicyRemoved(change.id);
+            }
+            if (need_mix_filters)
+            {
+                /// Clear the flag only after a successful rebuild, so a throwing mixFilters() is retried next batch.
+                mixFilters();
+                need_mix_filters = false;
+            }
         });
-
-    batch_subscription = access_control.subscribeForBatchFinished([this] { mixFiltersIfNeeded(); });
 
     for (const UUID & id : access_control.findAll<RowPolicy>())
     {
@@ -172,7 +180,7 @@ void RowPolicyCache::ensureAllRowPoliciesRead()
 
 void RowPolicyCache::rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     auto it = all_policies.find(policy_id);
     if (it == all_policies.end())
     {
@@ -192,20 +200,9 @@ void RowPolicyCache::rowPolicyAddedOrChanged(const UUID & policy_id, const RowPo
 
 void RowPolicyCache::rowPolicyRemoved(const UUID & policy_id)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     all_policies.erase(policy_id);
     need_mix_filters = true;
-}
-
-
-void RowPolicyCache::mixFiltersIfNeeded()
-{
-    std::lock_guard lock{mutex};
-    if (!need_mix_filters)
-        return;
-    /// Clear the flag only after a successful rebuild, so a throwing mixFilters() is retried next batch.
-    mixFilters();
-    need_mix_filters = false;
 }
 
 

--- a/src/Access/RowPolicyCache.h
+++ b/src/Access/RowPolicyCache.h
@@ -39,8 +39,9 @@ private:
     void ensureAllRowPoliciesRead();
     void rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy) TSA_REQUIRES(mutex);
     void rowPolicyRemoved(const UUID & policy_id) TSA_REQUIRES(mutex);
-    void mixFilters();
-    void mixFiltersFor(EnabledRowPolicies & enabled);
+    void mixFiltersIfNeeded() TSA_REQUIRES(mutex);
+    void mixFilters() TSA_REQUIRES(mutex);
+    void mixFiltersFor(EnabledRowPolicies & enabled) TSA_REQUIRES(mutex);
 
     const AccessControl & access_control;
     std::unordered_map<UUID, PolicyInfo> all_policies;

--- a/src/Access/RowPolicyCache.h
+++ b/src/Access/RowPolicyCache.h
@@ -37,19 +37,17 @@ private:
     };
 
     void ensureAllRowPoliciesRead();
-    void rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy);
-    void rowPolicyRemoved(const UUID & policy_id);
-    void mixFiltersIfNeeded();
+    void rowPolicyAddedOrChanged(const UUID & policy_id, const RowPolicyPtr & new_policy) TSA_REQUIRES(mutex);
+    void rowPolicyRemoved(const UUID & policy_id) TSA_REQUIRES(mutex);
     void mixFilters();
     void mixFiltersFor(EnabledRowPolicies & enabled);
 
     const AccessControl & access_control;
     std::unordered_map<UUID, PolicyInfo> all_policies;
     bool all_policies_read = false;
-    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    /// Set while applying a batch of changes; the rebuild is coalesced to once per notification batch.
     bool need_mix_filters TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
-    scope_guard batch_subscription;
     std::map<EnabledRowPolicies::Params, std::weak_ptr<EnabledRowPolicies>> enabled_row_policies;
     std::mutex mutex;
 };

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -37,15 +37,23 @@ void SettingsProfilesCache::ensureAllProfilesRead()
     all_profiles_read = true;
 
     subscription = access_control.subscribeForChanges<SettingsProfile>(
-        [&](const UUID & id, const AccessEntityPtr & entity)
+        [this](const std::vector<AccessChangesNotifier::Change> & changes)
         {
-            if (entity)
-                profileAddedOrChanged(id, typeid_cast<SettingsProfilePtr>(entity));
-            else
-                profileRemoved(id);
+            std::lock_guard lock{mutex};
+            for (const auto & change : changes)
+            {
+                if (change.entity)
+                    profileAddedOrChanged(change.id, typeid_cast<SettingsProfilePtr>(change.entity));
+                else
+                    profileRemoved(change.id);
+            }
+            if (need_merge_settings_and_constraints)
+            {
+                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+                mergeSettingsAndConstraints();
+                need_merge_settings_and_constraints = false;
+            }
         });
-
-    batch_subscription = access_control.subscribeForBatchFinished([this] { mergeSettingsAndConstraintsIfNeeded(); });
 
     for (const UUID & id : access_control.findAll<SettingsProfile>())
     {
@@ -61,7 +69,7 @@ void SettingsProfilesCache::ensureAllProfilesRead()
 
 void SettingsProfilesCache::profileAddedOrChanged(const UUID & profile_id, const SettingsProfilePtr & new_profile)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     auto it = all_profiles.find(profile_id);
     if (it == all_profiles.end())
     {
@@ -83,7 +91,7 @@ void SettingsProfilesCache::profileAddedOrChanged(const UUID & profile_id, const
 
 void SettingsProfilesCache::profileRemoved(const UUID & profile_id)
 {
-    std::lock_guard lock{mutex};
+    /// `mutex` is already locked.
     auto it = all_profiles.find(profile_id);
     if (it == all_profiles.end())
         return;
@@ -91,17 +99,6 @@ void SettingsProfilesCache::profileRemoved(const UUID & profile_id)
     all_profiles.erase(it);
     profile_infos_cache.clear();
     need_merge_settings_and_constraints = true;
-}
-
-
-void SettingsProfilesCache::mergeSettingsAndConstraintsIfNeeded()
-{
-    std::lock_guard lock{mutex};
-    if (!need_merge_settings_and_constraints)
-        return;
-    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-    mergeSettingsAndConstraints();
-    need_merge_settings_and_constraints = false;
 }
 
 

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -47,12 +47,7 @@ void SettingsProfilesCache::ensureAllProfilesRead()
                 else
                     profileRemoved(change.id);
             }
-            if (need_merge_settings_and_constraints)
-            {
-                /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
-                mergeSettingsAndConstraints();
-                need_merge_settings_and_constraints = false;
-            }
+            mergeSettingsAndConstraintsIfNeeded();
         });
 
     for (const UUID & id : access_control.findAll<SettingsProfile>())
@@ -118,6 +113,17 @@ void SettingsProfilesCache::setDefaultProfileName(const String & default_profile
         throw Exception(ErrorCodes::THERE_IS_NO_PROFILE, "Settings profile {} not found", backQuote(default_profile_name));
 
     default_profile_id = it->second;
+}
+
+
+void SettingsProfilesCache::mergeSettingsAndConstraintsIfNeeded()
+{
+    /// `mutex` is already locked.
+    if (!need_merge_settings_and_constraints)
+        return;
+    /// Clear the flag only after a successful rebuild, so a throwing recompute is retried next batch.
+    mergeSettingsAndConstraints();
+    need_merge_settings_and_constraints = false;
 }
 
 

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -34,7 +34,6 @@ void SettingsProfilesCache::ensureAllProfilesRead()
     /// `mutex` is already locked.
     if (all_profiles_read)
         return;
-    all_profiles_read = true;
 
     subscription = access_control.subscribeForChanges<SettingsProfile>(
         [this](const std::vector<AccessChangesNotifier::Change> & changes)
@@ -50,6 +49,9 @@ void SettingsProfilesCache::ensureAllProfilesRead()
             mergeSettingsAndConstraintsIfNeeded();
         });
 
+    /// Start clean: a previous attempt may have thrown mid-scan.
+    all_profiles.clear();
+    profiles_by_name.clear();
     for (const UUID & id : access_control.findAll<SettingsProfile>())
     {
         auto profile = access_control.tryRead<SettingsProfile>(id);
@@ -59,6 +61,9 @@ void SettingsProfilesCache::ensureAllProfilesRead()
             profiles_by_name[profile->getName()] = id;
         }
     }
+
+    /// Set only after the subscription and the initial read succeed.
+    all_profiles_read = true;
 }
 
 

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -35,8 +35,9 @@ private:
     void ensureAllProfilesRead();
     void profileAddedOrChanged(const UUID & profile_id, const SettingsProfilePtr & new_profile) TSA_REQUIRES(mutex);
     void profileRemoved(const UUID & profile_id) TSA_REQUIRES(mutex);
-    void mergeSettingsAndConstraints();
-    void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const;
+    void mergeSettingsAndConstraintsIfNeeded() TSA_REQUIRES(mutex);
+    void mergeSettingsAndConstraints() TSA_REQUIRES(mutex);
+    void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const TSA_REQUIRES(mutex);
 
     void substituteProfiles(SettingsProfileElements & elements,
         std::vector<UUID> & profiles,

--- a/src/Access/SettingsProfilesCache.h
+++ b/src/Access/SettingsProfilesCache.h
@@ -33,10 +33,9 @@ public:
 
 private:
     void ensureAllProfilesRead();
-    void profileAddedOrChanged(const UUID & profile_id, const SettingsProfilePtr & new_profile);
-    void profileRemoved(const UUID & profile_id);
+    void profileAddedOrChanged(const UUID & profile_id, const SettingsProfilePtr & new_profile) TSA_REQUIRES(mutex);
+    void profileRemoved(const UUID & profile_id) TSA_REQUIRES(mutex);
     void mergeSettingsAndConstraints();
-    void mergeSettingsAndConstraintsIfNeeded();
     void mergeSettingsAndConstraintsFor(EnabledSettings & enabled) const;
 
     void substituteProfiles(SettingsProfileElements & elements,
@@ -48,10 +47,9 @@ private:
     std::unordered_map<UUID, SettingsProfilePtr> all_profiles;
     std::unordered_map<String, UUID> profiles_by_name;
     bool all_profiles_read = false;
-    /// Set by the per-entity handler; the rebuild is coalesced to once per notification batch.
+    /// Set while applying a batch of changes; the rebuild is coalesced to once per notification batch.
     bool need_merge_settings_and_constraints TSA_GUARDED_BY(mutex) = false;
     scope_guard subscription;
-    scope_guard batch_subscription;
     std::map<EnabledSettings::Params, std::weak_ptr<EnabledSettings>> enabled_settings;
     std::optional<UUID> default_profile_id;
     Poco::LRUCache<UUID, std::shared_ptr<const SettingsProfilesInfo>> profile_infos_cache;

--- a/src/Access/tests/gtest_access_changes_notifier.cpp
+++ b/src/Access/tests/gtest_access_changes_notifier.cpp
@@ -131,3 +131,40 @@ TEST(AccessChangesNotifier, ByIdHandlerOnlyCalledWhenItsEntityChanged)
     EXPECT_EQ(handler_calls, 1u);
     EXPECT_EQ(total_changes, 1u);
 }
+
+/// A handler may enqueue more changes while sendNotifications() runs: LDAP role mapping reacts to a Role
+/// change by updating the mapped users through this same notifier. Those handler-generated changes must be
+/// delivered before sendNotifications() returns (it drains until the queue is empty), otherwise a session's
+/// by-id subscription would keep stale access until some unrelated change flushes the queue.
+TEST(AccessChangesNotifier, HandlerEnqueuedChangesDeliveredInSameCall)
+{
+    AccessChangesNotifier notifier;
+
+    auto user_id = UUIDHelpers::generateV4();
+    bool user_change_injected = false;
+    size_t user_changes_delivered = 0;
+
+    /// Reacts to a Role change by enqueueing a User change, the way LDAP role mapping updates mapped users.
+    auto role_subscription = notifier.subscribeForChanges(
+        AccessEntityType::ROLE,
+        [&](const std::vector<AccessChangesNotifier::Change> & changes)
+        {
+            if (!changes.empty() && !user_change_injected)
+            {
+                user_change_injected = true;
+                notifier.onEntityRemoved(user_id, AccessEntityType::USER);
+            }
+        });
+
+    /// Models a per-session ContextAccess subscription on that user.
+    auto user_subscription = notifier.subscribeForChanges(
+        user_id,
+        [&](const std::vector<AccessChangesNotifier::Change> & changes) { user_changes_delivered += changes.size(); });
+
+    notifier.onEntityRemoved(UUIDHelpers::generateV4(), AccessEntityType::ROLE);
+    notifier.sendNotifications();
+
+    /// The User change the Role handler enqueued is delivered within this single sendNotifications() call.
+    EXPECT_TRUE(user_change_injected);
+    EXPECT_EQ(user_changes_delivered, 1u);
+}

--- a/src/Access/tests/gtest_access_changes_notifier.cpp
+++ b/src/Access/tests/gtest_access_changes_notifier.cpp
@@ -3,30 +3,32 @@
 #include <Access/AccessChangesNotifier.h>
 #include <Access/Common/AccessEntityType.h>
 #include <Core/UUID.h>
+#include <Common/Exception.h>
 
 using namespace DB;
 
-/// The per-entity caches (RowPolicyCache, RoleCache, SettingsProfilesCache, QuotaCache) rely on
-/// subscribeForBatchFinished firing exactly once after a whole notification batch is drained, so that
-/// they patch their per-entity maps in the cheap per-entity handlers and run the expensive O(enabled
-/// sets * entities) rebuild only once per batch (a full refresh delivers one notification per entity).
-TEST(AccessChangesNotifier, BatchFinishedCoalescesRecompute)
+namespace DB::ErrorCodes
+{
+    extern const int UNFINISHED;
+}
+
+/// The per-entity caches (RowPolicyCache, RoleCache, SettingsProfilesCache, QuotaCache) rely on a whole
+/// notification batch being delivered to a by-type handler in a single call, so that they patch their
+/// per-entity maps for each change and run the expensive O(enabled sets * entities) rebuild only once per
+/// batch (a full refresh delivers one notification per entity, but needs a single rebuild).
+TEST(AccessChangesNotifier, BatchedChangesDeliveredOncePerBatch)
 {
     AccessChangesNotifier notifier;
 
-    size_t per_entity_calls = 0;
-    size_t batch_calls = 0;
-    size_t per_entity_calls_seen_by_last_batch = 0;
+    size_t handler_calls = 0;
+    size_t total_changes = 0;
 
-    auto entity_subscription = notifier.subscribeForChanges(
+    auto subscription = notifier.subscribeForChanges(
         AccessEntityType::ROW_POLICY,
-        [&](const UUID &, const AccessEntityPtr &) { ++per_entity_calls; });
-
-    auto batch_subscription = notifier.subscribeForBatchFinished(
-        [&]
+        [&](const std::vector<AccessChangesNotifier::Change> & changes)
         {
-            ++batch_calls;
-            per_entity_calls_seen_by_last_batch = per_entity_calls;
+            ++handler_calls;
+            total_changes += changes.size();
         });
 
     /// A refresh that touches many entities: one notification per entity, drained in a single batch.
@@ -36,33 +38,31 @@ TEST(AccessChangesNotifier, BatchFinishedCoalescesRecompute)
 
     notifier.sendNotifications();
 
-    /// Every entity is dispatched, but the batch-finished hook runs exactly once - this is the
-    /// coalescing the caches depend on (without it the rebuild would run num_entities times).
-    EXPECT_EQ(per_entity_calls, num_entities);
-    EXPECT_EQ(batch_calls, 1u);
-    /// The batch hook runs after all per-entity notifications within the same sendNotifications() call,
-    /// so the derived state is current once sendNotifications() returns.
-    EXPECT_EQ(per_entity_calls_seen_by_last_batch, num_entities);
+    /// The whole batch is delivered in a single call - this is the coalescing the caches depend on (without
+    /// it the handler, and so the rebuild, would run num_entities times).
+    EXPECT_EQ(handler_calls, 1u);
+    EXPECT_EQ(total_changes, num_entities);
 
-    /// A single DDL still recomputes exactly once.
+    /// A single DDL delivers one change in one call.
     notifier.onEntityRemoved(UUIDHelpers::generateV4(), AccessEntityType::ROW_POLICY);
     notifier.sendNotifications();
-    EXPECT_EQ(per_entity_calls, num_entities + 1);
-    EXPECT_EQ(batch_calls, 2u);
+    EXPECT_EQ(handler_calls, 2u);
+    EXPECT_EQ(total_changes, num_entities + 1);
 
-    /// An empty queue still invokes the batch hook: real handlers early-return on their per-entity
-    /// flag, so this is cheap, and it must keep firing so a rebuild that previously threw is retried
-    /// without waiting for a fresh access change (see BatchFinishedRetriedAfterThrow).
+    /// A by-type handler is called even on an empty batch (with no changes): real handlers early-return on
+    /// their flag, so this is cheap, and it must keep firing so a rebuild that previously threw is retried
+    /// without waiting for a fresh access change (see ThrowingRebuildRetried).
     notifier.sendNotifications();
-    EXPECT_EQ(batch_calls, 3u);
+    EXPECT_EQ(handler_calls, 3u);
+    EXPECT_EQ(total_changes, num_entities + 1); /// unchanged - the batch was empty
 }
 
-/// A per-batch rebuild that throws must not lose the pending work: the caches clear their "needs
-/// rebuild" flag only on success, so the notifier has to keep invoking batch-finished handlers on
-/// later sendNotifications() calls - including ones that drain no events - otherwise the derived
-/// state stays stale until some unrelated access change happens to queue a notification (and an
-/// up-to-date SYSTEM RELOAD USERS, which diffs to zero, would never trigger the retry).
-TEST(AccessChangesNotifier, BatchFinishedRetriedAfterThrow)
+/// A batch handler that throws must not lose the pending work: the caches clear their "needs rebuild" flag
+/// only on success, so the notifier has to keep invoking by-type handlers on later sendNotifications() calls
+/// - including ones that drain no events - otherwise the derived state stays stale until some unrelated
+/// access change happens to queue a notification (and an up-to-date SYSTEM RELOAD USERS, which diffs to
+/// zero, would never trigger the retry).
+TEST(AccessChangesNotifier, ThrowingRebuildRetried)
 {
     AccessChangesNotifier notifier;
 
@@ -70,19 +70,18 @@ TEST(AccessChangesNotifier, BatchFinishedRetriedAfterThrow)
     size_t rebuilds = 0;
     bool fail_next_rebuild = true;
 
-    auto entity_subscription = notifier.subscribeForChanges(
+    auto subscription = notifier.subscribeForChanges(
         AccessEntityType::ROW_POLICY,
-        [&](const UUID &, const AccessEntityPtr &) { need_rebuild = true; });
-
-    auto batch_subscription = notifier.subscribeForBatchFinished(
-        [&]
+        [&](const std::vector<AccessChangesNotifier::Change> & changes)
         {
+            if (!changes.empty())
+                need_rebuild = true;
             if (!need_rebuild)
                 return;
             if (fail_next_rebuild)
             {
                 fail_next_rebuild = false;
-                throw std::runtime_error("rebuild failed"); /// caught and logged by sendNotifications()
+                throw Exception(ErrorCodes::UNFINISHED, "rebuild failed"); /// caught and logged by sendNotifications()
             }
             ++rebuilds;
             need_rebuild = false; /// cleared only after a successful rebuild
@@ -92,11 +91,43 @@ TEST(AccessChangesNotifier, BatchFinishedRetriedAfterThrow)
     notifier.sendNotifications(); /// first attempt throws; the work stays pending
     EXPECT_EQ(rebuilds, 0u);
 
-    /// No new event is queued, yet the pending rebuild must still be retried and now succeed.
+    /// No new event is queued, yet the by-type handler is still called and retries the pending rebuild.
     notifier.sendNotifications();
     EXPECT_EQ(rebuilds, 1u);
 
     /// Once it has succeeded an empty flush is a no-op, guarded by the handler's own flag.
     notifier.sendNotifications();
     EXPECT_EQ(rebuilds, 1u);
+}
+
+/// A by-id subscription is targeted: it is called only when its own entity changed in the batch (with all
+/// of that entity's changes), so per-session ContextAccess subscriptions are not woken on every call.
+TEST(AccessChangesNotifier, ByIdHandlerOnlyCalledWhenItsEntityChanged)
+{
+    AccessChangesNotifier notifier;
+
+    auto tracked_id = UUIDHelpers::generateV4();
+    auto other_id = UUIDHelpers::generateV4();
+    size_t handler_calls = 0;
+    size_t total_changes = 0;
+
+    auto subscription = notifier.subscribeForChanges(
+        tracked_id,
+        [&](const std::vector<AccessChangesNotifier::Change> & changes)
+        {
+            ++handler_calls;
+            total_changes += changes.size();
+        });
+
+    /// A batch that does not touch the tracked id must not call its handler.
+    notifier.onEntityRemoved(other_id, AccessEntityType::ROW_POLICY);
+    notifier.sendNotifications();
+    EXPECT_EQ(handler_calls, 0u);
+
+    /// A batch that touches the tracked id calls its handler once with that id's changes.
+    notifier.onEntityRemoved(tracked_id, AccessEntityType::ROW_POLICY);
+    notifier.onEntityRemoved(other_id, AccessEntityType::ROW_POLICY);
+    notifier.sendNotifications();
+    EXPECT_EQ(handler_calls, 1u);
+    EXPECT_EQ(total_changes, 1u);
 }

--- a/tests/integration/test_access_cache_recompute_coalescing/test.py
+++ b/tests/integration/test_access_cache_recompute_coalescing/test.py
@@ -129,7 +129,7 @@ def test_role_recompute_coalesced_on_reread(started_cluster):
 
     # Build a live EnabledRoles set for u2 on node2: this subscribes RoleCache and marks every granted
     # role as referenced, so a later change to one of them triggers a recalculation.
-    node2.query("SELECT 1", user="u2")
+    node2.query_with_retry("SELECT 1", user="u2")
 
     baseline = get_role_recalculations(node2)
 

--- a/tests/integration/test_access_cache_recompute_coalescing/test.py
+++ b/tests/integration/test_access_cache_recompute_coalescing/test.py
@@ -20,6 +20,7 @@ node2 = cluster.add_instance(
 )
 
 NUM_POLICIES = 50
+NUM_ROLES = 50
 
 
 @pytest.fixture(scope="module")
@@ -99,4 +100,61 @@ def test_recompute_coalesced_on_reread(started_cluster):
     assert 1 <= delta <= 2, (
         f"row policy cache recomputed {delta} times for a {NUM_POLICIES}-entity reread; "
         f"expected 1 (coalesced); without coalescing it would be ~{NUM_POLICIES}"
+    )
+
+
+def get_role_recalculations(node):
+    value = node.query(
+        "SELECT value FROM system.events WHERE event = 'RoleCacheRecalculations'"
+    ).strip()
+    return int(value) if value else 0
+
+
+# The same multi-entity reread, but for the role cache: a user with many granted roles, every role
+# altered at once while node2 misses the changes, then a single reread. RoleCache subscribes for all
+# roles in one batched subscription and must coalesce collectEnabledRoles to once per batch instead of
+# once per changed role.
+def test_role_recompute_coalesced_on_reread(started_cluster):
+    node1.query(
+        "CREATE USER u2 IDENTIFIED WITH no_password;"
+        + "".join(f"CREATE ROLE r{i};" for i in range(NUM_ROLES))
+        + "".join(f"GRANT r{i} TO u2;" for i in range(NUM_ROLES))
+        + "ALTER USER u2 DEFAULT ROLE ALL;"
+    )
+
+    node2.query_with_retry(
+        "SELECT count() FROM system.roles WHERE name LIKE 'r%'",
+        check_callback=lambda r: r.strip() == str(NUM_ROLES),
+    )
+
+    # Build a live EnabledRoles set for u2 on node2: this subscribes RoleCache and marks every granted
+    # role as referenced, so a later change to one of them triggers a recalculation.
+    node2.query("SELECT 1", user="u2")
+
+    baseline = get_role_recalculations(node2)
+
+    # Same three required steps as in test_recompute_coalesced_on_reread (see the comment there).
+    with PartitionManager() as pm:
+        pm.drop_instance_zk_connections(node2)
+        node1.query(
+            "".join(
+                f"ALTER ROLE r{i} SETTINGS max_threads = {i + 1};"
+                for i in range(NUM_ROLES)
+            )
+        )
+        node2.query("SYSTEM RECONNECT ZOOKEEPER")
+
+    node2.query_with_retry("SYSTEM RELOAD USERS")
+
+    delta = get_role_recalculations(node2) - baseline
+
+    node1.query(
+        "DROP USER u2;" + "".join(f"DROP ROLE r{i};" for i in range(NUM_ROLES))
+    )
+
+    # Same bounds as the row policy case: at least one recompute (guards a broken setup), at most two
+    # (coalesced per batch), not once per changed role (~50).
+    assert 1 <= delta <= 2, (
+        f"role cache recomputed {delta} times for a {NUM_ROLES}-role reread; "
+        f"expected 1 (coalesced); without coalescing it would be ~{NUM_ROLES}"
     )


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Simplify access-change notifications: replace two-tier notifications.

PRs https://github.com/ClickHouse/ClickHouse/pull/107672, https://github.com/ClickHouse/ClickHouse/pull/108124 fixed the issue with performance but introduced a complicated system of two-tier access-change notifications. Here I simplified that system back to one tier. So instead of two tiers `subscribeForChanges` & `subscribeForBatchFinished` now we have only `subscribeForChanges` again.

Performance is unchanged: one rebuild per batch, not one per changed entity. The throw-retry behavior is preserved: by-type handlers fire even on an empty batch, so a rebuild that threw is retried on the next `sendNotifications` (including a no-diff `SYSTEM RELOAD USERS`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.409` (included in `26.7` and later)
- Backported to: `26.6.5.35`
<!-- ch-version-info:end -->