### PR TITLE
Fix flaky test 04240_statistics_countmin_numeric_types

### DIFF
--- a/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.reference
+++ b/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.reference
@@ -1,12 +1,12 @@
-Float32 - expect b first (BUG: shows a first):
+Float32 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 1.5_Float64), equals(a, 1.5_Float64)) (removed)
-Float64 - expect b first (CORRECT):
+Float64 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 1.5_Float64), equals(a, 1.5_Float64)) (removed)
-Int16 - expect b first (CORRECT):
+Int16 - expect b first:
         Prewhere info
           Prewhere filter
           Prewhere filter column: and(equals(b, 15_UInt8), equals(a, 15_UInt8)) (removed)

--- a/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.sql
+++ b/tests/queries/0_stateless/04240_statistics_countmin_numeric_types.sql
@@ -9,31 +9,34 @@ SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;
 SET allow_reorder_prewhere_conditions = 1;
 
+-- b matches exactly 1 of 1010 rows (selectivity ~0.001, well below default_cond_equal_factor 0.01),
+-- so PREWHERE keeps b first even if a's estimate falls back to the default; refresh_statistics_interval = 0
+-- disables the background statistics cache so EXPLAIN never reads a stale single-part snapshot where a and b tie.
 DROP TABLE IF EXISTS test_f32;
-CREATE TABLE test_f32 (a Float32 STATISTICS(countmin), b Float32 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_f32 SELECT 1.5, 1.5 FROM numbers(10);
-INSERT INTO test_f32 SELECT 1.5, 99.5 FROM numbers(990);
+CREATE TABLE test_f32 (a Float32 STATISTICS(countmin), b Float32 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_f32 SELECT 1.5, 1.5 FROM numbers(1);
+INSERT INTO test_f32 SELECT 1.5, 99.5 FROM numbers(999);
 INSERT INTO test_f32 SELECT 99.5, 99.5 FROM numbers(10);
 
 DROP TABLE IF EXISTS test_f64;
-CREATE TABLE test_f64 (a Float64 STATISTICS(countmin), b Float64 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_f64 SELECT 1.5, 1.5 FROM numbers(10);
-INSERT INTO test_f64 SELECT 1.5, 99.5 FROM numbers(990);
+CREATE TABLE test_f64 (a Float64 STATISTICS(countmin), b Float64 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_f64 SELECT 1.5, 1.5 FROM numbers(1);
+INSERT INTO test_f64 SELECT 1.5, 99.5 FROM numbers(999);
 INSERT INTO test_f64 SELECT 99.5, 99.5 FROM numbers(10);
 
 DROP TABLE IF EXISTS test_i16;
-CREATE TABLE test_i16 (a Int16 STATISTICS(countmin), b Int16 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '';
-INSERT INTO test_i16 SELECT 15, 15 FROM numbers(10);
-INSERT INTO test_i16 SELECT 15, 995 FROM numbers(990);
+CREATE TABLE test_i16 (a Int16 STATISTICS(countmin), b Int16 STATISTICS(countmin)) ENGINE = MergeTree() ORDER BY tuple() SETTINGS auto_statistics_types = '', refresh_statistics_interval = 0;
+INSERT INTO test_i16 SELECT 15, 15 FROM numbers(1);
+INSERT INTO test_i16 SELECT 15, 995 FROM numbers(999);
 INSERT INTO test_i16 SELECT 995, 995 FROM numbers(10);
 
-SELECT 'Float32 - expect b first (BUG: shows a first):';
+SELECT 'Float32 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_f32 WHERE a = 1.5 AND b = 1.5) WHERE explain LIKE '%Prewhere%';
 
-SELECT 'Float64 - expect b first (CORRECT):';
+SELECT 'Float64 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_f64 WHERE a = 1.5 AND b = 1.5) WHERE explain LIKE '%Prewhere%';
 
-SELECT 'Int16 - expect b first (CORRECT):';
+SELECT 'Int16 - expect b first:';
 SELECT replaceRegexpAll(explain, '__table1\\.', '') FROM (EXPLAIN actions=1 SELECT count(*) FROM test_i16 WHERE a = 15 AND b = 15) WHERE explain LIKE '%Prewhere%';
 
 DROP TABLE test_f32;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

No related open issue found.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `04240_statistics_countmin_numeric_types` on master.

CI report (master, `Stateless tests (arm_binary, parallel)`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=56872ea43989837ad4cc018bb8cffe2f2d51d71f&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

The test checks that countmin statistics keep the more selective condition first in PREWHERE. PREWHERE order is chosen by `std::min_element` over each condition's `estimated_row_count` and falls back to source order `a, b` only on a tie, so any tie flips the asserted plan shape (results stay correct).

Two independent tie sources are fixed:

1. Transiently unavailable per-part statistics: `loadStatistics` failures are swallowed, so `a` can fall back to `default_cond_equal_factor` (0.01). The previous shape had `b` matching 10/1010 rows (~0.0099), which collides with 0.01. `b` now matches exactly 1/1010 rows (~0.001), an order of magnitude below 0.01, so `b` stays first even on the fallback estimate.

2. Stale statistics cache: `refreshStatistics` (the only writer of `cached_estimator`) is scheduled immediately at table startup and can snapshot a single-part state where `a` and `b` each have one row; with `use_statistics_cache = 1` every later EXPLAIN reads that stale 1 vs 1 snapshot and ties. Setting the per-table MergeTree setting `refresh_statistics_interval = 0` (the documented way to disable the refresh) means the task is never created, so `cached_estimator` stays null and the estimator always fresh-loads all current parts regardless of `use_statistics_cache`. Unlike the session setting `use_statistics_cache`, this is immune to the CI settings randomizer.

Validated on a debug server: the new shape with a forced single-part snapshot still flips 5/5; adding `refresh_statistics_interval = 0` gives the correct `b`-first order 5/5, and the full test passes 20/20 against the reference.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.101`
<!-- ch-version-info:end -->