### PR TITLE
[DOCS] Fix broken replaceRegexpOne / replaceRegexpAll documentation examples

### DIFF
--- a/src/Functions/replaceRegexpAll.cpp
+++ b/src/Functions/replaceRegexpAll.cpp
@@ -33,7 +33,7 @@ As an exception, if a regular expression worked on an empty substring, the repla
     FunctionDocumentation::Examples examples = {
     {
         "Replace all characters with doubled version",
-        R"(SELECT replaceRegexpAll('Hello123', '.', '\\\\0\\\\0') AS res)",
+        R"(SELECT replaceRegexpAll('Hello123', '.', '\\0\\0') AS res)",
         R"(
 ┌─res──────────────────┐
 │ HHeelllloo112233     │

--- a/src/Functions/replaceRegexpOne.cpp
+++ b/src/Functions/replaceRegexpOne.cpp
@@ -36,27 +36,19 @@ Also keep in mind that string literals require extra escaping.
     FunctionDocumentation::Examples examples = {
     {
         "Converting ISO dates to American format",
+        R"(SELECT replaceRegexpOne(d, '(\\d{4})-(\\d{2})-(\\d{2})', '\\2/\\3/\\1') AS res
+FROM values('d String', '2014-03-17', '2014-03-18', '2014-03-19'))",
         R"(
-SELECT DISTINCT
-    EventDate,
-    replaceRegexpOne(toString(EventDate), '(\\d{4})-(\\d{2})-(\\d{2})', '\\2/\\3/\\1') AS res
-FROM test.hits
-LIMIT 7
-FORMAT TabSeparated
-        )",
-        R"(
-2014-03-17      03/17/2014
-2014-03-18      03/18/2014
-2014-03-19      03/19/2014
-2014-03-20      03/20/2014
-2014-03-21      03/21/2014
-2014-03-22      03/22/2014
-2014-03-23      03/23/2014
+┌─res────────┐
+│ 03/17/2014 │
+│ 03/18/2014 │
+│ 03/19/2014 │
+└────────────┘
         )"
     },
     {
         "Copying a string ten times",
-        R"(SELECT replaceRegexpOne('Hello, World!', '.*', '\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0\\\\0') AS res)",
+        R"(SELECT replaceRegexpOne('Hello, World!', '.*', '\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0') AS res)",
         R"(
 ┌─res────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │ Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World!Hello, World! │


### PR DESCRIPTION
## Problem

The `replaceRegexpOne` / `replaceRegexpAll` documentation examples (embedded `FunctionDocumentation`, surfaced via `system.documentation` and the docs site) don't work as shown. Reported in [DOC-828](https://github.com/ClickHouse/clickhouse-docs/issues/6402):

1. **`test.hits` dependency** — `replaceRegexpOne`'s first example runs `... FROM test.hits`, which doesn't exist in a fresh install, so it fails with `UNKNOWN_DATABASE`.
2. **Over-escaped `\0` substitution** — the "copy a string" examples use `'\\\\0...'`. In a SQL string literal that becomes `\\0` (two backslashes), which RE2 reads as a literal backslash + `0`, so the output is `\0\0...` instead of the matched text. The documented output (the repeated string) is what the *correctly* escaped query produces, so the example and its output disagreed. `replaceRegexpAll` had the same bug in its "doubled version" example.

## Fix

- `replaceRegexpOne` example 1 → self-contained `values(...)` source instead of `test.hits`.
- `replaceRegexpOne` / `replaceRegexpAll` `\0` examples → `\\0` (one backslash-pair), matching the documented output.

## Verification

Ran all examples against `clickhouse-local` 26.7.1.42 — the corrected queries now produce exactly the documented output:

```
replaceRegexpOne(..., '\\0\\0...')        -> Hello, World! x10
replaceRegexpAll('Hello123', '.', '\\0\\0') -> HHeelllloo112233
replaceRegexpOne over values(...)         -> 03/17/2014, 03/18/2014, 03/19/2014
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.391` (included in `26.7` and later)
<!-- ch-version-info:end -->