### PR TITLE
Fix flaky test_parallel_quorum_actually_quorum

### DIFF
--- a/tests/integration/test_quorum_inserts_parallel/test.py
+++ b/tests/integration/test_quorum_inserts_parallel/test.py
@@ -78,7 +78,10 @@ def test_parallel_quorum_actually_parallel(started_cluster):
 def test_parallel_quorum_actually_quorum(started_cluster):
     for i, node in enumerate([node1, node2, node3]):
         node.query(
-            "CREATE TABLE q (a UInt64, b String) ENGINE=ReplicatedMergeTree('/test/q', '{num}') ORDER BY tuple()".format(
+            # node2 stays partitioned off node1/node3 (port 9009) for the whole test, so its
+            # GET_PART entries fail repeatedly and accumulate exponential fetch backoff. Disable
+            # it so node2 catches up promptly once the partition heals (see SYSTEM SYNC REPLICA).
+            "CREATE TABLE q (a UInt64, b String) ENGINE=ReplicatedMergeTree('/test/q', '{num}') ORDER BY tuple() SETTINGS max_postpone_time_for_failed_replicated_fetches_ms = 0".format(
                 num=i
             )
         )
@@ -175,5 +178,8 @@ def test_parallel_quorum_actually_quorum(started_cluster):
         p.close()
         p.join()
 
-    node2.query("SYSTEM SYNC REPLICA q", timeout=10)
+    # Generous barrier timeout: under the parallel sanitizer flaky-check the post-heal
+    # catch-up fetch can take several seconds. Correctness is still gated by the retrying
+    # assert below, so a real "node2 never syncs" bug fails there rather than being hidden.
+    node2.query("SYSTEM SYNC REPLICA q", timeout=60)
     assert_eq_with_retry(node2, "SELECT COUNT() FROM q", "3")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106963
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky integration test `test_quorum_inserts_parallel/test.py::test_parallel_quorum_actually_quorum`.

**Failure:** the final line `node2.query("SYSTEM SYNC REPLICA q", timeout=10)` raises `QueryTimeoutExceedException: Client timed out!`. 100% of the 30-day CIDB failures are on slow sanitizer integration shards (asan / tsan / msan); ~13 distinct PRs + 2 master hits, none related to the failing test.

**Root cause:** the test partitions `node2` from `node1`/`node3` on the interserver port (9009) for the whole body. While partitioned, `node2` still reaches ZooKeeper, pulls the log and creates `GET_PART` queue entries, but every fetch fails ("Connection refused"). Each failure increments the entry's `num_tries`, and `ReplicatedMergeTreeQueue::getPostponeTimeMsForEntry` schedules the next attempt `1 << num_tries` ms out (capped at `max_postpone_time_for_failed_replicated_fetches_ms`, default `60000`). After enough failed tries the next retry is scheduled more than 10s out, so once the partition heals the `SYSTEM SYNC REPLICA` must wait out that accumulated backoff and the client times out. On the slow sanitizer shards the partition phase lasts long enough for `num_tries` to cross the threshold, which is why it is sanitizer-only.

**Fix:** disable the fetch-failure backoff for this table (`max_postpone_time_for_failed_replicated_fetches_ms = 0`) so `node2` retries the fetch on the next queue tick after the partition heals. This is the same idiom used by `test_postpone_failed_tasks`'s `no_backoff_policy.xml`. Quorum semantics and every assertion are unchanged.

**Validation:** reproduced deterministically with a partition held long enough to drive `num_tries` past the threshold. With the default backoff the 10s `SYSTEM SYNC REPLICA` times out; with `max_postpone_time_for_failed_replicated_fetches_ms = 0` it completes within 10s.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.146` (included in `26.7` and later)
- Backported to: `26.6.2.101`
<!-- ch-version-info:end -->