### PR TITLE
Fix LOGICAL_ERROR Invalid action query tree node for distributed query with table-function argument

### DIFF
--- a/src/Storages/buildQueryTreeForShard.cpp
+++ b/src/Storages/buildQueryTreeForShard.cpp
@@ -878,7 +878,12 @@ public:
 
     static bool needChildVisit(const QueryTreeNodePtr & /*parent*/, const QueryTreeNodePtr & child)
     {
-        return child->getNodeType() != QueryTreeNodeType::QUERY && child->getNodeType() != QueryTreeNodeType::UNION;
+        /// Table/table-function argument lists are not expression scopes whose names need translating, and they may
+        /// contain unresolved identifiers (e.g. the `key = value` named-collection overrides of `s3`/`oss`/`url`) that
+        /// `calculateActionNodeName` cannot name. Skip them, like the nested QUERY/UNION scopes above.
+        auto child_type = child->getNodeType();
+        return child_type != QueryTreeNodeType::QUERY && child_type != QueryTreeNodeType::UNION
+            && child_type != QueryTreeNodeType::TABLE_FUNCTION && child_type != QueryTreeNodeType::TABLE;
     }
 
 private:

--- a/tests/queries/0_stateless/04367_distributed_alias_collapse_table_function_arg.sql
+++ b/tests/queries/0_stateless/04367_distributed_alias_collapse_table_function_arg.sql
@@ -1,0 +1,38 @@
+-- Tags: distributed, no-fasttest
+-- Tag no-fasttest: Depends on AWS (uses the `oss`/`s3` table function against the test MinIO)
+
+-- Regression test for the LOGICAL_ERROR "Invalid action query tree node ..." server abort.
+-- When a Distributed query deduplicates structurally-identical duplicate-ALIAS columns, the
+-- shard-collapse reconstruction walks the whole shard query tree to translate action names. It
+-- must NOT descend into table-function argument lists: a `key = value` named-collection override
+-- (e.g. `oss(s3_conn, filename = '...')`) leaves `key` as an unresolved identifier that
+-- `calculateActionNodeName` cannot name, which previously aborted the server.
+
+DROP TABLE IF EXISTS local_tf_arg;
+DROP TABLE IF EXISTS dist_tf_arg;
+
+CREATE TABLE local_tf_arg
+(
+    x UInt8,
+    a1 String ALIAS toString(x),
+    a2 String ALIAS toString(x)
+)
+ENGINE = MergeTree ORDER BY x;
+
+CREATE TABLE dist_tf_arg AS local_tf_arg
+ENGINE = Distributed('test_cluster_two_shards_localhost', currentDatabase(), local_tf_arg, rand());
+
+INSERT INTO local_tf_arg (x) VALUES (7);
+
+SET enable_analyzer = 1;
+
+-- The duplicate ALIAS columns a1/a2 collapse to a single shard column, triggering the
+-- shard-collapse reconstruction. The right side GLOBAL-joins a table function whose arguments
+-- contain a `filename = '...'` named-collection override (an unresolved identifier). The wildcard
+-- matches no object, so the result is empty; the point is that planning must not crash.
+SELECT a1, a2, count() AS c FROM dist_tf_arg
+    GLOBAL NATURAL FULL OUTER JOIN oss(s3_conn, filename = '04367_no_such_object_*.csv', format = 'CSV', structure = 'p String, q String') AS j
+    GROUP BY a1, a2 ORDER BY a1;
+
+DROP TABLE dist_tf_arg;
+DROP TABLE local_tf_arg;

--- a/tests/queries/0_stateless/04367_distributed_alias_collapse_table_function_arg.sql
+++ b/tests/queries/0_stateless/04367_distributed_alias_collapse_table_function_arg.sql
@@ -1,12 +1,12 @@
 -- Tags: distributed, no-fasttest
 -- Tag no-fasttest: Depends on AWS (uses the `oss`/`s3` table function against the test MinIO)
 
--- Regression test for the LOGICAL_ERROR "Invalid action query tree node ..." server abort.
+-- Regression test for the LOGICAL_ERROR "Invalid action query tree node ..." exception.
 -- When a Distributed query deduplicates structurally-identical duplicate-ALIAS columns, the
 -- shard-collapse reconstruction walks the whole shard query tree to translate action names. It
 -- must NOT descend into table-function argument lists: a `key = value` named-collection override
 -- (e.g. `oss(s3_conn, filename = '...')`) leaves `key` as an unresolved identifier that
--- `calculateActionNodeName` cannot name, which previously aborted the server.
+-- `calculateActionNodeName` cannot name, which previously threw a `LOGICAL_ERROR` exception.
 
 DROP TABLE IF EXISTS local_tf_arg;
 DROP TABLE IF EXISTS dist_tf_arg;
@@ -29,7 +29,7 @@ SET enable_analyzer = 1;
 -- The duplicate ALIAS columns a1/a2 collapse to a single shard column, triggering the
 -- shard-collapse reconstruction. The right side GLOBAL-joins a table function whose arguments
 -- contain a `filename = '...'` named-collection override (an unresolved identifier). The wildcard
--- matches no object, so the result is empty; the point is that planning must not crash.
+-- matches no object, so the result is empty; the point is that planning must not throw a `LOGICAL_ERROR` exception.
 SELECT a1, a2, count() AS c FROM dist_tf_arg
     GLOBAL NATURAL FULL OUTER JOIN oss(s3_conn, filename = '04367_no_such_object_*.csv', format = 'CSV', structure = 'p String, q String') AS j
     GROUP BY a1, a2 ORDER BY a1;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107913
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/107913
No related open issue found (found by the AST fuzzer in CI).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` ("Invalid action query tree node ...") exception when a distributed query both deduplicated structurally-identical duplicate-`ALIAS` columns and referenced a table function with a `key = value` named-collection argument (for example `oss(s3_conn, filename = '...')`).

### Description

Found by the AST fuzzer. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108415&sha=f641ece7d2f420a053c20eff25cbbef9ed42d8e6&name_0=PR&name_1=Stress%20test%20%28amd_msan%29 (`Stress test (amd_msan)`, signal Aborted, `Logical error: 'Invalid action query tree node filename'`).

Root cause: #107913 added `CollectAliasNameTranslationVisitor` / `buildShardCollapseFanOut` in `src/Storages/buildQueryTreeForShard.cpp`. When a `Distributed` query deduplicates duplicate-`ALIAS` columns on the shard, the visitor walks the whole shard query tree and calls `calculateActionNodeName` on every COLUMN/FUNCTION/CONSTANT to translate initiator names to shard names. Its `needChildVisit` only skipped nested `QUERY`/`UNION` scopes, so it descended into `TABLE_FUNCTION` argument lists. A `key = value` named-collection override (`s3`/`oss`/`url`/...) parses as `equals(<key>, '<value>')` where `<key>` is an unresolved `IdentifierNode` (a collection key, never resolved to a column). `calculateActionNodeName` has no case for `IDENTIFIER` and hits its unreachable `default:`, throwing a `LOGICAL_ERROR` exception.

Fix: skip `TABLE_FUNCTION` and `TABLE` subtrees in `needChildVisit`, like the existing `QUERY`/`UNION` skip. Their argument lists are not expression scopes whose names need translating.

Minimal reproducer (throws the `LOGICAL_ERROR` before the fix, returns normally after):
```sql
SELECT a1, a2, count() AS c FROM dist_table
    GLOBAL NATURAL FULL OUTER JOIN oss(s3_conn, filename = 'x.csv') AS j
    GROUP BY a1, a2 ORDER BY a1;
-- where dist_table is Distributed over a table with `a1 String ALIAS toString(x), a2 String ALIAS toString(x)`
```

Verified locally on a debug build: the regression test `04367_distributed_alias_collapse_table_function_arg` throws the `LOGICAL_ERROR` without the fix and passes with it; the existing `04357_distributed_alias_same_expression` is unaffected.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.376` (included in `26.7` and later)
<!-- ch-version-info:end -->