### PR TITLE
Fix flaky test_shutdown_cancels_backup and test_long_disconnection_stops_backup

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
+++ b/tests/integration/test_backup_restore_on_cluster/test_cancel_backup.py
@@ -381,6 +381,31 @@ class NoTrashChecker:
             assert False
 
 
+# Waits until every BACKUP process from a previous test has finished, so its residual errors
+# and ZooKeeper cleanup don't land inside the next test's NoTrashChecker window. Tests run in
+# random order in CI, so any test may precede another.
+def wait_for_backups_to_finish():
+    for _ in range(30):
+        if not any(
+            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
+            for node in nodes
+        ):
+            break
+        time.sleep(1)
+
+    backup_process_counts = {
+        get_node_name(node): int(
+            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
+        )
+        for node in nodes
+    }
+    total_backup_processes = sum(backup_process_counts.values())
+    assert total_backup_processes == 0, (
+        "Backup queries still running after pre-test wait: "
+        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
+    )
+
+
 __backup_id_of_successful_backup = None
 
 
@@ -534,7 +559,20 @@ def test_cancel_restore():
 
 # Test that shutdown cancels a running backup and doesn't wait until it finishes.
 def test_shutdown_cancels_backup():
+    wait_for_backups_to_finish()
+
     with NoTrashChecker() as no_trash_checker:
+        # Restarting a node mid-backup makes the surviving node briefly lose its connection
+        # to the restarting peer and to Keeper, so transient network/Keeper errors are expected.
+        no_trash_checker.allow_errors = [
+            "KEEPER_EXCEPTION",
+            "SOCKET_TIMEOUT",
+            "CANNOT_READ_ALL_DATA",
+            "NETWORK_ERROR",
+            "TABLE_IS_READ_ONLY",
+            "NO_REPLICA_HAS_PART",
+        ]
+
         create_and_fill_table(random_node())
 
         initiator = random_node()
@@ -598,25 +636,17 @@ def test_error_leaves_no_trash():
 
 # A backup must be stopped if Zookeeper is disconnected longer than `failure_after_host_disconnected_for_seconds`.
 def test_long_disconnection_stops_backup():
+    wait_for_backups_to_finish()
+
     create_and_fill_table(random_node(), num_parts=100)
 
     with NoTrashChecker() as no_trash_checker, ConfigManager() as config_manager:
-        # Config "faster_zk_disconnect_detect.xml" is used in this test to decrease number of retries when reconnecting to ZooKeeper.
-        # Without this config this test can take several minutes (instead of seconds) to run.
-        config_manager.add_main_config(nodes, "configs/faster_zk_disconnect_detect.xml")
-
-        initiator = random_node()
-        print(f"Using {get_node_name(initiator)} as initiator")
-
         backup_id = random_id()
-        initiator.query(
-            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC",
-            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 3},
-        )
 
-        assert get_status(initiator, backup_id=backup_id) == "CREATING_BACKUP"
-        assert get_num_system_processes(initiator, backup_id=backup_id) >= 1
-
+        # Set the relaxations before any statement that can raise, so __exit__ doesn't mask
+        # a real body failure with a spurious "unexpected error" assertion: this test
+        # deliberately disconnects ZooKeeper, so transient ZK/network errors are expected and
+        # the backup is left unfinished.
         no_trash_checker.allow_unfinished_backups = [backup_id]
         no_trash_checker.allow_errors = [
             "FAILED_TO_SYNC_BACKUP_OR_RESTORE",
@@ -628,6 +658,21 @@ def test_long_disconnection_stops_backup():
             "NO_REPLICA_HAS_PART",
         ]
         no_trash_checker.check_zookeeper = False
+
+        # Config "faster_zk_disconnect_detect.xml" is used in this test to decrease number of retries when reconnecting to ZooKeeper.
+        # Without this config this test can take several minutes (instead of seconds) to run.
+        config_manager.add_main_config(nodes, "configs/faster_zk_disconnect_detect.xml")
+
+        initiator = random_node()
+        print(f"Using {get_node_name(initiator)} as initiator")
+
+        initiator.query(
+            f"BACKUP TABLE tbl ON CLUSTER 'cluster' TO {get_backup_name(backup_id)} SETTINGS id='{backup_id}' ASYNC",
+            settings={"backup_restore_failure_after_host_disconnected_for_seconds": 3},
+        )
+
+        assert get_status(initiator, backup_id=backup_id) == "CREATING_BACKUP"
+        assert get_num_system_processes(initiator, backup_id=backup_id) >= 1
 
         with PartitionManager() as pm:
             random_sleep(3)
@@ -656,28 +701,7 @@ def test_long_disconnection_stops_backup():
 
 # A backup must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_backup():
-    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
-    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
-    for _ in range(30):
-        if not any(
-            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
-            for node in nodes
-        ):
-            break
-        time.sleep(1)
-
-    backup_process_counts = {
-        get_node_name(node): int(
-            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
-        )
-        for node in nodes
-    }
-    total_backup_processes = sum(backup_process_counts.values())
-    assert total_backup_processes == 0, (
-        "Backup queries still running after pre-test wait in "
-        "test_short_disconnection_doesnt_stop_backup: "
-        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
-    )
+    wait_for_backups_to_finish()
 
     create_and_fill_table(random_node())
 
@@ -734,28 +758,7 @@ def test_short_disconnection_doesnt_stop_backup():
 
 # A restore must NOT be stopped if Zookeeper is disconnected shorter than `failure_after_host_disconnected_for_seconds`.
 def test_short_disconnection_doesnt_stop_restore():
-    # Wait for any backup processes from the previous test to finish their ZooKeeper cleanup
-    # before creating the NoTrashChecker, so residual errors don't fall in its time window.
-    for _ in range(30):
-        if not any(
-            int(node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")) > 0
-            for node in nodes
-        ):
-            break
-        time.sleep(1)
-
-    backup_process_counts = {
-        get_node_name(node): int(
-            node.query("SELECT count() FROM system.processes WHERE query_kind = 'Backup'")
-        )
-        for node in nodes
-    }
-    total_backup_processes = sum(backup_process_counts.values())
-    assert total_backup_processes == 0, (
-        "Backup queries still running after pre-test wait in "
-        "test_short_disconnection_doesnt_stop_backup: "
-        + ", ".join(f"{name}={count}" for name, count in backup_process_counts.items())
-    )
+    wait_for_backups_to_finish()
 
     # Make a backup.
     backup_id = get_backup_id_of_successful_backup()


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/89286
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes two flaky modes in `test_backup_restore_on_cluster/test_cancel_backup.py`. Both trip `NoTrashChecker.__exit__` (the "no unexpected errors" assertion) when a transient ZooKeeper/network error lands inside the checker's error-collection window. PR-only flaky, master clean.

`test_shutdown_cancels_backup`: it restarts a node mid-backup, so the surviving node briefly loses its connection to the restarting peer and to Keeper, producing `KEEPER_EXCEPTION`/`NETWORK_ERROR`. The test declared no `allow_errors`, so the checker asserted. Now allows the same transient-error family the sibling disconnection tests already allow. The `expect_errors=["QUERY_WAS_CANCELLED"]` requirement is unchanged.

`test_long_disconnection_stops_backup`: `allow_errors` was set only near the end of the body. When the body raised earlier (e.g. a transient `SOCKET_TIMEOUT` during the BACKUP setup), `__exit__` ran with still-empty lists and masked the real exception with a spurious assertion. The relaxations are now set immediately after entering `NoTrashChecker`.

Also drains backups left running by a previous test before creating the `NoTrashChecker` in all four affected tests (tests run in random order in CI), via a shared `wait_for_backups_to_finish()` helper that replaces the drain blocks previously duplicated inline in the two short-disconnection tests.

Related to #89286 (engine-side cancellation-ordering change, ZooKeeperImpl.cpp); this PR is the orthogonal test-side hardening.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.137`
<!-- ch-version-info:end -->