### PR TITLE
Restrict catboostEvaluate model path to user_files

### DIFF
--- a/src/Functions/catboostEvaluate.cpp
+++ b/src/Functions/catboostEvaluate.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/assert_cast.h>
+#include <Common/filesystemHelpers.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -23,6 +24,7 @@ namespace ErrorCodes
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
     extern const int TOO_FEW_ARGUMENTS_FOR_FUNCTION;
     extern const int ILLEGAL_COLUMN;
+    extern const int PATH_ACCESS_DENIED;
 }
 
 /// Evaluate CatBoost model.
@@ -53,6 +55,18 @@ public:
             throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Can't load library {}: file doesn't exist", library_path);
 
         String model_path = name_col->getValue<String>();
+
+        /// model_path is user-controlled: restrict it to user_files (like file()/dictionaries).
+        /// Checked before the existence test so out-of-sandbox paths all return the same error (no oracle).
+        auto context = getContext();
+        if (context->getApplicationType() != Context::ApplicationType::LOCAL)
+        {
+            const String user_files_path = context->getUserFilesPath();
+            if (!fileOrSymlinkPathStartsWith(model_path, user_files_path))
+                throw Exception(ErrorCodes::PATH_ACCESS_DENIED,
+                    "CatBoost model path must be inside the user_files directory ({})", user_files_path);
+        }
+
         if (!std::filesystem::exists(model_path))
             throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Can't load model {}: file doesn't exist", model_path);
 
@@ -208,17 +222,19 @@ communicate using a HTTP interface. By default, port `9012` is used. A different
 2. Train a catboost model using libcatboost
 
 See [Training and applying models](https://catboost.ai/docs/features/training.html#training) for how to train catboost models from a training data set.
+
+The model file must be located inside the [`user_files`](/operations/server-configuration-parameters/settings#user_files_path) directory, like for the [`file`](/sql-reference/functions/files#file) function.
 )";
     FunctionDocumentation::Syntax syntax = "catboostEvaluate(path_to_model, feature_1[, feature_2, ..., feature_n])";
     FunctionDocumentation::Arguments arguments = {
-        {"path_to_model", "Path to catboost model.", {"const String"}},
+        {"path_to_model", "Path to the catboost model, located inside the `user_files` directory.", {"const String"}},
         {"feature", "One or more model features/arguments.", {"Float*"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the model evaluation result.", {"Float64"}};
     FunctionDocumentation::Examples examples = {
     {
         "catboostEvaluate",
-        "SELECT catboostEvaluate('/root/occupy.bin', Temperature, Humidity, Light, CO2, HumidityRatio) AS prediction FROM occupancy LIMIT 1",
+        "SELECT catboostEvaluate('/var/lib/clickhouse/user_files/occupy.bin', Temperature, Humidity, Light, CO2, HumidityRatio) AS prediction FROM occupancy LIMIT 1",
         "4.695691092573497"
     }
     };

--- a/tests/integration/test_catboost_evaluate/test.py
+++ b/tests/integration/test_catboost_evaluate/test.py
@@ -16,13 +16,22 @@ instance = cluster.add_instance(
     main_configs=["config/models_config.xml", "config/logger_library_bridge.xml"],
 )
 
+# The catboost library (.so) is configured server-side (catboost_lib_path) and is not
+# user-controlled, so it stays in /etc/clickhouse-server/model.
+LIB_DIR = "/etc/clickhouse-server/model"
+# The model path is the user-controlled first argument of catboostEvaluate() and is
+# restricted to user_files (like file() and dictionaries), so models live there.
+USER_FILES = "/var/lib/clickhouse/user_files"
+SIMPLE_MODEL = f"{USER_FILES}/simple_model.bin"
+AMAZON_MODEL = f"{USER_FILES}/amazon_model.bin"
+
 
 @pytest.fixture(scope="module")
 def ch_cluster():
     try:
         cluster.start()
 
-        instance.exec_in_container(["mkdir", "/etc/clickhouse-server/model/"])
+        instance.exec_in_container(["mkdir", f"{LIB_DIR}/"])
 
         machine = instance.get_machine_name()
         for source_name in os.listdir(os.path.join(SCRIPT_DIR, "model/.")):
@@ -35,7 +44,18 @@ def ch_cluster():
                 "docker cp {local} {cont_id}:{dist}".format(
                     local=os.path.join(SCRIPT_DIR, f"model/{source_name}"),
                     cont_id=instance.docker_id,
-                    dist=f"/etc/clickhouse-server/model/{dest_name}",
+                    dist=f"{LIB_DIR}/{dest_name}",
+                )
+            )
+
+        # Place the model files inside user_files: catboostEvaluate() restricts
+        # the model path to user_files, so the evaluated models must live there.
+        for model_name in ("simple_model.bin", "amazon_model.bin"):
+            os.system(
+                "docker cp {local} {cont_id}:{dist}".format(
+                    local=os.path.join(SCRIPT_DIR, f"model/{model_name}"),
+                    cont_id=instance.docker_id,
+                    dist=f"{USER_FILES}/{model_name}",
                 )
             )
 
@@ -58,7 +78,7 @@ def testConstantFeatures(ch_cluster):
     result = instance.query("system reload models")
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
@@ -77,7 +97,7 @@ def testNonConstantFeatures(ch_cluster):
     instance.query("INSERT INTO T VALUES(0, 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);")
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11) from T;"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11) from T;"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
@@ -117,13 +137,11 @@ def testWrongNumberOfFeatureArguments(ch_cluster):
 
     instance.query("system reload models")
 
-    err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin');"
-    )
+    err = instance.query_and_get_error(f"select catboostEvaluate('{SIMPLE_MODEL}');")
     assert "Function catboostEvaluate expects at least 2 arguments" in err
 
     err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1, 2);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1, 2);"
     )
     assert (
         "Number of columns is different with number of features: columns size 2 float features size 2 + cat features size 9"
@@ -138,7 +156,7 @@ def testFloatFeatureMustBeNumeric(ch_cluster):
     instance.query("system reload models")
 
     err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 'a', 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 'a', 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     assert "Column 1 should be numeric to make float feature" in err
 
@@ -150,7 +168,7 @@ def testCategoricalFeatureMustBeNumericOrString(ch_cluster):
     instance.query("system reload models")
 
     err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, tuple(8), 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, tuple(8), 9, 10, 11);"
     )
     assert "Column 7 should be numeric or string" in err
 
@@ -163,7 +181,7 @@ def testOnLowCardinalityFeatures(ch_cluster):
 
     # same but on domain-compressed data
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', toLowCardinality(1.0), toLowCardinality(2.0), toLowCardinality(3), toLowCardinality(4), toLowCardinality(5), toLowCardinality(6), toLowCardinality(7), toLowCardinality(8), toLowCardinality(9), toLowCardinality(10), toLowCardinality(11));"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', toLowCardinality(1.0), toLowCardinality(2.0), toLowCardinality(3), toLowCardinality(4), toLowCardinality(5), toLowCardinality(6), toLowCardinality(7), toLowCardinality(8), toLowCardinality(9), toLowCardinality(10), toLowCardinality(11));"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
@@ -176,14 +194,14 @@ def testOnNullableFeatures(ch_cluster):
     result = instance.query("system reload models")
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', toNullable(1.0), toNullable(2.0), toNullable(3), toNullable(4), toNullable(5), toNullable(6), toNullable(7), toNullable(8), toNullable(9), toNullable(10), toNullable(11));"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', toNullable(1.0), toNullable(2.0), toNullable(3), toNullable(4), toNullable(5), toNullable(6), toNullable(7), toNullable(8), toNullable(9), toNullable(10), toNullable(11));"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
 
     # Actual NULLs are disallowed
     err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL));"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL), toNullable(NULL));"
     )
     assert "Column 0 should be numeric to make float feature" in err
 
@@ -199,16 +217,15 @@ def testInvalidLibraryPath(ch_cluster):
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/libcatboostmodel.so /etc/clickhouse-server/model/nonexistant.so",
+            f"mv {LIB_DIR}/libcatboostmodel.so {LIB_DIR}/nonexistant.so",
         ]
     )
 
     err = instance.query_and_get_error(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     assert (
-        "Can't load library /etc/clickhouse-server/model/libcatboostmodel.so: file doesn't exist"
-        in err
+        f"Can't load library {LIB_DIR}/libcatboostmodel.so: file doesn't exist" in err
     )
 
     # restore
@@ -216,7 +233,7 @@ def testInvalidLibraryPath(ch_cluster):
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/nonexistant.so /etc/clickhouse-server/model/libcatboostmodel.so",
+            f"mv {LIB_DIR}/nonexistant.so {LIB_DIR}/libcatboostmodel.so",
         ]
     )
 
@@ -227,15 +244,54 @@ def testInvalidModelPath(ch_cluster):
 
     instance.query("system reload models")
 
+    # A path inside user_files that does not exist still reports FILE_DOESNT_EXIST
+    # (probing existence inside one's own sandbox is not an information leak).
     err = instance.query_and_get_error(
-        "select catboostEvaluate('', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{USER_FILES}/model_non_existant.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
-    assert "Can't load model : file doesn't exist" in err
+    assert (
+        f"Can't load model {USER_FILES}/model_non_existant.bin: file doesn't exist"
+        in err
+    )
 
-    err = instance.query_and_get_error(
-        "select catboostEvaluate('model_non_existant.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
-    )
-    assert "Can't load model model_non_existant.bin: file doesn't exist" in err
+
+def testModelPathOutsideUserFilesIsDenied(ch_cluster):
+    # Security: the model path is restricted to user_files. Any path outside it must be
+    # rejected with the same PATH_ACCESS_DENIED error regardless of whether the target
+    # file exists, is permission-denied, or does not exist - otherwise catboostEvaluate
+    # would be a filesystem existence oracle and an arbitrary file read trigger.
+    if instance.is_built_with_memory_sanitizer():
+        pytest.skip("Memory Sanitizer cannot work with third-party shared libraries")
+
+    instance.query("system reload models")
+
+    # An existing file outside user_files, a permission-denied file, a missing
+    # file, a path-traversal attempt, a relative path and an empty path must all
+    # be indistinguishable.
+    paths = [
+        "/etc/passwd",  # exists, readable
+        "/root/.ssh/id_rsa",  # permission denied / does not exist
+        "/nonexistent_file_xyz",  # does not exist
+        f"{USER_FILES}/../../../etc/passwd",  # path traversal out of the sandbox
+        "model_non_existant.bin",  # relative path (resolved outside user_files)
+        "",  # empty path
+    ]
+
+    errors = []
+    for path in paths:
+        err = instance.query_and_get_error(
+            f"select catboostEvaluate('{path}', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        )
+        assert "must be inside the user_files directory" in err, (path, err)
+        # No FILE_DOESNT_EXIST leak: the error must not reveal whether the file exists.
+        assert "file doesn't exist" not in err, (path, err)
+        # Keep only the stable part of the message (the probed path only appears in the
+        # echoed query after "In scope") so the responses can be compared for
+        # indistinguishability.
+        errors.append(err.split("In scope")[0])
+
+    # Every probed path produces the same response - no oracle.
+    assert len(set(errors)) == 1, errors
 
 
 def testRecoveryAfterCrash(ch_cluster):
@@ -245,7 +301,7 @@ def testRecoveryAfterCrash(ch_cluster):
     result = instance.query("system reload models")
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
@@ -255,7 +311,7 @@ def testRecoveryAfterCrash(ch_cluster):
     )
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     assert result == expected
 
@@ -271,7 +327,7 @@ def testAmazonModelSingleRow(ch_cluster):
     result = instance.query("system reload models")
 
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/amazon_model.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
+        f"select catboostEvaluate('{AMAZON_MODEL}', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
     )
     expected = "0.7774665009089274\n"
     assert result == expected
@@ -296,7 +352,7 @@ def testAmazonModelManyRows(ch_cluster):
     # First compute prediction, then as a very crude way to fingerprint and compare the result: sum and floor
     # (the focus is to test that the exchange of large result sets between the server and the bridge works)
     result = instance.query(
-        "SELECT floor(sum(catboostEvaluate('/etc/clickhouse-server/model/amazon_model.bin', RESOURCE, MGR_ID, ROLE_ROLLUP_1, ROLE_ROLLUP_2, ROLE_DEPTNAME, ROLE_TITLE, ROLE_FAMILY_DESC, ROLE_FAMILY, ROLE_CODE))) FROM amazon"
+        f"SELECT floor(sum(catboostEvaluate('{AMAZON_MODEL}', RESOURCE, MGR_ID, ROLE_ROLLUP_1, ROLE_ROLLUP_2, ROLE_DEPTNAME, ROLE_TITLE, ROLE_FAMILY_DESC, ROLE_FAMILY, ROLE_CODE))) FROM amazon"
     )
 
     expected = "583092\n"
@@ -311,7 +367,7 @@ def testModelUpdate(ch_cluster):
 
     result = instance.query("system reload models")
 
-    query = "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+    query = f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
 
     result = instance.query(query)
     expected = "-1.930268705869267\n"
@@ -322,25 +378,23 @@ def testModelUpdate(ch_cluster):
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/simple_model.bin /etc/clickhouse-server/model/simple_model.bin.bak",
+            f"mv {SIMPLE_MODEL} {SIMPLE_MODEL}.bak",
         ]
     )
     instance.exec_in_container(
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/amazon_model.bin /etc/clickhouse-server/model/simple_model.bin",
+            f"mv {AMAZON_MODEL} {SIMPLE_MODEL}",
         ]
     )
 
     # unload simple model
-    result = instance.query(
-        "system reload model '/etc/clickhouse-server/model/simple_model.bin'"
-    )
+    result = instance.query(f"system reload model '{SIMPLE_MODEL}'")
 
     # load the simple-model-camouflaged amazon model
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
     )
     expected = "0.7774665009089274\n"
     assert result == expected
@@ -350,14 +404,14 @@ def testModelUpdate(ch_cluster):
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/simple_model.bin /etc/clickhouse-server/model/amazon_model.bin",
+            f"mv {SIMPLE_MODEL} {AMAZON_MODEL}",
         ]
     )
     instance.exec_in_container(
         [
             "bash",
             "-c",
-            "mv /etc/clickhouse-server/model/simple_model.bin.bak /etc/clickhouse-server/model/simple_model.bin",
+            f"mv {SIMPLE_MODEL}.bak {SIMPLE_MODEL}",
         ]
     )
 
@@ -375,7 +429,7 @@ def testSystemModelsAndModelRefresh(ch_cluster):
 
     # load simple model
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/simple_model.bin', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
+        f"select catboostEvaluate('{SIMPLE_MODEL}', 1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10, 11);"
     )
     expected = "-1.930268705869267\n"
     assert result == expected
@@ -383,12 +437,12 @@ def testSystemModelsAndModelRefresh(ch_cluster):
     # check model system view with one model loaded
     result = instance.query("select * from system.models")
     assert result.count("\n") == 1
-    expected = "/etc/clickhouse-server/model/simple_model.bin"
+    expected = SIMPLE_MODEL
     assert expected in result
 
     # load amazon model
     result = instance.query(
-        "select catboostEvaluate('/etc/clickhouse-server/model/amazon_model.bin', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
+        f"select catboostEvaluate('{AMAZON_MODEL}', 1, 2, 3, 4, 5, 6, 7, 8, 9);"
     )
     expected = "0.7774665009089274\n"
     assert result == expected
@@ -396,18 +450,16 @@ def testSystemModelsAndModelRefresh(ch_cluster):
     # check model system view with one model loaded
     result = instance.query("select * from system.models")
     assert result.count("\n") == 2
-    expected = "/etc/clickhouse-server/model/simple_model.bin"
+    expected = SIMPLE_MODEL
     assert expected in result
-    expected = "/etc/clickhouse-server/model/amazon_model.bin"
+    expected = AMAZON_MODEL
     assert expected in result
 
     # unload simple model
-    result = instance.query(
-        "system reload model '/etc/clickhouse-server/model/simple_model.bin'"
-    )
+    result = instance.query(f"system reload model '{SIMPLE_MODEL}'")
 
     # check model system view, it should not display the removed model
     result = instance.query("select * from system.models")
     assert result.count("\n") == 1
-    expected = "/etc/clickhouse-server/model/amazon_model.bin"
+    expected = AMAZON_MODEL
     assert expected in result


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Restrict the model path of `catboostEvaluate` to the `user_files` directory, like `file()` and the dictionary sources. Previously the function accepted an arbitrary filesystem path with no containment check, which allowed probing the existence of and triggering reads of files outside `user_files`. Models must now be located inside `user_files`.

### Description

`catboostEvaluate(path, ...)` accepted an arbitrary filesystem path as its first argument with no containment check. Once `catboost_lib_path` is configured, any user with the function grant could:

1. **Probe arbitrary paths** - the existing `std::filesystem::exists` check returned distinct errors for exists / permission-denied / does-not-exist, making the function a filesystem existence oracle across the whole filesystem.
2. **Trigger reads of arbitrary files** - the path was forwarded to `clickhouse-library-bridge`, which opens it.

Every other file-reading entry point (`file()`, `StorageFile`, dictionaries, executable user scripts) validates the path against `user_files_path`; `catboostEvaluate` was the lone exception.

The model path (the only user-controlled path - `library_path` comes from the server config) is now restricted to `user_files`, matching `file()` and the dictionary sources:

- The check uses `fileOrSymlinkPathStartsWith` (normalizes without `canonical`, so legitimate symlinks inside `user_files` keep working, identical to `file()`).
- It runs **before** the existence check, so any path outside the sandbox returns the same `PATH_ACCESS_DENIED` regardless of whether the target exists - this closes the oracle.
- `clickhouse-local` (`ApplicationType::LOCAL`) is exempt, as for `file()`.

`SYSTEM RELOAD MODEL` is unaffected: it is gated behind the `SYSTEM_RELOAD_MODEL` (global admin) grant and only sends the path string to the bridge cache; it performs no server-side filesystem access.

The integration test `test_catboost_evaluate` is updated to place models under `user_files` (the catboost library `.so` stays server-side), and a new test asserts that paths outside `user_files` (existing, permission-denied, missing, path-traversal, relative, empty) all return the same error - i.e. there is no oracle.

No related open issue found (reported via a private security channel; the upstream security team cleared a public patch).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.606` (included in `26.7` and later)
- Backported to: `26.6.2.49`, `26.5.6.30`, `26.4.5.116`, `26.3.17.35`
<!-- ch-version-info:end -->