### PR TITLE
Add SHOW COLUMNS access check to hasColumnInTable

### DIFF
--- a/src/Functions/hasColumnInTable.cpp
+++ b/src/Functions/hasColumnInTable.cpp
@@ -1,3 +1,5 @@
+#include <Access/Common/AccessFlags.h>
+#include <Access/Common/AccessType.h>
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
@@ -29,10 +31,12 @@ public:
     static constexpr auto name = "hasColumnInTable";
     static FunctionPtr create(ContextPtr context_)
     {
-        return std::make_shared<FunctionHasColumnInTable>(context_->getGlobalContext());
+        return std::make_shared<FunctionHasColumnInTable>(context_);
     }
 
-    explicit FunctionHasColumnInTable(ContextPtr global_context_) : WithContext(global_context_)
+    /// Holds the query context for the access check in executeImpl. The check must not run
+    /// against the global context, which has full access by construction.
+    explicit FunctionHasColumnInTable(ContextPtr context_) : WithContext(context_)
     {
     }
 
@@ -93,6 +97,11 @@ ColumnPtr FunctionHasColumnInTable::executeImpl(const ColumnsWithTypeAndName & a
     if (table_name.empty())
         throw Exception(ErrorCodes::UNKNOWN_TABLE, "Table name is empty");
 
+    /// Check access on the raw names before resolving the table, so denial does not
+    /// depend on the table/database existing (no existence oracle). SHOW_COLUMNS is the
+    /// same grant required by DESCRIBE and SHOW CREATE TABLE.
+    getContext()->checkAccess(AccessType::SHOW_COLUMNS, database_name, table_name);
+
     // FIXME this (probably) needs a non-constant access to query context,
     // because it might initialized a storage. Ideally, the tables required
     // by the query should be initialized at an earlier stage.
@@ -114,6 +123,11 @@ REGISTER_FUNCTION(HasColumnInTable)
 Checks if a specific column exists in a database table.
 For elements in a nested data structure, the function checks for the existence of a column.
 For the nested data structure itself, the function returns `0`.
+
+:::note Privilege `SHOW COLUMNS` is required
+The function requires the `SHOW COLUMNS` privilege on the target table (the same grant needed by `DESCRIBE` and `SHOW CREATE TABLE`).
+Without it the call fails with `ACCESS_DENIED` instead of returning `1` or `0`, so column names cannot be probed without access.
+:::
     )";
     FunctionDocumentation::Syntax syntax = "hasColumnInTable(database, table, column)";
     FunctionDocumentation::Arguments arguments = {

--- a/tests/queries/0_stateless/04401_has_column_in_table_access_check.reference
+++ b/tests/queries/0_stateless/04401_has_column_in_table_access_check.reference
@@ -1,0 +1,10 @@
+-- without SHOW COLUMNS: denied (existing column)
+ACCESS_DENIED
+-- without SHOW COLUMNS: denied for a non-existing table (no existence oracle)
+ACCESS_DENIED
+-- without SHOW COLUMNS: denied for a non-existing database (no existence oracle)
+ACCESS_DENIED
+-- with SHOW COLUMNS: existing column
+1
+-- with SHOW COLUMNS: non-existing column
+0

--- a/tests/queries/0_stateless/04401_has_column_in_table_access_check.sh
+++ b/tests/queries/0_stateless/04401_has_column_in_table_access_check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# hasColumnInTable must require SHOW COLUMNS, like DESCRIBE / SHOW CREATE TABLE.
+# User and table names are scoped to ${CLICKHOUSE_DATABASE} so the test is parallel-safe.
+
+user="user_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user}"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user} IDENTIFIED WITH plaintext_password BY 'password'"
+${CLICKHOUSE_CLIENT} --query "GRANT SELECT ON system.one TO ${user}"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${CLICKHOUSE_DATABASE}.secret (id UInt64, password String) ENGINE = MergeTree ORDER BY id"
+
+run_as_user() { ${CLICKHOUSE_CLIENT} --user "${user}" --password password "$@"; }
+
+echo "-- without SHOW COLUMNS: denied (existing column)"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret', 'password')" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+echo "-- without SHOW COLUMNS: denied for a non-existing table (no existence oracle)"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'no_such_table', 'id')" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+echo "-- without SHOW COLUMNS: denied for a non-existing database (no existence oracle)"
+run_as_user --query "SELECT hasColumnInTable('no_such_db_${CLICKHOUSE_DATABASE}', 'secret', 'id')" 2>&1 | grep -Fo "ACCESS_DENIED" | uniq
+
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.secret TO ${user}"
+
+echo "-- with SHOW COLUMNS: existing column"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret', 'password')"
+echo "-- with SHOW COLUMNS: non-existing column"
+run_as_user --query "SELECT hasColumnInTable('${CLICKHOUSE_DATABASE}', 'secret', 'not_a_column')"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${CLICKHOUSE_DATABASE}.secret"
+${CLICKHOUSE_CLIENT} --query "DROP USER ${user}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/110881


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `hasColumnInTable` function now requires the `SHOW COLUMNS` privilege on the target table, the same grant required by `DESCRIBE` and `SHOW CREATE TABLE`. Previously any user could call `hasColumnInTable` to probe column names and test table and database existence without any access check.

### Description

`hasColumnInTable` read table column metadata without an access check. A user with no privileges on a table (for example one granted only `SELECT ON system.one`) could still enumerate its column names (the function returns 1/0), probe table existence (`UNKNOWN_TABLE` vs `0`), and probe database existence. `DESCRIBE` and `SHOW CREATE TABLE` on the same table are gated by `SHOW COLUMNS`; this function was a bypass.

Rebased onto master after #110881 removed the remote-server overload, so only the local `hasColumnInTable(database, table, column)` form remains and is the only path that needs this gate.

#### Why the naive fix does not work

`create()` stored the global context (`context_->getGlobalContext()`), which has full access by construction (it never has a user id set), so a `checkAccess` on it would always pass. The fix keeps the query context, which carries the caller's rights.

#### Fix

`create()` now retains the query context. `executeImpl` checks `SHOW_COLUMNS` on the raw database and table names before the table is resolved, so denial does not depend on the table or database existing (closing the existence oracle). This mirrors `InterpreterDescribeQuery` (`checkAccess(AccessType::SHOW_COLUMNS, table_id)`).

#### Testing

New stateless test `04401_has_column_in_table_access_check`: a user with only `SELECT ON system.one` gets `ACCESS_DENIED` from `hasColumnInTable` for an existing table, a non-existing table, and a non-existing database (existence-independent), then succeeds after `GRANT SHOW COLUMNS`. Verified locally that an unprivileged user got the column/existence result before this change (bypass) and gets `ACCESS_DENIED` after (50/50 runs). The existing test `00386_has_column_in_table` is unchanged and still passes (it runs as a full-access user).



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1206` (included in `26.7` and later)
- Backported to: `26.3.33.118`
<!-- ch-version-info:end -->