### PR TITLE
Validate S3 301 redirect target against RemoteHostFilter

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -1045,7 +1045,15 @@ std::optional<S3::URI> Client::getURIFromError(const Aws::S3::S3Error & error) c
     auto uri = resolved_endpoint.GetResult().GetURI();
     uri.SetAuthority(endpoint);
 
-    return S3::URI(uri.GetURIString());
+    S3::URI result(uri.GetURIString());
+
+    /// The endpoint is taken from an attacker-controllable 301 response (Location header or
+    /// <Endpoint> XML), so validate it against RemoteHostFilter before following the redirect,
+    /// otherwise a malicious S3 server can redirect us to internal hosts (SSRF). This mirrors
+    /// the Poco 307 path in PocoHTTPClient. Throws UNACCEPTABLE_URL.
+    client_configuration.remote_host_filter.checkURL(result.uri);
+
+    return result;
 }
 
 // Do a list request because head requests don't have body in response

--- a/tests/integration/test_s3_redirect_remote_host_filter/configs/config.xml
+++ b/tests/integration/test_s3_redirect_remote_host_filter/configs/config.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <!-- Allow the initial S3 endpoint (the resolver) but NOT the 301 redirect target
+         (the resolver's raw IP address). A correctly-behaving server must reject the
+         redirect target via RemoteHostFilter instead of following it (SSRF). -->
+    <remote_url_allow_hosts>
+        <host>resolver:8080</host>
+    </remote_url_allow_hosts>
+    <!-- Keep retries low so the test fails fast. -->
+    <s3_retry_attempts>1</s3_retry_attempts>
+</clickhouse>

--- a/tests/integration/test_s3_redirect_remote_host_filter/s3_endpoint/endpoint.py
+++ b/tests/integration/test_s3_redirect_remote_host_filter/s3_endpoint/endpoint.py
@@ -11,7 +11,7 @@
 # asserts never happens.
 import socket
 
-from bottle import request, response, route, run
+from bottle import response, route, run
 
 # Resolve our own container IP. It is reachable (same container) but is a different
 # "host" from the allow-listed name "resolver", so the host filter must deny it.

--- a/tests/integration/test_s3_redirect_remote_host_filter/s3_endpoint/endpoint.py
+++ b/tests/integration/test_s3_redirect_remote_host_filter/s3_endpoint/endpoint.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Malicious S3 endpoint used to test that the AWS-SDK 301 redirect path in
+# Client::getURIFromError validates the redirect target against RemoteHostFilter
+# (SSRF protection), mirroring the Poco 307 path.
+#
+# Every S3 request is answered with 301 Moved Permanently whose Location points at
+# this same container's IP address, reached under a name (the raw IP) that is NOT in
+# <remote_url_allow_hosts>. A correctly-behaving server rejects that target with
+# UNACCEPTABLE_URL before connecting. If the redirect were followed, the rewritten
+# request would land on /forbidden_hit and flip the "followed" flag -- which the test
+# asserts never happens.
+import socket
+
+from bottle import request, response, route, run
+
+# Resolve our own container IP. It is reachable (same container) but is a different
+# "host" from the allow-listed name "resolver", so the host filter must deny it.
+OWN_IP = socket.gethostbyname(socket.gethostname())
+REDIRECT_TARGET = OWN_IP + ":8080"
+
+followed_redirect = {"hit": False}
+
+
+@route("/forbidden_hit/<_path:path>", ["GET", "POST", "PUT", "HEAD", "DELETE"])
+def forbidden(_path):
+    # Reached only if ClickHouse followed the 301 to the disallowed target (the bug).
+    followed_redirect["hit"] = True
+    response.status = 200
+    return "SHOULD_NOT_BE_REACHED"
+
+
+@route("/followed")
+def followed():
+    return "YES" if followed_redirect["hit"] else "NO"
+
+
+@route("/<_bucket>", ["GET", "POST", "PUT", "HEAD", "DELETE"])
+@route("/<_bucket>/<_path:path>", ["GET", "POST", "PUT", "HEAD", "DELETE"])
+def server(_bucket, _path=""):
+    suffix = _bucket if not _path else _bucket + "/" + _path
+    response.set_header("Location", "http://" + REDIRECT_TARGET + "/forbidden_hit/" + suffix)
+    response.status = 301
+    return "Redirected"
+
+
+@route("/")
+def ping():
+    return "OK"
+
+
+run(host="0.0.0.0", port=8080)

--- a/tests/integration/test_s3_redirect_remote_host_filter/test.py
+++ b/tests/integration/test_s3_redirect_remote_host_filter/test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Regression test for the AWS-SDK 301 redirect SSRF: a malicious/compromised
+# S3-compatible endpoint returns 301 Moved Permanently with a Location header (or
+# <Endpoint> XML) pointing at an arbitrary host. Client::getURIFromError must validate
+# that target against RemoteHostFilter (like the Poco 307 path already does) instead of
+# blindly following it. Without the fix the s3() query reaches the disallowed host
+# (SSRF to internal services / cloud metadata); with the fix it fails with UNACCEPTABLE_URL.
+import logging
+import os
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+
+def run_endpoint(cluster):
+    logging.info("Starting custom S3 endpoint")
+    container_id = cluster.get_container_id("resolver")
+    current_dir = os.path.dirname(__file__)
+    cluster.copy_file_to_container(
+        container_id,
+        os.path.join(current_dir, "s3_endpoint", "endpoint.py"),
+        "endpoint.py",
+    )
+    cluster.exec_in_container(container_id, ["python", "endpoint.py"], detach=True)
+
+    # Wait for S3 endpoint start
+    num_attempts = 100
+    for attempt in range(num_attempts):
+        ping_response = cluster.exec_in_container(
+            cluster.get_container_id("resolver"),
+            ["curl", "-s", "http://resolver:8080/"],
+            nothrow=True,
+        )
+        if ping_response != "OK":
+            if attempt == num_attempts - 1:
+                assert ping_response == "OK", 'Expected "OK", but got "{}"'.format(
+                    ping_response
+                )
+            else:
+                time.sleep(1)
+        else:
+            break
+
+    logging.info("S3 endpoint started")
+
+
+@pytest.fixture(scope="module")
+def cluster():
+    try:
+        cluster = ClickHouseCluster(__file__)
+        cluster.add_instance(
+            "node",
+            main_configs=["configs/config.xml"],
+            with_minio=True,
+        )
+        logging.info("Starting cluster...")
+        cluster.start()
+        logging.info("Cluster started")
+
+        run_endpoint(cluster)
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _followed(cluster):
+    return cluster.exec_in_container(
+        cluster.get_container_id("resolver"),
+        ["curl", "-s", "http://resolver:8080/followed"],
+        nothrow=True,
+    )
+
+
+def test_301_redirect_target_is_host_filtered(cluster):
+    node = cluster.instances["node"]
+
+    # The s3() endpoint (resolver:8080) is allow-listed, but it 301-redirects to its own
+    # raw IP, which is NOT allow-listed. The redirect target must be rejected.
+    error = node.query_and_get_error(
+        "SELECT * FROM s3('http://resolver:8080/bucket/key', 'TSV', 'x String') "
+        "SETTINGS s3_max_redirects=5"
+    )
+    assert "not allowed in configuration file" in error, (
+        "expected RemoteHostFilter to reject the 301 redirect target, got: " + error
+    )
+
+    # And the server must not have sent a single request to the disallowed target.
+    assert _followed(cluster) == "NO", "ClickHouse followed the 301 to a disallowed host (SSRF)"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Validate the redirect target of an S3 `301 Moved Permanently` response against `remote_url_allow_hosts` (`RemoteHostFilter`). Previously the AWS-SDK 301 handling followed the attacker-supplied endpoint from the response (`Location` header or `<Endpoint>` element) without the host check, so a malicious or compromised S3-compatible server could redirect ClickHouse to an arbitrary host (SSRF). The 307 redirect path already performed this check; both paths are now consistent.

### Description

`Client::getURIFromError()` (`src/IO/S3/Client.cpp`) handles `301 Moved Permanently` responses by extracting an endpoint from the response (`ExtractEndpoint` reads the `Location` header or the `<Endpoint>` XML element) and returning it as the new request URI. `doRequest()` then follows that endpoint. The endpoint is fully controlled by the remote S3 server, and it was used without any `RemoteHostFilter` check, so a malicious or compromised S3-compatible endpoint could redirect the server to internal hosts (for example cloud metadata at `169.254.169.254` or other in-VPC services) and have it re-sign and resend the request there.

The Poco transport already validates `307 Temporary Redirect` targets via `remote_host_filter.checkURL()` before following them (`src/IO/S3/PocoHTTPClient.cpp`); only the AWS-SDK `301` path was missing the equivalent check. This adds the same validation on the resolved redirect URI inside `getURIFromError()`, so every `301`-derived endpoint is filtered before it is followed. Disallowed targets now fail with `UNACCEPTABLE_URL`. The `IllegalLocationConstraintException` branch in `doRequest()` builds its URI from the already-validated initial endpoint and is unaffected. The filter is reachable because `Client` already holds `client_configuration`, which carries `remote_host_filter`.

Behavior change is limited to redirect targets that are not in `remote_url_allow_hosts`: a `301` to an allowed host is still followed exactly as before, and a server with no `remote_url_allow_hosts` configured (allow-all) is unchanged.

A new integration test `test_s3_redirect_remote_host_filter` adds a mock S3 endpoint that returns `301` to a host outside `remote_url_allow_hosts` and asserts the `s3()` query fails with `UNACCEPTABLE_URL` and that no request reaches the redirect target. The test passes with this change and fails without it.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.108` (included in `26.7` and later)
- Backported to: `26.3.33.124`
<!-- ch-version-info:end -->