### PR TITLE
CI: move trusted contributors list into a config file

### DIFF
--- a/ci/defs/trusted_contributors.json
+++ b/ci/defs/trusted_contributors.json
@@ -1,0 +1,8 @@
+{
+    "amosbird": "",
+    "den-crane": "Documentation contributor",
+    "taiyang-li": "",
+    "ucasFL": "Amos Bird's friend",
+    "canhld94": "",
+    "uladzislauNestsiaruk": "Student working on https://github.com/ClickHouse/ClickHouse/pull/91416, remove by 05/2026"
+}

--- a/ci/defs/trusted_contributors.json
+++ b/ci/defs/trusted_contributors.json
@@ -3,6 +3,5 @@
     "den-crane": "Documentation contributor",
     "taiyang-li": "",
     "ucasFL": "Amos Bird's friend",
-    "canhld94": "",
-    "uladzislauNestsiaruk": "Student working on https://github.com/ClickHouse/ClickHouse/pull/91416, remove by 05/2026"
+    "canhld94": ""
 }

--- a/ci/jobs/scripts/workflow_hooks/trusted.py
+++ b/ci/jobs/scripts/workflow_hooks/trusted.py
@@ -1,18 +1,14 @@
+import json
 import sys
+from pathlib import Path
 
 from praktika.info import Info
 from praktika.utils import Shell
 
+TRUSTED_CONTRIBUTORS_CONFIG = Path(__file__).parents[3] / "defs" / "trusted_contributors.json"
 TRUSTED_CONTRIBUTORS = {
-    e.lower()
-    for e in [
-        "amosbird",
-        "den-crane",  # Documentation contributor
-        "taiyang-li",
-        "ucasFL",  # Amos Bird's friend
-        "canhld94",
-        "uladzislauNestsiaruk",  # Student working on https://github.com/ClickHouse/ClickHouse/pull/91416, remove by 05/2026
-    ]
+    login.lower()
+    for login in json.loads(TRUSTED_CONTRIBUTORS_CONFIG.read_text(encoding="utf-8"))
 }
 
 CAN_BE_TESTED = "can be tested"


### PR DESCRIPTION
Move the individually-trusted-contributors list out of
`ci/jobs/scripts/workflow_hooks/trusted.py` and into a standalone config
file `ci/defs/trusted_contributors.json`. The workflow hook now reads the
list from JSON instead of a hardcoded set.

This keeps the trusted list as data in one place so it can be reused by
other tooling. No functional change — the set of trusted contributors is
identical.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.97`
<!-- ch-version-info:end -->