### PR TITLE
Enforce http_forbid_headers during URL schema inference

### DIFF
--- a/src/Storages/StorageURL.cpp
+++ b/src/Storages/StorageURL.cpp
@@ -1054,6 +1054,12 @@ std::pair<ColumnsDescription, String> IStorageURLBase::getTableStructureAndForma
     const ContextPtr & context)
 {
     context->getRemoteHostFilter().checkURL(Poco::URI(uri));
+    /// Enforce <http_forbid_headers> before any network access. This is the single funnel for
+    /// schema inference (StorageURL ctor, StorageURLCluster, TableFunctionURL analysis), so the
+    /// check here also covers the DESCRIBE / INSERT..SELECT / format-detection paths that never
+    /// reach the StorageURL ctor body. checkAndNormalizeHeaders mutates, so validate a copy.
+    HTTPHeaderEntries headers_to_check(headers);
+    context->getHTTPHeaderFilter().checkAndNormalizeHeaders(headers_to_check);
 
     Poco::Net::HTTPBasicCredentials credentials;
 

--- a/tests/queries/0_stateless/02752_forbidden_headers.sql
+++ b/tests/queries/0_stateless/02752_forbidden_headers.sql
@@ -24,3 +24,15 @@ SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('bad_header_name: test\nexact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('random_header' = 'value')); -- { serverError S3_ERROR }
+
+-- Schema-inference paths must enforce http_forbid_headers BEFORE any network access.
+-- These previously bypassed the filter: the request was sent during inference and a forbidden
+-- header (e.g. a cloud-metadata auth header) reached the wire, and its response body could leak
+-- via a parse error (Regexp), or the filter was never consulted at all (auto-format / DESCRIBE).
+SELECT * FROM url('http://localhost:8123/', Regexp, headers('exact_header' = 'value')) SETTINGS format_regexp = 'a'; -- { serverError BAD_ARGUMENTS }
+SELECT * FROM url('http://localhost:8123/', Regexp, headers('cAsE_INSENSITIVE_header' = 'value')) SETTINGS format_regexp = 'a'; -- { serverError BAD_ARGUMENTS }
+SELECT * FROM url('http://localhost:8123/', headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM url('http://localhost:8123/', headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }
+DESCRIBE url('http://localhost:8123/', headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+DESCRIBE url('http://localhost:8123/', headers('cAsE_INSENSITIVE_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+DESCRIBE url('http://localhost:8123/', Regexp, headers('exact_header' = 'value')) SETTINGS format_regexp = 'a'; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enforce the `http_forbid_headers` configuration during schema inference for the `url()` table function and `URL` storage engine. Previously a forbidden header was still sent over the network while inferring the schema (for example with the `Regexp` format or `DESCRIBE`), and its response body could be reflected back in a parse error, leaking secrets. The header filter is now checked before any network access on the inference path, matching the existing behavior of `urlCluster`.


### Description

`http_forbid_headers` was enforced too late and was skipped entirely on the schema-inference path.

`IStorageURLBase::getTableStructureAndFormatFromDataImpl` is the single funnel every schema-inference caller passes through (the `StorageURL`/`URL` engine constructor, `StorageURLCluster`, and `TableFunctionURL::getActualTableStructure` used by `DESCRIBE` / `INSERT ... SELECT` / format detection). It validated only the remote-host filter and never the HTTP header filter, so the request was sent with the forbidden header before the constructor body's later `checkAndNormalizeHeaders` call ran. The fix adds the header-filter check right next to the existing host-filter check, before any network access, so both bypass paths are closed at once. `StorageURLCluster` already validated headers before inference; this aligns the non-cluster paths with it.

Concretely, on an affected server (with `<http_forbid_headers><header>Metadata-Flavor</header></http_forbid_headers>` configured), `url(..., LineAsString, headers('Metadata-Flavor'='Google'))` was correctly rejected, but `url(..., Regexp, headers('Metadata-Flavor'='Google')) SETTINGS format_regexp='a'` and `DESCRIBE url(..., headers('Metadata-Flavor'='Google'))` sent the request anyway; with `Regexp` the fetched body was echoed in a parse error (information disclosure).

Regression tests added to `02752_forbidden_headers.sql` cover the `Regexp`, auto-format, and `DESCRIBE` inference paths for both the exact and regexp forbidden-header rules. Verified the new cases reach the parser/network without the fix and throw `BAD_ARGUMENTS` (before any request is sent) with the fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.103` (included in `26.7` and later)
- Backported to: `26.6.5.29`, `26.3.32.14`
<!-- ch-version-info:end -->