### PR TITLE
Do not cache query condition results for sampled reads

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2804,8 +2804,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
 
         std::optional<size_t> condition_hash;
         /// Vector search filters through the ORDER BY, so excluded ranges are not described by the WHERE DAG hash alone.
+        /// Sampling narrows the marks too, but the cache key encodes only the WHERE predicate, so a sampling-narrowed
+        /// mask would poison the entry for a later non-sampled query with the same predicate.
         if (reader_settings.use_query_condition_cache && query_info_.filter_actions_dag && !query_info_.isFinal()
-                && !vector_search_parameters.has_value())
+                && !vector_search_parameters.has_value() && !result.sampling.use_sampling)
         {
             const auto & outputs = query_info_.filter_actions_dag->getOutputs();
             /// `isDeterministicAllowingTopKFilter` keeps the previous `COLUMN`-node strictness
@@ -3787,6 +3789,12 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, [[ma
     /// consult/skip side is gated separately in selectRangesToReadImpl.
     /// TODO(unique-key): re-enable with a CSN/snapshot-aware query-condition cache.
     if (storage_snapshot->metadata->hasUniqueKey())
+        reader_settings.use_query_condition_cache = false;
+
+    /// Sampling restricts which marks are read, but the query condition cache key encodes only the
+    /// WHERE/PREWHERE predicate, not the SAMPLE clause. Writing a sampling-narrowed mask would poison
+    /// the entry so a later non-sampled query with the same predicate skips marks SAMPLE excluded.
+    if (result.sampling.use_sampling)
         reader_settings.use_query_condition_cache = false;
 
     /// Initializing parallel replicas coordinator with empty ranges to read in case of

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2803,11 +2803,10 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
         }
 
         std::optional<size_t> condition_hash;
-        /// Vector search filters through the ORDER BY, so excluded ranges are not described by the WHERE DAG hash alone.
-        /// Sampling narrows the marks too, but the cache key encodes only the WHERE predicate, so a sampling-narrowed
-        /// mask would poison the entry for a later non-sampled query with the same predicate.
         if (reader_settings.use_query_condition_cache && query_info_.filter_actions_dag && !query_info_.isFinal()
-                && !vector_search_parameters.has_value() && !result.sampling.use_sampling)
+                && !vector_search_parameters.has_value() /// Vector search filters through the ORDER BY, so excluded ranges are not described by the WHERE DAG hash alone.
+                && !result.sampling.use_sampling)        /// SAMPLE-ing narrows the marks too, but the query condition cache cache key encodes only the WHERE predicate.
+                                                         /// Avoid that SAMPLE-narrowed entries poison the cache (later non-SAMPLE-ing queries would return wrong results).
         {
             const auto & outputs = query_info_.filter_actions_dag->getOutputs();
             /// `isDeterministicAllowingTopKFilter` keeps the previous `COLUMN`-node strictness
@@ -3791,9 +3790,8 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, [[ma
     if (storage_snapshot->metadata->hasUniqueKey())
         reader_settings.use_query_condition_cache = false;
 
-    /// Sampling restricts which marks are read, but the query condition cache key encodes only the
-    /// WHERE/PREWHERE predicate, not the SAMPLE clause. Writing a sampling-narrowed mask would poison
-    /// the entry so a later non-sampled query with the same predicate skips marks SAMPLE excluded.
+    /// SAMPLE-ing narrows the marks too, but the query condition cache cache key encodes only the WHERE predicate.
+    /// Avoid that SAMPLE-narrowed entries poison the cache (later non-SAMPLE-ing queries would return wrong results).
     if (result.sampling.use_sampling)
         reader_settings.use_query_condition_cache = false;
 

--- a/tests/queries/0_stateless/03229_query_condition_cache_sample.reference
+++ b/tests/queries/0_stateless/03229_query_condition_cache_sample.reference
@@ -1,10 +1,10 @@
---- WHERE on non-key column (PREWHERE write path)
-A sampled query must not write to the query condition cache.
+--- WHERE on non-primary-key column
+A SAMPLEing query must NOT write to the query condition cache.
 0
-A later non-sampled query returns the full count (not poisoned).
-1200000
---- WHERE on key column (index-analysis write path)
-A sampled query must not write to the query condition cache.
+A non-SAMPLEing query must returns the entire table content.
+600000
+--- WHERE on primary key column
+A SAMPLEing query must NOT write to the query condition cache.
 0
-A later non-sampled query returns the full count (not poisoned).
-12
+A non-SAMPLEing query must returns the entire table content.
+6

--- a/tests/queries/0_stateless/03229_query_condition_cache_sample.reference
+++ b/tests/queries/0_stateless/03229_query_condition_cache_sample.reference
@@ -1,0 +1,10 @@
+--- WHERE on non-key column (PREWHERE write path)
+A sampled query must not write to the query condition cache.
+0
+A later non-sampled query returns the full count (not poisoned).
+1200000
+--- WHERE on key column (index-analysis write path)
+A sampled query must not write to the query condition cache.
+0
+A later non-sampled query returns the full count (not poisoned).
+12

--- a/tests/queries/0_stateless/03229_query_condition_cache_sample.sql
+++ b/tests/queries/0_stateless/03229_query_condition_cache_sample.sql
@@ -3,19 +3,18 @@
 -- no-parallel-replicas: the query condition cache is populated per replica, so the poisoning is
 --   not reliably reproducible with parallel replicas
 
--- Tests that a sampled query does not poison the query condition cache for a later non-sampled query.
--- The cache key encodes only the WHERE/PREWHERE predicate, not the SAMPLE clause, so a sampling-narrowed
--- mark mask must never be written (issue: SAMPLE facet of the #104203 query-condition-cache family).
-
-SET allow_experimental_analyzer = 1;
+-- Bug #104203: SAMPLE clauses in SELECTs confuse ("poison") the query condition cache.
+-- This was resolved by not writing in the query condition cache for SELECTs with SAMPLE clause.
 
 DROP TABLE IF EXISTS tab;
 
-CREATE TABLE tab (sk UInt64, id UInt64, v String)
-ENGINE = MergeTree ORDER BY (sk, id) SAMPLE BY sk
+CREATE TABLE tab (sample_key UInt64, id UInt64, val String)
+ENGINE = MergeTree
+ORDER BY (sample_key, id)
+SAMPLE BY sample_key
 SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0;
 
--- 12 separate parts, each with several marks; the sampling key varies so SAMPLE prunes whole marks.
+-- Insert 6 parts. The sampling key varies so SAMPLE prunes whole marks.
 SYSTEM STOP MERGES tab;
 INSERT INTO tab SELECT sipHash64(number * 100 + 1), number, 'hit' FROM numbers(100000);
 INSERT INTO tab SELECT sipHash64(number * 100 + 2), number, 'hit' FROM numbers(100000);
@@ -23,32 +22,26 @@ INSERT INTO tab SELECT sipHash64(number * 100 + 3), number, 'hit' FROM numbers(1
 INSERT INTO tab SELECT sipHash64(number * 100 + 4), number, 'hit' FROM numbers(100000);
 INSERT INTO tab SELECT sipHash64(number * 100 + 5), number, 'hit' FROM numbers(100000);
 INSERT INTO tab SELECT sipHash64(number * 100 + 6), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 7), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 8), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 9), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 10), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 11), number, 'hit' FROM numbers(100000);
-INSERT INTO tab SELECT sipHash64(number * 100 + 12), number, 'hit' FROM numbers(100000);
 
--- WHERE on a non-key column: predicate is moved to PREWHERE (runtime write path).
-SELECT '--- WHERE on non-key column (PREWHERE write path)';
-SET optimize_move_to_prewhere = true;
+SELECT '--- WHERE on non-primary-key column';
 
 SYSTEM DROP QUERY CONDITION CACHE;
-SELECT 'A sampled query must not write to the query condition cache.';
-SELECT count() FROM tab SAMPLE 0.1 WHERE v = 'hit' SETTINGS use_query_condition_cache = true FORMAT Null;
-SELECT count() FROM system.query_condition_cache;
-SELECT 'A later non-sampled query returns the full count (not poisoned).';
-SELECT count() FROM tab WHERE v = 'hit' SETTINGS use_query_condition_cache = true;
 
--- WHERE on a key-prefix column: predicate is resolved by index analysis (analysis write path).
-SELECT '--- WHERE on key column (index-analysis write path)';
+SELECT 'A SAMPLEing query must NOT write to the query condition cache.';
+SELECT count() FROM tab SAMPLE 0.1 WHERE val = 'hit' FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+
+SELECT 'A non-SAMPLEing query must returns the entire table content.';
+SELECT count() FROM tab WHERE val = 'hit' SETTINGS use_query_condition_cache = true;
+
+SELECT '--- WHERE on primary key column';
 
 SYSTEM DROP QUERY CONDITION CACHE;
-SELECT 'A sampled query must not write to the query condition cache.';
-SELECT count() FROM tab SAMPLE 0.1 WHERE id = 42 SETTINGS use_query_condition_cache = true FORMAT Null;
+
+SELECT 'A SAMPLEing query must NOT write to the query condition cache.';
+SELECT count() FROM tab SAMPLE 0.1 WHERE id = 42 FORMAT Null;
 SELECT count() FROM system.query_condition_cache;
-SELECT 'A later non-sampled query returns the full count (not poisoned).';
-SELECT count() FROM tab WHERE id = 42 SETTINGS use_query_condition_cache = true;
+SELECT 'A non-SAMPLEing query must returns the entire table content.';
+SELECT count() FROM tab WHERE id = 42;
 
 DROP TABLE tab;

--- a/tests/queries/0_stateless/03229_query_condition_cache_sample.sql
+++ b/tests/queries/0_stateless/03229_query_condition_cache_sample.sql
@@ -1,0 +1,54 @@
+-- Tags: no-parallel, no-parallel-replicas
+-- no-parallel: drops the (instance-wide) query condition cache
+-- no-parallel-replicas: the query condition cache is populated per replica, so the poisoning is
+--   not reliably reproducible with parallel replicas
+
+-- Tests that a sampled query does not poison the query condition cache for a later non-sampled query.
+-- The cache key encodes only the WHERE/PREWHERE predicate, not the SAMPLE clause, so a sampling-narrowed
+-- mark mask must never be written (issue: SAMPLE facet of the #104203 query-condition-cache family).
+
+SET allow_experimental_analyzer = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab (sk UInt64, id UInt64, v String)
+ENGINE = MergeTree ORDER BY (sk, id) SAMPLE BY sk
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0;
+
+-- 12 separate parts, each with several marks; the sampling key varies so SAMPLE prunes whole marks.
+SYSTEM STOP MERGES tab;
+INSERT INTO tab SELECT sipHash64(number * 100 + 1), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 2), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 3), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 4), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 5), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 6), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 7), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 8), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 9), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 10), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 11), number, 'hit' FROM numbers(100000);
+INSERT INTO tab SELECT sipHash64(number * 100 + 12), number, 'hit' FROM numbers(100000);
+
+-- WHERE on a non-key column: predicate is moved to PREWHERE (runtime write path).
+SELECT '--- WHERE on non-key column (PREWHERE write path)';
+SET optimize_move_to_prewhere = true;
+
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT 'A sampled query must not write to the query condition cache.';
+SELECT count() FROM tab SAMPLE 0.1 WHERE v = 'hit' SETTINGS use_query_condition_cache = true FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+SELECT 'A later non-sampled query returns the full count (not poisoned).';
+SELECT count() FROM tab WHERE v = 'hit' SETTINGS use_query_condition_cache = true;
+
+-- WHERE on a key-prefix column: predicate is resolved by index analysis (analysis write path).
+SELECT '--- WHERE on key column (index-analysis write path)';
+
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT 'A sampled query must not write to the query condition cache.';
+SELECT count() FROM tab SAMPLE 0.1 WHERE id = 42 SETTINGS use_query_condition_cache = true FORMAT Null;
+SELECT count() FROM system.query_condition_cache;
+SELECT 'A later non-sampled query returns the full count (not poisoned).';
+SELECT count() FROM tab WHERE id = 42 SETTINGS use_query_condition_cache = true;
+
+DROP TABLE tab;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/104203

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results when using `SELECT [...] SAMPLE [...]` together with the query condition cache (setting `use_query_condition_cache = 1` which is also the default).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.421` (included in `26.7` and later)
- Backported to: `26.6.2.21`, `26.5.6.14`, `26.4.5.102`, `26.3.17.21`
<!-- ch-version-info:end -->