### PR TITLE
Stress test: ignore benign filesystem-cache background-download No such key

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -334,7 +334,9 @@ function check_logs_for_critical_errors()
     #  - "ReadBuffer is canceled by the exception" -- this is a normal situation when the buffer is canceled, the message neded for debug purposes
     #  - "ReadBufferFromDistributedCache", "AsynchronousBoundedReadBuffer", "ReadBufferFromS3", "ReadBufferFromAzureBlobStorage"
     #    exceptions printed internally by a buffer, exception will be rethrown and handled correctly
-    rg --text "Code: 499.*The specified key does not exist" /var/log/clickhouse-server/clickhouse-server*.log | grep -v -e "a.myext" -e "ReadBuffer is canceled by the exception" -e "DistributedCacheTCPHandler" -e "ReadBufferFromDistributedCache" -e "ReadBufferFromS3" -e "ReadBufferFromAzureBlobStorage" -e "AsynchronousBoundedReadBuffer" -e "caller id: None:DistribCache" > /test_output/no_such_key_errors.txt \
+    #  - "Error during background download" printed by the filesystem cache background download worker (CacheMetadata):
+    #    the prefetched object may be concurrently removed (DROP/mutation/part removal), the download is just marked failed and the data is re-read directly
+    rg --text "Code: 499.*The specified key does not exist" /var/log/clickhouse-server/clickhouse-server*.log | grep -v -e "a.myext" -e "ReadBuffer is canceled by the exception" -e "DistributedCacheTCPHandler" -e "ReadBufferFromDistributedCache" -e "ReadBufferFromS3" -e "ReadBufferFromAzureBlobStorage" -e "AsynchronousBoundedReadBuffer" -e "Error during background download" -e "caller id: None:DistribCache" > /test_output/no_such_key_errors.txt \
         && echo -e "S3_ERROR No such key thrown (see clickhouse-server.log or no_such_key_errors.txt)$FAIL$(trim_server_logs no_such_key_errors.txt)" >> /test_output/test_results.tsv \
         || echo -e "No lost s3 keys$OK" >> /test_output/test_results.tsv
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The stress critical-error scan flags benign filesystem-cache background-download `No such key` errors as lost s3 keys.

The filesystem cache background-download worker (`CacheMetadata`, `src/Interpreters/FileCache/Metadata.cpp`) continues prefetching a partially-downloaded file segment. Under stress the underlying S3 object can be concurrently removed (DROP, mutation, part removal), so the GET returns `Code: 499` `NoSuchKey`. The worker catches this, marks the segment download failed and logs `Error during background download` (no rethrow); the data is simply re-read from the source later, so it is benign.

`tests/docker_scripts/stress_tests.lib` greps for `Code: 499 ... The specified key does not exist` and already excludes the foreground form of this event (`ReadBufferFromS3`, `AsynchronousBoundedReadBuffer`, `ReadBuffer is canceled by the exception`), but not the background-download form, so it was reported as `S3_ERROR No such key thrown`.

This adds `Error during background download` to the `grep -v` allowlist, following the precedent of the existing exclusions. The token is unique to the `CacheMetadata` background-download log line (`Metadata.cpp:824`), so a genuinely lost key reported from any other path is still flagged.

Chronic trunk failure: ~10 distinct unrelated PRs + 1 master hit over 30 days, ~1 occurrence each.

Example CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108441&sha=cdabef4635c981dd60507f49d1307f9f7dc4d62a&name_0=PR&name_1=Stress%20test%20%28arm_release%29

Server log line:
```
<Error> CacheMetadata: Error during background download of <hash>:4194304 (File segment: [4194304, 8388607], ..., state: PARTIALLY_DOWNLOADED_NO_CONTINUATION, ..., background download: 1): Code: 499. DB::Exception: The specified key does not exist. ... (S3_ERROR)
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.207` (included in `26.7` and later)
<!-- ch-version-info:end -->