### PR TITLE
Mirror integration-test images through Docker Hub and enforce it in style check

### DIFF
--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -499,6 +499,60 @@ def check_file_names(files):
     return ""
 
 
+def check_compose_images(files) -> str:
+    """Ensure every image referenced in docker compose files is served from Docker Hub.
+
+    CI runners pull Docker Hub images through the dockerhub-proxy cache (see
+    tests/ci/terraform/dockerhub-proxy.md). Images hosted on other registries
+    (ghcr.io, mcr.microsoft.com, quay.io, ...) bypass that proxy and are pulled
+    directly, exposing CI to those registries' anonymous rate limits. Mirror such
+    images into the clickhouse/ Docker Hub namespace (see
+    tests/integration/compose/mirror-images.sh) and reference the mirror instead.
+    """
+    image_re = re.compile(r"^\s*image:\s*(.+?)\s*$")
+    # ${VAR:-default} -> default; used to resolve compose variable interpolation.
+    var_default_re = re.compile(r"\$\{[^}:]+:-([^}]*)\}")
+    hub_aliases = {"docker.io", "registry-1.docker.io", "index.docker.io"}
+
+    violations = []
+    for file in files:
+        try:
+            with open(file, "r", encoding="utf-8", errors="replace") as fh:
+                lines = fh.readlines()
+        except OSError as e:
+            violations.append(f"{file}: could not read file: {e}")
+            continue
+
+        for i, line in enumerate(lines):
+            m = image_re.match(line)
+            if not m:
+                continue
+
+            # Strip trailing inline comment and surrounding quotes.
+            value = re.sub(r"\s+#.*$", "", m.group(1)).strip().strip("'\"")
+            # Resolve ${VAR:-default} interpolations to their default value.
+            ref = var_default_re.sub(r"\1", value)
+            # A bare ${VAR} without default leaves the registry undeterminable; skip.
+            if "${" in ref:
+                continue
+
+            # Docker's rule: the first path component is a registry host only when
+            # it contains a '.' or ':' or equals 'localhost'. Otherwise it is a
+            # Docker Hub namespace/official image.
+            first = ref.split("/", 1)[0] if "/" in ref else ""
+            is_registry_host = first and (
+                "." in first or ":" in first or first == "localhost"
+            )
+            if is_registry_host and first not in hub_aliases:
+                violations.append(
+                    f"{file}:{i + 1}: image '{ref}' is not from Docker Hub "
+                    f"(registry '{first}'). Mirror it into the clickhouse/ namespace "
+                    f"via tests/integration/compose/mirror-images.sh and reference the mirror."
+                )
+
+    return "\n".join(violations)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="ClickHouse Style Check Job")
     parser.add_argument("--test", help="Sub check name", default="")
@@ -536,6 +590,12 @@ if __name__ == "__main__":
         include_paths=["./tests/queries"],
         exclude_paths=[],
         file_suffixes=[".sql", ".sh", ".py", ".j2"],
+    )
+
+    compose_files = Utils.traverse_paths(
+        include_paths=["./tests/integration/compose"],
+        exclude_paths=[],
+        file_suffixes=[".yml", ".yaml"],
     )
 
     testname = "whitespace_check"
@@ -608,6 +668,15 @@ if __name__ == "__main__":
                 check_name=testname,
                 check_function=check_catch_all,
                 files=cpp_files,
+            )
+        )
+    testname = "compose_images_from_dockerhub"
+    if testpattern.lower() in testname.lower():
+        results.append(
+            run_check_concurrent(
+                check_name=testname,
+                check_function=check_compose_images,
+                files=compose_files,
             )
         )
     testname = "cpp"

--- a/tests/integration/compose/docker_compose_azurite.yml
+++ b/tests/integration/compose/docker_compose_azurite.yml
@@ -1,6 +1,8 @@
 services:
   azurite1:
-    image: mcr.microsoft.com/azure-storage/azurite:3.35.0
+    # Mirror of mcr.microsoft.com/azure-storage/azurite:3.35.0 (see compose/mirror-images.sh).
+    # Pulled via the dockerhub-proxy cache; mcr.microsoft.com is not behind the proxy and rate-limits CI.
+    image: clickhouse/azure-storage-azurite:3.35.0
     ports:
       - "${AZURITE_PORT}:${AZURITE_PORT}"
     volumes:

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -1,6 +1,8 @@
 services:
   nessie:
-    image: ghcr.io/projectnessie/nessie:0.107.2
+    # Mirror of ghcr.io/projectnessie/nessie:0.107.2 (see compose/mirror-images.sh).
+    # Pulled via the dockerhub-proxy cache; ghcr.io is not behind the proxy.
+    image: clickhouse/projectnessie-nessie:0.107.2
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:19120"
     environment:

--- a/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
+++ b/tests/integration/compose/docker_compose_letsencrypt_pebble.yml
@@ -1,6 +1,8 @@
 services:
   pebble:
-    image: ghcr.io/letsencrypt/pebble:2.9.0
+    # Mirror of ghcr.io/letsencrypt/pebble:2.9.0 (see compose/mirror-images.sh).
+    # Pulled via the dockerhub-proxy cache; ghcr.io is not behind the proxy.
+    image: clickhouse/letsencrypt-pebble:2.9.0
     command: -config test/config/pebble-config.json -strict -dnsserver 10.5.11.3:8053
     environment:
       - PEBBLE_WFE_NONCEREJECT=0
@@ -13,7 +15,9 @@ services:
         ipv4_address: 10.5.11.2
     cpus: 3
   challtestsrv:
-    image: ghcr.io/letsencrypt/pebble-challtestsrv:2.9.0
+    # Mirror of ghcr.io/letsencrypt/pebble-challtestsrv:2.9.0 (see compose/mirror-images.sh).
+    # Pulled via the dockerhub-proxy cache; ghcr.io is not behind the proxy.
+    image: clickhouse/letsencrypt-pebble-challtestsrv:2.9.0
     command: -defaultIPv6 "" -defaultIPv4 10.5.11.3
     ports:
       - ${LE_PEBBLE_CHALSRV_EXTERNAL_API_PORT:-8055}:${LE_PEBBLE_CHALSRV_INTERNAL_API_PORT:-8055}

--- a/tests/integration/compose/docker_compose_ytsaurus.yml
+++ b/tests/integration/compose/docker_compose_ytsaurus.yml
@@ -1,6 +1,8 @@
 services:
     ytsaurus_backend1:
-        image: ghcr.io/ytsaurus/local:stable-24.2
+        # Mirror of ghcr.io/ytsaurus/local:stable-24.2 (see compose/mirror-images.sh).
+        # Pulled via the dockerhub-proxy cache; ghcr.io is not behind the proxy.
+        image: clickhouse/ytsaurus-local:stable-24.2
         restart: always
         environment:
             YT_FORCE_IPV4: 1

--- a/tests/integration/compose/mirror-images.sh
+++ b/tests/integration/compose/mirror-images.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Mirror third-party integration-test images into the clickhouse/ Docker Hub namespace.
+#
+# Why: CI runners pull Docker Hub images through the dockerhub-proxy cache
+# (registry:2 + nginx, backed by S3 — see tests/ci/terraform/dockerhub-proxy.md).
+# That proxy only fronts Docker Hub. Images hosted on other registries
+# (mcr.microsoft.com, ghcr.io) bypass the proxy and are pulled directly, so CI is
+# exposed to those registries' anonymous rate limits (e.g. mcr.microsoft.com
+# returns HTTP 429 "toomanyrequests" under load). Re-hosting them under
+# clickhouse/ routes the pulls back through the proxy + S3 cache.
+#
+# Usage: log in to Docker Hub with an account that can push to the clickhouse org,
+# then run this script. It is idempotent — re-run it to add images or bump versions.
+# Keep the mapping below in sync with the image references in compose/*.yml.
+
+set -xeuo pipefail
+
+# upstream-reference  clickhouse-reference (slash flattened to dash; Docker Hub repos are org/name only)
+IMAGES=(
+    "mcr.microsoft.com/azure-storage/azurite:3.35.0           clickhouse/azure-storage-azurite:3.35.0"
+    "ghcr.io/projectnessie/nessie:0.107.2                     clickhouse/projectnessie-nessie:0.107.2"
+    "ghcr.io/ytsaurus/local:stable-24.2                       clickhouse/ytsaurus-local:stable-24.2"
+    "ghcr.io/letsencrypt/pebble:2.9.0                         clickhouse/letsencrypt-pebble:2.9.0"
+    "ghcr.io/letsencrypt/pebble-challtestsrv:2.9.0            clickhouse/letsencrypt-pebble-challtestsrv:2.9.0"
+)
+
+for entry in "${IMAGES[@]}"; do
+    read -r src dst <<< "$entry"
+    # Copy the full manifest list (all architectures) registry-to-registry. This
+    # preserves multi-arch so both amd64 and arm64 runners are served; a plain
+    # `docker pull && docker push` would only re-push the host's single arch.
+    docker buildx imagetools create --tag "$dst" "$src"
+done


### PR DESCRIPTION
CI runners pull Docker Hub images through the `dockerhub-proxy` cache (`registry:2` + nginx backed by S3). That proxy only fronts Docker Hub, so integration-test images hosted on other registries (`mcr.microsoft.com`, `ghcr.io`) bypass it and are pulled directly, exposing CI to those registries' anonymous rate limits (e.g. `mcr.microsoft.com` returns HTTP 429 `toomanyrequests` under load).

This PR:

- Re-hosts the affected images under the `clickhouse/` Docker Hub namespace and repoints the compose files to the mirrors:
  - `mcr.microsoft.com/azure-storage/azurite` → `clickhouse/azure-storage-azurite`
  - `ghcr.io/projectnessie/nessie` → `clickhouse/projectnessie-nessie`
  - `ghcr.io/ytsaurus/local` → `clickhouse/ytsaurus-local`
  - `ghcr.io/letsencrypt/pebble` → `clickhouse/letsencrypt-pebble`
  - `ghcr.io/letsencrypt/pebble-challtestsrv` → `clickhouse/letsencrypt-pebble-challtestsrv`
- Adds `tests/integration/compose/mirror-images.sh`, which copies these multi-arch manifests into the `clickhouse/` namespace (registry-to-registry, preserving all architectures) and documents how to add or bump images.
- Adds a `compose_images_from_dockerhub` sub-check to the style check job that scans `tests/integration/compose/*.yml` and fails if any `image:` references an explicit non-Docker-Hub registry host, to prevent reintroducing off-proxy images.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.86`
<!-- ch-version-info:end -->