### PR TITLE
apply predicate to iceberg_history table

### DIFF
--- a/src/Storages/System/StorageSystemIcebergHistory.cpp
+++ b/src/Storages/System/StorageSystemIcebergHistory.cpp
@@ -1,31 +1,33 @@
-#include <Storages/System/StorageSystemIcebergHistory.h>
-#include <Storages/System/SystemTableSourceRegistry.h>
 #include <mutex>
-#include <DataTypes/DataTypesNumber.h>
-#include <DataTypes/DataTypeString.h>
-#include <DataTypes/DataTypeMap.h>
-#include <DataTypes/DataTypeDateTime.h>
+#include <Access/ContextAccess.h>
+#include <Columns/ColumnString.h>
+#include <Core/Field.h>
+#include <Core/Settings.h>
 #include <DataTypes/DataTypeDate.h>
-#include <DataTypes/DataTypeUUID.h>
-#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeDateTime.h>
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeEnum.h>
-#include <Interpreters/InterpreterSelectQuery.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeUUID.h>
+#include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/InterpreterSelectQuery.h>
 #include <Processors/LimitTransform.h>
 #include <Processors/Port.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromSystemNumbersStep.h>
-#include <Storages/SelectQueryInfo.h>
-#include <Storages/ObjectStorage/StorageObjectStorage.h>
-#include <Access/ContextAccess.h>
 #include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
-#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/Constant.h>
+#include <Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.h>
-#include <Interpreters/DatabaseCatalog.h>
-#include <Core/Settings.h>
-#include <Core/Field.h>
+#include <Storages/ObjectStorage/StorageObjectStorage.h>
+#include <Storages/SelectQueryInfo.h>
+#include <Storages/System/StorageSystemIcebergHistory.h>
+#include <Storages/System/SystemTableSourceRegistry.h>
+#include <Storages/VirtualColumnUtils.h>
 
 #if USE_AVRO
 #include <base/EnumReflection.h>
@@ -39,8 +41,8 @@ namespace DB
 
 namespace Setting
 {
-    extern const SettingsSeconds lock_acquire_timeout;
-    extern const SettingsBool use_iceberg_metadata_files_cache;
+extern const SettingsSeconds lock_acquire_timeout;
+extern const SettingsBool use_iceberg_metadata_files_cache;
 }
 
 ColumnsDescription StorageSystemIcebergHistory::getColumnsDescription()
@@ -75,7 +77,11 @@ ColumnsDescription StorageSystemIcebergHistory::getColumnsDescription()
          "Snapshot summary fields"}};
 }
 
-void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res_columns, [[maybe_unused]] ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const
+void StorageSystemIcebergHistory::fillData(
+    [[maybe_unused]] MutableColumns & res_columns,
+    [[maybe_unused]] ContextPtr context,
+    [[maybe_unused]] const ActionsDAG::Node * predicate,
+    std::vector<UInt8>) const
 {
 #if USE_AVRO
     ContextMutablePtr context_copy = Context::createCopy(context);
@@ -85,9 +91,12 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
 
     const auto access = context_copy->getAccess();
 
-    auto add_history_record = [&](const DatabaseTablesIteratorPtr & it, StorageObjectStorage * object_storage)
+    if (!access->isGranted(AccessType::SHOW_TABLES))
+        return;
+
+    auto add_history_record = [&](const String & database_name, const String & table_name, StorageObjectStorage * object_storage)
     {
-        if (!access->isGranted(AccessType::SHOW_TABLES, it->databaseName(), it->name()))
+        if (!access->isGranted(AccessType::SHOW_TABLES, database_name, table_name))
             return;
 
         if (!object_storage->isIcebergStorage())
@@ -97,15 +106,16 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
         /// to handle properly all possible errors which we can get when attempting to read metadata of iceberg table
         try
         {
-            if (IcebergMetadata * iceberg_metadata = dynamic_cast<IcebergMetadata *>(object_storage->getExternalMetadata(context_copy)); iceberg_metadata)
+            if (IcebergMetadata * iceberg_metadata = dynamic_cast<IcebergMetadata *>(object_storage->getExternalMetadata(context_copy));
+                iceberg_metadata)
             {
                 IcebergMetadata::IcebergHistory iceberg_history_items = iceberg_metadata->getHistory(context_copy);
 
                 for (auto & iceberg_history_item : iceberg_history_items)
                 {
                     size_t column_index = 0;
-                    res_columns[column_index++]->insert(it->databaseName());
-                    res_columns[column_index++]->insert(it->name());
+                    res_columns[column_index++]->insert(database_name);
+                    res_columns[column_index++]->insert(table_name);
                     res_columns[column_index++]->insert(iceberg_history_item.made_current_at);
                     res_columns[column_index++]->insert(iceberg_history_item.snapshot_id);
                     res_columns[column_index++]->insert(iceberg_history_item.parent_id);
@@ -127,35 +137,87 @@ void StorageSystemIcebergHistory::fillData([[maybe_unused]] MutableColumns & res
         }
         catch (...)
         {
-            tryLogCurrentException(getLogger("SystemIcebergHistory"), fmt::format("Ignoring broken table {}", object_storage->getStorageID().getFullTableName()));
+            tryLogCurrentException(
+                getLogger("SystemIcebergHistory"),
+                fmt::format("Ignoring broken table {}", object_storage->getStorageID().getFullTableName()));
         }
-
     };
 
-    const bool show_tables_granted = access->isGranted(AccessType::SHOW_TABLES);
+    /// Filter databases first: listing tables of a remote database (PostgreSQL/MySQL/...)
+    /// opens a connection, which a query filtering by database should not need to do.
+    MutableColumnPtr database_name_column = ColumnString::create();
 
-    if (show_tables_granted)
+    auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_remote_databases = true});
+    for (const auto & [database_name, database] : databases)
+        database_name_column->insert(database_name);
+
+    Block databases_block{
+        {std::move(database_name_column), std::make_shared<DataTypeString>(), "database"},
+    };
+    VirtualColumnUtils::filterBlockWithPredicate(predicate, databases_block, context_copy);
+    const ColumnString & filtered_databases = assert_cast<const ColumnString &>(*databases_block.getByName("database").column);
+
+    MutableColumnPtr database_column = ColumnString::create();
+    MutableColumnPtr table_column = ColumnString::create();
+
+    for (size_t i = 0; i < filtered_databases.size(); ++i)
     {
-        auto databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_remote_databases = true});
-        for (const auto & db: databases)
+        const String database_name{filtered_databases.getDataAt(i)};
+        DatabasePtr database = DatabaseCatalog::instance().tryGetDatabase(database_name);
+        if (!database)
+            continue;
+
+        for (auto iterator = database->getTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
         {
-            /// with last flag we are filtering out all non iceberg table
-            for (auto iterator = db.second->getTablesIterator(context_copy, {}, true); iterator->isValid(); iterator->next())
-            {
-                StoragePtr storage = iterator->table();
-
-                TableLockHolder lock = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
-                if (!lock)
-                    // Table was dropped while acquiring the lock, skipping table
-                    continue;
-
-                if (auto * object_storage_table = dynamic_cast<StorageObjectStorage *>(storage.get()))
-                {
-                    add_history_record(iterator, object_storage_table);
-                }
-            }
+            database_column->insert(database_name);
+            table_column->insert(iterator->name());
         }
     }
+
+    Block filtered_block{
+        {std::move(database_column), std::make_shared<DataTypeString>(), "database"},
+        {std::move(table_column), std::make_shared<DataTypeString>(), "table"},
+    };
+    VirtualColumnUtils::filterBlockWithPredicate(predicate, filtered_block, context_copy);
+
+    const ColumnString & databases_to_read = assert_cast<const ColumnString &>(*filtered_block.getByName("database").column);
+    const ColumnString & tables_to_read = assert_cast<const ColumnString &>(*filtered_block.getByName("table").column);
+
+    for (size_t i = 0; i < databases_to_read.size(); ++i)
+    {
+        const String database_name{databases_to_read.getDataAt(i)};
+        const String table_name{tables_to_read.getDataAt(i)};
+
+        DatabasePtr database = DatabaseCatalog::instance().tryGetDatabase(database_name);
+        if (!database)
+            continue;
+
+        StoragePtr storage = database->tryGetTable(table_name, context_copy);
+        if (!storage)
+            continue;
+
+        TableLockHolder lock
+            = storage->tryLockForShare(context_copy->getCurrentQueryId(), context_copy->getSettingsRef()[Setting::lock_acquire_timeout]);
+        if (!lock)
+            // Table was dropped while acquiring the lock, skipping table
+            continue;
+
+        if (auto * object_storage_table = dynamic_cast<StorageObjectStorage *>(storage.get()))
+        {
+            add_history_record(database_name, table_name, object_storage_table);
+        }
+    }
+#endif
+}
+Block StorageSystemIcebergHistory::getFilterSampleBlock() const
+{
+#if USE_AVRO
+    return {
+        {{}, std::make_shared<DataTypeString>(), "database"},
+        {{}, std::make_shared<DataTypeString>(), "table"},
+    };
+#else
+    return {};
 #endif
 }
 }

--- a/src/Storages/System/StorageSystemIcebergHistory.h
+++ b/src/Storages/System/StorageSystemIcebergHistory.h
@@ -29,7 +29,13 @@ public:
 protected:
     using IStorageSystemOneBlock::IStorageSystemOneBlock;
 
-    void fillData([[maybe_unused]] MutableColumns & res_columns, [[maybe_unused]] ContextPtr context, const ActionsDAG::Node *, std::vector<UInt8>) const override;
+    void fillData(
+        [[maybe_unused]] MutableColumns & res_columns,
+        [[maybe_unused]] ContextPtr context,
+        [[maybe_unused]] const ActionsDAG::Node * predicate,
+        std::vector<UInt8>) const override;
+
+    Block getFilterSampleBlock() const override;
 };
 
 }


### PR DESCRIPTION
Filter the `database` and `table` columns through the query predicate
before opening any tables, so that querying `system.iceberg_history`
with a `WHERE database = ...` / `table = ...` condition no longer
iterates every table in every database.

Databases are filtered first, before listing their tables, so a
predicate on `database` avoids opening connections to remote databases
(PostgreSQL/MySQL/...) whose tables are irrelevant to the query.

Adds the `getFilterSampleBlock` override and threads the
`ActionsDAG::Node * predicate` into `fillData`, applying it via
`VirtualColumnUtils::filterBlockWithPredicate`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
If you provide WHERE with `table` and `database` filters then `system.iceberg_history` will list only matched databases. It can save some time if you have many non-related remote databases on the server.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.105`
<!-- ch-version-info:end -->