### PR TITLE
Use DockerHub images for `redpanda`

### DIFF
--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -1,7 +1,7 @@
 # docker build -t clickhouse/stateless-test .
 ARG FROM_TAG=latest
 ARG REDPANDA_VERSION=v25.1.3
-FROM docker.redpanda.com/redpandadata/redpanda:${REDPANDA_VERSION} AS redpanda
+FROM redpandadata/redpanda:${REDPANDA_VERSION} AS redpanda
 
 FROM clickhouse/test-base:$FROM_TAG
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108400&sha=411eb19ad4c15627824cfa3a8ff6df65a47b9c74&name_0=PR

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.166` (included in `26.7` and later)
<!-- ch-version-info:end -->