### PR TITLE
CI: AI review posts one batched review instead of many inline comments

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -107,12 +107,18 @@ Tools:
   `resolve-pr-review-thread` / `unresolve-pr-review-thread`: they take only `--thread-id` (a globally
   unique GraphQL node id that already identifies the repo) and reject `--repo` with
   `error: unrecognized arguments`.
-- Post a new inline review comment by writing the body to a file and running:
-  `{GH_PREFIX} python3 -m ci.praktika.gh post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> --repo {repo_name} [--side RIGHT|LEFT]`.
-  This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
-- Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
-  string as the body when the wrong `gh` flag was used.
-- Do NOT use `gh pr review`; that posts a single batched review, not individual line comments.
+- Post ALL new inline findings as ONE batched review, not as separate comments. Write each finding's
+  body to its own Markdown file, then list the findings in a single JSON file: an array of objects
+  `{{"path": "<file>", "line": <N>, "side": "RIGHT", "body_file": "<body.md>"}}` (for a multi-line
+  range add `"start_line": <N>` and `"start_side": "RIGHT"`; use `"side": "LEFT"` for a deleted line).
+  Submit the whole batch with a single call:
+  `{GH_PREFIX} python3 -m ci.praktika.gh post-pr-review --comments-file <comments.json> --commit <sha> --repo {repo_name}`.
+  The wrapper reads each `body_file` and assembles the review payload, so multi-line Markdown is
+  uploaded correctly. Call it exactly once per run, and only if there is at least one new inline finding.
+- Do NOT post new findings as individual comments (`post-pr-line-comment` without `--reply-to`); that
+  is reserved for thread replies (see below). Do NOT call `gh api .../pulls/.../comments`,
+  `gh api .../pulls/.../reviews`, or `gh pr review` directly: the wrappers exist to avoid the
+  `-f`/`-F` and JSON-escaping footguns that have posted literal `@<file>` / `\\n` bodies before.
 - Fetch inline review threads with:
   `{GH_PREFIX} python3 -m ci.praktika.gh list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
   The command returns JSON; each thread carries its node `id`, `isResolved`, `resolvedBy.login`
@@ -164,9 +170,11 @@ Procedure:
        prematurely or a later commit reintroduced the issue). Re-open silently, no reply needed.
    (b) case 6(b) fires -- re-open AND post the 6(b) reply in the same run.
    Never resolve or unresolve threads whose first comment was authored by anyone else.
-8. For genuinely new issues that do not already have a thread, post individual inline comments on the
-   relevant changed lines. For architectural issues that do not map cleanly to one line, post around
-   the most relevant change in the diff.
+8. For genuinely new issues that do not already have a thread, collect them all into the single
+   batched review described under Tools (one inline comment per issue, on the relevant changed line).
+   For architectural issues that do not map cleanly to one line, attach the comment to the most
+   relevant change in the diff. Submit the whole batch with one `post-pr-review` call; never post new
+   findings one at a time.
 9. Do NOT post inline comments for issues that dedicated CI jobs already catch and report: build /
    compilation failures (missing headers, undeclared symbols, type errors, link errors) and style
    check failures (formatting, linters, `check_cpp.sh` / `check_style.sh` output). These are not

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -350,6 +350,85 @@ class GH:
         return cls.do_command_with_retries(cmd)
 
     @classmethod
+    def post_pr_review(
+        cls,
+        commit_id,
+        comments,
+        body="",
+        pr=None,
+        repo=None,
+    ):
+        """Post all inline findings as a single ``COMMENT`` PR review (one
+        review event, one notification) instead of many standalone inline
+        comments.
+
+        Only the ``COMMENT`` event is supported; this helper never approves or
+        requests changes, so an empty review is always a no-op rather than a
+        meaningful action.
+
+        ``comments`` is a list of dicts, each describing one inline comment::
+
+            {"path": <file>, "line": <int>, "side": "RIGHT"|"LEFT",
+             "start_line": <int> (optional), "start_side": <str> (optional),
+             "body_file": <path>}
+
+        Each comment body is read from its ``body_file`` and the whole payload
+        is assembled with ``json.dumps``, so multi-line Markdown is escaped
+        correctly. This avoids the ``-f`` vs ``-F`` / literal ``@<file>`` and
+        literal ``\\n`` footguns that standalone ``gh api`` calls have hit.
+
+        GitHub rejects a ``COMMENT`` review with neither a body nor any
+        comments, so when ``comments`` is empty and ``body`` is empty the call
+        is skipped and True is returned.
+        """
+        if not repo:
+            repo = _Environment.get().REPOSITORY
+        if not pr:
+            pr = _Environment.get().PR_NUMBER
+
+        payload_comments = []
+        for c in comments:
+            body_file = c["body_file"]
+            if not os.path.exists(body_file):
+                raise FileNotFoundError(f"Body file [{body_file}] not found")
+            if os.path.getsize(body_file) == 0:
+                raise ValueError(f"Body file [{body_file}] is empty")
+            with open(body_file, "r", encoding="utf-8") as f:
+                comment = {"path": c["path"], "body": f.read()}
+            if c.get("start_line") is not None:
+                comment["start_line"] = int(c["start_line"])
+                comment["start_side"] = c.get("start_side", c.get("side", "RIGHT"))
+            comment["line"] = int(c["line"])
+            comment["side"] = c.get("side", "RIGHT")
+            payload_comments.append(comment)
+
+        if not payload_comments and not body:
+            print("No review body and no inline comments; skipping review post")
+            return True
+
+        payload = {"event": "COMMENT", "comments": payload_comments}
+        if commit_id:
+            payload["commit_id"] = commit_id
+        if body:
+            payload["body"] = body
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(payload, f)
+            payload_file = f.name
+        try:
+            cmd = (
+                f"gh api -X POST "
+                f'-H "Accept: application/vnd.github.v3+json" '
+                f'"/repos/{repo}/pulls/{pr}/reviews" '
+                f"--input {shlex.quote(payload_file)}"
+            )
+            return cls.do_command_with_retries(cmd)
+        finally:
+            os.unlink(payload_file)
+
+    @classmethod
     def _gh_graphql_json(cls, query, variables, verbose=False):
         """Run a GraphQL query via ``gh api graphql`` and return parsed JSON.
 
@@ -1294,6 +1373,34 @@ if __name__ == "__main__":
         "--repo", default=None, help="Repository in owner/repo format"
     )
 
+    review_parser = subparsers.add_parser(
+        "post-pr-review",
+        help="Post all inline findings as a single batched PR review",
+    )
+    review_parser.add_argument(
+        "--comments-file",
+        required=True,
+        dest="comments_file",
+        help="Path to a JSON file with a list of "
+        '{"path", "line", "side", "start_line"?, "start_side"?, "body_file"} '
+        "objects; each body_file holds that comment's Markdown body",
+    )
+    review_parser.add_argument(
+        "--body-file",
+        default=None,
+        dest="body_file",
+        help="Optional file with the top-level review body",
+    )
+    review_parser.add_argument(
+        "--commit",
+        default=None,
+        help="Commit SHA the review refers to",
+    )
+    review_parser.add_argument("--pr", type=int, default=None, help="PR number")
+    review_parser.add_argument(
+        "--repo", default=None, help="Repository in owner/repo format"
+    )
+
     threads_parser = subparsers.add_parser(
         "list-pr-review-threads",
         help="List PR review threads via GraphQL (prints JSON to stdout)",
@@ -1354,6 +1461,24 @@ if __name__ == "__main__":
         if args.repo is not None:
             kwargs["repo"] = args.repo
         ok = GH.post_pr_line_comment(**kwargs)
+        sys.exit(0 if ok else 1)
+    elif args.command == "post-pr-review":
+        with open(args.comments_file, "r", encoding="utf-8") as f:
+            comments = json.load(f)
+        body = ""
+        if args.body_file is not None:
+            with open(args.body_file, "r", encoding="utf-8") as f:
+                body = f.read()
+        kwargs = dict(
+            commit_id=args.commit,
+            comments=comments,
+            body=body,
+        )
+        if args.pr is not None:
+            kwargs["pr"] = args.pr
+        if args.repo is not None:
+            kwargs["repo"] = args.repo
+        ok = GH.post_pr_review(**kwargs)
         sys.exit(0 if ok else 1)
     elif args.command == "list-pr-review-threads":
         kwargs = {}


### PR DESCRIPTION
The AI Code Review job instructed the agent to post each finding as a separate inline comment (`post-pr-line-comment`, one `gh` call per finding), producing many standalone comments and a notification per comment on every run.

This adds a `GH.post_pr_review` helper and a `post-pr-review` wrapper subcommand that build a single GitHub review (`POST /repos/.../pulls/.../reviews`) with all inline comments in the `comments` array, so a run posts one review event and one notification. Each comment body is read from its own file and the payload is assembled with `json.dumps`, keeping the same anti-footgun property as `post-pr-line-comment` (no literal `@<file>` / `\n` bodies).

The helper posts only `COMMENT` reviews; it never approves or requests changes, so an empty review is always a no-op and is skipped. Thread replies keep using `post-pr-line-comment --reply-to`, and the resolve/unresolve/reply thread-management logic is unchanged.

No new permissions are required: creating a review and creating an inline comment share the same `Pull requests: write` scope the Code Review job already uses.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Not for changelog (CI Fix or Improvement).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.69`
<!-- ch-version-info:end -->