### PR TITLE
RabbitMQ: bound all blocking event loops with a timeout to prevent indefinite hangs on dead connections

### DIFF
--- a/src/Storages/RabbitMQ/RabbitMQHandler.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.cpp
@@ -66,6 +66,37 @@ int RabbitMQHandler::startBlockingLoop()
     return uv_run(loop, UV_RUN_DEFAULT);
 }
 
+bool RabbitMQHandler::startBlockingLoopWithTimeout(uint64_t timeout_ms)
+{
+    LOG_DEBUG(log, "Started blocking loop with {}ms timeout.", timeout_ms);
+
+    bool timed_out = false;
+
+    uv_timer_t timer;
+    uv_timer_init(loop, &timer);
+    timer.data = &timed_out;
+
+    uv_timer_start(
+        &timer,
+        [](uv_timer_t * t)
+        {
+            *static_cast<bool *>(t->data) = true;
+            uv_stop(t->loop);
+        },
+        timeout_ms,
+        /* repeat = */ 0);
+
+    uv_run(loop, UV_RUN_DEFAULT);
+
+    uv_timer_stop(&timer);
+    /// Close the timer handle so libuv can release its resources.
+    /// The close callback runs on the next NOWAIT tick below.
+    uv_close(reinterpret_cast<uv_handle_t *>(&timer), nullptr);
+    uv_run(loop, UV_RUN_NOWAIT);
+
+    return !timed_out;
+}
+
 void RabbitMQHandler::stopLoop()
 {
     LOG_DEBUG(log, "Stopping background loop.");

--- a/src/Storages/RabbitMQ/RabbitMQHandler.h
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.h
@@ -18,6 +18,11 @@ namespace Loop
     static const UInt8 STOP = 2;
 }
 
+/// Default timeout for any blocking AMQP wait that relies on broker callbacks to stop the loop
+/// (table setup, exchange unbind, queue cleanup, producer channel close). Bounds how long
+/// DROP TABLE / INSERT shutdown / server shutdown can block when the broker connection is dead.
+static const uint64_t BLOCKING_LOOP_TIMEOUT_MS = 30000;
+
 using ChannelPtr = std::unique_ptr<AMQP::TcpChannel>;
 
 class RabbitMQHandler : public AMQP::LibUvHandler

--- a/src/Storages/RabbitMQ/RabbitMQHandler.h
+++ b/src/Storages/RabbitMQ/RabbitMQHandler.h
@@ -40,6 +40,10 @@ public:
     /// No synchronization is done with the main loop thread.
     int startBlockingLoop();
 
+    /// Like startBlockingLoop() but stops automatically after timeout_ms milliseconds.
+    /// Returns true if the loop exited naturally (callbacks fired), false if it timed out.
+    bool startBlockingLoopWithTimeout(uint64_t timeout_ms);
+
     void stopLoop();
     void stopBlockingLoop();
 

--- a/src/Storages/RabbitMQ/RabbitMQProducer.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQProducer.cpp
@@ -287,8 +287,12 @@ void RabbitMQProducer::startProducingTaskLoop()
         connection.getHandler().stopBlockingLoop();
     });
 
-    int active = connection.getHandler().startBlockingLoop();
-    LOG_DEBUG(log, "Producer on channel completed (not finished events: {})", active);
+    /// If the connection is dead the close() callbacks never fire. Bound the wait so that INSERT
+    /// producer shutdown (and therefore server shutdown) cannot block indefinitely.
+    if (!connection.getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
+        LOG_WARNING(log, "Timed out waiting for producer channel to close — connection may be dead");
+    else
+        LOG_DEBUG(log, "Producer on channel completed");
 }
 
 

--- a/src/Storages/RabbitMQ/RabbitMQProducer.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQProducer.cpp
@@ -275,14 +275,21 @@ void RabbitMQProducer::startProducingTaskLoop()
         LOG_TEST(log, "Waiting for pending callbacks to finish (count: {}, try: {})", res, try_num);
     }
 
+    /// Shared flag so that a late-dispatched close() callback becomes a no-op if we stop waiting
+    /// on timeout, mirroring the setup/cleanup paths in StorageRabbitMQ.
+    auto abandoned = std::make_shared<bool>(false);
     producer_channel->close()
-    .onSuccess([&]()
+    .onSuccess([this, abandoned]()
     {
+        if (*abandoned)
+            return;
         LOG_TRACE(log, "Successfully closed producer channel");
         connection.getHandler().stopBlockingLoop();
     })
-    .onError([&](const char * message)
+    .onError([this, abandoned](const char * message)
     {
+        if (*abandoned)
+            return;
         LOG_ERROR(log, "Failed to close producer channel: {}", message);
         connection.getHandler().stopBlockingLoop();
     });
@@ -290,7 +297,11 @@ void RabbitMQProducer::startProducingTaskLoop()
     /// If the connection is dead the close() callbacks never fire. Bound the wait so that INSERT
     /// producer shutdown (and therefore server shutdown) cannot block indefinitely.
     if (!connection.getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
-        LOG_WARNING(log, "Timed out waiting for producer channel to close — connection may be dead");
+    {
+        /// Make any late-dispatched callback above a no-op before we return.
+        *abandoned = true;
+        LOG_WARNING(log, "Timed out waiting for producer channel to close - connection may be dead");
+    }
     else
         LOG_DEBUG(log, "Producer on channel completed");
 }

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -86,9 +86,6 @@ static const uint32_t QUEUE_SIZE = 100000;
 static const auto MAX_FAILED_READ_ATTEMPTS = 10;
 static const auto RESCHEDULE_MS = 500;
 static const auto MAX_THREAD_WORK_DURATION_MS = 60000;
-/// Timeout for AMQP operations that use a blocking event loop (setup, cleanup, queue removal).
-/// Bounds how long DROP TABLE / server shutdown can block when the broker connection is dead.
-static const auto BLOCKING_LOOP_TIMEOUT_MS = 30000;
 
 namespace ErrorCodes
 {
@@ -768,7 +765,12 @@ void StorageRabbitMQ::unbindExchange()
                 error = fmt::format("Unable to remove exchange. Reason: {}", std::string(message));
             });
 
-            connection->getHandler().startBlockingLoop();
+            /// If the connection is dead the removeExchange callbacks never fire. Bound the wait so
+            /// MV detach / shutdown cannot block forever. The bridge exchange is declared autodelete,
+            /// so the broker reaps it once the dead connection drops — log and continue on timeout.
+            if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
+                LOG_WARNING(log, "Timed out waiting for exchange unbind — RabbitMQ connection may be dead. "
+                                 "The bridge exchange will be auto-deleted by the broker.");
             rabbit_channel->close();
             if (!error.empty())
                 throw Exception(ErrorCodes::CANNOT_REMOVE_RABBITMQ_EXCHANGE, "{}", error);

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -495,6 +495,22 @@ void StorageRabbitMQ::initRabbitMQ()
 }
 
 
+namespace
+{
+/// Shared state for AMQP setup/teardown callbacks that may be dispatched after the blocking
+/// loop has already returned (e.g. on the timeout path, when a slow broker responds late).
+/// AMQP-CPP keeps deferred callbacks alive in the connection after the local channel wrapper is
+/// destroyed, so the callbacks must not capture stack locals by reference. They capture this
+/// object by value (shared_ptr) instead; once `abandoned` is set, any late callback is a no-op.
+struct AMQPSetupState
+{
+    std::string error;
+    int error_code = 0;
+    size_t bound_keys = 0;
+    bool abandoned = false;
+};
+}
+
 void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
 {
     /// Exchange hierarchy:
@@ -508,30 +524,35 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
     /// 1. `durable` (survive RabbitMQ server restart)
     /// 2. `autodelete` (auto delete in case of queue bindings are dropped).
 
-    std::string error;
-    int error_code = 0;
+    /// State is shared by value into every callback (see AMQPSetupState) so that a late dispatch
+    /// after a timeout cannot touch freed stack memory.
+    auto state = std::make_shared<AMQPSetupState>();
     rabbit_channel.declareExchange(exchange_name, exchange_type, AMQP::durable)
-    .onError([&](const char * message)
+    .onError([this, state](const char * message)
     {
+        if (state->abandoned)
+            return;
         connection->getHandler().stopBlockingLoop();
         /// This error can be a result of attempt to declare exchange if it was already declared but
         /// 1) with different exchange type.
         /// 2) with different exchange settings.
-        error = "Unable to declare exchange. "
+        state->error = "Unable to declare exchange. "
             "Make sure specified exchange is not already declared. Error: " + std::string(message);
-        error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
+        state->error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
     });
 
     rabbit_channel.declareExchange(bridge_exchange, AMQP::fanout, AMQP::durable | AMQP::autodelete)
-    .onError([&](const char * message)
+    .onError([this, state](const char * message)
     {
+        if (state->abandoned)
+            return;
         connection->getHandler().stopBlockingLoop();
         /// This error is not supposed to happen as this exchange name is always unique to type and its settings.
-        if (error.empty())
+        if (state->error.empty())
         {
-            error = fmt::format("Unable to declare bridge exchange ({}). Reason: {}",
+            state->error = fmt::format("Unable to declare bridge exchange ({}). Reason: {}",
                                 bridge_exchange, std::string(message));
-            error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
+            state->error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
         }
     });
 
@@ -546,30 +567,34 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
 
         /// Declare hash exchange for sharding.
         rabbit_channel.declareExchange(sharding_exchange, AMQP::consistent_hash, AMQP::durable | AMQP::autodelete, binding_arguments)
-        .onError([&](const char * message)
+        .onError([this, state](const char * message)
         {
+            if (state->abandoned)
+                return;
             connection->getHandler().stopBlockingLoop();
             /// This error can be a result of same reasons as above for exchange_name, i.e. it will mean that sharding exchange name appeared
             /// to be the same as some other exchange (which purpose is not for sharding). So probably actual error reason: queue_base parameter
             /// is bad.
-            if (error.empty())
+            if (state->error.empty())
             {
-                error = fmt::format("Unable to declare sharding exchange ({}). Reason: {}",
+                state->error = fmt::format("Unable to declare sharding exchange ({}). Reason: {}",
                                     sharding_exchange, std::string(message));
-                error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
+                state->error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
             }
         });
 
         rabbit_channel.bindExchange(bridge_exchange, sharding_exchange, routing_keys[0])
-        .onError([&](const char * message)
+        .onError([this, state](const char * message)
         {
+            if (state->abandoned)
+                return;
             connection->getHandler().stopBlockingLoop();
-            if (error.empty())
+            if (state->error.empty())
             {
-                error = fmt::format(
+                state->error = fmt::format(
                     "Unable to bind bridge exchange ({}) to sharding exchange ({}). Reason: {}",
                     bridge_exchange, sharding_exchange, std::string(message));
-                error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
+                state->error_code = ErrorCodes::CANNOT_DECLARE_RABBITMQ_EXCHANGE;
             }
         });
 
@@ -579,8 +604,6 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
     {
         consumer_exchange = bridge_exchange;
     }
-
-    size_t bound_keys = 0;
 
     if (exchange_type == AMQP::ExchangeType::headers)
     {
@@ -593,27 +616,31 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
         }
 
         rabbit_channel.bindExchange(exchange_name, bridge_exchange, routing_keys[0], bind_headers)
-        .onSuccess([&]() { connection->getHandler().stopBlockingLoop(); })
-        .onError([&](const char * message)
+        .onSuccess([this, state]() { if (!state->abandoned) connection->getHandler().stopBlockingLoop(); })
+        .onError([this, state](const char * message)
         {
+            if (state->abandoned)
+                return;
             connection->getHandler().stopBlockingLoop();
-            error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
+            state->error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
                                 exchange_name, bridge_exchange, std::string(message));
-            error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
+            state->error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
         });
     }
     else if (exchange_type == AMQP::ExchangeType::fanout || exchange_type == AMQP::ExchangeType::consistent_hash)
     {
         rabbit_channel.bindExchange(exchange_name, bridge_exchange, routing_keys[0])
-        .onSuccess([&]() { connection->getHandler().stopBlockingLoop(); })
-        .onError([&](const char * message)
+        .onSuccess([this, state]() { if (!state->abandoned) connection->getHandler().stopBlockingLoop(); })
+        .onError([this, state](const char * message)
         {
+            if (state->abandoned)
+                return;
             connection->getHandler().stopBlockingLoop();
-            if (error.empty())
+            if (state->error.empty())
             {
-                error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
+                state->error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
                                     exchange_name, bridge_exchange, std::string(message));
-                error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
+                state->error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
             }
         });
     }
@@ -622,37 +649,49 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
         for (const auto & routing_key : routing_keys)
         {
             rabbit_channel.bindExchange(exchange_name, bridge_exchange, routing_key)
-            .onSuccess([&]()
+            .onSuccess([this, state]()
             {
-                ++bound_keys;
-                if (bound_keys == routing_keys.size())
+                if (state->abandoned)
+                    return;
+                ++state->bound_keys;
+                if (state->bound_keys == routing_keys.size())
                     connection->getHandler().stopBlockingLoop();
             })
-            .onError([&](const char * message)
+            .onError([this, state](const char * message)
             {
+                if (state->abandoned)
+                    return;
                 connection->getHandler().stopBlockingLoop();
-                if (error.empty())
+                if (state->error.empty())
                 {
-                    error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
+                    state->error = fmt::format("Unable to bind exchange {} to bridge exchange ({}). Reason: {}",
                                         exchange_name, bridge_exchange, std::string(message));
-                    error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
+                    state->error_code = ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE;
                 }
             });
         }
     }
 
     if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
-        throw Exception(ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE, "Timed out waiting for exchange setup — RabbitMQ may be unreachable");
-    if (!error.empty())
-        throw Exception(error_code, "{}", error);
+    {
+        /// Make any late-dispatched callback above a no-op before the captured stack frame unwinds.
+        state->abandoned = true;
+        throw Exception(ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE, "Timed out waiting for exchange setup - RabbitMQ may be unreachable");
+    }
+    if (!state->error.empty())
+        throw Exception(state->error_code, "{}", state->error);
 }
 
 
 void StorageRabbitMQ::bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_channel)
 {
-    std::string error;
-    auto success_callback = [&](const std::string &  queue_name, int msgcount, int /* consumercount */)
+    /// State is shared by value into every callback (see AMQPSetupState) so that a late dispatch
+    /// after a timeout cannot touch freed stack memory or the destroyed channel.
+    auto state = std::make_shared<AMQPSetupState>();
+    auto success_callback = [this, state, &rabbit_channel, queue_id](const std::string &  queue_name, int msgcount, int /* consumercount */)
     {
+        if (state->abandoned)
+            return;
         queues.emplace_back(queue_name);
         LOG_DEBUG(log, "Queue {} is declared", queue_name);
 
@@ -664,25 +703,29 @@ void StorageRabbitMQ::bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_chann
         * fanout exchange it can be arbitrary
         */
         rabbit_channel.bindQueue(consumer_exchange, queue_name, std::to_string(queue_id))
-        .onSuccess([&] { connection->getHandler().stopBlockingLoop(); })
-        .onError([&](const char * message)
+        .onSuccess([this, state] { if (!state->abandoned) connection->getHandler().stopBlockingLoop(); })
+        .onError([this, state](const char * message)
         {
+            if (state->abandoned)
+                return;
             connection->getHandler().stopBlockingLoop();
-            error = fmt::format("Failed to create queue binding for exchange {}. Reason: {}",
+            state->error = fmt::format("Failed to create queue binding for exchange {}. Reason: {}",
                                 exchange_name, std::string(message));
         });
     };
 
-    auto error_callback([&](const char * message)
+    auto error_callback([this, state](const char * message)
     {
+        if (state->abandoned)
+            return;
         connection->getHandler().stopBlockingLoop();
         /* This error is most likely a result of an attempt to declare queue with different settings if it was declared before. So for a
          * given queue name either deadletter_exchange parameter changed or queue_size changed, i.e. table was declared with different
          * max_block_size parameter. Solution: client should specify a different queue_base parameter or manually delete previously
          * declared queues via any of the various cli tools.
          */
-         if (error.empty())
-             error = fmt::format(
+         if (state->error.empty())
+             state->error = fmt::format(
                  "Failed to declare queue. Probably queue settings are conflicting: "
                  "max_block_size, deadletter_exchange. Attempt specifying differently those settings "
                  "or use a different queue_base or manually delete previously declared queues, "
@@ -725,9 +768,13 @@ void StorageRabbitMQ::bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_chann
     /// and deleting queues should not take place.
     rabbit_channel.declareQueue(queue_name, AMQP::durable, queue_settings).onSuccess(success_callback).onError(error_callback);
     if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
-        throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "Timed out waiting for queue setup — RabbitMQ may be unreachable");
-    if (!error.empty())
-        throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "{}", error);
+    {
+        /// Make any late-dispatched callback above a no-op before the captured stack frame unwinds.
+        state->abandoned = true;
+        throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "Timed out waiting for queue setup - RabbitMQ may be unreachable");
+    }
+    if (!state->error.empty())
+        throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "{}", state->error);
 }
 
 
@@ -751,29 +798,37 @@ void StorageRabbitMQ::unbindExchange()
 
             stopLoop();
             looping_task->deactivate();
-            std::string error;
-
+            /// State is shared by value into the callbacks (see AMQPSetupState) so that a late
+            /// dispatch after a timeout cannot touch freed stack memory or the destroyed channel.
+            auto state = std::make_shared<AMQPSetupState>();
             auto rabbit_channel = connection->createChannel();
             rabbit_channel->removeExchange(bridge_exchange)
-            .onSuccess([&]()
+            .onSuccess([this, state]()
             {
-                connection->getHandler().stopBlockingLoop();
+                if (!state->abandoned)
+                    connection->getHandler().stopBlockingLoop();
             })
-            .onError([&](const char * message)
+            .onError([this, state](const char * message)
             {
+                if (state->abandoned)
+                    return;
                 connection->getHandler().stopBlockingLoop();
-                error = fmt::format("Unable to remove exchange. Reason: {}", std::string(message));
+                state->error = fmt::format("Unable to remove exchange. Reason: {}", std::string(message));
             });
 
             /// If the connection is dead the removeExchange callbacks never fire. Bound the wait so
             /// MV detach / shutdown cannot block forever. The bridge exchange is declared autodelete,
-            /// so the broker reaps it once the dead connection drops — log and continue on timeout.
+            /// so the broker reaps it once the dead connection drops - log and continue on timeout.
             if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
-                LOG_WARNING(log, "Timed out waiting for exchange unbind — RabbitMQ connection may be dead. "
+            {
+                /// Make any late-dispatched callback above a no-op before the channel/state go out of scope.
+                state->abandoned = true;
+                LOG_WARNING(log, "Timed out waiting for exchange unbind - RabbitMQ connection may be dead. "
                                  "The bridge exchange will be auto-deleted by the broker.");
+            }
             rabbit_channel->close();
-            if (!error.empty())
-                throw Exception(ErrorCodes::CANNOT_REMOVE_RABBITMQ_EXCHANGE, "{}", error);
+            if (!state->error.empty())
+                throw Exception(ErrorCodes::CANNOT_REMOVE_RABBITMQ_EXCHANGE, "{}", state->error);
         }
         catch (...)
         {
@@ -998,6 +1053,10 @@ void StorageRabbitMQ::cleanupRabbitMQ() const
         return;
     }
 
+    /// State is shared by value into the callbacks (see AMQPSetupState) so that a late dispatch
+    /// after a timeout cannot touch freed stack memory or the destroyed channel. The queue name
+    /// is captured by value for the same reason.
+    auto state = std::make_shared<AMQPSetupState>();
     auto rabbit_channel = connection->createChannel();
     for (const auto & queue : queues)
     {
@@ -1006,20 +1065,28 @@ void StorageRabbitMQ::cleanupRabbitMQ() const
         /// AMQP::ifempty is not used on purpose.
 
         rabbit_channel->removeQueue(queue, AMQP::ifunused)
-        .onSuccess([&](uint32_t num_messages)
+        .onSuccess([this, state, queue](uint32_t num_messages)
         {
+            if (state->abandoned)
+                return;
             LOG_TRACE(log, "Successfully deleted queue {}, messages contained {}", queue, num_messages);
             connection->getHandler().stopBlockingLoop();
         })
-        .onError([&](const char * message)
+        .onError([this, state, queue](const char * message)
         {
+            if (state->abandoned)
+                return;
             LOG_ERROR(log, "Failed to delete queue {}. Error message: {}", queue, message);
             connection->getHandler().stopBlockingLoop();
         });
     }
     if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
-        LOG_WARNING(log, "Timed out waiting for queue cleanup — RabbitMQ connection may be dead. "
+    {
+        /// Make any late-dispatched callback above a no-op before the channel/state go out of scope.
+        state->abandoned = true;
+        LOG_WARNING(log, "Timed out waiting for queue cleanup - RabbitMQ connection may be dead. "
                          "Queues may need to be deleted manually.");
+    }
     rabbit_channel->close();
 
     /// Also there is no need to cleanup exchanges as they were created with AMQP::autodelete option. Once queues

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -86,6 +86,9 @@ static const uint32_t QUEUE_SIZE = 100000;
 static const auto MAX_FAILED_READ_ATTEMPTS = 10;
 static const auto RESCHEDULE_MS = 500;
 static const auto MAX_THREAD_WORK_DURATION_MS = 60000;
+/// Timeout for AMQP operations that use a blocking event loop (setup, cleanup, queue removal).
+/// Bounds how long DROP TABLE / server shutdown can block when the broker connection is dead.
+static const auto BLOCKING_LOOP_TIMEOUT_MS = 30000;
 
 namespace ErrorCodes
 {
@@ -641,7 +644,8 @@ void StorageRabbitMQ::bindExchange(AMQP::TcpChannel & rabbit_channel)
         }
     }
 
-    connection->getHandler().startBlockingLoop();
+    if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
+        throw Exception(ErrorCodes::CANNOT_BIND_RABBITMQ_EXCHANGE, "Timed out waiting for exchange setup — RabbitMQ may be unreachable");
     if (!error.empty())
         throw Exception(error_code, "{}", error);
 }
@@ -723,7 +727,8 @@ void StorageRabbitMQ::bindQueue(size_t queue_id, AMQP::TcpChannel & rabbit_chann
     /// AMQP::autodelete setting is not allowed, because in case of server restart there will be no consumers
     /// and deleting queues should not take place.
     rabbit_channel.declareQueue(queue_name, AMQP::durable, queue_settings).onSuccess(success_callback).onError(error_callback);
-    connection->getHandler().startBlockingLoop();
+    if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
+        throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "Timed out waiting for queue setup — RabbitMQ may be unreachable");
     if (!error.empty())
         throw Exception(ErrorCodes::CANNOT_CREATE_RABBITMQ_QUEUE_BINDING, "{}", error);
 }
@@ -971,6 +976,10 @@ void StorageRabbitMQ::cleanupRabbitMQ() const
         return;
 
     connection->heartbeat();
+    /// Run the event loop briefly so that any I/O error triggered by the heartbeat write on a
+    /// dead socket is processed before we check isConnected(). Without this, the error event
+    /// only surfaces inside startBlockingLoop() — after the guard has already passed.
+    connection->getHandler().iterateLoop();
     if (!connection->isConnected())
     {
         String queue_names;
@@ -1006,7 +1015,9 @@ void StorageRabbitMQ::cleanupRabbitMQ() const
             connection->getHandler().stopBlockingLoop();
         });
     }
-    connection->getHandler().startBlockingLoop();
+    if (!connection->getHandler().startBlockingLoopWithTimeout(BLOCKING_LOOP_TIMEOUT_MS))
+        LOG_WARNING(log, "Timed out waiting for queue cleanup — RabbitMQ connection may be dead. "
+                         "Queues may need to be deleted manually.");
     rabbit_channel->close();
 
     /// Also there is no need to cleanup exchanges as they were created with AMQP::autodelete option. Once queues

--- a/src/Storages/tests/gtest_rabbitmq_handler.cpp
+++ b/src/Storages/tests/gtest_rabbitmq_handler.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include <config.h>
+
+#if USE_AMQPCPP
+
+#include <Storages/UVLoop.h>
+#include <Storages/RabbitMQ/RabbitMQHandler.h>
+#include <Common/logger_useful.h>
+
+using namespace DB;
+
+/// Regression test for the dead-connection hang (issue #108496). When RabbitMQ closes the
+/// connection without a clean AMQP handshake, the broker callbacks that would call
+/// stopBlockingLoop() never fire. startBlockingLoopWithTimeout() must still return, reporting
+/// a timeout, instead of blocking forever on uv_run().
+TEST(RabbitMQHandler, BlockingLoopReturnsOnTimeoutWithoutStopper)
+{
+    UVLoop loop;
+    RabbitMQHandler handler(loop.getLoop(), getLogger("RabbitMQHandlerTest"));
+
+    /// Nothing ever calls stopBlockingLoop(), mimicking a dead broker connection.
+    /// The call must come back via the timeout rather than hang (if it hangs, the test times out).
+    bool finished_naturally = handler.startBlockingLoopWithTimeout(/* timeout_ms = */ 100);
+
+    EXPECT_FALSE(finished_naturally);
+}
+
+/// The timeout must not fire spuriously: when something does call stopBlockingLoop() (as the AMQP
+/// success/error callbacks do on a healthy connection), the helper returns true and does not wait
+/// for the full timeout. The stopper runs as an on-loop timer, exactly like an AMQP callback that
+/// is dispatched from within uv_run() on the loop thread.
+TEST(RabbitMQHandler, BlockingLoopReturnsTrueWhenStopped)
+{
+    UVLoop loop;
+    RabbitMQHandler handler(loop.getLoop(), getLogger("RabbitMQHandlerTest"));
+
+    uv_timer_t stopper;
+    uv_timer_init(loop.getLoop(), &stopper);
+    stopper.data = &handler;
+    uv_timer_start(
+        &stopper,
+        [](uv_timer_t * t) { static_cast<RabbitMQHandler *>(t->data)->stopBlockingLoop(); },
+        /* timeout_ms = */ 50,
+        /* repeat = */ 0);
+
+    bool finished_naturally = handler.startBlockingLoopWithTimeout(/* timeout_ms = */ 30000);
+
+    uv_close(reinterpret_cast<uv_handle_t *>(&stopper), nullptr);
+    uv_run(loop.getLoop(), UV_RUN_NOWAIT);
+
+    EXPECT_TRUE(finished_naturally);
+}
+
+#endif


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues

- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1788
<!-- End of fixes issue link part, do not remove -->

Closes: https://github.com/ClickHouse/ClickHouse/issues/108496

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fixed RabbitMQ table engine hanging indefinitely on `DROP TABLE` or server shutdown when the broker closes the AMQP connection due to missed heartbeats without sending a TCP RST. All blocking event loop calls now have a 30-second timeout so shutdown always completes.

### Problem

When RabbitMQ closes the AMQP connection due to missed heartbeats **without sending a TCP RST** (common in Kubernetes overlay networks), ClickHouse never detects the closure. Three things go wrong in sequence:

1. **`isConnectedImpl()` stays `true`** — `connectionRunning` is only cleared inside `onError()`, which AMQP-CPP never calls when the broker closes ungracefully. So `isConnected()` returns `true` on a dead socket.

2. **The heartbeat guard in `cleanupRabbitMQ()` is a no-op** — `connection->heartbeat()` writes a frame into the TCP send buffer (succeeds at kernel level even on a dead socket). The resulting I/O error only surfaces when `uv_run()` processes it — which happens *inside* `startBlockingLoop()`, after the `isConnected()` guard has already returned `true`.

3. **`startBlockingLoop()` hangs forever** — it calls `uv_run(loop, UV_RUN_DEFAULT)`, which only exits when `uv_stop()` is called. The only callers of `uv_stop()` are the `removeQueue` success/error callbacks in `cleanupRabbitMQ()`. On a dead connection those callbacks never fire — so `DROP TABLE` and server shutdown block indefinitely.

The same unbounded `startBlockingLoop()` is also called in `bindExchange()` and `bindQueue()` during table setup, making those paths susceptible too.

### Fix

**`RabbitMQHandler`** — add `startBlockingLoopWithTimeout(uint64_t timeout_ms)`:
- Registers a `uv_timer_t` on the loop that calls `uv_stop()` after the deadline.
- Returns `true` if callbacks fired naturally, `false` if it timed out.
- Cleans up the timer handle correctly before returning.

**`StorageRabbitMQ`** — replace `startBlockingLoop()` with the timeout version everywhere:
- `cleanupRabbitMQ()`: logs a warning on timeout (cleanup is best-effort; exchanges auto-delete anyway).
- `bindExchange()` / `bindQueue()`: throws on timeout so the caller gets a proper error instead of hanging.
- Adds `iterateLoop()` after `heartbeat()` in `cleanupRabbitMQ()` so pending I/O errors surface *before* the `isConnected()` guard, not after it.

Default timeout: **30 seconds** (`BLOCKING_LOOP_TIMEOUT_MS`). On a healthy connection nothing changes — the timer fires only if AMQP callbacks don't.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.165` (included in `26.7` and later)
- Backported to: `26.6.5.80`, `26.3.33.26`
<!-- ch-version-info:end -->