### PR TITLE
Fix flaky test 02161_addressToLineWithInlines

### DIFF
--- a/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
+++ b/tests/queries/0_stateless/02161_addressToLineWithInlines.sql
@@ -12,6 +12,10 @@ SET log_queries = 0;
 SET query_profiler_cpu_time_period_ns = 0;
 SYSTEM FLUSH LOGS query_log, trace_log;
 
+-- Symbolization test, not a perf test: reading system.trace_log can be slow
+-- and false-positives the execution-time guards (TOO_SLOW / TIMEOUT_EXCEEDED).
+SET max_estimated_execution_time = 0, max_execution_time = 0;
+
 WITH
     lineWithInlines AS
     (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107333
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02161_addressToLineWithInlines` is a symbolization-correctness test, not a perf test. Its final query symbolizes CPU-profiler samples by scanning `system.trace_log`. When that scan is slow (e.g. on s3-backed `system.trace_log` storage), the query crosses the `timeout_before_checking_execution_speed` (300s) checkpoint; `ExecutionSpeedLimits` then extrapolates the projected total runtime past the CI server profile's `max_estimated_execution_time = 600` and kills it with `TOO_SLOW` (160). On branches still carrying the historical `SET max_execution_time = 300`, the same slow read trips `TIMEOUT_EXCEEDED` (159) instead. Both guards are false positives here.

Fix: disable both execution-time guards for that one symbolization query. The `has inlines: 1` assertion and the whole symbolization flow are unchanged.

Same change/rationale already in the tree: `03560_parallel_replicas_memory_bound_merging_projection.sql` (`set max_estimated_execution_time = 0;`), `04214` documents the same CI budget.

No related open issue. Builds on the prior 02161 fix #107333.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.100` (included in `26.7` and later)
- Backported to: `26.6.2.40`, `26.5.7.42`, `26.4.5.168`
<!-- ch-version-info:end -->