### PR TITLE
Enforce remote_url_allow_hosts for ArrowFlight engine and table function

### DIFF
--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -5,6 +5,7 @@
 
 #if USE_ARROWFLIGHT
 #include <Common/Logger.h>
+#include <Common/RemoteHostFilter.h>
 #include <Common/parseAddress.h>
 #include <Interpreters/Context.h>
 #include <Core/Settings.h>
@@ -71,6 +72,11 @@ StorageArrowFlight::Configuration StorageArrowFlight::getConfiguration(ASTs & ar
             configuration.password = checkAndGetLiteralArgument<String>(args[3], "password");
         }
     }
+
+    /// Enforce <remote_url_allow_hosts> before any connection is established.
+    context_->getGlobalContext()->getRemoteHostFilter().checkHostAndPort(
+        configuration.host, std::to_string(configuration.port));
+
     return configuration;
 }
 

--- a/tests/integration/test_arrowflight_storage/configs/remote_host_filter.xml
+++ b/tests/integration/test_arrowflight_storage/configs/remote_host_filter.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <remote_url_allow_hosts>
+        <host>arrowflight1</host>
+    </remote_url_allow_hosts>
+</clickhouse>

--- a/tests/integration/test_arrowflight_storage/test.py
+++ b/tests/integration/test_arrowflight_storage/test.py
@@ -6,7 +6,12 @@ from helpers.config_cluster import arrowflight_user, arrowflight_pass
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
-node = cluster.add_instance("node", with_arrowflight=True, stay_alive=True)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/remote_host_filter.xml"],
+    with_arrowflight=True,
+    stay_alive=True,
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -343,3 +348,39 @@ def test_arrowflight_storage_with_named_collection():
     node.query("DROP TABLE arrow_test_named")
     node.query("DROP TABLE arrow_test_named_2")
     node.query("DROP NAMED COLLECTION arrowflight_storage_collection")
+
+
+def test_remote_host_filter():
+    # Only "arrowflight1" is allow-listed in configs/remote_host_filter.xml,
+    # so a connection to any other host must be rejected before it is opened.
+    error = node.query_and_get_error(
+        "SELECT * FROM arrowFlight('127.0.0.1:5005', 'ABC')"
+    )
+    assert "not allowed in configuration file" in error
+
+    error = node.query_and_get_error(
+        """
+        CREATE TABLE arrow_blocked (column1 String, column2 String)
+        ENGINE=ArrowFlight('127.0.0.1:5005', 'ABC')
+        """
+    )
+    assert "not allowed in configuration file" in error
+
+    # The named-collection branch of getConfiguration is also guarded: creating
+    # the collection is harmless (no connection), but using it must be rejected.
+    node.query(
+        """
+        CREATE NAMED COLLECTION arrowflight_blocked_collection AS
+        host = '127.0.0.1',
+        port = 5005,
+        dataset = 'ABC',
+        use_basic_authentication = False
+        """
+    )
+    try:
+        error = node.query_and_get_error(
+            "SELECT * FROM arrowFlight(arrowflight_blocked_collection)"
+        )
+        assert "not allowed in configuration file" in error
+    finally:
+        node.query("DROP NAMED COLLECTION arrowflight_blocked_collection")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The `ArrowFlight` table engine and the `arrowFlight` table function now honor the `<remote_url_allow_hosts>` allow-list. Previously the connection host and port were not validated, so a query could reach hosts not present in the allow-list.

### Description

`ArrowFlightConnection::connect()` opened a gRPC connection to the user-supplied `host:port` without consulting `RemoteHostFilter`, so `<remote_url_allow_hosts>` was never enforced for ArrowFlight. An authenticated user with the `ARROW_FLIGHT` source grant could reach arbitrary internal TCP/gRPC endpoints (SSRF, internal service access, port scanning).

The fix adds a single host-and-port check at `StorageArrowFlight::getConfiguration()`, the choke point both the storage factory (`registerStorageArrowFlight`) and the table function (`TableFunctionArrowFlight::parseArguments`) route through. `host`/`port` are populated there for both the positional `ArrowFlight('host:port', ...)` form and the named-collection form, so both argument styles are covered. This mirrors `TableFunctionRemote`, `ClickHouseDictionarySource` and `StoragePostgreSQL`.

Backward compatible: the check only enforces the existing setting; the default empty allow-list permits all hosts, so existing setups are unaffected.

Reproduction (with `<remote_url_allow_hosts>` configured to not include the target):

```sql
SELECT * FROM arrowFlight('169.254.169.254:80', 'meta');
CREATE TABLE t (x Int32) ENGINE = ArrowFlight('127.0.0.1:9000', 'dataset');
-- Both are now rejected with UNACCEPTABLE_URL before any connection is opened.
```

A new integration test (`test_arrowflight_storage::test_remote_host_filter`) asserts that a disallowed host is rejected with `UNACCEPTABLE_URL` for the table function, the storage engine, and the named-collection forms.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1222` (included in `26.7` and later)
- Backported to: `26.6.5.19`, `26.3.33.38`
<!-- ch-version-info:end -->