### PR TITLE
Match http_forbid_headers case-insensitively

### DIFF
--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -32,15 +32,19 @@ void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) con
                 [](char c) { return std::iscntrl(static_cast<unsigned char>(c)) || std::isspace(static_cast<unsigned char>(c)); }),
             normalized_name.end());
 
-        /// HTTP header names are case-insensitive (RFC 7230 3.2), so match case-insensitively.
+        /// HTTP header names are case-insensitive (RFC 7230 3.2). The exact-set
+        /// entries are stored lower-cased, so lower-case the name for that lookup.
         const std::string lower_name = Poco::toLower(normalized_name);
 
         if (forbidden_headers.contains(lower_name))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                     "see <http_forbid_headers>", entry.name);
 
+        /// Match the regexp against the original-case name: patterns are compiled
+        /// case-insensitive by default, but an inline (?-i) scope must see the real
+        /// case (lower-casing here would stop existing (?-i) configs from matching).
         for (const auto & header_regex : forbidden_headers_regexp)
-            if (re2::RE2::FullMatch(lower_name, *header_regex))
+            if (re2::RE2::FullMatch(normalized_name, *header_regex))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                         "see <http_forbid_headers>", entry.name);
     }

--- a/src/Common/HTTPHeaderFilter.cpp
+++ b/src/Common/HTTPHeaderFilter.cpp
@@ -1,7 +1,9 @@
 #include <Common/HTTPHeaderFilter.h>
 #include <Common/StringUtils.h>
 #include <Common/Exception.h>
+#include <Common/logger_useful.h>
 #include <Common/re2.h>
+#include <Poco/String.h>
 #include <algorithm>
 #include <cctype>
 
@@ -30,12 +32,15 @@ void HTTPHeaderFilter::checkAndNormalizeHeaders(HTTPHeaderEntries & entries) con
                 [](char c) { return std::iscntrl(static_cast<unsigned char>(c)) || std::isspace(static_cast<unsigned char>(c)); }),
             normalized_name.end());
 
-        if (forbidden_headers.contains(normalized_name))
+        /// HTTP header names are case-insensitive (RFC 7230 3.2), so match case-insensitively.
+        const std::string lower_name = Poco::toLower(normalized_name);
+
+        if (forbidden_headers.contains(lower_name))
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                     "see <http_forbid_headers>", entry.name);
 
         for (const auto & header_regex : forbidden_headers_regexp)
-            if (re2::RE2::FullMatch(normalized_name, header_regex))
+            if (re2::RE2::FullMatch(lower_name, *header_regex))
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "HTTP header \"{}\" is forbidden in configuration file, "
                                                         "see <http_forbid_headers>", entry.name);
     }
@@ -56,9 +61,31 @@ void HTTPHeaderFilter::setValuesFromConfig(const Poco::Util::AbstractConfigurati
         for (const auto & key : keys)
         {
             if (startsWith(key, "header_regexp"))
-                forbidden_headers_regexp.push_back(config.getString("http_forbid_headers." + key));
+            {
+                const std::string pattern = config.getString("http_forbid_headers." + key);
+                /// Case insensitivity must come from RE2 options, not from lower-casing the
+                /// pattern string (that would corrupt metacharacters such as \D or [A-Z]).
+                re2::RE2::Options options;
+                options.set_case_sensitive(false);
+                options.set_log_errors(false);
+                auto regexp = std::make_shared<const re2::RE2>(pattern, options);
+                if (!regexp->ok())
+                {
+                    /// Keep the existing behaviour of not aborting config load on a bad pattern,
+                    /// but surface it: an uncompilable pattern silently forbids nothing.
+                    LOG_WARNING(
+                        getLogger("HTTPHeaderFilter"),
+                        "Ignoring invalid <http_forbid_headers> regexp \"{}\": {}",
+                        pattern, regexp->error());
+                    continue;
+                }
+                forbidden_headers_regexp.push_back(std::move(regexp));
+            }
             else if (startsWith(key, "header"))
-                forbidden_headers.insert(config.getString("http_forbid_headers." + key));
+            {
+                /// Stored lower-cased so the case-insensitive lookup in checkAndNormalizeHeaders works.
+                forbidden_headers.insert(Poco::toLower(config.getString("http_forbid_headers." + key)));
+            }
         }
     }
 }

--- a/src/Common/HTTPHeaderFilter.h
+++ b/src/Common/HTTPHeaderFilter.h
@@ -2,10 +2,12 @@
 
 #include <IO/HTTPHeaderEntries.h>
 #include <Poco/Util/AbstractConfiguration.h>
+#include <memory>
 #include <vector>
 #include <unordered_set>
 #include <mutex>
 
+namespace re2 { class RE2; }
 
 namespace DB
 {
@@ -18,8 +20,11 @@ public:
     void checkAndNormalizeHeaders(HTTPHeaderEntries & entries) const;
 
 private:
+    /// Header names are case-insensitive (RFC 7230 3.2): entries are stored
+    /// lower-cased and the incoming name is lower-cased before lookup.
     std::unordered_set<std::string> forbidden_headers;
-    std::vector<std::string> forbidden_headers_regexp;
+    /// Pre-compiled once with case-insensitive matching (compiling per check would also be case-sensitive).
+    std::vector<std::shared_ptr<const re2::RE2>> forbidden_headers_regexp;
 
     mutable std::mutex mutex;
 };

--- a/src/Common/tests/gtest_http_header_filter.cpp
+++ b/src/Common/tests/gtest_http_header_filter.cpp
@@ -1,0 +1,175 @@
+#include <Common/HTTPHeaderFilter.h>
+#include <IO/HTTPHeaderEntries.h>
+#include <Common/Exception.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace DB;
+
+namespace
+{
+
+Poco::AutoPtr<Poco::Util::XMLConfiguration> configFromXML(const std::string & xml)
+{
+    std::istringstream stream(xml);
+    return new Poco::Util::XMLConfiguration(stream);
+}
+
+/// HTTPHeaderFilter holds a std::mutex, so it is neither copyable nor movable;
+/// configure it in place rather than returning it by value.
+void configure(HTTPHeaderFilter & filter, const std::string & xml)
+{
+    auto config = configFromXML(xml);
+    filter.setValuesFromConfig(*config);
+}
+
+bool isForbidden(const HTTPHeaderFilter & filter, const std::string & name)
+{
+    HTTPHeaderEntries entries{{name, "value"}};
+    try
+    {
+        filter.checkAndNormalizeHeaders(entries);
+    }
+    catch (const Exception &)
+    {
+        return true;
+    }
+    return false;
+}
+
+}
+
+/// HTTP header names are case-insensitive (RFC 7230 section 3.2). A forbidden
+/// exact header configured as "Authorization" must block every case variant,
+/// otherwise the http_forbid_headers blocklist is trivially bypassed.
+TEST(HTTPHeaderFilter, ExactMatchIsCaseInsensitive)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header>Authorization</header>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "Authorization"));
+    EXPECT_TRUE(isForbidden(filter, "authorization"));
+    EXPECT_TRUE(isForbidden(filter, "AUTHORIZATION"));
+    EXPECT_TRUE(isForbidden(filter, "aUtHoRiZaTiOn"));
+}
+
+/// The configured name itself may be in any case; matching must still be
+/// case-insensitive against the incoming header.
+TEST(HTTPHeaderFilter, ExactMatchLowerCaseConfigMixedCaseInput)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header>authorization</header>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "Authorization"));
+    EXPECT_TRUE(isForbidden(filter, "AUTHORIZATION"));
+}
+
+/// A regexp pattern without an explicit (?i) flag must still match
+/// case-insensitively, because header names are case-insensitive.
+TEST(HTTPHeaderFilter, RegexpMatchIsCaseInsensitiveWithoutFlag)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header_regexp>x-custom-.*</header_regexp>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "x-custom-token"));
+    EXPECT_TRUE(isForbidden(filter, "X-Custom-Token"));
+    EXPECT_TRUE(isForbidden(filter, "X-CUSTOM-SECRET"));
+}
+
+/// An explicit (?i) prefix (the pre-existing way admins requested case
+/// insensitivity) must keep working.
+TEST(HTTPHeaderFilter, RegexpMatchExplicitInlineFlagStillWorks)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header_regexp>(?i)(secret_header)</header_regexp>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "secret_header"));
+    EXPECT_TRUE(isForbidden(filter, "SECRET_HEADER"));
+    EXPECT_TRUE(isForbidden(filter, "Secret_Header"));
+}
+
+/// Case normalization must compose with whitespace/control-character stripping:
+/// a name padded with whitespace and in a different case is still forbidden.
+TEST(HTTPHeaderFilter, CaseInsensitiveComposesWithWhitespaceStripping)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header>Authorization</header>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "  aUtHoRiZaTiOn  "));
+    EXPECT_TRUE(isForbidden(filter, "Auth\torization"));
+}
+
+/// Headers not on the blocklist must still be allowed, in any case.
+TEST(HTTPHeaderFilter, UnrelatedHeadersStillAllowed)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header>Authorization</header>
+                <header_regexp>x-custom-.*</header_regexp>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_FALSE(isForbidden(filter, "Content-Type"));
+    EXPECT_FALSE(isForbidden(filter, "accept"));
+    EXPECT_FALSE(isForbidden(filter, "X-Other-Header"));
+}
+
+/// Regexp metacharacters must keep their meaning under case-insensitive
+/// matching: case insensitivity must come from RE2 options, not from
+/// lower-casing the pattern string (which would corrupt \d, char classes, ...).
+TEST(HTTPHeaderFilter, RegexpMetacharactersPreserved)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header_regexp>x-id-\d+</header_regexp>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    EXPECT_TRUE(isForbidden(filter, "x-id-123"));
+    EXPECT_TRUE(isForbidden(filter, "X-ID-456"));
+    EXPECT_FALSE(isForbidden(filter, "x-id-abc"));
+}
+
+/// An empty configuration forbids nothing.
+TEST(HTTPHeaderFilter, EmptyConfigForbidsNothing)
+{
+    HTTPHeaderFilter filter;
+    EXPECT_FALSE(isForbidden(filter, "Authorization"));
+}

--- a/src/Common/tests/gtest_http_header_filter.cpp
+++ b/src/Common/tests/gtest_http_header_filter.cpp
@@ -113,6 +113,28 @@ TEST(HTTPHeaderFilter, RegexpMatchExplicitInlineFlagStillWorks)
     EXPECT_TRUE(isForbidden(filter, "Secret_Header"));
 }
 
+/// An inline (?-i) scope re-enables case-sensitive matching for that literal.
+/// On master the regexp matched the original-case header, so such a config must
+/// keep blocking it: the regexp is matched against the original-case name, not a
+/// lower-cased one, otherwise an existing (?-i) blocklist would silently weaken.
+TEST(HTTPHeaderFilter, RegexpInlineCaseSensitiveScopeStillBlocksOriginalCase)
+{
+    HTTPHeaderFilter filter;
+    configure(filter, R"(
+        <clickhouse>
+            <http_forbid_headers>
+                <header_regexp>(?-i)Authorization</header_regexp>
+            </http_forbid_headers>
+        </clickhouse>
+    )");
+
+    /// The case-sensitive literal still matches the header it matched on master.
+    EXPECT_TRUE(isForbidden(filter, "Authorization"));
+    /// And the (?-i) scope keeps its case-sensitive semantics for other cases.
+    EXPECT_FALSE(isForbidden(filter, "authorization"));
+    EXPECT_FALSE(isForbidden(filter, "AUTHORIZATION"));
+}
+
 /// Case normalization must compose with whitespace/control-character stripping:
 /// a name padded with whitespace and in a different case is still forbidden.
 TEST(HTTPHeaderFilter, CaseInsensitiveComposesWithWhitespaceStripping)

--- a/tests/queries/0_stateless/02752_forbidden_headers.sql
+++ b/tests/queries/0_stateless/02752_forbidden_headers.sql
@@ -2,24 +2,28 @@
 -- Tag no-fasttest: Depends on AWS
 
 SELECT * FROM url('http://localhost:8123/', LineAsString, headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM url('http://localhost:8123/', LineAsString, headers('EXACT_HEADER' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM url('http://localhost:8123/', LineAsString, headers('cAsE_INSENSITIVE_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM url('http://localhost:8123/', LineAsString, headers('bad_header_name: test\nexact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM url('http://localhost:8123/', LineAsString, headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM url('http://localhost:8123/', LineAsString, headers('random_header' = 'value')) FORMAT Null;
 
 SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('EXACT_HEADER' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('cAsE_INSENSITIVE_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('bad_header_name: test\nexact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM urlCluster('test_cluster_two_shards_localhost', 'http://localhost:8123/', LineAsString, headers('random_header' = 'value')) FORMAT Null;
 
 SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('EXACT_HEADER' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('cAsE_INSENSITIVE_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('bad_header_name: test\nexact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3('http://localhost:8123/123/4', LineAsString, headers('random_header' = 'value')); -- { serverError S3_ERROR }
 
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('exact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
+SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('EXACT_HEADER' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('cAsE_INSENSITIVE_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('bad_header_name: test\nexact_header' = 'value')); -- { serverError BAD_ARGUMENTS }
 SELECT * FROM s3Cluster('test_cluster_two_shards_localhost', 'http://localhost:8123/123/4', LineAsString, headers('bad_header_value' = 'test\nexact_header: value')); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Match `http_forbid_headers` case-insensitively. HTTP header names are case-insensitive, so forbidding `Authorization` now also blocks `authorization`, `AUTHORIZATION` and other case variants. Configured `header_regexp` patterns are now matched case-insensitively without needing an explicit `(?i)` flag.


### Description

`http_forbid_headers` matched header names case-sensitively, but HTTP header names are case-insensitive (RFC 7230 3.2). The exact set used a verbatim `std::unordered_set` lookup, and each `header_regexp` was compiled case-sensitively. So an administrator forbidding `Authorization` did not block `authorization`, `AUTHORIZATION` or `aUtHoRiZaTiOn`, and a regexp pattern had to carry an explicit `(?i)` to work. The blocklist enforced for `url()`, the `URL`/`S3` engines, the HTTP dictionary source and DataLakeCatalog auth headers was therefore trivially bypassable.

`HTTPHeaderFilter::checkAndNormalizeHeaders` is the single funnel every URL-based header check goes through, so the fix is contained to `src/Common/HTTPHeaderFilter.{h,cpp}`:

- Exact set: entries are stored lower-cased at config load, and the (already whitespace/control-stripped) incoming name is lower-cased before the lookup.
- Regexp: each pattern is pre-compiled once with `re2::RE2::Options::set_case_sensitive(false)` instead of being recompiled case-sensitively on every check. Case insensitivity comes from the RE2 option, not from lower-casing the pattern string, so metacharacters such as `\d` are preserved.
- An uncompilable configured pattern is now logged and skipped (it previously also never matched, but silently).

The change is strictly more restrictive (more case variants blocked, never fewer), so no setting is needed to restore the old behavior, and existing `(?i)` patterns keep working.

Tests:
- New unit test `src/Common/tests/gtest_http_header_filter.cpp` covering exact + regexp case insensitivity, lower-case config with mixed-case input, regexp without explicit `(?i)`, composition with whitespace stripping, metacharacter preservation, and that unrelated headers are still allowed. Fails on master, passes with this change.
- `02752_forbidden_headers.sql` extended with upper-case exact-header variants for `url`/`urlCluster`/`s3`/`s3Cluster`.

Possible follow-up (left out deliberately, since it changes server start/reload behavior): rejecting an invalid `<http_forbid_headers>` regexp at config load with `CANNOT_COMPILE_REGEXP` instead of logging and skipping it. Happy to do that in a separate PR if maintainers prefer.

No related open issue found on the public tracker.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.565` (included in `26.7` and later)
- Backported to: `26.6.2.39`, `26.5.6.20`, `26.4.5.109`, `26.3.17.28`, `25.8.29.4`
<!-- ch-version-info:end -->