### PR TITLE
Fast Test: drop non-core contribs that are never built

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -31,16 +31,12 @@ def clone_submodules():
         "contrib/zlib-ng",
         "contrib/libxml2",
         "contrib/fmtlib",
-        "contrib/base64",
         "contrib/cctz",
-        "contrib/libcpuid",
         "contrib/libdivide",
         "contrib/double-conversion",
         "contrib/llvm-project",
         "contrib/lz4",
         "contrib/zstd",
-        "contrib/fastops",
-        "contrib/rapidjson",
         "contrib/re2",
         "contrib/sparsehash-c11",
         "contrib/croaring",
@@ -56,7 +52,6 @@ def clone_submodules():
         "contrib/morton-nd",
         "contrib/xxHash",
         "contrib/simdjson",
-        "contrib/simdcomp",
         "contrib/liburing",
         "contrib/libfiu",
         "contrib/yaml-cpp",
@@ -64,7 +59,6 @@ def clone_submodules():
         "contrib/StringZilla",
         "contrib/rust_vendor",
         "contrib/clickstack",
-        "contrib/libpng",
     ]
 
     res = Shell.check("git submodule sync", verbose=True, strict=True)
@@ -271,7 +265,7 @@ def main():
                 -DENABLE_TESTS=0 -DENABLE_UTILS=0 -DENABLE_THINLTO=0 -DENABLE_NURAFT=1 -DENABLE_SIMDJSON=1 \
                 -DENABLE_LEXER_TEST=1 \
                 -DBUILD_STRIPPED_BINARY=1 \
-                -DENABLE_JEMALLOC=1 -DENABLE_LIBURING=1 -DENABLE_YAML_CPP=1 -DENABLE_RUST=1 -DENABLE_LIBPNG=1 \
+                -DENABLE_JEMALLOC=1 -DENABLE_LIBURING=1 -DENABLE_YAML_CPP=1 -DENABLE_RUST=1 \
                 -B {build_dir_normalized}",
                 workdir=repo_path_normalized,
             )


### PR DESCRIPTION
`ci/jobs/fast_test.py` configures the build with `-DENABLE_LIBRARIES=0` plus a short explicit allow-list of `-DENABLE_*=1` flags. Several submodules in `clone_submodules` are gated by `ENABLE_X = ${ENABLE_LIBRARIES}` and are not on that allow-list, so they are checked out but never built: `base64`, `rapidjson`, `fastops`, `libcpuid`, `simdcomp`.

`libpng` was the only one of these actually compiled, via an explicit `-DENABLE_LIBPNG=1`. Its tests (`04326`-`04339_png_*`) are already tagged `no-fasttest` (the `PNG` format also needs base64, which Fast Test does not enable), so building libpng produced nothing the job uses.

This removes all six from the submodule checkout list and drops `-DENABLE_LIBPNG=1`. No test changes are needed: the five gated-off libraries were already disabled, and the PNG tests are already excluded.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.81`
<!-- ch-version-info:end -->