### PR TITLE
Fix flaky test_keeper_disks::test_snapshots_with_disks

### DIFF
--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -231,11 +231,25 @@ def test_snapshots_with_disks(started_cluster):
             cleanup_disks=False,
         )
 
-        ## all but the latest log should be on S3
+        # Relocating non-latest snapshots to the configured disk runs after the
+        # "Created persistent snapshot" log line, so poll for the count to settle
+        # instead of checking once (mirrors assert_single_local_log above).
+        def assert_single_local_snapshot():
+            local_snapshot_files = get_local_snapshots(node_snapshot)
+            start_time = time.time()
+            while len(local_snapshot_files) != 1:
+                logging.debug(f"Local snapshot files: {local_snapshot_files}")
+                assert (
+                    time.time() - start_time < 60
+                ), "local_snapshot_files size is not equal to 1 after 60s"
+                time.sleep(1)
+                local_snapshot_files = get_local_snapshots(node_snapshot)
+
+        ## all but the latest snapshot should be on S3
+        assert_single_local_snapshot()
+        local_snapshot_files = get_local_snapshots(node_snapshot)
         s3_snapshot_files = list_s3_objects(started_cluster, "snapshots/")
         assert set(s3_snapshot_files) == set(previous_snapshot_files[:-1])
-        local_snapshot_files = get_local_snapshots(node_snapshot)
-        assert len(local_snapshot_files) == 1
         assert local_snapshot_files[0] == previous_snapshot_files[-1]
 
         previous_snapshot_files = s3_snapshot_files + local_snapshot_files
@@ -250,9 +264,9 @@ def test_snapshots_with_disks(started_cluster):
         snapshot_idx = keeper_utils.send_4lw_cmd(cluster, node_snapshot, "csnp")
         node_snapshot.wait_for_log_line(f"Created persistent snapshot {snapshot_idx}")
 
-        snapshot_files = list_s3_objects(started_cluster, "snapshots/")
+        assert_single_local_snapshot()
         local_snapshot_files = get_local_snapshots(node_snapshot)
-        assert len(local_snapshot_files) == 1
+        snapshot_files = list_s3_objects(started_cluster, "snapshots/")
 
         snapshot_files.extend(local_snapshot_files)
 

--- a/tests/integration/test_keeper_disks/test.py
+++ b/tests/integration/test_keeper_disks/test.py
@@ -59,7 +59,8 @@ def stop_clickhouse(cluster, node, cleanup_disks):
     node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/logs"])
     node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/snapshots"])
 
-    s3_objects = list_s3_objects(cluster, prefix="")
+    # Wipe everything, including any leftover "tmp_" markers, so the bucket is clean.
+    s3_objects = list_s3_objects(cluster, prefix="", exclude_tmp=False)
     if len(s3_objects) == 0:
         return
 
@@ -106,7 +107,15 @@ def setup_local_storage(cluster, node):
     )
 
 
-def list_s3_objects(cluster, prefix=""):
+# Keeper writes an empty "tmp_<name>" marker on the target disk while moving a snapshot/log
+# file between disks and removes it once the copy completes (moveFileBetweenDisks in
+# KeeperCommon.cpp). Such markers are never real snapshots/logs: the server skips
+# "tmp_"-prefixed entries when scanning disks. A listing taken while a move is in flight can
+# transiently observe a marker, so exclude it instead of counting it as a snapshot/log file.
+tmp_keeper_file_prefix = "tmp_"
+
+
+def list_s3_objects(cluster, prefix="", exclude_tmp=True):
     minio = cluster.minio_client
     prefix_len = len(prefix)
     return [
@@ -114,11 +123,16 @@ def list_s3_objects(cluster, prefix=""):
         for obj in minio.list_objects(
             cluster.minio_bucket, prefix=prefix, recursive=True
         )
+        if not (
+            exclude_tmp
+            and os.path.basename(obj.object_name).startswith(tmp_keeper_file_prefix)
+        )
     ]
 
 
 def get_local_files(path, node):
     files = node.exec_in_container(["ls", path]).strip().split("\n")
+    files = [f for f in files if not f.startswith(tmp_keeper_file_prefix)]
     files.sort()
     return files
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `test_keeper_disks/test.py::test_snapshots_with_disks`. Two distinct races, same area (cross-disk snapshot moves); both are test-only issues, no server behavior is changed.

**1) Local snapshot count race (`assert len(local_snapshot_files) == 1` -> `assert 2 == 1`).**
When a separate `latest_snapshot_storage_disk` is configured, creating a snapshot relocates the previous (non-latest) snapshot off the local "latest" disk. In `KeeperStateMachine::create_snapshot` the `Created persistent snapshot {idx}` log line is emitted in the under-lock publish step (`publishWrittenSnapshot`), while the actual move runs afterwards in the deferred, outside-the-lock maintenance step (`runSnapshotMaintenance` -> `moveSnapshotCandidate`). The test waited on that log line and checked the local count once, racing the still-pending move (`selectSnapshotsToMove` also defers a move while the old snapshot is transiently pinned, `use_count > 1`). The move is eventually consistent, so the fix polls for the count to settle to 1 (up to 60s), mirroring the `assert_single_local_log` helper already used by `test_logs_with_disks`.

**2) Transient `tmp_` marker counted as a snapshot (`assert set(local_snapshot_files) == set(previous_snapshot_files)`).**
This is now the dominant variant and also hits master. `moveFileBetweenDisks` (KeeperCommon.cpp) writes an empty `tmp_<name>` marker on the target disk during a move and removes it once the copy completes. The test's `list_s3_objects` / `get_local_files` helpers listed everything, so a listing taken while a move was in flight captured the transient `tmp_snapshot_<idx>` marker into `previous_snapshot_files`. After the next restart only the real `snapshot_<idx>` remained, so the set comparison failed with a lone `tmp_`-prefixed entry on the expected side. The server itself never treats `tmp_`-prefixed entries as snapshots/logs (it skips them when scanning disks), so the helpers now exclude them too; the disk-cleanup path still wipes them (`exclude_tmp=False`).

Validation: for (1), injecting an 8s delay before the move made the bare assertion fail 3/3 and the polling version pass 3/3. For (2), injecting a transient `tmp_` marker at the listing point made the raw listing fail with the exact CI signature (`{snapshot_34}` vs `{snapshot_34, tmp_snapshot_34}`) and the `tmp_`-excluding listing pass. The full test passed 6/6 (both tests, random order) on a clean build.

CI failure (variant 2, master): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b3461b9116ed78b84a6c37fa846134523a46e21f&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29
CI failure (variant 1): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108458&sha=c79ebbf375b04bea319369ed0efff2d275aae491&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.175` (included in `26.7` and later)
<!-- ch-version-info:end -->