### PR TITLE
Reuse already-built action nodes when building ActionsDAG from expressions

### DIFF
--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -524,7 +524,7 @@ public:
         return scope_node;
     }
 
-    [[maybe_unused]] bool containsNode(const std::string & node_name)
+    bool containsNode(const std::string & node_name)
     {
         return node_name_to_node.contains(node_name);
     }
@@ -1209,12 +1209,22 @@ PlannerActionsVisitorImpl::NodeNameAndNodeMinLevel PlannerActionsVisitorImpl::vi
     if (function_node.getFunctionName() == "exists")
         return visitExistsFunction(node);
 
+    auto function_node_name = action_node_name_helper.calculateActionNodeName(node);
+
+    /// Fast path for the no-lambda case: when there is a single actions scope, an expression that
+    /// has already been built can be reused as-is instead of re-traversing it. With the analyzer,
+    /// WITH-aliases are shared by pointer in the query tree (a DAG), so without this we would
+    /// re-visit shared subtrees once per reference, which is exponential for deeply nested aliases.
+    /// Keying on the action node name also reuses identical repeated subexpressions that are not
+    /// aliased. Lambda scopes (actions_stack.size() > 1) are intentionally excluded, because the
+    /// captured Levels must be recomputed per scope.
+    if (actions_stack.size() == 1 && actions_stack.front().containsNode(function_node_name))
+        return {function_node_name, Levels(0)};
+
     std::optional<NodeNameAndNodeMinLevel> in_function_second_argument_node_name_with_level;
 
     if (isNameOfInFunction(function_node.getFunctionName()))
         in_function_second_argument_node_name_with_level = makeSetForInFunction(node);
-
-    auto function_node_name = action_node_name_helper.calculateActionNodeName(node);
 
     /* Aggregate functions, window functions, and GROUP BY expressions were already analyzed in the previous steps.
      * If we have already visited some expression, we don't need to revisit it or its arguments again.

--- a/tests/performance/analyzer_nested_if_alias_chain.xml
+++ b/tests/performance/analyzer_nested_if_alias_chain.xml
@@ -1,0 +1,33 @@
+<test>
+    <!--
+        A chain of WITH-clause aliases where each alias is a deeply nested `if` expression that
+        references the previous alias several times (col2 uses col1 five times, col3 uses col2 five
+        times, ...). With the analyzer the aliases are shared by pointer in the query tree (a DAG),
+        so building the ActionsDAG used to re-traverse the shared subtrees once per reference, which
+        is exponential in the chain depth. `PlannerActionsVisitor::visitFunction` now reuses an
+        action node whose name already exists in the single actions scope instead of re-traversing
+        it, removing the exponential planner cost.
+
+        The input column is non-constant (so the chain is not constant-folded and the planner path
+        is actually exercised). Depth is kept moderate so the query stays sub-second.
+    -->
+    <settings>
+        <enable_analyzer>1</enable_analyzer>
+        <max_expanded_ast_elements>5000000000</max_expanded_ast_elements>
+    </settings>
+
+    <query><![CDATA[
+WITH
+    if(value = 10, 'A', if(value = 20, 'B', if(value = 30, 'C', if(value = 40, 'D', if(value = 50, 'E', 'F'))))) AS col1,
+    if(col1 = 'A', 'Alpha', if(col1 = 'B', 'Beta', if(col1 = 'C', 'Gamma', if(col1 = 'D', 'Delta', if(col1 = 'E', 'Epsilon', 'Other'))))) AS col2,
+    if(col2 = 'Alpha', 1, if(col2 = 'Beta', 2, if(col2 = 'Gamma', 3, if(col2 = 'Delta', 4, if(col2 = 'Epsilon', 5, 0))))) AS col3,
+    if(col3 = 1, 'One', if(col3 = 2, 'Two', if(col3 = 3, 'Three', if(col3 = 4, 'Four', if(col3 = 5, 'Five', 'Zero'))))) AS col4,
+    if(col4 = 'One', 'Uno', if(col4 = 'Two', 'Dos', if(col4 = 'Three', 'Tres', if(col4 = 'Four', 'Cuatro', if(col4 = 'Five', 'Cinco', 'Cero'))))) AS col5,
+    if(col5 = 'Uno', 'I', if(col5 = 'Dos', 'II', if(col5 = 'Tres', 'III', if(col5 = 'Cuatro', 'IV', if(col5 = 'Cinco', 'V', 'Other'))))) AS col6,
+    if(col6 = 'I', 'Primero', if(col6 = 'II', 'Segundo', if(col6 = 'III', 'Tercero', if(col6 = 'IV', 'Cuarto', if(col6 = 'V', 'Quinto', 'Otro'))))) AS col7
+SELECT col1, col2, col3, col4, col5, col6, col7
+FROM (SELECT number AS value FROM system.numbers LIMIT 100)
+FORMAT Null
+    ]]></query>
+
+</test>

--- a/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.reference
+++ b/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.reference
@@ -1,0 +1,11 @@
+A	Alpha	1	100	one	1.5
+B	Beta	2	200	two	2.5
+C	Gamma	3	300	three	3.5
+D	Delta	4	400	four	4.5
+E	Epsilon	5	500	five	5.5
+F	Other	0	0	zero	0.5
+0	0
+2	4
+4	8
+1	2
+3	6

--- a/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.reference
+++ b/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.reference
@@ -1,9 +1,9 @@
-A	Alpha	1	100	one	1.5
-B	Beta	2	200	two	2.5
-C	Gamma	3	300	three	3.5
-D	Delta	4	400	four	4.5
-E	Epsilon	5	500	five	5.5
-F	Other	0	0	zero	0.5
+A	Alpha	1
+B	Beta	2
+C	Gamma	3
+D	Delta	4
+E	Epsilon	5
+F	Other	0
 0	0
 2	4
 4	8

--- a/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.sql
+++ b/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.sql
@@ -1,0 +1,24 @@
+-- Guards planner action-DAG reuse of shared/repeated subexpressions under the analyzer.
+-- With enable_analyzer = 1, WITH-clause aliases are shared by pointer in the query tree (a DAG),
+-- and PlannerActionsVisitor::visitFunction reuses an action node whose name already exists in the
+-- single actions scope instead of re-traversing it. This test checks correctness (results unchanged)
+-- for (a) nested alias chains referencing the previous alias multiple times and (b) identical
+-- repeated subexpressions that are not aliased (common-subexpression reuse via the name key).
+SET enable_analyzer = 1;
+
+-- Query 1: nested if(...) alias chain over a non-constant value column.
+WITH
+    if(value = 10, 'A', if(value = 20, 'B', if(value = 30, 'C', if(value = 40, 'D', if(value = 50, 'E', 'F'))))) AS col1,
+    if(col1 = 'A', 'Alpha', if(col1 = 'B', 'Beta', if(col1 = 'C', 'Gamma', if(col1 = 'D', 'Delta', if(col1 = 'E', 'Epsilon', 'Other'))))) AS col2,
+    if(col2 = 'Alpha', 1, if(col2 = 'Beta', 2, if(col2 = 'Gamma', 3, if(col2 = 'Delta', 4, if(col2 = 'Epsilon', 5, 0))))) AS col3,
+    if(col3 = 1, 100, if(col3 = 2, 200, if(col3 = 3, 300, if(col3 = 4, 400, if(col3 = 5, 500, 0))))) AS col4,
+    if(col4 = 100, 'one', if(col4 = 200, 'two', if(col4 = 300, 'three', if(col4 = 400, 'four', if(col4 = 500, 'five', 'zero'))))) AS col5,
+    if(col5 = 'one', 1.5, if(col5 = 'two', 2.5, if(col5 = 'three', 3.5, if(col5 = 'four', 4.5, if(col5 = 'five', 5.5, 0.5))))) AS col6
+SELECT col1, col2, col3, col4, col5, col6
+FROM (SELECT arrayJoin([toUInt64(10), 20, 30, 40, 50, 999]) AS value)
+ORDER BY col1, col2, col3, col4, col5, col6;
+
+-- Query 2: identical repeated subexpression that is not aliased (name-keyed CSE reuse).
+SELECT (number * 7 % 5) AS e, (number * 7 % 5) + (number * 7 % 5)
+FROM numbers(5)
+ORDER BY number;

--- a/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.sql
+++ b/tests/queries/0_stateless/04411_planner_actions_visitor_shared_subexpr_reuse.sql
@@ -6,17 +6,19 @@
 -- repeated subexpressions that are not aliased (common-subexpression reuse via the name key).
 SET enable_analyzer = 1;
 
--- Query 1: nested if(...) alias chain over a non-constant value column.
+-- Query 1: nested if(...) alias chain over a non-constant value column. Each alias references the
+-- previous one several times, so col2 reuses the shared col1 node and col3 reuses the shared col2
+-- node. The chain is kept shallow on purpose: the analyzer's pass cost is exponential in the chain
+-- depth and is not affected by this change, so a deep chain only makes the test slow (it timed out
+-- in the TSan flaky check) without adding correctness coverage - the fast-path fires on any
+-- repeated reference, regardless of depth.
 WITH
     if(value = 10, 'A', if(value = 20, 'B', if(value = 30, 'C', if(value = 40, 'D', if(value = 50, 'E', 'F'))))) AS col1,
     if(col1 = 'A', 'Alpha', if(col1 = 'B', 'Beta', if(col1 = 'C', 'Gamma', if(col1 = 'D', 'Delta', if(col1 = 'E', 'Epsilon', 'Other'))))) AS col2,
-    if(col2 = 'Alpha', 1, if(col2 = 'Beta', 2, if(col2 = 'Gamma', 3, if(col2 = 'Delta', 4, if(col2 = 'Epsilon', 5, 0))))) AS col3,
-    if(col3 = 1, 100, if(col3 = 2, 200, if(col3 = 3, 300, if(col3 = 4, 400, if(col3 = 5, 500, 0))))) AS col4,
-    if(col4 = 100, 'one', if(col4 = 200, 'two', if(col4 = 300, 'three', if(col4 = 400, 'four', if(col4 = 500, 'five', 'zero'))))) AS col5,
-    if(col5 = 'one', 1.5, if(col5 = 'two', 2.5, if(col5 = 'three', 3.5, if(col5 = 'four', 4.5, if(col5 = 'five', 5.5, 0.5))))) AS col6
-SELECT col1, col2, col3, col4, col5, col6
+    if(col2 = 'Alpha', 1, if(col2 = 'Beta', 2, if(col2 = 'Gamma', 3, if(col2 = 'Delta', 4, if(col2 = 'Epsilon', 5, 0))))) AS col3
+SELECT col1, col2, col3
 FROM (SELECT arrayJoin([toUInt64(10), 20, 30, 40, 50, 999]) AS value)
-ORDER BY col1, col2, col3, col4, col5, col6;
+ORDER BY col1, col2, col3;
 
 -- Query 2: identical repeated subexpression that is not aliased (name-keyed CSE reuse).
 SELECT (number * 7 % 5) AS e, (number * 7 % 5) + (number * 7 % 5)


### PR DESCRIPTION
With the analyzer, `WITH`-clause expression aliases are shared by pointer in the
query tree (a DAG). When building the `ActionsDAG` for an expression,
`PlannerActionsVisitorImpl::visitFunction` re-traversed shared subtrees once per
reference. For deeply nested aliases — where each alias references the previous
one several times — this is exponential in the chain depth, so building the
`ActionsDAG` could dominate query planning time.

When there is a single actions scope (no lambda is being built), `visitFunction`
now reuses an action node whose name already exists in the scope instead of
re-traversing it. The `ActionsDAG` already de-duplicates added nodes via
`addFunctionIfNecessary`, so the resulting DAG is unchanged; this only avoids
redundant traversal and the hashing of large action node names. Keying on the
action node name additionally reuses identical repeated subexpressions that are
not aliased.

Measured on the deeply-nested-`if` repro from the report (same commit, with vs
without the change): query planning of the example dropped from ~14.5s to ~12.3s
with byte-identical results. This change does not touch the analyzer's pass
manager, which re-traverses the same shared DAG and remains the larger cost for
such queries (a separate follow-up).

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Speed up query planning under the analyzer for expressions that reference the same `WITH` alias or repeat the same subexpression many times (for example deeply nested `if`/`multiIf` chains), by not rebuilding shared subexpressions when constructing the actions DAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.115`
<!-- ch-version-info:end -->