### PR TITLE
Restore O(1) name-to-value lookup for String-to-Enum casts

### DIFF
--- a/src/DataTypes/EnumValues.cpp
+++ b/src/DataTypes/EnumValues.cpp
@@ -1,11 +1,11 @@
 #include <DataTypes/EnumValues.h>
 #include <boost/algorithm/string.hpp>
 #include <base/sort.h>
+#include <Common/HashTable/HashMap.h>
 #include <Core/Field.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <algorithm>
-#include <numeric>
 
 
 namespace DB
@@ -19,8 +19,12 @@ namespace ErrorCodes
 }
 
 template <typename T>
+class EnumValues<T>::NameToValueMap : public HashMap<std::string_view, T, StringViewHash> {};
+
+template <typename T>
 EnumValues<T>::EnumValues(const Values & values_, ValidationMode validation_mode)
     : values(values_)
+    , name_to_value_map(std::make_unique<NameToValueMap>())
 {
     if (values.empty())
         throw Exception(ErrorCodes::EMPTY_DATA_PASSED, "DataTypeEnum enumeration cannot be empty");
@@ -47,26 +51,15 @@ void EnumValues<T>::buildLookupStructures(ValidationMode validation_mode)
 {
     const size_t n = values.size();
 
-    /// Build name-sorted index for binary search on names
-    name_sorted_index.resize(n);
-    std::iota(name_sorted_index.begin(), name_sorted_index.end(), static_cast<uint16_t>(0));
-
-    ::sort(name_sorted_index.begin(), name_sorted_index.end(), [this](uint16_t a, uint16_t b)
+    /// Build O(1) exact name-to-value lookup (used by String-to-Enum casts) and check for duplicate names.
+    /// Keys are string_views into `values` names, which are stable for this object's lifetime.
+    name_to_value_map->reserve(n);
+    for (const auto & name_and_value : values)
     {
-        return values[a].first < values[b].first;
-    });
-
-    /// Check for duplicate names
-    for (size_t i = 1; i < n; ++i)
-    {
-        if (values[name_sorted_index[i - 1]].first == values[name_sorted_index[i]].first)
-        {
-            const auto & dup_name = values[name_sorted_index[i]].first;
+        const auto inserted = name_to_value_map->insert({std::string_view{name_and_value.first}, name_and_value.second});
+        if (!inserted.second)
             throw Exception(ErrorCodes::SYNTAX_ERROR, "Duplicate names in enum: '{}' = {} and {}",
-                    dup_name,
-                    toString(values[name_sorted_index[i - 1]].second),
-                    toString(values[name_sorted_index[i]].second));
-        }
+                    name_and_value.first, toString(name_and_value.second), toString(inserted.first->getMapped()));
     }
 
     /// `ADD ENUM VALUES` may temporarily rewrite a leading implicit prefix to `1..N`. These numbers are
@@ -184,13 +177,9 @@ T EnumValues<T>::getValue(std::string_view field_name) const
 template <typename T>
 bool EnumValues<T>::findValueByName(std::string_view field_name, T & result) const
 {
-    /// Binary search on name-sorted index
-    auto it = std::lower_bound(name_sorted_index.begin(), name_sorted_index.end(), field_name,
-        [this](uint16_t idx, std::string_view name) { return values[idx].first < name; });
-
-    if (it != name_sorted_index.end() && values[*it].first == field_name)
+    if (auto it = name_to_value_map->find(field_name); it != name_to_value_map->end())
     {
-        result = values[*it].second;
+        result = it->getMapped();
         return true;
     }
 
@@ -216,7 +205,9 @@ size_t EnumValues<T>::allocatedBytes() const
     size_t bytes = values.capacity() * sizeof(typename Values::value_type);
     for (const auto & [name, _] : values)
         bytes += name.capacity();
-    bytes += name_sorted_index.capacity() * sizeof(typename decltype(name_sorted_index)::value_type);
+    /// Hash-table buffer; the name strings themselves are accounted above (keys point into `values`).
+    if (name_to_value_map)
+        bytes += name_to_value_map->getBufferSizeInBytes();
     bytes += value_to_index.capacity() * sizeof(typename decltype(value_to_index)::value_type);
     return bytes;
 }

--- a/src/DataTypes/EnumValues.h
+++ b/src/DataTypes/EnumValues.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+#include <memory>
 #include <unordered_set>
 #include <string>
 #include <string_view>
@@ -13,7 +14,7 @@ namespace DB
 
 /// Compact enum storage with efficient lookups.
 /// - Strings stored in values vector (sorted by value for compatibility)
-/// - Name-to-value: binary search on sorted name index (O(log N))
+/// - Name-to-value: hash map (O(1)), used by String-to-Enum casts
 /// - Value-to-name: direct array lookup (O(1)) for small ranges, binary search for large ranges
 template <typename T>
 class EnumValues : public IHints<>
@@ -34,8 +35,11 @@ private:
     /// Original values sorted by numeric value (for getValues() compatibility)
     Values values;
 
-    /// Index into values, sorted by name (for binary search on names)
-    std::vector<uint16_t> name_sorted_index;
+    /// Exact name-to-value hash lookup used by String-to-Enum casts.
+    /// Keys are string_views into `values` names, whose storage is stable after construction.
+    /// Held by pointer (pimpl) to keep the heavy HashMap header out of this widely included file.
+    class NameToValueMap;
+    std::unique_ptr<NameToValueMap> name_to_value_map;
 
     /// Value-to-name lookup strategy.
     /// For Enum8: always direct (max 256 entries of `uint16_t` = 512 bytes).
@@ -67,7 +71,7 @@ public:
 
     /// Approximate number of heap-allocated bytes owned by this object:
     /// the `values` vector (including each name's string capacity) plus the
-    /// `name_sorted_index` and `value_to_index` lookup vectors.
+    /// `name_to_value_map` and `value_to_index` lookup structures.
     size_t allocatedBytes() const;
 
     /// Check if value exists in enum

--- a/tests/queries/0_stateless/04342_enum_string_lookup.reference
+++ b/tests/queries/0_stateless/04342_enum_string_lookup.reference
@@ -1,0 +1,16 @@
+LI
+OTHER
+LY
+min
+max
+LY
+LI
+1
+LY
+LY
+LY
+\N
+1000	3
+a	2
+b	1
+c	1

--- a/tests/queries/0_stateless/04342_enum_string_lookup.sql
+++ b/tests/queries/0_stateless/04342_enum_string_lookup.sql
@@ -1,0 +1,44 @@
+-- Exercises the EnumValues name<->value lookups behind String->Enum casts.
+-- Guards the lookup correctness restored together with the O(1) name->value map.
+
+-- Exact String->Enum name lookup, Enum8 and Enum16, including boundary values.
+SELECT 'LI'::Enum8('LI' = -128, 'OTHER' = 0, 'LY' = 127);
+SELECT 'OTHER'::Enum8('LI' = -128, 'OTHER' = 0, 'LY' = 127);
+SELECT 'LY'::Enum8('LI' = -128, 'OTHER' = 0, 'LY' = 127);
+SELECT 'min'::Enum16('min' = -32768, 'zero' = 0, 'max' = 32767);
+SELECT 'max'::Enum16('min' = -32768, 'zero' = 0, 'max' = 32767);
+
+-- Numeric-string fallback: a string that is not a name is parsed as the underlying value.
+SELECT '127'::Enum8('LI' = -128, 'LY' = 127);
+SELECT '-128'::Enum8('LI' = -128, 'LY' = 127);
+
+-- A name that looks numeric must be matched as a name, not parsed as a value.
+SELECT '1'::Enum8('1' = 42, '2' = 7);
+
+-- The lookup chokepoint is reached through wrapper types as well.
+SELECT CAST(materialize('LY'), 'Enum8(\'LI\' = -128, \'LY\' = 127)');
+SELECT CAST(toLowCardinality('LY'), 'Enum8(\'LI\' = -128, \'LY\' = 127)');
+SELECT CAST(CAST('LY', 'Nullable(String)'), 'Enum8(\'LI\' = -128, \'LY\' = 127)');
+SELECT CAST(CAST(NULL, 'Nullable(String)'), 'Nullable(Enum8(\'LI\' = -128, \'LY\' = 127))');
+
+-- Whole-column String->Enum cast (the path measured by the `enum` performance test).
+SELECT count(), countDistinct(e) FROM (
+    SELECT (number % 3 = 0 ? 'LI' : (number % 3 = 1 ? 'OTHER' : 'LY'))::Enum8('LI' = -128, 'OTHER' = 0, 'LY' = 127) AS e
+    FROM numbers(1000)
+);
+
+-- Unknown name fails, with a hint.
+SELECT 'ZZ'::Enum8('LI' = -128, 'LY' = 127); -- { serverError UNKNOWN_ELEMENT_OF_ENUM }
+
+-- Duplicate names / values are rejected at type construction time.
+SELECT CAST('a', 'Enum8(\'a\' = 1, \'a\' = 2)'); -- { serverError SYNTAX_ERROR }
+SELECT CAST('a', 'Enum8(\'a\' = 1, \'b\' = 1)'); -- { serverError SYNTAX_ERROR }
+
+-- containsAll: an extended enum contains the narrower one, so the data is preserved on ALTER.
+DROP TABLE IF EXISTS t_04342;
+CREATE TABLE t_04342 (x Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04342 VALUES ('a'), ('b'), ('a');
+ALTER TABLE t_04342 MODIFY COLUMN x Enum8('a' = 1, 'b' = 2, 'c' = 3);
+INSERT INTO t_04342 VALUES ('c');
+SELECT x, count() FROM t_04342 GROUP BY x ORDER BY x;
+DROP TABLE t_04342;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/108312
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/108312

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up `String`-to-`Enum` casts by restoring an O(1) name-to-value lookup in `EnumValues`. A `code::String::Enum8(...)`-style cast over many rows was up to several times slower since 26.6.

### Description

Reported in #108312 (cc reporter, automated bisect): the `enum` performance test, query 2 (`code_enum::String::Enum8(...)` over 10M rows, `max_threads = 1`) regressed about +233% on both ARM and AMD. Bisected to #95668.

Root cause: #95668 made `EnumValues` storage compact and, in doing so, replaced the `HashMap<string_view, T>` name-to-value lookup with a name-sorted index plus binary search in `findValueByName()`. For an enum with N names the lookup went from O(1) to O(log N) cache-unfriendly indirect string comparisons (each `values[idx].first` chases into the values vector), which dominates a whole-column String-to-Enum cast.

Fix: restore the O(1) exact name lookup with `HashMap<string_view, T, StringViewHash>`, kept behind a pimpl `unique_ptr` so the HashMap header stays out of the widely included `EnumValues.h`. The compact value-to-name direct array (`value_to_index`) added by #95668 is kept unchanged, so the value-to-name path and its memory savings are preserved. Duplicate-name detection now happens on map insertion (same error, same message). `name_sorted_index` is removed since it had no other users.

`findValueByName` is the single chokepoint for every name-to-value lookup (`getValue`, `tryGetValue`, `containsAll`), so there is no sibling path with the same slowdown. `getNameForValue` (value-to-name) is untouched.

Performance (local debug build, identical 10M-row table, `max_threads = 1`, 5 runs each, median; debug inflates absolute numbers, the relative recovery is the signal):

| Leg | before | after |
| --- | --- | --- |
| raw enum read | 0.25s | 0.24s |
| `enum -> String` | 0.32s | 0.32s |
| `Int8 -> Enum` | 0.29s | 0.27s |
| `String -> Enum` (regressed) | 1.15s | 0.46s |

Subtracting the read+startup floor, the String-to-Enum cast cost drops about 76%, matching the reporter's validated source variant (-77.31%). The other legs are unchanged. CI Performance Comparison will produce the authoritative release numbers.

Tests: added `04342_enum_string_lookup` (exact name lookup incl. boundary values, numeric-string fallback, numeric-looking names matched as names, casts through `materialize`/`LowCardinality`/`Nullable` wrappers, whole-column cast, unknown-name error, duplicate-name and duplicate-value errors, and `containsAll`/`ALTER MODIFY` enum extension). Existing enum and cast functional tests pass.

CI report for the regressed test: https://github.com/ClickHouse/ClickHouse/issues/108312 (bisect by automated tooling, introduced at `42010f7a15dc`).
