### PR TITLE
Fix flaky test_distributed_frozen_replica: pin lightweight_deletes_sync on DELETE

### DIFF
--- a/tests/integration/test_distributed_frozen_replica/test.py
+++ b/tests/integration/test_distributed_frozen_replica/test.py
@@ -129,7 +129,13 @@ def test_distributed_query(
     # Stop fetches on node2 so that it will be considered stale and node1 is tried first
     node2.query("SYSTEM STOP FETCHES")
     try:
-        node1.query("DELETE FROM local_table WHERE i = 5")
+        # lightweight_deletes_sync defaults to 2 (wait on all replicas); node2 is
+        # deliberately stalled above, so the default would block until node2 applies
+        # the mutation. Wait only on node1 (=1) to keep node2 stale, as intended.
+        node1.query(
+            "DELETE FROM local_table WHERE i = 5",
+            settings={"lightweight_deletes_sync": 1},
+        )
         node1.query("INSERT INTO local_table VALUES (5, now())")
         time.sleep(10)
         assert (
@@ -188,7 +194,13 @@ def test_distributed_query_network_timeout(
     # Stop fetches on node2 so that it will be considered stale and node1 is tried first
     node2.query("SYSTEM STOP FETCHES")
     try:
-        node1.query("DELETE FROM local_table WHERE i = 5")
+        # lightweight_deletes_sync defaults to 2 (wait on all replicas); node2 is
+        # deliberately stalled above, so the default would block until node2 applies
+        # the mutation. Wait only on node1 (=1) to keep node2 stale, as intended.
+        node1.query(
+            "DELETE FROM local_table WHERE i = 5",
+            settings={"lightweight_deletes_sync": 1},
+        )
         node1.query("INSERT INTO local_table VALUES (5, now())")
         time.sleep(10)
         assert (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/issues/104443


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_distributed_query` and `test_distributed_query_network_timeout` in `test_distributed_frozen_replica` stop fetches on `node2` to keep it stale, then run a lightweight `DELETE` on `node1`. The `DELETE` inherits `lightweight_deletes_sync=2` (the default), which `InterpreterDeleteQuery` maps to `mutations_sync=2`, so `StorageReplicatedMergeTree::waitMutation` waits for the mutation to finish on all replicas - including the deliberately-stalled `node2`. When `node2` cannot promptly apply the mutation, `node1`'s `DELETE` blocks until the 600s client timeout and the test fails.

Pin `lightweight_deletes_sync=1` on these two `DELETE`s so they wait only on `node1`. This keeps `node2` stale as the tests intend (they assert `absolute_delay >= 5` and exercise `node3`'s distributed query against the stale/paused replica).

Reproduced deterministically with a 2-replica `ReplicatedMergeTree`: with the second replica's queue stopped, the `DELETE` hangs at `sync=2` and returns immediately at `sync=1`.

CIDB: this `[3-distributed_table]` signature is a 600s client timeout on the `DELETE` line, seen on master (2026-06-24, `Integration tests (arm_binary, distributed plan, 2/4)`) and PR runs. Report example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101841&sha=7269edeb1d85b2366f49792a5c79af0d88bf95d6&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.178` (included in `26.7` and later)
<!-- ch-version-info:end -->