### PR TITLE
Document missing SYSTEM cache statements

### DIFF
--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -97,6 +97,11 @@ For more convenient (automatic) cache management, see `disable_internal_dns_cach
 
 Clears the mark cache.
 
+## SYSTEM CLEAR|DROP PRIMARY INDEX CACHE {#drop-primary-index-cache}
+
+Clears the primary index cache, which holds the primary keys of [`MergeTree`](../../engines/table-engines/mergetree-family/mergetree.md) tables in memory.
+Its size is configured with the server-level setting [`primary_index_cache_size`](../../operations/server-configuration-parameters/settings.md#primary_index_cache_size).
+
 ## SYSTEM CLEAR|DROP ICEBERG METADATA CACHE {#drop-iceberg-metadata-cache}
 
 Clears the iceberg metadata cache.
@@ -111,13 +116,85 @@ Clears the parquet metadata cache.
 
 ## SYSTEM CLEAR|DROP TEXT INDEX CACHES {#drop-text-index-caches}
 
-Clears the text index's header, dictionary and postings caches.
+Clears the text index's tokens, header and postings caches.
 
 If you like to drop one of these caches individually, you can run
 
-- `SYSTEM CLEAR TEXT INDEX HEADER CACHE`,
-- `SYSTEM CLEAR TEXT INDEX DICTIONARY CACHE`, or
+- `SYSTEM CLEAR TEXT INDEX TOKENS CACHE`,
+- `SYSTEM CLEAR TEXT INDEX HEADER CACHE`, or
 - `SYSTEM CLEAR TEXT INDEX POSTINGS CACHE`
+
+## SYSTEM CLEAR|DROP INDEX MARK CACHE {#drop-index-mark-cache}
+
+Clears the cache of marks for secondary (data-skipping) indexes.
+
+## SYSTEM CLEAR|DROP INDEX UNCOMPRESSED CACHE {#drop-index-uncompressed-cache}
+
+Clears the cache of uncompressed blocks for secondary (data-skipping) indexes.
+
+## SYSTEM CLEAR|DROP MMAP CACHE {#drop-mmap-cache}
+
+Clears the cache of memory-mapped files.
+
+## SYSTEM CLEAR|DROP PAGE CACHE {#drop-page-cache}
+
+Clears the userspace page cache, ClickHouse's own in-memory cache of data read from the underlying storage.
+
+## SYSTEM CLEAR|DROP VECTOR SIMILARITY INDEX CACHE {#drop-vector-similarity-index-cache}
+
+Clears the vector similarity index cache.
+
+## SYSTEM CLEAR|DROP CONNECTIONS CACHE {#drop-connections-cache}
+
+Clears the cache of HTTP connection pools used for outgoing connections.
+
+## SYSTEM CLEAR|DROP S3 CLIENT CACHE {#drop-s3-client-cache}
+
+Clears the cache of S3 clients.
+
+## SYSTEM PREWARM MARK CACHE {#prewarm-mark-cache}
+
+Loads the marks of a table into the [mark cache](#drop-mark-cache).
+
+```sql
+SYSTEM PREWARM MARK CACHE [ON CLUSTER cluster_name] [db.]table
+```
+
+## SYSTEM PREWARM PRIMARY INDEX CACHE {#prewarm-primary-index-cache}
+
+Loads the primary indexes of a `MergeTree` table into the [primary index cache](#drop-primary-index-cache).
+
+```sql
+SYSTEM PREWARM PRIMARY INDEX CACHE [ON CLUSTER cluster_name] [db.]table
+```
+
+## SYSTEM CLEAR|DROP DISK METADATA CACHE {#drop-disk-metadata-cache}
+
+Clears the metadata cache of the specified disk.
+
+```sql
+SYSTEM DROP DISK METADATA CACHE <disk_name>
+```
+
+## SYSTEM SYNC FILESYSTEM CACHE {#sync-filesystem-cache}
+
+Reconciles ClickHouse's in-memory state of the filesystem cache with the cache files actually present on disk, and returns the `cache_name`, `path` and downloaded `size` of each cached file segment. An optional cache name limits the operation to a single cache.
+
+```sql
+SYSTEM SYNC FILESYSTEM CACHE [<cache_name>]
+```
+
+## SYSTEM CLEAR|DROP DISTRIBUTED CACHE {#drop-distributed-cache}
+
+:::note
+`SYSTEM CLEAR|DROP DISTRIBUTED CACHE` is available only in ClickHouse Cloud.
+:::
+
+Drops the distributed cache. Use `CONNECTIONS` to drop only the cached connections to the distributed cache servers, or pass a server identifier to target a single server.
+
+```sql
+SYSTEM DROP DISTRIBUTED CACHE [CONNECTIONS | 'server_id']
+```
 
 ## SYSTEM DROP REPLICA {#drop-replica}
 

--- a/docs/en/sql-reference/statements/system.md
+++ b/docs/en/sql-reference/statements/system.md
@@ -154,7 +154,7 @@ Clears the cache of S3 clients.
 
 ## SYSTEM PREWARM MARK CACHE {#prewarm-mark-cache}
 
-Loads the marks of a table into the [mark cache](#drop-mark-cache).
+Loads the marks of a table into the [mark cache](#drop-mark-cache). Secondary-index marks are also loaded into the [index mark cache](#drop-index-mark-cache).
 
 ```sql
 SYSTEM PREWARM MARK CACHE [ON CLUSTER cluster_name] [db.]table
@@ -181,7 +181,7 @@ SYSTEM DROP DISK METADATA CACHE <disk_name>
 Reconciles ClickHouse's in-memory state of the filesystem cache with the cache files actually present on disk, and returns the `cache_name`, `path` and downloaded `size` of each cached file segment. An optional cache name limits the operation to a single cache.
 
 ```sql
-SYSTEM SYNC FILESYSTEM CACHE [<cache_name>]
+SYSTEM SYNC FILESYSTEM CACHE ['<cache_name>']
 ```
 
 ## SYSTEM CLEAR|DROP DISTRIBUTED CACHE {#drop-distributed-cache}


### PR DESCRIPTION
## What

[DOC-848](https://github.com/ClickHouse/clickhouse-docs/issues/...) reported that `SYSTEM DROP PRIMARY INDEX CACHE` was missing from the [system statements docs](https://clickhouse.com/docs/sql-reference/statements/system). While adding it, I swept the `SYSTEM` command enum against the docs and found **13** undocumented cache commands in total, so this PR documents the whole set.

Added sections:

- **Drops:** `PRIMARY INDEX CACHE`, `INDEX MARK CACHE`, `INDEX UNCOMPRESSED CACHE`, `MMAP CACHE`, `PAGE CACHE`, `VECTOR SIMILARITY INDEX CACHE`, `CONNECTIONS CACHE`, `S3 CLIENT CACHE`
- **Prewarm:** `PREWARM MARK CACHE`, `PREWARM PRIMARY INDEX CACHE` (with `[ON CLUSTER] db.table` syntax)
- **Other shapes:** `DISK METADATA CACHE` (targets a disk), `SYNC FILESYSTEM CACHE` (returns a result set), `DROP DISTRIBUTED CACHE` (ClickHouse Cloud, with a Cloud-only note)

Also fixes the existing **TEXT INDEX CACHES** section: it referred to a "dictionary" cache, but the code clears a **tokens** cache (`clearTextIndexTokensCache`).

## How it was verified

- Command names, verbs (`CLEAR`/`DROP` synonyms), and syntax from `src/Parsers/ParserSystemQuery.cpp`.
- Behavior from the handlers in `src/Interpreters/InterpreterSystemQuery.cpp`.

One caveat: `DROP DISTRIBUTED CACHE` has no open-source execution handler (it's a ClickHouse Cloud feature), so it's documented from its parser syntax + Cloud-only status with a conservative description — worth a Cloud-team sanity check on the wording.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.314` (included in `26.7` and later)
<!-- ch-version-info:end -->