### PR TITLE
Fix function property stress test scale-blind validity gate and changeDate result scale

### DIFF
--- a/src/Columns/tests/gtest_validate_column_type.cpp
+++ b/src/Columns/tests/gtest_validate_column_type.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/validateColumnType.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypesDecimal.h>
+
+using namespace DB;
+
+/// columnMatchesType is the property fuzzer's validity gate (gtest_functions_stress.cpp).
+/// getDataType() reports only the physical TypeIndex (Decimal64 for any DateTime64 scale), so
+/// without strict_decimal_scale a scale-7 column passes against a DateTime64(3) type, gets
+/// stashed, and is later reused as an argument, surfacing the writeSlice LOGICAL_ERROR in an
+/// innocent consumer (issue #108517). strict_decimal_scale rejects it at the producer's gate.
+
+namespace
+{
+
+ColumnPtr makeDateTime64Column(UInt32 scale, size_t rows)
+{
+    auto col = ColumnDecimal<DateTime64>::create(0, scale);
+    for (size_t i = 0; i < rows; ++i)
+        col->insertDefault();
+    return col;
+}
+
+ColumnPtr makeDateTime64Array(UInt32 element_scale, size_t elements)
+{
+    auto data = ColumnDecimal<DateTime64>::create(0, element_scale);
+    for (size_t i = 0; i < elements; ++i)
+        data->insertDefault();
+
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert(elements);
+    return ColumnArray::create(std::move(data), std::move(offsets));
+}
+
+}
+
+TEST(ValidateColumnType, DecimalScaleDivergence)
+{
+    auto type_dt64_3 = std::make_shared<DataTypeDateTime64>(3);
+
+    auto matching = makeDateTime64Column(3, 4);
+    auto divergent = makeDateTime64Column(7, 4);
+
+    /// Scale is ignored by default, so the divergent column passes (engine callers rely on this).
+    EXPECT_TRUE(columnMatchesType(*matching, *type_dt64_3));
+    EXPECT_TRUE(columnMatchesType(*divergent, *type_dt64_3));
+
+    /// Strict mode compares scale: the matching column still passes, the divergent one is rejected.
+    EXPECT_TRUE(columnMatchesType(*matching, *type_dt64_3, /*strict_decimal_scale=*/ true));
+    EXPECT_FALSE(columnMatchesType(*divergent, *type_dt64_3, /*strict_decimal_scale=*/ true));
+}
+
+TEST(ValidateColumnType, DecimalScaleDivergenceNested)
+{
+    /// The divergence reaches the gate nested inside Array(DateTime64(3)) (the exact #108517 shape).
+    auto array_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime64>(3));
+
+    auto matching_array = makeDateTime64Array(3, 2);
+    auto divergent_array = makeDateTime64Array(7, 2);
+
+    EXPECT_TRUE(columnMatchesType(*matching_array, *array_type));
+    EXPECT_TRUE(columnMatchesType(*divergent_array, *array_type));
+
+    EXPECT_TRUE(columnMatchesType(*matching_array, *array_type, /*strict_decimal_scale=*/ true));
+    EXPECT_FALSE(columnMatchesType(*divergent_array, *array_type, /*strict_decimal_scale=*/ true));
+}

--- a/src/Columns/validateColumnType.cpp
+++ b/src/Columns/validateColumnType.cpp
@@ -1,6 +1,7 @@
 #include <Columns/validateColumnType.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
@@ -13,11 +14,50 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeVariant.h>
+#include <DataTypes/DataTypesDecimal.h>
+
+#include <optional>
 
 namespace DB
 {
 
-bool columnMatchesType(const IColumn & column, const IDataType & type)
+namespace
+{
+
+/// A Decimal/DateTime64/Time64 column carries its scale in the column object, but
+/// getDataType() reports only the physical TypeIndex (Decimal32/64/128/256), which is the
+/// same for every scale. So the top-level TypeIndex check passes a scale-7 column against a
+/// DateTime64(3) type. Compare the column's own scale against the type's declared scale.
+bool decimalScaleMatches(const IColumn & col, const IDataType & type)
+{
+    auto type_scale = tryGetDecimalScale(type);
+    if (!type_scale)
+        return true; /// Not a decimal-backed type.
+
+    std::optional<UInt32> col_scale;
+    if (const auto * c32 = typeid_cast<const ColumnDecimal<Decimal32> *>(&col))
+        col_scale = c32->getScale();
+    else if (const auto * c64 = typeid_cast<const ColumnDecimal<Decimal64> *>(&col))
+        col_scale = c64->getScale();
+    else if (const auto * c128 = typeid_cast<const ColumnDecimal<Decimal128> *>(&col))
+        col_scale = c128->getScale();
+    else if (const auto * c256 = typeid_cast<const ColumnDecimal<Decimal256> *>(&col))
+        col_scale = c256->getScale();
+    else if (const auto * cdt = typeid_cast<const ColumnDecimal<DateTime64> *>(&col))
+        col_scale = cdt->getScale();
+    else if (const auto * ctime = typeid_cast<const ColumnDecimal<Time64> *>(&col))
+        col_scale = ctime->getScale();
+
+    /// TypeIndex already matched, so a non-ColumnDecimal here should not happen; do not over-reject.
+    if (!col_scale)
+        return true;
+
+    return *col_scale == *type_scale;
+}
+
+}
+
+bool columnMatchesType(const IColumn & column, const IDataType & type, bool strict_decimal_scale)
 {
     const IColumn * col = &column;
 
@@ -30,17 +70,20 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
     if (col->getDataType() != type.getColumnType())
         return false;
 
+    if (strict_decimal_scale && !decimalScaleMatches(*col, type))
+        return false;
+
     if (const auto * col_array = typeid_cast<const ColumnArray *>(col))
     {
         if (const auto * type_array = typeid_cast<const DataTypeArray *>(&type))
-            return columnMatchesType(col_array->getData(), *type_array->getNestedType());
+            return columnMatchesType(col_array->getData(), *type_array->getNestedType(), strict_decimal_scale);
         return false;
     }
 
     if (const auto * col_nullable = typeid_cast<const ColumnNullable *>(col))
     {
         if (const auto * type_nullable = typeid_cast<const DataTypeNullable *>(&type))
-            return columnMatchesType(col_nullable->getNestedColumn(), *type_nullable->getNestedType());
+            return columnMatchesType(col_nullable->getNestedColumn(), *type_nullable->getNestedType(), strict_decimal_scale);
         return false;
     }
 
@@ -52,7 +95,7 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
             if (col_tuple->tupleSize() != type_elements.size())
                 return false;
             for (size_t i = 0; i < col_tuple->tupleSize(); ++i)
-                if (!columnMatchesType(col_tuple->getColumn(i), *type_elements[i]))
+                if (!columnMatchesType(col_tuple->getColumn(i), *type_elements[i], strict_decimal_scale))
                     return false;
             return true;
         }
@@ -62,14 +105,14 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
     if (const auto * col_map = typeid_cast<const ColumnMap *>(col))
     {
         if (const auto * type_map = typeid_cast<const DataTypeMap *>(&type))
-            return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType());
+            return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType(), strict_decimal_scale);
         return false;
     }
 
     if (const auto * col_lc = typeid_cast<const ColumnLowCardinality *>(col))
     {
         if (const auto * type_lc = typeid_cast<const DataTypeLowCardinality *>(&type))
-            return columnMatchesType(*col_lc->getDictionary().getNestedColumn(), *type_lc->getDictionaryType());
+            return columnMatchesType(*col_lc->getDictionary().getNestedColumn(), *type_lc->getDictionaryType(), strict_decimal_scale);
         return false;
     }
 
@@ -81,7 +124,7 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
             if (col_variant->getVariants().size() != type_variants.size())
                 return false;
             for (size_t i = 0; i < type_variants.size(); ++i)
-                if (!columnMatchesType(col_variant->getVariantByGlobalDiscriminator(i), *type_variants[i]))
+                if (!columnMatchesType(col_variant->getVariantByGlobalDiscriminator(i), *type_variants[i], strict_decimal_scale))
                     return false;
             return true;
         }

--- a/src/Columns/validateColumnType.h
+++ b/src/Columns/validateColumnType.h
@@ -10,6 +10,12 @@ namespace DB
 /// Returns true if the column is compatible with the type, false otherwise.
 /// This goes deeper than comparing top-level TypeIndex values: it recurses
 /// into Array, Nullable, Tuple, and Map to verify nested element types.
-bool columnMatchesType(const IColumn & column, const IDataType & type);
+///
+/// With strict_decimal_scale, a Decimal/DateTime64/Time64 column must also have the
+/// same scale as the type (getDataType() alone is scale-blind: every scale maps to the
+/// same physical TypeIndex). Off by default because a scale-divergent column behaves
+/// correctly almost everywhere; the property fuzzer enables it to reject such a column at
+/// the producing function's gate before stashing and reusing it.
+bool columnMatchesType(const IColumn & column, const IDataType & type, bool strict_decimal_scale = false);
 
 }

--- a/src/Functions/changeDate.cpp
+++ b/src/Functions/changeDate.cpp
@@ -107,9 +107,12 @@ public:
         typename ResultDataType::ColumnType::MutablePtr result_col;
         if constexpr (std::is_same_v<ResultDataType, DataTypeDateTime64>)
         {
-            auto scale = DataTypeDateTime64::default_scale;
-            if constexpr (std::is_same_v<InputDataType, DateTime64>)
-                scale = static_cast<UInt8>(typeid_cast<const DataTypeDateTime64 &>(*result_type).getScale());
+            /// result_type is the DataTypeDateTime64 this function returns (the input type for a
+            /// DateTime64 input, or DateTime64(default_scale) for a Date32 input), so its scale is
+            /// the scale the result column must carry. The result data is already computed at this
+            /// scale below; the column object must declare the same scale, otherwise it is
+            /// structurally inconsistent with its type (a scale-3 column labelled DateTime64(8)).
+            const auto scale = typeid_cast<const DataTypeDateTime64 &>(*result_type).getScale();
             result_col = ResultDataType::ColumnType::create(input_rows_count, scale);
         }
         else

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1667,8 +1667,12 @@ struct FunctionsStressTestThread
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned nullptr column");
         if (column->size() != expected_rows)
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned unexpected number of rows: {} instead of {}", column->size(), expected_rows);
-        if (!columnMatchesType(*column, *data_type))
-            throw Exception(ErrorCodes::INCORRECT_DATA, "function returned column of unexpected type: {} instead of {}", column->getName(), data_type->getName());
+        /// strict_decimal_scale also rejects a Decimal/DateTime64/Time64 column whose physical
+        /// scale diverges from its declared type. Such a column is structurally inconsistent and,
+        /// if stashed and reused as a later argument, surfaces as a misattributed LOGICAL_ERROR in
+        /// an innocent consumer (e.g. arrayPush's generic writeSlice). Reject it at the producer.
+        if (!columnMatchesType(*column, *data_type, /*strict_decimal_scale=*/ true))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "function returned column of unexpected type or scale: {} instead of {}", column->getName(), data_type->getName());
 
         auto apply = [&](IColumn & col)
         {

--- a/src/Functions/timeSlots.cpp
+++ b/src/Functions/timeSlots.cpp
@@ -275,7 +275,7 @@ public:
             std::max(start_time_scale, duration_scale), extractTimeZoneNameFromFunctionArguments(arguments, 3, 0, false)));
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         if (WhichDataType(arguments[0].type).isDateTime())
         {
@@ -352,7 +352,16 @@ public:
             const auto start_time_scale = assert_cast<const DataTypeDateTime64 *>(arguments[0].type.get())->getScale();
             const auto duration_scale = assert_cast<const DataTypeDecimal64 *>(arguments[1].type.get())->getScale();
 
-            auto res = ColumnArray::create(DataTypeDateTime64(start_time_scale).createColumn());
+            /// The result element scale is max(start_time_scale, duration_scale) as declared by
+            /// getReturnTypeImpl; read it from result_type so the column object always carries the
+            /// scale of its declared type. Building the column at start_time_scale alone leaves a
+            /// scale-N values column labelled DateTime64(M) when duration_scale > start_time_scale,
+            /// a structural inconsistency invisible in SQL output but rejected by structure-sensitive
+            /// consumers such as array push/concat.
+            const auto result_scale = assert_cast<const DataTypeDateTime64 &>(
+                *assert_cast<const DataTypeArray &>(*result_type).getNestedType()).getScale();
+
+            auto res = ColumnArray::create(DataTypeDateTime64(result_scale).createColumn());
             DataTypeDateTime64::ColumnType::Container & res_values = typeid_cast<DataTypeDateTime64::ColumnType &>(res->getData()).getData();
 
             if (starts && durations)

--- a/src/Functions/timeSlots.cpp
+++ b/src/Functions/timeSlots.cpp
@@ -271,8 +271,14 @@ public:
 
         auto start_time_scale = assert_cast<const DataTypeDateTime64 &>(*arguments[0].type).getScale();
         auto duration_scale = assert_cast<const DataTypeDecimal64 &>(*arguments[1].type).getScale();
+        auto result_scale = std::max(start_time_scale, duration_scale);
+        /// The optional Size argument also participates in value rescaling (executeImpl uses the
+        /// highest scale among all arguments), so its scale must be included in the declared return
+        /// scale; otherwise the result column holds values at a larger scale than its declared type.
+        if (arguments.size() == 3)
+            result_scale = std::max(result_scale, assert_cast<const DataTypeDecimal64 &>(*arguments[2].type).getScale());
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime64>(
-            std::max(start_time_scale, duration_scale), extractTimeZoneNameFromFunctionArguments(arguments, 3, 0, false)));
+            result_scale, extractTimeZoneNameFromFunctionArguments(arguments, 3, 0, false)));
     }
 
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
@@ -1,0 +1,12 @@
+changeSecond scale 7 into arrayPushBack
+['2020-01-01 00:00:00.0000000','2020-01-01 12:00:30.0000000']
+changeMinute scale 7 into arrayPushFront
+['2020-01-01 12:45:00.0000000','2020-01-01 00:00:00.0000000']
+changeHour scale 1 into arrayConcat
+['2020-01-01 00:00:00.0','2020-01-01 05:00:00.0']
+changeDay scale 6 into arrayPushBack
+['2020-01-01 00:00:00.000000','2020-01-20 12:00:00.000000']
+changeMonth scale 5 into arrayPushFront
+['2020-06-01 12:00:00.00000','2020-01-01 00:00:00.00000']
+result column scale matches declared type
+DateTime64(7)

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
@@ -10,3 +10,11 @@ changeMonth scale 5 into arrayPushFront
 ['2020-06-01 12:00:00.00000','2020-01-01 00:00:00.00000']
 result column scale matches declared type
 DateTime64(7)
+timeSlots start scale 1, duration scale 5 into arrayConcat
+['2012-01-01 12:00:00.00000','2012-01-01 12:30:00.00000','2000-01-01 00:00:00.00000']
+timeSlots start scale 2, duration scale 6 into arrayPushBack
+['2000-01-01 00:00:00.000000','2012-01-01 12:00:00.000000']
+timeSlots constant start, duration scale 4 column into arrayConcat
+['2012-01-01 12:00:00.0000','2012-01-01 12:30:00.0000','2000-01-01 00:00:00.0000']
+timeSlots result column scale matches declared type
+Array(DateTime64(5))

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
@@ -18,3 +18,9 @@ timeSlots constant start, duration scale 4 column into arrayConcat
 ['2012-01-01 12:00:00.0000','2012-01-01 12:30:00.0000','2000-01-01 00:00:00.0000']
 timeSlots result column scale matches declared type
 Array(DateTime64(5))
+timeSlots size scale largest: value at scale 4
+['1970-01-01 00:00:01.0000','1970-01-01 00:00:01.5000','1970-01-01 00:00:02.0000']
+timeSlots size scale largest: type is Array(DateTime64(4))
+Array(DateTime64(4, \'UTC\'))
+timeSlots size scale largest into arrayConcat
+['1970-01-01 00:00:01.0000','1970-01-01 00:00:01.5000','1970-01-01 00:00:02.0000','2000-01-01 00:00:00.0000']

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
@@ -42,3 +42,18 @@ SELECT arrayConcat(timeSlots(toDateTime64('2012-01-01 12:20:00', 1), materialize
 
 SELECT 'timeSlots result column scale matches declared type';
 SELECT toTypeName(timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 1)), toDecimal64(600, 5)));
+
+-- The optional Size (3rd) argument also participates in value rescaling, so its scale must be
+-- included in the declared return scale. getReturnTypeImpl used to declare only
+-- max(start_scale, duration_scale), so when the Size scale was the largest the values were
+-- computed at the larger scale but the column declared the smaller one, returning wrong
+-- timestamps (and reaching writeSlice through a structure-sensitive consumer).
+
+SELECT 'timeSlots size scale largest: value at scale 4';
+SELECT timeSlots(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC'), toDecimal64(1, 1), toDecimal64(0.5, 4));
+
+SELECT 'timeSlots size scale largest: type is Array(DateTime64(4))';
+SELECT toTypeName(timeSlots(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC'), toDecimal64(1, 1), toDecimal64(0.5, 4)));
+
+SELECT 'timeSlots size scale largest into arrayConcat';
+SELECT arrayConcat(timeSlots(materialize(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC')), toDecimal64(1, 1), toDecimal64(0.5, 4)), [toDateTime64('2000-01-01 00:00:00', 4, 'UTC')]);

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
@@ -1,0 +1,26 @@
+-- Regression test for issue #108517. changeYear/changeMonth/changeDay/changeHour/
+-- changeMinute/changeSecond over DateTime64(N) used to build the result column with the
+-- hardcoded default scale 3 instead of N, so a result declared DateTime64(N != 3) carried a
+-- physically scale-3 column. Feeding it into a structure-sensitive consumer (arrayPushBack /
+-- arrayPushFront / arrayConcat over Array(DateTime64(N))) skips the cast on declared-type
+-- equality and reaches the generic writeSlice, whose ColumnDecimal::structureEquals throws a
+-- LOGICAL_ERROR on the scale mismatch. materialize() prevents constant folding so the divergent
+-- column actually reaches the array function.
+
+SELECT 'changeSecond scale 7 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2020-01-01 00:00:00', 7)], changeSecond(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 30));
+
+SELECT 'changeMinute scale 7 into arrayPushFront';
+SELECT arrayPushFront([toDateTime64('2020-01-01 00:00:00', 7)], changeMinute(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 45));
+
+SELECT 'changeHour scale 1 into arrayConcat';
+SELECT arrayConcat([toDateTime64('2020-01-01 00:00:00', 1)], [changeHour(materialize(toDateTime64('2020-01-01 12:00:00', 1)), 5)]);
+
+SELECT 'changeDay scale 6 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2020-01-01 00:00:00', 6)], changeDay(materialize(toDateTime64('2020-01-15 12:00:00', 6)), 20));
+
+SELECT 'changeMonth scale 5 into arrayPushFront';
+SELECT arrayPushFront([toDateTime64('2020-01-01 00:00:00', 5)], changeMonth(materialize(toDateTime64('2020-01-01 12:00:00', 5)), 6));
+
+SELECT 'result column scale matches declared type';
+SELECT toTypeName(changeSecond(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 30));

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
@@ -24,3 +24,21 @@ SELECT arrayPushFront([toDateTime64('2020-01-01 00:00:00', 5)], changeMonth(mate
 
 SELECT 'result column scale matches declared type';
 SELECT toTypeName(changeSecond(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 30));
+
+-- Same producer bug class in timeSlots: getReturnTypeImpl declares
+-- Array(DateTime64(max(start_scale, duration_scale))) but executeImpl built the values column
+-- at start_scale only, so a duration with a larger scale produced a result column whose physical
+-- scale was below its declared type. The same structure-sensitive consumers reach writeSlice and
+-- throw. Read the scale from result_type so the column always matches its declared type.
+
+SELECT 'timeSlots start scale 1, duration scale 5 into arrayConcat';
+SELECT arrayConcat(timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 1)), toDecimal64(600, 5)), [toDateTime64('2000-01-01 00:00:00', 5)]);
+
+SELECT 'timeSlots start scale 2, duration scale 6 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2000-01-01 00:00:00', 6)], (timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 2)), toDecimal64(600, 6)))[1]);
+
+SELECT 'timeSlots constant start, duration scale 4 column into arrayConcat';
+SELECT arrayConcat(timeSlots(toDateTime64('2012-01-01 12:20:00', 1), materialize(toDecimal64(600, 4))), [toDateTime64('2000-01-01 00:00:00', 4)]);
+
+SELECT 'timeSlots result column scale matches declared type';
+SELECT toTypeName(timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 1)), toDecimal64(600, 5)));


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/108517
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `changeYear`/`changeMonth`/`changeDay`/`changeHour`/`changeMinute`/`changeSecond` over a `DateTime64(N)` argument creating the result column with the hardcoded default scale (3) instead of `N`. The values were computed at scale `N` but the column object declared scale 3, leaving it structurally inconsistent with its type.


### Description

Closes #108517.

Retargeted after review (https://github.com/ClickHouse/ClickHouse/pull/108551#issuecomment-4824782869): the `writeSlice` `LOGICAL_ERROR` is correct (it asserts a state that cannot arise from SQL), and the Function Stress Test's validity gate was wrong.

The function property stress test (`gtest_functions_stress`) validates every `(column, type)` pair it holds with `columnMatchesType`. For `Decimal`/`DateTime64`/`Time64` that check compared only `getDataType()` (the physical `TypeIndex`, `Decimal64` for every scale), so a column whose physical scale diverged from its declared type passed the gate, was stashed in `additional_random_values`, and was reused as a later argument, surfacing as a misattributed `writeSlice` `LOGICAL_ERROR` in an innocent consumer such as `arrayPush`.

`columnMatchesType` gains an opt-in `strict_decimal_scale` argument. The default keeps the prior behavior, so the engine callers (`resolveFunction`, `ColumnFunction::reduce`, `ExpressionActions`, `ActionsDAG`) are unchanged; the stress test passes `true`, rejecting a scale-divergent column at the producing function's own gate.

That strict gate immediately caught a real producer: the `change*` date/time functions over `DateTime64(N)` created the result column with the hardcoded `default_scale` (3) instead of `N`, because `if constexpr (std::is_same_v<InputDataType, DateTime64>)` compared a `DataType` class against a value-type alias and was always false. The data was computed at scale `N` (so normal SQL output looked correct, since formatting uses the type's scale), but the column object declared scale 3. The scale is now read from `result_type`, which is correct for both the `DateTime64` and `Date32` result paths.

The original SQL repro cannot construct the divergent column (the analyzer unifies operands to the least supertype before execution), so the regression coverage is a focused unit test of the gate itself (`gtest_validate_column_type`): with `strict_decimal_scale` a scale-7 column labelled `DateTime64(3)` is rejected, both at top level and nested inside `Array(DateTime64(3))`; without it (the engine default) it is accepted. The `change*` fix is verified by the stress test now passing with the strict gate enabled.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.272` (included in `26.7` and later)
<!-- ch-version-info:end -->