### PR TITLE
Fix flaky test_executable_udf_profile_events peak-memory tests under Thread Sanitizer

### DIFF
--- a/tests/integration/test_executable_udf_profile_events/test.py
+++ b/tests/integration/test_executable_udf_profile_events/test.py
@@ -22,6 +22,16 @@ def _skip_msan():
         pytest.skip("Memory Sanitizer cannot work with vfork")
 
 
+def _skip_unreliable_peak_memory_sampling():
+    # PeakMemoryByteSeconds is sampled from /proc/<pid>/VmHWM on a ~5 ms throttle.
+    # Under Thread Sanitizer the scheduling skew makes that best-effort sampling
+    # miss the child's at-peak window or read an inflated value, so the tight
+    # implied-peak bounds below are not deterministic there. The metric itself is
+    # exercised on every other build.
+    if node.is_built_with_thread_sanitizer():
+        pytest.skip("/proc VmHWM peak sampling is not deterministic under Thread Sanitizer")
+
+
 def _copy_into_container(local_path, container_path):
     os.system(f"docker cp {local_path} {node.docker_id}:{container_path}")
 
@@ -146,6 +156,7 @@ def test_system_time_microseconds(started_cluster):
 
 def test_peak_memory_byte_seconds(started_cluster):
     _skip_msan()
+    _skip_unreliable_peak_memory_sampling()
     qid = "exec-mem-procfs-1"
     # udf_mem.py allocates ~32 MiB in the UDF process itself (no forked children),
     # so the VmHWM sampled from /proc/<pid>/status while the process writes output
@@ -278,6 +289,7 @@ def test_unwaited_child_cpu_excluded(started_cluster):
 
 def test_reaped_child_memory_rolls_up(started_cluster):
     _skip_msan()
+    _skip_unreliable_peak_memory_sampling()
     qid = "exec-child-mem-1"
     # One ~64 MiB child is forked before the input loop, signals readiness, and
     # stays blocked at its peak until the parent has emitted all output rows.
@@ -311,6 +323,7 @@ def test_reaped_child_memory_rolls_up(started_cluster):
 
 def test_peak_memory_is_max_not_sum(started_cluster):
     _skip_msan()
+    _skip_unreliable_peak_memory_sampling()
     qid_concurrent = "exec-two-mem-concurrent-1"
     qid_sequential = "exec-two-mem-sequential-1"
     # concurrent: both ~100 MiB children are forked before the input loop, signal
@@ -414,6 +427,7 @@ def test_check_exit_code_false_no_spurious_log(started_cluster):
 
 def test_peak_memory_reflects_udf_not_server(started_cluster):
     _skip_msan()
+    _skip_unreliable_peak_memory_sampling()
     # The metric must reflect the UDF's own peak RSS, not the ClickHouse server's
     # footprint. The original bug reported the server RSS (~hundreds of MiB)
     # identically for every UDF regardless of its allocation; a lower-bound floor


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108192
Related: https://github.com/ClickHouse/ClickHouse/pull/105618
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/108192#issuecomment-4777634318: fix the flaky `test_executable_udf_profile_events`.

The recurring flakiness is confined to four `/proc`-`VmHWM` peak-memory tests, and only on Thread Sanitizer: `test_peak_memory_is_max_not_sum`, `test_peak_memory_reflects_udf_not_server`, `test_peak_memory_byte_seconds`, `test_reaped_child_memory_rolls_up`. Over 30 days they fail across many unrelated PRs, all on `amd_tsan`, in both directions: `concurrent implied peak 10.1 MiB < 60 MiB floor` (children never sampled) and `concurrent peak 933523455 ... > 1.6x sequential` (inflated reading). Example report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108248&sha=ca87a98980ffe3ce7777c05d576fad48532eaccf&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%203%2F6%29 . The suite's other tests (invocations, bytes, elapsed, CPU) are stable.

Root cause: `PeakMemoryByteSeconds` is sampled from `/proc/<pid>/VmHWM` across the UDF subtree on a best-effort ~5 ms throttle (`UDFProcessSubtreeSampler`). Under Thread Sanitizer the scheduling skew and sanitizer memory bloat make that sampling non-deterministic over the test's one-row window, so the tight implied-peak bounds are unreliable there. The metric is correct on every non-sanitizer build (verified locally: stable ~107 MiB; the assertions still pass and still catch a deliberately broken UDF that reports parent-only memory).

Fix: skip only the `/proc`-`VmHWM` peak-memory assertions under Thread Sanitizer, matching the existing pattern in other memory/timing integration tests (`test_fetch_memory_usage`, `test_hedged_requests`). All assertions stay active on every non-sanitizer build, so the metric keeps full regression coverage.

The TSAN-specific timing artifact is not reproducible without a TSAN integration build; the change targets the best-effort sampling fragility the sampler's own documentation already calls out.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.163` (included in `26.7` and later)
<!-- ch-version-info:end -->