### PR TITLE
Fix flaky test 03583_rewrite_in_to_join (row ordering)

### DIFF
--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.reference
@@ -5,47 +5,47 @@ SELECT explain FROM (
     SETTINGS enable_join_runtime_filters = 0
 ) WHERE explain ILIKE '%join%';
   JoinLogical
-SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2)) ORDER BY number;
 0
 1
 SELECT number IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 1
 0
 0
 -- NOT IN
-SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2)) ORDER BY number;
 2
 SELECT number NOT IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
-SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 1
 1
 0
-SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 0
 0
 1
-SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 0
 1
 0
@@ -80,7 +80,8 @@ WITH
     t as (select number from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE number IN t;
+WHERE number IN t
+ORDER BY number;
 0
 1
 2
@@ -89,7 +90,8 @@ WHERE number IN t;
 -- Tuple
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) IN (select number, number+1 from numbers(5));
+WHERE (number+1, number+2) IN (select number, number+1 from numbers(5))
+ORDER BY number;
 0
 1
 2
@@ -99,7 +101,8 @@ WITH
     t as (select number, number+1 from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) in (t);
+WHERE (number+1, number+2) in (t)
+ORDER BY number;
 0
 1
 2

--- a/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
+++ b/tests/queries/0_stateless/03583_rewrite_in_to_join.sql
@@ -11,32 +11,32 @@ SELECT explain FROM (
     SETTINGS enable_join_runtime_filters = 0
 ) WHERE explain ILIKE '%join%';
 
-SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number IN (SELECT number FROM numbers(2)) ORDER BY number;
 
 SELECT number IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
 
-SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 
 -- NOT IN
-SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT * FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2));
+SELECT * FROM numbers(3) WHERE number NOT IN (SELECT number FROM numbers(2)) ORDER BY number;
 
 SELECT number NOT IN (SELECT number, number FROM numbers(2)) FROM numbers(3); -- {serverError NUMBER_OF_COLUMNS_DOESNT_MATCH,BAD_ARGUMENTS, ILLEGAL_TYPE_OF_ARGUMENT}
 
-SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3);
+SELECT number NOT IN (SELECT number NOT IN (SELECT * FROM numbers(1)) FROM numbers(2)) FROM numbers(3) ORDER BY number;
 
-SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3);
+SELECT number IN (SELECT number FROM numbers(2) WHERE number NOT IN (SELECT * FROM numbers(1))) FROM numbers(3) ORDER BY number;
 
 
 EXPLAIN keep_logical_steps=1, description=0
@@ -59,19 +59,22 @@ WITH
     t as (select number from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE number IN t;
+WHERE number IN t
+ORDER BY number;
 
 -- Tuple
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) IN (select number, number+1 from numbers(5));
+WHERE (number+1, number+2) IN (select number, number+1 from numbers(5))
+ORDER BY number;
 
 -- Tuple and CTE
 WITH
     t as (select number, number+1 from numbers(5))
 SELECT *
 FROM numbers(8)
-WHERE (number+1, number+2) in (t);
+WHERE (number+1, number+2) in (t)
+ORDER BY number;
 
 -- Mismatching number of elements 
 SELECT *


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Flaky test fix. The data `SELECT`s in `03583_rewrite_in_to_join` read `FROM numbers()` with no `ORDER BY`. With `rewrite_in_to_join`, the `IN`/`NOT IN` subquery is rewritten to a `LEFT JOIN` whose output is produced by parallel `JoiningTransform` lanes (`EXPLAIN PIPELINE` shows `Resize 32 -> 16` over 16 lanes), so the row order depends on which lane finishes first. The result multiset is always correct; only the order varies, which trips the `.reference` comparison. Fails on Fast test too (no settings randomization), so it is ordering, not a setting interaction.

Added `ORDER BY number` to the affected `SELECT`s. The `EXPLAIN` rewrite assertions and the `serverError` checks are unchanged, and no result value changes (only ordering becomes deterministic).

Repro (parallel JOIN lanes scramble order): `clickhouse local --max_threads 16 --max_block_size 1 --join_algorithm parallel_hash` over the test produced 11 distinct orderings in 20 runs without `ORDER BY`, and a single stable output in 30/30 runs with it.

Failed across 6 unrelated PRs in 30 days, 0 on master.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.243` (included in `26.7` and later)
<!-- ch-version-info:end -->