### PR TITLE
Filter benign throwIf-non-zero plain mutation from the upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -337,6 +337,14 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       UInt64` is filtered: it appears in all three emitted lines (the `MutatePlainMergeTreeTask:` line, its
 #       `executeStep()` line, and the `MergeTreeBackgroundExecutor` wrapper line), so one entry covers them all
 #       while a genuinely different plain-mutation error still surfaces.
+#       The `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` variant of the same #39174 class comes from:
+#       - 02597_column_update_tricky_expression_and_replication: `ALTER TABLE test UPDATE d = d + throwIf(1)`
+#         (mutations_sync=0) leaves an intentionally-failing background mutation that the upgraded server
+#         retries on restart before the test's later `KILL MUTATION ... LIKE '%throwIf%'` cleans it up.
+#       The narrow inner-text `Value passed to 'throwIf' function is non-zero` is filtered: like the CAST
+#       variant above it appears in all three emitted lines (`MutatePlainMergeTreeTask:`, its `executeStep()`,
+#       and the `MergeTreeBackgroundExecutor` wrapper), so one entry covers them all while a genuinely
+#       different background-mutation error still surfaces.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
 # `Unknown tokenizer: 'unicode_word'` appears because the `unicode_word` tokenizer was renamed to `asciiCJK`
@@ -435,6 +443,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Unknown index: idx." \
            -e "Cannot parse string 'Hello' as UInt64" \
            -e "Cannot parse string 'x' as UInt64" \
+           -e "Value passed to 'throwIf' function is non-zero" \
            -e "Cannot parse string 'Hello' as UInt32" \
            -e "Cannot parse string \'Hello\' as UInt32" \
            -e "Cannot parse string \\'Hello\\' as UInt32" \

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -327,8 +327,16 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       `CANNOT_PARSE_TEXT` errors come from:
 #       - 00834_kill_mutation{,_replicated_zookeeper}: `DELETE WHERE toUInt32(s) = 1` on String data ('a', 'b')
 #       - 01414_mutations_and_errors_zookeeper: `MODIFY COLUMN value UInt64` on String data ('Hello')
+#       - 03047_on_fly_mutations_alters / 03100_lwu_25_update_alters / 04338_on_fly_mutation_read_overwritten_lc_source:
+#         `UPDATE v = 'x'` then `MODIFY COLUMN v UInt64` leaves a non-replicated MergeTree part holding the
+#         unconvertible value 'x' that a background mutation later fails to CAST to UInt64.
 #       `MutateFromLogEntryTask` is also excluded for the same reason, but only catches the first log line;
 #       the wrapping `MergeTreeBackgroundExecutor` line also needs to be excluded.
+#       For the non-replicated path the wrapper is `MutatePlainMergeTreeTask` (not `MutateFromLogEntryTask`).
+#       Rather than exclude the broad task-component names, the narrow inner-text `Cannot parse string 'x' as
+#       UInt64` is filtered: it appears in all three emitted lines (the `MutatePlainMergeTreeTask:` line, its
+#       `executeStep()` line, and the `MergeTreeBackgroundExecutor` wrapper line), so one entry covers them all
+#       while a genuinely different plain-mutation error still surfaces.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
 # from replicas that are being restarted and whose interserver endpoints are temporarily unavailable.
 # `Unknown tokenizer: 'unicode_word'` appears because the `unicode_word` tokenizer was renamed to `asciiCJK`
@@ -426,6 +434,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "is lost forever." \
            -e "Unknown index: idx." \
            -e "Cannot parse string 'Hello' as UInt64" \
+           -e "Cannot parse string 'x' as UInt64" \
            -e "Cannot parse string 'Hello' as UInt32" \
            -e "Cannot parse string \'Hello\' as UInt32" \
            -e "Cannot parse string \\'Hello\\' as UInt32" \


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/39174
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #39174

Filters the benign `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` background-mutation `<Error>` line from the `Upgrade check (amd_release)` server.log scan.

Test `02597_column_update_tricky_expression_and_replication` runs `ALTER TABLE test UPDATE d = d + throwIf(1)` with `mutations_sync=0`, then later `KILL MUTATION ... LIKE '%throwIf%'`. Under upgrade stress the intentionally-failing async mutation can be left behind; the restarted server retries it and logs `Value passed to 'throwIf' function is non-zero` at `<Error>`. This is the issue #39174 class (a bad mutation, not a backward incompatibility).

The `CANNOT_PARSE_TEXT` sibling (`Cannot parse string 'x' as UInt64`) is already in the allow-list on master (#107985); this adds the `throwIf` counterpart. The narrow inner-text `Value passed to 'throwIf' function is non-zero` matches all three emitted line shapes (`MutatePlainMergeTreeTask:`, its `executeStep()`, and the `MergeTreeBackgroundExecutor` wrapper) without masking a genuinely different background-mutation error.

Validated against the real leaked `upgrade_error_messages.txt` (159 lines from PR #106386, 255 from PR #105991): without the entry every line leaks and the gate fails; with it 0 lines leak; a control `LOGICAL_ERROR` in the same `MutatePlainMergeTreeTask` still surfaces.

CI report (throwIf leak, PR #106386): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106386&sha=767b2cacddb2da81a9698d767ee5fa387995e69b&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
