### PR TITLE
Fix flaky test_async_backup_restore_with_max_execution_time_zero on slow CI lanes

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -2260,7 +2260,9 @@ def test_async_backup_restore_with_max_execution_time_zero():
     backup_name = new_backup_name()
     inst.query("CREATE DATABASE IF NOT EXISTS test")
     inst.query("CREATE TABLE test.table(x UInt32, y String) ENGINE=MergeTree ORDER BY y PARTITION BY x%10")
-    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100)")
+    # The node's 0.5s profile timeout (used below to trigger the bug) also caps this
+    # foreground setup query; disable it so a slow CI lane can't time out the INSERT.
+    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100) SETTINGS max_execution_time = 0")
 
     try:
         # Pause backup before it starts so the 500ms profile-level timeout fires.
@@ -2298,7 +2300,11 @@ def test_async_backup_restore_with_max_execution_time_zero():
             TSV([["RESTORED", ""]]),
         )
 
-        assert inst.query("SELECT count(), sum(x) FROM test.table") == "100\t4950\n"
+        # Same: don't let the 0.5s profile timeout cap this foreground verification query.
+        assert (
+            inst.query("SELECT count(), sum(x) FROM test.table SETTINGS max_execution_time = 0")
+            == "100\t4950\n"
+        )
     finally:
         inst.query("SYSTEM DISABLE FAILPOINT backup_pause_on_start")
         inst.query("SYSTEM DISABLE FAILPOINT restore_pause_on_start")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

No related open issue found.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_backup_restore_new/test.py::test_async_backup_restore_with_max_execution_time_zero` is flaky on the `amd_msan` integration lane (3 failures across 3 unrelated PRs in the last 30 days, 0 on master).

The `instance_with_short_timeout` node sets `max_execution_time = 0.5` in its default profile so the profile-level timeout reliably fires on the paused async `BACKUP`/`RESTORE` task (that timeout firing is the bug under test). That same 0.5s cap also applies to the test's foreground setup `INSERT` and final verification `SELECT`, which are not part of what the test checks. On a slow sanitizer lane the setup `INSERT`'s pipeline finalization exceeded 500ms and the query failed before the test could run:

```
test.py:2263: in test_async_backup_restore_with_max_execution_time_zero
    inst.query("INSERT INTO test.table SELECT number, toString(number) FROM numbers(100)")
Code: 159. DB::Exception: Timeout exceeded: elapsed 532.921871 ms, maximum: 500 ms. (TIMEOUT_EXCEEDED)
  5. ExecutionSpeedLimits::checkTimeLimit
  6. QueryStatus::checkTimeLimit()
  7. PipelineExecutor::finalizeExecution()
```

Fix: add `SETTINGS max_execution_time = 0` to those two foreground scaffolding queries so a loaded lane cannot time them out. The profile cap and the async `BACKUP`/`RESTORE` query settings are unchanged, so the bug-detection mechanism is fully preserved: the failpoint still pauses the background task past the 0.5s profile timeout, and the `system.backups` status assertions still catch a regression of the original bug (profile `max_execution_time` cached in `QueryStatus` and not overridden by the query's `max_execution_time = 0`).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/PRs/108184/480c9f8720e5d3d4c01cfa755d357a1df7f8f097/integration_tests_amd_msan_4_6/job.log


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.405` (included in `26.7` and later)
<!-- ch-version-info:end -->