### PR TITLE
Fix projection incorrectly reading a newly-added column as the type default instead of its DEFAULT value

### DIFF
--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -514,15 +514,8 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
             ColumnDescription column_description(column_with_type_name.name, column_with_type_name.type);
             /// Carry over the parent column's DEFAULT so a column missing from a projection part written
             /// before the column was added reads the table default, not the column type's default.
-            /// Only stored kinds (DEFAULT/MATERIALIZED) may be inherited: an ALIAS/EPHEMERAL parent column
-            /// is materialized into an ordinary stored projection column, so it must not become non-stored here.
-            if (columns.has(column_with_type_name.name))
-            {
-                const auto & parent_default = columns.get(column_with_type_name.name).default_desc;
-                if (parent_default.expression
-                    && (parent_default.kind == ColumnDefaultKind::Default || parent_default.kind == ColumnDefaultKind::Materialized))
-                    column_description.default_desc = parent_default;
-            }
+            if (columns.has(column_with_type_name.name) && columns.get(column_with_type_name.name).default_desc.expression)
+                column_description.default_desc = columns.get(column_with_type_name.name).default_desc;
             metadata_columns.add(std::move(column_description));
         }
     }

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -494,7 +494,7 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
     result.with_block_number = result.sample_block.has(BlockNumberColumn::name);
     result.with_block_offset = result.sample_block.has(BlockOffsetColumn::name);
 
-    NamesAndTypesList metadata_columns;
+    ColumnsDescription metadata_columns;
     for (const auto & column_with_type_name : result.sample_block)
     {
         if (column_with_type_name.column && isColumnConst(*column_with_type_name.column))
@@ -511,11 +511,16 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
         }
         else
         {
-            metadata_columns.emplace_back(column_with_type_name.name, column_with_type_name.type);
+            ColumnDescription column_description(column_with_type_name.name, column_with_type_name.type);
+            /// Carry over the parent column's DEFAULT so a column missing from a projection part written
+            /// before the column was added reads the table default, not the column type's default.
+            if (columns.has(column_with_type_name.name) && columns.get(column_with_type_name.name).default_desc.expression)
+                column_description.default_desc = columns.get(column_with_type_name.name).default_desc;
+            metadata_columns.add(std::move(column_description));
         }
     }
 
-    metadata.setColumns(ColumnsDescription(metadata_columns));
+    metadata.setColumns(std::move(metadata_columns));
     metadata.setVirtuals(MergeTreeData::createVirtuals(partition_key));
 
     /// Initialize implicit-minmax skip indices from the effective projection-level MergeTree settings

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -514,8 +514,15 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
             ColumnDescription column_description(column_with_type_name.name, column_with_type_name.type);
             /// Carry over the parent column's DEFAULT so a column missing from a projection part written
             /// before the column was added reads the table default, not the column type's default.
-            if (columns.has(column_with_type_name.name) && columns.get(column_with_type_name.name).default_desc.expression)
-                column_description.default_desc = columns.get(column_with_type_name.name).default_desc;
+            /// Only stored kinds (DEFAULT/MATERIALIZED) may be inherited: an ALIAS/EPHEMERAL parent column
+            /// is materialized into an ordinary stored projection column, so it must not become non-stored here.
+            if (columns.has(column_with_type_name.name))
+            {
+                const auto & parent_default = columns.get(column_with_type_name.name).default_desc;
+                if (parent_default.expression
+                    && (parent_default.kind == ColumnDefaultKind::Default || parent_default.kind == ColumnDefaultKind::Materialized))
+                    column_description.default_desc = parent_default;
+            }
             metadata_columns.add(std::move(column_description));
         }
     }

--- a/tests/queries/0_stateless/04412_projection_added_column_default.reference
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.reference
@@ -2,3 +2,5 @@ c-base	-1
 c-proj	-1
 d-base	0
 d-proj	0
+alias	1	2
+alias	2	3

--- a/tests/queries/0_stateless/04412_projection_added_column_default.reference
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.reference
@@ -2,5 +2,6 @@ c-base	-1
 c-proj	-1
 d-base	0
 d-proj	0
+m	42
 alias	1	2
 alias	2	3

--- a/tests/queries/0_stateless/04412_projection_added_column_default.reference
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.reference
@@ -1,0 +1,4 @@
+c-base	-1
+c-proj	-1
+d-base	0
+d-proj	0

--- a/tests/queries/0_stateless/04412_projection_added_column_default.sql
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.sql
@@ -1,0 +1,32 @@
+-- A column added via metadata-only ALTER ADD COLUMN ... DEFAULT is physically absent from a projection
+-- part that was written before the column existed. Reading it through that projection must return the
+-- column's DDL DEFAULT (-1), not the column type's default (0) -- matching the base-table read path.
+
+DROP TABLE IF EXISTS t_proj_added_default;
+
+CREATE TABLE t_proj_added_default
+(
+    a UInt64,
+    b UInt64,
+    id UInt64,
+    PROJECTION p (SELECT * ORDER BY (a, b))
+)
+ENGINE = MergeTree ORDER BY (a, id);
+
+-- Projection 'p' is materialized here, WITHOUT column c.
+INSERT INTO t_proj_added_default SELECT 1, number % 10000, number FROM numbers(500000);
+
+-- Metadata-only adds: existing projection part is not rewritten and still lacks c and d.
+ALTER TABLE t_proj_added_default ADD COLUMN c Int64 DEFAULT -1;   -- with a DDL default
+ALTER TABLE t_proj_added_default ADD COLUMN d Int64;             -- no default -> type default (0) is correct
+
+-- WHERE matches the projection's ORDER BY (a, b), so the query is served by the projection.
+-- (parallel replicas disabled: it does not interact with this single-node projection read and only adds flakiness.)
+-- c: base-table read and projection read must both return the DDL default -1, not the type default 0.
+SELECT 'c-base' AS path, c FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY c SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
+SELECT 'c-proj' AS path, c FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY c SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
+-- d: no DDL default, so both reads must return the type default 0 (the fix must not inject a default here).
+SELECT 'd-base' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY d SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
+SELECT 'd-proj' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY d SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
+
+DROP TABLE t_proj_added_default;

--- a/tests/queries/0_stateless/04412_projection_added_column_default.sql
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.sql
@@ -30,3 +30,13 @@ SELECT 'd-base' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GR
 SELECT 'd-proj' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY d SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
 
 DROP TABLE t_proj_added_default;
+
+-- An explicitly selected ALIAS parent column is materialized into an ordinary stored projection output
+-- column; inheriting defaults must not turn it into a non-stored ALIAS inside the projection (which would
+-- drop it from the projection's physical columns). Reading the alias column through the projection must
+-- still return the computed value.
+DROP TABLE IF EXISTS t_proj_alias;
+CREATE TABLE t_proj_alias (a UInt64, b UInt64 ALIAS a + 1, PROJECTION p (SELECT a, b ORDER BY a)) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_proj_alias (a) VALUES (1), (2);
+SELECT 'alias' AS path, a, b FROM t_proj_alias ORDER BY a;
+DROP TABLE t_proj_alias;

--- a/tests/queries/0_stateless/04412_projection_added_column_default.sql
+++ b/tests/queries/0_stateless/04412_projection_added_column_default.sql
@@ -1,6 +1,9 @@
 -- A column added via metadata-only ALTER ADD COLUMN ... DEFAULT is physically absent from a projection
--- part that was written before the column existed. Reading it through that projection must return the
--- column's DDL DEFAULT (-1), not the column type's default (0) -- matching the base-table read path.
+-- part written before the column existed. Reading it through that projection must return the column's
+-- DDL DEFAULT (-1), not the column type's default (0) -- matching the base-table read path.
+-- This also covers the other column-default kinds (no-default, MATERIALIZED, ALIAS) to confirm the
+-- DEFAULT inheritance does not affect them. EPHEMERAL columns cannot be selected into a projection, so
+-- they are not applicable here.
 
 DROP TABLE IF EXISTS t_proj_added_default;
 
@@ -13,28 +16,30 @@ CREATE TABLE t_proj_added_default
 )
 ENGINE = MergeTree ORDER BY (a, id);
 
--- Projection 'p' is materialized here, WITHOUT column c.
+-- Projection 'p' is materialized here, without c / d / m.
 INSERT INTO t_proj_added_default SELECT 1, number % 10000, number FROM numbers(500000);
 
--- Metadata-only adds: existing projection part is not rewritten and still lacks c and d.
-ALTER TABLE t_proj_added_default ADD COLUMN c Int64 DEFAULT -1;   -- with a DDL default
-ALTER TABLE t_proj_added_default ADD COLUMN d Int64;             -- no default -> type default (0) is correct
+-- Metadata-only adds; the existing projection part is not rewritten.
+ALTER TABLE t_proj_added_default ADD COLUMN c Int64 DEFAULT -1;        -- DDL default
+ALTER TABLE t_proj_added_default ADD COLUMN d Int64;                  -- no default -> type default
+ALTER TABLE t_proj_added_default ADD COLUMN m Int64 MATERIALIZED 42;  -- materialized
 
--- WHERE matches the projection's ORDER BY (a, b), so the query is served by the projection.
--- (parallel replicas disabled: it does not interact with this single-node projection read and only adds flakiness.)
--- c: base-table read and projection read must both return the DDL default -1, not the type default 0.
+-- WHERE matches the projection's ORDER BY (a, b), so reads are served by the projection.
+-- (parallel replicas disabled: irrelevant to this single-node projection read and only adds flakiness.)
+-- c: base and projection reads must both return the DDL default -1, not the type default 0.
 SELECT 'c-base' AS path, c FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY c SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
 SELECT 'c-proj' AS path, c FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY c SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
--- d: no DDL default, so both reads must return the type default 0 (the fix must not inject a default here).
+-- d: no DDL default -> both reads return the type default 0.
 SELECT 'd-base' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY d SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
 SELECT 'd-proj' AS path, d FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY d SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
+-- m: materialized column reads its expression value.
+SELECT 'm' AS path, m FROM t_proj_added_default WHERE a = 1 AND b = 4665 GROUP BY m SETTINGS optimize_use_projections = 1, enable_parallel_replicas = 0;
 
 DROP TABLE t_proj_added_default;
 
 -- An explicitly selected ALIAS parent column is materialized into an ordinary stored projection output
--- column; inheriting defaults must not turn it into a non-stored ALIAS inside the projection (which would
--- drop it from the projection's physical columns). Reading the alias column through the projection must
--- still return the computed value.
+-- column; the DEFAULT inheritance must not affect it. Reading it through the projection returns the
+-- computed value.
 DROP TABLE IF EXISTS t_proj_alias;
 CREATE TABLE t_proj_alias (a UInt64, b UInt64 ALIAS a + 1, PROJECTION p (SELECT a, b ORDER BY a)) ENGINE = MergeTree ORDER BY a;
 INSERT INTO t_proj_alias (a) VALUES (1), (2);


### PR DESCRIPTION
## Problem

A query answered by a `SELECT *` projection returns a column's **type default** (e.g. `0` for `Int64`) instead of the column's **`DEFAULT` value** (e.g. `-1`) for a column that was added with a metadata-only `ALTER TABLE ... ADD COLUMN c T DEFAULT d` *after* the projection was created.

- Reading the same column from the base table returns the correct `-1`; only reads served by the projection are wrong, so two query plans over the same data disagree.
- The wrong value is read-time (the column is physically absent from the old projection part), so it disappears once a merge / `OPTIMIZE` / `MATERIALIZE PROJECTION` rebuilds the projection — which makes it easy to miss and hard to reproduce after the fact.

Reproducer:
```sql
CREATE TABLE t (a UInt64, b UInt64, id UInt64, PROJECTION p (SELECT * ORDER BY (a, b)))
  ENGINE = MergeTree ORDER BY (a, id);
INSERT INTO t SELECT 1, number % 10000, number FROM numbers(500000);   -- projection built without c
ALTER TABLE t ADD COLUMN c Int64 DEFAULT -1;                           -- metadata-only

SELECT c FROM t WHERE a = 1 AND b = 4665 SETTINGS optimize_use_projections = 0;  -- -1 (correct)
SELECT c FROM t WHERE a = 1 AND b = 4665 SETTINGS optimize_use_projections = 1;  --  0 (wrong)
```

## Root cause

`ProjectionDescription::fillProjectionDescriptionByQuery` (`src/Storages/ProjectionsDescription.cpp`) builds the projection's metadata columns as a bare `NamesAndTypesList`, dropping their `DEFAULT` expressions. A metadata-only `ADD COLUMN` does not rewrite existing projection parts, so the column is absent from older ones; on read, `DB::fillMissingColumns` (`src/Interpreters/inplaceBlockConversions.cpp`) sees `hasDefault() == false` on the default-less projection snapshot and fills the column type's default via `createColumnWithDefaultValue`. The base-table read keeps the `DEFAULT` in its snapshot, so it instead defers to `evaluateMissingDefaults` and returns the correct value.

## Fix

When building the projection's metadata columns, copy each passthrough column's `default_desc` from the parent table's `ColumnsDescription`. The projection's storage snapshot then reports the column's `DEFAULT`, so a column missing from an older projection part resolves to the table default — matching the base-table read path. Columns without a default, and computed projection columns (no matching parent column name), are left unchanged.

Regression test `tests/queries/0_stateless/04412_projection_added_column_default.sql`: a `SELECT *` projection, a column added with `DEFAULT -1` and another added without a default; asserts the defaulted column reads `-1` through both the base and the (forced) projection path, and that the no-default column still reads the type default `0` through both.

Related: #91127, #92475.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a `SELECT *` projection returning a column's type default (e.g. `0`) instead of its `DEFAULT` value (e.g. `-1`) when reading a column added with `ALTER TABLE ... ADD COLUMN ... DEFAULT` after the projection was created. Reads from the base table were already correct; only reads answered by the projection were affected, until the projection was rebuilt.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.355` (included in `26.7` and later)
- Backported to: `26.6.2.60`, `26.5.6.34`, `26.4.5.122`, `26.3.17.39`, `25.8.29.14`
<!-- ch-version-info:end -->