### PR TITLE
Skip jemalloc profile flushing on memory-exceeded path when allocations are denied

### DIFF
--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -372,7 +372,16 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
             current_hard_limit && (will_be > current_hard_limit || (level == VariableContext::Global && will_be_rss > current_hard_limit))))
     {
 #if USE_JEMALLOC
-        if (level == VariableContext::Global && (jemalloc_flush_profile_on_memory_exceeded_interval_s || jemalloc_flush_profile_on_memory_exceeded))
+        /// Skip jemalloc profile flushing if allocations are denied in the current scope
+        /// (e.g. in signal handlers or MergeTreeBackgroundExecutor), because flushProfile allocates.
+        /// Mirrors the same guard in updatePeak; this path is reached via the member
+        /// MemoryTracker::allocImpl (adjustWithUntrackedMemory), which bypasses
+        /// CurrentMemoryTracker's own deny check, so the deny flag is still set here.
+        if (level == VariableContext::Global && (jemalloc_flush_profile_on_memory_exceeded_interval_s || jemalloc_flush_profile_on_memory_exceeded)
+#ifdef MEMORY_TRACKER_DEBUG_CHECKS
+            && !memory_tracker_always_throw_logical_error_on_allocation
+#endif
+            )
         {
             MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
             bool prof_active = false;

--- a/src/Common/tests/gtest_memory_tracker_flush_profile_deny.cpp
+++ b/src/Common/tests/gtest_memory_tracker_flush_profile_deny.cpp
@@ -1,0 +1,121 @@
+#include "config.h"
+
+#if USE_JEMALLOC
+
+#include <Common/MemoryTracker.h>
+
+/// DENY_ALLOCATIONS_IN_SCOPE only enforces (and the source guard under test is only
+/// compiled) when MEMORY_TRACKER_DEBUG_CHECKS is defined, i.e. assertion-enabled builds
+/// (debug, sanitizers). On release-based builds such as coverage, DENY is a no-op and
+/// there is no allocation-denial to guard, so the flush path legitimately runs and the
+/// invariant below does not hold there. Gate the test on the same macro the guard uses.
+#ifdef MEMORY_TRACKER_DEBUG_CHECKS
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <system_error>
+
+#include <unistd.h>
+
+#include <base/scope_guard.h>
+#include <Common/Jemalloc.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// flushProfile() asks jemalloc to write a heap dump into the current directory
+/// (named "<prof_prefix>.<pid>.<seq>.heap"). Counting these files lets us assert
+/// whether a flush actually happened, independent of how the dump path is formatted.
+size_t countHeapDumps(const std::filesystem::path & dir)
+{
+    size_t count = 0;
+    std::error_code ec;
+    for (std::filesystem::directory_iterator it(dir, ec), end; !ec && it != end; it.increment(ec))
+        if (it->path().extension() == ".heap")
+            ++count;
+    return count;
+}
+
+void removeHeapDumps(const std::filesystem::path & dir)
+{
+    std::error_code ec;
+    for (std::filesystem::directory_iterator it(dir, ec), end; !ec && it != end; it.increment(ec))
+        if (it->path().extension() == ".heap")
+            std::filesystem::remove(it->path(), ec);
+}
+
+/// Trigger the global memory-limit-exceeded path that conditionally flushes the
+/// jemalloc profile. adjustWithUntrackedMemory routes to the member
+/// MemoryTracker::allocImpl with enforce_memory_limit=false (so no
+/// MEMORY_LIMIT_EXCEEDED is thrown), and 4 MiB exceeds the 1-byte hard limit.
+void hitMemoryExceededFlushPath()
+{
+    MemoryTracker tracker(/*parent_=*/nullptr, VariableContext::Global);
+    tracker.setHardLimit(1);
+    tracker.setJemallocFlushProfileOnMemoryExceeded(true);
+    tracker.adjustWithUntrackedMemory(4 * 1024 * 1024);
+}
+
+}
+
+/// The memory-limit-exceeded jemalloc flush path must be skipped while allocations
+/// are denied: flushProfile() allocates (it formats the dump path with fmt::format
+/// once the path outgrows the small-string buffer) and asks jemalloc to write a
+/// heap dump. The path is reachable under DENY_ALLOCATIONS_IN_SCOPE (signal
+/// handler, MergeTreeBackgroundExecutor flushing untracked memory) via the member
+/// MemoryTracker::allocImpl, which bypasses CurrentMemoryTracker's own deny check.
+/// updatePeak() already guards this; we pin the symmetric memory-exceeded path.
+///
+/// The invariant is asserted independently of PID length: while allocations are
+/// denied, NO heap dump file may be produced. A fixed build skips flushProfile
+/// entirely (0 files); an unfixed build either writes a dump (short PID -> the
+/// assertion below fails) or allocates and aborts with LOGICAL_ERROR
+/// "Memory tracker: allocations not allowed." (long PID -> the test process
+/// crashes). Either way an unfixed build fails the test.
+TEST(MemoryTrackerJemallocFlushProfile, MemoryExceededFlushSkippedUnderDeny)
+{
+    bool prof_active = false;
+    if (!(Jemalloc::tryGetValue("prof.active", prof_active) && prof_active))
+        GTEST_SKIP() << "jemalloc profiler not active in this build/runtime";
+
+    /// Profile dumps land in the current directory; run from a scratch dir and
+    /// remove it afterwards so the test is parallel-safe and leaves nothing.
+    const auto old_cwd = std::filesystem::current_path();
+    const auto scratch = std::filesystem::temp_directory_path()
+        / ("ch_flush_profile_deny_" + std::to_string(getpid()));
+    std::filesystem::create_directories(scratch);
+    std::filesystem::current_path(scratch);
+    SCOPE_EXIT({
+        std::filesystem::current_path(old_cwd);
+        std::error_code ec;
+        std::filesystem::remove_all(scratch, ec);
+    });
+
+    /// Positive control: with allocations allowed, the very same code path must
+    /// produce a heap dump here. This proves the dump mechanism is live in this
+    /// runtime, so the "no dump under deny" assertion below cannot pass vacuously.
+    hitMemoryExceededFlushPath();
+    if (countHeapDumps(scratch) == 0)
+        GTEST_SKIP() << "memory-exceeded jemalloc flush produced no dump in this runtime; cannot verify the guard";
+    removeHeapDumps(scratch);
+    ASSERT_EQ(countHeapDumps(scratch), 0u);
+
+    /// The invariant: under DENY_ALLOCATIONS_IN_SCOPE the flush must be skipped,
+    /// so no new heap dump appears. (The guard is checked before the per-callsite
+    /// flush counter, so a fixed build never even reaches the flush throttle.)
+    {
+        DENY_ALLOCATIONS_IN_SCOPE;
+        hitMemoryExceededFlushPath();
+    }
+
+    EXPECT_EQ(countHeapDumps(scratch), 0u)
+        << "jemalloc profile was flushed under DENY_ALLOCATIONS_IN_SCOPE; "
+           "the memory-exceeded flush path is not guarded";
+}
+
+#endif // MEMORY_TRACKER_DEBUG_CHECKS
+#endif // USE_JEMALLOC


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/97025
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Skip jemalloc profile flushing on the memory-limit-exceeded path while allocations are denied, mirroring the existing guard in `updatePeak`.

`MemoryTracker::allocImpl` calls `Jemalloc::flushProfile` from two symmetric places: `updatePeak` (the `jemalloc_flush_profile_interval_bytes` path) and the memory-limit-exceeded path (`jemalloc_flush_profile_on_memory_exceeded`). `flushProfile` allocates: it builds the dump path `<prefix>.<pid>.<counter>.heap` with `fmt::format`, and once the shared counter grows past the small-string-optimization threshold this heap-allocates.

Both call sites are reachable while allocations are denied (`DENY_ALLOCATIONS_IN_SCOPE`), for example from `MergeTreeBackgroundExecutor::threadFunction` flushing untracked memory, or in a signal handler. The path enters through the member `MemoryTracker::allocImpl` (via `adjustWithUntrackedMemory`), which bypasses the deny check in `CurrentMemoryTracker::allocImpl`, so the deny flag is still set when `flushProfile` runs. The allocation then throws `LOGICAL_ERROR` "Memory tracker: allocations not allowed.", which aborts the process in debug and sanitizer builds.

`updatePeak` already received this guard in #97025, but the symmetric memory-limit-exceeded block was missed. This adds the same `!memory_tracker_always_throw_logical_error_on_allocation` check (under `MEMORY_TRACKER_DEBUG_CHECKS`) there. Release builds are unaffected: the guard, the deny flag, and the abort all live under `MEMORY_TRACKER_DEBUG_CHECKS` (i.e. `!NDEBUG`), so this only changes debug and sanitizer builds.

Added a unit test (`gtest_memory_tracker_flush_profile_deny`) that advances the shared profile counter past the SSO threshold and then exercises the memory-limit-exceeded path under `DENY_ALLOCATIONS_IN_SCOPE`. It aborts before the fix and passes after.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.237` (included in `26.7` and later)
<!-- ch-version-info:end -->