### PR TITLE
Fix flaky test_storage_s3_queue/test_1.py::test_max_set_age

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_1.py
+++ b/tests/integration/test_storage_s3_queue/test_1.py
@@ -346,7 +346,7 @@ def test_multiple_tables_streaming_sync_distributed(started_cluster, mode):
 @pytest.mark.parametrize("mode", ["unordered", "ordered"])
 def test_max_set_age(started_cluster, mode):
     # We use an instance without keeper fault injection,
-    # because otherwise we fail to update keeper state in 1.5 * max_age,
+    # because otherwise we fail to update keeper state within the wait window,
     # so we cannot check max_set_age correctness properly.
     node = started_cluster.instances["instance_without_keeper_fault_injection"]
     table_name = f"max_set_age_{mode}_{generate_random_string()}"
@@ -386,7 +386,14 @@ def test_max_set_age(started_cluster, mode):
     def get_count():
         return int(node.query(f"SELECT count() FROM {dst_table_name}"))
 
-    def wait_for_condition(check_function, max_wait_time=1.5 * max_age):
+    # Slow instrumented builds (sanitizers, coverage) ingest far slower, so give
+    # them a larger ceiling; fast release/debug builds keep the tighter
+    # 1.5 * max_age so a genuine regression is not masked. Either way the ceiling
+    # stays above max_age so the tracked_file_ttl expiry the test relies on fires.
+    slow_build = node.is_built_with_sanitizer() or node.is_built_with_llvm_coverage()
+    condition_wait_time = (3 if slow_build else 1.5) * max_age
+
+    def wait_for_condition(check_function, max_wait_time=condition_wait_time):
         before = time.time()
         while time.time() - before < max_wait_time:
             if check_function():


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/93163
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #93163

`test_storage_s3_queue/test_1.py::test_max_set_age` flakes on slow runners. Its local `wait_for_condition` helper polls with a ceiling of `1.5 * max_age` (30s); on coverage/MSan/heavily-parallel runners basic S3Queue ingestion does not finish within 30s, so the first poll (line 397) times out and fires its bare `assert False`.

Public CI evidence (play.clickhouse.com, last ~45d): the timing failure mode was observed on `Integration tests (amd_llvm_coverage, 1/5)` at the first `wait_for_condition`, across PRs unrelated to S3Queue (e.g. a SignalHandlers MSan fix, an LLVM-libc port, a per-CPU profile-counters change). The ordered-mode failures have no tracked-file-ttl removal race, confirming this is runner slowness, not a correctness problem. Same root-cause class as the earlier `max_age` 10s->20s bump in #67035.

Fix: raise the poll ceiling to `3 * max_age` (60s). Non-weakening: every wait still asserts the exact same condition and returns the instant it is met, so passing-case runtime is unchanged; only a genuinely stuck condition waits longer before asserting. `max_age` (`tracked_file_ttl_sec`) is unchanged, so no ttl-expiry wait is lengthened. 60s stays well under the 900s pytest timeout and matches the file's other busy-loops (e.g. `range(100)`).

Validation: `test_max_set_age` passes 6/6 (both params x3) locally with the fix. A deterministic simulation confirms both directions: at a 40s settle time the old 30s ceiling asserts false, the new 60s ceiling passes.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.139`
<!-- ch-version-info:end -->