### PR TITLE
Fix use-after-free in borrowed ThreadGroup parent counters

### DIFF
--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -86,6 +86,13 @@ public:
     const Int32 os_threads_nice_value;
 
     MemorySpillScheduler::Ptr memory_spill_scheduler;
+
+    /// For a "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue),
+    /// performance_counters and memory_tracker below hold RAW pointers into the parent group's
+    /// counters. Keep the parent alive so those pointers never dangle. Declared before the two
+    /// trackers so it is destroyed after them (members are destroyed in reverse order).
+    ThreadGroupPtr parent_thread_group;
+
     ProfileEvents::Counters performance_counters{VariableContext::Process};
     MemoryTracker memory_tracker{VariableContext::Process};
 

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -79,6 +79,37 @@ TEST(BorrowedThreadGroupLifetime, IncrementThroughBorrowedChildAfterParentDroppe
     t.join();
 }
 
+/// Same hazard for the OTHER borrowed ctor: ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent),
+/// used by createForFlushAsyncInsertQueue. It takes its own query context and master thread id, but borrows
+/// the SAME raw pointers into the parent's performance_counters / memory_tracker, so it must keep the parent
+/// alive identically. Drop the only external parent reference, then verify the parent is still alive and that
+/// incrementing through the borrowed counters does not touch freed memory.
+TEST(BorrowedThreadGroupLifetime, TwoArgCtorChildKeepsParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child via the two-arg ctor (own context + parent). Same borrowed counter pointers.
+        auto child = std::make_shared<ThreadGroup>(context, parent);
+
+        /// Drop the only external owner of the parent. With the fix the child still owns it.
+        parent.reset();
+
+        EXPECT_FALSE(parent_weak.expired())
+            << "Two-arg borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
+
+        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
+        child->performance_counters.increment(ProfileEvents::Query, 1);
+        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
+    });
+    t.join();
+}
+
 /// Same lifetime hazard exercised through the real attach path: attachToGroupImpl calls
 /// performance_counters.setParent(&thread_group->performance_counters) and
 /// memory_tracker.setParent(&thread_group->memory_tracker), i.e. it dereferences the borrowed child's

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -1,0 +1,108 @@
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <Common/CurrentThread.h>
+#include <Common/ProfileEvents.h>
+#include <Common/ThreadGroupSwitcher.h>
+#include <Common/ThreadStatus.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/Context.h>
+
+namespace ProfileEvents
+{
+    extern const Event Query;
+}
+
+/// Regression test for the borrowed-ThreadGroup use-after-free.
+///
+/// A "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue) stores RAW
+/// pointers into its parent group's performance_counters / memory_tracker. The documented invariant
+/// (MemoryTracker.h: "Lifetime of these trackers should include lifetime of current tracker") was not
+/// enforced: nothing kept the parent alive, so a child pinned past the source query's end (e.g. by a
+/// MergeTreeDeduplicationLog writer's captured thread-pool scheduler under s3_allow_parallel_part_upload)
+/// outlived its parent. The next counter increment / MemoryTracker::setParent then walked freed memory.
+///
+/// The fix makes the borrowed child own a shared_ptr to its parent. These tests drop every EXTERNAL
+/// reference to the parent and then exercise the borrowed pointers; without the fix this is a UAF that
+/// ASan/TSan catch, with the fix the parent stays alive for exactly as long as the child needs it.
+
+namespace DB
+{
+
+/// Dropping the only external shared_ptr to the parent must not free the parent group while a borrowed
+/// child is still alive: the child keeps it referenced (use_count stays >= the child's hold).
+TEST(BorrowedThreadGroupLifetime, ChildKeepsParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child: holds raw pointers into parent->performance_counters / parent->memory_tracker.
+        auto child = std::make_shared<ThreadGroup>(parent);
+
+        /// Drop the only external owner of the parent. With the fix the child still owns it.
+        parent.reset();
+
+        EXPECT_FALSE(parent_weak.expired())
+            << "Borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
+    });
+    t.join();
+}
+
+/// The classic crash shape: increment a counter through a borrowed child after the external parent
+/// reference is gone. increment() walks current->parent up the chain into the parent group's Counters.
+/// If the parent were freed, this reads freed memory. With the fix the parent is alive, so the walk is safe.
+TEST(BorrowedThreadGroupLifetime, IncrementThroughBorrowedChildAfterParentDropped)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        auto child = std::make_shared<ThreadGroup>(parent);
+
+        /// Only the child references the parent now.
+        parent.reset();
+
+        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
+        child->performance_counters.increment(ProfileEvents::Query, 1);
+        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
+
+        SUCCEED();
+    });
+    t.join();
+}
+
+/// Same lifetime hazard exercised through the real attach path: attachToGroupImpl calls
+/// performance_counters.setParent(&thread_group->performance_counters) and
+/// memory_tracker.setParent(&thread_group->memory_tracker), i.e. it dereferences the borrowed child's
+/// parent counters. Attaching to a borrowed child whose external parent reference is gone must be safe.
+TEST(BorrowedThreadGroupLifetime, AttachToBorrowedChildAfterParentDropped)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        auto child = std::make_shared<ThreadGroup>(parent);
+        parent.reset();
+
+        CurrentThread::attachToGroupIfDetached(child);
+        /// Allocate a little so the memory tracker chain (child -> parent group's tracker) is walked.
+        std::vector<int> v(1024, 7);
+        ProfileEvents::increment(ProfileEvents::Query, 1);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        EXPECT_EQ(getCurrentThreadGroup(), nullptr);
+    });
+    t.join();
+}
+
+} // namespace DB

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -130,6 +130,8 @@ ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
+    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
+    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
     , shared_data(parent->getSharedData())
@@ -144,6 +146,8 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
+    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
+    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
 {


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107030
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a use-after-free where a materialized-view / async-insert "borrowed" thread group could outlive the parent query's thread group, causing a crash while updating `ProfileEvents` counters or the memory tracker.

### Description

A borrowed child `ThreadGroup` (`createForMaterializedView` / `createForFlushAsyncInsertQueue`) stores raw pointers into its parent group's `performance_counters` and `memory_tracker`, but did not keep the parent alive. The invariant in `MemoryTracker.h` ("Lifetime of these trackers should include lifetime of current tracker") was unenforced.

When the borrowed child is pinned past the source query's end (e.g. a per-table `MergeTreeDeduplicationLog` writer whose thread-pool scheduler captured the current group under `s3_allow_parallel_part_upload`), the parent group is freed while the child still references it. The next counter increment / attach then walks the freed parent chain in `ProfileEvents::Counters::increment` (`current = current->parent`) or `MemoryTracker::setParent`, reading freed memory.

Root cause was identified by @ filimonov in the instrumentation PR #107030 (ASan report: https://gist.github.com/filimonov/1ec59047c65e3a5367c5c83f6021cc27).

Fix: the borrowed child now holds a `shared_ptr` to its parent group, declared before the two trackers so it is destroyed after them. No reference cycle (a child references its parent only). Adds a unit test that drops the only external parent reference while a borrowed child is alive and checks the parent stays alive and increment/attach through the child does not touch freed memory.

Surfaced in CI as a sanitizer/segfault crash in `ProfileEvents::Counters::increment` at thread-group attach/detach (TSan amd_tsan s3: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105890&sha=3dc0e76362eb18e27f1fffcd3f61ca9f13725fe8&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20sequential%2C%201%2F2%29 ; ASan Stress arm_asan_ubsan: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101549&sha=ee6992be72ffa65500f361740ec846b912eaa872&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29 ).
