### PR TITLE
feat: Allow runtime filters on mixed equi + non-equi joins by ignoring non-equi

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinRuntimeFilter.cpp
@@ -230,12 +230,24 @@ bool tryAddJoinRuntimeFilter(QueryPlan::Node & node, QueryPlan::Nodes & nodes, c
     ColumnsWithTypeAndName join_keys_probe_side;
     ColumnsWithTypeAndName join_keys_build_side;
 
-    /// Check that there are only equality predicates
+    /// Collect equality predicates for runtime filter construction.
+    /// Non-equality predicates (e.g. range conditions) are skipped for non-ANTI-JOIN:
+    /// the runtime filter is an over-approximation, so skipping them only lets extra rows
+    /// through the filter, which the join then rejects — no false negatives.
+    ///
+    /// For LEFT ANTI JOIN (check_left_does_not_contain) the all-equality requirement is
+    /// kept: the runtime filter is a NOT IN exclusion, so an over-broad set (built from
+    /// right-side rows that a post-condition would have excluded) produces false exclusions
+    /// — wrong results.
     for (const auto & condition : join_operator.expression)
     {
         auto [predicate_op, lhs, rhs] = condition.asBinaryPredicate();
         if (predicate_op != JoinConditionOperator::Equals)
-            return false;
+        {
+            if (check_left_does_not_contain)
+                return false;
+            continue;
+        }
 
         /// For the case of ANTI JOIN (more specifically for check_left_does_not_contain) the hash table in JOIN can have extra rows that can be filtered
         /// out by post-condition. In this case we cannot build set of keys for runtime filter from right-side rows because the set will contain more rows

--- a/tests/performance/join_runtime_filter.xml
+++ b/tests/performance/join_runtime_filter.xml
@@ -125,6 +125,42 @@
         SETTINGS enable_join_runtime_filters=1
     </query>
 
+    <!-- Mixed equi + non-equi ON predicate: before this fix no runtime filter was built at all -->
+
+    <!-- 1 element in filter (ETHIOPIA): equality key filters ~99.999% of probe rows -->
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'ETHIOPIA') AS cn
+        ON c_custkey = o_custkey AND o_totalprice > 100
+        SETTINGS enable_join_runtime_filters=0
+    </query>
+
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'ETHIOPIA') AS cn
+        ON c_custkey = o_custkey AND o_totalprice > 100
+        SETTINGS enable_join_runtime_filters=1
+    </query>
+
+    <!-- 10000 elements in filter (GERMANY): equality key filters ~90% of probe rows -->
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'GERMANY') AS cn
+        ON c_custkey = o_custkey AND o_totalprice > 100
+        SETTINGS enable_join_runtime_filters=0
+    </query>
+
+    <query>
+        SELECT avg(o_totalprice)
+        FROM orders
+        JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'GERMANY') AS cn
+        ON c_custkey = o_custkey AND o_totalprice > 100
+        SETTINGS enable_join_runtime_filters=1
+    </query>
+
     <drop_query>DROP TABLE orders</drop_query>
     <drop_query>DROP TABLE customer</drop_query>
     <drop_query>DROP TABLE nation</drop_query>

--- a/tests/performance/join_runtime_filter.xml
+++ b/tests/performance/join_runtime_filter.xml
@@ -125,14 +125,16 @@
         SETTINGS enable_join_runtime_filters=1
     </query>
 
-    <!-- Mixed equi + non-equi ON predicate: before this fix no runtime filter was built at all -->
+    <!-- Mixed equi + non-equi ON predicate: before this fix no runtime filter was built at all.
+         o_totalprice > c_nationkey * 100 spans both sides so it cannot be pushed to PREWHERE
+         and stays as a post-join filter, while the runtime filter is built on c_custkey only. -->
 
     <!-- 1 element in filter (ETHIOPIA): equality key filters ~99.999% of probe rows -->
     <query>
         SELECT avg(o_totalprice)
         FROM orders
         JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'ETHIOPIA') AS cn
-        ON c_custkey = o_custkey AND o_totalprice > 100
+        ON c_custkey = o_custkey AND o_totalprice > c_nationkey * 100
         SETTINGS enable_join_runtime_filters=0
     </query>
 
@@ -140,7 +142,7 @@
         SELECT avg(o_totalprice)
         FROM orders
         JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'ETHIOPIA') AS cn
-        ON c_custkey = o_custkey AND o_totalprice > 100
+        ON c_custkey = o_custkey AND o_totalprice > c_nationkey * 100
         SETTINGS enable_join_runtime_filters=1
     </query>
 
@@ -149,7 +151,7 @@
         SELECT avg(o_totalprice)
         FROM orders
         JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'GERMANY') AS cn
-        ON c_custkey = o_custkey AND o_totalprice > 100
+        ON c_custkey = o_custkey AND o_totalprice > c_nationkey * 100
         SETTINGS enable_join_runtime_filters=0
     </query>
 
@@ -157,7 +159,7 @@
         SELECT avg(o_totalprice)
         FROM orders
         JOIN (SELECT * FROM customer JOIN nation ON c_nationkey = n_nationkey WHERE n_name = 'GERMANY') AS cn
-        ON c_custkey = o_custkey AND o_totalprice > 100
+        ON c_custkey = o_custkey AND o_totalprice > c_nationkey * 100
         SETTINGS enable_join_runtime_filters=1
     </query>
 

--- a/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.reference
+++ b/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.reference
@@ -4,7 +4,7 @@
 1	10	15
 3	30	35
 --- runtime filter IS applied to equality key when filters enabled ---
-Filter (Apply runtime join filter)
+BuildRuntimeFilter (Build runtime join filter on __table2.id)
 --- LEFT SEMI JOIN: same result without and with runtime filter ---
 1	10
 3	30

--- a/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.reference
+++ b/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.reference
@@ -1,0 +1,17 @@
+--- INNER JOIN: same result without and with runtime filter ---
+1	10	15
+3	30	35
+1	10	15
+3	30	35
+--- runtime filter IS applied to equality key when filters enabled ---
+Filter (Apply runtime join filter)
+--- LEFT SEMI JOIN: same result without and with runtime filter ---
+1	10
+3	30
+1	10
+3	30
+--- LEFT ANTI JOIN with mixed predicates: runtime filter disabled (correct) ---
+2	20
+4	40
+2	20
+4	40

--- a/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.sql
+++ b/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.sql
@@ -1,0 +1,72 @@
+-- Runtime filter should be built on equality keys even when the ON clause also
+-- contains non-equality predicates (e.g. range conditions).
+-- The filter is an over-approximation: rows that pass the Bloom filter on the
+-- equality key but fail the range condition are rejected at join time.
+
+SET enable_analyzer = 1;
+SET enable_parallel_replicas = 0;
+SET join_algorithm = 'hash';
+SET query_plan_join_swap_table = 0;
+
+DROP TABLE IF EXISTS t_rf_mixed_left;
+DROP TABLE IF EXISTS t_rf_mixed_right;
+
+CREATE TABLE t_rf_mixed_left (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_rf_mixed_right (id UInt64, val UInt64) ENGINE = MergeTree ORDER BY id;
+
+-- id=1: 10 < 15 -> match; id=2: 20 < 10 -> no match; id=3: 30 < 35 -> match; id=4: 40 < 38 -> no match
+INSERT INTO t_rf_mixed_left VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+INSERT INTO t_rf_mixed_right VALUES (1, 15), (2, 10), (3, 35), (4, 38);
+
+SELECT '--- INNER JOIN: same result without and with runtime filter ---';
+
+SELECT l.id, l.val, r.val
+FROM t_rf_mixed_left l JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT l.id, l.val, r.val
+FROM t_rf_mixed_left l JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 1;
+
+SELECT '--- runtime filter IS applied to equality key when filters enabled ---';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN
+    SELECT l.id, l.val, r.val
+    FROM t_rf_mixed_left l JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+    ORDER BY l.id
+    SETTINGS enable_join_runtime_filters = 1
+)
+WHERE explain LIKE '%Apply runtime join filter%';
+
+SELECT '--- LEFT SEMI JOIN: same result without and with runtime filter ---';
+
+SELECT l.id, l.val
+FROM t_rf_mixed_left l LEFT SEMI JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT l.id, l.val
+FROM t_rf_mixed_left l LEFT SEMI JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 1;
+
+SELECT '--- LEFT ANTI JOIN with mixed predicates: runtime filter disabled (correct) ---';
+
+-- For LEFT ANTI JOIN the NOT IN filter would be over-broad with non-equality conditions,
+-- so the runtime filter must not be applied. Verify results are still correct.
+SELECT l.id, l.val
+FROM t_rf_mixed_left l LEFT ANTI JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 0;
+
+SELECT l.id, l.val
+FROM t_rf_mixed_left l LEFT ANTI JOIN t_rf_mixed_right r ON l.id = r.id AND l.val < r.val
+ORDER BY l.id
+SETTINGS enable_join_runtime_filters = 1;
+
+DROP TABLE t_rf_mixed_left;
+DROP TABLE t_rf_mixed_right;

--- a/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.sql
+++ b/tests/queries/0_stateless/04410_join_runtime_filter_mixed_predicates.sql
@@ -40,7 +40,7 @@ FROM (
     ORDER BY l.id
     SETTINGS enable_join_runtime_filters = 1
 )
-WHERE explain LIKE '%Apply runtime join filter%';
+WHERE explain LIKE '%Build runtime join filter%';
 
 SELECT '--- LEFT SEMI JOIN: same result without and with runtime filter ---';
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/108576

Previously, `tryAddJoinRuntimeFilter` bailed out entirely if the `ON` clause contained any non-equality predicate (e.g. `ON a.id = b.id AND a.val < b.val`), leaving those joins with zero runtime filtering. This change makes the loop `continue` past non-equality predicates and build filters on the equality keys only. The join applies the non-equality condition at join time as before.

`LEFT ANTI JOIN` is excluded: its NOT IN exclusion filter would be over-broad if non-equality predicates are present (the hash table may contain rows that a post-condition would have rejected, making the exclusion set too large and producing wrong results).

### Performance evidence

The benchmark uses `ON c_custkey = o_custkey AND o_totalprice > c_nationkey * 100`. The non-equality condition spans both sides so it cannot be pushed to PREWHERE and stays as a post-join filter — this is the code path our fix enables. The runtime filter is built on `c_custkey` only.

Local debug build, 100M-row `orders` table, cold cache:

| Nation (build side size) | `enable_join_runtime_filters=0` | `enable_join_runtime_filters=1` | speedup |
|--------------------------|----------------------------------|---------------------------------|---------|
| ETHIOPIA (1 row)         | 0.126 s                          | 0.043 s                         | **3×**  |
| GERMANY (10 000 rows)    | 0.367 s                          | 0.295 s                         | **1.25×** |

These are debug-build numbers (conservative lower bound). The new query pairs are added to `tests/performance/join_runtime_filter.xml` for CI measurement on release hardware.

`EXPLAIN` confirms the plan shape: `__applyFilter` is in PREWHERE on the equality key, the non-equality condition appears as a post-join `Filter`, and `BuildRuntimeFilter` is present on the build side:

```
Prewhere filter column: __applyFilter(_runtime_filter_..., o_custkey) (removed)
…
Filter (Post Join Actions)
Filter column: greater(o_totalprice, multiply(c_nationkey, 100)) (removed)
…
BuildRuntimeFilter (Build runtime join filter on c_custkey)
```

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Runtime filters are now built on equality keys even when the `ON` clause also contains non-equality predicates, reducing rows entering the hash join for mixed equi + non-equi joins. `LEFT ANTI JOIN` is unaffected.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.151` (included in `26.7` and later)
<!-- ch-version-info:end -->