### PR TITLE
Don't block server shutdown on idle keep-alive connections

### DIFF
--- a/base/poco/Net/include/Poco/Net/HTTPServerSession.h
+++ b/base/poco/Net/include/Poco/Net/HTTPServerSession.h
@@ -25,6 +25,8 @@
 #include "Poco/Net/SocketAddress.h"
 #include "Poco/Timespan.h"
 
+#include <functional>
+
 
 namespace Poco
 {
@@ -62,10 +64,21 @@ namespace Net
 
         size_t getMaxKeepAliveRequests() const { return _maxKeepAliveRequests; }
 
+        void setStopCallback(std::function<bool()> stopCallback);
+        /// Sets a predicate that aborts the wait for the next request as soon as
+        /// it returns true. Used to stop waiting promptly when the server is shutting
+        /// down instead of blocking for the whole keep-alive timeout.
+
     private:
+        bool waitForRequest(Poco::Timespan timeout);
+        /// Polls the socket for an incoming request, waking up periodically to
+        /// re-evaluate the stop callback so an idle connection does not block
+        /// shutdown for the whole timeout.
+
         bool _firstRequest;
         Poco::Timespan _keepAliveTimeout;
         size_t _maxKeepAliveRequests;
+        std::function<bool()> _stopCallback;
     };
 
 

--- a/base/poco/Net/src/HTTPServerSession.cpp
+++ b/base/poco/Net/src/HTTPServerSession.cpp
@@ -38,6 +38,32 @@ void HTTPServerSession::setKeepAliveTimeout(Poco::Timespan keepAliveTimeout)
     _keepAliveTimeout = keepAliveTimeout;
 }
 
+void HTTPServerSession::setStopCallback(std::function<bool()> stopCallback)
+{
+    _stopCallback = std::move(stopCallback);
+}
+
+bool HTTPServerSession::waitForRequest(Poco::Timespan timeout)
+{
+    if (!_stopCallback)
+        return socket().poll(timeout, Socket::SELECT_READ);
+
+    // Poll in bounded slices so that a connection idle in keep-alive does not
+    // block server shutdown for the whole timeout: the stop callback is checked
+    // between slices and aborts the wait as soon as the server stops.
+    static const Poco::Timespan slice(1, 0); // 1 second
+    Poco::Timespan remaining = timeout;
+    while (remaining > 0)
+    {
+        if (_stopCallback())
+            return false;
+        Poco::Timespan step = remaining < slice ? remaining : slice;
+        if (socket().poll(step, Socket::SELECT_READ))
+            return true;
+        remaining -= step;
+    }
+    return false;
+}
 
 
 bool HTTPServerSession::hasMoreRequests()
@@ -48,13 +74,13 @@ bool HTTPServerSession::hasMoreRequests()
 	{
 		_firstRequest = false;
 		--_maxKeepAliveRequests;
-		return socket().poll(getTimeout(), Socket::SELECT_READ);
+		return waitForRequest(getTimeout());
 	}
 	else if (canKeepAlive())
 	{
         if (_maxKeepAliveRequests > 0)
             --_maxKeepAliveRequests;
-        return buffered() > 0 || socket().poll(_keepAliveTimeout, Socket::SELECT_READ);
+        return buffered() > 0 || waitForRequest(_keepAliveTimeout);
     }
 	else
 		return false;

--- a/src/Server/HTTP/HTTPServerConnection.cpp
+++ b/src/Server/HTTP/HTTPServerConnection.cpp
@@ -39,6 +39,11 @@ void HTTPServerConnection::run()
     std::string server = params->getSoftwareVersion();
     Poco::Net::HTTPServerSession session(socket(), params);
 
+    /// Stop waiting for the next request as soon as the server is shutting down,
+    /// otherwise an idle keep-alive connection would block shutdown until the
+    /// keep-alive timeout elapses (`server_pool.joinAll()` waits for this thread).
+    session.setStopCallback([this] { return stopped || !tcp_server.isOpen(); });
+
     ProfileEvents::increment(ProfileEvents::HTTPServerConnectionsCreated);
 
     while (!stopped && tcp_server.isOpen() && session.connected())

--- a/tests/integration/test_keep_alive_shutdown/configs/keep_alive.xml
+++ b/tests/integration/test_keep_alive_shutdown/configs/keep_alive.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <!-- Large value so a regression (shutdown blocking for the whole timeout)
+         is clearly distinguishable from a fast shutdown. -->
+    <keep_alive_timeout>50</keep_alive_timeout>
+    <interserver_http_port>9009</interserver_http_port>
+</clickhouse>

--- a/tests/integration/test_keep_alive_shutdown/test.py
+++ b/tests/integration/test_keep_alive_shutdown/test.py
@@ -1,0 +1,63 @@
+import http.client
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keep_alive.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_shutdown_with_idle_keep_alive_connection(started_cluster):
+    """
+    An idle keep-alive connection must not block server shutdown for the whole
+    keep_alive_timeout.
+
+    The interserver HTTP server belongs to the group stopped before tables; that
+    shutdown phase waits on `server_pool.joinAll`, which blocks until the handler
+    thread exits. A handler parked in `HTTPServerSession::hasMoreRequests` (a socket
+    read bounded by keep_alive_timeout) does not observe `server.stop` until the
+    read returns, so shutdown used to stall for the whole keep_alive_timeout
+    (set to 50s here). Shutdown must complete quickly regardless.
+    """
+    # Open a connection to the interserver HTTP port, send one request and read the
+    # full response, then leave the connection idle in keep-alive state. The
+    # server-side handler thread now parks waiting for the next request.
+    conn = http.client.HTTPConnection(node.ip_address, 9009, timeout=30)
+    try:
+        conn.request("GET", "/")
+        response = conn.getresponse()
+        response.read()
+        # The connection must actually be kept alive for the test to be meaningful.
+        assert response.getheader("Connection", "").lower() != "close"
+
+        node.query("SYSTEM SHUTDOWN")
+
+        timeout = 20
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if node.get_process_pid("clickhouse") is None:
+                break
+            time.sleep(0.5)
+        else:
+            raise Exception("Server did not stop within timeout")
+    finally:
+        # Closing the connection lets a stalled server finish shutting down so the
+        # instance can be restarted for cluster teardown.
+        conn.close()
+        node.start_clickhouse()


### PR DESCRIPTION
On shutdown, `server.stop` only closes the listening socket. A handler thread already parked in `HTTPServerSession::hasMoreRequests` — a socket read bounded by `keep_alive_timeout` — is not woken, and `HTTPServerConnection::run` only re-checks `tcp_server.isOpen()` after that read returns. The interserver ("servers for tables") shutdown phase then blocks in `server_pool.joinAll` for the full `keep_alive_timeout`, since (unlike the client-connection phase, which calls `safeExit`) it has no force-close fallback. Any idle keep-alive connection on such a server stalls shutdown for the whole timeout.

Fix: make the keep-alive wait interruptible. `hasMoreRequests` polls in 1-second slices and re-checks a stop callback (`!tcp_server.isOpen()`) between slices, so an idle connection observes shutdown within ~1s. The wait is only shortened while idle — buffered and in-flight requests are handled before it — so no traffic is truncated.

Added integration test `test_keep_alive_shutdown` that holds an idle keep-alive connection on the interserver port with `keep_alive_timeout=50` and asserts shutdown still completes quickly. Verified: it fails (`Server did not stop within timeout`) without the fix and passes with it.

Tradeoffs:
- Touches the vendored Poco fork (`HTTPServerSession`), extending its existing keep-alive machinery.
- Idle keep-alive connections now wake ~once per second to check the stop flag (a single-fd `poll` that returns immediately) — negligible per connection, a minor change in a hot path at very high idle-connection counts.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed server shutdown blocking for up to `keep_alive_timeout` seconds when an idle keep-alive HTTP connection (for example, an interserver connection) is open.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
