### PR TITLE
Do not treat a transient liveness-probe timeout as a dead fuzzer server

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -286,8 +286,17 @@ function fuzz
 
     # Default: the loop leaves this unset if it exhausts all retries via the
     # "alive but busy" branches (TOO_MANY_SIMULTANEOUS_QUERIES /
-    # MEMORY_LIMIT_EXCEEDED); a dead server sets server_died=1 and breaks.
+    # MEMORY_LIMIT_EXCEEDED / probe timeout); a dead server sets server_died=1
+    # and breaks. A receive/socket timeout means the server is alive but slow to
+    # answer (common right after a 30m ASAN fuzz run), not dead -- a dead server
+    # returns "Connection refused"/EOF instead -- so count repeated timeouts and
+    # only declare a hang once they persist, otherwise a single transient timeout
+    # turns a clean (exit 143) run into a bogus "server died" FAIL.
+    # BEGIN: server-liveness probe loop (exercised verbatim by
+    # ci/tests/test_fuzzer_liveness_loop.py)
     server_died=0
+    timeouts=0
+    timeouts_max=12
 
     for _ in {1..100}
     do
@@ -305,10 +314,26 @@ function fuzz
                 # it, do not abort the script (that would skip the status.tsv
                 # write below and surface as a missing-status job ERROR).
                 clickhouse-client --query "SHOW PROCESSLIST" ||:
+                timeouts=0
                 sleep 1
             elif grep -F 'MEMORY_LIMIT_EXCEEDED' err
             then
                 # Server is alive but at memory limit, give it time to reclaim
+                timeouts=0
+                sleep 1
+            elif grep -F 'Timeout exceeded while' err
+            then
+                # Alive but slow to answer: retry, and only treat it as a real
+                # hang once the timeouts persist (a dead server hits the branch
+                # below with "Connection refused"/EOF, not a timeout).
+                timeouts=$((timeouts + 1))
+                if [[ "$timeouts" -ge "$timeouts_max" ]]
+                then
+                    echo "Server live check: probe timed out $timeouts times, treating server as hung"
+                    cat err
+                    server_died=1
+                    break
+                fi
                 sleep 1
             else
                 echo "Server live check returns $?"
@@ -318,6 +343,7 @@ function fuzz
             fi
         fi
     done
+    # END: server-liveness probe loop
 
     # Stop the server in background so we can wait for the subshell to
     # finish in the foreground. We wait on server_bg_pid (the subshell running

--- a/ci/tests/test_fuzzer_liveness_loop.py
+++ b/ci/tests/test_fuzzer_liveness_loop.py
@@ -1,0 +1,125 @@
+"""
+Regression test for the post-fuzz server-liveness probe loop in
+ci/jobs/scripts/fuzzer/run-fuzzer.sh.
+
+A run that ends cleanly (the fuzzer is SIGTERM'd at its 30m time limit, exit
+143) was reported as a bogus "Received signal 15" FAIL whenever the very first
+post-fuzz `SELECT 1` probe hit its 5s receive timeout: the server is alive but
+slow to answer right after 30m of ASAN fuzzing, yet the loop's catch-all branch
+treated that single timeout as `server_died=1`. The Python side then checks
+`server_died` before the exit-143 OK branch and scrapes the server's NORMAL
+shutdown "Received signal 15" line.
+
+This test runs the actual loop text (extracted verbatim between the
+BEGIN/END markers in run-fuzzer.sh) against a mock `clickhouse-client`, and
+asserts:
+  - a transient timeout that then recovers leaves server_died=0,
+  - a genuinely dead server (Connection refused / EOF) sets server_died=1 at once,
+  - a persistent timeout (a real hang) still sets server_died=1 once it persists.
+"""
+
+import os
+import re
+import stat
+import subprocess
+import textwrap
+
+_RUN_FUZZER = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "jobs",
+    "scripts",
+    "fuzzer",
+    "run-fuzzer.sh",
+)
+
+
+def _extract_loop() -> str:
+    """The liveness loop, verbatim, from between the BEGIN/END markers."""
+    text = open(_RUN_FUZZER, encoding="utf-8").read()
+    m = re.search(
+        r"# BEGIN: server-liveness probe loop.*?\n(.*?)\n\s*# END: server-liveness probe loop",
+        text,
+        re.DOTALL,
+    )
+    assert m, "BEGIN/END liveness-probe markers not found in run-fuzzer.sh"
+    return textwrap.dedent(m.group(1))
+
+
+def _run_loop(tmp_path, mock_body: str):
+    """Run the extracted loop with `clickhouse-client` mocked by mock_body.
+
+    The mock reads the per-attempt counter from a file so it can vary its
+    behavior across attempts. Returns the final server_died value (0/1).
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    counter = tmp_path / "attempt"
+    counter.write_text("0", encoding="utf-8")
+
+    mock = bindir / "clickhouse-client"
+    mock.write_text(
+        "#!/bin/bash\n"
+        f'n=$(cat "{counter}"); n=$((n+1)); echo "$n" > "{counter}"\n'
+        + mock_body,
+        encoding="utf-8",
+    )
+    mock.chmod(mock.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    # `sleep` is mocked to a no-op so the test does not actually wait.
+    sleep = bindir / "sleep"
+    sleep.write_text("#!/bin/bash\nexit 0\n", encoding="utf-8")
+    sleep.chmod(sleep.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    script = (
+        "set -u\n"
+        f'cd "{tmp_path}"\n'
+        f'export PATH="{bindir}:$PATH"\n'
+        + _extract_loop()
+        + '\necho "SERVER_DIED=$server_died"\n'
+    )
+    out = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    m = re.search(r"SERVER_DIED=(\d)", out.stdout)
+    assert m, f"loop produced no SERVER_DIED marker:\nSTDOUT:\n{out.stdout}\nSTDERR:\n{out.stderr}"
+    return int(m.group(1))
+
+
+_TIMEOUT_ERR = (
+    'echo "Code: 209. DB::NetException: Timeout exceeded while receiving data '
+    'from server. Waited for 5 seconds, timeout is 5 seconds." >&2; exit 1'
+)
+_REFUSED_ERR = (
+    'echo "Code: 210. DB::NetException: Connection refused (localhost:9000). '
+    '(NETWORK_ERROR)" >&2; exit 1'
+)
+
+
+def test_transient_timeout_then_recovers_is_not_server_died(tmp_path):
+    # First 3 probes time out (alive but slow), 4th succeeds -> NOT dead.
+    mock = textwrap.dedent(
+        f"""\
+        if [[ "$n" -le 3 ]]; then
+            {_TIMEOUT_ERR}
+        fi
+        echo 1
+        exit 0
+        """
+    )
+    assert _run_loop(tmp_path, mock) == 0
+
+
+def test_connection_refused_is_server_died_immediately(tmp_path):
+    # A genuinely dead server -> server_died=1 on the first probe.
+    mock = f"{_REFUSED_ERR}\n"
+    assert _run_loop(tmp_path, mock) == 1
+
+
+def test_persistent_timeout_is_eventually_server_died(tmp_path):
+    # The server never answers -> a real hang -> server_died=1 once timeouts persist.
+    mock = f"{_TIMEOUT_ERR}\n"
+    assert _run_loop(tmp_path, mock) == 1


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108508

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `AST fuzzer (...)` job intermittently reports a `Received signal 15` failure across unrelated PRs (8 PRs in the last 30 days on `arm_asan_ubsan`, `amd_msan`, `amd_tsan`, `amd_debug-targeted`; 0 on master). The reported row has no STID, no stack, and no fuzzed query.

**Root cause.** It is a false positive in the post-fuzz server-liveness probe, not a crash. After the fuzzer is SIGTERM'd at its 30m time limit (a clean run, `fuzzer_exit_code=143`), `run-fuzzer.sh` probes the server with `clickhouse-client --receive_timeout=5 --query "SELECT 1"`. When that first probe hits its 5s receive timeout (the server is alive but slow to answer right after 30m of ASAN fuzzing), the loop's catch-all `else` branch sets `server_died=1` and breaks on the first failure. `status.tsv` then carries `server_died=1`, and `ast_fuzzer_job.py` checks `server_died` *before* the `fuzzer_exit_code in (0, 137, 143)` OK branch, so the healthy run is reported as a FAIL whose only "stack" is the server's normal-shutdown `Received signal 15` line. `stop_server` confirms it in the same logs (`Server exit code is 0`) — the server shut down cleanly and was never dead.

Evidence from the triggering run (PR #108508, SHA `88795dc6caed`, `AST fuzzer (arm_asan_ubsan)`, [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108508&sha=88795dc6caedc63227f7b61532a58b15345cf712&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29)):
- `04:11:26` fuzzer started (30m budget); `04:41:26` (+30m) `timeout --signal TERM` → fuzzer exit `143`, `server_died=0`.
- `04:41:32` post-fuzz probe → `Timeout exceeded while receiving data from server. Waited for 5 seconds` → catch-all sets `server_died=1`, breaks.
- `04:41:46` `Server exit code is 0` (clean shutdown). `fuzzer.log` ends at `Fuzzing step 602 out of 1000` then `timeout: sending signal TERM` — no ASan/LOGICAL_ERROR/signal 11/6. `server.log` has only `Received signal 15`/`Received signal -2` shutdown markers, no `<Fatal>`, no sanitizer report, no OOM.

**Fix.** A receive/socket timeout means the server is alive but slow, not dead — a dead server returns `Connection refused` (code 210) or EOF (code 32), neither of which contains `Timeout`. The loop now counts *consecutive* probe timeouts and only declares a hang once they persist (12 in a row), so a single transient timeout no longer turns a clean run into a bogus `server died` FAIL, while a genuine hang is still caught. The existing `Connection refused`/EOF path is unchanged, so a real dead server is still detected immediately.

`ci/tests/test_fuzzer_liveness_loop.py` drives the loop text verbatim against a mock `clickhouse-client` for three cases: transient-timeout-then-recovers (`server_died=0`), connection-refused (`server_died=1` on the first probe), and persistent-timeout/hang (`server_died=1` once it persists). The transient case fails against the pre-fix loop and passes after the fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.160` (included in `26.7` and later)
<!-- ch-version-info:end -->