### PR TITLE
Add test: Distributed-read projection guard untested for the explicit aggregate-projection caller

### DIFF
--- a/tests/queries/0_stateless/04411_distributed_plan_aggregate_projection.reference
+++ b/tests/queries/0_stateless/04411_distributed_plan_aggregate_projection.reference
@@ -1,0 +1,22 @@
+-- distributed aggregate over an aggregate-projected table does not abort
+0	400
+1	400
+2	400
+3	400
+4	400
+5	400
+6	400
+7	400
+8	400
+9	400
+-- matches the single-node result
+0	400
+1	400
+2	400
+3	400
+4	400
+5	400
+6	400
+7	400
+8	400
+9	400

--- a/tests/queries/0_stateless/04411_distributed_plan_aggregate_projection.sql
+++ b/tests/queries/0_stateless/04411_distributed_plan_aggregate_projection.sql
@@ -1,0 +1,31 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: make_distributed_plan requires the analyzer.
+
+-- Regression test: an explicit aggregate projection over a distributed read (make_distributed_plan)
+-- must not be applied to the sharded read; the projection optimization declines for distributed reads,
+-- otherwise the Union split exposes different shard lists and makeDistributedPlan aborts.
+
+DROP TABLE IF EXISTS agg2;
+
+CREATE TABLE agg2 (id1 UInt32, id2 UInt32) ENGINE = MergeTree ORDER BY id1 SETTINGS index_granularity = 16;
+
+-- Mixed parts: the first batch has no projection, the second does, so a match would split the read
+-- into a Union of (surviving parts, projection parts).
+INSERT INTO agg2 SELECT number, number % 10 FROM numbers(2000);
+ALTER TABLE agg2 ADD PROJECTION aggproj (SELECT id2, count() GROUP BY id2);
+INSERT INTO agg2 SELECT number, number % 10 FROM numbers(2000);
+
+-- Pin settings that randomized runs could flip and mask the regression.
+SET max_rows_to_group_by = 0;
+SET optimize_use_projections = 1;
+SET make_distributed_plan = 1, enable_parallel_replicas = 0, distributed_plan_execute_locally = 1,
+    distributed_plan_default_shuffle_join_bucket_count = 3, distributed_plan_default_reader_bucket_count = 3,
+    distributed_plan_max_rows_to_broadcast = 10;
+
+SELECT '-- distributed aggregate over an aggregate-projected table does not abort';
+SELECT id2, count() FROM agg2 GROUP BY id2 ORDER BY id2;
+
+SELECT '-- matches the single-node result';
+SELECT id2, count() FROM agg2 GROUP BY id2 ORDER BY id2 SETTINGS make_distributed_plan = 0;
+
+DROP TABLE agg2;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #108256](https://github.com/ClickHouse/ClickHouse/pull/108256).
That PR (1) The PR adds a single guard to `canUseProjectionForReadingStep` in `projectionsCommon.cpp`: `if (reading->getDistributedReadBucketCount() > 0) return false;`. This declines ANY projection optimization for a `ReadFromMergeTree` that an earlier `make_distributed_plan` pass already turned into a sha

**1. Distributed-read projection guard untested for the explicit aggregate-projection caller**
  `src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp:74`, `src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp:563`
  **Risk:** `optimizeUseAggregateProjection.cpp:563` calls `canUseProjectionForReadingStep`, which the PR extends with `if (reading->getDistributedReadBucketCount() > 0) return false;` at line 74. EXPLAIN confirms the projection is applied single-node but declined under `make_distributed_plan`, so this caller genuinely reaches the new branch. RISK: if the shared guard is scoped to the normal-projection caller only (a plausible refactor), an aggregate projection would be applied to the sharded read, the …
  **What's unique vs PR tests:** The PR's test 04342 drives the NORMAL projection caller (optimizeUseNormalProjection.cpp:94) with a `SELECT id2 ORDER BY id2` projection and PREWHERE/WHERE. This test drives the AGGREGATE projection caller (optimizeUseAggregateProjection.cpp:563) with an explicit `GROUP BY count()` projection and a matching aggregate query — a structurally different optimization (AggregatingProjection Union) that 04342 never exercises, and that 04321 (implicit trivial-count, no explicit projection) also does …
  **Tags:** `-- Tags: no-old-analyzer` — `no-old-analyzer`: make_distributed_plan requires the analyzer; the old planner cannot build a distributed plan, so the guarded path is unreachable there.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)