### PR TITLE
Fix flaky test_e2e_catalogs[glue]: implement wait_for_table_ready

### DIFF
--- a/tests/integration/helpers/catalog_manager_aws_glue.py
+++ b/tests/integration/helpers/catalog_manager_aws_glue.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import logging
 import os
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -218,11 +219,86 @@ class AwsGlueCatalogManager(CatalogManager):
         log.info("Created Glue Iceberg table '%s'", table_identifier)
         return table_name
 
-    def wait_for_table_ready(self, table_name: str) -> None:
-        pass
+    def _namespace_for(self, table_name: str) -> Optional[str]:
+        # Each create_table() puts the table in its own namespace; use the
+        # most recent matching entry.
+        for ns, tn in reversed(self._tables_created):
+            if tn == table_name:
+                return ns
+        return None
 
-    def wait_for_table_gone(self, table_name: str) -> None:
-        pass
+    def wait_for_table_ready(
+        self,
+        table_name: str,
+        timeout: float = 120,
+        poll_interval: float = 5,
+    ) -> None:
+        """Poll until the table is both loadable AND visible in the Glue
+        namespace listing. Glue is eventually-consistent for GetTables, so a
+        freshly-created table can be briefly absent from the listing.
+        """
+        namespace = self._namespace_for(table_name)
+        if namespace is None:
+            return
+        identifier = f"{namespace}.{table_name}"
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self.catalog.load_table(identifier)
+                listed = self.catalog.list_tables(namespace)
+                listed_names = [t[-1] for t in listed]
+                if table_name in listed_names:
+                    log.info(
+                        "Table '%s' ready and listed after %d attempts",
+                        identifier, attempt,
+                    )
+                    return
+                log.warning(
+                    "Table '%s' loadable but not yet listed (attempt %d)",
+                    identifier, attempt,
+                )
+            except Exception as exc:
+                log.warning(
+                    "load_table('%s') failed (attempt %d): %s",
+                    identifier, attempt, exc,
+                )
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Table '{identifier}' not ready/listed via pyiceberg "
+                    f"after {timeout}s ({attempt} attempts)."
+                )
+            time.sleep(poll_interval)
+
+    def wait_for_table_gone(
+        self,
+        table_name: str,
+        timeout: float = 120,
+        poll_interval: float = 5,
+    ) -> None:
+        """Poll until load_table raises, confirming the table is gone."""
+        namespace = self._namespace_for(table_name)
+        if namespace is None:
+            return
+        identifier = f"{namespace}.{table_name}"
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self.catalog.load_table(identifier)
+            except Exception:
+                log.info("Table '%s' gone after %d attempts", identifier, attempt)
+                return
+
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Table '{identifier}' still visible via pyiceberg "
+                    f"after {timeout}s ({attempt} attempts)."
+                )
+            time.sleep(poll_interval)
 
     def _delete_s3_prefix(self, namespace: str, table_name: str) -> None:
         prefix = f"{self.config.prefix}/{namespace}/{table_name}/"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a flaky failure in `test_e2e_catalogs` on the AWS Glue backend that surfaces as:

```
AssertionError: Table 'tbl_xxxxxxxx' not found in SHOW TABLES output:
```

`AwsGlueCatalogManager.wait_for_table_ready` and `wait_for_table_gone` were bare `pass`
no-ops, whereas the sibling `BigLakeCatalogManager` and `OneLakeCatalogManager` implement
them as bounded pyiceberg polling loops. The module-scoped fixtures (`sales_table`,
`customers_table`, `types_table`, `complex_table`) and several tests call
`wait_for_table_ready(name)` right after `create_table`, expecting it to block until the
table is catalog-visible.

AWS Glue is eventually-consistent for `GetTables` listing (`GlueCatalog::getTablesForDatabase`
issues a `GetTables` call per query with no server-side cache), so for the glue backend the
no-op returned immediately and the first `resolve_table_name` / `SHOW TABLES` could race
ahead of Glue's listing propagation. `resolve_table_name` retries for ~15s, which was not
always enough.

This implements both methods to poll `self.catalog` (pyiceberg glue) until the table is
loadable AND listed (ready) or `load_table` raises (gone), bounded by a wall-clock deadline,
mirroring the proven `BigLakeCatalogManager` / `OneLakeCatalogManager` pattern. Glue places
each table in its own namespace, so `_namespace_for` resolves the namespace from
`_tables_created`. Test assertions and `resolve_table_name`'s existing retry backstop are
unchanged.

Note: the `[glue]` E2E job requires real AWS Glue credentials and does not run on the public
CI dashboard.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1026` (included in `26.7` and later)
<!-- ch-version-info:end -->