### PR TITLE
Fix direct read from multiple partially materialized text indexes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -99,7 +99,7 @@ MergeTreeReadTask::MergeTreeReadTask(
 }
 
 /// Returns pointer to the index if all columns in the read step belongs to the read step for that index.
-static const IndexReadTask * getIndexReadTaskForReadStep(const IndexReadTasks & index_read_tasks, const NamesAndTypesList & columns_to_read)
+static const IndexReadTask * getIndexReadTaskForReadStep(const IndexReadTasks & index_read_tasks, const NamesAndTypesList & columns_to_read, const IMergeTreeDataPart & data_part)
 {
     if (index_read_tasks.empty())
         return nullptr;
@@ -133,14 +133,23 @@ static const IndexReadTask * getIndexReadTaskForReadStep(const IndexReadTasks & 
         }
     }
 
-    /// Allow mixing index columns with regular columns when the regular columns are dependencies
-    /// for evaluating default expressions of text index virtual columns (e.g., for partially materialized text indexes).
-    /// In this case, don't return an index task - let the main reader handle all columns.
-    /// The main reader will evaluate the default expression and fill the virtual column.
+    /// Allow mixing index columns with regular columns when the regular columns are dependencies for evaluating
+    /// default expressions of text index virtual columns (e.g., for partially materialized text indexes).
     if (!index_for_step.empty() && has_non_index_columns)
         return nullptr;
 
-    return index_for_step.empty() ? nullptr : &index_read_tasks.at(index_for_step);
+    if (index_for_step.empty())
+        return nullptr;
+
+    /// The index may be not materialized in this part. There is no index file to read, so let
+    /// the main reader handle the step and evaluate the virtual column's default expression instead.
+    const auto & index_task = index_read_tasks.at(index_for_step);
+    const auto & index = index_task.index.index;
+
+    if (!index->getDeserializedFormat(data_part.checksums, index->getFileName(), &data_part.getDataPartStorage()))
+        return nullptr;
+
+    return &index_task;
 }
 
 MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
@@ -178,7 +187,7 @@ MergeTreeReadTask::Readers MergeTreeReadTask::createReaders(
 
     for (const auto & pre_columns_per_step : read_info->task_columns.pre_columns)
     {
-        if (const auto * index_read_task = getIndexReadTaskForReadStep(read_info->index_read_tasks, pre_columns_per_step))
+        if (const auto * index_read_task = getIndexReadTaskForReadStep(read_info->index_read_tasks, pre_columns_per_step, *read_info->data_part))
         {
             new_readers.prewhere.push_back(createMergeTreeReaderIndex(
                 new_readers.main.get(),

--- a/tests/queries/0_stateless/04411_text_index_multiple_partially_materialized.reference
+++ b/tests/queries/0_stateless/04411_text_index_multiple_partially_materialized.reference
@@ -1,0 +1,15 @@
+-- two indexes, both partially materialized
+AND, direct read off	1
+AND, direct read on 	1
+OR,  direct read off	1
+OR,  direct read on 	1
+-- two indexes fully materialized (defined in DDL) give the same results
+AND	1
+OR 	1
+-- three indexes, all partially materialized
+AND all three	1
+AND two	1
+OR all three	1
+-- two indexes with hasToken (splitByNonAlpha tokenizer), partially materialized
+AND	1
+OR 	2

--- a/tests/queries/0_stateless/04411_text_index_multiple_partially_materialized.sql
+++ b/tests/queries/0_stateless/04411_text_index_multiple_partially_materialized.sql
@@ -1,0 +1,96 @@
+-- Direct read from text index must work when a query uses several text indexes that are
+-- only partially materialized (added by ALTER ... ADD INDEX after some data was inserted,
+-- so the older parts have no index files).
+--
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/108530:
+-- the physical fallback column injected for a not-yet-materialized index is shared between
+-- the per-index read steps and deduplicated away from all but the first one, which routed the
+-- remaining steps to a text index reader that threw `FILE_DOESNT_EXIST` for the missing file.
+
+SET use_skip_indexes = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+
+DROP TABLE IF EXISTS users;
+
+-- 'John'/'1231' goes into a part written before the indexes exist (not materialized),
+-- 'Alice'/'1232' goes into a part written after (materialized).
+CREATE TABLE users (user String, host String) ENGINE = MergeTree ORDER BY tuple()
+AS SELECT 'John', '1231';
+
+ALTER TABLE users
+    ADD INDEX user_idx user TYPE text(tokenizer = sparseGrams(3)),
+    ADD INDEX host_idx host TYPE text(tokenizer = sparseGrams(3));
+
+SYSTEM STOP MERGES users;
+INSERT INTO users VALUES ('Alice', '1232');
+
+SELECT '-- two indexes, both partially materialized';
+SELECT 'AND, direct read off', count() FROM users WHERE user = 'John' AND host = '1231' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT 'AND, direct read on ', count() FROM users WHERE user = 'John' AND host = '1231';
+SELECT 'OR,  direct read off', count() FROM users WHERE user = 'John' OR host = '1231' SETTINGS query_plan_direct_read_from_text_index = 0;
+SELECT 'OR,  direct read on ', count() FROM users WHERE user = 'John' OR host = '1231';
+
+DROP TABLE users;
+
+SELECT '-- two indexes fully materialized (defined in DDL) give the same results';
+
+DROP TABLE IF EXISTS users_full;
+
+CREATE TABLE users_full
+(
+    user String,
+    host String,
+    INDEX user_idx user TYPE text(tokenizer = sparseGrams(3)),
+    INDEX host_idx host TYPE text(tokenizer = sparseGrams(3))
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+SYSTEM STOP MERGES users_full;
+INSERT INTO users_full VALUES ('John', '1231');
+INSERT INTO users_full VALUES ('Alice', '1232');
+
+SELECT 'AND', count() FROM users_full WHERE user = 'John' AND host = '1231';
+SELECT 'OR ', count() FROM users_full WHERE user = 'John' OR host = '1231';
+
+DROP TABLE users_full;
+
+SELECT '-- three indexes, all partially materialized';
+
+DROP TABLE IF EXISTS triple;
+
+CREATE TABLE triple (a String, b String, c String) ENGINE = MergeTree ORDER BY tuple()
+AS SELECT 'alpha', 'beta', 'gamma';
+
+ALTER TABLE triple
+    ADD INDEX a_idx a TYPE text(tokenizer = sparseGrams(3)),
+    ADD INDEX b_idx b TYPE text(tokenizer = sparseGrams(3)),
+    ADD INDEX c_idx c TYPE text(tokenizer = sparseGrams(3));
+
+SYSTEM STOP MERGES triple;
+INSERT INTO triple VALUES ('delta', 'epsilon', 'zeta');
+
+SELECT 'AND all three', count() FROM triple WHERE a = 'alpha' AND b = 'beta' AND c = 'gamma';
+SELECT 'AND two',       count() FROM triple WHERE a = 'alpha' AND c = 'gamma';
+SELECT 'OR all three',  count() FROM triple WHERE a = 'alpha' OR b = 'beta' OR c = 'gamma';
+
+DROP TABLE triple;
+
+SELECT '-- two indexes with hasToken (splitByNonAlpha tokenizer), partially materialized';
+
+DROP TABLE IF EXISTS logs;
+
+CREATE TABLE logs (msg String, tag String) ENGINE = MergeTree ORDER BY tuple()
+AS SELECT 'error connection refused', 'net';
+
+ALTER TABLE logs
+    ADD INDEX msg_idx msg TYPE text(tokenizer = splitByNonAlpha),
+    ADD INDEX tag_idx tag TYPE text(tokenizer = splitByNonAlpha);
+
+SYSTEM STOP MERGES logs;
+INSERT INTO logs VALUES ('warning disk full', 'io');
+
+SELECT 'AND', count() FROM logs WHERE hasToken(msg, 'connection') AND hasToken(tag, 'net');
+SELECT 'OR ', count() FROM logs WHERE hasToken(msg, 'connection') OR hasToken(tag, 'io');
+
+DROP TABLE logs;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed direct read from multiple partially materialized text indexes.

Fixes #108530.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.123` (included in `26.7` and later)
- Backported to: `26.6.2.4`, `26.5.5.4`, `26.4.5.82`, `26.3.17.5`
<!-- ch-version-info:end -->