### PR TITLE
Follow-up to #108147

### DIFF
--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1408,9 +1408,17 @@ bool FileCache::doEviction(
                 CurrentMetrics::get(CurrentMetrics::FilesystemCacheDownloadQueueElements));
         };
 
-        bool continue_from_last_eviction_pos = cache_reserve_active_threads.load(std::memory_order_relaxed) > 1;
-        if (!continue_from_last_eviction_pos)
-            main_priority->resetEvictionPos();
+        /// Concurrent reservers resume from the shared reserve cursor so they do not all
+        /// re-scan the queue head and collide on the same candidates. A lone reserver instead
+        /// starts from the head and resets the reserve cursor so the next contended round
+        /// starts fresh. The background free-space keeper uses a separate cursor and is not
+        /// affected by this reset.
+        const bool resume_reserve_cursor = cache_reserve_active_threads.load(std::memory_order_relaxed) > 1;
+        const auto eviction_cursor = resume_reserve_cursor
+            ? IFileCachePriority::EvictionCursor::Reserve
+            : IFileCachePriority::EvictionCursor::FromHead;
+        if (!resume_reserve_cursor)
+            main_priority->resetEvictionPos(IFileCachePriority::EvictionCursor::Reserve);
 
         if (query_eviction_info && query_eviction_info->requiresEviction())
         {
@@ -1421,7 +1429,7 @@ bool FileCache::doEviction(
                     eviction_candidates,
                     invalidated_entries,
                     /* reservee */{},
-                    continue_from_last_eviction_pos,
+                    eviction_cursor,
                     /* max_candidates_size */0,
                     /* is_total_space_cleanup */false,
                     origin_info,
@@ -1442,7 +1450,7 @@ bool FileCache::doEviction(
                 eviction_candidates,
                 invalidated_entries,
                 main_priority_iterator,
-                continue_from_last_eviction_pos,
+                eviction_cursor,
                 /* max_candidates_size */0,
                 /* is_total_space_cleanup */false,
                 origin_info,
@@ -1712,7 +1720,7 @@ void FileCache::freeSpaceRatioImpl(size_t & reschedule_ms)
             FileCacheReserveStat stat;
             main_priority->collectCandidatesForEviction(
                 *eviction_info, stat, *batch->candidates, batch->invalidated_entries,
-                /* reservee */nullptr, /* continue_from_last_eviction_pos */true,
+                /* reservee */nullptr, IFileCachePriority::EvictionCursor::Background,
                 /* max_candidates_size */keep_up_free_space_remove_batch,
                 /* is_total_space_cleanup */true, getInternalOrigin(),
                 cache_guard, cache_state_guard);
@@ -2694,7 +2702,7 @@ bool FileCache::doDynamicResizeImpl(
             eviction_candidates,
             invalidated_entries,
             /* reservee */nullptr,
-            /* continue_from_last_eviction_pos */false,
+            IFileCachePriority::EvictionCursor::FromHead,
             /* max_candidates_size */0,
             /* is_total_space_cleanup */true,
             getInternalOrigin(),

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1408,11 +1408,10 @@ bool FileCache::doEviction(
                 CurrentMetrics::get(CurrentMetrics::FilesystemCacheDownloadQueueElements));
         };
 
-        /// Concurrent reservers resume from the shared reserve cursor so they do not all
-        /// re-scan the queue head and collide on the same candidates. A lone reserver instead
-        /// starts from the head and resets the reserve cursor so the next contended round
-        /// starts fresh. The background free-space keeper uses a separate cursor and is not
-        /// affected by this reset.
+        /// Concurrent reservers resume from the shared reserve cursor to avoid all re-scanning
+        /// the head and colliding on the same candidates. A lone reserver starts from the head
+        /// and resets the cursor for the next contended round. The background keeper has its
+        /// own cursor and is unaffected by this reset.
         const bool resume_reserve_cursor = cache_reserve_active_threads.load(std::memory_order_relaxed) > 1;
         const auto eviction_cursor = resume_reserve_cursor
             ? IFileCachePriority::EvictionCursor::Reserve

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1690,6 +1690,8 @@ void FileCache::freeSpaceRatioImpl(size_t & reschedule_ms)
             removers_scheduled = true;
         }
 
+        main_priority->resetEvictionPos(IFileCachePriority::EvictionCursor::Background);
+
         while (!shutdown)
         {
             /// On the first iteration `eviction_info` is the one collected above; afterwards it is

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1408,10 +1408,6 @@ bool FileCache::doEviction(
                 CurrentMetrics::get(CurrentMetrics::FilesystemCacheDownloadQueueElements));
         };
 
-        /// Concurrent reservers resume from the shared reserve cursor to avoid all re-scanning
-        /// the head and colliding on the same candidates. A lone reserver starts from the head
-        /// and resets the cursor for the next contended round. The background keeper has its
-        /// own cursor and is unaffected by this reset.
         const bool resume_reserve_cursor = cache_reserve_active_threads.load(std::memory_order_relaxed) > 1;
         const auto eviction_cursor = resume_reserve_cursor
             ? IFileCachePriority::EvictionCursor::Reserve

--- a/src/Interpreters/FileCache/IFileCachePriority.h
+++ b/src/Interpreters/FileCache/IFileCachePriority.h
@@ -317,15 +317,13 @@ public:
 
     virtual PriorityDumpPtr dump(const CachePriorityGuard::ReadLock &) = 0;
 
-    /// Selects which persistent eviction cursor a candidate-collection pass resumes from.
-    /// Independent eviction drivers (the foreground reserve path and the background
-    /// free-space keeper) each keep their own cursor, so neither perturbs the other's
-    /// progress through the LRU queue (see `eviction_pos` in LRUFileCachePriority).
+    /// Which cursor a candidate-collection pass resumes from. The reserve path and the
+    /// background keeper each get their own cursor so neither perturbs the other's progress.
     enum class EvictionCursor
     {
-        FromHead,   /// Always start scanning from the queue head; do not persist a position.
-        Reserve,    /// The foreground reserve path's cursor (shared by concurrent reservers).
-        Background, /// The background free-space keeping thread's cursor.
+        FromHead,   /// Start from the queue head; do not persist a position.
+        Reserve,    /// Foreground reserve path (shared by concurrent reservers).
+        Background, /// Background free-space keeping thread.
     };
 
     /// Collect eviction candidates sufficient to free `size` bytes

--- a/src/Interpreters/FileCache/IFileCachePriority.h
+++ b/src/Interpreters/FileCache/IFileCachePriority.h
@@ -317,6 +317,17 @@ public:
 
     virtual PriorityDumpPtr dump(const CachePriorityGuard::ReadLock &) = 0;
 
+    /// Selects which persistent eviction cursor a candidate-collection pass resumes from.
+    /// Independent eviction drivers (the foreground reserve path and the background
+    /// free-space keeper) each keep their own cursor, so neither perturbs the other's
+    /// progress through the LRU queue (see `eviction_pos` in LRUFileCachePriority).
+    enum class EvictionCursor
+    {
+        FromHead,   /// Always start scanning from the queue head; do not persist a position.
+        Reserve,    /// The foreground reserve path's cursor (shared by concurrent reservers).
+        Background, /// The background free-space keeping thread's cursor.
+    };
+
     /// Collect eviction candidates sufficient to free `size` bytes
     /// and `elements` elements from cache.
     virtual bool collectCandidatesForEviction(
@@ -325,7 +336,7 @@ public:
         EvictionCandidates & res,
         InvalidatedEntriesInfos & invalidated_entries,
         IteratorPtr reservee,
-        bool continue_from_last_eviction_pos,
+        EvictionCursor eviction_cursor,
         size_t max_candidates_size,
         bool is_total_space_cleanup,
         const OriginInfo & origin_info,
@@ -359,7 +370,7 @@ public:
         const OriginInfo & origin_info,
         const CacheStateGuard::Lock & lock) = 0;
 
-    virtual void resetEvictionPos() = 0;
+    virtual void resetEvictionPos(EvictionCursor cursor) = 0;
 
     /// Remove given queue entries for the queue.
     /// Used to cleanup invalidated queue entries.

--- a/src/Interpreters/FileCache/IFileCachePriority.h
+++ b/src/Interpreters/FileCache/IFileCachePriority.h
@@ -317,8 +317,7 @@ public:
 
     virtual PriorityDumpPtr dump(const CachePriorityGuard::ReadLock &) = 0;
 
-    /// Which cursor a candidate-collection pass resumes from. The reserve path and the
-    /// background keeper each get their own cursor so neither perturbs the other's progress.
+    /// Which cursor a candidate-collection pass resumes from.
     enum class EvictionCursor
     {
         FromHead,   /// Start from the queue head; do not persist a position.

--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -933,8 +933,7 @@ LRUFileCachePriority::LRUQueue::iterator & LRUFileCachePriority::evictionPos(Evi
 LRUFileCachePriority::LRUQueue::iterator LRUFileCachePriority::getEvictionPos(EvictionCursor cursor, const CachePriorityGuard::ReadLock &) const
 {
     std::lock_guard lk(eviction_pos_mutex);
-    /// `evictionPos` is logically const here (it only selects a member), but is declared
-    /// non-const because it returns a mutable reference for the setters.
+    /// evictionPos only selects a member, but returns a mutable reference for the setters.
     return const_cast<LRUFileCachePriority *>(this)->evictionPos(cursor);
 }
 

--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -81,7 +81,8 @@ LRUFileCachePriority::LRUFileCachePriority(
     : IFileCachePriority(queue_type_, max_size_, max_elements_)
     , description(description_)
     , log(getLogger("LRUFileCachePriority" + (description.empty() ? "" : "(" + description + ")")))
-    , eviction_pos(queue.end())
+    , reserve_eviction_pos(queue.end())
+    , background_eviction_pos(queue.end())
     , queue_id(randomSeed())
 {
     if (state_)
@@ -529,7 +530,7 @@ bool LRUFileCachePriority::collectCandidatesForEviction(
     EvictionCandidates & res,
     InvalidatedEntriesInfos & invalidated_entries,
     IFileCachePriority::IteratorPtr /* reservee */,
-    bool continue_from_last_eviction_pos,
+    EvictionCursor eviction_cursor,
     size_t max_candidates_size,
     bool /* is_total_space_cleanup */,
     const OriginInfo &,
@@ -559,15 +560,19 @@ bool LRUFileCachePriority::collectCandidatesForEviction(
 
     auto lock = cache_guard.readLock();
 
+    const bool use_cursor = eviction_cursor != EvictionCursor::FromHead;
+
     auto start_pos = queue.begin();
-    auto current_eviction_pos = getEvictionPos(lock);
-    if (continue_from_last_eviction_pos
-        && current_eviction_pos != LRUQueue::iterator{}
-        && current_eviction_pos != queue.end()
-        && start_pos != current_eviction_pos)
+    if (use_cursor)
     {
-        ProfileEvents::increment(ProfileEvents::FilesystemCacheEvictionReusedIterator);
-        start_pos = current_eviction_pos;
+        auto current_eviction_pos = getEvictionPos(eviction_cursor, lock);
+        if (current_eviction_pos != LRUQueue::iterator{}
+            && current_eviction_pos != queue.end()
+            && start_pos != current_eviction_pos)
+        {
+            ProfileEvents::increment(ProfileEvents::FilesystemCacheEvictionReusedIterator);
+            start_pos = current_eviction_pos;
+        }
     }
 
     auto iteration_pos = iterateImpl(
@@ -601,8 +606,8 @@ bool LRUFileCachePriority::collectCandidatesForEviction(
     },
     stat, invalidated_entries, lock);
 
-    if (continue_from_last_eviction_pos)
-        setEvictionPos(iteration_pos, lock);
+    if (use_cursor)
+        setEvictionPos(eviction_cursor, iteration_pos, lock);
 
     lock.unlock();
 
@@ -843,7 +848,8 @@ bool LRUFileCachePriority::LRUIterator::assertValid() const
 
 void LRUFileCachePriority::shuffle(const CachePriorityGuard::WriteLock &)
 {
-    chassert(TSA_SUPPRESS_WARNING_FOR_READ(eviction_pos) == queue.end());
+    chassert(TSA_SUPPRESS_WARNING_FOR_READ(reserve_eviction_pos) == queue.end());
+    chassert(TSA_SUPPRESS_WARNING_FOR_READ(background_eviction_pos) == queue.end());
     std::vector<LRUQueue::iterator> its;
     its.reserve(queue.size());
     for (auto it = queue.begin(); it != queue.end(); ++it)
@@ -911,22 +917,40 @@ void LRUFileCachePriority::releaseImpl(size_t size, size_t elements)
     //LOG_TEST(log, "Released {} by size and {} by elements", size, elements);
 }
 
-LRUFileCachePriority::LRUQueue::iterator LRUFileCachePriority::getEvictionPos(const CachePriorityGuard::ReadLock &) const
+LRUFileCachePriority::LRUQueue::iterator & LRUFileCachePriority::evictionPos(EvictionCursor cursor)
 {
-    std::lock_guard lk(eviction_pos_mutex);
-    return eviction_pos;
+    switch (cursor)
+    {
+        case EvictionCursor::Reserve:
+            return reserve_eviction_pos;
+        case EvictionCursor::Background:
+            return background_eviction_pos;
+        case EvictionCursor::FromHead:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "EvictionCursor::FromHead has no persistent cursor");
+    }
 }
 
-void LRUFileCachePriority::setEvictionPos(LRUQueue::iterator it, const CachePriorityGuard::ReadLock &)
+LRUFileCachePriority::LRUQueue::iterator LRUFileCachePriority::getEvictionPos(EvictionCursor cursor, const CachePriorityGuard::ReadLock &) const
 {
     std::lock_guard lk(eviction_pos_mutex);
-    eviction_pos = it;
+    /// `evictionPos` is logically const here (it only selects a member), but is declared
+    /// non-const because it returns a mutable reference for the setters.
+    return const_cast<LRUFileCachePriority *>(this)->evictionPos(cursor);
+}
+
+void LRUFileCachePriority::setEvictionPos(EvictionCursor cursor, LRUQueue::iterator it, const CachePriorityGuard::ReadLock &)
+{
+    std::lock_guard lk(eviction_pos_mutex);
+    evictionPos(cursor) = it;
 }
 
 void LRUFileCachePriority::moveEvictionPosIfEqual(LRUQueue::iterator it, const CachePriorityGuard::WriteLock &)
 {
     std::lock_guard lk(eviction_pos_mutex);
-    if (eviction_pos != LRUQueue::iterator{} && eviction_pos == it)
-        eviction_pos = std::next(it);
+    for (auto * pos : {&reserve_eviction_pos, &background_eviction_pos})
+    {
+        if (*pos != LRUQueue::iterator{} && *pos == it)
+            *pos = std::next(it);
+    }
 }
 }

--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -930,11 +930,23 @@ LRUFileCachePriority::LRUQueue::iterator & LRUFileCachePriority::evictionPos(Evi
     }
 }
 
+const LRUFileCachePriority::LRUQueue::iterator & LRUFileCachePriority::evictionPos(EvictionCursor cursor) const
+{
+    switch (cursor)
+    {
+        case EvictionCursor::Reserve:
+            return reserve_eviction_pos;
+        case EvictionCursor::Background:
+            return background_eviction_pos;
+        case EvictionCursor::FromHead:
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "EvictionCursor::FromHead has no persistent cursor");
+    }
+}
+
 LRUFileCachePriority::LRUQueue::iterator LRUFileCachePriority::getEvictionPos(EvictionCursor cursor, const CachePriorityGuard::ReadLock &) const
 {
     std::lock_guard lk(eviction_pos_mutex);
-    /// evictionPos only selects a member, but returns a mutable reference for the setters.
-    return const_cast<LRUFileCachePriority *>(this)->evictionPos(cursor);
+    return evictionPos(cursor);
 }
 
 void LRUFileCachePriority::setEvictionPos(EvictionCursor cursor, LRUQueue::iterator it, const CachePriorityGuard::ReadLock &)

--- a/src/Interpreters/FileCache/LRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.h
@@ -186,6 +186,7 @@ private:
 
     /// Select the cursor member for `cursor`. `FromHead` has no cursor and must not be passed.
     LRUQueue::iterator & evictionPos(EvictionCursor cursor) TSA_REQUIRES(eviction_pos_mutex);
+    const LRUQueue::iterator & evictionPos(EvictionCursor cursor) const TSA_REQUIRES(eviction_pos_mutex);
     struct InvalidatedRef
     {
         std::weak_ptr<Entry> entry;

--- a/src/Interpreters/FileCache/LRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.h
@@ -97,7 +97,7 @@ public:
         EvictionCandidates & res,
         InvalidatedEntriesInfos & invalidated_entries,
         IFileCachePriority::IteratorPtr reservee,
-        bool continue_from_last_eviction_pos,
+        EvictionCursor eviction_cursor,
         size_t max_candidates_size,
         bool is_total_space_cleanup,
         const OriginInfo & origin_info,
@@ -131,19 +131,19 @@ public:
     FileCachePriorityPtr copy() const { return std::make_unique<LRUFileCachePriority>(getQueueType(), max_size, max_elements, description, state); }
 
     /// See a comment near eviction_pos.
-    void resetEvictionPos() override
+    void resetEvictionPos(EvictionCursor cursor) override
     {
         std::lock_guard lock(eviction_pos_mutex);
-        eviction_pos = LRUQueue::iterator{};
+        evictionPos(cursor) = LRUQueue::iterator{};
     }
 
     /// Used only for unit test.
-    size_t getEvictionPosCount()
+    size_t getEvictionPosCount(EvictionCursor cursor)
     {
         std::lock_guard lock(eviction_pos_mutex);
-        if (eviction_pos == LRUQueue::iterator{})
+        if (evictionPos(cursor) == LRUQueue::iterator{})
             return 0;
-        return std::distance(queue.begin(), eviction_pos);
+        return std::distance(queue.begin(), evictionPos(cursor));
     }
 
 protected:
@@ -176,13 +176,18 @@ private:
     const std::string description;
     LoggerPtr log;
     StatePtr state;
-    /// Eviction position is a pointer used in collectCandidatesForEviction
-    /// to track where the last collectCandidatesForEviction stopped.
-    /// This is an optimization for concurrently made eviction attempts,
-    /// which allows us not to iterate the queue from scratch,
-    /// skipping elements which are likely in non-evictable state.
-    LRUQueue::iterator eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
+    /// Eviction positions track where the last collectCandidatesForEviction stopped,
+    /// so a pass can resume instead of iterating the queue from scratch (skipping elements
+    /// which are likely in a non-evictable state). There is one cursor per independent
+    /// eviction driver (see EvictionCursor): the foreground reserve path and the background
+    /// free-space keeper run concurrently and would otherwise clobber each other's progress.
+    LRUQueue::iterator reserve_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
+    LRUQueue::iterator background_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
     mutable std::mutex eviction_pos_mutex;
+
+    /// Select the cursor for `cursor`. Must be called under `eviction_pos_mutex`.
+    /// `EvictionCursor::FromHead` has no persistent cursor and must not be passed here.
+    LRUQueue::iterator & evictionPos(EvictionCursor cursor) TSA_REQUIRES(eviction_pos_mutex);
     struct InvalidatedRef
     {
         std::weak_ptr<Entry> entry;
@@ -245,8 +250,9 @@ private:
 
     std::string getApproxStateInfoForLog() const;
 
-    LRUQueue::iterator getEvictionPos(const CachePriorityGuard::ReadLock &) const;
-    void setEvictionPos(LRUQueue::iterator it, const CachePriorityGuard::ReadLock &);
+    LRUQueue::iterator getEvictionPos(EvictionCursor cursor, const CachePriorityGuard::ReadLock &) const;
+    void setEvictionPos(EvictionCursor cursor, LRUQueue::iterator it, const CachePriorityGuard::ReadLock &);
+    /// Advance every cursor that points at `it` (which is about to be removed/spliced out).
     void moveEvictionPosIfEqual(LRUQueue::iterator it, const CachePriorityGuard::WriteLock &);
 };
 

--- a/src/Interpreters/FileCache/LRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.h
@@ -177,9 +177,7 @@ private:
     LoggerPtr log;
     StatePtr state;
     /// Where the last collectCandidatesForEviction stopped, so a pass resumes instead of
-    /// rescanning from the head (skipping likely non-evictable entries). One per eviction
-    /// driver (see EvictionCursor) so the reserve path and the background keeper, which run
-    /// concurrently, do not clobber each other's progress.
+    /// rescanning from the head
     LRUQueue::iterator reserve_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
     LRUQueue::iterator background_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
     mutable std::mutex eviction_pos_mutex;

--- a/src/Interpreters/FileCache/LRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.h
@@ -176,17 +176,15 @@ private:
     const std::string description;
     LoggerPtr log;
     StatePtr state;
-    /// Eviction positions track where the last collectCandidatesForEviction stopped,
-    /// so a pass can resume instead of iterating the queue from scratch (skipping elements
-    /// which are likely in a non-evictable state). There is one cursor per independent
-    /// eviction driver (see EvictionCursor): the foreground reserve path and the background
-    /// free-space keeper run concurrently and would otherwise clobber each other's progress.
+    /// Where the last collectCandidatesForEviction stopped, so a pass resumes instead of
+    /// rescanning from the head (skipping likely non-evictable entries). One per eviction
+    /// driver (see EvictionCursor) so the reserve path and the background keeper, which run
+    /// concurrently, do not clobber each other's progress.
     LRUQueue::iterator reserve_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
     LRUQueue::iterator background_eviction_pos TSA_GUARDED_BY(eviction_pos_mutex);
     mutable std::mutex eviction_pos_mutex;
 
-    /// Select the cursor for `cursor`. Must be called under `eviction_pos_mutex`.
-    /// `EvictionCursor::FromHead` has no persistent cursor and must not be passed here.
+    /// Select the cursor member for `cursor`. `FromHead` has no cursor and must not be passed.
     LRUQueue::iterator & evictionPos(EvictionCursor cursor) TSA_REQUIRES(eviction_pos_mutex);
     struct InvalidatedRef
     {

--- a/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
@@ -202,10 +202,10 @@ void SLRUFileCachePriority::iterate(
     probationary_queue.iterate(func, stat, lock);
 }
 
-void SLRUFileCachePriority::resetEvictionPos()
+void SLRUFileCachePriority::resetEvictionPos(EvictionCursor cursor)
 {
-    protected_queue.resetEvictionPos();
-    probationary_queue.resetEvictionPos();
+    protected_queue.resetEvictionPos(cursor);
+    probationary_queue.resetEvictionPos(cursor);
 }
 
 EvictionInfoPtr SLRUFileCachePriority::collectEvictionInfo(
@@ -292,7 +292,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
     EvictionCandidates & res,
     InvalidatedEntriesInfos & invalidated_entries,
     IFileCachePriority::IteratorPtr reservee,
-    bool continue_from_last_eviction_pos,
+    EvictionCursor eviction_cursor,
     size_t max_candidates_size,
     bool is_total_space_cleanup,
     const OriginInfo & origin_info,
@@ -314,7 +314,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -334,7 +334,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -357,7 +357,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -382,7 +382,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -398,7 +398,7 @@ bool SLRUFileCachePriority::collectCandidatesForEviction(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -417,7 +417,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
     EvictionCandidates & res,
     InvalidatedEntriesInfos & invalidated_entries,
     IFileCachePriority::IteratorPtr reservee,
-    bool continue_from_last_eviction_pos,
+    EvictionCursor eviction_cursor,
     size_t max_candidates_size,
     bool is_total_space_cleanup,
     const OriginInfo & origin_info,
@@ -433,7 +433,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
         *downgrade_candidates,
         invalidated_entries,
         reservee,
-        continue_from_last_eviction_pos,
+        eviction_cursor,
         max_candidates_size,
         is_total_space_cleanup,
         origin_info,
@@ -477,7 +477,7 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
             res,
             invalidated_entries,
             reservee,
-            continue_from_last_eviction_pos,
+            eviction_cursor,
             max_candidates_size,
             is_total_space_cleanup,
             origin_info,
@@ -715,7 +715,7 @@ bool SLRUFileCachePriority::tryIncreasePriority(
         eviction_candidates,
         invalidated_entries,
         /* reservee */nullptr,
-        /* continue_from_last_eviction_pos */false,
+        EvictionCursor::FromHead,
         /* max_candidates_size */0,
         /* is_total_space_cleanup */false,
         FileCache::getInternalOrigin(),

--- a/src/Interpreters/FileCache/SLRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.h
@@ -83,7 +83,7 @@ public:
         EvictionCandidates & res,
         InvalidatedEntriesInfos & invalidated_entries,
         IFileCachePriority::IteratorPtr reservee,
-        bool continue_from_last_eviction_pos,
+        EvictionCursor eviction_cursor,
         size_t max_candidates_size,
         bool is_total_space_cleanup,
         const OriginInfo & origin_info,
@@ -103,7 +103,7 @@ public:
 
     void shuffle(const CachePriorityGuard::WriteLock &) override;
 
-    void resetEvictionPos() override;
+    void resetEvictionPos(EvictionCursor cursor) override;
 
     PriorityDumpPtr dump(const CachePriorityGuard::ReadLock &) override;
 
@@ -164,7 +164,7 @@ private:
         EvictionCandidates & res,
         InvalidatedEntriesInfos & invalidated_entries,
         IFileCachePriority::IteratorPtr reservee,
-        bool continue_from_last_eviction_pos,
+        EvictionCursor eviction_cursor,
         size_t max_candidates_size,
         bool is_total_space_cleanup,
         const OriginInfo & origin_info,

--- a/src/Interpreters/FileCache/SplitFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SplitFileCachePriority.cpp
@@ -268,7 +268,7 @@ bool SplitFileCachePriority::collectCandidatesForEviction(
     EvictionCandidates & res,
     InvalidatedEntriesInfos & invalidated_entries,
     IFileCachePriority::IteratorPtr reservee,
-    bool continue_from_last_eviction_pos,
+    EvictionCursor eviction_cursor,
     size_t max_candidates_size,
     bool is_total_space_cleanup,
     const OriginInfo & origin_info,
@@ -284,14 +284,14 @@ bool SplitFileCachePriority::collectCandidatesForEviction(
         FileCacheReserveStat data_stat;
         bool success = getPriority(SegmentType::Data).collectCandidatesForEviction(
             eviction_info, data_stat, res, invalidated_entries, /* reservee */nullptr,
-            continue_from_last_eviction_pos, max_candidates_size,
+            eviction_cursor, max_candidates_size,
             is_total_space_cleanup, origin_info, priority_guard, state_guard);
 
         /// Collect candidates even if success == false, we will process them anyway.
         FileCacheReserveStat system_stat;
         success &= getPriority(SegmentType::System).collectCandidatesForEviction(
             eviction_info, system_stat, res, invalidated_entries, /* reservee */nullptr,
-            continue_from_last_eviction_pos, max_candidates_size,
+            eviction_cursor, max_candidates_size,
             is_total_space_cleanup, origin_info, priority_guard, state_guard);
 
         stat += data_stat;
@@ -302,7 +302,7 @@ bool SplitFileCachePriority::collectCandidatesForEviction(
     const auto type = getPriorityType(origin_info.segment_type);
     return getPriority(type).collectCandidatesForEviction(
         eviction_info, stat, res, invalidated_entries, reservee,
-        continue_from_last_eviction_pos, max_candidates_size,
+        eviction_cursor, max_candidates_size,
         is_total_space_cleanup, origin_info, priority_guard, state_guard);
 }
 
@@ -316,10 +316,10 @@ bool SplitFileCachePriority::tryIncreasePriority(
     return getPriority(type).tryIncreasePriority(iterator, is_space_reservation_complete, queue_guard, state_guard);
 }
 
-void SplitFileCachePriority::resetEvictionPos()
+void SplitFileCachePriority::resetEvictionPos(EvictionCursor cursor)
 {
-    getPriority(SegmentType::Data).resetEvictionPos();
-    getPriority(SegmentType::System).resetEvictionPos();
+    getPriority(SegmentType::Data).resetEvictionPos(cursor);
+    getPriority(SegmentType::System).resetEvictionPos(cursor);
 }
 
 size_t SplitFileCachePriority::getHoldSize()

--- a/src/Interpreters/FileCache/SplitFileCachePriority.h
+++ b/src/Interpreters/FileCache/SplitFileCachePriority.h
@@ -88,7 +88,7 @@ public:
         EvictionCandidates & res,
         InvalidatedEntriesInfos & invalidated_entries,
         IFileCachePriority::IteratorPtr reservee,
-        bool continue_from_last_eviction_pos,
+        EvictionCursor eviction_cursor,
         size_t max_candidates_size,
         bool is_total_space_cleanup,
         const OriginInfo & origin_info,
@@ -116,7 +116,7 @@ public:
         const OriginInfo & origin_info,
         const CacheStateGuard::Lock & lock) override;
 
-    void resetEvictionPos() override;
+    void resetEvictionPos(EvictionCursor cursor) override;
 
 protected:
     void setInvalidateNotifier(size_t threshold, std::function<void()> on_invalidate) override

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1939,12 +1939,14 @@ TEST_F(FileCacheTest, MoveEvictionPos)
     auto it_middle = add_to_src(10, 10);
     add_to_src(20, 10);
 
-    /// Point src's eviction position at the middle entry — the one we are about to move out.
+    /// Point both eviction cursors at the middle entry — the one we are about to move out.
     {
         auto read_lock = cache_guard.readLock();
         src.setEvictionPos(IFileCachePriority::EvictionCursor::Reserve, it_middle.get(), read_lock);
+        src.setEvictionPos(IFileCachePriority::EvictionCursor::Background, it_middle.get(), read_lock);
     }
     ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Reserve, cache_guard.readLock()))->offset, 10u);
+    ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Background, cache_guard.readLock()))->offset, 10u);
 
     /// Move the middle entry out of `src` into `dst` (as an SLRU upgrade/downgrade would).
     /// `move` is called on the destination queue; `src` is the source.
@@ -1957,7 +1959,22 @@ TEST_F(FileCacheTest, MoveEvictionPos)
     /// The moved node was spliced out of src, so src's eviction position must advance to the
     /// next surviving src entry (offset 20). Before the fix it kept pointing at the moved node,
     /// which now lives in `dst` (offset 10) — a dangling cross-queue eviction position.
+    /// Both cursors were set at the moved node, so `moveEvictionPosIfEqual` must advance both:
+    /// a regression advancing only one would leave the other dangling.
     ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Reserve, cache_guard.readLock()))->offset, 20u);
+    ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Background, cache_guard.readLock()))->offset, 20u);
+
+    /// The two cursors are independent: resetting one must not disturb the other. Put them at
+    /// different positions, reset only Reserve, and check Background is untouched. A regression
+    /// where `resetEvictionPos(Reserve)` also cleared Background would be caught here.
+    {
+        auto read_lock = cache_guard.readLock();
+        src.setEvictionPos(IFileCachePriority::EvictionCursor::Reserve, src.queue.begin(), read_lock);
+        src.setEvictionPos(IFileCachePriority::EvictionCursor::Background, std::next(src.queue.begin()), read_lock);
+    }
+    src.resetEvictionPos(IFileCachePriority::EvictionCursor::Reserve);
+    ASSERT_EQ(src.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 0u);
+    ASSERT_EQ(src.getEvictionPosCount(IFileCachePriority::EvictionCursor::Background), 1u);
 }
 
 TEST_F(FileCacheTest, LoadMetadataParallelism)

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1837,33 +1837,33 @@ TEST_F(FileCacheTest, ContinueEvictionPos)
     auto it2 = add_file_segment(10, 10);
 
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 2);
-    ASSERT_EQ(priority.getEvictionPosCount(), 2); /// queue.end()
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 2); /// queue.end()
 
     FileCacheReserveStat stat;
     IFileCachePriority::InvalidatedEntriesInfos invalidated_entries;
     auto evicted = std::make_unique<EvictionCandidates>(&FileCache::onSegmentEvicted);
 
     auto eviction_info = priority.collectEvictionInfo(10, 1, nullptr, false, origin, state_guard.lock());
-    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, true, 0, false, origin, cache_guard, state_guard);
+    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, IFileCachePriority::EvictionCursor::Reserve, 0, false, origin, cache_guard, state_guard);
     eviction_info.reset();
 
     ASSERT_EQ(evicted->size(), 0); /// Nothing is evicted.
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 2);
-    ASSERT_EQ(priority.getEvictionPosCount(), 2); /// queue.end()
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 2); /// queue.end()
 
     auto it3 = add_file_segment(20, 10);
 
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 3);
-    ASSERT_EQ(priority.getEvictionPosCount(), 3); /// queue.end()
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 3); /// queue.end()
 
     evicted = std::make_unique<EvictionCandidates>(&FileCache::onSegmentEvicted);
     stat = {};
     eviction_info = priority.collectEvictionInfo(10, 1, nullptr, false, origin, state_guard.lock());
-    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, true, 0, false, origin, cache_guard, state_guard);
+    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, IFileCachePriority::EvictionCursor::Reserve, 0, false, origin, cache_guard, state_guard);
 
     ASSERT_EQ(evicted->size(), 1);
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 3);
-    ASSERT_EQ(priority.getEvictionPosCount(), 0); /// queue.begin()
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 0); /// queue.begin()
 
     {
         evicted->evict();
@@ -1873,7 +1873,7 @@ TEST_F(FileCacheTest, ContinueEvictionPos)
         evicted.reset();
     }
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 2);
-    ASSERT_EQ(priority.getEvictionPosCount(), 0); /// still queue.begin(), but it2
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 0); /// still queue.begin(), but it2
 
     auto get_file_segment = [&](size_t offset)
     {
@@ -1889,22 +1889,22 @@ TEST_F(FileCacheTest, ContinueEvictionPos)
 
     auto it4 = add_file_segment(30, 10);
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 3);
-    ASSERT_EQ(priority.getEvictionPosCount(), 0);
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 0);
 
     evicted = std::make_unique<EvictionCandidates>(&FileCache::onSegmentEvicted);
     stat = {};
     eviction_info = priority.collectEvictionInfo(10, 1, nullptr, false, origin, state_guard.lock());
-    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, true, 0, false, origin, cache_guard, state_guard);
+    priority.collectCandidatesForEviction(*eviction_info, stat, *evicted, invalidated_entries, nullptr, IFileCachePriority::EvictionCursor::Reserve, 0, false, origin, cache_guard, state_guard);
 
     ASSERT_EQ(evicted->size(), 1);
     ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 3);
-    ASSERT_EQ(priority.getEvictionPosCount(), 3); /// 3 and not 2, because 1 entry is invalidated.
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 3); /// 3 and not 2, because 1 entry is invalidated.
 
     fs2.reset();
     fs3.reset();
 
-    priority.resetEvictionPos();
-    ASSERT_EQ(priority.getEvictionPosCount(), 0); /// queue.begin()
+    priority.resetEvictionPos(IFileCachePriority::EvictionCursor::Reserve);
+    ASSERT_EQ(priority.getEvictionPosCount(IFileCachePriority::EvictionCursor::Reserve), 0); /// queue.begin()
 }
 
 TEST_F(FileCacheTest, MoveEvictionPos)
@@ -1942,9 +1942,9 @@ TEST_F(FileCacheTest, MoveEvictionPos)
     /// Point src's eviction position at the middle entry — the one we are about to move out.
     {
         auto read_lock = cache_guard.readLock();
-        src.setEvictionPos(it_middle.get(), read_lock);
+        src.setEvictionPos(IFileCachePriority::EvictionCursor::Reserve, it_middle.get(), read_lock);
     }
-    ASSERT_EQ((*src.getEvictionPos(cache_guard.readLock()))->offset, 10u);
+    ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Reserve, cache_guard.readLock()))->offset, 10u);
 
     /// Move the middle entry out of `src` into `dst` (as an SLRU upgrade/downgrade would).
     /// `move` is called on the destination queue; `src` is the source.
@@ -1957,7 +1957,7 @@ TEST_F(FileCacheTest, MoveEvictionPos)
     /// The moved node was spliced out of src, so src's eviction position must advance to the
     /// next surviving src entry (offset 20). Before the fix it kept pointing at the moved node,
     /// which now lives in `dst` (offset 10) — a dangling cross-queue eviction position.
-    ASSERT_EQ((*src.getEvictionPos(cache_guard.readLock()))->offset, 20u);
+    ASSERT_EQ((*src.getEvictionPos(IFileCachePriority::EvictionCursor::Reserve, cache_guard.readLock()))->offset, 20u);
 }
 
 TEST_F(FileCacheTest, LoadMetadataParallelism)
@@ -2454,7 +2454,7 @@ TEST_F(FileCacheTest, SplitResizeCollectsSystemCandidates)
     EvictionCandidates evicted(IFileCachePriority::OnEvictCallback{});
     priority.collectCandidatesForEviction(
         *eviction_info, stat, evicted, invalidated_entries, /* reservee */ nullptr,
-        /* continue_from_last_eviction_pos */ false, /* max_candidates_size */ 0,
+        IFileCachePriority::EvictionCursor::FromHead, /* max_candidates_size */ 0,
         /* is_total_space_cleanup */ true, FileCache::getInternalOrigin(), cache_guard, state_guard);
 
     /// With the bug, dispatch goes to the empty data sub-queue and no System candidates
@@ -2530,7 +2530,7 @@ TEST_F(FileCacheTest, SLRUDowngradeRollbackResetsEvictingOnSkippedFinalization)
         auto evicted = std::make_unique<EvictionCandidates>(IFileCachePriority::OnEvictCallback{});
         priority.collectCandidatesForEviction(
             *eviction_info, stat, *evicted, invalidated_entries, reservee,
-            /* continue_from_last_eviction_pos */ false, /* max_candidates_size */ 0,
+            IFileCachePriority::EvictionCursor::FromHead, /* max_candidates_size */ 0,
             /* is_total_space_cleanup */ false, origin, cache_guard, state_guard);
 
         /// Run only the write phase, then drop the candidates WITHOUT running the state
@@ -2615,7 +2615,7 @@ TEST_F(FileCacheTest, SplitSLRUTotalSpaceCleanupSystemOnly)
     /// Must not throw on the empty Data SLRU's absent queue ids.
     ASSERT_NO_THROW(priority.collectCandidatesForEviction(
         *eviction_info, stat, evicted, invalidated_entries, /* reservee */ nullptr,
-        /* continue_from_last_eviction_pos */ false, /* max_candidates_size */ 0,
+        IFileCachePriority::EvictionCursor::FromHead, /* max_candidates_size */ 0,
         /* is_total_space_cleanup */ true, FileCache::getInternalOrigin(), cache_guard, state_guard));
 
     ASSERT_GT(evicted.size(), 0u);


### PR DESCRIPTION
Follow up to https://github.com/ClickHouse/ClickHouse/pull/108147: improve `eviction_pos` usage by not sharing it between background and in-place eviction.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.246` (included in `26.7` and later)
<!-- ch-version-info:end -->