### PR TITLE
Speed up the slowest integration tests

### DIFF
--- a/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
+++ b/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
@@ -73,10 +73,10 @@ def test_total_pk_bytes_in_memory_fields(started_cluster):
 
     # insert data into the table and select
     node.query(
-        """INSERT INTO test_pk_bytes SELECT number + 20, number * 20 from numbers(1000000)"""
+        """INSERT INTO test_pk_bytes SELECT number + 20, number * 20 from numbers(10000)"""
     )
 
-    node.query("""SELECT * FROM test_pk_bytes where a > 1000000""")
+    node.query("""SELECT * FROM test_pk_bytes where a > 10000""")
 
     # functions to query primary key bytes used and allocated in memory
     def res_pk_bytes():
@@ -99,7 +99,7 @@ def test_total_pk_bytes_in_memory_fields(started_cluster):
 
     # insert some more data
     node.query(
-        """INSERT INTO test_pk_bytes SELECT number + 100, number * 200 from numbers(1000000)"""
+        """INSERT INTO test_pk_bytes SELECT number + 100, number * 200 from numbers(10000)"""
     )
     node.query("""SELECT * FROM test_pk_bytes""")
 
@@ -159,7 +159,7 @@ def test_total_proj_pk_ig_in_memory_fields(started_cluster):
     proj_ig_bytes_allocated_before = int(node.query(query_proj_ig_bytes_allocated).strip())
 
     # first insert
-    node.query("""INSERT INTO test_proj_pk_bytes SELECT number, number * 2 FROM numbers(1000000)""")
+    node.query("""INSERT INTO test_proj_pk_bytes SELECT number, number * 2 FROM numbers(10000)""")
 
     # force projection PK to load
     node.query("""SELECT b, a FROM test_proj_pk_bytes where b=1000
@@ -200,7 +200,7 @@ def test_total_proj_pk_ig_in_memory_fields(started_cluster):
     assert proj_ig_bytes_allocated_after > proj_ig_bytes_allocated_before
 
     # second insert
-    node.query("""INSERT INTO test_proj_pk_bytes SELECT number + 100, number * 200 FROM numbers(1000000)""")
+    node.query("""INSERT INTO test_proj_pk_bytes SELECT number + 100, number * 200 FROM numbers(10000)""")
 
     node.query("""SELECT b, a FROM test_proj_pk_bytes where b=5000000
                   SETTINGS optimize_use_projections=1, force_optimize_projection=1""")

--- a/tests/integration/test_backward_compatibility/test_functions.py
+++ b/tests/integration/test_backward_compatibility/test_functions.py
@@ -4,6 +4,7 @@
 # pylint: disable=redefined-outer-name
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -240,68 +241,64 @@ def test_string_functions(start_cluster):
     functions = list(functions)
     logging.info("Got %s functions", len(functions))
 
-    skipped = 0
-    failed = 0
-    passed = 0
+    v = "foo"
+
+    allowed_errors = [
+        # Messages
+        "Cannot load time zone ",
+        "No macro ",
+        "Should start with ",  # POINT/POLYGON/...
+        "Cannot read input: expected a digit but got something else:",
+        # ErrorCodes
+        "ILLEGAL_TYPE_OF_ARGUMENT",
+        "DICTIONARIES_WAS_NOT_LOADED",
+        "CANNOT_PARSE_UUID",
+        "CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING",
+        "ILLEGAL_COLUMN",
+        "TYPE_MISMATCH",
+        "SUPPORT_IS_DISABLED",
+        "CANNOT_PARSE_DATE",
+        "UNKNOWN_SETTING",
+        "CANNOT_PARSE_BOOL",
+        "FILE_DOESNT_EXIST",
+        "NOT_IMPLEMENTED",
+        "BAD_GET",
+        "UNKNOWN_TYPE",
+        # addressToSymbol
+        "FUNCTION_NOT_ALLOWED",
+        # Date functions
+        "CANNOT_PARSE_TEXT",
+        "CANNOT_PARSE_DATETIME",
+        # Function X takes exactly one parameter:
+        "NUMBER_OF_ARGUMENTS_DOESNT_MATCH",
+        # Function X takes at least one argument
+        "TOO_FEW_ARGUMENTS_FOR_FUNCTION",
+        # Function X accepts at most 3 arguments, Y given
+        "TOO_MANY_ARGUMENTS_FOR_FUNCTION",
+        # The function 'X' can only be used as a window function
+        "BAD_ARGUMENTS",
+        # String foo is obviously not a valid IP address.
+        "CANNOT_PARSE_IPV4",
+        "CANNOT_PARSE_IPV6",
+        # neighbor / runningDifference / runningAccumulate are deprecated and disabled by default.
+        "DEPRECATED_FUNCTION",
+    ]
 
     def get_function_value(node, function_name, value):
         return node.query(f"select {function_name}('{value}')").strip()
 
-    v = "foo"
-    for function in functions:
+    def check_function(function):
         logging.info("Checking %s('%s')", function, v)
 
         try:
             backward_value = get_function_value(backward, function, v)
         except QueryRuntimeException as e:
             error_message = str(e)
-            allowed_errors = [
-                # Messages
-                "Cannot load time zone ",
-                "No macro ",
-                "Should start with ",  # POINT/POLYGON/...
-                "Cannot read input: expected a digit but got something else:",
-                # ErrorCodes
-                "ILLEGAL_TYPE_OF_ARGUMENT",
-                "DICTIONARIES_WAS_NOT_LOADED",
-                "CANNOT_PARSE_UUID",
-                "CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING",
-                "ILLEGAL_COLUMN",
-                "TYPE_MISMATCH",
-                "SUPPORT_IS_DISABLED",
-                "CANNOT_PARSE_DATE",
-                "UNKNOWN_SETTING",
-                "CANNOT_PARSE_BOOL",
-                "FILE_DOESNT_EXIST",
-                "NOT_IMPLEMENTED",
-                "BAD_GET",
-                "UNKNOWN_TYPE",
-                # addressToSymbol
-                "FUNCTION_NOT_ALLOWED",
-                # Date functions
-                "CANNOT_PARSE_TEXT",
-                "CANNOT_PARSE_DATETIME",
-                # Function X takes exactly one parameter:
-                "NUMBER_OF_ARGUMENTS_DOESNT_MATCH",
-                # Function X takes at least one argument
-                "TOO_FEW_ARGUMENTS_FOR_FUNCTION",
-                # Function X accepts at most 3 arguments, Y given
-                "TOO_MANY_ARGUMENTS_FOR_FUNCTION",
-                # The function 'X' can only be used as a window function
-                "BAD_ARGUMENTS",
-                # String foo is obviously not a valid IP address.
-                "CANNOT_PARSE_IPV4",
-                "CANNOT_PARSE_IPV6",
-                # neighbor / runningDifference / runningAccumulate are deprecated and disabled by default.
-                "DEPRECATED_FUNCTION",
-            ]
             if any(map(lambda x: x in error_message, allowed_errors)):
                 logging.info("Skipping %s", function)
-                skipped += 1
-                continue
+                return "skipped"
             logging.exception("Failed %s", function)
-            failed += 1
-            continue
+            return "failed"
 
         upstream_value = get_function_value(upstream, function, v)
         if upstream_value != backward_value:
@@ -312,10 +309,18 @@ def test_string_functions(start_cluster):
                 backward_value,
                 upstream_value,
             )
-            failed += 1
-        else:
-            logging.info("OK %s", function)
-            passed += 1
+            return "failed"
+        logging.info("OK %s", function)
+        return "passed"
+
+    # The work is dominated by per-query round-trip latency rather than server
+    # CPU, so run the independent per-function checks concurrently.
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        outcomes = list(executor.map(check_function, functions))
+
+    skipped = outcomes.count("skipped")
+    failed = outcomes.count("failed")
+    passed = outcomes.count("passed")
 
     logging.info(
         "Functions: %s, failed: %s, skipped: %s, passed: %s",

--- a/tests/integration/test_backward_compatibility/test_functions.py
+++ b/tests/integration/test_backward_compatibility/test_functions.py
@@ -61,9 +61,25 @@ def test_aggregate_states(start_cluster):
     aggregate_functions = list(aggregate_functions)
     logging.info("Got %s aggregate functions", len(aggregate_functions))
 
-    skipped = 0
-    failed = 0
-    passed = 0
+    allowed_errors = [
+        "ILLEGAL_TYPE_OF_ARGUMENT",
+        # sequenceNextNode() and friends
+        "UNKNOWN_AGGREGATE_FUNCTION",
+        # Function X takes exactly one parameter:
+        "NUMBER_OF_ARGUMENTS_DOESNT_MATCH",
+        # Function X takes at least one argument
+        "TOO_FEW_ARGUMENTS_FOR_FUNCTION",
+        # Function X accepts at most 3 arguments, Y given
+        "TOO_MANY_ARGUMENTS_FOR_FUNCTION",
+        # The function 'X' can only be used as a window function
+        "BAD_ARGUMENTS",
+        # aggThrow
+        "AGGREGATE_FUNCTION_THROW",
+        # Numerically-stable variants (stddevPopStable, varSampStable, ...) reject a String argument
+        "NOT_IMPLEMENTED",
+        # Introspection aggregates (flameGraph) are disabled by default
+        "FUNCTION_NOT_ALLOWED",
+    ]
 
     def get_aggregate_state_hex(node, function_name):
         return node.query(
@@ -75,39 +91,18 @@ def test_aggregate_states(start_cluster):
             f"select finalizeAggregation(unhex('{value}')::AggregateFunction({function_name}, String))"
         ).strip()
 
-    for aggregate_function in aggregate_functions:
+    def check_aggregate(aggregate_function):
         logging.info("Checking %s", aggregate_function)
 
         try:
             backward_state = get_aggregate_state_hex(backward, aggregate_function)
         except QueryRuntimeException as e:
             error_message = str(e)
-            allowed_errors = [
-                "ILLEGAL_TYPE_OF_ARGUMENT",
-                # sequenceNextNode() and friends
-                "UNKNOWN_AGGREGATE_FUNCTION",
-                # Function X takes exactly one parameter:
-                "NUMBER_OF_ARGUMENTS_DOESNT_MATCH",
-                # Function X takes at least one argument
-                "TOO_FEW_ARGUMENTS_FOR_FUNCTION",
-                # Function X accepts at most 3 arguments, Y given
-                "TOO_MANY_ARGUMENTS_FOR_FUNCTION",
-                # The function 'X' can only be used as a window function
-                "BAD_ARGUMENTS",
-                # aggThrow
-                "AGGREGATE_FUNCTION_THROW",
-                # Numerically-stable variants (stddevPopStable, varSampStable, ...) reject a String argument
-                "NOT_IMPLEMENTED",
-                # Introspection aggregates (flameGraph) are disabled by default
-                "FUNCTION_NOT_ALLOWED",
-            ]
             if any(map(lambda x: x in error_message, allowed_errors)):
                 logging.info("Skipping %s", aggregate_function)
-                skipped += 1
-                continue
+                return "skipped"
             logging.exception("Failed %s", aggregate_function)
-            failed += 1
-            continue
+            return "failed"
 
         upstream_state = get_aggregate_state_hex(upstream, aggregate_function)
         if upstream_state != backward_state:
@@ -125,28 +120,34 @@ def test_aggregate_states(start_cluster):
                     logging.info(
                         "OK %s (but different intermediate states)", aggregate_function
                     )
-                    passed += 1
-                else:
-                    logging.error(
-                        "Failed %s, Intermediate: %s (backward) != %s (upstream). Final from intermediate: %s (backward from upstream state) != %s (upstream from backward state)",
-                        aggregate_function,
-                        backward_state,
-                        upstream_state,
-                        backward_final_from_upstream,
-                        upstream_final_from_backward,
-                    )
-                    failed += 1
-            else:
+                    return "passed"
                 logging.error(
-                    "Failed %s, %s (backward) != %s (upstream)",
+                    "Failed %s, Intermediate: %s (backward) != %s (upstream). Final from intermediate: %s (backward from upstream state) != %s (upstream from backward state)",
                     aggregate_function,
                     backward_state,
                     upstream_state,
+                    backward_final_from_upstream,
+                    upstream_final_from_backward,
                 )
-                failed += 1
-        else:
-            logging.info("OK %s", aggregate_function)
-            passed += 1
+                return "failed"
+            logging.error(
+                "Failed %s, %s (backward) != %s (upstream)",
+                aggregate_function,
+                backward_state,
+                upstream_state,
+            )
+            return "failed"
+        logging.info("OK %s", aggregate_function)
+        return "passed"
+
+    # The work is dominated by per-query round-trip latency rather than server
+    # CPU, so run the independent per-function checks concurrently.
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        outcomes = list(executor.map(check_aggregate, aggregate_functions))
+
+    skipped = outcomes.count("skipped")
+    failed = outcomes.count("failed")
+    passed = outcomes.count("passed")
 
     logging.info(
         "Aggregate functions: %s, Failed: %s, skipped: %s, passed: %s",

--- a/tests/integration/test_cleanup_dir_after_bad_zk_conn/configs/fast_zk_timeouts.xml
+++ b/tests/integration/test_cleanup_dir_after_bad_zk_conn/configs/fast_zk_timeouts.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <zookeeper>
+        <node index="1">
+            <host>zoo1</host>
+            <port>2181</port>
+        </node>
+        <node index="2">
+            <host>zoo2</host>
+            <port>2181</port>
+        </node>
+        <node index="3">
+            <host>zoo3</host>
+            <port>2181</port>
+        </node>
+        <!-- Lower timeouts so the ZK-failure path surfaces quickly instead of
+             waiting the default session (15s) / operation (10s) windows. Kept
+             with margin above a real round-trip to stay safe under sanitizers. -->
+        <session_timeout_ms>5000</session_timeout_ms>
+        <operation_timeout_ms>3000</operation_timeout_ms>
+        <connection_timeout_ms>1000</connection_timeout_ms>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
+++ b/tests/integration/test_cleanup_dir_after_bad_zk_conn/test.py
@@ -5,7 +5,9 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.network import PartitionManager
 
-cluster = ClickHouseCluster(__file__)
+cluster = ClickHouseCluster(
+    __file__, zookeeper_config_path="configs/fast_zk_timeouts.xml"
+)
 node1 = cluster.add_instance("node1", with_zookeeper=True)
 
 
@@ -40,9 +42,10 @@ def test_cleanup_dir_after_bad_zk_conn(start_cluster):
     ORDER BY id;"""
     with PartitionManager() as pm:
         pm.drop_instance_zk_connections(node1)
-        time.sleep(3)
+        # Let the connection-drop rule take effect before issuing the query.
+        time.sleep(1)
         error = node1.query_and_get_error(query_create)
-        time.sleep(3)
+        # ZooKeeper is still unreachable, no extra settle needed before retrying.
         error = node1.query_and_get_error(query_create)
         assert "Directory for table data data/replica/test/ already exists" not in error
     node1.query_with_retry(query_create)

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1100,7 +1100,10 @@ def test_writes_schema_evolution_concurrent_add_columns(started_cluster):
 
     node.query(f"INSERT INTO {table_ref} VALUES ('123', 1);", settings=write_settings)
 
-    num_columns = 10
+    # Concurrent ADD COLUMN commits must contend on the REST catalog to surface
+    # the commit-conflict/retry race. A handful of concurrent writers is enough
+    # to interleave; the original count of 10 just multiplied catalog round-trips.
+    num_columns = 4
 
     def add_column(idx):
         node.query(

--- a/tests/integration/test_http_failover/test.py
+++ b/tests/integration/test_http_failover/test.py
@@ -85,8 +85,12 @@ def test_url_destination_host_with_multiple_addrs(dst_node_addrs, expectation):
 
 def test_url_invalid_hostname(started_cluster):
     with pytest.raises(QueryRuntimeException):
+        # http_max_tries=2 still exercises the retry path (one retry) but avoids
+        # the default 10 attempts, each of which pays a DNS-resolution timeout for
+        # the bogus host plus exponential backoff (~33s total).
         src_node.query(
-            "SELECT count(*) FROM url('http://notvalidhost:8123/?query=SELECT+1', TSV, 'column1 UInt32');"
+            "SELECT count(*) FROM url('http://notvalidhost:8123/?query=SELECT+1', TSV, 'column1 UInt32');",
+            settings={"http_max_tries": "2"},
         )
 
 

--- a/tests/integration/test_log_query_probability/test.py
+++ b/tests/integration/test_log_query_probability/test.py
@@ -46,7 +46,12 @@ def test_log_queries_probability_one(start_cluster):
 
 
 def test_log_queries_probability_two(start_cluster):
-    for i in range(100):
+    # Each iteration checks an invariant (both nodes log the same number of
+    # entries for the same distributed query), not a probability fraction, so
+    # the count only governs how many independent chances we get to catch a
+    # discrepancy. 20 iterations is plenty; 100 just multiplies CPU cost under
+    # instrumentation.
+    for i in range(20):
         node1.query(
             "SELECT 12345 FROM remote('node2', system, one)",
             settings={"log_queries_probability": 0.5},

--- a/tests/integration/test_named_collections/test.py
+++ b/tests/integration/test_named_collections/test.py
@@ -967,7 +967,7 @@ def test_concurrent_create_drop_race_condition(cluster):
     node1 = cluster.instances["node_with_keeper"]
     node2 = cluster.instances["node_with_keeper_2"]
 
-    num_iterations = 50
+    num_iterations = 15
     stop_flag = threading.Event()
 
     def create_collections(node, prefix, count):
@@ -997,7 +997,7 @@ def test_concurrent_create_drop_race_condition(cluster):
 
     try:
         # Run multiple iterations to increase chance of hitting the race
-        for iteration in range(5):
+        for iteration in range(3):
             prefix = f"race_test_{iteration}"
             threads = []
 
@@ -1020,7 +1020,7 @@ def test_concurrent_create_drop_race_condition(cluster):
                 t.join(timeout=60)
 
             # Small delay between iterations
-            time.sleep(0.5)
+            time.sleep(0.1)
 
         # Verify both nodes are still healthy by running a simple query
         for node in [node1, node2]:

--- a/tests/integration/test_refreshable_mat_view/test.py
+++ b/tests/integration/test_refreshable_mat_view/test.py
@@ -426,9 +426,9 @@ def test_long_query_cancel(fn_setup_tables):
 
     create_sql = CREATE_RMV.render(
         table_name="test_rmv",
-        refresh_interval="EVERY 3 SECONDS",
+        refresh_interval="EVERY 2 SECONDS",
         to_clause="tgt1",
-        select_query="SELECT now() a, sleep(1) b from numbers(5) settings max_block_size=1",
+        select_query="SELECT now() a, sleep(1) b from numbers(3) settings max_block_size=1",
         with_append=False,
         empty=True,
         settings={"refresh_retries": "0"},
@@ -451,7 +451,7 @@ def test_long_query_cancel(fn_setup_tables):
         node, "test_rmv", delay=0.1, max_attempts=1000, wait_status="Scheduled"
     )
 
-    assert node.query("SELECT count() FROM tgt1") == "5\n"
+    assert node.query("SELECT count() FROM tgt1") == "3\n"
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/test_storage_azure_blob_storage/test.py
+++ b/tests/integration/test_storage_azure_blob_storage/test.py
@@ -433,10 +433,14 @@ def test_azure_glob_scheherazade(cluster):
     node = cluster.instances["node"]  # type: ClickHouseInstance
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
     values = "(1, 1, 1)"
-    nights_per_job = 1001 // 30
+    # The glob pattern night_*/tale.csv is fully exercised across many distinct
+    # directories with far fewer than the original 1001 files; the absolute
+    # count only drives CPU cost (heavily amplified under coverage/sanitizers).
+    nights = 101
+    nights_per_job = max(1, nights // 30)
     jobs = []
     used_names = []
-    for night in range(0, 1001, nights_per_job):
+    for night in range(0, nights, nights_per_job):
 
         def add_tales(start, end):
             for i in range(start, end):
@@ -455,7 +459,7 @@ def test_azure_glob_scheherazade(cluster):
 
         jobs.append(
             threading.Thread(
-                target=add_tales, args=(night, min(night + nights_per_job, 1001))
+                target=add_tales, args=(night, min(night + nights_per_job, nights))
             )
         )
         jobs[-1].start()
@@ -469,7 +473,7 @@ def test_azure_glob_scheherazade(cluster):
         f"storage_account_url = '{cluster.env_variables['AZURITE_STORAGE_ACCOUNT_URL']}', container='cont', blob_path='night_*/tale.csv', format='CSV')",
     )
     query = "select count(), sum(column1), sum(column2), sum(column3) from test_glob_select_scheherazade"
-    assert azure_query(node, query).splitlines() == ["1001\t1001\t1001\t1001"]
+    assert azure_query(node, query).splitlines() == [f"{nights}\t{nights}\t{nights}\t{nights}"]
     azure_query(node, "DROP TABLE test_glob_select_scheherazade")
 
     drop_jobs = []

--- a/tests/integration/test_storage_iceberg_concurrent/test_concurrent_reads.py
+++ b/tests/integration/test_storage_iceberg_concurrent/test_concurrent_reads.py
@@ -32,9 +32,12 @@ def test_concurrent_reads(started_cluster_iceberg):
 
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg)
 
+    # Keep the concurrency width wide enough for inserts and selects to interleave
+    # and surface read/commit races. The per-insert row count and the number of
+    # outer rounds dominate wall time without adding coverage, so they are small.
     num_insert_threads = 15
     num_select_threads = 25
-    batch_size = 50
+    batch_size = 5
 
     def run_concurrent_queries(i):
         def select(_):
@@ -88,5 +91,5 @@ def test_concurrent_reads(started_cluster_iceberg):
 
         assert rows_in_ch == expected_rows, f"Expected {expected_rows} rows, but got {rows_in_ch}"
 
-    for i in range(10):
+    for i in range(3):
         run_concurrent_queries(i)

--- a/tests/integration/test_storage_kafka/test_batch_slow_1.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_1.py
@@ -145,7 +145,10 @@ def test_kafka_unavailable(kafka_cluster, create_query_generator):
                 "key UInt64, value UInt64",
                 topic_list=topic_name,
                 consumer_group=topic_name,
-                settings={"kafka_max_block_size": 1000},
+                settings={
+                    "kafka_max_block_size": 1000,
+                    "kafka_flush_interval_ms": 1000,
+                },
             )
             instance.query(create_query)
 
@@ -167,8 +170,9 @@ def test_kafka_unavailable(kafka_cluster, create_query_generator):
             """)
             instance.query(f"SELECT count() FROM test.{kafka_table}_destination")
 
-            # enough to trigger issue
-            time.sleep(30)
+            # enough to trigger issue: several failed poll cycles while the
+            # broker is paused (poll/session timeouts are well under this)
+            time.sleep(15)
 
         result = instance.query_with_retry(
             f"SELECT count() FROM test.{kafka_table}_destination",

--- a/tests/integration/test_storage_kafka/test_batch_slow_2.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_2.py
@@ -112,7 +112,11 @@ def test_row_based_formats(kafka_cluster, create_query_generator):
                 topic_list=topic_name,
                 consumer_group=topic_name,
                 format=format_name,
-                settings={"kafka_max_rows_per_message": max_rows_per_message},
+                settings={
+                    "kafka_max_rows_per_message": max_rows_per_message,
+                    "kafka_flush_interval_ms": 500,
+                    "kafka_poll_timeout_ms": 200,
+                },
             )
 
             instance.query(

--- a/tests/integration/test_storage_kafka/test_batch_slow_4.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_4.py
@@ -96,6 +96,7 @@ def test_kafka_consumer_failover(kafka_cluster, create_query_generator):
                     settings={
                         "kafka_max_block_size": 1,
                         "kafka_poll_timeout_ms": 200,
+                        "kafka_flush_interval_ms": 500,
                     },
                 )
             )

--- a/tests/integration/test_storage_kafka/test_batch_slow_5.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_5.py
@@ -134,6 +134,8 @@ def test_formats_errors(kafka_cluster):
                             kafka_group_name = '{format_name}',
                             kafka_format = '{format_name}',
                             kafka_max_rows_per_message = 5,
+                            kafka_flush_interval_ms = 500,
+                            kafka_poll_timeout_ms = 200,
                             format_template_row='template_row.format',
                             format_regexp='id: (.+?)',
                             input_format_with_names_use_header=0,

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -391,20 +391,20 @@ def test_concurrent_queries(started_cluster):
     )
 
     def node_select(_):
-        for i in range(20):
+        for i in range(5):
             node1.query("SELECT * FROM test.test_table", user="default")
 
     def node_insert(_):
-        for i in range(20):
+        for i in range(5):
             node1.query(
-                "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
+                "INSERT INTO test.test_table SELECT number, number FROM numbers(100)",
                 user="default",
             )
 
     def node_insert_select(_):
-        for i in range(20):
+        for i in range(5):
             node1.query(
-                "INSERT INTO test.test_table SELECT number, number FROM numbers(1000)",
+                "INSERT INTO test.test_table SELECT number, number FROM numbers(100)",
                 user="default",
             )
             node1.query(

--- a/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
+++ b/tests/integration/test_storage_s3/s3_mocks/unstable_server.py
@@ -101,7 +101,10 @@ class RequestHandler(http.server.BaseHTTPRequestHandler):
                     break
 
         if self.path == "/root/slow_send_test.csv":
-            self.send_block_size = 81920
+            # Stream the whole dataset with a 1s stall after each block so the
+            # slow-GET path is still exercised. A 1 MiB block keeps the number
+            # of stalls (~17 for the full file) low enough to bound test time.
+            self.send_block_size = 1024 * 1024
 
             for c, i in enumerate(
                 range(self.from_bytes, self.end_bytes, self.send_block_size)

--- a/tests/integration/test_storage_s3_queue/test_4.py
+++ b/tests/integration/test_storage_s3_queue/test_4.py
@@ -13,6 +13,7 @@ from helpers.s3_queue_common import (
     create_mv,
     generate_random_string,
 )
+from helpers.test_tools import assert_eq_with_retry
 
 AVAILABLE_MODES = ["unordered", "ordered"]
 
@@ -260,7 +261,7 @@ def test_alter_settings(started_cluster):
     mv_name = f"{table_name}_mv"
     keeper_path = f"/clickhouse/test_{table_name}"
     files_path = f"{table_name}_data"
-    files_to_generate = 1000
+    files_to_generate = 100
 
     node1.query("DROP DATABASE IF EXISTS r")
     node2.query("DROP DATABASE IF EXISTS r")
@@ -306,19 +307,14 @@ def test_alter_settings(started_cluster):
 
     create_mv(node1, f"r.{table_name}", f"r.{dst_table_name}", mv_name=f"r.{mv_name}")
 
-    def get_count():
-        return int(
-            node1.query(
-                f"SELECT count() FROM clusterAllReplicas(cluster, r.{dst_table_name})"
-            )
-        )
-
     expected_rows = files_to_generate
-    for _ in range(300):
-        if expected_rows == get_count():
-            break
-        time.sleep(1)
-    assert expected_rows == get_count()
+    assert_eq_with_retry(
+        node1,
+        f"SELECT count() FROM clusterAllReplicas(cluster, r.{dst_table_name})",
+        str(expected_rows),
+        retry_count=300,
+        sleep_time=1,
+    )
 
     assert (
         "true"

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -250,9 +250,6 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
     dst_table_name = f"{table_name}_dst"
     keeper_path = f"/clickhouse/test_{table_name}"
     files_path = f"{table_name}_data"
-    # Must exceed the S3 list page size (1000) so a deep relist would span more
-    # than one ListObjects call; otherwise the list-call assertion below could
-    # not tell StartAfter apart from a full relist.
     initial_files = 1100
 
     create_table(
@@ -263,8 +260,8 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
         files_path,
         additional_settings={
             "keeper_path": keeper_path,
-            "polling_min_timeout_ms": 100,
-            "polling_max_timeout_ms": 100,
+            "polling_min_timeout_ms": 60000,
+            "polling_max_timeout_ms": 60000,
             "polling_backoff_ms": 0,
         },
     )
@@ -281,13 +278,14 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
 
     create_mv(node, table_name, dst_table_name)
 
-    assert_eq_with_retry(
-        node,
-        f"SELECT count() FROM {dst_table_name}",
-        str(initial_files),
-        retry_count=120,
-        sleep_time=0.5,
-    )
+    def get_count():
+        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
+
+    for _ in range(60):
+        if initial_files == get_count():
+            break
+        time.sleep(1)
+    assert initial_files == get_count()
 
     node.query(f"DROP TABLE {table_name}_mv SYNC")
     baseline_list_calls = int(
@@ -316,13 +314,13 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
     )
 
     expected_rows = initial_files + 1
-    assert_eq_with_retry(
-        node,
-        f"SELECT count() FROM {dst_table_name}",
-        str(expected_rows),
-        retry_count=120,
-        sleep_time=0.5,
-    )
+    # Polling interval is configured to 60s for this test, so allow enough
+    # time for the first post-restart polling cycle to process the new file.
+    for _ in range(90):
+        if expected_rows == get_count():
+            break
+        time.sleep(1)
+    assert expected_rows == get_count(), f"Timed out waiting for {expected_rows} rows"
 
     list_calls_delta = int(
         node.query(

--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -15,6 +15,7 @@ from helpers.s3_queue_common import (
     generate_random_string,
 )
 from helpers.config_cluster import minio_secret_key
+from helpers.test_tools import assert_eq_with_retry
 
 AVAILABLE_MODES = ["unordered", "ordered"]
 
@@ -249,6 +250,9 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
     dst_table_name = f"{table_name}_dst"
     keeper_path = f"/clickhouse/test_{table_name}"
     files_path = f"{table_name}_data"
+    # Must exceed the S3 list page size (1000) so a deep relist would span more
+    # than one ListObjects call; otherwise the list-call assertion below could
+    # not tell StartAfter apart from a full relist.
     initial_files = 1100
 
     create_table(
@@ -259,8 +263,8 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
         files_path,
         additional_settings={
             "keeper_path": keeper_path,
-            "polling_min_timeout_ms": 60000,
-            "polling_max_timeout_ms": 60000,
+            "polling_min_timeout_ms": 100,
+            "polling_max_timeout_ms": 100,
             "polling_backoff_ms": 0,
         },
     )
@@ -277,14 +281,13 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
 
     create_mv(node, table_name, dst_table_name)
 
-    def get_count():
-        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
-
-    for _ in range(60):
-        if initial_files == get_count():
-            break
-        time.sleep(1)
-    assert initial_files == get_count()
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM {dst_table_name}",
+        str(initial_files),
+        retry_count=120,
+        sleep_time=0.5,
+    )
 
     node.query(f"DROP TABLE {table_name}_mv SYNC")
     baseline_list_calls = int(
@@ -313,13 +316,13 @@ def test_ordered_start_after_avoids_deep_relisting(started_cluster):
     )
 
     expected_rows = initial_files + 1
-    # Polling interval is configured to 60s for this test, so allow enough
-    # time for the first post-restart polling cycle to process the new file.
-    for _ in range(90):
-        if expected_rows == get_count():
-            break
-        time.sleep(1)
-    assert expected_rows == get_count(), f"Timed out waiting for {expected_rows} rows"
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM {dst_table_name}",
+        str(expected_rows),
+        retry_count=120,
+        sleep_time=0.5,
+    )
 
     list_calls_delta = int(
         node.query(
@@ -1124,9 +1127,9 @@ def test_mv_settings(started_cluster, mode, limit):
     )
 
     num_rows = 10
+    files_to_generate = 5
 
     def insert():
-        files_to_generate = 5
         table_name_suffix = f"{uuid.uuid4()}"
         for i in range(files_to_generate):
             file_name = f"file_{table_name}_{table_name_suffix}_{i}.csv"
@@ -1147,14 +1150,15 @@ def test_mv_settings(started_cluster, mode, limit):
     )
     node.query(f"SYSTEM STOP MERGES {dst_table_name}")
 
-    def get_count():
-        return int(node.query(f"SELECT count() FROM {dst_table_name}"))
-
-    expected_rows = num_rows
-    for _ in range(100):
-        if expected_rows == get_count():
-            break
-        time.sleep(1)
+    # All inserted rows must land in the destination before the part-count check.
+    expected_rows = num_rows * files_to_generate
+    assert_eq_with_retry(
+        node,
+        f"SELECT count() FROM {dst_table_name}",
+        str(expected_rows),
+        retry_count=120,
+        sleep_time=0.5,
+    )
 
     assert expected_parts_num == int(
         node.query(

--- a/tests/integration/test_system_clusters_actual_information/configs/users.xml
+++ b/tests/integration/test_system_clusters_actual_information/configs/users.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <!-- Speeds up the test: estimated_recovery_time decreases over
+                 distributed_replica_error_half_life seconds per halving round.
+                 The default 60s makes recovery from 3 errors take ~120s. 10s keeps
+                 ~20 one-second poll samples (so the strict-decrease assertions stay
+                 robust) while cutting the wait to ~20s. -->
+            <distributed_replica_error_half_life>10</distributed_replica_error_half_life>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_system_clusters_actual_information/test.py
+++ b/tests/integration/test_system_clusters_actual_information/test.py
@@ -10,7 +10,10 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
-    "node", with_zookeeper=True, main_configs=["configs/remote_servers.xml"]
+    "node",
+    with_zookeeper=True,
+    main_configs=["configs/remote_servers.xml"],
+    user_configs=["configs/users.xml"],
 )
 
 

--- a/tests/integration/test_system_detached_tables/test.py
+++ b/tests/integration/test_system_detached_tables/test.py
@@ -96,4 +96,9 @@ def test_system_detached_tables(
     result = node.query(querry)
     assert result == expected_after_restart
 
+    node.restart_clickhouse()
+
+    result = node.query(querry)
+    assert result == expected_after_restart
+
     node.query(f"DROP DATABASE {db_name}")

--- a/tests/integration/test_system_detached_tables/test.py
+++ b/tests/integration/test_system_detached_tables/test.py
@@ -96,9 +96,4 @@ def test_system_detached_tables(
     result = node.query(querry)
     assert result == expected_after_restart
 
-    node.restart_clickhouse()
-
-    result = node.query(querry)
-    assert result == expected_after_restart
-
     node.query(f"DROP DATABASE {db_name}")

--- a/tests/integration/test_ttl_replicated/test.py
+++ b/tests/integration/test_ttl_replicated/test.py
@@ -704,7 +704,7 @@ def test_ttl_compatibility(started_cluster, node_left, node_right, num_run):
 def test_ttl_drop_parts_limit(started_cluster):
     table = f"test_merges_mutations_limit_{uuid.uuid4().hex}"
 
-    max_parts_to_merge_at_once = 20
+    max_parts_to_merge_at_once = 5
     node1.query(
         f"""
         CREATE TABLE {table} (
@@ -727,7 +727,7 @@ def test_ttl_drop_parts_limit(started_cluster):
     node1.query(f"SYSTEM STOP MERGES {table}")
 
     # More parts than max_parts_to_merge_at_once so the TTL drop runs in several rounds; keep it small.
-    parts_count = 50
+    parts_count = 8
     old_date = "toDateTime('2000-01-01 00:00:00')"
 
     for i in range(parts_count):


### PR DESCRIPTION
Several integration tests were among the slowest in CI (especially under MSan
and LLVM coverage), dominated by oversized data volumes, fixed sleeps, long
polling/timeout constants, or serial per-query loops. This speeds them up while
keeping what each test verifies.

Highlights:
- test_string_functions / test_aggregate_states: run the per-function
  old-vs-new comparisons on a thread pool instead of a serial loop (~26x
  locally for test_string_functions).
- test_storage_s3_get_slow: stream the dataset in larger blocks so the
  1s-per-block stall fires ~17 times instead of ~205.
- Kafka slow-batch tests: set a short kafka_flush_interval_ms so each format
  iteration no longer waits the 7.5s default flush.
- S3Queue tests: fix a wait that targeted a row count that was never reached
  (so it always hit the full timeout) and lower oversized polling intervals.
- Many tests: reduce data/iteration counts that were far larger than needed,
  lower oversized ZooKeeper/connection/recovery timeouts, and replace fixed
  sleeps with event-based waits.

Each change keeps the assertions intact; all modified tests were verified to
still pass locally.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.159` (included in `26.7` and later)
<!-- ch-version-info:end -->