### PR TITLE
Bump distroless cc-debian13 base digests to clear libssl3t64 CVE-2026-45447 (25.12 backport)

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -139,7 +139,7 @@ RUN mkdir -p \
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-26. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:8f960b7fc6a5d6e28bb07f982655925d6206678bd9a6cde2ad00ddb5e2077d78 AS production
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -162,7 +162,7 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-26. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:55dd32378f7562c890342098a04726f4ef386bb86c87bec3db6ed4eef27d99fb AS debug
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -157,7 +157,7 @@ RUN { \
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-26. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:8f960b7fc6a5d6e28bb07f982655925d6206678bd9a6cde2ad00ddb5e2077d78 AS production
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d3cda6e91129130d7229a1806b6a73d292ef245ab032da7851907798024cefba AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -180,7 +180,7 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-26. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:55dd32378f7562c890342098a04726f4ef386bb86c87bec3db6ed4eef27d99fb AS debug
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:61e8df8909b98d2cf65fa8f620ee8292be40becd9de3b85d42852bee3f86fdb0 AS debug
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Bump cc-debian13 digests preemptively, same libssl3t64 CVE-2026-45447 fix as :26.3-distroless.

### Changelog category

- CI Fix or improvement (changelog entry is not required)

### Changelog entry

Bump cc-debian13 digests, clears libssl3t64 CVE-2026-45447.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)