### PR TITLE
Enforce access check on loop() table function structure resolution

### DIFF
--- a/src/TableFunctions/TableFunctionLoop.cpp
+++ b/src/TableFunctions/TableFunctionLoop.cpp
@@ -101,12 +101,16 @@ namespace DB
         if (inner_table_function_ast)
         {
             auto inner_table_function = TableFunctionFactory::instance().get(inner_table_function_ast, context);
-            return inner_table_function->getActualTableStructure(context, is_insert_query);
+            /// Enforce the inner function's source access (as execute() does), not the raw structure.
+            return inner_table_function->getActualTableStructureWithAccess(context, is_insert_query);
         }
 
         String database_name = loop_database_name;
         if (database_name.empty())
             database_name = context->getCurrentDatabase();
+
+        /// Reading the schema requires SHOW COLUMNS, same as a direct DESCRIBE of the table.
+        context->checkAccess(AccessType::SHOW_COLUMNS, database_name, loop_table_name);
 
         auto database = DatabaseCatalog::instance().getDatabase(database_name);
         auto storage = database->tryGetTable(loop_table_name, context);

--- a/tests/queries/0_stateless/04411_loop_table_function_describe_access_check.reference
+++ b/tests/queries/0_stateless/04411_loop_table_function_describe_access_check.reference
@@ -1,0 +1,5 @@
+user_id	UInt64					
+password_hash	String					
+number	UInt64					
+x	UInt32					
+secret	String					

--- a/tests/queries/0_stateless/04411_loop_table_function_describe_access_check.sh
+++ b/tests/queries/0_stateless/04411_loop_table_function_describe_access_check.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# Regression for the loop() metadata-disclosure: DESCRIBE loop(db, table) must
+# require SHOW COLUMNS, exactly like a direct DESCRIBE of the table.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user04411_${CLICKHOUSE_DATABASE}_$RANDOM"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} <<EOF
+CREATE TABLE $db.secret (user_id UInt64, password_hash String) ENGINE = MergeTree ORDER BY user_id;
+INSERT INTO $db.secret VALUES (1, 'hash');
+
+DROP USER IF EXISTS $user;
+CREATE USER $user;
+GRANT CREATE TEMPORARY TABLE ON *.* TO $user;
+EOF
+
+# Zero grants on the table: schema must not leak through any DESCRIBE form.
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE $db.secret FORMAT Null; -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop('$db', 'secret') FORMAT Null; -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop($db.secret) FORMAT Null; -- { serverError ACCESS_DENIED }"
+
+# SHOW COLUMNS is enough to read the schema (same as a direct DESCRIBE) but not the data.
+${CLICKHOUSE_CLIENT} --query "GRANT SHOW COLUMNS ON $db.secret TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop('$db', 'secret') FORMAT TSV"
+${CLICKHOUSE_CLIENT} --user "$user" --query "SELECT * FROM loop('$db', 'secret') LIMIT 1; -- { serverError ACCESS_DENIED }"
+
+# An inner table function with no source object (numbers) needs no extra grant.
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop(numbers(3)) FORMAT TSV"
+
+# An inner table function with a source (file) must enforce its source access on
+# the structure path too, so reverting it to raw getActualTableStructure regresses.
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop(file('nonexistent.csv', 'CSV', 'x UInt32, secret String')) FORMAT Null; -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --query "GRANT READ ON FILE TO $user"
+${CLICKHOUSE_CLIENT} --user "$user" --query "DESCRIBE loop(file('nonexistent.csv', 'CSV', 'x UInt32, secret String')) FORMAT TSV"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $user"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a metadata-disclosure where `DESCRIBE loop('db', 'table')` and `DESCRIBE loop(<inner table function>)` bypassed the `SHOW COLUMNS` / source access check, letting an unprivileged user read a table's column schema.

### Description

`TableFunctionLoop::getActualTableStructure` resolved the table structure without any access check, so a user with zero grants on a table could read its full column schema via `DESCRIBE loop(...)`. A direct `DESCRIBE` of the table correctly requires `SHOW COLUMNS` (see `InterpreterDescribeQuery::fillColumnsFromTable`), and the `loop()` data path already checks `SELECT` in `executeImpl`; only the structure path was unguarded.

```sql
-- unprivileged user with no grants on db.secret:
DESCRIBE loop('db', 'secret');   -- leaked the full schema (now ACCESS_DENIED)
DESCRIBE loop(db.secret);        -- same leak via identifier form (now ACCESS_DENIED)
DESCRIBE db.secret;              -- already correctly ACCESS_DENIED
```

Fix, matching the canonical `DESCRIBE` behavior:
- `loop('db','table')`: `checkAccess(SHOW_COLUMNS, db, table)` before the table lookup (placed first so it is not a table-existence oracle, matching `InterpreterDescribeQuery` ordering).
- `loop(<inner table function>)`: call `getActualTableStructureWithAccess` so the inner function's source access is enforced on the structure path too, the same way `execute()` enforces it on the data path.

Any user that can `SELECT` the table implicitly has `SHOW COLUMNS` (`ContextAccess` implicit-grant expansion: any column flag => `SHOW_COLUMNS`), so this does not regress legitimate `SELECT`/`DESCRIBE` usage. Follow-up to #88802, which added the `SELECT` check on the data path but did not cover the structure path.

Regression test: `tests/queries/0_stateless/04411_loop_table_function_describe_access_check.sh`.

No public issue is linked (reported via the private core-security tracker under the `public-patch` flow).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.161` (included in `26.7` and later)
- Backported to: `26.6.2.6`, `26.5.4.20`, `26.4.5.75`, `26.3.16.16`
<!-- ch-version-info:end -->