### PR TITLE
Populate _etag virtual column for S3Queue/ObjectStorageQueue

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.cpp
@@ -1293,6 +1293,7 @@ Chunk ObjectStorageQueueSource::generateImpl()
                     .storage_id = storage_id,
                     .size = object_metadata->size_bytes,
                     .last_modified = object_metadata->last_modified,
+                    .etag = &(object_metadata->etag),
                 },
                 getContext(),
                 format_settings);

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -1111,7 +1111,7 @@ def test_virtual_columns(started_cluster):
         node,
         table_name,
         dst_table_name,
-        virtual_columns="_path String, _file String, _size UInt64, _time DateTime",
+        virtual_columns="_path String, _file String, _size UInt64, _time DateTime, _etag String",
     )
     expected_values = set([tuple(i) for i in total_values])
     for i in range(20):
@@ -1126,15 +1126,17 @@ def test_virtual_columns(started_cluster):
         time.sleep(1)
     assert selected_values == expected_values
     virtual_values = node.query(
-        f"SELECT count(), _path, _file, _size, _time FROM {dst_table_name} GROUP BY _path, _file, _size, _time"
+        f"SELECT count(), _path, _file, _size, _time, _etag FROM {dst_table_name} GROUP BY _path, _file, _size, _time, _etag"
     ).splitlines()
     assert len(virtual_values) > 0
-    (_, res_path, res_file, res_size, res_time) = virtual_values[0].split("\t")
+    (_, res_path, res_file, res_size, res_time, res_etag) = virtual_values[0].split("\t")
     finish_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     assert f"{files_path}/{res_file}" == res_path
     assert int(res_size) > 0
     assert start_time <= res_time
     assert res_time <= finish_time
+    # _etag must be populated (issue #108605: it was declared but never filled, always empty)
+    assert res_etag != ""
 
 
 def test_message_queue_disable_insertion_does_not_affect_s3queue(started_cluster):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108605
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/108605

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `_etag` virtual column for the `S3Queue` and `AzureQueue` table engines: it was declared but never populated, so `SELECT _etag` always returned an empty string. It now returns the object ETag, like the `S3` engine and the `s3()` table function.


### Description

The `_etag` virtual column is declared for `ObjectStorageQueue` engines (`S3Queue`, `AzureQueue`) through the shared file-like virtual column list, but the read path in `ObjectStorageQueueSource` built the virtuals struct without the `etag` pointer. Since `VirtualsForFileLikeStorage::etag` defaults to `nullptr`, `_etag` was always filled with a default empty string. The plain `S3` engine and the `s3()` function populate it correctly.

The ETag is already in scope at the call site (`object_metadata->etag`, also used to build the deduplication token a few lines above), so this just forwards it, mirroring `StorageObjectStorageSource`.

Note: `_tags` is also omitted at the same call site, but the queue iterator lists objects with `with_tags = false`, so tags are genuinely not fetched on the queue read path. Populating `_tags` would be a separate, larger change and is out of scope here.

Reproduction (reported on 26.4, still present on master): `SELECT _etag` from an `S3Queue`/`AzureQueue` table (directly or via a materialized view) returns an empty string instead of the object ETag.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.140`
<!-- ch-version-info:end -->