### PR TITLE
Avoid vertical TTL delete for TTLDrop merges

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1063,6 +1063,14 @@ bool MergeTask::isVerticalLightweightDelete(const GlobalRuntimeContext & global_
 
 bool MergeTask::canVerticalTTLDelete(const GlobalRuntimeContext & global_ctx)
 {
+    /// For an unconditional rows `TTLDrop`, all source rows are deleted. The
+    /// vertical TTL-delete path still scans key rows to write an all-skipped
+    /// row-source file, so use the existing horizontal `TTLTransform`
+    /// all-data-dropped short-circuit instead.
+    if (global_ctx.future_part->merge_type == MergeType::TTLDrop
+        && global_ctx.metadata_snapshot->hasRowsTTL())
+        return false;
+
     if (global_ctx.merging_params.mode != MergeTreeData::MergingParams::Ordinary)
         return false;
 

--- a/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.reference
+++ b/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.reference
@@ -7,7 +7,6 @@ test1_parts	1
 test1_algo	Vertical
 test2_before	2000
 test2_after	0
-test2_algo	Vertical
 test3_before	2000
 test3_after	1000
 test3_check_cols	4995000	49950000	499500000	4995000000

--- a/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
+++ b/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
@@ -46,8 +46,10 @@ SELECT 'test1_check_cols', sum(c1), sum(c2), sum(c3), sum(c4) FROM t_ttl_vert_1;
 SELECT 'test1_parts', count() FROM system.parts WHERE database = currentDatabase() AND table = 't_ttl_vert_1' AND active;
 
 SYSTEM FLUSH LOGS part_log;
+-- A background TTLDrop merge can race with OPTIMIZE; this case checks the partial TTL-delete merge.
 SELECT 'test1_algo', merge_algorithm FROM system.part_log
     WHERE database = currentDatabase() AND table = 't_ttl_vert_1' AND event_type = 'MergeParts'
+        AND merge_reason != 'TTLDropMerge'
     ORDER BY event_time_microseconds LIMIT 1;
 
 DROP TABLE IF EXISTS t_ttl_vert_1;
@@ -91,11 +93,6 @@ SYSTEM START MERGES t_ttl_vert_2;
 OPTIMIZE TABLE t_ttl_vert_2 FINAL;
 
 SELECT 'test2_after', count() FROM t_ttl_vert_2;
-
-SYSTEM FLUSH LOGS part_log;
-SELECT 'test2_algo', merge_algorithm FROM system.part_log
-    WHERE database = currentDatabase() AND table = 't_ttl_vert_2' AND event_type = 'MergeParts'
-    ORDER BY event_time_microseconds LIMIT 1;
 
 DROP TABLE IF EXISTS t_ttl_vert_2;
 

--- a/tests/queries/0_stateless/04411_ttl_drop_not_vertical.reference
+++ b/tests/queries/0_stateless/04411_ttl_drop_not_vertical.reference
@@ -1,0 +1,4 @@
+TTLDropMerge	Horizontal	0
+0
+TTLDropMerge	Horizontal	0
+0

--- a/tests/queries/0_stateless/04411_ttl_drop_not_vertical.sh
+++ b/tests/queries/0_stateless/04411_ttl_drop_not_vertical.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+TABLE=t_ttl_drop_not_vertical
+
+function wait_for_ttl_drop_merge()
+{
+    for _ in $(seq 1 300); do
+        local part_count
+        part_count=$(${CLICKHOUSE_CLIENT} -q "
+            SELECT count()
+            FROM system.parts
+            WHERE database = currentDatabase()
+                AND table = '${TABLE}'
+                AND active")
+
+        if [ "${part_count}" -le "1" ]; then
+            break
+        fi
+        sleep 0.1
+    done
+
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS part_log"
+
+    for _ in $(seq 1 60); do
+        local merge_count
+        merge_count=$(${CLICKHOUSE_CLIENT} -q "
+            SELECT count()
+            FROM system.part_log
+            WHERE database = currentDatabase()
+                AND table = '${TABLE}'
+                AND event_type = 'MergeParts'
+                AND merge_reason = 'TTLDropMerge'")
+
+        if [ "${merge_count}" -gt "0" ]; then
+            return
+        fi
+        sleep 0.1
+        ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH LOGS part_log"
+    done
+}
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${TABLE}"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE ${TABLE}
+    (
+        id UInt64,
+        d DateTime DEFAULT '2000-01-01 00:00:00',
+        c1 UInt64,
+        c2 UInt64,
+        c3 UInt64,
+        c4 UInt64
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    TTL d + INTERVAL 1 DAY
+    SETTINGS
+        ttl_only_drop_parts = 1,
+        merge_with_ttl_timeout = 0,
+        min_bytes_for_wide_part = 0,
+        min_bytes_for_full_part_storage = 0,
+        enable_block_number_column = 0,
+        enable_block_offset_column = 0,
+        vertical_merge_algorithm_min_rows_to_activate = 1,
+        vertical_merge_algorithm_min_columns_to_activate = 1,
+        vertical_merge_optimize_ttl_delete = 1,
+        ratio_of_defaults_for_sparse_serialization = 1.0"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM STOP TTL MERGES ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "SYSTEM STOP MERGES ${TABLE}"
+
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO ${TABLE}
+    SELECT number, '2000-01-01 00:00:00', number, number, number, number
+    FROM numbers(1000)"
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO ${TABLE}
+    SELECT number + 1000, '2000-01-01 00:00:00', number, number, number, number
+    FROM numbers(1000)"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM START TTL MERGES ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "SYSTEM START MERGES ${TABLE}"
+
+wait_for_ttl_drop_merge
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        merge_reason,
+        merge_algorithm,
+        rows
+    FROM system.part_log
+    WHERE database = currentDatabase()
+        AND table = '${TABLE}'
+        AND event_type = 'MergeParts'
+        AND merge_reason = 'TTLDropMerge'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${TABLE}"
+
+TABLE=t_ttl_drop_not_vertical_mixed_ttl
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${TABLE}"
+
+${CLICKHOUSE_CLIENT} -q "
+    CREATE TABLE ${TABLE}
+    (
+        id UInt64,
+        d DateTime DEFAULT '2000-01-01 00:00:00',
+        c1 UInt64,
+        c2 UInt64,
+        c3 UInt64,
+        c4 UInt64
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    TTL d + INTERVAL 1 DAY, d + INTERVAL 2 DAY RECOMPRESS CODEC(ZSTD)
+    SETTINGS
+        ttl_only_drop_parts = 1,
+        merge_with_ttl_timeout = 0,
+        min_bytes_for_wide_part = 0,
+        min_bytes_for_full_part_storage = 0,
+        enable_block_number_column = 0,
+        enable_block_offset_column = 0,
+        vertical_merge_algorithm_min_rows_to_activate = 1,
+        vertical_merge_algorithm_min_columns_to_activate = 1,
+        vertical_merge_optimize_ttl_delete = 1,
+        ratio_of_defaults_for_sparse_serialization = 1.0"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM STOP TTL MERGES ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "SYSTEM STOP MERGES ${TABLE}"
+
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO ${TABLE}
+    SELECT number, '2000-01-01 00:00:00', number, number, number, number
+    FROM numbers(1000)"
+${CLICKHOUSE_CLIENT} -q "
+    INSERT INTO ${TABLE}
+    SELECT number + 1000, '2000-01-01 00:00:00', number, number, number, number
+    FROM numbers(1000)"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM START TTL MERGES ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "SYSTEM START MERGES ${TABLE}"
+
+wait_for_ttl_drop_merge
+
+${CLICKHOUSE_CLIENT} -q "
+    SELECT
+        merge_reason,
+        merge_algorithm,
+        rows
+    FROM system.part_log
+    WHERE database = currentDatabase()
+        AND table = '${TABLE}'
+        AND event_type = 'MergeParts'
+        AND merge_reason = 'TTLDropMerge'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1"
+
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${TABLE}"


### PR DESCRIPTION
TTLDrop merges know that all source rows are expired. The vertical TTL-delete path still scans key rows to write an all-skipped row-source file, which can make fully expired large parts _very expensive_ to drop. Use the existing horizontal all-data-dropped short-circuit for this case instead.

I think this behavior is a bug, because it doesn't match the expected behavior of efficiently TTL dropping expired parts, especially with `ttl_only_drop_parts = 1`. It would be nice to have this fix backported to recent stable releases, please.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed dropping whole parts with TTL (`ttl_only_drop_parts = 1`) still reading all data from large, fully-expired parts.