### PR TITLE
Fix inconsistent gcs table function examples

### DIFF
--- a/docs/en/sql-reference/table-functions/gcs.md
+++ b/docs/en/sql-reference/table-functions/gcs.md
@@ -65,7 +65,7 @@ A table with the specified structure for reading or writing data in the specifie
 
 ## Examples {#examples}
 
-Selecting the first two rows from the table from GCS file `https://storage.googleapis.com/my-test-bucket-768/data.csv`:
+Selecting the first two rows from the GCS file `https://storage.googleapis.com/clickhouse_public_datasets/my-test-bucket-768/data.csv.gz`. The compression method is detected automatically from the `.gz` file extension:
 
 ```sql
 SELECT *
@@ -80,7 +80,7 @@ LIMIT 2;
 └─────────┴─────────┴─────────┘
 ```
 
-The similar but from file with `gzip` compression method:
+The same query as above, but with the `gzip` compression method specified explicitly instead of relying on autodetection:
 
 ```sql
 SELECT *


### PR DESCRIPTION
## What

Fixes the inconsistent `gcs` table function examples reported in DOC-858:

- The first example's description pointed at `https://storage.googleapis.com/my-test-bucket-768/data.csv` (a non-existent file), but the query actually reads `clickhouse_public_datasets/my-test-bucket-768/data.csv.gz`.
- The second example was introduced as a `gzip` variant but ran essentially the same query as the first, so the distinction was unclear.

## Fix

Aligned both descriptions with the queries they precede:

- First example: references the actual `.gz` file and notes the compression method is auto-detected from the extension (3-argument form).
- Second example: clarifies it's the same query with `gzip` specified explicitly (4-argument form) rather than relying on autodetection.

Documentation-only; the queries and their outputs were already correct.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.121`
<!-- ch-version-info:end -->