### PR TITLE
Iceberg: do not throw from `SnapshotSummary::fromJSON`

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.cpp
@@ -243,9 +243,9 @@ try
 
     return result;
 }
-catch (const DB::Exception & error)
+catch (const std::exception & error)
 {
-    return std::unexpected(error.message());
+    return std::unexpected(error.what());
 }
 
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SnapshotSummary.cpp
@@ -128,6 +128,7 @@ Map SnapshotSummary::toMap() const
 }
 
 SnapshotSummary::Expected SnapshotSummary::fromJSON(const Poco::JSON::Object & obj, bool with_extra_fields)
+try
 {
     std::unordered_set<std::string_view> parsed;
 
@@ -242,6 +243,11 @@ SnapshotSummary::Expected SnapshotSummary::fromJSON(const Poco::JSON::Object & o
 
     return result;
 }
+catch (const DB::Exception & error)
+{
+    return std::unexpected(error.message());
+}
+
 
 void SnapshotSummary::forEachField(std::function<void(std::string_view, std::string)> && fn, bool with_extra_fields) const
 {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/tests/gtest_iceberg_snapshot_summary.cpp
@@ -468,4 +468,26 @@ TEST(IcebergSnapshotSummary, AppendPreservesInheritedEqualityDeletes)
     EXPECT_EQ(append.getTotals().records, 55);
 }
 
+TEST(IcebergSnapshotSummary, FromJSONNegativeCounterReturnsErrorNotThrows)
+{
+    /// Regression: an underflowed total is serialized as a negative number
+    /// (e.g. `total-files-size = -924`). `fromJSON` must report it as an error
+    /// instead of throwing `CANNOT_PARSE_NUMBER`, otherwise the exception escapes
+    /// `IcebergMetadata::getHistory` and `system.iceberg_history` reports the
+    /// whole table as broken instead of one snapshot with an UNKNOWN summary.
+    Poco::JSON::Object obj;
+    obj.set(DB::Iceberg::f_operation, std::string(DB::Iceberg::f_append));
+    obj.set(DB::Iceberg::f_total_files_size, std::string("-924"));
+
+    bool has_value = true;
+    EXPECT_NO_THROW({ has_value = SnapshotSummary::fromJSON(obj).has_value(); });
+    EXPECT_FALSE(has_value);
+
+    /// Sanity: the same summary with a valid value parses successfully.
+    obj.set(DB::Iceberg::f_total_files_size, std::string("924"));
+    auto ok = SnapshotSummary::fromJSON(obj);
+    EXPECT_TRUE(ok.has_value());
+    EXPECT_EQ(ok->getTotals().files_size, 924);
+}
+
 #endif


### PR DESCRIPTION
Make `SnapshotSummary::fromJSON` return an error instead of throwing when a snapshot summary cannot be parsed. Previously the exception escaped `IcebergMetadata::getHistory`, so a query on `system.iceberg_history` failed for the whole table instead of reporting the affected snapshot with an `UNKNOWN` summary. Includes a regression unit test.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Queries to `system.iceberg_history` no longer fail when an Iceberg table has a snapshot whose summary cannot be read. Such snapshots are now shown with an `UNKNOWN` summary instead.
