### PR TITLE
Retry delete_topics RPC in kafka_delete_topic to fix flaky teardown

### DIFF
--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -573,7 +573,19 @@ def clean_test_database_and_topics(instance, cluster):
 
     topics = get_topics_to_delete()
     logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
+    # Retry the delete RPC on transient broker/controller errors, like kafka_create_topic.
+    retries = 0
+    while True:
+        try:
+            result = admin_client.delete_topics(topics)
+            break
+        except Exception as e:
+            retries += 1
+            time.sleep(0.5)
+            if retries < 50:
+                logging.warning(f"Failed to delete topics {e}")
+            else:
+                raise
     for topic, error in result.topic_error_codes:
         if error != 0:
             logging.warning(f"Received error {error} while deleting topic {topic}")

--- a/tests/integration/helpers/kafka/common.py
+++ b/tests/integration/helpers/kafka/common.py
@@ -79,7 +79,20 @@ def kafka_create_topic(
 
 
 def kafka_delete_topic(admin_client, topic, max_retries=50):
-    result = admin_client.delete_topics([topic])
+    # Retry the delete RPC on transient broker/controller errors, like kafka_create_topic.
+    retries = 0
+    while True:
+        try:
+            result = admin_client.delete_topics([topic])
+            break
+        except Exception as e:
+            retries += 1
+            time.sleep(0.5)
+            if retries < max_retries:
+                logging.warning(f"Failed to delete topic {e}")
+            else:
+                raise
+
     for topic, e in result.topic_error_codes:
         if e == 0:
             logging.debug(f"Topic {topic} deleted")

--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -70,29 +70,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import time
 
 from confluent_kafka.avro.cached_schema_registry_client import (
     CachedSchemaRegistryClient,
@@ -47,29 +46,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_1.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_1.py
@@ -43,29 +43,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_2.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_2.py
@@ -1,7 +1,6 @@
 """Long running tests, longer than 30 seconds"""
 
 import logging
-import time
 
 import pytest
 
@@ -42,29 +41,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_4.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_4.py
@@ -1,8 +1,6 @@
 """Long running tests, longer than 30 seconds"""
 
 import json
-import logging
-import time
 
 from kafka import KafkaProducer
 import pytest
@@ -44,29 +42,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_5.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_5.py
@@ -1,7 +1,5 @@
 """Long running tests, longer than 30 seconds"""
 
-import logging
-import time
 
 from kafka import KafkaAdminClient
 import pytest
@@ -43,29 +41,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_6.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_6.py
@@ -46,29 +46,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_batch_slow_7.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_7.py
@@ -1,8 +1,6 @@
 """Long running tests, longer than 30 seconds"""
 
 import json
-import logging
-import time
 
 import pytest
 
@@ -43,29 +41,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_intent_sizes.py
+++ b/tests/integration/test_storage_kafka/test_intent_sizes.py
@@ -1,6 +1,5 @@
 import logging
 
-import time
 
 import pytest
 
@@ -53,29 +52,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_kafka_zone_awareness.py
+++ b/tests/integration/test_storage_kafka/test_kafka_zone_awareness.py
@@ -185,29 +185,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 

--- a/tests/integration/test_storage_kafka/test_poll_timeout_after_assignment.py
+++ b/tests/integration/test_storage_kafka/test_poll_timeout_after_assignment.py
@@ -43,18 +43,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    topics = [t for t in admin_client.list_topics() if not t.startswith("_")]
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
+    k.clean_test_database_and_topics(instance, cluster)
     yield
 
 

--- a/tests/integration/test_storage_kafka/test_produce_http_interface.py
+++ b/tests/integration/test_storage_kafka/test_produce_http_interface.py
@@ -1,11 +1,10 @@
 import logging
-import time
 
 import pytest
 from kafka import KafkaAdminClient
-from kafka.admin import NewTopic
 
 from helpers.cluster import ClickHouseCluster
+import helpers.kafka.common as k
 from helpers.test_tools import TSV
 
 cluster = ClickHouseCluster(__file__)
@@ -44,61 +43,6 @@ def kafka_setup_teardown():
     instance.query("DROP DATABASE IF EXISTS test; CREATE DATABASE test;")
     # logging.debug("kafka is available - running test")
     yield  # run test
-
-
-def kafka_create_topic(
-    admin_client,
-    topic_name,
-    num_partitions=1,
-    replication_factor=1,
-    max_retries=50,
-    config=None,
-):
-    logging.debug(
-        f"Kafka create topic={topic_name}, num_partitions={num_partitions}, replication_factor={replication_factor}"
-    )
-    topics_list = [
-        NewTopic(
-            name=topic_name,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            topic_configs=config,
-        )
-    ]
-    retries = 0
-    while True:
-        try:
-            admin_client.create_topics(new_topics=topics_list, validate_only=False)
-            logging.debug("Admin client succeed")
-            return
-        except Exception as e:
-            retries += 1
-            time.sleep(0.5)
-            if retries < max_retries:
-                logging.warning(f"Failed to create topic {e}")
-            else:
-                raise
-
-
-def kafka_delete_topic(admin_client, topic, max_retries=50):
-    result = admin_client.delete_topics([topic])
-    for topic, e in result.topic_error_codes:
-        if e == 0:
-            logging.debug(f"Topic {topic} deleted")
-        else:
-            logging.error(f"Failed to delete topic {topic}: {e}")
-
-    retries = 0
-    while True:
-        topics_listed = admin_client.list_topics()
-        logging.debug(f"TOPICS LISTED: {topics_listed}")
-        if topic not in topics_listed:
-            return
-        else:
-            retries += 1
-            time.sleep(0.5)
-            if retries > max_retries:
-                raise Exception(f"Failed to delete topics {topic}, {result}")
 
 
 def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
@@ -180,7 +124,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
     for format in formats_to_test:
         logging.debug(f"Creating tables and writing messages to {format}")
         topic = topic_prefix + format
-        kafka_create_topic(admin_client, topic)
+        k.kafka_create_topic(admin_client, topic)
 
         extra_setting = extra_settings.get(format, "")
 
@@ -230,7 +174,7 @@ def test_kafka_produce_http_interface_row_based_format(kafka_cluster):
 
         assert TSV(result) == TSV(expected)
 
-        kafka_delete_topic(admin_client, topic)
+        k.kafka_delete_topic(admin_client, topic)
 
 
 def test_kafka_produce_http_interface_single_column_format(kafka_cluster):
@@ -266,7 +210,7 @@ def test_kafka_produce_http_interface_single_column_format(kafka_cluster):
     for format, config in formats_to_test.items():
         logging.debug(f"Creating tables and writing messages to {format}")
         topic = topic_prefix + format
-        kafka_create_topic(admin_client, topic)
+        k.kafka_create_topic(admin_client, topic)
 
         instance.query(
             f"""
@@ -309,7 +253,7 @@ def test_kafka_produce_http_interface_single_column_format(kafka_cluster):
 
         assert TSV(result) == TSV(config["expected"]), f"Format {format}: expected {config['expected']!r}, got {result!r}"
 
-        kafka_delete_topic(admin_client, topic)
+        k.kafka_delete_topic(admin_client, topic)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_storage_kafka/test_zookeeper_locks.py
+++ b/tests/integration/test_storage_kafka/test_zookeeper_locks.py
@@ -1,7 +1,6 @@
 import json
 import time
 import pytest
-import logging
 
 from helpers.cluster import ClickHouseCluster
 import helpers.kafka.common as k
@@ -39,29 +38,7 @@ def kafka_cluster():
 
 @pytest.fixture(autouse=True)
 def kafka_setup_teardown():
-    instance.query("DROP DATABASE IF EXISTS test SYNC; CREATE DATABASE test;")
-    admin_client = k.get_admin_client(cluster)
-
-    def get_topics_to_delete():
-        return [t for t in admin_client.list_topics() if not t.startswith("_")]
-
-    topics = get_topics_to_delete()
-    logging.debug(f"Deleting topics: {topics}")
-    result = admin_client.delete_topics(topics)
-    for topic, error in result.topic_error_codes:
-        if error != 0:
-            logging.warning(f"Received error {error} while deleting topic {topic}")
-        else:
-            logging.info(f"Deleted topic {topic}")
-
-    retries = 0
-    topics = get_topics_to_delete()
-    while len(topics) != 0:
-        logging.info(f"Existing topics: {topics}")
-        if retries >= 5:
-            raise Exception(f"Failed to delete topics {topics}")
-        retries += 1
-        time.sleep(0.5)
+    k.clean_test_database_and_topics(instance, cluster)
     yield  # run test
 
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/83683
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/83683

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The Kafka integration test helper `kafka_delete_topic()` called `admin_client.delete_topics([topic])` with no retry on the RPC, unlike its sibling `kafka_create_topic()` which retries `create_topics()` up to `max_retries` times. A transient broker/controller error during test teardown (`delete_topics` -> `_send_request_to_controller` raising) therefore failed an otherwise-passing test. This wraps the `delete_topics()` call in the same retry-on-exception loop, mirroring `kafka_create_topic()`. Persistent failures still raise after exhausting `max_retries`; the happy path is unchanged.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108567&sha=2e30a6b9ae669015526971d597f7ea0b204183ed&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

Failure stack (teardown):
```
test_kafka_bad_messages/test.py:122 - in bad_messages_parsing_mode
    k.kafka_delete_topic(admin_client, f"{topic_name}")
helpers/kafka/common.py:82 - in kafka_delete_topic
    result = admin_client.delete_topics([topic])
kafka/admin/client.py:480 - in delete_topics
    response = self._send_request_to_controller(request)
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.145`
<!-- ch-version-info:end -->