### PR TITLE
Wait for setup_minio.sh to finish before starting the server

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -154,14 +154,26 @@ class ClickHouseProc:
             )
         print(f"Started setup_minio.sh asynchronously with PID {self.minio_proc.pid}")
 
-        if Shell.check(
-            "/mc ls clickminio/test | grep -q .",
-            verbose=False,
-            retries=6,
-        ):
-            return True
-        print("Failed to start minio")
-        return False
+        # Wait for setup_minio.sh to fully exit, not just for the bucket to be
+        # listable: the server's S3 disks authenticate at startup and need the
+        # whole user/policy/ACL setup in place. The minio server is nohup'd and
+        # outlives the script, so waiting on the script is safe. Its internal
+        # waits are bounded (wait_for_it caps at 60s), so pad the timeout.
+        try:
+            returncode = self.minio_proc.wait(timeout=120)
+        except subprocess.TimeoutExpired:
+            print("Failed to start minio: setup_minio.sh did not finish in time")
+            self.minio_proc.kill()
+            return False
+        if returncode != 0:
+            print(f"setup_minio.sh exited with code {returncode}")
+            return False
+
+        # wait_for_it can exit 0 even if minio is down, so confirm the bucket.
+        if not Shell.check("/mc ls clickminio/test", verbose=False, retries=3):
+            print("Failed to start minio: bucket clickminio/test not reachable")
+            return False
+        return True
 
     def start_azurite(self):
         # Raise the open files limit before launching azurite-rs.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108647
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a `Fail [Start ClickHouse Server]` flake in functional-test jobs that use S3 storage (e.g. `Stateless tests (..., s3 storage, DatabaseReplicated, WasmEdge, ...)`).

`start_minio()` launched `setup_minio.sh` asynchronously and returned as soon as the bucket was listable (`/mc ls clickminio/test`). But the script keeps going after creating the bucket: it adds the `test` user, attaches the `readwrite` policy, sets the public ACL, and uploads data. The server starts a few seconds later and authenticates its S3 disks at startup, so it can race an in-flight MinIO IAM reload and get a transient `403 Access Denied`. `IDisk::startup()` rethrows it as `Code: 499 (S3_ERROR)` and the server aborts, surfacing as the job-level "Start ClickHouse Server" failure.

Fix: wait for the `setup_minio.sh` process to exit before returning, the same way `start_kafka()` already waits for `setup_kafka.sh`. The minio server is `nohup`'d inside the script and outlives it, so waiting on the script is safe.

Found via @ serxa's PR #108647: [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108647&sha=7c5ee6dbfc31f1369665f09b982420d2ca3fedae&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20WasmEdge%2C%20sequential%29), [job](https://github.com/ClickHouse/ClickHouse/actions/runs/28255972730/job/83731757539). Server log: `While checking access for disk disk_encrypted_03517. (S3_ERROR)` -> exit 243, unrelated to that PR's scheduler clock change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.235` (included in `26.7` and later)
<!-- ch-version-info:end -->