### PR TITLE
start_minio: wait for setup_minio.sh to exit, not for bucket-listability

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -154,14 +154,20 @@ class ClickHouseProc:
             )
         print(f"Started setup_minio.sh asynchronously with PID {self.minio_proc.pid}")
 
-        if Shell.check(
-            "/mc ls clickminio/test | grep -q .",
-            verbose=False,
-            retries=6,
-        ):
-            return True
-        print("Failed to start minio")
-        return False
+        # setup_minio.sh exits 0 only after IAM (user/policy/anonymous) is applied
+        # and test data is uploaded; the minio server itself is nohup'd and survives.
+        # Wait on the script: a bucket-listable poll returns mid-IAM-reload, so the
+        # server could start and hit a transient S3 AccessDenied during disk access
+        # check. Its internal readiness wait is 60s; pad here.
+        try:
+            returncode = self.minio_proc.wait(timeout=120)
+        except subprocess.TimeoutExpired:
+            print("Failed to start minio: setup_minio.sh did not finish in time")
+            return False
+        if returncode != 0:
+            print(f"setup_minio.sh exited with code {returncode}")
+            return False
+        return True
 
     def start_azurite(self):
         # Raise the open files limit before launching azurite-rs.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108647
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a `Fail [Start ClickHouse Server]` flake on s3-storage functional-test jobs caused by a MinIO setup race.

`start_minio()` in `ci/jobs/scripts/clickhouse_proc.py` launched `setup_minio.sh` asynchronously and returned as soon as `mc ls clickminio/test` listed the bucket. But the bucket exists *before* `setup_minio.sh` applies IAM (`mc admin user add test` / `policy attach readwrite` / `anonymous set public`) and uploads data, so the function could return while the access policy was still being reloaded.

The functional-test server then starts immediately and runs its per-disk S3 access check. During the IAM-reload window this can hit a transient `403 AccessDenied`, which `IDisk::startup()` rethrows as `Code: 499. S3_ERROR`, aborting the server. All subsequent client queries get `Connection refused` (exit 210) and the job reports `Fail [Start ClickHouse Server]`.

The fix waits on the `setup_minio.sh` process instead of polling for bucket-listability, mirroring `start_kafka` which was changed the same way in b3eaa3c687c. The `minio server` itself is `nohup`'d inside the script and survives the script's exit, so all IAM and data upload is complete before the ClickHouse server starts.

Observed on `Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DatabaseReplicated, WasmEdge, sequential)` (PR #108647, commit 7c5ee6db, [CI run 28255972730](https://github.com/ClickHouse/ClickHouse/actions/runs/28255972730/job/83731757539)). Server log (replica 0):

```
21:14:50  Started setup_minio.sh asynchronously with PID 1932
21:14:56  <server replica 0 starts, ~9s after async minio launch>
21:14:59.767  <Error> AWSClient: Response status: 403, Forbidden
21:14:59.768  <Error> WriteBufferFromS3: S3Exception AccessDenied ... key common/__root/clickhouse_access_check_<uuid>
21:14:59.783  <Error> IDisk::startup(): Code: 499. Access Denied ... While checking access for disk disk_encrypted_03517. (S3_ERROR)
21:15:00.891  <Error> Application: Code: 499 ... (S3_ERROR)  -> server aborts
              -> Code: 210 Connection refused (localhost:9000)  -> Fail [Start ClickHouse Server]
```

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108647&sha=7c5ee6dbfc31f1369665f09b982420d2ca3fedae&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DatabaseReplicated%2C%20WasmEdge%2C%20sequential%29
