### PR TITLE
Fix flaky test_kafka_many_materialized_views (view2 result race)

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1262,11 +1262,20 @@ def test_kafka_many_materialized_views(kafka_cluster, create_query_generator):
     k.kafka_produce(kafka_cluster, topic_name, messages)
 
     with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
+        # query_with_retry returns the last (possibly short) snapshot once its retry
+        # budget is spent, so use a larger budget like the single-view test above to
+        # let each view receive all rows before the assertion below.
         result1 = instance.query_with_retry(
-            f"SELECT * FROM test.{kafka_table}_view1", check_callback=k.kafka_check_result
+            f"SELECT * FROM test.{kafka_table}_view1",
+            check_callback=k.kafka_check_result,
+            retry_count=40,
+            sleep_time=0.75,
         )
         result2 = instance.query_with_retry(
-            f"SELECT * FROM test.{kafka_table}_view2", check_callback=k.kafka_check_result
+            f"SELECT * FROM test.{kafka_table}_view2",
+            check_callback=k.kafka_check_result,
+            retry_count=40,
+            sleep_time=0.75,
         )
 
         instance.query(f"""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108635
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

No related open issue found (the test has no tracking issue).

`test_storage_kafka/test_batch_fast.py::test_kafka_many_materialized_views` reads each
materialized view's target table with `query_with_retry(check_callback=kafka_check_result)`.
`query_with_retry` returns the *last* query snapshot once its retry budget is exhausted, even
when `check_callback` never passed. The Kafka -> MV insert flushes all 50 rows to a view
atomically (0 -> 50) at the end of a `streamToViews` cycle; under heavy load that flush can
exceed the default budget (`20 * 0.5s = 10s`). `view2` is polled after `view1`, so it has less
time to catch up and is the consistent victim — `kafka_check_result(result2, True)` asserts on
a short snapshot and the test fails.

Fix: extend the retry budget for both views (`retry_count=40, sleep_time=0.75`), matching the
single-view test `test_kafka_materialized_view_with_subquery` directly above. No assertion is
weakened — both views must still contain all 50 reference rows.

The failure signature is always `kafka_check_result(result2, True)` (view2 short). Public CI
occurrences (all on sanitizer builds, where flushes are slower):
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101504&sha=514c43866245522f4cc77d135769e575e7f22a19&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29 — `Integration tests (amd_tsan, 2/6)`
- `Integration tests (amd_msan, 2/6)` and `Integration tests (amd_asan_ubsan, db disk, old analyzer, 2/6)` show the same `assert TSV(result) == TSV(reference_content)` at `helpers/kafka/common.py`.

Validated locally: throttling `view2`'s MV with `sleepEachRow` and shrinking the retry budget
makes `result2` return 0 rows and the assertion fail; the extended budget returns all 50 and
passes. The unmodified test passes 6/6.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.285` (included in `26.7` and later)
<!-- ch-version-info:end -->