### PR TITLE
Fix build: migrate two aggregate functions to `mergeImpl`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupFormat.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupFormat.cpp
@@ -162,7 +162,7 @@ public:
             add(place, &values, offset_it.getValueIndex(), arena);
     }
 
-    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override
+    void mergeImpl(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena *) const override
     {
         auto & state = data(place);
         const auto & rhs_state = data(rhs);

--- a/src/AggregateFunctions/AggregateFunctionMVTEncode.cpp
+++ b/src/AggregateFunctions/AggregateFunctionMVTEncode.cpp
@@ -572,7 +572,7 @@ public:
         ++state.num_features;
     }
 
-    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override
+    void mergeImpl(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override
     {
         const auto & rhs_state = Base::data(rhs);
         if (rhs_state.data_size == 0)


### PR DESCRIPTION
The base class `IAggregateFunction` was refactored so that the public `merge` is now a non-virtual wrapper around the pure-virtual `mergeImpl`. Two aggregate functions were missed during that migration and still declared a `merge` override, which no longer matched any virtual method — leaving the classes abstract and breaking the build:

- `AggregateFunctionMVTEncode`
- `AggregateFunctionGroupFormat`

This renames their overrides from `merge` to `mergeImpl` to match the new interface.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.142`
<!-- ch-version-info:end -->