### PR TITLE
Do not validate DataLakeCatalog auth_header or build catalog on ATTACH

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -128,7 +128,8 @@ DatabaseDataLake::DatabaseDataLake(
     const DatabaseDataLakeSettings & settings_,
     ASTPtr database_engine_definition_,
     ASTPtr table_engine_definition_,
-    UUID uuid)
+    UUID uuid,
+    bool lazy_init)
     : IDatabase(database_name_)
     , url(url_)
     , settings(settings_)
@@ -138,7 +139,14 @@ DatabaseDataLake::DatabaseDataLake(
     , db_uuid(uuid)
 {
     validateSettings();
-    initialize();
+    /// On ATTACH (server startup) defer catalog construction to first use: building it can
+    /// perform network I/O or credential validation that must not block startup. On CREATE
+    /// build eagerly so misconfiguration is reported immediately.
+    if (!lazy_init)
+    {
+        std::lock_guard lock(catalog_mutex);
+        initialize();
+    }
 }
 
 void DatabaseDataLake::validateSettings()
@@ -158,11 +166,10 @@ void DatabaseDataLake::validateSettings()
     }
 }
 
-void DatabaseDataLake::initialize()
+void DatabaseDataLake::initialize() const
 {
-    /// This function is intentionally not synchronized: it is invoked only from the
-    /// constructor, before the `DatabaseDataLake` instance becomes reachable by any
-    /// other thread.
+    /// Caller holds `catalog_mutex`: this runs either from the constructor (CREATE, eager)
+    /// or from `getCatalog` on first access (ATTACH, lazy).
     if (settings[DatabaseDataLakeSetting::catalog_type].value == DatabaseDataLakeCatalogType::NONE)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unspecified catalog type");
 
@@ -308,6 +315,10 @@ void DatabaseDataLake::initialize()
 
 std::shared_ptr<DataLake::ICatalog> DatabaseDataLake::getCatalog() const
 {
+    std::lock_guard lock(catalog_mutex);
+    /// Lazily build the catalog on first access for databases attached at startup (see ctor).
+    if (!catalog_impl)
+        initialize();
     return catalog_impl;
 }
 
@@ -981,9 +992,13 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             database_settings.loadFromQuery(*database_engine_define, args.create_query.attach);
 
         const auto & auth_header_str = database_settings[DatabaseDataLakeSetting::auth_header].value;
-        if (!auth_header_str.empty())
+        /// Validate `auth_header` on CREATE only (matches the `allow_experimental_database_*`
+        /// gates below, which also self-skip on attach). An already-persisted database whose
+        /// `auth_header` was accepted by an older version must still attach at startup, so a
+        /// single misconfigured database cannot block the server from starting. The malformed
+        /// header is then reported lazily on first use of the database.
+        if (!args.create_query.attach && !auth_header_str.empty())
         {
-            /// Validate `auth_header` against the forbidden HTTP header filter at creation time.
             /// Only headers with a valid `name: value` format are accepted.
             auto pos = auth_header_str.find(':');
             if (pos != std::string::npos)
@@ -1114,7 +1129,8 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             database_settings,
             database_engine_define->clone(),
             std::move(engine_for_tables),
-            args.uuid);
+            args.uuid,
+            /*lazy_init=*/args.create_query.attach);
     };
     /// TODO: DataLakeCatalog is polymorphic — underlying source (S3, Azure, HDFS, etc.) depends
     /// on the catalog type chosen at runtime. Consider adding source_access_type once a mechanism

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -22,7 +22,8 @@ public:
         const DatabaseDataLakeSettings & settings_,
         ASTPtr database_engine_definition_,
         ASTPtr table_engine_definition_,
-        UUID uuid);
+        UUID uuid,
+        bool lazy_init);
 
     String getEngineName() const override { return DataLake::DATABASE_ENGINE_NAME; }
     UUID getUUID() const override { return db_uuid; }
@@ -81,16 +82,18 @@ private:
     /// Crendetials to authenticate Iceberg Catalog.
     Poco::Net::HTTPBasicCredentials credentials;
 
-    std::shared_ptr<DataLake::ICatalog> catalog_impl;
+    mutable std::mutex catalog_mutex;
+    mutable std::shared_ptr<DataLake::ICatalog> catalog_impl TSA_GUARDED_BY(catalog_mutex);
 
     void validateSettings();
 
-    /// Builds `catalog_impl` based on the configured catalog type.
-    /// Called only from the constructor, so no synchronization is required; `catalog_impl`
-    /// is published when the constructed `DatabaseDataLake` is handed off to other threads.
-    /// If `initialize` is called outside the constructor (e.g. on config reload),
-    /// a mutex must be added to guard `catalog_impl` against concurrent readers in `getCatalog`.
-    void initialize();
+    /// Builds `catalog_impl` based on the configured catalog type. Constructing a catalog can
+    /// validate credentials and perform network I/O (e.g. RestCatalog reads the catalog config),
+    /// so on ATTACH (server startup) it is deferred to the first access via `getCatalog` instead
+    /// of running eagerly in the constructor. That keeps one misconfigured or unreachable database
+    /// from blocking server startup. On CREATE it still runs eagerly so problems are reported up
+    /// front. Guarded by `catalog_mutex` because lazy initialization can race concurrent readers.
+    void initialize() const TSA_REQUIRES(catalog_mutex);
 
     std::shared_ptr<StorageObjectStorageConfiguration> getConfiguration(
         DatabaseDataLakeStorageType type,

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -22,6 +22,7 @@
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/Base64.h>
 #include <Common/checkStackSize.h>
+#include <Common/HTTPHeaderFilter.h>
 
 #include <IO/ConnectionTimeouts.h>
 #include <IO/GCPOAuth.h>
@@ -186,6 +187,14 @@ RestCatalog::RestCatalog(
     else if (!auth_header_.empty())
     {
         auth_header = parseAuthHeader(auth_header_);
+        /// `registerDatabaseDataLake` validates `auth_header` on CREATE only, so that a database
+        /// persisted with a forbidden or malformed header does not block server startup on ATTACH.
+        /// The catalog is built lazily on first use instead; this is where the user-provided
+        /// `auth_header` first becomes a header sent to the catalog, so enforce `http_forbid_headers`
+        /// here, before `loadConfig` issues any request. Mirrors the CREATE-path check: a copy is
+        /// validated and the original parsed header is kept.
+        DB::HTTPHeaderEntries header_to_check{auth_header.value()};
+        getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_to_check);
     }
     config = loadConfig();
 }

--- a/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.reference
+++ b/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.reference
@@ -1,0 +1,4 @@
+baddb
+netdb
+Unexpected format of auth header
+Invalid auth header format

--- a/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.reference
+++ b/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.reference
@@ -2,3 +2,5 @@ baddb
 netdb
 Unexpected format of auth header
 Invalid auth header format
+1
+is forbidden

--- a/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.sh
+++ b/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# A DataLakeCatalog database persisted by an older version (which validated auth_header lazily)
+# must still attach when loaded by a newer version, so that one misconfigured or unreachable
+# database cannot block server startup. The error is reported lazily on first use instead.
+# Regression test for the eager auth_header validation / eager catalog construction on ATTACH.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+WORKDIR="${CLICKHOUSE_TMP}/04401_datalake_attach"
+rm -rf "${WORKDIR}"
+mkdir -p "${WORKDIR}/metadata"
+
+# Database with a malformed auth_header (no colon), as an older version would have persisted it.
+cat > "${WORKDIR}/metadata/baddb.sql" <<'EOF'
+ATTACH DATABASE baddb
+ENGINE = DataLakeCatalog('http://localhost:8181/v1')
+SETTINGS catalog_type = 'rest', auth_header = 'malformed_without_colon', warehouse = 'demo'
+EOF
+
+# Database with a well-formed auth_header but an unreachable endpoint.
+cat > "${WORKDIR}/metadata/netdb.sql" <<'EOF'
+ATTACH DATABASE netdb
+ENGINE = DataLakeCatalog('http://localhost:18181/v1')
+SETTINGS catalog_type = 'rest', auth_header = 'Authorization: Bearer xyz', warehouse = 'demo'
+EOF
+
+# Loading the data dir re-attaches every database, exactly as server startup does.
+# Both databases must attach successfully (no validation, no network I/O on attach).
+${CLICKHOUSE_LOCAL} --path "${WORKDIR}" --query "SELECT name FROM system.databases WHERE name IN ('baddb', 'netdb') ORDER BY name"
+
+# First use of the malformed database must still report the error (lazy validation).
+${CLICKHOUSE_LOCAL} --path "${WORKDIR}" --query "CHECK DATABASE baddb" 2>&1 | grep -o 'Unexpected format of auth header'
+
+# CREATE with a malformed auth_header must still be rejected up front.
+${CLICKHOUSE_LOCAL} --query "
+SET allow_experimental_database_iceberg = 1;
+CREATE DATABASE baddb_create
+ENGINE = DataLakeCatalog('http://localhost:8181/v1')
+SETTINGS catalog_type = 'rest', auth_header = 'malformed_without_colon', warehouse = 'demo';
+" 2>&1 | grep -o "Invalid auth header format"
+
+rm -rf "${WORKDIR}"

--- a/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.sh
+++ b/tests/queries/0_stateless/04401_datalake_attach_does_not_block_startup.sh
@@ -6,6 +6,10 @@
 # database cannot block server startup. The error is reported lazily on first use instead.
 # Regression test for the eager auth_header validation / eager catalog construction on ATTACH.
 
+# The server prints the rejected-header exception to its log and (at least in CI) forwards Error
+# log messages to the client, which would duplicate the expected "is forbidden" line. Suppress it.
+CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal
+
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
@@ -44,3 +48,18 @@ SETTINGS catalog_type = 'rest', auth_header = 'malformed_without_colon', warehou
 " 2>&1 | grep -o "Invalid auth header format"
 
 rm -rf "${WORKDIR}"
+
+# A forbidden auth_header (http_forbid_headers) persisted by an older version must also attach
+# without blocking startup, but it must still be rejected on first use so the forbidden header
+# is never sent to the catalog. http_forbid_headers is read only by the server (not by
+# clickhouse-local), and 'exact_header' is forbidden via tests/config/config.d/forbidden_headers.xml,
+# so this part runs against the test server.
+FORBIDDEN_DB="${CLICKHOUSE_DATABASE}_04401_forbidden"
+${CLICKHOUSE_CLIENT} --query "
+ATTACH DATABASE ${FORBIDDEN_DB}
+ENGINE = DataLakeCatalog('http://localhost:18181/v1')
+SETTINGS catalog_type = 'rest', auth_header = 'exact_header: some_value', warehouse = 'demo';
+"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.databases WHERE name = '${FORBIDDEN_DB}'"
+${CLICKHOUSE_CLIENT} --query "CHECK DATABASE ${FORBIDDEN_DB}" 2>&1 | grep -o 'is forbidden'
+${CLICKHOUSE_CLIENT} --query "DROP DATABASE IF EXISTS ${FORBIDDEN_DB}"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/108671
-->

Closes: #108671

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a startup failure where a `DataLakeCatalog` database created by an older version (25.12 or earlier) with a malformed `auth_header` could not be attached after upgrading to 26.2 or later, preventing the server from starting. The `auth_header` is now validated only on `CREATE`, and on `ATTACH` the catalog is built lazily on first use instead of during startup, so a single misconfigured or unreachable catalog database no longer blocks server startup.


### Description

`auth_header` was validated eagerly in `registerDatabaseDataLake` (`src/Databases/DataLake/DatabaseDataLake.cpp`), and that validation ran on `ATTACH` as well as `CREATE`. At startup every database is re-attached, so one database with a malformed `auth_header` threw `BAD_ARGUMENTS` during attach and the server failed to start (exit 36). In 25.12 the same setting was parsed lazily on first use, so it never affected startup.

On `master` the failure additionally came from the constructor, because `DatabaseDataLake::initialize()` builds the catalog eagerly (the `RestCatalog` constructor calls `parseAuthHeader` and `loadConfig()`), so any database with an unreachable endpoint also failed to attach at startup.

Fix:
- Gate the `auth_header` validation on `CREATE` only (`if (!args.create_query.attach && ...)`), matching the existing `allow_experimental_database_*` gates in the same function, which already self-skip on attach.
- Defer catalog construction to first use on `ATTACH`: `initialize()` is no longer called from the constructor for attach, and `getCatalog()` builds the catalog lazily under `catalog_mutex`. The eager construction was originally added as a race fix, so the lazy path is now synchronized. On `CREATE` the catalog is still built eagerly so misconfiguration is reported up front.

A malformed `auth_header` is reported lazily on first use of the database (as in 25.12), so one misconfigured database can no longer block server startup.

Affected: 26.2, 26.3, master (26.6). Introduced by #98827.

Test: `04401_datalake_attach_does_not_block_startup` loads previously-persisted DataLakeCatalog databases (a malformed `auth_header`, and a well-formed header with an unreachable endpoint) and asserts both attach, that first use of the malformed one still reports the error, and that `CREATE` with a malformed header is still rejected.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.192` (included in `26.7` and later)
- Backported to: `26.6.2.12`, `26.5.5.11`, `26.4.5.89`, `26.3.17.11`
<!-- ch-version-info:end -->