### PR TITLE
Retry wget downloads in Keeper Dockerfiles

### DIFF
--- a/docker/keeper/Dockerfile
+++ b/docker/keeper/Dockerfile
@@ -53,21 +53,37 @@ ARG DEFAULT_GID="101"
 RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
     adduser -S -h "/var/lib/clickhouse" -s /bin/bash -G clickhouse -g "ClickHouse keeper" -u "${DEFAULT_UID}" clickhouse
 
+# Number of `wget` retries and delay between them, for resilience against
+# transient HTTP errors (e.g. `clickhouse-builds.s3.amazonaws.com` returning
+# `500 Internal Server Error` / `503 Service Unavailable` during builds).
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
 ARG TARGETARCH
 RUN arch=${TARGETARCH:-amd64} \
     && cd /tmp && rm -f /tmp/*tgz && rm -f /tmp/*tgz.sha512 |: \
+    && wget_with_retry() { \
+        local url="$1"; local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget -c -q "$url"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed for $url, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download $url after ${WGET_RETRIES} attempts"; return 1; \
+    } \
     && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         echo "installing from provided urls with tgz packages: ${DIRECT_DOWNLOAD_URLS}" \
         && for url in $DIRECT_DOWNLOAD_URLS; do \
             echo "Get ${url}" \
-            && wget -c -q "$url" \
+            && wget_with_retry "$url" \
         ; done \
     else \
         for package in ${PACKAGES}; do \
             cd /tmp \
             && echo "Get ${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
+            && wget_with_retry "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
+            && wget_with_retry "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
         ; done \
     fi \
     && cat *.tgz.sha512 | sha512sum -c \

--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -39,12 +39,28 @@ ARG DIRECT_DOWNLOAD_URLS=""
 ARG single_binary_location_url=""
 ARG TARGETARCH
 
+# Number of `wget` retries and delay between them, for resilience against
+# transient HTTP errors (e.g. `clickhouse-builds.s3.amazonaws.com` returning
+# `500 Internal Server Error` / `503 Service Unavailable` during builds).
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
 # Install from direct URLs (deb packages provided by CI).
-RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+RUN wget_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget --progress=bar:force:noscroll "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         rm -rf /tmp/clickhouse_debs \
         && mkdir -p /tmp/clickhouse_debs \
         && for url in $DIRECT_DOWNLOAD_URLS; do \
-            wget --progress=bar:force:noscroll "$url" -P /tmp/clickhouse_debs || exit 1 \
+            wget_with_retry "$url" -P /tmp/clickhouse_debs || exit 1 \
         ; done \
         && dpkg -i /tmp/clickhouse_debs/*.deb \
         && rm -rf /tmp/* ; \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/105139
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `Docker keeper image` job intermittently fails while fetching the prebuilt packages from `clickhouse-builds.s3.amazonaws.com`. The `clickhouse-common-static` package downloads fine, then the `clickhouse-keeper` package gets a `503 Service Unavailable` and the single-shot `wget ... || exit 1` kills the whole build. The downstream `docker library image test` then reports `image does not exist!` (a secondary victim, not a second failure).

Recent example, PR #108573 (`docker/keeper/Dockerfile.distroless`, amd64):

```
--2026-06-26 22:05:41--  https://clickhouse-builds.s3.amazonaws.com/PRs/108573/.../build_amd_release/clickhouse-keeper_26.7.1.1_amd64.deb
HTTP request sent, awaiting response... 503 Service Unavailable
2026-06-26 22:05:41 ERROR 503: Service Unavailable.
Dockerfile.distroless:43
ERROR: failed to build: ... exit code: 1
```

The server Dockerfiles already wrap `wget` with a retry helper for exactly this transient-S3 class: `docker/server/Dockerfile.alpine` since #100380 (tgz path) and `docker/server/Dockerfile.ubuntu` / `docker/server/Dockerfile.distroless` since #105139 (deb path). The Keeper Dockerfiles were left calling `wget` on the first attempt only, so a single `500`/`503` from S3 fails the build.

This ports the same `wget_with_retry` wrapper to both Keeper Dockerfiles:

- `docker/keeper/Dockerfile.distroless`: the deb `DIRECT_DOWNLOAD_URLS` path (the one CI uses), mirroring `docker/server/Dockerfile.distroless`.
- `docker/keeper/Dockerfile` (alpine/ubuntu): the tgz `DIRECT_DOWNLOAD_URLS` path and the repository fallback, mirroring `docker/server/Dockerfile.alpine`.

`WGET_RETRIES` (default `5`) and `WGET_RETRY_DELAY` (default `1s`) match the server Dockerfiles and remain overridable via `--build-arg`. A persistent error still fails the build after the retries are exhausted, so a genuinely-broken S3 is not masked.

Recurrence (30 days): `Docker keeper image` FAIL = 165 hits across 15 distinct PRs + 21 on master, all the scattered transient-S3 signature that re-runs clean.

CI report (PR #108573): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108573&sha=1766fdb7f5dd9384c444db648ceaa4a4548dc4db&name_0=PR&name_1=Docker%20keeper%20image

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.196` (included in `26.7` and later)
<!-- ch-version-info:end -->