### PR TITLE
Fix flaky test 04402_map_functions_lowcardinality

### DIFF
--- a/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
+++ b/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
@@ -36,19 +36,24 @@ SELECT '-- the reproducer from the issue: CREATE TABLE AS keeps the column type 
 DROP TABLE IF EXISTS t_map_lc_src;
 DROP TABLE IF EXISTS t_map_lc_dst;
 
+-- Pin Map serialization to 'basic' so randomized 'with_buckets' serialization does not
+-- reorder Map keys by hash bucket. This test checks the column type and CHECK TABLE, not
+-- the Map key order, so the stored order must stay the insertion order.
 CREATE TABLE t_map_lc_src
 (
     key String,
     attributes_map Map(LowCardinality(String), String)
 )
 ENGINE = MergeTree
-ORDER BY tuple();
+ORDER BY tuple()
+SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic';
 
 INSERT INTO t_map_lc_src VALUES ('key_1', {'attr_1': 'value_1', 'attr_2': 'value_2', 'attr_3': 'value_3'});
 
 CREATE TABLE t_map_lc_dst
 ENGINE = MergeTree
 ORDER BY tuple()
+SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic'
 AS SELECT key, mapFilter((k, v) -> k != 'attr_1', attributes_map) AS attributes_map FROM t_map_lc_src;
 
 SELECT name, type FROM system.columns WHERE database = currentDatabase() AND table = 't_map_lc_dst' ORDER BY name;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04402_map_functions_lowcardinality` builds MergeTree tables with a `Map(LowCardinality(String), String)` column and reads the Map back to verify that `CREATE TABLE AS` preserves the column type and that `CHECK TABLE` passes. It does not check the Map key order.

CI randomizes `map_serialization_version_for_zero_level_parts` to `with_buckets`, which stores Map keys in hash-bucket order in zero-level parts instead of insertion order. Reading the Map back then yields a reordered Map and the output differs from the reference:

```
-key_1	{'attr_2':'value_2','attr_3':'value_3'}
+key_1	{'attr_3':'value_3','attr_2':'value_2'}
```

CI's own randomized-settings diagnosis confirmed the root cause: same randomized settings reproduce 190/190, no randomization passes 329/329, minimization isolates `--map_serialization_version_for_zero_level_parts with_buckets`.

Fix: pin `map_serialization_version` and `map_serialization_version_for_zero_level_parts` to `basic` on both tables so the stored order stays the insertion order. This is the same approach as the merged fixes for `03399_mapContains_functions` (#101541) and `02030_function_mapContainsKeyLike` (#101538).

CI report (master, arm_binary): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a115e2281161cc8955e2590afdd34cfd63084b1f&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

Verification: 50/50 pass with full randomization after the fix; 30/30 fail before the fix when the culprit MergeTree settings are injected (exact reorder diff above).
