### PR TITLE
Fix server abort for non-nullable LowCardinality tuple-element sort key

### DIFF
--- a/src/Columns/ColumnLowCardinality.h
+++ b/src/Columns/ColumnLowCardinality.h
@@ -291,6 +291,10 @@ public:
     void nestedRemoveNullable() { dictionary.getColumnUnique().nestedRemoveNullable(); }
     MutableColumnPtr cloneNullable() const;
 
+    /// Promote a non-nullable dictionary to `Nullable(T)` in place, rebuilding it with a NULL placeholder
+    /// and remapping the indexes accordingly. Unlike `nestedToNullable()`, this keeps existing values valid.
+    void convertDictionaryToNullableInplace() { compactInplaceToNullable(); }
+
     ColumnPtr cloneWithDefaultOnNull() const;
 
     const IColumnUnique & getDictionary() const { return dictionary.getColumnUnique(); }

--- a/src/DataTypes/NullableUtils.cpp
+++ b/src/DataTypes/NullableUtils.cpp
@@ -177,12 +177,9 @@ void applyParentNullMapToExtractedSubcolumn(
 
 DataTypePtr NullableSubcolumnCreator::create(const DataTypePtr & prev) const
 {
-    if (canExtractedSubcolumnsBeInsideNullable(prev))
-        return makeNullableSafe(prev);
-
-    /// A non-nullable `LowCardinality(T)` cannot be wrapped in `Nullable`, but it must still be able to
-    /// represent the outer column's NULLs, so promote it to `LowCardinality(Nullable(T))`. For every other
-    /// type this returns `prev` unchanged, matching the previous behaviour.
+    /// Wrap into `Nullable(...)` when possible, or `LowCardinality(Nullable(T))` for a non-nullable
+    /// `LowCardinality(T)` element (which cannot be wrapped in plain `Nullable`) so it can still
+    /// represent the outer column's NULLs. Returns `prev` unchanged for types that can do neither.
     return makeExtractedSubcolumnsNullableOrLowCardinalityNullableSafe(prev);
 }
 

--- a/src/DataTypes/NullableUtils.cpp
+++ b/src/DataTypes/NullableUtils.cpp
@@ -169,9 +169,13 @@ void applyParentNullMapToExtractedSubcolumn(
 
 DataTypePtr NullableSubcolumnCreator::create(const DataTypePtr & prev) const
 {
-    if (!canExtractedSubcolumnsBeInsideNullable(prev))
-        return prev;
-    return makeNullableSafe(prev);
+    if (canExtractedSubcolumnsBeInsideNullable(prev))
+        return makeNullableSafe(prev);
+
+    /// A non-nullable `LowCardinality(T)` cannot be wrapped in `Nullable`, but it must still be able to
+    /// represent the outer column's NULLs, so promote it to `LowCardinality(Nullable(T))`. For every other
+    /// type this returns `prev` unchanged, matching the previous behaviour.
+    return makeExtractedSubcolumnsNullableOrLowCardinalityNullableSafe(prev);
 }
 
 SerializationPtr NullableSubcolumnCreator::create(const SerializationPtr & prev_serialization, const DataTypePtr & prev_type) const
@@ -195,14 +199,29 @@ ColumnPtr NullableSubcolumnCreator::create(const ColumnPtr & prev) const
     if (canExtractedSubcolumnsBeInsideNullable(prev))
         return ColumnNullable::create(prev, null_map);
 
-    /// The extracted subcolumn cannot be wrapped into Nullable, but if it can represent NULL itself,
-    /// mark rows that are NULL in the outer column as NULL in it.
-    if (null_map && canContainNull(*prev))
+    if (null_map)
     {
         const auto & outer_null_map_data = assert_cast<const ColumnUInt8 &>(*null_map).getData();
-        auto mutable_column = IColumn::mutate(prev);
-        applyParentNullMapToExtractedSubcolumn(mutable_column, outer_null_map_data, 0, 0);
-        return mutable_column;
+
+        /// The extracted subcolumn cannot be wrapped into Nullable, but if it can already represent NULL
+        /// itself, mark rows that are NULL in the outer column as NULL in it.
+        if (canContainNull(*prev))
+        {
+            auto mutable_column = IColumn::mutate(prev);
+            applyParentNullMapToExtractedSubcolumn(mutable_column, outer_null_map_data, 0, 0);
+            return mutable_column;
+        }
+
+        /// A non-nullable `LowCardinality(T)` cannot represent NULL as-is, but it can once promoted to
+        /// `LowCardinality(Nullable(T))` -- which is what the type `create(DataTypePtr)` returns. Promote the
+        /// column the same way with `cloneNullable()` before folding in the outer null map, so the extracted
+        /// (type, column) pair stays consistent.
+        if (const auto * prev_lc = checkAndGetColumn<ColumnLowCardinality>(prev.get()))
+        {
+            auto mutable_column = prev_lc->cloneNullable();
+            applyParentNullMapToExtractedSubcolumn(mutable_column, outer_null_map_data, 0, 0);
+            return mutable_column;
+        }
     }
 
     return prev;

--- a/src/DataTypes/NullableUtils.cpp
+++ b/src/DataTypes/NullableUtils.cpp
@@ -127,6 +127,14 @@ void applyParentNullMapToExtractedSubcolumn(
     const size_t length = column->size() - column_offset;
     chassert(parent_null_map_offset + length <= parent_null_map.size());
 
+    /// A non-nullable `LowCardinality(T)` read from disk has no NULL placeholder in its dictionary, so
+    /// promote it to `LowCardinality(Nullable(T))` in place. The extracted subcolumn's type is
+    /// `LowCardinality(Nullable(T))` (see `create(DataTypePtr)`), so this keeps the (type, column) pair
+    /// consistent even for ranges that contain no parent NULLs (handled before the early-out below).
+    if (auto * low_cardinality_to_promote = typeid_cast<ColumnLowCardinality *>(column.get());
+        low_cardinality_to_promote && !low_cardinality_to_promote->nestedIsNullable())
+        low_cardinality_to_promote->convertDictionaryToNullableInplace();
+
     /// When no row of the range is NULL in the parent, the subcolumn already holds the correct values and
     /// nothing needs to be marked NULL.
     if (memoryIsZero(parent_null_map.data(), parent_null_map_offset, parent_null_map_offset + length))
@@ -186,7 +194,14 @@ SerializationPtr NullableSubcolumnCreator::create(const SerializationPtr & prev_
         /// themselves: Nullable (possibly inside LowCardinality), Dynamic and Variant. For them return a
         /// serialization that also reads the outer null map and marks the corresponding rows as NULL in
         /// the subcolumn's own null representation.
-        if (canContainNull(*prev_type))
+        ///
+        /// A non-nullable `LowCardinality(T)` cannot represent NULL as-is, but its extracted subcolumn's
+        /// type is promoted to `LowCardinality(Nullable(T))` (see `create(DataTypePtr)`). Wrap the original
+        /// (non-nullable) serialization so the on-disk stream layout is unchanged; the wrapper reads the
+        /// `LowCardinality(T)` column and `applyParentNullMapToExtractedSubcolumn` promotes it to
+        /// `LowCardinality(Nullable(T))` before folding in the outer null map, keeping the read
+        /// (type, column) pair consistent with the in-memory one.
+        if (canContainNull(*prev_type) || prev_type->lowCardinality())
             return SerializationNullableWithParentNullMap::create(prev_serialization);
         return prev_serialization;
     }

--- a/src/Functions/tupleElement.cpp
+++ b/src/Functions/tupleElement.cpp
@@ -198,13 +198,40 @@ public:
 
             if (null_map_column)
             {
-                /// Fold the outer `Nullable(Tuple(...))` null map into the extracted element using the exact
-                /// same logic as the subcolumn path (`t.a`): wrap wrappable elements in `ColumnNullable`, OR
-                /// the outer null map into an element that already carries NULLs (Nullable / LowCardinality
-                /// (Nullable) / Dynamic / Variant), and promote a non-nullable `LowCardinality(T)` element to
-                /// `LowCardinality(Nullable(T))` before applying the mask. This keeps the (type, column) pair
-                /// consistent with both `getReturnTypeImpl` and the subcolumn reader.
-                res = NullableSubcolumnCreator(null_map_column).create(res);
+                const DataTypePtr & element_type = input_type_as_tuple->getElements()[index.value()];
+
+                if (canExtractedSubcolumnsBeInsideNullableOrLowCardinalityNullable(element_type) || canContainNull(*element_type))
+                {
+                    /// The element can represent NULL: fold the outer `Nullable(Tuple(...))` null map in with
+                    /// the exact same logic as the subcolumn path (`t.a`) -- wrap wrappable elements in
+                    /// `ColumnNullable`, OR the mask into an element that already carries NULLs (Nullable /
+                    /// LowCardinality(Nullable) / Dynamic / Variant), and promote a non-nullable
+                    /// `LowCardinality(T)` element to `LowCardinality(Nullable(T))` first. Keeps the
+                    /// (type, column) pair consistent with `getReturnTypeImpl` and the subcolumn reader.
+                    res = NullableSubcolumnCreator(null_map_column).create(res);
+                }
+                else
+                {
+                    /// The element (e.g. Map, Array) can neither be wrapped in `Nullable` nor carry NULL
+                    /// itself, so it has no NULL representation. Write the element's default for outer-NULL
+                    /// rows -- matching `NestedUtils::unwrapNullableTuple` and the stored subcolumn -- instead
+                    /// of leaking whatever payload sits under the null map in the hidden nested column.
+                    const auto & null_map = assert_cast<const ColumnUInt8 &>(*null_map_column).getData();
+
+                    auto result_column = element_type->createColumn();
+                    result_column->reserve(res->size());
+
+                    Field default_field = element_type->getDefault();
+                    for (size_t i = 0; i < res->size(); ++i)
+                    {
+                        if (null_map[i])
+                            result_column->insert(default_field);
+                        else
+                            result_column->insertFrom(*res, i);
+                    }
+
+                    res = std::move(result_column);
+                }
             }
         }
         else if (const DataTypeQBit * input_type_as_qbit = checkAndGetDataType<DataTypeQBit>(input_type))

--- a/src/Functions/tupleElement.cpp
+++ b/src/Functions/tupleElement.cpp
@@ -28,34 +28,10 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int ARGUMENT_OUT_OF_BOUND;
     extern const int BAD_ARGUMENTS;
-    extern const int LOGICAL_ERROR;
 }
 
 namespace
 {
-
-ColumnPtr mergeNullMaps(const ColumnPtr & left, const ColumnPtr & right)
-{
-    if (!left)
-        return right;
-
-    if (!right)
-        return left;
-
-    const auto & left_data = assert_cast<const ColumnUInt8 &>(*left).getData();
-    const auto & right_data = assert_cast<const ColumnUInt8 &>(*right).getData();
-
-    if (left_data.size() != right_data.size())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Null maps have different sizes");
-
-    auto merged_column = ColumnUInt8::create(left_data.size());
-    auto & merged_data = merged_column->getData();
-
-    for (size_t i = 0; i < merged_data.size(); ++i)
-        merged_data[i] = left_data[i] || right_data[i];
-
-    return merged_column;
-}
 
 /** Extract element of tuple by constant index or name. The operation is essentially free.
   * Also the function looks through Arrays: you can get Array of tuple elements from Array of Tuples.
@@ -73,6 +49,11 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
     ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
     bool useDefaultImplementationForNulls() const override { return false; }
+    /// Keep nested LowCardinality element types intact: the default implementation would strip them via
+    /// `recursiveRemoveLowCardinality` before extraction, making `tupleElement(t, 'a')` disagree with the
+    /// subcolumn path `t.a` (which preserves `LowCardinality(...)`). tupleElement only extracts a column, so
+    /// it is naturally correct for any element type without the framework's LowCardinality unwrapping.
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
     bool useDefaultImplementationForDynamic() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
@@ -108,8 +89,11 @@ public:
             {
                 DataTypePtr element_type = tuple->getElements()[index.value()];
 
-                if (is_input_type_nullable && canExtractedSubcolumnsBeInsideNullable(element_type))
-                    element_type = std::make_shared<DataTypeNullable>(element_type);
+                /// For a Nullable(Tuple(...)) input, promote the element so it can represent the outer NULLs,
+                /// using the same rule as the subcolumn path (`t.a`): `Nullable(T)` for wrappable types and
+                /// `LowCardinality(Nullable(T))` for a non-nullable `LowCardinality(T)` element.
+                if (is_input_type_nullable)
+                    element_type = makeExtractedSubcolumnsNullableOrLowCardinalityNullableSafe(element_type);
 
                 return wrapInArrays(std::move(element_type), count_arrays);
             }
@@ -214,36 +198,13 @@ public:
 
             if (null_map_column)
             {
-                DataTypePtr element_type = input_type_as_tuple->getElements()[index.value()];
-
-                if (const auto * res_nullable = typeid_cast<const ColumnNullable *>(res.get()))
-                {
-                    ColumnPtr merged_null_map = mergeNullMaps(null_map_column, res_nullable->getNullMapColumnPtr());
-                    res = ColumnNullable::create(res_nullable->getNestedColumnPtr(), merged_null_map);
-                }
-                else if (canExtractedSubcolumnsBeInsideNullable(element_type))
-                {
-                    res = ColumnNullable::create(res, null_map_column);
-                }
-                else
-                {
-                    const auto & null_map = assert_cast<const ColumnUInt8 &>(*null_map_column).getData();
-
-                    auto result_column = element_type->createColumn();
-                    result_column->reserve(res->size());
-
-                    Field default_field = element_type->getDefault();
-
-                    for (size_t i = 0; i < res->size(); ++i)
-                    {
-                        if (null_map[i])
-                            result_column->insert(default_field);
-                        else
-                            result_column->insertFrom(*res, i);
-                    }
-
-                    res = std::move(result_column);
-                }
+                /// Fold the outer `Nullable(Tuple(...))` null map into the extracted element using the exact
+                /// same logic as the subcolumn path (`t.a`): wrap wrappable elements in `ColumnNullable`, OR
+                /// the outer null map into an element that already carries NULLs (Nullable / LowCardinality
+                /// (Nullable) / Dynamic / Variant), and promote a non-nullable `LowCardinality(T)` element to
+                /// `LowCardinality(Nullable(T))` before applying the mask. This keeps the (type, column) pair
+                /// consistent with both `getReturnTypeImpl` and the subcolumn reader.
+                res = NullableSubcolumnCreator(null_map_column).create(res);
             }
         }
         else if (const DataTypeQBit * input_type_as_qbit = checkAndGetDataType<DataTypeQBit>(input_type))

--- a/tests/queries/0_stateless/04338_tuple_inside_nullable_null_carrying_elements.reference
+++ b/tests/queries/0_stateless/04338_tuple_inside_nullable_null_carrying_elements.reference
@@ -82,15 +82,15 @@ SELECT tup.a, tup.v, tup.s, isNull(tup.a), isNull(tup.v), isNull(tup.s) FROM t_n
 SELECT count(tup.a), count(tup.v), count(tup.s) FROM t_null_carrying_mem;
 4	4	2
 DROP TABLE t_null_carrying_mem;
--- A plain LowCardinality element without Nullable inside cannot represent NULL: the extracted subcolumn
--- keeps its type and rows where the outer tuple is NULL read as default values.
+-- A plain LowCardinality(T) element cannot be wrapped in Nullable, so the extracted subcolumn is promoted
+-- to LowCardinality(Nullable(T)) and rows where the outer tuple is NULL read as NULL through it.
 DROP TABLE IF EXISTS t_lc_plain;
 CREATE TABLE t_lc_plain (tup Nullable(Tuple(p LowCardinality(String)))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
 INSERT INTO t_lc_plain VALUES (('a')), (NULL), (('b')), (NULL);
 SELECT toTypeName(tup.p), tup, tup.p, isNull(tup) FROM t_lc_plain;
-LowCardinality(String)	('a')	a	0
-LowCardinality(String)	\N		1
-LowCardinality(String)	('b')	b	0
-LowCardinality(String)	\N		1
+LowCardinality(Nullable(String))	('a')	a	0
+LowCardinality(Nullable(String))	\N	\N	1
+LowCardinality(Nullable(String))	('b')	b	0
+LowCardinality(Nullable(String))	\N	\N	1
 DROP TABLE t_lc_plain;

--- a/tests/queries/0_stateless/04338_tuple_inside_nullable_null_carrying_elements.sql
+++ b/tests/queries/0_stateless/04338_tuple_inside_nullable_null_carrying_elements.sql
@@ -46,8 +46,8 @@ SELECT tup.a, tup.v, tup.s, isNull(tup.a), isNull(tup.v), isNull(tup.s) FROM t_n
 SELECT count(tup.a), count(tup.v), count(tup.s) FROM t_null_carrying_mem;
 DROP TABLE t_null_carrying_mem;
 
--- A plain LowCardinality element without Nullable inside cannot represent NULL: the extracted subcolumn
--- keeps its type and rows where the outer tuple is NULL read as default values.
+-- A plain LowCardinality(T) element cannot be wrapped in Nullable, so the extracted subcolumn is promoted
+-- to LowCardinality(Nullable(T)) and rows where the outer tuple is NULL read as NULL through it.
 DROP TABLE IF EXISTS t_lc_plain;
 CREATE TABLE t_lc_plain (tup Nullable(Tuple(p LowCardinality(String)))) ENGINE = MergeTree ORDER BY tuple()
 SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;

--- a/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.reference
+++ b/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.reference
@@ -4,3 +4,11 @@
 0
 1	1
 LowCardinality(Nullable(String))
+LowCardinality(Nullable(String))	p	0	0
+LowCardinality(Nullable(String))	p	0	0
+LowCardinality(Nullable(String))	\N	1	1
+LowCardinality(Nullable(String))	\N	1	1
+LowCardinality(Nullable(String))	p	0	0
+LowCardinality(Nullable(String))	p	0	0
+LowCardinality(Nullable(String))	\N	1	1
+LowCardinality(Nullable(String))	\N	1	1

--- a/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.reference
+++ b/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.reference
@@ -2,3 +2,5 @@
 0
 1	1
 0
+1	1
+LowCardinality(Nullable(String))

--- a/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.sql
+++ b/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.sql
@@ -49,3 +49,30 @@ SELECT count() > 0, uniqExact(_part) FROM t_105356_lc;
 SELECT countIf(c0 IS NULL AND isNotNull(`c0.2`)) FROM t_105356_lc;
 
 DROP TABLE t_105356_lc;
+
+-- Carrier 3: inner element `LowCardinality(String)` that is NOT nullable. It reaches the subcolumn creator
+-- as a ColumnLowCardinality with a non-nullable dictionary, so `canExtractedSubcolumnsBeInsideNullable` and
+-- `canContainNull` are both false and the outer null map was dropped, tripping `Sort order of blocks
+-- violated` during OPTIMIZE FINAL. The creator now promotes such an element to
+-- `LowCardinality(Nullable(String))` before folding in the outer mask, so the merge no longer aborts and the
+-- extracted subcolumn type can represent the outer NULLs.
+DROP TABLE IF EXISTS t_105356_lc_nn;
+
+CREATE TABLE t_105356_lc_nn
+(
+    c0 Nullable(Tuple(String, LowCardinality(String))),
+    c2 Decimal
+)
+ENGINE = SummingMergeTree()
+ORDER BY (`c0.2`, c2)
+SETTINGS allow_nullable_key = 1, index_granularity = 1;
+
+INSERT INTO t_105356_lc_nn SELECT if(number % 2 = 0, NULL, ('a', toLowCardinality('p'))), toDecimal32(number, 0) FROM numbers(4);
+INSERT INTO t_105356_lc_nn SELECT if(number % 2 = 0, NULL, ('b', toLowCardinality('q'))), toDecimal32(number + 10, 0) FROM numbers(4);
+
+OPTIMIZE TABLE t_105356_lc_nn FINAL;
+
+SELECT count() > 0, uniqExact(_part) FROM t_105356_lc_nn;
+SELECT toTypeName(`c0.2`) FROM t_105356_lc_nn LIMIT 1;
+
+DROP TABLE t_105356_lc_nn;

--- a/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.sql
+++ b/tests/queries/0_stateless/04339_105356_nullable_tuple_subcolumn_sort_order.sql
@@ -76,3 +76,26 @@ SELECT count() > 0, uniqExact(_part) FROM t_105356_lc_nn;
 SELECT toTypeName(`c0.2`) FROM t_105356_lc_nn LIMIT 1;
 
 DROP TABLE t_105356_lc_nn;
+
+-- Read path: extracting the same non-nullable LowCardinality element directly from disk must produce a
+-- consistent `LowCardinality(Nullable(String))` column. The type creator promotes the element, but the read
+-- (`create(SerializationPtr)`) path was not promoted, so the column carried a non-nullable dictionary:
+-- `isNull(`c0.2`)` aborted with `ColumnUnique can't contain null values` and the value leaked the inner
+-- entry for outer-NULL rows. The read path now promotes the column too. Exercise both wide and compact parts.
+DROP TABLE IF EXISTS t_105356_lc_nn_read;
+
+CREATE TABLE t_105356_lc_nn_read (c0 Nullable(Tuple(String, LowCardinality(String))))
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
+INSERT INTO t_105356_lc_nn_read SELECT if(number % 2 = 0, NULL, ('a', toLowCardinality('p'))) FROM numbers(4);
+SELECT toTypeName(`c0.2`), `c0.2`, isNull(`c0.2`), isNull(c0) FROM t_105356_lc_nn_read ORDER BY isNull(c0), `c0.2`;
+DROP TABLE t_105356_lc_nn_read;
+
+DROP TABLE IF EXISTS t_105356_lc_nn_read_compact;
+
+CREATE TABLE t_105356_lc_nn_read_compact (c0 Nullable(Tuple(String, LowCardinality(String))))
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = '100G';
+INSERT INTO t_105356_lc_nn_read_compact SELECT if(number % 2 = 0, NULL, ('a', toLowCardinality('p'))) FROM numbers(4);
+SELECT toTypeName(`c0.2`), `c0.2`, isNull(`c0.2`), isNull(c0) FROM t_105356_lc_nn_read_compact ORDER BY isNull(c0), `c0.2`;
+DROP TABLE t_105356_lc_nn_read_compact;

--- a/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.reference
+++ b/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.reference
@@ -48,3 +48,26 @@ SELECT n.m, tupleElement(n, 'm'), tupleElement(materialize(n), 'm') FROM t_04344
 {'k':'v'}	{'k':'v'}	{'k':'v'}
 {}	{}	{}
 DROP TABLE t_04344;
+-- A `Map` / `Array` element of a `Nullable(Tuple(...))` can neither be wrapped in `Nullable` nor carry
+-- NULL itself, so outer-NULL rows must read as the element default ({} / []) -- matching a stored subcolumn
+-- and `NestedUtils::unwrapNullableTuple`. The construction below nulls the outer tuple with `if(...)` while
+-- leaving a non-default payload ({'k2':'v2'} / [3,4]) in the hidden nested column, and `materialize(...)`
+-- forces the non-optimized function path. The outer-NULL row must read the default, not that hidden payload.
+SELECT n, tupleElement(materialize(n), 'm') AS via_function
+FROM (
+    SELECT if(t.1 = 'b', NULL, t)::Nullable(Tuple(a String, m Map(String, String))) AS n
+    FROM (SELECT arrayJoin([tuple('a', map('k1', 'v1'))::Tuple(a String, m Map(String, String)),
+                            tuple('b', map('k2', 'v2'))::Tuple(a String, m Map(String, String))]) AS t)
+)
+SETTINGS allow_experimental_nullable_tuple_type = 1;
+('a',{'k1':'v1'})	{'k1':'v1'}
+\N	{}
+SELECT n, tupleElement(materialize(n), 'arr') AS via_function
+FROM (
+    SELECT if(t.1 = 'b', NULL, t)::Nullable(Tuple(a String, arr Array(UInt32))) AS n
+    FROM (SELECT arrayJoin([tuple('a', [1, 2])::Tuple(a String, arr Array(UInt32)),
+                            tuple('b', [3, 4])::Tuple(a String, arr Array(UInt32))]) AS t)
+)
+SETTINGS allow_experimental_nullable_tuple_type = 1;
+('a',[1,2])	[1,2]
+\N	[]

--- a/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.reference
+++ b/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.reference
@@ -1,0 +1,50 @@
+-- { echo }
+-- The `tupleElement` function must agree with the subcolumn path (`t.a`) on both the result type and the
+-- values, including for `LowCardinality` elements. Previously `tupleElement` inherited the default
+-- LowCardinality implementation, which stripped a nested `LowCardinality(...)` element via
+-- `recursiveRemoveLowCardinality` before extraction, so `tupleElement(t, 'a')` returned `String` /
+-- `Nullable(String)` while `t.a` returned `LowCardinality(String)` / `LowCardinality(Nullable(String))`.
+-- `materialize(...)` forces the non-optimized function path (the subcolumn optimization cannot fire).
+
+SET allow_experimental_nullable_tuple_type = 1;
+DROP TABLE IF EXISTS t_04344;
+CREATE TABLE t_04344
+(
+    t Tuple(a LowCardinality(String), b UInt32),
+    n Nullable(Tuple(a LowCardinality(String), lcn LowCardinality(Nullable(String)), s String, m Map(String, String)))
+)
+ENGINE = Memory;
+INSERT INTO t_04344 VALUES (('x', 1), ('p', 'q', 's', map('k', 'v'))), (('y', 2), NULL);
+-- Plain Tuple: element stays LowCardinality(String) on both the subcolumn and the function paths.
+SELECT toTypeName(t.a), toTypeName(tupleElement(t, 'a')), toTypeName(tupleElement(materialize(t), 'a')) FROM t_04344 LIMIT 1;
+LowCardinality(String)	LowCardinality(String)	LowCardinality(String)
+SELECT t.a, tupleElement(t, 'a'), tupleElement(materialize(t), 'a') FROM t_04344 ORDER BY t.b;
+x	x	x
+y	y	y
+-- Nullable(Tuple): a non-nullable LowCardinality(String) element is promoted to
+-- LowCardinality(Nullable(String)) and reads NULL for outer-NULL rows on every path.
+SELECT toTypeName(n.a), toTypeName(tupleElement(n, 'a')), toTypeName(tupleElement(materialize(n), 'a')) FROM t_04344 LIMIT 1;
+LowCardinality(Nullable(String))	LowCardinality(Nullable(String))	LowCardinality(Nullable(String))
+SELECT n.a, tupleElement(n, 'a'), tupleElement(materialize(n), 'a') FROM t_04344 ORDER BY t.b;
+p	p	p
+\N	\N	\N
+-- LowCardinality(Nullable(String)) element already carries NULL: type and values stay consistent.
+SELECT toTypeName(n.lcn), toTypeName(tupleElement(n, 'lcn')), toTypeName(tupleElement(materialize(n), 'lcn')) FROM t_04344 LIMIT 1;
+LowCardinality(Nullable(String))	LowCardinality(Nullable(String))	LowCardinality(Nullable(String))
+SELECT n.lcn, tupleElement(n, 'lcn'), tupleElement(materialize(n), 'lcn') FROM t_04344 ORDER BY t.b;
+q	q	q
+\N	\N	\N
+-- Plain String element inside Nullable(Tuple) wraps into Nullable(String) on every path.
+SELECT toTypeName(n.s), toTypeName(tupleElement(n, 's')), toTypeName(tupleElement(materialize(n), 's')) FROM t_04344 LIMIT 1;
+Nullable(String)	Nullable(String)	Nullable(String)
+SELECT n.s, tupleElement(n, 's'), tupleElement(materialize(n), 's') FROM t_04344 ORDER BY t.b;
+s	s	s
+\N	\N	\N
+-- Map element cannot be wrapped into Nullable, so it stays Map(String, String) and outer-NULL rows read as
+-- the default empty map on every path (unchanged behavior).
+SELECT toTypeName(n.m), toTypeName(tupleElement(n, 'm')), toTypeName(tupleElement(materialize(n), 'm')) FROM t_04344 LIMIT 1;
+Map(String, String)	Map(String, String)	Map(String, String)
+SELECT n.m, tupleElement(n, 'm'), tupleElement(materialize(n), 'm') FROM t_04344 ORDER BY t.b;
+{'k':'v'}	{'k':'v'}	{'k':'v'}
+{}	{}	{}
+DROP TABLE t_04344;

--- a/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.sql
+++ b/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.sql
@@ -41,3 +41,24 @@ SELECT toTypeName(n.m), toTypeName(tupleElement(n, 'm')), toTypeName(tupleElemen
 SELECT n.m, tupleElement(n, 'm'), tupleElement(materialize(n), 'm') FROM t_04344 ORDER BY t.b;
 
 DROP TABLE t_04344;
+
+-- A `Map` / `Array` element of a `Nullable(Tuple(...))` can neither be wrapped in `Nullable` nor carry
+-- NULL itself, so outer-NULL rows must read as the element default ({} / []) -- matching a stored subcolumn
+-- and `NestedUtils::unwrapNullableTuple`. The construction below nulls the outer tuple with `if(...)` while
+-- leaving a non-default payload ({'k2':'v2'} / [3,4]) in the hidden nested column, and `materialize(...)`
+-- forces the non-optimized function path. The outer-NULL row must read the default, not that hidden payload.
+SELECT n, tupleElement(materialize(n), 'm') AS via_function
+FROM (
+    SELECT if(t.1 = 'b', NULL, t)::Nullable(Tuple(a String, m Map(String, String))) AS n
+    FROM (SELECT arrayJoin([tuple('a', map('k1', 'v1'))::Tuple(a String, m Map(String, String)),
+                            tuple('b', map('k2', 'v2'))::Tuple(a String, m Map(String, String))]) AS t)
+)
+SETTINGS allow_experimental_nullable_tuple_type = 1;
+
+SELECT n, tupleElement(materialize(n), 'arr') AS via_function
+FROM (
+    SELECT if(t.1 = 'b', NULL, t)::Nullable(Tuple(a String, arr Array(UInt32))) AS n
+    FROM (SELECT arrayJoin([tuple('a', [1, 2])::Tuple(a String, arr Array(UInt32)),
+                            tuple('b', [3, 4])::Tuple(a String, arr Array(UInt32))]) AS t)
+)
+SETTINGS allow_experimental_nullable_tuple_type = 1;

--- a/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.sql
+++ b/tests/queries/0_stateless/04344_tuple_element_lowcardinality_consistency.sql
@@ -1,0 +1,43 @@
+-- { echo }
+-- The `tupleElement` function must agree with the subcolumn path (`t.a`) on both the result type and the
+-- values, including for `LowCardinality` elements. Previously `tupleElement` inherited the default
+-- LowCardinality implementation, which stripped a nested `LowCardinality(...)` element via
+-- `recursiveRemoveLowCardinality` before extraction, so `tupleElement(t, 'a')` returned `String` /
+-- `Nullable(String)` while `t.a` returned `LowCardinality(String)` / `LowCardinality(Nullable(String))`.
+-- `materialize(...)` forces the non-optimized function path (the subcolumn optimization cannot fire).
+
+SET allow_experimental_nullable_tuple_type = 1;
+
+DROP TABLE IF EXISTS t_04344;
+CREATE TABLE t_04344
+(
+    t Tuple(a LowCardinality(String), b UInt32),
+    n Nullable(Tuple(a LowCardinality(String), lcn LowCardinality(Nullable(String)), s String, m Map(String, String)))
+)
+ENGINE = Memory;
+
+INSERT INTO t_04344 VALUES (('x', 1), ('p', 'q', 's', map('k', 'v'))), (('y', 2), NULL);
+
+-- Plain Tuple: element stays LowCardinality(String) on both the subcolumn and the function paths.
+SELECT toTypeName(t.a), toTypeName(tupleElement(t, 'a')), toTypeName(tupleElement(materialize(t), 'a')) FROM t_04344 LIMIT 1;
+SELECT t.a, tupleElement(t, 'a'), tupleElement(materialize(t), 'a') FROM t_04344 ORDER BY t.b;
+
+-- Nullable(Tuple): a non-nullable LowCardinality(String) element is promoted to
+-- LowCardinality(Nullable(String)) and reads NULL for outer-NULL rows on every path.
+SELECT toTypeName(n.a), toTypeName(tupleElement(n, 'a')), toTypeName(tupleElement(materialize(n), 'a')) FROM t_04344 LIMIT 1;
+SELECT n.a, tupleElement(n, 'a'), tupleElement(materialize(n), 'a') FROM t_04344 ORDER BY t.b;
+
+-- LowCardinality(Nullable(String)) element already carries NULL: type and values stay consistent.
+SELECT toTypeName(n.lcn), toTypeName(tupleElement(n, 'lcn')), toTypeName(tupleElement(materialize(n), 'lcn')) FROM t_04344 LIMIT 1;
+SELECT n.lcn, tupleElement(n, 'lcn'), tupleElement(materialize(n), 'lcn') FROM t_04344 ORDER BY t.b;
+
+-- Plain String element inside Nullable(Tuple) wraps into Nullable(String) on every path.
+SELECT toTypeName(n.s), toTypeName(tupleElement(n, 's')), toTypeName(tupleElement(materialize(n), 's')) FROM t_04344 LIMIT 1;
+SELECT n.s, tupleElement(n, 's'), tupleElement(materialize(n), 's') FROM t_04344 ORDER BY t.b;
+
+-- Map element cannot be wrapped into Nullable, so it stays Map(String, String) and outer-NULL rows read as
+-- the default empty map on every path (unchanged behavior).
+SELECT toTypeName(n.m), toTypeName(tupleElement(n, 'm')), toTypeName(tupleElement(materialize(n), 'm')) FROM t_04344 LIMIT 1;
+SELECT n.m, tupleElement(n, 'm'), tupleElement(materialize(n), 'm') FROM t_04344 ORDER BY t.b;
+
+DROP TABLE t_04344;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/105356
Related: https://github.com/ClickHouse/ClickHouse/pull/102942
Related: https://github.com/ClickHouse/ClickHouse/pull/107761
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/105356
Related: https://github.com/ClickHouse/ClickHouse/pull/102942


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server abort (`Sort order of blocks violated`) during a merge, and incorrect reads, when a non-nullable `LowCardinality` element of a `Nullable(Tuple(...))` column is used as a subcolumn (for example as a sort key).

### Description

Residual carrier of #105356 that #102942 (merged) does not cover. Carriers 1 (`Nullable(Decimal)`) and 2 (`LowCardinality(Nullable(String))`) are fixed there; a **non-nullable** `LowCardinality(String)` element was still mishandled.

Repro on current master (debug), git hash `07643905aae`, report shape from issue #105356:

```sql
SET allow_experimental_nullable_tuple_type = 1;
CREATE TABLE t (c0 Nullable(Tuple(String, LowCardinality(String))), c2 Decimal)
ENGINE = SummingMergeTree() ORDER BY (`c0.2`, c2)
SETTINGS allow_nullable_key = 1, index_granularity = 1;
INSERT INTO t SELECT if(number % 2 = 0, NULL, ('a', toLowCardinality('p'))), toDecimal32(number, 0) FROM numbers(4);
INSERT INTO t SELECT if(number % 2 = 0, NULL, ('b', toLowCardinality('q'))), toDecimal32(number + 10, 0) FROM numbers(4);
OPTIMIZE TABLE t FINAL;  -- Logical error: 'Sort order of blocks violated for column number 1, left: 'p', right: ''.'
```

Such an element reaches `NullableSubcolumnCreator::create` as a `ColumnLowCardinality` whose dictionary is not nullable, so both `canExtractedSubcolumnsBeInsideNullable` and `canContainNull` are false. None of the three `create` overloads applied the outer tuple null map, so the extracted subcolumn dropped the outer NULLs entirely.

The extracted subcolumn type is promoted to `LowCardinality(Nullable(T))` so it can represent the outer NULLs. All three creator overloads are now made consistent with that type:

- **Type** (`create(DataTypePtr)`): promote the non-nullable `LowCardinality(T)` to `LowCardinality(Nullable(T))` via the existing `makeExtractedSubcolumnsNullableOrLowCardinalityNullableSafe`.
- **In-memory column** (`create(ColumnPtr)`): promote the column with `cloneNullable()` and fold in the outer null map. This fixes the merge abort, where the in-memory sort key was re-extracted and exposed the inner dictionary value for outer-`NULL` rows, contradicting the on-disk sort key and tripping `CheckSortedTransform`.
- **Read path** (`create(SerializationPtr)`): wrap the original (non-nullable) `LowCardinality` serialization in `SerializationNullableWithParentNullMap`, keeping the on-disk stream layout unchanged. `applyParentNullMapToExtractedSubcolumn` promotes the read `LowCardinality(T)` column to `LowCardinality(Nullable(T))` (rebuilding the dictionary with a NULL placeholder and remapping indexes) before folding in the outer null map. The promotion runs before the no-NULL-rows early-out so the column type is consistent across all read ranges.

Without the read-path part, reading the subcolumn directly from a part (`SELECT c0.2`) produced a `ColumnLowCardinality` with a non-nullable dictionary while its declared type was `LowCardinality(Nullable(T))`: `isNull(c0.2)` then aborted with `ColumnUnique can't contain null values`, and outer-`NULL` rows leaked the inner dictionary value instead of reading `NULL`. With the fix, the subcolumn reads `NULL` for outer-`NULL` rows on both wide and compact parts.

Other carriers (`ColumnNullable`, `LowCardinality(Nullable)`, `Dynamic`, `Variant`) are unchanged. The `04338`/`04339` tests are extended to cover reading the subcolumn directly (value and `isNull`) from both wide and compact parts; both tests fail on master and pass with this change.

#### Follow-up: `tupleElement` consistency (@Avogar review)

The same inconsistency existed on the `tupleElement` function path. It inherited the default `LowCardinality` implementation, whose `convertLowCardinalityColumnsToFull` -> `recursiveRemoveLowCardinality` recurses into the tuple and strips a nested `LowCardinality(...)` element before `getReturnTypeImpl`/`executeImpl` run. So `t.a` (subcolumn) kept `LowCardinality(...)` while `tupleElement(t, 'a')` returned `String` / `Nullable(String)`, and a `LowCardinality(Nullable(String))` element was downgraded to `Nullable(String)`:

```sql
SELECT t.a, toTypeName(t.a), tupleElement(t, 'a'), toTypeName(tupleElement(t, 'a')) FROM test;
```

`useDefaultImplementationForLowCardinalityColumns()` is now disabled for `tupleElement`, and both its return type and its `Nullable(Tuple(...))` null-map folding are routed through the same helpers the subcolumn path uses (`makeExtractedSubcolumnsNullableOrLowCardinalityNullableSafe` and `NullableSubcolumnCreator`). The function now produces a `(type, column)` pair identical to the subcolumn reader for every element type. New test `04344_tuple_element_lowcardinality_consistency` forces the non-optimized path via `materialize(t)` and asserts type+value equality across the subcolumn path, the optimized function path, and the materialized path (plain `LowCardinality`, `LowCardinality(Nullable)`, `String`, `Map` elements); it fails on HEAD before this change and passes after.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.941` (included in `26.7` and later)
<!-- ch-version-info:end -->