### PR TITLE
Fix DECIMAL_OVERFLOW in changeYear/changeXxx for nanosecond DateTime64

### DIFF
--- a/src/Functions/changeDate.cpp
+++ b/src/Functions/changeDate.cpp
@@ -136,9 +136,20 @@ public:
 
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                Int64 time = date_lut.toNumYYYYMMDDhhmmss(date_time_col_data[i] / deg);
+                /// Split into whole seconds and a non-negative fraction, rounding the whole-seconds part
+                /// toward negative infinity. Plain '/' and '%' truncate toward zero, which for pre-epoch
+                /// sub-second values would attribute the last fractional second to the next calendar boundary
+                /// (for example, '1969-12-31 23:59:59.500' would decompose as '1970-01-01 00:00:00' minus
+                /// 500 ms), shifting the untouched calendar fields of the result.
+                Int64 whole_seconds = date_time_col_data[i] / deg;
                 Int64 fraction = date_time_col_data[i] % deg;
+                if (fraction < 0)
+                {
+                    fraction += deg;
+                    --whole_seconds;
+                }
 
+                Int64 time = date_lut.toNumYYYYMMDDhhmmss(whole_seconds);
                 result_col_data[i] = getChangedDate(time, value_col_data[i], result_type, date_lut, scale, fraction);
             }
         }

--- a/src/Functions/changeDate.cpp
+++ b/src/Functions/changeDate.cpp
@@ -290,20 +290,26 @@ public:
         else if (isDateTime(result_type))
             result = date_lut.makeDateTime(year, month, day, hours, minutes, seconds);
         else
+        {
+            const Int64 whole_seconds = date_lut.makeDateTime(year, month, day, hours, minutes, seconds);
 #ifndef __clang_analyzer__
             /// ^^ This looks funny. It is the least terrible suppression of a false positive reported by clang-analyzer (a sub-class
             /// of clang-tidy checks) deep down in 'decimalFromComponents'. Usual suppressions of the form NOLINT* don't work here (they
             /// would only affect code in _this_ file), and suppressing the issue in 'decimalFromComponents' may suppress true positives.
-            result = DecimalUtils::dateTimeFromComponents(
-                date_lut.makeDateTime(year, month, day, hours, minutes, seconds),
-                fraction,
-                static_cast<UInt32>(scale));
+            DateTime64 result_val;
+            if (DecimalUtils::tryGetDateTimeFromComponents(whole_seconds, fraction, static_cast<UInt32>(scale), result_val))
+                result = result_val;
+            else
+                /// The requested components do not fit into DateTime64 at this scale (for example, a year close to 2299 at
+                /// scale 9, where seconds * 10^9 overflows Int64). Clamp to the nearest representable boundary; the min/max
+                /// checks below finish the clamp. Overflow direction follows the sign of the whole-seconds value.
+                result = whole_seconds < 0 ? min_date : max_date;
 #else
-        {
             UNUSED(fraction);
+            UNUSED(whole_seconds);
             result = 0;
-        }
 #endif
+        }
 
         if (result < min_date)
             return min_date;

--- a/src/Functions/changeDate.cpp
+++ b/src/Functions/changeDate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <Common/DateLUTImpl.h>
 #include <Common/Exception.h>
 #include <Columns/ColumnDecimal.h>
@@ -232,10 +233,17 @@ public:
             Int64 deg = 1;
             for (Int64 j = 0; j < scale; ++j)
                 deg *= 10;
-            max_date = DecimalUtils::dateTimeFromComponents(
-                date_lut.makeDateTime(2299, 12, 31, 23, 59, 59),
-                static_cast<Int64>(deg - 1),
-                static_cast<UInt32>(scale));
+            DateTime64 max_date_val;
+            if (DecimalUtils::tryGetDateTimeFromComponents(
+                    date_lut.makeDateTime(2299, 12, 31, 23, 59, 59),
+                    static_cast<Int64>(deg - 1),
+                    static_cast<UInt32>(scale),
+                    max_date_val))
+                max_date = max_date_val;
+            else
+                /// At scale 9 the year-2299 boundary does not fit into Int64; clamp to the
+                /// maximum representable DateTime64 value (2262-04-11 23:47:16.854775807).
+                max_date = std::numeric_limits<Int64>::max();
             min_year = 1900;
             max_year = 2299;
         }

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
@@ -39,3 +39,16 @@
 2262-04-11 23:47:16.854775807
 2262-04-11 23:47:16.854775807
 2262-04-10 00:00:00.000000000
+-- Pre-epoch sub-second values: the whole-second part must round toward negative infinity, not truncate toward zero
+1969-12-31 23:59:59.500
+1965-12-31 23:59:59.500
+1969-03-30 23:59:59.500
+1969-12-15 23:59:59.500
+1969-12-31 10:59:59.500
+1969-12-31 23:45:59.500
+1969-06-15 12:30:30.500
+-- Pre-epoch sub-second values at scale=9
+1969-12-31 23:59:59.999999999
+1969-12-31 23:59:00.999999999
+-- Pre-epoch value exactly on a whole second is unaffected
+1968-12-31 23:59:59.000

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
@@ -31,3 +31,11 @@
 -- Verify fractional seconds are preserved
 2023-03-15 08:30:45.999999999
 2024-07-15 08:30:45.999999999
+-- In-range year past the representable scale=9 boundary (2262-04-11 23:47:16.854775807) must clamp, not overflow
+2262-04-11 23:47:16.854775807
+2262-04-11 23:47:16.854775807
+2262-01-01 00:00:00.000000000
+-- Component change moving a representable scale=9 value past the boundary must clamp, not overflow
+2262-04-11 23:47:16.854775807
+2262-04-11 23:47:16.854775807
+2262-04-10 00:00:00.000000000

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.reference
@@ -1,0 +1,33 @@
+-- changeYear with DateTime64 scale=9 (the original bug)
+2025-01-01 00:00:00.000000000
+2000-06-15 12:30:45.123456789
+1970-06-15 12:30:45.123456789
+-- changeYear with DateTime64 scale=9, out-of-bounds year (should clamp to max)
+2262-04-11 23:47:16.854775807
+1900-01-01 00:00:00.000000000
+-- changeMonth with DateTime64 scale=9
+2024-06-15 10:20:30.123456789
+2024-12-15 10:20:30.123456789
+1900-01-01 00:00:00.000000000
+-- changeDay with DateTime64 scale=9
+2024-01-15 10:20:30.123456789
+2024-01-31 10:20:30.123456789
+1900-01-01 00:00:00.000000000
+-- changeHour with DateTime64 scale=9
+2024-01-01 23:20:30.123456789
+1900-01-01 00:00:00.000000000
+-- changeMinute with DateTime64 scale=9
+2024-01-01 10:59:30.123456789
+1900-01-01 00:00:00.000000000
+-- changeSecond with DateTime64 scale=9
+2024-01-01 10:20:59.123456789
+1900-01-01 00:00:00.000000000
+-- Regression test: scale=3 and scale=6 still work
+2025-01-01 00:00:00.000
+2025-01-01 00:00:00.000000
+-- Regression test: scale=3 and scale=6 out-of-bounds still work
+2299-12-31 23:59:59.999
+2299-12-31 23:59:59.999999
+-- Verify fractional seconds are preserved
+2023-03-15 08:30:45.999999999
+2024-07-15 08:30:45.999999999

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
@@ -56,3 +56,19 @@ SELECT '-- Component change moving a representable scale=9 value past the bounda
 SELECT changeMonth(toDateTime64('2262-01-01 00:00:00.000000000', 9), 12);
 SELECT changeDay(toDateTime64('2262-04-01 00:00:00.000000000', 9), 30);
 SELECT changeDay(toDateTime64('2262-04-01 00:00:00.000000000', 9), 10);
+
+SELECT '-- Pre-epoch sub-second values: the whole-second part must round toward negative infinity, not truncate toward zero';
+SELECT changeYear(toDateTime64('1969-12-31 23:59:59.500', 3, 'UTC'), 1969);
+SELECT changeYear(toDateTime64('1969-12-31 23:59:59.500', 3, 'UTC'), 1965);
+SELECT changeMonth(toDateTime64('1969-06-30 23:59:59.500', 3, 'UTC'), 3);
+SELECT changeDay(toDateTime64('1969-12-31 23:59:59.500', 3, 'UTC'), 15);
+SELECT changeHour(toDateTime64('1969-12-31 23:59:59.500', 3, 'UTC'), 10);
+SELECT changeMinute(toDateTime64('1969-12-31 23:59:59.500', 3, 'UTC'), 45);
+SELECT changeSecond(toDateTime64('1969-06-15 12:30:45.500', 3, 'UTC'), 30);
+
+SELECT '-- Pre-epoch sub-second values at scale=9';
+SELECT changeYear(toDateTime64('1969-12-31 23:59:59.999999999', 9, 'UTC'), 1969);
+SELECT changeSecond(toDateTime64('1969-12-31 23:59:59.999999999', 9, 'UTC'), 0);
+
+SELECT '-- Pre-epoch value exactly on a whole second is unaffected';
+SELECT changeYear(toDateTime64('1969-12-31 23:59:59.000', 3, 'UTC'), 1968);

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
@@ -1,0 +1,48 @@
+-- Tags: no-fasttest
+-- Test for bug #72019: changeYear + nanosecond DateTime64 (scale=9) causes DECIMAL_OVERFLOW
+-- The overflow occurred when computing max_date boundary (year 2299 * 10^9 > Int64 max).
+
+SET session_timezone = 'UTC';
+
+SELECT '-- changeYear with DateTime64 scale=9 (the original bug)';
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), 2025);
+SELECT changeYear(toDateTime64('2024-06-15 12:30:45.123456789', 9), 2000);
+SELECT changeYear(toDateTime64('2024-06-15 12:30:45.123456789', 9), 1970);
+
+SELECT '-- changeYear with DateTime64 scale=9, out-of-bounds year (should clamp to max)';
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), 2500);
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), -5000);
+
+SELECT '-- changeMonth with DateTime64 scale=9';
+SELECT changeMonth(toDateTime64('2024-01-15 10:20:30.123456789', 9), 6);
+SELECT changeMonth(toDateTime64('2024-01-15 10:20:30.123456789', 9), 12);
+SELECT changeMonth(toDateTime64('2024-01-15 10:20:30.123456789', 9), 0);
+
+SELECT '-- changeDay with DateTime64 scale=9';
+SELECT changeDay(toDateTime64('2024-01-01 10:20:30.123456789', 9), 15);
+SELECT changeDay(toDateTime64('2024-01-01 10:20:30.123456789', 9), 31);
+SELECT changeDay(toDateTime64('2024-01-01 10:20:30.123456789', 9), 0);
+
+SELECT '-- changeHour with DateTime64 scale=9';
+SELECT changeHour(toDateTime64('2024-01-01 10:20:30.123456789', 9), 23);
+SELECT changeHour(toDateTime64('2024-01-01 10:20:30.123456789', 9), -1);
+
+SELECT '-- changeMinute with DateTime64 scale=9';
+SELECT changeMinute(toDateTime64('2024-01-01 10:20:30.123456789', 9), 59);
+SELECT changeMinute(toDateTime64('2024-01-01 10:20:30.123456789', 9), -1);
+
+SELECT '-- changeSecond with DateTime64 scale=9';
+SELECT changeSecond(toDateTime64('2024-01-01 10:20:30.123456789', 9), 59);
+SELECT changeSecond(toDateTime64('2024-01-01 10:20:30.123456789', 9), -1);
+
+SELECT '-- Regression test: scale=3 and scale=6 still work';
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000', 3), 2025);
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000', 6), 2025);
+
+SELECT '-- Regression test: scale=3 and scale=6 out-of-bounds still work';
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000', 3), 2500);
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000', 6), 2500);
+
+SELECT '-- Verify fractional seconds are preserved';
+SELECT changeYear(toDateTime64('2024-03-15 08:30:45.999999999', 9), 2023);
+SELECT changeMonth(toDateTime64('2024-03-15 08:30:45.999999999', 9), 7);

--- a/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
+++ b/tests/queries/0_stateless/04413_changeyear_nanosecond_datetime64.sql
@@ -46,3 +46,13 @@ SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000', 6), 2500);
 SELECT '-- Verify fractional seconds are preserved';
 SELECT changeYear(toDateTime64('2024-03-15 08:30:45.999999999', 9), 2023);
 SELECT changeMonth(toDateTime64('2024-03-15 08:30:45.999999999', 9), 7);
+
+SELECT '-- In-range year past the representable scale=9 boundary (2262-04-11 23:47:16.854775807) must clamp, not overflow';
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), 2299);
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), 2263);
+SELECT changeYear(toDateTime64('2024-01-01 00:00:00.000000000', 9), 2262);
+
+SELECT '-- Component change moving a representable scale=9 value past the boundary must clamp, not overflow';
+SELECT changeMonth(toDateTime64('2262-01-01 00:00:00.000000000', 9), 12);
+SELECT changeDay(toDateTime64('2262-04-01 00:00:00.000000000', 9), 30);
+SELECT changeDay(toDateTime64('2262-04-01 00:00:00.000000000', 9), 10);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `DateTime64` bugs in `changeYear`, `changeMonth`, `changeDay`, `changeHour`, `changeMinute` and `changeSecond`: nanosecond-precision (scale 9) inputs no longer throw `DECIMAL_OVERFLOW`, and pre-epoch sub-second inputs now return the correct calendar second.


### Summary

`changeYear`, `changeMonth`, `changeDay`, `changeHour`, `changeMinute` and `changeSecond` share `getChangedDate`. This PR fixes two `DateTime64` issues in that shared path:

1. **Overflow on every scale-9 input.** `getChangedDate` precomputes the `max_date` boundary for year 2299 as a `DateTime64`. At scale 9 that value (`2299 * 10^9` seconds) does not fit into `Int64`, so `DecimalUtils::dateTimeFromComponents` threw `DECIMAL_OVERFLOW` before the result was ever computed, and every scale-9 input failed. The fix builds both the boundary and the final candidate with the non-throwing `tryGetDateTimeFromComponents`, and on overflow clamps to the nearest representable boundary (`std::numeric_limits<Int64>::max()` = `2262-04-11 23:47:16.854775807`, the maximum representable scale-9 `DateTime64`, or the minimum for negative values).

2. **Pre-epoch sub-second split.** The `DateTime64` input path split the stored value into whole seconds and a fraction with plain `/` and `%`, which truncate toward zero. For a pre-epoch value with a non-zero fraction the whole-seconds part was rounded toward zero instead of toward negative infinity, so the calendar fields were read off the next boundary and the resulting second was wrong (e.g. `changeSecond('1969-12-31 23:59:58.500', 30)` returned `...:29.500` instead of `...:30.500`). The fix floor-normalizes the split (adds one degree to a negative fraction and decrements the whole seconds), so the calendar fields match the actual instant. This affects any sub-second scale, including 3 and 9.

Closes https://github.com/ClickHouse/ClickHouse/issues/72019


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.417` (included in `26.7` and later)
<!-- ch-version-info:end -->