### PR TITLE
Add test: `GeoJSONRowOutputFormat::resetFormatterImpl` (formatter reuse via `formatRow`) is untested

### DIFF
--- a/tests/queries/0_stateless/04413_geojson_output_format_row.reference
+++ b/tests/queries/0_stateless/04413_geojson_output_format_row.reference
@@ -1,0 +1,6 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[0,2]},"properties":{"name":"s0"}}]}\n
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"name":"s1"}}]}\n
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[2,2]},"properties":{"name":"s2"}}]}\n
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[0,2]},"properties":{"name":"s0"}}]}\n
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{"name":"s1"}}]}\n
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[2,2]},"properties":{"name":"s2"}}]}\n

--- a/tests/queries/0_stateless/04413_geojson_output_format_row.sql
+++ b/tests/queries/0_stateless/04413_geojson_output_format_row.sql
@@ -1,0 +1,11 @@
+-- Tags: no-random-settings
+-- Test formatRow('GeoJSON', ...) reusing one formatter: resetFormatter() runs after every row,
+-- exercising GeoJSONRowOutputFormat::resetFormatterImpl (buffer-pointer re-sync after reset).
+SELECT formatRow('GeoJSON', (n + 0.0, 2.0)::Point AS geometry, concat('s', toString(n)) AS name) AS r
+FROM (SELECT number AS n FROM numbers(3)) ORDER BY n;
+
+-- Same path with UTF-8 validation on, so the wrapper write buffer is recreated on each reset and the
+-- re-fetched ostr must point at the new buffer for rows after the first.
+SELECT formatRow('GeoJSON', (n + 0.0, 2.0)::Point AS geometry, concat('s', toString(n)) AS name) AS r
+FROM (SELECT number AS n FROM numbers(3)) ORDER BY n
+SETTINGS output_format_json_validate_utf8 = 1;

--- a/tests/queries/0_stateless/04413_geojson_output_format_row.sql
+++ b/tests/queries/0_stateless/04413_geojson_output_format_row.sql
@@ -1,6 +1,9 @@
 -- Tags: no-random-settings
 -- Test formatRow('GeoJSON', ...) reusing one formatter: resetFormatter() runs after every row,
 -- exercising GeoJSONRowOutputFormat::resetFormatterImpl (buffer-pointer re-sync after reset).
+
+SET enable_analyzer = 1;
+
 SELECT formatRow('GeoJSON', (n + 0.0, 2.0)::Point AS geometry, concat('s', toString(n)) AS name) AS r
 FROM (SELECT number AS n FROM numbers(3)) ORDER BY n;
 


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #108065](https://github.com/ClickHouse/ClickHouse/pull/108065).
PR 108065 adds the `GeoJSON` OUTPUT format (`GeoJSONRowOutputFormat`) — writing a result set as a single `FeatureCollection`, one `Feature` per row — and makes input-format tweaks: a new `format_geojson_validate_geometry` setting (default `true`) that gates RFC 7946 shape validation on both read and

**1. `GeoJSONRowOutputFormat::resetFormatterImpl` (formatter reuse via `formatRow`) is untested**
  `src/Processors/Formats/Impl/GeoJSONRowOutputFormat.cpp:438`
  **Risk:** `formatRow.cpp:101` calls `row_output_format->resetFormatter()` per row → `IOutputFormat::resetFormatter()` → `GeoJSONRowOutputFormat::resetFormatterImpl()` (GeoJSONRowOutputFormat.cpp:436-440). When a wrapper buffer exists (`output_format_json_validate_utf8=1` creates a `WriteBufferValidUTF8`, or `valid_output_on_exception` creates a `PeekableWriteBuffer`), the adaptor reset recreates that wrapper, so line 439 must re-fetch `ostr = getWriteBufferPtr()`. RISK: if line 439 is …
  **What's unique vs PR tests:** The PR's tests (04402-04412) all run the GeoJSON output formatter once per query (single FeatureCollection) or via the parallel formatter (which throws NOT_IMPLEMENTED for resetFormatterImpl). None reuse a single formatter instance, so none reach `resetFormatterImpl`; this test reaches it via `formatRow` over multiple rows.
  **Tags:** `-- Tags: no-random-settings` — `no-random-settings`: Test asserts exact JSON output bytes; random injection of output_format_json_* settings could alter quoting/format and flake the comparison.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/bbbf6f7e-63aa-4e5f-87a7-cdc52df57da6)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.172` (included in `26.7` and later)
<!-- ch-version-info:end -->