### PR TITLE
Fix use-after-free in SYSTEM FLUSH DISTRIBUTED

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2372,7 +2372,12 @@ void InterpreterSystemQuery::flushDistributed(ASTSystemQuery & query)
     if (query.query_settings)
         settings_changes = query.query_settings->as<ASTSetQuery>()->changes;
 
-    if (auto * storage_distributed = dynamic_cast<StorageDistributed *>(DatabaseCatalog::instance().getTable(table_id, getContext()).get()))
+    /// Keep the StoragePtr alive for the whole flush: the table holds no other owning
+    /// reference here (DROP on an Atomic database does not take the exclusive drop_lock,
+    /// and the flush does not hold an async-insert lock), so a concurrent DROP could
+    /// otherwise destroy the table while flushClusterNodesAllData() is still running.
+    auto table = DatabaseCatalog::instance().getTable(table_id, getContext());
+    if (auto * storage_distributed = dynamic_cast<StorageDistributed *>(table.get()))
         storage_distributed->flushClusterNodesAllData(getContext(), settings_changes);
     else
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table {} is not distributed", table_id.getNameForLogs());

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2375,7 +2375,7 @@ void InterpreterSystemQuery::flushDistributed(ASTSystemQuery & query)
     /// Keep the StoragePtr alive for the whole flush: the table holds no other owning
     /// reference here (DROP on an Atomic database does not take the exclusive drop_lock,
     /// and the flush does not hold an async-insert lock), so a concurrent DROP could
-    /// otherwise destroy the table while flushClusterNodesAllData() is still running.
+    /// otherwise destroy the table while flushClusterNodesAllData is still running.
     auto table = DatabaseCatalog::instance().getTable(table_id, getContext());
     if (auto * storage_distributed = dynamic_cast<StorageDistributed *>(table.get()))
         storage_distributed->flushClusterNodesAllData(getContext(), settings_changes);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a possible crash (use-after-free) when `SYSTEM FLUSH DISTRIBUTED` runs concurrently with `DROP TABLE` of the same `Distributed` table.

### Description

No related open issue found.

`InterpreterSystemQuery::flushDistributed` took a raw `StorageDistributed *` from a temporary `StoragePtr`:

```cpp
if (auto * storage_distributed = dynamic_cast<StorageDistributed *>(DatabaseCatalog::instance().getTable(table_id, getContext()).get()))
    storage_distributed->flushClusterNodesAllData(getContext(), settings_changes);
```

The owning `shared_ptr` returned by `getTable()` is destroyed at the end of the `if`-condition full-expression, before `flushClusterNodesAllData()` runs, and the interpreter holds no other owning reference to the table.

On an `Atomic` database (the default) nothing keeps the table alive for the duration of the flush:
- `DROP`/`DETACH` does not take the exclusive `drop_lock` (`InterpreterDropQuery` only calls `lockExclusively()` when `database->getUUID() == UUIDHelpers::Nil`, i.e. for the legacy `Ordinary` engine), so the `lockForShare` taken inside `flushClusterNodesAllDataImpl` provides no mutual exclusion against a concurrent drop;
- the flush holds no async-insert action lock, and `async_insert_blocker.cancel()` is a non-blocking flag rather than a barrier.

The background drop-cleanup task in `DatabaseCatalog` destroys a dropped table once `isSharedPtrUnique()` holds. With only a raw pointer in flight, that check passes and the `StorageDistributed` is freed while `flushClusterNodesAllDataImpl()` is still running; the subsequent access through the table (`this->log` in the trailing `LOG_INFO`) then reads freed memory and the server crashes.

Fix: keep the `StoragePtr` alive for the whole flush, matching the sibling `flushObjectStorageQueue()`.

No automated regression test is included. The crash is a sub-microsecond race between the flush releasing its locks and the trailing access through the freed table, so it only surfaces under the CI Thread Fuzzer (which is how the `Stress test (amd_debug)` originally hit it). A plain stateless test cannot land that window reliably (about 460 flush-vs-drop windows on debug and ASan builds reproduced it zero times), and a debug failpoint is not usable here because bugfix validation runs the downloaded master-HEAD binary, which would not contain a new failpoint. The fix was validated locally by widening the post-flush window with a temporary sleep: without the fix the table's `shared_ptr` use count drops to 0 during the flush and the server crashes; with the fix the use count stays positive and the server survives.

Found by the server-side AST fuzzer running `SYSTEM FLUSH DISTRIBUTED` concurrently with table churn (`Stress test (amd_debug)`):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104431&sha=5f721efc5cad3546671a1a6474da0be869399eb5&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

This is a pre-existing issue and is unrelated to the PR whose stress run surfaced it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.269` (included in `26.7` and later)
<!-- ch-version-info:end -->