### PR TITLE
PRVersionInfo: write version info into resolved issue body instead of a comment

### DIFF
--- a/tests/ci/github_helper.py
+++ b/tests/ci/github_helper.py
@@ -421,36 +421,6 @@ class GitHub(github.Github):
             repo, "get_issue", cache_file, number, obj_updated_at=obj_updated_at
         )
 
-    def upsert_issue_comment(
-        self,
-        repo: Repository,
-        issue_number: int,
-        marker: str,
-        body: str,
-        dry_run: bool = False,
-    ) -> Optional[str]:
-        """Create or update a single marker-identified comment on an issue.
-
-        Idempotent: scans the issue's comments for one containing ``marker``
-        (a bot-owned delimiter); if found, it is edited only when the body
-        actually changed; otherwise a new comment is created. Returns
-        ``"created"``, ``"updated"``, or ``None`` when nothing changed.
-
-        The issue is fetched live (not via the pickle cache) so the comment
-        list reflects the current state.
-        """
-        issue = repo.get_issue(issue_number)
-        for comment in issue.get_comments():
-            if marker in (comment.body or ""):
-                if (comment.body or "") == body:
-                    return None
-                if not dry_run:
-                    comment.edit(body)
-                return "updated"
-        if not dry_run:
-            issue.create_comment(body)
-        return "created"
-
     def _get_repo_obj_cached(
         self,
         repo: Repository,

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -23,9 +23,11 @@ and list the versions those backports shipped in.
 
 When an original PR resolves issues -- taken from GitHub's "Development" links
 (`closingIssuesReferences`), i.e. the issues it closes -- the same version-info
-section is also posted as a comment on each such issue, so a reader of the issue
-sees which release the fix shipped in. The comment is idempotent (created once,
-edited only when the version info changes), keyed by the same section markers.
+section is written into each such issue's body, so a reader of the issue sees
+which release the fix shipped in. The section is the same delimited, bot-owned
+block used in PR bodies (with an added `Resolved by` line), upserted the same
+way, so it is idempotent: written once and re-edited only when the version info
+changes.
 
 The job is idempotent: it re-derives everything from GitHub + `version_history`
 on each run and only edits a PR when the section content actually changes. A
@@ -120,18 +122,18 @@ def render_section(merged_into: Optional[str], backported_to: List[str]) -> str:
     return "\n".join(lines)
 
 
-def render_issue_comment(pr_number: int, section_body: str) -> str:
-    """Render the bot-owned comment posted on an issue a PR resolved.
+def render_issue_section(pr_number: int, section_body: str) -> str:
+    """Render the version-info section written into a resolved issue's body.
 
-    Wraps the same version-info section used in PR bodies in the section markers
-    so it can be found and updated idempotently, with a `Resolved by` item added
-    as the first entry of the list (right after the `### Version info` header).
+    Same inner markdown as the PR-body section, but with a `Resolved by` item
+    added as the first entry of the list (right after the `### Version info`
+    header). The delimiters are added by `upsert_section`, exactly as for PRs.
     """
     header, _, rest = section_body.partition("\n")
     inner = f"{header}\n- Resolved by: #{pr_number}"
     if rest:
         inner += f"\n{rest}"
-    return f"{SECTION_START}\n{inner}\n{SECTION_END}"
+    return inner
 
 
 def upsert_section(body: Optional[str], section_body: str) -> str:
@@ -334,37 +336,50 @@ def scan_backport_versions(
     )
 
 
-def comment_linked_issues(gh, repo, info, section_body: str, dry_run: bool) -> int:
-    """Post (or update) the version-info comment on every issue the PR resolves.
+def apply_issue_section(gh, repo, issue_number: int, section_body: str, dry_run: bool) -> bool:
+    """Upsert the version-info section into an issue's body. Returns True if it
+    changed. The issue is fetched live so the body reflects the current state."""
+    issue = repo.get_issue(issue_number)
+    new_body = upsert_section(issue.body, section_body)
+    if new_body == (issue.body or ""):
+        return False
+    if dry_run:
+        print(
+            f"DRY RUN: would update issue #{issue_number} version info:\n"
+            f"{section_body}\n"
+        )
+        return True
+    issue.edit(body=new_body)
+    logging.info("Updated issue #%s version info", issue_number)
+    return True
+
+
+def update_linked_issues(gh, repo, info, section_body: str, dry_run: bool) -> int:
+    """Write the version-info section into the body of every issue the PR resolves.
 
     The issues come from the PR's GitHub "Development" links
-    (`closingIssuesReferences`), not from re-parsing the body. The comment is
-    idempotent via the section markers: created once, edited only when the
-    version info changes. A per-issue failure is logged and skipped so it is
-    reconciled on the next run rather than aborting the whole PR.
+    (`closingIssuesReferences`), not from re-parsing the body. The section is
+    idempotent via its markers: written once, edited only when the version info
+    changes. A per-issue failure is logged and skipped so it is reconciled on
+    the next run rather than aborting the whole PR.
     """
     count = 0
+    issue_section = render_issue_section(info.number, section_body)
     for issue_number in info.closing_issue_numbers:
-        body = render_issue_comment(info.number, section_body)
         try:
-            action = gh.upsert_issue_comment(
-                repo, issue_number, SECTION_START, body, dry_run
-            )
+            if apply_issue_section(gh, repo, issue_number, issue_section, dry_run):
+                count += 1
+                logging.info(
+                    "Updated version info on issue #%s (resolved by PR #%s)",
+                    issue_number,
+                    info.number,
+                )
         except Exception as ex:  # pylint: disable=broad-except
             logging.error(
-                "Failed to comment version info on issue #%s (from PR #%s): %s",
+                "Failed to update version info on issue #%s (from PR #%s): %s",
                 issue_number,
                 info.number,
                 ex,
-            )
-            continue
-        if action:
-            count += 1
-            logging.info(
-                "%s version-info comment on issue #%s (resolved by PR #%s)",
-                action,
-                issue_number,
-                info.number,
             )
     return count
 
@@ -377,8 +392,8 @@ def update_original_pr(
     backported: List[str],
     dry_run: bool,
 ) -> bool:
-    """Set `Merged into` and `Backported to` on a merged original PR, and post
-    the same info as a comment on every issue the PR resolves."""
+    """Set `Merged into` and `Backported to` on a merged original PR, and write
+    the same info into the body of every issue the PR resolves."""
     if not info.merged:
         return False
     merged_into = version_history.version_for_commit(info.merge_commit_sha)
@@ -388,10 +403,10 @@ def update_original_pr(
         return False
     section_body = render_section(merged_into, backported)
     changed = apply_section(gh, repo, info, section_body, dry_run)
-    # Mirror the section onto the issues this PR resolved (its "Development"
-    # links). Only PRs that actually close an issue pay for this.
+    # Mirror the section into the body of the issues this PR resolved (its
+    # "Development" links). Only PRs that actually close an issue pay for this.
     if info.closing_issue_numbers:
-        comment_linked_issues(gh, repo, info, section_body, dry_run)
+        update_linked_issues(gh, repo, info, section_body, dry_run)
     return changed
 
 

--- a/tests/ci/test_pr_version_info.py
+++ b/tests/ci/test_pr_version_info.py
@@ -19,7 +19,7 @@ from pr_version_info import (
     original_pr_number_from_backport_ref,
     partition_merged_prs,
     release_from_backport_ref,
-    render_issue_comment,
+    render_issue_section,
     render_section,
     upsert_section,
     version_key,
@@ -92,25 +92,30 @@ class TestUpsertSection(unittest.TestCase):
         self.assertNotIn("old", updated)
 
 
-class TestRenderIssueComment(unittest.TestCase):
-    def test_wraps_section_with_markers_and_credit(self):
+class TestRenderIssueSection(unittest.TestCase):
+    def test_inserts_resolved_by_after_header(self):
         section = render_section("26.6.1.1", ["25.12.1.100"])
-        comment = render_issue_comment(12345, section)
-        self.assertTrue(comment.startswith(SECTION_START))
-        self.assertTrue(comment.endswith(SECTION_END))
-        self.assertIn("Merged into: `26.6.1.1`", comment)
-        self.assertIn("Backported to: `25.12.1.100`", comment)
+        issue_section = render_issue_section(12345, section)
+        # No delimiters here -- `upsert_section` adds them, as for PR bodies.
+        self.assertNotIn(SECTION_START, issue_section)
+        self.assertNotIn(SECTION_END, issue_section)
         # `Resolved by` is the first list item, right after the header.
-        self.assertIn(
-            "### Version info\n- Resolved by: #12345\n- Merged into:", comment
+        self.assertEqual(
+            issue_section,
+            "### Version info\n"
+            "- Resolved by: #12345\n"
+            "- Merged into: `26.6.1.1`\n"
+            "- Backported to: `25.12.1.100`",
         )
 
-    def test_idempotent_markers(self):
-        # The markers must match the PR-body section markers so the comment can
-        # be found and updated on later runs.
-        comment = render_issue_comment(1, render_section("26.6.1.1", []))
-        self.assertEqual(comment.count(SECTION_START), 1)
-        self.assertEqual(comment.count(SECTION_END), 1)
+    def test_upserts_into_issue_body_idempotently(self):
+        section = render_issue_section(1, render_section("26.6.1.1", []))
+        once = upsert_section("Issue description.", section)
+        twice = upsert_section(once, section)
+        self.assertEqual(once, twice)
+        self.assertEqual(once.count(SECTION_START), 1)
+        self.assertTrue(once.startswith("Issue description."))
+        self.assertIn("- Resolved by: #1", once)
 
 
 class TestVersionKey(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #108587. That PR posted the version info as a **comment** on each issue a merged PR resolves; this changes it to write the same section into the **issue body** instead.

The version-info section (`### Version info` with `Resolved by`, `Merged into`, `Backported to`) is upserted into the resolved issue's body exactly the way it is upserted into PR bodies: a delimited, bot-owned block, idempotent via its markers, re-edited only when the version info changes. The original issue description is preserved; the block is appended (or replaced in place if already present).

Resolved issues are still taken from GitHub's "Development" links (`closingIssuesReferences`), restricted to the PR's own repository. Only PRs that actually close an issue do any issue work.

Implementation:
- `render_issue_comment` -> `render_issue_section`: returns the inner section (with the `Resolved by` line) without delimiters; `upsert_section` adds them.
- `comment_linked_issues` -> `update_linked_issues` + `apply_issue_section`: fetch the issue live, upsert the section into its body, edit only when it changed.
- Dropped the now-unused `GitHub.upsert_issue_comment` helper.

Existing unit tests in `tests/ci/test_pr_version_info.py` are updated and pass.

Related: https://github.com/ClickHouse/ClickHouse/pull/108587

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.173` (included in `26.7` and later)
<!-- ch-version-info:end -->