### PR TITLE
Add `use_lightweight_primary_key_index_analysis` to randomized setting

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1351,6 +1351,7 @@ class SettingsRandomizer:
         "optimize_or_like_chain": lambda: random.randint(0, 1),
         "optimize_substitute_columns": lambda: random.randint(0, 1),
         "enable_multiple_prewhere_read_steps": lambda: random.randint(0, 1),
+        "use_lightweight_primary_key_index_analysis": lambda: random.random() > 0.40,
         "read_in_order_two_level_merge_threshold": lambda: random.randint(0, 100),
         "optimize_aggregation_in_order": lambda: random.randint(0, 1),
         "aggregation_in_order_max_block_bytes": lambda: random.randint(0, 50000000),


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

The old users will use the legacy `checkInRange()` in `KeyCondition` because of compatibility setting; however, after the introduction of `use_lightweight_primary_key_index_analysis=0` does not have as much coverage as expected, so randomizing it so that the old path does not regress.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.180` (included in `26.7` and later)
<!-- ch-version-info:end -->