### PR TITLE
Make perf CIDB metrics/history inserts best-effort

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1361,7 +1361,13 @@ def main():
 
         def insert_raw_query_metrics_data():
             cidb = CIDBCluster()
-            assert cidb.is_ready()
+            # Metrics insertion is a reporting side-effect, not the perf
+            # verdict. A transient LogCluster (play.clickhouse.com) timeout
+            # must not fail the whole job - skip and warn, like
+            # insert_report_aggregates() and prepare_historical_data() do.
+            if not cidb.is_ready():
+                print("WARNING: CIDB not ready - skipping raw query metrics insert")
+                return True
 
             if not build_raw_query_metrics_tsv():
                 print("WARNING: Failed to prepare raw query metrics TSV")
@@ -1423,7 +1429,12 @@ def main():
 
         def insert_historical_data():
             cidb = CIDBCluster()
-            assert cidb.is_ready()
+            # Reporting side-effect, not the perf verdict - a transient
+            # LogCluster timeout must not fail the job (see
+            # insert_raw_query_metrics_data / insert_report_aggregates).
+            if not cidb.is_ready():
+                print("WARNING: CIDB not ready - skipping historical data insert")
+                return True
 
             now = datetime.now()
             date = now.date().isoformat()

--- a/ci/tests/test_perf_slow_gate.py
+++ b/ci/tests/test_perf_slow_gate.py
@@ -1,8 +1,10 @@
+import inspect
 import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+import ci.jobs.performance_tests as performance_tests
 from ci.jobs.performance_tests import (
     INSERT_HISTORICAL_DATA,
     SLOWER_QUERIES_FAIL_THRESHOLD,
@@ -45,10 +47,28 @@ def test_slower_count_above_threshold_fails():
         assert too_many_slow(f"1 faster, {n} slower") is True, n
 
 
+def test_cidb_inserts_are_best_effort_not_asserted():
+    # CIDB metrics/history inserts are a reporting side-effect, NOT the perf
+    # verdict. A bare `assert cidb.is_ready()` turns a transient LogCluster
+    # (play.clickhouse.com) timeout into a whole-job exit-1, which is exactly
+    # what failed arm_release/master_head shards (PR #107236). Every is_ready()
+    # call site in the perf job must use the graceful skip-and-warn guard
+    # (`if not cidb.is_ready(): ... return True`) instead of asserting.
+    source = inspect.getsource(performance_tests.main)
+    assert "assert cidb.is_ready()" not in source, (
+        "A bare `assert cidb.is_ready()` re-introduces the whole-job failure on "
+        "transient CIDB timeouts. Use `if not cidb.is_ready(): ... return True`."
+    )
+    # All four is_ready() call sites must be guarded; none asserted.
+    assert source.count("cidb.is_ready()") == 4
+    assert source.count("if not cidb.is_ready():") == 4
+
+
 if __name__ == "__main__":
     test_historical_insert_parses_threshold_columns()
     test_gate_threshold_value()
     test_no_slower_queries_does_not_fail()
     test_slower_count_at_or_below_threshold_does_not_fail()
     test_slower_count_above_threshold_fails()
+    test_cidb_inserts_are_best_effort_not_asserted()
     print("All perf slow-gate tests passed.")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107236
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `Performance Comparison` job opened `insert_raw_query_metrics_data()` and `insert_historical_data()` with a bare `assert cidb.is_ready()`. A transient LogCluster (`play.clickhouse.com`) `SELECT 1` timeout (3s) therefore raised `AssertionError` and failed the whole perf job with exit code 1, even though metrics insertion is a reporting side-effect and the perf verdict itself was green.

Observed on PR #107236, `Performance Comparison (arm_release, master_head)` shards 2/6 and 5/6:

```
Fail [Performance Comparison (arm_release, master_head, 2/6)]
  | 2 slower, 4 unstable
  Fail [Insert raw query metrics data]
    | File ".../ci/jobs/performance_tests.py", line 1364, in insert_raw_query_metrics_data
    |     assert cidb.is_ready()
    | AssertionError
    | ERROR: LogCluster connection failed ... play.clickhouse.com ... Read timed out. (read timeout=3)
ERROR: Run failed with exit code [1]
```

In the same run, sibling shards with comparable or worse perf annotations passed because their metrics insert succeeded:

| Shard | Perf summary | Metrics insert | Job status |
|---|---|---|---|
| 1/6 | 1 slower, 1 unstable | Inserted 5080784 rows | OK |
| 3/6 | 7 unstable | Inserted 5227872 rows | OK |
| 2/6 | 2 slower, 4 unstable | `assert cidb.is_ready()` -> AssertionError | FAIL |
| 5/6 | 1 too long, 2 slower, 2 unstable | `assert cidb.is_ready()` -> AssertionError | FAIL |

Shard 3/6 had 7 unstable and still passed, confirming "slower/unstable/too long" are informational; the perf gate only fails on `> 10` slower queries (`SLOWER_QUERIES_FAIL_THRESHOLD`). The job's exit-1 came solely from the metrics-insert assert.

These functions already treat a failed insert as non-fatal (log and `return True`), and `CIDBCluster.do_insert_query()` already calls `is_ready()` internally and returns False gracefully, so the top-level `assert` was both redundant and harmful. This change replaces it with the same skip-and-warn guard already used by `insert_report_aggregates()` and `prepare_historical_data()` in this file:

```python
if not cidb.is_ready():
    print("WARNING: CIDB not ready - skipping ...")
    return True
```

Adds a regression test in `ci/tests/test_perf_slow_gate.py` asserting that no perf CIDB-insert path re-introduces a bare `assert cidb.is_ready()` and that every `is_ready()` call site in the job is guarded.

Failure report (shard 2/6): https://s3.amazonaws.com/clickhouse-test-reports/PRs/107236/15cd4c31d28e40d015ba4830937a5a8df2c9073a/performance_comparison_arm_release_master_head_2_6/report.html

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.183` (included in `26.7` and later)
<!-- ch-version-info:end -->