### PR TITLE
Set use_legacy_to_time to 0 by default

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1276,7 +1276,7 @@ This setting exists only for compatibility reasons. In ClickHouse, the time zone
 Enabling this setting gives the wrong impression that different values within a column can have different timezones.
 Therefore, please do not enable this setting.
 )", 0) \
-    DECLARE(Bool, use_legacy_to_time, true, R"(
+    DECLARE(Bool, use_legacy_to_time, false, R"(
 When enabled, allows to use legacy toTime function, which converts a date with time to a certain fixed date, while preserving the time.
 Otherwise, uses a new toTime function, that converts different type of data into the Time type.
 The old legacy function is also unconditionally accessible as toTimeWithFixedDate.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.7",
         {
+            {"use_legacy_to_time", true, false, "Use the new `toTime` function (converting values to the `Time` data type) by default instead of the legacy `toTime` (which is still available as `toTimeWithFixedDate`)."},
             {"reserve_memory", 0, 0, "New setting to reserve memory for specific workload before starting a query."},
             {"format_geojson_validate_geometry", true, true, "New setting that controls whether the GeoJSON format enforces RFC 7946 geometry validity (minimum points per line and ring, ring closure, non-empty multi-geometries) when reading and writing"},
             {"allow_delta_lake_writes", false, false, "Added an alias for setting `allow_experimental_delta_lake_writes`, which was moved to Beta."},

--- a/tests/queries/0_stateless/04415_use_legacy_to_time_default.reference
+++ b/tests/queries/0_stateless/04415_use_legacy_to_time_default.reference
@@ -1,0 +1,4 @@
+Default
+Time	00:00:12
+compatibility = 26.6
+DateTime	1970-01-02 00:00:12

--- a/tests/queries/0_stateless/04415_use_legacy_to_time_default.sql
+++ b/tests/queries/0_stateless/04415_use_legacy_to_time_default.sql
@@ -1,0 +1,15 @@
+-- Verify the default behavior of `toTime` after `use_legacy_to_time` was flipped to 0 by default.
+
+SET session_timezone = 'UTC';
+
+-- By default (use_legacy_to_time = 0), toTime converts the value into the Time data type.
+SELECT 'Default';
+WITH toTime(toDateTime(12)) AS a
+SELECT toTypeName(a), a;
+
+-- An old compatibility version restores the legacy toTime (fixed date, DateTime result),
+-- because the default change is registered in SettingsChangesHistory under version 26.7.
+SET compatibility = '26.6';
+SELECT 'compatibility = 26.6';
+WITH toTime(toDateTime(12)) AS a
+SELECT toTypeName(a), a;


### PR DESCRIPTION
Make the new `toTime` function the default by changing the `use_legacy_to_time` setting default from `1` to `0`.

When `use_legacy_to_time = 0`, `toTime` converts values into the `Time` data type. When it is `1` (the previous default), `toTime` behaves as the legacy function that converts a date with time to a fixed date while preserving the time. The legacy function remains unconditionally accessible as `toTimeWithFixedDate`, so users who relied on the old behavior can either call `toTimeWithFixedDate` directly or set `use_legacy_to_time = 1`.

### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The setting `use_legacy_to_time` is now `0` by default, so `toTime` converts values into the `Time` data type instead of converting a date with time to a fixed date. The legacy behavior is still available via the `toTimeWithFixedDate` function or by setting `use_legacy_to_time = 1`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.203` (included in `26.7` and later)
<!-- ch-version-info:end -->