### PR TITLE
Fix logical error on const-folded sharding key in skipUnusedShards

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -305,6 +305,49 @@ bool isExpressionActionsDeterministic(const ExpressionActionsPtr & actions)
     return true;
 }
 
+/// Find the sharding key output node in `sharding_key_dag`.
+/// `sharding_key_column_name` is the name of the unanalyzed sharding key AST and can differ from the
+/// analyzed DAG output name: the analyzer may const-fold or otherwise rewrite the expression, so a name
+/// lookup misses. The DAG produced with `project=false` has the sharding key output plus its
+/// source-column inputs. When the name lookup fails we resolve by structure: a single output is the key
+/// (even if it is a source column, for keys that fold to a bare column); otherwise the key is the unique
+/// output that is not a source column. Returns nullptr when the node can't be resolved unambiguously, so
+/// callers skip the optimization (and query all shards) rather than assert.
+const ActionsDAG::Node * tryFindShardingKeyOutput(const ActionsDAG & sharding_key_dag, const std::string & sharding_key_column_name)
+{
+    if (const auto * node = sharding_key_dag.tryFindInOutputs(sharding_key_column_name))
+        return node;
+
+    /// The name lookup missed because the analyzer rewrote the key: it const-folds e.g.
+    /// `if(2, toInt32(id), t0)` to the computed output `toInt32(id)`, or folds `if(1, id, id + 1)`
+    /// all the way down to the bare source column `id`. The DAG built with `project=false` has the
+    /// sharding key output plus its source-column inputs.
+    const auto & outputs = sharding_key_dag.getOutputs();
+
+    /// A single output is unambiguously the sharding key, even when that output is a source column
+    /// (a key that folds to a bare column, e.g. `if(1, id, id + 1)` -> `id`).
+    if (outputs.size() == 1)
+        return outputs.front();
+
+    /// With several outputs the key is the one that is not a source/input column: for `intHash64(id)`
+    /// the outputs are [id, intHash64(id)] and `id` is only a source column.
+    NameSet source_columns;
+    for (const auto & name : sharding_key_dag.getRequiredColumnsNames())
+        source_columns.insert(name);
+
+    const ActionsDAG::Node * result = nullptr;
+    for (const auto * output : outputs)
+    {
+        if (source_columns.contains(output->result_name))
+            continue;
+        if (result)
+            return nullptr; /// More than one non-source output: ambiguous, bail out.
+        result = output;
+    }
+
+    return result;
+}
+
 class ReplacingConstantExpressionsMatcher
 {
 public:
@@ -432,6 +475,12 @@ StorageDistributed::StorageDistributed(
         checkShardingKeyExistsAndIsNumeric(sharding_key_, getContext(), storage_metadata.getColumns().getAllPhysical());
         sharding_key_expr = buildShardingKeyExpression(sharding_key_, getContext(), storage_metadata.getColumns().getAllPhysical(), false);
         sharding_key_column_name = sharding_key_->getColumnName();
+        /// Building the expression analyzes (and may rewrite) the sharding key: e.g. the analyzer const-folds
+        /// `if(2, toInt32(id), t0)` down to `toInt32(id)`, so the raw AST name is absent from the expression
+        /// outputs. Resolve it to the actual output name so every consumer that looks the column up in the
+        /// expression's result (shard skipping, sharding key IN rewrite, DistributedSink selector) finds it.
+        if (const auto * node = tryFindShardingKeyOutput(sharding_key_expr->getActionsDAG(), sharding_key_column_name))
+            sharding_key_column_name = node->result_name;
         sharding_key_is_deterministic = isExpressionActionsDeterministic(sharding_key_expr);
     }
 
@@ -609,8 +658,10 @@ bool StorageDistributed::isShardingKeySuitsQueryTreeNodeExpression(
     /// For example, if the sharding key is `intHash64(user_id)`, then `getOutputs() = [intHash64(user_id), user_id]`. The `user_id` column is a source
     /// column but not a key value, and should be excluded from checks. We need to find the actual sharding key output
     /// node to check that it depends only on the allowed set of nodes (`irreducible_nodes`).
-    const auto sharding_key_outputs = sharding_key_dag.findInOutputs(Names{sharding_key_column_name});
-    return allOutputsDependsOnlyOnAllowedNodes(sharding_key_outputs, irreducibe_nodes, matches);
+    const auto * sharding_key_output = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
+    if (!sharding_key_output)
+        return false;
+    return allOutputsDependsOnlyOnAllowedNodes({sharding_key_output}, irreducibe_nodes, matches);
 }
 
 std::optional<QueryProcessingStage::Enum> StorageDistributed::getOptimizedQueryProcessingStageAnalyzer(const SelectQueryInfo & query_info, const Settings & settings) const
@@ -1783,11 +1834,11 @@ ClusterPtr StorageDistributed::skipUnusedShardsWithAnalyzer(
     }
 
     const auto & sharding_key_dag = sharding_key_expr->getActionsDAG();
-    const auto * expr_node = sharding_key_dag.tryFindInOutputs(sharding_key_column_name);
+    const auto * expr_node = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
     if (!expr_node)
-        throw Exception(
-            ErrorCodes::LOGICAL_ERROR, "Cannot find sharding key column {} in expression {}",
-            sharding_key_column_name, sharding_key_dag.dumpDAG());
+        /// Sharding key column can't be resolved in the analyzed expression (e.g. a const-folded key like
+        /// `if(2, toInt32(id), t0)`). Skip the optimization and query all shards instead of asserting.
+        return nullptr;
 
     const auto * predicate = query_info.filter_actions_dag->getOutputs().at(0);
     const auto variants = evaluateExpressionOverConstantCondition(predicate, {expr_node}, local_context, limit);

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -315,14 +315,14 @@ bool isExpressionActionsDeterministic(const ExpressionActionsPtr & actions)
 /// callers skip the optimization (and query all shards) rather than assert.
 const ActionsDAG::Node * tryFindShardingKeyOutput(const ActionsDAG & sharding_key_dag, const std::string & sharding_key_column_name)
 {
-    if (const auto * node = sharding_key_dag.tryFindInOutputs(sharding_key_column_name))
+    if (const ActionsDAG::Node * node = sharding_key_dag.tryFindInOutputs(sharding_key_column_name))
         return node;
 
     /// The name lookup missed because the analyzer rewrote the key: it const-folds e.g.
     /// `if(2, toInt32(id), t0)` to the computed output `toInt32(id)`, or folds `if(1, id, id + 1)`
     /// all the way down to the bare source column `id`. The DAG built with `project=false` has the
     /// sharding key output plus its source-column inputs.
-    const auto & outputs = sharding_key_dag.getOutputs();
+    const ActionsDAG::NodeRawConstPtrs & outputs = sharding_key_dag.getOutputs();
 
     /// A single output is unambiguously the sharding key, even when that output is a source column
     /// (a key that folds to a bare column, e.g. `if(1, id, id + 1)` -> `id`).
@@ -331,16 +331,15 @@ const ActionsDAG::Node * tryFindShardingKeyOutput(const ActionsDAG & sharding_ke
 
     /// With several outputs the key is the one that is not a source/input column: for `intHash64(id)`
     /// the outputs are [id, intHash64(id)] and `id` is only a source column.
-    NameSet source_columns;
-    for (const auto & name : sharding_key_dag.getRequiredColumnsNames())
-        source_columns.insert(name);
+    const Names & names = sharding_key_dag.getRequiredColumnsNames();
+    const NameSet source_columns(names.begin(), names.end());
 
     const ActionsDAG::Node * result = nullptr;
-    for (const auto * output : outputs)
+    for (const ActionsDAG::Node * output : outputs)
     {
         if (source_columns.contains(output->result_name))
             continue;
-        if (result)
+        if (result != nullptr)
             return nullptr; /// More than one non-source output: ambiguous, bail out.
         result = output;
     }
@@ -479,7 +478,7 @@ StorageDistributed::StorageDistributed(
         /// `if(2, toInt32(id), t0)` down to `toInt32(id)`, so the raw AST name is absent from the expression
         /// outputs. Resolve it to the actual output name so every consumer that looks the column up in the
         /// expression's result (shard skipping, sharding key IN rewrite, DistributedSink selector) finds it.
-        if (const auto * node = tryFindShardingKeyOutput(sharding_key_expr->getActionsDAG(), sharding_key_column_name))
+        if (const ActionsDAG::Node * node = tryFindShardingKeyOutput(sharding_key_expr->getActionsDAG(), sharding_key_column_name))
             sharding_key_column_name = node->result_name;
         sharding_key_is_deterministic = isExpressionActionsDeterministic(sharding_key_expr);
     }
@@ -658,8 +657,8 @@ bool StorageDistributed::isShardingKeySuitsQueryTreeNodeExpression(
     /// For example, if the sharding key is `intHash64(user_id)`, then `getOutputs() = [intHash64(user_id), user_id]`. The `user_id` column is a source
     /// column but not a key value, and should be excluded from checks. We need to find the actual sharding key output
     /// node to check that it depends only on the allowed set of nodes (`irreducible_nodes`).
-    const auto * sharding_key_output = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
-    if (!sharding_key_output)
+    const ActionsDAG::Node * sharding_key_output = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
+    if (sharding_key_output == nullptr)
         return false;
     return allOutputsDependsOnlyOnAllowedNodes({sharding_key_output}, irreducibe_nodes, matches);
 }
@@ -1833,9 +1832,9 @@ ClusterPtr StorageDistributed::skipUnusedShardsWithAnalyzer(
         throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "optimize_skip_unused_shards_limit out of range (0, {}]", SSIZE_MAX);
     }
 
-    const auto & sharding_key_dag = sharding_key_expr->getActionsDAG();
-    const auto * expr_node = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
-    if (!expr_node)
+    const ActionsDAG & sharding_key_dag = sharding_key_expr->getActionsDAG();
+    const ActionsDAG::Node * expr_node = tryFindShardingKeyOutput(sharding_key_dag, sharding_key_column_name);
+    if (expr_node == nullptr)
         /// Sharding key column can't be resolved in the analyzed expression (e.g. a const-folded key like
         /// `if(2, toInt32(id), t0)`). Skip the optimization and query all shards instead of asserting.
         return nullptr;

--- a/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.reference
+++ b/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.reference
@@ -150,3 +150,21 @@ select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) 
 -- modulo(UInt8)
 select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt8(id)%255) where id in (-1) order by _shard_num, id;
 1	-1
+-- A sharding key that the analyzer const-folds (e.g. `if(1, x, y)` -> `x`) produces an
+-- expression whose output name differs from the unfolded key name. This must not throw
+-- "Cannot find sharding key column"; the result must match the equivalent plain key.
+-- Folds to a computed output `toInt32(id)`:
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), if(1, toInt32(id), toInt32(id) + 1)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+1	0
+1	0
+2	1
+4	2147483647
+-- Folds all the way down to the bare source column `id` (the expression output is then an input):
+select _shard_num, * from remote('127.{1..4}', view(select id from data), if(1, id, id + 1)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+1	0
+2	1
+4	2147483647
+select _shard_num, * from remote('127.{1..4}', view(select id from data), id) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+1	0
+2	1
+4	2147483647

--- a/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.sql
+++ b/tests/queries/0_stateless/01930_optimize_skip_unused_shards_rewrite_in.sql
@@ -56,6 +56,15 @@ select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) 
 -- modulo(UInt8)
 select distinct _shard_num, * from remote('127.{1..4}', view(select toInt16(id) id from data), toUInt8(id)%255) where id in (-1) order by _shard_num, id;
 
+-- A sharding key that the analyzer const-folds (e.g. `if(1, x, y)` -> `x`) produces an
+-- expression whose output name differs from the unfolded key name. This must not throw
+-- "Cannot find sharding key column"; the result must match the equivalent plain key.
+-- Folds to a computed output `toInt32(id)`:
+select _shard_num, * from remote('127.{1..4}', view(select toInt32(id) id from data), if(1, toInt32(id), toInt32(id) + 1)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+-- Folds all the way down to the bare source column `id` (the expression output is then an input):
+select _shard_num, * from remote('127.{1..4}', view(select id from data), if(1, id, id + 1)) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+select _shard_num, * from remote('127.{1..4}', view(select id from data), id) where id in (0, 1, 0x7fffffff) order by _shard_num, id;
+
 -- { echoOff }
 
 -- those two had been reported initially by amosbird:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
No related open issue found (searched "Cannot find sharding key column", "skipUnusedShardsWithAnalyzer", "sharding key column expression").


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix an exception (`Cannot find sharding key column`, and in debug/sanitizer builds a server abort) when a `Distributed` table's sharding key is an expression the analyzer const-folds, for example `if(1, toInt32(id), toInt32(id) + 1)`, with `optimize_skip_unused_shards = 1`.


### Description

The sharding key column name is captured from the unanalyzed sharding key AST in the `StorageDistributed` constructor. Building the sharding key expression analyzes (and may rewrite) it: the analyzer const-folds an expression like `if(1, toInt32(id), toInt32(id) + 1)` (or the fuzzer's `if(2 AS a, toInt32(id), t0)`) down to `toInt32(id)`, so the stored raw name is absent from the expression outputs. Every consumer that then looks the column up in the analyzed expression failed:

- `skipUnusedShardsWithAnalyzer` threw `LOGICAL_ERROR: Cannot find sharding key column ...` (aborts the server in debug/sanitizer builds, handled exception in release);
- `isShardingKeySuitsQueryTreeNodeExpression` (the `GROUP BY` sharding-key pushdown path) threw `UNKNOWN_IDENTIFIER`;
- the sharding-key `IN` rewrite (`OptimizeShardingKeyRewriteIn`) and `DistributedSink::createSelector` threw `NOT_FOUND_COLUMN_IN_BLOCK`.

Fix: resolve `sharding_key_column_name` to the actual expression output name once at construction. The expression is built with `project = false`, so its DAG has the sharding key output plus its source-column inputs. Resolve by structure: a single-output DAG is the key (even when that output is an input column, for a key that folds all the way down to a bare source column such as `if(1, id, id + 1)` -> `id`); otherwise the key is the unique output that is not a source column (e.g. `intHash64(id)`, whose outputs are `[id, intHash64(id)]`). As defense in depth, `skipUnusedShardsWithAnalyzer` and `isShardingKeySuitsQueryTreeNodeExpression` now degrade gracefully (skip the optimization and query all shards) instead of asserting when the column still cannot be resolved unambiguously.

Reproducer (aborts the server in a debug build before this change):

```sql
CREATE TABLE data (id Int32) ENGINE = MergeTree ORDER BY id;
INSERT INTO data SELECT number FROM numbers(100);
SET optimize_skip_unused_shards = 1;
SELECT _shard_num, * FROM remote('127.{1..4}', view(SELECT toInt32(id) AS id FROM data), if(1, toInt32(id), toInt32(id) + 1))
WHERE id IN (0, 1, 2147483647) ORDER BY _shard_num, id;
```

After the fix the query returns the same result as the equivalent plain `toInt32(id)` sharding key. A regression case is added to `01930_optimize_skip_unused_shards_rewrite_in`.

Found by the AST fuzzer (STID 3926-38e4) as a mutation of `01930_optimize_skip_unused_shards_rewrite_in`.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.255` (included in `26.7` and later)
<!-- ch-version-info:end -->