### PR TITLE
CherryPick workflow: run every 20 minutes and never run two jobs concurrently

### DIFF
--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -6,9 +6,14 @@ env:
 
 concurrency:
   group: cherry-pick
+  # Never run two cherry-pick jobs at the same time: a new scheduled run waits
+  # for the in-progress one to finish instead of cancelling it.
+  cancel-in-progress: false
 on: # yamllint disable-line rule:truthy
   schedule:
-    - cron: '0 * * * *'
+    # Every 20 minutes. Offset from round values (e.g. */20 -> :00/:20/:40),
+    # which are popular and get their launches delayed by GitHub.
+    - cron: '9,29,49 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `CherryPick` workflow drives the backporting bot (`tests/ci/cherry_pick.py`). It currently runs hourly on `cron: '0 * * * *'`, so a merged PR labelled for backport waits up to ~1 hour before its cherry-pick/backport PRs are even opened.

This change makes two adjustments:

- **Run every 20 minutes** instead of hourly, cutting the worst-case "merged → backport PR opened" latency from ~60 min to ~20 min. The schedule uses offset minutes (`9,29,49`) rather than round values (`*/20` → `:00/:20/:40`), because GitHub delays the launch of workflows scheduled at popular/round cron times.
- **Guarantee only one job runs at a time.** The workflow already has `concurrency.group: cherry-pick`; this makes the intent explicit with `cancel-in-progress: false`, so a new scheduled run queues behind an in-progress one (which can run longer than 20 minutes due to the full checkout) instead of overlapping with it or cancelling it. The bot is not safe to run concurrently — it mutates shared cherry-pick/backport branches.

No change to the job body, runner, or `cherry_pick.py`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.201` (included in `26.7` and later)
<!-- ch-version-info:end -->