### PR TITLE
Add good-prs skill to list merge-ready PRs blocked only on CH Inc sync

### DIFF
--- a/.claude/skills/good-prs/SKILL.md
+++ b/.claude/skills/good-prs/SKILL.md
@@ -51,6 +51,18 @@ bash .claude/skills/good-prs/report.sh $ARGUMENTS
 The script fetches PR lists with `gh pr list`, classifies each PR's checks with
 `gh pr checks`, and looks up state + approvals with `gh pr view`, all parallelized with
 `xargs -P 12`. For groeneai-sized author sets (~200 open PRs) it takes roughly a minute.
+Every `gh` call is pinned to `--repo ClickHouse/ClickHouse`, so the report is correct
+regardless of the directory the skill is run from.
+
+## Testing
+
+`test.sh` runs `report.sh` against a stubbed `gh` (no network) and checks the
+`bucket`→label classification, the "only `CH Inc sync` is non-green" criterion, empty
+input, `--repo` pinning, and the fail-loud-on-real-error behaviour:
+
+```bash
+bash .claude/skills/good-prs/test.sh
+```
 
 ## Presentation
 
@@ -68,4 +80,11 @@ The script fetches PR lists with `gh pr list`, classifies each PR's checks with
 - The aggregate gates excluded from the "everything else is green" test are `PR`,
   `Mergeable Check`, and `A Sync (only for tests)`. If ClickHouse CI renames or adds an
   aggregate gate, update the `select(...)` filter in `report.sh`.
+- Checks are classified by `gh pr checks`' own `bucket` field (`pass` / `fail` /
+  `pending` / `skipping` / `cancel`), not by raw state strings, so unusual states such as
+  `QUEUED`, `TIMED_OUT`, `CANCELLED`, or `STARTUP_FAILURE` are handled without a PR being
+  silently dropped.
+- The script fails loudly: if a `gh` call cannot read a PR's data (an API, rate-limit, or
+  permission error, as opposed to a legitimately check-less PR), it aborts with the
+  original `gh` diagnostic rather than silently omitting that PR from the report.
 - The script needs `gh` authenticated and `jq` available.

--- a/.claude/skills/good-prs/SKILL.md
+++ b/.claude/skills/good-prs/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: good-prs
+description: Show a report of open ClickHouse PRs whose only non-green CI check is "CH Inc sync" (or that are fully green) — i.e. effectively ready to merge. Groups by your authored PRs, PRs assigned to you (authored by others), and PRs by tracked authors (default groeneai). Shows the CH Inc sync state and whether each PR was ever approved; excludes already-merged PRs. Use when asked for "good PRs", merge-ready PRs, or PRs blocked only on the sync job.
+argument-hint: "[tracked-author ...]   # default: groeneai"
+disable-model-invocation: false
+allowed-tools: Bash(bash:*), Bash(gh:*), Bash(jq:*), Bash(xargs:*), Bash(awk:*), Bash(grep:*), Bash(cut:*), Bash(sed:*), Read
+---
+
+# Good PRs Skill
+
+Produce a report of open pull requests in `ClickHouse/ClickHouse` that are effectively
+ready to merge: every CI check is green/skipped **except possibly `CH Inc sync`**, which
+is the private-repo sync job and is frequently the last thing standing between a PR and
+merge. Fully-green PRs are included too.
+
+## What counts as a "good PR"
+
+For each PR, look at all checks and ignore the aggregate gates (`PR`, `Mergeable Check`,
+`A Sync (only for tests)`). A PR qualifies when **every remaining check other than
+`CH Inc sync` is `SUCCESS`, `SKIPPED`, or `NEUTRAL`** (nothing else is failing or still
+running). The `CH Inc sync` state is then reported as one of:
+
+- **GREEN** — `CH Inc sync` also passed → fully green / merge-ready.
+- **FAILED** — only `CH Inc sync` failed.
+- **INPROG** — only `CH Inc sync` is still running (`PENDING`/`IN_PROGRESS`).
+- **NOSYNC** — there is no `CH Inc sync` check at all and everything else is green
+  (typically release-branch backports).
+
+Already-merged or closed PRs are excluded. Each row also shows whether the PR was
+**approved by anyone at least once** (any historical `APPROVED` review event; it does
+*not* require the approval to still be current after later pushes).
+
+## Sections
+
+1. **Your own PRs** — authored by the authenticated `gh` user.
+2. **Assigned to you, authored by others** — assigned to you, excluding your own PRs and
+   the tracked authors (those get their own section).
+3. **PRs by each tracked author** — every qualifying PR by the author, regardless of
+   assignee. Default tracked author: `groeneai`. Pass author logins as arguments to
+   change this (e.g. `good-prs groeneai azat`).
+
+## How to run
+
+Run the bundled script and present its Markdown output directly to the user (it already
+emits finished tables):
+
+```bash
+bash .claude/skills/good-prs/report.sh $ARGUMENTS
+```
+
+The script fetches PR lists with `gh pr list`, classifies each PR's checks with
+`gh pr checks`, and looks up state + approvals with `gh pr view`, all parallelized with
+`xargs -P 12`. For groeneai-sized author sets (~200 open PRs) it takes roughly a minute.
+
+## Presentation
+
+- The script's stdout is a complete report — show it as-is.
+- Statuses drift constantly as CI runs; if the user asks to "check again", just re-run
+  the script. Mention it is a point-in-time snapshot.
+- If the user wants only the failed/in-progress subset (not the fully-green ones), filter
+  the rows to `FAILED`/`INPROG` after running, or note which rows are `GREEN`.
+
+## Notes and caveats
+
+- `gh pr list --author <login>` is backed by GitHub's search index, which can
+  occasionally omit an individual PR (a stale-index gap). If a specific PR is known to be
+  missing, fetch it explicitly with `gh pr view <n>` and add it.
+- The aggregate gates excluded from the "everything else is green" test are `PR`,
+  `Mergeable Check`, and `A Sync (only for tests)`. If ClickHouse CI renames or adds an
+  aggregate gate, update the `select(...)` filter in `report.sh`.
+- The script needs `gh` authenticated and `jq` available.

--- a/.claude/skills/good-prs/report.sh
+++ b/.claude/skills/good-prs/report.sh
@@ -68,11 +68,17 @@ done
 cat "$WORK"/*.meta | cut -f1 | sort -un > "$WORK/all_nums.txt"
 
 # ---- classify checks + approvals for every PR (parallel) -------------------
-xargs -P 12 -n 1 "$WORK/classify.sh" < "$WORK/all_nums.txt" > "$WORK/checks.tsv" 2>/dev/null
+# `-r` (--no-run-if-empty) is required: without it GNU xargs runs the helper
+# once even on empty input, and the helper would read an unset "$1" and emit a
+# bogus row. With `-r` the helper is skipped, and the redirect below still
+# creates an empty output file, so the report renders clean empty sections when
+# nobody has a qualifying PR (empty all_nums.txt) or none of them match the
+# "only CH Inc sync is non-green" criterion (empty match_nums.txt).
+xargs -r -P 12 -n 1 "$WORK/classify.sh" < "$WORK/all_nums.txt" > "$WORK/checks.tsv" 2>/dev/null
 # Only PRs that match the criterion need an approval/state lookup
 awk -F'\t' '$3==0 && ($2=="SUCCESS"||$2=="FAILURE"||$2=="PENDING"||$2=="IN_PROGRESS"||$2=="ABSENT"){print $1}' \
   "$WORK/checks.tsv" | sort -un > "$WORK/match_nums.txt"
-xargs -P 12 -n 1 "$WORK/approval.sh" < "$WORK/match_nums.txt" > "$WORK/appr.tsv" 2>/dev/null
+xargs -r -P 12 -n 1 "$WORK/approval.sh" < "$WORK/match_nums.txt" > "$WORK/appr.tsv" 2>/dev/null
 
 # ---- render one markdown section -------------------------------------------
 # args: <meta-file> <show-author-col:0|1> <exclude-authors-csv>

--- a/.claude/skills/good-prs/report.sh
+++ b/.claude/skills/good-prs/report.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# good-prs/report.sh — list open PRs whose ONLY non-green check is "CH Inc sync"
+# (or that are fully green), so they are effectively ready to merge.
+#
+# Sections:
+#   1. PRs you authored
+#   2. PRs assigned to you, authored by others (excluding tracked authors)
+#   3. one section per "tracked author" (default: groeneai), regardless of assignee
+#
+# For every PR we report:
+#   - the "CH Inc sync" state: GREEN (also passed), FAILED, or INPROG (still running)
+#   - whether it was APPROVED by anyone at least once
+# Already-merged / closed PRs are excluded.
+#
+# Usage:
+#   report.sh [tracked-author ...]      # default tracked author: groeneai
+#
+set -euo pipefail
+
+TRACK_AUTHORS=("groeneai")
+if [ "$#" -gt 0 ]; then TRACK_AUTHORS=("$@"); fi
+
+ME=$(gh api user --jq .login)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ---- helper invoked per-PR by xargs: classify the checks --------------------
+# Output: "<num>\t<CH-Inc-sync-state>\t<#other-non-green>"
+cat > "$WORK/classify.sh" <<'SH'
+#!/usr/bin/env bash
+n="$1"
+json=$(gh pr checks "$n" --json name,state 2>/dev/null)
+if [ -z "$json" ] || [ "$json" = "[]" ]; then echo -e "$n\tNO_CHECKS\t99"; exit 0; fi
+echo "$json" | jq -r --arg n "$n" '
+  (map(select(.name=="CH Inc sync")) | .[0].state // "ABSENT") as $ch
+  | (map(select(.name!="CH Inc sync" and .name!="PR" and .name!="Mergeable Check"
+               and .name!="A Sync (only for tests)"))) as $others
+  | ($others | map(select(.state!="SUCCESS" and .state!="SKIPPED" and .state!="NEUTRAL")) | length) as $nbad
+  | "\($n)\t\($ch)\t\($nbad)"'
+SH
+chmod +x "$WORK/classify.sh"
+
+# ---- helper invoked per-PR by xargs: state + ever-approved -----------------
+# Output: "<num>\t<STATE>\t<true|false>"
+cat > "$WORK/approval.sh" <<'SH'
+#!/usr/bin/env bash
+n="$1"
+res=$(gh pr view "$n" --json state,reviews \
+  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv' 2>/dev/null)
+[ -z "$res" ] && res="ERR\tfalse"
+printf '%s\t%s\n' "$n" "$res"
+SH
+chmod +x "$WORK/approval.sh"
+
+# ---- gather metadata (number, author, title) for each query group ----------
+gh pr list --author "$ME"   --state open --limit 1000 --json number,title,author \
+  --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' > "$WORK/authored.meta"
+gh pr list --assignee "$ME" --state open --limit 1000 --json number,title,author \
+  --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' > "$WORK/assigned.meta"
+: > "$WORK/tracked.meta"
+for a in "${TRACK_AUTHORS[@]}"; do
+  gh pr list --author "$a" --state open --limit 1000 --json number,title,author \
+    --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' >> "$WORK/tracked.meta"
+done
+
+# union of all PR numbers we care about
+cat "$WORK"/*.meta | cut -f1 | sort -un > "$WORK/all_nums.txt"
+
+# ---- classify checks + approvals for every PR (parallel) -------------------
+xargs -P 12 -n 1 "$WORK/classify.sh" < "$WORK/all_nums.txt" > "$WORK/checks.tsv" 2>/dev/null
+# Only PRs that match the criterion need an approval/state lookup
+awk -F'\t' '$3==0 && ($2=="SUCCESS"||$2=="FAILURE"||$2=="PENDING"||$2=="IN_PROGRESS"||$2=="ABSENT"){print $1}' \
+  "$WORK/checks.tsv" | sort -un > "$WORK/match_nums.txt"
+xargs -P 12 -n 1 "$WORK/approval.sh" < "$WORK/match_nums.txt" > "$WORK/appr.tsv" 2>/dev/null
+
+# ---- render one markdown section -------------------------------------------
+# args: <meta-file> <show-author-col:0|1> <exclude-authors-csv>
+emit() {
+  local meta="$1" showauth="$2" excl="$3"
+  awk -F'\t' '$3==0 && ($2=="SUCCESS"||$2=="FAILURE"||$2=="PENDING"||$2=="IN_PROGRESS"||$2=="ABSENT"){print $1"\t"$2}' \
+    "$WORK/checks.tsv" \
+  | while IFS=$'\t' read -r n st; do
+      a=$(awk -F'\t' -v n="$n" '$1==n{print $2"\t"$3}' "$WORK/appr.tsv")
+      state=$(echo "$a" | cut -f1); approved=$(echo "$a" | cut -f2)
+      [ "$state" != "OPEN" ] && continue
+      line=$(grep -m1 "^$n	" "$meta") || continue
+      [ -z "$line" ] && continue
+      auth=$(echo "$line" | cut -f2)
+      title=$(echo "$line" | cut -f3 | sed 's/|/\\|/g')
+      case ",$excl," in *",$auth,"*) continue;; esac
+      case "$st" in
+        SUCCESS) g=3; gl="GREEN";; FAILURE) g=1; gl="FAILED";;
+        PENDING|IN_PROGRESS) g=2; gl="INPROG";; ABSENT) g=4; gl="NOSYNC";;
+      esac
+      [ "$approved" = "true" ] && av="yes" || av="-"
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$g" "$gl" "$n" "$av" "$auth" "$title"
+    done | sort -t$'\t' -k1,1n -k3,3n \
+  | while IFS=$'\t' read -r g gl n av auth title; do
+      if [ "$showauth" = "1" ]; then
+        printf '| %s | %s | [#%s](https://github.com/ClickHouse/ClickHouse/pull/%s) | %s | %s |\n' \
+          "$gl" "$av" "$n" "$n" "$auth" "$title"
+      else
+        printf '| %s | %s | [#%s](https://github.com/ClickHouse/ClickHouse/pull/%s) | %s |\n' \
+          "$gl" "$av" "$n" "$n" "$title"
+      fi
+    done
+}
+
+excl_csv=$(IFS=,; echo "${TRACK_AUTHORS[*]}")
+
+echo "# Good PRs — only \`CH Inc sync\` blocking (or fully green)"
+echo
+echo "_Legend: GREEN = fully green / merge-ready · FAILED = only \`CH Inc sync\` failed · INPROG = only \`CH Inc sync\` still running · NOSYNC = no \`CH Inc sync\` check, everything else green (e.g. release-branch backports). Approved = approved by someone at least once. Merged/closed PRs excluded._"
+echo
+echo "## 1. Your own PRs (authored by \`$ME\`)"
+echo
+echo "| sync | approved | PR | title |"
+echo "|------|:--:|----|-------|"
+emit "$WORK/authored.meta" 0 ""
+echo
+echo "## 2. Assigned to you, authored by others (excluding: ${excl_csv})"
+echo
+echo "| sync | approved | PR | author | title |"
+echo "|------|:--:|----|--------|-------|"
+emit "$WORK/assigned.meta" 1 "$ME,$excl_csv"
+for a in "${TRACK_AUTHORS[@]}"; do
+  echo
+  echo "## 3. PRs by \`$a\` (regardless of assignee)"
+  echo
+  echo "| sync | approved | PR | title |"
+  echo "|------|:--:|----|-------|"
+  grep -P "^\d+\t$a\t" "$WORK/tracked.meta" > "$WORK/one_author.meta" || true
+  emit "$WORK/one_author.meta" 0 ""
+done

--- a/.claude/skills/good-prs/report.sh
+++ b/.claude/skills/good-prs/report.sh
@@ -9,7 +9,8 @@
 #   3. one section per "tracked author" (default: groeneai), regardless of assignee
 #
 # For every PR we report:
-#   - the "CH Inc sync" state: GREEN (also passed), FAILED, or INPROG (still running)
+#   - the "CH Inc sync" state: GREEN (also passed), FAILED, INPROG (still running),
+#     or NOSYNC (no such check, e.g. release-branch backports)
 #   - whether it was APPROVED by anyone at least once
 # Already-merged / closed PRs are excluded.
 #
@@ -17,6 +18,12 @@
 #   report.sh [tracked-author ...]      # default tracked author: groeneai
 #
 set -euo pipefail
+
+# Pin the repository explicitly so the report always describes ClickHouse/ClickHouse
+# regardless of the directory the skill is run from. The output links below are also
+# hardcoded to ClickHouse/ClickHouse, so the data source must match them.
+REPO="ClickHouse/ClickHouse"
+export REPO
 
 TRACK_AUTHORS=("groeneai")
 if [ "$#" -gt 0 ]; then TRACK_AUTHORS=("$@"); fi
@@ -26,41 +33,80 @@ WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
 # ---- helper invoked per-PR by xargs: classify the checks --------------------
-# Output: "<num>\t<CH-Inc-sync-state>\t<#other-non-green>"
+# Output: "<num>\t<sync-label>\t<#other-non-green>" where <sync-label> is one of
+# GREEN / FAILED / INPROG / NOSYNC, or NO_CHECKS (with count 99, so it is excluded).
+#
+# Classification uses `gh pr checks`' own `bucket` field, which groups the many raw
+# states (SUCCESS, FAILURE, TIMED_OUT, STARTUP_FAILURE, QUEUED, CANCELLED, SKIPPED,
+# NEUTRAL, ...) into pass / fail / pending / skipping / cancel. Using the bucket
+# avoids silently dropping a PR whose sync (or another check) is in a raw state we
+# did not enumerate.
+#
+# Failure handling: with `--json`, `gh pr checks` exits 0 and prints a JSON array
+# whenever it could read the checks (even if some are failing or pending). A
+# non-zero exit therefore means either "no checks reported" (a legitimate empty
+# result) or a real API / auth / rate-limit error. We treat the former as NO_CHECKS
+# and abort the whole run on the latter, rather than silently dropping the row.
 cat > "$WORK/classify.sh" <<'SH'
 #!/usr/bin/env bash
+set -uo pipefail
 n="$1"
-json=$(gh pr checks "$n" --json name,state 2>/dev/null)
-if [ -z "$json" ] || [ "$json" = "[]" ]; then echo -e "$n\tNO_CHECKS\t99"; exit 0; fi
+err=$(mktemp)
+trap 'rm -f "$err"' EXIT
+if json=$(gh pr checks "$n" --repo "$REPO" --json name,state,bucket 2>"$err"); then
+  if [ -z "$json" ] || [ "$json" = "[]" ]; then
+    printf '%s\tNO_CHECKS\t99\n' "$n"; exit 0
+  fi
+elif grep -qi 'no checks reported' "$err"; then
+  printf '%s\tNO_CHECKS\t99\n' "$n"; exit 0
+else
+  echo "good-prs: 'gh pr checks $n' failed: $(tr '\n' ' ' <"$err")" >&2
+  exit 255   # 255 makes xargs stop immediately; set -e then aborts report.sh
+fi
 echo "$json" | jq -r --arg n "$n" '
-  (map(select(.name=="CH Inc sync")) | .[0].state // "ABSENT") as $ch
+  (map(select(.name=="CH Inc sync")) | .[0].bucket // "absent") as $sync
   | (map(select(.name!="CH Inc sync" and .name!="PR" and .name!="Mergeable Check"
                and .name!="A Sync (only for tests)"))) as $others
-  | ($others | map(select(.state!="SUCCESS" and .state!="SKIPPED" and .state!="NEUTRAL")) | length) as $nbad
-  | "\($n)\t\($ch)\t\($nbad)"'
+  # a non-sync check counts as "not green" unless its bucket is pass or skipping
+  | ($others | map(select(.bucket!="pass" and .bucket!="skipping")) | length) as $nbad
+  | (if   $sync=="pass"     then "GREEN"
+     elif $sync=="fail"     then "FAILED"
+     elif $sync=="cancel"   then "FAILED"
+     elif $sync=="pending"  then "INPROG"
+     else                        "NOSYNC"   # skipping / absent
+     end) as $synclabel
+  | "\($n)\t\($synclabel)\t\($nbad)"'
 SH
 chmod +x "$WORK/classify.sh"
 
 # ---- helper invoked per-PR by xargs: state + ever-approved -----------------
 # Output: "<num>\t<STATE>\t<true|false>"
+# A valid PR always yields data here; an empty result means a real gh failure, so
+# we surface the diagnostic and abort rather than silently dropping the row.
 cat > "$WORK/approval.sh" <<'SH'
 #!/usr/bin/env bash
+set -uo pipefail
 n="$1"
-res=$(gh pr view "$n" --json state,reviews \
-  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv' 2>/dev/null)
-[ -z "$res" ] && res="ERR\tfalse"
-printf '%s\t%s\n' "$n" "$res"
+err=$(mktemp)
+trap 'rm -f "$err"' EXIT
+if res=$(gh pr view "$n" --repo "$REPO" --json state,reviews \
+  --jq '[.state, ([.reviews[].state] | any(. == "APPROVED"))] | @tsv' 2>"$err"); then
+  printf '%s\t%s\n' "$n" "$res"
+else
+  echo "good-prs: 'gh pr view $n' failed: $(tr '\n' ' ' <"$err")" >&2
+  exit 255
+fi
 SH
 chmod +x "$WORK/approval.sh"
 
 # ---- gather metadata (number, author, title) for each query group ----------
-gh pr list --author "$ME"   --state open --limit 1000 --json number,title,author \
+gh pr list --repo "$REPO" --author "$ME"   --state open --limit 1000 --json number,title,author \
   --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' > "$WORK/authored.meta"
-gh pr list --assignee "$ME" --state open --limit 1000 --json number,title,author \
+gh pr list --repo "$REPO" --assignee "$ME" --state open --limit 1000 --json number,title,author \
   --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' > "$WORK/assigned.meta"
 : > "$WORK/tracked.meta"
 for a in "${TRACK_AUTHORS[@]}"; do
-  gh pr list --author "$a" --state open --limit 1000 --json number,title,author \
+  gh pr list --repo "$REPO" --author "$a" --state open --limit 1000 --json number,title,author \
     --jq '.[]|"\(.number)\t\(.author.login)\t\(.title)"' >> "$WORK/tracked.meta"
 done
 
@@ -74,17 +120,21 @@ cat "$WORK"/*.meta | cut -f1 | sort -un > "$WORK/all_nums.txt"
 # creates an empty output file, so the report renders clean empty sections when
 # nobody has a qualifying PR (empty all_nums.txt) or none of them match the
 # "only CH Inc sync is non-green" criterion (empty match_nums.txt).
-xargs -r -P 12 -n 1 "$WORK/classify.sh" < "$WORK/all_nums.txt" > "$WORK/checks.tsv" 2>/dev/null
+#
+# We deliberately do NOT discard the helpers' stderr: on a real gh failure the
+# helper prints a diagnostic and exits 255, xargs propagates a non-zero status,
+# and `set -e` aborts the run with that diagnostic visible.
+xargs -r -P 12 -n 1 "$WORK/classify.sh" < "$WORK/all_nums.txt" > "$WORK/checks.tsv"
 # Only PRs that match the criterion need an approval/state lookup
-awk -F'\t' '$3==0 && ($2=="SUCCESS"||$2=="FAILURE"||$2=="PENDING"||$2=="IN_PROGRESS"||$2=="ABSENT"){print $1}' \
+awk -F'\t' '$3==0 && ($2=="GREEN"||$2=="FAILED"||$2=="INPROG"||$2=="NOSYNC"){print $1}' \
   "$WORK/checks.tsv" | sort -un > "$WORK/match_nums.txt"
-xargs -r -P 12 -n 1 "$WORK/approval.sh" < "$WORK/match_nums.txt" > "$WORK/appr.tsv" 2>/dev/null
+xargs -r -P 12 -n 1 "$WORK/approval.sh" < "$WORK/match_nums.txt" > "$WORK/appr.tsv"
 
 # ---- render one markdown section -------------------------------------------
 # args: <meta-file> <show-author-col:0|1> <exclude-authors-csv>
 emit() {
   local meta="$1" showauth="$2" excl="$3"
-  awk -F'\t' '$3==0 && ($2=="SUCCESS"||$2=="FAILURE"||$2=="PENDING"||$2=="IN_PROGRESS"||$2=="ABSENT"){print $1"\t"$2}' \
+  awk -F'\t' '$3==0 && ($2=="GREEN"||$2=="FAILED"||$2=="INPROG"||$2=="NOSYNC"){print $1"\t"$2}' \
     "$WORK/checks.tsv" \
   | while IFS=$'\t' read -r n st; do
       a=$(awk -F'\t' -v n="$n" '$1==n{print $2"\t"$3}' "$WORK/appr.tsv")
@@ -96,8 +146,8 @@ emit() {
       title=$(echo "$line" | cut -f3 | sed 's/|/\\|/g')
       case ",$excl," in *",$auth,"*) continue;; esac
       case "$st" in
-        SUCCESS) g=3; gl="GREEN";; FAILURE) g=1; gl="FAILED";;
-        PENDING|IN_PROGRESS) g=2; gl="INPROG";; ABSENT) g=4; gl="NOSYNC";;
+        FAILED) g=1; gl="FAILED";; INPROG) g=2; gl="INPROG";;
+        GREEN)  g=3; gl="GREEN";;  NOSYNC) g=4; gl="NOSYNC";;
       esac
       [ "$approved" = "true" ] && av="yes" || av="-"
       printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$g" "$gl" "$n" "$av" "$auth" "$title"

--- a/.claude/skills/good-prs/test.sh
+++ b/.claude/skills/good-prs/test.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Focused tests for report.sh. No network access: `gh` is replaced by a stub on
+# PATH that serves canned fixtures, so the tests exercise report.sh's own logic
+# (bucket -> label classification, the "only CH Inc sync is non-green" criterion,
+# empty-input handling, --repo pinning, and fail-loud-on-real-error behaviour).
+#
+# Usage: bash test.sh
+#
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPORT="$HERE/report.sh"
+
+RC=0
+ok()  { printf '  ok   - %s\n' "$*"; }
+bad() { printf '  FAIL - %s\n' "$*"; RC=1; }
+
+# Write the `gh` stub into <dir>/bin. It dispatches on the gh subcommand and reads
+# canned fixtures from $GH_STUB_DIR, logging every invocation to $GH_STUB_LOG.
+write_stub()
+{
+  local bin="$1/bin"
+  mkdir -p "$bin"
+  cat > "$bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+printf '%s\n' "$*" >> "$GH_STUB_LOG"
+sub="${1:-} ${2:-}"
+case "$sub" in
+  "api user")
+    cat "$GH_STUB_DIR/me" ;;
+  "pr list")
+    mode=""; who=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --author)   mode=author;   who="$2"; shift 2 ;;
+        --assignee) mode=assignee; who="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    f="$GH_STUB_DIR/list/${mode}_${who}.tsv"
+    [ -f "$f" ] && cat "$f"
+    ;;
+  "pr checks")
+    n="$3"
+    if [ -f "$GH_STUB_DIR/checks/$n.err" ]; then cat "$GH_STUB_DIR/checks/$n.err" >&2; exit 1; fi
+    if [ -f "$GH_STUB_DIR/checks/$n.nochecks" ]; then echo "no checks reported on the 'br-$n' branch" >&2; exit 1; fi
+    cat "$GH_STUB_DIR/checks/$n.json"
+    ;;
+  "pr view")
+    n="$3"
+    if [ -f "$GH_STUB_DIR/view/$n.err" ]; then cat "$GH_STUB_DIR/view/$n.err" >&2; exit 1; fi
+    cat "$GH_STUB_DIR/view/$n.tsv"
+    ;;
+  *)
+    echo "gh stub: unhandled args: $*" >&2; exit 99 ;;
+esac
+exit 0   # success branches return 0 even when a list fixture is absent (empty list)
+STUB
+  chmod +x "$bin/gh"
+}
+
+# run_report <stub-dir> -> sets globals: OUT, ERRF, EXIT
+run_report()
+{
+  local d="$1"
+  OUT="$d/out"; ERRF="$d/err"
+  PATH="$d/bin:$PATH" GH_STUB_DIR="$d/fix" GH_STUB_LOG="$d/calls.log" \
+    bash "$REPORT" > "$OUT" 2> "$ERRF"
+  EXIT=$?
+}
+
+row_has() { # <out> <pr-num> <label> <desc>
+  if grep -F "#$2" "$1" | grep -qF "$3"; then ok "$4"; else bad "$4"; fi
+}
+not_present() { # <out> <pr-num> <desc>
+  if grep -qF "#$1" "$2"; then bad "$3"; else ok "$3"; fi
+}
+
+# Every PR-scoped gh call must be pinned to ClickHouse/ClickHouse.
+assert_repo_pinned() { # <calls.log> <desc>
+  if grep -E '^pr (list|checks|view)' "$1" | grep -vq -- '--repo ClickHouse/ClickHouse'; then
+    bad "$2"
+  else
+    ok "$2"
+  fi
+}
+
+############################ Test A: classification ############################
+echo "Test A: bucket -> label classification and the only-sync criterion"
+A=$(mktemp -d); write_stub "$A"; mkdir -p "$A/fix/list" "$A/fix/checks" "$A/fix/view"
+printf 'testuser\n' > "$A/fix/me"
+{
+  printf '101\ttestuser\tFully green PR\n'
+  printf '102\ttestuser\tSync failed PR\n'
+  printf '103\ttestuser\tSync in progress PR\n'
+  printf '104\ttestuser\tBackport, no sync check\n'
+  printf '105\ttestuser\tNon-sync check failing\n'
+  printf '106\ttestuser\tMerged between list and view\n'
+  printf '107\ttestuser\tSync QUEUED\n'
+  printf '108\ttestuser\tSync CANCELLED\n'
+  printf '109\ttestuser\tSync SKIPPED\n'
+} > "$A/fix/list/author_testuser.tsv"
+printf '201\tgroeneai\tGroeneai green PR\n' > "$A/fix/list/author_groeneai.tsv"
+
+c() { printf '%s\n' "$2" > "$A/fix/checks/$1.json"; }
+c 101 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"},{"name":"Tests","state":"SKIPPED","bucket":"skipping"},{"name":"PR","state":"SUCCESS","bucket":"pass"},{"name":"Mergeable Check","state":"SUCCESS","bucket":"pass"}]'
+c 102 '[{"name":"CH Inc sync","state":"FAILURE","bucket":"fail"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 103 '[{"name":"CH Inc sync","state":"IN_PROGRESS","bucket":"pending"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 104 '[{"name":"Build","state":"SUCCESS","bucket":"pass"},{"name":"Docs","state":"SKIPPED","bucket":"skipping"}]'
+c 105 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Tests","state":"FAILURE","bucket":"fail"}]'
+c 106 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 107 '[{"name":"CH Inc sync","state":"QUEUED","bucket":"pending"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 108 '[{"name":"CH Inc sync","state":"CANCELLED","bucket":"cancel"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 109 '[{"name":"CH Inc sync","state":"SKIPPED","bucket":"skipping"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+c 201 '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"},{"name":"Build","state":"SUCCESS","bucket":"pass"}]'
+
+v() { printf '%s\t%s\n' "$2" "$3" > "$A/fix/view/$1.tsv"; }
+v 101 OPEN true
+v 102 OPEN false
+v 103 OPEN false
+v 104 OPEN false
+v 106 MERGED false
+v 107 OPEN false
+v 108 OPEN false
+v 109 OPEN false
+v 201 OPEN true
+
+run_report "$A"
+[ "$EXIT" = 0 ] && ok "exit code 0" || { bad "exit code 0 (got $EXIT)"; cat "$ERRF"; }
+row_has "$OUT" 101 GREEN  "#101 fully green -> GREEN"
+row_has "$OUT" 102 FAILED "#102 sync FAILURE -> FAILED"
+row_has "$OUT" 103 INPROG "#103 sync IN_PROGRESS -> INPROG"
+row_has "$OUT" 104 NOSYNC "#104 no sync check -> NOSYNC"
+not_present 105 "$OUT" "#105 non-sync failure -> excluded"
+not_present 106 "$OUT" "#106 merged -> excluded"
+row_has "$OUT" 107 INPROG "#107 sync QUEUED (bucket pending) -> INPROG"
+row_has "$OUT" 108 FAILED "#108 sync CANCELLED (bucket cancel) -> FAILED"
+row_has "$OUT" 109 NOSYNC "#109 sync SKIPPED (bucket skipping) -> NOSYNC"
+row_has "$OUT" 201 GREEN  "#201 groeneai section rendered"
+assert_repo_pinned "$A/calls.log" "every PR-scoped gh call pins --repo ClickHouse/ClickHouse"
+rm -rf "$A"
+
+############################ Test B: empty input ###############################
+echo "Test B: no PRs at all -> clean empty sections, exit 0"
+B=$(mktemp -d); write_stub "$B"; mkdir -p "$B/fix/list" "$B/fix/checks" "$B/fix/view"
+printf 'testuser\n' > "$B/fix/me"
+run_report "$B"
+[ "$EXIT" = 0 ] && ok "exit code 0 on empty input" || { bad "exit code 0 on empty input (got $EXIT)"; cat "$ERRF"; }
+if grep -q '## 1. Your own PRs' "$OUT"; then ok "section headers still rendered"; else bad "section headers still rendered"; fi
+if grep -q '\[#' "$OUT"; then bad "no PR rows on empty input"; else ok "no PR rows on empty input"; fi
+rm -rf "$B"
+
+####################### Test C: real gh failure on checks ######################
+echo "Test C: transient gh pr checks failure -> abort with diagnostic"
+C=$(mktemp -d); write_stub "$C"; mkdir -p "$C/fix/list" "$C/fix/checks" "$C/fix/view"
+printf 'testuser\n' > "$C/fix/me"
+printf '301\ttestuser\tWill error\n' > "$C/fix/list/author_testuser.tsv"
+printf 'HTTP 403: API rate limit exceeded\n' > "$C/fix/checks/301.err"
+run_report "$C"
+[ "$EXIT" != 0 ] && ok "non-zero exit on gh checks failure" || bad "non-zero exit on gh checks failure (got $EXIT)"
+if grep -qF "'gh pr checks 301' failed" "$ERRF"; then ok "diagnostic names the failing PR"; else bad "diagnostic names the failing PR"; fi
+if grep -qF "rate limit" "$ERRF"; then ok "original gh diagnostic preserved"; else bad "original gh diagnostic preserved"; fi
+rm -rf "$C"
+
+####################### Test D: real gh failure on view ########################
+echo "Test D: transient gh pr view failure -> abort with diagnostic"
+D=$(mktemp -d); write_stub "$D"; mkdir -p "$D/fix/list" "$D/fix/checks" "$D/fix/view"
+printf 'testuser\n' > "$D/fix/me"
+printf '401\ttestuser\tView errors\n' > "$D/fix/list/author_testuser.tsv"
+printf '%s\n' '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"}]' > "$D/fix/checks/401.json"
+printf 'HTTP 500: server error\n' > "$D/fix/view/401.err"
+run_report "$D"
+[ "$EXIT" != 0 ] && ok "non-zero exit on gh view failure" || bad "non-zero exit on gh view failure (got $EXIT)"
+if grep -qF "'gh pr view 401' failed" "$ERRF"; then ok "diagnostic names the failing PR"; else bad "diagnostic names the failing PR"; fi
+rm -rf "$D"
+
+################## Test E: 'no checks reported' is not fatal ####################
+echo "Test E: a 'no checks reported' PR is excluded, not fatal"
+E=$(mktemp -d); write_stub "$E"; mkdir -p "$E/fix/list" "$E/fix/checks" "$E/fix/view"
+printf 'testuser\n' > "$E/fix/me"
+{ printf '501\ttestuser\tNo checks reported\n'; printf '502\ttestuser\tGreen PR\n'; } > "$E/fix/list/author_testuser.tsv"
+: > "$E/fix/checks/501.nochecks"
+printf '%s\n' '[{"name":"CH Inc sync","state":"SUCCESS","bucket":"pass"}]' > "$E/fix/checks/502.json"
+v502() { printf 'OPEN\ttrue\n' > "$E/fix/view/502.tsv"; }; v502
+run_report "$E"
+[ "$EXIT" = 0 ] && ok "exit code 0 (no-checks is legitimate)" || { bad "exit code 0 (got $EXIT)"; cat "$ERRF"; }
+not_present 501 "$OUT" "#501 with no checks -> excluded"
+row_has "$OUT" 502 GREEN "#502 green PR still rendered alongside excluded one"
+rm -rf "$E"
+
+echo
+if [ "$RC" = 0 ]; then echo "ALL TESTS PASSED"; else echo "SOME TESTS FAILED"; fi
+exit "$RC"


### PR DESCRIPTION
Adds a `good-prs` Claude Code skill that reports open `ClickHouse/ClickHouse` pull requests whose only non-green CI check is `CH Inc sync` (the private-repo sync job), or that are already fully green — i.e. pull requests that are effectively ready to merge.

Motivation: it is hard to see at a glance which of one's own (and one's reviewees') pull requests are done with public CI and waiting only on the private sync. This skill answers that in one command.

The bundled `report.sh` resolves the authenticated `gh` user and prints three sections: pull requests you authored, pull requests assigned to you authored by others, and pull requests by tracked authors (default `groeneai`). For each it shows the `CH Inc sync` state (`GREEN` / `FAILED` / `INPROG` / `NOSYNC`) and whether it was ever approved, and excludes already-merged or closed pull requests. The aggregate gates `PR`, `Mergeable Check`, and `A Sync (only for tests)` are ignored when deciding whether everything else is green.

This is developer tooling under `.claude/skills/` only; it changes no product code.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...