### PR TITLE
Add a "share" Claude Code skill to publish sessions to Pastila

### DIFF
--- a/.claude/skills/share/SKILL.md
+++ b/.claude/skills/share/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: share
+description: Share a Claude Code session to pastila.nl and return a viewer link. Shares the current session by default, or a session specified as a transcript path, a session id, or a project. Use when the user asks to share, publish, or get a link to this conversation or to a session/transcript.
+argument-hint: "[session: path | session-id | project]"
+disable-model-invocation: false
+allowed-tools: Bash
+---
+
+# Share a Claude session
+
+Upload a Claude Code session transcript to pastila.nl (encrypted) and return a
+`.claude.jsonl` link that renders it like the viewer at
+https://github.com/ClickHouse/alexeyprompts
+
+## Steps
+
+1. Run the bundled helper. It lives in the same directory as this SKILL.md — use
+   its absolute path (here this is `.claude/skills/share/share.py`):
+
+   ```sh
+   python3 <skill-dir>/share.py [session]
+   ```
+
+   - **No argument** → shares the **current** session (identified by
+     `$CLAUDE_CODE_SESSION_ID`).
+   - **`[session]`** → shares another session, given as one of:
+     - a path to a `.jsonl` transcript,
+     - a session id (uuid), or
+     - a project path or its `~/.claude/projects` directory name (shares the
+       newest session in it).
+
+2. Report the URL the script prints to the user.
+
+The script delegates the upload to `pastila.py` (encryption + INSERT), so that
+logic is not duplicated; it then inserts the `.claude.jsonl` extension before the
+`#` key anchor to produce the viewer link.
+
+## Notes
+
+- The link contains the decryption key in its `#` fragment — anyone with the link
+  can read the session. Share it only intentionally.
+- Sessions include tool calls and results (file fragments, command output). Take a
+  quick look before sharing potentially sensitive ones.
+- `pastila.py` (the encryption + upload script from the pastila repo) is bundled
+  next to `share.py` in this skill, so the skill is self-contained. It still needs
+  the Python packages `requests` and `cryptography` installed.

--- a/.claude/skills/share/SKILL.md
+++ b/.claude/skills/share/SKILL.md
@@ -21,8 +21,11 @@ https://github.com/ClickHouse/alexeyprompts
    python3 <skill-dir>/share.py [session]
    ```
 
-   - **No argument** → shares the **current** session (identified by
-     `$CLAUDE_CODE_SESSION_ID`).
+   - **No argument** → shares the **current** session (identified strictly by
+     `$CLAUDE_CODE_SESSION_ID`). If that variable is unset or its transcript
+     cannot be found, the script errors out and asks for an explicit argument
+     rather than guessing — it never falls back to "the newest transcript", so
+     it cannot publish an unrelated session by mistake.
    - **`[session]`** → shares another session, given as one of:
      - a path to a `.jsonl` transcript,
      - a session id (uuid), or

--- a/.claude/skills/share/pastila.py
+++ b/.claude/skills/share/pastila.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python3
+import sys, requests, json, re, base64, os
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+
+#
+# Script to upload/download to/from pastila.nl from command line.
+# Put it somewhere in PATH and use like this:
+#
+# % echo henlo | pastila.py
+# https://pastila.nl/?cafebabe/c8570701492af2ac7269064a661686e3#oj6jpBCRzIOSGTgRFgMquA==
+#
+# % pastila.py 'https://pastila.nl/?cafebabe/c8570701492af2ac7269064a661686e3#oj6jpBCRzIOSGTgRFgMquA=='
+# henlo
+#
+
+
+def sipHash128(m: bytes):
+    mask = (1 << 64) - 1
+
+    def rotl(v, offset, bits):
+        v[offset] = ((v[offset] << bits) & mask) | ((v[offset] & mask) >> (64 - bits))
+
+    def compress(v):
+        v[0] += v[1]
+        v[2] += v[3]
+        rotl(v, 1, 13)
+        rotl(v, 3, 16)
+        v[1] ^= v[0]
+        v[3] ^= v[2]
+        rotl(v, 0, 32)
+        v[2] += v[1]
+        v[0] += v[3]
+        rotl(v, 1, 17)
+        rotl(v, 3, 21)
+        v[1] ^= v[2]
+        v[3] ^= v[0]
+        rotl(v, 2, 32)
+
+    v = [0x736f6d6570736575, 0x646f72616e646f6d, 0x6c7967656e657261, 0x7465646279746573]
+    offset = 0
+    while offset < len(m) - 7:
+        word = int.from_bytes(m[offset:offset + 8], 'little')
+        v[3] ^= word
+        compress(v)
+        compress(v)
+        v[0] ^= word
+        offset += 8
+
+    buf = bytearray(8)
+    buf[:len(m) - offset] = m[offset:]
+    buf[7] = len(m) & 0xff
+
+    word = int.from_bytes(buf, 'little')
+    v[3] ^= word
+    compress(v)
+    compress(v)
+    v[0] ^= word
+    v[2] ^= 0xFF
+    compress(v)
+    compress(v)
+    compress(v)
+    compress(v)
+
+    hash_val = ((v[0] ^ v[1]) & mask) + (((v[2] ^ v[3]) & mask) << 64)
+    s = '{:032x}'.format(hash_val)
+    return ''.join(s[i:i+2] for i in range(30,-2,-2))
+
+def error(s):
+    sys.stderr.write(f"error: {s}\n")
+    sys.exit(1)
+
+# This is too slow, and doesn't seem important.
+#def getFingerprint(text):
+#    words = re.findall(r'\b\w{4,}\b', text.decode()) # doesn't exactly match the JS code, but it doesn't have to
+#    triplets = [''.join(words[i:i+3]) for i in range(len(words) - 2)]
+#    uniq = set(triplets)
+#    hashes = [sipHash128(s.encode())[:8] for s in uniq]
+#    hashes.append('ffffffff')
+#    return min(hashes)
+
+def load(url):
+    r = re.match(r"^(?:(?:(?:(?:(?:https?:)?//)?pastila\.nl)?/)?\?)?([a-f0-9]+)/([a-f0-9]+)(?:#(.+))?$", url)
+    if r is None: error('bad url')
+    fingerprint, hash_hex, key = r.groups()
+
+    response = requests.post('https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste', data=f"SELECT content, is_encrypted FROM data_view(fingerprint = '{fingerprint}', hash = '{hash_hex}') FORMAT JSON")
+    if not response.ok: error(f"{response} {response.content}")
+
+    j = json.loads(response.content)
+    if j['rows'] != 1: error("paste not found")
+    #if 'statistics' in j: sys.stderr.write(f"{j['statistics']}")
+    content, is_encrypted = j['data'][0]['content'], j['data'][0]['is_encrypted']
+
+    if is_encrypted:
+        if key is None: error("paste is encrypted, but the url contains no key (part after '#')")
+        key = base64.b64decode(key)
+        content = base64.b64decode(content)
+        cipher = Cipher(algorithms.AES(key), modes.CTR(b'\x00' * 16), backend=default_backend())
+        decryptor = cipher.decryptor()
+        decrypted = decryptor.update(content) + decryptor.finalize()
+        content = decrypted
+
+    return content
+
+def save(data, encrypt):
+    key = os.urandom(16)
+    url_suffix = ""
+    if encrypt:
+        cipher = Cipher(algorithms.AES(key), modes.CTR(b'\x00' * 16), backend=default_backend())
+        encryptor = cipher.encryptor()
+        encrypted = encryptor.update(data) + encryptor.finalize()
+        data = base64.b64encode(encrypted)
+        url_suffix = '#' + base64.b64encode(key).decode()
+
+    h = sipHash128(data)
+    fingerprint = 'cafebabe' # getFingerprint(data)
+
+    payload = json.dumps({
+        'fingerprint_hex': fingerprint,
+        'hash_hex': h,
+        'content': data.decode(),
+        'is_encrypted': encrypt,
+    })
+    response = requests.post('https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste', data=f'INSERT INTO data (fingerprint_hex, hash_hex, content, is_encrypted) FORMAT JSONEachRow {payload}')
+    if not response.ok: error(f"{response} {response.content}")
+    print(f"https://pastila.nl/?{fingerprint}/{h}{url_suffix}")
+
+
+if len(sys.argv) == 1:
+    data = sys.stdin.buffer.read()
+    save(data, True)
+elif len(sys.argv) == 2 and sys.argv[1] == 'plain':
+    data = sys.stdin.buffer.read()
+    save(data, False)
+elif len(sys.argv) == 2:
+    data = load(sys.argv[1])
+    sys.stdout.buffer.write(data)
+else:
+    print("usage: pastila.py [url]")
+    sys.exit(1)

--- a/.claude/skills/share/share.py
+++ b/.claude/skills/share/share.py
@@ -69,22 +69,23 @@ def resolve_session(arg):
                     return n
         die("could not resolve a session from %r" % arg)
 
-    # No argument: the current session, identified by its id.
+    # No argument: the current session, identified strictly by its id. There is
+    # deliberately no "newest transcript" fallback here. This skill performs an
+    # external, irreversible upload of a private transcript, so when the current
+    # session cannot be resolved we fail closed rather than risk publishing an
+    # unrelated session that merely happens to be the most recently modified
+    # (e.g. when run from a different checkout or a non-Claude shell).
     sid = os.environ.get("CLAUDE_CODE_SESSION_ID")
-    if sid:
-        matches = glob.glob(str(PROJECTS / "*" / (sid + ".jsonl")))
-        if matches:
-            return Path(matches[0])
-
-    # Fallbacks: newest session in the current project's directory, then newest
-    # session anywhere.
-    n = newest_in_dir(PROJECTS / encode(os.getcwd()))
-    if n:
-        return n
-    n = newest(glob.glob(str(PROJECTS / "*" / "*.jsonl")))
-    if n:
-        return n
-    die("no session transcript found under " + str(PROJECTS))
+    if not sid:
+        die("CLAUDE_CODE_SESSION_ID is not set, so the current session cannot be "
+            "identified. Pass an explicit transcript path, session id, or project "
+            "to choose what to share.")
+    matches = glob.glob(str(PROJECTS / "*" / (sid + ".jsonl")))
+    if not matches:
+        die("no transcript found for the current session id %s under %s. Pass an "
+            "explicit transcript path, session id, or project to choose what to "
+            "share." % (sid, PROJECTS))
+    return Path(matches[0])
 
 
 def find_pastila():

--- a/.claude/skills/share/share.py
+++ b/.claude/skills/share/share.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Share a Claude Code session to pastila.nl and print a `.claude.jsonl` viewer link.
+
+By default it shares the *current* session (the one running this skill, identified
+by $CLAUDE_CODE_SESSION_ID). An explicit session may be passed as the first
+argument, given as any of:
+  - a path to a .jsonl transcript file,
+  - a session id (uuid),
+  - a project path or its ~/.claude/projects directory name (newest session there).
+
+The actual upload (encryption + INSERT) is delegated to pastila.py, so none of
+that logic is duplicated here -- this script only locates the transcript, runs
+pastila.py on it, and turns the resulting paste URL into a session-viewer URL by
+inserting the `.claude.jsonl` extension before the `#` key anchor.
+"""
+
+import os
+import re
+import sys
+import glob
+import shutil
+import subprocess
+from pathlib import Path
+
+PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def die(msg):
+    sys.stderr.write("share: " + msg + "\n")
+    sys.exit(1)
+
+
+def encode(path):
+    # Claude Code names a project's transcript directory after its path with every
+    # non-alphanumeric character replaced by '-' (e.g. /home/u/p -> -home-u-p).
+    return re.sub(r"[^A-Za-z0-9]", "-", path)
+
+
+def newest(paths):
+    paths = [p for p in paths if Path(p).name != "history.jsonl"]
+    if not paths:
+        return None
+    return Path(max(paths, key=lambda p: Path(p).stat().st_mtime))
+
+
+def newest_in_dir(d):
+    return newest(glob.glob(str(Path(d) / "*.jsonl")))
+
+
+def resolve_session(arg):
+    """Return the Path of the transcript to share."""
+    if arg:
+        p = Path(arg).expanduser()
+        if p.is_file():
+            return p
+        # A bare session id (uuid): look it up across all projects.
+        if "/" not in arg and not arg.endswith(".jsonl"):
+            matches = glob.glob(str(PROJECTS / "*" / (arg + ".jsonl")))
+            if matches:
+                return Path(matches[0])
+        # A project: either a ~/.claude/projects subdirectory name, or a project
+        # path that needs encoding. Share the newest session found in it.
+        for cand in (PROJECTS / arg, PROJECTS / encode(arg),
+                     PROJECTS / encode(str(p if p.is_absolute() else p.resolve()))):
+            if cand.is_dir():
+                n = newest_in_dir(cand)
+                if n:
+                    return n
+        die("could not resolve a session from %r" % arg)
+
+    # No argument: the current session, identified by its id.
+    sid = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    if sid:
+        matches = glob.glob(str(PROJECTS / "*" / (sid + ".jsonl")))
+        if matches:
+            return Path(matches[0])
+
+    # Fallbacks: newest session in the current project's directory, then newest
+    # session anywhere.
+    n = newest_in_dir(PROJECTS / encode(os.getcwd()))
+    if n:
+        return n
+    n = newest(glob.glob(str(PROJECTS / "*" / "*.jsonl")))
+    if n:
+        return n
+    die("no session transcript found under " + str(PROJECTS))
+
+
+def find_pastila():
+    candidates = [
+        Path(__file__).resolve().parent / "pastila.py",      # bundled next to this script
+        Path(__file__).resolve().parents[3] / "pastila.py",  # the pastila repo
+        Path.cwd() / "pastila.py",
+    ]
+    on_path = shutil.which("pastila.py")
+    if on_path:
+        candidates.append(Path(on_path))
+    for c in candidates:
+        if c.is_file():
+            return c
+    die("cannot find pastila.py (looked next to this skill's script, in the "
+        "pastila repo, the current directory, and PATH)")
+
+
+def to_view_url(url):
+    # Turn .../?fp/hash#key into .../?fp/hash.claude.jsonl#key
+    if "#" in url:
+        base, frag = url.split("#", 1)
+        return base + ".claude.jsonl#" + frag
+    return url + ".claude.jsonl"
+
+
+def main():
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    session = resolve_session(arg)
+    pastila = find_pastila()
+
+    data = session.read_bytes()
+    proc = subprocess.run([sys.executable, str(pastila)], input=data,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        die("upload failed: " + (proc.stderr.decode(errors="replace").strip() or
+                                 "pastila.py exited with %d" % proc.returncode))
+
+    url = proc.stdout.decode().strip()
+    if not url.startswith("http"):
+        die("unexpected pastila.py output: " + url)
+
+    print(to_view_url(url))
+    sys.stderr.write("shared %s (%d bytes)\n" % (session, len(data)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a `share` Claude Code skill that uploads the current (or a specified) Claude Code session transcript — encrypted — to pastila.nl and returns a `.claude.jsonl` viewer link, rendered like the viewer at https://github.com/ClickHouse/alexeyprompts.

This is a port of the same skill from the `ClickHouse/pastila` repository (https://github.com/ClickHouse/pastila/tree/master/.claude/skills/share). `share.py` locates the transcript and turns the resulting paste URL into a session-viewer link; the encryption and upload are delegated to `pastila.py`. Since this repository has no `pastila.py` at its root, `pastila.py` is bundled next to `share.py` so the skill is self-contained, and `find_pastila` looks there first. Only the Python packages `requests` and `cryptography` are required at runtime.

The skill shares the current session by default, or a session given as a transcript path, a session id, or a project.

Verified end-to-end on a throwaway dummy transcript: the upload produced a `.claude.jsonl` link and downloading the bare paste URL decrypted back to the exact original bytes.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.211` (included in `26.7` and later)
<!-- ch-version-info:end -->