### PR TITLE
Fix `Bad cast` with `group_by_use_nulls` over a LowCardinality key constant

### DIFF
--- a/src/Analyzer/ConstantNode.cpp
+++ b/src/Analyzer/ConstantNode.cpp
@@ -5,6 +5,7 @@
 #include <Analyzer/Utils.h>
 
 #include <Columns/ColumnNullable.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <Common/assert_cast.h>
 #include <Common/FieldVisitorToString.h>
 #include <DataTypes/FieldToDataType.h>
@@ -111,7 +112,16 @@ void ConstantNode::dumpTreeImpl(WriteBuffer & buffer, FormatState & format_state
 
 void ConstantNode::convertToNullable()
 {
-    constant_value = { makeNullableSafe(constant_value.getColumn()), makeNullableSafe(constant_value.getType()) };
+    /// Use the LowCardinality-aware variant so that a `LowCardinality(T)` key becomes
+    /// `LowCardinality(Nullable(T))` rather than being left unchanged (a plain `Nullable`
+    /// cannot wrap `LowCardinality`). This keeps the analyzer in sync with `ColumnNode`,
+    /// `FunctionNode` and the planner, which all use `makeNullableOrLowCardinalityNullableSafe`
+    /// when `group_by_use_nulls` is enabled. Otherwise the declared key type would stay
+    /// non-Nullable while the runtime produces a Nullable column, leading to a logical error.
+    const auto & column = constant_value.getColumn();
+    constant_value
+        = {ColumnConst::create(makeNullableOrLowCardinalityNullableSafe(column->getDataColumnPtr()), column->size()),
+           makeNullableOrLowCardinalityNullableSafe(constant_value.getType())};
 }
 
 bool ConstantNode::isEqualImpl(const IQueryTreeNode & rhs, CompareOptions /*compare_options*/) const

--- a/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.reference
+++ b/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.reference
@@ -1,0 +1,5 @@
+LowCardinality(Nullable(String))
+Nullable(String)
+1
+1
+1

--- a/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.sql
+++ b/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.sql
@@ -1,3 +1,8 @@
+-- Tags: no-old-analyzer
+-- no-old-analyzer: the fix is in `ConstantNode::convertToNullable` (query tree, new analyzer only);
+-- the old analyzer does not convert a constant grouping key to Nullable under `group_by_use_nulls`,
+-- so it produces a different type for the plain-String key.
+
 -- Tests that a LowCardinality GROUP BY key constant is correctly converted to
 -- LowCardinality(Nullable(...)) (not left unchanged) when `group_by_use_nulls` is enabled with
 -- GROUPING SETS / ROLLUP / CUBE. Previously the analyzer kept the constant key type as

--- a/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.sql
+++ b/tests/queries/0_stateless/04416_group_by_use_nulls_low_cardinality_constant.sql
@@ -1,0 +1,22 @@
+-- Tests that a LowCardinality GROUP BY key constant is correctly converted to
+-- LowCardinality(Nullable(...)) (not left unchanged) when `group_by_use_nulls` is enabled with
+-- GROUPING SETS / ROLLUP / CUBE. Previously the analyzer kept the constant key type as
+-- LowCardinality(String), while the runtime produced a LowCardinality(Nullable(String)) column,
+-- which led to a `Bad cast from type DB::ColumnNullable to DB::ColumnString` logical error
+-- (e.g. when an aggregate function like `minOrDefault` was resolved against the wrong type).
+-- https://github.com/ClickHouse/ClickHouse/issues/77485
+
+SET group_by_use_nulls = 1;
+
+-- The declared key type must be LowCardinality(Nullable(String)), matching the runtime column.
+SELECT toTypeName(x) FROM (SELECT toLowCardinality('1') AS x GROUP BY GROUPING SETS ((), (x)));
+
+-- Plain String keys were already correct; keep them as a regression guard.
+SELECT toTypeName(x) FROM (SELECT '1' AS x GROUP BY GROUPING SETS ((), (x)));
+
+-- Aggregating over such a key with -OrDefault / -OrNull must not produce a logical error.
+SELECT minOrDefault(*) FROM (SELECT toLowCardinality('1') GROUP BY GROUPING SETS ((), (1)));
+SELECT minOrNull(*) FROM (SELECT toLowCardinality('1') GROUP BY GROUPING SETS ((), (1)));
+
+-- The original fuzzer query that crashed.
+SELECT min(c0 >= (SELECT minOrDefault(*) FROM (SELECT DISTINCT toLowCardinality('1') GROUP BY GROUPING SETS ((), (1)) LIMIT 848))) FROM (SELECT 1 AS c0) AS t0;


### PR DESCRIPTION
When `group_by_use_nulls` is enabled together with `GROUPING SETS` / `ROLLUP` / `CUBE`, GROUP BY keys are converted to Nullable. For a constant key of `LowCardinality(T)` type, `ConstantNode::convertToNullable` used `makeNullableSafe`, which leaves the type unchanged because `LowCardinality` cannot be placed directly inside `Nullable` (`canBeInsideNullable` is false). The declared key type therefore stayed `LowCardinality(T)`, while the runtime (planner) correctly produced a `LowCardinality(Nullable(T))` column.

This type mismatch made an aggregate function such as `minOrDefault` resolve against the wrong argument type: its `SingleValueDataString` received a `ColumnNullable` instead of a `ColumnString` and aborted with the logical error `Bad cast from type DB::ColumnNullable to DB::ColumnString`. In release builds the column is read as garbage instead, producing a `TOO_LARGE_STRING_SIZE` exception or undefined behavior.

`ConstantNode::convertToNullable` now uses `makeNullableOrLowCardinalityNullableSafe`, consistent with `ColumnNode::convertToNullable`, `FunctionNode`, `AggregatingStep` and `RollupTransform`, so the constant key correctly becomes `LowCardinality(Nullable(T))` and stays consistent with the runtime column. This was the last remaining conversion site still using `makeNullableSafe` for this purpose.

Reproducer:

```sql
SELECT minOrDefault(*)
FROM (SELECT toLowCardinality('1') GROUP BY GROUPING SETS ((), (1)))
SETTINGS group_by_use_nulls = 1;
```

Found by the stress test (azure, amd_msan) on master.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7dda23a8ec1552f04de5601a1fe59708a5406ee1&name_0=MasterCI&name_1=Stress%20test%20%28azure%2C%20amd_msan%29

Related: https://github.com/ClickHouse/ClickHouse/issues/103426
Related: https://github.com/ClickHouse/ClickHouse/issues/77485

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a logical error (`Bad cast from type DB::ColumnNullable to DB::ColumnString`) and possible wrong results when using `group_by_use_nulls` with a `LowCardinality` constant grouping key in `GROUPING SETS`/`ROLLUP`/`CUBE`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.248` (included in `26.7` and later)
<!-- ch-version-info:end -->