### PR TITLE
Keep the version-info block out of changelog entries

### DIFF
--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -311,6 +311,17 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
         return None
 
     description = item.body
+    # Strip the auto-maintained version-info block (added by pr_version_info.py)
+    # so it can never leak into the changelog entry: when the entry is empty it
+    # is the first content after the header and would otherwise be parsed as the
+    # entry. The markers are HTML comments, invisible in the rendered body.
+    if description:
+        description = re.sub(
+            r"<!-- ch-version-info:start -->.*?<!-- ch-version-info:end -->",
+            "",
+            description,
+            flags=re.DOTALL,
+        )
     # Don't skip empty lines because they delimit parts of description
     lines = [x.strip() for x in (description.split("\n") if description else [])]
     lines = [re.sub(r"\s+", " ", ln) for ln in lines]

--- a/tests/ci/pr_version_info.py
+++ b/tests/ci/pr_version_info.py
@@ -151,7 +151,9 @@ def upsert_section(body: Optional[str], section_body: str) -> str:
     if body and not body.endswith("\n"):
         body += "\n"
     if body:
-        body += "\n"
+        # Two blank lines before the block to visually separate the version-info
+        # section from the preceding PR/issue description.
+        body += "\n\n"
     return body + block
 
 

--- a/tests/ci/test_pr_version_info.py
+++ b/tests/ci/test_pr_version_info.py
@@ -53,7 +53,8 @@ class TestUpsertSection(unittest.TestCase):
         body = "Original description."
         section = render_section("26.6.1.1", [])
         result = upsert_section(body, section)
-        self.assertTrue(result.startswith("Original description.\n\n"))
+        # Two blank lines separate the section from the preceding description.
+        self.assertTrue(result.startswith("Original description.\n\n\n"))
         self.assertIn(SECTION_START, result)
         self.assertIn(SECTION_END, result)
         self.assertIn("Merged into: `26.6.1.1`", result)


### PR DESCRIPTION
Keep the auto-maintained `### Version info` block (added to PR/issue bodies by `tests/ci/pr_version_info.py`) from leaking into generated changelog entries, and improve its visual separation.

**Background.** The changelog generator (`tests/ci/changelog.py:generate_description`) reads the entry from the PR body: it finds the `Changelog entry` header, skips at most one blank line, and takes all following non-empty lines until the next blank line. When a PR's changelog entry is empty, the version-info block — appended to the end of the body — becomes the first content after the header and gets parsed as the entry. This actually shipped, e.g. `docs/changelogs/v26.6.1.1193-stable.md` contains:

```
* <!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.214` (included in `26.7` and later)
<!-- ch-version-info:end -->. [#94937]...
```

**Two complementary changes:**

1. `tests/ci/changelog.py` — strip the `<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.214` (included in `26.7` and later)
<!-- ch-version-info:end -->` block from the PR body before parsing. The markers exist precisely so tools can find the block; this makes the entry leak-proof regardless of layout or blank-line counts.
2. `tests/ci/pr_version_info.py` — insert two blank lines before the block instead of one (in `upsert_section`, used for both PR and resolved-issue bodies). This separates the section more clearly in the rendered body, and — because the entry parser skips only one blank line — independently prevents the empty-entry leak. `tests/ci/test_pr_version_info.py` updated; suite passes (27 tests).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Not for changelog.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
