### PR TITLE
Fix partition pruning for LowCardinality(FixedString) key columns

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2031,23 +2031,32 @@ static bool applyDeterministicDagToColumn(
             return true;
         }
 
-        if (!target_type->isNullable() && !target_type->canBeInsideNullable())
+        /// `castColumnAccurateOrNull` needs a target that can represent NULLs so a lossy cast is
+        /// observable. `LowCardinality` is only an encoding and is not itself nullable-able, so run
+        /// the accuracy probe against the `LowCardinality`-stripped target; otherwise a key column of
+        /// type `LowCardinality(FixedString)` (and similar) is wrongly rejected here, which silently
+        /// disables partition/key pruning. The requested `target_type` is re-applied afterwards so the
+        /// transform DAG still receives the type it was built against.
+        const DataTypePtr probe_type = removeLowCardinality(target_type);
+
+        if (!probe_type->isNullable() && !probe_type->canBeInsideNullable())
         {
             /// We cannot apply castColumnAccurateOrNull() because it will throw exception
             return false;
         }
 
-        column = castColumnAccurateOrNull({column, type, ""}, target_type);
-        const auto & n = assert_cast<const ColumnNullable &>(*column);
+        ColumnPtr probe_column = castColumnAccurateOrNull({column, type, ""}, probe_type);
+        const auto & n = assert_cast<const ColumnNullable &>(*probe_column);
 
         /// If we have any NULLs after cast, that means cast could not be applied accurately for all values
         for (char8_t b : n.getNullMapData())
             if (b)
                 return false;
 
-        if (!target_type->isNullable())
-            column = n.getNestedColumnPtr();
-
+        /// No NULLs were introduced, so the cast is accurate for every value. Produce the requested
+        /// target_type (which may be LowCardinality and/or Nullable); the accurate cast cannot throw
+        /// here because the probe above already proved every value fits.
+        column = castColumnAccurate({column, type, ""}, target_type);
         type = target_type;
         return true;
     };

--- a/tests/queries/0_stateless/04401_low_cardinality_fixed_string_partition_pruning.reference
+++ b/tests/queries/0_stateless/04401_low_cardinality_fixed_string_partition_pruning.reference
@@ -1,0 +1,6 @@
+LowCardinality(FixedString) condition built	1
+FixedString condition built	1
+LowCardinality(String) condition built	1
+LowCardinality(Nullable(FixedString)) condition built	1
+correctness match	1
+correctness no-match	0

--- a/tests/queries/0_stateless/04401_low_cardinality_fixed_string_partition_pruning.sql
+++ b/tests/queries/0_stateless/04401_low_cardinality_fixed_string_partition_pruning.sql
@@ -1,0 +1,53 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/108776
+-- Partition pruning was silently disabled when a LowCardinality(FixedString) key column
+-- was wrapped in a function in the partition key (e.g. PARTITION BY sipHash64(k) % N) and the
+-- WHERE compared it against a String literal. Transforming the String constant into key space
+-- failed because the LowCardinality wrapper is not nullable-able, so the accuracy probe in
+-- applyDeterministicDagToColumn rejected the String -> LowCardinality(FixedString) cast and the
+-- partition condition degraded to "true" (scan all partitions). The test asserts the
+-- optimization is PRESERVED: a real partition condition is built and prunes. Correct-result
+-- checks alone cannot catch this regression.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- The fix must work for LowCardinality(FixedString) and LowCardinality(Nullable(FixedString)),
+-- and must NOT regress the shapes that already worked (plain FixedString, LowCardinality(String)).
+-- The String literal in WHERE is the trigger: with toFixedString(...) the constant is already
+-- FixedString and the broken cast path is never reached.
+
+DROP TABLE IF EXISTS t_lc_fs;
+CREATE TABLE t_lc_fs (k LowCardinality(FixedString(8))) ENGINE = MergeTree ORDER BY k PARTITION BY sipHash64(k) % 8;
+INSERT INTO t_lc_fs SELECT toFixedString(leftPad(toString(number), 8, '0'), 8) FROM numbers(200);
+SELECT 'LowCardinality(FixedString) condition built',
+       countIf(explain ILIKE '%moduloLegacy(sipHash64(k), 8)%') > 0 AS condition_built
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_lc_fs WHERE k = '00000001');
+
+DROP TABLE IF EXISTS t_fs;
+CREATE TABLE t_fs (k FixedString(8)) ENGINE = MergeTree ORDER BY k PARTITION BY sipHash64(k) % 8;
+INSERT INTO t_fs SELECT toFixedString(leftPad(toString(number), 8, '0'), 8) FROM numbers(200);
+SELECT 'FixedString condition built',
+       countIf(explain ILIKE '%moduloLegacy(sipHash64(k), 8)%') > 0 AS condition_built
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_fs WHERE k = '00000001');
+
+DROP TABLE IF EXISTS t_lc_s;
+CREATE TABLE t_lc_s (k LowCardinality(String)) ENGINE = MergeTree ORDER BY k PARTITION BY sipHash64(k) % 8;
+INSERT INTO t_lc_s SELECT leftPad(toString(number), 8, '0') FROM numbers(200);
+SELECT 'LowCardinality(String) condition built',
+       countIf(explain ILIKE '%moduloLegacy(sipHash64(k), 8)%') > 0 AS condition_built
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_lc_s WHERE k = '00000001');
+
+DROP TABLE IF EXISTS t_lc_n_fs;
+CREATE TABLE t_lc_n_fs (k LowCardinality(Nullable(FixedString(8)))) ENGINE = MergeTree ORDER BY k PARTITION BY sipHash64(k) % 8 SETTINGS allow_nullable_key = 1;
+INSERT INTO t_lc_n_fs SELECT toFixedString(leftPad(toString(number), 8, '0'), 8) FROM numbers(200);
+SELECT 'LowCardinality(Nullable(FixedString)) condition built',
+       countIf(explain ILIKE '%moduloLegacy(sipHash64(k), 8)%') > 0 AS condition_built
+FROM (EXPLAIN indexes = 1 SELECT count() FROM t_lc_n_fs WHERE k = '00000001');
+
+-- Results stay correct after pruning.
+SELECT 'correctness match', count() FROM t_lc_fs WHERE k = '00000001';
+SELECT 'correctness no-match', count() FROM t_lc_fs WHERE k = '99999999';
+
+DROP TABLE t_lc_fs;
+DROP TABLE t_fs;
+DROP TABLE t_lc_s;
+DROP TABLE t_lc_n_fs;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108776
Related: https://github.com/ClickHouse/ClickHouse/pull/97675
-->

Closes: #108776
Related: #97675 (bisected cause)


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed partition and primary key pruning being silently disabled when a `LowCardinality(FixedString)` (or `LowCardinality(Nullable(FixedString))`) key column is wrapped in a function in the key, for example `PARTITION BY sipHash64(k) % N` with `WHERE k = 'literal'`. Such queries scanned all partitions instead of pruning them.


### Description

Bisected to #97675.

Reported shape (from the issue):
```sql
CREATE TABLE t
(
    timestamp DateTime64(3),
    from LowCardinality(FixedString(42))
)
ENGINE = MergeTree
PARTITION BY (sipHash64(from) % 12, toYear(timestamp))
ORDER BY (from, timestamp);

-- WHERE from = '0x...01' scanned every partition instead of pruning.
```

Root cause is in `applyDeterministicDagToColumn` (`src/Storages/MergeTree/KeyCondition.cpp`). To transform the `WHERE` constant into key space, the `String` constant has to be cast to the key column type, which is the un-stripped `LowCardinality(FixedString(N))`. The safe cast fails (`String` to `FixedString` is not a safe cast), so the code falls back to an accurate-or-null probe (`castColumnAccurateOrNull`). That probe needs a target type that can hold `NULL` so a lossy cast is observable, but `LowCardinality` is not itself nullable-able (`canBeInsideNullable()` is false), so the cast was rejected, the transform failed, and the partition condition degraded to `true` (scan all partitions). `LowCardinality(String)` was unaffected only because `String` to `LowCardinality(String)` is a safe cast and short-circuits before this branch.

`LowCardinality` is only an encoding and must be transparent to the null-accuracy probe. The fix runs the probe against the `LowCardinality`-stripped target (which is nullable-able), and if accurate, produces the requested `target_type` so the transform DAG still receives the type it was built against. This keeps the #97675 fix intact (its regression test `03402_has_low_cardinality_key_condition` still passes) and also fixes `LowCardinality(Nullable(FixedString))`.

The added test `04401_low_cardinality_fixed_string_partition_pruning` asserts the partition condition `moduloLegacy(sipHash64(k), 8)` is built (the optimization is preserved) across `LowCardinality(FixedString)`, `FixedString`, `LowCardinality(String)`, and `LowCardinality(Nullable(FixedString))`. It fails on the unfixed binary for the two `LowCardinality(FixedString)` shapes and passes with the fix. A correct-result check alone cannot catch this regression because results stay correct when pruning is disabled.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.229` (included in `26.7` and later)
- Backported to: `26.6.2.13`, `26.5.5.5`, `26.4.5.83`, `26.3.17.6`
<!-- ch-version-info:end -->