### PR TITLE
Allowlist `Cannot parse string 'x' as UInt64` upgrade-check errors from `04338`

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -327,6 +327,7 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       `CANNOT_PARSE_TEXT` errors come from:
 #       - 00834_kill_mutation{,_replicated_zookeeper}: `DELETE WHERE toUInt32(s) = 1` on String data ('a', 'b')
 #       - 01414_mutations_and_errors_zookeeper: `MODIFY COLUMN value UInt64` on String data ('Hello')
+#       - 04338_on_fly_mutation_read_overwritten_lc_source: `MODIFY COLUMN v UInt64` on String data ('x')
 #       `MutateFromLogEntryTask` is also excluded for the same reason, but only catches the first log line;
 #       the wrapping `MergeTreeBackgroundExecutor` line also needs to be excluded.
 # `NO_SUCH_INTERSERVER_IO_ENDPOINT` is expected during upgrades because replicated tables try to fetch parts
@@ -426,6 +427,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "is lost forever." \
            -e "Unknown index: idx." \
            -e "Cannot parse string 'Hello' as UInt64" \
+           -e "Cannot parse string 'x' as UInt64" \
            -e "Cannot parse string 'Hello' as UInt32" \
            -e "Cannot parse string \'Hello\' as UInt32" \
            -e "Cannot parse string \\'Hello\\' as UInt32" \


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/39174
Related: https://github.com/ClickHouse/ClickHouse/pull/108011

## Description / motivation

The stateless test `04338_on_fly_mutation_read_overwritten_lc_source` (table
`t_overwrite_before_consume`) chains the async mutations `UPDATE v = toString(id + 100)`,
`UPDATE b = isNotNull(materialize(v))` and `MODIFY COLUMN v UInt64` over a column whose
on-disk value is the unconvertible String `'x'`. This is an intentionally-broken mutation
of exactly the class already documented in the `CANNOT_PARSE_TEXT` allowlist (issue #39174):
a `MODIFY COLUMN ... UInt64` on un-parseable String data, just like the already-allowlisted
`'Hello'`/`'a'`/`'b'` variants from `00834_kill_mutation` and `01414_mutations_and_errors_zookeeper`.

After the upgrade restart the broken mutation is retried and logs
`Cannot parse string 'x' as UInt64: syntax error at begin of string` (`CANNOT_PARSE_TEXT`)
to `clickhouse-server.upgrade.log`, which fails the `Upgrade check` with
`Error message in clickhouse-server.log (see upgrade_error_messages.txt)`. This is not a
backward-incompatibility or a regression; it is the expected test-induced error.

This change adds the narrow `'x'` message to the upgrade-check allowlist and documents
`04338` in the comment block. The failure is not caused by any product change — it surfaces
on any pull request that runs the Upgrade check (observed on PR #108011 and the unrelated
PR #107433).

Example failing run (Upgrade check (amd_release) on PR #108011):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108011&sha=5542272b83f723c3e98d32aa069be94c71cb8cbc&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.221` (included in `26.7` and later)
<!-- ch-version-info:end -->