### PR TITLE
Fix server abort on cancelled INSERT through Alias table

### DIFF
--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -15,6 +15,7 @@
 #include <Core/Settings.h>
 #include <Access/Common/AccessFlags.h>
 #include <Common/assert_cast.h>
+#include <Common/Exception.h>
 
 
 namespace DB
@@ -81,6 +82,24 @@ public:
         , non_materialized_header(metadata_snapshot_->getSampleBlockNonMaterialized())
         , async_insert(async_insert_)
     {
+    }
+
+    ~AliasSink() override
+    {
+        /// On cancellation without an exception (e.g. timeout_overflow_mode='break') neither
+        /// onFinish() nor onException() runs, leaving the nested executor started but unfinished.
+        /// Cancel it so ~PushingPipelineExecutor's finished-or-unwinding invariant holds.
+        if (executor)
+        {
+            try
+            {
+                executor->cancel();
+            }
+            catch (...)
+            {
+                tryLogCurrentException("AliasSink");
+            }
+        }
     }
 
     String getName() const override { return "AliasSink"; }

--- a/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.reference
+++ b/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.reference
@@ -1,0 +1,1 @@
+survived

--- a/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.sh
+++ b/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Inserting through an Alias table runs a nested INSERT pipeline inside AliasSink.
+# When the outer query is cancelled without an exception (timeout_overflow_mode='break'),
+# AliasSink must finalize that nested executor; otherwise ~PushingPipelineExecutor aborts
+# with the assertion 'finished || std::uncaught_exceptions() || std::current_exception()'.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "
+    SET allow_experimental_alias_table_engine = 1;
+    CREATE TABLE alias_cancel_target (x UInt64) ENGINE = MergeTree ORDER BY x;
+    CREATE TABLE alias_cancel ENGINE = Alias('alias_cancel_target');
+"
+
+# The SELECT is throttled with sleepEachRow so the 0.3s execution timeout reliably fires
+# while the nested AliasSink insert pipeline is still running. timeout_overflow_mode='break'
+# cancels the pipeline without raising an exception. Before the fix this crashed the server.
+${CLICKHOUSE_CLIENT} --query "
+    INSERT INTO alias_cancel
+        SELECT number FROM numbers(100) WHERE sleepEachRow(0.05) = 0
+        SETTINGS max_execution_time = 0.3, timeout_overflow_mode = 'break', max_block_size = 1;
+" 2>&1 | grep -vF 'survived' ||:
+
+# The server is still alive: a follow-up query succeeds.
+${CLICKHOUSE_CLIENT} --query "SELECT 'survived'"
+
+${CLICKHOUSE_CLIENT} --query "
+    DROP TABLE alias_cancel;
+    DROP TABLE alias_cancel_target;
+"

--- a/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.sh
+++ b/tests/queries/0_stateless/04416_storage_alias_insert_cancel_no_crash.sh
@@ -10,7 +10,6 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 ${CLICKHOUSE_CLIENT} --query "
-    SET allow_experimental_alias_table_engine = 1;
     CREATE TABLE alias_cancel_target (x UInt64) ENGINE = MergeTree ORDER BY x;
     CREATE TABLE alias_cancel ENGINE = Alias('alias_cancel_target');
 "


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/57097
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server abort (`LOGICAL_ERROR` / assertion in debug and sanitizer builds) when an `INSERT ... SELECT` through an `Alias` table is cancelled without an exception, for example with `timeout_overflow_mode = 'break'`.

### Description

Found by the BuzzHouse fuzzer (STID 2508-3db8) on `BuzzHouse (amd_tsan)`. CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94517&sha=3c12bcb37db2a61b84abfc2f03b6ed5ffdd97f29&name_0=PR&name_1=BuzzHouse%20%28amd_tsan%29

`AliasSink` runs a nested INSERT pipeline into the target table via a `PushingPipelineExecutor`. It finalized that executor only in `onFinish()` (normal completion, calls `executor->finish()`) and `onException()` (exception path, calls `executor->cancel()`). When the outer pipeline is cancelled WITHOUT an exception (`timeout_overflow_mode = 'break'`, early `LIMIT`, sibling-processor teardown), `IProcessor::cancel()` only invokes `onCancel()`, which `AliasSink` did not override, so neither hook ran. The implicit `~AliasSink` then destroyed the started-but-unfinished executor with no in-flight exception, tripping the `~PushingPipelineExecutor` invariant:

```
Logical error: 'finished || std::uncaught_exceptions() || std::current_exception()'.
2. DB::PushingPipelineExecutor::~PushingPipelineExecutor()  PushingPipelineExecutor.cpp:68
3. ~AliasSink()
```

The fix adds a `~AliasSink` destructor that cancels the executor, mirroring the sibling transforms that own the same `PushingPipelineExecutor` and release it on every teardown path (`CreatingSetsTransform::~CreatingSetsTransform`, `MaterializingCTETransform`). `PushingPipelineExecutor::cancel()` sets `finished = true`, so the destructor invariant holds; `cancel` (not `finish`) is the correct semantics on abort, matching the existing `onException()` path. This is the same cancellation-without-exception class as the previously fixed issue #57097.

Deterministic reproducer (debug build):

```sql
CREATE TABLE target (x UInt64) ENGINE = MergeTree ORDER BY x;
CREATE TABLE al ENGINE = Alias('target');
INSERT INTO al SELECT number FROM numbers(100000000)
    SETTINGS max_execution_time = 0.1, timeout_overflow_mode = 'break';
```

Aborts before the fix, returns cleanly after. Regression test: `04416_storage_alias_insert_cancel_no_crash`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.258` (included in `26.7` and later)
<!-- ch-version-info:end -->