### PR TITLE
Fix flaky test_startup_without_zookeeper: retry the recursive ZooKeeper delete

### DIFF
--- a/tests/integration/test_replication_without_zookeeper/test.py
+++ b/tests/integration/test_replication_without_zookeeper/test.py
@@ -49,7 +49,7 @@ def test_startup_without_zookeeper(start_cluster):
         == "0\n"
     )
 
-    cluster.run_kazoo_commands_with_retries(drop_zk)
+    cluster.run_kazoo_commands_with_retries(drop_zk, repeats=5)
 
     time.sleep(5)
     assert node1.query("SELECT COUNT(*) from test_table") == "3\n"


### PR DESCRIPTION
Fixes a flaky integration test.

`test_replication_without_zookeeper/test.py::test_startup_without_zookeeper` intermittently fails with `kazoo.exceptions.NotEmptyError` while executing `zk.delete(path="/clickhouse", recursive=True)` in `drop_zk`.

The recursive delete runs while ClickHouse (`node1`) is still alive, so its `ReplicatedMergeTree` background threads keep re-creating ZooKeeper nodes under `/clickhouse`. kazoo's recursive delete races with that: between `get_children` and `delete` a new child node can appear, and kazoo raises `NotEmptyError` without retrying.

The test already called `cluster.run_kazoo_commands_with_retries`, but with the default `repeats=1`. In that helper the retry loop is `for i in range(repeats - 1)`, so `repeats=1` performs zero retries — the callback runs exactly once with no exception handling. Pass `repeats=5` (matching the existing usages in `helpers/cluster.py`) so the drop is retried on the transient `NotEmptyError`.

This is a pre-existing flaky test, not a regression — the same `NotEmptyError` in `drop_zk` has been observed on unrelated pull requests.

Related: https://github.com/ClickHouse/ClickHouse/pull/103540
Related: https://github.com/ClickHouse/ClickHouse/pull/101757

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d40ea5d0da4103b54971ac01a9960ef9153242bb&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%203%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.240` (included in `26.7` and later)
<!-- ch-version-info:end -->