### PR TITLE
Fix server abort on cancelled INSERT into TimeSeries table

### DIFF
--- a/src/Storages/TimeSeries/TimeSeriesSink.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSink.cpp
@@ -359,7 +359,23 @@ void TimeSeriesSink::TargetPipeline::push(Block block) const
     executor->push(std::move(block));
 }
 
-TimeSeriesSink::TargetPipeline::~TargetPipeline() = default;
+TimeSeriesSink::TargetPipeline::~TargetPipeline()
+{
+    /// On cancellation without an exception (e.g. `timeout_overflow_mode='break'`) neither
+    /// `onFinish` nor `onException` runs, leaving the executor started but unfinished.
+    /// Cancel it so `~PushingPipelineExecutor`'s finished-or-unwinding invariant holds.
+    if (executor)
+    {
+        try
+        {
+            executor->cancel();
+        }
+        catch (...)
+        {
+            tryLogCurrentException("TimeSeriesSink");
+        }
+    }
+}
 
 
 ColumnPtr TimeSeriesSink::calculateId(const Block & tags_block) const

--- a/tests/queries/0_stateless/04416_timeseries_insert_cancel_no_crash.reference
+++ b/tests/queries/0_stateless/04416_timeseries_insert_cancel_no_crash.reference
@@ -1,0 +1,1 @@
+survived

--- a/tests/queries/0_stateless/04416_timeseries_insert_cancel_no_crash.sh
+++ b/tests/queries/0_stateless/04416_timeseries_insert_cancel_no_crash.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Inserting into a TimeSeries table runs nested INSERT pipelines inside `TimeSeriesSink`.
+# When the outer query is cancelled without an exception (`timeout_overflow_mode='break'`),
+# `TimeSeriesSink` must finalize those nested executors; otherwise `~PushingPipelineExecutor`
+# aborts with `finished || std::uncaught_exceptions() || std::current_exception()`.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "
+    SET allow_experimental_time_series_table = 1;
+    CREATE TABLE ts_cancel ENGINE = TimeSeries;
+"
+
+# The SELECT is throttled with `sleepEachRow` so the 0.3s execution timeout reliably fires
+# while the nested `TimeSeriesSink` insert pipelines are still running. `timeout_overflow_mode='break'`
+# cancels the pipeline without raising an exception. Before the fix this aborted the server.
+${CLICKHOUSE_CLIENT} --query "
+    INSERT INTO ts_cancel (metric_name, tags, time_series)
+        SELECT
+            'cpu' || toString(number) AS metric_name,
+            map('n', toString(number)) AS tags,
+            [(toDateTime64(number, 3), toFloat64(number))] AS time_series
+        FROM numbers(100) WHERE sleepEachRow(0.05) = 0
+        SETTINGS max_execution_time = 0.3, timeout_overflow_mode = 'break', max_block_size = 1;
+" 2>&1 | grep -vF 'survived' ||:
+
+# The server is still alive: a follow-up query succeeds.
+${CLICKHOUSE_CLIENT} --query "SELECT 'survived'"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ts_cancel;"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108783
Related: https://github.com/ClickHouse/ClickHouse/issues/57097

### Problem

Inserting into a `TimeSeries` table runs nested INSERT pipelines inside `TimeSeriesSink`. When the outer query is cancelled without an exception — for example with `timeout_overflow_mode = 'break'`, an early `LIMIT`, or sibling-processor teardown — the server aborts in debug and sanitizer builds:

```
Logical error: 'finished || std::uncaught_exceptions() || std::current_exception()'.
2. DB::PushingPipelineExecutor::~PushingPipelineExecutor()  PushingPipelineExecutor.cpp:68
3. DB::TimeSeriesSink::TargetPipeline::~TargetPipeline()    TimeSeriesSink.cpp:362
4. DB::TimeSeriesSink::~TimeSeriesSink()
... Received signal Aborted (6)
```

This is the same cancellation-without-exception class as `AliasSink` (fixed in #108783) and issue #57097, found while explaining that PR.

### Root cause

`TimeSeriesSink` owns up to three `TargetPipeline` structs, each holding a `PushingPipelineExecutor` created and immediately started in `createTargetPipeline`. The sink finalized those executors only in `onFinish` (`executor->finish()`); it did not override `onException` or `onCancel`, and `~TargetPipeline` was `= default`. On a no-exception cancel, the graph is cancelled via `PipelineExecutor::cancel(CancelledByTimeout)` → `graph->cancel`, and `IProcessor::cancel` only invokes the default no-op `onCancel`, so neither `onFinish` nor `onException` runs. The defaulted destructor then destroyed a started-but-unfinished executor with no in-flight exception, tripping `~PushingPipelineExecutor`'s `finished || std::uncaught_exceptions() || std::current_exception()` invariant. The exception path was already safe because `std::uncaught_exceptions()` holds during unwinding; only the no-exception cancel path was broken.

### Fix

Give `TargetPipeline` a destructor that cancels the executor, mirroring `AliasSink::~AliasSink` (#108783), `CreatingSetsTransform`, and `MaterializingCTETransform`. `PushingPipelineExecutor::cancel` sets `finished = true`, satisfying the destructor invariant; on the normal path `onFinish` already finished the executor, so the destructor's `cancel` is a no-op. Regression test `04416_timeseries_insert_cancel_no_crash` exercises the `timeout_overflow_mode = 'break'` path and asserts the server survives; it reproduces the abort on the unfixed binary and passes after the fix (verified locally in a debug build).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server abort (`LOGICAL_ERROR` / assertion in debug and sanitizer builds) when an `INSERT ... SELECT` into a `TimeSeries` table is cancelled without an exception, for example with `timeout_overflow_mode = 'break'`.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.277` (included in `26.7` and later)
<!-- ch-version-info:end -->