### PR TITLE
Add a Map branch to recursiveLowCardinalityTypeConversion

### DIFF
--- a/src/DataTypes/DataTypeLowCardinalityHelpers.cpp
+++ b/src/DataTypes/DataTypeLowCardinalityHelpers.cpp
@@ -273,6 +273,29 @@ ColumnPtr recursiveLowCardinalityTypeConversion(const ColumnPtr & column, const 
         }
     }
 
+    if (const auto * from_map_type = typeid_cast<const DataTypeMap *>(from_type.get()))
+    {
+        if (const auto * to_map_type = typeid_cast<const DataTypeMap *>(to_type.get()))
+        {
+            const auto * column_map = typeid_cast<const ColumnMap *>(column.get());
+            if (!column_map)
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Unexpected column {} for type {}", column->getName(), from_type->getName());
+
+            /// A Map is stored as Array(Tuple(key, value)); delegate to that nested
+            /// representation so the Array/Tuple/LowCardinality branches above rebuild
+            /// the key and value types (recursing through nested Maps as well).
+            const auto & nested_from = from_map_type->getNestedType();
+            const auto & nested_to = to_map_type->getNestedType();
+
+            auto nested_result = recursiveLowCardinalityTypeConversion(column_map->getNestedColumnPtr(), nested_from, nested_to);
+
+            if (nested_result.get() == column_map->getNestedColumnPtr().get())
+                return column;
+
+            return ColumnMap::create(nested_result);
+        }
+    }
+
     throw Exception(ErrorCodes::TYPE_MISMATCH, "Cannot convert: {} to {}", from_type->getName(), to_type->getName());
 }
 

--- a/tests/queries/0_stateless/04402_map_functions_lowcardinality.reference
+++ b/tests/queries/0_stateless/04402_map_functions_lowcardinality.reference
@@ -21,6 +21,22 @@ UInt8
 UInt8
 -- plain Map (no LowCardinality) is unaffected
 Map(String, String)
+-- issue #108439: functions returning a Map must rebuild a nested Map value type
+Map(LowCardinality(String), Map(LowCardinality(String), String))
+{'a':{'x':'y'}}
+Map(LowCardinality(String), Map(LowCardinality(String), String))
+{'a':{'z':'w'},'b':{'x':'y'}}
+Map(LowCardinality(String), Map(LowCardinality(String), String))
+Map(LowCardinality(String), Map(LowCardinality(String), String))
+Map(LowCardinality(String), Map(LowCardinality(String), String))
+{'a':{'x':'y'}}
+-- nested Map inside Array / Tuple value
+Map(LowCardinality(String), Array(Map(LowCardinality(String), String)))
+{'a':[{'x':'y'}]}
+Map(LowCardinality(String), Tuple(Map(LowCardinality(String), String)))
+{'a':({'x':'y'})}
+-- nested Map with LowCardinality only in the inner value
+Map(String, Map(String, LowCardinality(String)))
 -- the reproducer from the issue: CREATE TABLE AS keeps the column type and passes CHECK
 attributes_map	Map(LowCardinality(String), String)
 key	String

--- a/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
+++ b/tests/queries/0_stateless/04402_map_functions_lowcardinality.sql
@@ -32,6 +32,25 @@ SELECT toTypeName(mapExists((k, v) -> 1, map('a'::LowCardinality(String), 'x')))
 SELECT '-- plain Map (no LowCardinality) is unaffected';
 SELECT toTypeName(mapFilter((k, v) -> 1, map('a', 'x')));
 
+SELECT '-- issue #108439: functions returning a Map must rebuild a nested Map value type';
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y'))));
+SELECT mapFilter((k, v) -> 1, map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y')));
+SELECT toTypeName(mapSort((k, v) -> k, map('b'::LowCardinality(String), map('x'::LowCardinality(String), 'y'), 'a'::LowCardinality(String), map('z'::LowCardinality(String), 'w'))));
+SELECT mapSort((k, v) -> k, map('b'::LowCardinality(String), map('x'::LowCardinality(String), 'y'), 'a'::LowCardinality(String), map('z'::LowCardinality(String), 'w')));
+SELECT toTypeName(mapReverseSort(map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y'))));
+SELECT toTypeName(mapPartialSort((k, v) -> k, 1, map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y'))));
+SELECT toTypeName(mapConcat(map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y'))));
+SELECT mapConcat(map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y')));
+
+SELECT '-- nested Map inside Array / Tuple value';
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a'::LowCardinality(String), [map('x'::LowCardinality(String), 'y')])));
+SELECT mapFilter((k, v) -> 1, map('a'::LowCardinality(String), [map('x'::LowCardinality(String), 'y')]));
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a'::LowCardinality(String), tuple(map('x'::LowCardinality(String), 'y')))));
+SELECT mapFilter((k, v) -> 1, map('a'::LowCardinality(String), tuple(map('x'::LowCardinality(String), 'y'))));
+
+SELECT '-- nested Map with LowCardinality only in the inner value';
+SELECT toTypeName(mapFilter((k, v) -> 1, map('a', map('x', 'y'::LowCardinality(String)))));
+
 SELECT '-- the reproducer from the issue: CREATE TABLE AS keeps the column type and passes CHECK';
 DROP TABLE IF EXISTS t_map_lc_src;
 DROP TABLE IF EXISTS t_map_lc_dst;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/108439
-->

Closes: #108439

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `TYPE_MISMATCH` in `mapFilter`, `mapSort`, `mapReverseSort`, `mapPartialSort` and `mapConcat` when a `Map` value contains a nested `Map` with `LowCardinality`, e.g. `mapFilter((k, v) -> 1, map('a'::LowCardinality(String), map('x'::LowCardinality(String), 'y')))`.

### Description

`recursiveRemoveLowCardinality` recurses through `Map` (stripping inner `LowCardinality` from both key and value), but its inverse `recursiveLowCardinalityTypeConversion` had no `Map` branch, so a `Map`-typed column fell through to the final `throw Exception(TYPE_MISMATCH, ...)`.

The map functions that preserve `LowCardinality` strip it with `recursiveRemoveLowCardinality`, run the array implementation on full columns, then restore the declared `LowCardinality` types with `recursiveLowCardinalityTypeConversion` (`FunctionMapToArrayAdapter::executeImpl`). For a nested `Map` value the restore step threw `Cannot convert: Map(String, String) to Map(LowCardinality(String), String)`. Regression from #108057.

Fix: add the symmetric `Map` branch. A `Map` is stored as `Array(Tuple(key, value))`, so it delegates to that nested representation, reusing the existing `Array`/`Tuple`/`LowCardinality` branches to rebuild the key and value types and recurse through nested `Map`s, `Array`s and `Tuple`s. The same gap affected every other caller of the helper (`NativeReader`, `FunctionsJSON`, `AggregatingSortedAlgorithm`, `SummingSortedAlgorithm`, `TTLAggregationAlgorithm`), all fixed by this change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.260` (included in `26.7` and later)
<!-- ch-version-info:end -->