### PR TITLE
Fix `insert_quorum = 'auto'` skipping the live replicas precondition …

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -246,6 +246,13 @@ size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(const ZooKeeperWithFault
             }
 
             replicas_number = replicas.size();
+
+            /// `getQuorumSize()` derives the majority quorum from `quorum_replicas_num`, but that member is
+            /// only assigned from the return value of this function (see `onStart()`), so it is still 0 here.
+            /// Populate it from the freshly read replica count first; otherwise the majority size collapses to
+            /// `0 / 2 + 1 == 1` and the live-replicas check below is silently skipped for `insert_quorum = 'auto'`.
+            quorum_replicas_num = replicas_number;
+
             size_t quorum_size = getQuorumSize();
 
             if (active_replicas < quorum_size)


### PR DESCRIPTION
# Issue

`ReplicatedMergeTreeSink::checkQuorumPrecondition` validates the live replica count against the required quorum using `getQuorumSize()`.

For majority quorum (`insert_quorum = 'auto'`, `required_quorum_size` unset), `getQuorumSize()` computes:

```cpp
quorum_replicas_num / 2 + 1
```

However, `quorum_replicas_num` is only assigned from the return value of `checkQuorumPrecondition()` in `onStart()`. During the precondition check itself, it still contains its default value of `0`.

As a result, the majority quorum size becomes:

```text
0 / 2 + 1 == 1
```

Since `active_replicas` is initialized to `1` (the local replica counts itself), the condition

```cpp
active_replicas < quorum_size
```

can never evaluate to true. Consequently, the "too few live replicas" precondition is silently bypassed for `insert_quorum = 'auto'`.

This regression was introduced by commit `7dfe727452a` ("quorum with async inserts"), which replaced:

```cpp
getQuorumSize(replicas_number)
```

with:

```cpp
getQuorumSize()
```

where the latter reads the not-yet-initialized member instead of using the freshly computed replica count.

Affected release: **v26.2**

---

# Impact

When `insert_quorum = 'auto'` and fewer than a majority of replicas are alive, inserts no longer fail fast with `TOO_FEW_LIVE_REPLICAS`.

Instead, the following sequence occurs:

1. The part is written and committed locally.
2. A quorum/status node is created.
3. The insert blocks until `insert_quorum_timeout`.
4. The operation eventually fails with `UNKNOWN_STATUS_OF_INSERT`.

This leaves the locally committed part in an unsatisfied quorum state. Additionally, the lingering quorum/status node causes the next non-parallel quorum insert to fail with:

```text
UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE
```

Only `insert_quorum = 'auto'` is affected.

Numeric quorum (`insert_quorum = N`) continues to work correctly because it uses `required_quorum_size` instead of `quorum_replicas_num`.

---

# Fix

Initialize `quorum_replicas_num` from the freshly computed replica count before calling `getQuorumSize()` inside `checkQuorumPrecondition()`.

```cpp
replicas_number = replicas.size();
quorum_replicas_num = replicas_number;   // getQuorumSize() reads this; otherwise it is still 0
size_t quorum_size = getQuorumSize();
```

This restores the original majority quorum calculation:

```text
replicas_number / 2 + 1
```

while keeping all quorum size logic centralized inside `getQuorumSize()`.

---

# Post-fix Impact

With this change, `insert_quorum = 'auto'` once again fails immediately with `TOO_FEW_LIVE_REPLICAS` whenever a majority of replicas is unavailable.

The failure now occurs **before**:

* writing any local part,
* committing the insert,
* creating any quorum/status node,

matching both:

* the behavior prior to the regression, and
* the behavior of numeric `insert_quorum = N`.

There is no behavior change for:

* numeric quorum (`insert_quorum = N`),
* disabled quorum (the function returns early before the new assignment executes),
* other `getQuorumSize()` call sites (they execute after `onStart()`, where `quorum_replicas_num` has already been initialized).

---

# Changelog Category

**Bug Fix** (user-visible misbehavior in an official stable release)

---

# Changelog Entry

Fixed `insert_quorum = 'auto'` not rejecting inserts up front when fewer than a majority of replicas were alive. Such inserts now fail immediately with `TOO_FEW_LIVE_REPLICAS` instead of writing a local part and later timing out with `UNKNOWN_STATUS_OF_INSERT`.
