### PR TITLE
Fix quorum precondition for insert_quorum = 'auto'

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -250,6 +250,7 @@ size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(const ZooKeeperWithFault
             /// `getQuorumSize()` reads `quorum_replicas_num`, which is still uninitialized here
             /// (it is normally assigned from this function's return value in `onStart()`). Populate
             /// it first so majority quorum is computed from the current replica count instead of 0
+            
             quorum_replicas_num = replicas_number;
             size_t quorum_size = getQuorumSize();
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -250,7 +250,6 @@ size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(const ZooKeeperWithFault
             /// `getQuorumSize()` reads `quorum_replicas_num`, which is still uninitialized here
             /// (it is normally assigned from this function's return value in `onStart()`). Populate
             /// it first so majority quorum is computed from the current replica count instead of 0
-            
             quorum_replicas_num = replicas_number;
             size_t quorum_size = getQuorumSize();
 

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -246,12 +246,7 @@ size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(const ZooKeeperWithFault
             }
 
             replicas_number = replicas.size();
-
-            /// `getQuorumSize()` reads `quorum_replicas_num`, which is still uninitialized here
-            /// (it is normally assigned from this function's return value in `onStart()`). Populate
-            /// it first so majority quorum is computed from the current replica count instead of 0
-            quorum_replicas_num = replicas_number;
-            size_t quorum_size = getQuorumSize();
+            size_t quorum_size = getQuorumSize(replicas_number);
 
             if (active_replicas < quorum_size)
             {
@@ -805,7 +800,7 @@ std::vector<DeduplicationHash> ReplicatedMergeTreeSink::commitPart(
         {
             ReplicatedMergeTreeQuorumEntry quorum_entry;
             quorum_entry.part_name = part->name;
-            quorum_entry.required_number_of_replicas = getQuorumSize();
+            quorum_entry.required_number_of_replicas = getQuorumSize(total_replicas_count);
             quorum_entry.replicas.insert(storage.replica_name);
 
             /** At this point, this node will contain information that the current replica received a part.
@@ -862,7 +857,7 @@ std::vector<DeduplicationHash> ReplicatedMergeTreeSink::commitPart(
         log_entry.source_replica = storage.replica_name;
         log_entry.new_part_name = part->name;
         /// TODO maybe add UUID here as well?
-        log_entry.quorum = getQuorumSize();
+        log_entry.quorum = getQuorumSize(total_replicas_count);
         log_entry.new_part_format = part->getFormat();
 
         if (!is_async_insert && !deduplication_hashes.empty() && deduplicate)
@@ -1251,7 +1246,7 @@ void ReplicatedMergeTreeSink::onStart()
     * And also check that during the insertion, the replica was not reinitialized or disabled (by the value of `is_active` node).
     * TODO Too complex logic, you can do better.
     */
-    quorum_replicas_num = checkQuorumPrecondition(zookeeper);
+    total_replicas_count = checkQuorumPrecondition(zookeeper);
 }
 
 void ReplicatedMergeTreeSink::onFinish()
@@ -1359,10 +1354,10 @@ String ReplicatedMergeTreeSink::quorumLogMessage() const
 {
     if (!isQuorumEnabled())
         return "";
-    return fmt::format(" (quorum {} of {} replicas)", getQuorumSize(), quorum_replicas_num);
+    return fmt::format(" (quorum {} of {} replicas)", getQuorumSize(total_replicas_count), total_replicas_count);
 }
 
-size_t ReplicatedMergeTreeSink::getQuorumSize() const
+size_t ReplicatedMergeTreeSink::getQuorumSize(size_t total_replicas) const
 {
     if (!isQuorumEnabled())
         return 0;
@@ -1370,7 +1365,7 @@ size_t ReplicatedMergeTreeSink::getQuorumSize() const
     if (required_quorum_size)
         return required_quorum_size.value();
 
-    return quorum_replicas_num / 2 + 1;
+    return total_replicas / 2 + 1;
 }
 
 bool ReplicatedMergeTreeSink::isQuorumEnabled() const

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -246,6 +246,11 @@ size_t ReplicatedMergeTreeSink::checkQuorumPrecondition(const ZooKeeperWithFault
             }
 
             replicas_number = replicas.size();
+
+            /// `getQuorumSize()` reads `quorum_replicas_num`, which is still uninitialized here
+            /// (it is normally assigned from this function's return value in `onStart()`). Populate
+            /// it first so majority quorum is computed from the current replica count instead of 0
+            quorum_replicas_num = replicas_number;
             size_t quorum_size = getQuorumSize();
 
             if (active_replicas < quorum_size)

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.h
@@ -111,7 +111,7 @@ protected:
     /// Returns total number of replicas.
     size_t checkQuorumPrecondition(const ZooKeeperWithFaultInjectionPtr & zookeeper);
 
-    size_t getQuorumSize() const;
+    size_t getQuorumSize(size_t total_replicas) const;
     bool isQuorumEnabled() const;
     String quorumLogMessage() const; /// Used in logs for debug purposes
     void resolveQuorum(const ZooKeeperWithFaultInjectionPtr & zookeeper, std::string actual_part_name);
@@ -132,10 +132,12 @@ protected:
     };
 
     QuorumInfo quorum_info;
-    /// std::nullopt means use majority quorum.
-    /// 0 or 1 means no quorum, larger than 1 means quorum size.
+    /// The configured quorum requirement (from the `insert_quorum` setting):
+    /// std::nullopt means majority quorum, 0 or 1 means no quorum, larger than 1 means a fixed quorum size.
     std::optional<size_t> required_quorum_size;
-    size_t quorum_replicas_num = 0;
+    /// The total number of replicas the table has, discovered at insert time in `checkQuorumPrecondition`.
+    /// Only the majority-quorum calculation in `getQuorumSize` needs it; it is 0 until then.
+    size_t total_replicas_count = 0;
     size_t quorum_timeout_ms;
     size_t max_parts_per_block;
 

--- a/tests/integration/test_quorum_inserts/test.py
+++ b/tests/integration/test_quorum_inserts/test.py
@@ -384,6 +384,78 @@ def test_insert_quorum_with_ttl(started_cluster):
     zero.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER cluster")
 
 
+def test_auto_quorum_rejects_when_too_few_live_replicas(started_cluster):
+    # Regression test for insert_quorum = 'auto': the majority quorum size must be
+    # computed from the actual replica count (replicas_number / 2 + 1), not from a
+    # not-yet-initialized member that used to leave it at 0 (giving 0 / 2 + 1 == 1,
+    # which active_replicas == 1 can never undercut, silently bypassing the check).
+    table_name = "test_auto_quorum_too_few_live_replicas_" + uuid.uuid4().hex
+    create_query = (
+        f"CREATE TABLE {table_name} "
+        "(a Int8, d Date) "
+        "Engine = ReplicatedMergeTree('/clickhouse/tables/{shard}/{table}', '{replica}') "
+        "PARTITION BY d ORDER BY a"
+    )
+
+    # Two registered replicas -> majority quorum size is 2 / 2 + 1 == 2.
+    zero.query(create_query)
+    first.query(create_query)
+
+    # Make the second replica inactive while it stays registered, so only one of the
+    # two replicas is alive. Detaching removes its /is_active node but keeps it in /replicas.
+    first.query(f"DETACH TABLE {table_name}")
+
+    is_active_path = f"/clickhouse/tables/0/{table_name}/replicas/first"
+    for _ in range(120):
+        if (
+            zero.query(
+                f"SELECT count() FROM system.zookeeper "
+                f"WHERE path = '{is_active_path}' AND name = 'is_active'"
+            ).strip()
+            == "0"
+        ):
+            break
+        time.sleep(1)
+    else:
+        raise Exception("Replica 'first' did not become inactive")
+
+    # With only one of two replicas alive, an 'auto' (majority) quorum insert must fail
+    # up front, before writing any local part. A short timeout makes sure that, if the
+    # regression were present, we would observe a quorum timeout instead of this error.
+    error = zero.query_and_get_error(
+        f"INSERT INTO {table_name}(a,d) VALUES (1, '2011-01-01')",
+        settings={"insert_quorum": "auto", "insert_quorum_timeout": 5000},
+    )
+    assert "TOO_FEW_LIVE_REPLICAS" in error, error
+    assert "Number of alive replicas (1) is less than requested quorum (2/2)" in error, error
+
+    # The insert must have failed before committing anything locally ...
+    assert TSV("") == TSV(
+        zero.query(
+            f"SELECT * FROM {table_name}",
+            settings={"select_sequential_consistency": 0},
+        )
+    )
+
+    # ... and before creating a quorum/status node, so it cannot poison the next insert
+    # with UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE.
+    assert "0" == zero.query(
+        f"SELECT count() FROM system.zookeeper "
+        f"WHERE path = '/clickhouse/tables/0/{table_name}/quorum' AND name = 'status'"
+    ).strip()
+
+    # Once the second replica is back, a majority is available again and the insert succeeds.
+    first.query(f"ATTACH TABLE {table_name}")
+    first.query(f"SYSTEM SYNC REPLICA {table_name}", timeout=20)
+    zero.query(
+        f"INSERT INTO {table_name}(a,d) VALUES (1, '2011-01-01')",
+        settings={"insert_quorum": "auto", "insert_quorum_timeout": 20000},
+    )
+    assert TSV("1\t2011-01-01\n") == TSV(zero.query(f"SELECT * FROM {table_name}"))
+
+    zero.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER cluster")
+
+
 def test_insert_quorum_with_keeper_loss_connection(started_cluster):
     table_name = "test_insert_quorum_with_keeper_loss_" + uuid.uuid4().hex
     create_query = (


### PR DESCRIPTION
# Issue

`ReplicatedMergeTreeSink::checkQuorumPrecondition` validates the live replica count against the required quorum using `getQuorumSize()`.

For majority quorum (`insert_quorum = 'auto'`, `required_quorum_size` unset), `getQuorumSize()` computes:

```cpp
quorum_replicas_num / 2 + 1
```

However, `quorum_replicas_num` is only assigned from the return value of `checkQuorumPrecondition()` in `onStart()`. During the precondition check itself, it still contains its default value of `0`.

As a result, the majority quorum size becomes:

```text
0 / 2 + 1 == 1
```

Since `active_replicas` is initialized to `1` (the local replica counts itself), the condition

```cpp
active_replicas < quorum_size
```

can never evaluate to true. Consequently, the "too few live replicas" precondition is silently bypassed for `insert_quorum = 'auto'`.

This regression was introduced by commit `7dfe727452a` ("quorum with async inserts"), which replaced:

```cpp
getQuorumSize(replicas_number)
```

with:

```cpp
getQuorumSize()
```

where the latter reads the not-yet-initialized member instead of using the freshly computed replica count.

Affected release: **v26.2**

---

# Impact

When `insert_quorum = 'auto'` and fewer than a majority of replicas are alive, inserts no longer fail fast with `TOO_FEW_LIVE_REPLICAS`.

Instead, the following sequence occurs:

1. The part is written and committed locally.
2. A quorum/status node is created.
3. The insert blocks until `insert_quorum_timeout`.
4. The operation eventually fails with `UNKNOWN_STATUS_OF_INSERT`.

This leaves the locally committed part in an unsatisfied quorum state. Additionally, the lingering quorum/status node causes the next non-parallel quorum insert to fail with:

```text
UNSATISFIED_QUORUM_FOR_PREVIOUS_WRITE
```

Only `insert_quorum = 'auto'` is affected.

Numeric quorum (`insert_quorum = N`) continues to work correctly because it uses `required_quorum_size` instead of `quorum_replicas_num`.

---

# Fix

Initialize `quorum_replicas_num` from the freshly computed replica count before calling `getQuorumSize()` inside `checkQuorumPrecondition()`.

```cpp
replicas_number = replicas.size();
quorum_replicas_num = replicas_number;   // getQuorumSize() reads this; otherwise it is still 0
size_t quorum_size = getQuorumSize();
```

This restores the original majority quorum calculation:

```text
replicas_number / 2 + 1
```

while keeping all quorum size logic centralized inside `getQuorumSize()`.

---

# Post-fix Impact

With this change, `insert_quorum = 'auto'` once again fails immediately with `TOO_FEW_LIVE_REPLICAS` whenever a majority of replicas is unavailable.

The failure now occurs **before**:

* writing any local part,
* committing the insert,
* creating any quorum/status node,

matching both:

* the behavior prior to the regression, and
* the behavior of numeric `insert_quorum = N`.

There is no behavior change for:

* numeric quorum (`insert_quorum = N`),
* disabled quorum (the function returns early before the new assignment executes),
* other `getQuorumSize()` call sites (they execute after `onStart()`, where `quorum_replicas_num` has already been initialized).

---

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `insert_quorum = 'auto'` not rejecting inserts up front when fewer than a majority of replicas were alive. Such inserts now fail immediately with `TOO_FEW_LIVE_REPLICAS` instead of writing a local part and later timing out with `UNKNOWN_STATUS_OF_INSERT`.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.282` (included in `26.7` and later)
- Backported to: `26.6.2.17`, `26.5.5.7`, `26.4.5.85`, `26.3.17.9`
<!-- ch-version-info:end -->