### PR TITLE
Fix Performance Comparison report-build host-OOM by disabling cgroup memory correction

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -24,6 +24,11 @@ perf_right_config = f"{perf_right}/config"
 perf_left_config = f"{perf_left}/config"
 raw_query_metrics_path = f"{perf_wd}/analyze/raw-query-metrics-upload.tsv"
 
+# Disable cgroup memory correction for report-building clickhouse-local so each
+# process is tracked against its own RSS, not the shared job cgroup (avoids Code 241).
+# Keep in sync with CHPC_REPORT_LOCAL_SERVER_SETTINGS in compare.sh.
+REPORT_LOCAL_SERVER_SETTINGS = ["--", "--memory_worker_use_cgroup=0"]
+
 GET_HISTORICAL_TRESHOLDS_QUERY = """\
 SELECT test, query_index,
     quantileExact(0.99)(abs(diff)) * 1.5 AS max_diff,
@@ -516,7 +521,7 @@ def get_insert_metadata(info, compare_against_release):
 def build_raw_query_metrics_tsv():
     Path(raw_query_metrics_path).unlink(missing_ok=True)
     result = subprocess.run(
-        ["clickhouse-local", "--query", BUILD_RAW_QUERY_METRICS_QUERY],
+        ["clickhouse-local", "--query", BUILD_RAW_QUERY_METRICS_QUERY, *REPORT_LOCAL_SERVER_SETTINGS],
         cwd=perf_wd,
         text=True,
         capture_output=True,
@@ -556,7 +561,7 @@ def build_flamegraph_upload_tsv():
     Path(ch_uploads_dir).mkdir(parents=True, exist_ok=True)
     Path(flamegraph_upload_path).unlink(missing_ok=True)
     result = subprocess.run(
-        ["clickhouse-local", "--query", BUILD_FLAMEGRAPH_UPLOAD_QUERY],
+        ["clickhouse-local", "--query", BUILD_FLAMEGRAPH_UPLOAD_QUERY, *REPORT_LOCAL_SERVER_SETTINGS],
         cwd=perf_wd,
         text=True,
         capture_output=True,

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -36,6 +36,12 @@ export MALLOC_CONF="abort_conf:true,abort:true,narenas:$(nproc --all)"
 # Must match CHServer.JEMALLOC_PROFILER_SAMPLING_RATE in performance_tests.py.
 JEMALLOC_PROFILER_SAMPLING_RATE=16
 
+# Disable cgroup memory correction for report-building clickhouse-local so each
+# process is tracked against its own RSS, not the shared job cgroup (avoids Code 241).
+# Passed after `--` so it word-splits into server settings. Keep in sync with
+# REPORT_LOCAL_SERVER_SETTINGS in performance_tests.py.
+CHPC_REPORT_LOCAL_SERVER_SETTINGS="--memory_worker_use_cgroup=0"
+
 function wait_for_server # port, pid
 {
     for _ in {1..60}
@@ -600,7 +606,7 @@ create table query_run_metrics_for_stats engine File(
 create table query_run_metric_names engine File(TSV, 'analyze/query-run-metric-names.tsv')
     as select metric_names from query_run_metric_arrays limit 1
     ;
-" 2> >(tee -a analyze/errors.log 1>&2)
+" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
 
 # This is a lateral join in bash... please forgive me.
 # We don't have arrayPermute(), so I have to make random permutations with
@@ -619,6 +625,7 @@ do
             --file \"$file\" \
             --structure 'test text, query text, run int, version UInt8, metrics Array(float)' \
             --query \"$(cat "$script_dir/eqmed.sql")\" \
+            -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS \
             >> \"analyze/query-metric-stats.tsv\"" \
             2>> analyze/errors.log \
         >> analyze/commands.txt
@@ -672,7 +679,7 @@ create table query_metric_stats_denorm engine File(TSVWithNamesAndTypes,
     left array join metric_name, left, right, diff, stat_threshold
     order by test, query_index, metric_name
     ;
-" 2> >(tee -a analyze/errors.log 1>&2)
+" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
 }
 
 # Analyze results
@@ -1002,7 +1009,7 @@ create table all_query_metrics_tsv engine File(TSV, 'report/all-query-metrics.ts
             and query_display_names.query_index = report_thresholds.query_index
             and query_display_names.query_display_name = report_thresholds.query_display_name
     order by test, query_index;
-" 2> >(tee -a report/errors.log 1>&2)
+" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2)
 
 # Prepare source data for metrics and flamegraphs for queries that were profiled
 # by perf.py.
@@ -1126,7 +1133,7 @@ create table stacks engine File(TSV, 'report/stacks.$version.tsv') as
     group by test, query_index, trace_type, trace
     order by test, query_index, trace_type, trace
     ;
-" 2> >(tee -a report/errors.log 1>&2) &
+" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2) &
 done
 wait
 
@@ -1259,7 +1266,7 @@ create table changes engine File(TSV, 'metrics/changes.tsv')
     )
     order by diff desc
     ;
-" 2> >(tee -a metrics/errors.log 1>&2)
+" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a metrics/errors.log 1>&2)
 
 IFS=$'\n'
 for prefix in $(cut -f1 "metrics/metrics.tsv" | sort | uniq)
@@ -1339,7 +1346,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             array join map('old', left, 'new', right) as test_desc_
     )
 ;
-    "
+    " -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS
 
     # Upload some run attributes. I use this weird form because it is the same
     # form that can be used for historical data when you only have compare.log.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

No related open issue found.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Fixes the recurring `Performance Comparison (..., master_head/release_base, N/6)` job failure "Errors while Building the Report", which is a host-OOM at the report-assembly stage, not a perf regression:

```
Code: 241. DB::Exception: (total) memory limit exceeded: would use 53.49 GiB
(attempt to allocate chunk of 64.00 MiB), current RSS: 42.98 GiB, maximum: 53.44 GiB:
While executing MergeSortingTransform. (MEMORY_LIMIT_EXCEEDED)
```

Seen across many unrelated PRs and on master (10+ distinct PRs in the last 7 days on `arm_release` alone).

Root cause: the report stage runs many `clickhouse-local` processes concurrently (GNU `parallel` in `compare.sh::analyze_queries`, one per query for the randomization step), all inside the job's single cgroup, alongside the OS page cache left by reading the multi-GB datasets and profile TSVs. `clickhouse-local` defaults to `memory_worker_use_cgroup=1`, so each process "corrects" its own total-memory tracker up to the cgroup-wide `memory.current` -- which sums every sibling `clickhouse-local` plus reclaimable page cache. The tracker then trips its hard limit (`Code 241`) inside `MergeSortingTransform`/`AggregatingTransform` even though each query's own allocations are small (the failing job's own request was well under 1 GiB; it was killed because the cgroup-wide RSS was 42.98 GiB).

Fix: pass `--memory_worker_use_cgroup=0` to every report-building `clickhouse-local` invocation (the analyze/report/metrics queries in `compare.sh` and the `build_raw_query_metrics_tsv` / `build_flamegraph_upload_tsv` calls in `performance_tests.py`). Each report query is then tracked against its own RSS via jemalloc/proc instead of the shared cgroup, so concurrent siblings and page cache no longer push it over the limit. This does not touch the `clickhouse-client` calls to the measured left/right servers -- those keep their normal memory limits. Per-query peak memory is unchanged (the queries are data-bound, not thread-bound), so aggregate anonymous memory stays well under the cap and the existing `parallel --memsuspend` remains the aggregate backstop.

Reproduced locally with the snapshot binary by running several report queries concurrently inside a memory-capped cgroup (`systemd-run --scope -p MemoryMax=...`): with the default (`memory_worker_use_cgroup=1`) the jobs fail with the exact `Code 241 ... MEMORY_LIMIT_EXCEEDED ... While executing MergeSortingTransform/AggregatingTransform` signature; with `--memory_worker_use_cgroup=0` they all complete.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.254` (included in `26.7` and later)
<!-- ch-version-info:end -->