### PR TITLE
Fix hasAnyTokens/hasAllTokens wrong results on Array(String) with a non-default text index tokenizer

### DIFF
--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -165,8 +165,10 @@ DataTypePtr FunctionHasAnyAllTokensOverloadResolver<HasTokensTraits>::getReturnT
 template <class HasTokensTraits>
 FunctionBasePtr FunctionHasAnyAllTokensOverloadResolver<HasTokensTraits>::buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const
 {
+    const auto input_type = removeNullable(arguments[arg_input].type);
+    const bool input_is_array = checkAndGetDataType<DataTypeArray>(input_type.get()) != nullptr;
     const auto tokenizer_name = arguments.size() < 3 || !arguments[arg_tokenizer].column
-        ? SplitByNonAlphaTokenizer::getExternalName()
+        ? (input_is_array ? ArrayTokenizer::getExternalName() : SplitByNonAlphaTokenizer::getExternalName())
         : arguments[arg_tokenizer].column->getDataAt(0);
 
     auto tokenizer = TokenizerFactory::instance().get(tokenizer_name);

--- a/tests/queries/0_stateless/4061_hasAnyAllTokens_array_tokenizer_consistency.reference
+++ b/tests/queries/0_stateless/4061_hasAnyAllTokens_array_tokenizer_consistency.reference
@@ -1,0 +1,16 @@
+has baseline projection
+47
+hasAnyTokens projection
+47
+hasAllTokens projection
+47
+hasAnyTokens WHERE use_skip_indexes=1
+47
+hasAnyTokens WHERE use_skip_indexes=0
+47
+hasAllTokens WHERE use_skip_indexes=1
+47
+hasAllTokens WHERE use_skip_indexes=0
+47
+hasAnyTokens projection explicit array tokenizer (workaround)
+47

--- a/tests/queries/0_stateless/4061_hasAnyAllTokens_array_tokenizer_consistency.sql
+++ b/tests/queries/0_stateless/4061_hasAnyAllTokens_array_tokenizer_consistency.sql
@@ -1,0 +1,51 @@
+-- Tags: no-parallel-replicas
+-- Test for https://github.com/ClickHouse/ClickHouse/issues/108808
+-- hasAnyTokens / hasAllTokens on an Array(String) column with a text(tokenizer = 'array') index
+-- must return the same result regardless of whether the text-index filter path is used.
+-- The row-level / projection path used to default to the splitByNonAlpha tokenizer (which splits
+-- 'foo-bar' into 'foo','bar') while the index keeps the element whole, so countIf(hasAnyTokens(...))
+-- and `SETTINGS use_skip_indexes = 0` silently returned 0 instead of 47. All paths must agree.
+
+SET enable_analyzer = 1;
+SET enable_full_text_index = 1;
+SET use_query_condition_cache = 0;
+
+DROP TABLE IF EXISTS t_4061;
+
+CREATE TABLE t_4061
+(
+    id UInt64,
+    tags Array(String),
+    INDEX idx_tags_text tags TYPE text(tokenizer = 'array')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_4061
+SELECT number, if(number < 47, ['foo-bar'], ['baz'])
+FROM numbers(100000);
+
+SELECT 'has baseline projection';
+SELECT countIf(has(tags, 'foo-bar')) FROM t_4061;
+
+SELECT 'hasAnyTokens projection';
+SELECT countIf(hasAnyTokens(tags, ['foo-bar'])) FROM t_4061;
+
+SELECT 'hasAllTokens projection';
+SELECT countIf(hasAllTokens(tags, ['foo-bar'])) FROM t_4061;
+
+SELECT 'hasAnyTokens WHERE use_skip_indexes=1';
+SELECT count() FROM t_4061 WHERE hasAnyTokens(tags, ['foo-bar']) SETTINGS use_skip_indexes = 1;
+
+SELECT 'hasAnyTokens WHERE use_skip_indexes=0';
+SELECT count() FROM t_4061 WHERE hasAnyTokens(tags, ['foo-bar']) SETTINGS use_skip_indexes = 0;
+
+SELECT 'hasAllTokens WHERE use_skip_indexes=1';
+SELECT count() FROM t_4061 WHERE hasAllTokens(tags, ['foo-bar']) SETTINGS use_skip_indexes = 1;
+
+SELECT 'hasAllTokens WHERE use_skip_indexes=0';
+SELECT count() FROM t_4061 WHERE hasAllTokens(tags, ['foo-bar']) SETTINGS use_skip_indexes = 0;
+
+SELECT 'hasAnyTokens projection explicit array tokenizer (workaround)';
+SELECT countIf(hasAnyTokens(tags, ['foo-bar'], 'array')) FROM t_4061;
+
+DROP TABLE t_4061;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/108808

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed `hasAnyTokens`/`hasAllTokens` on an `Array(String)` column with a non-`splitByNonAlpha` `text` index (e.g. `tokenizer = 'array'`) returning wrong results when evaluated outside the index filter path (in a projection such as `countIf(hasAnyTokens(...))`, or with `SETTINGS use_skip_indexes = 0`).

### Description

`hasAnyTokens`/`hasAllTokens` are tokenized with the column's text-index tokenizer only on the filter path, where the planner pass `optimizeDirectReadFromTextIndex` injects the index tokenizer. The standalone function has no access to table/index metadata and defaulted to `splitByNonAlpha`, so the row-level path (projection, or `use_skip_indexes = 0`) split whole array elements (`foo-bar` → `foo`, `bar`) and silently returned `0`, disagreeing with the `array`-tokenizer index that keeps elements whole.

Fix: default `Array` input to the `array` tokenizer when no tokenizer is given explicitly, matching `array`-tokenizer indexes and `has` semantics for array membership. The filter/index path is unchanged — the planner still injects the index tokenizer there, and no third argument is added, so index direct-read is preserved.

Scope: this targets the common `Array` + `array`-tokenizer case. The general mismatch class (other tokenizers, scalar columns, preprocessors) is described in #108808 and is not fully addressed here.
