### PR TITLE
Fix segfault in StreamingStorageRegistry

### DIFF
--- a/src/Storages/StreamingStorageRegistry.cpp
+++ b/src/Storages/StreamingStorageRegistry.cpp
@@ -166,7 +166,9 @@ void StreamingStorageRegistry::shutdown()
     {
         runner.enqueueAndKeepTrack([&]()
         {
-            DatabaseCatalog::instance().tryGetTable(storage, Context::getGlobalContextInstance())->shutdown();
+            /// The StorageID may remain in `StreamingStorageRegistry::storages` while the table is gone from `DatabaseCatalog`.
+            if (auto table = DatabaseCatalog::instance().tryGetTable(storage, Context::getGlobalContextInstance()))
+                table->shutdown();
         });
     }
 


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1900
<!-- End of fixes issue link part, do not remove -->

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a null-pointer dereference segfault in `StreamingStorageRegistry` that occurs when `StreamingStorageRegistry::shutdown` and `StorageObjectStorageQueue::shutdown` are called concurrently.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.5.54`, `26.4.5.169`, `26.3.18.16`
<!-- ch-version-info:end -->