### PR TITLE
Revert "Apply exact row-positioning for vector search rescoring queries" (#105591)

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -351,15 +351,13 @@ We note that setting `vector_search_index_fetch_multiplier` can mitigate the pro
 
 Skip indexes in ClickHouse generally filter at the granule level, i.e. a lookup in a skip index (internally) returns a list of potentially matching granules which reduces the number of read data in the subsequent scan.
 This works well for skip indexes in general but in the case of vector similarity indexes, it creates a "granularity mismatch".
-In more detail, the vector similarity index determines the row numbers of the N most similar vectors for a given reference vector.
-With setting `vector_search_with_rescoring = 1`, ClickHouse reads the original full-precision vectors for candidate rows and computes the final distance in the regular SQL pipeline.
-When the query plan allows it, ClickHouse filters the scan to the candidate rows returned by the vector index before the final distance computation.
-This step is called rescoring and can improve accuracy, especially with quantized vector indexes, because the final ranking uses the stored vectors instead of index distances.
-If additional filters remove too many candidates or more recall is needed, increase setting `vector_search_index_fetch_multiplier` so the vector index returns more candidate rows for rescoring.
+In more detail, the vector similarity index determines the row numbers of the N most similar vectors for a given reference vector, but it then needs to extrapolate these row numbers to granule numbers.
+ClickHouse will then load these granules from disk, and repeat the distance calculation for all vectors in these granules.
+This step is called rescoring and while it can theoretically improve accuracy - remember the vector similarity index returns only an _approximate_ result, it is obvious not optimal in terms of performance.
 
 ClickHouse therefore provides an optimization which disables rescoring and returns the most similar vectors and their distances directly from the index.
 The optimization is enabled by default, see setting [vector_search_with_rescoring](../../../operations/settings/settings#vector_search_with_rescoring).
-The way it works at a high level is that ClickHouse makes the most similar vectors and their distances available as a virtual column `_distance`.
+The way it works at a high level is that ClickHouse makes the most similar vectors and their distances available as a virtual column `_distances`.
 To see this, run a vector search query with `EXPLAIN header = 1`:
 
 ```sql
@@ -572,16 +570,15 @@ When a user defines a vector similarity index on a column, ClickHouse internally
 The sub-index is "local" in the sense that it only knows about the rows of its containing index block.
 In the previous example and assuming that a column has 65536 rows, we obtain four index blocks (spanning eight granules) and a vector similarity sub-index for each index block.
 A sub-index is theoretically able to return the rows with the N closest points within its index block directly.
-For queries with `vector_search_with_rescoring = 1`, ClickHouse can use these row positions to filter rows before computing the final distance from the stored vectors when the query plan allows this optimization.
-Without rescoring, ClickHouse uses the distances from the vector index directly through the virtual column `_distance`.
-Both modes still use the surrounding granule ranges to schedule reads, which is different from regular skipping indexes that skip data at the granularity of index blocks.
+However, since ClickHouse loads data from disk to memory at the granularity of granules, sub-indexes extrapolate matching rows to granule granularity.
+This is different from regular skipping indexes which skip data at the granularity of index blocks.
 
 The `GRANULARITY` parameter determines how many vector similarity sub-indexes are created.
 Bigger `GRANULARITY` values mean fewer but larger vector similarity sub-indexes, up to the point where a column (or a column's data part) has only a single sub-index.
 In that case, the sub-index has a "global" view of all column rows and can directly return all granules of the column (part) with relevant rows (there are at most `LIMIT [N]`-many such granules).
-With `vector_search_with_rescoring = 1`, ClickHouse can then read the matching row positions and compute the exact distance for those rows.
-With a small `GRANULARITY` value, each sub-index can return up to `LIMIT N` candidate rows.
-As a result, more candidate rows may need to be read and post-filtered.
+In a second step, ClickHouse will load these granules and identify the actually best rows by performing a brute-force distance calculation over all rows of the granules.
+With a small `GRANULARITY` value, each of the sub-indexes returns up to `LIMIT N`-many granules.
+As a result, more granules need to be loaded and post-filtered.
 Note that the search accuracy is with both cases equally good, only the processing performance differs.
 It is generally recommended to use a large `GRANULARITY` for vector similarity indexes and fall back to a smaller `GRANULARITY` values only in case of problems like excessive memory consumption of the vector similarity structures.
 If no `GRANULARITY` was specified for vector similarity indexes, the default value is 100 million.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7718,11 +7718,8 @@ The size of the dynamic candidate list when searching the vector similarity inde
     DECLARE(Bool, vector_search_with_rescoring, false, R"(
 If ClickHouse performs rescoring for queries that use the vector similarity index.
 Without rescoring, the vector similarity index returns the rows containing the best matches directly.
-With rescoring, the vector similarity index fetches candidate rows and ClickHouse computes the exact distance
-for these rows from the original full-precision vectors in the regular SQL pipeline.
-When possible, ClickHouse filters the scan to candidate rows before the final distance computation.
-Increase `vector_search_index_fetch_multiplier` if more candidate rows are needed for better recall, especially
-with additional filters or quantized vector indexes.
+With rescoring, the rows are extrapolated to granule level and all rows in the granule are checked again.
+In most situations, rescoring helps only marginally with accuracy but it deteriorates performance of vector search queries significantly.
 Note: A query run without rescoring and with parallel replicas enabled may fall back to rescoring.
 )", 0) \
     DECLARE(VectorSearchFilterStrategy, vector_search_filter_strategy, VectorSearchFilterStrategy::AUTO, R"(

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -180,11 +180,11 @@ void optimizePrewhere(QueryPlan::Node & parent_node, const bool remove_unused_co
         return;
 
     /// These two optimizations conflict:
-    /// - vector search lookups
+    /// - vector search lookups with disabled rescoring
     /// - PREWHERE
     /// The former is more impactful, therefore disable PREWHERE if both may be used.
     auto * read_from_merge_tree_step = typeid_cast<ReadFromMergeTree *>(child_node->step.get());
-    if (read_from_merge_tree_step && read_from_merge_tree_step->getVectorSearchParameters().has_value())
+    if (read_from_merge_tree_step && read_from_merge_tree_step->getVectorSearchParameters().has_value() && !settings[Setting::vector_search_with_rescoring])
         return;
 
     /// Extract column compressed sizes

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -485,9 +485,8 @@ void optimizeTreeSecondPass(
         materializeConstantsForSetOperationBranches(root, nodes);
 
     /// Vector search first pass optimization sets up everything for vector index usage.
-    /// In the 2nd pass, we optimize further by attempting to do an "index-only scan"
-    /// or by filtering rescoring queries to vector-index candidate rows.
-    if (optimization_settings.try_use_vector_search)
+    /// In the 2nd pass, we optimize further by attempting to do an "index-only scan".
+    if (optimization_settings.try_use_vector_search && !extra_settings.vector_search_with_rescoring)
     {
         chassert(stack.empty());
         stack.push_back({.node = &root});

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -340,13 +340,12 @@ bool optimizeVectorSearchSecondPass(QueryPlan::Node & /*root*/, Stack & stack, Q
     /// is slightly at odds with vector search optimizations. There are two optimizations in vector
     /// search -
     /// 1. Lookup the vector index and shortlist a handful of granules containing neighbours.
-    /// 2. Apply the candidate-row filter from the vector index before distance
-    ///    computation for rescoring queries, or use `_distance` from the index
-    ///    for non-rescoring queries.
+    /// 2. The rescoring optimization goes even further and does not read the 'heavy' vector column at all and
+    ///    only sends the exact neighbour rows to the Sorting + Output step.
     /// Thus, explicit or implicit PREWHERE after above two optimizations does not bring additional benefit. Also,
-    /// the PREWHERE filter implementation conflicts with the vector-search candidate-row filter. If explicit PREWHERE
-    /// is requested, we turn the vector-search optimization off. If there is a WHERE clause and even with
-    /// optimize_move_to_prewhere = 1, we retain vector-search optimization and disable the implicit PREWHERE
+    /// the PREWHERE filter implementation conflicts with rescoring optimization filter. If explicit PREWHERE is
+    /// requested, we turn the rescoring optimization off. If there is a WHERE clause and even with
+    /// optimize_move_to_prewhere = 1, we retain the rescoring optimization and disable the implicit PREWHERE
     /// optimization. (check optimizePrewhere.cpp)
     if (const auto & prewhere_info = read_from_mergetree_step->getPrewhereInfo())
         return false;
@@ -382,17 +381,6 @@ bool optimizeVectorSearchSecondPass(QueryPlan::Node & /*root*/, Stack & stack, Q
     ActionsDAG & expression = expression_step->getExpression();
 
     bool optimize_plan = !settings.vector_search_with_rescoring;
-    bool apply_row_filter_for_rescoring = settings.vector_search_with_rescoring;
-    if (optimize_plan)
-    {
-        /// If `_distance` is already requested explicitly, do not rewrite the
-        /// read step by adding `_distance` again. Keep the original distance
-        /// expression and let the reader populate the explicitly requested
-        /// virtual column from vector-search hints.
-        if (read_from_mergetree_step->isVectorColumnReplaced())
-            optimize_plan = false;
-    }
-
     if (optimize_plan)
     {
         auto search_column = vector_search_parameters.value().column;
@@ -500,39 +488,7 @@ bool optimizeVectorSearchSecondPass(QueryPlan::Node & /*root*/, Stack & stack, Q
         sorting_step->updateInputHeader(expression_node->step->getOutputHeader());
     }
 
-    if (apply_row_filter_for_rescoring)
-    {
-        auto analyzed_result = read_from_mergetree_step->getAnalyzedResult();
-        analyzed_result = analyzed_result ? analyzed_result : read_from_mergetree_step->selectRangesToRead();
-
-        bool can_apply_row_filter = analyzed_result != nullptr;
-        if (can_apply_row_filter)
-        {
-            for (const auto & part_with_ranges : analyzed_result->parts_with_ranges)
-            {
-                if (!part_with_ranges.ranges.empty() && !part_with_ranges.read_hints.vector_search_results.has_value())
-                {
-                    can_apply_row_filter = false;
-                    break;
-                }
-            }
-        }
-
-        if (can_apply_row_filter)
-        {
-            for (auto & part_with_ranges : analyzed_result->parts_with_ranges)
-            {
-                if (!part_with_ranges.ranges.empty())
-                    part_with_ranges.read_hints.use_vector_search_result_filter = true;
-            }
-        }
-        else
-        {
-            apply_row_filter_for_rescoring = false;
-        }
-    }
-
-    return optimize_plan || apply_row_filter_for_rescoring;
+    return true;
 }
 
 }

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -87,7 +87,7 @@ public:
 
     void setReadHints(const RangesInDataPartReadHints & read_hints_, const NamesAndTypesList & read_columns) override
     {
-        if (read_columns.contains("_distance") || read_hints_.use_vector_search_result_filter)
+        if (read_columns.contains("_distance"))
             read_hints = read_hints_;
     }
 

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2200,8 +2200,6 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
     MarkRanges res;
     size_t ranges_size = ranges.size();
     RangesInDataPartReadHints read_hints = in_read_hints;
-    if (index_helper->isVectorSimilarityIndex())
-        read_hints.vector_search_results.reset();
 
     auto create_update_partial_disjunction_result_fn = [&](size_t range_begin) -> KeyCondition::UpdatePartialDisjunctionResultFn
     {
@@ -2333,10 +2331,10 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
 
                 if (index_helper->isVectorSimilarityIndex())
                 {
-                    auto vector_search_results = condition->calculateApproximateNearestNeighbors(granule);
+                    read_hints.vector_search_results = condition->calculateApproximateNearestNeighbors(granule);
 
                     /// We need to sort the result ranges ascendingly
-                    auto rows = vector_search_results.rows;
+                    auto rows = read_hints.vector_search_results.value().rows;
                     std::sort(rows.begin(), rows.end());
 #ifndef NDEBUG
                     /// Duplicates should in theory not be possible but better be safe than sorry ...
@@ -2344,33 +2342,8 @@ std::pair<MarkRanges, RangesInDataPartReadHints> MergeTreeDataSelectExecutor::fi
                     if (has_duplicates)
                         throw Exception(ErrorCodes::INCORRECT_DATA, "Usearch returned duplicate row numbers");
 #endif
-                    if (!vector_search_results.distances.has_value())
-                    {
+                    if (!(read_hints.vector_search_results.value().distances.has_value()))
                         read_hints = {};
-                    }
-                    else
-                    {
-                        const auto & distances = vector_search_results.distances.value();
-                        if (vector_search_results.rows.size() != distances.size())
-                            throw Exception(
-                                ErrorCodes::LOGICAL_ERROR,
-                                "Vector search read hints size mismatch: {} row offsets and {} distances",
-                                vector_search_results.rows.size(),
-                                distances.size());
-
-                        auto & accumulated_results = read_hints.vector_search_results;
-                        if (!accumulated_results.has_value())
-                            accumulated_results.emplace();
-                        if (!accumulated_results->distances.has_value())
-                            accumulated_results->distances.emplace();
-
-                        const size_t first_row_in_index_granule = part->index_granularity->getMarkStartingRow(index_mark * skip_index_granularity);
-                        for (size_t result_pos = 0; result_pos < vector_search_results.rows.size(); ++result_pos)
-                        {
-                            accumulated_results->rows.push_back(first_row_in_index_granule + vector_search_results.rows[result_pos]);
-                            accumulated_results->distances->push_back(distances[result_pos]);
-                        }
-                    }
 
                     for (auto row : rows)
                     {

--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -1221,9 +1221,7 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
     if (read_sample_block.has("_part_granule_offset"))
         add_offset_column("_part_granule_offset");
 
-    const auto & read_hints = merge_tree_reader->data_part_info_for_read->getReadHints();
-    bool is_vector_search = read_hints.vector_search_results.has_value()
-        && (read_sample_block.has("_distance") || read_hints.use_vector_search_result_filter);
+    bool is_vector_search = merge_tree_reader->data_part_info_for_read->getReadHints().vector_search_results.has_value();
     if (is_vector_search)
     {
         ColumnPtr part_offsets_auto_column = createPartOffsetColumn(result);
@@ -1272,18 +1270,10 @@ void MergeTreeRangeReader::fillVirtualColumns(Columns & columns, ReadResult & re
 
 void MergeTreeRangeReader::fillDistanceColumnAndFilterForVectorSearch(Columns & columns, ReadResult & /*result*/, ColumnPtr & part_offsets_auto_column)
 {
-    /// Populate the `_distance` virtual column from the distances we got from vector index
-    /// only when the query plan requested it. Rescoring queries still use the row filter
-    /// below, while the SQL pipeline computes the exact distance expression.
-    const bool fill_distance = read_sample_block.has("_distance");
-    MutableColumnPtr distance_column;
-    Float32 * distances = nullptr;
-    if (fill_distance)
-    {
-        auto mutable_distance_column = ColumnFloat32::create(part_offsets_auto_column->size(), Float32(999999.99));
-        distances = mutable_distance_column->getData().data();
-        distance_column = std::move(mutable_distance_column);
-    }
+    /// Populate the "_distance" virtual column from the distances we got from vector index
+    auto distance_column = ColumnFloat32::create(part_offsets_auto_column->size(), Float32(999999.99));
+    ColumnFloat32::Container & distance_container = distance_column->getData();
+    Float32 * distances = distance_container.data();
 
     /// Populate a filter that is True only for the exact "neighbour" part offsets we got from vector index
     auto filter_data = ColumnUInt8::create(part_offsets_auto_column->size(), UInt8(0));
@@ -1292,25 +1282,14 @@ void MergeTreeRangeReader::fillDistanceColumnAndFilterForVectorSearch(Columns & 
     const auto & read_hints = merge_tree_reader->data_part_info_for_read->getReadHints();
     const auto & offsets_and_distances = read_hints.vector_search_results.value();
     auto row_offsets_from_index = offsets_and_distances.rows;
+    chassert(offsets_and_distances.distances.has_value());
+    const auto distances_from_index = offsets_and_distances.distances.value();
+    chassert(row_offsets_from_index.size() == distances_from_index.size());
 
     /// Stash the distance for an offset before sorting the offsets
     std::unordered_map<UInt64, Float32> offset_to_distance;
-    if (fill_distance)
-    {
-        if (!offsets_and_distances.distances.has_value())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Vector search read hints must contain distances");
-
-        const auto & distances_from_index = offsets_and_distances.distances.value();
-        if (row_offsets_from_index.size() != distances_from_index.size())
-            throw Exception(
-                ErrorCodes::LOGICAL_ERROR,
-                "Vector search read hints size mismatch: {} row offsets and {} distances",
-                row_offsets_from_index.size(),
-                distances_from_index.size());
-
-        for (size_t i = 0; i < distances_from_index.size(); ++i)
-            offset_to_distance[row_offsets_from_index[i]] = distances_from_index[i];
-    }
+    for (size_t i = 0; i < distances_from_index.size(); ++i)
+        offset_to_distance[row_offsets_from_index[i]] = distances_from_index[i];
 
     std::sort(row_offsets_from_index.begin(), row_offsets_from_index.end());
 
@@ -1327,23 +1306,13 @@ void MergeTreeRangeReader::fillDistanceColumnAndFilterForVectorSearch(Columns & 
         if (offsets[i] == row_offsets_from_index[j])
         {
             filter[i] = true;
-            if (fill_distance)
-            {
-                auto distance_it = offset_to_distance.find(offsets[i]);
-                if (distance_it == offset_to_distance.end())
-                    throw Exception(ErrorCodes::LOGICAL_ERROR, "Vector search read hints do not contain distance for row offset {}", offsets[i]);
-
-                distances[i] = distance_it->second;
-            }
+            distances[i] = offset_to_distance[offsets[i]];
             j++;
         }
     }
 
-    if (fill_distance)
-    {
-        auto distance_column_pos = read_sample_block.getPositionByName("_distance");
-        columns[distance_column_pos] = std::move(distance_column);
-    }
+    auto distance_column_pos = read_sample_block.getPositionByName("_distance");
+    columns[distance_column_pos] = std::move(distance_column);
     part_offsets_filter_for_vector_search = FilterWithCachedCount(std::move(filter_data));
 }
 

--- a/src/Storages/MergeTree/RangesInDataPart.h
+++ b/src/Storages/MergeTree/RangesInDataPart.h
@@ -93,11 +93,6 @@ struct RangesInDataPartReadHints
 {
     /// Currently only information related to vector search
     std::optional<NearestNeighbours> vector_search_results;
-    /// If false, `vector_search_results` may still be used for mark pruning or
-    /// to fill `_distance`, but the reader must not filter individual rows by
-    /// these offsets. If true, the reader also keeps only the candidate rows
-    /// from these offsets inside the selected mark ranges.
-    bool use_vector_search_result_filter = false;
     /// Pre-computed index granules for indexes that are
     /// created for the whole part. For example, text indexes.
     IndexGranulesMap index_granules;

--- a/tests/queries/0_stateless/02354_vector_search_rescoring.reference
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring.reference
@@ -8,26 +8,6 @@ _distance Float32
 6
 7
 -- Dont expect column "_distance" in EXPLAIN.
--- Test that rescoring evaluates the distance only for candidate rows.
-5	0
--- Test that rescoring preserves candidates from multiple vector index granules.
-2
-3
-4
-5
-2
-3
-4
-5
-Test explicit "_distance" without and with rescoring
-2	0
-3	0.01
-4	0.04
-5	0.09
-2	0
-3	0.01
-4	0.04
-5	0.09
 Test "SELECT id, vec" without and with rescoring
 5	[0,2]
 6	[0,2.1]

--- a/tests/queries/0_stateless/02354_vector_search_rescoring.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring.sql
@@ -50,54 +50,6 @@ SELECT trimLeft(explain) AS explain FROM (
     SETTINGS vector_search_with_rescoring = 1)
 WHERE (explain LIKE '%_distance%');
 
-SELECT '-- Test that rescoring evaluates the distance only for candidate rows.';
-
-WITH [0.0, 2.0] AS reference_vec
-SELECT id, throwIf(id = 4, 'Expected rescoring to skip non-candidate rows')
-FROM tab
-ORDER BY L2Distance(vec, reference_vec)
-LIMIT 1
-SETTINGS vector_search_with_rescoring = 1;
-
-SELECT '-- Test that rescoring preserves candidates from multiple vector index granules.';
-
-DROP TABLE IF EXISTS tab_multi_granule;
-
-CREATE TABLE tab_multi_granule(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 2) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 1;
-INSERT INTO tab_multi_granule VALUES (0, [10.0, 0.0]), (1, [11.0, 0.0]), (2, [0.0, 0.0]), (3, [0.1, 0.0]), (4, [0.2, 0.0]), (5, [0.3, 0.0]), (6, [12.0, 0.0]), (7, [13.0, 0.0]);
-
-WITH [0.0, 0.0] AS reference_vec
-SELECT id
-FROM tab_multi_granule
-ORDER BY L2Distance(vec, reference_vec)
-LIMIT 4
-SETTINGS vector_search_with_rescoring = 0;
-
-WITH [0.0, 0.0] AS reference_vec
-SELECT id
-FROM tab_multi_granule
-ORDER BY L2Distance(vec, reference_vec)
-LIMIT 4
-SETTINGS vector_search_with_rescoring = 1;
-
-SELECT 'Test explicit "_distance" without and with rescoring';
-
-WITH [0.0, 0.0] AS reference_vec
-SELECT id, round(_distance, 2)
-FROM tab_multi_granule
-ORDER BY L2Distance(vec, reference_vec)
-LIMIT 4
-SETTINGS vector_search_with_rescoring = 0;
-
-WITH [0.0, 0.0] AS reference_vec
-SELECT id, round(_distance, 2)
-FROM tab_multi_granule
-ORDER BY L2Distance(vec, reference_vec)
-LIMIT 4
-SETTINGS vector_search_with_rescoring = 1;
-
-DROP TABLE tab_multi_granule;
-
 SELECT 'Test "SELECT id, vec" without and with rescoring';
 
 -- SELECTing vec explicitly disables the optimization

--- a/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.reference
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.reference
@@ -27,6 +27,8 @@ Ensure rescoring optimization works with enabled and disabled PREWHERE
 Test with enabled rescoring
 16
 19
+18
+17
 With enabled rescoring and post-filter multiplier = 3, search quality will be slightly different (better)
 16
 19

--- a/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.sql
@@ -47,7 +47,7 @@ FROM tab
 ORDER BY L2Distance(vec, [0.2, 0.3]);
 
 SELECT 'Ensure rescoring optimization works with enabled and disabled PREWHERE';
--- Expect 16 & 19.
+-- Expect IDs 16 & 19 for next 2 queries
 
 SELECT id
 FROM tab
@@ -66,7 +66,7 @@ SETTINGS query_plan_optimize_prewhere = 1,
          optimize_move_to_prewhere = 1;
 
 SELECT 'Test with enabled rescoring';
--- Expect 16 & 19.
+-- Expect 16 & 19, and additionally 18 and 17 because they are in the same granules
 
 SELECT id
 FROM tab
@@ -93,7 +93,6 @@ SELECT trimLeft(explain) AS explain FROM (
     PREWHERE attr1 > 110
     ORDER BY L2Distance(vec, [0.2, 0.3])
     LIMIT 4
-    SETTINGS vector_search_with_rescoring = 1
     )
 WHERE (explain LIKE '%_distance%');
 
@@ -102,8 +101,7 @@ SELECT id
 FROM tab
 PREWHERE attr1 > 110
 ORDER BY L2Distance(vec, [0.2, 0.3])
-LIMIT 4
-SETTINGS vector_search_with_rescoring = 1;
+LIMIT 4;
 
 SELECT 'Select all 20 neighbours with the rescoring optimization, distances got from vector index';
 SELECT id, attr1, attr2


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/pull/105591
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Reverts the merge of #105591 (commit `d56213874eb`), reversing changes made to `6519f67a9eb`.

#105591 broke `02354_vector_search_rescoring` on master across all build configs (amd_debug, amd_asan_ubsan, amd_tsan, amd_llvm_coverage, arm_binary) with a deterministic `Code: 44. ILLEGAL_COLUMN` ("The `_distance` column is an internal virtual column of vector search and cannot be referenced directly in queries"). CI randomized-settings diagnosis: "Runs: 350, Failed: 350, Passed: 0. Test also fails without randomized settings (not a randomization issue)."

Report (amd_debug, parallel): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d56213874eb9a8630fb1dd4862525efcf564d30f&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

**Root cause** is a base-skew semantic conflict: #105591 was developed and CI-tested on a base that predated the `_distance` guard, then merged onto a master that already contained it.

- #108423 (merged `7625ed4f8f2` @ 2026-06-28 02:32 UTC) added a hard `ILLEGAL_COLUMN` guard in both passes of `useVectorSearch.cpp` (and in `ReadFromMergeTree.cpp`), making `_distance` an internal-only virtual column. It added `02354_vector_search_incident1654.sql` (customer incident #1654) asserting the guard fires.
- #105591 (merged `d56213874eb` @ 2026-06-29 11:10 UTC; PR branch tip last updated 2026-06-26) added a feature that deliberately supports referencing `_distance` directly, with test queries and reference output in `02354_vector_search_rescoring.sql` that expect those queries to succeed. Its CI ran on a guard-free base and passed.

The guard from #108423 pre-empts #105591's new code path at `useVectorSearch.cpp:236`, so #105591's own added queries throw `ILLEGAL_COLUMN` once both changes are on master. Master bisect confirms: `6519f67a9eb` (pre-#105591, guard already present) was green for the existing tests; `d56213874eb` (#105591) is red across all configs.

Reverting #105591 (the later, feature PR) restores master to green while preserving the customer-incident #1654 guard. The product decision of whether `_distance` should be user-referenceable is left to the vector-search owners to reconcile and re-land #105591 on top of the #108423 guard.

Local verification on the reverted branch (build id `16173c3a04...`):
- `02354_vector_search_rescoring` output matches reference exactly
- `02354_vector_search_rescoring_and_prewhere` passes
- `02354_vector_search_incident1654` guard still fires `ILLEGAL_COLUMN` for both queries

Note: an earlier version of this description attributed the `_distance` guard to #107985; that was incorrect. #107985 ("Add ProfileEvents to observe distributed query plan execution") is unrelated. The guard was added by #108423, as pointed out by @Algunenano below.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.244` (included in `26.7` and later)
<!-- ch-version-info:end -->