### PR TITLE
Round ThreadStack::getSize() up to a page multiple for aligned_alloc

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -90,6 +90,11 @@ struct ThreadStack
     {
         auto size = std::max<size_t>({UNWIND_MINSIGSTKSZ, static_cast<size_t>(MINSIGSTKSZ), static_cast<size_t>(getPageSize())});
 
+        /// aligned_alloc() requires size to be a multiple of alignment, but MINSIGSTKSZ on
+        /// glibc >= 2.34 is a runtime sysconf(_SC_SIGSTKSZ) value that may not be page-aligned.
+        /// Not the case for official builds: they use the static MINSIGSTKSZ from the bundled sysroot.
+        size = ::Memory::alignUp(size, getPageSize());
+
         if constexpr (guardPagesEnabled())
             size += getPageSize();
 

--- a/src/Common/tests/gtest_allocation_interceptors.cpp
+++ b/src/Common/tests/gtest_allocation_interceptors.cpp
@@ -9,7 +9,11 @@
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ThreadStatus.h>
+#include <Common/memory.h>
+#include <base/getPageSize.h>
 #include <base/scope_guard.h>
+#include <cerrno>
+#include <cstdlib>
 #include <limits>
 
 namespace DB::ErrorCodes
@@ -318,6 +322,37 @@ TEST(AllocationInterceptors, MinAllocSizeToThrowRespectsLockMemoryExceptionInThr
     useMisterPointer(ptr);
     *ptr = 'a';
     delete[] ptr;
+}
+
+/// Our aligned_alloc override (src/Common/malloc.cpp) strictly enforces the C11 rule that size
+/// be a multiple of alignment, unlike glibc's lenient implementation. ThreadStack::getSize() can
+/// produce a non-page-aligned size (MINSIGSTKSZ on glibc >= 2.34 is a runtime sysconf value, e.g.
+/// 47808 on Sapphire Rapids/AMX), which used to abort startup via this override (issue #108811).
+TEST(AllocationInterceptors, AlignedAllocRejectsNonMultipleOfAlignment)
+{
+    const size_t page_size = getPageSize();
+    /// A size between 32 KiB and the next page boundary, not a multiple of the page size.
+    const size_t unaligned_size = 47808;
+    ASSERT_NE(unaligned_size % page_size, 0u);
+
+    errno = 0;
+    void * ptr = aligned_alloc(page_size, unaligned_size);
+    EXPECT_EQ(ptr, nullptr);
+    EXPECT_EQ(errno, EINVAL);
+    free(ptr);
+}
+
+TEST(AllocationInterceptors, AlignedAllocAcceptsPageRoundedSize)
+{
+    const size_t page_size = getPageSize();
+    /// The fix rounds the requested size up to a page multiple before allocating.
+    const size_t rounded_size = ::Memory::alignUp(static_cast<size_t>(47808), page_size);
+    ASSERT_EQ(rounded_size % page_size, 0u);
+
+    void * ptr = aligned_alloc(page_size, rounded_size);
+    ASSERT_NE(ptr, nullptr);
+    useMisterPointer(ptr);
+    free(ptr);
 }
 
 /// NOLINTEND

--- a/src/Common/tests/gtest_allocation_interceptors.cpp
+++ b/src/Common/tests/gtest_allocation_interceptors.cpp
@@ -1,5 +1,7 @@
 #if !defined(SANITIZER)
 
+#include "config.h"
+
 #include <gtest/gtest.h>
 
 #include <Common/CurrentMemoryTracker.h>
@@ -324,6 +326,10 @@ TEST(AllocationInterceptors, MinAllocSizeToThrowRespectsLockMemoryExceptionInThr
     delete[] ptr;
 }
 
+/// The strict aligned_alloc override lives in src/Common/malloc.cpp only under this condition;
+/// without it glibc's lenient aligned_alloc(4096, 47808) succeeds and these assertions do not hold.
+#if USE_JEMALLOC && (defined(OS_LINUX) || defined(OS_FREEBSD))
+
 /// Our aligned_alloc override (src/Common/malloc.cpp) strictly enforces the C11 rule that size
 /// be a multiple of alignment, unlike glibc's lenient implementation. ThreadStack::getSize() can
 /// produce a non-page-aligned size (MINSIGSTKSZ on glibc >= 2.34 is a runtime sysconf value, e.g.
@@ -354,6 +360,8 @@ TEST(AllocationInterceptors, AlignedAllocAcceptsPageRoundedSize)
     useMisterPointer(ptr);
     free(ptr);
 }
+
+#endif // USE_JEMALLOC && (OS_LINUX || OS_FREEBSD)
 
 /// NOLINTEND
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108811
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a startup abort (`Cannot allocate ThreadStack`, `EINVAL`) on glibc builds running on CPUs with a large signal-stack size (for example Intel Sapphire Rapids / Granite Rapids with an AMX-aware kernel), where the signal alt-stack size was not rounded up to a multiple of the page size before `aligned_alloc`.


### Description

Closes: #108811 (reported by @ BorisTyshkevich, PDT Partners).

`ThreadStack::getSize()` returns `max(UNWIND_MINSIGSTKSZ, MINSIGSTKSZ, page_size)` and is allocated with `aligned_alloc(getPageSize(), getSize())`. ClickHouse's `aligned_alloc` override (`src/Common/malloc.cpp`) strictly enforces the C11 rule that `size` be a multiple of `alignment` and returns `EINVAL` otherwise, unlike glibc's lenient implementation.

On glibc >= 2.34 built with `_GNU_SOURCE`, `<signal.h>` redefines `MINSIGSTKSZ` to the runtime value `sysconf(_SC_SIGSTKSZ)`. On Sapphire Rapids / Granite Rapids with an AMX-aware kernel this is `47808`, which is not a multiple of the 4096-byte page (`47808 % 4096 = 2752`). So `getSize()` returns `47808`, `aligned_alloc(4096, 47808)` is rejected with `EINVAL`, and the `thread_local` alt-stack constructor in `ThreadStatus` throws before logging is initialized, aborting startup of every binary that constructs a `ThreadStatus` (clickhouse-server, -local, -client).

Not reachable in official builds, which use the bundled glibc-2.27 sysroot (and musl) where `MINSIGSTKSZ` is the static constant `2048`, so `getSize()` lands on the page-aligned `UNWIND_MINSIGSTKSZ` (32768) and the check passes.

Fix: round `getSize()` up to a page multiple with `::Memory::alignUp` before the guard-page add, matching the existing pattern in `src/Common/memory.h`. No-op where the size is already page-aligned (cost is at most one extra page per thread). `getSize()` feeds both the allocation and `altstack_description.ss_size`, so they stay consistent and `ss_size` stays >= `MINSIGSTKSZ`.

Verified on an Intel Xeon 6975P-C (Granite Rapids, AMX) host where `sysconf(_SC_SIGSTKSZ) = 47808`, `47808 % 4096 = 2752`: without the fix `getSize()` = 47808 and the strict `aligned_alloc(4096, 47808)` returns `EINVAL`; with the fix `getSize()` = 49152 and the allocation succeeds. Regression tests added in `gtest_allocation_interceptors.cpp` assert the override rejects a non-page-multiple size and accepts the rounded size.

The sibling `aligned_alloc` in `FiberStack::allocate()` is unaffected: its size is `num_pages * page_size`, already a page multiple by construction.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.604` (included in `26.7` and later)
<!-- ch-version-info:end -->