### PR TITLE
Fix flaky test test_clickhouse_writes_trino_reads (No nodes available to run query)

### DIFF
--- a/tests/integration/test_storage_iceberg_with_trino/test.py
+++ b/tests/integration/test_storage_iceberg_with_trino/test.py
@@ -17,6 +17,11 @@ WAREHOUSE_BUCKET = "warehouse-rest"
 
 CATALOG_DATABASE = "iceberg_trino_test"
 
+# Transient at startup: the coordinator registers in system.runtime.nodes (so the
+# readiness probe passes) before the scheduler's worker node map is populated, so the
+# first distributed scans fail with this until scheduling catches up.
+TRINO_NO_NODES_ERROR = "No nodes available to run query"
+
 
 def _get_uuid_str() -> str:
     return str(uuid.uuid4()).replace("-", "_")
@@ -56,34 +61,41 @@ def _trino_container_name(cluster: ClickHouseCluster) -> str:
     return f"{project}-trino-1"
 
 
-def _trino_exec(cluster: ClickHouseCluster, sql: str) -> str:
+def _trino_exec(cluster: ClickHouseCluster, sql: str, retries: int = 20) -> str:
     container = _trino_container_name(cluster)
-    proc = subprocess.run(
-        [
-            "docker",
-            "exec",
-            container,
-            "trino",
-            "--server",
-            "http://localhost:8080",
-            "--catalog",
-            "iceberg",
-            "--schema",
-            NAMESPACE,
-            "--output-format",
-            "TSV",
-            "--execute",
-            sql,
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError(
-            f"Trino query failed (exit {proc.returncode}):\n"
-            f"  SQL: {sql}\n  stdout: {proc.stdout}\n  stderr: {proc.stderr}"
+    last_proc = None
+    for attempt in range(retries):
+        last_proc = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container,
+                "trino",
+                "--server",
+                "http://localhost:8080",
+                "--catalog",
+                "iceberg",
+                "--schema",
+                NAMESPACE,
+                "--output-format",
+                "TSV",
+                "--execute",
+                sql,
+            ],
+            capture_output=True,
+            text=True,
         )
-    return proc.stdout
+        if last_proc.returncode == 0:
+            return last_proc.stdout
+        # Retry only the startup scheduling race; any other error is a real failure.
+        if TRINO_NO_NODES_ERROR in last_proc.stderr and attempt < retries - 1:
+            time.sleep(1)
+            continue
+        break
+    raise RuntimeError(
+        f"Trino query failed (exit {last_proc.returncode}):\n"
+        f"  SQL: {sql}\n  stdout: {last_proc.stdout}\n  stderr: {last_proc.stderr}"
+    )
 
 
 def _wait_for_trino_ready(cluster: ClickHouseCluster, timeout_seconds: int) -> None:


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN
Related: https://github.com/ClickHouse/ClickHouse/issues/105524
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/105524

Fixes the recurring flaky integration test
`test_storage_iceberg_with_trino/test.py::test_clickhouse_writes_trino_reads`,
which fails with `Trino query failed (exit 1): ... No nodes available to run query`.

**Recurrence (0 master, PR-only, `arm_binary, distributed plan` shards):**
The previous readiness fix (#105561, merged 2026-05-21) did not fully fix it.
The exact `No nodes available to run query` signature recurred on 3 unrelated
PRs after that merge:
- 2026-06-29 PR #107476, `Integration tests (arm_binary, distributed plan, 3/4)` — [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107476&sha=98993f5cbfbed334cbc4a0a4c776954b1b91bc3b&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29)
- 2026-05-27 PR #105948, `Integration tests (arm_binary, distributed plan, 4/4)`
- 2026-05-22 PR #100226, `Integration tests (arm_binary, distributed plan, 3/4)`

**Root cause.** The Trino stack is single-node (`trinodb/trino:474`). The
readiness probe added in #105561 waits until
`SELECT count(*) FROM system.runtime.nodes WHERE state = 'active'` is >= 1.
That `system` table is served coordinator-locally and reports the coordinator
active the instant it registers with the discovery service, several seconds
before the scheduler's worker node map is populated. Any distributed scan
issued in that window fails with `NO_NODES_AVAILABLE`. The probe cannot
observe the scheduler gap, and even a perfect probe leaves a check-then-act
window before the next query runs.

**Fix.** Retry `_trino_exec` on this one transient startup signature only
(`No nodes available to run query`), with a bounded 20 x 1s budget. Every
other error still fails fast and loud, so the tests keep their full
sensitivity to real Trino/Iceberg errors. The existing node-count probe is
left in place as a cheap fast-path. No assertions changed, no tests removed.

**Reproduced and validated** against a standalone `trinodb/trino:474`: the
instant the node-count probe passes, a real distributed scan returns
`No nodes available to run query` for ~3.5-4s. With the old `_trino_exec` the
scan raised in 3/3 fresh starts; with the retry it succeeded (correct result)
in 3/3; and on a genuine (non-race) error the retry still fails fast.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.310` (included in `26.7` and later)
<!-- ch-version-info:end -->