### PR TITLE
Make sanitizer allocators return null on oversized allocations instead of aborting

### DIFF
--- a/base/base/sanitizer_options.h
+++ b/base/base/sanitizer_options.h
@@ -16,11 +16,13 @@ extern "C" {
 #ifdef ADDRESS_SANITIZER
 const char * __asan_default_options()
 {
-    return "halt_on_error=1 abort_on_error=1";
+    /// allocator_may_return_null=1: oversized allocation returns null (recoverable) instead of
+    /// aborting. Removable once llvm/llvm-project#206649 lands in our toolchain.
+    return "halt_on_error=1 abort_on_error=1 allocator_may_return_null=1";
 }
 const char * __lsan_default_options()
 {
-    return "max_allocation_size_mb=32768";
+    return "max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
 const char * __lsan_default_suppressions()
 {
@@ -45,21 +47,21 @@ const char * __lsan_default_suppressions()
 #ifdef MEMORY_SANITIZER
 const char * __msan_default_options()
 {
-    return "abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768";
+    return "abort_on_error=1 poison_in_dtor=1 max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
 #endif
 
 #ifdef THREAD_SANITIZER
 const char * __tsan_default_options()
 {
-    return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768";
+    return "halt_on_error=1 abort_on_error=1 history_size=7 second_deadlock_stack=1 max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
 #endif
 
 #ifdef UNDEFINED_BEHAVIOR_SANITIZER
 const char * __ubsan_default_options()
 {
-    return "print_stacktrace=1 max_allocation_size_mb=32768";
+    return "print_stacktrace=1 max_allocation_size_mb=32768 allocator_may_return_null=1";
 }
 #endif
 }

--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1307,6 +1307,9 @@ void LocalServer::processConfig()
 
     setupUsers();
 
+    /// SYSTEM ALLOCATE MEMORY is a diagnostic command, harmless to enable in clickhouse-local.
+    global_context->allowSystemAllocateMemory(true);
+
     /// Limit on total number of concurrently executing queries.
     /// Plain `clickhouse-local` runs a single query at a time, but once it is turned into a server
     /// via `SYSTEM START LISTEN` it accepts external connections and must honor the configured

--- a/tests/queries/0_stateless/04417_sanitizer_allocator_oversized_alloc_no_abort.reference
+++ b/tests/queries/0_stateless/04417_sanitizer_allocator_oversized_alloc_no_abort.reference
@@ -1,0 +1,2 @@
+server alive
+failed to allocate

--- a/tests/queries/0_stateless/04417_sanitizer_allocator_oversized_alloc_no_abort.sh
+++ b/tests/queries/0_stateless/04417_sanitizer_allocator_oversized_alloc_no_abort.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# With allocator_may_return_null=1 an oversized single allocation returns null (recoverable)
+# instead of aborting, so the "server alive" query after it still runs. ASan/MSan also print a
+# benign "<Sanitizer> failed to allocate <N> bytes" warning; TSan and non-sanitizer builds
+# recover silently. Route the sanitizer log to our own file (last log_path wins, so it stays out
+# of the runner's fatal log) and normalize the warning to its build-invariant substring with
+# "grep -o" so one .reference matches every build.
+log="${CLICKHOUSE_TMP:-.}/04417_$$"
+rm -f "$log"*
+o="log_path=$log"
+ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}$o" MSAN_OPTIONS="${MSAN_OPTIONS:+$MSAN_OPTIONS:}$o" \
+TSAN_OPTIONS="${TSAN_OPTIONS:+$TSAN_OPTIONS:}$o" UBSAN_OPTIONS="${UBSAN_OPTIONS:+$UBSAN_OPTIONS:}$o" \
+    $CLICKHOUSE_LOCAL --query "SYSTEM ALLOCATE MEMORY 999999999999999999; SELECT 'server alive'"
+grep -hom1 'failed to allocate' "$log"* 2>/dev/null || echo 'failed to allocate'
+rm -f "$log"*


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Set `allocator_may_return_null=1` in the default sanitizer options. A single oversized allocation now returns null (recoverable `CANNOT_ALLOCATE_MEMORY`) instead of the runtime aborting via `ReportAllocationSizeTooBig`. aarch64 MSan caps one allocation at 8 GiB, below our `max_allocation_size_mb=32768`, so only arm_msan hit the abort as `Server died`. The flag governs only OOM/oversized paths; it does not weaken sanitizer detection. Removable once https://github.com/llvm/llvm-project/pull/206649 lands in our toolchain.

Report (master, `Stress test (experimental, serverfuzz, arm_msan)`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=81a8bcef7e8ba2dae3dfdc762dde87a853f40070&name_0=MasterCI&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_msan%29

The runtime prints a benign `<Sanitizer> failed to allocate ... bytes` warning, added to clickhouse-test `IGNORED_SANITIZER_ERRORS`. `SYSTEM ALLOCATE MEMORY` is enabled in clickhouse-local so test `04417_sanitizer_allocator_oversized_alloc_no_abort` can use clickhouse-local: it issues an oversized `SYSTEM ALLOCATE MEMORY`, then asserts a `SELECT` still runs.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.653` (included in `26.7` and later)
<!-- ch-version-info:end -->