### PR TITLE
Fix flaky test_restore_db_replica_with_diffrent_table_metadata

### DIFF
--- a/tests/integration/test_restore_db_replica/test.py
+++ b/tests/integration/test_restore_db_replica/test.py
@@ -510,14 +510,14 @@ def test_restore_db_replica_with_diffrent_table_metadata(
     for node in nodes:
         restore_database_and_wait(node, exclusive_database_name, None)
 
-    assert node_1.query_with_retry(
-        f"SELECT count(*) FROM {exclusive_database_name}.{test_table_1}",
-        check_callback=lambda x: x.strip() == str(count_test_table_1),
-    ) == TSV([count_test_table_1])
-    assert node_2.query_with_retry(
-        f"SELECT count(*) FROM {exclusive_database_name}.{test_table_1}",
-        check_callback=lambda x: x.strip() == str(count_test_table_1),
-    ) == TSV([count_test_table_1])
+    # SYSTEM SYNC REPLICA waits for the background fetch of all parts after the
+    # restore, instead of a fixed-budget count poll that can expire on slow builds.
+    check_contains_table(
+        node_1, f"{exclusive_database_name}.{test_table_1}", count_test_table_1
+    )
+    check_contains_table(
+        node_2, f"{exclusive_database_name}.{test_table_1}", count_test_table_1
+    )
 
     expected_count = ["0"]
     if restore_firstly_node_where_created:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108070
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108070

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky integration test `test_restore_db_replica/test.py::test_restore_db_replica_with_diffrent_table_metadata` (reported by @ alexey-milovidov on #108070).

The assertion that `test_table_1` contains 100 rows on both replicas after `SYSTEM RESTORE DATABASE REPLICA` used a bare `count(*)` polled by `query_with_retry` (`retry_count=20`, `sleep_time=0.5s`, a fixed ~10s budget). After the restore the replica that did not originally hold the data must fetch all parts in the background; on slow CI builds (coverage, msan, arm) the last part can land after that budget expires, so the poll returns `90` (9 of the 10 `PARTITION BY n % 10` parts) and the test fails.

The fix replaces those two count polls with the existing `check_contains_table` helper, which issues `SYSTEM SYNC REPLICA` before checking the count. That waits for the background fetch to complete with no artificial timeout, the same barrier every other count check in this file already uses. Test assertion (100 rows on both replicas) is unchanged.

CIDB confirms it is an environmental flake unrelated to #108070 (CLI autocompletion): the `count(*)` returns `90` instead of `100` across unrelated PRs over the last 30 days, never on master.

Verified locally: the test passes 6/6 (both parametrizations x 3) with the fix.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.297` (included in `26.7` and later)
<!-- ch-version-info:end -->