### PR TITLE
Fix undefined behaviour stringifying out-of-range protocol packet types

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1922,7 +1922,7 @@ bool ClientBase::receiveSampleBlock(Block & out, ColumnsDescription & columns_de
             default:
                 throw NetException(ErrorCodes::UNEXPECTED_PACKET_FROM_SERVER,
                     "Unexpected packet from server (expected Data, Exception, Log or TimezoneUpdate, got {})",
-                    String(Protocol::Server::toString(packet.type)));
+                    Protocol::Server::toString(packet.type));
         }
     }
 }
@@ -2384,7 +2384,7 @@ bool ClientBase::receiveEndOfQueryForInsert()
             default:
                 throw NetException(ErrorCodes::UNEXPECTED_PACKET_FROM_SERVER,
                     "Unexpected packet from server (expected Exception, EndOfStream, Log, Progress or ProfileEvents. Got {})",
-                    String(Protocol::Server::toString(packet.type)));
+                    Protocol::Server::toString(packet.type));
         }
     }
 }

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1668,7 +1668,7 @@ void Connection::throwUnexpectedPacket(UInt64 packet_type, const char * expected
 
     throw NetException(ErrorCodes::UNEXPECTED_PACKET_FROM_SERVER,
             "Unexpected packet from server {} (expected {}, got {})",
-                       getDescription(), expected, String(Protocol::Server::toString(packet_type)));
+                       getDescription(), expected, Protocol::Server::toString(packet_type));
 }
 
 ServerConnectionPtr Connection::createConnection(const ConnectionParameters & parameters, ContextPtr)

--- a/src/Core/Protocol.cpp
+++ b/src/Core/Protocol.cpp
@@ -9,6 +9,11 @@ namespace Server
 
 std::string_view toString(UInt64 packet)
 {
+    /// packet comes straight off the wire and may be out of range (stream desync,
+    /// fuzzing). Loading an out-of-range value into Enum is undefined behavior, so
+    /// reject it before the cast; magic_enum already maps unknown values to "".
+    if (packet > MAX)
+        return {};
     return magic_enum::enum_name(Enum(packet));
 }
 
@@ -19,6 +24,8 @@ namespace Client
 
 std::string_view toString(UInt64 packet)
 {
+    if (packet > MAX)
+        return {};
     return magic_enum::enum_name(Enum(packet));
 }
 

--- a/src/Core/Protocol.cpp
+++ b/src/Core/Protocol.cpp
@@ -7,14 +7,15 @@ namespace DB::Protocol
 namespace Server
 {
 
-std::string_view toString(UInt64 packet)
+std::string toString(UInt64 packet)
 {
     /// packet comes straight off the wire and may be out of range (stream desync,
     /// fuzzing). Loading an out-of-range value into Enum is undefined behavior, so
-    /// reject it before the cast; magic_enum already maps unknown values to "".
+    /// reject it before the cast and fall back to the numeric value, which keeps the
+    /// "unexpected packet" error messages debuggeable.
     if (packet > MAX)
-        return {};
-    return magic_enum::enum_name(Enum(packet));
+        return std::to_string(packet);
+    return std::string(magic_enum::enum_name(Enum(packet)));
 }
 
 }
@@ -22,11 +23,11 @@ std::string_view toString(UInt64 packet)
 namespace Client
 {
 
-std::string_view toString(UInt64 packet)
+std::string toString(UInt64 packet)
 {
     if (packet > MAX)
-        return {};
-    return magic_enum::enum_name(Enum(packet));
+        return std::to_string(packet);
+    return std::string(magic_enum::enum_name(Enum(packet)));
 }
 
 }

--- a/src/Core/Protocol.h
+++ b/src/Core/Protocol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <string_view>
 #include <base/types.h>
 
@@ -100,11 +101,13 @@ namespace Protocol
 
         };
 
+        /// Returns the packet name, or the numeric value itself when it is out of range
+        /// (a desynced or fuzzed wire byte), so error messages stay debuggeable.
         /// NOTE: If the type of packet argument would be Enum, the comparison packet >= 0 && packet < 10
         /// would always be true because of compiler optimization. That would lead to out-of-bounds error
         /// if the packet is invalid.
         /// See https://www.securecoding.cert.org/confluence/display/cplusplus/INT36-CPP.+Do+not+use+out-of-range+enumeration+values
-        std::string_view toString(UInt64 packet);
+        std::string toString(UInt64 packet);
     }
 
     /// Packet types that client transmits.
@@ -134,7 +137,8 @@ namespace Protocol
             MAX = QueryPlan,
         };
 
-        std::string_view toString(UInt64 packet);
+        /// See the note on Server::toString: returns the numeric value for out-of-range packets.
+        std::string toString(UInt64 packet);
     }
 
     /// Whether the compression must be used.

--- a/src/Core/tests/gtest_protocol_packet_to_string.cpp
+++ b/src/Core/tests/gtest_protocol_packet_to_string.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include <Core/Protocol.h>
+
+#include <limits>
+
+using namespace DB;
+
+/// Out-of-range packet types come off the wire (stream desync, fuzzing). Stringifying
+/// them must not load an out-of-range value into the unscoped enum (undefined behavior,
+/// flagged by UBSan -fsanitize=enum). Out-of-range values map to an empty name.
+
+TEST(ProtocolPacketToString, ServerValid)
+{
+    EXPECT_EQ(Protocol::Server::toString(Protocol::Server::Hello), "Hello");
+    EXPECT_EQ(Protocol::Server::toString(Protocol::Server::Exception), "Exception");
+    EXPECT_EQ(Protocol::Server::toString(Protocol::Server::SSHChallenge), "SSHChallenge");
+}
+
+TEST(ProtocolPacketToString, ServerOutOfRange)
+{
+    /// 138 is the exact value that triggered the UBSan report in arm_ubsan stress.
+    EXPECT_TRUE(Protocol::Server::toString(138).empty());
+    EXPECT_TRUE(Protocol::Server::toString(Protocol::Server::MAX + 1).empty());
+    EXPECT_TRUE(Protocol::Server::toString(255).empty());
+    EXPECT_TRUE(Protocol::Server::toString(std::numeric_limits<UInt64>::max()).empty());
+}
+
+TEST(ProtocolPacketToString, ClientValid)
+{
+    EXPECT_EQ(Protocol::Client::toString(Protocol::Client::Hello), "Hello");
+    EXPECT_EQ(Protocol::Client::toString(Protocol::Client::Query), "Query");
+    EXPECT_EQ(Protocol::Client::toString(Protocol::Client::QueryPlan), "QueryPlan");
+}
+
+TEST(ProtocolPacketToString, ClientOutOfRange)
+{
+    EXPECT_TRUE(Protocol::Client::toString(138).empty());
+    EXPECT_TRUE(Protocol::Client::toString(Protocol::Client::MAX + 1).empty());
+    EXPECT_TRUE(Protocol::Client::toString(255).empty());
+    EXPECT_TRUE(Protocol::Client::toString(std::numeric_limits<UInt64>::max()).empty());
+}

--- a/src/Core/tests/gtest_protocol_packet_to_string.cpp
+++ b/src/Core/tests/gtest_protocol_packet_to_string.cpp
@@ -8,7 +8,8 @@ using namespace DB;
 
 /// Out-of-range packet types come off the wire (stream desync, fuzzing). Stringifying
 /// them must not load an out-of-range value into the unscoped enum (undefined behavior,
-/// flagged by UBSan -fsanitize=enum). Out-of-range values map to an empty name.
+/// flagged by UBSan -fsanitize=enum). Out-of-range values render as their numeric value so
+/// the "unexpected packet" error messages stay debuggeable.
 
 TEST(ProtocolPacketToString, ServerValid)
 {
@@ -20,10 +21,11 @@ TEST(ProtocolPacketToString, ServerValid)
 TEST(ProtocolPacketToString, ServerOutOfRange)
 {
     /// 138 is the exact value that triggered the UBSan report in arm_ubsan stress.
-    EXPECT_TRUE(Protocol::Server::toString(138).empty());
-    EXPECT_TRUE(Protocol::Server::toString(Protocol::Server::MAX + 1).empty());
-    EXPECT_TRUE(Protocol::Server::toString(255).empty());
-    EXPECT_TRUE(Protocol::Server::toString(std::numeric_limits<UInt64>::max()).empty());
+    EXPECT_EQ(Protocol::Server::toString(138), "138");
+    EXPECT_EQ(Protocol::Server::toString(Protocol::Server::MAX + 1), std::to_string(Protocol::Server::MAX + 1));
+    EXPECT_EQ(Protocol::Server::toString(255), "255");
+    EXPECT_EQ(Protocol::Server::toString(std::numeric_limits<UInt64>::max()),
+              std::to_string(std::numeric_limits<UInt64>::max()));
 }
 
 TEST(ProtocolPacketToString, ClientValid)
@@ -35,8 +37,9 @@ TEST(ProtocolPacketToString, ClientValid)
 
 TEST(ProtocolPacketToString, ClientOutOfRange)
 {
-    EXPECT_TRUE(Protocol::Client::toString(138).empty());
-    EXPECT_TRUE(Protocol::Client::toString(Protocol::Client::MAX + 1).empty());
-    EXPECT_TRUE(Protocol::Client::toString(255).empty());
-    EXPECT_TRUE(Protocol::Client::toString(std::numeric_limits<UInt64>::max()).empty());
+    EXPECT_EQ(Protocol::Client::toString(138), "138");
+    EXPECT_EQ(Protocol::Client::toString(Protocol::Client::MAX + 1), std::to_string(Protocol::Client::MAX + 1));
+    EXPECT_EQ(Protocol::Client::toString(255), "255");
+    EXPECT_EQ(Protocol::Client::toString(std::numeric_limits<UInt64>::max()),
+              std::to_string(std::numeric_limits<UInt64>::max()));
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/101972
-->

Related: #101972

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed undefined behaviour when stringifying an out-of-range protocol packet type (e.g. in the "Unexpected packet from server" / "Received ... packet" error messages) for a desynced or fuzzed connection.

### Description

`Protocol::Server::toString(UInt64)` and `Protocol::Client::toString(UInt64)` take a packet type read straight off the wire and do `magic_enum::enum_name(Enum(packet))`. The `UInt64` argument (and the accompanying comment about not using `Enum` for the parameter) exists precisely because the value may be invalid, but the body still casts it to the unscoped `Enum` unconditionally. Loading an out-of-range value into an enum is undefined behaviour (`-fsanitize=enum`); it is flagged inside `magic_enum::enum_name` before magic_enum's own range check runs.

`Stress test (arm_ubsan)` hit this on a desynced byte:

```
contrib/magic_enum/include/magic_enum/magic_enum.hpp:1293:39: runtime error: load of value 138, which is not a valid value for type 'DB::Protocol::Server::Enum'
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97540&sha=cd7b1b2fd68f282c7e10c3c9f7a7ced85a1bad18&name_0=PR&name_1=Stress%20test%20%28arm_ubsan%29 (STID 2821-33c8, `Stress test (arm_ubsan)`). The surfacing PR is unrelated to the protocol code; `src/Core/Protocol.cpp` is byte-identical to master, so this is a pre-existing trunk bug.

These functions are only ever used to render the value into an exception or log message, and `magic_enum::enum_name` already maps unknown values to an empty string, so rejecting out-of-range values before the cast keeps the existing behaviour while removing the UB. This is the same bug class as the client->server enums fixed in #101972 (`QueryProcessingStage`, `Compression`, `query_kind`); this covers the remaining server->client and client packet-type stringifiers.

Added a unit test (`gtest_protocol_packet_to_string`) that asserts both valid names resolve and out-of-range values (138, `MAX + 1`, `UInt64` max) return empty without tripping UBSan. The test aborts under UBSan on the pre-fix code and passes after.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.340` (included in `26.7` and later)
<!-- ch-version-info:end -->