### PR TITLE
Preserve borrowed thread name and only borrow group while unwinding in ~CallbackRunnerTask

### DIFF
--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -47,7 +47,13 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
             else if (!allow_existing_group)
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Thread ({}) is already attached to a group (master_thread_id {})", thread_name, prev_thread_group->master_thread_id);
             else
+            {
+                /// Borrowing a thread that owns a group: remember its name (even UNKNOWN) before the
+                /// setThreadName below renames it, so we can restore it with the group.
+                prev_thread_name = getThreadName();
+                should_restore_prev_thread_name = true;
                 CurrentThread::detachFromGroupIfNotDetached();
+            }
         }
 
         if (!prev_thread)
@@ -77,9 +83,12 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
             /// leaving the thread on the target group. Detach it first.
             if (CurrentThread::getGroup() == thread_group)
                 CurrentThread::detachFromGroupIfNotDetached();
-            /// Restore the previous group for allow_existing_group=true callers.
+            /// Restore the borrowed group and name here: the destructor early-returns on this path
+            /// (both groups are nulled below).
             if (prev_thread_group && !CurrentThread::getGroup())
                 CurrentThread::attachToGroup(prev_thread_group);
+            if (should_restore_prev_thread_name)
+                setThreadName(prev_thread_name);
         }
         catch (...)
         {
@@ -111,6 +120,10 @@ ThreadGroupSwitcher::~ThreadGroupSwitcher()
         {
             LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
             CurrentThread::attachToGroup(prev_thread_group);
+            /// Restore the borrowed thread's original name, else it keeps the async-pool name and
+            /// misattributes later logs, traces, /proc names and jemalloc thread profiles.
+            if (should_restore_prev_thread_name)
+                setThreadName(prev_thread_name);
         }
     }
     catch (...)

--- a/src/Common/ThreadGroupSwitcher.h
+++ b/src/Common/ThreadGroupSwitcher.h
@@ -36,7 +36,7 @@ public:
     /// allow_existing_group:
     ///  * If false, asserts that the thread is not already attached to a different group.
     ///    Use this when running a task in a thread pool.
-    ///  * If true, remembers the current group and restores it in destructor.
+    ///  * If true, remembers the current group and thread name and restores them in destructor.
     /// If thread_name is not empty, calls setThreadName along the way; should be at most 15 bytes long.
     ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadName thread_name, bool allow_existing_group = false) noexcept;
     ~ThreadGroupSwitcher();
@@ -45,6 +45,10 @@ private:
     ThreadStatus * prev_thread = nullptr;
     ThreadGroupPtr prev_thread_group;
     ThreadGroupPtr thread_group;
+    /// Name of a borrowed thread (allow_existing_group=true), saved before renaming and restored in the
+    /// destructor. A separate bool gates the restore because UNKNOWN is a valid saved name, not a sentinel.
+    ThreadName prev_thread_name = ThreadName::UNKNOWN;
+    bool should_restore_prev_thread_name = false;
 };
 
 

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -52,7 +52,10 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
                 << "Post-attach failure from detached state must leave the thread detached";
         }
 
-        /// --- Starting attached to G0: every failed switch must restore G0. ---
+        /// --- Starting attached to G0 and named: every failed allow_existing_group switch must
+        /// restore both G0 and the original name (post_attach_failure throws after setThreadName
+        /// has already renamed the thread, so the catch block must put the name back too). ---
+        setThreadName(ThreadName::TCP_HANDLER);
         CurrentThread::attachToGroupIfDetached(G0);
 
         FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
@@ -61,6 +64,8 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
             EXPECT_EQ(getCurrentThreadGroup(), G0)
                 << "Failed allow_existing_group attach must restore the original group";
         }
+        EXPECT_EQ(getThreadName(), ThreadName::TCP_HANDLER)
+            << "Failed allow_existing_group attach must restore the original name";
 
         FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_post_attach_failure);
         {
@@ -68,7 +73,59 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
             EXPECT_EQ(getCurrentThreadGroup(), G0)
                 << "Post-attach failure must detach the target group and restore the original";
         }
+        EXPECT_EQ(getThreadName(), ThreadName::TCP_HANDLER)
+            << "Post-attach failure must restore the original name after setThreadName renamed the thread";
+
+        /// --- Same post-attach failure, but the borrowed thread starts UNKNOWN (initially unnamed).
+        /// UNKNOWN is a valid previous name, not a "nothing to restore" sentinel, so the catch must
+        /// still put it back rather than leave the thread renamed to MERGE_MUTATE. ---
+        setThreadName(ThreadName::UNKNOWN); /// writes "Unknown" to the OS name; getThreadName() now reports UNKNOWN
+        ASSERT_EQ(getThreadName(), ThreadName::UNKNOWN);
+        FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_post_attach_failure);
+        {
+            ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
+            EXPECT_EQ(getCurrentThreadGroup(), G0)
+                << "Post-attach failure must restore the original group for an initially-unnamed borrowed thread";
+        }
+        EXPECT_EQ(getThreadName(), ThreadName::UNKNOWN)
+            << "Post-attach failure must restore an UNKNOWN previous name; the restore is gated by a bool, not by the name value";
         CurrentThread::detachFromGroupIfNotDetached();
+    });
+    t.join();
+}
+
+/// The destructor borrow path (allow_existing_group=true on a group-owning thread) must restore the
+/// borrowed thread's NAME, not just its group. master's DroppedSynchronouslyWhileAttachedToAnotherGroup
+/// covers the group restore and the no-abort, but never checks the name -- which is what this PR adds.
+/// Both a real previous name and UNKNOWN (initially unnamed) must be restored: UNKNOWN is a valid
+/// previous name, not a "nothing to restore" sentinel, so the restore is gated by a bool, not the value.
+TEST(ThreadGroupSwitcher, RestoresBorrowedThreadName)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+        auto G0 = std::make_shared<ThreadGroup>(context, 0);
+        auto G1 = std::make_shared<ThreadGroup>(context, 0);
+
+        for (auto prev_name : {ThreadName::TCP_HANDLER, ThreadName::UNKNOWN})
+        {
+            /// setThreadName(UNKNOWN) writes "Unknown" to the OS name so getThreadName() reports UNKNOWN.
+            setThreadName(prev_name);
+            CurrentThread::attachToGroupIfDetached(G0);
+            ASSERT_EQ(getThreadName(), prev_name);
+
+            {
+                /// Borrows the group-owning thread and renames it to the async-pool name.
+                ThreadGroupSwitcher switcher(G1, ThreadName::S3_COPY_POOL, /*allow_existing_group*/ true);
+                EXPECT_EQ(getThreadName(), ThreadName::S3_COPY_POOL);
+            } /// ~ThreadGroupSwitcher must put both the group and the name back.
+
+            EXPECT_EQ(getCurrentThreadGroup(), G0);
+            EXPECT_EQ(getThreadName(), prev_name)
+                << "borrowed thread's name must be restored, not left as the async-pool name";
+            CurrentThread::detachFromGroupIfNotDetached();
+        }
     });
     t.join();
 }

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -33,13 +33,10 @@ namespace detail
 /// Runnable wrapper around a callback and its std::promise, used by threadPoolCallbackRunnerUnsafe.
 ///
 /// Unlike a bare std::packaged_task, this satisfies the promise from its own destructor when the
-/// task was never run. A queued task can be dropped without running when ThreadPool::finalize()
-/// drains the queue on shutdown (ThreadPool::worker destroys the pending job via job_data.reset()).
-/// A bare packaged_task left unrun would destruct its std::promise with no stored value, so
-/// ~promise() stores a broken-promise std::future_error -- which is a std::logic_error and is
-/// therefore reported by the server as a LOGICAL_ERROR (getCurrentExceptionMessageAndPattern ->
-/// abortOnFailedAssertion), aborting the process during shutdown. Storing a normal DB::Exception
-/// instead lets the waiter observe an ordinary, catchable error from future.get().
+/// task was never run (dropped on shutdown, or on a synchronous scheduleOrThrowOnError throw).
+/// A bare packaged_task left unrun stores a broken-promise std::future_error, a std::logic_error
+/// reported as a LOGICAL_ERROR that aborts the server; storing a DB::Exception instead lets the
+/// waiter observe an ordinary catchable error from future.get().
 template <typename Result, typename Callback>
 struct CallbackRunnerTask
 {
@@ -93,38 +90,22 @@ struct CallbackRunnerTask
         if (was_run)
             return;
 
-        /// The task was dropped without running. This happens in two ways:
-        ///  * The pool was shut down while the task was still queued, so ThreadPool::worker drains it
-        ///    via job_data.reset() on a pool worker thread (which has no thread group attached).
-        ///  * scheduleOrThrowOnError() threw synchronously (e.g. the pool is shutting down or its queue
-        ///    is full), so the just-created job lambda -- the sole owner of this task -- is destroyed
-        ///    during stack unwinding on the SCHEDULING thread, which is typically running a query and is
-        ///    already attached to its own thread group.
-        ///
-        /// Mirror the run() path above:
-        ///
-        /// 1. Release the callback (destroying its captures) under the task's thread group and
-        ///    BEFORE satisfying the promise. set_exception can wake a waiter immediately; a waiter
-        ///    that treats future.get() as "the task is done" may then tear down state that the
-        ///    captures reference, so the captures must be gone first (same ordering the run path
-        ///    keeps with ThreadGroupSwitcher + SCOPE_EXIT_SAFE before set_value). Because the drop can
-        ///    run on a thread already attached to a different group (the scheduling-thread case above),
-        ///    pass allow_existing_group=true so ThreadGroupSwitcher saves and restores that group
-        ///    instead of asserting -- constructing the LOGICAL_ERROR would abort the server in builds
-        ///    that treat logical errors as assertions. SCOPE_EXIT_SAFE keeps a throwing capture
-        ///    destructor from escaping this destructor.
+        /// Release the callback under the task's thread group and BEFORE satisfying the promise, so a
+        /// woken waiter cannot tear down state the captures reference (same ordering as run()).
+        /// When scheduleOrThrowOnError() throws synchronously, this destructor runs during stack
+        /// unwinding on the SCHEDULING thread, which is usually a query thread already attached to its
+        /// own group; only then allow borrowing it (the switcher saves and restores that group, instead
+        /// of the LOGICAL_ERROR that would abort debug/sanitizer builds). A drop that is not an unwind
+        /// (e.g. shutdown drain) runs on a group-less pool worker and must keep asserting.
         {
-            ThreadGroupSwitcher switcher(thread_group, thread_name, /*allow_existing_group=*/ true);
+            ThreadGroupSwitcher switcher(thread_group, thread_name, /*allow_existing_group=*/ std::uncaught_exceptions() > 0);
             SCOPE_EXIT_SAFE({ [[maybe_unused]] auto released = std::move(callback); });
         }
 
-        /// 2. Satisfy the promise with a normal DB::Exception instead of letting ~promise() store a
-        ///    broken-promise std::future_error (a std::logic_error reported via
-        ///    getCurrentExceptionMessageAndPattern -> abortOnFailedAssertion, which aborts the server).
-        ///    Build the exception_ptr first: constructing the DB::Exception captures a stack trace and
-        ///    may itself throw (e.g. std::bad_alloc under shutdown memory pressure). If it does, fall
-        ///    back to the in-flight exception so the promise is NEVER left unset (an unset promise here
-        ///    recreates the very broken-promise std::future_error this class exists to prevent).
+        /// Satisfy the promise with a DB::Exception instead of a broken-promise std::future_error.
+        /// Build the exception_ptr first: constructing the DB::Exception may itself throw (bad_alloc
+        /// under shutdown pressure); if it does, fall back to the in-flight exception so the promise is
+        /// never left unset (which would recreate the very future_error this class prevents).
         std::exception_ptr eptr;
         try
         {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108730
Related: https://github.com/ClickHouse/ClickHouse/pull/106462

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

The `~CallbackRunnerTask` abort fix (borrow the existing group when an unrun task is dropped) is now in master (9307102e084). Surviving change here:

- `ThreadGroupSwitcher` saves and restores the borrowed thread's name on the `allow_existing_group=true` path; it was left wearing the async-pool name, leaking into logs, traces, `/proc` names and jemalloc attribution.
- `~CallbackRunnerTask` gates the borrow on `std::uncaught_exceptions() > 0`, so only a synchronous `scheduleOrThrowOnError` throw (unwinding on the query thread) borrows the group; a non-unwinding drop (shutdown drain on a group-less pool worker) keeps asserting.
- Regression tests in `gtest_thread_group_switcher.cpp`.

Originally found by Stress test (`arm_tsan`), STID 4298-42a4.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.686` (included in `26.7` and later)
<!-- ch-version-info:end -->