### PR TITLE
Fix flaky test_refreshable_mv_attach_without_multi_read

### DIFF
--- a/tests/integration/test_refreshable_mv_no_multi_read/test.py
+++ b/tests/integration/test_refreshable_mv_no_multi_read/test.py
@@ -11,6 +11,7 @@
 # gracefully and leave the server running.
 
 import os
+import time
 
 import pytest
 
@@ -47,23 +48,68 @@ def use_keeper_config(config_name):
     )
 
 
+def negotiated_multi_read():
+    """MULTI_READ as negotiated by the server's current Keeper session: True/False, or None
+    if there is no Keeper session yet (system.zookeeper_connection empty)."""
+    # Touch system.zookeeper to force the server to open its (lazy) Keeper session.
+    node.query(
+        "SELECT count() FROM system.zookeeper WHERE path = '/'", ignore_error=True
+    )
+    rows = node.query(
+        "SELECT has(arrayMap(x -> toString(x), enabled_feature_flags), 'MULTI_READ') "
+        "FROM system.zookeeper_connection WHERE name = 'default'"
+    ).strip()
+    if rows == "":
+        return None
+    return rows.splitlines()[0] == "1"
+
+
+def restart_with_keeper_config(config_name, want_multi_read):
+    """Switch the embedded Keeper config and restart, then wait until the server's Keeper
+    session has actually negotiated the wanted MULTI_READ state before returning.
+
+    The embedded Keeper restarts together with the server, and on a loaded host the Keeper
+    can still be applying the new feature_flags config (re-deriving the /keeper/feature_flags
+    system znode) while it already accepts client connections. If the server's ZooKeeper
+    client negotiates feature flags in that window, it caches the stale value for the whole
+    session - and a coordinated refreshable MV reads MULTI_READ only once, at attach. So
+    without this barrier the view could attach against a stale MULTI_READ=enabled view of a
+    Keeper that is actually configured without it, making the test flaky (observed only on
+    slow CI environments). Restart until the live session's negotiated flag matches the config.
+    """
+    deadline = time.monotonic() + 180
+    while True:
+        use_keeper_config(config_name)
+        node.restart_clickhouse()
+        # The server must be up and answering queries (no crash, no crash-loop).
+        assert node.query("SELECT 1").strip() == "1"
+        # Wait for an actual Keeper session, then check the negotiated flag (None = no session yet).
+        while time.monotonic() < deadline:
+            flag = negotiated_multi_read()
+            if flag is not None:
+                break
+            time.sleep(0.5)
+        if flag == want_multi_read:
+            return
+        assert (
+            time.monotonic() < deadline
+        ), f"Keeper session never negotiated MULTI_READ={want_multi_read} after restart"
+
+
 def test_refreshable_mv_attach_without_multi_read(started_cluster):
-    use_keeper_config("enable_keeper_multi_read.xml")
-    node.restart_clickhouse()
+    restart_with_keeper_config("enable_keeper_multi_read.xml", want_multi_read=True)
 
     node.query(
         "CREATE DATABASE rdb ENGINE = Replicated('/clickhouse/rdb', '{shard}', '{replica}')"
     )
     # Non-APPEND refreshable MV in a Replicated database is always coordinated.
-    node.query(
-        """
+    node.query("""
         CREATE MATERIALIZED VIEW rdb.mv
         REFRESH EVERY 1 SECOND
         ENGINE = ReplicatedMergeTree ORDER BY x
         EMPTY
         AS SELECT number AS x FROM numbers(3)
-        """
-    )
+        """)
 
     # Refresh once while MULTI_READ is available, so coordination znodes exist and the view's
     # persisted state is the normal coordinated one.
@@ -72,12 +118,10 @@ def test_refreshable_mv_attach_without_multi_read(started_cluster):
     assert node.query("SELECT count() FROM rdb.mv").strip() == "3"
 
     # Downgrade Keeper: disable MULTI_READ, then restart. On startup the Replicated database
-    # re-attaches rdb.mv (attach=true), which is exactly the path that used to crash.
-    use_keeper_config("enable_keeper_no_multi_read.xml")
-    node.restart_clickhouse()
-
-    # The server must be up and answering queries (no crash, no crash-loop).
-    assert node.query("SELECT 1").strip() == "1"
+    # re-attaches rdb.mv (attach=true), which is exactly the path that used to crash. Wait until
+    # the server's Keeper session actually sees MULTI_READ gone before checking the view, so the
+    # re-attach is guaranteed to happen against the no-multi-read Keeper.
+    restart_with_keeper_config("enable_keeper_no_multi_read.xml", want_multi_read=False)
 
     # Attach schedules the graceful-stop pass asynchronously, so the status read can otherwise
     # observe the transient Scheduling state before doScheduling reaches the Disabled state. Wait
@@ -112,8 +156,6 @@ def test_refreshable_mv_attach_without_multi_read(started_cluster):
     assert not node.contains_in_log("Unexpected exception in refresh scheduling")
 
     # Restoring MULTI_READ and restarting must keep the server healthy.
-    use_keeper_config("enable_keeper_multi_read.xml")
-    node.restart_clickhouse()
-    assert node.query("SELECT 1").strip() == "1"
+    restart_with_keeper_config("enable_keeper_multi_read.xml", want_multi_read=True)
 
     node.query("DROP DATABASE rdb SYNC")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/106737
Related: https://github.com/ClickHouse/ClickHouse/pull/100394
-->

Related: #106737
Related: #100394


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

Fixes a flaky `test_refreshable_mv_no_multi_read/test.py::test_refreshable_mv_attach_without_multi_read` (added in #108441). It failed deterministically in the `db disk` integration shards with `AssertionError: assert 'Disabled' in 'Scheduled\t\n'`, reported on #100394.

The test downgrades the embedded Keeper from `multi_read=1` to `multi_read=0` and restarts, expecting the coordinated refreshable MV to re-attach and stop gracefully (`Disabled`). The embedded Keeper restarts together with the server; on a loaded host it can still be applying the new `feature_flags` config (re-deriving the `/keeper/feature_flags` system znode) while it already accepts client connections. If the server's ZooKeeper client negotiates feature flags in that window, it caches the stale `MULTI_READ=enabled` for the whole session. `RefreshTask` reads `MULTI_READ` only once, at attach, so the view comes up healthy (coordinated) and reports `Scheduled` with an empty exception instead of `Disabled`. Fast hosts win this race; the slower `db disk` shards lose it consistently.

Fix is test-only: after each Keeper config swap + restart, wait until the server's live Keeper session (`system.zookeeper_connection.enabled_feature_flags`) actually reflects the wanted `MULTI_READ` state before relying on the view's state, retrying the restart if the session raced to the stale value. The graceful-stop production code path is unchanged and is still exercised (the no-multi-read attach still logs "The view is stopped").

Validated with `CLICKHOUSE_USE_DATABASE_DISK=1` on a debug build: the updated test passes repeatedly, and a controlled reproduction of the old single-restart logic under the stale-flag condition reproduces the exact `assert 'Disabled' in 'Scheduled\t\n'` failure.
