### PR TITLE
Show table count next to opened database in Web UI

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -433,6 +433,14 @@
             font-weight: bold;
         }
 
+        /* Number of tables shown next to an opened database name. Kept non-bold even when the
+           database is the current one (which renders the name in bold). */
+        .database-table-count
+        {
+            font-weight: normal;
+            color: var(--misc-text-color);
+        }
+
         .table
         {
             background-repeat: no-repeat;
@@ -2667,6 +2675,8 @@ async function loadDatabases(server_address, user, password) {
             } else {
                 delete database.dataset['opened'];
                 while (tables.firstChild) tables.removeChild(tables.firstChild);
+                let count_elem = database_link.querySelector('.database-table-count');
+                if (count_elem) count_elem.remove();
             }
         });
     }
@@ -2807,6 +2817,16 @@ async function loadTables(server_address, user, password, database, container) {
     container.firstChild.classList.add('current');
     let tables_elem = container.querySelector('.tables');
     while (tables_elem.firstChild) tables_elem.removeChild(tables_elem.firstChild);
+
+    /// Show the number of tables in parentheses next to the database name, e.g. `default (123)`.
+    let database_link = container.firstChild;
+    let count_elem = database_link.querySelector('.database-table-count');
+    if (!count_elem) {
+        count_elem = document.createElement('span');
+        count_elem.className = 'database-table-count';
+        database_link.appendChild(count_elem);
+    }
+    count_elem.textContent = ` (${json.data.length})`;
 
     let max_total_bytes = Math.max(...json.data.map(elem => +elem.total_bytes));
 


### PR DESCRIPTION
When a database is expanded in the database panel of the Web UI (`play.html`), the number of tables is now shown in parentheses next to the database name, e.g. `default (123)`.

The count is rendered in non-bold, muted text so it does not compete with the database name (which is bold for the current database), and it is removed when the database is collapsed.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Show the number of tables in parentheses next to a database name when it is expanded in the database panel of the Web UI.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.303` (included in `26.7` and later)
<!-- ch-version-info:end -->