### PR TITLE
Parse nested literal collections in linear time

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1497,7 +1497,11 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
                     return true;
                 }
 
-                layers.back().arr.push_back(literal->value);
+                /// Move the just-finished nested collection into its parent instead of copying it.
+                /// `literal` is a local that is discarded right after (only the outermost layer is
+                /// kept as `node`), so moving its value out is safe. Copying here made parsing a
+                /// deeply nested literal such as `[[[ ... ]]]` quadratic in its depth.
+                layers.back().arr.push_back(std::move(literal->value));
                 continue;
             }
             if (pos->type == TokenType::Comma)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108832
-->

`ParserCollectionOfLiterals::parseImpl` builds an array or tuple literal iteratively with an explicit stack of layers. When a nested collection was finished it was appended to its parent layer with `layers.back().arr.push_back(literal->value)`, which deep-copies the whole nested `Field` accumulated so far. For a deeply nested literal such as `[[[ ... ]]]` this made parsing **quadratic** in the nesting depth.

`literal` is a local `ASTLiteral` that is discarded immediately after this line (only the outermost layer is kept as `node`), so its value can be **moved** into the parent instead of copied. This makes the parse linear and leaves the produced `Field` byte-identical.

`ParserCollectionOfLiterals` is instantiated only for `Array` and `Tuple` — it is what parses array and tuple literals inside expressions, e.g. `SELECT [[[ ... ]]]`. Map literals and the `SET param_… = …` collection path go through `ParserAllCollectionsOfLiterals`, which already moves nested values into their parent and was therefore already linear; this PR does not touch that path.

### Motivation

Surfaced by the 26.6 backport #108832 of #108493. The quadratic parse showed up in the regression test `04412_deep_nested_literal_format` (`formatQuery($$SELECT [...]$$)`), which is tagged `no-fasttest, no-debug, no-sanitizers`. The stress-test job deliberately ignores `no-{build}` tags (every test must run under stress), and there the quadratic parse of the depth-20000 literal was slow enough — ~1620s and non-cancellable under ThreadSanitizer — to trip the hung check. With the linear parse the literal is built quickly; the test still reports `TOO_DEEP_RECURSION` from the `FieldVisitorToString` stack guard, exactly as before.

The sibling test `04413_set_param_deep_collection` (`SET param_p = [...]`) exercises the same `TOO_DEEP_RECURSION` guard through `ParameterFieldVisitorToString`, but its `SET param_…` value is parsed by `ParserAllCollectionsOfLiterals` (already linear), so it was not affected by the quadratic parse and is left unchanged here.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Parse deeply nested array and tuple literals in linear instead of quadratic time.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.291` (included in `26.7` and later)
<!-- ch-version-info:end -->