### PR TITLE
Stabilize 04201_trivial_count_with_additional_filter on 25.8

### DIFF
--- a/tests/queries/0_stateless/04201_trivial_count_with_additional_filter.reference
+++ b/tests/queries/0_stateless/04201_trivial_count_with_additional_filter.reference
@@ -2,8 +2,8 @@ baseline
       (ReadFromPreparedSource)
       SourceFromSingleChunk 0 → 1
 filtered_this_table
-        (ReadFromMergeTree)
-        MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
+      (ReadFromMergeTree)
+      MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder) 0 → 1
 filter_other_table
       (ReadFromPreparedSource)
       SourceFromSingleChunk 0 → 1

--- a/tests/queries/0_stateless/04201_trivial_count_with_additional_filter.sql
+++ b/tests/queries/0_stateless/04201_trivial_count_with_additional_filter.sql
@@ -22,18 +22,24 @@ INSERT INTO t_trivial_count_filter SELECT number FROM numbers(100);
 
 SET enable_analyzer = 1;
 SET optimize_trivial_count_query = 1;
+SET max_threads = 1;
+SET optimize_use_implicit_projections = 0;
+SET optimize_use_projections = 0;
 
 -- Baseline: no filter at all, trivial-count fires.
 SELECT 'baseline';
 SELECT explain FROM (EXPLAIN PIPELINE SELECT count() FROM t_trivial_count_filter)
 WHERE explain LIKE '%ReadFromPreparedSource%' OR explain LIKE '%ReadFromMergeTree%'
-   OR explain LIKE '%SourceFromSingleChunk%' OR explain LIKE '%MergeTreeSelect%';
+   OR explain LIKE '%SourceFromSingleChunk%' OR explain LIKE '%MergeTreeSelect%'
+   OR explain LIKE '%Resize%' OR explain LIKE '%Filter%'
+;
 
 -- Filter targets THIS table: trivial-count is disabled.
 SELECT 'filtered_this_table';
 SELECT explain FROM (EXPLAIN PIPELINE SELECT count() FROM t_trivial_count_filter)
 WHERE explain LIKE '%ReadFromPreparedSource%' OR explain LIKE '%ReadFromMergeTree%'
    OR explain LIKE '%SourceFromSingleChunk%' OR explain LIKE '%MergeTreeSelect%'
+   OR explain LIKE '%Resize%' OR explain LIKE '%Filter%'
 SETTINGS additional_table_filters = {'t_trivial_count_filter': 'id < 5'};
 
 -- Filter targets a DIFFERENT table only: trivial-count must still fire.
@@ -43,6 +49,7 @@ SELECT 'filter_other_table';
 SELECT explain FROM (EXPLAIN PIPELINE SELECT count() FROM t_trivial_count_filter)
 WHERE explain LIKE '%ReadFromPreparedSource%' OR explain LIKE '%ReadFromMergeTree%'
    OR explain LIKE '%SourceFromSingleChunk%' OR explain LIKE '%MergeTreeSelect%'
+   OR explain LIKE '%Resize%' OR explain LIKE '%Filter%'
 SETTINGS additional_table_filters = {'some_other_table': 'id < 5'};
 
 DROP TABLE t_trivial_count_filter;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108763
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Stabilizes `04201_trivial_count_with_additional_filter` on the 25.8 release branch (separate PR requested by alexey-milovidov on #108763, where this was the only red and is unrelated to that SSL-auth backport).

The test captures `EXPLAIN PIPELINE` output with its indentation. The 25.8 copy pinned no settings, so under the fuzzer's randomized `max_threads` the `(ReadFromMergeTree)` block loses one `Resize` nesting level (8 -> 6 spaces) and the committed reference no longer matches. Confirmed via the test runner on a 25.8 binary: the old test fails when `max_threads=1` is injected, passes when it is >= 2.

Fix: pin `max_threads = 1`, `optimize_use_implicit_projections = 0`, `optimize_use_projections = 0` (same settings master pins via #104296) so the pipeline shape is deterministic, and regenerate the reference against a 25.8 binary. Query-level `SET max_threads = 1` overrides any value the runner injects, so the output is identical across injected `max_threads` 1/2/4/8/16.

The master reference is not cherry-pickable to 25.8: master's pipeline shows a `(Filter)/FilterTransform` wrapper from `a17b94ec153` ("Skip the recursive Planner after trivial-count optimization"), which is not in 25.8. The 25.8 reference therefore differs (no Filter wrapper).

Test-only change. Validated on 25.8.25.1: fails 3/3 without the fix under injected `--max_threads 1`; passes 5/5 with it, 40/40 with random settings on.
