### PR TITLE
Fix Inconsistent AST formatting for a Tuple with mixed named/unnamed elements

### DIFF
--- a/src/Parsers/ASTTupleDataType.cpp
+++ b/src/Parsers/ASTTupleDataType.cpp
@@ -81,8 +81,11 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
                     ostr << ',';
                 ostr << indent_str;
 
-                /// Print element name if present
-                if (i < element_names.size())
+                /// Print element name if present.
+                /// An empty name is the placeholder for an unnamed element in a
+                /// mixed named/unnamed tuple; formatting it as `` (an empty
+                /// backquoted identifier) is not parseable back, so skip it.
+                if (i < element_names.size() && !element_names[i].empty())
                     ostr << backQuoteIfNeed(element_names[i]) << ' ';
 
                 /// Print the type
@@ -97,8 +100,8 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
                 if (i > 0)
                     ostr << ", ";
 
-                /// Print element name if present
-                if (i < element_names.size())
+                /// See the multiline branch above: skip an empty placeholder name.
+                if (i < element_names.size() && !element_names[i].empty())
                     ostr << backQuoteIfNeed(element_names[i]) << ' ';
 
                 /// Print the type

--- a/src/Parsers/ASTTupleDataType.cpp
+++ b/src/Parsers/ASTTupleDataType.cpp
@@ -81,10 +81,8 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
                     ostr << ',';
                 ostr << indent_str;
 
-                /// Print element name if present.
-                /// An empty name is the placeholder for an unnamed element in a
-                /// mixed named/unnamed tuple; formatting it as `` (an empty
-                /// backquoted identifier) is not parseable back, so skip it.
+                /// An unnamed element is represented by an empty name, which has
+                /// nothing to serialize, so skip it.
                 if (i < element_names.size() && !element_names[i].empty())
                     ostr << backQuoteIfNeed(element_names[i]) << ' ';
 
@@ -100,7 +98,7 @@ void ASTTupleDataType::formatImpl(WriteBuffer & ostr, const FormatSettings & set
                 if (i > 0)
                     ostr << ", ";
 
-                /// See the multiline branch above: skip an empty placeholder name.
+                /// As in the multiline branch above, skip an unnamed (empty-name) element.
                 if (i < element_names.size() && !element_names[i].empty())
                     ostr << backQuoteIfNeed(element_names[i]) << ' ';
 

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
@@ -6,6 +6,10 @@ CREATE TABLE t (`x` Tuple(a UInt8, UInt16)) ENGINE = Memory
 CREATE TABLE t (`t` Tuple(JSON, f1 Array(Float64))) ENGINE = Memory
 ALTER TABLE t (MODIFY COLUMN `s` Tuple(a UInt8, UInt16))
 CREATE TABLE t (`x` Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory
+CREATE TABLE t (`x` Tuple(a UInt8, UInt16)) ENGINE = Memory
+CREATE TABLE t (`t` Tuple(JSON, f1 Array(Float64))) ENGINE = Memory
+ALTER TABLE t (MODIFY COLUMN `s` Tuple(a UInt8, UInt16))
+CREATE TABLE t (`x` Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory
 Syntax error
 Syntax error
 Syntax error

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
@@ -2,6 +2,10 @@ ALTER TABLE columns_with_multiple_streams (MODIFY COLUMN `field1` Nullable(tuple
 ALTER TABLE t_update_empty_nested (ADD COLUMN `nested.arr2` Array(tuple('- ON NULL -', toLowCardinality(11), 11, 11, toLowCardinality(11), 11), UInt64))
 ALTER TABLE enum_alter_issue (MODIFY COLUMN `a` Enum8(equals('one', timeSlots(timeSlots(arrayEnumerateDense(tuple('0.2147483646', toLowCardinality(toUInt128)), NULL), 4, 12.34, materialize(73), 2)), 1)))
 ALTER TABLE t_sparse_mutations_3 (MODIFY COLUMN `s` Tuple(Nullable(tupleElement(s, 1), UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(String)))
+CREATE TABLE t (`x` Tuple(a UInt8, UInt16)) ENGINE = Memory
+CREATE TABLE t (`t` Tuple(JSON, f1 Array(Float64))) ENGINE = Memory
+ALTER TABLE t (MODIFY COLUMN `s` Tuple(a UInt8, UInt16))
+CREATE TABLE t (`x` Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory
 Syntax error
 Syntax error
 Syntax error

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
@@ -19,6 +19,15 @@ $CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (\`t\` Tuple(JSON, f1 Array
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t MODIFY COLUMN s Tuple(a UInt8, UInt16)" | $CLICKHOUSE_FORMAT --oneline
 $CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (x Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
 
+# Same mixed named/unnamed tuples, but formatted without --oneline so the first
+# pass takes the pretty (multi-line) branch of ASTTupleDataType::formatImpl
+# (print_pretty_type_names = true, more than one element). The multi-line output
+# must reparse cleanly; re-format it with --oneline to assert a stable result.
+$CLICKHOUSE_FORMAT --query "CREATE TABLE t (x Tuple(a UInt8, UInt16)) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --query "CREATE TABLE t (\`t\` Tuple(JSON, f1 Array(Float64))) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --query "ALTER TABLE t MODIFY COLUMN s Tuple(a UInt8, UInt16)" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --query "CREATE TABLE t (x Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+
 # These invalid queries don't parse and this is normal.
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC((2 + ignore(1, toUInt128(materialize(2)), 2 + toNullable(toNullable(3))), 3), NONE)" 2>&1 | grep -o -F 'Syntax error'
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE test_table ADD COLUMN \`array\` Array(('110', 3, toLowCardinality(3), 3, toNullable(3), toLowCardinality(toNullable(3)), 3), UInt8) DEFAULT [1, 2, 3]" 2>&1 | grep -o -F 'Syntax error'

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
@@ -10,6 +10,15 @@ $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t_update_empty_nested ADD COLU
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE enum_alter_issue (MODIFY COLUMN a Enum8(equals('one', timeSlots(timeSlots(arrayEnumerateDense(tuple('0.2147483646', toLowCardinality(toUInt128(12))), NULL), 4, 12.34, materialize(73), 2)), 1)))" | $CLICKHOUSE_FORMAT --oneline
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t_sparse_mutations_3 MODIFY COLUMN s Tuple(Nullable(tupleElement(s, 1), UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(String))" | $CLICKHOUSE_FORMAT --oneline
 
+# A Tuple type that mixes named and unnamed elements (e.g. produced by the AST
+# fuzzer) must still round-trip through formatting. The unnamed element used to
+# be formatted as an empty backquoted identifier `` which could not be parsed
+# back, breaking the round-trip (STID 1941-26fa).
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (x Tuple(a UInt8, UInt16)) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (\`t\` Tuple(JSON, f1 Array(Float64))) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t MODIFY COLUMN s Tuple(a UInt8, UInt16)" | $CLICKHOUSE_FORMAT --oneline
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (x Tuple(a Tuple(b UInt8, UInt16), c String)) ENGINE = Memory" | $CLICKHOUSE_FORMAT --oneline
+
 # These invalid queries don't parse and this is normal.
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC((2 + ignore(1, toUInt128(materialize(2)), 2 + toNullable(toNullable(3))), 3), NONE)" 2>&1 | grep -o -F 'Syntax error'
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE test_table ADD COLUMN \`array\` Array(('110', 3, toLowCardinality(3), 3, toNullable(3), toLowCardinality(toNullable(3)), 3), UInt8) DEFAULT [1, 2, 3]" 2>&1 | grep -o -F 'Syntax error'


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/108372
-->

Related: #108372

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` ("Inconsistent AST formatting") that aborted the server in debug and sanitizer builds when formatting a `Tuple` data type that mixes named and unnamed elements (for example `Tuple(a UInt8, UInt16)`).

### Description

The AST fuzzer hit `Inconsistent AST formatting` (STID `1941-26fa`) on a fuzzer-mangled `CREATE TABLE` whose column type was a `Tuple` mixing named and unnamed elements. This is the nested named-tuple / `JSON` shape tracked by #108372; it is unrelated to the PRs it shows up on and reproduces on `master`. It is a different shape from #107806 (no-argument window function in `CODEC`).

Root cause: a `Tuple(a UInt8, UInt16)` is parsed into `ASTTupleDataType` whose `element_names` holds an empty-string placeholder for each unnamed element. `ASTTupleDataType::formatImpl` emitted that empty name via `backQuoteIfNeed("")`, which produces an empty backquoted identifier ` `` `. The formatted SQL `Tuple(a UInt8, `` UInt16)` cannot be parsed back, so the parse/format round-trip check in `executeQueryImpl` (`#ifndef NDEBUG`) raised the `LOGICAL_ERROR`.

Fix: skip the name and its trailing space when the placeholder is empty, in both the single-line and pretty (multiline) branches. The type now formats as `Tuple(a UInt8, UInt16)`, which round-trips and still raises the normal `BAD_ARGUMENTS` ("Names are specified not for all elements of Tuple type") at type resolution.

Verified on a debug build (both directions): the previously-aborting `clickhouse-local` `CREATE TABLE t (x Tuple(a UInt8, UInt16))` now returns a clean `BAD_ARGUMENTS` instead of `SIGABRT`, the server survives, and valid named/unnamed tuples are unchanged. Regression coverage added to `03210_inconsistent_formatting_of_data_types`.

CI report (AST fuzzer (amd_debug), STID 1941-26fa, on #91358): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91358&sha=fec6b590416b97167791253cb52586db7bd50d56&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.428` (included in `26.7` and later)
<!-- ch-version-info:end -->