### PR TITLE
Fix flaky 02676_optimize_old_parts_replicated by capping max_merge_selecting_sleep_ms

### DIFF
--- a/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
+++ b/tests/queries/0_stateless/02676_optimize_old_parts_replicated.sh
@@ -41,7 +41,7 @@ DROP TABLE test_without_merge;
 SELECT 'With merge replicated any part range';
 
 CREATE TABLE test_replicated (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676', 'node')  ORDER BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=false;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=2000, min_age_to_force_merge_on_partition_only=false;
 INSERT INTO test_replicated SELECT 1;
 INSERT INTO test_replicated SELECT 2;
 INSERT INTO test_replicated SELECT 3;"
@@ -55,7 +55,7 @@ SELECT 'With merge replicated partition only';
 
 CREATE TABLE test_replicated (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=2000, min_age_to_force_merge_on_partition_only=true;
 INSERT INTO test_replicated SELECT 1;
 INSERT INTO test_replicated SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older
@@ -75,7 +75,7 @@ SELECT 'With merge replicated partition only and disable limit';
 
 CREATE TABLE test_replicated_limit (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only_limit', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=false, max_bytes_to_merge_at_max_space_in_pool=1;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=2000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=false, max_bytes_to_merge_at_max_space_in_pool=1;
 INSERT INTO test_replicated_limit SELECT 1;
 INSERT INTO test_replicated_limit SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older
@@ -91,7 +91,7 @@ SELECT 'With merge replicated partition only and enable limit';
 
 CREATE TABLE test_replicated_limit (i Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test02676_partition_only_limit', 'node')  ORDER BY i
 PARTITION BY i
-SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=true, max_bytes_to_merge_at_max_space_in_pool=1;
+SETTINGS min_age_to_force_merge_seconds=1, merge_selecting_sleep_ms=1000, max_merge_selecting_sleep_ms=2000, min_age_to_force_merge_on_partition_only=true, enable_max_bytes_limit_for_min_age_to_force_merge=true, max_bytes_to_merge_at_max_space_in_pool=1;
 INSERT INTO test_replicated_limit SELECT 1;
 INSERT INTO test_replicated_limit SELECT 2;
 SELECT sleep(3) FORMAT Null; -- Sleep so the first partition is older


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/107506
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes: #107506

`02676_optimize_old_parts_replicated` is flaky: it intermittently prints `3`/extra rows instead of `2` at the "With merge replicated partition only" sections, predominantly on `Stateless tests (amd_tsan, s3 storage, parallel)`. Reruns always pass (timing flaky).

Root cause: the test pins `merge_selecting_sleep_ms=1000` on its force-merge tables but leaves `max_merge_selecting_sleep_ms` at the default `60000`. The merge-selecting task uses an adaptive backoff (`StorageReplicatedMergeTree::mergeSelectingTask`): every `CannotSelect` poll multiplies the sleep by `merge_selecting_sleep_slowdown_factor` (1.2) and clamps it up to `max_merge_selecting_sleep_ms`. While the freshly inserted partition is younger than `min_age_to_force_merge_seconds`, repeated `CannotSelect` polls inflate the interval; under TSan + S3 + parallel background-pool starvation it grows to tens of seconds (up to 60s), so once the part becomes eligible the next selection poll can be far beyond the test's 100s `wait_for_number_of_parts` budget and the force-merge has not happened yet.

Fix: cap `max_merge_selecting_sleep_ms=2000` on the four force-merge tables (the same pattern already used by `02448_clone_replica_lost_part.sh` and `02995_forget_partition.sh`). This bounds the worst-case wait between merge-selection attempts to 2s while keeping the merge-selection logic exercised. The `test_without_merge` table is left untouched (it must NOT merge). Neither setting is part of CI settings randomization, so this is deterministic.

Validated locally (debug build, embedded Keeper): the merge-selecting interval inflates 1.3s -> 11s -> ... -> 60s without the cap, and is held at exactly 2s with it. All five sections reach their reference values within 1-3s with the fix.
