### PR TITLE
Fix move partition intersecting parts

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2991,11 +2991,12 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         auto future_parts = initCoverageWithNewEmptyParts(src_parts);
         auto [new_empty_covering_src_parts, _] = createEmptyDataParts(*this, future_parts, txn);
 
+        auto dest_data_parts_lock = dest_table_storage->lockParts();
+        auto src_data_parts_lock = lockParts();
+
         Transaction dest_transaction(*dest_table_storage, txn.get());
         std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
         {
-            auto dest_data_parts_lock = dest_table_storage->lockParts();
-
             for (auto & part : dst_parts)
             {
                 block_holders.push_back(dest_table_storage->fillNewPartName(part, dest_data_parts_lock));
@@ -3005,8 +3006,6 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
 
         Transaction src_transaction(*this, txn.get());
         {
-            auto src_data_parts_lock = lockParts();
-
             for (auto & part : new_empty_covering_src_parts)
             {
                 renameTempPartAndReplaceUnlocked(part, src_data_parts_lock, src_transaction, /*rename_in_transaction=*/true);
@@ -3014,10 +3013,10 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         }
 
         dest_transaction.renameParts();
-        dest_transaction.commit();
+        dest_transaction.commit(dest_data_parts_lock);
 
         src_transaction.renameParts();
-        src_transaction.commit();
+        src_transaction.commit(src_data_parts_lock);
 
         clearOldPartsFromFilesystem();
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2991,37 +2991,39 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         auto future_parts = initCoverageWithNewEmptyParts(src_parts);
         auto [new_empty_covering_src_parts, _] = createEmptyDataParts(*this, future_parts, txn);
 
-        std::optional<DataPartsLock> dest_data_parts_lock = dest_table_storage->lockParts();
-        std::optional<DataPartsLock> src_data_parts_lock = lockParts();
+        auto dest_data_parts_lock = dest_table_storage->lockParts();
+        auto src_data_parts_lock = lockParts();
 
         Transaction dest_transaction(*dest_table_storage, txn.get());
-        std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
+        Transaction src_transaction(*this, txn.get());
+
+        try
         {
+            std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
+
             for (auto & part : dst_parts)
             {
-                block_holders.push_back(dest_table_storage->fillNewPartName(part, dest_data_parts_lock.value()));
-                dest_table_storage->renameTempPartAndReplaceUnlocked(part, dest_transaction, dest_data_parts_lock.value(), /*rename_in_transaction=*/true);
+                block_holders.push_back(dest_table_storage->fillNewPartName(part, dest_data_parts_lock));
+                dest_table_storage->renameTempPartAndReplaceUnlocked(part, dest_transaction, dest_data_parts_lock, /*rename_in_transaction=*/true);
             }
-        }
 
-        Transaction src_transaction(*this, txn.get());
-        {
             for (auto & part : new_empty_covering_src_parts)
             {
-                renameTempPartAndReplaceUnlocked(part, src_data_parts_lock.value(), src_transaction, /*rename_in_transaction=*/true);
+                renameTempPartAndReplaceUnlocked(part, src_data_parts_lock, src_transaction, /*rename_in_transaction=*/true);
             }
+
+            dest_transaction.renameParts();
+            dest_transaction.commit(dest_data_parts_lock);
+
+            src_transaction.renameParts();
+            src_transaction.commit(src_data_parts_lock);
         }
-
-        dest_transaction.renameParts();
-        dest_transaction.commit(dest_data_parts_lock.value());
-
-        src_transaction.renameParts();
-        src_transaction.commit(src_data_parts_lock.value());
-
-        dest_data_parts_lock.reset();
-        src_data_parts_lock.reset();
-
-        clearOldPartsFromFilesystem();
+        catch (...)
+        {
+            tryLogCurrentException(log.load());
+            dest_transaction.rollback(&dest_data_parts_lock);
+            src_transaction.rollback(&src_data_parts_lock);
+        }
 
         /// Note: same elapsed time and profile events for all parts is used
         PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(dst_parts, watch.elapsed(), profile_events_scope.getSnapshot()));
@@ -3031,6 +3033,8 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         PartLog::addNewParts(getContext(), PartLog::createPartLogEntries(dst_parts, watch.elapsed()), ExecutionStatus::fromCurrentException("", true));
         throw;
     }
+
+    clearOldPartsFromFilesystem();
 }
 
 ActionLock StorageMergeTree::getActionLock(StorageActionBlockType action_type)

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2991,14 +2991,13 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         auto future_parts = initCoverageWithNewEmptyParts(src_parts);
         auto [new_empty_covering_src_parts, _] = createEmptyDataParts(*this, future_parts, txn);
 
-        auto dest_data_parts_lock = dest_table_storage->lockParts();
-        auto src_data_parts_lock = lockParts();
-
         Transaction dest_transaction(*dest_table_storage, txn.get());
         Transaction src_transaction(*this, txn.get());
 
-        try
         {
+            auto dest_data_parts_lock = dest_table_storage->lockParts();
+            auto src_data_parts_lock = lockParts();
+
             std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
 
             for (auto & part : dst_parts)
@@ -3017,13 +3016,6 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
 
             src_transaction.renameParts();
             src_transaction.commit(src_data_parts_lock);
-        }
-        catch (...)
-        {
-            tryLogCurrentException(log.load());
-            dest_transaction.rollback(&dest_data_parts_lock);
-            src_transaction.rollback(&src_data_parts_lock);
-            throw;
         }
 
         /// Note: same elapsed time and profile events for all parts is used

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -3023,6 +3023,7 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
             tryLogCurrentException(log.load());
             dest_transaction.rollback(&dest_data_parts_lock);
             src_transaction.rollback(&src_data_parts_lock);
+            throw;
         }
 
         /// Note: same elapsed time and profile events for all parts is used

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -2991,16 +2991,16 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         auto future_parts = initCoverageWithNewEmptyParts(src_parts);
         auto [new_empty_covering_src_parts, _] = createEmptyDataParts(*this, future_parts, txn);
 
-        auto dest_data_parts_lock = dest_table_storage->lockParts();
-        auto src_data_parts_lock = lockParts();
+        std::optional<DataPartsLock> dest_data_parts_lock = dest_table_storage->lockParts();
+        std::optional<DataPartsLock> src_data_parts_lock = lockParts();
 
         Transaction dest_transaction(*dest_table_storage, txn.get());
         std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
         {
             for (auto & part : dst_parts)
             {
-                block_holders.push_back(dest_table_storage->fillNewPartName(part, dest_data_parts_lock));
-                dest_table_storage->renameTempPartAndReplaceUnlocked(part, dest_transaction, dest_data_parts_lock, /*rename_in_transaction=*/true);
+                block_holders.push_back(dest_table_storage->fillNewPartName(part, dest_data_parts_lock.value()));
+                dest_table_storage->renameTempPartAndReplaceUnlocked(part, dest_transaction, dest_data_parts_lock.value(), /*rename_in_transaction=*/true);
             }
         }
 
@@ -3008,15 +3008,18 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         {
             for (auto & part : new_empty_covering_src_parts)
             {
-                renameTempPartAndReplaceUnlocked(part, src_data_parts_lock, src_transaction, /*rename_in_transaction=*/true);
+                renameTempPartAndReplaceUnlocked(part, src_data_parts_lock.value(), src_transaction, /*rename_in_transaction=*/true);
             }
         }
 
         dest_transaction.renameParts();
-        dest_transaction.commit(dest_data_parts_lock);
+        dest_transaction.commit(dest_data_parts_lock.value());
 
         src_transaction.renameParts();
-        src_transaction.commit(src_data_parts_lock);
+        src_transaction.commit(src_data_parts_lock.value());
+
+        dest_data_parts_lock.reset();
+        src_data_parts_lock.reset();
 
         clearOldPartsFromFilesystem();
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes a possible race condition in the intersecting parts produced by the move partition operation. The problem is that the commit of moved parts and block number allocation were not under the same parts lock. Because of that, parts were in the PreActive state with an already allocated block number but without a lock, which means  intersecting merge can be assigned, since, for a regular merge tree, we do not check for committed blocks during merge selection.

Data: https://pastila.clickhouse.com/?0003e3e6/85ad122327fc6a761f8e08e24993f00a#dB7j1GSu4tH2B5mpzj6hug==GCM

Fixes: https://github.com/ClickHouse/ClickHouse/issues/108515


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.471` (included in `26.7` and later)
<!-- ch-version-info:end -->