### PR TITLE
Fix flaky test 02441_alter_delete_and_drop_column

### DIFF
--- a/tests/queries/0_stateless/02441_alter_delete_and_drop_column.sql
+++ b/tests/queries/0_stateless/02441_alter_delete_and_drop_column.sql
@@ -8,21 +8,21 @@ insert into mut values (1, 2, 3), (10, 20, 30);
 
 alter table mut delete where n = 10;
 
--- a funny way to wait for a MUTATE_PART to be assigned
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+-- a funny way to wait for a MUTATE_PART to be assigned (assignment is async via mergeSelectingTask; under load it can lag, so poll up to 60s)
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
             'select 1 where ''MUTATE_PART'' not in (select type from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'')'
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 
 alter table mut drop column k settings alter_sync=0;
 
 -- a funny way to wait for ALTER_METADATA to disappear from the replication queue
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
     'select * from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'' and type=''ALTER_METADATA'''
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 
 system sync replica mut pull;
 
-select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..10}&query=' || encodeURLComponent(
+select sleepEachRow(2) from url('http://localhost:8123/?param_tries={1..30}&query=' || encodeURLComponent(
     'select * from system.replication_queue where database=''' || currentDatabase() || ''' and table=''mut'' and type=''ALTER_METADATA'''
     ), 'LineAsString', 's String') settings max_threads=1, http_make_head_request=0 format Null;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106821
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky test `02441_alter_delete_and_drop_column`.

### Description

Requested by @alexey-milovidov in #106821, where this was the only red check (in `Stateless tests (amd_tsan, parallel, 2/2)`) and unrelated to that PR.

**Root cause.** After `SYSTEM STOP MERGES` + `ALTER TABLE ... DELETE`, the test waits for the `MUTATE_PART` log entry to appear in `system.replication_queue` via a bounded poll loop (`url(... param_tries={1..10} ...)` with `sleepEachRow(2)`, i.e. up to 20s). That entry is assigned asynchronously by `mergeSelectingTask`. `StorageReplicatedMergeTree::mutate()` wakes the task immediately, but under heavy parallel CI load the `BackgroundSchedulePool` can run it late, and a `CannotSelect` attempt backs off (`merge_selecting_sleep_ms` = 5s, growing x1.2). When assignment lands past the 20s window the loop gives up, the queue select misses the `MUTATE_PART` line, and the `n=10` row is never deleted, giving the observed result-differs:

```
-MUTATE_PART	all_0_0_0_1	['all_0_0_0']
 1	2
+10	20
```

`STOP MERGES` blocks mutation *execution*, not *assignment*, so once assigned the entry stays queued until `START MERGES`; waiting for it to appear is correct, it just needs a reliable budget.

**Fix.** Extend the three poll loops from `{1..10}` (20s) to `{1..30}` (60s, matching the test's own `receive_timeout=30`). The loops early-terminate as soon as the condition holds, so a normal run is unaffected (~sub-second). The reference output and the test's assertions are unchanged.

**Reproduction (local).** With the `rmt_merge_selecting_task_pause_when_scheduled` failpoint forcing a delayed assignment, the old `{1..10}` loop produces exactly the failure signature above, while the new `{1..30}` loop (assignment released after ~8s) produces the expected reference output. The flake is rare (the specific signature appears in CIDB only twice in 90 days; there are no true-master occurrences).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.431` (included in `26.7` and later)
<!-- ch-version-info:end -->