### PR TITLE
Reduce flakiness of test_distributed_ddl_parallel and test_restore_replica

### DIFF
--- a/tests/integration/test_distributed_ddl_parallel/configs/dict.xml
+++ b/tests/integration/test_distributed_ddl_parallel/configs/dict.xml
@@ -5,6 +5,8 @@
            <executable>
                <command>sleep 7</command>
                <format>TabSeparated</format>
+               <!-- Raise the 10s default: sanitizer-induced pipe-read delay must not look like a hang. -->
+               <command_read_timeout>60000</command_read_timeout>
            </executable>
         </source>
         <layout>
@@ -29,6 +31,8 @@
            <executable>
                <command>sleep 3</command>
                <format>TabSeparated</format>
+               <!-- Raise the 10s default: sanitizer-induced pipe-read delay must not look like a hang. -->
+               <command_read_timeout>60000</command_read_timeout>
            </executable>
         </source>
         <layout>

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -8,17 +8,18 @@ from helpers.test_tools import assert_eq_with_retry
 
 def fill_nodes(nodes):
     for node in nodes:
-        node.query("DROP TABLE IF EXISTS test SYNC")
+        query_with_connect_retry(node, "DROP TABLE IF EXISTS test SYNC")
 
     for node in nodes:
-        node.query(
+        query_with_connect_retry(
+            node,
             """
             CREATE TABLE test(n UInt32)
             ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/', '{replica}')
             ORDER BY n PARTITION BY n % 10;
         """.format(
                 replica=node.name
-            )
+            ),
         )
 
 
@@ -36,16 +37,16 @@ def fill_table():
     check_data(0, 0)
 
     # it will create multiple parts in each partition and probably cause merges
-    node_1.query("INSERT INTO test SELECT number + 0 FROM numbers(200)")
-    node_1.query("INSERT INTO test SELECT number + 200 FROM numbers(200)")
-    node_1.query("INSERT INTO test SELECT number + 400 FROM numbers(200)")
-    node_1.query("INSERT INTO test SELECT number + 600 FROM numbers(200)")
-    node_1.query("INSERT INTO test SELECT number + 800 FROM numbers(200)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 0 FROM numbers(200)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 200 FROM numbers(200)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 400 FROM numbers(200)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 600 FROM numbers(200)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 800 FROM numbers(200)")
     check_data(499500, 1000)
 
 def drop_tables():
     for node in nodes:
-        node.query("DROP TABLE IF EXISTS test SYNC")
+        query_with_connect_retry(node, "DROP TABLE IF EXISTS test SYNC")
 
 
 # kazoo.delete may throw NotEmptyError on concurrent modifications of the path
@@ -58,6 +59,21 @@ def zk_rmr_with_retries(zk, path):
             print(ex)
             time.sleep(0.5)
     assert False
+
+
+# Retry only on "Connection refused": the TCP connection was rejected, so the query never
+# reached the server. That makes it safe to retry even non-idempotent statements (INSERT,
+# SYSTEM RESTORE REPLICA). Any other error is re-raised immediately.
+def query_with_connect_retry(node, sql, retries=20, sleep_time=0.5, **kwargs):
+    for attempt in range(retries):
+        try:
+            return node.query(sql, **kwargs)
+        except Exception as ex:
+            if "Connection refused" in str(ex) and attempt + 1 < retries:
+                print(f"Connection refused from {node.name}, retry {attempt + 1}: {ex}")
+                time.sleep(sleep_time)
+                continue
+            raise
 
 
 @pytest.fixture(scope="module")
@@ -103,29 +119,29 @@ def test_restore_replica_sequential(start_cluster):
     zk_rmr_with_retries(zk, "/clickhouse/tables/test")
     assert zk.exists("/clickhouse/tables/test") is None
 
-    node_1.query("SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_1, "SYSTEM RESTART REPLICA test")
     node_1.query_and_get_error(
         "INSERT INTO test SELECT number AS num FROM numbers(1000,2000) WHERE num % 2 = 0"
     )
 
     print("Restoring replica1")
 
-    node_1.query("SYSTEM RESTORE REPLICA test")
+    query_with_connect_retry(node_1, "SYSTEM RESTORE REPLICA test")
     assert zk.exists("/clickhouse/tables/test")
     check_data(499500, 1000)
 
-    node_1.query("INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
 
     print("Restoring other replicas")
 
-    node_2.query("SYSTEM RESTART REPLICA test")
-    node_2.query("SYSTEM RESTORE REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM RESTORE REPLICA test")
 
-    node_3.query("SYSTEM RESTART REPLICA test")
-    node_3.query("SYSTEM RESTORE REPLICA test")
+    query_with_connect_retry(node_3, "SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_3, "SYSTEM RESTORE REPLICA test")
 
-    node_2.query("SYSTEM SYNC REPLICA test")
-    node_3.query("SYSTEM SYNC REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM SYNC REPLICA test")
+    query_with_connect_retry(node_3, "SYSTEM SYNC REPLICA test")
 
     check_after_restoration()
     drop_tables()
@@ -139,22 +155,22 @@ def test_restore_replica_parallel(start_cluster):
     zk_rmr_with_retries(zk, "/clickhouse/tables/test")
     assert zk.exists("/clickhouse/tables/test") is None
 
-    node_1.query("SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_1, "SYSTEM RESTART REPLICA test")
     node_1.query_and_get_error(
         "INSERT INTO test SELECT number AS num FROM numbers(1000,2000) WHERE num % 2 = 0"
     )
 
     print("Restoring replicas in parallel")
 
-    node_2.query("SYSTEM RESTART REPLICA test")
-    node_3.query("SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_3, "SYSTEM RESTART REPLICA test")
 
-    node_1.query("SYSTEM RESTORE REPLICA test ON CLUSTER test_cluster")
+    query_with_connect_retry(node_1, "SYSTEM RESTORE REPLICA test ON CLUSTER test_cluster")
 
     assert zk.exists("/clickhouse/tables/test")
     check_data(499500, 1000)
 
-    node_1.query("INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
 
     check_after_restoration()
     drop_tables()
@@ -173,18 +189,18 @@ def test_restore_replica_alive_replicas(start_cluster):
     zk_rmr_with_retries(zk, "/clickhouse/tables/test/replicas/replica1")
     assert zk.exists("/clickhouse/tables/test/replicas/replica1") is None
 
-    node_1.query("SYSTEM RESTART REPLICA test")
-    node_1.query("SYSTEM RESTORE REPLICA test")
+    query_with_connect_retry(node_1, "SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_1, "SYSTEM RESTORE REPLICA test")
 
-    node_2.query("SYSTEM RESTART REPLICA test")
-    node_2.query("SYSTEM RESTORE REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM RESTART REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM RESTORE REPLICA test")
 
     check_data(499500, 1000)
 
-    node_1.query("INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
+    query_with_connect_retry(node_1, "INSERT INTO test SELECT number + 1000 FROM numbers(1000)")
 
-    node_2.query("SYSTEM SYNC REPLICA test")
-    node_3.query("SYSTEM SYNC REPLICA test")
+    query_with_connect_retry(node_2, "SYSTEM SYNC REPLICA test")
+    query_with_connect_retry(node_3, "SYSTEM SYNC REPLICA test")
 
     check_after_restoration()
     drop_tables()
@@ -196,7 +212,8 @@ def test_restore_replica_keeps_duplicate_parts(start_cluster):
 
     try:
         for node in nodes:
-            node.query(
+            query_with_connect_retry(
+                node,
                 """
                 CREATE TABLE test(n UInt32)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/test/', '{replica}')
@@ -205,18 +222,19 @@ def test_restore_replica_keeps_duplicate_parts(start_cluster):
                     replicated_deduplication_window_for_async_inserts = 0;
                 """.format(
                     replica=node.name
-                )
+                ),
             )
 
-        node_1.query("SYSTEM STOP MERGES test")
+        query_with_connect_retry(node_1, "SYSTEM STOP MERGES test")
 
-        node_1.query("INSERT INTO test VALUES (0)")
-        node_1.query("INSERT INTO test VALUES (0)")
-        node_1.query(
+        query_with_connect_retry(node_1, "INSERT INTO test VALUES (0)")
+        query_with_connect_retry(node_1, "INSERT INTO test VALUES (0)")
+        query_with_connect_retry(
+            node_1,
             """
             ALTER TABLE test MODIFY SETTING replicated_deduplication_window = 10000,
                 replicated_deduplication_window_for_async_inserts = 10000
-            """
+            """,
         )
 
         assert node_1.query("SELECT count() FROM test") == "2\n"
@@ -230,8 +248,8 @@ def test_restore_replica_keeps_duplicate_parts(start_cluster):
         zk_rmr_with_retries(zk, "/clickhouse/tables/test")
         assert zk.exists("/clickhouse/tables/test") is None
 
-        node_1.query("SYSTEM RESTART REPLICA test")
-        node_1.query("SYSTEM RESTORE REPLICA test")
+        query_with_connect_retry(node_1, "SYSTEM RESTART REPLICA test")
+        query_with_connect_retry(node_1, "SYSTEM RESTORE REPLICA test")
 
         assert node_1.query("SELECT count() FROM test") == "2\n"
         assert node_1.query("SELECT count(), sum(sipHash64(*)) FROM test") == expected

--- a/tests/integration/test_restore_replica/test.py
+++ b/tests/integration/test_restore_replica/test.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 
+from helpers.client import QueryRuntimeException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
@@ -61,15 +62,23 @@ def zk_rmr_with_retries(zk, path):
     assert False
 
 
-# Retry only on "Connection refused": the TCP connection was rejected, so the query never
-# reached the server. That makes it safe to retry even non-idempotent statements (INSERT,
-# SYSTEM RESTORE REPLICA). Any other error is re-raised immediately.
+# Retry only when clickhouse-client could not open its connection to this node's own
+# server (NETWORK_ERROR with "Connection refused (<node ip>:9000)"). In that case the
+# query never reached any server, so it is safe to retry even non-idempotent statements.
+# A server-side or downstream "Connection refused" (remote shard / Keeper) carries a
+# different address and is re-raised immediately, so an already-enqueued ON CLUSTER DDL
+# or a partially-applied INSERT is never resubmitted.
 def query_with_connect_retry(node, sql, retries=20, sleep_time=0.5, **kwargs):
+    connect_refused = f"Connection refused ({node.ip_address}:9000)"
     for attempt in range(retries):
         try:
             return node.query(sql, **kwargs)
-        except Exception as ex:
-            if "Connection refused" in str(ex) and attempt + 1 < retries:
+        except QueryRuntimeException as ex:
+            if (
+                ex.returncode == 210
+                and connect_refused in str(ex)
+                and attempt + 1 < retries
+            ):
                 print(f"Connection refused from {node.name}, retry {attempt + 1}: {ex}")
                 time.sleep(sleep_time)
                 continue


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108896
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108896

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Reduce flakiness of two integration tests that fail together under sanitizer load (asan/msan), reported on PR #108896 (CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108896&sha=680c1a359cb1def9c09acf4dc2d33cc90466c3aa&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20old%20analyzer%2C%203%2F6%29). Both are CI-only flakes: 0 master failures in 30 days, hits spread across unrelated PRs (#107442, #107566, #107652, #108896). No tracking issue exists.

**test_distributed_ddl_parallel::test_smoke_parallel_dict_reload** fails with `Code: 159. TIMEOUT_EXCEEDED: Pipe read timeout exceeded 10000 milliseconds ... ShellCommandSource`. The `slow_dict_3` / `slow_dict_7` executable-dictionary sources rely on the default `command_read_timeout` of 10s (`ShellCommandSource.h`). The test issues 30 concurrent `SYSTEM RELOAD DICTIONARY ON CLUSTER`, each spawning a `sleep` command. Under sanitizer slowdown the server thread can fail to read the command pipe within 10s and aborts the load, even though the command itself only sleeps 3-7s. Fix: set `command_read_timeout` to 60s on both dictionaries. The commands never approach 60s, so nothing is masked; the 30-thread concurrency that exercises DDL queueing (above `cluster_b.pool_size = 20`) is preserved.

Verified deterministically: a `sleep 3` executable dict with `command_read_timeout=2000` reproduces the exact `Code: 159 Pipe read timeout exceeded 2000 milliseconds ... ShellCommandSource`; raising it to 60000 makes the same reload complete in ~3s and load the dictionary.

**test_restore_replica** (parallel / sequential / keeps_duplicate_parts) fails with `Code: 210. NetException: Connection refused (NETWORK_ERROR)` when a server node is transiently unreachable under sanitizer load (sibling subtests in the same run still pass, so the node recovers). The mutating queries (`SYSTEM RESTART/RESTORE/SYNC REPLICA`, `INSERT`) had no connection-level retry, while `check_data` already retries via `assert_eq_with_retry`. Fix: a `query_with_connect_retry` helper that retries only on "Connection refused". That error means the TCP connection was rejected and the query never reached the server, so retrying is safe even for the non-idempotent `INSERT` / `SYSTEM RESTORE REPLICA` statements (including the dedup-window-0 inserts). Any other error is re-raised immediately.

Verified deterministically: querying a closed port yields `Code: 210 Connection refused (NETWORK_ERROR)`; the helper retries while the node is down and succeeds the moment it becomes reachable.

Test-only change (one dictionary config, one test file). No product code is modified.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.427` (included in `26.7` and later)
<!-- ch-version-info:end -->