### PR TITLE
Clear ColumnReplicated insertion cache on rollback

### DIFF
--- a/src/Columns/ColumnReplicated.cpp
+++ b/src/Columns/ColumnReplicated.cpp
@@ -600,6 +600,9 @@ void ColumnReplicated::rollback(const ColumnCheckpoint & checkpoint)
 
     nested_column->rollback(*with_nested.nested);
     indexes.resizeAssumeReserve(with_nested.size);
+    /// The cache maps source ids to absolute indexes in nested_column; rolling nested_column back
+    /// invalidates them, so it must be cleared (same as filter() does when it mutates the indexes).
+    insertion_cache.clear();
 }
 
 void ColumnReplicated::forEachMutableSubcolumn(MutableColumnCallback callback)

--- a/src/Columns/tests/gtest_column_replicated.cpp
+++ b/src/Columns/tests/gtest_column_replicated.cpp
@@ -99,6 +99,48 @@ TEST(ColumnReplicated, InsertRangeFrom)
     checkColumn(*column_to, {"s0", "s1", "s4", "s2", "s3"}, {0, 1, 2, 3, 3, 4});
 }
 
+TEST(ColumnReplicated, RollbackClearsInsertionCache)
+{
+    /// insertion_cache memoizes absolute indexes into nested_column keyed by the source id.
+    /// rollback() shrinks nested_column and indexes, so it must invalidate the cache (like filter() does);
+    /// otherwise a re-insert from the same source hits a stale entry, skips the real insert and stores a
+    /// dangling index >= nested_column->size().
+    MutableColumnPtr src_nested = ColumnUInt64::create();
+    src_nested->insert(10);
+    src_nested->insert(11);
+    src_nested->insert(12);
+    MutableColumnPtr src_indexes = ColumnUInt8::create();
+    src_indexes->insert(0);
+    src_indexes->insert(1);
+    src_indexes->insert(2);
+    auto src = ColumnReplicated::create(std::move(src_nested), std::move(src_indexes));
+
+    MutableColumnPtr dest_nested = ColumnUInt64::create();
+    auto dest = ColumnReplicated::create(std::move(dest_nested));
+    auto checkpoint = dest->getCheckpoint();
+
+    dest->insertFrom(*src, 0);
+    dest->insertFrom(*src, 1);
+    dest->insertFrom(*src, 2);
+    ASSERT_EQ(dest->size(), 3);
+    ASSERT_EQ(dest->getNestedColumn()->size(), 3);
+
+    dest->rollback(*checkpoint);
+    ASSERT_EQ(dest->size(), 0);
+    ASSERT_EQ(dest->getNestedColumn()->size(), 0);
+
+    /// Re-insert the source value that was cached before the rollback.
+    dest->insertFrom(*src, 2);
+    ASSERT_EQ(dest->size(), 1);
+    /// The value must have been re-inserted into nested_column (cache miss), not skipped via a stale entry.
+    ASSERT_EQ(dest->getNestedColumn()->size(), 1)
+        << "rollback() left a stale insertion_cache; the re-insert was skipped and the stored index is dangling";
+    ASSERT_LT(assert_cast<const ColumnReplicated &>(*dest).getIndexes().getIndexAt(0), dest->getNestedColumn()->size());
+    auto full = assert_cast<const ColumnReplicated &>(*dest).convertToFullColumnIfReplicated();
+    ASSERT_EQ(full->size(), 1u);
+    ASSERT_EQ(full->getUInt(0), 12u);
+}
+
 TEST(ColumnReplicated, IndicesOfNonDefaultRows)
 {
     auto column = createColumn({"s1", "s2", "", "s3", ""}, {0, 1, 1, 3, 2, 0, 0, 3, 1, 2, 0, 3, 4});


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/106370
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed possible wrong results or out-of-bounds reads when an `INSERT` is rolled back after a mid-batch error (for example in `Buffer` tables, asynchronous inserts, or the `Kafka`/`RabbitMQ`/`FileLog` engines) while lazy column replication (`enable_lazy_columns_replication`) is in effect.

### Description

`ColumnReplicated` keeps an `insertion_cache` that memoizes, per source column `id`, the absolute index in its `nested_column` where each previously inserted source value landed, so that repeated `insertFrom` / `insertRangeFrom` / `insertManyFrom` from the same source do not copy the value again.

`filter(const Filter &)` already clears this cache because it mutates the index set. `rollback()` did not: it rolls `nested_column` and `indexes` back to a checkpoint but leaves the cache populated. A later insert from the same source `id` then finds a stale entry whose cached absolute index now points past the shrunken `nested_column`, skips the real insert and stores a dangling index. Materializing the column afterwards (`nested_column->index(indexes)`) reads out of bounds.

`rollback()` is reached for arbitrary column types (including lazy-replicated `ColumnReplicated`) on insert error-recovery paths that roll a partially filled column back and then keep inserting from the same source columns:

- `StorageBuffer::appendBlock` (rollback on a mid-batch insertion exception),
- `AsynchronousInsertQueue` (rollback of result columns on a parse error),
- the `Kafka` / `RabbitMQ` / `FileLog` streaming sources and `StreamingFormatExecutor` (per-row error recovery).

The fix clears `insertion_cache` in `rollback()`, mirroring `filter()`.

A unit test (`ColumnReplicated.RollbackClearsInsertionCache`) reproduces the bug: it inserts from a source, rolls back, and re-inserts the same source value. Before the fix the re-insert is skipped and a dangling index is stored (the test fails / reads OOB under ASan); after the fix the value is correctly re-inserted.

Found while investigating the cross-thread heap-corruption family tracked in #106370 (ASan free-time crashes around MergeTree merges / lazy-replicated columns). This is a real, deterministic correctness bug in the same `ColumnReplicated` area; it is not claimed to be the specific corruptor behind every #106370 occurrence (the merge-output path does not go through `rollback()`), but it is an independent out-of-bounds bug worth fixing on its own.
