### PR TITLE
Reduce lock-contention from getTotalByteCount in ConcurrentHashJoin

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -320,6 +320,10 @@ bool ConcurrentHashJoin::addBlockToJoin(const Block & right_block_, bool check_l
                 auto [block, selector] = std::move(dispatched_block).detachData();
                 bool limit_exceeded = !hash_join->data->addBlockToJoin(block, std::move(selector), check_limits);
 
+                /// Update the snapshot of total rows and bytes for the current join instance
+                hash_join->total_rows.store(hash_join->data->getTotalRowCount(), std::memory_order_relaxed);
+                hash_join->total_bytes.store(hash_join->data->getTotalByteCount(), std::memory_order_relaxed);
+
                 dispatched_block = {};
                 blocks_left--;
 
@@ -454,10 +458,7 @@ size_t ConcurrentHashJoin::getTotalRowCount() const
 {
     size_t res = 0;
     for (const auto & hash_join : hash_joins)
-    {
-        std::lock_guard lock(hash_join->mutex);
-        res += hash_join->data->getTotalRowCount();
-    }
+        res += hash_join->total_rows.load(std::memory_order_relaxed);
     return res;
 }
 
@@ -465,10 +466,7 @@ size_t ConcurrentHashJoin::getTotalByteCount() const
 {
     size_t res = 0;
     for (const auto & hash_join : hash_joins)
-    {
-        std::lock_guard lock(hash_join->mutex);
-        res += hash_join->data->getTotalByteCount();
-    }
+        res += hash_join->total_bytes.load(std::memory_order_relaxed);
     return res;
 }
 
@@ -735,6 +733,8 @@ BlocksList ConcurrentHashJoin::releaseSlotBlocks(size_t slot_idx)
     std::lock_guard lock(hash_join->mutex);
     if (!hash_join->data || !hash_join->data->getJoinedData())
         return {};
+    hash_join->total_rows.store(0, std::memory_order_relaxed);
+    hash_join->total_bytes.store(0, std::memory_order_relaxed);
     return hash_join->data->releaseJoinedBlocks(/*restructure=*/ false);
 }
 

--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -220,6 +220,7 @@ ConcurrentHashJoin::ConcurrentHashJoin(
                         /*use_two_level_maps*/ true);
                     inner_hash_join->data->setMaxJoinedBlockRows(table_join->maxJoinedBlockRows());
                     inner_hash_join->data->setMaxJoinedBlockBytes(table_join->maxJoinedBlockBytes());
+                    inner_hash_join->total_bytes.store(inner_hash_join->data->getTotalByteCount(), std::memory_order_relaxed);
                     hash_joins[i] = std::move(inner_hash_join);
                 });
         }

--- a/src/Interpreters/ConcurrentHashJoin.h
+++ b/src/Interpreters/ConcurrentHashJoin.h
@@ -110,6 +110,11 @@ public:
         std::mutex mutex;
         std::unique_ptr<HashJoin> data;
         bool space_was_preallocated = false;
+
+        /// Snapshot of the total rows and bytes held by the hash join. This is updated during
+        /// `addBlockToJoin` and is used to track the whole join state without locking.
+        std::atomic<size_t> total_rows{0};
+        std::atomic<size_t> total_bytes{0};
     };
 
     friend class NotJoinedHash;


### PR DESCRIPTION
`getTotalByteCount` (and `getTotalRowCount`) in ConcurrentHashJoin loop over all HashJoin instances and lock them to extract the total. This leads to high lock contention when such a function is called frequently (this is the case for SpillingHashJoin that checks the byte limit on each block).
The contention can add a lot of overhead and make queries flaky.

For query 9 from TPC-H at sf100 for 7 queries runtime (warm) fluctuates between 2690ms and 2966ms (`getTotalByteCount` taking between 164ms and 347ms).
<img width="3386" height="1378" alt="image" src="https://github.com/user-attachments/assets/a9f22926-62a1-4b75-9a09-32737c615ebb" />
<img width="3456" height="1368" alt="image" src="https://github.com/user-attachments/assets/3a59cb5c-8fe6-46d2-87fe-235907ca21bf" />

This change records the current totals of each hash join instance during insert while the lock is already held and makes `getTotalByteCount` (and `getTotalRowCount`) lock-free.

TPC-H q9 runtime improves to 2.4~2.5ms
<img width="3458" height="1362" alt="image" src="https://github.com/user-attachments/assets/3a38a302-5f71-451f-9f1f-d4eb879b8006" />


<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduce the overhead coming from lock-contention in `parallel_hash` join algorithm.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.474` (included in `26.7` and later)
<!-- ch-version-info:end -->