### PR TITLE
Fix horizontal scroll reset in Web UI when clicking a link in a table cell

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1376,7 +1376,7 @@ class QueryResultElement extends HTMLElement
                 }
 
                 /* The selected cell receives keyboard focus; selection is shown by
-                   `.td-selected`, so suppress the default focus outline. */
+                   the .td-selected class, so suppress the default focus outline. */
                 td:focus
                 {
                     outline: none;

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1375,6 +1375,13 @@ class QueryResultElement extends HTMLElement
                     vertical-align: top;
                 }
 
+                /* The selected cell receives keyboard focus; selection is shown by
+                   `.td-selected`, so suppress the default focus outline. */
+                td:focus
+                {
+                    outline: none;
+                }
+
                 /* Inner div limits cell height to 3 lines; expands on selection */
                 .cell-content
                 {
@@ -1724,12 +1731,35 @@ class QueryResultElement extends HTMLElement
         this._current_selected_cell = null;
     }
 
+    /// Select a cell and move keyboard focus to it. We focus the cell itself rather than
+    /// the whole result element: the browser scrolls the focused element into view both on
+    /// `focus` and when the tab is re-focused (e.g. after opening a link in a new tab). The
+    /// result element spans the full width starting at the left edge, so focusing it would
+    /// scroll the horizontal position back to the start; focusing the cell keeps the current
+    /// scroll position because the cell is already in view. `preventScroll` avoids an extra
+    /// jump here since we scroll the cell into view explicitly with `block: 'nearest'`.
+    _selectCell(td)
+    {
+        if (this._current_selected_cell)
+        {
+            this._current_selected_cell.classList.remove('td-selected');
+            this._current_selected_cell.parentElement.classList.remove('tr-selected');
+        }
+        this._current_selected_cell = td;
+        td.classList.add('td-selected');
+        td.parentElement.classList.add('tr-selected');
+        (td.querySelector('.cell-content') || td).scrollIntoView({ block: 'nearest' });
+        td.tabIndex = -1;
+        td.focus({ preventScroll: true });
+    }
+
     clearSelection()
     {
         if (this._current_selected_cell)
         {
             this._current_selected_cell.classList.remove('td-selected');
             this._current_selected_cell.parentElement.classList.remove('tr-selected');
+            this._current_selected_cell.removeAttribute('tabindex');
         }
         this._current_selected_cell = null;
     }
@@ -1884,16 +1914,7 @@ class QueryResultElement extends HTMLElement
             const td = this._renderCell(column.name, row[column.name]);
 
             td.onclick = () => {
-                if (this._current_selected_cell)
-                {
-                    this._current_selected_cell.classList.remove('td-selected');
-                    this._current_selected_cell.parentElement.classList.remove('tr-selected');
-                }
-                this._current_selected_cell = td;
-                td.classList.add('td-selected');
-                td.parentElement.classList.add('tr-selected');
-                (td.querySelector('.cell-content') || td).scrollIntoView({ block: 'nearest' });
-                this.focus();
+                this._selectCell(td);
             };
 
             tr.appendChild(td);
@@ -2258,12 +2279,8 @@ class QueryResultElement extends HTMLElement
 
         e.preventDefault();
 
-        cell.classList.remove('td-selected');
-        cell.parentElement.classList.remove('tr-selected');
-        new_cell.classList.add('td-selected');
-        new_cell.parentElement.classList.add('tr-selected');
-        (new_cell.querySelector('.cell-content') || new_cell).scrollIntoView({ block: 'nearest' });
-        this._current_selected_cell = new_cell;
+        cell.removeAttribute('tabindex');
+        this._selectCell(new_cell);
     }
 
     _loadJS(src, integrity)


### PR DESCRIPTION
When a result cell contained a link and the table was scrolled horizontally to the right, clicking the link (which opens in a new tab) and returning to the Web UI reset the horizontal scroll position back to the left.

The cause: selecting a cell called `this.focus()` on the whole `query-result` element. That element spans the full width with its left edge at the start of the scroll container, so the browser scrolled it into view both on `focus` and when the tab was re-focused on return, resetting the horizontal scroll.

The fix focuses the selected cell itself instead. Every scroll-into-view now targets the cell, which is already at the scrolled position, so the horizontal scroll is preserved. Keyboard navigation still works because `keydown` bubbles from the focused cell up to the listener on the component.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the horizontal scroll position of the result table being reset in the Web UI when clicking a link in a cell and returning to the page.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.309` (included in `26.7` and later)
<!-- ch-version-info:end -->