### PR TITLE
Don't check empty schema in SchemaProcessor

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.cpp
@@ -210,6 +210,12 @@ void IcebergSchemaProcessor::addIcebergTableSchema(Poco::JSON::Object::Ptr schem
     std::lock_guard lock(mutex);
 
     Int32 schema_id = schema_ptr->getValue<Int32>(f_schema_id);
+
+    /// Databricks UniForm writes a degenerate placeholder schema (e.g. {"schema-id":0,"fields":[]})
+    /// into manifest files, while the real schema with the same schema-id lives in metadata.json.
+    if (!schema_ptr->isArray(f_fields) || schema_ptr->getArray(f_fields)->size() == 0)
+        return;
+
     current_schema_id = schema_id;
     if (iceberg_table_schemas_by_ids.contains(schema_id))
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.304` (included in `26.7` and later)
- Backported to: `26.5.6.8`, `26.3.17.14`, `25.8.29.36`
<!-- ch-version-info:end -->