### PR TITLE
Fix flaky test_implicit_index_upgrade_alter_replay (replica fetch race)

### DIFF
--- a/tests/integration/test_implicit_index_upgrade/test.py
+++ b/tests/integration/test_implicit_index_upgrade/test.py
@@ -225,6 +225,12 @@ def test_implicit_index_upgrade_alter_replay(started_cluster):
 
     wait_for_active_replica(node2, "test_alter_replay")
 
+    # wait_for_active_replica only waits for is_readonly = 0, not for the freshly-joined
+    # replica to finish fetching parts. SYSTEM SYNC REPLICA blocks until node2 has fetched
+    # all parts; otherwise the count assertion below races with the background fetch and can
+    # observe only the small VALUES part (1 row) before the 10000-row part arrives.
+    node2.query("SYSTEM SYNC REPLICA test_alter_replay;")
+
     # Verify node2 has the ALTER-added column and all data.
     assert node2.query("SELECT count() FROM test_alter_replay;").strip() == "10001"
     assert (


### PR DESCRIPTION
The integration test `test_implicit_index_upgrade/test.py::test_implicit_index_upgrade_alter_replay` creates a second replica `node2` and asserts `SELECT count() FROM test_alter_replay` equals `10001` immediately after `wait_for_active_replica`.

`wait_for_active_replica` only waits for `is_readonly = 0`, not for the freshly-joined replica to finish fetching parts. As a result `node2` can observe only the small `VALUES` part (1 row, `key = 99999`) before the 10000-row part is fetched, and the assertion fails with `assert '1' == '10001'`. This raced once each on several unrelated PRs over the last 30 days (e.g. #108084, #99280, #107566, #107442).

The fix adds `SYSTEM SYNC REPLICA test_alter_replay` after the replica becomes active — it blocks until all parts are fetched — before checking the row count.

CI report (one occurrence): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108770&sha=bb760616d54e3d8e5d20968022085506c31b5f37&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%201%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.308` (included in `26.7` and later)
<!-- ch-version-info:end -->