### PR TITLE
Fix flaky test 04051_pk_analysis_stats: QCC entry evicted by parallel tests

### DIFF
--- a/tests/queries/0_stateless/04051_pk_analysis_stats.sql
+++ b/tests/queries/0_stateless/04051_pk_analysis_stats.sql
@@ -1,3 +1,7 @@
+-- Tags: no-parallel
+-- Tag no-parallel: depends on the server-level query condition cache entry written by the
+-- pre-warm query still being resident for the measured query (same reason as 04065, 04275).
+
 -- Previously, the logs looked like this:
 --
 -- (SelectExecutor): Key condition: unknown


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/107306
Related: https://github.com/ClickHouse/ClickHouse/pull/100365
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to the `04051_pk_analysis_stats` flakiness, fixing a second, independent mechanism (the parallel-replicas facet is fixed separately in #107306).

The test pre-warms the query condition cache with one query, then a second query asserts PK analysis processed fewer marks than the total, because the QCC dropped granules:

```sql
-- pre-warm
select avg(a) from t where s != 'xxx' format Null;
-- measured
select avg(a) from t where s != 'xxx' settings log_comment = '04051_pk_analysis_stats_query' format Null;
-- assert: FilteringMarksWithPrimaryKeyProcessedMarks < total_marks (25)
```

The QCC is server-level shared state: a bounded 100 MiB SLRU keyed by `table_uuid + part_name + condition_hash`, whose size is a server setting (`query_condition_cache_size`), not a per-session setting. A stateless test therefore cannot size or pin its own entry.

About 40 other stateless tests run in the parallel phase with `use_query_condition_cache = 1` and write to the same cache. On slow builds (`amd_msan, WasmEdge`) the gap between the pre-warm and the measured query stretches, and cumulative writes from those concurrent tests size-evict 04051's small probationary entry. The measured query then misses the cache, PK analysis processes all 25 marks, and `throwIf(processed >= total_marks)` fires.

Tagging the test `no-parallel` runs it in the sequential phase with no concurrent QCC writers, matching the existing QCC tests 04065 and 04275 (whose comment notes the same "messes with the server-level query condition cache" reason). The tag is orthogonal to the existing `no-parallel-replicas` fix (a different mechanism), and the assertion is unchanged.

Verified deterministically on a debug build: with the entry resident the measured query processes 14 marks (passes); after evicting it between the two queries (`SYSTEM DROP QUERY CONDITION CACHE`, or flooding a shrunk QCC with 60 distinct conditions) it processes all 25 marks and the assertion fires, reproducing the CI failure exactly.

Failure report (latest, `Stateless tests (amd_msan, WasmEdge, parallel, 1/2)`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100365&sha=4b7f8c434d651b93cc28344564932df9f8312ce4&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29
