### PR TITLE
Fix wrong access type for SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2733,7 +2733,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
         }
         case Type::PREWARM_PRIMARY_INDEX_CACHE:
         {
-            required_access.emplace_back(AccessType::SYSTEM_PREWARM_MARK_CACHE, query.getDatabase(), query.getTable());
+            required_access.emplace_back(AccessType::SYSTEM_PREWARM_PRIMARY_INDEX_CACHE, query.getDatabase(), query.getTable());
             break;
         }
         case Type::SYNC_DATABASE_REPLICA:

--- a/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.reference
+++ b/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.reference
@@ -1,0 +1,6 @@
+local
+ok
+on cluster
+ok
+denied without grant
+the grant SYSTEM PREWARM PRIMARY INDEX CACHE

--- a/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.sh
+++ b/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.sh
@@ -35,14 +35,15 @@ $CLICKHOUSE_CLIENT -mq "
 "
 
 # Local form: already works (checks SYSTEM_PREWARM_PRIMARY_INDEX_CACHE).
+# Assert the command actually succeeds (zero exit), not just the absence of ACCESS_DENIED.
 echo "local"
-$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE $CLICKHOUSE_DATABASE.$table" 2>&1 \
-    | grep -m1 -F -o "ACCESS_DENIED" || echo "ok"
+$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE $CLICKHOUSE_DATABASE.$table" >/dev/null || exit 1
+echo "ok"
 
 # ON CLUSTER form: before the fix it was denied asking for SYSTEM PREWARM MARK CACHE.
 echo "on cluster"
-$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICKHOUSE_DATABASE.$table" 2>&1 \
-    | grep -m1 -F -o "ACCESS_DENIED" || echo "ok"
+$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICKHOUSE_DATABASE.$table" >/dev/null || exit 1
+echo "ok"
 
 # Negative control: a user WITHOUT the privilege is denied, and the required grant
 # named in the error is SYSTEM PREWARM PRIMARY INDEX CACHE (not MARK CACHE).

--- a/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.sh
+++ b/tests/queries/0_stateless/03801_prewarm_primary_index_cache_on_cluster_grant.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, zookeeper
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/108956
+# The ON CLUSTER form of SYSTEM PREWARM PRIMARY INDEX CACHE used to require
+# SYSTEM PREWARM MARK CACHE (copy-paste bug in getRequiredAccessForDDLOnCluster).
+# A user granted only SYSTEM PREWARM PRIMARY INDEX CACHE must be able to run the
+# ON CLUSTER form, matching the local-execution access check.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+user="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+table="t_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT -mq "
+        DROP USER IF EXISTS $user;
+        DROP TABLE IF EXISTS $table;
+    "
+}
+cleanup
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -mq "
+    CREATE TABLE $table (a UInt64) ENGINE = MergeTree ORDER BY a
+    SETTINGS prewarm_primary_key_cache = 1, use_primary_key_cache = 1;
+    INSERT INTO $table SELECT number FROM numbers(100);
+
+    CREATE USER $user;
+    -- Grant ONLY the primary-index-cache prewarm privilege (and CLUSTER), NOT mark-cache.
+    -- SYSTEM PREWARM PRIMARY INDEX CACHE is a GLOBAL privilege (granted ON *.*).
+    GRANT CLUSTER, SYSTEM PREWARM PRIMARY INDEX CACHE ON *.* TO $user;
+"
+
+# Local form: already works (checks SYSTEM_PREWARM_PRIMARY_INDEX_CACHE).
+echo "local"
+$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE $CLICKHOUSE_DATABASE.$table" 2>&1 \
+    | grep -m1 -F -o "ACCESS_DENIED" || echo "ok"
+
+# ON CLUSTER form: before the fix it was denied asking for SYSTEM PREWARM MARK CACHE.
+echo "on cluster"
+$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICKHOUSE_DATABASE.$table" 2>&1 \
+    | grep -m1 -F -o "ACCESS_DENIED" || echo "ok"
+
+# Negative control: a user WITHOUT the privilege is denied, and the required grant
+# named in the error is SYSTEM PREWARM PRIMARY INDEX CACHE (not MARK CACHE).
+echo "denied without grant"
+$CLICKHOUSE_CLIENT -q "REVOKE SYSTEM PREWARM PRIMARY INDEX CACHE ON *.* FROM $user"
+$CLICKHOUSE_CLIENT --user "$user" -q "SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICKHOUSE_DATABASE.$table" 2>&1 \
+    | grep -m1 -F -o "the grant SYSTEM PREWARM PRIMARY INDEX CACHE" || echo "wrong error"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108956
Related: https://github.com/ClickHouse/ClickHouse/pull/108546
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER` requiring the `SYSTEM PREWARM MARK CACHE` privilege instead of `SYSTEM PREWARM PRIMARY INDEX CACHE`. A user granted only `SYSTEM PREWARM PRIMARY INDEX CACHE` can now run the `ON CLUSTER` form, matching local execution.


### Description

The `PREWARM_PRIMARY_INDEX_CACHE` case in `getRequiredAccessForDDLOnCluster()` was a copy of the `PREWARM_MARK_CACHE` case and was never updated to its own `AccessType`, so the ON CLUSTER access check diverged from the local-execution check in `prewarmPrimaryIndexCache()` (which correctly uses `SYSTEM_PREWARM_PRIMARY_INDEX_CACHE`). Reported in #108956 (found while documenting SYSTEM cache statements in #108546).

Reproduced locally in both directions (added stateless test `03801_prewarm_primary_index_cache_on_cluster_grant`): with the buggy mapping a user holding only `SYSTEM PREWARM PRIMARY INDEX CACHE` is denied the ON CLUSTER form asking for `SYSTEM PREWARM MARK CACHE`; with the fix both the local and ON CLUSTER forms succeed.
