### PR TITLE
Perf optimization for parsing of deeply nested array and tuple literals

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1497,7 +1497,7 @@ bool ParserCollectionOfLiterals<Collection>::parseImpl(Pos & pos, ASTPtr & node,
                     return true;
                 }
 
-                layers.back().arr.push_back(literal->value);
+                layers.back().arr.push_back(std::move(literal->value));
                 continue;
             }
             if (pos->type == TokenType::Comma)

--- a/tests/queries/0_stateless/04412_deep_nested_literal_format.sh
+++ b/tests/queries/0_stateless/04412_deep_nested_literal_format.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-debug, no-sanitizers
-#       no-fasttest/no-debug/no-sanitizers: building the deeply nested literal is quadratic and
-#       only fast enough in an optimized build; the stack guard it exercises is build-independent.
+# Tags: no-fasttest
+#       no-fasttest: test pipes a 40KB query string through stdin and uses very high 
+#       max_parser_depth, which is awkward in fasttest's constrained environment
 # A deeply nested literal lives inside a single ASTLiteral::value, and formatting/hashing it
 # walks that nested Field through recursive Field visitors. Reaching the format path without
-# type inference (formatQuery) used to overflow the native stack and crash the server. The
-# literal Field is built in quadratic time, so this is only fast enough in optimized builds;
-# the stack guard it exercises is build-independent, so an optimized build is sufficient.
+# type inference (formatQuery) used to overflow the native stack and crash the server.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix quadratic parsing of deeply nested literals for arrays and tuples. Basically replaces copying with moving. Around 10-30x perf benefit on deep nesting cases
