### PR TITLE
Retry docker buildx on transient docker.io registry errors

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -222,19 +222,19 @@ def gen_tags(version_str: str, tag_type: str) -> List[str]:
 
 
 # `docker buildx build` resolves base/SBOM-scanner images from docker.io, which
-# intermittently returns transient HTTP errors. Retry the buildx commands on those
-# signatures (Shell.run uses exponential backoff and only retries on these strings,
-# so a genuine Dockerfile/build error still fails fast).
+# intermittently returns transient HTTP errors. Retry the buildx commands only on
+# genuine registry/network *failure* signatures. None of these strings appear in
+# normal `--progress=plain` output (unlike progress text such as "resolve image
+# config"), so a real Dockerfile/build error (RUN/COPY/package install) still fails
+# fast on the first attempt.
 BUILDX_RETRIES = 5
 BUILDX_RETRY_ERRORS = [
-    "registry-1.docker.io",
-    "resolve image config",
     "failed to do request",
     "unexpected status from HEAD request",
     "TLS handshake timeout",
     "i/o timeout",
     "connection reset by peer",
-    "error from registry",
+    "connection refused",
 ]
 
 

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -221,6 +221,23 @@ def gen_tags(version_str: str, tag_type: str) -> List[str]:
     return tags
 
 
+# `docker buildx build` resolves base/SBOM-scanner images from docker.io, which
+# intermittently returns transient HTTP errors. Retry the buildx commands on those
+# signatures (Shell.run uses exponential backoff and only retries on these strings,
+# so a genuine Dockerfile/build error still fails fast).
+BUILDX_RETRIES = 5
+BUILDX_RETRY_ERRORS = [
+    "registry-1.docker.io",
+    "resolve image config",
+    "failed to do request",
+    "unexpected status from HEAD request",
+    "TLS handshake timeout",
+    "i/o timeout",
+    "connection reset by peer",
+    "error from registry",
+]
+
+
 def buildx_args(
     urls: Dict[str, str],
     arch: str,
@@ -331,7 +348,12 @@ def build_and_push_image(
         cmd = " ".join(cmd_args)
         logging.info("Building image %s:%s for arch %s: %s", image.name, tag, arch, cmd)
         result.append(
-            Result.from_commands_run(name=f"{image.name}:{tag}-{arch}", command=cmd)
+            Result.from_commands_run(
+                name=f"{image.name}:{tag}-{arch}",
+                command=cmd,
+                retries=BUILDX_RETRIES,
+                retry_errors=BUILDX_RETRY_ERRORS,
+            )
         )
         if not result[-1].is_ok():
             return result
@@ -344,7 +366,14 @@ def build_and_push_image(
             f"--tag {image.name}:{tag} {' '.join(digests)}"
         )
         logging.info("Pushing merged %s:%s image: %s", image.name, tag, cmd)
-        result.append(Result.from_commands_run(name=f"{image.name}:{tag}", command=cmd))
+        result.append(
+            Result.from_commands_run(
+                name=f"{image.name}:{tag}",
+                command=cmd,
+                retries=BUILDX_RETRIES,
+                retry_errors=BUILDX_RETRY_ERRORS,
+            )
+        )
         if not result[-1].is_ok():
             return result
     else:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/105139
Related: https://github.com/ClickHouse/ClickHouse/pull/108675


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

The `Docker server image` job builds the distroless/alpine/ubuntu images with `docker buildx build`. buildx resolves the SBOM scanner image (`docker/buildkit-syft-scanner`, pulled because of `--sbom=true`) and the base images from docker.io. A transient docker.io outage fails the build at the resolve step, e.g.:

```
#2 resolve image config for docker-image://docker.io/docker/buildkit-syft-scanner:stable-1
#2 ERROR: unexpected status from HEAD request to https://registry-1.docker.io/...
```

and the downstream `docker library image test` then reports `image does not exist!` as a secondary victim.

praktika's `Shell.run` / `Result.from_commands_run` already support retries with exponential backoff plus an error allowlist, but the buildx build and the imagetools merge ran with no retries. This wires `retries=5` and an allowlist of transient registry/network signatures into both calls. The allowlist keeps fail-fast behavior for genuine Dockerfile/build errors. Mirrors the existing retry hardening for in-Dockerfile wget downloads (#105139) and the keeper image S3 artifact fetch (#108675).

Observed on master and PRs during a ~6 min docker.io blip on 2026-06-30 15:00-15:06 UTC (recovered on its own). Report (master): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=36f0c2d95475aafa597cacebace14f5888908dcd&name_0=MasterCI&name_1=Docker%20server%20image


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.307` (included in `26.7` and later)
<!-- ch-version-info:end -->