### PR TITLE
Web UI: fix download failing with authentication error

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5335,22 +5335,37 @@ document.getElementById('download-button').addEventListener('click', async funct
 
     let downloadQuery = query.replaceAll(/\bFORMAT\s+\w+/ig, '');
 
-    // Create a form and submit it to trigger download
-    const form = document.createElement('form');
-    form.method = 'POST';
-    form.action = url;
-    form.enctype = 'multipart/form-data';
-    form.style.display = 'none';
+    // Fetch the result and save it. We use `fetch` (not a form submit) so we can
+    // send the `Authorization: never` header, which prevents the browser from
+    // attaching a cached Basic-auth header. That header would otherwise conflict
+    // with the `user`/`password` URL parameters and the server would reject the
+    // request with "Code: 516 ... not allowed to use Authorization HTTP header and
+    // authentication via parameters simultaneously" (a form submit cannot set
+    // headers, so it cannot suppress the cached credentials).
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            body: downloadQuery,
+            headers: { 'Authorization': 'never' },
+        });
 
-    const queryInput = document.createElement('input');
-    queryInput.type = 'hidden';
-    queryInput.name = 'query';
-    queryInput.value = downloadQuery;
-    form.appendChild(queryInput);
+        if (!response.ok) {
+            alert('Download failed:\n' + (await response.text()));
+            return;
+        }
 
-    document.body.appendChild(form);
-    form.submit();
-    document.body.removeChild(form);
+        const blob = await response.blob();
+        const object_url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = object_url;
+        a.download = `result.${extension}`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(object_url);
+    } catch (e) {
+        alert('Download failed:\n' + e);
+    }
 
     // Close dropdown
     document.getElementById('download-dropdown').classList.remove('show');


### PR DESCRIPTION
Downloading a query result in the Web UI (`play.html`) failed with:

```
Code: 516. DB::Exception: Invalid authentication: it is not allowed to use Authorization HTTP header and authentication via parameters simultaneously. (AUTHENTICATION_FAILED)
```

The download used a hidden `<form>` POST submit, which cannot set request headers. When the browser had cached Basic-auth credentials, it attached an `Authorization` header to the submit, which conflicted with the `user`/`password` URL parameters the page also adds — so the server rejected the request.

Every other request in the page already avoids this by sending the `Authorization: never` header via `fetch` to suppress the cached credentials. This change switches the download to the same mechanism: `fetch` the result with `Authorization: never` and save the response blob via an object URL. As a bonus, download errors are now surfaced to the user instead of silently navigating a hidden form.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI (`play.html`): fix downloading a result failing with `AUTHENTICATION_FAILED` (error 516) when the browser holds cached Basic-auth credentials.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
