### PR TITLE
Retry integration-test image pre-pull with exponential backoff

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -240,7 +240,7 @@ def get_images_from_compose_files(compose_files: List[Path]) -> List[str]:
 
 
 def prefetch_images(
-    images: List[str], retries: int = 3, pull_timeout: int = 300
+    images: List[str], retries: int = 5, pull_timeout: int = 300
 ) -> bool:
     """Pull every image in parallel using `ci/prefetch-integration-test-images`.
 

--- a/ci/jobs/scripts/prefetch-integration-test-images
+++ b/ci/jobs/scripts/prefetch-integration-test-images
@@ -8,13 +8,17 @@
 #   ci/prefetch-integration-test-images IMAGE [IMAGE ...]
 #
 # Environment variables:
-#   PULL_RETRIES   Number of pull attempts per image (default: 3)
-#   PULL_TIMEOUT   Per-attempt timeout in seconds (default: 300)
+#   PULL_RETRIES        Number of pull attempts per image (default: 5)
+#   PULL_TIMEOUT        Per-attempt timeout in seconds (default: 300)
+#   PULL_BACKOFF_BASE   Base backoff in seconds; doubled each retry (default: 5)
+#   PULL_BACKOFF_MAX    Cap on a single backoff sleep in seconds (default: 60)
 
 set -uo pipefail
 
-PULL_RETRIES="${PULL_RETRIES:-3}"
+PULL_RETRIES="${PULL_RETRIES:-5}"
 PULL_TIMEOUT="${PULL_TIMEOUT:-300}"
+PULL_BACKOFF_BASE="${PULL_BACKOFF_BASE:-5}"
+PULL_BACKOFF_MAX="${PULL_BACKOFF_MAX:-60}"
 
 images=("$@")
 if [[ ${#images[@]} -eq 0 ]]; then
@@ -34,7 +38,7 @@ pull_one()
 {
     local image="$1"
     local fail_file="$2"
-    local attempt out start elapsed
+    local attempt out start elapsed backoff
 
     for ((attempt = 1; attempt <= PULL_RETRIES; attempt++)); do
         echo "Pulling $image (attempt $attempt/$PULL_RETRIES) ..."
@@ -53,7 +57,15 @@ pull_one()
         echo "Pull of $image failed on attempt $attempt (${elapsed}s elapsed):"
         echo "$out"
         if ((attempt < PULL_RETRIES)); then
-            sleep 5
+            # Exponential backoff with jitter. The registry intermittently returns
+            # transient errors (e.g. HTTP 500) under load; a fixed short sleep is too
+            # narrow to ride those out, and all images pull in parallel, so jitter also
+            # de-synchronizes the retries instead of hammering the registry in lockstep.
+            backoff=$((PULL_BACKOFF_BASE * (1 << (attempt - 1))))
+            ((backoff > PULL_BACKOFF_MAX)) && backoff=$PULL_BACKOFF_MAX
+            backoff=$((backoff + RANDOM % (PULL_BACKOFF_BASE + 1)))
+            echo "Retrying $image in ${backoff}s ..."
+            sleep "$backoff"
         fi
     done
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

No related open issue (generic CI infrastructure reliability fix).
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Integration test jobs pre-pull all Docker images for the batch before tests start (`ci/jobs/scripts/prefetch-integration-test-images`). When the registry returns a transient error for one image, the whole job fails at the pre-pull stage with `Failed to pre-pull Docker images needed by the test batch` and no per-test result, so an unrelated PR's check goes red.

Example: PR #108550, `Integration tests (arm_binary, distributed plan, 4/4)`, [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108550&sha=f977bcab0500783c0f6a86d3898183486557f5c6&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29). `clickhouse/test-mysql57` and `clickhouse/kerberos-kdc` each returned `received unexpected HTTP status: 500 Internal Server Error` on all 3 attempts within a ~13s window, while ~18 other images pulled fine. This pattern recurs across many unrelated PRs (e.g. a registry outage on 2026-06-15 produced ~295 such job-level failures across 22 PRs in one day).

The previous retry policy was 3 attempts with a fixed 5s sleep, a ~13s window that is too narrow to ride out a registry hiccup, and because all images pull in parallel the retries hit the registry in lockstep.

This change:
- raises the default retries to 5 (matching the buildx retry count introduced in #108969),
- replaces the fixed sleep with exponential backoff (`PULL_BACKOFF_BASE` doubled each retry, capped at `PULL_BACKOFF_MAX`) plus a small random jitter that de-synchronizes the parallel retries.

Genuine errors still fail fast: arch-missing manifests are skipped on the first attempt, and a persistent failure still exits non-zero after the retries are exhausted.
