### PR TITLE
Retry tests on server-wide (total) memory limit errors

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -120,6 +120,11 @@ MESSAGES_TO_RETRY = [
     # Transient Keeper errors that happen under heavy load (e.g. ARM ASan builds)
     "Coordination::Exception: Connection loss",
     "Coordination::Exception: Session expired",
+    # Server-wide RSS hard limit hit by the OvercommitTracker: the box is over
+    # its total memory budget (co-running tests), so an innocent query is killed.
+    # Uniquely worded "(total)" by the global tracker; per-query/user limits read
+    # "Query"/"User" and are NOT matched, so real per-query OOMs still fail.
+    "(total) memory limit exceeded",
 ]
 
 IGNORED_SANITIZER_ERRORS = [


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108103
Related: https://github.com/ClickHouse/ClickHouse/pull/107441
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108103
Related: https://github.com/ClickHouse/ClickHouse/pull/107441

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @alexey-milovidov in https://github.com/ClickHouse/ClickHouse/pull/108103#issuecomment (CI triage of `03748_join_on_complex_condition_result_memory`).

`03748_join_on_complex_condition_result_memory` (and ~148 other tests over the last 30 days) fail on `Stateless tests (arm_asan_ubsan, azure, parallel)` with:

```
Code: 241. DB::Exception: (total) memory limit exceeded: would use 4.55 GiB
(attempt to allocate chunk of 1.39 MiB), current RSS: 54.38 GiB, maximum: 53.69 GiB.
OvercommitTracker decision: Query was selected to stop by OvercommitTracker.
```

This is the server-wide `OvercommitTracker` stopping a query because the whole runner is over its total memory budget (RSS ~54 GiB vs the 53.69 GiB cap) from ~19 co-running ASan-instrumented tests, not the test's own per-query limit. `03748` itself pins `max_memory_usage = '50M'` and is an innocent victim. The same class of failure has hit `master` directly.

Fix: add `"(total) memory limit exceeded"` to `MESSAGES_TO_RETRY` so the runner retries (up to `MAX_RETRIES`), matching the existing transient-heavy-load retries (Keeper connection loss, etc.). The retry-then-fail behavior still surfaces genuine, persistent server OOM regressions.

Why this preserves the test's assertion: the `"(total)"` description is emitted only by the global memory tracker (`Server.cpp` / `LocalServer.cpp` `setDescription("(total)")`). Per-query and per-user limits read `"Query"` / `"User"` (`ProcessList.cpp`), so a real per-query OOM, including this test's own 50M assertion, still fails. No stateless test expects `"(total) memory limit exceeded"` in its output.

Complements #107441 (lowered concurrency on this shard); this addresses the residual host-pressure flakes across the whole suite rather than one test.

Report (the directive's failing run): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108103&sha=a6745c96cdeac9f697b73f53f633732bf6e79b3e&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29
