### PR TITLE
Analyzer: fix FINAL leaking onto other tables of a JOIN

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -4263,6 +4263,9 @@ void ReadFromMergeTree::describeActions(FormatSettings & format_settings) const
     std::string_view read_type_label = format_settings.pretty ? "Read type: " : "ReadType: ";
     format_settings.out << prefix << read_type_label << readTypeToString(result.read_type) << '\n';
 
+    if (isQueryWithFinal())
+        format_settings.out << prefix << "FINAL: 1\n";
+
     if (!result.index_stats.empty())
     {
         std::string_view delimiter = format_settings.pretty ? " | " : "\n";
@@ -4385,6 +4388,8 @@ void ReadFromMergeTree::describeActions(JSONBuilder::JSONMap & map) const
 {
     const auto & result = getAnalysisResult();
     map.add("Read Type", readTypeToString(result.read_type));
+    if (isQueryWithFinal())
+        map.add("FINAL", true);
     if (!result.index_stats.empty())
     {
         map.add("Parts", result.index_stats.back().num_parts_after);

--- a/src/Storages/SelectQueryInfo.cpp
+++ b/src/Storages/SelectQueryInfo.cpp
@@ -15,6 +15,9 @@ bool SelectQueryInfo::isFinal() const
     if (table_expression_modifiers)
         return table_expression_modifiers->hasFinal();
 
+    if (query_tree)
+        return false;
+
     const auto & select = query->as<ASTSelectQuery &>();
     return select.final();
 }

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1276,6 +1276,13 @@ ReadFromMerge::ChildPlan ReadFromMerge::createPlanForTable(
         /// NOTE: It may not work correctly in some cases, because query was analyzed without final.
         /// However, it's needed for Materialized...SQL and it's unlikely that someone will use it with Merge tables.
         modified_select.setFinal();
+
+        if (modified_query_info.query_tree)
+        {
+            if (!modified_query_info.table_expression_modifiers)
+                modified_query_info.table_expression_modifiers.emplace();
+            modified_query_info.table_expression_modifiers->setHasFinal(true);
+        }
     }
 
     bool use_analyzer = modified_context->getSettingsRef()[Setting::allow_experimental_analyzer];

--- a/tests/integration/test_postgresql_replica_database_engine/configs/users.xml
+++ b/tests/integration/test_postgresql_replica_database_engine/configs/users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <allow_experimental_database_materialized_postgresql>1</allow_experimental_database_materialized_postgresql>
+            <allow_experimental_materialized_postgresql_table>1</allow_experimental_materialized_postgresql_table>
             <postgresql_fault_injection_probability>0.1</postgresql_fault_injection_probability>
         </default>
     </profiles>

--- a/tests/integration/test_postgresql_replica_database_engine/test_1.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_1.py
@@ -5,6 +5,7 @@ import time
 import pytest
 
 from helpers.cluster import ClickHouseCluster
+from helpers.config_cluster import pg_pass
 from helpers.postgres_utility import (
     PostgresManager,
     assert_nested_table_is_created,
@@ -295,7 +296,6 @@ def test_abrupt_connection_loss_while_heavy_replication(started_cluster):
 
     time.sleep(2)
 
-
     with started_cluster.pause_container_using_signal("postgres1"):
         # for i in range(NUM_TABLES):
         #     result = instance.query(f"SELECT count() FROM test_database.postgresql_replica_{i}")
@@ -436,6 +436,55 @@ def test_user_managed_slots(started_cluster):
     pg_manager.drop_materialized_db()
     drop_replication_slot(replication_connection, slot_name)
     replication_connection.close()
+
+
+def test_merge_table_over_materialized_postgresql(started_cluster):
+    """
+    Reading a MaterializedPostgreSQL table through Merge forces FINAL on the child read
+    """
+    table_name = "postgresql_replica_final"
+    pg_manager.create_postgres_table(table_name)
+    instance.query(
+        f"INSERT INTO postgres_database.{table_name} SELECT number, number FROM numbers(3)"
+    )
+
+    instance.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
+    instance.query(
+        f"""
+        CREATE TABLE {table_name} (key Int32, value Int32)
+        ENGINE=MaterializedPostgreSQL('{started_cluster.postgres_ip}:{started_cluster.postgres_port}', 'postgres_database', '{table_name}', 'postgres', '{pg_pass}') ORDER BY key
+        """
+    )
+
+    try:
+        check_tables_are_synchronized(
+            instance, table_name, materialized_database="default"
+        )
+
+        # Stop merges so the nested ReplacingMergeTree keeps both versions of the
+        # updated row and the read has to deduplicate them with FINAL.
+        instance.query(f"SYSTEM STOP MERGES {table_name}")
+        pg_manager.execute(f"UPDATE {table_name} SET value = 42 WHERE key = 1")
+
+        check_tables_are_synchronized(
+            instance, table_name, materialized_database="default"
+        )
+
+        expected = "0\t0\n1\t42\n2\t2\n"
+        direct_query = f"SELECT key, value FROM {table_name} ORDER BY key, value"
+        merge_query = (
+            f"SELECT key, value FROM merge('default', '^{table_name}$')"
+            " ORDER BY key, value"
+        )
+
+        for query in [direct_query, merge_query]:
+            explain = instance.query(f"EXPLAIN actions=1 {query}")
+            assert "FINAL: 1" in explain, explain
+
+        assert instance.query(direct_query) == expected
+        assert instance.query(merge_query) == expected
+    finally:
+        instance.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
 
 
 if __name__ == "__main__":

--- a/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
+++ b/tests/queries/0_stateless/03928_deferred_filters_after_final_in_explain.reference
@@ -20,6 +20,7 @@ Positions: 3 0 1
     Positions: 0 3 1
       ReadFromMergeTree (default.tab)
       ReadType: InOrder
+      FINAL: 1
       Parts: 3
       Granules: 3
       Prewhere info
@@ -61,6 +62,7 @@ Positions: 3 0 1
     Positions: 0 3 1
       ReadFromMergeTree (default.tab)
       ReadType: InOrder
+      FINAL: 1
       Parts: 3
       Granules: 3
       Prewhere info

--- a/tests/queries/0_stateless/04489_analyzer_final_join_prewhere_pushdown.reference
+++ b/tests/queries/0_stateless/04489_analyzer_final_join_prewhere_pushdown.reference
@@ -1,0 +1,12 @@
+analyzer tables read with FINAL	1
+legacy tables read with FINAL	1
+result analyzer	x	a
+result legacy	x	a
+final reads none	0
+final reads left	1
+final reads right	1
+final reads both	2
+result none	['l_new/r_new','l_new/r_old','l_old/r_new','l_old/r_old']
+result left	['l_new/r_new','l_new/r_old']
+result right	['l_new/r_new','l_old/r_new']
+result both	['l_new/r_new']

--- a/tests/queries/0_stateless/04489_analyzer_final_join_prewhere_pushdown.sql
+++ b/tests/queries/0_stateless/04489_analyzer_final_join_prewhere_pushdown.sql
@@ -1,0 +1,87 @@
+-- FINAL is a per-table modifier: `<t1> FINAL JOIN <t2>` must read only `t1` with FINAL, not `t2`.
+
+DROP TABLE IF EXISTS t1_final_join;
+DROP TABLE IF EXISTS t2_final_join;
+
+CREATE TABLE t1_final_join (id Int32, s String) ENGINE = ReplacingMergeTree ORDER BY id;
+CREATE TABLE t2_final_join (id Int32, v String) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t1_final_join VALUES (1, 'a'), (2, 'b'), (3, 'c');
+INSERT INTO t2_final_join VALUES (1, 'x'), (2, 'y'), (3, 'z');
+
+-- Exactly one table (t1) must be read with FINAL; before the fix t2 was read with FINAL too (count 2).
+
+SET enable_analyzer = 1;
+SELECT 'analyzer tables read with FINAL', countIf(explain LIKE '%FINAL: 1%')
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT t2_final_join.v, t1_final_join.s
+    FROM t1_final_join FINAL
+    JOIN t2_final_join ON t2_final_join.id = t1_final_join.id
+    WHERE t2_final_join.v = 'x'
+);
+
+SET enable_analyzer = 0;
+SELECT 'legacy tables read with FINAL', countIf(explain LIKE '%FINAL: 1%')
+FROM
+(
+    EXPLAIN actions = 1
+    SELECT t2_final_join.v, t1_final_join.s
+    FROM t1_final_join FINAL
+    JOIN t2_final_join ON t2_final_join.id = t1_final_join.id
+    WHERE t2_final_join.v = 'x'
+);
+
+-- Results must stay correct in both modes.
+SET enable_analyzer = 1;
+SELECT 'result analyzer', t2_final_join.v, t1_final_join.s
+FROM t1_final_join FINAL
+JOIN t2_final_join ON t2_final_join.id = t1_final_join.id
+WHERE t2_final_join.v = 'x';
+
+SET enable_analyzer = 0;
+SELECT 'result legacy', t2_final_join.v, t1_final_join.s
+FROM t1_final_join FINAL
+JOIN t2_final_join ON t2_final_join.id = t1_final_join.id
+WHERE t2_final_join.v = 'x';
+
+DROP TABLE t1_final_join;
+DROP TABLE t2_final_join;
+
+-- FINAL is a per-table modifier: every FINAL/JOIN combination must read (and deduplicate) exactly the
+-- tables the `FINAL` keyword is attached to, and only those. Both tables are ReplacingMergeTree with
+-- un-merged duplicate parts; merges are stopped so the un-merged state (and thus the observable effect
+-- of FINAL) is deterministic. Only enable_analyzer = 1 is checked here: the old planner mishandles
+-- FINAL on the right (non-first) table, so it disagrees on the `right`/`both` shapes.
+
+DROP TABLE IF EXISTS lhs_final;
+DROP TABLE IF EXISTS rhs_final;
+
+CREATE TABLE lhs_final (id Int32, s String, ver UInt32) ENGINE = ReplacingMergeTree(ver) ORDER BY id;
+CREATE TABLE rhs_final (id Int32, s String, ver UInt32) ENGINE = ReplacingMergeTree(ver) ORDER BY id;
+
+SYSTEM STOP MERGES lhs_final;
+SYSTEM STOP MERGES rhs_final;
+
+INSERT INTO lhs_final VALUES (1, 'l_old', 1);
+INSERT INTO lhs_final VALUES (1, 'l_new', 2);
+INSERT INTO rhs_final VALUES (1, 'r_old', 1);
+INSERT INTO rhs_final VALUES (1, 'r_new', 2);
+
+SET enable_analyzer = 1;
+
+-- The number of tables planned as FINAL reads must equal the number of `FINAL` keywords.
+SELECT 'final reads none',  countIf(explain LIKE '%FINAL: 1%') FROM (EXPLAIN actions = 1 SELECT lhs_final.s, rhs_final.s FROM lhs_final       JOIN rhs_final       ON rhs_final.id = lhs_final.id);
+SELECT 'final reads left',  countIf(explain LIKE '%FINAL: 1%') FROM (EXPLAIN actions = 1 SELECT lhs_final.s, rhs_final.s FROM lhs_final FINAL JOIN rhs_final       ON rhs_final.id = lhs_final.id);
+SELECT 'final reads right', countIf(explain LIKE '%FINAL: 1%') FROM (EXPLAIN actions = 1 SELECT lhs_final.s, rhs_final.s FROM lhs_final       JOIN rhs_final FINAL ON rhs_final.id = lhs_final.id);
+SELECT 'final reads both',  countIf(explain LIKE '%FINAL: 1%') FROM (EXPLAIN actions = 1 SELECT lhs_final.s, rhs_final.s FROM lhs_final FINAL JOIN rhs_final FINAL ON rhs_final.id = lhs_final.id);
+
+-- Results: FINAL deduplicates only the table(s) it is attached to.
+SELECT 'result none',  arraySort(groupArray(lhs_final.s || '/' || rhs_final.s)) FROM lhs_final       JOIN rhs_final       ON rhs_final.id = lhs_final.id;
+SELECT 'result left',  arraySort(groupArray(lhs_final.s || '/' || rhs_final.s)) FROM lhs_final FINAL JOIN rhs_final       ON rhs_final.id = lhs_final.id;
+SELECT 'result right', arraySort(groupArray(lhs_final.s || '/' || rhs_final.s)) FROM lhs_final       JOIN rhs_final FINAL ON rhs_final.id = lhs_final.id;
+SELECT 'result both',  arraySort(groupArray(lhs_final.s || '/' || rhs_final.s)) FROM lhs_final FINAL JOIN rhs_final FINAL ON rhs_final.id = lhs_final.id;
+
+DROP TABLE lhs_final;
+DROP TABLE rhs_final;


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fixed a bug in the new analyzer where FINAL on one table of a JOIN (e.g. `FROM t1 FINAL JOIN t2`) was incorrectly applied to the other joined tables as well, what could made such queries slower.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.719` (included in `26.7` and later)
- Backported to: `26.6.2.56`
<!-- ch-version-info:end -->