### PR TITLE
Stabilize flaky test_modify_column_comment_only_on_cluster

### DIFF
--- a/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
+++ b/tests/integration/test_alter_settings_or_comment_on_cluster/test.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -61,6 +63,43 @@ def list_part_index_files(node, database, table, part_name):
     return sorted(f for f in files.splitlines() if f.endswith((".idx", ".idx2")))
 
 
+def wait_show_create(
+    node, table, *, contains=(), not_contains=(), retries=60, sleep_time=0.5
+):
+    # An ON CLUSTER ALTER returns once the distributed DDL task is finished on every
+    # host, which does not guarantee the change is already visible in that host's
+    # in-memory metadata: the replicated ALTER_METADATA entry (or the local
+    # settings/comment fast path) can still be in flight, especially right after a
+    # replica restart. Poll SHOW CREATE until it converges; a value that never
+    # converges still fails the caller's assert with the final SHOW CREATE.
+    show_create = ""
+    for _ in range(retries):
+        show_create = node.query(
+            database="test_db", sql=f"SHOW CREATE {table} FORMAT TSVRaw"
+        )
+        if all(s in show_create for s in contains) and all(
+            s not in show_create for s in not_contains
+        ):
+            break
+        time.sleep(sleep_time)
+    return show_create
+
+
+def wait_column_order(node, table, expected, *, retries=60, sleep_time=0.5):
+    # Same convergence reasoning as wait_show_create, for the column order read from
+    # system.columns after an ON CLUSTER MODIFY COLUMN with a positional modifier.
+    order = []
+    for _ in range(retries):
+        order = node.query(
+            database="test_db",
+            sql=f"SELECT name FROM system.columns WHERE database = 'test_db' AND table = '{table}' ORDER BY position FORMAT TSVRaw",
+        ).split()
+        if order == expected:
+            break
+        time.sleep(sleep_time)
+    return order
+
+
 def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
     # ON CLUSTER ALTER batches mixing MODIFY SETTING / RESET SETTING with
     # column or table comments must converge on every replica. The storage
@@ -92,9 +131,8 @@ def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
 
     # Both replicas must see the new comment and the new setting value.
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "mixed_alter", contains=["old_parts_lifetime = 123", "mixed-on-cluster"]
         )
         assert "old_parts_lifetime = 123" in show_create, (node.name, show_create)
         assert "mixed-on-cluster" in show_create, (node.name, show_create)
@@ -106,9 +144,11 @@ def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
     )
 
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node,
+            "mixed_alter",
+            contains=["second-mixed"],
+            not_contains=["old_parts_lifetime = 123"],
         )
         assert "old_parts_lifetime = 123" not in show_create, (node.name, show_create)
         assert "second-mixed" in show_create, (node.name, show_create)
@@ -120,9 +160,8 @@ def test_mixed_settings_and_comment_alter_on_cluster(started_cluster):
     )
 
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE mixed_alter FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "mixed_alter", contains=["old_parts_lifetime = 234", "x-col-comment"]
         )
         assert "old_parts_lifetime = 234" in show_create, (node.name, show_create)
         assert "x-col-comment" in show_create, (node.name, show_create)
@@ -160,9 +199,8 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
 
     assert get_zk_metadata_version(ch1, zookeeper_path) == version_before
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "modcol_comment", contains=["modcol-comment-v1"]
         )
         assert "modcol-comment-v1" in show_create, (node.name, show_create)
 
@@ -173,9 +211,10 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
     )
 
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node,
+            "modcol_comment",
+            contains=["modcol-comment-v2", "old_parts_lifetime = 345"],
         )
         assert "modcol-comment-v2" in show_create, (node.name, show_create)
         assert "old_parts_lifetime = 345" in show_create, (node.name, show_create)
@@ -187,9 +226,10 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
     )
 
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node,
+            "modcol_comment",
+            contains=["modcol-comment-v3", "table-comment-modcol"],
         )
         assert "modcol-comment-v3" in show_create, (node.name, show_create)
         assert "table-comment-modcol" in show_create, (node.name, show_create)
@@ -210,15 +250,11 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
 
     assert get_zk_metadata_version(ch1, zookeeper_path) > version_before
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "modcol_comment", contains=["modcol-placement-comment"]
         )
         assert "modcol-placement-comment" in show_create, (node.name, show_create)
-        order = node.query(
-            database="test_db",
-            sql="SELECT name FROM system.columns WHERE database = 'test_db' AND table = 'modcol_comment' ORDER BY position FORMAT TSVRaw",
-        ).split()
+        order = wait_column_order(node, "modcol_comment", ["x", "id"])
         assert order == ["x", "id"], (node.name, order)
 
     # Restart both replicas: the local columns (reordered to x, id) must match the
@@ -227,14 +263,10 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
     for node in [ch1, ch2]:
         node.restart_clickhouse()
     for node in [ch1, ch2]:
-        order = node.query(
-            database="test_db",
-            sql="SELECT name FROM system.columns WHERE database = 'test_db' AND table = 'modcol_comment' ORDER BY position FORMAT TSVRaw",
-        ).split()
+        order = wait_column_order(node, "modcol_comment", ["x", "id"])
         assert order == ["x", "id"], (node.name, order)
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "modcol_comment", contains=["modcol-placement-comment"]
         )
         assert "modcol-placement-comment" in show_create, (node.name, show_create)
 
@@ -246,9 +278,8 @@ def test_modify_column_comment_only_on_cluster(started_cluster):
     )
 
     for node in [ch1, ch2]:
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE modcol_comment FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "modcol_comment", contains=["modcol-with-type"]
         )
         assert "modcol-with-type" in show_create, (node.name, show_create)
 
@@ -302,9 +333,8 @@ def test_mixed_setting_escape_index_filenames_on_cluster(started_cluster):
             node.name,
             index_files,
         )
-        show_create = node.query(
-            database="test_db",
-            sql="SHOW CREATE escape_mixed FORMAT TSVRaw",
+        show_create = wait_show_create(
+            node, "escape_mixed", contains=["escape_index_filenames = 0", "escape-mixed"]
         )
         assert "escape_index_filenames = 0" in show_create, (node.name, show_create)
         assert "escape-mixed" in show_create, (node.name, show_create)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Stabilize the flaky integration test `test_alter_settings_or_comment_on_cluster::test_modify_column_comment_only_on_cluster` (and its two sibling tests in the same file).

An `ALTER ... ON CLUSTER` returns once the distributed DDL task has finished on every host. That does not guarantee the just-applied change is already reflected in a host's in-memory metadata, which is what `SHOW CREATE` / `system.columns` read: the replicated `ALTER_METADATA` log entry (or the local settings/comment fast path) can still be in flight on a replica, especially right after the replica restart this test performs. The test asserted on a single immediate `SHOW CREATE` read per replica, so it raced that propagation window and intermittently failed (observed almost exclusively on slow builds, e.g. `arm_binary, distributed plan` and `amd_msan`; 0 master failures).

Failure signature (e.g. `Integration tests (arm_binary, distributed plan)`):

```
File: test_alter_settings_or_comment_on_cluster/test.py:253 - in test_modify_column_comment_only_on_cluster
    assert "modcol-with-type" in show_create, (node.name, show_create)
E   AssertionError: ('ch1', "CREATE TABLE test_db.modcol_comment ... COMMENT 'modcol-placement-comment' ...")
```
The previous comment is still shown because the last `MODIFY COLUMN ... String COMMENT 'modcol-with-type'` had not yet become visible on `ch1` when the assert ran.

Fix (test-only): poll `SHOW CREATE` / `system.columns` until the expected value converges before asserting, via two small helpers (`wait_show_create`, `wait_column_order`) — the same `assert_eq_with_retry` convergence idiom already used by the sibling `test_alter_comment_on_cluster`. The asserts themselves are unchanged, so a value that never converges still fails the test with the final `SHOW CREATE`: the test keeps its full ability to catch a real routing/divergence regression. The ZooKeeper `/metadata` version checks stay immediate — they read ZooKeeper directly (synchronous source of truth) and are what verify the routing (fast-path vs replicated-log) correctness.

Validated with the local integration runner (debug build): the whole suite passed 30/30 (10 iterations x 3 tests). A standalone simulation of a lagging `SHOW CREATE` confirms the old single-read pattern fails the race while the polling helper converges, and a never-converging value still fails (intent preserved).
