### PR TITLE
Fix flaky `Run server init.d` install check on 25.8 (backport of #106056)

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -26,7 +26,12 @@ set -e
 trap "bash -ex /packages/preserve_logs.sh" ERR
 test_env='TEST_THE_DEFAULT_PARAMETER=15'
 echo "$test_env" >> /etc/default/clickhouse
+# The init.d wrapper prints "Server started" once the pid file exists, but the TCP
+# listener can take longer to open on a slow CI host; poll for up to 30s. See #86278.
 /etc/init.d/clickhouse-server start
+for i in {1..30}; do
+    clickhouse-client -q 'SELECT version()' && break || sleep 1
+done
 clickhouse-client -q 'SELECT version()'
 grep "$test_env" /proc/$(cat /var/run/clickhouse-server/clickhouse-server.pid)/environ"""
     keeper_test = r"""#!/bin/bash


### PR DESCRIPTION
The `Run server init.d` test in the `Install packages` job flakes on the `25.8` release branch: the server reports `Server started` via the init.d wrapper, but `clickhouse-client -q 'SELECT version()'` then fails with `Code: 210. DB::NetException: Connection refused (localhost:9000)`.

The `initd_test` script in `ci/jobs/install_check.py` on `25.8` runs `SELECT version()` exactly once, immediately after the wrapper prints `Server started`. The wrapper only checks that the pid file exists, but on a slow CI host (notably the `amd_debug` build) the server takes several more seconds to open the TCP listener. In the very same job the sibling `binary_test` already retries `SELECT version()` and, on `25.8` backport runs, routinely needs ~4 seconds before the debug server accepts connections — while `initd_test` gives up after the first attempt.

This is the same failure mode as #86278, fixed on `master` by #106056 ("Extend `Run server init.d` retry budget from 5s to 30s"). That fix never reached `25.8`, so the flake keeps blocking `25.8` backport PRs (for example #108965 and #108917). Because the `25.8` `initd_test` predates the retry loop entirely, #106056 does not cherry-pick cleanly; this PR adapts the same fix by adding a 30-iteration poll loop that breaks early on success, matching the existing `binary_test` and `keeper_test` patterns. `SYSTEMCTL_SKIP_REDIRECT` is intentionally not added, since the `25.8` init.d script does not support it.

Related issue: #86278
Backport of: #106056

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)