### PR TITLE
Fixed a use-after-free in async callbacks scheduled from borrowed `ThreadGroup` scopes

### DIFF
--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -26,6 +26,16 @@ ThreadGroupPtr getCurrentThreadGroup()
     return current_thread->getThreadGroup();
 }
 
+ThreadGroupPtr getCurrentThreadGroupForAsyncCallback()
+{
+    ThreadGroupPtr result = getCurrentThreadGroup();
+    if (result && result->isBorrowed())
+        result = nullptr;
+
+    chassert(!result || !result->isBorrowed());
+    return result;
+}
+
 ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadName thread_name, bool allow_existing_group) noexcept
     : thread_group(std::move(thread_group_))
 {

--- a/src/Common/ThreadGroupSwitcher.h
+++ b/src/Common/ThreadGroupSwitcher.h
@@ -19,6 +19,10 @@ class ThreadStatus;
 /// This is equivalent to CurrentThread::getGroup() but avoids including CurrentThread.h.
 ThreadGroupPtr getCurrentThreadGroup();
 
+/// Returns the current thread group for async callback capture.
+/// Borrowed groups are scoped accounting objects, so async callbacks must not keep them alive.
+ThreadGroupPtr getCurrentThreadGroupForAsyncCallback();
+
 /**
  * RAII wrapper around CurrentThread::attachToGroup/detachFromGroupIfNotDetached.
  *

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -15,6 +15,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <unordered_set>
@@ -72,8 +73,8 @@ class ThreadGroup
 public:
     using FatalErrorCallback = std::function<void()>;
     ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_, FatalErrorCallback fatal_error_callback_ = {});
-    explicit ThreadGroup(ThreadGroupPtr parent);
-    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
+
+    bool isBorrowed() const;
 
     /// The first thread created this thread group
     const UInt64 master_thread_id;
@@ -88,12 +89,8 @@ public:
 
     MemorySpillScheduler::Ptr memory_spill_scheduler;
 
-    /// For a "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue),
-    /// performance_counters and memory_tracker below hold RAW pointers into the parent group's
-    /// counters. Keep the parent alive so those pointers never dangle. Declared before the two
-    /// trackers so it is destroyed after them (members are destroyed in reverse order).
-    ThreadGroupPtr parent_thread_group;
-
+    /// Borrowed child groups (`createForMaterializedView` / `createForFlushAsyncInsertQueue`) keep
+    /// raw accounting pointers into the parent group. They are valid only while the parent is alive.
     ProfileEvents::Counters performance_counters{VariableContext::Process};
     MemoryTracker memory_tracker{VariableContext::Process};
 
@@ -145,6 +142,14 @@ public:
     void unlinkThread();
 
 private:
+    enum class ThreadGroupKind : uint8_t
+    {
+        Root,
+        Borrowed,
+    };
+
+    const ThreadGroupKind kind = ThreadGroupKind::Root;
+
     mutable std::mutex mutex;
 
     /// Set up at creation, no race when reading
@@ -161,6 +166,9 @@ private:
 
     Stopwatch effective_group_stopwatch TSA_GUARDED_BY(mutex) = Stopwatch(STOPWATCH_DEFAULT_CLOCK, 0, /* is running */ false);
     UInt64 elapsed_group_ms TSA_GUARDED_BY(mutex) = 0;
+
+    explicit ThreadGroup(ThreadGroupPtr parent);
+    ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent);
 
     static ThreadGroupPtr create(ContextPtr context, Int32 os_threads_nice_value);
 };

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -87,6 +87,13 @@ public:
     const Int32 os_threads_nice_value;
 
     MemorySpillScheduler::Ptr memory_spill_scheduler;
+
+    /// For a "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue),
+    /// performance_counters and memory_tracker below hold RAW pointers into the parent group's
+    /// counters. Keep the parent alive so those pointers never dangle. Declared before the two
+    /// trackers so it is destroyed after them (members are destroyed in reverse order).
+    ThreadGroupPtr parent_thread_group;
+
     ProfileEvents::Counters performance_counters{VariableContext::Process};
     MemoryTracker memory_tracker{VariableContext::Process};
 

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -79,6 +79,37 @@ TEST(BorrowedThreadGroupLifetime, IncrementThroughBorrowedChildAfterParentDroppe
     t.join();
 }
 
+/// Same hazard for the OTHER borrowed ctor: ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent),
+/// used by createForFlushAsyncInsertQueue. It takes its own query context and master thread id, but borrows
+/// the SAME raw pointers into the parent's performance_counters / memory_tracker, so it must keep the parent
+/// alive identically. Drop the only external parent reference, then verify the parent is still alive and that
+/// incrementing through the borrowed counters does not touch freed memory.
+TEST(BorrowedThreadGroupLifetime, TwoArgCtorChildKeepsParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child via the two-arg ctor (own context + parent). Same borrowed counter pointers.
+        auto child = std::make_shared<ThreadGroup>(context, parent);
+
+        /// Drop the only external owner of the parent. With the fix the child still owns it.
+        parent.reset();
+
+        EXPECT_FALSE(parent_weak.expired())
+            << "Two-arg borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
+
+        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
+        child->performance_counters.increment(ProfileEvents::Query, 1);
+        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
+    });
+    t.join();
+}
+
 /// Same lifetime hazard exercised through the real attach path: attachToGroupImpl calls
 /// performance_counters.setParent(&thread_group->performance_counters) and
 /// memory_tracker.setParent(&thread_group->memory_tracker), i.e. it dereferences the borrowed child's

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -3,135 +3,212 @@
 #include <gtest/gtest.h>
 
 #include <Common/CurrentThread.h>
-#include <Common/ProfileEvents.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/ThreadPool.h>
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/ThreadStatus.h>
+#include <Common/threadPoolCallbackRunner.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Interpreters/Context.h>
 
-namespace ProfileEvents
+namespace CurrentMetrics
 {
-    extern const Event Query;
+    extern const Metric LocalThread;
+    extern const Metric LocalThreadActive;
+    extern const Metric LocalThreadScheduled;
 }
 
-/// Regression test for the borrowed-ThreadGroup use-after-free.
+/// Regression coverage for borrowed `ThreadGroup` async accounting.
 ///
-/// A "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue) stores RAW
-/// pointers into its parent group's performance_counters / memory_tracker. The documented invariant
-/// (MemoryTracker.h: "Lifetime of these trackers should include lifetime of current tracker") was not
-/// enforced: nothing kept the parent alive, so a child pinned past the source query's end (e.g. by a
-/// MergeTreeDeduplicationLog writer's captured thread-pool scheduler under s3_allow_parallel_part_upload)
-/// outlived its parent. The next counter increment / MemoryTracker::setParent then walked freed memory.
-///
-/// The fix makes the borrowed child own a shared_ptr to its parent. These tests drop every EXTERNAL
-/// reference to the parent and then exercise the borrowed pointers; without the fix this is a UAF that
-/// ASan/TSan catch, with the fix the parent stays alive for exactly as long as the child needs it.
+/// Borrowed groups keep raw accounting pointers into the parent query group. They must stay scoped:
+/// async captures must not extend borrowed accounting past the parent query lifetime.
 
 namespace DB
 {
 
-/// Dropping the only external shared_ptr to the parent must not free the parent group while a borrowed
-/// child is still alive: the child keeps it referenced (use_count stays >= the child's hold).
-TEST(BorrowedThreadGroupLifetime, ChildKeepsParentAlive)
+TEST(BorrowedThreadGroupLifetime, AsyncCallbackCaptureDropsBorrowedGroup)
 {
     std::thread t([&]
     {
         ThreadStatus ts;
         auto context = getContext().context;
 
-        auto parent = std::make_shared<ThreadGroup>(context, 0);
-        std::weak_ptr<ThreadGroup> parent_weak = parent;
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        auto borrowed = ThreadGroup::createForFlushAsyncInsertQueue(context, root);
 
-        /// Borrowed child: holds raw pointers into parent->performance_counters / parent->memory_tracker.
-        auto child = std::make_shared<ThreadGroup>(parent);
+        CurrentThread::attachToGroupIfDetached(borrowed);
 
-        /// Drop the only external owner of the parent. With the fix the child still owns it.
-        parent.reset();
+        EXPECT_EQ(getCurrentThreadGroupForAsyncCallback(), nullptr);
 
-        EXPECT_FALSE(parent_weak.expired())
-            << "Borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
+        CurrentThread::detachFromGroupIfNotDetached();
     });
     t.join();
 }
 
-/// The classic crash shape: increment a counter through a borrowed child after the external parent
-/// reference is gone. increment() walks current->parent up the chain into the parent group's Counters.
-/// If the parent were freed, this reads freed memory. With the fix the parent is alive, so the walk is safe.
-TEST(BorrowedThreadGroupLifetime, IncrementThroughBorrowedChildAfterParentDropped)
+TEST(BorrowedThreadGroupLifetime, AsyncCallbackCaptureDropsNestedBorrowedGroup)
 {
     std::thread t([&]
     {
         ThreadStatus ts;
         auto context = getContext().context;
 
-        auto parent = std::make_shared<ThreadGroup>(context, 0);
-        auto child = std::make_shared<ThreadGroup>(parent);
-
-        /// Only the child references the parent now.
-        parent.reset();
-
-        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
-        child->performance_counters.increment(ProfileEvents::Query, 1);
-        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
-
-        SUCCEED();
-    });
-    t.join();
-}
-
-/// Same hazard for the OTHER borrowed ctor: ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent),
-/// used by createForFlushAsyncInsertQueue. It takes its own query context and master thread id, but borrows
-/// the SAME raw pointers into the parent's performance_counters / memory_tracker, so it must keep the parent
-/// alive identically. Drop the only external parent reference, then verify the parent is still alive and that
-/// incrementing through the borrowed counters does not touch freed memory.
-TEST(BorrowedThreadGroupLifetime, TwoArgCtorChildKeepsParentAlive)
-{
-    std::thread t([&]
-    {
-        ThreadStatus ts;
-        auto context = getContext().context;
-
-        auto parent = std::make_shared<ThreadGroup>(context, 0);
-        std::weak_ptr<ThreadGroup> parent_weak = parent;
-
-        /// Borrowed child via the two-arg ctor (own context + parent). Same borrowed counter pointers.
-        auto child = std::make_shared<ThreadGroup>(context, parent);
-
-        /// Drop the only external owner of the parent. With the fix the child still owns it.
-        parent.reset();
-
-        EXPECT_FALSE(parent_weak.expired())
-            << "Two-arg borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
-
-        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
-        child->performance_counters.increment(ProfileEvents::Query, 1);
-        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
-    });
-    t.join();
-}
-
-/// Same lifetime hazard exercised through the real attach path: attachToGroupImpl calls
-/// performance_counters.setParent(&thread_group->performance_counters) and
-/// memory_tracker.setParent(&thread_group->memory_tracker), i.e. it dereferences the borrowed child's
-/// parent counters. Attaching to a borrowed child whose external parent reference is gone must be safe.
-TEST(BorrowedThreadGroupLifetime, AttachToBorrowedChildAfterParentDropped)
-{
-    std::thread t([&]
-    {
-        ThreadStatus ts;
-        auto context = getContext().context;
-
-        auto parent = std::make_shared<ThreadGroup>(context, 0);
-        auto child = std::make_shared<ThreadGroup>(parent);
-        parent.reset();
-
-        CurrentThread::attachToGroupIfDetached(child);
-        /// Allocate a little so the memory tracker chain (child -> parent group's tracker) is walked.
-        std::vector<int> v(1024, 7);
-        ProfileEvents::increment(ProfileEvents::Query, 1);
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        CurrentThread::attachToGroupIfDetached(root);
+        auto borrowed = ThreadGroup::createForMaterializedView(context);
         CurrentThread::detachFromGroupIfNotDetached();
 
-        EXPECT_EQ(getCurrentThreadGroup(), nullptr);
+        CurrentThread::attachToGroupIfDetached(borrowed);
+        auto nested_borrowed = ThreadGroup::createForMaterializedView(context);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        CurrentThread::attachToGroupIfDetached(nested_borrowed);
+        EXPECT_TRUE(nested_borrowed->isBorrowed());
+        EXPECT_EQ(getCurrentThreadGroupForAsyncCallback(), nullptr);
+
+        CurrentThread::detachFromGroupIfNotDetached();
+    });
+    t.join();
+}
+
+TEST(BorrowedThreadGroupLifetime, UnsafeRunnerCreatedUnderBorrowedGroupRunsWithoutBorrowedGroup)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        ThreadPool pool(
+            CurrentMetrics::LocalThread,
+            CurrentMetrics::LocalThreadActive,
+            CurrentMetrics::LocalThreadScheduled,
+            /*max_threads=*/ 1,
+            /*max_free_threads=*/ 1,
+            /*queue_size=*/ 10);
+
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        auto borrowed = ThreadGroup::createForFlushAsyncInsertQueue(context, root);
+
+        CurrentThread::attachToGroupIfDetached(borrowed);
+        auto runner = threadPoolCallbackRunnerUnsafe<bool>(pool, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        auto future = runner([]
+        {
+            auto group = getCurrentThreadGroup();
+            return group && group->isBorrowed();
+        }, Priority{});
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        EXPECT_FALSE(future.get());
+        pool.wait();
+    });
+    t.join();
+}
+
+TEST(BorrowedThreadGroupLifetime, UnsafeRunnerCreatedUnderRootGroupDoesNotKeepItAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        ThreadPool pool(
+            CurrentMetrics::LocalThread,
+            CurrentMetrics::LocalThreadActive,
+            CurrentMetrics::LocalThreadScheduled,
+            /*max_threads=*/ 1,
+            /*max_free_threads=*/ 1,
+            /*queue_size=*/ 10);
+
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> root_weak = root;
+
+        CurrentThread::attachToGroupIfDetached(root);
+        auto runner = threadPoolCallbackRunnerUnsafe<void>(pool, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        root.reset();
+
+        EXPECT_TRUE(root_weak.expired());
+        pool.wait();
+    });
+    t.join();
+}
+
+TEST(BorrowedThreadGroupLifetime, LocalRunnerCreatedUnderBorrowedGroupRunsWithoutBorrowedGroup)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        ThreadPool pool(
+            CurrentMetrics::LocalThread,
+            CurrentMetrics::LocalThreadActive,
+            CurrentMetrics::LocalThreadScheduled,
+            /*max_threads=*/ 1,
+            /*max_free_threads=*/ 1,
+            /*queue_size=*/ 10);
+
+        auto root = std::make_shared<ThreadGroup>(context, 0);
+        auto borrowed = ThreadGroup::createForFlushAsyncInsertQueue(context, root);
+
+        CurrentThread::attachToGroupIfDetached(borrowed);
+        ThreadPoolCallbackRunnerLocal<bool> runner(pool, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        auto task = runner.enqueueAndGiveOwnership([]
+        {
+            auto group = getCurrentThreadGroup();
+            return group && group->isBorrowed();
+        }, Priority{});
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        ASSERT_TRUE(task->future.valid());
+        EXPECT_FALSE(task->future.get());
+        pool.wait();
+    });
+    t.join();
+}
+
+TEST(BorrowedThreadGroupLifetime, ChildDoesNotKeepParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child: holds raw pointers into `parent->performance_counters` / `parent->memory_tracker`.
+        CurrentThread::attachToGroupIfDetached(parent);
+        auto child = ThreadGroup::createForMaterializedView(context);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        /// Do not dereference the child after this point: it has raw accounting pointers into `parent`.
+        parent.reset();
+
+        EXPECT_TRUE(parent_weak.expired())
+            << "Borrowed child must not keep its parent `ThreadGroup` alive";
+    });
+    t.join();
+}
+
+TEST(BorrowedThreadGroupLifetime, FlushAsyncInsertQueueGroupDoesNotKeepParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child via the public async-insert factory. Same borrowed counter pointers.
+        auto child = ThreadGroup::createForFlushAsyncInsertQueue(context, parent);
+
+        /// Do not dereference the child after this point: it has raw accounting pointers into `parent`.
+        parent.reset();
+
+        EXPECT_TRUE(parent_weak.expired())
+            << "Async-insert borrowed child must not keep its parent `ThreadGroup` alive";
     });
     t.join();
 }

--- a/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
+++ b/src/Common/tests/gtest_borrowed_thread_group_lifetime.cpp
@@ -1,0 +1,108 @@
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <Common/CurrentThread.h>
+#include <Common/ProfileEvents.h>
+#include <Common/ThreadGroupSwitcher.h>
+#include <Common/ThreadStatus.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/Context.h>
+
+namespace ProfileEvents
+{
+    extern const Event Query;
+}
+
+/// Regression test for the borrowed-ThreadGroup use-after-free.
+///
+/// A "borrowed" child group (createForMaterializedView / createForFlushAsyncInsertQueue) stores RAW
+/// pointers into its parent group's performance_counters / memory_tracker. The documented invariant
+/// (MemoryTracker.h: "Lifetime of these trackers should include lifetime of current tracker") was not
+/// enforced: nothing kept the parent alive, so a child pinned past the source query's end (e.g. by a
+/// MergeTreeDeduplicationLog writer's captured thread-pool scheduler under s3_allow_parallel_part_upload)
+/// outlived its parent. The next counter increment / MemoryTracker::setParent then walked freed memory.
+///
+/// The fix makes the borrowed child own a shared_ptr to its parent. These tests drop every EXTERNAL
+/// reference to the parent and then exercise the borrowed pointers; without the fix this is a UAF that
+/// ASan/TSan catch, with the fix the parent stays alive for exactly as long as the child needs it.
+
+namespace DB
+{
+
+/// Dropping the only external shared_ptr to the parent must not free the parent group while a borrowed
+/// child is still alive: the child keeps it referenced (use_count stays >= the child's hold).
+TEST(BorrowedThreadGroupLifetime, ChildKeepsParentAlive)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        std::weak_ptr<ThreadGroup> parent_weak = parent;
+
+        /// Borrowed child: holds raw pointers into parent->performance_counters / parent->memory_tracker.
+        auto child = std::make_shared<ThreadGroup>(parent);
+
+        /// Drop the only external owner of the parent. With the fix the child still owns it.
+        parent.reset();
+
+        EXPECT_FALSE(parent_weak.expired())
+            << "Borrowed child must keep its parent ThreadGroup alive (raw counter pointers would dangle otherwise)";
+    });
+    t.join();
+}
+
+/// The classic crash shape: increment a counter through a borrowed child after the external parent
+/// reference is gone. increment() walks current->parent up the chain into the parent group's Counters.
+/// If the parent were freed, this reads freed memory. With the fix the parent is alive, so the walk is safe.
+TEST(BorrowedThreadGroupLifetime, IncrementThroughBorrowedChildAfterParentDropped)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        auto child = std::make_shared<ThreadGroup>(parent);
+
+        /// Only the child references the parent now.
+        parent.reset();
+
+        /// Walks child->performance_counters then up into the (still-alive) parent group's counters.
+        child->performance_counters.increment(ProfileEvents::Query, 1);
+        child->performance_counters.incrementNoTrace(ProfileEvents::Query, 1);
+
+        SUCCEED();
+    });
+    t.join();
+}
+
+/// Same lifetime hazard exercised through the real attach path: attachToGroupImpl calls
+/// performance_counters.setParent(&thread_group->performance_counters) and
+/// memory_tracker.setParent(&thread_group->memory_tracker), i.e. it dereferences the borrowed child's
+/// parent counters. Attaching to a borrowed child whose external parent reference is gone must be safe.
+TEST(BorrowedThreadGroupLifetime, AttachToBorrowedChildAfterParentDropped)
+{
+    std::thread t([&]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+
+        auto parent = std::make_shared<ThreadGroup>(context, 0);
+        auto child = std::make_shared<ThreadGroup>(parent);
+        parent.reset();
+
+        CurrentThread::attachToGroupIfDetached(child);
+        /// Allocate a little so the memory tracker chain (child -> parent group's tracker) is walked.
+        std::vector<int> v(1024, 7);
+        ProfileEvents::increment(ProfileEvents::Query, 1);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        EXPECT_EQ(getCurrentThreadGroup(), nullptr);
+    });
+    t.join();
+}
+
+} // namespace DB

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -144,9 +144,12 @@ struct CallbackRunnerTask
 template <typename Result, typename Callback = std::function<Result()>>
 ThreadPoolCallbackRunnerUnsafe<Result, Callback> threadPoolCallbackRunnerUnsafe(ThreadPool & pool, ThreadName thread_name)
 {
-    return [my_pool = &pool, thread_group = getCurrentThreadGroup(), thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
+    return [my_pool = &pool, thread_name](Callback && callback, Priority priority) mutable -> std::future<Result>
     {
-        auto task = std::make_shared<detail::CallbackRunnerTask<Result, Callback>>(thread_group, thread_name, std::move(callback));
+        /// Capture the current `ThreadGroup` at enqueue time. The runner object can be stored longer
+        /// than the query, and the worker thread has its own current group, so neither is a safe source.
+        auto captured_thread_group = getCurrentThreadGroupForAsyncCallback();
+        auto task = std::make_shared<detail::CallbackRunnerTask<Result, Callback>>(std::move(captured_thread_group), thread_name, std::move(callback));
 
         auto future = task->promise.get_future();
 
@@ -302,8 +305,10 @@ public:
         auto promise = std::make_shared<std::promise<Result>>();
         auto task = std::make_shared<Task>();
         task->future = promise->get_future();
+        /// Capture the current `ThreadGroup` at enqueue time, before the callback moves to a pool thread.
+        auto captured_thread_group = getCurrentThreadGroupForAsyncCallback();
 
-        auto task_func = [this, task, thread_group = getCurrentThreadGroup(), my_callback = std::move(callback), promise]() mutable -> void
+        auto task_func = [this, task, thread_group = std::move(captured_thread_group), my_callback = std::move(callback), promise]() mutable -> void
         {
             TaskState expected = SCHEDULED;
             if (!task->state.compare_exchange_strong(expected, RUNNING))

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -130,6 +130,8 @@ ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
+    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
+    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
     , shared_data(parent->getSharedData())
@@ -144,6 +146,8 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
+    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
+    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
 {

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -122,7 +122,14 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, Int32 os_threads_nice_value_
     };
 }
 
-// c-tor for method createForMaterializedView
+bool ThreadGroup::isBorrowed() const
+{
+    return kind == ThreadGroupKind::Borrowed;
+}
+
+// Borrowed groups point their counters and memory tracker at `parent` without owning it.
+// They must stay scoped to synchronous work and must not be captured by async tasks.
+// Constructor for `createForMaterializedView`
 ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
     : master_thread_id(parent->master_thread_id)
     , query_context(parent->query_context)
@@ -130,15 +137,14 @@ ThreadGroup::ThreadGroup(ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
-    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
-    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
+    , kind(ThreadGroupKind::Borrowed)
     , shared_data(parent->getSharedData())
 {
 }
 
-// c-tor for method createForFlushAsyncInsertQueue
+// Constructor for `createForFlushAsyncInsertQueue`
 ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
     : master_thread_id(CurrentThread::get().thread_id)
     , query_context(query_context_)
@@ -146,10 +152,9 @@ ThreadGroup::ThreadGroup(ContextPtr query_context_, ThreadGroupPtr parent)
     , fatal_error_callback(parent->fatal_error_callback)
     , os_threads_nice_value(parent->os_threads_nice_value)
     , memory_spill_scheduler(parent->memory_spill_scheduler)
-    /// Keep the parent alive: performance_counters/memory_tracker below borrow raw pointers into it.
-    , parent_thread_group(parent)
     , performance_counters(VariableContext::Process, &parent->performance_counters)
     , memory_tracker(&parent->memory_tracker, VariableContext::Process, /*log_peak_memory_usage_in_destructor*/ false)
+    , kind(ThreadGroupKind::Borrowed)
 {
     shared_data.query_is_canceled_predicate = [this] () -> bool {
         if (auto context_locked = query_context.lock())
@@ -238,7 +243,7 @@ ThreadGroupPtr ThreadGroup::createForMaterializedView(ContextPtr context)
     ThreadGroupPtr res_group;
     if (auto current_group = CurrentThread::getGroup())
     {
-        res_group = std::make_shared<ThreadGroup>(current_group);
+        res_group = ThreadGroupPtr(new ThreadGroup(current_group));
     }
     else
     {
@@ -251,7 +256,7 @@ ThreadGroupPtr ThreadGroup::createForMaterializedView(ContextPtr context)
 
 ThreadGroupPtr ThreadGroup::createForFlushAsyncInsertQueue(ContextPtr context, ThreadGroupPtr parent)
 {
-    auto res_group = std::make_shared<ThreadGroup>(context, parent);
+    auto res_group = ThreadGroupPtr(new ThreadGroup(context, parent));
     res_group->memory_tracker.setDescription("FlushAsyncInsertQueue");
     return res_group;
 }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107030
Related: https://github.com/ClickHouse/ClickHouse/pull/108577
CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105890&sha=3dc0e76362eb18e27f1fffcd3f61ca9f13725fe8&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20sequential%2C%201%2F2%29

Fixes a use-after-free risk in asynchronous work scheduled while a borrowed `ThreadGroup` is current.

Borrowed `ThreadGroup` objects used by materialized view and async insert flush paths point their `performance_counters` and `memory_tracker` to the parent query group, so they are valid only while that parent group is alive. Async callbacks could capture such a borrowed group and later attach it on a pool thread after the parent query group had finished.

Instead of keeping the parent `ThreadGroup` alive with a `shared_ptr`, this change keeps borrowed accounting scoped. Borrowed groups are marked explicitly, async callback capture drops borrowed groups, and thread pool callback runners capture the normalized group at task enqueue time rather than when a potentially long-lived runner object is created.

This preserves synchronous borrowed accounting, but async work started from a borrowed scope runs under normal thread/global accounting instead of writing into, or prolonging the lifetime of, an already finished query group.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a memory safety issue where asynchronous work scheduled from materialized view processing could keep using query-level accounting after the query had finished.