### PR TITLE
investigate-ci skill: search for existing issues and fixes per failure

### DIFF
--- a/.claude/settings.investigate.json
+++ b/.claude/settings.investigate.json
@@ -1,5 +1,5 @@
 {
-  "//": "Reduced-prompt profile for CI-failure investigation. Launch with: claude --settings .claude/settings.investigate.json. Settings MERGE (union) with your project/user settings.json -- this file can ADD allows or ADD denies but cannot remove an allow another source grants; deny wins everywhere. The deny list blocks irreversible actions (Edit/Write/NotebookEdit, mutating git/gh, rm/mv) outright. The allow list covers only read-only commands the skill runs, so they do not prompt. The two non-trivial commands the skill runs every time are auto-approved ONLY in their exact safe shapes by the PreToolUse hook allow_investigate_cmds.py (default-deny -- anything outside the shape prompts): (1) the play.clickhouse.com read-only SELECT query, and (2) node .claude/tools/fetch_ci_report.js against known CI-report hosts with only read/report flags and no file-writing forms (--download-logs and stdout redirection are NOT hook-approved -- a string-pinned write target cannot be made symlink-safe -- so they prompt). Commands this file neither allow-lists nor hooks -- arbitrary curl, tar -x (an appended -C / or crafted archive could overwrite files), broader node/python -- prompt, UNLESS your base settings.json already allows them: because settings MERGE, this profile cannot remove allows your project/user config grants. It adds denies for the riskiest inherited ones outside the investigation surface (WebSearch and gh search/run view, alongside the irreversible-action denies), but it cannot enumerate an arbitrary base config -- inherited read allows (e.g. which, strings, gh reads) still run. NOTE: this is a prompt-reducer, not a sandbox -- a prefix allow cannot model composed shell syntax (e.g. 'grep x f > f' writes via redirection), fetch_ci_report.js once approved runs as a repo-local script whose child processes are unconstrained, and the merged base config is outside this file's control. The real boundary for an untrusted PR (external, unreviewed, or one that may have modified .claude/* or anything the skill runs) is the environment: run in a throwaway git worktree, on a trusted base-branch checkout of .claude, with a minimal base settings.json and no credentials.",
+  "//": "Reduced-prompt profile for CI-failure investigation. Launch with: claude --settings .claude/settings.investigate.json. Settings MERGE (union) with your project/user settings.json -- this file can ADD allows or ADD denies but cannot remove an allow another source grants; deny wins everywhere. The deny list blocks irreversible actions (Edit/Write/NotebookEdit, mutating git/gh, rm/mv) outright. The allow list covers only read-only commands the skill runs, so they do not prompt. All GitHub reads go through .claude/tools/gh-ro.sh (allow-listed), which drops a poisoned GH_CONFIG_DIR and refuses non-read-only subcommands; raw `gh pr/issue view/list/diff/checks` are therefore DENIED here (deny wins over any base-settings allow) so the skill cannot nondeterministically fall back to the raw path that fails on GH_CONFIG_DIR-poisoned runners -- the wrapper's own child `gh` runs unchecked, so this does not block it. The two non-trivial commands the skill runs every time are auto-approved ONLY in their exact safe shapes by the PreToolUse hook allow_investigate_cmds.py (default-deny -- anything outside the shape prompts): (1) the play.clickhouse.com read-only SELECT query, and (2) node .claude/tools/fetch_ci_report.js against known CI-report hosts with only read/report flags and no file-writing forms (--download-logs and stdout redirection are NOT hook-approved -- a string-pinned write target cannot be made symlink-safe -- so they prompt). Commands this file neither allow-lists nor hooks -- arbitrary curl, tar -x (an appended -C / or crafted archive could overwrite files), broader node/python -- prompt, UNLESS your base settings.json already allows them: because settings MERGE, this profile cannot remove allows your project/user config grants. It adds denies for the riskiest inherited ones outside the investigation surface (WebSearch, gh search/run view, and raw gh reads -- forcing the gh-ro.sh wrapper -- alongside the irreversible-action denies), but it cannot enumerate an arbitrary base config -- inherited read allows (e.g. which, strings) still run. NOTE: this is a prompt-reducer, not a sandbox -- a prefix allow cannot model composed shell syntax (e.g. 'grep x f > f' writes via redirection), fetch_ci_report.js once approved runs as a repo-local script whose child processes are unconstrained, and the merged base config is outside this file's control. The real boundary for an untrusted PR (external, unreviewed, or one that may have modified .claude/* or anything the skill runs) is the environment: run in a throwaway git worktree, on a trusted base-branch checkout of .claude, with a minimal base settings.json and no credentials.",
   "permissions": {
     "deny": [
       "Edit",
@@ -35,6 +35,12 @@
       "Bash(gh api:*)",
       "Bash(gh search:*)",
       "Bash(gh run view:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
       "WebSearch"
     ],
     "allow": [
@@ -48,12 +54,6 @@
       "Bash(tail:*)",
       "Bash(wc:*)",
       "Bash(.claude/tools/gh-ro.sh:*)",
-      "Bash(gh pr view:*)",
-      "Bash(gh pr diff:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh pr checks:*)",
-      "Bash(gh issue view:*)",
-      "Bash(gh issue list:*)",
       "Bash(git log:*)",
       "Bash(git show:*)",
       "Bash(git status)",

--- a/.claude/settings.investigate.json
+++ b/.claude/settings.investigate.json
@@ -47,6 +47,7 @@
       "Bash(head:*)",
       "Bash(tail:*)",
       "Bash(wc:*)",
+      "Bash(.claude/tools/gh-ro.sh:*)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",
       "Bash(gh pr list:*)",

--- a/.claude/settings.investigate.json
+++ b/.claude/settings.investigate.json
@@ -59,6 +59,7 @@
       "Bash(git diff:*)",
       "Bash(git rev-parse:*)",
       "Bash(git cat-file:*)",
+      "Bash(git merge-base:*)",
       "WebFetch(domain:play.clickhouse.com)",
       "WebFetch(domain:s3.amazonaws.com)",
       "WebFetch(domain:github.com)"

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -100,12 +100,13 @@ can re-read or `grep`. If `node` is **absent**, skip the report fetch (and the s
 and rely on the issue body's failure output plus step 3 — do not treat a missing `node` as a
 fatal error.
 
-**The tool prints only the log *tail* (the last ~30 non-empty lines of each `result.info`), not the
-full output.** CI's matchers test `Failure reason` against the **whole** `result.info`, so a
-`Failure reason` located earlier than the tail will match in CI yet be **invisible** here — when
-mirroring CI's attribution (step 2a) or judging whether a reason string is present, do not read a
-"not in the visible output" as a definitive non-match; drill via the CIDB link or the full artifact
-(step 4) if it matters.
+Per failure the tool prints a `🏷️ labels:` line (CI's non-CIDB labels — the `issue` match link and
+flags like `retry_ok`; see step 2a), the CIDB link, and the **log *tail*** — the last ~30 non-empty
+lines of `result.info`, **not** the full output. CI's matchers test `Failure reason` against the
+**whole** `result.info`, so a `Failure reason` located earlier than the tail will match in CI yet be
+**invisible** here — when mirroring CI's attribution (step 2a) or judging whether a reason string is
+present, do not read a "not in the visible output" as a definitive non-match; drill via the CIDB
+link or the full artifact (step 4) if it matters.
 
 - If `$0` is a PR URL with many reports and the noise is high, narrow with `--report <n>`
   after listing reports (run the tool with no `--failed` to see the index).
@@ -169,10 +170,21 @@ last ~8 hours**, and routes each by whether it also carries the **`infrastructur
   [#92089](https://github.com/ClickHouse/ClickHouse/issues/92089) (`Job pattern: Stateless tests (amd_msan%`,
   `Failure reason: DB::Exception: Timeout exceeded`).
 
-(CI attaches an `issue` label to a matched failure internally, but `fetch_ci_report.js` prints
-**only** CIDB links — not the `issue` label or the linked issue URL — so its output is **not** a
-"tracked" signal. The GitHub issue search below is the authoritative way to reproduce CI's
-attribution; never read the absence of a marker in the report output as "not tracked".)
+**Fast path — read the labels `fetch_ci_report.js` prints.** The tool surfaces each failure's
+non-CIDB labels on a `🏷️ labels:` line. Two are decisive:
+
+- An **`issue`** label means CI matched a tracking issue **at run time** — the printed link **is**
+  that issue (e.g. `Server died` → `issue (…/issues/107487)`, `Hung check …` → `…/107941`). That is
+  a definitive `tracked #N`; no search needed to establish tracking (still read the issue for the
+  fix).
+- **Failure flags** (e.g. `retry_ok`) appear here too — these are exactly the labels an
+  infrastructure issue matches on via `Failure flags:` (below), so this line is how you verify that
+  constraint.
+
+But **absence** of an `issue` label is **not** proof of "untracked": CI stamps it from the catalog
+*as it was at that run* (open + closed-within-8h then), so a tracking issue filed or reopened
+**after** the run won't show. So: an `issue` label → `tracked` immediately; no label → still run the
+GitHub search below before concluding `needs issue`/`untracked`.
 
 **For an `INFRA/BUILD` or timeout/harness-level failure, also run the infrastructure path.** A
 test-name search alone will miss these, so a pre-existing, already-tracked infra failure would be
@@ -186,10 +198,13 @@ gh issue list --repo ClickHouse/ClickHouse --state all --label testing --label i
   --limit 100 --json number,title,url,body,state,closedAt
 ```
 
-Compare each candidate's `Job pattern:`/`Test pattern:`/`Failure reason:`/`Failure flags:` fields
-to the failing job name and output the way `_check_infrastructure_match` does. A match on an open
-issue — or one closed within ~8 h (check `closedAt`) — is `tracked #N` exactly as CI would
-attribute it; a match on an issue closed longer ago is a `stale #N` reopen candidate (same
+Compare each candidate's fields the way `_check_infrastructure_match` does: `Failure reason:` is a
+substring of the output; `Job pattern:`/`Test pattern:` match the failing job/test name; and every
+`Failure flags:` value must appear on the failure's `🏷️ labels:` line from step 1 (that line is
+the only place these flags are visible — e.g. `test_dns_cache … → retry_ok`). All present fields
+must hold. A match on an open issue — or one closed within ~8 h (check `closedAt`) — is `tracked #N`
+exactly as CI would attribute it; a match on an issue closed longer ago is a `stale #N` reopen
+candidate (same
 same-failure/recurrence check as the flaky case).
 
 **Always run the issue search for every failed name** — it is one cheap `gh issue list` and is the
@@ -207,9 +222,10 @@ makes no sense. It is a "searched, nothing matched, and not worth filing" verdic
 
 Determine, per test:
 
-- **Tracked** — an open (or closed within ~8 h — check `closedAt`) `testing` issue matches by the
-  rule above. No new issue needed; CI will keep auto-matching it. This applies to generic-bucket
-  names too when a `testing` issue exists (e.g. `Server died` → #107487).
+- **Tracked** — the failure carries an `issue` label in the report (its link **is** the tracking
+  issue), or an open / closed-within-~8 h (`closedAt`) `testing` issue matches by the rule above. No
+  new issue needed; CI will keep auto-matching it. Applies to generic-bucket names too when a
+  `testing` issue exists (e.g. `Server died` → #107487).
 - **Needs an issue** — the failure is a pre-existing **FLAKY** or **INFRA/BUILD** problem (per
   step 3), names a **specific** test/crash (a `NNNNN_*`/`test_*` case, or an identifiable crash/race
   with a stable `STID` mapping to one code site), and has **no** matching `testing` issue. Flag it
@@ -307,22 +323,27 @@ This check is **asymmetric — trust only the positive**:
 - **`is-ancestor` true** → the fix is definitely present. If the test still failed, the fix is
   incomplete/unrelated → keep investigating; do **not** report "already fixed".
 - **`is-ancestor` false** → conclusive **only for a master PR report**, where the fix must be that
-  exact merge commit. For an S3 `REF`/master-CI report, a **release/backport branch**, or any
-  non-master base, the fix may already be present under a **different** commit (a cherry-pick), so a
-  false result does **not** prove absence. Do **not** emit `rebase/retry` or short-circuit on it.
-  First check whether an equivalent change is on the failing branch — e.g. search that branch's
-  history for the fix by subject or by the file/line it changed:
+  exact merge commit, so false ⇒ `merged #N — not in this branch → rebase/retry`. For an S3
+  `REF`/master-CI report, a **release/backport branch**, or any non-master base, the fix may already
+  be present under a **different** commit (a cherry-pick), so a false result does **not** prove
+  absence. You may *search* for the equivalent change, but treat only a **positive** find as
+  conclusive:
 
   ```bash
   git log --oneline <report-sha> --grep "<fix PR title or key phrase>"
   git log --oneline <report-sha> -- <file the fix touched>   # look for a backport/cherry-pick
   ```
 
-  Only conclude `merged #N — not in this branch → rebase/retry` when the base is `master` **and**
-  the merge commit is genuinely absent, or when a branch-history search also finds no equivalent
-  change. If you cannot resolve it (commit absent locally, base unknown), report
-  `merged #N — presence unverified` and keep the failure open for step 5 rather than declaring it
-  fixed — never turn an unverified guess into an "already fixed on master" recommendation.
+  - **Found an equivalent change** → `merged #N — in branch` (fix present; if the test still failed,
+    keep digging).
+  - **Not found** → this is a **failed heuristic, not proof**: a cherry-pick can rewrite the subject,
+    squash a different file set, or fall past shallow history. Do **not** downgrade to `rebase/retry`
+    or short-circuit. Report `merged #N — presence unverified` and keep the failure open for step 5.
+
+  So `rebase/retry` is reached **only** on a master PR report with the merge commit genuinely absent.
+  On any non-master/`REF` report, or when you cannot resolve it (commit absent locally, base
+  unknown), the outcome is `in branch` (positive find) or `presence unverified` — never turn a
+  negative `git log` into an "already fixed" recommendation.
 
 Time order is a weak last resort, not a substitute: a fix `mergedAt` **after** the run's
 commit/`check_start_time` cannot be in the run, but "before" does **not** prove presence (the branch

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -311,9 +311,11 @@ Three complementary sources, cheapest first:
   **A bare number is ambiguous — every hit is a candidate, never a confirmed fix.** GitHub matches
   the number as free text, so this returns PRs that merely *mention* it (e.g. searching `75982`
   returns this docs PR, which only cites `#75982`). Before using any hit in the `Fix` column,
-  **verify it genuinely references this issue** — its body has a `Closes/Fixes/Related #<issue-number>`
-  (not the number in prose), or it plainly addresses the same failing test/symptom. Discard mentions
-  that don't. Never emit `WIP`/`merged` from an unverified number match.
+  **verify it genuinely references this issue** — its body has a relationship line naming the issue,
+  in **either** ClickHouse's full-URL convention (`Closes:`/`Fixes:`/`Related:`
+  `https://github.com/ClickHouse/ClickHouse/issues/<n>` — the form repo PRs are supposed to use) or
+  the short `Closes/Fixes/Related #<n>` form, or it plainly addresses the same failing test/symptom.
+  Discard bare prose mentions that don't. Never emit `WIP`/`merged` from an unverified number match.
 
   Do **not** rely on the by-test-name search below to catch cross-references — a fix PR that
   references the issue but never names the test is invisible to it, which would emit a false

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -298,15 +298,22 @@ Three complementary sources, cheapest first:
 
   This surfaces PRs that **closed** the issue and any fix named in comments — but **not** a PR that
   merely cross-references it (`Related #<issue>`) without closing it. The issue timeline would show
-  those, but the investigate profile denies `gh api` (it can POST). So find them with a read-only
-  **PR search by issue number**, which catches closing *and* non-closing references regardless of
-  whether the PR mentions the failing test:
+  those, but the investigate profile denies `gh api` (it can POST). So look for them with a
+  read-only **PR search by issue number** — scoped to title/body, and treated as **candidates
+  only**:
 
   ```bash
   .claude/tools/gh-ro.sh pr list --repo ClickHouse/ClickHouse --state all --limit 20 \
-    --search "<issue-number>" \
+    --search "<issue-number> in:title,body" \
     --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
   ```
+
+  **A bare number is ambiguous — every hit is a candidate, never a confirmed fix.** GitHub matches
+  the number as free text, so this returns PRs that merely *mention* it (e.g. searching `75982`
+  returns this docs PR, which only cites `#75982`). Before using any hit in the `Fix` column,
+  **verify it genuinely references this issue** — its body has a `Closes/Fixes/Related #<issue-number>`
+  (not the number in prose), or it plainly addresses the same failing test/symptom. Discard mentions
+  that don't. Never emit `WIP`/`merged` from an unverified number match.
 
   Do **not** rely on the by-test-name search below to catch cross-references — a fix PR that
   references the issue but never names the test is invisible to it, which would emit a false

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -173,18 +173,21 @@ last ~8 hours**, and routes each by whether it also carries the **`infrastructur
 **Fast path — read the labels `fetch_ci_report.js` prints.** The tool surfaces each failure's
 non-CIDB labels on a `🏷️ labels:` line. Two are decisive:
 
-- An **`issue`** label means CI matched a tracking issue **at run time** — the printed link **is**
-  that issue (e.g. `Server died` → `issue (…/issues/107487)`, `Hung check …` → `…/107941`). That is
-  a definitive `tracked #N`; no search needed to establish tracking (still read the issue for the
-  fix).
+- An **`issue`** label gives you the matched issue number **for free** — the printed link is the
+  issue CI matched **at run time** (e.g. `Server died` → `issue (…/issues/107487)`, `Hung check …`
+  → `…/107941`). It saves the *search*, but it is **not** by itself `tracked #N`: the label reflects
+  the catalog when the report was produced, not the issue's state **now**. Always `gh issue view`
+  the linked issue and classify from its **current** `state`/`closedAt` — an issue closed after the
+  run and aged past the ~8 h window is `stale #N` (reopen candidate), not `tracked`. The label
+  shortcuts the lookup; it does not replace the tracked-vs-stale decision below.
 - **Failure flags** (e.g. `retry_ok`) appear here too — these are exactly the labels an
   infrastructure issue matches on via `Failure flags:` (below), so this line is how you verify that
   constraint.
 
-But **absence** of an `issue` label is **not** proof of "untracked": CI stamps it from the catalog
+And **absence** of an `issue` label is **not** proof of "untracked": CI stamps it from the catalog
 *as it was at that run* (open + closed-within-8h then), so a tracking issue filed or reopened
-**after** the run won't show. So: an `issue` label → `tracked` immediately; no label → still run the
-GitHub search below before concluding `needs issue`/`untracked`.
+**after** the run won't show. So: an `issue` label → look up that issue and classify by current
+state; no label → still run the GitHub search below before concluding `needs issue`/`untracked`.
 
 **For an `INFRA/BUILD` or timeout/harness-level failure, also run the infrastructure path.** A
 test-name search alone will miss these, so a pre-existing, already-tracked infra failure would be
@@ -222,10 +225,11 @@ makes no sense. It is a "searched, nothing matched, and not worth filing" verdic
 
 Determine, per test:
 
-- **Tracked** — the failure carries an `issue` label in the report (its link **is** the tracking
-  issue), or an open / closed-within-~8 h (`closedAt`) `testing` issue matches by the rule above. No
-  new issue needed; CI will keep auto-matching it. Applies to generic-bucket names too when a
-  `testing` issue exists (e.g. `Server died` → #107487).
+- **Tracked** — a `testing` issue matches (by the rule above, or reached via the report's `issue`
+  label) and is **currently** open or closed within ~8 h (`gh issue view` → `state`/`closedAt`). No
+  new issue needed; CI will keep auto-matching it. Applies to generic-bucket names too when such an
+  issue exists (e.g. `Server died` → #107487). If the linked/ matched issue is closed longer ago,
+  it is `stale #N`, not `tracked`.
 - **Needs an issue** — the failure is a pre-existing **FLAKY** or **INFRA/BUILD** problem (per
   step 3), names a **specific** test/crash (a `NNNNN_*`/`test_*` case, or an identifiable crash/race
   with a stable `STID` mapping to one code site), and has **no** matching `testing` issue. Flag it

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -27,6 +27,11 @@ A read-only first pass over a CI failure: turn a single URL into a per-test verd
   act on them. To read source at the report's commit, use `git show <sha>:<path>` rather than
   checking it out; only fetch/switch after asking the user (see step 4).
 - Use `tmp/investigate/` for all working files, never `/tmp` (per CLAUDE.md).
+- **Run every `gh` read through `.claude/tools/gh-ro.sh` (same args as `gh`).** It drops a poisoned
+  `GH_CONFIG_DIR` — some agent/CI runners set it to a config dir with no working auth, which makes
+  raw `gh` fail — and refuses any non-read-only subcommand, so it can never create/close/edit/merge/
+  comment. The examples below use it for this reason. (`fetch_ci_report.js` clears `GH_CONFIG_DIR`
+  internally, so drive it as `node .claude/tools/fetch_ci_report.js …` directly.)
 - Wrap test names, identifiers, and log excerpts in backticks per the project style rule.
 - Say "exception", not "crash", for logical errors.
 
@@ -38,13 +43,14 @@ A read-only first pass over a CI failure: turn a single URL into a per-test verd
 issue links. If `$0` is `.../issues/NNNNN`, read the issue body and extract the report URL first:
 
 ```bash
-gh issue view <NNNNN> --repo ClickHouse/ClickHouse --json title,body
+.claude/tools/gh-ro.sh issue view <NNNNN> --repo ClickHouse/ClickHouse --json title,body
 ```
 
 Read the issue from the command output — do **not** redirect to a file. A
-`gh issue view … > tmp/investigate/issue.json` redirect is a file write that rides the wildcard
-`Bash(gh issue view:*)` allow (not the hook), so a symlinked `tmp`/`tmp/investigate` could land it
-outside the scratch dir without a prompt. (Step 1 creates `tmp/investigate`.)
+`.claude/tools/gh-ro.sh issue view … > tmp/investigate/issue.json` redirect is a file write that
+rides the wildcard `Bash(.claude/tools/gh-ro.sh:*)` allow (not the hook), so a symlinked
+`tmp`/`tmp/investigate` could land it outside the scratch dir without a prompt. (Step 1 creates
+`tmp/investigate`.)
 
 Bot-generated `flaky test` issues use this body format:
 
@@ -133,7 +139,7 @@ Search issues (open **and** closed) by test name — a hit often names the track
 and its comments may already carry the root cause, a fix PR, or a "known flaky" note.
 
 ```bash
-gh issue list --repo ClickHouse/ClickHouse --state all --limit 10 \
+.claude/tools/gh-ro.sh issue list --repo ClickHouse/ClickHouse --state all --limit 10 \
   --search "<distinctive test-name fragment> in:title,body" \
   --json number,title,state,stateReason,url,labels,closedAt
 ```
@@ -144,7 +150,7 @@ name rarely matches. If a candidate looks relevant, read it **with its comments*
 already provide the diagnosis:
 
 ```bash
-gh issue view <NNNNN> --repo ClickHouse/ClickHouse \
+.claude/tools/gh-ro.sh issue view <NNNNN> --repo ClickHouse/ClickHouse \
   --json number,title,state,stateReason,body,comments,labels,closedAt
 ```
 
@@ -176,7 +182,7 @@ non-CIDB labels on a `🏷️ labels:` line. Two are decisive:
 - An **`issue`** label gives you the matched issue number **for free** — the printed link is the
   issue CI matched **at run time** (e.g. `Server died` → `issue (…/issues/107487)`, `Hung check …`
   → `…/107941`). It saves the *search*, but it is **not** by itself `tracked #N`: the label reflects
-  the catalog when the report was produced, not the issue's state **now**. Always `gh issue view`
+  the catalog when the report was produced, not the issue's state **now**. Always `.claude/tools/gh-ro.sh issue view`
   the linked issue and classify from its **current** `state`/`closedAt` — an issue closed after the
   run and aged past the ~8 h window is `stale #N` (reopen candidate), not `tracked`. The label
   shortcuts the lookup; it does not replace the tracked-vs-stale decision below.
@@ -197,7 +203,7 @@ includes not just open ones but every `testing` issue closed in the last ~8 h
 by `Job pattern` / `Failure reason` against the failing job and its output:
 
 ```bash
-gh issue list --repo ClickHouse/ClickHouse --state all --label testing --label infrastructure \
+.claude/tools/gh-ro.sh issue list --repo ClickHouse/ClickHouse --state all --label testing --label infrastructure \
   --limit 100 --json number,title,url,body,state,closedAt
 ```
 
@@ -226,7 +232,7 @@ makes no sense. It is a "searched, nothing matched, and not worth filing" verdic
 Determine, per test:
 
 - **Tracked** — a `testing` issue matches (by the rule above, or reached via the report's `issue`
-  label) and is **currently** open or closed within ~8 h (`gh issue view` → `state`/`closedAt`). No
+  label) and is **currently** open or closed within ~8 h (`.claude/tools/gh-ro.sh issue view` → `state`/`closedAt`). No
   new issue needed; CI will keep auto-matching it. Applies to generic-bucket names too when such an
   issue exists (e.g. `Server died` → #107487). If the linked/ matched issue is closed longer ago,
   it is `stale #N`, not `tracked`.
@@ -281,7 +287,7 @@ Three complementary sources, cheapest first:
   **not** support a `timelineItems` field — it errors `Unknown JSON field`):
 
   ```bash
-  gh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,comments
+  .claude/tools/gh-ro.sh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,comments
   ```
 
   This surfaces PRs that closed the issue and any fix mentioned in comments. A PR that only
@@ -296,14 +302,14 @@ Three complementary sources, cheapest first:
   `test_dns_cache`):
 
   ```bash
-  gh pr view <pr> --repo ClickHouse/ClickHouse --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
+  .claude/tools/gh-ro.sh pr view <pr> --repo ClickHouse/ClickHouse --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
   ```
 
 - **By test name:** search PRs (open **and** merged) whose title/body names the test or its
   fragment:
 
   ```bash
-  gh pr list --repo ClickHouse/ClickHouse --state all --limit 20 \
+  .claude/tools/gh-ro.sh pr list --repo ClickHouse/ClickHouse --state all --limit 20 \
     --search "<distinctive test-name fragment>" \
     --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
   ```
@@ -457,7 +463,7 @@ mean distinct bugs.
   run the cross-PR corroboration query first**, then:
   - Fails across multiple *unrelated* PRs with the same error → **FLAKY** (low rate; it just
     rarely lands on a direct-master run), not a regression.
-  - The PR *adds* this test (`gh pr diff` shows the test file as new) → new test, judge on its
+  - The PR *adds* this test (`.claude/tools/gh-ro.sh pr diff` shows the test file as new) → new test, judge on its
     own output, not history.
   - Absent on master **and** across other PRs, and the test already exists on master →
     **likely a REAL regression introduced by this PR**.
@@ -496,7 +502,7 @@ every failed test is `FLAKY`, **skip this step entirely**.
 **Read the error and the source before downloading anything.** The step-1 failure output usually
 already contains the decisive evidence — an assertion message, an exception, a result diff, or a
 stack trace. Read it, then open the referenced code (the stack-trace `file:line`, and
-`gh pr diff <PR>` for the suspect change). For a large category of failures —
+`.claude/tools/gh-ro.sh pr diff <PR>` for the suspect change). For a large category of failures —
 logical-error / assertion aborts with a symbolized stack, exceptions with a clear message, simple
 stateless-test result diffs — that is enough to root-cause, and **no artifacts need to be
 downloaded at all** (this investigation root-caused a `KeeperStateMachine.cpp` assertion straight
@@ -574,7 +580,7 @@ selected failure (or per shared-cause group) in parallel. Give each subagent:
 
 - the failure output from step 1,
 - the path(s) to any artifacts downloaded in step 4 (omit if none were needed),
-- the PR diff for cross-referencing — run `gh pr diff <PR>` and pass its output (or have the
+- the PR diff for cross-referencing — run `.claude/tools/gh-ro.sh pr diff <PR>` and pass its output (or have the
   subagent run it); do **not** redirect to a file (same symlink-write reason as step 0),
 - the report `SHA`, instructing it to read source at that commit (`git show <sha>:<path>`) for
   accurate `file:line`, per step 4.

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -340,7 +340,16 @@ Three complementary sources, cheapest first:
 - **By symptom:** for a `REAL`/`UNCERTAIN` failure, once step 5 names the suspect `file:line`,
   search PRs touching that file or the error string the same way.
 
-For each candidate fix PR, classify its **status** — this is what goes in the report's Fix column:
+**Every search here (by issue number, by test name, by symptom) returns candidates only.** GitHub
+matches the term as free text, so a PR that merely *mentions* the test/symptom comes back too — e.g.
+searching `test_dns_cache` returns this very docs PR because its text names that test. Before a hit
+may fill the `Fix` column you must **confirm it actually addresses this failure**: open its diff
+(`.claude/tools/gh-ro.sh pr diff <pr>`) and check the change targets the failing test/code, not just
+a passing mention. **Ignore the PR under investigation itself** (the `$0` PR) unless its own diff
+genuinely fixes the failure. Discard unconfirmed hits — a `none` is correct when nothing verifiably
+addresses the failure; never emit `WIP`/`merged` from an unverified name/symptom match.
+
+For each **verified** fix PR, classify its **status** — this is what goes in the report's Fix column:
 
 - **WIP** — open PR. Note draft vs in-review (`isDraft`). Not yet protecting any run.
 - **Merged** — `state == MERGED`, with a `mergeCommit`. Then decide **whether it is already in the

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -352,27 +352,40 @@ or the same patch authored directly in the PR). So:
 
 - **`is-ancestor` true** → the fix is definitely present. If the test still failed, the fix is
   incomplete/unrelated → keep investigating; do **not** report "already fixed".
-- **`is-ancestor` false (or the merge commit is absent locally)** → **do not conclude yet.** Always
-  run the equivalent-change search first, and treat only a **positive** find as conclusive:
+- **`is-ancestor` false (or the merge commit is absent locally)** → **do not conclude yet, and do
+  not conclude from `git log` alone.** Establish what the fix actually changed, then check that
+  **content** against the failing branch:
 
-  ```bash
-  git log --oneline <report-sha> --grep "<fix PR title or key phrase>"
-  git log --oneline <report-sha> -- <file the fix touched>   # catches a cherry-pick / self-applied copy
-  ```
+  1. Get the fix's actual change (its hunks) — the diff of the merged PR:
 
-  - **Found an equivalent change** → `merged #N — in branch` (fix present; if the test still failed,
-    it is incomplete → keep digging). This holds regardless of report type.
-  - **Not found** → a failed search is a **heuristic, not proof** (a cherry-pick can rewrite the
-    subject, squash a different file set, or fall past shallow history). Decide by report type:
-    - **master PR report** → `merged #N — not in this branch → rebase/retry`. The `git log -- <file>`
-      search reliably catches an in-branch copy (it does not depend on the commit subject), so "not
-      found" on a master-based branch is a sound basis for rebase/retry — the common, useful case.
-    - **S3 `REF`/master-CI report, release/backport branch, non-master base, or commit absent /
-      base unknown** → `merged #N — presence unverified`; keep the failure open for step 5. Do
-      **not** emit `rebase/retry` here.
+     ```bash
+     .claude/tools/gh-ro.sh pr diff <fix-pr> --repo ClickHouse/ClickHouse
+     ```
 
-  Never turn a bare negative `is-ancestor` — without the equivalent-change search — into any
-  conclusion.
+  2. Use `git log` only to *find candidate* commits on the branch — never as the verdict (a
+     `--grep` hit can be a coincidental subject; a `-- <file>` hit only proves some commit touched
+     that path, not that it carries the fix; and a **miss proves nothing** — the fix may be present
+     after conflict resolution, a refactor, or manual transcription):
+
+     ```bash
+     git log --oneline <report-sha> --grep "<fix PR title or key phrase>"   # candidates only
+     git log --oneline <report-sha> -- <file the fix touched>               # candidates only
+     ```
+
+  3. **Verify at the content level** before emitting any verdict: inspect the fix's key hunk in the
+     branch's own version of the file at the report commit (and/or a candidate commit), e.g.
+     `git show <report-sha>:<path>` and look for the specific guard/line/logic the fix added, or
+     `git show <candidate>` to confirm it is the same change.
+
+  Then:
+  - **The fix's logic is present in the branch (content confirmed)** → `merged #N — in branch`
+    (if the test still failed, it is incomplete → keep digging). Holds regardless of report type.
+  - **The fix's logic is confirmed absent from the branch's file content, and the base is `master`**
+    → `merged #N — not in this branch → rebase/retry`.
+  - **Anything you could not confirm at the content level** — no access to the fix diff, a
+    backport/`REF`/non-master base, the commit absent locally, or an ambiguous/refactored match →
+    `merged #N — presence unverified`; keep the failure open for step 5. Never emit `in branch` or
+    `rebase/retry` from a `git log` subject/path hit-or-miss alone.
 
 Time order is a weak last resort, not a substitute: a fix `mergedAt` **after** the run's
 commit/`check_start_time` cannot be in the run, but "before" does **not** prove presence (the branch

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -296,16 +296,26 @@ Three complementary sources, cheapest first:
   .claude/tools/gh-ro.sh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,comments
   ```
 
-  This surfaces PRs that closed the issue and any fix mentioned in comments. A PR that only
-  cross-references the issue without closing it (a `Related #<issue>`) is not returned here — the
-  investigate profile denies `gh api` (it can POST), so do not reach for the issue timeline API;
-  the by-test-name PR search below catches those.
+  This surfaces PRs that **closed** the issue and any fix named in comments — but **not** a PR that
+  merely cross-references it (`Related #<issue>`) without closing it. The issue timeline would show
+  those, but the investigate profile denies `gh api` (it can POST). So find them with a read-only
+  **PR search by issue number**, which catches closing *and* non-closing references regardless of
+  whether the PR mentions the failing test:
 
-  **`closedByPullRequestsReferences` gives only `number`/`url` — not the fields you classify on.**
-  So for every PR discovered from the issue (references or comments), fetch the classification
-  fields explicitly before scoring the Fix column; do **not** rely on the by-name search to
-  re-find it (it often won't — e.g. issue #75982's fixer #80765 is not returned by searching
-  `test_dns_cache`):
+  ```bash
+  .claude/tools/gh-ro.sh pr list --repo ClickHouse/ClickHouse --state all --limit 20 \
+    --search "<issue-number>" \
+    --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
+  ```
+
+  Do **not** rely on the by-test-name search below to catch cross-references — a fix PR that
+  references the issue but never names the test is invisible to it, which would emit a false
+  `Fix: none`.
+
+  The by-issue-number `pr list` above already returns the classification fields. But
+  `closedByPullRequestsReferences` and comment mentions give only a PR **number/url** — so for any
+  fix PR you learned of only as a bare number (and that the search above did not already return),
+  fetch the classification fields explicitly before scoring the Fix column:
 
   ```bash
   .claude/tools/gh-ro.sh pr view <pr> --repo ClickHouse/ClickHouse --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -285,6 +285,16 @@ Three complementary sources, cheapest first:
   investigate profile denies `gh api` (it can POST), so do not reach for the issue timeline API;
   the by-test-name PR search below catches those.
 
+  **`closedByPullRequestsReferences` gives only `number`/`url` — not the fields you classify on.**
+  So for every PR discovered from the issue (references or comments), fetch the classification
+  fields explicitly before scoring the Fix column; do **not** rely on the by-name search to
+  re-find it (it often won't — e.g. issue #75982's fixer #80765 is not returned by searching
+  `test_dns_cache`):
+
+  ```bash
+  gh pr view <pr> --repo ClickHouse/ClickHouse --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
+  ```
+
 - **By test name:** search PRs (open **and** merged) whose title/body names the test or its
   fragment:
 
@@ -301,13 +311,14 @@ For each candidate fix PR, classify its **status** — this is what goes in the 
 
 - **WIP** — open PR. Note draft vs in-review (`isDraft`). Not yet protecting any run.
 - **Merged** — `state == MERGED`, with a `mergeCommit`. Then decide **whether it is already in the
-  failing run**, which determines the recommendation:
-  - **Merged, NOT in this branch** → the fix landed on master after the report's commit. The PR
-    just needs a rebase/retry. This is the common "already fixed on master — rebase and retry"
-    case.
-  - **Merged, ALREADY in this branch** → the fix was present in the failing run yet the test still
-    failed. The "fix" is incomplete or unrelated — do **not** treat the failure as resolved; keep
-    investigating (step 5).
+  failing run** using the containment rule below (never from `mergedAt` alone), which determines the
+  recommendation:
+  - **Merged, present in this branch** → the fix was in the failing run yet the test still failed.
+    Incomplete or unrelated — do **not** treat as resolved; keep investigating (step 5).
+  - **Merged, not in this branch (master PR report)** → the fix landed on master after the report's
+    commit → rebase/retry. The common "already fixed on master — rebase and retry" case.
+  - **Merged, presence unverified (backport/`REF`/non-master)** → cannot confirm containment; keep
+    the failure open, do not call it fixed.
 - **None** — no fix PR found.
 
 **Deciding "already in this branch or not".** Compare the fix's merge against the report commit
@@ -318,32 +329,34 @@ git cat-file -e <mergeCommit> && git merge-base --is-ancestor <mergeCommit> <rep
   && echo "fix commit IS in the failing run" || echo "fix commit is NOT in the failing run history (or absent locally)"
 ```
 
-This check is **asymmetric — trust only the positive**:
+This check is **asymmetric — trust only the positive**. A **negative never concludes on its own**,
+on *any* report type: the exact merge commit being absent does not prove the fix *logic* is absent,
+because the branch may carry it under a different SHA (a cherry-pick, a copy merged from elsewhere,
+or the same patch authored directly in the PR). So:
 
 - **`is-ancestor` true** → the fix is definitely present. If the test still failed, the fix is
   incomplete/unrelated → keep investigating; do **not** report "already fixed".
-- **`is-ancestor` false** → conclusive **only for a master PR report**, where the fix must be that
-  exact merge commit, so false ⇒ `merged #N — not in this branch → rebase/retry`. For an S3
-  `REF`/master-CI report, a **release/backport branch**, or any non-master base, the fix may already
-  be present under a **different** commit (a cherry-pick), so a false result does **not** prove
-  absence. You may *search* for the equivalent change, but treat only a **positive** find as
-  conclusive:
+- **`is-ancestor` false (or the merge commit is absent locally)** → **do not conclude yet.** Always
+  run the equivalent-change search first, and treat only a **positive** find as conclusive:
 
   ```bash
   git log --oneline <report-sha> --grep "<fix PR title or key phrase>"
-  git log --oneline <report-sha> -- <file the fix touched>   # look for a backport/cherry-pick
+  git log --oneline <report-sha> -- <file the fix touched>   # catches a cherry-pick / self-applied copy
   ```
 
   - **Found an equivalent change** → `merged #N — in branch` (fix present; if the test still failed,
-    keep digging).
-  - **Not found** → this is a **failed heuristic, not proof**: a cherry-pick can rewrite the subject,
-    squash a different file set, or fall past shallow history. Do **not** downgrade to `rebase/retry`
-    or short-circuit. Report `merged #N — presence unverified` and keep the failure open for step 5.
+    it is incomplete → keep digging). This holds regardless of report type.
+  - **Not found** → a failed search is a **heuristic, not proof** (a cherry-pick can rewrite the
+    subject, squash a different file set, or fall past shallow history). Decide by report type:
+    - **master PR report** → `merged #N — not in this branch → rebase/retry`. The `git log -- <file>`
+      search reliably catches an in-branch copy (it does not depend on the commit subject), so "not
+      found" on a master-based branch is a sound basis for rebase/retry — the common, useful case.
+    - **S3 `REF`/master-CI report, release/backport branch, non-master base, or commit absent /
+      base unknown** → `merged #N — presence unverified`; keep the failure open for step 5. Do
+      **not** emit `rebase/retry` here.
 
-  So `rebase/retry` is reached **only** on a master PR report with the merge commit genuinely absent.
-  On any non-master/`REF` report, or when you cannot resolve it (commit absent locally, base
-  unknown), the outcome is `in branch` (positive find) or `presence unverified` — never turn a
-  negative `git log` into an "already fixed" recommendation.
+  Never turn a bare negative `is-ancestor` — without the equivalent-change search — into any
+  conclusion.
 
 Time order is a weak last resort, not a substitute: a fix `mergedAt` **after** the run's
 commit/`check_start_time` cannot be in the run, but "before" does **not** prove presence (the branch

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -102,9 +102,15 @@ This prints the failed tests **and their output** straight from the praktika `re
 copy-paste), with a CIDB link per failed test. Read it from the command output — do **not** add a
 `> tmp/investigate/…` redirect (a redirect is a file write the hook won't auto-approve, since it
 can't be made symlink-safe, so it would prompt); the harness persists large output to a file you
-can re-read or `grep`. If `node` is **absent**, skip the report fetch (and the step-4 download)
-and rely on the issue body's failure output plus step 3 — do not treat a missing `node` as a
-fatal error.
+can re-read or `grep`. **If `node` is absent, the fallback depends on the input type:**
+
+- **Issue URL** (step 0 already gave you `Test name:` and the `Failing test history` link) → proceed
+  without the report: run step 3 on that named test; the S3 report and step-4 artifacts are
+  best-effort enrichment. A missing `node` is not fatal here.
+- **PR or S3 report URL** → `node` is **required**. Without the report you have no failed test
+  names, job names, or labels, so steps 2–3 (issue/fix search and the `test_name IN (...)` history
+  query) cannot run. Do **not** limp on with a partial investigation — stop and tell the user to
+  install `node` (or re-run where `node` is on `PATH`).
 
 Per failure the tool prints a `🏷️ labels:` line (CI's non-CIDB labels — the `issue` match link and
 flags like `retry_ok`; see step 2a), the CIDB link, and the **log *tail*** — the last ~30 non-empty

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: investigate-ci
-description: Investigate a ClickHouse CI failure end-to-end from a PR or S3 report URL. Fetches the failed tests and their output, searches for an existing tracking GitHub issue, classifies each as flaky vs a real regression using play.clickhouse.com master history, downloads and reads the harness artifacts only for failures that history does not explain, and reports a root-cause hypothesis. Read-only first pass — never commits, pushes, or edits.
+description: Investigate a ClickHouse CI failure end-to-end from a PR or S3 report URL. Fetches the failed tests and their output, classifies each as flaky vs a real regression using play.clickhouse.com master history, and for every failure searches for both an existing tracking GitHub issue and an existing fix (open/merged PR) — reporting, per failure, whether an issue still needs to be created and whether a fix exists with its status (WIP, merged, already in this branch or not). Downloads and reads the harness artifacts only for failures that history does not explain, and reports a root-cause hypothesis. Read-only first pass — never commits, pushes, or edits.
 argument-hint: "<PR-url | S3-report-url | issue-url> [threshold-days]"
 disable-model-invocation: false
 allowed-tools: Bash, Read, Grep, Glob, Agent, Task, WebFetch
@@ -107,17 +107,27 @@ fatal error.
 - Record the **count** of failed tests. The cheap steps (2–3) always run over all of them, but
   a large count changes how step 3 scopes the expensive deep-dive — see "Scope the deep-dive".
 
-### 2. Search for an existing GitHub issue
+### 2. Search for an existing tracking issue and an existing fix
 
-Before querying history, check whether the failure is already tracked. For each failed test,
-search issues (open **and** closed) by test name — a hit often names the tracking flaky-test
-issue, and its comments may already carry the root cause, a fix PR, or a "known flaky" note that
-short-circuits the rest of the investigation.
+For **every** failed test, run two searches and record a per-test answer to two questions that go
+into the final report:
+
+- **Issue:** is the failure already tracked, or does an issue still need to be created?
+- **Fix:** does a fix already exist, and what is its status (WIP / merged / already in this branch
+  or not)?
+
+Do both before the deep-dive — a tracked failure with a merged fix often short-circuits the rest
+of the investigation.
+
+#### 2a. Existing tracking issue + "does an issue need to be created?"
+
+Search issues (open **and** closed) by test name — a hit often names the tracking flaky-test issue,
+and its comments may already carry the root cause, a fix PR, or a "known flaky" note.
 
 ```bash
 gh issue list --repo ClickHouse/ClickHouse --state all --limit 10 \
   --search "<distinctive test-name fragment> in:title,body" \
-  --json number,title,state,stateReason,url
+  --json number,title,state,stateReason,url,labels
 ```
 
 Search on a distinctive fragment (the function or `test_*` name **without** the parametrization
@@ -127,14 +137,107 @@ already provide the diagnosis:
 
 ```bash
 gh issue view <NNNNN> --repo ClickHouse/ClickHouse \
-  --json number,title,state,stateReason,body,comments
+  --json number,title,state,stateReason,body,comments,labels
 ```
 
-Record the matching issue number, its state (open vs closed/`completed`), and any root cause or
-fix PR mentioned — feed it into the step-3 classification and the final report. A closed
-`completed` issue whose fix post-dates the failing run points straight at "retry, already fixed".
-If the input was itself an issue (step 0) you already have it, but still scan for duplicate or
-related issues and read its comments.
+**How CI decides a failure is already tracked** (so you can answer "needs an issue?" the same way
+CI's matcher does — see `ci/praktika/issue.py`, `Issue._check_flaky_test_match`): CI builds a
+catalog from issues labeled **`testing`** (`IssueLabels.CI_ISSUE`) that are **open, or were closed
+within the last ~8 hours**. A failure matches a catalog issue when:
+
+- the issue's `Test name:` body field is a **suffix** of the failing test's name
+  (`result.name.endswith(test_name)`; pytest parametrization/module rules apply), **and**
+- if the issue sets a `Failure reason:`, that exact text is a **substring** of the failure output.
+
+A matched failure is flagged with an `issue` label in the CI report — visible in the
+`fetch_ci_report.js` output — which is the fastest "already tracked" signal.
+
+**First, decide whether the per-test issue search even applies.** Some failures are not a single
+test with one cause but a **generic, harness-level failure bucket** that aggregates many unrelated
+causes: check-level verdicts like `Server died`, `Hung check failed, possible deadlock found`, or
+the upgrade `Error message in clickhouse-server.log` check, and anonymized error *classes* like
+`Logical error: Bad cast from type A to B` (the harness replaces concrete types with `A`/`B` and
+groups by stack hash `STID`). Filing a per-failure tracking issue for these makes no sense — they
+recur fleet-wide for shifting reasons. For such a bucket, **skip the issue search**: do not assert
+`tracked`/`needs issue`, and record the Issue value as **`generic failure / untracked`**. Step 3's
+master/cross-PR frequency is what establishes these are pre-existing and not caused by the PR; that
+is the relevant signal, not a tracking issue. Run the per-test search below only for failures that
+name a **specific** test (a `NNNNN_*`/`test_*` case) or a **specific, identifiable** crash/race
+(e.g. a data race with a stable `STID` that maps to one code site).
+
+Then determine, per test:
+
+- **Generic failure / untracked** — a harness-level bucket or anonymized error class as above. No
+  issue search run, no issue to file; rely on the step-3 frequency for the verdict.
+- **Tracked** — an open (or just-closed) `testing` issue matches by the rule above (or the report
+  already carries the `issue` label). No new issue needed; CI will keep auto-matching it.
+- **Needs an issue** — the failure is a pre-existing **FLAKY** or **INFRA/BUILD** problem (per
+  step 3), names a specific test/crash, and has **no** matching `testing` issue. Flag it as "issue
+  needed" in the report.
+- **No issue (fix instead)** — a **REAL** regression introduced by this PR. Do **not** flag it for
+  a tracking issue: a `testing` issue would mask a real bug. The recommendation is to fix the code.
+- **Stale/closed match** — only a closed issue matches, and it was closed more than ~8 h ago. CI
+  no longer auto-matches it, so if the test is still flaky a fresh issue (or reopening) is needed;
+  note the old issue number.
+
+Never label a cell with an asserted fact you did not verify (e.g. "(known)" implying a tracking
+issue exists when you ran no search). If you did not search, the value is `generic failure /
+untracked`, not a tracking claim.
+
+Record the matching issue number, its state (open vs closed/`completed`), labels, and any root
+cause or fix PR mentioned. A closed `completed` issue whose fix post-dates the failing run points
+straight at "retry, already fixed". If the input was itself an issue (step 0) you already have it,
+but still scan for duplicate or related issues and read its comments.
+
+#### 2b. Existing fix + its status
+
+Independently of whether an issue exists, search for a **fix** — a PR that addresses this failure.
+Three complementary sources, cheapest first:
+
+- **From the tracking issue:** a fix PR is usually linked from the issue. Read its timeline for
+  cross-referencing PRs (a `Closes #<issue>` in a PR shows up here):
+
+  ```bash
+  gh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,timelineItems
+  ```
+
+- **By test name:** search PRs (open **and** merged) whose title/body names the test or its
+  fragment:
+
+  ```bash
+  gh pr list --repo ClickHouse/ClickHouse --state all --limit 20 \
+    --search "<distinctive test-name fragment>" \
+    --json number,title,state,isDraft,mergedAt,mergeCommit,headRefName,url
+  ```
+
+- **By symptom:** for a `REAL`/`UNCERTAIN` failure, once step 5 names the suspect `file:line`,
+  search PRs touching that file or the error string the same way.
+
+For each candidate fix PR, classify its **status** — this is what goes in the report's Fix column:
+
+- **WIP** — open PR. Note draft vs in-review (`isDraft`). Not yet protecting any run.
+- **Merged** — `state == MERGED`, with a `mergeCommit`. Then decide **whether it is already in the
+  failing run**, which determines the recommendation:
+  - **Merged, NOT in this branch** → the fix landed on master after the report's commit. The PR
+    just needs a rebase/retry. This is the common "already fixed on master — rebase and retry"
+    case.
+  - **Merged, ALREADY in this branch** → the fix was present in the failing run yet the test still
+    failed. The "fix" is incomplete or unrelated — do **not** treat the failure as resolved; keep
+    investigating (step 5).
+- **None** — no fix PR found.
+
+**Deciding "already in this branch or not".** Compare the fix's merge against the report commit
+(`SHA` from step 1). If the fix's merge commit is in the local object store, ancestry is exact:
+
+```bash
+git cat-file -e <mergeCommit> && git merge-base --is-ancestor <mergeCommit> <report-sha> \
+  && echo "fix IS in the failing run" || echo "fix is NOT in the failing run (or commit absent locally)"
+```
+
+If the merge commit is absent locally (`git cat-file -e` fails), fall back to time order: a fix
+with `mergedAt` **after** the run's commit/`check_start_time` cannot be in the failing run →
+"merged, not in this branch → rebase/retry". Surface that you used the time-order fallback rather
+than exact ancestry.
 
 ### 3. Flaky-vs-real: query master history
 
@@ -354,14 +457,24 @@ the suspect change in the PR diff. Tell it to read only; it must not modify anyt
 
 Print one verdict table, then a short narrative per real/uncertain failure:
 
-| Test | Verdict | Master freq (7/14/30/90d) | Last master fail | Root-cause hypothesis | Suspect | CIDB |
-|------|---------|---------------------------|------------------|-----------------------|---------|------|
+| Test | Verdict | Master freq (7/14/30/90d) | Last master fail | Issue | Fix | Root-cause hypothesis | Suspect | CIDB |
+|------|---------|---------------------------|------------------|-------|-----|-----------------------|---------|------|
 
 - **Verdict** ∈ {`FLAKY`, `REAL`, `UNCERTAIN`, `NEW-TEST`, `INFRA/BUILD`}.
+- **Issue** (from step 2a) ∈ {`generic failure / untracked` (harness-level bucket or anonymized
+  error class — no issue search run, none to file), `tracked #N`, `needs issue`, `fix instead`
+  (REAL — don't mask), `stale #N` (closed >~8 h ago)}. Never write a tracking claim like "(known)"
+  for a failure you did not search.
+- **Fix** (from step 2b) ∈ {`none`, `WIP #N` (open; note draft), `merged #N — in branch` (fix was
+  present yet test still failed → keep digging), `merged #N — rebase/retry` (landed after the run)}.
 - For `REAL`/`UNCERTAIN`, give the `file:line` evidence and the suspect PR change.
 - For `FLAKY`, state the master frequency and the tracking flaky-test issue from step 2 (number,
   state, and any root cause / fix PR its comments revealed).
-- End with a one-line recommendation per test (e.g. "retry — flaky on master",
-  "real regression in `<file>`, see `<commit>`", "needs manual look — logs inconclusive").
+- End with a one-line recommendation per test that combines verdict, issue, and fix, e.g.:
+  - "retry — flaky on master, tracked by #N";
+  - "retry — already fixed on master by #N (merged after this run), rebase";
+  - "flaky on master, **no tracking issue — create one**";
+  - "real regression in `<file>`, see `<commit>` — fix the PR, do not file a tracking issue";
+  - "merged fix #N is already in this branch but the test still failed — needs manual look".
 
 Include the original report URL (and PR link) so the human can confirm. Do not take any action.

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -152,28 +152,31 @@ within the last ~8 hours**. A failure matches a catalog issue when:
 A matched failure is flagged with an `issue` label in the CI report — visible in the
 `fetch_ci_report.js` output — which is the fastest "already tracked" signal.
 
-**First, decide whether the per-test issue search even applies.** Some failures are not a single
-test with one cause but a **generic, harness-level failure bucket** that aggregates many unrelated
-causes: check-level verdicts like `Server died`, `Hung check failed, possible deadlock found`, or
-the upgrade `Error message in clickhouse-server.log` check, and anonymized error *classes* like
-`Logical error: Bad cast from type A to B` (the harness replaces concrete types with `A`/`B` and
-groups by stack hash `STID`). Filing a per-failure tracking issue for these makes no sense — they
-recur fleet-wide for shifting reasons. For such a bucket, **skip the issue search**: do not assert
-`tracked`/`needs issue`, and record the Issue value as **`generic failure / untracked`**. Step 3's
-master/cross-PR frequency is what establishes these are pre-existing and not caused by the PR; that
-is the relevant signal, not a tracking issue. Run the per-test search below only for failures that
-name a **specific** test (a `NNNNN_*`/`test_*` case) or a **specific, identifiable** crash/race
-(e.g. a data race with a stable `STID` that maps to one code site).
+**Always run the issue search for every failed name** — it is one cheap `gh issue list` and is the
+only way to mirror CI's attribution. Generic, harness-level names get tracked too: `Server died`,
+`Hung check failed, possible deadlock found`, and the upgrade `Error message in
+clickhouse-server.log` check frequently *do* have a `testing` issue (e.g. `Server died` →
+[#107487](https://github.com/ClickHouse/ClickHouse/issues/107487), `Test name: Server died`), and
+`Issue._check_flaky_test_match` will mark such a result with the `issue` label. So do **not** skip
+the search for them. The `generic failure / untracked` value is **only** for a generic bucket or
+anonymized error *class* (e.g. `Logical error: Bad cast from type A to B`, where the harness
+replaces concrete types with `A`/`B` and groups by stack hash `STID`) **after** the search finds no
+matching `testing` issue — because filing a *new* per-failure issue for such a shifting bucket
+makes no sense. It is a "searched, nothing matched, and not worth filing" verdict, never a
+"didn't look" one.
 
-Then determine, per test:
+Determine, per test:
 
-- **Generic failure / untracked** — a harness-level bucket or anonymized error class as above. No
-  issue search run, no issue to file; rely on the step-3 frequency for the verdict.
 - **Tracked** — an open (or just-closed) `testing` issue matches by the rule above (or the report
-  already carries the `issue` label). No new issue needed; CI will keep auto-matching it.
+  already carries the `issue` label). No new issue needed; CI will keep auto-matching it. This
+  applies to generic-bucket names too when a `testing` issue exists (e.g. `Server died` → #107487).
 - **Needs an issue** — the failure is a pre-existing **FLAKY** or **INFRA/BUILD** problem (per
-  step 3), names a specific test/crash, and has **no** matching `testing` issue. Flag it as "issue
-  needed" in the report.
+  step 3), names a **specific** test/crash (a `NNNNN_*`/`test_*` case, or an identifiable crash/race
+  with a stable `STID` mapping to one code site), and has **no** matching `testing` issue. Flag it
+  as "issue needed" in the report.
+- **Generic failure / untracked** — a generic harness bucket or anonymized error class for which
+  the search found **no** matching `testing` issue, and filing a new per-failure issue makes no
+  sense. Rely on the step-3 frequency for the verdict.
 - **No issue (fix instead)** — a **REAL** regression introduced by this PR. Do **not** flag it for
   a tracking issue: a `testing` issue would mask a real bug. The recommendation is to fix the code.
 - **Stale/closed match** — only a closed issue matches, and it was closed more than ~8 h ago. CI
@@ -181,8 +184,8 @@ Then determine, per test:
   note the old issue number.
 
 Never label a cell with an asserted fact you did not verify (e.g. "(known)" implying a tracking
-issue exists when you ran no search). If you did not search, the value is `generic failure /
-untracked`, not a tracking claim.
+issue exists). `generic failure / untracked` requires that you actually ran the search and it
+returned no match — it is not a substitute for searching.
 
 Record the matching issue number, its state (open vs closed/`completed`), labels, and any root
 cause or fix PR mentioned. A closed `completed` issue whose fix post-dates the failing run points
@@ -194,11 +197,19 @@ but still scan for duplicate or related issues and read its comments.
 Independently of whether an issue exists, search for a **fix** — a PR that addresses this failure.
 Three complementary sources, cheapest first:
 
-- **From the tracking issue:** a fix PR is usually linked from the issue. Read its timeline for
-  cross-referencing PRs (a `Closes #<issue>` in a PR shows up here):
+- **From the tracking issue:** a fix PR is usually linked from the issue. `closedByPullRequestsReferences`
+  names the PR(s) that closed it, and `comments` often mention the fix (`gh issue view --json` does
+  **not** support a `timelineItems` field — it errors `Unknown JSON field`):
 
   ```bash
-  gh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,timelineItems
+  gh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,comments
+  ```
+
+  For cross-referencing PRs that mention the issue but did not close it (a `Related #<issue>`), use
+  the timeline via `gh api`:
+
+  ```bash
+  gh api repos/ClickHouse/ClickHouse/issues/<issue-number>/timeline --jq '.[] | select(.event=="cross-referenced") | .source.issue.html_url'
   ```
 
 - **By test name:** search PRs (open **and** merged) whose title/body names the test or its
@@ -461,10 +472,11 @@ Print one verdict table, then a short narrative per real/uncertain failure:
 |------|---------|---------------------------|------------------|-------|-----|-----------------------|---------|------|
 
 - **Verdict** ∈ {`FLAKY`, `REAL`, `UNCERTAIN`, `NEW-TEST`, `INFRA/BUILD`}.
-- **Issue** (from step 2a) ∈ {`generic failure / untracked` (harness-level bucket or anonymized
-  error class — no issue search run, none to file), `tracked #N`, `needs issue`, `fix instead`
-  (REAL — don't mask), `stale #N` (closed >~8 h ago)}. Never write a tracking claim like "(known)"
-  for a failure you did not search.
+- **Issue** (from step 2a) ∈ {`tracked #N`, `needs issue`, `generic failure / untracked` (generic
+  bucket or anonymized error class — searched, no `testing` issue matched, and not worth filing),
+  `fix instead` (REAL — don't mask), `stale #N` (closed >~8 h ago)}. The search runs for every
+  failure (generic buckets included — e.g. `Server died` is often `tracked`); never write a
+  tracking claim like "(known)", and never use `untracked` as a stand-in for not searching.
 - **Fix** (from step 2b) ∈ {`none`, `WIP #N` (open; note draft), `merged #N — in branch` (fix was
   present yet test still failed → keep digging), `merged #N — rebase/retry` (landed after the run)}.
 - For `REAL`/`UNCERTAIN`, give the `file:line` evidence and the suspect PR change.

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -334,7 +334,10 @@ This is the cheap, decisive triage — run it **before** downloading any artifac
 since a `FLAKY` verdict usually makes the heavy download unnecessary.
 
 Run **one** batch query against `play.clickhouse.com` for all failed test names. The `checks`
-table is publicly readable via the `play` user. Adapt the threshold to `$1` (default `14`).
+table is publicly readable via the `play` user. The query below always computes the same fixed
+7/14/30/90-day buckets; `$1` (default `14`) does **not** change the SQL — it selects **which
+precomputed bucket is the gate** you read for the verdict (`fail_<$1>d`). If `$1` is not one of
+7/14/30/90, round to the nearest bucket (or add that column).
 
 **Guard the empty case:** if no test names were extracted, `test_name IN ()` is invalid SQL —
 skip and report "no named tests to classify" (the failure may be a build/infra error; go to

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -134,7 +134,7 @@ and its comments may already carry the root cause, a fix PR, or a "known flaky" 
 ```bash
 gh issue list --repo ClickHouse/ClickHouse --state all --limit 10 \
   --search "<distinctive test-name fragment> in:title,body" \
-  --json number,title,state,stateReason,url,labels
+  --json number,title,state,stateReason,url,labels,closedAt
 ```
 
 Search on a distinctive fragment (the function or `test_*` name **without** the parametrization
@@ -144,7 +144,7 @@ already provide the diagnosis:
 
 ```bash
 gh issue view <NNNNN> --repo ClickHouse/ClickHouse \
-  --json number,title,state,stateReason,body,comments,labels
+  --json number,title,state,stateReason,body,comments,labels,closedAt
 ```
 
 **How CI decides a failure is already tracked** (so you can answer "needs an issue?" the same way
@@ -169,22 +169,28 @@ last ~8 hours**, and routes each by whether it also carries the **`infrastructur
   [#92089](https://github.com/ClickHouse/ClickHouse/issues/92089) (`Job pattern: Stateless tests (amd_msan%`,
   `Failure reason: DB::Exception: Timeout exceeded`).
 
-A matched failure is flagged with an `issue` label in the CI report — visible in the
-`fetch_ci_report.js` output — which is the fastest "already tracked" signal.
+(CI attaches an `issue` label to a matched failure internally, but `fetch_ci_report.js` prints
+**only** CIDB links — not the `issue` label or the linked issue URL — so its output is **not** a
+"tracked" signal. The GitHub issue search below is the authoritative way to reproduce CI's
+attribution; never read the absence of a marker in the report output as "not tracked".)
 
 **For an `INFRA/BUILD` or timeout/harness-level failure, also run the infrastructure path.** A
 test-name search alone will miss these, so a pre-existing, already-tracked infra failure would be
-mis-reported as `needs issue`. List the open infra issues and match by `Job pattern` / `Failure
-reason` against the failing job and its output:
+mis-reported as `needs issue`. List the infra issues — **`--state all`**, because CI's catalog
+includes not just open ones but every `testing` issue closed in the last ~8 h
+(`TestCaseIssueCatalog.from_gh`), and a just-closed infra issue is still auto-matched — and match
+by `Job pattern` / `Failure reason` against the failing job and its output:
 
 ```bash
-gh issue list --repo ClickHouse/ClickHouse --state open --label testing --label infrastructure \
-  --limit 100 --json number,title,url,body
+gh issue list --repo ClickHouse/ClickHouse --state all --label testing --label infrastructure \
+  --limit 100 --json number,title,url,body,state,closedAt
 ```
 
 Compare each candidate's `Job pattern:`/`Test pattern:`/`Failure reason:`/`Failure flags:` fields
-to the failing job name and output the way `_check_infrastructure_match` does; a match is
-`tracked #N` exactly as CI would attribute it.
+to the failing job name and output the way `_check_infrastructure_match` does. A match on an open
+issue — or one closed within ~8 h (check `closedAt`) — is `tracked #N` exactly as CI would
+attribute it; a match on an issue closed longer ago is a `stale #N` reopen candidate (same
+same-failure/recurrence check as the flaky case).
 
 **Always run the issue search for every failed name** — it is one cheap `gh issue list` and is the
 only way to mirror CI's attribution. Generic, harness-level names get tracked too: `Server died`,
@@ -201,9 +207,9 @@ makes no sense. It is a "searched, nothing matched, and not worth filing" verdic
 
 Determine, per test:
 
-- **Tracked** — an open (or just-closed) `testing` issue matches by the rule above (or the report
-  already carries the `issue` label). No new issue needed; CI will keep auto-matching it. This
-  applies to generic-bucket names too when a `testing` issue exists (e.g. `Server died` → #107487).
+- **Tracked** — an open (or closed within ~8 h — check `closedAt`) `testing` issue matches by the
+  rule above. No new issue needed; CI will keep auto-matching it. This applies to generic-bucket
+  names too when a `testing` issue exists (e.g. `Server died` → #107487).
 - **Needs an issue** — the failure is a pre-existing **FLAKY** or **INFRA/BUILD** problem (per
   step 3), names a **specific** test/crash (a `NNNNN_*`/`test_*` case, or an identifiable crash/race
   with a stable `STID` mapping to one code site), and has **no** matching `testing` issue. Flag it
@@ -237,8 +243,9 @@ Never label a cell with an asserted fact you did not verify (e.g. "(known)" impl
 issue exists). `generic failure / untracked` requires that you actually ran the search and it
 returned no match — it is not a substitute for searching.
 
-Record the matching issue number, its state (open vs closed/`completed`), labels, and any root
-cause or fix PR mentioned. A closed `completed` issue whose fix post-dates the failing run points
+Record the matching issue number, its state (open vs closed/`completed`), **`closedAt`** (needed for
+the ~8 h window and the stale/reopen check), labels, and any root cause or fix PR mentioned. A
+closed `completed` issue whose fix post-dates the failing run points
 at "retry, already fixed" — **but only if the same failure has not recurred on `master` since the
 issue's `closedAt`** (see the stale/reopen check above); if it has, the fix regressed and the issue
 is a reopen candidate, not an "already fixed". If the input was itself an issue (step 0) you already
@@ -551,7 +558,9 @@ Print one verdict table, then a short narrative per real/uncertain failure:
   every failure (generic buckets included — e.g. `Server died` is often `tracked`); never write a
   tracking claim like "(known)", and never use `untracked` as a stand-in for not searching.
 - **Fix** (from step 2b) ∈ {`none`, `WIP #N` (open; note draft), `merged #N — in branch` (fix was
-  present yet test still failed → keep digging), `merged #N — rebase/retry` (landed after the run)}.
+  present yet test still failed → keep digging), `merged #N — rebase/retry` (landed after the run),
+  `merged #N — presence unverified` (ancestry inconclusive on a backport/release/`REF` report and no
+  cherry-pick confirmed — do **not** call it fixed; keep the failure open for step 5)}.
 - For `REAL`/`UNCERTAIN`, give the `file:line` evidence and the suspect PR change.
 - For `FLAKY`, state the master frequency and the tracking flaky-test issue from step 2 (number,
   state, and any root cause / fix PR its comments revealed).
@@ -560,6 +569,8 @@ Print one verdict table, then a short narrative per real/uncertain failure:
   - "retry — already fixed on master by #N (merged after this run), rebase";
   - "flaky on master, **no tracking issue — create one**";
   - "real regression in `<file>`, see `<commit>` — fix the PR, do not file a tracking issue";
-  - "merged fix #N is already in this branch but the test still failed — needs manual look".
+  - "merged fix #N is already in this branch but the test still failed — needs manual look";
+  - "fix #N merged but presence on this backport/`REF` report is unverified — do not assume fixed;
+    check for a cherry-pick, keep investigating".
 
 Include the original report URL (and PR link) so the human can confirm. Do not take any action.

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -100,6 +100,13 @@ can re-read or `grep`. If `node` is **absent**, skip the report fetch (and the s
 and rely on the issue body's failure output plus step 3 — do not treat a missing `node` as a
 fatal error.
 
+**The tool prints only the log *tail* (the last ~30 non-empty lines of each `result.info`), not the
+full output.** CI's matchers test `Failure reason` against the **whole** `result.info`, so a
+`Failure reason` located earlier than the tail will match in CI yet be **invisible** here — when
+mirroring CI's attribution (step 2a) or judging whether a reason string is present, do not read a
+"not in the visible output" as a definitive non-match; drill via the CIDB link or the full artifact
+(step 4) if it matters.
+
 - If `$0` is a PR URL with many reports and the noise is high, narrow with `--report <n>`
   after listing reports (run the tool with no `--failed` to see the index).
 - Record the PR number and the exact failed **test names** as they appear — the names must
@@ -250,12 +257,10 @@ Three complementary sources, cheapest first:
   gh issue view <issue-number> --repo ClickHouse/ClickHouse --json number,state,stateReason,closedByPullRequestsReferences,comments
   ```
 
-  For cross-referencing PRs that mention the issue but did not close it (a `Related #<issue>`), use
-  the timeline via `gh api`:
-
-  ```bash
-  gh api repos/ClickHouse/ClickHouse/issues/<issue-number>/timeline --jq '.[] | select(.event=="cross-referenced") | .source.issue.html_url'
-  ```
+  This surfaces PRs that closed the issue and any fix mentioned in comments. A PR that only
+  cross-references the issue without closing it (a `Related #<issue>`) is not returned here — the
+  investigate profile denies `gh api` (it can POST), so do not reach for the issue timeline API;
+  the by-test-name PR search below catches those.
 
 - **By test name:** search PRs (open **and** merged) whose title/body names the test or its
   fragment:

--- a/.claude/skills/investigate-ci/SKILL.md
+++ b/.claude/skills/investigate-ci/SKILL.md
@@ -141,16 +141,43 @@ gh issue view <NNNNN> --repo ClickHouse/ClickHouse \
 ```
 
 **How CI decides a failure is already tracked** (so you can answer "needs an issue?" the same way
-CI's matcher does — see `ci/praktika/issue.py`, `Issue._check_flaky_test_match`): CI builds a
-catalog from issues labeled **`testing`** (`IssueLabels.CI_ISSUE`) that are **open, or were closed
-within the last ~8 hours**. A failure matches a catalog issue when:
+CI's matcher does — see `ci/praktika/issue.py`, `Issue.check_result`): CI builds a catalog from
+issues labeled **`testing`** (`IssueLabels.CI_ISSUE`) that are **open, or were closed within the
+last ~8 hours**, and routes each by whether it also carries the **`infrastructure`** label:
 
-- the issue's `Test name:` body field is a **suffix** of the failing test's name
-  (`result.name.endswith(test_name)`; pytest parametrization/module rules apply), **and**
-- if the issue sets a `Failure reason:`, that exact text is a **substring** of the failure output.
+- **Flaky-test issues** (no `infrastructure` label) → `Issue._check_flaky_test_match`. Matches when
+  the issue's `Test name:` body field is a **suffix** of the failing test's name
+  (`result.name.endswith(test_name)`; pytest parametrization/module rules apply), **and** if the
+  issue sets a `Failure reason:`, that text is a **substring** of the failure output.
+- **Infrastructure issues** (`testing` **+** `infrastructure` label) → `Issue._check_infrastructure_match`.
+  These do **not** match by `Test name:`. They match a failure when **all** of the present fields
+  hold: `Failure reason:` is a substring of the output; every `Failure flags:` value (e.g.
+  `retry_ok`) is a label on the result; `Test pattern:` matches the test name; and `Job pattern:`
+  matches the **job** name. Note the pattern matching is **not** true SQL `LIKE`: the pattern is
+  split on `%`, empty fragments are dropped, and it matches if **any** remaining fragment is a plain
+  substring (so it is OR-across-fragments, order is not enforced, and a bare `%` — like an empty
+  field — is treated as no constraint). Examples:
+  [#87123](https://github.com/ClickHouse/ClickHouse/issues/87123) (`Job pattern: Unit%`),
+  [#91410](https://github.com/ClickHouse/ClickHouse/issues/91410),
+  [#92089](https://github.com/ClickHouse/ClickHouse/issues/92089) (`Job pattern: Stateless tests (amd_msan%`,
+  `Failure reason: DB::Exception: Timeout exceeded`).
 
 A matched failure is flagged with an `issue` label in the CI report — visible in the
 `fetch_ci_report.js` output — which is the fastest "already tracked" signal.
+
+**For an `INFRA/BUILD` or timeout/harness-level failure, also run the infrastructure path.** A
+test-name search alone will miss these, so a pre-existing, already-tracked infra failure would be
+mis-reported as `needs issue`. List the open infra issues and match by `Job pattern` / `Failure
+reason` against the failing job and its output:
+
+```bash
+gh issue list --repo ClickHouse/ClickHouse --state open --label testing --label infrastructure \
+  --limit 100 --json number,title,url,body
+```
+
+Compare each candidate's `Job pattern:`/`Test pattern:`/`Failure reason:`/`Failure flags:` fields
+to the failing job name and output the way `_check_infrastructure_match` does; a match is
+`tracked #N` exactly as CI would attribute it.
 
 **Always run the issue search for every failed name** — it is one cheap `gh issue list` and is the
 only way to mirror CI's attribution. Generic, harness-level names get tracked too: `Server died`,
@@ -179,9 +206,25 @@ Determine, per test:
   sense. Rely on the step-3 frequency for the verdict.
 - **No issue (fix instead)** — a **REAL** regression introduced by this PR. Do **not** flag it for
   a tracking issue: a `testing` issue would mask a real bug. The recommendation is to fix the code.
-- **Stale/closed match** — only a closed issue matches, and it was closed more than ~8 h ago. CI
-  no longer auto-matches it, so if the test is still flaky a fresh issue (or reopening) is needed;
-  note the old issue number.
+- **Stale/closed match (reopen candidate)** — only a **closed** issue matches, and it was closed
+  more than ~8 h ago, so CI's catalog no longer contains it and will **not** auto-match: the next
+  failing run gets treated as unknown and `check_ci.py` would file a **duplicate**. Before treating
+  it as *the* tracking issue, run two checks:
+  - **Is it actually the same failure?** A title/`Test name:` match is not proof. Read the issue
+    and confirm the **failure mode** matches — same error/exception text, same assertion or stack
+    site, same `STID`, same job/config scope. A broader issue (e.g. a generic `Server died`, or one
+    covering a whole job) or a different error under the same test name is **not** a match for the
+    specific failure you are exploring — treat that as `needs issue`, do **not** reopen the wrong or
+    broader issue.
+  - **Does it still fail after `closedAt`?** (step 3 already has the history; if not, run a dated
+    query bounded by `check_start_time > <closedAt>` on `master` / across PRs):
+    - **Still failing after `closedAt`** (and same failure mode) → the close was premature or the
+      fix regressed. Recommend **reopening #N** — preferred over a fresh issue, since it avoids a
+      duplicate and CI re-matches it once open again. This is the case the "already fixed → retry"
+      line below must **not** swallow.
+    - **No failures after `closedAt`** and the fix commit post-dates the failing run → genuinely
+      **already fixed**; recommend retry/rebase, not reopen.
+  Report it as `stale #N` with the recommendation (reopen vs retry vs needs-new) spelled out.
 
 Never label a cell with an asserted fact you did not verify (e.g. "(known)" implying a tracking
 issue exists). `generic failure / untracked` requires that you actually ran the search and it
@@ -189,8 +232,10 @@ returned no match — it is not a substitute for searching.
 
 Record the matching issue number, its state (open vs closed/`completed`), labels, and any root
 cause or fix PR mentioned. A closed `completed` issue whose fix post-dates the failing run points
-straight at "retry, already fixed". If the input was itself an issue (step 0) you already have it,
-but still scan for duplicate or related issues and read its comments.
+at "retry, already fixed" — **but only if the same failure has not recurred on `master` since the
+issue's `closedAt`** (see the stale/reopen check above); if it has, the fix regressed and the issue
+is a reopen candidate, not an "already fixed". If the input was itself an issue (step 0) you already
+have it, but still scan for duplicate or related issues and read its comments.
 
 #### 2b. Existing fix + its status
 
@@ -238,17 +283,38 @@ For each candidate fix PR, classify its **status** — this is what goes in the 
 - **None** — no fix PR found.
 
 **Deciding "already in this branch or not".** Compare the fix's merge against the report commit
-(`SHA` from step 1). If the fix's merge commit is in the local object store, ancestry is exact:
+(`SHA` from step 1). If the fix's merge commit is in the local object store, check ancestry:
 
 ```bash
 git cat-file -e <mergeCommit> && git merge-base --is-ancestor <mergeCommit> <report-sha> \
-  && echo "fix IS in the failing run" || echo "fix is NOT in the failing run (or commit absent locally)"
+  && echo "fix commit IS in the failing run" || echo "fix commit is NOT in the failing run history (or absent locally)"
 ```
 
-If the merge commit is absent locally (`git cat-file -e` fails), fall back to time order: a fix
-with `mergedAt` **after** the run's commit/`check_start_time` cannot be in the failing run →
-"merged, not in this branch → rebase/retry". Surface that you used the time-order fallback rather
-than exact ancestry.
+This check is **asymmetric — trust only the positive**:
+
+- **`is-ancestor` true** → the fix is definitely present. If the test still failed, the fix is
+  incomplete/unrelated → keep investigating; do **not** report "already fixed".
+- **`is-ancestor` false** → conclusive **only for a master PR report**, where the fix must be that
+  exact merge commit. For an S3 `REF`/master-CI report, a **release/backport branch**, or any
+  non-master base, the fix may already be present under a **different** commit (a cherry-pick), so a
+  false result does **not** prove absence. Do **not** emit `rebase/retry` or short-circuit on it.
+  First check whether an equivalent change is on the failing branch — e.g. search that branch's
+  history for the fix by subject or by the file/line it changed:
+
+  ```bash
+  git log --oneline <report-sha> --grep "<fix PR title or key phrase>"
+  git log --oneline <report-sha> -- <file the fix touched>   # look for a backport/cherry-pick
+  ```
+
+  Only conclude `merged #N — not in this branch → rebase/retry` when the base is `master` **and**
+  the merge commit is genuinely absent, or when a branch-history search also finds no equivalent
+  change. If you cannot resolve it (commit absent locally, base unknown), report
+  `merged #N — presence unverified` and keep the failure open for step 5 rather than declaring it
+  fixed — never turn an unverified guess into an "already fixed on master" recommendation.
+
+Time order is a weak last resort, not a substitute: a fix `mergedAt` **after** the run's
+commit/`check_start_time` cannot be in the run, but "before" does **not** prove presence (the branch
+may predate or not contain it). Use it only to rule *out*, and say you relied on it.
 
 ### 3. Flaky-vs-real: query master history
 
@@ -474,8 +540,10 @@ Print one verdict table, then a short narrative per real/uncertain failure:
 - **Verdict** ∈ {`FLAKY`, `REAL`, `UNCERTAIN`, `NEW-TEST`, `INFRA/BUILD`}.
 - **Issue** (from step 2a) ∈ {`tracked #N`, `needs issue`, `generic failure / untracked` (generic
   bucket or anonymized error class — searched, no `testing` issue matched, and not worth filing),
-  `fix instead` (REAL — don't mask), `stale #N` (closed >~8 h ago)}. The search runs for every
-  failure (generic buckets included — e.g. `Server died` is often `tracked`); never write a
+  `fix instead` (REAL — don't mask), `stale #N` (same-failure issue closed >~8 h ago → CI no longer
+  auto-matches; give the recommendation: reopen if it still fails after `closedAt`, retry if truly
+  fixed, or needs-new if the closed issue is broader/a different failure mode)}. The search runs for
+  every failure (generic buckets included — e.g. `Server died` is often `tracked`); never write a
   tracking claim like "(known)", and never use `untracked` as a stand-in for not searching.
 - **Fix** (from step 2b) ∈ {`none`, `WIP #N` (open; note draft), `merged #N — in branch` (fix was
   present yet test still failed → keep digging), `merged #N — rebase/retry` (landed after the run)}.

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -618,6 +618,9 @@ async function fetchReport(inputUrl, options = {}) {
       console.log('--- Failures ---');
       for (const test of failed) {
         console.log(`❌ FAIL  ${test.name}  (${test.duration}s)`);
+        if (test.labels && test.labels.length > 0) {
+          console.log(`   🏷️  labels: ${test.labels.join(', ')}`);
+        }
         if (options.showCidb && test.cidbLinks && test.cidbLinks.length > 0) {
           for (const cidbLink of test.cidbLinks) {
             console.log(`   📊 CIDB: ${cidbLink}`);

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -200,9 +200,14 @@ function parseTestResults(jsonData) {
         // Nested results
         extractTests(result.results, prefix ? `${prefix}/${result.name}` : result.name);
       } else {
-        // Leaf result - this is a test or build step
+        // Leaf result - this is a test or build step.
+        // Use the leaf's own name, NOT the ancestor-prefixed path: the leaf name is exactly the
+        // `checks.test_name` value (e.g. "Server died", "test_dns_cache/test.py::..."), whereas a
+        // prefixed form like "Tests/Server died" matches no `checks` row and would break the
+        // history query and issue matching in steps 2-3. The `prefix` (grouping nodes such as
+        // "Tests") is intra-report context already conveyed by the report header.
         const test = {
-          name: prefix ? `${prefix}/${result.name}` : result.name,
+          name: result.name,
           status: result.status || 'UNKNOWN',
           duration: result.duration || 0
         };
@@ -497,10 +502,15 @@ async function fetchReport(inputUrl, options = {}) {
           const passed = testResults.filter(t => t.status === 'success' || t.status === 'OK');
           const skipped = testResults.filter(t => t.status === 'skipped' || t.status === 'SKIPPED');
 
-          totalTests += testResults.length;
-          totalPassed += passed.length;
-          totalFailed += failed.length;
-          totalSkipped += skipped.length;
+          // Don't let the top-level PR report contribute to the totals when nested per-job reports
+          // are also present — it aggregates the same failures, so counting both double-counts.
+          // (When the PR report is the only one, onlyPRLevel is true and it does count.)
+          if (!result.isPRLevel || onlyPRLevel) {
+            totalTests += testResults.length;
+            totalPassed += passed.length;
+            totalFailed += failed.length;
+            totalSkipped += skipped.length;
+          }
 
           const status = failed.length > 0 ? '❌' : '✅';
           console.log(`[${result.index}] ${status} ${result.jobName}`);

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -581,6 +581,20 @@ async function fetchReport(inputUrl, options = {}) {
       }
     }
 
+    // A direct top-level workflow result JSON (result_pr.json / result_masterci.json / result_ref.json
+    // located directly under the <sha> dir — NOT under a job subdir) is a workflow index, just like
+    // the json.html?...&name_0=PR form. Rewrite it to that HTML form so the index handling below
+    // applies uniformly (expand into per-job reports; refuse per-job --download-logs) instead of
+    // treating the whole PR/workflow as a single job. Concrete job reports are result_<job>.json
+    // (or live under <sha>/<job>/...), so they never match this and stay on the single-report path.
+    const topJson = inputUrl.match(/\/(?:PRs\/(\d+)|REFs\/([^/]+))\/([0-9a-f]{40})\/result_(?:pr|masterci|ref)\.json(?:$|\?)/i);
+    if (topJson) {
+      const prefix = inputUrl.slice(0, topJson.index);
+      inputUrl = topJson[1]
+        ? `${prefix}/json.html?PR=${topJson[1]}&sha=${topJson[3]}&name_0=PR`
+        : `${prefix}/json.html?REF=${encodeURIComponent(topJson[2])}&sha=${topJson[3]}&name_0=MasterCI`;
+    }
+
     // Check if this is a direct JSON URL or an HTML URL with parameters
     const isDirectJsonUrl = inputUrl.includes('.json') || !inputUrl.includes('?');
 

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -217,33 +217,42 @@ function parseTestResults(jsonData) {
           test.links = result.links;
         }
 
-        // Extract CIDB links and other labels from unified ext.labels (or legacy ext.hlabels).
-        // Non-cidb labels (e.g. `issue`, `retry_ok`) mirror how CI attributes a failure:
-        // an `issue` label means CI matched a tracking issue; `retry_ok` etc. are the flags an
-        // infrastructure tracking issue matches on via `Failure flags:`.
+        // Extract CIDB links and other labels, mirroring ci/praktika/json.html `normalizeLabels`:
+        // `ext.labels` entries are either bare strings (legacy) or {name, link} objects, and
+        // `ext.hlabels` entries are [name, link] pairs; all are merged by name (a link wins over a
+        // bare occurrence). Non-cidb labels (e.g. `issue`, `retry_ok`) mirror how CI attributes a
+        // failure: an `issue` label means CI matched a tracking issue; `retry_ok` etc. are the flags
+        // an infrastructure issue matches on via `Failure flags:`.
         if (result.ext) {
-          const cidbLinks = [];
-          const labels = [];
+          const byName = new Map();
+          const upsert = (name, link) => {
+            if (!name) return;
+            const prev = byName.get(name) || {};
+            byName.set(name, { name, link: link || prev.link });
+          };
           if (Array.isArray(result.ext.labels)) {
-            for (const label of result.ext.labels) {
-              if (label && typeof label === 'object' && label.name) {
-                if (label.name === 'cidb' && label.link) {
-                  cidbLinks.push(label.link);
-                } else if (label.name !== 'cidb') {
-                  labels.push(label.link ? `${label.name} (${label.link})` : label.name);
-                }
+            for (const item of result.ext.labels) {
+              if (typeof item === 'string') {
+                upsert(item);
+              } else if (item && typeof item === 'object' && item.name) {
+                upsert(item.name, item.link);
               }
             }
           }
           if (Array.isArray(result.ext.hlabels)) {
-            for (const hlabel of result.ext.hlabels) {
-              if (Array.isArray(hlabel) && hlabel[0]) {
-                if (hlabel[0] === 'cidb' && hlabel[1]) {
-                  cidbLinks.push(hlabel[1]);
-                } else if (hlabel[0] !== 'cidb') {
-                  labels.push(hlabel[1] ? `${hlabel[0]} (${hlabel[1]})` : hlabel[0]);
-                }
+            for (const item of result.ext.hlabels) {
+              if (Array.isArray(item) && item[0]) {
+                upsert(item[0], item[1]);
               }
+            }
+          }
+          const cidbLinks = [];
+          const labels = [];
+          for (const { name, link } of byName.values()) {
+            if (name === 'cidb') {
+              if (link) cidbLinks.push(link);
+            } else {
+              labels.push(link ? `${name} (${link})` : name);
             }
           }
           if (cidbLinks.length > 0) {

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -217,25 +217,40 @@ function parseTestResults(jsonData) {
           test.links = result.links;
         }
 
-        // Extract CIDB links from unified ext.labels (or legacy ext.hlabels).
+        // Extract CIDB links and other labels from unified ext.labels (or legacy ext.hlabels).
+        // Non-cidb labels (e.g. `issue`, `retry_ok`) mirror how CI attributes a failure:
+        // an `issue` label means CI matched a tracking issue; `retry_ok` etc. are the flags an
+        // infrastructure tracking issue matches on via `Failure flags:`.
         if (result.ext) {
           const cidbLinks = [];
+          const labels = [];
           if (Array.isArray(result.ext.labels)) {
             for (const label of result.ext.labels) {
-              if (label && typeof label === 'object' && label.name === 'cidb' && label.link) {
-                cidbLinks.push(label.link);
+              if (label && typeof label === 'object' && label.name) {
+                if (label.name === 'cidb' && label.link) {
+                  cidbLinks.push(label.link);
+                } else if (label.name !== 'cidb') {
+                  labels.push(label.link ? `${label.name} (${label.link})` : label.name);
+                }
               }
             }
           }
           if (Array.isArray(result.ext.hlabels)) {
             for (const hlabel of result.ext.hlabels) {
-              if (Array.isArray(hlabel) && hlabel[0] === 'cidb' && hlabel[1]) {
-                cidbLinks.push(hlabel[1]);
+              if (Array.isArray(hlabel) && hlabel[0]) {
+                if (hlabel[0] === 'cidb' && hlabel[1]) {
+                  cidbLinks.push(hlabel[1]);
+                } else if (hlabel[0] !== 'cidb') {
+                  labels.push(hlabel[1] ? `${hlabel[0]} (${hlabel[1]})` : hlabel[0]);
+                }
               }
             }
           }
           if (cidbLinks.length > 0) {
             test.cidbLinks = cidbLinks;
+          }
+          if (labels.length > 0) {
+            test.labels = labels;
           }
         }
 
@@ -452,6 +467,9 @@ async function fetchReport(inputUrl, options = {}) {
           if (failed.length > 0 && options.failedOnly && !result.isPRLevel) {
             for (const test of failed) {
               console.log(`      ❌ FAIL: ${test.name}`);
+              if (test.labels && test.labels.length > 0) {
+                console.log(`         🏷️  labels: ${test.labels.join(', ')}`);
+              }
               if (options.showCidb && test.cidbLinks && test.cidbLinks.length > 0) {
                 for (const cidbLink of test.cidbLinks) {
                   console.log(`         📊 CIDB: ${cidbLink}`);

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -391,6 +391,144 @@ async function getCIReportsFromPR(prUrl) {
 /**
  * Fetch and parse the CI report
  */
+/**
+ * Given a top-level index report URL (json.html?...&name_0=X, no name_1) and its raw JSON, return
+ * the per-job report URLs (json.html?...&name_1=<job>) for the FAILED jobs. Child names come from
+ * the report's IMMEDIATE children (the job/check rows) -- never from flattened leaf tests, whose
+ * names (e.g. "Server died") are not valid name_1 job identifiers.
+ */
+function childReportUrlsForFailedJobs(topLevelUrl, jsonData) {
+  const jobs = (jsonData && Array.isArray(jsonData.results)) ? jsonData.results : [];
+  return jobs
+    .filter(j => isFailureStatus(j.status))
+    .map(j => topLevelUrl.replace(/&name_1=[^&]*/, '') + `&name_1=${encodeURIComponent(j.name)}`);
+}
+
+/**
+ * Render a set of report URLs as a multi-report summary (one row per report, failures under each).
+ * Shared by the GitHub-PR path and the direct top-level-index path.
+ */
+async function renderMultiReport(ciUrls, options) {
+  console.log(`Fetching all reports...\n`);
+  const allResults = [];
+
+  for (let i = 0; i < ciUrls.length; i++) {
+    const url = ciUrls[i];
+    const nameMatch = url.match(/name_0=([^&]+)/);
+    const name1Match = url.match(/name_1=([^&]+)/);
+    const jobName = nameMatch ? decodeURIComponent(nameMatch[1]) : 'Unknown';
+    const subJobName = name1Match ? decodeURIComponent(name1Match[1]) : null;
+    const fullJobName = subJobName ? `${jobName} -> ${subJobName}` : jobName;
+
+    try {
+      console.log(`[${i + 1}/${ciUrls.length}] ${fullJobName}...`);
+      const result = await fetchReport(url, { ...options, isSingleReport: true });
+      allResults.push({
+        index: i + 1,
+        jobName: fullJobName,
+        url,
+        isPRLevel: !subJobName, // true if this is a PR-level report (no name_1)
+        ...result
+      });
+    } catch (error) {
+      console.log(`  Error: ${error.message}\n`);
+      allResults.push({
+        index: i + 1,
+        jobName: fullJobName,
+        url,
+        isPRLevel: !subJobName,
+        error: error.message
+      });
+    }
+  }
+
+  // Print summary
+  console.log('\n' + '='.repeat(80));
+  console.log('CI REPORTS SUMMARY');
+  console.log('='.repeat(80) + '\n');
+
+  let totalTests = 0;
+  let totalPassed = 0;
+  let totalFailed = 0;
+  let totalSkipped = 0;
+
+  // Per-failure detail is normally suppressed for the top-level PR report to avoid
+  // duplicating the nested per-job reports. But when the PR report is the ONLY report
+  // discovered (the bot comment exposed no nested job URLs), suppressing it would leave a
+  // PR URL with no failed leaves at all — so show them in that case.
+  const onlyPRLevel = allResults.every(r => r.error || r.isPRLevel);
+
+  for (const result of allResults) {
+    if (result.error) {
+      console.log(`[${result.index}] ${result.jobName}`);
+      console.log(`    ❌ Error: ${result.error}\n`);
+      continue;
+    }
+
+    const { testResults = [] } = result;
+    const failed = testResults.filter(t => isFailureStatus(t.status));
+    const passed = testResults.filter(t => t.status === 'success' || t.status === 'OK');
+    const skipped = testResults.filter(t => t.status === 'skipped' || t.status === 'SKIPPED');
+
+    // Don't let the top-level PR report contribute to the totals when nested per-job reports
+    // are also present — it aggregates the same failures, so counting both double-counts.
+    // (When the PR report is the only one, onlyPRLevel is true and it does count.)
+    if (!result.isPRLevel || onlyPRLevel) {
+      totalTests += testResults.length;
+      totalPassed += passed.length;
+      totalFailed += failed.length;
+      totalSkipped += skipped.length;
+    }
+
+    const status = failed.length > 0 ? '❌' : '✅';
+    console.log(`[${result.index}] ${status} ${result.jobName}`);
+    console.log(`    Total: ${testResults.length} | ✅ Passed: ${passed.length} | ❌ Failed: ${failed.length} | ⏭️  Skipped: ${skipped.length}`);
+
+    // For reports with failures, show the HTML link (also for the PR report when it's the
+    // only one, so the investigator can drill in).
+    if ((!result.isPRLevel || onlyPRLevel) && failed.length > 0 && result.url) {
+      console.log(`    🔗 Report: ${result.url}`);
+    }
+
+    // Show individual failures for nested reports; for the PR-level report only when it is
+    // the sole report (otherwise skip it to avoid duplicating the nested job reports).
+    if (failed.length > 0 && options.failedOnly && (!result.isPRLevel || onlyPRLevel)) {
+      for (const test of failed) {
+        console.log(`      ❌ FAIL: ${test.name}`);
+        if (test.labels && test.labels.length > 0) {
+          console.log(`         🏷️  labels: ${test.labels.join(', ')}`);
+        }
+        if (options.showCidb && test.cidbLinks && test.cidbLinks.length > 0) {
+          for (const cidbLink of test.cidbLinks) {
+            console.log(`         📊 CIDB: ${cidbLink}`);
+          }
+        }
+        if (test.links && test.links.length > 0) {
+          for (const link of test.links) {
+            console.log(`         🔗 ${link}`);
+          }
+        }
+        if (test.info) {
+          const lines = test.info.split('\n').filter(l => l.trim());
+          const tail = lines.slice(-30);
+          console.log('         --- log tail ---');
+          for (const line of tail) {
+            console.log(`         ${line}`);
+          }
+          console.log('         --- end ---');
+        }
+      }
+    }
+    console.log();
+  }
+
+  console.log('='.repeat(80));
+  console.log(`TOTAL: ${totalTests} tests | ✅ ${totalPassed} passed | ❌ ${totalFailed} failed | ⏭️  ${totalSkipped} skipped`);
+  console.log('='.repeat(80) + '\n');
+
+  return { allResults, summary: { totalTests, totalPassed, totalFailed, totalSkipped } };
+}
+
 async function fetchReport(inputUrl, options = {}) {
   try {
     if (!options.isSingleReport) {
@@ -416,13 +554,12 @@ async function fetchReport(inputUrl, options = {}) {
       if (!hasNested && topLevelUrl) {
         try {
           const top = await fetchReport(topLevelUrl, { ...options, isSingleReport: true });
-          const failedJobs = (top.testResults || []).filter(t => isFailureStatus(t.status));
-          for (const job of failedJobs) {
-            const childUrl = topLevelUrl.replace(/&name_1=[^&]*/, '') + `&name_1=${encodeURIComponent(job.name)}`;
+          const childUrls = childReportUrlsForFailedJobs(topLevelUrl, top.jsonData);
+          for (const childUrl of childUrls) {
             if (!ciUrls.includes(childUrl)) ciUrls.push(childUrl);
           }
-          if (failedJobs.length > 0) {
-            console.log(`Top-level PR report is an index — descending into ${failedJobs.length} failed job report(s).`);
+          if (childUrls.length > 0) {
+            console.log(`Top-level PR report is an index — descending into ${childUrls.length} failed job report(s).`);
           }
         } catch (e) {
           console.log(`Note: could not expand the top-level PR report into job reports (${e.message}); showing job-level failures only.`);
@@ -440,125 +577,7 @@ async function fetchReport(inputUrl, options = {}) {
         console.log(`Fetching report #${options.reportIndex}...\n`);
         inputUrl = ciUrls[idx];
       } else {
-        // Fetch all reports
-        console.log(`Fetching all reports...\n`);
-        const allResults = [];
-
-        for (let i = 0; i < ciUrls.length; i++) {
-          const url = ciUrls[i];
-          const nameMatch = url.match(/name_0=([^&]+)/);
-          const name1Match = url.match(/name_1=([^&]+)/);
-          const jobName = nameMatch ? decodeURIComponent(nameMatch[1]) : 'Unknown';
-          const subJobName = name1Match ? decodeURIComponent(name1Match[1]) : null;
-          const fullJobName = subJobName ? `${jobName} -> ${subJobName}` : jobName;
-
-          try {
-            console.log(`[${i + 1}/${ciUrls.length}] ${fullJobName}...`);
-            const result = await fetchReport(url, { ...options, isSingleReport: true });
-            allResults.push({
-              index: i + 1,
-              jobName: fullJobName,
-              url,
-              isPRLevel: !subJobName, // true if this is a PR-level report (no name_1)
-              ...result
-            });
-          } catch (error) {
-            console.log(`  Error: ${error.message}\n`);
-            allResults.push({
-              index: i + 1,
-              jobName: fullJobName,
-              url,
-              isPRLevel: !subJobName,
-              error: error.message
-            });
-          }
-        }
-
-        // Print summary
-        console.log('\n' + '='.repeat(80));
-        console.log('CI REPORTS SUMMARY');
-        console.log('='.repeat(80) + '\n');
-
-        let totalTests = 0;
-        let totalPassed = 0;
-        let totalFailed = 0;
-        let totalSkipped = 0;
-
-        // Per-failure detail is normally suppressed for the top-level PR report to avoid
-        // duplicating the nested per-job reports. But when the PR report is the ONLY report
-        // discovered (the bot comment exposed no nested job URLs), suppressing it would leave a
-        // PR URL with no failed leaves at all — so show them in that case.
-        const onlyPRLevel = allResults.every(r => r.error || r.isPRLevel);
-
-        for (const result of allResults) {
-          if (result.error) {
-            console.log(`[${result.index}] ${result.jobName}`);
-            console.log(`    ❌ Error: ${result.error}\n`);
-            continue;
-          }
-
-          const { testResults = [] } = result;
-          const failed = testResults.filter(t => isFailureStatus(t.status));
-          const passed = testResults.filter(t => t.status === 'success' || t.status === 'OK');
-          const skipped = testResults.filter(t => t.status === 'skipped' || t.status === 'SKIPPED');
-
-          // Don't let the top-level PR report contribute to the totals when nested per-job reports
-          // are also present — it aggregates the same failures, so counting both double-counts.
-          // (When the PR report is the only one, onlyPRLevel is true and it does count.)
-          if (!result.isPRLevel || onlyPRLevel) {
-            totalTests += testResults.length;
-            totalPassed += passed.length;
-            totalFailed += failed.length;
-            totalSkipped += skipped.length;
-          }
-
-          const status = failed.length > 0 ? '❌' : '✅';
-          console.log(`[${result.index}] ${status} ${result.jobName}`);
-          console.log(`    Total: ${testResults.length} | ✅ Passed: ${passed.length} | ❌ Failed: ${failed.length} | ⏭️  Skipped: ${skipped.length}`);
-
-          // For reports with failures, show the HTML link (also for the PR report when it's the
-          // only one, so the investigator can drill in).
-          if ((!result.isPRLevel || onlyPRLevel) && failed.length > 0 && result.url) {
-            console.log(`    🔗 Report: ${result.url}`);
-          }
-
-          // Show individual failures for nested reports; for the PR-level report only when it is
-          // the sole report (otherwise skip it to avoid duplicating the nested job reports).
-          if (failed.length > 0 && options.failedOnly && (!result.isPRLevel || onlyPRLevel)) {
-            for (const test of failed) {
-              console.log(`      ❌ FAIL: ${test.name}`);
-              if (test.labels && test.labels.length > 0) {
-                console.log(`         🏷️  labels: ${test.labels.join(', ')}`);
-              }
-              if (options.showCidb && test.cidbLinks && test.cidbLinks.length > 0) {
-                for (const cidbLink of test.cidbLinks) {
-                  console.log(`         📊 CIDB: ${cidbLink}`);
-                }
-              }
-              if (test.links && test.links.length > 0) {
-                for (const link of test.links) {
-                  console.log(`         🔗 ${link}`);
-                }
-              }
-              if (test.info) {
-                const lines = test.info.split('\n').filter(l => l.trim());
-                const tail = lines.slice(-30);
-                console.log('         --- log tail ---');
-                for (const line of tail) {
-                  console.log(`         ${line}`);
-                }
-                console.log('         --- end ---');
-              }
-            }
-          }
-          console.log();
-        }
-
-        console.log('='.repeat(80));
-        console.log(`TOTAL: ${totalTests} tests | ✅ ${totalPassed} passed | ❌ ${totalFailed} failed | ⏭️  ${totalSkipped} skipped`);
-        console.log('='.repeat(80) + '\n');
-
-        return { allResults, summary: { totalTests, totalPassed, totalFailed, totalSkipped } };
+        return await renderMultiReport(ciUrls, options);
       }
     }
 
@@ -586,6 +605,24 @@ async function fetchReport(inputUrl, options = {}) {
       const jsonUrl = constructJsonUrl(baseUrl, suffix, sha, nameParams[0]);
       if (!options.isSingleReport) {
         console.log(`Fetching JSON: ${jsonUrl}\n`);
+      }
+
+      // A direct top-level index URL (only name_0, no name_1) aggregates every job — it is NOT a
+      // single job report. Treat it like the PR-URL path: refuse per-job operations (they would act
+      // on the wrong job), and otherwise expand into the failed jobs' per-job reports.
+      if (nameParams.length === 1 && !options.isSingleReport && !options.reportIndex) {
+        const topJson = JSON.parse(await fetchUrl(jsonUrl, options.credentials));
+        const childUrls = childReportUrlsForFailedJobs(inputUrl, topJson);
+        if (options.downloadLogs) {
+          const failedNames = (topJson.results || []).filter(j => isFailureStatus(j.status)).map(j => j.name);
+          throw new Error(
+            `'${nameParams[0]}' is a top-level index report, not a single job — --download-logs would ` +
+            `fetch the wrong job's artifacts. Re-run against a concrete job report by appending ` +
+            `&name_1=<job>. Failed jobs: ${failedNames.join(', ') || '(none)'}.`
+          );
+        }
+        console.log(`Top-level '${nameParams[0]}' index — expanding into ${childUrls.length} failed job report(s).\n`);
+        return await renderMultiReport([inputUrl, ...childUrls], options);
       }
 
       // Fetch name_0 JSON data, and name_1 separately if present (matching json.html behavior)

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -452,6 +452,12 @@ async function fetchReport(inputUrl, options = {}) {
         let totalFailed = 0;
         let totalSkipped = 0;
 
+        // Per-failure detail is normally suppressed for the top-level PR report to avoid
+        // duplicating the nested per-job reports. But when the PR report is the ONLY report
+        // discovered (the bot comment exposed no nested job URLs), suppressing it would leave a
+        // PR URL with no failed leaves at all — so show them in that case.
+        const onlyPRLevel = allResults.every(r => r.error || r.isPRLevel);
+
         for (const result of allResults) {
           if (result.error) {
             console.log(`[${result.index}] ${result.jobName}`);
@@ -473,13 +479,15 @@ async function fetchReport(inputUrl, options = {}) {
           console.log(`[${result.index}] ${status} ${result.jobName}`);
           console.log(`    Total: ${testResults.length} | ✅ Passed: ${passed.length} | ❌ Failed: ${failed.length} | ⏭️  Skipped: ${skipped.length}`);
 
-          // For nested reports with failures, show the HTML link
-          if (!result.isPRLevel && failed.length > 0 && result.url) {
+          // For reports with failures, show the HTML link (also for the PR report when it's the
+          // only one, so the investigator can drill in).
+          if ((!result.isPRLevel || onlyPRLevel) && failed.length > 0 && result.url) {
             console.log(`    🔗 Report: ${result.url}`);
           }
 
-          // Skip showing individual test failures for PR-level reports to avoid duplication
-          if (failed.length > 0 && options.failedOnly && !result.isPRLevel) {
+          // Show individual failures for nested reports; for the PR-level report only when it is
+          // the sole report (otherwise skip it to avoid duplicating the nested job reports).
+          if (failed.length > 0 && options.failedOnly && (!result.isPRLevel || onlyPRLevel)) {
             for (const test of failed) {
               console.log(`      ❌ FAIL: ${test.name}`);
               if (test.labels && test.labels.length > 0) {

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -360,13 +360,17 @@ async function getCIReportsFromPR(prUrl) {
       throw new Error('No CI bot comment found');
     }
 
-    // Search through all bot comments for CI report URLs (not just the latest)
-    const reportUrlPattern = /https:\/\/s3\.amazonaws\.com\/clickhouse-test-reports\/json\.html\?[^\s)]+/g;
+    // Search through all bot comments for CI report URLs (not just the latest). Exclude backtick and
+    // quote chars so a URL quoted in markdown (e.g. inside the AI-review text) is not captured with
+    // trailing junk, strip trailing punctuation, and dedupe -- otherwise the same report is fetched
+    // twice and the summary is doubled.
+    const reportUrlPattern = /https:\/\/s3\.amazonaws\.com\/clickhouse-test-reports\/json\.html\?[^\s)`'"]+/g;
     for (const comment of comments) {
       if (!comment.body) continue;
-      const urls = comment.body.match(reportUrlPattern);
+      let urls = comment.body.match(reportUrlPattern);
       if (urls && urls.length > 0) {
-        return urls;
+        urls = urls.map(u => u.replace(/[.,;]+$/, ''));
+        return [...new Set(urls)];
       }
     }
 
@@ -396,6 +400,29 @@ async function fetchReport(inputUrl, options = {}) {
     if (isGitHubPR) {
       // GitHub PR URL - extract CI report URLs
       const ciUrls = await getCIReportsFromPR(inputUrl);
+
+      // If the bot comment exposed only the top-level `PR` report (name_0=PR, no name_1), treat it
+      // as an INDEX: its leaves are job/check names, not test cases, so descend into each FAILED
+      // job by synthesizing its per-job report URL (json.html?...&name_1=<job>, the same form the
+      // loop below already fetches). Without this, a failing PR URL would yield only failed job
+      // names -- no test names, labels, or CIDB links for steps 2-3.
+      const hasNested = ciUrls.some(u => /[?&]name_1=/.test(u));
+      const topLevelUrl = ciUrls.find(u => /[?&]name_0=/.test(u) && !/[?&]name_1=/.test(u));
+      if (!hasNested && topLevelUrl) {
+        try {
+          const top = await fetchReport(topLevelUrl, { ...options, isSingleReport: true });
+          const failedJobs = (top.testResults || []).filter(t => isFailureStatus(t.status));
+          for (const job of failedJobs) {
+            const childUrl = topLevelUrl.replace(/&name_1=[^&]*/, '') + `&name_1=${encodeURIComponent(job.name)}`;
+            if (!ciUrls.includes(childUrl)) ciUrls.push(childUrl);
+          }
+          if (failedJobs.length > 0) {
+            console.log(`Top-level PR report is an index — descending into ${failedJobs.length} failed job report(s).`);
+          }
+        } catch (e) {
+          console.log(`Note: could not expand the top-level PR report into job reports (${e.message}); showing job-level failures only.`);
+        }
+      }
 
       console.log(`Found ${ciUrls.length} CI report(s)\n`);
 

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -341,11 +341,17 @@ async function getCIReportsFromPR(prUrl) {
 
   console.log(`Fetching CI reports for PR #${prNumber}...\n`);
 
-  // Fetch PR comments to find CI bot comment
+  // Fetch PR comments to find CI bot comment.
+  // Drop GH_CONFIG_DIR before spawning gh: some agent/runner checkouts set it to a poisoned
+  // config dir (no/expired auth) that makes `gh api` fail, while the default config is fine.
+  // Other repo tooling (patch-release-check) does the same via `env -u GH_CONFIG_DIR gh`.
+  const ghEnv = { ...process.env };
+  delete ghEnv.GH_CONFIG_DIR;
   try {
     const commentsJson = execSync(`gh api repos/ClickHouse/ClickHouse/issues/${prNumber}/comments --paginate --jq '.[] | select(.user.login == "clickhouse-gh[bot]") | {body, created_at}'`, {
       encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: ghEnv
     });
 
     const comments = commentsJson.trim().split('\n').filter(l => l.trim()).map(l => JSON.parse(l));

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -607,10 +607,14 @@ async function fetchReport(inputUrl, options = {}) {
         console.log(`Fetching JSON: ${jsonUrl}\n`);
       }
 
-      // A direct top-level index URL (only name_0, no name_1) aggregates every job — it is NOT a
-      // single job report. Treat it like the PR-URL path: refuse per-job operations (they would act
-      // on the wrong job), and otherwise expand into the failed jobs' per-job reports.
-      if (nameParams.length === 1 && !options.isSingleReport && !options.reportIndex) {
+      // A workflow-index URL (name_0 is the WORKFLOW — PR / MasterCI / REF — with no name_1)
+      // aggregates every job; it is NOT a single job report. Treat it like the PR-URL path: refuse
+      // per-job operations (they would act on the wrong job), and otherwise expand into the failed
+      // jobs' per-job reports. A concrete single-job URL also has one nameParam but its name_0 is the
+      // JOB (e.g. name_0=Stateless tests (...)) — those must stay on the single-report path below,
+      // so gate on the workflow name, not merely nameParams.length.
+      const isWorkflowIndex = /^(PR|MasterCI|REF|master)$/i.test(nameParams[0]);
+      if (isWorkflowIndex && nameParams.length === 1 && !options.isSingleReport && !options.reportIndex) {
         const topJson = JSON.parse(await fetchUrl(jsonUrl, options.credentials));
         const childUrls = childReportUrlsForFailedJobs(inputUrl, topJson);
         if (options.downloadLogs) {

--- a/.claude/tools/gh-ro.sh
+++ b/.claude/tools/gh-ro.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Read-only `gh` wrapper for the investigate-ci skill.
+#
+# Two jobs:
+#   1. Drop GH_CONFIG_DIR before invoking gh. Some agent/CI runners set it to a
+#      poisoned config dir (no/expired auth) that makes every `gh` call fail,
+#      while the default config (~/.config/gh) authenticates fine. This mirrors
+#      how patch-release-check reaches the CLI (env -u GH_CONFIG_DIR gh).
+#   2. Enforce read-only. Only a fixed allowlist of non-mutating subcommands is
+#      permitted, so a single `Bash(.claude/tools/gh-ro.sh:*)` allow in
+#      settings.investigate.json cannot be used to create/close/edit/merge/
+#      comment, or to reach the write-capable `gh api`. Anything else exits 2.
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+  "pr view"|"pr list"|"pr diff"|"pr checks"|"issue view"|"issue list") ;;
+  *)
+    echo "gh-ro.sh: refusing non-read-only invocation: gh ${*:-}" >&2
+    echo "gh-ro.sh: allowed: pr {view,list,diff,checks}, issue {view,list}" >&2
+    exit 2
+    ;;
+esac
+
+exec env -u GH_CONFIG_DIR gh "$@"


### PR DESCRIPTION
Improve the `investigate-ci` skill so that, for every CI failure, it searches for both an existing tracking GitHub issue and an existing fix, and reports per failure whether an issue is needed and the fix status (WIP, merged, already in this branch or not).

The "does an issue need to be created?" determination mirrors CI's own matcher in `ci/praktika/issue.py` (the `testing`-labeled catalog, suffix test-name match, `Failure reason` substring). A `generic failure / untracked` Issue value is added for harness-level buckets (`Server died`, `Hung check failed`, anonymized `Bad cast` classes, upgrade log-error) where filing a per-failure issue makes no sense — so the report never asserts a tracking claim that was not verified.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.632` (included in `26.7` and later)
<!-- ch-version-info:end -->