### PR TITLE
Add fallback to listRecursive

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1263,6 +1263,43 @@ Coordination::Error ZooKeeper::tryRemoveRecursive(const std::string & path, uint
     return code;
 }
 
+Coordination::Error ZooKeeper::listRecursiveFallback(const std::string & path, Strings & res, uint32_t children_nodes_limit)
+{
+    res.clear();
+
+    /// `res` doubles as the BFS queue: seeded with `path`, which we drop before returning so only descendants remain.
+    res.push_back(path);
+    for (size_t frontier = 0; frontier < res.size(); ++frontier)
+    {
+        Strings children;
+        Coordination::Error code = tryGetChildren(res[frontier], children);
+        /// A node may be removed concurrently while we walk the tree; just skip it.
+        if (code == Coordination::Error::ZNONODE)
+            continue;
+        if (code != Coordination::Error::ZOK)
+        {
+            res.clear();
+            return code;
+        }
+
+        /// `res[frontier]` may be invalidated by the push_back below, so copy it first.
+        const std::string current = res[frontier];
+        for (const auto & child : children)
+        {
+            /// `res.size() - 1` excludes the seed `path`, matching the server-side `children_nodes_limit` accounting.
+            if (res.size() - 1 >= children_nodes_limit)
+            {
+                res.erase(res.begin());
+                return Coordination::Error::ZOK;
+            }
+            res.push_back(fs::path(current) / child);
+        }
+    }
+
+    res.erase(res.begin());
+    return Coordination::Error::ZOK;
+}
+
 Strings ZooKeeper::listRecursive(const std::string & path, uint32_t children_nodes_limit)
 {
     Strings res;
@@ -1285,8 +1322,14 @@ Coordination::Error ZooKeeper::tryListRecursive(const std::string & path, String
         );
         DB::OpenTelemetry::SetTraceFlagInCurrentContext(DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS, true);
     }
+    /// Older backends do not support the recursive listing request; fall back to a non-atomic
+    /// breadth-first traversal built from `getChildren` calls.
     if (!isFeatureEnabled(DB::KeeperFeatureFlag::GET_CHILDREN_RECURSIVE))
-        return Coordination::Error::ZBADARGUMENTS;
+    {
+        Coordination::Error code = listRecursiveFallback(path, res, children_nodes_limit);
+        maybeSetSpanStatus(maybe_span, code);
+        return code;
+    }
 
     auto promise = std::make_shared<std::promise<Coordination::ListRecursiveResponse>>();
     auto future = promise->get_future();

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -664,6 +664,8 @@ private:
     Coordination::Error existsImpl(const std::string & path, Coordination::Stat * stat_, Coordination::WatchCallbackPtrOrEventPtr watch_callback);
     Coordination::Error syncImpl(const std::string & path, std::string & returned_path);
 
+    Coordination::Error listRecursiveFallback(const std::string & path, Strings & res, uint32_t children_nodes_limit);
+
     bool sampleForOpenTelemetryTracing() const
     {
         /// Avoiding using random number generation and std::bernoulli_distribution because it's too slow.


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add fallback to Keeper's listRecursive function to use getChildren

cc @azat 