### PR TITLE
Fix flaky test_backup_restore_on_cluster restore timeout

### DIFF
--- a/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
+++ b/tests/integration/test_backup_restore_on_cluster/configs/lesser_timeouts.xml
@@ -2,6 +2,6 @@
     <backups>
         <sync_period_ms>1000</sync_period_ms>
         <consistent_metadata_snapshot_timeout>10000</consistent_metadata_snapshot_timeout>
-        <create_table_timeout>3000</create_table_timeout>
+        <create_table_timeout>30000</create_table_timeout>
     </backups>
 </clickhouse>

--- a/tests/integration/test_backup_restore_on_cluster_with_checksum_data_file_name/configs/lesser_timeouts.xml
+++ b/tests/integration/test_backup_restore_on_cluster_with_checksum_data_file_name/configs/lesser_timeouts.xml
@@ -2,6 +2,6 @@
     <backups>
         <sync_period_ms>1000</sync_period_ms>
         <consistent_metadata_snapshot_timeout>10000</consistent_metadata_snapshot_timeout>
-        <create_table_timeout>3000</create_table_timeout>
+        <create_table_timeout>30000</create_table_timeout>
     </backups>
 </clickhouse>


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/44454
Related: https://github.com/ClickHouse/ClickHouse/pull/100391
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `test_backup_restore_on_cluster/test.py::test_replicated_database_async` (and sibling restore-on-cluster tests) failing with `CANNOT_RESTORE_TABLE` / "Couldn't restore table `mydb.tbl2` on other node or sync it".

Root cause: the test config `lesser_timeouts.xml` shrinks `backups.create_table_timeout` from its 300s production default to 3s purely for test speed. In `DatabaseReplicated::createTableRestoredFromBackup` the node that did not win the restore-coordination race waits up to that timeout for the winner's `CREATE TABLE` DDL to replicate. On slow sanitizer / old-analyzer / db-disk lanes this takes just over 3s, so it throws right at the 3s boundary (CI errors literally say "elapsed 3.076417s" / "elapsed 3.034979s"). Master with the 300s default never hits this (0 master failures in 60 days; the failure spans 8 unrelated PRs, e.g. #86768, #101757, #107652, #107442, #108565).

Fix: bump `create_table_timeout` 3000 -> 30000 in both copies of `lesser_timeouts.xml`. The wait loop returns the instant the table appears, so a larger timeout costs nothing on a successful run; 30s is still 10x below the production default and only widens the deadline for the (untested) failure path, so bug detection is unchanged. Same fix @ vitlibar applied in 2022 (1s -> 3s, b211dff0133); 3s has again become too small for instrumented lanes.

Verified locally (debug build, integration runner): with `create_table_timeout=1` the test FAILS with the exact CI signature; with `30000` it PASSES (18.8s). Found via the read-in-order PR #100391 CI; reported by @ alexey-milovidov.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.3.33.110`
<!-- ch-version-info:end -->