### PR TITLE
Fix changeDate and timeSlots DateTime64 result column scale

### DIFF
--- a/src/Functions/changeDate.cpp
+++ b/src/Functions/changeDate.cpp
@@ -107,9 +107,12 @@ public:
         typename ResultDataType::ColumnType::MutablePtr result_col;
         if constexpr (std::is_same_v<ResultDataType, DataTypeDateTime64>)
         {
-            auto scale = DataTypeDateTime64::default_scale;
-            if constexpr (std::is_same_v<InputDataType, DateTime64>)
-                scale = static_cast<UInt8>(typeid_cast<const DataTypeDateTime64 &>(*result_type).getScale());
+            /// result_type is the DateTime64 this function returns; its scale is the scale the
+            /// result column must carry (the values below are computed at this scale). The previous
+            /// guard `is_same_v<InputDataType, DateTime64>` was always false (InputDataType is a
+            /// DataType class while DateTime64 is a value-type alias), so the column was built at the
+            /// hardcoded default_scale 3 and a DateTime64(N != 3) result was structurally inconsistent.
+            const auto scale = static_cast<UInt8>(typeid_cast<const DataTypeDateTime64 &>(*result_type).getScale());
             result_col = ResultDataType::ColumnType::create(input_rows_count, scale);
         }
         else

--- a/src/Functions/timeSlots.cpp
+++ b/src/Functions/timeSlots.cpp
@@ -271,11 +271,18 @@ public:
 
         auto start_time_scale = assert_cast<const DataTypeDateTime64 &>(*arguments[0].type).getScale();
         auto duration_scale = assert_cast<const DataTypeDecimal64 &>(*arguments[1].type).getScale();
+        auto result_scale = std::max(start_time_scale, duration_scale);
+        /// The optional Size argument also participates in value rescaling (executeImpl computes
+        /// values at max(start, duration, size)), so it must be reflected in the declared scale,
+        /// otherwise a Size with the largest scale yields values exposed at a smaller declared scale
+        /// (wrong timestamps). This honors the documented "highest scale among all arguments".
+        if (arguments.size() == 3)
+            result_scale = std::max(result_scale, assert_cast<const DataTypeDecimal64 &>(*arguments[2].type).getScale());
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime64>(
-            std::max(start_time_scale, duration_scale), extractTimeZoneNameFromFunctionArguments(arguments, 3, 0, false)));
+            result_scale, extractTimeZoneNameFromFunctionArguments(arguments, 3, 0, false)));
     }
 
-    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
         if (WhichDataType(arguments[0].type).isDateTime())
         {
@@ -352,7 +359,15 @@ public:
             const auto start_time_scale = assert_cast<const DataTypeDateTime64 *>(arguments[0].type.get())->getScale();
             const auto duration_scale = assert_cast<const DataTypeDecimal64 *>(arguments[1].type.get())->getScale();
 
-            auto res = ColumnArray::create(DataTypeDateTime64(start_time_scale).createColumn());
+            /// The result element scale is max(start, duration, size) as declared by
+            /// getReturnTypeImpl (and the scale TimeSlotsImpl computes values at). Read it back from
+            /// result_type so the column object always carries the scale of its declared type;
+            /// building at start_time_scale alone left a scale-N values column labelled DateTime64(M)
+            /// when duration_scale or time_slot_scale exceeded start_time_scale.
+            const auto result_scale = assert_cast<const DataTypeDateTime64 &>(
+                *assert_cast<const DataTypeArray &>(*result_type).getNestedType()).getScale();
+
+            auto res = ColumnArray::create(DataTypeDateTime64(result_scale).createColumn());
             DataTypeDateTime64::ColumnType::Container & res_values = typeid_cast<DataTypeDateTime64::ColumnType &>(res->getData()).getData();
 
             if (starts && durations)

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.reference
@@ -1,0 +1,26 @@
+changeSecond scale 7 into arrayPushBack
+['2020-01-01 00:00:00.0000000','2020-01-01 12:00:30.0000000']
+changeMinute scale 7 into arrayPushFront
+['2020-01-01 12:45:00.0000000','2020-01-01 00:00:00.0000000']
+changeHour scale 1 into arrayConcat
+['2020-01-01 00:00:00.0','2020-01-01 05:00:00.0']
+changeDay scale 6 into arrayPushBack
+['2020-01-01 00:00:00.000000','2020-01-20 12:00:00.000000']
+changeMonth scale 5 into arrayPushFront
+['2020-06-01 12:00:00.00000','2020-01-01 00:00:00.00000']
+result column scale matches declared type
+DateTime64(7)
+timeSlots start scale 1, duration scale 5 into arrayConcat
+['2012-01-01 12:00:00.00000','2012-01-01 12:30:00.00000','2000-01-01 00:00:00.00000']
+timeSlots start scale 2, duration scale 6 into arrayPushBack
+['2000-01-01 00:00:00.000000','2012-01-01 12:00:00.000000']
+timeSlots constant start, duration scale 4 column into arrayConcat
+['2012-01-01 12:00:00.0000','2012-01-01 12:30:00.0000','2000-01-01 00:00:00.0000']
+timeSlots result column scale matches declared type
+Array(DateTime64(5))
+timeSlots size scale largest: value at scale 4
+['1970-01-01 00:00:01.0000','1970-01-01 00:00:01.5000','1970-01-01 00:00:02.0000']
+timeSlots size scale largest: type is Array(DateTime64(4))
+Array(DateTime64(4, \'UTC\'))
+timeSlots size scale largest into arrayConcat
+['1970-01-01 00:00:01.0000','1970-01-01 00:00:01.5000','1970-01-01 00:00:02.0000','2000-01-01 00:00:00.0000']

--- a/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
+++ b/tests/queries/0_stateless/04338_changedate_datetime64_scale_array_push.sql
@@ -1,0 +1,59 @@
+-- Regression test for issue #108517. changeYear/changeMonth/changeDay/changeHour/
+-- changeMinute/changeSecond over DateTime64(N) used to build the result column with the
+-- hardcoded default scale 3 instead of N, so a result declared DateTime64(N != 3) carried a
+-- physically scale-3 column. Feeding it into a structure-sensitive consumer (arrayPushBack /
+-- arrayPushFront / arrayConcat over Array(DateTime64(N))) skips the cast on declared-type
+-- equality and reaches the generic writeSlice, whose ColumnDecimal::structureEquals throws a
+-- LOGICAL_ERROR on the scale mismatch. materialize() prevents constant folding so the divergent
+-- column actually reaches the array function.
+
+SELECT 'changeSecond scale 7 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2020-01-01 00:00:00', 7)], changeSecond(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 30));
+
+SELECT 'changeMinute scale 7 into arrayPushFront';
+SELECT arrayPushFront([toDateTime64('2020-01-01 00:00:00', 7)], changeMinute(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 45));
+
+SELECT 'changeHour scale 1 into arrayConcat';
+SELECT arrayConcat([toDateTime64('2020-01-01 00:00:00', 1)], [changeHour(materialize(toDateTime64('2020-01-01 12:00:00', 1)), 5)]);
+
+SELECT 'changeDay scale 6 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2020-01-01 00:00:00', 6)], changeDay(materialize(toDateTime64('2020-01-15 12:00:00', 6)), 20));
+
+SELECT 'changeMonth scale 5 into arrayPushFront';
+SELECT arrayPushFront([toDateTime64('2020-01-01 00:00:00', 5)], changeMonth(materialize(toDateTime64('2020-01-01 12:00:00', 5)), 6));
+
+SELECT 'result column scale matches declared type';
+SELECT toTypeName(changeSecond(materialize(toDateTime64('2020-01-01 12:00:00', 7)), 30));
+
+-- Same producer bug class in timeSlots: getReturnTypeImpl declares
+-- Array(DateTime64(max(start_scale, duration_scale))) but executeImpl built the values column
+-- at start_scale only, so a duration with a larger scale produced a result column whose physical
+-- scale was below its declared type. The same structure-sensitive consumers reach writeSlice and
+-- throw. Read the scale from result_type so the column always matches its declared type.
+
+SELECT 'timeSlots start scale 1, duration scale 5 into arrayConcat';
+SELECT arrayConcat(timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 1)), toDecimal64(600, 5)), [toDateTime64('2000-01-01 00:00:00', 5)]);
+
+SELECT 'timeSlots start scale 2, duration scale 6 into arrayPushBack';
+SELECT arrayPushBack([toDateTime64('2000-01-01 00:00:00', 6)], (timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 2)), toDecimal64(600, 6)))[1]);
+
+SELECT 'timeSlots constant start, duration scale 4 column into arrayConcat';
+SELECT arrayConcat(timeSlots(toDateTime64('2012-01-01 12:20:00', 1), materialize(toDecimal64(600, 4))), [toDateTime64('2000-01-01 00:00:00', 4)]);
+
+SELECT 'timeSlots result column scale matches declared type';
+SELECT toTypeName(timeSlots(materialize(toDateTime64('2012-01-01 12:20:00', 1)), toDecimal64(600, 5)));
+
+-- The optional Size (3rd) argument also participates in value rescaling, so its scale must be
+-- included in the declared return scale. getReturnTypeImpl used to declare only
+-- max(start_scale, duration_scale), so when the Size scale was the largest the values were
+-- computed at the larger scale but the column declared the smaller one, returning wrong
+-- timestamps (and reaching writeSlice through a structure-sensitive consumer).
+
+SELECT 'timeSlots size scale largest: value at scale 4';
+SELECT timeSlots(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC'), toDecimal64(1, 1), toDecimal64(0.5, 4));
+
+SELECT 'timeSlots size scale largest: type is Array(DateTime64(4))';
+SELECT toTypeName(timeSlots(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC'), toDecimal64(1, 1), toDecimal64(0.5, 4)));
+
+SELECT 'timeSlots size scale largest into arrayConcat';
+SELECT arrayConcat(timeSlots(materialize(toDateTime64('1970-01-01 00:00:01.0', 1, 'UTC')), toDecimal64(1, 1), toDecimal64(0.5, 4)), [toDateTime64('2000-01-01 00:00:00', 4, 'UTC')]);


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/108517
Related: https://github.com/ClickHouse/ClickHouse/pull/108981
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `changeYear`/`changeMonth`/`changeDay`/`changeHour`/`changeMinute`/`changeSecond` over `DateTime64(N)` building the result column at the hardcoded default scale 3 instead of `N`, and `timeSlots` over `DateTime64` ignoring the optional `Size` argument scale in its declared return type. Both produced a column whose physical scale diverged from its declared type, which led to a `LOGICAL_ERROR` (`writeSlice expects same column types`) when the result was passed to `arrayPushBack`/`arrayPushFront`/`arrayConcat`, and `timeSlots` with the largest scale in `Size` returned wrong timestamps.


### Description

Re-lands the two producer fixes from #108517 (originally in #108551, reverted by #108981 for an unrelated reason: that PR also added a strict `columnMatchesType` scale gate to the function property stress test, which reddened `FunctionsStress.stress`). This change re-lands only the producer fixes, without the gate, so it cannot affect the stress test.

`changeDate`: the `DataTypeDateTime64` result branch built the column at `DataTypeDateTime64::default_scale` (3) because the `if constexpr (std::is_same_v<InputDataType, DateTime64>)` guard was always false (`InputDataType` is a `DataType` class, `DateTime64` a value-type alias). The values were computed at the declared scale `N`, so a `DateTime64(N != 3)` result carried a physically scale-3 column. Now reads the scale from `result_type`.

`timeSlots`: `getReturnTypeImpl` declared `Array(DateTime64(max(start_scale, duration_scale)))` and `executeImpl` built the values column at `start_scale`, but `TimeSlotsImpl` rescales values to `max(start_scale, duration_scale, time_slot_scale)`. The 3rd `Size` argument scale is now included in the declared return type, and the column is built at the declared scale read from `result_type`.

Either divergence is invisible to a same-declared-type cast, so feeding the result into a structure-sensitive consumer (`arrayPush*`/`arrayConcat` over `Array(DateTime64(N))`) reached the generic `writeSlice`, whose `ColumnDecimal::structureEquals` raised the `LOGICAL_ERROR`. The production check is correct and unchanged; the fix makes each producer build a column consistent with its declared type.

Regression test `04338_changedate_datetime64_scale_array_push` (parallel-safe) covers both functions over `DateTime64(N != 3)` through the array consumers. It raises the `writeSlice` `LOGICAL_ERROR` on clean master (server abort in debug/sanitizer builds) and passes with the fix.

The `reinterpret` producer of the same divergence is fixed separately in #108878.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.710` (included in `26.7` and later)
<!-- ch-version-info:end -->