### PR TITLE
Ignore benign PostgreSQL background-reconnection errors in the upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -403,6 +403,16 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       regex in the secondary pipe below to require BOTH the `SystemLog` flush wrapper for `metric_log` AND
 #       the `DEADLOCK_AVOIDED` error code together, so unrelated lock-timeout errors and unrelated
 #       `metric_log` errors are not masked.
+# `PostgreSQLConnectionPool: Connection error` and `DatabasePostgreSQL::removeOutdatedTables` + `Connection to`
+#       + `failed` are benign background-reconnection errors from a `DatabasePostgreSQL` engine left behind by
+#       `04210_show_remote_databases_in_system_tables` when the stress phase interrupts that test between its
+#       `CREATE DATABASE ... ENGINE = PostgreSQL('192.0.2.1:5432', ...)` and the final `DROP DATABASE` (the
+#       documentation IP `192.0.2.1`, RFC 5737, is intentionally unreachable). `DatabasePostgreSQL::startup`
+#       always activates the `PostgreSQLCleanerTask`, so after the upgrade restart the leftover database's cleaner
+#       task (`removeOutdatedTables`) tries to connect and the connection pool logs `<Error>` for each retry.
+#       Filtered via regex in the secondary pipe below to require the PostgreSQL connection-pool / cleaner-task
+#       context AND the connection-failure symptom together, so real PostgreSQL regressions (auth, protocol,
+#       query errors) are not masked.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -487,6 +497,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "wrong_metadata.*Detaching broken part.*backward incompatibility" \
     | grep -av -e "RaftInstance: session.*failed to read rpc header from socket.*due to error" \
     | grep -av -e "SystemLog.*Failed to flush system log system\.metric_log.*DEADLOCK_AVOIDED" \
+    | grep -av -e "PostgreSQLConnectionPool: Connection error" \
+    | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true
 
 if [ -s /test_output/upgrade_error_messages.txt ]; then


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108939

## What & why

The upgrade check (`tests/docker_scripts/upgrade_runner.sh`) scans the post-upgrade server log for `<Error>` lines and fails on anything not in its allow-list. It intermittently fails with:

```
<Error> PostgreSQLConnectionPool: Connection error: connection to server at "192.0.2.1", port 5432 failed: timeout expired
<Error> void DB::DatabasePostgreSQL::removeOutdatedTables(): Code: 614. DB::Exception: Try 2. Connection to `192.0.2.1:5432` failed ...
```

These come from a leftover `DatabasePostgreSQL` engine created by `04210_show_remote_databases_in_system_tables`, which points at the RFC 5737 documentation IP `192.0.2.1` (intentionally unreachable). The stress phase runs the stateless tests under a global time limit and can interrupt that test between its `CREATE DATABASE ... ENGINE = PostgreSQL('192.0.2.1:5432', ...)` and the final `DROP DATABASE`, leaving the database in metadata. After the upgrade restart, `DatabasePostgreSQL::startup` unconditionally activates the `PostgreSQLCleanerTask`, whose `removeOutdatedTables` tries to connect and the connection pool logs `<Error>` for each retry.

This `Error message in clickhouse-server.log` subcheck has tripped on ~89 distinct PRs in the last 7 days; it is environmental, not a compatibility regression.

## Fix

This is the same class of benign background-reconnection-after-restart noise already allow-listed for Kafka (`rdk:FAIL` / `StorageKafka2`), Azure DNS, and NuRaft. Two regex filters are added to the secondary pipe, each requiring the PostgreSQL connection-pool / cleaner-task context **together with** the connection-failure symptom, so real PostgreSQL regressions (auth, protocol, query errors) are not masked:

```
| grep -av -e "PostgreSQLConnectionPool: Connection error" \
| grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
```

Verified locally that both benign lines are suppressed while a real PostgreSQL auth/query error and an unrelated `DatabasePostgreSQL` error still surface.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108939&sha=27734f50667a6b77ca59b768e605b4d843acde3c&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes
Not applicable — CI test infrastructure only.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.317` (included in `26.7` and later)
<!-- ch-version-info:end -->