### PR TITLE
Fix flaky test 04312_client_chime_on_slow_query_92718

### DIFF
--- a/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
+++ b/tests/queries/0_stateless/04312_client_chime_on_slow_query_92718.sh
@@ -57,7 +57,9 @@ echo "3. clickhouse-client (no --chime), 1.5s < default 5s threshold: $(bel_coun
 # Case 4: `--chime 1`, slow query that ends in an error, stderr redirected — expect no
 # `BEL` (suppressed by the TTY guard) AND verify the error path actually fires so the
 # test would loudly notice if `throwIf` semantics or the error path itself changes.
-${CLICKHOUSE_CLIENT} --chime 1 -q "SELECT sleep(1.5), throwIf(1 = 1, 'expected error')" 2> "$err4" > /dev/null
+# `sleep` is nested inside `throwIf`'s argument so it always runs before the throw;
+# as sibling projection columns their evaluation order would be unspecified.
+${CLICKHOUSE_CLIENT} --chime 1 -q "SELECT throwIf(sleep(1.5) = 0, 'expected error')" 2> "$err4" > /dev/null
 rc=$?
 if [ "$rc" -eq 0 ]; then
     case4_status="FAIL: query unexpectedly succeeded"
@@ -121,7 +123,9 @@ echo "10. clickhouse-client (no --chime), slow query (~6s > default 5s threshold
 # place where the "chime on error in TTY" contract is exercised: case 4 covers
 # the non-TTY suppression branch and would still pass if a regression emitted
 # `BEL` only on success and silently dropped it on errors.
-/usr/bin/script -eqc "${CLICKHOUSE_CLIENT} --chime 1 -q \"SELECT sleep(1.5), throwIf(1 = 1, 'expected error')\"" /dev/null > "$tty11" 2>&1
+# `sleep` is nested inside `throwIf`'s argument so it always runs before the throw;
+# as sibling projection columns their evaluation order would be unspecified.
+/usr/bin/script -eqc "${CLICKHOUSE_CLIENT} --chime 1 -q \"SELECT throwIf(sleep(1.5) = 0, 'expected error')\"" /dev/null > "$tty11" 2>&1
 rc=$?
 if [ "$rc" -eq 0 ]; then
     case11_status="FAIL: query unexpectedly succeeded"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/92718
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Fixes flaky `04312_client_chime_on_slow_query_92718` (seen on `Stateless tests (amd_tsan, parallel, 1/2)` and `(arm_asan_ubsan, azure, parallel)`).

Cases 4 and 11 ran `SELECT sleep(1.5), throwIf(1 = 1, 'expected error')` as two sibling projection columns. Their evaluation order is unspecified, so `throwIf` could fire before `sleep` ran: the query then errored at ~0s elapsed, below the `--chime 1` threshold, and no `BEL` was emitted. Case 11 (pty) intermittently printed `no BEL` instead of the expected `BEL` while the `'expected error'` message was still present, which is exactly the diff signature seen in CI. Thread-fuzzer / sanitizer slowdown widens the race window, so it surfaced mostly under tsan/asan.

The fix nests `sleep` inside `throwIf`'s argument: `SELECT throwIf(sleep(1.5) = 0, 'expected error')`. `sleep(1.5)` returns `0`, so the predicate is true and `throwIf` still throws `'expected error'`, but only after the 1.5s sleep has run. Elapsed time is therefore always >= 1.5s and the chime fires deterministically.

Verified locally with a `--chime`-capable build (clickhouse-local exercises the same `ClientBase` chime path): the new form emits `BEL` 25/25 under a pty, wall time is always ~1.85s, and `--chime 10` still emits no `BEL` (the threshold gate, hence the test's ability to catch a threshold regression, is unchanged).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.321` (included in `26.7` and later)
<!-- ch-version-info:end -->