### PR TITLE
Add test: `table_readonly` alterPartition gate `default: break;` allow-path (FREEZE/UNFREEZE) untested

### DIFF
--- a/tests/queries/0_stateless/04492_table_readonly_freeze_forget_allowed.reference
+++ b/tests/queries/0_stateless/04492_table_readonly_freeze_forget_allowed.reference
@@ -1,0 +1,3 @@
+freeze ok
+unfreeze ok
+8

--- a/tests/queries/0_stateless/04492_table_readonly_freeze_forget_allowed.sql
+++ b/tests/queries/0_stateless/04492_table_readonly_freeze_forget_allowed.sql
@@ -1,0 +1,26 @@
+-- Test that non-mutating partition commands (FREEZE/UNFREEZE) are still allowed on a table
+-- marked read-only via the `table_readonly` MergeTree setting.
+
+DROP TABLE IF EXISTS t_readonly_freeze;
+
+CREATE TABLE t_readonly_freeze (k UInt64) ENGINE = MergeTree ORDER BY k PARTITION BY k % 2;
+
+INSERT INTO t_readonly_freeze SELECT number FROM numbers(8);
+
+ALTER TABLE t_readonly_freeze MODIFY SETTING table_readonly = 1;
+
+-- Mutating partition commands are rejected while read-only.
+ALTER TABLE t_readonly_freeze DROP PARTITION 0; -- { serverError TABLE_IS_PERMANENTLY_READ_ONLY }
+
+-- FREEZE does not modify the table's data, so it is allowed while read-only.
+ALTER TABLE t_readonly_freeze FREEZE PARTITION 0 WITH NAME 'freeze_ro';
+SELECT 'freeze ok';
+
+-- UNFREEZE of the backup is allowed while read-only.
+ALTER TABLE t_readonly_freeze UNFREEZE PARTITION 0 WITH NAME 'freeze_ro';
+SELECT 'unfreeze ok';
+
+-- Data is untouched.
+SELECT count() FROM t_readonly_freeze;
+
+DROP TABLE t_readonly_freeze;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #95079](https://github.com/ClickHouse/ClickHouse/pull/95079).
That PR The PR adds a `table_readonly` MergeTree setting that (1) rejects foreground modifications on `StorageMergeTree` (`assertNotReadonly` for INSERT/mutation/OPTIMIZE), (2) rejects data-mutating partition commands in `MergeTreeData::alterPartition` (ATTACH/MOVE/DROP/DROP DETACHED/FETCH/REPLACE PARTITION

**1. `table_readonly` alterPartition gate `default: break;` allow-path (FREEZE/UNFREEZE) untested**
  `src/Storages/MergeTree/MergeTreeData.cpp:7026`
  **Risk:** The readonly gate switch at `MergeTreeData.cpp`:7017-7028 only throws for the six mutating `PartitionCommand` types and falls through `default: break;` for everything else. PR tests only cover the throwing cases (04490) — the allow path is uncovered (LLVM: 7025-7026 marked >>). Risk: if the switch is ever refactored into a reject-by-default whitelist (or the `default` case dropped), FREEZE/UNFREEZE (backup) of a read-only table — e.g. a rotated system log table an operator wants to archive — …
  **What's unique vs PR tests:** PR test 04490 covers only the REJECTED partition commands (DROP/DETACH/ATTACH) on a read-only table. This test covers the complementary ALLOW path — FREEZE/UNFREEZE succeed on a read-only table — which is the `default: break;` branch the PR's own tests never reach.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)