### PR TITLE
Allow-list benign throwIf mutation retry noise in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -413,6 +413,16 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       Filtered via regex in the secondary pipe below to require the PostgreSQL connection-pool / cleaner-task
 #       context AND the connection-failure symptom together, so real PostgreSQL regressions (auth, protocol,
 #       query errors) are not masked.
+# `MutatePlainMergeTreeTask`/`MergeTreeBackgroundExecutor` + `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` is another
+#       member of the #39174 family (intentionally-broken mutations retry after the upgrade restart). Test
+#       04341_broken_mutation_part_log_flush runs `ALTER TABLE ... UPDATE x = x + throwIf(1)`, which fails a
+#       plain-MergeTree mutation on purpose; if the mutation is still queued when the server restarts it is
+#       replayed and logs code 395 at `<Error>`. Code 395 is by definition a user `throwIf` expression
+#       evaluating non-zero (an expected error, never a server malfunction), so a genuine upgrade regression
+#       would surface as a different code. Filtered via two regexes in the secondary pipe below, each requiring
+#       the mutation-executor context (`MutatePlainMergeTreeTask` or the `MergeTreeBackgroundExecutor`
+#       background-task wrapper) AND the `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` code together, so unrelated
+#       mutation-executor errors and unrelated code-395 errors are not masked.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -499,6 +509,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "SystemLog.*Failed to flush system log system\.metric_log.*DEADLOCK_AVOIDED" \
     | grep -av -e "PostgreSQLConnectionPool: Connection error" \
     | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
+    | grep -av -e "MutatePlainMergeTreeTask.*FUNCTION_THROW_IF_VALUE_IS_NON_ZERO" \
+    | grep -av -e "MergeTreeBackgroundExecutor: Exception while executing background task.*FUNCTION_THROW_IF_VALUE_IS_NON_ZERO" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true
 
 if [ -s /test_output/upgrade_error_messages.txt ]; then


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108957
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Requested by @ alexey-milovidov on #108957 (CI triage): own this upgrade-check flake in a separate PR.

The upgrade check's "Error message in clickhouse-server.log" assertion (`Upgrade check (amd_release)`) has been failing across many unrelated PRs since ~2026-06-26 with `FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` (code 395) at `<Error>` from a background mutation. CIDB: 40 failures / 39 distinct PRs / 0 on master in the last 60 days, onset 2026-06-26.

Root cause: test `04341_broken_mutation_part_log_flush` runs `ALTER TABLE t_failed_mutation_part_log UPDATE x = x + throwIf(1) WHERE 1`, which fails a plain-MergeTree mutation on purpose (to exercise the failed-`MutatePart` `part_log` path added in 189f8023c72). This is a new member of the #39174 family: if the intentionally-broken mutation is still queued when the server restarts for the upgrade step, it is replayed and logs code 395 at `<Error>`, tripping the "no error messages in server log" check.

Fix: add two allow-list regexes to the secondary grep pipe in `tests/docker_scripts/upgrade_runner.sh`, matching the two `<Error>` line shapes this produces:
- `MutatePlainMergeTreeTask.*FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` (the task line and its `executeStep()` line)
- `MergeTreeBackgroundExecutor: Exception while executing background task.*FUNCTION_THROW_IF_VALUE_IS_NON_ZERO` (the background-executor wrapper line)

Each regex requires the mutation-executor context AND the code-395 signature together. Code 395 is by definition a user `throwIf` expression evaluating non-zero (an expected error, never a server malfunction), so a genuine upgrade regression surfaces as a different code and is not masked. This mirrors the existing `CANNOT_PARSE_TEXT` exclusions for the same #39174 family (00834_kill_mutation, 01414_mutations_and_errors_zookeeper, 04338_on_fly_mutation_read_overwritten_lc_source).

Validation: the two regexes were run against the exact `<Error>` log lines captured from real CI failures plus decoy lines (a genuine `Application`/`LOGICAL_ERROR` regression, a real code-999 `MutatePlainMergeTreeTask` error, and a real `MEMORY_LIMIT_EXCEEDED` background-task error). Without the fix all benign throwIf lines leak (check fails, as today); with the fix all benign throwIf lines are filtered while every decoy survives.

CI report example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107566&sha=ff5b03a6889ac814851c78b9ceca8ee83e8977d5&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
