### PR TITLE
 Move UNIQUE KEY comparable serialization into IColumn

### DIFF
--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/IColumn.h>
+#include <Columns/IColumnImpl.h>
 #include <Core/Field.h>
 #include <Common/PODArray.h>
 #include <Common/assert_cast.h>
@@ -201,15 +202,13 @@ public:
         /// (and a possible NOT_IMPLEMENTED from an unsupported nested type).
         if (num_rows == 0)
             return;
+
         String encoded;
         data->serializeAsComparable(0, encoded);
-        for (size_t r = 0; r < num_rows; ++r)
-        {
-            const size_t src = permutation ? (*permutation)[r] : r;
-            if (null_map && null_map[src])
-                continue;
-            out[r].append(encoded);
-        }
+        /// All rows share `encoded`; `src` only matters for the null-map check.
+        batchSerializeAsComparableImpl(
+            num_rows, out, permutation, null_map,
+            [&encoded](size_t /*src*/, String & dst) { dst.append(encoded); });
     }
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -195,7 +195,7 @@ public:
         size_t num_rows,
         VectorWithMemoryTracking<String> & out,
         const IColumn::Permutation * permutation,
-        const UInt8 * null_map = nullptr) const override
+        const UInt8 * null_map) const override
     {
         /// Match the base class no-op for empty batches: avoid touching the payload
         /// (and a possible NOT_IMPLEMENTED from an unsupported nested type).

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -183,6 +183,24 @@ public:
         return data->serializeValueIntoMemory(0, memory, settings);
     }
 
+    void serializeAsComparable(size_t, String & out) const override
+    {
+        data->serializeAsComparable(0, out);
+    }
+
+    /// All rows are identical: encode row 0 once and append to every output row.
+    /// Permutation is irrelevant for a constant column.
+    void batchSerializeAsComparable(
+        size_t num_rows,
+        VectorWithMemoryTracking<String> & out,
+        const IColumn::Permutation * /*permutation*/) const override
+    {
+        String encoded;
+        data->serializeAsComparable(0, encoded);
+        for (size_t r = 0; r < num_rows; ++r)
+            out[r].append(encoded);
+    }
+
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override
     {
         data->deserializeAndInsertFromArena(in, settings);

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -189,11 +189,13 @@ public:
     }
 
     /// All rows are identical: encode row 0 once and append to every output row.
-    /// Permutation is irrelevant for a constant column.
+    /// Permutation is irrelevant for a constant column. Rows masked by `null_map`
+    /// (set by a Nullable wrapper) are skipped, matching the other columns.
     void batchSerializeAsComparable(
         size_t num_rows,
         VectorWithMemoryTracking<String> & out,
-        const IColumn::Permutation * /*permutation*/) const override
+        const IColumn::Permutation * permutation,
+        const UInt8 * null_map = nullptr) const override
     {
         /// Match the base class no-op for empty batches: avoid touching the payload
         /// (and a possible NOT_IMPLEMENTED from an unsupported nested type).
@@ -202,7 +204,12 @@ public:
         String encoded;
         data->serializeAsComparable(0, encoded);
         for (size_t r = 0; r < num_rows; ++r)
+        {
+            const size_t src = permutation ? (*permutation)[r] : r;
+            if (null_map && null_map[src])
+                continue;
             out[r].append(encoded);
+        }
     }
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override

--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -195,6 +195,10 @@ public:
         VectorWithMemoryTracking<String> & out,
         const IColumn::Permutation * /*permutation*/) const override
     {
+        /// Match the base class no-op for empty batches: avoid touching the payload
+        /// (and a possible NOT_IMPLEMENTED from an unsupported nested type).
+        if (num_rows == 0)
+            return;
         String encoded;
         data->serializeAsComparable(0, encoded);
         for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -24,6 +24,9 @@
 
 #include <Processors/Transforms/ColumnGathererTransform.h>
 
+#include <bit>
+#include <cstring>
+
 #include <base/TypeName.h>
 #include <base/sort.h>
 
@@ -38,6 +41,7 @@ namespace ErrorCodes
     extern const int PARAMETER_OUT_OF_BOUND;
     extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
     extern const int NOT_IMPLEMENTED;
+    extern const int LOGICAL_ERROR;
 }
 
 template <is_decimal T>
@@ -691,6 +695,60 @@ void ColumnDecimal<T>::updateAt(const IColumn & src, size_t dst_pos, size_t src_
 {
     const auto & src_data = assert_cast<const Self &>(src).getData();
     data[dst_pos] = src_data[src_pos];
+}
+
+template <is_decimal T>
+ALWAYS_INLINE char * ColumnDecimal<T>::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+{
+    using Native = typename T::NativeType;
+    if constexpr (std::is_integral_v<Native>)
+    {
+        Native value = data[n].value;
+        if constexpr (std::endian::native == std::endian::little)
+            value = std::byteswap(value);
+        /// Flip sign bit for signed types.
+        char * bytes = reinterpret_cast<char *>(&value);
+        bytes[0] ^= 0x80;
+        memcpy(memory, &value, sizeof(Native));
+        return memory + sizeof(Native);
+    }
+    else if constexpr (is_big_int_v<Native>)
+    {
+        Native value = data[n].value;
+        constexpr unsigned item_count = sizeof(Native) / sizeof(uint64_t);
+        for (unsigned i = 0; i < item_count; ++i)
+        {
+            uint64_t item = value.items[Native::_impl::big(i)];
+            if constexpr (std::endian::native == std::endian::little)
+                item = std::byteswap(item);
+            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
+        }
+        /// Flip sign bit (all Decimal NativeTypes are signed).
+        memory[0] ^= 0x80;
+        return memory + sizeof(Native);
+    }
+}
+
+template <is_decimal T>
+void ColumnDecimal<T>::batchSerializeComparableIntoMemory(
+    PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
+template <is_decimal T>
+void ColumnDecimal<T>::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
+{
+    size_t rows = data.size();
+    if (sizes.empty())
+        sizes.resize_fill(rows);
+    else if (sizes.size() != rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
+
+    for (auto & sz : sizes)
+        sz += sizeof(T);
 }
 
 template class ColumnDecimal<Decimal32>;

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -727,6 +727,10 @@ ALWAYS_INLINE char * ColumnDecimal<T>::serializeValueIntoMemoryAsComparable(size
         memory[0] ^= 0x80;
         return memory + sizeof(Native);
     }
+    else
+    {
+        return IColumn::serializeValueIntoMemoryAsComparable(n, memory);
+    }
 }
 
 template <is_decimal T>

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -1,5 +1,6 @@
 #include <Common/Exception.h>
 #include <Common/FieldVisitorToString.h>
+#include <Common/transformEndianness.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/HashTable/Hash.h>
 #include <Common/RadixSort.h>
@@ -698,61 +699,21 @@ void ColumnDecimal<T>::updateAt(const IColumn & src, size_t dst_pos, size_t src_
 }
 
 template <is_decimal T>
-ALWAYS_INLINE char * ColumnDecimal<T>::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+void ColumnDecimal<T>::serializeAsComparable(size_t n, String & out) const
 {
-    using Native = typename T::NativeType;
-    if constexpr (std::is_integral_v<Native>)
+    using Native = T::NativeType;
+    if constexpr (std::is_integral_v<Native> || is_big_int_v<Native>)
     {
         Native value = data[n].value;
-        if constexpr (std::endian::native == std::endian::little)
-            value = std::byteswap(value);
-        /// Flip sign bit for signed types.
+        transformEndianness<std::endian::big>(value);
         char * bytes = reinterpret_cast<char *>(&value);
         bytes[0] ^= 0x80;
-        memcpy(memory, &value, sizeof(Native));
-        return memory + sizeof(Native);
-    }
-    else if constexpr (is_big_int_v<Native>)
-    {
-        Native value = data[n].value;
-        constexpr unsigned item_count = sizeof(Native) / sizeof(uint64_t);
-        for (unsigned i = 0; i < item_count; ++i)
-        {
-            uint64_t item = value.items[Native::_impl::big(i)];
-            if constexpr (std::endian::native == std::endian::little)
-                item = std::byteswap(item);
-            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
-        }
-        /// Flip sign bit (all Decimal NativeTypes are signed).
-        memory[0] ^= 0x80;
-        return memory + sizeof(Native);
+        out.append(reinterpret_cast<const char *>(&value), sizeof(Native));
     }
     else
     {
-        return IColumn::serializeValueIntoMemoryAsComparable(n, memory);
+        IColumn::serializeAsComparable(n, out);
     }
-}
-
-template <is_decimal T>
-void ColumnDecimal<T>::batchSerializeComparableIntoMemory(
-    PaddedPODArray<char *> & memories) const
-{
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
-}
-
-template <is_decimal T>
-void ColumnDecimal<T>::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
-{
-    size_t rows = data.size();
-    if (sizes.empty())
-        sizes.resize_fill(rows);
-    else if (sizes.size() != rows)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
-
-    for (auto & sz : sizes)
-        sz += sizeof(T);
 }
 
 template class ColumnDecimal<Decimal32>;

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -716,17 +716,15 @@ template <is_decimal T>
 void ColumnDecimal<T>::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation) const
+    const IColumn::Permutation * permutation,
+    const UInt8 * null_map) const
 {
-    if (permutation)
+    for (size_t r = 0; r < num_rows; ++r)
     {
-        for (size_t r = 0; r < num_rows; ++r)
-            serializeAsComparable((*permutation)[r], out[r]);
-    }
-    else
-    {
-        for (size_t r = 0; r < num_rows; ++r)
-            serializeAsComparable(r, out[r]);
+        const size_t src = permutation ? (*permutation)[r] : r;
+        if (null_map && null_map[src])
+            continue;
+        serializeAsComparable(src, out[r]);
     }
 }
 

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -25,9 +25,6 @@
 
 #include <Processors/Transforms/ColumnGathererTransform.h>
 
-#include <bit>
-#include <cstring>
-
 #include <base/TypeName.h>
 #include <base/sort.h>
 
@@ -42,7 +39,6 @@ namespace ErrorCodes
     extern const int PARAMETER_OUT_OF_BOUND;
     extern const int SIZES_OF_COLUMNS_DOESNT_MATCH;
     extern const int NOT_IMPLEMENTED;
-    extern const int LOGICAL_ERROR;
 }
 
 template <is_decimal T>

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -698,7 +698,7 @@ template <is_decimal T>
 void ColumnDecimal<T>::serializeAsComparable(size_t n, String & out) const
 {
     using Native = T::NativeType;
-    if constexpr (std::is_integral_v<Native> || is_big_int_v<Native>)
+    if constexpr (!std::is_same_v<T, Time64> && (std::is_integral_v<Native> || is_big_int_v<Native>))
     {
         Native value = data[n].value;
         transformEndianness<std::endian::big>(value);

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -712,6 +712,24 @@ void ColumnDecimal<T>::serializeAsComparable(size_t n, String & out) const
     }
 }
 
+template <is_decimal T>
+void ColumnDecimal<T>::batchSerializeAsComparable(
+    size_t num_rows,
+    VectorWithMemoryTracking<String> & out,
+    const IColumn::Permutation * permutation) const
+{
+    if (permutation)
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serializeAsComparable((*permutation)[r], out[r]);
+    }
+    else
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serializeAsComparable(r, out[r]);
+    }
+}
+
 template class ColumnDecimal<Decimal32>;
 template class ColumnDecimal<Decimal64>;
 template class ColumnDecimal<Decimal128>;

--- a/src/Columns/ColumnDecimal.cpp
+++ b/src/Columns/ColumnDecimal.cpp
@@ -719,13 +719,9 @@ void ColumnDecimal<T>::batchSerializeAsComparable(
     const IColumn::Permutation * permutation,
     const UInt8 * null_map) const
 {
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        serializeAsComparable(src, out[r]);
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, null_map,
+        [this](size_t src, String & dst) { serializeAsComparable(src, dst); });
 }
 
 template class ColumnDecimal<Decimal32>;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -162,10 +162,7 @@ public:
 
     UInt32 getScale() const { return scale; }
 
-    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const final;
-    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const final;
-    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const final;
-    bool supportsComparableSerialization() const final { return !std::is_same_v<T, Time64>; }
+    void serializeAsComparable(size_t n, String & out) const final;
 
 protected:
     Container data;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -162,6 +162,11 @@ public:
 
     UInt32 getScale() const { return scale; }
 
+    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const final;
+    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const final;
+    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const final;
+    bool supportsComparableSerialization() const final { return !std::is_same_v<T, Time64>; }
+
 protected:
     Container data;
     UInt32 scale;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -164,6 +164,8 @@ public:
 
     void serializeAsComparable(size_t n, String & out) const final;
 
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+
 protected:
     Container data;
     UInt32 scale;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -164,7 +164,7 @@ public:
 
     void serializeAsComparable(size_t n, String & out) const final;
 
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
 
 protected:
     Container data;

--- a/src/Columns/ColumnDecimal.h
+++ b/src/Columns/ColumnDecimal.h
@@ -164,7 +164,7 @@ public:
 
     void serializeAsComparable(size_t n, String & out) const final;
 
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map) const override;
 
 protected:
     Container data;

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -616,7 +616,7 @@ void ColumnFixedString::serializeAsComparable(size_t row, String & out) const
 
 void ColumnFixedString::batchSerializeAsComparable(
     size_t num_rows,
-    std::vector<String> & out,
+    VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
     for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -609,4 +609,30 @@ std::span<char> ColumnFixedString::insertRawUninitialized(size_t count)
     return {reinterpret_cast<char *>(chars.data() + start), count * n};
 }
 
+ALWAYS_INLINE char * ColumnFixedString::serializeValueIntoMemoryAsComparable(size_t row, char * memory) const
+{
+    memcpy(memory, &chars[row * n], n);
+    return memory + n;
+}
+
+void ColumnFixedString::batchSerializeComparableIntoMemory(
+    PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
+void ColumnFixedString::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
+{
+    size_t rows = size();
+    if (sizes.empty())
+        sizes.resize_fill(rows);
+    else if (sizes.size() != rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
+
+    for (auto & sz : sizes)
+        sz += n;
+}
+
 }

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -609,30 +609,21 @@ std::span<char> ColumnFixedString::insertRawUninitialized(size_t count)
     return {reinterpret_cast<char *>(chars.data() + start), count * n};
 }
 
-ALWAYS_INLINE char * ColumnFixedString::serializeValueIntoMemoryAsComparable(size_t row, char * memory) const
+void ColumnFixedString::serializeAsComparable(size_t row, String & out) const
 {
-    memcpy(memory, &chars[row * n], n);
-    return memory + n;
+    out.append(reinterpret_cast<const char *>(&chars[row * n]), n);
 }
 
-void ColumnFixedString::batchSerializeComparableIntoMemory(
-    PaddedPODArray<char *> & memories) const
+void ColumnFixedString::batchSerializeAsComparable(
+    size_t num_rows,
+    std::vector<String> & out,
+    const IColumn::Permutation * permutation) const
 {
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
-}
-
-void ColumnFixedString::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
-{
-    size_t rows = size();
-    if (sizes.empty())
-        sizes.resize_fill(rows);
-    else if (sizes.size() != rows)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
-
-    for (auto & sz : sizes)
-        sz += n;
+    for (size_t r = 0; r < num_rows; ++r)
+    {
+        const size_t src = permutation ? (*permutation)[r] : r;
+        out[r].append(reinterpret_cast<const char *>(&chars[src * n]), n);
+    }
 }
 
 }

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -620,13 +620,10 @@ void ColumnFixedString::batchSerializeAsComparable(
     const IColumn::Permutation * permutation,
     const UInt8 * null_map) const
 {
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        out[r].append(reinterpret_cast<const char *>(&chars[src * n]), n);
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, null_map,
+        [this](size_t src, String & dst)
+        { dst.append(reinterpret_cast<const char *>(&chars[src * n]), n); });
 }
 
 }

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -617,11 +617,14 @@ void ColumnFixedString::serializeAsComparable(size_t row, String & out) const
 void ColumnFixedString::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation) const
+    const IColumn::Permutation * permutation,
+    const UInt8 * null_map) const
 {
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
+        if (null_map && null_map[src])
+            continue;
         out[r].append(reinterpret_cast<const char *>(&chars[src * n]), n);
     }
 }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -232,7 +232,7 @@ public:
     std::string_view getRawData() const override { return {reinterpret_cast<const char *>(chars.data()), chars.size()}; }
     std::span<char> insertRawUninitialized(size_t count) override;
 
-    void serializeAsComparable(size_t n, String & out) const override;
+    void serializeAsComparable(size_t row, String & out) const override;
     void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
 
     /// Specialized part of interface, not from IColumn.

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -233,7 +233,7 @@ public:
     std::span<char> insertRawUninitialized(size_t count) override;
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
 
     /// Specialized part of interface, not from IColumn.
     void insertString(const String & string) { insertData(string.c_str(), string.size()); }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -233,7 +233,7 @@ public:
     std::span<char> insertRawUninitialized(size_t count) override;
 
     void serializeAsComparable(size_t row, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map) const override;
 
     /// Specialized part of interface, not from IColumn.
     void insertString(const String & string) { insertData(string.c_str(), string.size()); }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -232,10 +232,8 @@ public:
     std::string_view getRawData() const override { return {reinterpret_cast<const char *>(chars.data()), chars.size()}; }
     std::span<char> insertRawUninitialized(size_t count) override;
 
-    char * serializeValueIntoMemoryAsComparable(size_t row, char * memory) const override;
-    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
-    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
-    bool supportsComparableSerialization() const override { return true; }
+    void serializeAsComparable(size_t n, String & out) const override;
+    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
 
     /// Specialized part of interface, not from IColumn.
     void insertString(const String & string) { insertData(string.c_str(), string.size()); }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -232,6 +232,11 @@ public:
     std::string_view getRawData() const override { return {reinterpret_cast<const char *>(chars.data()), chars.size()}; }
     std::span<char> insertRawUninitialized(size_t count) override;
 
+    char * serializeValueIntoMemoryAsComparable(size_t row, char * memory) const override;
+    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
+    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
+    bool supportsComparableSerialization() const override { return true; }
+
     /// Specialized part of interface, not from IColumn.
     void insertString(const String & string) { insertData(string.c_str(), string.size()); }
     Chars & getChars() { return chars; }

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -233,7 +233,7 @@ public:
     std::span<char> insertRawUninitialized(size_t count) override;
 
     void serializeAsComparable(size_t row, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
 
     /// Specialized part of interface, not from IColumn.
     void insertString(const String & string) { insertData(string.c_str(), string.size()); }

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1064,6 +1064,52 @@ void ColumnNullable::takeOrCalculateStatisticsFrom(const VectorWithMemoryTrackin
     nested_column->takeOrCalculateStatisticsFrom(nested_source_columns);
 }
 
+ALWAYS_INLINE char * ColumnNullable::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+{
+    const auto & null_map_data = getNullMapData();
+    /// NULL flag: 0x00 = non-NULL (sorts before), 0x01 = NULL (sorts after).
+    if (null_map_data[n])
+    {
+        *memory++ = 0x01;
+        return memory;
+    }
+    *memory++ = 0x00;
+    return nested_column->serializeValueIntoMemoryAsComparable(n, memory);
+}
+
+void ColumnNullable::batchSerializeComparableIntoMemory(
+    PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
+void ColumnNullable::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
+{
+    const auto & null_map_data = getNullMapData();
+    size_t rows = size();
+    if (sizes.empty())
+        sizes.resize_fill(rows);
+    else if (sizes.size() != rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
+
+    /// 1 byte per row for null flag.
+    for (auto & sz : sizes)
+        sz += 1;
+
+    /// For non-null rows, accumulate nested column's per-row sizes.
+    /// First collect nested sizes, then add only for non-null rows.
+    PaddedPODArray<UInt64> nested_sizes;
+    nested_column->collectComparableSerializedRowSizes(nested_sizes);
+
+    for (size_t i = 0; i < rows; ++i)
+    {
+        if (!null_map_data[i])
+            sizes[i] += nested_sizes[i];
+    }
+}
+
 ColumnPtr makeNullable(const ColumnPtr & column)
 {
     if (isColumnNullable(*column))

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1064,49 +1064,27 @@ void ColumnNullable::takeOrCalculateStatisticsFrom(const VectorWithMemoryTrackin
     nested_column->takeOrCalculateStatisticsFrom(nested_source_columns);
 }
 
-ALWAYS_INLINE char * ColumnNullable::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 {
     const auto & null_map_data = getNullMapData();
-    /// NULL flag: 0x00 = non-NULL (sorts before), 0x01 = NULL (sorts after).
     if (null_map_data[n])
     {
-        *memory++ = 0x01;
-        return memory;
+        out.push_back('\x01');
+        return;
     }
-    *memory++ = 0x00;
-    return nested_column->serializeValueIntoMemoryAsComparable(n, memory);
+    out.push_back('\x00');
+    nested_column->serializeAsComparable(n, out);
 }
 
-void ColumnNullable::batchSerializeComparableIntoMemory(
-    PaddedPODArray<char *> & memories) const
+void ColumnNullable::batchSerializeAsComparable(
+    size_t num_rows,
+    std::vector<String> & out,
+    const IColumn::Permutation * permutation) const
 {
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
-}
-
-void ColumnNullable::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
-{
-    const auto & null_map_data = getNullMapData();
-    size_t rows = size();
-    if (sizes.empty())
-        sizes.resize_fill(rows);
-    else if (sizes.size() != rows)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
-
-    /// 1 byte per row for null flag.
-    for (auto & sz : sizes)
-        sz += 1;
-
-    /// For non-null rows, accumulate nested column's per-row sizes.
-    /// First collect nested sizes, then add only for non-null rows.
-    PaddedPODArray<UInt64> nested_sizes;
-    nested_column->collectComparableSerializedRowSizes(nested_sizes);
-
-    for (size_t i = 0; i < rows; ++i)
+    for (size_t r = 0; r < num_rows; ++r)
     {
-        if (!null_map_data[i])
-            sizes[i] += nested_sizes[i];
+        const size_t src = permutation ? (*permutation)[r] : r;
+        serializeAsComparable(src, out[r]);
     }
 }
 

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1064,36 +1064,31 @@ void ColumnNullable::takeOrCalculateStatisticsFrom(const VectorWithMemoryTrackin
     nested_column->takeOrCalculateStatisticsFrom(nested_source_columns);
 }
 
-namespace
+/// Leading flag byte of a Nullable row's comparable encoding. `\x00` (non-NULL)
+/// sorts before `\x01` (NULL), so NULLs compare greater, matching compareAt with
+/// null_direction_hint = 1. A non-NULL row is `\x00` followed by the nested value's
+/// encoding; a NULL row is just `\x01`.
+void ColumnNullable::validateNestedComparable() const
 {
-    /// Encode one Nullable row: a leading NULL flag plus the nested encoding for
-    /// non-NULL values. `\x00` (non-NULL) sorts before `\x01` (NULL), so NULLs
-    /// compare greater, matching compareAt with null_direction_hint = 1.
-    /// Assumes the nested type has already been validated by the caller.
-    void serializeNullableRow(const IColumn & nested_column, const NullMap & null_map_data, size_t n, String & out)
-    {
-        if (null_map_data[n])
-        {
-            out.push_back('\x01');
-            return;
-        }
-        out.push_back('\x00');
-        nested_column.serializeAsComparable(n, out);
-    }
+    /// A NULL row emits only the flag byte and never touches the nested column, so an
+    /// unsupported nested type (e.g. LowCardinality, Array) would slip through silently.
+    /// Probe row 0 once so every row rejects the same types a non-NULL row would, even
+    /// in an all-NULL block. Not on the hot path.
+    String probe;
+    nested_column->serializeAsComparable(0, probe);
 }
 
 void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 {
     const auto & null_map_data = getNullMapData();
-    /// A NULL row would otherwise skip the nested column entirely, silently accepting
-    /// unsupported nested types (e.g. LowCardinality, Array). Probe the nested column
-    /// on NULL rows so they reject the same types a non-NULL row would.
     if (null_map_data[n])
     {
-        String probe;
-        nested_column->serializeAsComparable(0, probe);
+        validateNestedComparable();
+        out.push_back('\x01');
+        return;
     }
-    serializeNullableRow(*nested_column, null_map_data, n, out);
+    out.push_back('\x00');
+    nested_column->serializeAsComparable(n, out);
 }
 
 void ColumnNullable::batchSerializeAsComparable(
@@ -1104,16 +1099,30 @@ void ColumnNullable::batchSerializeAsComparable(
     if (num_rows == 0)
         return;
 
-    /// Validate the nested type once here rather than per row, so an all-NULL block
-    /// still rejects unsupported nested types without repeating the probe.
-    String probe;
-    nested_column->serializeAsComparable(0, probe);
+    validateNestedComparable();
+
+    /// Encode the nested values in one shot: a single virtual dispatch into the nested
+    /// concrete type, then its own monomorphic row loop (e.g. ColumnVector<UInt64>).
+    /// This is what keeps Nullable(UInt64) / Nullable(DateTime64) UNIQUE KEY batches
+    /// off the per-row single-row virtual. `nested_out` is a scratch buffer because the
+    /// nested column knows nothing about the NULL flag: we splice the flag in below.
+    VectorWithMemoryTracking<String> nested_out;
+    nested_out.resize(num_rows);
+    nested_column->batchSerializeAsComparable(num_rows, nested_out, permutation);
 
     const auto & null_map_data = getNullMapData();
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
-        serializeNullableRow(*nested_column, null_map_data, src, out[r]);
+        if (null_map_data[src])
+        {
+            out[r].push_back('\x01');
+        }
+        else
+        {
+            out[r].push_back('\x00');
+            out[r].append(nested_out[r]);
+        }
     }
 }
 

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1064,16 +1064,36 @@ void ColumnNullable::takeOrCalculateStatisticsFrom(const VectorWithMemoryTrackin
     nested_column->takeOrCalculateStatisticsFrom(nested_source_columns);
 }
 
+namespace
+{
+    /// Encode one Nullable row: a leading NULL flag plus the nested encoding for
+    /// non-NULL values. `\x00` (non-NULL) sorts before `\x01` (NULL), so NULLs
+    /// compare greater, matching compareAt with null_direction_hint = 1.
+    /// Assumes the nested type has already been validated by the caller.
+    void serializeNullableRow(const IColumn & nested_column, const NullMap & null_map_data, size_t n, String & out)
+    {
+        if (null_map_data[n])
+        {
+            out.push_back('\x01');
+            return;
+        }
+        out.push_back('\x00');
+        nested_column.serializeAsComparable(n, out);
+    }
+}
+
 void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 {
     const auto & null_map_data = getNullMapData();
+    /// A NULL row would otherwise skip the nested column entirely, silently accepting
+    /// unsupported nested types (e.g. LowCardinality, Array). Probe the nested column
+    /// on NULL rows so they reject the same types a non-NULL row would.
     if (null_map_data[n])
     {
-        out.push_back('\x01');
-        return;
+        String probe;
+        nested_column->serializeAsComparable(0, probe);
     }
-    out.push_back('\x00');
-    nested_column->serializeAsComparable(n, out);
+    serializeNullableRow(*nested_column, null_map_data, n, out);
 }
 
 void ColumnNullable::batchSerializeAsComparable(
@@ -1084,19 +1104,16 @@ void ColumnNullable::batchSerializeAsComparable(
     if (num_rows == 0)
         return;
 
-    /// Eagerly validate that the nested type supports comparable serialization.
-    /// Without this, an all-NULL block would skip nested_column->serializeAsComparable
-    /// entirely, silently accepting unsupported nested types (e.g. LowCardinality, Array).
-    /// rejects unsupported key types.
-    {
-        String probe;
-        nested_column->serializeAsComparable(0, probe);
-    }
+    /// Validate the nested type once here rather than per row, so an all-NULL block
+    /// still rejects unsupported nested types without repeating the probe.
+    String probe;
+    nested_column->serializeAsComparable(0, probe);
 
+    const auto & null_map_data = getNullMapData();
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
-        serializeAsComparable(src, out[r]);
+        serializeNullableRow(*nested_column, null_map_data, src, out[r]);
     }
 }
 

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1078,7 +1078,7 @@ void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 
 void ColumnNullable::batchSerializeAsComparable(
     size_t num_rows,
-    std::vector<String> & out,
+    VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
     for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1081,6 +1081,9 @@ void ColumnNullable::batchSerializeAsComparable(
     VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
+    if (num_rows == 0)
+        return;
+
     /// Eagerly validate that the nested type supports comparable serialization.
     /// Without this, an all-NULL block would skip nested_column->serializeAsComparable
     /// entirely, silently accepting unsupported nested types (e.g. LowCardinality, Array).

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1094,36 +1094,44 @@ void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 void ColumnNullable::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation) const
+    const IColumn::Permutation * permutation,
+    const UInt8 * outer_null_map) const
 {
     if (num_rows == 0)
         return;
 
     validateNestedComparable();
 
-    /// Encode the nested values in one shot: a single virtual dispatch into the nested
-    /// concrete type, then its own monomorphic row loop (e.g. ColumnVector<UInt64>).
-    /// This is what keeps Nullable(UInt64) / Nullable(DateTime64) UNIQUE KEY batches
-    /// off the per-row single-row virtual. `nested_out` is a scratch buffer because the
-    /// nested column knows nothing about the NULL flag: we splice the flag in below.
-    VectorWithMemoryTracking<String> nested_out;
-    nested_out.resize(num_rows);
-    nested_column->batchSerializeAsComparable(num_rows, nested_out, permutation);
-
+    /// Write the null flag for every row first: NULL=0x01 (sorts after),
+    /// non-NULL=0x00 (sorts before) — matches compareAt with nulls_direction=1.
+    /// A row that is NULL either here or in an outer wrapper contributes only
+    /// this flag and no nested payload.
     const auto & null_map_data = getNullMapData();
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map_data[src])
-        {
-            out[r].push_back('\x01');
-        }
-        else
-        {
-            out[r].push_back('\x00');
-            out[r].append(nested_out[r]);
-        }
+        if (outer_null_map && outer_null_map[src])
+            continue;
+        out[r].push_back(null_map_data[src] ? '\x01' : '\x00');
     }
+
+    /// Encode the nested values in one shot: a single virtual dispatch into the
+    /// nested concrete type, then its own monomorphic row loop (e.g.
+    /// ColumnVector<UInt64>). Passing our null map lets the nested loop skip NULL
+    /// rows and append non-NULL payload directly into `out[r]` — no scratch buffer,
+    /// no second copy, and NULL rows never materialize hidden nested payload.
+    /// `outer_null_map` (if any) also propagates so a row masked by an enclosing
+    /// wrapper is skipped too.
+    const UInt8 * effective_null_map = null_map_data.data();
+    PaddedPODArray<UInt8> merged_null_map;
+    if (outer_null_map)
+    {
+        merged_null_map.resize(null_map_data.size());
+        for (size_t i = 0; i < null_map_data.size(); ++i)
+            merged_null_map[i] = null_map_data[i] | outer_null_map[i];
+        effective_null_map = merged_null_map.data();
+    }
+    nested_column->batchSerializeAsComparable(num_rows, out, permutation, effective_null_map);
 }
 
 ColumnPtr makeNullable(const ColumnPtr & column)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -7,6 +7,7 @@
 #include <Common/SipHash.h>
 #include <Common/assert_cast.h>
 #include <Columns/ColumnNullable.h>
+#include <Columns/IColumnImpl.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnCompressed.h>
 #include <Columns/ColumnLowCardinality.h>
@@ -1064,20 +1065,20 @@ void ColumnNullable::takeOrCalculateStatisticsFrom(const VectorWithMemoryTrackin
     nested_column->takeOrCalculateStatisticsFrom(nested_source_columns);
 }
 
-/// Leading flag byte of a Nullable row's comparable encoding. `\x00` (non-NULL)
-/// sorts before `\x01` (NULL), so NULLs compare greater, matching compareAt with
-/// null_direction_hint = 1. A non-NULL row is `\x00` followed by the nested value's
-/// encoding; a NULL row is just `\x01`.
+/// A NULL row emits only the flag byte and never touches the nested column, so an
+/// unsupported nested type (e.g. LowCardinality, Array) would slip through silently.
+/// Probe row 0 once so every row rejects the same types a non-NULL row would, even
+/// in an all-NULL block. Not on the hot path.
 void ColumnNullable::validateNestedComparable() const
 {
-    /// A NULL row emits only the flag byte and never touches the nested column, so an
-    /// unsupported nested type (e.g. LowCardinality, Array) would slip through silently.
-    /// Probe row 0 once so every row rejects the same types a non-NULL row would, even
-    /// in an all-NULL block. Not on the hot path.
     String probe;
     nested_column->serializeAsComparable(0, probe);
 }
 
+/// Leading flag byte of a Nullable row's comparable encoding. `\x00` (non-NULL)
+/// sorts before `\x01` (NULL), so NULLs compare greater, matching compareAt with
+/// null_direction_hint = 1. A non-NULL row is `\x00` followed by the nested value's
+/// encoding; a NULL row is just `\x01`.
 void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 {
     const auto & null_map_data = getNullMapData();
@@ -1094,7 +1095,7 @@ void ColumnNullable::serializeAsComparable(size_t n, String & out) const
 void ColumnNullable::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation,
+    const Permutation * permutation,
     const UInt8 * outer_null_map) const
 {
     if (num_rows == 0)
@@ -1102,26 +1103,14 @@ void ColumnNullable::batchSerializeAsComparable(
 
     validateNestedComparable();
 
-    /// Write the null flag for every row first: NULL=0x01 (sorts after),
-    /// non-NULL=0x00 (sorts before) — matches compareAt with nulls_direction=1.
-    /// A row that is NULL either here or in an outer wrapper contributes only
-    /// this flag and no nested payload.
+    /// Write the null flag for every row: NULL=0x01 (sorts after), non-NULL=0x00.
     const auto & null_map_data = getNullMapData();
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (outer_null_map && outer_null_map[src])
-            continue;
-        out[r].push_back(null_map_data[src] ? '\x01' : '\x00');
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, outer_null_map,
+        [&](size_t src, String & dst) { dst.push_back(null_map_data[src] ? '\x01' : '\x00'); });
 
-    /// Encode the nested values in one shot: a single virtual dispatch into the
-    /// nested concrete type, then its own monomorphic row loop (e.g.
-    /// ColumnVector<UInt64>). Passing our null map lets the nested loop skip NULL
-    /// rows and append non-NULL payload directly into `out[r]` — no scratch buffer,
-    /// no second copy, and NULL rows never materialize hidden nested payload.
-    /// `outer_null_map` (if any) also propagates so a row masked by an enclosing
-    /// wrapper is skipped too.
+    /// Encode the nested values with one virtual dispatch; the merged null map
+    /// lets the nested loop skip NULL rows.
     const UInt8 * effective_null_map = null_map_data.data();
     PaddedPODArray<UInt8> merged_null_map;
     if (outer_null_map)

--- a/src/Columns/ColumnNullable.cpp
+++ b/src/Columns/ColumnNullable.cpp
@@ -1081,6 +1081,15 @@ void ColumnNullable::batchSerializeAsComparable(
     VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
+    /// Eagerly validate that the nested type supports comparable serialization.
+    /// Without this, an all-NULL block would skip nested_column->serializeAsComparable
+    /// entirely, silently accepting unsupported nested types (e.g. LowCardinality, Array).
+    /// rejects unsupported key types.
+    {
+        String probe;
+        nested_column->serializeAsComparable(0, probe);
+    }
+
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -208,6 +208,11 @@ public:
     bool onlyNull() const override { return nested_column->isDummy(); }
     bool isCollationSupported() const override { return nested_column->isCollationSupported(); }
 
+    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
+    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
+    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
+    bool supportsComparableSerialization() const override { return nested_column->supportsComparableSerialization(); }
+
 
     /// Return the column that represents values.
     IColumn & getNestedColumn() { return *nested_column; }

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -208,10 +208,8 @@ public:
     bool onlyNull() const override { return nested_column->isDummy(); }
     bool isCollationSupported() const override { return nested_column->isCollationSupported(); }
 
-    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
-    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
-    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
-    bool supportsComparableSerialization() const override { return nested_column->supportsComparableSerialization(); }
+    void serializeAsComparable(size_t n, String & out) const override;
+    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
 
 
     /// Return the column that represents values.

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -209,7 +209,7 @@ public:
     bool isCollationSupported() const override { return nested_column->isCollationSupported(); }
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map) const override;
 
 
     /// Return the column that represents values.

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -262,6 +262,10 @@ private:
     template <bool negative>
     void applyNullMapImpl(const NullMap & map, size_t offset = 0);
 
+    /// Probe the nested column's comparable serialization once so unsupported nested
+    /// types are rejected even on all-NULL blocks. Shared by the single-row and batch paths.
+    void validateNestedComparable() const;
+
     int compareAtImpl(size_t n, size_t m, const IColumn & rhs_, int null_direction_hint, const Collator * collator=nullptr) const;
 
     void getPermutationImpl(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -209,7 +209,7 @@ public:
     bool isCollationSupported() const override { return nested_column->isCollationSupported(); }
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
 
 
     /// Return the column that represents values.

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -209,7 +209,7 @@ public:
     bool isCollationSupported() const override { return nested_column->isCollationSupported(); }
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
 
 
     /// Return the column that represents values.

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -380,6 +380,57 @@ void ColumnString::skipSerializedInArena(ReadBuffer & in) const
     in.ignore(string_size);
 }
 
+/// Byte-comparable encoding: 0x00 inside string → [0x00, 0x01]; terminated with [0x00, 0x00].
+ALWAYS_INLINE char * ColumnString::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+{
+    size_t string_size = sizeAt(n);
+    auto offset = offsetAt(n);
+
+    for (size_t i = 0; i < string_size; ++i)
+    {
+        UInt8 byte = chars[offset + i];
+        *memory++ = static_cast<char>(byte);
+        if (byte == 0)
+            *memory++ = 1;
+    }
+
+    *memory++ = 0;
+    *memory++ = 0;
+    return memory;
+}
+
+void ColumnString::batchSerializeComparableIntoMemory(
+    PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
+void ColumnString::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
+{
+    if (empty())
+        return;
+
+    size_t rows = size();
+    if (sizes.empty())
+        sizes.resize_fill(rows);
+    else if (sizes.size() != rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
+
+    /// NUL-escape encoding: each byte is 1 byte, except 0x00 which becomes 2 bytes.
+    /// Terminator is 2 bytes (0x00 0x00).
+    for (size_t row = 0; row < rows; ++row)
+    {
+        size_t string_size = sizeAt(row);
+        auto offset = offsetAt(row);
+        size_t encoded_size = string_size + 2;
+        for (size_t i = 0; i < string_size; ++i)
+            encoded_size += (chars[offset + i] == 0);
+        sizes[row] += encoded_size;
+    }
+}
+
 ColumnPtr ColumnString::index(const IColumn & indexes, size_t limit) const
 {
     return selectIndexImpl(*this, indexes, limit);

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -1,5 +1,6 @@
 #include <Columns/ColumnString.h>
 
+#include <cstring>
 #include <Columns/Collator.h>
 #include <Columns/findEqualRangeEndAssumeSorted.h>
 #include <Columns/ColumnsCommon.h>
@@ -378,57 +379,6 @@ void ColumnString::skipSerializedInArena(ReadBuffer & in) const
     size_t string_size = 0;
     readBinaryLittleEndian<size_t>(string_size, in);
     in.ignore(string_size);
-}
-
-/// Byte-comparable encoding: 0x00 inside string → [0x00, 0x01]; terminated with [0x00, 0x00].
-ALWAYS_INLINE char * ColumnString::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
-{
-    size_t string_size = sizeAt(n);
-    auto offset = offsetAt(n);
-
-    for (size_t i = 0; i < string_size; ++i)
-    {
-        UInt8 byte = chars[offset + i];
-        *memory++ = static_cast<char>(byte);
-        if (byte == 0)
-            *memory++ = 1;
-    }
-
-    *memory++ = 0;
-    *memory++ = 0;
-    return memory;
-}
-
-void ColumnString::batchSerializeComparableIntoMemory(
-    PaddedPODArray<char *> & memories) const
-{
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
-}
-
-void ColumnString::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
-{
-    if (empty())
-        return;
-
-    size_t rows = size();
-    if (sizes.empty())
-        sizes.resize_fill(rows);
-    else if (sizes.size() != rows)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
-
-    /// NUL-escape encoding: each byte is 1 byte, except 0x00 which becomes 2 bytes.
-    /// Terminator is 2 bytes (0x00 0x00).
-    for (size_t row = 0; row < rows; ++row)
-    {
-        size_t string_size = sizeAt(row);
-        auto offset = offsetAt(row);
-        size_t encoded_size = string_size + 2;
-        for (size_t i = 0; i < string_size; ++i)
-            encoded_size += (chars[offset + i] == 0);
-        sizes[row] += encoded_size;
-    }
 }
 
 ColumnPtr ColumnString::index(const IColumn & indexes, size_t limit) const
@@ -933,6 +883,51 @@ ColumnPtr ColumnString::createSizeSubcolumn() const
     }
 
     return column_sizes;
+}
+
+/// Byte-comparable encoding: 0x00 → [0x00, 0x01]; terminated with [0x00, 0x00].
+/// Uses memchr+append fast path: no-NUL strings are copied in one append call.
+void ColumnString::serializeAsComparable(size_t n, String & out) const
+{
+    const size_t string_size = sizeAt(n);
+    const auto string_offset = offsetAt(n);
+    const char * src = reinterpret_cast<const char *>(&chars[string_offset]);
+    const char * const end = src + string_size;
+
+    out.reserve(out.size() + string_size + 2);
+
+    const char * p = static_cast<const char *>(std::memchr(src, '\0', string_size));
+    if (p == nullptr)
+    {
+        out.append(src, string_size);
+    }
+    else
+    {
+        const char * cursor = src;
+        do
+        {
+            out.append(cursor, p - cursor);
+            out.append("\0\x01", 2);
+            cursor = p + 1;
+            p = static_cast<const char *>(std::memchr(cursor, '\0', end - cursor));
+        }
+        while (p != nullptr);
+        out.append(cursor, end - cursor);
+    }
+
+    out.append("\0\x00", 2);
+}
+
+void ColumnString::batchSerializeAsComparable(
+    size_t num_rows,
+    std::vector<String> & out,
+    const IColumn::Permutation * permutation) const
+{
+    for (size_t r = 0; r < num_rows; ++r)
+    {
+        const size_t src = permutation ? (*permutation)[r] : r;
+        serializeAsComparable(src, out[r]);
+    }
 }
 
 }

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -921,11 +921,14 @@ void ColumnString::serializeAsComparable(size_t n, String & out) const
 void ColumnString::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation) const
+    const IColumn::Permutation * permutation,
+    const UInt8 * null_map) const
 {
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
+        if (null_map && null_map[src])
+            continue;
         serializeAsComparable(src, out[r]);
     }
 }

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -920,7 +920,7 @@ void ColumnString::serializeAsComparable(size_t n, String & out) const
 
 void ColumnString::batchSerializeAsComparable(
     size_t num_rows,
-    std::vector<String> & out,
+    VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
     for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -924,13 +924,9 @@ void ColumnString::batchSerializeAsComparable(
     const IColumn::Permutation * permutation,
     const UInt8 * null_map) const
 {
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        serializeAsComparable(src, out[r]);
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, null_map,
+        [this](size_t src, String & dst) { serializeAsComparable(src, dst); });
 }
 
 }

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -214,10 +214,8 @@ public:
 
     void batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *> & memories, const IColumn::SerializationSettings * settings) const override;
 
-    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
-    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
-    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
-    bool supportsComparableSerialization() const override { return true; }
+    void serializeAsComparable(size_t n, String & out) const override;
+    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -214,6 +214,11 @@ public:
 
     void batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *> & memories, const IColumn::SerializationSettings * settings) const override;
 
+    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
+    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
+    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
+    bool supportsComparableSerialization() const override { return true; }
+
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 
     void skipSerializedInArena(ReadBuffer & in) const override;

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -215,7 +215,7 @@ public:
     void batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *> & memories, const IColumn::SerializationSettings * settings) const override;
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -215,7 +215,7 @@ public:
     void batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *> & memories, const IColumn::SerializationSettings * settings) const override;
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -215,7 +215,7 @@ public:
     void batchSerializeValueIntoMemory(VectorWithMemoryTracking<char *> & memories, const IColumn::SerializationSettings * settings) const override;
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map) const override;
 
     void deserializeAndInsertFromArena(ReadBuffer & in, const IColumn::SerializationSettings * settings) override;
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -27,6 +27,7 @@
 #include <IO/ReadHelpers.h>
 
 #include <bit>
+#include <cmath>
 #include <cstring>
 
 #include "config.h"
@@ -1413,6 +1414,134 @@ std::span<char> ColumnVector<T>::insertRawUninitialized(size_t count)
     size_t start = data.size();
     data.resize(start + count);
     return {reinterpret_cast<char *>(data.data() + start), count * sizeof(T)};
+}
+
+template <typename T>
+ALWAYS_INLINE char * ColumnVector<T>::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+{
+    if constexpr (std::is_integral_v<T>)
+    {
+        auto value = data[n];
+        if constexpr (std::endian::native == std::endian::little)
+            value = std::byteswap(value);
+        if constexpr (std::is_signed_v<T>)
+        {
+            /// Flip sign bit for correct unsigned byte ordering.
+            char * bytes = reinterpret_cast<char *>(&value);
+            bytes[0] ^= 0x80;
+        }
+        memcpy(memory, &value, sizeof(T));
+        return memory + sizeof(T);
+    }
+    else if constexpr (is_big_int_v<T>)
+    {
+        auto value = data[n];
+        constexpr unsigned item_count = sizeof(T) / sizeof(uint64_t);
+        for (unsigned i = 0; i < item_count; ++i)
+        {
+            uint64_t item = value.items[T::_impl::big(i)];
+            if constexpr (std::endian::native == std::endian::little)
+                item = std::byteswap(item);
+            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
+        }
+        if constexpr (is_signed_v<T>)
+            memory[0] ^= 0x80;
+        return memory + sizeof(T);
+    }
+    else if constexpr (std::is_same_v<T, Float32>)
+    {
+        UInt32 bits = std::bit_cast<UInt32>(data[n]);
+        if (std::isnan(data[n]))
+        {
+            /// NaN → all-0xff sentinel (sorts after ±Inf).
+            bits = 0xffffffffU;
+        }
+        else
+        {
+            /// Collapse -0.0 → +0.0.
+            if (bits == 0x80000000U)
+                bits = 0;
+            /// IEEE-754 total order: invert all bits when negative, else flip sign bit.
+            if (bits & 0x80000000U)
+                bits = ~bits;
+            else
+                bits ^= 0x80000000U;
+        }
+        if constexpr (std::endian::native == std::endian::little)
+            bits = std::byteswap(bits);
+        memcpy(memory, &bits, sizeof(UInt32));
+        return memory + sizeof(UInt32);
+    }
+    else if constexpr (std::is_same_v<T, Float64>)
+    {
+        UInt64 bits = std::bit_cast<UInt64>(data[n]);
+        if (std::isnan(data[n]))
+        {
+            bits = 0xffffffffffffffffULL;
+        }
+        else
+        {
+            if (bits == 0x8000000000000000ULL)
+                bits = 0;
+            if (bits & 0x8000000000000000ULL)
+                bits = ~bits;
+            else
+                bits ^= 0x8000000000000000ULL;
+        }
+        if constexpr (std::endian::native == std::endian::little)
+            bits = std::byteswap(bits);
+        memcpy(memory, &bits, sizeof(UInt64));
+        return memory + sizeof(UInt64);
+    }
+    else if constexpr (std::is_same_v<T, UUID>)
+    {
+        const auto & under = data[n].toUnderType();
+        constexpr unsigned item_count = sizeof(UInt128) / sizeof(uint64_t);
+        for (unsigned i = 0; i < item_count; ++i)
+        {
+            uint64_t item = under.items[UInt128::_impl::big(i)];
+            if constexpr (std::endian::native == std::endian::little)
+                item = std::byteswap(item);
+            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
+        }
+        return memory + sizeof(UInt128);
+    }
+    else
+    {
+        return IColumn::serializeValueIntoMemoryAsComparable(n, memory);
+    }
+}
+
+template <typename T>
+void ColumnVector<T>::batchSerializeComparableIntoMemory(
+    PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
+template <typename T>
+void ColumnVector<T>::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
+{
+    size_t rows = data.size();
+    if (sizes.empty())
+        sizes.resize_fill(rows);
+    else if (sizes.size() != rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
+
+    for (auto & sz : sizes)
+        sz += sizeof(T);
+}
+
+template <typename T>
+bool ColumnVector<T>::supportsComparableSerialization() const
+{
+    return std::is_integral_v<T>
+        || is_big_int_v<T>
+        || std::is_same_v<T, Float32>
+        || std::is_same_v<T, Float64>
+        || std::is_same_v<T, UUID>;
 }
 
 /// Explicit template instantiations - to avoid code bloat in headers.

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -20,6 +20,7 @@
 #include <Common/RadixSort.h>
 #include <Common/SipHash.h>
 #include <Common/TargetSpecific.h>
+#include <Common/transformEndianness.h>
 #include <Common/assert_cast.h>
 #include <Common/findExtreme.h>
 #include <Common/iota.h>
@@ -1417,68 +1418,52 @@ std::span<char> ColumnVector<T>::insertRawUninitialized(size_t count)
 }
 
 template <typename T>
-ALWAYS_INLINE char * ColumnVector<T>::serializeValueIntoMemoryAsComparable(size_t n, char * memory) const
+void ColumnVector<T>::serializeAsComparable(size_t n, String & out) const
 {
     if constexpr (std::is_integral_v<T>)
     {
         auto value = data[n];
-        if constexpr (std::endian::native == std::endian::little)
-            value = std::byteswap(value);
+        transformEndianness<std::endian::big>(value);
         if constexpr (std::is_signed_v<T>)
         {
-            /// Flip sign bit for correct unsigned byte ordering.
             char * bytes = reinterpret_cast<char *>(&value);
             bytes[0] ^= 0x80;
         }
-        memcpy(memory, &value, sizeof(T));
-        return memory + sizeof(T);
+        out.append(reinterpret_cast<const char *>(&value), sizeof(T));
     }
     else if constexpr (is_big_int_v<T>)
     {
         auto value = data[n];
-        constexpr unsigned item_count = sizeof(T) / sizeof(uint64_t);
-        for (unsigned i = 0; i < item_count; ++i)
-        {
-            uint64_t item = value.items[T::_impl::big(i)];
-            if constexpr (std::endian::native == std::endian::little)
-                item = std::byteswap(item);
-            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
-        }
+        transformEndianness<std::endian::big>(value);
         if constexpr (is_signed_v<T>)
-            memory[0] ^= 0x80;
-        return memory + sizeof(T);
+        {
+            char * bytes = reinterpret_cast<char *>(&value);
+            bytes[0] ^= 0x80;
+        }
+        out.append(reinterpret_cast<const char *>(&value), sizeof(T));
     }
     else if constexpr (std::is_same_v<T, Float32>)
     {
         UInt32 bits = std::bit_cast<UInt32>(data[n]);
         if (std::isnan(data[n]))
-        {
-            /// NaN → all-0xff sentinel (sorts after ±Inf).
-            bits = 0xffffffffU;
-        }
+            bits = 0xFFFFFFFFU;
         else
         {
-            /// Collapse -0.0 → +0.0.
             if (bits == 0x80000000U)
                 bits = 0;
-            /// IEEE-754 total order: invert all bits when negative, else flip sign bit.
             if (bits & 0x80000000U)
                 bits = ~bits;
             else
                 bits ^= 0x80000000U;
         }
-        if constexpr (std::endian::native == std::endian::little)
-            bits = std::byteswap(bits);
-        memcpy(memory, &bits, sizeof(UInt32));
-        return memory + sizeof(UInt32);
+        transformEndianness<std::endian::big>(bits);
+        out.append(reinterpret_cast<const char *>(&bits), sizeof(UInt32));
     }
     else if constexpr (std::is_same_v<T, Float64>)
     {
         UInt64 bits = std::bit_cast<UInt64>(data[n]);
         if (std::isnan(data[n]))
-        {
-            bits = 0xffffffffffffffffULL;
-        }
+            bits = 0xFFFFFFFFFFFFFFFFULL;
         else
         {
             if (bits == 0x8000000000000000ULL)
@@ -1488,60 +1473,37 @@ ALWAYS_INLINE char * ColumnVector<T>::serializeValueIntoMemoryAsComparable(size_
             else
                 bits ^= 0x8000000000000000ULL;
         }
-        if constexpr (std::endian::native == std::endian::little)
-            bits = std::byteswap(bits);
-        memcpy(memory, &bits, sizeof(UInt64));
-        return memory + sizeof(UInt64);
+        transformEndianness<std::endian::big>(bits);
+        out.append(reinterpret_cast<const char *>(&bits), sizeof(UInt64));
     }
     else if constexpr (std::is_same_v<T, UUID>)
     {
-        const auto & under = data[n].toUnderType();
-        constexpr unsigned item_count = sizeof(UInt128) / sizeof(uint64_t);
-        for (unsigned i = 0; i < item_count; ++i)
-        {
-            uint64_t item = under.items[UInt128::_impl::big(i)];
-            if constexpr (std::endian::native == std::endian::little)
-                item = std::byteswap(item);
-            memcpy(memory + i * sizeof(uint64_t), &item, sizeof(uint64_t));
-        }
-        return memory + sizeof(UInt128);
+        auto value = data[n].toUnderType();
+        transformEndianness<std::endian::big>(value);
+        out.append(reinterpret_cast<const char *>(&value), sizeof(UInt128));
     }
     else
     {
-        return IColumn::serializeValueIntoMemoryAsComparable(n, memory);
+        IColumn::serializeAsComparable(n, out);
     }
 }
 
 template <typename T>
-void ColumnVector<T>::batchSerializeComparableIntoMemory(
-    PaddedPODArray<char *> & memories) const
+void ColumnVector<T>::batchSerializeAsComparable(
+    size_t num_rows,
+    std::vector<String> & out,
+    const IColumn::Permutation * permutation) const
 {
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
-}
-
-template <typename T>
-void ColumnVector<T>::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const
-{
-    size_t rows = data.size();
-    if (sizes.empty())
-        sizes.resize_fill(rows);
-    else if (sizes.size() != rows)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Size of sizes: {} doesn't match rows_num: {}. It is a bug", sizes.size(), rows);
-
-    for (auto & sz : sizes)
-        sz += sizeof(T);
-}
-
-template <typename T>
-bool ColumnVector<T>::supportsComparableSerialization() const
-{
-    return std::is_integral_v<T>
-        || is_big_int_v<T>
-        || std::is_same_v<T, Float32>
-        || std::is_same_v<T, Float64>
-        || std::is_same_v<T, UUID>;
+    if (permutation)
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serializeAsComparable((*permutation)[r], out[r]);
+    }
+    else
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serializeAsComparable(r, out[r]);
+    }
 }
 
 /// Explicit template instantiations - to avoid code bloat in headers.

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -1492,17 +1492,15 @@ template <typename T>
 void ColumnVector<T>::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const IColumn::Permutation * permutation) const
+    const IColumn::Permutation * permutation,
+    const UInt8 * null_map) const
 {
-    if (permutation)
+    for (size_t r = 0; r < num_rows; ++r)
     {
-        for (size_t r = 0; r < num_rows; ++r)
-            serializeAsComparable((*permutation)[r], out[r]);
-    }
-    else
-    {
-        for (size_t r = 0; r < num_rows; ++r)
-            serializeAsComparable(r, out[r]);
+        const size_t src = permutation ? (*permutation)[r] : r;
+        if (null_map && null_map[src])
+            continue;
+        serializeAsComparable(src, out[r]);
     }
 }
 

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -1491,7 +1491,7 @@ void ColumnVector<T>::serializeAsComparable(size_t n, String & out) const
 template <typename T>
 void ColumnVector<T>::batchSerializeAsComparable(
     size_t num_rows,
-    std::vector<String> & out,
+    VectorWithMemoryTracking<String> & out,
     const IColumn::Permutation * permutation) const
 {
     if (permutation)

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -1495,13 +1495,9 @@ void ColumnVector<T>::batchSerializeAsComparable(
     const IColumn::Permutation * permutation,
     const UInt8 * null_map) const
 {
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        serializeAsComparable(src, out[r]);
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, null_map,
+        [this](size_t src, String & dst) { serializeAsComparable(src, dst); });
 }
 
 /// Explicit template instantiations - to avoid code bloat in headers.

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -358,10 +358,8 @@ public:
     /// Replace elements that match the filter with zeroes. If inverted replaces not matched elements.
     void applyZeroMap(const IColumn::Filter & filt, bool inverted = false);
 
-    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
-    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
-    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
-    bool supportsComparableSerialization() const override;
+    void serializeAsComparable(size_t n, String & out) const override;
+    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
 
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -358,6 +358,11 @@ public:
     /// Replace elements that match the filter with zeroes. If inverted replaces not matched elements.
     void applyZeroMap(const IColumn::Filter & filt, bool inverted = false);
 
+    char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const override;
+    void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const override;
+    void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const override;
+    bool supportsComparableSerialization() const override;
+
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()
     {

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -359,7 +359,7 @@ public:
     void applyZeroMap(const IColumn::Filter & filt, bool inverted = false);
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map) const override;
 
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -359,7 +359,7 @@ public:
     void applyZeroMap(const IColumn::Filter & filt, bool inverted = false);
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, std::vector<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
 
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()

--- a/src/Columns/ColumnVector.h
+++ b/src/Columns/ColumnVector.h
@@ -359,7 +359,7 @@ public:
     void applyZeroMap(const IColumn::Filter & filt, bool inverted = false);
 
     void serializeAsComparable(size_t n, String & out) const override;
-    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation) const override;
+    void batchSerializeAsComparable(size_t num_rows, VectorWithMemoryTracking<String> & out, const IColumn::Permutation * permutation, const UInt8 * null_map = nullptr) const override;
 
     /** More efficient methods of manipulation - to manipulate with data directly. */
     Container & getData()

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -246,13 +246,9 @@ void IColumn::batchSerializeAsComparable(
     const Permutation * permutation,
     const UInt8 * null_map) const
 {
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        serializeAsComparable(src, out[r]);
-    }
+    batchSerializeAsComparableImpl(
+        num_rows, out, permutation, null_map,
+        [this](size_t src, String & dst) { serializeAsComparable(src, dst); });
 }
 
 void IColumn::updateAt(const IColumn &, size_t, size_t)

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -235,6 +235,23 @@ void IColumn::collectSerializedValueSizes(PaddedPODArray<UInt64> & sizes, const 
     }
 }
 
+char * IColumn::serializeValueIntoMemoryAsComparable(size_t /* n */, char * /* memory */) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method serializeValueIntoMemoryAsComparable is not supported for {}", getName());
+}
+
+void IColumn::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & /* sizes */) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method collectComparableSerializedRowSizes is not supported for {}", getName());
+}
+
+void IColumn::batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const
+{
+    const size_t num_rows = memories.size();
+    for (size_t i = 0; i < num_rows; ++i)
+        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+}
+
 void IColumn::updateAt(const IColumn &, size_t, size_t)
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method updateAt is not supported for {}", getName());

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -242,7 +242,7 @@ void IColumn::serializeAsComparable(size_t /* n */, String & /* out */) const
 
 void IColumn::batchSerializeAsComparable(
     size_t num_rows,
-    std::vector<String> & out,
+    VectorWithMemoryTracking<String> & out,
     const Permutation * permutation) const
 {
     for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -243,11 +243,14 @@ void IColumn::serializeAsComparable(size_t /* n */, String & /* out */) const
 void IColumn::batchSerializeAsComparable(
     size_t num_rows,
     VectorWithMemoryTracking<String> & out,
-    const Permutation * permutation) const
+    const Permutation * permutation,
+    const UInt8 * null_map) const
 {
     for (size_t r = 0; r < num_rows; ++r)
     {
         const size_t src = permutation ? (*permutation)[r] : r;
+        if (null_map && null_map[src])
+            continue;
         serializeAsComparable(src, out[r]);
     }
 }

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -235,21 +235,21 @@ void IColumn::collectSerializedValueSizes(PaddedPODArray<UInt64> & sizes, const 
     }
 }
 
-char * IColumn::serializeValueIntoMemoryAsComparable(size_t /* n */, char * /* memory */) const
+void IColumn::serializeAsComparable(size_t /* n */, String & /* out */) const
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method serializeValueIntoMemoryAsComparable is not supported for {}", getName());
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method serializeAsComparable is not supported for {}", getName());
 }
 
-void IColumn::collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & /* sizes */) const
+void IColumn::batchSerializeAsComparable(
+    size_t num_rows,
+    std::vector<String> & out,
+    const Permutation * permutation) const
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method collectComparableSerializedRowSizes is not supported for {}", getName());
-}
-
-void IColumn::batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const
-{
-    const size_t num_rows = memories.size();
-    for (size_t i = 0; i < num_rows; ++i)
-        memories[i] = serializeValueIntoMemoryAsComparable(i, memories[i]);
+    for (size_t r = 0; r < num_rows; ++r)
+    {
+        const size_t src = permutation ? (*permutation)[r] : r;
+        serializeAsComparable(src, out[r]);
+    }
 }
 
 void IColumn::updateAt(const IColumn &, size_t, size_t)

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -367,6 +367,27 @@ public:
     /// in a single step. For more details, refer to the HashMethodSerialized implementation.
     virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */, const SerializationSettings * settings) const;
 
+    /// Serialize n-th element into memory in a byte-comparable format.
+    /// memcmp on the output preserves the same ordering as compareAt.
+    /// Returns pointer past the last written byte.
+    virtual char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const;
+
+    /// Batch serialize all rows in column-outer fashion.
+    /// memories[i] is advanced past the last written byte for row i.
+    /// Only one virtual dispatch per column; inner loop is tight.
+    /// Default implementation calls serializeValueIntoMemoryAsComparable in a loop.
+    virtual void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const;
+
+    /// Accumulate per-row comparable serialized sizes into `sizes`.
+    /// sizes[i] += encoded_size_of_row(i). Used to pre-allocate a
+    /// contiguous buffer before column-outer serialization.
+    /// For fixed-width types, adds a constant per row.
+    /// For variable-width types (String), computes exact per-row overhead.
+    virtual void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const;
+
+    /// Whether this column type supports comparable serialization.
+    virtual bool supportsComparableSerialization() const { return false; }
+
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Note that it needs to deal with user input
     virtual void deserializeAndInsertFromArena(ReadBuffer & in, const SerializationSettings * settings) = 0;

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -374,12 +374,17 @@ public:
     /// Batch serialize rows in column-outer fashion: one virtual dispatch per
     /// column, tight row loop inside. `out[r]` gets the encoding of row `src`
     /// where `src = permutation ? (*permutation)[r] : r`.
+    /// When `null_map` is non-null (set by a Nullable wrapper), rows whose
+    /// `null_map[src]` is set are skipped: nothing is appended for them, so the
+    /// wrapper's null flag is the whole encoding of a NULL row. This keeps NULL
+    /// rows from materializing hidden nested payload and avoids a second copy.
     /// Default implementation calls serializeAsComparable in a loop.
     using Permutation = IColumnPermutation;
     virtual void batchSerializeAsComparable(
         size_t num_rows,
         VectorWithMemoryTracking<String> & out,
-        const Permutation * permutation) const;
+        const Permutation * permutation,
+        const UInt8 * null_map = nullptr) const;
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Note that it needs to deal with user input

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -378,7 +378,7 @@ public:
     using Permutation = IColumnPermutation;
     virtual void batchSerializeAsComparable(
         size_t num_rows,
-        std::vector<String> & out,
+        VectorWithMemoryTracking<String> & out,
         const Permutation * permutation) const;
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -379,12 +379,17 @@ public:
     /// wrapper's null flag is the whole encoding of a NULL row. This keeps NULL
     /// rows from materializing hidden nested payload and avoids a second copy.
     /// Default implementation calls serializeAsComparable in a loop.
+    ///
+    /// Precondition: when `permutation` is non-null it must contain exactly
+    /// `num_rows` entries and every entry must be < `size()`. The caller is
+    /// responsible for validating this; the implementation indexes
+    /// `(*permutation)[r]` directly without bounds checking.
     using Permutation = IColumnPermutation;
     virtual void batchSerializeAsComparable(
         size_t num_rows,
         VectorWithMemoryTracking<String> & out,
         const Permutation * permutation,
-        const UInt8 * null_map = nullptr) const;
+        const UInt8 * null_map) const;
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Note that it needs to deal with user input

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string_view>
+#include <vector>
 #include <Columns/IColumn_fwd.h>
 #include <Core/TypeId.h>
 #include <Common/AllocatorWithMemoryTracking.h>
@@ -367,26 +368,19 @@ public:
     /// in a single step. For more details, refer to the HashMethodSerialized implementation.
     virtual void collectSerializedValueSizes(PaddedPODArray<UInt64> & /* sizes */, const UInt8 * /* is_null */, const SerializationSettings * settings) const;
 
-    /// Serialize n-th element into memory in a byte-comparable format.
+    /// Append byte-comparable encoding of row n to `out`.
     /// memcmp on the output preserves the same ordering as compareAt.
-    /// Returns pointer past the last written byte.
-    virtual char * serializeValueIntoMemoryAsComparable(size_t n, char * memory) const;
+    virtual void serializeAsComparable(size_t n, String & out) const;
 
-    /// Batch serialize all rows in column-outer fashion.
-    /// memories[i] is advanced past the last written byte for row i.
-    /// Only one virtual dispatch per column; inner loop is tight.
-    /// Default implementation calls serializeValueIntoMemoryAsComparable in a loop.
-    virtual void batchSerializeComparableIntoMemory(PaddedPODArray<char *> & memories) const;
-
-    /// Accumulate per-row comparable serialized sizes into `sizes`.
-    /// sizes[i] += encoded_size_of_row(i). Used to pre-allocate a
-    /// contiguous buffer before column-outer serialization.
-    /// For fixed-width types, adds a constant per row.
-    /// For variable-width types (String), computes exact per-row overhead.
-    virtual void collectComparableSerializedRowSizes(PaddedPODArray<UInt64> & sizes) const;
-
-    /// Whether this column type supports comparable serialization.
-    virtual bool supportsComparableSerialization() const { return false; }
+    /// Batch serialize rows in column-outer fashion: one virtual dispatch per
+    /// column, tight row loop inside. `out[r]` gets the encoding of row `src`
+    /// where `src = permutation ? (*permutation)[r] : r`.
+    /// Default implementation calls serializeAsComparable in a loop.
+    using Permutation = IColumnPermutation;
+    virtual void batchSerializeAsComparable(
+        size_t num_rows,
+        std::vector<String> & out,
+        const Permutation * permutation) const;
 
     /// Deserializes a value that was serialized using IColumn::serializeValueIntoArena method.
     /// Note that it needs to deal with user input
@@ -463,7 +457,6 @@ public:
 
     /// Permutes elements using specified permutation. Is used in sorting.
     /// limit - if it isn't 0, puts only first limit elements in the result.
-    using Permutation = IColumnPermutation;
     [[nodiscard]] virtual Ptr permute(const Permutation & perm, size_t limit) const = 0;
 
     /// Creates new column with values column[indexes[:limit]]. If limit is 0, all indexes are used.

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string_view>
-#include <vector>
 #include <Columns/IColumn_fwd.h>
 #include <Core/TypeId.h>
 #include <Common/AllocatorWithMemoryTracking.h>

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -372,8 +372,11 @@ public:
     virtual void serializeAsComparable(size_t n, String & out) const;
 
     /// Batch serialize rows in column-outer fashion: one virtual dispatch per
-    /// column, tight row loop inside. `out[r]` gets the encoding of row `src`
-    /// where `src = permutation ? (*permutation)[r] : r`.
+    /// column, tight row loop inside. The encoding of row `src` (where
+    /// `src = permutation ? (*permutation)[r] : r`) is appended to `out[r]`;
+    /// existing contents of `out[r]` are preserved, not replaced. `out` is
+    /// grown to `num_rows` if it is shorter, so the caller may pass an empty
+    /// vector.
     /// When `null_map` is non-null (set by a Nullable wrapper), rows whose
     /// `null_map[src]` is set are skipped: nothing is appended for them, so the
     /// wrapper's null flag is the whole encoding of a NULL row. This keeps NULL

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -371,22 +371,14 @@ public:
     /// memcmp on the output preserves the same ordering as compareAt.
     virtual void serializeAsComparable(size_t n, String & out) const;
 
-    /// Batch serialize rows in column-outer fashion: one virtual dispatch per
-    /// column, tight row loop inside. The encoding of row `src` (where
-    /// `src = permutation ? (*permutation)[r] : r`) is appended to `out[r]`;
-    /// existing contents of `out[r]` are preserved, not replaced. `out` is
-    /// grown to `num_rows` if it is shorter, so the caller may pass an empty
-    /// vector.
-    /// When `null_map` is non-null (set by a Nullable wrapper), rows whose
-    /// `null_map[src]` is set are skipped: nothing is appended for them, so the
-    /// wrapper's null flag is the whole encoding of a NULL row. This keeps NULL
-    /// rows from materializing hidden nested payload and avoids a second copy.
-    /// Default implementation calls serializeAsComparable in a loop.
+    /// Batch serialize rows: append the encoding of row `src` (where
+    /// `src = permutation ? (*permutation)[r] : r`) to `out[r]`. `out` is
+    /// grown to `num_rows` if needed; existing contents are preserved.
+    /// When `null_map` is non-null, rows with `null_map[src]` set are skipped.
     ///
-    /// Precondition: when `permutation` is non-null it must contain exactly
-    /// `num_rows` entries and every entry must be < `size()`. The caller is
-    /// responsible for validating this; the implementation indexes
-    /// `(*permutation)[r]` directly without bounds checking.
+    /// Precondition: `num_rows <= size()`; `permutation` (if non-null) has
+    /// `num_rows` entries each < `size()`; `null_map` (if non-null) has at
+    /// least `size()` elements. The caller must validate; no bounds checking.
     using Permutation = IColumnPermutation;
     virtual void batchSerializeAsComparable(
         size_t num_rows,

--- a/src/Columns/IColumnImpl.h
+++ b/src/Columns/IColumnImpl.h
@@ -220,6 +220,9 @@ void batchSerializeAsComparableImpl(
     const UInt8 * null_map,
     SerializeOne && serialize_one)
 {
+    if (out.size() < num_rows)
+        out.resize(num_rows);
+
     if (!permutation && !null_map)
     {
         for (size_t r = 0; r < num_rows; ++r)

--- a/src/Columns/IColumnImpl.h
+++ b/src/Columns/IColumnImpl.h
@@ -210,4 +210,41 @@ void IColumn::updatePermutationImpl(
     equal_ranges = std::move(new_ranges);
 }
 
+
+/// Shared skeleton for IColumn::batchSerializeAsComparable overrides.
+template <typename SerializeOne>
+void batchSerializeAsComparableImpl(
+    size_t num_rows,
+    VectorWithMemoryTracking<String> & out,
+    const IColumnPermutation * permutation,
+    const UInt8 * null_map,
+    SerializeOne && serialize_one)
+{
+    if (!permutation && !null_map)
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serialize_one(r, out[r]);
+    }
+    else if (!permutation)
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            if (!null_map[r])
+                serialize_one(r, out[r]);
+    }
+    else if (!null_map)
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+            serialize_one((*permutation)[r], out[r]);
+    }
+    else
+    {
+        for (size_t r = 0; r < num_rows; ++r)
+        {
+            const size_t src = (*permutation)[r];
+            if (!null_map[src])
+                serialize_one(src, out[r]);
+        }
+    }
+}
+
 }

--- a/src/Storages/MergeTree/UniqueKey/SSTIndexWriter.cpp
+++ b/src/Storages/MergeTree/UniqueKey/SSTIndexWriter.cpp
@@ -401,7 +401,7 @@ UInt64 SSTIndexWriter::writeFromBlock(
             "SSTIndexWriter::writeFromBlock: part has {} rows, exceeds UInt32 row-number capacity",
             num_rows);
 
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(uk_columns, permutation, max_encoded_size, encoded);
 
     SSTIndexWriter writer(part_storage, context);
@@ -469,7 +469,7 @@ UInt64 SSTIndexWriter::writeFromBlockUnsorted(
             uk_perm[i] = i;
     }
 
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(uk_columns, &uk_perm, max_encoded_size, encoded);
 
     /// Caller's `permutation` maps part_offset → source_row; invert once

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -2,7 +2,8 @@
 
 #include <Columns/ColumnNullable.h>
 #include <Common/Exception.h>
-#include <Common/PODArray.h>
+
+#include <cstddef>
 
 
 namespace DB
@@ -12,7 +13,6 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
-    extern const int NOT_IMPLEMENTED;
 }
 
 namespace UniqueKeyEncoding
@@ -42,59 +42,23 @@ void encodeBlock(
     if (num_rows == 0)
         return;
 
-    /// Materialize ColumnConst so comparable serialization works.
+    /// Materialize ColumnConst so batchSerializeAsComparable sees concrete column types.
     Columns materialized;
     materialized.reserve(columns.size());
     for (const auto & col : columns)
         materialized.push_back(col->convertToFullColumnIfConst());
 
-    /// Pre-check all columns support comparable serialization.
     for (const auto & col_ptr : materialized)
     {
-        const IColumn * col = col_ptr.get();
-        const IColumn * inner = col;
-        if (const auto * nullable = typeid_cast<const ColumnNullable *>(col))
-            inner = &nullable->getNestedColumn();
-        if (!inner->supportsComparableSerialization())
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                            "UNIQUE KEY encoding: column type {} is not supported",
-                            inner->getName());
-    }
+        col_ptr->batchSerializeAsComparable(num_rows, out, permutation);
 
-    /// Compute per-row serialized sizes (in original row order).
-    PaddedPODArray<UInt64> row_sizes;
-    for (const auto & col_ptr : materialized)
-        col_ptr->collectComparableSerializedRowSizes(row_sizes);
-
-    /// Pre-allocate per-row buffers in original row order.
-    /// memories[i] points to the buffer for source row i.
-    std::vector<String> row_buffers(num_rows);
-    PaddedPODArray<char *> memories(num_rows);
-    for (size_t i = 0; i < num_rows; ++i)
-    {
-        if (row_sizes[i] > max_size)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "UNIQUE KEY encoded size exceeds unique_key_max_encoded_size={} bytes",
-                            max_size);
-        row_buffers[i].resize(row_sizes[i]);
-        memories[i] = row_buffers[i].data();
-    }
-
-    /// Column-outer serialization: one virtual dispatch per column, zero extra copy.
-    /// No permutation needed — serializes in original row order like community batchSerializeValueIntoMemory.
-    for (const auto & col_ptr : materialized)
-        col_ptr->batchSerializeComparableIntoMemory(memories);
-
-    /// Output in permutation order.
-    if (permutation)
-    {
-        for (size_t i = 0; i < num_rows; ++i)
-            out[i] = std::move(row_buffers[(*permutation)[i]]);
-    }
-    else
-    {
-        for (size_t i = 0; i < num_rows; ++i)
-            out[i] = std::move(row_buffers[i]);
+        for (size_t r = 0; r < num_rows; ++r)
+        {
+            if (out[r].size() > max_size)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                                "UNIQUE KEY encoded size exceeds unique_key_max_encoded_size={} bytes",
+                                max_size);
+        }
     }
 }
 

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -1,20 +1,8 @@
 #include <Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h>
 
-#include <Columns/ColumnDecimal.h>
-#include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnNullable.h>
-#include <Columns/ColumnString.h>
-#include <Columns/ColumnVector.h>
-#include <Columns/ColumnsNumber.h>
 #include <Common/Exception.h>
-#include <Common/transformEndianness.h>
-#include <Core/TypeId.h>
-#include <DataTypes/IDataType.h>
-
-#include <bit>
-#include <cmath>
-#include <cstdint>
-#include <cstring>
+#include <Common/PODArray.h>
 
 
 namespace DB
@@ -25,320 +13,6 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
-}
-
-namespace
-{
-
-/// Order-preserving big-endian byte append. Reuses ClickHouse's
-/// `transformEndianness` so integer / wide-integer / float byte-swap shares
-/// the same primitive as the rest of the IO stack.
-template <typename T>
-void appendBigEndian(T v, String & out)
-{
-    transformEndianness<std::endian::big>(v);
-    out.append(reinterpret_cast<const char *>(&v), sizeof(v));
-}
-
-/// Signed: flip the sign bit on the MSB byte, then big-endian.
-template <typename Signed>
-void appendSignedBigEndian(Signed v, String & out)
-{
-    using Unsigned = std::make_unsigned_t<Signed>;
-    static constexpr Unsigned sign_bit = Unsigned{1} << (sizeof(Unsigned) * 8 - 1);
-    appendBigEndian(static_cast<Unsigned>(static_cast<Unsigned>(v) ^ sign_bit), out);
-}
-
-/// Wide signed (Int128 / Int256): flip the top bit of the most-significant
-/// limb in the unsigned representation, then big-endian. `make_unsigned_t`
-/// returns the wrong type for `wide::integer<N, int>`, so the unsigned
-/// counterpart is passed in explicitly.
-void appendWideSignedBigEndian(const Int128 & v, String & out)
-{
-    UInt128 u = static_cast<UInt128>(v);
-    u.items[UInt128::_impl::big(0)] ^= 0x8000000000000000ULL;
-    appendBigEndian(u, out);
-}
-
-void appendWideSignedBigEndian(const Int256 & v, String & out)
-{
-    UInt256 u = static_cast<UInt256>(v);
-    u.items[UInt256::_impl::big(0)] ^= 0x8000000000000000ULL;
-    appendBigEndian(u, out);
-}
-
-/// IEEE-754 total-order: invert all bits when sign bit is set, else flip
-/// the sign bit. Canonicalize -0.0 → +0.0; canonicalize every NaN to the
-/// all-`0xFF` sentinel (sorts strictly after ±Inf, matches
-/// `IColumn::compareAt(.., nan_direction_hint=1)`).
-void appendFloat32(Float32 v, String & out)
-{
-    UInt32 bits = std::bit_cast<UInt32>(v);
-    if (std::isnan(v))
-    {
-        appendBigEndian<UInt32>(0xFFFFFFFFU, out);
-        return;
-    }
-    if (bits == 0x80000000U)
-        bits = 0;
-    if (bits & 0x80000000U)
-        bits = ~bits;
-    else
-        bits ^= 0x80000000U;
-    appendBigEndian(bits, out);
-}
-
-void appendFloat64(Float64 v, String & out)
-{
-    UInt64 bits = std::bit_cast<UInt64>(v);
-    if (std::isnan(v))
-    {
-        appendBigEndian<UInt64>(0xFFFFFFFFFFFFFFFFULL, out);
-        return;
-    }
-    if (bits == 0x8000000000000000ULL)
-        bits = 0;
-    if (bits & 0x8000000000000000ULL)
-        bits = ~bits;
-    else
-        bits ^= 0x8000000000000000ULL;
-    appendBigEndian(bits, out);
-}
-
-/// String escape: `'\0'` → `'\0\x01'`; terminate with `'\0\x00'`.
-/// Prefix-free: every encoded value ends in `'\0\x00'`, embedded `'\0'`
-/// becomes `'\0\x01'`. Fast path uses `memchr` to find the first
-/// embedded NUL; slow path walks segment-by-segment.
-void appendEscapedString(const char * data, size_t size, String & out)
-{
-    out.reserve(out.size() + size + 2);
-
-    const char * const end = data + size;
-    const char * p = static_cast<const char *>(std::memchr(data, '\0', size));
-
-    if (p == nullptr)
-    {
-        out.append(data, size);
-    }
-    else
-    {
-        const char * cursor = data;
-        do
-        {
-            out.append(cursor, p - cursor);
-            out.append("\0\x01", 2);
-            cursor = p + 1;
-            p = static_cast<const char *>(std::memchr(cursor, '\0', end - cursor));
-        }
-        while (p != nullptr);
-        out.append(cursor, end - cursor);
-    }
-
-    out.append("\0\x00", 2);
-}
-
-/// Column-wise free functions: one `typeid_cast` per column, tight row
-/// loop per type. `null_map` is non-null when called from a Nullable
-/// wrapper and skips null rows. `permutation`, if non-null, indexes the
-/// row reads via `(*permutation)[r]`.
-
-template <typename Col, typename Append>
-void appendVectorColumn(
-    const Col & c,
-    const UInt8 * null_map,
-    const IColumn::Permutation * permutation,
-    size_t num_rows,
-    std::vector<String> & out,
-    Append && row_appender)
-{
-    const auto & data = c.getData();
-    if (permutation)
-    {
-        if (null_map)
-        {
-            for (size_t r = 0; r < num_rows; ++r)
-            {
-                const size_t src = (*permutation)[r];
-                if (!null_map[src])
-                    row_appender(data[src], out[r]);
-            }
-        }
-        else
-        {
-            for (size_t r = 0; r < num_rows; ++r)
-                row_appender(data[(*permutation)[r]], out[r]);
-        }
-    }
-    else if (null_map)
-    {
-        for (size_t r = 0; r < num_rows; ++r)
-            if (!null_map[r])
-                row_appender(data[r], out[r]);
-    }
-    else
-    {
-        for (size_t r = 0; r < num_rows; ++r)
-            row_appender(data[r], out[r]);
-    }
-}
-
-void appendStringColumn(
-    const ColumnString & c,
-    const UInt8 * null_map,
-    const IColumn::Permutation * permutation,
-    size_t num_rows,
-    std::vector<String> & out)
-{
-    auto run = [&](size_t r, size_t src)
-    {
-        const std::string_view view = c.getDataAt(src);
-        appendEscapedString(view.data(), view.size(), out[r]);
-    };
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        run(r, src);
-    }
-}
-
-void appendFixedStringColumn(
-    const ColumnFixedString & c,
-    const UInt8 * null_map,
-    const IColumn::Permutation * permutation,
-    size_t num_rows,
-    std::vector<String> & out)
-{
-    const size_t n = c.getN();
-    for (size_t r = 0; r < num_rows; ++r)
-    {
-        const size_t src = permutation ? (*permutation)[r] : r;
-        if (null_map && null_map[src])
-            continue;
-        const std::string_view view = c.getDataAt(src);
-        out[r].append(view.substr(0, n));
-    }
-}
-
-/// Single jump-table on `IColumn::getDataType()`. Alias rows share branches
-/// via `static_cast` (Date↔UInt16, Date32↔Int32, DateTime↔UInt32,
-/// UUID↔UInt128; Enum8/Enum16 land on Int8/Int16 — no dedicated ColumnEnum).
-/// Throws NOT_IMPLEMENTED at entry for any TypeIndex outside the supported
-/// set so an all-NULL block of an unsupported nested type can't slip
-/// through silently.
-void dispatchNonNullableColumnWise(
-    const IColumn & column,
-    const UInt8 * null_map,
-    const IColumn::Permutation * permutation,
-    size_t num_rows,
-    std::vector<String> & out)
-{
-    /// `getDataType()` reports the nested type for these wrappers, but
-    /// the dynamic type is still the wrapper — `static_cast` below would
-    /// be UB. They are not part of the UK part-build contract.
-    if (column.isSparse() || column.isReplicated())
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "UNIQUE KEY encoding: ColumnSparse/ColumnReplicated unsupported");
-
-    switch (column.getDataType())
-    {
-        case TypeIndex::UInt8:
-            appendVectorColumn(static_cast<const ColumnUInt8 &>(column), null_map, permutation, num_rows, out,
-                [](UInt8 v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::UInt16:
-        case TypeIndex::Date:
-            appendVectorColumn(static_cast<const ColumnUInt16 &>(column), null_map, permutation, num_rows, out,
-                [](UInt16 v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::UInt32:
-        case TypeIndex::DateTime:
-            appendVectorColumn(static_cast<const ColumnUInt32 &>(column), null_map, permutation, num_rows, out,
-                [](UInt32 v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::UInt64:
-            appendVectorColumn(static_cast<const ColumnUInt64 &>(column), null_map, permutation, num_rows, out,
-                [](UInt64 v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int8:
-            appendVectorColumn(static_cast<const ColumnInt8 &>(column), null_map, permutation, num_rows, out,
-                [](Int8 v, String & dst) { appendSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int16:
-            appendVectorColumn(static_cast<const ColumnInt16 &>(column), null_map, permutation, num_rows, out,
-                [](Int16 v, String & dst) { appendSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int32:
-        case TypeIndex::Date32:
-            appendVectorColumn(static_cast<const ColumnInt32 &>(column), null_map, permutation, num_rows, out,
-                [](Int32 v, String & dst) { appendSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int64:
-            appendVectorColumn(static_cast<const ColumnInt64 &>(column), null_map, permutation, num_rows, out,
-                [](Int64 v, String & dst) { appendSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::Float32:
-            appendVectorColumn(static_cast<const ColumnFloat32 &>(column), null_map, permutation, num_rows, out,
-                [](Float32 v, String & dst) { appendFloat32(v, dst); });
-            return;
-        case TypeIndex::Float64:
-            appendVectorColumn(static_cast<const ColumnFloat64 &>(column), null_map, permutation, num_rows, out,
-                [](Float64 v, String & dst) { appendFloat64(v, dst); });
-            return;
-        case TypeIndex::String:
-            appendStringColumn(static_cast<const ColumnString &>(column), null_map, permutation, num_rows, out);
-            return;
-        case TypeIndex::FixedString:
-            appendFixedStringColumn(static_cast<const ColumnFixedString &>(column), null_map, permutation, num_rows, out);
-            return;
-        case TypeIndex::UUID:
-            appendVectorColumn(static_cast<const ColumnUUID &>(column), null_map, permutation, num_rows, out,
-                [](const UUID & v, String & dst) { appendBigEndian(v.toUnderType(), dst); });
-            return;
-        case TypeIndex::UInt128:
-            appendVectorColumn(static_cast<const ColumnUInt128 &>(column), null_map, permutation, num_rows, out,
-                [](const UInt128 & v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int128:
-            appendVectorColumn(static_cast<const ColumnInt128 &>(column), null_map, permutation, num_rows, out,
-                [](const Int128 & v, String & dst) { appendWideSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::UInt256:
-            appendVectorColumn(static_cast<const ColumnUInt256 &>(column), null_map, permutation, num_rows, out,
-                [](const UInt256 & v, String & dst) { appendBigEndian(v, dst); });
-            return;
-        case TypeIndex::Int256:
-            appendVectorColumn(static_cast<const ColumnInt256 &>(column), null_map, permutation, num_rows, out,
-                [](const Int256 & v, String & dst) { appendWideSignedBigEndian(v, dst); });
-            return;
-        case TypeIndex::Decimal32:
-            appendVectorColumn(static_cast<const ColumnDecimal<Decimal32> &>(column), null_map, permutation, num_rows, out,
-                [](const Decimal32 & v, String & dst) { appendSignedBigEndian(v.value, dst); });
-            return;
-        case TypeIndex::Decimal64:
-            appendVectorColumn(static_cast<const ColumnDecimal<Decimal64> &>(column), null_map, permutation, num_rows, out,
-                [](const Decimal64 & v, String & dst) { appendSignedBigEndian(v.value, dst); });
-            return;
-        case TypeIndex::Decimal128:
-            appendVectorColumn(static_cast<const ColumnDecimal<Decimal128> &>(column), null_map, permutation, num_rows, out,
-                [](const Decimal128 & v, String & dst) { appendWideSignedBigEndian(v.value, dst); });
-            return;
-        case TypeIndex::Decimal256:
-            appendVectorColumn(static_cast<const ColumnDecimal<Decimal256> &>(column), null_map, permutation, num_rows, out,
-                [](const Decimal256 & v, String & dst) { appendWideSignedBigEndian(v.value, dst); });
-            return;
-        case TypeIndex::DateTime64:
-            appendVectorColumn(static_cast<const ColumnDecimal<DateTime64> &>(column), null_map, permutation, num_rows, out,
-                [](const DateTime64 & v, String & dst) { appendSignedBigEndian(v.value, dst); });
-            return;
-        default:
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                            "UNIQUE KEY encoding: column type {} is not supported",
-                            column.getName());
-    }
-}
-
 }
 
 namespace UniqueKeyEncoding
@@ -355,7 +29,6 @@ void encodeBlock(
         return;
 
     const size_t num_rows = columns.front()->size();
-    /// Block invariant: equal-length columns. Permutation is trusted.
     for (size_t c = 1; c < columns.size(); ++c)
     {
         const size_t sz = columns[c]->size();
@@ -369,44 +42,59 @@ void encodeBlock(
     if (num_rows == 0)
         return;
 
-    /// `ColumnConst` can legitimately reach the encoder (expression-
-    /// evaluated UK columns); materialize it so the dispatch's
-    /// `static_cast` lands on the concrete column type.
+    /// Materialize ColumnConst so comparable serialization works.
     Columns materialized;
     materialized.reserve(columns.size());
     for (const auto & col : columns)
         materialized.push_back(col->convertToFullColumnIfConst());
 
+    /// Pre-check all columns support comparable serialization.
     for (const auto & col_ptr : materialized)
     {
         const IColumn * col = col_ptr.get();
-
-        const UInt8 * null_map = nullptr;
         const IColumn * inner = col;
         if (const auto * nullable = typeid_cast<const ColumnNullable *>(col))
-        {
-            null_map = nullable->getNullMapData().data();
             inner = &nullable->getNestedColumn();
-            for (size_t r = 0; r < num_rows; ++r)
-            {
-                const size_t src = permutation ? (*permutation)[r] : r;
-                /// Null flag: NULL=0x01 (after), non-NULL=0x00 (before) —
-                /// matches `compareAt` with `nulls_direction=1` (the direction
-                /// the writer's `stableGetPermutation` and Float NaN sentinel
-                /// both use).
-                out[r].push_back(null_map[src] ? '\x01' : '\x00');
-            }
-        }
+        if (!inner->supportsComparableSerialization())
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+                            "UNIQUE KEY encoding: column type {} is not supported",
+                            inner->getName());
+    }
 
-        dispatchNonNullableColumnWise(*inner, null_map, permutation, num_rows, out);
+    /// Compute per-row serialized sizes (in original row order).
+    PaddedPODArray<UInt64> row_sizes;
+    for (const auto & col_ptr : materialized)
+        col_ptr->collectComparableSerializedRowSizes(row_sizes);
 
-        for (size_t r = 0; r < num_rows; ++r)
-        {
-            if (out[r].size() > max_size)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                                "UNIQUE KEY encoded size exceeds unique_key_max_encoded_size={} bytes",
-                                max_size);
-        }
+    /// Pre-allocate per-row buffers in original row order.
+    /// memories[i] points to the buffer for source row i.
+    std::vector<String> row_buffers(num_rows);
+    PaddedPODArray<char *> memories(num_rows);
+    for (size_t i = 0; i < num_rows; ++i)
+    {
+        if (row_sizes[i] > max_size)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "UNIQUE KEY encoded size exceeds unique_key_max_encoded_size={} bytes",
+                            max_size);
+        row_buffers[i].resize(row_sizes[i]);
+        memories[i] = row_buffers[i].data();
+    }
+
+    /// Column-outer serialization: one virtual dispatch per column, zero extra copy.
+    /// No permutation needed — serializes in original row order like community batchSerializeValueIntoMemory.
+    for (const auto & col_ptr : materialized)
+        col_ptr->batchSerializeComparableIntoMemory(memories);
+
+    /// Output in permutation order.
+    if (permutation)
+    {
+        for (size_t i = 0; i < num_rows; ++i)
+            out[i] = std::move(row_buffers[(*permutation)[i]]);
+    }
+    else
+    {
+        for (size_t i = 0; i < num_rows; ++i)
+            out[i] = std::move(row_buffers[i]);
     }
 }
 

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -45,7 +45,6 @@ void encodeBlock(
                         "UNIQUE KEY encoding: permutation contains an out-of-range index (number of rows {})",
                         num_rows);
 
-    out.resize(num_rows);
     if (num_rows == 0)
         return;
 

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -3,9 +3,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Common/Exception.h>
 
-#include <cstddef>
-
-
 namespace DB
 {
 

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -35,6 +35,16 @@ void encodeBlock(
                             c, sz, num_rows);
     }
 
+    if (permutation && permutation->size() != num_rows)
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                        "UNIQUE KEY encoding: permutation size {} != number of rows {}",
+                        permutation->size(), num_rows);
+
+    if (permutation && std::any_of(permutation->begin(), permutation->end(), [&](size_t src) { return src >= num_rows; }))
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                        "UNIQUE KEY encoding: permutation contains an out-of-range index (number of rows {})",
+                        num_rows);
+
     out.resize(num_rows);
     if (num_rows == 0)
         return;

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -51,7 +51,7 @@ void encodeBlock(
 
     for (const auto & col_ptr : columns)
     {
-        col_ptr->batchSerializeAsComparable(num_rows, out, permutation);
+        col_ptr->batchSerializeAsComparable(num_rows, out, permutation, nullptr);
 
         for (size_t r = 0; r < num_rows; ++r)
         {

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -39,13 +39,7 @@ void encodeBlock(
     if (num_rows == 0)
         return;
 
-    /// Materialize ColumnConst so batchSerializeAsComparable sees concrete column types.
-    Columns materialized;
-    materialized.reserve(columns.size());
-    for (const auto & col : columns)
-        materialized.push_back(col->convertToFullColumnIfConst());
-
-    for (const auto & col_ptr : materialized)
+    for (const auto & col_ptr : columns)
     {
         col_ptr->batchSerializeAsComparable(num_rows, out, permutation);
 

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.cpp
@@ -19,7 +19,7 @@ void encodeBlock(
     const Columns & columns,
     const IColumn::Permutation * permutation,
     size_t max_size,
-    std::vector<String> & out)
+    VectorWithMemoryTracking<String> & out)
 {
     out.clear();
     if (columns.empty())

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
@@ -16,21 +16,24 @@ namespace DB::UniqueKeyEncoding
 /// encodeBlock(B))` agrees in sign with `IColumn::compareAt` applied
 /// column-by-column in schema order.
 ///
-/// Implementation delegates to IColumn::batchSerializeComparableIntoMemory
-/// for each column type, which internally calls
-/// IColumn::serializeValueIntoMemoryAsComparable per row.
-/// Supported types: integers (UInt/Int 8-256),
-/// Float32/64 (IEEE-754 total order), Decimal32/64/128/256,
-/// Date/Date32/DateTime/DateTime64, String (NUL-escaped), FixedString,
-/// UUID, Nullable(T) (1-byte null flag).
-///
-/// The encoding uses a column-outer loop: one virtual dispatch per column,
-/// tight row loop per type. This avoids per-row virtual call overhead.
+/// Supported types: integers (UInt/Int 8/16/32/64/128/256), Float32/64
+/// (IEEE-754 total order; NaN canonicalizes to all-`0xFF`; ±0.0 collapse),
+/// Decimal32/64/128/256, Date / Date32 / DateTime / DateTime64, String
+/// (`'\0'` escaped to `'\0\x01'` + `'\0\x00'` terminator), FixedString,
+/// UUID, Nullable(T) (1-byte null flag — non-NULL=0x00, NULL=0x01;
+/// NULL sorts AFTER non-NULL, matching `IColumn::compareAt` with
+/// `nulls_direction=1` and the Float NaN-as-all-`0xFF` sentinel).
+/// Compound keys concatenate per-column encodings; each per-column
+/// encoding is prefix-free, so the concatenation is order-preserving.
+/// Decoding is not provided — the probe path only compares.
 
-/// Encode all rows of `columns` into `out[row]`. `permutation`,
+/// Encode all rows of `columns` into `out[row]`, column-outer (one
+/// dispatch per column, tight row loop per type). `permutation`,
 /// if non-null, drives iteration order so `out[i]` is the encoded form
 /// of row `(*permutation)[i]`. Throws BAD_ARGUMENTS if any encoded row
 /// exceeds `max_size`; `out` is left in an indeterminate state on throw.
+/// Misuse (mismatched column sizes or an invalid permutation) raises
+/// LOGICAL_ERROR.
 void encodeBlock(
     const Columns & columns,
     const IColumn::Permutation * permutation,

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
@@ -16,24 +16,21 @@ namespace DB::UniqueKeyEncoding
 /// encodeBlock(B))` agrees in sign with `IColumn::compareAt` applied
 /// column-by-column in schema order.
 ///
-/// Supported types: integers (UInt/Int 8/16/32/64/128/256), Float32/64
-/// (IEEE-754 total order; NaN canonicalizes to all-`0xFF`; ±0.0 collapse),
-/// Decimal32/64/128/256, Date / Date32 / DateTime / DateTime64, String
-/// (`'\0'` escaped to `'\0\x01'` + `'\0\x00'` terminator), FixedString,
-/// UUID, Nullable(T) (1-byte null flag — non-NULL=0x00, NULL=0x01;
-/// NULL sorts AFTER non-NULL, matching `IColumn::compareAt` with
-/// `nulls_direction=1` and the Float NaN-as-all-`0xFF` sentinel).
-/// Compound keys concatenate per-column encodings; each per-column
-/// encoding is prefix-free, so the concatenation is order-preserving.
-/// Decoding is not provided — the probe path only compares.
+/// Implementation delegates to IColumn::batchSerializeComparableIntoMemory
+/// for each column type, which internally calls
+/// IColumn::serializeValueIntoMemoryAsComparable per row.
+/// Supported types: integers (UInt/Int 8-256),
+/// Float32/64 (IEEE-754 total order), Decimal32/64/128/256,
+/// Date/Date32/DateTime/DateTime64, String (NUL-escaped), FixedString,
+/// UUID, Nullable(T) (1-byte null flag).
+///
+/// The encoding uses a column-outer loop: one virtual dispatch per column,
+/// tight row loop per type. This avoids per-row virtual call overhead.
 
-/// Encode all rows of `columns` into `out[row]`, column-outer (one
-/// dispatch per column, tight row loop per type). `permutation`,
+/// Encode all rows of `columns` into `out[row]`. `permutation`,
 /// if non-null, drives iteration order so `out[i]` is the encoded form
 /// of row `(*permutation)[i]`. Throws BAD_ARGUMENTS if any encoded row
 /// exceeds `max_size`; `out` is left in an indeterminate state on throw.
-/// Misuse (mismatched column sizes or an invalid permutation) raises
-/// LOGICAL_ERROR.
 void encodeBlock(
     const Columns & columns,
     const IColumn::Permutation * permutation,

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h
@@ -3,9 +3,7 @@
 #include <Core/Block.h>
 #include <Core/Types.h>
 #include <Columns/IColumn.h>
-
-#include <vector>
-#include <string>
+#include <Common/VectorWithMemoryTracking.h>
 
 namespace DB::UniqueKeyEncoding
 {
@@ -38,6 +36,6 @@ void encodeBlock(
     const Columns & columns,
     const IColumn::Permutation * permutation,
     size_t max_size,
-    std::vector<String> & out);
+    VectorWithMemoryTracking<String> & out);
 
 }

--- a/src/Storages/MergeTree/UniqueKey/UniqueKeyProbeSimple.cpp
+++ b/src/Storages/MergeTree/UniqueKey/UniqueKeyProbeSimple.cpp
@@ -48,7 +48,7 @@ std::vector<ProbeResult> UniqueKeyProbeSimple::probeBatch(const Block & keys, co
     for (const auto & name : unique_key_column_names)
         uk_columns.push_back(keys.getByName(name).column);
 
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(uk_columns, /*permutation=*/nullptr, max_encoded_size, encoded);
 
     std::vector<std::string_view> views;

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -3,6 +3,7 @@
 #include <Storages/MergeTree/UniqueKey/UniqueKeyEncoding.h>
 
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
 #include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
@@ -850,6 +851,51 @@ TEST(UniqueKeyEncoding, NullableOrdering)
 }
 
 /// ---------------------------------------------------------------------------
+/// Nullable batch path (ColumnNullable::batchSerializeAsComparable delegating to
+/// the nested column's batch). Encode a multi-row block with interleaved NULL /
+/// non-NULL rows and assert the batch-encoded memcmp order agrees with compareAt
+/// across all pairs. Pins the nested-batch delegation so it does not regress to
+/// a per-row virtual in the hot loop.
+/// ---------------------------------------------------------------------------
+TEST(UniqueKeyEncoding, NullableBatchMultiRowOrdering)
+{
+    auto nested = ColumnUInt64::create();
+    nested->insert(Field(UInt64(0)));     /// 0 non-null 0
+    nested->insert(Field(UInt64(0)));     /// 1 null (placeholder)
+    nested->insert(Field(UInt64(50)));    /// 2 non-null 50
+    nested->insert(Field(UInt64(0)));     /// 3 null (placeholder)
+    nested->insert(Field(UInt64(100)));   /// 4 non-null 100
+
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(Field(UInt64(0)));
+    null_map->insert(Field(UInt64(1)));
+    null_map->insert(Field(UInt64(0)));
+    null_map->insert(Field(UInt64(1)));
+    null_map->insert(Field(UInt64(0)));
+
+    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Columns cols{std::move(col)};
+
+    VectorWithMemoryTracking<String> encoded;
+    UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 4096, encoded);
+    ASSERT_EQ(encoded.size(), 5u);
+
+    for (size_t a = 0; a < encoded.size(); ++a)
+        for (size_t b = 0; b < encoded.size(); ++b)
+        {
+            int mem = std::memcmp(encoded[a].data(), encoded[b].data(),
+                                  std::min(encoded[a].size(), encoded[b].size()));
+            if (mem == 0 && encoded[a].size() != encoded[b].size())
+                mem = encoded[a].size() > encoded[b].size() ? 1 : -1;
+            int expected = columnCompareRows(cols, a, b);
+            int expected_sign = (expected > 0) - (expected < 0);
+            int actual_sign = (mem > 0) - (mem < 0);
+            EXPECT_EQ(expected_sign, actual_sign)
+                << "nullable batch pair a=" << a << " b=" << b;
+        }
+}
+
+/// ---------------------------------------------------------------------------
 /// Compound keys — concatenation preserves order when each component is
 /// prefix-free and individually order-preserving.
 /// Shuffle-and-sort: encode a bunch of random rows, sort by encoding, and
@@ -973,6 +1019,39 @@ TEST(UniqueKeyEncoding, EncodeBlockPermutationValidAccepted)
     VectorWithMemoryTracking<String> out;
     EXPECT_NO_THROW(UniqueKeyEncoding::encodeBlock(cols, &perm, 256, out));
     ASSERT_EQ(out.size(), 3u);
+}
+
+/// ColumnConst must be accepted directly by encodeBlock (no NOT_IMPLEMENTED,
+/// no external materialization) and produce the same encoding as the equivalent
+/// full column. Pins the ColumnConst::serializeAsComparable /
+/// batchSerializeAsComparable delegates.
+TEST(UniqueKeyEncoding, ColumnConstEncodeBlockMatchesFullColumn)
+{
+    auto data = ColumnUInt64::create();
+    data->insert(Field(UInt64(42)));
+    auto const_col = ColumnConst::create(std::move(data), 4);
+
+    auto full = ColumnUInt64::create();
+    for (int i = 0; i < 4; ++i)
+        full->insert(Field(UInt64(42)));
+
+    Columns const_cols{const_col};
+    Columns full_cols{std::move(full)};
+
+    VectorWithMemoryTracking<String> const_out;
+    VectorWithMemoryTracking<String> full_out;
+    UniqueKeyEncoding::encodeBlock(const_cols, /*permutation=*/nullptr, 4096, const_out);
+    UniqueKeyEncoding::encodeBlock(full_cols, /*permutation=*/nullptr, 4096, full_out);
+
+    ASSERT_EQ(const_out.size(), 4u);
+    ASSERT_EQ(full_out.size(), 4u);
+    for (size_t r = 0; r < 4u; ++r)
+    {
+        EXPECT_EQ(const_out[r], full_out[r])
+            << "ColumnConst row " << r << " must match full-column encoding";
+        EXPECT_EQ(const_out[r], const_out[0])
+            << "ColumnConst row " << r << " must be identical across rows";
+    }
 }
 
 /// Empty-block: must produce an empty output vector without touching max_size.

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -895,6 +895,42 @@ TEST(UniqueKeyEncoding, NullableBatchMultiRowOrdering)
         }
 }
 
+/// Nullable batch + permutation. The NULL flag and the nested encoding must stay
+/// aligned to the same permuted source row. Encoded output row r must equal the
+/// single-row encoding of source row permutation[r].
+TEST(UniqueKeyEncoding, NullableBatchPermutationAlignsFlagAndNested)
+{
+    auto nested = ColumnUInt64::create();
+    nested->insert(Field(UInt64(0)));     /// 0 non-null
+    nested->insert(Field(UInt64(0)));     /// 1 null
+    nested->insert(Field(UInt64(50)));    /// 2 non-null
+    nested->insert(Field(UInt64(0)));     /// 3 null
+    nested->insert(Field(UInt64(100)));   /// 4 non-null
+
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(Field(UInt64(0)));
+    null_map->insert(Field(UInt64(1)));
+    null_map->insert(Field(UInt64(0)));
+    null_map->insert(Field(UInt64(1)));
+    null_map->insert(Field(UInt64(0)));
+
+    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Columns cols{std::move(col)};
+
+    IColumn::Permutation perm{4, 0, 3, 1, 2};
+    VectorWithMemoryTracking<String> encoded;
+    UniqueKeyEncoding::encodeBlock(cols, &perm, 4096, encoded);
+    ASSERT_EQ(encoded.size(), perm.size());
+
+    for (size_t r = 0; r < perm.size(); ++r)
+    {
+        String expected = testEncodeRow(cols, perm[r], 4096);
+        EXPECT_EQ(encoded[r], expected)
+            << "permuted batch row " << r << " (src=" << perm[r]
+            << ") must equal single-row encoding of source row";
+    }
+}
+
 /// ---------------------------------------------------------------------------
 /// Compound keys — concatenation preserves order when each component is
 /// prefix-free and individually order-preserving.

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -1126,11 +1126,11 @@ TEST(UniqueKeyEncoding, LowCardinalityThrowsNotImplemented)
 }
 
 /// ---------------------------------------------------------------------------
-/// Nullable wrapping unsupported types with all-NULL rows. Before the eager
-/// probe in ColumnNullable::appendUniqueKeyEncodedValue, an all-NULL block
-/// would skip the nested column's serializeAsComparable entirely, silently
-/// accepting unsupported nested types. These regressions pin that the probe
-/// catches them.
+/// Nullable wrapping unsupported types with all-NULL rows. Without eager
+/// validation in ColumnNullable::serializeAsComparable, a NULL row would skip
+/// the nested column's serializeAsComparable entirely, silently accepting
+/// unsupported nested types. These regressions pin that the validation catches
+/// them via the batch/encodeBlock path.
 /// ---------------------------------------------------------------------------
 TEST(UniqueKeyEncoding, NullableLowCardinalityAllNullThrowsNotImplemented)
 {
@@ -1158,4 +1158,34 @@ TEST(UniqueKeyEncoding, NullableArrayAllNullThrowsNotImplemented)
     Columns cols;
     cols.push_back(std::move(col));
     expectEncodeRowThrowsNotImplemented(cols, "Nullable(Array(UInt64)) all-NULL");
+}
+
+/// ---------------------------------------------------------------------------
+/// Direct single-row serializeAsComparable on a NULL row of an unsupported
+/// nullable column. The NULL branch must still validate the nested type, so an
+/// unsupported nullable schema is rejected on every row, not only once a
+/// non-NULL value is hit. One nested type suffices: LowCardinality and Array
+/// go through the same NULL-branch probe.
+/// ---------------------------------------------------------------------------
+TEST(UniqueKeyEncoding, NullableUnsupportedNullRowDirectSerializeThrowsNotImplemented)
+{
+    auto type_lc = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+    auto nested = type_lc->createColumn();
+    nested->insertDefault();
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(Field(UInt64(1)));
+
+    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
+
+    try
+    {
+        String out;
+        col->serializeAsComparable(0, out);
+        FAIL() << "serializeAsComparable on NULL row of Nullable(LowCardinality(String)) did not throw";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::NOT_IMPLEMENTED)
+            << "should throw NOT_IMPLEMENTED, got " << e.code() << ": " << e.message();
+    }
 }

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -1241,16 +1241,23 @@ TEST(UniqueKeyEncoding, LowCardinalityThrowsNotImplemented)
 }
 
 /// ---------------------------------------------------------------------------
-/// Nullable wrapping unsupported types with all-NULL rows. Without eager
+/// Nullable wrapping an unsupported type with all-NULL rows. Without eager
 /// validation in ColumnNullable::serializeAsComparable, a NULL row would skip
 /// the nested column's serializeAsComparable entirely, silently accepting
-/// unsupported nested types. These regressions pin that the validation catches
+/// unsupported nested types. This regression pins that the validation catches
 /// them via the batch/encodeBlock path.
+///
+/// The nested type must be one that ColumnNullable can actually hold
+/// (canBeInsideNullable() == true) yet serializeAsComparable does not support.
+/// Tuple fits: it can be inside Nullable but has no comparable encoding.
+/// LowCardinality and Array cannot be inside Nullable at all, so they can
+/// never reach this code path.
 /// ---------------------------------------------------------------------------
-TEST(UniqueKeyEncoding, NullableLowCardinalityAllNullThrowsNotImplemented)
+TEST(UniqueKeyEncoding, NullableTupleAllNullThrowsNotImplemented)
 {
-    auto type_lc = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
-    auto nested = type_lc->createColumn();
+    DataTypes inner{std::make_shared<DataTypeUInt64>(), std::make_shared<DataTypeUInt64>()};
+    auto type_tup = std::make_shared<DataTypeTuple>(inner);
+    auto nested = type_tup->createColumn();
     nested->insertDefault();
     auto null_map = ColumnUInt8::create();
     null_map->insert(Field(UInt64(1)));
@@ -1258,34 +1265,20 @@ TEST(UniqueKeyEncoding, NullableLowCardinalityAllNullThrowsNotImplemented)
     auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
     Columns cols;
     cols.push_back(std::move(col));
-    expectEncodeRowThrowsNotImplemented(cols, "Nullable(LowCardinality(String)) all-NULL");
-}
-
-TEST(UniqueKeyEncoding, NullableArrayAllNullThrowsNotImplemented)
-{
-    auto type_arr = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
-    auto nested = type_arr->createColumn();
-    nested->insertDefault();
-    auto null_map = ColumnUInt8::create();
-    null_map->insert(Field(UInt64(1)));
-
-    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
-    Columns cols;
-    cols.push_back(std::move(col));
-    expectEncodeRowThrowsNotImplemented(cols, "Nullable(Array(UInt64)) all-NULL");
+    expectEncodeRowThrowsNotImplemented(cols, "Nullable(Tuple(UInt64,UInt64)) all-NULL");
 }
 
 /// ---------------------------------------------------------------------------
 /// Direct single-row serializeAsComparable on a NULL row of an unsupported
 /// nullable column. The NULL branch must still validate the nested type, so an
 /// unsupported nullable schema is rejected on every row, not only once a
-/// non-NULL value is hit. One nested type suffices: LowCardinality and Array
-/// go through the same NULL-branch probe.
+/// non-NULL value is hit.
 /// ---------------------------------------------------------------------------
 TEST(UniqueKeyEncoding, NullableUnsupportedNullRowDirectSerializeThrowsNotImplemented)
 {
-    auto type_lc = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
-    auto nested = type_lc->createColumn();
+    DataTypes inner{std::make_shared<DataTypeUInt64>(), std::make_shared<DataTypeUInt64>()};
+    auto type_tup = std::make_shared<DataTypeTuple>(inner);
+    auto nested = type_tup->createColumn();
     nested->insertDefault();
     auto null_map = ColumnUInt8::create();
     null_map->insert(Field(UInt64(1)));
@@ -1296,7 +1289,7 @@ TEST(UniqueKeyEncoding, NullableUnsupportedNullRowDirectSerializeThrowsNotImplem
     {
         String out;
         col->serializeAsComparable(0, out);
-        FAIL() << "serializeAsComparable on NULL row of Nullable(LowCardinality(String)) did not throw";
+        FAIL() << "serializeAsComparable on NULL row of Nullable(Tuple(UInt64,UInt64)) did not throw";
     }
     catch (const Exception & e)
     {

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -719,6 +719,68 @@ TEST(UniqueKeyEncoding, Decimal64Ordering)
 }
 
 /// ---------------------------------------------------------------------------
+/// Wide signed integers (Int128 / Int256) — exercise the multi-limb sign-flip
+/// path in ColumnVector::appendUniqueKeyEncodedValue where the high byte is
+/// XOR'd with 0x80 after big-endian transform.
+/// ---------------------------------------------------------------------------
+TEST(UniqueKeyEncoding, Int128Ordering)
+{
+    auto col = ColumnInt128::create();
+    col->insert(Field(Int128(std::numeric_limits<Int64>::min())));
+    col->insert(Field(Int128(-1)));
+    col->insert(Field(Int128(0)));
+    col->insert(Field(Int128(1)));
+    col->insert(Field(Int128(std::numeric_limits<Int64>::max())));
+
+    Columns cols{std::move(col)};
+    for (size_t i = 0; i + 1 < cols[0]->size(); ++i)
+        EXPECT_TRUE(agrees(cols, i, i + 1)) << "Int128 adjacent pair " << i;
+    /// Cross-check extremes.
+    EXPECT_TRUE(agrees(cols, 0, cols[0]->size() - 1));
+}
+
+TEST(UniqueKeyEncoding, Int256Ordering)
+{
+    auto col = ColumnInt256::create();
+    col->insert(Field(Int256(std::numeric_limits<Int64>::min())));
+    col->insert(Field(Int256(-1)));
+    col->insert(Field(Int256(0)));
+    col->insert(Field(Int256(1)));
+    col->insert(Field(Int256(std::numeric_limits<Int64>::max())));
+
+    Columns cols{std::move(col)};
+    for (size_t i = 0; i + 1 < cols[0]->size(); ++i)
+        EXPECT_TRUE(agrees(cols, i, i + 1)) << "Int256 adjacent pair " << i;
+    EXPECT_TRUE(agrees(cols, 0, cols[0]->size() - 1));
+}
+
+/// ---------------------------------------------------------------------------
+/// Wide decimals (Decimal128 / Decimal256) — same sign-flip pattern applied
+/// via ColumnDecimal. Verify negative-to-positive ordering is preserved.
+/// ---------------------------------------------------------------------------
+TEST(UniqueKeyEncoding, Decimal128Ordering)
+{
+    auto col = ColumnDecimal<Decimal128>::create(0, /*scale=*/4);
+    for (Int64 raw : {Int64(-1000000), Int64(-1), Int64(0), Int64(1), Int64(1000000)})
+        col->insert(DecimalField<Decimal128>(Decimal128(raw), 4));
+
+    Columns cols{std::move(col)};
+    for (size_t i = 0; i + 1 < cols[0]->size(); ++i)
+        EXPECT_TRUE(agrees(cols, i, i + 1)) << "Decimal128 adjacent pair " << i;
+}
+
+TEST(UniqueKeyEncoding, Decimal256Ordering)
+{
+    auto col = ColumnDecimal<Decimal256>::create(0, /*scale=*/4);
+    for (Int64 raw : {Int64(-1000000), Int64(-1), Int64(0), Int64(1), Int64(1000000)})
+        col->insert(DecimalField<Decimal256>(Decimal256(raw), 4));
+
+    Columns cols{std::move(col)};
+    for (size_t i = 0; i + 1 < cols[0]->size(); ++i)
+        EXPECT_TRUE(agrees(cols, i, i + 1)) << "Decimal256 adjacent pair " << i;
+}
+
+/// ---------------------------------------------------------------------------
 /// Date / Date32 / DateTime / DateTime64.
 /// ---------------------------------------------------------------------------
 TEST(UniqueKeyEncoding, DateVariants)
@@ -1061,4 +1123,39 @@ TEST(UniqueKeyEncoding, LowCardinalityThrowsNotImplemented)
     Columns cols;
     cols.push_back(std::move(col));
     expectEncodeRowThrowsNotImplemented(cols, "LowCardinality(String)");
+}
+
+/// ---------------------------------------------------------------------------
+/// Nullable wrapping unsupported types with all-NULL rows. Before the eager
+/// probe in ColumnNullable::appendUniqueKeyEncodedValue, an all-NULL block
+/// would skip the nested column's serializeAsComparable entirely, silently
+/// accepting unsupported nested types. These regressions pin that the probe
+/// catches them.
+/// ---------------------------------------------------------------------------
+TEST(UniqueKeyEncoding, NullableLowCardinalityAllNullThrowsNotImplemented)
+{
+    auto type_lc = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+    auto nested = type_lc->createColumn();
+    nested->insertDefault();
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(Field(UInt64(1)));
+
+    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Columns cols;
+    cols.push_back(std::move(col));
+    expectEncodeRowThrowsNotImplemented(cols, "Nullable(LowCardinality(String)) all-NULL");
+}
+
+TEST(UniqueKeyEncoding, NullableArrayAllNullThrowsNotImplemented)
+{
+    auto type_arr = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+    auto nested = type_arr->createColumn();
+    nested->insertDefault();
+    auto null_map = ColumnUInt8::create();
+    null_map->insert(Field(UInt64(1)));
+
+    auto col = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Columns cols;
+    cols.push_back(std::move(col));
+    expectEncodeRowThrowsNotImplemented(cols, "Nullable(Array(UInt64)) all-NULL");
 }

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -1071,7 +1071,7 @@ TEST(UniqueKeyEncoding, ColumnConstEncodeBlockMatchesFullColumn)
     for (int i = 0; i < 4; ++i)
         full->insert(Field(UInt64(42)));
 
-    Columns const_cols{const_col};
+    Columns const_cols{std::move(const_col)};
     Columns full_cols{std::move(full)};
 
     VectorWithMemoryTracking<String> const_out;

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_encoding.cpp
@@ -13,6 +13,7 @@
 #include <Columns/ColumnsNumber.h>
 #include <Common/Exception.h>
 #include <Common/ErrorCodes.h>
+#include <Common/VectorWithMemoryTracking.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDate32.h>
@@ -54,7 +55,7 @@ String testEncodeRow(const Columns & cols, size_t row, size_t max_size = 4096)
     row_cols.reserve(cols.size());
     for (const auto & c : cols)
         row_cols.push_back(c->cut(row, 1));
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     UniqueKeyEncoding::encodeBlock(row_cols, /*permutation=*/nullptr, max_size, out);
     return out.at(0);
 }
@@ -483,7 +484,7 @@ void expectBlockEncodesAs(const std::vector<String> & inputs)
     for (const auto & s : inputs)
         col->insert(Field(s));
     Columns cols{std::move(col)};
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, /*max_size=*/4096, encoded);
     ASSERT_EQ(encoded.size(), inputs.size());
     for (size_t r = 0; r < inputs.size(); ++r)
@@ -591,7 +592,7 @@ TEST(UniqueKeyEncoding, FixedStringBlockEncoderByteEquivalentEmbeddedNull)
     col->insertData("\x00""1234567", N);
     Columns cols{std::move(col)};
 
-    std::vector<String> got;
+    VectorWithMemoryTracking<String> got;
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, /*max_size=*/4096, got);
     ASSERT_EQ(got.size(), 4u);
 
@@ -872,7 +873,7 @@ TEST(UniqueKeyEncoding, EncodeBlockBasic)
     col->insert(Field(UInt64(3)));
 
     Columns cols{std::move(col)};
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 4096, encoded);
 
     ASSERT_EQ(encoded.size(), 3u);
@@ -889,7 +890,7 @@ TEST(UniqueKeyEncoding, EncodeBlockSizeLimitRejection)
 
     Columns cols{std::move(col)};
 
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     EXPECT_THROW(UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 100, out), DB::Exception);
 
     /// Sufficient limit — both rows should encode successfully.
@@ -907,7 +908,7 @@ TEST(UniqueKeyEncoding, EncodeBlockPermutationValidAccepted)
     Columns cols{std::move(col)};
 
     IColumn::Permutation perm{2, 0, 1};
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     EXPECT_NO_THROW(UniqueKeyEncoding::encodeBlock(cols, &perm, 256, out));
     ASSERT_EQ(out.size(), 3u);
 }
@@ -918,7 +919,7 @@ TEST(UniqueKeyEncoding, EncodeBlockEmptyBlock)
     auto col = ColumnUInt64::create();
     Columns cols{std::move(col)};
 
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 256, out);
     EXPECT_TRUE(out.empty());
 }
@@ -936,7 +937,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchUInt641M)
         col->insert(Field(rng()));
     Columns cols{std::move(col)};
 
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     auto t0 = std::chrono::steady_clock::now();
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 256, out);
     auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -960,7 +961,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchString321M)
     }
     Columns cols{std::move(col)};
 
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     auto t0 = std::chrono::steady_clock::now();
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 256, out);
     auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -986,7 +987,7 @@ TEST(UniqueKeyEncoding, DISABLED_MicrobenchCompoundUInt64String1M)
     }
     Columns cols{std::move(col_u), std::move(col_s)};
 
-    std::vector<String> out;
+    VectorWithMemoryTracking<String> out;
     auto t0 = std::chrono::steady_clock::now();
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, 256, out);
     auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_probe.cpp
@@ -69,7 +69,7 @@ namespace
         auto col = ColumnUInt64::create();
         col->insertValue(k);
         Columns cols{std::move(col)};
-        std::vector<String> out;
+        VectorWithMemoryTracking<String> out;
         UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, MAX_ENC, out);
         return out.at(0);
     }

--- a/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_sst_probe.cpp
+++ b/src/Storages/MergeTree/UniqueKey/tests/gtest_unique_key_sst_probe.cpp
@@ -18,6 +18,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/tests/gtest_global_context.h>
+#include <Common/VectorWithMemoryTracking.h>
 #include <Interpreters/Context.h>
 #include <Core/Block.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -188,7 +189,7 @@ TEST_F(SSTFixture, RoundTrip10K)
     auto status = reader.Open(finalPath());
     ASSERT_TRUE(status.ok()) << status.ToString();
 
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(cols, /*permutation=*/nullptr, /*max_size=*/256, encoded);
     for (size_t i = 0; i < N; ++i)
     {
@@ -246,7 +247,7 @@ TEST_F(SSTFixture, CorruptionRebuild)
     rocksdb::SstFileReader reader(makeReaderOptions());
     ASSERT_TRUE(reader.Open(finalPath()).ok());
     auto one_col = makeUInt64Columns({keys[42]});
-    std::vector<String> encoded;
+    VectorWithMemoryTracking<String> encoded;
     UniqueKeyEncoding::encodeBlock(one_col, /*permutation=*/nullptr, 256, encoded);
     EXPECT_TRUE(sstIteratorContains(reader, encoded[0]));
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Move UNIQUE KEY byte-comparable serialization from a centralized type-switch into per-column virtual methods on `IColumn`. 

### Descrption

The previous implementation in `UniqueKeyEncoding.cpp` placed all type-specific encoding logic in a single monolithic switch, requiring modifications to this central file for every new type.

This refactoring moves the encoding logic into the column classes themselves as virtual methods (`serializeValueIntoMemoryAsComparable`,`batchSerializeComparableIntoMemory`), following the same pattern as `serializeValueIntoArena`. Adding support for a new column type now only requires overriding these methods in the column class — no central dispatch table to maintain.

The encoding algorithm for every supported type is unchanged — same byte layout, same ordering semantics, fully wire-compatible. 

Memory pre-allocation can be added in a follow-up if profiling shows the per-row append overhead is worth it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.334` (included in `26.8` and later)
<!-- ch-version-info:end -->