### PR TITLE
Fix logical error in automatic parallel replicas with min_number_of_rows_per_replica

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
+++ b/src/Processors/QueryPlan/Optimizations/considerEnablingParallelReplicas.cpp
@@ -356,7 +356,8 @@ void considerEnablingParallelReplicas(
                 ReadFromMergeTree * local_replica_plan_reading_step = findReadingStep(*final_node_in_replica_plan);
                 if (!local_replica_plan_reading_step)
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot find ReadFromMergeTree step in local parallel replicas plan");
-                chassert(local_replica_plan_reading_step->getAnalyzedResult() == nullptr);
+                /// The step may already carry an analysis (planner runs index analysis on it when
+                /// parallel_replicas_min_number_of_rows_per_replica > 0); overwrite it to reuse the single-replica one.
                 local_replica_plan_reading_step->setAnalyzedResult(analysis);
                 moveSetsFromLocalPlanToReplicasPlan(query_plan, *plan_with_parallel_replicas);
                 query_plan.replaceNodeWithPlan(query_plan.getRootNode(), std::move(*plan_with_parallel_replicas));

--- a/tests/queries/0_stateless/04034_autopr_min_rows_per_replica_reuses_index_analysis.reference
+++ b/tests/queries/0_stateless/04034_autopr_min_rows_per_replica_reuses_index_analysis.reference
@@ -1,0 +1,4 @@
+query	stats_collected	pr_used
+04034_autopr_min_rows_per_replica_reuses_index_analysis_query_0	1	0
+04034_autopr_min_rows_per_replica_reuses_index_analysis_query_1	0	1
+04034_autopr_min_rows_per_replica_reuses_index_analysis_query_2	0	1

--- a/tests/queries/0_stateless/04034_autopr_min_rows_per_replica_reuses_index_analysis.sql
+++ b/tests/queries/0_stateless/04034_autopr_min_rows_per_replica_reuses_index_analysis.sql
@@ -1,0 +1,56 @@
+-- Tags: no-sanitizers
+-- no-sanitizers: too slow
+
+-- Regression test: automatic parallel replicas must not hit
+-- 'local_replica_plan_reading_step->getAnalyzedResult() == nullptr' when
+-- parallel_replicas_min_number_of_rows_per_replica > 0. In that case the planner runs index
+-- analysis on the local parallel-replicas reading step to estimate the replica count, so the
+-- step already carries an analysis when automatic parallel replicas reuses the single-replica one.
+
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t(WatchID UInt64, ClientIP UInt32, ResolutionWidth UInt16) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity=128;
+
+SET enable_parallel_replicas=1, automatic_parallel_replicas_mode=1, parallel_replicas_local_plan=1, parallel_replicas_index_analysis_only_on_coordinator=1,
+    parallel_replicas_for_non_replicated_merge_tree=1, max_parallel_replicas=3, cluster_for_parallel_replicas='parallel_replicas';
+
+SET enable_analyzer=1;
+
+-- max_block_size is set explicitly to ensure enough blocks will be fed to the statistics collector
+SET max_threads=4, max_block_size=128;
+
+SET automatic_parallel_replicas_min_bytes_per_replica=0;
+SET merge_tree_min_bytes_per_task_for_remote_reading=0;
+
+-- External aggregation is not supported at the moment, i.e., no statistics will be reported
+SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
+
+-- This is the setting that triggers index analysis on the parallel-replicas reading step during planning.
+SET parallel_replicas_min_number_of_rows_per_replica=1000;
+
+INSERT INTO t SELECT number % 1000, number % 500, number % 200 FROM numbers(5e5);
+
+-- Query 0: empty cache, collect stats
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_min_rows_per_replica_reuses_index_analysis_query_0';
+
+-- Query 1: stats available now, automatic parallel replicas transplants the single-replica analysis
+-- onto the already-analyzed local reading step. Used to hit the LOGICAL_ERROR assertion.
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_min_rows_per_replica_reuses_index_analysis_query_1';
+
+-- Query 2: repeat, still fine
+SELECT WatchID, ClientIP, COUNT(*) AS c, AVG(ResolutionWidth) FROM t GROUP BY WatchID, ClientIP ORDER BY c DESC LIMIT 10 FORMAT Null
+    SETTINGS log_comment='04034_autopr_min_rows_per_replica_reuses_index_analysis_query_2';
+
+SET enable_parallel_replicas=0, automatic_parallel_replicas_mode=0;
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT log_comment query, ProfileEvents['RuntimeDataflowStatisticsInputBytes'] > 0 stats_collected, ProfileEvents['ParallelReplicasUsedCount'] > 0 pr_used
+FROM system.query_log
+WHERE (event_date >= yesterday()) AND (event_time >= (NOW() - toIntervalMinute(15))) AND (current_database = currentDatabase()) AND (log_comment LIKE '04034_autopr_min_rows_per_replica_reuses_index_analysis_query_%') AND (type = 'QueryFinish')
+ORDER BY log_comment
+FORMAT TSVWithNames;
+
+DROP TABLE t;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/100752
Related: https://github.com/ClickHouse/ClickHouse/pull/71028
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a `LOGICAL_ERROR` (`local_replica_plan_reading_step->getAnalyzedResult() == nullptr`) in the automatic parallel replicas planner that could occur when `automatic_parallel_replicas_mode` is enabled together with `parallel_replicas_min_number_of_rows_per_replica` greater than 0.

### Description

`considerEnablingParallelReplicas()` asserted that the local parallel-replicas reading step carried no index analysis yet before transplanting the single-replica analysis into it:

```cpp
chassert(local_replica_plan_reading_step->getAnalyzedResult() == nullptr);
```

This holds when `parallel_replicas_min_number_of_rows_per_replica == 0`, but not otherwise. With that setting greater than 0, the planner (`PlannerJoinTree.cpp`, `canUseParallelReplicasOnInitiator()` branch) runs index analysis on the reading step to estimate how many replicas to use, and that same step is then moved into the parallel-replicas plan. So it already carries an analysis by the time automatic parallel replicas wants to reuse the single-replica one, and the assertion fails. This is an exception that is handled in release builds, but it aborts the server in debug and sanitizer builds.

The pre-existing analysis is legitimate, so instead of asserting we overwrite it with the single-replica analysis, which is exactly what the `parallel_replicas_min_number_of_rows_per_replica == 0` path already does. Both analyses are `selectRangesToRead()` over the same table and query, so the result is identical.

**Reproduction** (deterministic on a debug build): an aggregation with `automatic_parallel_replicas_mode = 1` and `parallel_replicas_min_number_of_rows_per_replica > 0`, run twice so the dataflow statistics cache is populated. The default of the setting is 0, which is why the existing test `04034_autopr_dataflow_cache_reuse_between_different_queries` does not hit it; CI randomizes the setting (see #71028), which is how the fuzzer found it.

The assertion was reported by the AST fuzzer (`AST fuzzer (amd_debug)`, STID 2508-5243). Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100752&sha=7af449dad33f6e6f34c5e583129fe1652fd54436&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29 . It is a pre-existing planner bug, unrelated to #100752 where it happened to surface; over 60 days it also appeared under #71028, #104513 and #106073.

A regression test `04034_autopr_min_rows_per_replica_reuses_index_analysis` is added that pins `parallel_replicas_min_number_of_rows_per_replica` to deterministically exercise the fixed path and asserts that automatic parallel replicas still engages.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.522` (included in `26.7` and later)
<!-- ch-version-info:end -->