### PR TITLE
Fix projection reading a TTL-expired DEFAULT column as the type default

### DIFF
--- a/src/Processors/TTL/TTLColumnAlgorithm.cpp
+++ b/src/Processors/TTL/TTLColumnAlgorithm.cpp
@@ -44,13 +44,29 @@ void TTLColumnAlgorithm::execute(Block & block)
 
     auto & column_with_type = block.getByName(column_name);
 
-    /// Reset the column to its default state so that dependent skip indices or
-    /// projections can correctly recalculate using it.
+    /// The whole block is past the column TTL. Reset the column to its default so that
+    /// dependent skip indices or projections recalculate against the value the base table
+    /// will logically read. Evaluate the DDL `DEFAULT` expression (matching the per-row slow
+    /// path below), falling back to the type default only when the column has no `DEFAULT`.
+    /// Filling the type default here would make a rebuilt projection materialize the type
+    /// default (e.g. `0`) while the base reads the DDL default (e.g. `-1`) via `expired_columns`.
     if (isMaxTTLExpired() && !is_compact_part)
     {
-        auto empty_column = column_with_type.column->cloneEmpty();
-        empty_column->insertManyDefaults(block.rows());
-        column_with_type.column = std::move(empty_column);
+        auto result_column = column_with_type.column->cloneEmpty();
+        result_column->reserve(block.rows());
+
+        auto default_column = executeExpressionAndGetColumn(default_expression, block, default_column_name);
+        if (default_column)
+        {
+            default_column = default_column->convertToFullColumnIfConst();
+            result_column->insertRangeFrom(*default_column, 0, block.rows());
+        }
+        else
+        {
+            result_column->insertManyDefaults(block.rows());
+        }
+
+        column_with_type.column = std::move(result_column);
         return;
     }
 

--- a/tests/queries/0_stateless/04492_projection_ttl_default_divergence.reference
+++ b/tests/queries/0_stateless/04492_projection_ttl_default_divergence.reference
@@ -1,0 +1,8 @@
+wide v base	-1	-1
+wide v proj	-1	-1
+wide w base	1000	1000
+wide w proj	1000	1000
+compact v base	-1	-1
+compact v proj	-1	-1
+nodefault u base	0	0
+nodefault u proj	0	0

--- a/tests/queries/0_stateless/04492_projection_ttl_default_divergence.sql
+++ b/tests/queries/0_stateless/04492_projection_ttl_default_divergence.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- A column with a non-type DDL DEFAULT and a column TTL, read through a projection, must return
 -- the DDL default (not the column type's default) once the TTL has expired. Regression test for the
 -- wide-part fully-expired fast path in TTLColumnAlgorithm, which reset the column to the type default

--- a/tests/queries/0_stateless/04492_projection_ttl_default_divergence.sql
+++ b/tests/queries/0_stateless/04492_projection_ttl_default_divergence.sql
@@ -1,0 +1,72 @@
+-- Tags: no-fasttest
+-- A column with a non-type DDL DEFAULT and a column TTL, read through a projection, must return
+-- the DDL default (not the column type's default) once the TTL has expired. Regression test for the
+-- wide-part fully-expired fast path in TTLColumnAlgorithm, which reset the column to the type default
+-- (e.g. 0); a rebuilt projection materialized that placeholder while the base read the DDL default
+-- (e.g. -1) via expired_columns, so a projection-served read diverged from the base-table read.
+
+DROP TABLE IF EXISTS t_proj_ttl_wide;
+
+CREATE TABLE t_proj_ttl_wide
+(
+    d Date,
+    k UInt32,
+    v Int32 DEFAULT -1 TTL d + INTERVAL 1 DAY,       -- constant DDL default
+    w Int32 DEFAULT k + 1000 TTL d + INTERVAL 1 DAY, -- per-row DDL default expression
+    PROJECTION p (SELECT k, v, w ORDER BY k)
+)
+ENGINE = MergeTree ORDER BY k SETTINGS min_bytes_for_wide_part = 0; -- force WIDE part
+
+INSERT INTO t_proj_ttl_wide SELECT '2000-01-01', number, 100 + number, 500 + number FROM numbers(1000);
+OPTIMIZE TABLE t_proj_ttl_wide FINAL; -- applies the column TTL and rebuilds the projection
+
+-- Constant DDL default: base and projection must both read -1.
+SELECT 'wide v base', min(v), max(v) FROM t_proj_ttl_wide SETTINGS optimize_use_projections = 0;
+SELECT 'wide v proj', min(v), max(v) FROM t_proj_ttl_wide SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+-- Per-row DDL default expression: base and projection must both read k + 1000 for every row.
+SELECT 'wide w base', sum(w = k + 1000), count() FROM t_proj_ttl_wide SETTINGS optimize_use_projections = 0;
+SELECT 'wide w proj', sum(w = k + 1000), count() FROM t_proj_ttl_wide SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_ttl_wide;
+
+-- Control: a compact part already used the DDL default (slow path); it must stay consistent.
+DROP TABLE IF EXISTS t_proj_ttl_compact;
+
+CREATE TABLE t_proj_ttl_compact
+(
+    d Date,
+    k UInt32,
+    v Int32 DEFAULT -1 TTL d + INTERVAL 1 DAY,
+    PROJECTION p (SELECT k, v ORDER BY k)
+)
+ENGINE = MergeTree ORDER BY k
+SETTINGS min_bytes_for_wide_part = '1G', min_rows_for_wide_part = 1000000000; -- force COMPACT part
+
+INSERT INTO t_proj_ttl_compact SELECT '2000-01-01', number, 100 + number FROM numbers(1000);
+OPTIMIZE TABLE t_proj_ttl_compact FINAL;
+
+SELECT 'compact v base', min(v), max(v) FROM t_proj_ttl_compact SETTINGS optimize_use_projections = 0;
+SELECT 'compact v proj', min(v), max(v) FROM t_proj_ttl_compact SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_ttl_compact;
+
+-- Must-not-regress: a column with no DDL DEFAULT keeps the column type's default (0) after expiry.
+DROP TABLE IF EXISTS t_proj_ttl_nodefault;
+
+CREATE TABLE t_proj_ttl_nodefault
+(
+    d Date,
+    k UInt32,
+    u Int32 TTL d + INTERVAL 1 DAY, -- no DDL DEFAULT -> type default 0
+    PROJECTION p (SELECT k, u ORDER BY k)
+)
+ENGINE = MergeTree ORDER BY k SETTINGS min_bytes_for_wide_part = 0; -- force WIDE part
+
+INSERT INTO t_proj_ttl_nodefault SELECT '2000-01-01', number, 100 + number FROM numbers(1000);
+OPTIMIZE TABLE t_proj_ttl_nodefault FINAL;
+
+SELECT 'nodefault u base', min(u), max(u) FROM t_proj_ttl_nodefault SETTINGS optimize_use_projections = 0;
+SELECT 'nodefault u proj', min(u), max(u) FROM t_proj_ttl_nodefault SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_ttl_nodefault;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108569

For a column with a non-type DDL `DEFAULT`, a column `TTL`, and a projection over it, once the column TTL expired on a **wide** part a projection-served read returned the column type's default (e.g. `0`) while the base-table read returned the DDL default (e.g. `-1`).

Root cause: `TTLColumnAlgorithm::execute`'s wide-part, fully-expired fast path reset the column with `insertManyDefaults` (the type default). For the base part that `0` is a discarded placeholder — the column is added to `expired_columns` and refilled with the DDL default at read time. But a row-reducing TTL merge rebuilds the projection from that block and materializes the placeholder `0` into the projection part (projections have no `expired_columns` machinery), so projection reads returned `0`. Compact parts were unaffected because they take the per-row slow path, which already evaluates the DDL `default_expression`.

Fix: make the wide fast path evaluate `default_expression` and fill all rows from it (falling back to `insertManyDefaults` only when the column has no DDL `DEFAULT`), matching the compact slow path. A rebuilt projection (and any dependent skip index) now materializes the same value the base logically reads.

Verified with a closed-loop test (`04492_projection_ttl_default_divergence`): with the fix, constant and per-row DDL defaults on a wide part read identically through base and projection; reverting the fix reproduces the divergence (projection reads `0`). Includes a compact-part control and a no-DDL-default must-not-regress case (type default `0` preserved).

This is a sibling of #108569, which fixed a *different* shape (a metadata-only-added `DEFAULT` column **missing** from a stale projection part). That fix does not cover this one — here the projection part physically materializes a wrong value.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a projection returning a column's type default (e.g. `0`) instead of its DDL `DEFAULT` (e.g. `-1`) after the column's `TTL` expired on a wide part.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.402` (included in `26.7` and later)
<!-- ch-version-info:end -->