### PR TITLE
Fix flaky transaction isolation tests by setting HTTP session_timeout in transactions.lib

### DIFF
--- a/tests/queries/0_stateless/transactions.lib
+++ b/tests/queries/0_stateless/transactions.lib
@@ -11,7 +11,7 @@ function tx()
     local session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
     local query_id="${session}_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
     local url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
-    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
+    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&session_timeout=600&max_execution_time=90"
 
     ${CLICKHOUSE_CURL} --max-time 90 -sSk "$url" --data "$query" | sed "s/^/tx$tx_num\t/"
 }
@@ -58,7 +58,7 @@ function tx_async()
     local session="${CLICKHOUSE_TEST_ZOOKEEPER_PREFIX}_tx$tx_num"
     local query_id="${session}_${RANDOM}"
     local url_without_session="http://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/?"
-    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&max_execution_time=90"
+    local url="${url_without_session}session_id=$session&query_id=$query_id&database=$CLICKHOUSE_DATABASE&apply_mutations_on_fly=0&session_timeout=600&max_execution_time=90"
 
     # We cannot be sure that query will actually start execution and appear in system.processes before the next call to tx_wait
     # Also we cannot use global map in bash to store last query_id for each tx_num, so we use tmp file...


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/71307
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/71307

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

Fixes a flaky failure of the transaction-isolation tests that use `transactions.lib` (`01167_isolation_hermitage` and siblings), surfaced under `Stateless tests (amd_tsan, s3 storage, parallel)`.

**Root cause.** `tx()`/`tx_async()` open each transaction in a named HTTP session but never set `session_timeout`, so the session inherits the 60s idle default (`default_session_timeout`, `HTTPHandler.cpp`). In a multi-transaction ping-pong scenario, one transaction can sit idle for more than 60s while a sibling does slow work under load. The idle session is then reaped by `NamedSessionsStorage`, which rolls back its open transaction. The next query in that session runs without a transaction, giving a wrong read and then `Code: 649. There is no current transaction. (INVALID_TRANSACTION)`.

Confirmed from the failing run's logs (session `..._tx4`): last activity at `04:18:44.5`, `Close session` at `04:19:45.9` (idle 61.4s > 60s), next request had to `Create new session` (transaction gone), `select` read the wrong value, and `commit` failed with error 649. CI's own rerun passed ("not reproducible, likely transient"), and the busy sibling session never expired.

**Fix.** Set `session_timeout=600` on the session URLs so a transaction survives the idle wait between its own queries. 600s is well under `max_session_timeout` (3600). This is a test-harness fix in the shared library, so it covers all tests that source `transactions.lib`.

**Validation** (local, server with `default_session_timeout=3`):
- Without `session_timeout`: begin -> idle 5s -> `commit` fails with `Code: 649 There is no current transaction` (reproduces the CI signature).
- With `session_timeout=600`: begin -> idle 5s -> `commit` succeeds.
- Isolation assertions unchanged: a concurrent same-row update still returns `Serialization error` and the aborted transaction still returns `INVALID_TRANSACTION`; final table state is correct.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.369` (included in `26.7` and later)
<!-- ch-version-info:end -->