### PR TITLE
Fix flaky 01600_quota_by_prefix_forwarded_ip

### DIFF
--- a/tests/queries/0_stateless/01600_quota_by_prefix_forwarded_ip.sh
+++ b/tests/queries/0_stateless/01600_quota_by_prefix_forwarded_ip.sh
@@ -4,6 +4,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# The CREATE/DROP QUOTA statements below run the access-entity notification batch
+# synchronously on the query thread. Under sanitizer slowdown the coalesced quota
+# recompute can exceed the 1s threshold and log a benign "Re-chose quotas" warning,
+# which server-log forwarding would leak into the captured stderr and fail the test.
+# --allow_repeated_settings lets this override the runner-injected --send_logs_level.
+CLICKHOUSE_CLIENT+=" --allow_repeated_settings --send_logs_level=fatal"
+
 $CLICKHOUSE_CLIENT --query "
 CREATE USER quoted_by_ip_${CLICKHOUSE_DATABASE};
 CREATE USER quoted_by_forwarded_ip_${CLICKHOUSE_DATABASE};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108721
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Flaky test requested by @alexey-milovidov in #108721 (no open tracking issue existed).

`01600_quota_by_prefix_forwarded_ip` fails under `Stateless tests (amd_tsan, parallel)` with "having stderror". The leaked line is a benign server log forwarded to the native client via `send_logs_level`:

```
<Warning> QuotaCache: Re-chose quotas for N enabled set(s) over M quotas in ... ms
```

logged at WARNING in `src/Access/QuotaCache.cpp` when the coalesced recompute takes at least 1000 ms (introduced in #107672). `CREATE`/`DROP QUOTA` runs the access-entity notification batch synchronously on the query thread, recomputing the quota cache. Under the thread fuzzer on sanitizer builds that recompute can cross the 1000 ms threshold (pure scheduler slowdown, not a pathological recompute), so the warning fires and is forwarded into the test's captured stderr.

Fix: silence server-log forwarding on the test's DDL client calls with `--send_logs_level=fatal` (`--allow_repeated_settings` lets it override the runner-injected `--send_logs_level`). The quota-masking assertions are unchanged.

Report (failing run): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108721&sha=c0949ccf2efd5566bdf132315ababfaf2fb7a23e&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29

Validated locally by temporarily forcing the warning to always fire: the test fails without this change (the warning leaks to stderr) and passes with it (20/20 runs, `send_logs_level=warning`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.440` (included in `26.7` and later)
<!-- ch-version-info:end -->