### PR TITLE
Fix flaky test_keeper_session_refuse_stale_server

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1,5 +1,4 @@
 import base64
-import concurrent
 import errno
 import http.client
 import json
@@ -4664,19 +4663,12 @@ class ClickHouseCluster:
 
     def process_integration_nodes(self, integration: str, nodes: list, action: str):
         base_cmd = getattr(self, f"base_{integration}_cmd")
-
-        def process_single_node(node):
-            logging.info("%sing %s node: %s", action.capitalize(), integration, node)
-            subprocess_check_call(base_cmd + [action, node])
-            logging.info("%sed %s node: %s", action.capitalize(), integration, node)
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=len(nodes)) as executor:
-            futures = []
-            for n in nodes:
-                futures += [executor.submit(process_single_node, n)]
-
-            for future in concurrent.futures.as_completed(futures):
-                future.result()
+        # One `docker compose` invocation for all nodes: concurrent compose commands on
+        # the same project race on shared project state and can silently drop a node's
+        # action. compose parallelizes the services internally.
+        logging.info("%sing %s nodes: %s", action.capitalize(), integration, nodes)
+        subprocess_check_call(base_cmd + [action] + list(nodes))
+        logging.info("%sed %s nodes: %s", action.capitalize(), integration, nodes)
 
     # Faster than waiting for clean stop
     def kill_zookeeper_nodes(self, zk_nodes):


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108074
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `test_keeper_session_refuse_stale_server` (requested by @alexey-milovidov on #108074).

The test restarts all three Keeper containers, then waits for them to come back. `stop_zookeeper_nodes()` stops them serially, but `start_zookeeper_nodes()` went through `process_integration_nodes()`, which ran one `docker compose start <node>` process per node **concurrently** (a `ThreadPoolExecutor`) against the **same compose project**.

Concurrent `docker compose` invocations on one project race on the project's shared state: on a loaded CI runner (integration tests run with `-n` workers) the start of one node can be silently dropped.

On the failing amd_msan run the Keeper's graceful stop overran docker's stop timeout and was SIGKILLed (exit 137); the three concurrent `docker compose start` processes then fired within ~2 ms of that stop returning, and dockerd received **no `/start` for zoo3** (it did for zoo1/zoo2). zoo3 never came back, so `wait_zookeeper_to_start()` timed out after 180 s and raised the generic `Cannot wait ZooKeeper container ... iptables-nft` exception at `test.py:73`. The same latent race affected `kill_zookeeper_nodes()`.

Fix: use a single `docker compose <action> <node1> <node2> ...` invocation instead of N concurrent ones. This is the pattern the framework already uses for startup (a single `docker compose up -d`); compose parallelizes the services internally, so there is no loss of parallelism and no shared-project race.

**CI failure this addresses** (Integration tests (amd_msan, 5/8), PR #108074, commit `817d237610a2d554f27994aedfdd07de1fef0bdc`):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108074&sha=817d237610a2d554f27994aedfdd07de1fef0bdc&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%205%2F8%29

Evidence from that report: dockerd received zoo3's container `/json` inspects but no `/start` while zoo1/zoo2 got `/start`; `docker.log` shows `zoo3-1 exited with code 137` with no subsequent restart; the gw0 log then polls `zoo3: bad hostname` for the full 180 s.

No related open issue found (searched by test name, `process_integration_nodes`, `start_zookeeper_nodes`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.370` (included in `26.7` and later)
<!-- ch-version-info:end -->