### PR TITLE
Move Code Review after fast PR checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -194,7 +194,7 @@ jobs:
 
   code_review:
     runs-on: [self-hosted, pr-style-checker-aarch64]
-    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
+    needs: [build_arm_tidy, ci_tests, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'Q29kZSBSZXZpZXc=') }}
     name: "Code Review"
     outputs:

--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -182,6 +182,12 @@ class Job:
             return res
 
         def set_run_after(self, job, reset=False):
+            """
+            Return a copy of this `Job.Config` that must start after the named jobs.
+
+            `set_run_after` controls execution order only. Use `set_requires` when
+            the job consumes artifacts produced by another job.
+            """
             res = copy.deepcopy(self)
             if not (isinstance(job, list) or isinstance(job, tuple)):
                 job = [job]

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -47,7 +47,7 @@ workflow = Workflow.Config(
     base_branches=[BASE_BRANCH],
     jobs=[
         JobConfigs.style_check,
-        JobConfigs.code_review,
+        JobConfigs.code_review.set_run_after(STYLE_AND_FAST_TESTS),
         JobConfigs.docs_job,
         JobConfigs.docs_job_mintlify,
         JobConfigs.fast_test,


### PR DESCRIPTION
Move `Code Review` after the fast PR gates by reusing `STYLE_AND_FAST_TESTS`, so it waits for `Style check`, `Fast test`, `CI Tests`, and `Build (arm_tidy)`.



### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

