### PR TITLE
Fix flaky test 00612_pk_in_tuple_perf

### DIFF
--- a/tests/queries/0_stateless/00612_pk_in_tuple_perf.sh
+++ b/tests/queries/0_stateless/00612_pk_in_tuple_perf.sh
@@ -25,7 +25,9 @@ query="SELECT count() FROM pk_in_tuple_perf WHERE (v, u) IN ((2, 10), (2, 20)) S
 $CLICKHOUSE_CLIENT --query "$query"
 $CLICKHOUSE_CLIENT --query "$query FORMAT JSON" | grep "rows_read"
 
-## Test with non-const args in tuple
+## Test with non-const args in tuple.
+## Use a fixed date, not today(): today() is evaluated separately at INSERT and SELECT time,
+## so a midnight straddle (widened by slow builds) would make count() drop to 0.
 
 $CLICKHOUSE_CLIENT <<EOF
 DROP TABLE IF EXISTS pk_in_tuple_perf_non_const;
@@ -37,10 +39,10 @@ CREATE TABLE pk_in_tuple_perf_non_const
 ORDER BY (u, d)
 SETTINGS index_granularity = 1;
 
-INSERT INTO pk_in_tuple_perf_non_const SELECT today() - number, number FROM numbers(100);
+INSERT INTO pk_in_tuple_perf_non_const SELECT toDate('2020-01-01') - number, number FROM numbers(100);
 EOF
 
-query="SELECT count() FROM pk_in_tuple_perf_non_const WHERE (u, d) IN ((0, today()), (1, today())) SETTINGS merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0"
+query="SELECT count() FROM pk_in_tuple_perf_non_const WHERE (u, d) IN ((0, toDate('2020-01-01')), (1, toDate('2020-01-01'))) SETTINGS merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0"
 
 $CLICKHOUSE_CLIENT --query "$query"
 $CLICKHOUSE_CLIENT --query "$query FORMAT JSON" | grep "rows_read"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a rare flaky failure of `00612_pk_in_tuple_perf`, seen on `Stateless tests (amd_msan, WasmEdge, parallel, 1/2)` and other slow builds.

The "non-const args in tuple" section used `today()` in both the INSERT (`today() - number`) and the SELECT (`(u, d) IN ((0, today()), (1, today()))`). `today()` is evaluated independently at INSERT time and at SELECT time (separate client invocations). If the wall clock crosses midnight (in the randomized session timezone) between the two, `today()@select` differs from `today()@insert`, so row 0 no longer matches and `count()` returns 0 instead of 1. `rows_read` stays 2 because the primary key still selects the same granules for `u IN (0, 1)`, matching the observed CI diff exactly (`-1`/`+0`, rows_read unchanged). The 15-25x slowdown of the msan/WasmEdge build widens the INSERT->SELECT window, making the straddle occasionally happen.

Replace `today()` with a fixed `toDate('2020-01-01')`. It is still a non-const function expression (preserving the test's original intent to cover non-const tuple elements), but it is timezone-independent and identical across the INSERT and SELECT, so no midnight race is possible. The `.reference` (count = 1, rows_read = 2) is unchanged.

Reproduced deterministically with `clickhouse local`: inserting with `today = 2020-06-15` then selecting with `today = 2020-06-16` yields `count() = 0, rows_read = 2` (the exact CI diff); the fixed version returns `count() = 1, rows_read = 2` under both the default and the `America/Hermosillo` session timezone. 50/50 passes through `clickhouse-test` with randomization enabled.

CI report of the failure this fixes: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109011&sha=4531517ba0a51a968862bc9d6e085733de02e91b&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.371` (included in `26.7` and later)
<!-- ch-version-info:end -->