### PR TITLE
Add regression test variant for materialized CTE Int64/UInt64 type drift (STID 2241-3a03)

### DIFF
--- a/tests/queries/0_stateless/04148_stid_3520_3e11_materialized_cte_outer_alias.sql
+++ b/tests/queries/0_stateless/04148_stid_3520_3e11_materialized_cte_outer_alias.sql
@@ -54,6 +54,20 @@ SELECT * FROM (
     ) ORDER BY a DESC, x ASC NULLS FIRST WITH FILL
 ) FORMAT Null; -- { serverError TYPE_MISMATCH }
 
+-- Non-nullable Int64 vs UInt64 pair (STID 2241-3a03, issue #103814): the two branches
+-- supply a signed (`-1`) and an unsigned-inducing (`257`) constant for `a`, so `x` infers
+-- as Int64 in the first reference (storage) and UInt64 in the second. Aborted with
+-- 'Bad cast from type DB::ColumnVector<unsigned long> to DB::ColumnVector<long>' before
+-- the guard; now rejected cleanly.
+SELECT * FROM (
+    WITH t AS MATERIALIZED (SELECT number + a AS x FROM numbers(1))
+    SELECT * FROM (
+        SELECT -1 AS a, x FROM t
+        UNION ALL
+        SELECT 257 AS a, x FROM t
+    )
+) FORMAT Null; -- { serverError TYPE_MISMATCH }
+
 -- Sanity checks: shapes that previously worked must still work after the fix.
 
 -- The CTE body has no outer-scope dependency, so all references agree on the type.


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/103814
Related: https://github.com/ClickHouse/ClickHouse/pull/103879
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: #103814

AST fuzzer STID 2241-3a03 (`Bad cast from type DB::ColumnVector<unsigned long> to DB::ColumnVector<long>`) is the non-nullable `Int64`/`UInt64` variant of the materialized-CTE outer-scope type-drift bug already fixed by #103879 (the analysis-time `verifyMaterializedCTESubqueryMatchesStorage` guard in `QueryAnalyzer.cpp`). That guard is a class fix, so this shape is already rejected with `TYPE_MISMATCH`; STID 2241-3a03 has had 0 master hits in 90 days and 0 hits anywhere since 2026-05-08.

The existing regression test `04148_stid_3520_3e11_materialized_cte_outer_alias.sql` only pinned Nullable/Float64 drift shapes. This adds the issue #103814 shape (signed `-1` vs unsigned-inducing `257` supplied for the outer alias `a`, driving `x` to `Int64` in storage and `UInt64` in the second reference) so the exact `ColumnVector<long>`/`ColumnVector<unsigned long>` pair is covered.

No source change. Test-only.
