### PR TITLE
Fix sync PR merge hook retry handling

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -13,10 +13,29 @@ def check():
         print(f"WARNING: Invalid or unknown pr number: {info.linked_pr_number}")
         return
 
-    sync_pr_number = Shell.get_output(
+    raw = Shell.get_output(
         f"gh pr list --state open --head sync-upstream/pr/{info.linked_pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
         verbose=True,
-    ).splitlines()[0]
+        retries=5,
+    )
+    if not raw:
+        print("WARNING: Failed to retrieve Sync PR list after retries - skipping merge")
+        return
+
+    sync_pr_numbers = [n.strip() for n in raw.splitlines() if n.strip()]
+
+    if len(sync_pr_numbers) == 0:
+        print("WARNING: No open Sync PR found - skipping merge")
+        return
+
+    if len(sync_pr_numbers) > 1:
+        print(
+            f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{info.linked_pr_number}, "
+            f"found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge"
+        )
+        return
+
+    sync_pr_number = sync_pr_numbers[0]
     if not sync_pr_number.isdigit() or not int(sync_pr_number):
         print("WARNING: Failed to retrieve Sync PR number")
         return


### PR DESCRIPTION
Make the sync PR merge hook robust when `gh pr list` fails transiently or returns no matching PR. The hook now retries the lookup, validates the result, and skips merging with a warning instead of raising `IndexError`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.346` (included in `26.7` and later)
<!-- ch-version-info:end -->