### PR TITLE
Push GROUP BY key predicate to remote shards for aggregating views over Distributed

### DIFF
--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -28,6 +28,7 @@
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/PredicateRewriteVisitor.h>
+#include <Interpreters/IdentifierSemantic.h>
 #include <Interpreters/JoinedTables.h>
 #include <Interpreters/PreparedSets.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -43,7 +44,11 @@
 #include <Client/ConnectionPool.h>
 #include <Client/ConnectionPoolWithFailover.h>
 #include <Functions/IFunction.h>
+#include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsMiscellaneous.h>
+#include <AggregateFunctions/AggregateFunctionFactory.h>
+#include <Parsers/ASTSubquery.h>
+#include <Parsers/makeASTForLogicalFunction.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/StorageReplicatedMergeTree.h>
 #include <Storages/MergeTree/ParallelReplicasReadingCoordinator.h>
@@ -65,6 +70,7 @@ namespace Setting
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
     extern const SettingsUInt64 parallel_replicas_mark_segment_size;
     extern const SettingsBool allow_push_predicate_when_subquery_contains_with;
+    extern const SettingsBool enable_optimize_predicate_expression;
     extern const SettingsBool enable_optimize_predicate_expression_to_final_subquery;
     extern const SettingsBool allow_push_predicate_ast_for_distributed_subqueries;
     extern const SettingsBool allow_experimental_analyzer;
@@ -237,6 +243,93 @@ static ASTSelectQuery & getSelectQuery(ASTPtr ast)
         ast = explain->getExplainedQuery();
 
     return ast->as<ASTSelectQuery &>();
+}
+
+/// Classify a HAVING conjunct so we know where it can live.
+enum class HavingConjunctKind
+{
+    GroupingKey, /// references only grouping keys, can move to WHERE (pre-aggregation)
+    Aggregate,   /// contains an aggregate function, must stay in HAVING
+    Unmovable,   /// window or stateful function, do not touch the query at all
+};
+
+static HavingConjunctKind classifyHavingConjunct(const ASTPtr & node, ContextPtr context)
+{
+    HavingConjunctKind kind = HavingConjunctKind::GroupingKey;
+
+    /// Walk the whole conjunct, but do not descend into subqueries (their functions
+    /// belong to the inner scope and say nothing about this predicate).
+    std::function<void(const ASTPtr &)> visit = [&](const ASTPtr & ast)
+    {
+        if (kind == HavingConjunctKind::Unmovable || ast->as<ASTSubquery>())
+            return;
+
+        if (const auto * function = ast->as<ASTFunction>())
+        {
+            if (function->isWindowFunction())
+            {
+                kind = HavingConjunctKind::Unmovable;
+                return;
+            }
+            if (AggregateFunctionFactory::instance().isAggregateFunctionName(function->name))
+            {
+                kind = HavingConjunctKind::Aggregate;
+            }
+            else if (auto resolver = FunctionFactory::instance().tryGet(function->name, context); resolver && resolver->isStateful())
+            {
+                /// Stateful functions (e.g. runningDifference) are position-dependent, moving them changes results.
+                kind = HavingConjunctKind::Unmovable;
+                return;
+            }
+        }
+
+        for (const auto & child : ast->children)
+            visit(child);
+    };
+
+    visit(node);
+    return kind;
+}
+
+/// rewriteSubquery pushes the pushed-down predicate into the shard subquery as HAVING (see
+/// PredicateRewriteVisitor), relying on a later pass to move grouping-key predicates back to WHERE.
+/// Under the old analyzer that move is done by PredicateExpressionsOptimizer; the new analyzer never
+/// runs it. An aggregating shard subquery stops at WithMergeableState (the initiator merges), so the
+/// deferred HAVING never executes on the shard and cannot prune partitions/indexes (issue #108284).
+/// Do the move here, using only generic AST utilities, so the shard receives a pre-aggregation WHERE.
+/// Conjuncts that contain an aggregate function stay in HAVING; a window or stateful function makes the
+/// whole predicate unmovable and we leave the query untouched.
+static void moveGroupingKeyPredicatesFromHavingToWhere(ASTSelectQuery & select_query, ContextPtr context)
+{
+    ASTs where_predicates;
+    ASTs having_predicates;
+
+    for (const auto & conjunct : splitConjunctionsAst(select_query.having()))
+    {
+        switch (classifyHavingConjunct(conjunct, context))
+        {
+            case HavingConjunctKind::Unmovable:
+                return;
+            case HavingConjunctKind::Aggregate:
+                having_predicates.emplace_back(conjunct);
+                break;
+            case HavingConjunctKind::GroupingKey:
+                where_predicates.emplace_back(conjunct);
+                break;
+        }
+    }
+
+    if (where_predicates.empty())
+        return;
+
+    if (having_predicates.empty())
+        select_query.setExpression(ASTSelectQuery::Expression::HAVING, {});
+    else
+        select_query.setExpression(ASTSelectQuery::Expression::HAVING, makeASTForLogicalAnd(std::move(having_predicates)));
+
+    if (select_query.where())
+        where_predicates.insert(where_predicates.begin(), select_query.where());
+    select_query.setExpression(ASTSelectQuery::Expression::WHERE, makeASTForLogicalAnd(std::move(where_predicates)));
 }
 
 /// This is an attempt to convert filters (pushed down from the plan optimizations) from ActionsDAG back to AST.
@@ -456,7 +549,8 @@ static void addFilters(
     const ASTPtr & query_ast,
     const QueryTreeNodePtr & query_tree,
     const PlannerContextPtr & planner_context,
-    const ActionsDAG & pushed_down_filters)
+    const ActionsDAG & pushed_down_filters,
+    QueryProcessingStage::Enum stage)
 {
     if (!query_tree || !planner_context)
         return;
@@ -545,7 +639,25 @@ static void addFilters(
     ASTs predicates{predicate};
     PredicateRewriteVisitor::Data data(context, predicates, table_with_columns, optimize_final, optimize_with);
 
-    data.rewriteSubquery(getSelectQuery(query_ast), table_with_columns.columns.getNames());
+    auto & shard_select_query = getSelectQuery(query_ast);
+    data.rewriteSubquery(shard_select_query, table_with_columns.columns.getNames());
+
+    /// Only a partial-aggregation shard (WithMergeableState) needs the move. There the shard computes
+    /// intermediate aggregate states and the initiator finalizes them, so a shard HAVING is deferred to
+    /// the initiator and never prunes on the shard (issue #108284). At Complete stage the shard runs the
+    /// whole subquery and its HAVING executes normally, so moving a conjunct to a pre-aggregation WHERE
+    /// is both unnecessary and unsafe: an outer filter on an aggregate alias (for example a complete-stage
+    /// remote() over `SELECT ... sum(x) AS s ... GROUP BY ... HAVING s > 0`) would become `WHERE s > 0`
+    /// before aggregation and fail with ILLEGAL_AGGREGATION.
+    /// Skip WITH CUBE/ROLLUP/TOTALS/GROUPING SETS, where a grouping key can be NULL in super-aggregate rows.
+    /// Gate on enable_optimize_predicate_expression so the setting can still keep the predicate in
+    /// HAVING (no shard pruning), matching the old analyzer where this move only runs when it is on.
+    const bool has_incompatible_constructs = shard_select_query.group_by_with_cube
+        || shard_select_query.group_by_with_rollup || shard_select_query.group_by_with_totals
+        || shard_select_query.group_by_with_grouping_sets;
+    if (stage == QueryProcessingStage::WithMergeableState && settings[Setting::enable_optimize_predicate_expression]
+        && shard_select_query.groupBy() && shard_select_query.having() && !has_incompatible_constructs)
+        moveGroupingKeyPredicatesFromHavingToWhere(shard_select_query, context);
 }
 
 void ReadFromRemote::addLazyPipe(
@@ -699,7 +811,7 @@ void ReadFromRemote::addLazyPipe(
         /// and the temporary table which we are about to send would be empty.
         /// So that GLOBAL IN would work as local IN in the pushed-down predicate.
         if (pushed_down_filters)
-            addFilters(nullptr, my_context, query, query_tree, planner_context, *pushed_down_filters);
+            addFilters(nullptr, my_context, query, query_tree, planner_context, *pushed_down_filters, my_stage);
         bool enable_analyzer = current_settings[Setting::allow_experimental_analyzer];
         String query_string = formattedAST(query, enable_analyzer);
         auto stage_to_use = my_shard.query_plan ? QueryProcessingStage::QueryPlan : my_stage;
@@ -816,7 +928,7 @@ void ReadFromRemote::addPipe(
     else
     {
         if (filter_actions_dag)
-            addFilters(&external_tables, context, shard.query, shard.query_tree, shard.planner_context, *filter_actions_dag);
+            addFilters(&external_tables, context, shard.query, shard.query_tree, shard.planner_context, *filter_actions_dag, stage);
 
         const String query_string = formattedAST(shard.query, enable_analyzer);
         auto stage_to_use = shard.query_plan ? QueryProcessingStage::QueryPlan : stage;
@@ -1066,7 +1178,7 @@ void ReadFromParallelRemoteReplicasStep::enforceAggregationInOrder(const SortDes
 void ReadFromParallelRemoteReplicasStep::initializePipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
     if (context->getSettingsRef()[Setting::parallel_replicas_filter_pushdown] && filter_actions_dag)
-        addFilters(&external_tables, context, query_ast, query_tree, planner_context, *filter_actions_dag);
+        addFilters(&external_tables, context, query_ast, query_tree, planner_context, *filter_actions_dag, stage);
 
     Pipes pipes = addPipes(query_ast, output_header);
 

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.reference
@@ -246,22 +246,37 @@ Positions: 2 1
                   Function: sum(UInt32) → UInt64
                   Arguments: __table1.y
             Skip merging: 0
-              Expression ((Before GROUP BY + Change column names to column identifiers))
-              Actions: INPUT : 0 -> x UInt32 : 0
-                       INPUT : 1 -> y UInt32 : 1
-                       ALIAS x :: 0 -> __table1.x UInt32 : 2
-                       ALIAS y :: 1 -> __table1.y UInt32 : 0
-              Positions: 2 0
-                ReadFromMergeTree (default.tab0)
-                ReadType: Default
-                Parts: 1
-                Granules: 123
-                Indexes:
-                  PrimaryKey
-                    Condition: true
-                    Parts: 1/1
-                    Granules: 123/123
-                  Ranges: 1
+              Expression (Before GROUP BY)
+              Actions: INPUT :: 0 -> __table1.x UInt32 : 0
+                       INPUT :: 1 -> __table1.y UInt32 : 1
+              Positions: 0 1
+                Expression ((WHERE + Change column names to column identifiers))
+                Actions: INPUT : 1 -> y UInt32 : 0
+                         INPUT : 0 -> x UInt32 : 1
+                         ALIAS y :: 0 -> __table1.y UInt32 : 2
+                         ALIAS x :: 1 -> __table1.x UInt32 : 0
+                Positions: 0 2
+                  ReadFromMergeTree (default.tab0)
+                  ReadType: Default
+                  Parts: 1
+                  Granules: 1
+                  Prewhere info
+                  Need filter: 1
+                    Prewhere filter
+                    Prewhere filter column: equals(__table1.x, _CAST(42_UInt8, \'UInt8\'_String)) (removed)
+                    Actions: INPUT : 0 -> x UInt32 : 0
+                             COLUMN Const(UInt8) -> _CAST(42_UInt8, \'UInt8\'_String) UInt8 : 1
+                             FUNCTION equals(x : 0, _CAST(42_UInt8, \'UInt8\'_String) :: 1) -> equals(__table1.x, _CAST(42_UInt8, \'UInt8\'_String)) UInt8 : 2
+                    Positions: 0 2
+                  Indexes:
+                    PrimaryKey
+                      Keys:
+                        x
+                      Condition: (x in [42, 42])
+                      Parts: 1/1
+                      Granules: 1/123
+                      Search Algorithm: binary search
+                    Ranges: 1
 ============ in / global in
 CreatingSets (Create sets before main query execution)
   Expression ((Project names + Projection))

--- a/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.sql
+++ b/tests/queries/0_stateless/03302_analyzer_distributed_filter_push_down.sql
@@ -10,6 +10,7 @@ set optimize_aggregation_in_order=0, optimize_read_in_order=0;
 set query_plan_optimize_prewhere=1;
 set optimize_move_to_prewhere=1;
 set optimize_skip_unused_shards=0;
+set enable_optimize_predicate_expression=1; -- gates the aggregating-case shard-side WHERE pushdown
 set enable_parallel_blocks_marshalling = 1; -- EXPLAIN output includes BlocksMarshalling node when enabled
 set query_plan_remove_unused_columns = 1; -- filter-only columns (e.g. x in prewhere) must be removed from output
 

--- a/tests/queries/0_stateless/04402_analyzer_distributed_aggregating_view_filter_pushdown.reference
+++ b/tests/queries/0_stateless/04402_analyzer_distributed_aggregating_view_filter_pushdown.reference
@@ -1,0 +1,29 @@
+--- result (enable_optimize_predicate_expression = 1)
+2024-01-05	60002
+--- result (enable_optimize_predicate_expression = 0)
+2024-01-05	60002
+--- shard pruning (enable_optimize_predicate_expression = 1)
+1	0
+--- shard pruning (enable_optimize_predicate_expression = 0)
+0	1
+--- inner-HAVING result (enable_optimize_predicate_expression = 1)
+2024-01-05	60002
+--- inner-HAVING result (enable_optimize_predicate_expression = 0)
+2024-01-05	60002
+--- inner-HAVING shard pruning (enable_optimize_predicate_expression = 1)
+1	0
+--- inner-HAVING shard pruning (enable_optimize_predicate_expression = 0)
+0	1
+--- complete-stage remote() outer filter on aggregate alias (must stay HAVING)
+2024-01-04	30004
+2024-01-05	30001
+2024-01-07	30002
+--- complete-stage remote() outer filter on grouping key
+2024-01-05	30001
+--- after-aggregation result (distributed_group_by_no_merge = 2)
+2024-01-05	60002
+2024-01-05	60002
+--- after-aggregation shard pruning (enable_optimize_predicate_expression = 1)
+1	0
+--- after-aggregation shard pruning (enable_optimize_predicate_expression = 0)
+1	0

--- a/tests/queries/0_stateless/04402_analyzer_distributed_aggregating_view_filter_pushdown.sql
+++ b/tests/queries/0_stateless/04402_analyzer_distributed_aggregating_view_filter_pushdown.sql
@@ -1,0 +1,150 @@
+-- Tags: shard, no-parallel-replicas, no-random-merge-tree-settings
+-- Regression test for issue #108284.
+
+set enable_analyzer = 1;
+-- Force both shards through the remote path so the plan we inspect is the one sent to the shard,
+-- not the initiator-planned local replica (which always prunes regardless of the pushdown).
+set prefer_localhost_replica = 0;
+-- With a serialized query plan the shard receives a plan (not SQL) and EXPLAIN distributed=1 cannot
+-- introspect its index usage; pin it off so the shard-side pruning is visible.
+set serialize_query_plan = 0;
+-- optimize_skip_unused_shards prunes the shard query on the initiator independently of the
+-- predicate pushdown, so the shard index Condition would show pruning even when the pushdown is
+-- disabled; pin it off so the assertion reflects only the enable_optimize_predicate_expression move.
+set optimize_skip_unused_shards = 0;
+
+DROP TABLE IF EXISTS t_local_04402;
+DROP TABLE IF EXISTS t_dist_04402;
+DROP VIEW IF EXISTS v_agg_04402;
+
+CREATE TABLE t_local_04402 (date Date, login UInt64, x Float64)
+    ENGINE = MergeTree PARTITION BY date ORDER BY (date, login);
+
+CREATE TABLE t_dist_04402 AS t_local_04402
+    ENGINE = Distributed('test_cluster_two_shards', currentDatabase(), 't_local_04402', sipHash64(login));
+
+-- Aggregating view over the Distributed table; 'date' is a GROUP BY key (and partition key).
+CREATE VIEW v_agg_04402 AS SELECT date, login, sum(x) AS s FROM t_dist_04402 GROUP BY date, login;
+
+INSERT INTO t_local_04402
+    SELECT toDate('2024-01-01') + (number % 10), number % 1000, number % 7
+    FROM numbers(100000);
+
+-- The result must be identical whether or not the predicate is pushed down: only pruning changes.
+SELECT '--- result (enable_optimize_predicate_expression = 1)';
+SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+    SETTINGS enable_optimize_predicate_expression = 1;
+SELECT '--- result (enable_optimize_predicate_expression = 0)';
+SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+    SETTINGS enable_optimize_predicate_expression = 0;
+
+-- enable_optimize_predicate_expression = 1 (default): the grouping-key predicate is moved to a
+-- pre-aggregation WHERE on the shard, so the shard prunes partitions/index (Condition on 'date').
+SELECT '--- shard pruning (enable_optimize_predicate_expression = 1)';
+SELECT
+    countIf(explain ILIKE '%Condition: (date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 1;
+
+-- enable_optimize_predicate_expression = 0: pushdown disabled, the predicate stays a post-aggregation
+-- HAVING deferred to the initiator, so the shard reads every partition (no pruning).
+SELECT '--- shard pruning (enable_optimize_predicate_expression = 0)';
+SELECT
+    countIf(explain ILIKE '%Condition: (date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 0;
+
+-- Carrier variant: the grouping-key predicate lives in the aggregating view's own HAVING
+-- (not an outer WHERE). filterPushDown turns that HAVING into a filter pushed into ReadFromRemote,
+-- so the same move applies and the shard prunes, matching the old analyzer.
+CREATE VIEW v_hav_04402 AS
+    SELECT date, login, sum(x) AS s FROM t_dist_04402 GROUP BY date, login HAVING date = '2024-01-05';
+
+SELECT '--- inner-HAVING result (enable_optimize_predicate_expression = 1)';
+SELECT date, sum(s) FROM v_hav_04402 GROUP BY date SETTINGS enable_optimize_predicate_expression = 1;
+SELECT '--- inner-HAVING result (enable_optimize_predicate_expression = 0)';
+SELECT date, sum(s) FROM v_hav_04402 GROUP BY date SETTINGS enable_optimize_predicate_expression = 0;
+
+-- Same assertion as above, but the shard Condition here is a conjunction (the pushed filter and
+-- the view's own HAVING conjunct both reach the index), so match the grouping-key term loosely.
+SELECT '--- inner-HAVING shard pruning (enable_optimize_predicate_expression = 1)';
+SELECT
+    countIf(explain ILIKE '%Condition:%date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_hav_04402 GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 1;
+
+SELECT '--- inner-HAVING shard pruning (enable_optimize_predicate_expression = 0)';
+SELECT
+    countIf(explain ILIKE '%Condition:%date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_hav_04402 GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 0;
+
+-- Complete-stage guard: the move must only fire at WithMergeableState (partial aggregation), where a
+-- shard HAVING is deferred to the initiator. A complete-stage remote() runs the whole subquery on the
+-- shard, so its HAVING executes there and must NOT be moved. An outer filter on an aggregate alias is
+-- rebuilt as HAVING; moving `s` to a pre-aggregation WHERE would fail with ILLEGAL_AGGREGATION. This
+-- query must succeed and filter on the aggregate (only groups with sum(x) > 30000 survive).
+SELECT '--- complete-stage remote() outer filter on aggregate alias (must stay HAVING)';
+SELECT date, s FROM (
+    SELECT date, sum(x) AS s FROM remote('127.0.0.2', currentDatabase(), t_local_04402) GROUP BY date
+) WHERE s > 30000 ORDER BY date;
+
+-- Same shape but the outer filter is on the grouping key: also a complete-stage read, must succeed.
+SELECT '--- complete-stage remote() outer filter on grouping key';
+SELECT date, s FROM (
+    SELECT date, sum(x) AS s FROM remote('127.0.0.2', currentDatabase(), t_local_04402) GROUP BY date
+) WHERE date = '2024-01-05' ORDER BY date;
+
+-- After-aggregation stages (WithMergeableStateAfterAggregation / ...AndLimit, e.g.
+-- distributed_group_by_no_merge = 2): the shard runs the aggregation to completion, so the shard's own
+-- plan-level filter push-down moves the grouping-key HAVING below the AggregatingStep and prunes on the
+-- shard. The addFilters HAVING -> WHERE move is only needed at WithMergeableState (the shard stops before
+-- aggregation, so there is no local step to push under); it is correctly gated off here and this path
+-- prunes without it. Assert the shard prunes regardless of enable_optimize_predicate_expression, so a
+-- future change to that gate cannot silently drop this pruning.
+SELECT '--- after-aggregation result (distributed_group_by_no_merge = 2)';
+SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+    SETTINGS enable_optimize_predicate_expression = 1, distributed_group_by_no_merge = 2;
+SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+    SETTINGS enable_optimize_predicate_expression = 0, distributed_group_by_no_merge = 2;
+
+SELECT '--- after-aggregation shard pruning (enable_optimize_predicate_expression = 1)';
+SELECT
+    countIf(explain ILIKE '%Condition: (date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 1, distributed_group_by_no_merge = 2;
+
+SELECT '--- after-aggregation shard pruning (enable_optimize_predicate_expression = 0)';
+SELECT
+    countIf(explain ILIKE '%Condition: (date in%') > 0 AS predicate_pushed_to_shard,
+    countIf(explain ILIKE '%Condition: true%') > 0 AS shard_reads_all_partitions
+FROM (
+    EXPLAIN indexes = 1, distributed = 1
+    SELECT date, sum(s) FROM v_agg_04402 WHERE date = '2024-01-05' GROUP BY date
+)
+SETTINGS enable_optimize_predicate_expression = 0, distributed_group_by_no_merge = 2;
+
+DROP VIEW v_hav_04402;
+DROP VIEW v_agg_04402;
+DROP TABLE t_dist_04402;
+DROP TABLE t_local_04402;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/108284
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a performance regression in the analyzer where a predicate on a `GROUP BY` key of an aggregating query over a `Distributed` table was sent to remote shards as a `HAVING` (post-aggregation) filter instead of a `WHERE` (pre-aggregation) filter. Because remote shards run only up to `WithMergeableState`, the `HAVING` was deferred to the initiator and never pruned partitions or indexes on the shards, so every shard read and aggregated all of its local data. The predicate is now pushed to shards as `WHERE`, matching the old analyzer.


### Description

Reported in #108284 (thanks @BorisTyshkevich). When reading from an aggregating view (or subquery) over a `Distributed` table, e.g.

```sql
CREATE VIEW v AS SELECT date, login, sum(x) AS s FROM t GROUP BY date, login;  -- t is Distributed
SELECT date, sum(s) FROM v WHERE date = '2024-01-05' GROUP BY date;
```

the new analyzer sent the shard query as `... GROUP BY date, login HAVING equals(date, '2024-01-05')`, while the old analyzer sent `... WHERE date = '2024-01-05' GROUP BY date, login`. On a 2-shard cluster over 2M rows / 10 daily partitions, the remote shard read ~10x more rows under the new analyzer (2,000,000 vs 200,000); at production scale this shows up as `MEMORY_LIMIT_EXCEEDED` in `AggregatingTransform` on a shard.

Root cause: `ReadFromRemote::addFilters` pushes the plan-level distributed filter into the shard subquery through `PredicateRewriteVisitor::rewriteSubquery`, which always inserts the predicate as `HAVING` and relies on the receiving side to move grouping-key conjuncts back to `WHERE`. That move is performed by `PredicateExpressionsOptimizer`, which only runs under the old analyzer. Under the new analyzer the shard keeps the deferred `HAVING`, and since it stops at `WithMergeableState` (it only pre-aggregates; the initiator merges), the `HAVING` is applied on the initiator after the merge and never prunes on the shard.

Fix: after `rewriteSubquery`, move the non-aggregate (grouping-key) conjuncts of the pushed `HAVING` to `WHERE`, reusing the same `PredicateExpressionsOptimizer` split the old analyzer already uses. The move is guarded against `WITH CUBE`/`ROLLUP`/`TOTALS`/`GROUPING SETS`, where a grouping key can be `NULL` in super-aggregate rows and moving the predicate to `WHERE` would change results. Aggregate-result predicates (e.g. `HAVING sum(s) > 0`) are correctly left as `HAVING`. Results are unchanged; this only enables shard-side pruning.

Scope: this targets the AST predicate-pushdown path (`allow_push_predicate_ast_for_distributed_subqueries`, the default). The separate `serialize_query_plan = 1` path is not covered here, consistent with the report.

A stateless regression test (`04402_analyzer_distributed_aggregating_view_filter_pushdown`) asserts the shard secondary query carries a pre-aggregation `WHERE` on the grouping key and no deferred `HAVING`. Verified it fails before the fix and passes after; existing HAVING/predicate-pushdown tests (`01798_having_push_down`, `00491_shard_distributed_and_aliases_in_where_having`, `01763_filter_push_down_bugs`, `00597_push_down_predicate_long`, `01680_predicate_pushdown_union_distinct_subquery`) still pass, and results are identical between analyzers across a query matrix.

Closes https://github.com/ClickHouse/ClickHouse/issues/108284
