### PR TITLE
Use try-lock in LRUFileCachePriority::tryIncreasePriority

### DIFF
--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -719,7 +719,10 @@ bool LRUFileCachePriority::tryIncreasePriority(
     CachePriorityGuard & queue_guard,
     CacheStateGuard &)
 {
-    auto lock = queue_guard.writeLock();
+    auto lock = queue_guard.tryWriteLock();
+    if (!lock.owns_lock())
+        return false;
+
     const auto & entry = iterator.getEntry();
     chassert(entry->getState() == Entry::State::Active);
 


### PR DESCRIPTION
Avoid blocking on the priority queue write lock in `LRUFileCachePriority::tryIncreasePriority`. If the lock can't be acquired immediately, return `false` so callers fall back instead of contending on a busy queue.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.2.20`, `26.5.6.16`, `26.4.5.103`, `26.3.17.22`
<!-- ch-version-info:end -->