### PR TITLE
Fix flaky test 00974_query_profiler

### DIFF
--- a/tests/queries/0_stateless/00974_query_profiler.sql
+++ b/tests/queries/0_stateless/00974_query_profiler.sql
@@ -18,6 +18,9 @@ WITH addressToLine(arrayJoin(trace) AS addr) || '#' || demangle(addressToSymbol(
 SELECT count() > 0 FROM system.trace_log t WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id = (SELECT query_id FROM system.query_log WHERE current_database = currentDatabase() AND query LIKE '%test real time query profiler%' AND query NOT LIKE '%system%' ORDER BY event_time DESC LIMIT 1) AND symbol LIKE '%FunctionSleep%';
 
 -- Also test the real time profiler with CPU-bound work (numbers_mt).
+-- Use a short period so the fast multi-threaded scan reliably spans several
+-- profiler periods (a 100ms period races the tens-of-ms scan -> 0 samples).
+SET query_profiler_real_time_period_ns = 1e6;
 SET max_rows_to_read = 0;
 SET log_queries = 1;
 SELECT count(), ignore('test real time query profiler numbers_mt') FROM numbers_mt(1e9);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found (searched issues/PRs for `00974_query_profiler` — none open).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Flaky `00974_query_profiler` (residual after #106495). The `numbers_mt` real-time profiler probe inherited the 100ms period (`query_profiler_real_time_period_ns = 1e8`) from the sleep probe above it. `count()` over `numbers_mt(1e9)` finishes in tens of milliseconds, so on fast hardware the whole multi-threaded scan can complete before the 100ms per-thread timer (first fire randomized in `[0, period]`) ever fires, yielding 0 `Source` samples and flipping the assertion on line 4 from `1` to `0`.

Fix: set a 1ms period for that probe so the fast scan reliably spans several profiler periods. The sleep probe (500ms >> 100ms) and the CPU-time probe are unchanged; the test still asserts the real-time profiler captures `Source` samples during the CPU-bound scan.

Note: bumping the row count was already tried and reverted in #106495 ("Revert number of rows ... so sanitizer builds can handle") — sanitizers cannot afford a larger scan, so the period is the correct lever, not the workload.

Validation (debug build, this exact failure signature — line 4 `1`->`0`):
- Without the change: numbers_mt probe returns 0 `Source` samples in ~7% of runs (4/60 with randomization; 5/30 even with `--no-random-settings`, confirming it is a pure timing race, not settings).
- With the change: 60/60 runs pass with randomization ON and 60/60 with `--no-random-settings`; the probe captures hundreds of `Source` samples.

Failure history: master 2 hits/30d (2026-06-04, 2026-06-27), plus 8 unrelated PRs. CI reruns always pass (its own diagnosis: "not reproducible, likely transient") - the hallmark of a low-rate timing flake.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.360` (included in `26.7` and later)
<!-- ch-version-info:end -->