### PR TITLE
Always set job timeout for functional tests

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -157,15 +157,16 @@ def run_tests(
         # clickhouse-test even starts. Read the timeout defensively from either a
         # mapping or a Job.Config object, defaulting to 2h when unset.
         job_cfg = Info().job_config
-        if isinstance(job_cfg, dict):
-            configured_timeout = job_cfg.get("timeout")
-        else:
-            configured_timeout = getattr(job_cfg, "timeout", None)
+        configured_timeout = job_cfg.get("timeout") if isinstance(job_cfg, dict) else getattr(job_cfg, "timeout", None)
         job_timeout = configured_timeout or 2 * 3600
         elapsed = int(job_stop_watch.duration) if job_stop_watch else 0
-        # Floor so a near-exhausted budget still passes a positive timeout to
-        # Shell.run (fire the SIGTERM promptly) rather than 0/negative.
-        outer_timeout = max(60, job_timeout - elapsed - RESERVE_SECONDS)
+        # Bound Shell.run by the time actually left before Praktika hard-kills the
+        # job (job_timeout - elapsed), reserving RESERVE_SECONDS of that for the
+        # SIGTERM + log/result collection. Once the reserve is already gone this goes
+        # <= 0; clamp to a minimal positive value (NOT a fixed floor like 60s, which
+        # would outlast the real remaining time and let the runner hard-kill fire
+        # first, losing logs) so clickhouse-test is SIGTERMed promptly instead.
+        outer_timeout = max(1, job_timeout - elapsed - RESERVE_SECONDS)
     return Shell.run(command, verbose=True, timeout=outer_timeout)
 
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -732,8 +732,14 @@ def main():
         global_time_limit = 0
         if is_flaky_check:
             FLAKY_CHECK_TIME_LIMIT = 45 * 60  # 45 min
+            # Floor at a positive value (as the targeted check below does): if the
+            # remaining flaky budget hit 0, run_tests would see global_time_limit == 0
+            # and fall into the regular-run branch, arming Shell.run for the whole
+            # remaining *job* budget instead of stopping this flaky check once its own
+            # 45-min budget is spent. Keeping it >= 60 stays on the graceful
+            # `--global_time_limit` path (bounded outer_timeout = limit + 900).
             global_time_limit = max(
-                FLAKY_CHECK_TIME_LIMIT - int(stop_watch.duration), 0
+                FLAKY_CHECK_TIME_LIMIT - int(stop_watch.duration), 60
             )
             print(
                 f"Flaky-check time limit: {FLAKY_CHECK_TIME_LIMIT}s"

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -131,7 +131,19 @@ def run_tests(
     # that bound (plus the worker shutdown wind-down) so the external SIGTERM
     # fires only for a genuinely frozen process and never pre-empts the graceful
     # `GLOBAL_TIME_LIMIT_EXIT_CODE` stop (which would be reported as "Server died").
-    outer_timeout = global_time_limit + 900 if global_time_limit > 0 else None
+    if global_time_limit > 0:
+        outer_timeout = global_time_limit + 900
+    else:
+        # Regular runs pass no graceful --global_time_limit, so without an external
+        # bound a frozen clickhouse-test/worker (e.g. a stuck test or --hung-check on
+        # the networked MinIO) runs until the job is force-cancelled - observed
+        # as a stateless MinIO job still "running" after 6h. Bound it by the job's own
+        # configured timeout, leaving margin to still SIGTERM clickhouse-test and
+        # collect logs/results before the job-level timeout fires.
+        job_cfg = Info().job_config
+        outer_timeout = (
+            job_cfg.timeout - 600 if job_cfg and job_cfg.timeout and job_cfg.timeout > 600 else 2 * 3600
+        )
     return Shell.run(command, verbose=True, timeout=outer_timeout)
 
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -150,10 +150,18 @@ def run_tests(
         # live so each bugfix build-type entry shrinks) and keep a reserve for the
         # SIGTERM + log/result collection to still complete before the job timeout.
         RESERVE_SECONDS = 600
+        # Info().job_config comes back as a plain dict in PR jobs: the runner
+        # serializes JOB_CONFIG into the workflow-status JSON and
+        # _Environment.from_dict rehydrates only PARAMETER (not JOB_CONFIG), so
+        # attribute access (job_cfg.timeout) would raise AttributeError before
+        # clickhouse-test even starts. Read the timeout defensively from either a
+        # mapping or a Job.Config object, defaulting to 2h when unset.
         job_cfg = Info().job_config
-        job_timeout = (
-            job_cfg.timeout if job_cfg and job_cfg.timeout else 2 * 3600
-        )
+        if isinstance(job_cfg, dict):
+            configured_timeout = job_cfg.get("timeout")
+        else:
+            configured_timeout = getattr(job_cfg, "timeout", None)
+        job_timeout = configured_timeout or 2 * 3600
         elapsed = int(job_stop_watch.duration) if job_stop_watch else 0
         # Floor so a near-exhausted budget still passes a positive timeout to
         # Shell.run (fire the SIGTERM promptly) rather than 0/negative.
@@ -273,6 +281,14 @@ def invert_bugfix_validation_status(test_result: Result) -> bool:
 
 
 def main():
+    # Start the job-wide stopwatch first thing: it is the basis for the
+    # remaining-budget backstop in run_tests (and the flaky/targeted time
+    # limits), so it must begin before any in-job setup that eats into the same
+    # Praktika job timeout - in particular the bugfix-validation block below,
+    # which finds/downloads/copies the master binaries from S3 (a slow fetch can
+    # take minutes). Starting it later would undercount that time and let
+    # outer_timeout drift past the real job deadline into the runner hard-kill.
+    stop_watch = Utils.Stopwatch()
     args = parse_args()
     test_options = [to.strip() for to in args.options.split(",")]
     batch_num, total_batches = 0, 0
@@ -493,8 +509,6 @@ def main():
             )
 
     Shell.check(f"chmod +x {ch_path}/clickhouse")
-
-    stop_watch = Utils.Stopwatch()
 
     res = True
     results = []

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -155,18 +155,27 @@ def run_tests(
         # _Environment.from_dict rehydrates only PARAMETER (not JOB_CONFIG), so
         # attribute access (job_cfg.timeout) would raise AttributeError before
         # clickhouse-test even starts. Read the timeout defensively from either a
-        # mapping or a Job.Config object, defaulting to 2h when unset.
+        # mapping or a Job.Config object.
         job_cfg = Info().job_config
         configured_timeout = job_cfg.get("timeout") if isinstance(job_cfg, dict) else getattr(job_cfg, "timeout", None)
-        job_timeout = configured_timeout or 2 * 3600
-        elapsed = int(job_stop_watch.duration) if job_stop_watch else 0
-        # Bound Shell.run by the time actually left before Praktika hard-kills the
-        # job (job_timeout - elapsed), reserving RESERVE_SECONDS of that for the
-        # SIGTERM + log/result collection. Once the reserve is already gone this goes
-        # <= 0; clamp to a minimal positive value (NOT a fixed floor like 60s, which
-        # would outlast the real remaining time and let the runner hard-kill fire
-        # first, losing logs) so clickhouse-test is SIGTERMed promptly instead.
-        outer_timeout = max(1, job_timeout - elapsed - RESERVE_SECONDS)
+        if configured_timeout:
+            # Bound Shell.run by the time actually left before Praktika hard-kills
+            # the job (configured_timeout - elapsed), reserving RESERVE_SECONDS of
+            # that for the SIGTERM + log/result collection. Once the reserve is
+            # already gone this goes <= 0; clamp to a minimal positive value (NOT a
+            # fixed floor like 60s, which would outlast the real remaining time and
+            # let the runner hard-kill fire first, losing logs) so clickhouse-test
+            # is SIGTERMed promptly instead.
+            elapsed = int(job_stop_watch.duration) if job_stop_watch else 0
+            outer_timeout = max(1, configured_timeout - elapsed - RESERVE_SECONDS)
+        else:
+            # No CI job timeout to mirror: local / non-CI runs never populate
+            # JOB_CONFIG (generate_local_run_environment leaves it unset and the
+            # local path skips _pre_run). Leave the run unbounded as it has always
+            # been, rather than imposing a synthetic cap that would SIGTERM a
+            # healthy local ASan/debug run mid-flight. The backstop is only meant to
+            # mirror a real job-level deadline.
+            outer_timeout = None
     return Shell.run(command, verbose=True, timeout=outer_timeout)
 
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -86,6 +86,7 @@ def run_tests(
     random_order=False,
     global_time_limit=0,
     build_type=None,
+    job_stop_watch=None,
 ):
     test_output_file = f"{temp_dir}/test_result.txt"
     if batch_num and batch_total:
@@ -137,13 +138,26 @@ def run_tests(
         # Regular runs pass no graceful --global_time_limit, so without an external
         # bound a frozen clickhouse-test/worker (e.g. a stuck test or --hung-check on
         # the networked MinIO) runs until the job is force-cancelled - observed
-        # as a stateless MinIO job still "running" after 6h. Bound it by the job's own
-        # configured timeout, leaving margin to still SIGTERM clickhouse-test and
-        # collect logs/results before the job-level timeout fires.
+        # as a stateless MinIO job still "running" after 6h.
+        #
+        # Bound it by the job's *remaining* budget, not the static configured
+        # timeout: run_tests is entered only after INSTALL/START have already
+        # consumed part of the budget, and bugfix validation enters it once per
+        # build type. Timing off the full `job_config.timeout` would let this
+        # Shell.run outlive the job-level (GitHub) timeout - the runner is then
+        # force-cancelled and we lose logs/results instead of getting a controlled
+        # SIGTERM. So subtract the elapsed time (from the job-wide stopwatch, read
+        # live so each bugfix build-type entry shrinks) and keep a reserve for the
+        # SIGTERM + log/result collection to still complete before the job timeout.
+        RESERVE_SECONDS = 600
         job_cfg = Info().job_config
-        outer_timeout = (
-            job_cfg.timeout - 600 if job_cfg and job_cfg.timeout and job_cfg.timeout > 600 else 2 * 3600
+        job_timeout = (
+            job_cfg.timeout if job_cfg and job_cfg.timeout else 2 * 3600
         )
+        elapsed = int(job_stop_watch.duration) if job_stop_watch else 0
+        # Floor so a near-exhausted budget still passes a positive timeout to
+        # Shell.run (fire the SIGTERM promptly) rather than 0/negative.
+        outer_timeout = max(60, job_timeout - elapsed - RESERVE_SECONDS)
     return Shell.run(command, verbose=True, timeout=outer_timeout)
 
 
@@ -720,6 +734,7 @@ def main():
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,
+                job_stop_watch=stop_watch,
             )
 
         elif is_targeted_check:
@@ -741,6 +756,7 @@ def main():
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,
+                job_stop_watch=stop_watch,
             )
 
         else:
@@ -753,6 +769,7 @@ def main():
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,
                 build_type=build_types[0] if is_bugfix_validation else None,
+                job_stop_watch=stop_watch,
             )
 
         test_result = ft_res_processor.run(runner_exit_code=runner_exit_code)
@@ -887,6 +904,7 @@ def main():
                         random_order=True,
                         rerun_count=1,
                         build_type=bugfix_bt,
+                        job_stop_watch=stop_watch,
                     )
                     bt_result = ft_res_processor_bt.run(
                         runner_exit_code=bt_runner_exit_code


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Make sure an outer timeout is always set for functional tests, so CI runs like this can be avoided: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=59547&sha=d33ae579a9429d3df9bf3333b863339f41b152d4&name_0=PR

cc @maxknv @leshikus