### PR TITLE
CI: retry transient LogCluster rejections for build profile telemetry

### DIFF
--- a/ci/jobs/scripts/log_cluster.py
+++ b/ci/jobs/scripts/log_cluster.py
@@ -1,3 +1,4 @@
+import random
 import time
 import traceback
 
@@ -5,6 +6,17 @@ import requests
 
 from ci.praktika.info import Info
 from ci.praktika.secret import Secret
+
+# The analytics cluster is shared by every "ci"-user query, so its per-user
+# memory budget is frequently near the ceiling from unrelated load. A telemetry
+# INSERT is then rejected mid-parse with a transient 5xx (Code 241
+# MEMORY_LIMIT_EXCEEDED, OvercommitTracker could not free enough) even though
+# its own payload is tiny. Retry such rejections with capped exponential backoff
+# so the upload rides out a busy window; a sustained saturation still exhausts
+# the retries and fails loudly.
+_UPLOAD_RETRIES = 8
+_UPLOAD_BACKOFF_BASE_SECONDS = 2.0
+_UPLOAD_BACKOFF_CAP_SECONDS = 30.0
 
 
 class LogCluster:
@@ -66,7 +78,7 @@ class LogCluster:
             return False
         return True
 
-    def do_query(self, query, data, db_name="", retries=1, timeout=5):
+    def do_query(self, query, data, db_name="", retries=_UPLOAD_RETRIES, timeout=5):
         if not self.is_ready():
             print("ERROR: LogCluster not ready")
             return False
@@ -92,6 +104,11 @@ class LogCluster:
 
         response = None
         for retry in range(retries):
+            # data may be a file object (the INSERT payload). A previous attempt
+            # consumed it, so rewind before resending, or the retry uploads an
+            # empty body.
+            if hasattr(data, "seek"):
+                data.seek(0)
             try:
                 response = self._session.post(
                     url=self.url,
@@ -102,22 +119,30 @@ class LogCluster:
                 )
                 if response.ok:
                     return True
-                else:
-                    print(
-                        f"WARNING: LogCluster query failed with code {response.status_code}"
-                    )
-                if response.status_code >= 500:
-                    # A retryable error
-                    time.sleep(1)
-                    continue
-                else:
+                print(
+                    f"WARNING: LogCluster query failed with code {response.status_code}"
+                    f" (attempt {retry + 1}/{retries})"
+                )
+                if response.status_code < 500:
+                    # Not retryable (e.g. a malformed query): fail fast.
                     break
             except Exception:
-                print("WARNING: LogCluster query failed with exception")
+                print(
+                    f"WARNING: LogCluster query failed with exception"
+                    f" (attempt {retry + 1}/{retries})"
+                )
                 traceback.print_exc()
+            if retry + 1 < retries:
+                # Capped exponential backoff with jitter, so concurrent uploaders
+                # do not retry in lockstep and re-collide on the shared budget.
+                delay = min(
+                    _UPLOAD_BACKOFF_CAP_SECONDS,
+                    _UPLOAD_BACKOFF_BASE_SECONDS * (2**retry),
+                )
+                time.sleep(delay + random.uniform(0, delay))
         if response is not None:
             print(
-                f"ERROR: Failed to query LogCluster, query:\n {query}\n    reason:\n {response.text}"
+                f"ERROR: Failed to query LogCluster after {retries} attempts, query:\n {query}\n    reason:\n {response.text}"
             )
         return False
 

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -17,7 +17,10 @@ Layers covered:
   propagate (not swallow) an upload rejection so lost telemetry stays visible.
 * The upload transport (``LogCluster.do_query``): the telemetry INSERT runs
   with parallel parsing disabled so its peak parse memory stays under the
-  shared cluster's per-user limit.
+  shared cluster's per-user limit; a transient 5xx rejection (the shared
+  cluster's per-user budget is momentarily saturated by unrelated load) is
+  retried with backoff and the payload is rewound before each retry, while a
+  4xx or a sustained failure is not retried and surfaces loudly.
 """
 
 import os
@@ -34,6 +37,7 @@ from ci.jobs.scripts.job_hooks.build_profile_hook import (
     _should_profile,
     _upload_profile_artifacts,
 )
+from ci.jobs.scripts import log_cluster as log_cluster_mod
 from ci.jobs.scripts.log_cluster import LogCluster
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -224,3 +228,105 @@ def test_do_query_disables_parallel_parsing():
 
     assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
     assert cluster._session.params["input_format_parallel_parsing"] == 0
+
+
+# --- upload transport: transient 5xx is retried, loud on exhaustion -------
+
+
+class _Resp:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self.text = f"code {status_code}"
+
+
+class _SequenceSession:
+    """A session that returns a preset sequence of responses, one per POST."""
+
+    def __init__(self, statuses):
+        self._statuses = list(statuses)
+        self.calls = 0
+
+    def post(self, url, params, data, headers, timeout):
+        self.calls += 1
+        return _Resp(self._statuses.pop(0))
+
+
+def _make_cluster(session):
+    cluster = LogCluster()
+    cluster.is_ready = lambda: True
+    cluster.url = "https://example"
+    cluster._auth = {}
+    cluster._session = session
+    return cluster
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Make the backoff instant so retry tests do not actually wait."""
+    monkeypatch.setattr(log_cluster_mod.time, "sleep", lambda _s: None)
+
+
+def test_do_query_retries_transient_5xx_then_succeeds(no_sleep):
+    """A transient 5xx (per-user budget momentarily saturated) is retried.
+
+    The real failure is HTTP 500 / Code 241 MEMORY_LIMIT_EXCEEDED on a tiny
+    (~5 MiB) parse chunk: the shared "ci"-user budget is transiently full from
+    unrelated load, not from this upload. do_query must retry and succeed once a
+    window opens, keeping the telemetry.
+    """
+    session = _SequenceSession([500, 503, 200])
+    cluster = _make_cluster(session)
+
+    assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
+    assert session.calls == 3
+
+
+def test_do_query_fails_loudly_after_exhausting_retries(no_sleep):
+    """A sustained 5xx is not swallowed: do_query returns False after retries.
+
+    Riding out a transient window is fine, but a persistently saturated cluster
+    must still fail so the check goes red rather than reporting a lost upload as
+    success.
+    """
+    session = _SequenceSession([500] * log_cluster_mod._UPLOAD_RETRIES)
+    cluster = _make_cluster(session)
+
+    assert not cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
+    assert session.calls == log_cluster_mod._UPLOAD_RETRIES
+
+
+def test_do_query_does_not_retry_4xx(no_sleep):
+    """A 4xx (e.g. a malformed query) is a real error, not transient: fail fast."""
+    session = _SequenceSession([400, 200])
+    cluster = _make_cluster(session)
+
+    assert not cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=b"")
+    assert session.calls == 1  # no retry after a 4xx
+
+
+def test_do_query_rewinds_file_payload_between_retries(no_sleep):
+    """The INSERT payload is a file object: it must be rewound before each retry.
+
+    Without the seek(0), the first attempt consumes the file and a retry uploads
+    an empty body, which silently loses the telemetry it was meant to preserve.
+    """
+    import io
+
+    payload = io.BytesIO(b"row-data")
+    bodies_seen = []
+
+    class _RecordingSession:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, params, data, headers, timeout):
+            self.calls += 1
+            bodies_seen.append(data.read())
+            return _Resp(500 if self.calls == 1 else 200)
+
+    cluster = _make_cluster(_RecordingSession())
+
+    assert cluster.do_query("INSERT INTO t FORMAT JSONEachRow", data=payload)
+    # Both attempts saw the full payload, not an empty body on the retry.
+    assert bodies_seen == [b"row-data", b"row-data"]


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/84159
Related: https://github.com/ClickHouse/ClickHouse/pull/108294
-->

Related: #84159
Related: #108294

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #108294. The Build "Post Hooks" check still fails about half the time on master for the two variants that upload build-profile telemetry (`amd_release`, `arm_release`); the other ~23 build variants are green now that the upload subset gate landed.

**Failure:** the telemetry INSERT is rejected with HTTP 500 / `Code: 241. DB::Exception: User memory limit exceeded: would use 29.82 GiB (attempt to allocate chunk of 5.07 MiB), maximum: 29.80 GiB. OvercommitTracker decision: Memory overcommit has not freed enough memory ... While executing JSONCompactEachRowRowInputFormat. (MEMORY_LIMIT_EXCEEDED)`.

**Root cause: transient cross-tenant contention, not an oversized upload.**
- The increment that tips the limit is only ~5 MiB, and the cap is a per-user budget shared by all `ci`-user queries. The same variant alternates OK/FAIL across commits (07-01: 17 FAIL / 11 OK on amd_release), which a size problem would not do (it would fail ~100%).
- `input_format_parallel_parsing=0` from #108294 is applied (the format is the single-threaded `JSONCompactEachRowRowInputFormat`, no longer `ParallelParsingBlockInputFormat`), so peak parse memory is not the remaining lever.
- `max_memory_usage_for_user=0` is clamped server-side (the rejection still reports `maximum: 29.80 GiB`), so the client cannot lift the cap.

**Fix:** `do_query` already had a retry loop, but it was dead code: `retries` defaulted to 1 and was never overridden, and the file payload was never rewound between attempts (a retry would upload an empty body). Make it work: default to 8 retries, `seek(0)` the payload before each attempt, back off with capped exponential delay plus jitter on a 5xx, and stop early on a 4xx. A transient window is ridden out and the telemetry is kept; a sustained saturation still exhausts the retries and fails loudly, so a genuine problem stays visible (no silent success). This keeps the direction @ nikitamikhaylov and @ maxknv already agreed on (keep the telemetry, do not swallow real errors).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=47589e56cb55a99ff3bacd3b5b8ce6248f08155f&name_0=MasterCI&name_1=Build%20%28amd_release%29

Tests: `ci/tests/test_build_profile_hook.py` (14 pass) covers retry-on-transient-5xx, loud failure after exhaustion, no-retry on 4xx, and payload rewind between retries.
