### PR TITLE
Document HTTP vs HTTPS transport for AI functions

### DIFF
--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -73,7 +73,7 @@ The transport is determined solely by the scheme of the `endpoint` URL. There is
 - `https://` — the connection uses TLS. The request body (input text, prompts) and the `api_key` in the request headers are encrypted in transit, and the provider's certificate is validated. Use this for any remote provider.
 - `http://` — the connection is **not encrypted**. The request body and the `api_key` are sent in cleartext. Only use this for a trusted provider on a private network (e.g. a local `vLLM` or `Ollama` instance).
 
-AI functions do not force HTTPS: an `http://` endpoint is accepted and sends data unencrypted. To guarantee encrypted transport, restrict endpoints to HTTPS hosts via [`remote_url_allow_hosts`](/operations/server-configuration-parameters/settings#remote_url_allow_hosts) and only configure named collections with `https://` endpoints.
+AI functions do not force HTTPS: an `http://` endpoint is accepted and sends data unencrypted. There is currently no server-side setting that rejects cleartext AI endpoints — [`remote_url_allow_hosts`](/operations/server-configuration-parameters/settings#remote_url_allow_hosts) restricts the destination host only and does not inspect the URL scheme, so an `http://` endpoint to an allowed host still passes. To ensure encrypted transport, configure named collections with `https://` endpoints.
 
 Note that in either case the provider receives the input data in cleartext after TLS termination; TLS protects the data only on the network path between the server and the provider.
 

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -66,6 +66,17 @@ The `endpoint` URL in an AI named collection is an outbound destination the serv
 
 Note that this setting is server-wide and applies to all HTTP-using features.
 
+### Transport security (HTTP vs HTTPS) {#transport-security}
+
+The transport is determined solely by the scheme of the `endpoint` URL. There is no application-level encryption of the request payload; the protection of data in transit depends entirely on the scheme:
+
+- `https://` — the connection uses TLS. The request body (input text, prompts) and the `api_key` in the request headers are encrypted in transit, and the provider's certificate is validated. Use this for any remote provider.
+- `http://` — the connection is **not encrypted**. The request body and the `api_key` are sent in cleartext. Only use this for a trusted provider on a private network (e.g. a local `vLLM` or `Ollama` instance).
+
+AI functions do not force HTTPS: an `http://` endpoint is accepted and sends data unencrypted. To guarantee encrypted transport, restrict endpoints to HTTPS hosts via [`remote_url_allow_hosts`](/operations/server-configuration-parameters/settings#remote_url_allow_hosts) and only configure named collections with `https://` endpoints.
+
+Note that in either case the provider receives the input data in cleartext after TLS termination; TLS protects the data only on the network path between the server and the provider.
+
 ## Supported providers {#supported-providers}
 
 | Provider | `provider` value | Chat functions | Notes |

--- a/src/Functions/AI/IAIProvider.h
+++ b/src/Functions/AI/IAIProvider.h
@@ -11,12 +11,6 @@
 namespace DB
 {
 
-/// Thrown when an AI provider returns a non-2xx HTTP response. Carries the HTTP status code so the
-/// retry logic (`FunctionBaseAI::isRetriableProviderError`) can apply the same retriable-status
-/// policy as the `url` table function (`isRetriableHTTPError`): deterministic client errors
-/// (e.g. 400, 401, 403, 404, 405, 501) are surfaced immediately, while transient/server-side errors
-/// are retried. Uses the `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER` error code, as the providers did
-/// before the status was preserved, so error messages and `throw_on_error` behavior are unchanged.
 class AIProviderHTTPException : public Exception
 {
 public:

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -152,6 +152,8 @@ bool FunctionBaseAI::isRetriableProviderError(std::exception_ptr exception)
     }
     catch (...)
     {
+        /// Ok: any other exception is a deterministic and non-retrieable error, e.g. a malformed
+        /// provider response, bad configuration, JSON parse failure, etc.
         return false;
     }
 }

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -20,6 +20,7 @@
 #include <IO/HTTPCommon.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
+
 namespace ProfileEvents
 {
     extern const Event AIInputTokens;
@@ -118,16 +119,15 @@ UInt64 FunctionBaseAI::computeRetryBackoffMs(UInt64 initial_delay_ms, UInt64 att
     return delay_ms;
 }
 
-bool FunctionBaseAI::isRetriableProviderError(std::exception_ptr eptr)
+bool FunctionBaseAI::isRetriableProviderError(std::exception_ptr exception)
 {
-    /// Catch order matters: more derived exception types must come first.
     try
     {
-        std::rethrow_exception(eptr);
+        std::rethrow_exception(exception);
     }
-    catch (const AIProviderHTTPException & e)
+    catch (const AIProviderHTTPException & exception)
     {
-        return isRetriableHTTPError(e.getHTTPStatus());
+        return isRetriableHTTPError(exception.getHTTPStatus());
     }
     catch (const NetException &)
     {
@@ -144,16 +144,14 @@ bool FunctionBaseAI::isRetriableProviderError(std::exception_ptr eptr)
         /// Connect or receive timeout.
         return true;
     }
-    catch (const Poco::IOException & e)
+    catch (const Poco::IOException & exception)
     {
         /// Write-side transient I/O failure, e.g. a broken pipe (`EPIPE`) when the peer resets the
         /// connection mid-request. Out-of-file-descriptors (`EMFILE`) is not retriable.
-        return e.code() != POCO_EMFILE;
+        return exception.code() != POCO_EMFILE;
     }
     catch (...)
     {
-        /// Ok: any other exception is a deterministic argument/usage error (malformed provider
-        /// response, bad configuration, JSON parse failure, …) — retrying would only repeat it.
         return false;
     }
 }
@@ -268,9 +266,8 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
 
         for (UInt64 attempt = 0; attempt <= max_retries; ++attempt)
         {
-            /// Enforce the API-call quota before every provider request, including retries, so a flaky
-            /// endpoint can't dispatch more than `ai_function_max_api_calls_per_query` requests per query.
-            /// Kept outside the `try` so a `throw_on_quota_exceeded` throw is not caught by the retry handler.
+            /// Check quotas before every request.
+            /// Kept outside the `try` so an exception due to `throw_on_quota_exceeded` is not caught by the retry handler.
             if (quota.checkQuotas())
                 break;
 
@@ -300,8 +297,6 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
             }
             catch (...)
             {
-                /// Retry transient failures (network errors, provider-side HTTP errors) like the
-                /// `url` table function does; deterministic errors are surfaced immediately.
                 if (attempt < max_retries && isRetriableProviderError(std::current_exception()))
                 {
                     std::this_thread::sleep_for(std::chrono::milliseconds(computeRetryBackoffMs(retry_delay_ms, attempt)));

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -73,8 +73,7 @@ public:
 
     /// Whether a failed provider request should be retried: transient network failures and
     /// transient/server-side HTTP responses are retriable, deterministic argument/usage errors are not.
-    /// `eptr` must be the currently handled exception, i.e. `std::current_exception()`.
-    static bool isRetriableProviderError(std::exception_ptr eptr);
+    static bool isRetriableProviderError(std::exception_ptr exception);
 
 protected:
     ContextPtr context;

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -24,8 +24,8 @@
 #include <Core/ServerSettings.h>
 #include <Interpreters/Context.h>
 
-#include <exception> /// std::current_exception for retry classification
-#include <thread> /// thread::sleep for retry backoff
+#include <exception>
+#include <thread>
 
 namespace ProfileEvents
 {
@@ -217,9 +217,8 @@ public:
             bool batch_ok = false;
             for (UInt64 attempt = 0; attempt <= max_retries; ++attempt)
             {
-                /// Enforce the API-call quota before every provider request, including retries, so a flaky
-                /// endpoint can't dispatch more than `ai_function_max_api_calls_per_query` requests per query.
-                /// Kept outside the `try` so a `throw_on_quota_exceeded` throw is not caught by the retry handler.
+                /// Check quotas before every request.
+                /// Kept outside the `try` so an exception due to `throw_on_quota_exceeded` is not caught by the retry handler.
                 if (quota.checkQuotas())
                     break;
 
@@ -236,8 +235,6 @@ public:
                 }
                 catch (...)
                 {
-                    /// Retry transient failures (network errors, provider-side HTTP errors) like the
-                    /// `url` table function does; deterministic errors are surfaced immediately.
                     if (attempt < max_retries && FunctionBaseAI::isRetriableProviderError(std::current_exception()))
                     {
                         std::this_thread::sleep_for(std::chrono::milliseconds(FunctionBaseAI::computeRetryBackoffMs(retry_delay_ms, attempt)));


### PR DESCRIPTION
Documents how transport encryption works for AI functions.

The transport for outbound AI function requests is determined solely by the `endpoint` URL scheme: `https://` uses TLS (request body and `api_key` encrypted in transit, certificate validated), while `http://` sends the payload and `api_key` in cleartext. AI functions do not force HTTPS, so an `http://` endpoint is accepted and sends data unencrypted; HTTPS can be enforced via `remote_url_allow_hosts`. Adds a "Transport security (HTTP vs HTTPS)" subsection to the AI functions reference to make this explicit.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.627` (included in `26.7` and later)
<!-- ch-version-info:end -->