### PR TITLE
Fix flaky 04256_packed_skip_indices_layout_transitions under randomized sparse serialization

### DIFF
--- a/tests/queries/0_stateless/04256_packed_skip_indices_layout_transitions.sql
+++ b/tests/queries/0_stateless/04256_packed_skip_indices_layout_transitions.sql
@@ -30,7 +30,10 @@ ORDER BY id
 SETTINGS min_bytes_for_wide_part = 0,
          packed_skip_index_max_bytes = 4096,
          auto_statistics_types = '',
-         index_granularity = 1024;
+         index_granularity = 1024,
+         -- Pinned: a randomized low ratio sparse-serializes some columns per part, adding column
+         -- files that break this test's "phases differ only in index layout" file-count assumption.
+         ratio_of_defaults_for_sparse_serialization = 1.0;
 
 -- Remembers the active part's file count at each phase so later phases can compare against the
 -- packed baseline without printing absolute counts.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04256_packed_skip_indices_layout_transitions` walks a single skip index through packed -> spilled -> repacked transitions and detects the spill by comparing `system.parts.files` (the total part file count) of the phase-3 (spilled) merged part against the phase-2 (packed) merged part, asserting phase 3 has strictly more files. It assumes the two parts differ only in the skip-index layout.

That assumption breaks under CI's randomized `ratio_of_defaults_for_sparse_serialization`. A low ratio makes ClickHouse decide sparse serialization per column per part based on that part's data. The phase-2 part (3072 rows) and the phase-3 part (13312 rows, different values) then disagree on whether the `id`/`w` columns are sparse-serialized, adding/removing per-column substream files (`id.sparse.idx.bin`, `id.sparse.idx.cmrk2`, ...). That column-file delta is unrelated to the index and can cancel or outweigh the +1 file from the index spill, so `phase3_spilled_has_more_files_than_packed` flips to 0 and the test fails.

CI's own random-settings diagnosis isolated the single culprit `ratio_of_defaults_for_sparse_serialization = 0.0013...`: 22/22 fail with it, 35/35 pass without it. Reproduced locally with that exact value: phase2 part = 12 files vs 10 without it, while phase3 stays at 11, flipping the assertion.

Fix: pin `ratio_of_defaults_for_sparse_serialization = 1.0` in the table's `CREATE ... SETTINGS` so column serialization is dense and identical across phases; the file-count delta then reflects only the index layout, which is what the test measures. A table-level `SETTINGS` value overrides the runner's `--allow_merge_tree_settings` injection (`ClientBase::addMergeTreeSettings` only adds settings not already present), so the pin is immune to randomization. The `.reference` output is unchanged.

Validated with the official `clickhouse-test` harness: forcing the culprit setting, the unfixed test fails with exactly `-phase3_spilled_has_more_files_than_packed 1` / `+...0`; with the fix it passes 20/20; and 50/50 runs pass with full randomization enabled.

Report of a failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104927&sha=1ee52dfe467a323c97bbf48f3e2be1da35db58f0&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%201%2F2%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.425` (included in `26.7` and later)
- Backported to: `26.6.2.24`
<!-- ch-version-info:end -->