### PR TITLE
Fix praktika job hang (exit 125) when timeout cleanup command misses

### DIFF
--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -1,9 +1,8 @@
 import copy
-import hashlib
 import json
 import os
 from dataclasses import dataclass, field
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Any, List, Optional
 
 from . import Artifact
@@ -312,15 +311,3 @@ class Job:
                     print(f"Warning: failed to check git submodules: {e}")
 
             return False
-
-        def __post_init__(self):
-            if self.timeout_shell_cleanup:
-                return
-            if self.run_in_docker:
-                container_name = (
-                    "praktika_"
-                    + hashlib.sha1(
-                        (Path(os.getcwd()).resolve().as_posix() + ":" + self.name).encode()
-                    ).hexdigest()[:12]
-                )
-                self.timeout_shell_cleanup = f"docker rm -f {container_name}"

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from shlex import quote
-from threading import Thread
+from threading import Event, Thread
 from types import SimpleNamespace
 from typing import Any, Dict, Iterator, List, Optional, Type, TypeVar, Union
 
@@ -1044,20 +1044,42 @@ class TeePopen:
         self.terminated_by_sigkill = False
         self.log_rolling_buffer = deque(maxlen=100)
         self.preserve_stdio = preserve_stdio
+        # Set as soon as the child is reaped, so the watchdog wakes immediately
+        # and skips signalling when the process finished before the timeout.
+        self.finished = Event()
 
     def _check_timeout(self) -> None:
         if self.timeout is None:
             return
-        time.sleep(self.timeout)
+        # Wait for the timeout, but wake as soon as the child finishes. A blind
+        # sleep would fire the watchdog even for a job that already succeeded --
+        # flipping timeout_exceeded, running cleanup, and, in a long-lived
+        # process, issuing a late killpg against an already-reaped (possibly
+        # PID-recycled) process group that may now belong to an unrelated job.
+        if self.finished.wait(self.timeout):
+            return
+        # Backstop for the race between the wait timing out and the child
+        # exiting: if the process is already gone, enforce nothing.
+        if self.process.poll() is not None:
+            return
         print(f"WARNING: Timeout exceeded [{self.timeout}] for [{self.process.pid}]")
         self.timeout_exceeded = True
 
-        if self.timeout_shell_cleanup:
-            Shell.check(self.timeout_shell_cleanup, verbose=True)
-            return
-
+        # Terminate the launched process group first: timeout enforcement must
+        # never depend on the external cleanup returning. Best-effort teardown
+        # (e.g. `docker rm -f <container>`) then runs in a bounded daemon thread,
+        # so a cleanup that wedges on a hung daemon cannot re-introduce the hang.
         self.send_signal(signal.SIGTERM)
         print(f"Send SIGTERM to [{self.process.pid}]")
+
+        if self.timeout_shell_cleanup:
+            Thread(
+                target=Shell.check,
+                args=(self.timeout_shell_cleanup,),
+                kwargs={"verbose": True, "timeout": 120},
+                daemon=True,
+            ).start()
+
         time_wait = 0
 
         while self.process.poll() is None and time_wait < 100:
@@ -1119,15 +1141,20 @@ class TeePopen:
             self.log_file.close()
 
     def wait(self) -> int:
-        # If preserving stdio, we don't have our own stdout pipe; just wait
-        if not self.preserve_stdio and self.process.stdout is not None:
-            for line in self.process.stdout:
-                sys.stdout.write(line)
+        try:
+            # If preserving stdio, we don't have our own stdout pipe; just wait
+            if not self.preserve_stdio and self.process.stdout is not None:
+                for line in self.process.stdout:
+                    sys.stdout.write(line)
 
-                if self.log_file:
-                    self.log_file.write(line)
-                self.log_rolling_buffer.append(line)
-        return self.process.wait()
+                    if self.log_file:
+                        self.log_file.write(line)
+                    self.log_rolling_buffer.append(line)
+            return self.process.wait()
+        finally:
+            # The child is reaped: wake the watchdog so it does not mark a
+            # timeout or signal a process group that no longer exists.
+            self.finished.set()
 
     def poll(self):
         return self.process.poll()

--- a/ci/tests/test_teepopen_timeout_kills_process.py
+++ b/ci/tests/test_teepopen_timeout_kills_process.py
@@ -1,0 +1,170 @@
+"""
+Regression test for the praktika watchdog (TeePopen._check_timeout).
+
+Background
+----------
+`Stateless tests (amd_tsan, s3 storage, parallel, 2/2)` jobs intermittently
+finished with a job-level ERROR (exit code 125) and `results: []`. The job.log
+showed the 9000s watchdog firing, running a `docker rm -f <container>` that
+removed nothing ("No such container"), and then the job hanging for another ~2h
+until an unrelated docker-daemon event closed the pipe.
+
+Root cause: when `timeout_shell_cleanup` was set, `_check_timeout` ran that
+command and `return`ed early -- it never signalled the launched process group.
+So if the cleanup command missed (which it did: the container was launched with
+one name and `docker rm -f` targeted a different, stale name) the inner process
+was never terminated and the whole job hung past its timeout. A second failure
+mode: even when the signal was sent, running the cleanup synchronously first
+meant a cleanup that wedged on a hung docker daemon still stalled the watchdog
+before it could terminate the group.
+
+The watchdog now signals the launched process group FIRST, then runs the
+best-effort cleanup in a bounded daemon thread, so timeout enforcement never
+depends on the cleanup returning.
+
+A third failure mode: the watchdog slept the full timeout unconditionally, so a
+child that exited early still tripped it -- it marked timeout_exceeded, ran the
+cleanup, and, in a long-lived process, issued a late killpg against an
+already-reaped (possibly PID-recycled) process group. The watchdog now waits on
+an event set when the child is reaped and re-checks poll() before enforcing, so
+an early-exiting child cancels it and no stray signal is sent.
+
+These tests drive `_check_timeout` directly. Two of them launch a child that
+sleeps far longer than the watchdog timeout (so a working watchdog must
+terminate it promptly regardless of the cleanup); the fast-exit test launches a
+child that finishes well before the timeout (so the watchdog must not fire).
+"""
+
+import os
+import signal
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.utils import TeePopen
+
+# Child sleeps much longer than the 1s watchdog timeout. A default `sleep`
+# terminates on SIGTERM, so a working watchdog stops it in ~1s; a broken one
+# (no signal sent) lets it run the full CHILD_SLEEP seconds.
+CHILD_SLEEP = 30
+# Generous ceiling: comfortably above the watchdog's ~1s reaction, far below
+# CHILD_SLEEP so an un-killed child is unambiguously detected.
+MAX_ELAPSED = 15
+
+
+def _run_with_watchdog(timeout_shell_cleanup):
+    start = time.monotonic()
+    with TeePopen(
+        f"sleep {CHILD_SLEEP}",
+        timeout=1,
+        timeout_shell_cleanup=timeout_shell_cleanup,
+    ) as p:
+        rc = p.wait()
+    return p, rc, time.monotonic() - start
+
+
+def test_timeout_terminates_process_when_cleanup_is_a_noop():
+    """The exit-125 scenario: cleanup command removes nothing (no-op `true`)."""
+    p, rc, elapsed = _run_with_watchdog(timeout_shell_cleanup="true")
+
+    assert p.timeout_exceeded, "watchdog did not mark timeout_exceeded"
+    # The launched process must have been terminated by the watchdog, not left
+    # to run its full sleep. Pre-fix, the early return after the no-op cleanup
+    # sent no signal, so the child ran all CHILD_SLEEP seconds (elapsed ~= 30,
+    # rc == 0) -- the hang that ended in exit 125. We assert on the reaped exit
+    # status and wall-clock, which are deterministic; the internal
+    # `terminated_by_*` flags are set by the watchdog thread only after its
+    # poll loop and lag behind the child's actual reaping, so are not asserted.
+    assert rc == -signal.SIGTERM, (
+        f"process was not SIGTERM-terminated (rc={rc}); the watchdog returned "
+        "without signalling the launched process (the exit-125 hang)"
+    )
+    assert elapsed < MAX_ELAPSED, (
+        f"watchdog took {elapsed:.1f}s to stop the process (>= {MAX_ELAPSED}s) -- "
+        "it did not terminate promptly after the no-op cleanup"
+    )
+
+
+def test_timeout_terminates_process_without_cleanup_command():
+    """The plain path (no cleanup command) must still terminate the group."""
+    p, rc, elapsed = _run_with_watchdog(timeout_shell_cleanup=None)
+
+    assert p.timeout_exceeded
+    assert rc == -signal.SIGTERM, f"process was not SIGTERM-terminated (rc={rc})"
+    assert elapsed < MAX_ELAPSED, f"watchdog took {elapsed:.1f}s (>= {MAX_ELAPSED}s)"
+
+
+def test_slow_cleanup_does_not_gate_the_kill():
+    """A cleanup that blocks (a wedged `docker rm -f`) must not delay the kill.
+
+    The cleanup sleeps almost as long as the child. If the watchdog ran cleanup
+    synchronously before signalling (the pre-fix ordering), the child would only
+    be terminated after the cleanup returned -- elapsed >= SLOW_CLEANUP. Because
+    the group is now signalled first and cleanup runs in a background thread, the
+    child is stopped in ~1s while the cleanup keeps running detached.
+    """
+    slow_cleanup = f"sleep {CHILD_SLEEP - 5}"
+    p, rc, elapsed = _run_with_watchdog(timeout_shell_cleanup=slow_cleanup)
+
+    assert p.timeout_exceeded, "watchdog did not mark timeout_exceeded"
+    assert rc == -signal.SIGTERM, (
+        f"process was not SIGTERM-terminated (rc={rc}); a blocking cleanup "
+        "gated the timeout kill"
+    )
+    assert elapsed < MAX_ELAPSED, (
+        f"watchdog took {elapsed:.1f}s (>= {MAX_ELAPSED}s) -- the blocking "
+        "cleanup delayed termination instead of running in the background"
+    )
+
+
+def test_early_exit_does_not_trip_the_watchdog():
+    """A child that finishes before the timeout must not trip the watchdog.
+
+    The child exits in ~1s; the watchdog timeout is FAST_TIMEOUT. Pre-fix, the
+    watchdog slept the full timeout and then unconditionally marked
+    timeout_exceeded, ran the cleanup, and signalled the (already-reaped,
+    possibly recycled) process group. Now it waits on an event set when the
+    child is reaped and re-checks poll(), so it bails without enforcing.
+
+    We wait past the timeout before asserting, giving a broken watchdog time to
+    (wrongly) fire. cleanup_ran flips only if the watchdog reached the cleanup
+    branch -- a direct probe that the watchdog did not act on a finished child.
+    """
+    cleanup_marker = f"/tmp/ch-slot-teepopen-cleanup-{os.getpid()}"
+    if os.path.exists(cleanup_marker):
+        os.remove(cleanup_marker)
+    fast_timeout = 2
+    child_sleep = 1
+
+    with TeePopen(
+        f"sleep {child_sleep}",
+        timeout=fast_timeout,
+        timeout_shell_cleanup=f"touch {cleanup_marker}",
+    ) as p:
+        rc = p.wait()
+
+    # Give a broken (blind-sleep) watchdog time to wake and (wrongly) enforce.
+    time.sleep(fast_timeout + 2)
+
+    assert rc == 0, f"child should exit cleanly (rc={rc})"
+    assert not p.timeout_exceeded, (
+        "watchdog marked timeout_exceeded for a child that exited before the "
+        "timeout -- the blind sleep fired instead of cancelling on early exit"
+    )
+    assert not os.path.exists(cleanup_marker), (
+        "watchdog ran timeout_shell_cleanup for an early-exiting child -- it "
+        "did not cancel when the process finished before the timeout"
+    )
+    assert not p.terminated_by_sigterm and not p.terminated_by_sigkill, (
+        "watchdog signalled a process that had already exited"
+    )
+
+
+if __name__ == "__main__":
+    t0 = time.monotonic()
+    test_timeout_terminates_process_when_cleanup_is_a_noop()
+    test_timeout_terminates_process_without_cleanup_command()
+    test_slow_cleanup_does_not_gate_the_kill()
+    test_early_exit_does_not_trip_the_watchdog()
+    print(f"ok in {time.monotonic() - t0:.1f}s")


### PR DESCRIPTION
<!--
Linked issues and pull requests.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/109071


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`Stateless tests (amd_tsan, s3 storage, parallel, 2/2)` jobs intermittently finished with a job-level ERROR (exit code 125) and empty `results: []` (28 occurrences across 25 PRs in the last 30 days; 0 on master). No individual test failed; the job wrapper itself hung and then errored.

Root cause is a bug in the praktika watchdog `TeePopen._check_timeout` (`ci/praktika/utils.py`):

```python
if self.timeout_shell_cleanup:
    Shell.check(self.timeout_shell_cleanup, verbose=True)
    return                       # <-- never signals the launched process
```

When `timeout_shell_cleanup` is set, the watchdog ran that command and returned early, without ever sending SIGTERM/SIGKILL to the launched process group. The cleanup command is `docker rm -f <container>`, and its container name was derived a second time in `Job.Config.__post_init__` at construction time, from the pre-parametrized job name. Parametrization later appends the ` (amd_tsan, s3 storage, parallel, 2/2)` suffix, so the two hashes diverge: the container is launched with `--name praktika_6ec74b80afda`, but cleanup runs `docker rm -f praktika_076d3e59c96c` and removes nothing ("No such container"). With the cleanup a no-op and no signal sent, the inner `docker run` process was never terminated, so the job hung well past its 9000s timeout until an unrelated docker-daemon event closed the pipe, yielding exit 125.

Observed in the job.log tail (PR #108493):
```
[19:31:05] StopTesting: test run was stopped (see earlier output for the cause)
[21:40:32] WARNING: Timeout exceeded [9000] for [2475]
[21:40:32] Run command: [docker rm -f praktika_076d3e59c96c]   # different name than launched
[23:38:50] Error waiting for container: ... grpc: the client connection is closing
[23:38:50] error during connect: ... docker.sock ... EOF
[23:38:50] WARNING: Job timed out: [...], timeout [9000], exit code [125]
```

Fix:
- `_check_timeout`: run `timeout_shell_cleanup` as a best-effort supplement and always fall through to terminate the launched process group. A timeout that does not kill the process defeats the watchdog.
- `Job.Config`: drop the construction-time `timeout_shell_cleanup` derivation. `Runner._run` already derives it from the final parametrized job name and uses the same `container_name` for both `--name` and `docker rm -f`, so the names always match.

A regression test (`ci/tests/test_teepopen_timeout_kills_process.py`) drives `_check_timeout` with a no-op cleanup command and a child that outlives the timeout, asserting the child is terminated promptly. It fails on the pre-fix code (child runs its full sleep, exit 0, wall-clock >= child sleep) and passes with the fix.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.590` (included in `26.7` and later)
<!-- ch-version-info:end -->