### PR TITLE
Web UI: do not rewrite the typed word when accepting an equal suggestion

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5670,8 +5670,12 @@ function acceptCompletion(index) {
 
     closeCompletions();
 
-    /// Nothing to do when the word is exactly what was already typed (same text, same case).
-    if (word === prefix) {
+    /// Nothing to do when the completion is the already-typed word itself: either the exact
+    /// same text, or the same word in a different canonical case (an "empty completion" whose
+    /// suffix is empty — every candidate starts with the prefix, so an equal length means an
+    /// equal word ignoring case). Accepting it must not rewrite the user's casing, e.g. typing
+    /// `hash` and pressing Right/Tab/Enter (with `HASH` offered) must leave `hash` unchanged.
+    if (word.length === prefix.length) {
         return;
     }
 

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5666,7 +5666,6 @@ function acceptCompletion(index) {
     /// Capture the prefix and its position before closeCompletions() resets them.
     const prefix = completionPrefix;
     const start = completionPrefixStart;
-    completionUsage.set(word, (completionUsage.get(word) || 0) + 1);
 
     closeCompletions();
 
@@ -5678,6 +5677,11 @@ function acceptCompletion(index) {
     if (word.length === prefix.length) {
         return;
     }
+
+    /// Record the acceptance only when we actually replace text, so the equal-word no-op
+    /// above stays a true no-op: accepting `HASH` for a typed `hash` must not bump its usage
+    /// and thus re-rank later suggestions (e.g. make `HASH` win the next time `ha` is typed).
+    completionUsage.set(word, (completionUsage.get(word) || 0) + 1);
 
     /// Replace the whole typed identifier with the canonical-cased completion word, so the
     /// already-typed prefix also takes the suggestion's case (e.g. "se" + accept -> "SELECT").


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI (Play): when the highlighted completion is the same word that is already typed, just in a different case (e.g. `HASH` offered for a typed `hash`), pressing Right/Tab/Enter no longer rewrites the word to the canonical spelling — it is now a no-op.

### Details

In `programs/server/play.html`, the suggestion popup keeps an "empty completion" for the word you have already typed so you can see it is recognized. That candidate is selected first and renders as empty text (nothing visible on the cursor line), while real extensions are shown below.

Accepting a completion (Right / Tab / Enter, or click) replaces the typed identifier with the canonical-cased completion word, so that `se` becomes `SELECT`. But the guard that skipped this for the already-typed word only matched when the case was identical (`word === prefix`). If you typed `hash` and `HASH` was the (invisible, selected) candidate, pressing Right silently rewrote your `hash` into `HASH`.

This broadens the guard so accepting adds nothing whenever the completion is the same word ignoring case (an empty suffix — every candidate starts with the prefix, so equal length means equal word). Real extensions such as `se` -> `SELECT` still rewrite casing as before.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.442` (included in `26.7` and later)
<!-- ch-version-info:end -->