### PR TITLE
Fix flaky 02024_storage_filelog_mv

### DIFF
--- a/tests/queries/0_stateless/02024_storage_filelog_mv.sh
+++ b/tests/queries/0_stateless/02024_storage_filelog_mv.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: long
+# Tags: long, no-parallel
+# Tag no-parallel: FileLog -> MV streaming latency depends on `BackgroundSchedulePool`
+# scheduling; under heavy parallel load the detection wait can drift past its timeout even
+# with a bounded backoff. Same precedent as `02968_file_log_multiple_read.sh`.
 
 set -eu
 

--- a/tests/queries/0_stateless/02024_storage_filelog_mv.sh
+++ b/tests/queries/0_stateless/02024_storage_filelog_mv.sh
@@ -16,21 +16,33 @@ do
 done
 
 ${CLICKHOUSE_CLIENT} --query "drop table if exists file_log;"
-${CLICKHOUSE_CLIENT} --query "create table file_log(k UInt8, v UInt8) engine=FileLog('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/', 'CSV');"
+# poll_directory_watch_events_backoff_max bounds the watcher/reader idle backoff to ~1s
+# (default 32s), so new files are detected quickly on slow lanes (e.g. WasmEdge+MSan).
+${CLICKHOUSE_CLIENT} --query "create table file_log(k UInt8, v UInt8) engine=FileLog('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/', 'CSV') settings poll_directory_watch_events_backoff_max = 1000;"
 
 ${CLICKHOUSE_CLIENT} --query "drop table if exists mv;"
 ${CLICKHOUSE_CLIENT} --query "create Materialized View mv engine=MergeTree order by k as select * from file_log;"
 
 function count()
 {
-	COUNT=$(${CLICKHOUSE_CLIENT} --query "select count() from mv;")
-	echo $COUNT
+	${CLICKHOUSE_CLIENT} --query "select count() from mv;"
 }
 
-while true; do
-	[[ $(count) == 20 ]] && break
-	sleep 1
-done
+function wait_for_count()
+{
+	local target="$1"
+	local timeout=120
+	local start=$EPOCHSECONDS
+	while [[ $(count) != "$target" ]]; do
+		if ((EPOCHSECONDS - start > timeout)); then
+			echo "Timeout (${timeout}s) waiting for count() == ${target}, got $(count)."
+			exit 1
+		fi
+		sleep 1
+	done
+}
+
+wait_for_count 20
 
 ${CLICKHOUSE_CLIENT} --query "select * from mv order by k;"
 
@@ -47,10 +59,7 @@ do
 	echo $i, $i >> ${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/d.txt
 done
 
-while true; do
-	[[ $(count) == 101 ]] && break
-	sleep 1
-done
+wait_for_count 101
 
 ${CLICKHOUSE_CLIENT} --query "select * from mv order by k;"
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107826
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #107826 (requested by @alexey-milovidov on that PR, where this test flaked on `Stateless tests (amd_msan, WasmEdge, parallel, 2/2)`).

Fix flaky `02024_storage_filelog_mv`.

The test waited for the materialized view with two unbounded `while true; sleep 1` loops. FileLog's directory watcher and reader task back off exponentially up to `poll_directory_watch_events_backoff_max` (32s default), so on slow lanes (WasmEdge+MSan) the reader reschedule path (`scheduleAfter(milliseconds_to_wait)`) can wait up to 32s per idle cycle. Stacked across the two wait phases plus `BackgroundSchedulePool` contention under parallel load, this exceeds the 600s per-test kill and a slow-but-correct run becomes a TIMEOUT FAIL.

Failing report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107826&sha=2e66578c83c3107834ab5e22b2f921ed42383ae8&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29 (`test_duration_ms=600100`, reason `Timeout!`, `sleep 1` still running; the runner's own rerun said "not reproducible", i.e. a timing flake).

Fix (same approach as the sibling `02968_file_log_multiple_read`, PR #101367):
- Set `poll_directory_watch_events_backoff_max = 1000` on the FileLog table to bound file-detection latency to ~1s.
- Replace the unbounded loops with a bounded wait helper that fails fast with a diagnostic instead of a silent 600s timeout.
- Mark the test `no-parallel`: FileLog -> MV detection latency depends on `BackgroundSchedulePool` scheduling, and under heavy parallel load pool contention can push the wait past its timeout even with a bounded backoff. This matches the `no-parallel` tag on the sibling `02968_file_log_multiple_read`.

Test intent is unchanged (MV streaming path, initial 20-row load, touch-produces-no-event, incremental detection to 101 rows, same reference).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.411` (included in `26.7` and later)
<!-- ch-version-info:end -->