### PR TITLE
Fix "already attached to a group" abort when a callback-runner task is dropped synchronously

### DIFF
--- a/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
+++ b/src/Common/tests/gtest_thread_pool_callback_runner_shutdown.cpp
@@ -1,9 +1,16 @@
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/ThreadPool.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/setThreadName.h>
+#include <Common/ThreadGroupSwitcher.h>
+#include <Common/ThreadStatus.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/Context.h>
+#include <base/scope_guard.h>
 
+#include <functional>
 #include <future>
 #include <vector>
 #include <gtest/gtest.h>
@@ -102,4 +109,80 @@ TEST(ThreadPoolCallbackRunner, DroppedOnShutdownDoesNotBreakPromise)
             }
         }
     }
+}
+
+/// Regression test for the "already attached to a group" abort (STID 4298-3e9f).
+///
+/// The task above is dropped by the pool worker while draining the queue, i.e. on a thread with no
+/// thread group attached. But a task can also be dropped SYNCHRONOUSLY on the scheduling thread:
+/// when scheduleOrThrowOnError() throws (the pool is shutting down, or -- as injected here -- a
+/// thread-allocation fault), the just-created job lambda that solely owns the CallbackRunnerTask is
+/// destroyed during stack unwinding on the caller's thread. That thread is typically running a query
+/// and is already attached to its own thread group, which differs from the group the runner captured
+/// at creation time (e.g. a persistent WriteBufferFromS3 whose scheduler was created by an earlier
+/// query). The drop path (~CallbackRunnerTask) must release the callback under the task's group
+/// WITHOUT asserting the thread is detached; otherwise it constructs a LOGICAL_ERROR, which aborts
+/// the server in builds that treat logical errors as assertions.
+TEST(ThreadPoolCallbackRunner, DroppedSynchronouslyWhileAttachedToAnotherGroup)
+{
+    /// Run in a dedicated thread so current_thread starts as nullptr, independent of whatever
+    /// ThreadStatus / thread group other gtests in unit_tests_dbms left behind.
+    std::thread t([]
+    {
+        ThreadStatus ts;
+        auto context = getContext().context;
+        auto task_group = std::make_shared<ThreadGroup>(context, 0);   /// group the runner captures
+        auto caller_group = std::make_shared<ThreadGroup>(context, 0); /// group the scheduling thread is on
+
+        ThreadPool pool(
+            CurrentMetrics::LocalThread,
+            CurrentMetrics::LocalThreadActive,
+            CurrentMetrics::LocalThreadScheduled,
+            /*max_threads=*/ 1);
+
+        /// The runner captures getCurrentThreadGroup() at creation, so create it while attached to
+        /// task_group. The dropped task will then try to switch to a group that differs from the
+        /// scheduling thread's own group.
+        CurrentThread::attachToGroupIfDetached(task_group);
+        auto runner = threadPoolCallbackRunnerUnsafe<void>(pool, ThreadName::REMOTE_FS_WRITE_THREAD_POOL);
+        CurrentThread::detachFromGroupIfNotDetached();
+
+        /// Now attach the scheduling thread to a different group, as a running query would be.
+        CurrentThread::attachToGroupIfDetached(caller_group);
+
+        /// Make scheduleOrThrowOnError() throw synchronously on this thread.
+        CannotAllocateThreadFaultInjector::setFaultProbability(1.0);
+        SCOPE_EXIT({ CannotAllocateThreadFaultInjector::setFaultProbability(0.0); });
+
+        /// Records the thread group active when the dropped callback's captures are released.
+        auto released_group = std::make_shared<ThreadGroupPtr>();
+        struct GroupRecorder
+        {
+            std::shared_ptr<ThreadGroupPtr> out;
+            explicit GroupRecorder(std::shared_ptr<ThreadGroupPtr> out_) : out(std::move(out_)) {}
+            ~GroupRecorder() { *out = getCurrentThreadGroup(); }
+        };
+        std::function<void()> callback = [rec = std::make_shared<GroupRecorder>(released_group)]() {};
+
+        bool threw_cannot_schedule = false;
+        try
+        {
+            /// Throws while unwinding, dropping the sole task owner on this thread (attached to
+            /// caller_group). With the bug this aborts; with the fix it unwinds cleanly.
+            runner(std::move(callback), Priority{});
+        }
+        catch (const Exception & e)
+        {
+            threw_cannot_schedule = (e.code() == ErrorCodes::CANNOT_SCHEDULE_TASK);
+        }
+
+        EXPECT_TRUE(threw_cannot_schedule) << "scheduling onto a faulted pool must throw CANNOT_SCHEDULE_TASK";
+        /// The drop path must release the callback under the task's group, not the caller's.
+        EXPECT_EQ(*released_group, task_group) << "dropped callback must be released under the task's thread group";
+        /// ... and it must restore the scheduling thread's original group afterwards.
+        EXPECT_EQ(getCurrentThreadGroup(), caller_group) << "the scheduling thread's group must be restored";
+
+        CurrentThread::detachFromGroupIfNotDetached();
+    });
+    t.join();
 }

--- a/src/Common/threadPoolCallbackRunner.h
+++ b/src/Common/threadPoolCallbackRunner.h
@@ -93,18 +93,28 @@ struct CallbackRunnerTask
         if (was_run)
             return;
 
-        /// The task was dropped without running (the pool was shut down while it was still queued,
-        /// so ThreadPool::worker drains it via job_data.reset()). Mirror the run() path above:
+        /// The task was dropped without running. This happens in two ways:
+        ///  * The pool was shut down while the task was still queued, so ThreadPool::worker drains it
+        ///    via job_data.reset() on a pool worker thread (which has no thread group attached).
+        ///  * scheduleOrThrowOnError() threw synchronously (e.g. the pool is shutting down or its queue
+        ///    is full), so the just-created job lambda -- the sole owner of this task -- is destroyed
+        ///    during stack unwinding on the SCHEDULING thread, which is typically running a query and is
+        ///    already attached to its own thread group.
+        ///
+        /// Mirror the run() path above:
         ///
         /// 1. Release the callback (destroying its captures) under the task's thread group and
         ///    BEFORE satisfying the promise. set_exception can wake a waiter immediately; a waiter
         ///    that treats future.get() as "the task is done" may then tear down state that the
         ///    captures reference, so the captures must be gone first (same ordering the run path
-        ///    keeps with ThreadGroupSwitcher + SCOPE_EXIT_SAFE before set_value). ThreadGroupSwitcher's
-        ///    ctor is noexcept and a no-op for a null/identical group, so this is safe on the drain
-        ///    thread; SCOPE_EXIT_SAFE keeps a throwing capture destructor from escaping this destructor.
+        ///    keeps with ThreadGroupSwitcher + SCOPE_EXIT_SAFE before set_value). Because the drop can
+        ///    run on a thread already attached to a different group (the scheduling-thread case above),
+        ///    pass allow_existing_group=true so ThreadGroupSwitcher saves and restores that group
+        ///    instead of asserting -- constructing the LOGICAL_ERROR would abort the server in builds
+        ///    that treat logical errors as assertions. SCOPE_EXIT_SAFE keeps a throwing capture
+        ///    destructor from escaping this destructor.
         {
-            ThreadGroupSwitcher switcher(thread_group, thread_name);
+            ThreadGroupSwitcher switcher(thread_group, thread_name, /*allow_existing_group=*/ true);
             SCOPE_EXIT_SAFE({ [[maybe_unused]] auto released = std::move(callback); });
         }
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107383

`~CallbackRunnerTask` (in `threadPoolCallbackRunnerUnsafe`) releases a dropped task's callback under the task's thread group. A task can be dropped in two ways:

* Drained by a pool worker when the pool shuts down — a thread with no group attached.
* When `scheduleOrThrowOnError` throws synchronously (the pool is shutting down or its queue is full), the just-created job lambda that solely owns the task is destroyed during stack unwinding **on the scheduling thread**, which is typically running a query and already attached to its own thread group.

The drop path constructed `ThreadGroupSwitcher` with the default `allow_existing_group=false`, so in the second case it raised the `Thread () is already attached to a group` `LOGICAL_ERROR`. Constructing a `LOGICAL_ERROR` aborts the server in builds that treat logical errors as assertions (stress/sanitizer), so `ThreadGroupSwitcher`'s own `try`/`catch` could not prevent the abort.

Observed in the `arm_release` stress test on `master` during `MergeTreeDeduplicationLog::shutdown` → `WriteBufferFromS3` finalize → `TaskTracker::add`, where the persistent S3 write scheduler had captured an earlier query's thread group.

Fix: pass `allow_existing_group=true` on the drop path so `ThreadGroupSwitcher` saves and restores the scheduling thread's group instead of asserting. Added a regression test that forces a synchronous schedule failure (via `CannotAllocateThreadFaultInjector`) while attached to a different group and verifies the callback is released under the task's group without aborting.

This is a regression introduced by https://github.com/ClickHouse/ClickHouse/pull/107383.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=85408e96f5c6339850577d9702ec5717665868a5&name_0=MasterCI&name_1=Stress%20test%20%28arm_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a spurious `Thread is already attached to a group` logical error (a server abort in assertion-enabled builds) when a `threadPoolCallbackRunnerUnsafe` task is dropped synchronously on a thread that is already attached to another thread group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)