### PR TITLE
Retry clickhouse-server boot in functional-test setup

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -656,13 +656,38 @@ def main():
             if not (CH.start_minio(test_type="stateless") and CH.start_azurite()):
                 print("SETUP FAILURE: minio/azurite did not start")
                 return False
-            if not CH.start():
-                print("SETUP FAILURE: clickhouse-server process did not start")
-                return False
-            if not CH.wait_ready():
-                # wait_ready() already tails the server err log to stdout on
-                # timeout; the marker just names the sub-step for triage.
-                print("SETUP FAILURE: clickhouse-server not ready (wait_ready)")
+            # A transient host condition at boot (e.g. a brief memory spike from
+            # a co-tenant job on the same runner) can make clickhouse-server exit
+            # a few seconds after start, before it even creates its err.log, with
+            # no diagnostics - a plain re-start then succeeds. Observed as an
+            # opaque "Start ClickHouse Server" FAIL across several unrelated PRs
+            # in the same short window. Retry the boot a few times so a single
+            # transient death does not fail the whole job; a persistent boot
+            # failure still fails after the last attempt with wait_ready()'s
+            # err-log tail preserved for triage. Only the initial setup boot is
+            # retried - the per-build-type binary-swap boot below stays fail-closed.
+            boot_attempts = 3
+            booted = False
+            for boot_attempt in range(boot_attempts):
+                if not CH.start():
+                    setup_failure = "clickhouse-server process did not start"
+                elif not CH.wait_ready():
+                    # wait_ready() already tails the server err log to stdout on
+                    # timeout; the marker just names the sub-step for triage.
+                    setup_failure = "clickhouse-server not ready (wait_ready)"
+                else:
+                    booted = True
+                    break
+                if boot_attempt + 1 < boot_attempts:
+                    print(
+                        f"SETUP WARNING: {setup_failure} "
+                        f"(attempt {boot_attempt + 1}/{boot_attempts}); restarting"
+                    )
+                    CH.stop_server()
+                    CH.clean_logs()
+                    Utils.sleep(5)
+            if not booted:
+                print(f"SETUP FAILURE: {setup_failure}")
                 return False
 
             if not CH.start_kafka():

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -670,10 +670,13 @@ def main():
                 else:
                     booted = True
                     break
-                # Only a boot the server did not survive is retried. While it is
+                # Only a boot no tracked replica survived is retried. While one is
                 # still up, the next attempt would wipe the run directory it is
                 # using, so this fails with `wait_ready`'s diagnostics instead.
-                if CH.proc.poll() is None:
+                if any(
+                    p is not None and p.poll() is None
+                    for p in (CH.proc, CH.proc_1, CH.proc_2)
+                ):
                     break
                 if boot_attempt + 1 < boot_attempts:
                     print(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -670,6 +670,11 @@ def main():
                 else:
                     booted = True
                     break
+                # Only a boot the server did not survive is retried. While it is
+                # still up, the next attempt would wipe the run directory it is
+                # using, so this fails with `wait_ready`'s diagnostics instead.
+                if CH.proc.poll() is None:
+                    break
                 if boot_attempt + 1 < boot_attempts:
                     print(
                         f"SETUP WARNING: {setup_failure} "

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -656,16 +656,8 @@ def main():
             if not (CH.start_minio(test_type="stateless") and CH.start_azurite()):
                 print("SETUP FAILURE: minio/azurite did not start")
                 return False
-            # A transient host condition at boot (e.g. a brief memory spike from
-            # a co-tenant job on the same runner) can make clickhouse-server exit
-            # a few seconds after start, before it even creates its err.log, with
-            # no diagnostics - a plain re-start then succeeds. Observed as an
-            # opaque "Start ClickHouse Server" FAIL across several unrelated PRs
-            # in the same short window. Retry the boot a few times so a single
-            # transient death does not fail the whole job; a persistent boot
-            # failure still fails after the last attempt with wait_ready()'s
-            # err-log tail preserved for triage. Only the initial setup boot is
-            # retried - the per-build-type binary-swap boot below stays fail-closed.
+            # Only the initial setup boot is retried; the per-build-type
+            # binary-swap boot below stays fail-closed.
             boot_attempts = 3
             booted = False
             for boot_attempt in range(boot_attempts):

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1029,6 +1029,17 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
                     proc.kill()
+            elif proc:
+                # start() spawned a server but timed out before the pid file
+                # appeared, so `pid` is unset and the graceful branch is skipped.
+                # `proc` may be the `sh -c` wrapper rather than the server, so
+                # kill by the unique --pid-file token (reaches wrapper, server
+                # and any duplicate), then reap the wrapper.
+                Shell.check(f"pkill -9 -f -- '--pid-file {pid_file}'", verbose=True)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
 
         return self
 

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -444,6 +444,16 @@ profiles:
             verbose=True,
         )
 
+    def _set_pid(self, replica_num, pid):
+        if replica_num == 1:
+            self.pid_1 = pid
+        elif replica_num == 2:
+            self.pid_2 = pid
+        elif replica_num == 0:
+            self.pid_0 = pid
+        else:
+            assert False
+
     def start(self, replica_num=0):
         if replica_num == 0:
             # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host
@@ -466,6 +476,9 @@ profiles:
 
         print(f"Starting ClickHouse server replica {replica_num}, command: {command}")
 
+        # The cached pid mirrors this file and must not outlive it: stop_server()
+        # keys its pid-less kill path off the cached value.
+        self._set_pid(replica_num, 0)
         Path(pid_file).unlink(missing_ok=True)
         Utils.clean_dir(Path(run_path))
         Utils.clean_dir(p_temp_dir / "jemalloc_profiles")
@@ -516,14 +529,7 @@ profiles:
                     continue
                 started = True
                 print(f"Got pid from fs [{pid}]")
-                if replica_num == 1:
-                    self.pid_1 = int(pid)
-                elif replica_num == 2:
-                    self.pid_2 = int(pid)
-                elif replica_num == 0:
-                    self.pid_0 = int(pid)
-                else:
-                    assert False
+                self._set_pid(replica_num, int(pid))
                 break
         except Exception:
             pass
@@ -1030,11 +1036,8 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 except subprocess.TimeoutExpired:
                     proc.kill()
             elif proc:
-                # start() spawned a server but timed out before the pid file
-                # appeared, so `pid` is unset and the graceful branch is skipped.
-                # `proc` may be the `sh -c` wrapper rather than the server, so
-                # kill by the unique --pid-file token (reaches wrapper, server
-                # and any duplicate), then reap the wrapper.
+                # `proc` is the `sh -c` wrapper, not the server, so kill by the
+                # unique --pid-file token, then reap the wrapper.
                 Shell.check(f"pkill -9 -f -- '--pid-file {pid_file}'", verbose=True)
                 try:
                     proc.wait(timeout=10)

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -476,7 +476,7 @@ profiles:
 
         print(f"Starting ClickHouse server replica {replica_num}, command: {command}")
 
-        # The cached pid mirrors this file and must not outlive it: stop_server()
+        # The cached pid mirrors this file and must not outlive it: `stop_server`
         # keys its pid-less kill path off the cached value.
         self._set_pid(replica_num, 0)
         Path(pid_file).unlink(missing_ok=True)
@@ -1037,7 +1037,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     proc.kill()
             elif proc:
                 # `proc` is the `sh -c` wrapper, not the server, so kill by the
-                # unique --pid-file token, then reap the wrapper.
+                # unique `--pid-file` token, then reap the wrapper.
                 Shell.check(f"pkill -9 -f -- '--pid-file {pid_file}'", verbose=True)
                 try:
                     proc.wait(timeout=10)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Retry the initial clickhouse-server boot in the functional-test setup so a single transient boot death does not fail the whole job.


### Description

**Problem.** In functional-test setup, `start` spawns the server and `wait_ready` polls `select 1`. A transient host condition at boot, such as a brief memory spike from a co-tenant job on the same runner, can make the server exit a few seconds in, before it creates `clickhouse-server.err.log`, so no diagnostics survive. A plain re-start then succeeds. It surfaces as an opaque `Start ClickHouse Server` setup FAIL, reddening the non-blocking `Bugfix validation (functional tests)` job and, through the rollup, `Finish Workflow` and `Mergeable Check`.

**Evidence it is transient.** In one 40-minute window the identical failure hit four unrelated PRs. On the commit that failed this step every other server-booting check passed, including Fast test, all Integration batches, AST fuzzer, BuzzHouse and Stress, and a sibling PR re-ran the same SHA and passed. Failing run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109052&sha=f03fe3af507daaf0a255f0cdc55867bc05662e59&name_0=PR&name_1=Bugfix%20validation%20%28functional%20tests%2C%20amd64%29

**Fix.** Retry the setup boot up to 3 times, but only a boot the server did not survive. `wait_ready` also fails by readiness timeout while the process is still up, and retrying that would let the next attempt's `Utils.clean_dir` wipe the run directory a live server is using, so the loop stops while any tracked replica is alive and fails with `wait_ready`'s own diagnostics. A persistent boot failure still fails after the last attempt with the err-log tail preserved. The first-try-success path is unchanged, and the per-build-type binary-swap boot stays fail-closed.

`clickhouse_proc.py` carries the two `stop_server` fixes the retry depends on: it now kills a server whose pid file never appeared within `start`'s poll, previously a silent no-op that left it running, and `start` clears the cached pid it had only ever assigned, so that path is reachable on a retry instead of shadowed by the previous attempt's pid.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109115&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109115](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109115+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->

