### PR TITLE
Make the filesystem cache download wait honor query cancellation

### DIFF
--- a/src/Interpreters/FileCache/FileSegment.cpp
+++ b/src/Interpreters/FileCache/FileSegment.cpp
@@ -9,6 +9,7 @@
 #include <base/getThreadId.h>
 #include <base/hex.h>
 #include <Common/CurrentThread.h>
+#include <Common/ThreadStatus.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/logger_useful.h>
@@ -45,6 +46,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int QUERY_WAS_CANCELLED;
 }
 
 namespace FailPoints
@@ -549,6 +551,12 @@ FileSegment::State FileSegment::wait(size_t offset)
 
         chassert(!getDownloaderUnlocked(lk).empty());
         chassert(!isDownloaderUnlocked(lk));
+
+        /// Don't (re-)enter the wait if our query was already cancelled: the wait only wakes on
+        /// download completion, so a stalled/dead downloader would otherwise pin us until timeout.
+        /// The caller re-enters wait() each loop, so a cancel during the wait is caught next round.
+        if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+            throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while waiting for file segment {} download", range().toString());
 
         [[maybe_unused]] const auto ok = cv.wait_for(lk, std::chrono::seconds(60), [&, this]()
         {

--- a/src/Interpreters/FileCache/FileSegment.cpp
+++ b/src/Interpreters/FileCache/FileSegment.cpp
@@ -5,11 +5,12 @@
 #include <IO/WriteBufferFromString.h>
 #include <Interpreters/FileCache/FileCache.h>
 #include <Interpreters/FileCache/FileCacheUtils.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <base/EnumReflection.h>
 #include <base/getThreadId.h>
 #include <base/hex.h>
 #include <Common/CurrentThread.h>
-#include <Common/ThreadStatus.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/logger_useful.h>
@@ -46,7 +47,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int QUERY_WAS_CANCELLED;
 }
 
 namespace FailPoints
@@ -552,17 +552,30 @@ FileSegment::State FileSegment::wait(size_t offset)
         chassert(!getDownloaderUnlocked(lk).empty());
         chassert(!isDownloaderUnlocked(lk));
 
-        /// Don't (re-)enter the wait if our query was already cancelled: the wait only wakes on
-        /// download completion, so a stalled/dead downloader would otherwise pin us until timeout.
-        /// The caller re-enters wait() each loop, so a cancel during the wait is caught next round.
-        if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
-            throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled while waiting for file segment {} download", range().toString());
+        /// Wait for the download in short slices so that cancellation of the waiting query
+        /// (KILL QUERY, max_execution_time, a dropped/stopped refreshable materialized view, ...)
+        /// is observed promptly. The condition variable is only notified on download progress, so a
+        /// stalled or dead downloader would otherwise pin this thread — and anything blocked on it,
+        /// e.g. RefreshTask::shutdown() -> deactivate() — until the full timeout. throwIfKilled()
+        /// re-raises the query's original cancellation reason rather than a generic one.
+        QueryStatusPtr query_status;
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            query_status = query_context->getProcessListElementSafe();
 
-        [[maybe_unused]] const auto ok = cv.wait_for(lk, std::chrono::seconds(60), [&, this]()
+        auto downloaded = [&, this]()
         {
             return download_state != State::DOWNLOADING || offset < getCurrentWriteOffset();
-        });
-        /// chassert(ok);
+        };
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(60);
+        while (true)
+        {
+            if (query_status)
+                query_status->throwIfKilled();
+            if (cv.wait_for(lk, std::chrono::seconds(1), downloaded))
+                break;
+            if (std::chrono::steady_clock::now() >= deadline)
+                break;
+        }
     }
 
     return download_state;

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1125,10 +1125,12 @@ std::optional<UUID> RefreshTask::executeRefreshUnlocked(int32_t root_znode_versi
                     if (execution.interrupt_execution.load())
                         throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Refresh for view {} cancelled", view_storage_id.getFullTableName());
                     execution.executor = &executor;
+                    execution.executing_query_status = process_list_entry ? process_list_entry->getQueryStatus() : nullptr;
                 }
                 SCOPE_EXIT({
                     std::unique_lock exec_lock(execution.executor_mutex);
                     execution.executor = nullptr;
+                    execution.executing_query_status = nullptr;
                 });
 
                 executor.execute(pipeline.getNumThreads(), pipeline.getConcurrencyControl());
@@ -1514,14 +1516,26 @@ bool RefreshTask::updateCoordinationState(CoordinationZnode root, bool running, 
 void RefreshTask::interruptExecution()
 {
     chassert(!mutex.try_lock());
-    std::unique_lock lock(execution.executor_mutex);
-    if (execution.interrupt_execution.exchange(true))
-        return;
-    if (execution.executor)
+    std::shared_ptr<QueryStatus> query_status;
     {
-        execution.executor->cancel();
-        LOG_DEBUG(getLogger(), "Cancelling refresh in {}", set_handle.getID().getFullNameNotQuoted());
+        std::unique_lock lock(execution.executor_mutex);
+        if (execution.interrupt_execution.exchange(true))
+            return;
+        query_status = execution.executing_query_status;
+        if (execution.executor)
+        {
+            execution.executor->cancel();
+            LOG_DEBUG(getLogger(), "Cancelling refresh in {}", set_handle.getID().getFullNameNotQuoted());
+        }
     }
+
+    /// Also mark the refresh query killed, not just cancel the pipeline: a refresh blocked in I/O
+    /// (e.g. a filesystem-cache download wait) doesn't observe pipeline cancellation and would keep
+    /// running, so shutdown()'s deactivate() — and any DROP driving it, including SharedCatalog
+    /// state apply — would block until the I/O returned on its own. Done outside executor_mutex
+    /// because cancelQuery() cancels registered executors, which take their own locks.
+    if (query_status)
+        query_status->cancelQuery(CancelReason::CANCELLED_BY_USER);
 }
 
 std::tuple<StoragePtr, TableLockHolder> RefreshTask::getAndLockTargetTable(const StorageID & storage_id, const ContextPtr & context)

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1531,9 +1531,9 @@ void RefreshTask::interruptExecution()
 
     /// Also mark the refresh query killed, not just cancel the pipeline: a refresh blocked in I/O
     /// (e.g. a filesystem-cache download wait) doesn't observe pipeline cancellation and would keep
-    /// running, so shutdown()'s deactivate() — and any DROP driving it, including SharedCatalog
-    /// state apply — would block until the I/O returned on its own. Done outside executor_mutex
-    /// because cancelQuery() cancels registered executors, which take their own locks.
+    /// running, so shutdown()'s deactivate() — and any DROP / SYSTEM STOP VIEW driving it — would
+    /// block until the I/O returned on its own. Done outside executor_mutex because cancelQuery()
+    /// cancels registered executors, which take their own locks.
     if (query_status)
         query_status->cancelQuery(CancelReason::CANCELLED_BY_USER);
 }

--- a/src/Storages/MaterializedView/RefreshTask.h
+++ b/src/Storages/MaterializedView/RefreshTask.h
@@ -21,6 +21,7 @@ namespace DB
 {
 
 class PipelineExecutor;
+class QueryStatus;
 
 class StorageMaterializedView;
 class ASTRefreshStrategy;
@@ -279,7 +280,7 @@ private:
             Finished,
         };
 
-        /// Protects interrupt_execution and executor.
+        /// Protects interrupt_execution, executor and executing_query_status.
         /// Can be locked while holding `mutex`.
         std::mutex executor_mutex;
         /// If there's a refresh in progress, it can be aborted by setting this flag and cancel()ling
@@ -287,6 +288,9 @@ private:
         /// `out_of_schedule_refresh_requested`, etc.
         std::atomic_bool interrupt_execution {false};
         PipelineExecutor * executor = nullptr;
+        /// Process-list entry of the in-flight refresh query, so interruptExecution() can mark it
+        /// killed. Set/cleared together with `executor`.
+        std::shared_ptr<QueryStatus> executing_query_status;
         /// Interrupts internal CREATE/EXCHANGE/DROP queries that refresh does. Only used during shutdown.
         StopSource cancel_ddl_queries;
         Progress progress;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a hang where a query reading through the filesystem cache could keep waiting on an in-progress download after being cancelled with `KILL QUERY`, and where dropping or `SYSTEM STOP VIEW`-ing a refreshable materialized view whose refresh was stuck in such a wait would block.

### Description

When a query needs a range of a file segment that another thread is downloading, it waits in `FileSegment::wait()`. That wait is only woken on download completion (with a 60s timeout, after which the caller re-loops), and it never checks whether the waiting query has been cancelled. So a stalled or dead downloader can keep a reader waiting for a long time, and `KILL QUERY` (or pipeline cancellation) has no effect on a thread parked in this wait — cancellation is cooperative and never reaches it.

For a refreshable materialized view this is worse: `DROP` / `SYSTEM STOP VIEW` goes through `RefreshTask::shutdown()` → `deactivate()`, which waits for the whole in-flight refresh to stop. If that refresh is blocked in the cache wait above, the drop/stop hangs, and `RefreshTask::interruptExecution()` — which only cancels the pipeline executor — doesn't reach it.

Fix:

1. `FileSegment::wait()` checks `CurrentThread::get().isQueryCanceled()` before entering the wait and throws `QUERY_WAS_CANCELLED`. The caller (`CachedOnDiskReadBufferFromFile::prepareReadFromFileSegmentState`) re-enters `wait()` on each loop, so a cancellation that lands mid-wait is observed on the next round. The 60s timeout and the fast path (cache hit / completed download) are unchanged. This mirrors how `StorageSharedMergeTree` already guards its own blocking waits.
2. `RefreshTask::interruptExecution()` additionally cancels the running refresh query through its process-list entry (not just the pipeline executor), so a refresh blocked in I/O actually stops and `shutdown()` → `deactivate()` returns promptly.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.435` (included in `26.7` and later)
<!-- ch-version-info:end -->