### PR TITLE
Fix FileNotFoundError race in clickhouse-test suite tag scan

### DIFF
--- a/ci/tests/test_shared_engine_replacer_discovery.py
+++ b/ci/tests/test_shared_engine_replacer_discovery.py
@@ -1,0 +1,103 @@
+"""
+Regression test for the `clickhouse-test` suite-discovery race fixed in PR #109120.
+
+Concurrent `clickhouse-test` invocations share one queries directory. When a run
+needs engine substitutions, `SharedEngineReplacer` writes a transient per-PID copy
+of a test file next to the original (see `SharedEngineReplacer.temp_file_path`) and
+removes it once the test finishes. Another invocation's suite scan (`os.listdir` in
+`get_selected_tests`) can observe that copy; because it ends in a supported
+extension, `is_test_from_dir` used to accept it and schedule it as a real test — which
+then failed either as `FileNotFoundError` once the copy vanished (in
+`load_tags_and_random_settings_limits_from_file` / `is_valid_utf_8`) or as
+`NO_REFERENCE` while the copy was still present.
+
+The fix embeds a dedicated marker (`SharedEngineReplacer.TEMP_FILE_MARKER`) into these
+copies and skips only marked files at the single discovery choke point
+(`is_transient_test_copy` in `is_test_from_dir`). This test pins that producer/filter
+contract:
+  - the marked temp copy `foo.shared_engine_replacer_tmp.<pid>.sql` is skipped, and
+  - a genuine test whose basename merely looks like `<name>.<digits><ext>` (e.g.
+    `foo.1.sql`) is still discovered even when `foo.sql` also exists.
+
+The second point guards against the earlier revision, which inferred "transient copy"
+from the basename shape and silently dropped a legitimate `foo.1.sql` whenever
+`foo.sql` was also present.
+"""
+
+import argparse
+import os
+import runpy
+import tempfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CLICKHOUSE_TEST = str(_REPO_ROOT / "tests" / "clickhouse-test")
+
+# Load clickhouse-test without running __main__ so path changes propagate
+# automatically. runpy.run_path handles the missing .py extension.
+_ct = runpy.run_path(_CLICKHOUSE_TEST)
+
+SharedEngineReplacer = _ct["SharedEngineReplacer"]
+is_test_from_dir = _ct["is_test_from_dir"]
+is_transient_test_copy = _ct["is_transient_test_copy"]
+TEST_FILE_EXTENSIONS = _ct["TEST_FILE_EXTENSIONS"]
+
+
+def _discovered(suite_dir):
+    return {case for case in os.listdir(suite_dir) if is_test_from_dir(suite_dir, case)}
+
+
+def test_transient_copy_skipped_but_lookalike_test_discovered():
+    with tempfile.TemporaryDirectory() as suite_dir:
+        original = os.path.join(suite_dir, "foo.sql")
+        lookalike = os.path.join(suite_dir, "foo.1.sql")
+        for path in (original, lookalike):
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("SELECT 1;\n")
+
+        # Only the attributes SharedEngineReplacer reads for a non-replicated,
+        # non-cloud substitution; enough to make it materialize the temp copy.
+        args = argparse.Namespace(
+            replace_log_memory_with_mergetree=False,
+            shared_catalog_stress=False,
+        )
+
+        # Materialize the transient per-PID copy exactly as a concurrent run would.
+        with SharedEngineReplacer(
+            args,
+            original,
+            False,  # replace_replicated
+            True,  # replace_non_replicated
+            False,  # reference_file
+            False,  # cloud
+        ) as replacer:
+            temp_path = replacer.get_path()
+            temp_case = os.path.basename(temp_path)
+
+            # Precondition: a real, marked, supported-extension copy was created.
+            assert temp_path != original, "SharedEngineReplacer did not create a copy"
+            assert os.path.isfile(temp_path), temp_path
+            assert (
+                temp_case
+                == f"foo.{SharedEngineReplacer.TEMP_FILE_MARKER}.{os.getpid()}.sql"
+            ), temp_case
+            assert any(temp_case.endswith(ext) for ext in TEST_FILE_EXTENSIONS)
+
+            # The marked copy is recognized as transient and excluded from discovery.
+            assert is_transient_test_copy(temp_case), temp_case
+            assert not is_test_from_dir(suite_dir, temp_case), temp_case
+
+            # Both originals — including the `foo.1.sql` look-alike the old shape
+            # heuristic dropped — are discovered normally.
+            assert not is_transient_test_copy("foo.sql")
+            assert not is_transient_test_copy("foo.1.sql")
+            assert is_test_from_dir(suite_dir, "foo.sql")
+            assert is_test_from_dir(suite_dir, "foo.1.sql")
+
+            # A whole-directory scan discovers exactly the two real tests and skips
+            # only the marked copy.
+            assert _discovered(suite_dir) == {"foo.sql", "foo.1.sql"}
+
+        # The context manager removed the copy; discovery is unchanged.
+        assert not os.path.isfile(temp_path)
+        assert _discovered(suite_dir) == {"foo.sql", "foo.1.sql"}

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3944,7 +3944,19 @@ class TestSuite:
         def load_tags_and_random_settings_limits_from_file(filepath):
             comment_sign = get_comment_sign(filepath)
             need_query_params = False
-            with open(filepath, "r", encoding="utf-8") as file:
+            try:
+                file = open(filepath, "r", encoding="utf-8")
+            except FileNotFoundError:
+                # Concurrent `clickhouse-test` workers share one queries directory. A
+                # worker that needs substitutions writes a transient per-PID copy of a
+                # test (`<name>.<pid><ext>`, see TestCase.temp_file_path) next to the
+                # original and removes it once done. Another worker's suite scan
+                # (os.listdir in get_selected_tests) can list that copy and only reach
+                # here after it was deleted, so the file is gone by the time we read its
+                # tags. A file that vanished mid-scan has no tags to contribute — skip it
+                # instead of aborting the whole run with a FileNotFoundError.
+                return [], {}, None
+            with file:
                 try:
                     lines = file.readlines()
                     tag_line = find_tag_line(lines, comment_sign)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3944,19 +3944,7 @@ class TestSuite:
         def load_tags_and_random_settings_limits_from_file(filepath):
             comment_sign = get_comment_sign(filepath)
             need_query_params = False
-            try:
-                file = open(filepath, "r", encoding="utf-8")
-            except FileNotFoundError:
-                # Concurrent `clickhouse-test` workers share one queries directory. A
-                # worker that needs substitutions writes a transient per-PID copy of a
-                # test (`<name>.<pid><ext>`, see TestCase.temp_file_path) next to the
-                # original and removes it once done. Another worker's suite scan
-                # (os.listdir in get_selected_tests) can list that copy and only reach
-                # here after it was deleted, so the file is gone by the time we read its
-                # tags. A file that vanished mid-scan has no tags to contribute — skip it
-                # instead of aborting the whole run with a FileNotFoundError.
-                return [], {}, None
-            with file:
+            with open(filepath, "r", encoding="utf-8") as file:
                 try:
                     lines = file.readlines()
                     tag_line = find_tag_line(lines, comment_sign)
@@ -5211,13 +5199,31 @@ def do_run_tests(
     return total_tests
 
 
+def is_transient_test_copy(suite_dir, case):
+    # `SharedEngineReplacer` writes a transient per-PID copy of a test next to the
+    # original while the test runs, named `<name>.<pid><ext>` (see
+    # `SharedEngineReplacer.temp_file_path`), and removes it afterwards. Concurrent
+    # `clickhouse-test` invocations share one queries directory, so another one's
+    # suite scan (`os.listdir` in `get_selected_tests`) can observe such a copy and
+    # would otherwise schedule it as a real test — which then fails either as
+    # `FileNotFoundError` once the copy is gone or as `NO_REFERENCE` for the bogus
+    # PID-suffixed name. Recognize and skip these copies at discovery so they never
+    # enter the test list. The copy is only skipped when the original it was made
+    # from is present, which makes a false positive on a genuine test impossible.
+    root, ext = os.path.splitext(case)
+    base, dot, pid = root.rpartition(".")
+    return bool(dot) and pid.isdigit() and os.path.isfile(os.path.join(suite_dir, base + ext))
+
+
 def is_test_from_dir(suite_dir, case):
     case_file = os.path.join(suite_dir, case)
     # We could also test for executable files (os.access(case_file, os.X_OK),
     # but it interferes with 01610_client_spawn_editor.editor, which is invoked
     # as a query editor in the test, and must be marked as executable.
-    return os.path.isfile(case_file) and any(
-        case_file.endswith(suppotred_ext) for suppotred_ext in TEST_FILE_EXTENSIONS
+    return (
+        os.path.isfile(case_file)
+        and any(case_file.endswith(suppotred_ext) for suppotred_ext in TEST_FILE_EXTENSIONS)
+        and not is_transient_test_copy(suite_dir, case)
     )
 
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -176,6 +176,13 @@ def shell_get_output(cmd: str, timeout: Optional[float] = None) -> str:
         return ""
 
 class SharedEngineReplacer:
+    # Infix marker embedded into the transient per-PID test and reference copies this
+    # class creates next to the originals. It contains a dot-delimited token that no
+    # real test filename uses, so suite discovery (`is_transient_test_copy`) can
+    # recognize and skip these copies unambiguously, without constraining the names of
+    # genuine tests.
+    TEMP_FILE_MARKER = "shared_engine_replacer_tmp"
+
     SPECIALIZED_ENGINES = "Collapsing|VersionedCollapsing|Summing|Replacing|Aggregating|Coalescing"
     ENGINES_NON_REPLICATED_REGEXP = (
         rf"(?i)ENGINE[ =]{{0,5}}(({SPECIALIZED_ENGINES}|)MergeTree\(?\)?)"
@@ -395,8 +402,10 @@ class SharedEngineReplacer:
         if not self._need_to_replace_something():
             return
 
-        self.temp_file_path = "{0}.{2}{1}".format(
-            *os.path.splitext(file_name), os.getpid()
+        self.temp_file_path = "{0}.{2}.{3}{1}".format(
+            *os.path.splitext(file_name),
+            SharedEngineReplacer.TEMP_FILE_MARKER,
+            os.getpid(),
         )
         shutil.copy2(self.file_name, self.temp_file_path)
 
@@ -5199,20 +5208,19 @@ def do_run_tests(
     return total_tests
 
 
-def is_transient_test_copy(suite_dir, case):
+def is_transient_test_copy(case):
     # `SharedEngineReplacer` writes a transient per-PID copy of a test next to the
-    # original while the test runs, named `<name>.<pid><ext>` (see
-    # `SharedEngineReplacer.temp_file_path`), and removes it afterwards. Concurrent
-    # `clickhouse-test` invocations share one queries directory, so another one's
-    # suite scan (`os.listdir` in `get_selected_tests`) can observe such a copy and
-    # would otherwise schedule it as a real test — which then fails either as
-    # `FileNotFoundError` once the copy is gone or as `NO_REFERENCE` for the bogus
-    # PID-suffixed name. Recognize and skip these copies at discovery so they never
-    # enter the test list. The copy is only skipped when the original it was made
-    # from is present, which makes a false positive on a genuine test impossible.
-    root, ext = os.path.splitext(case)
-    base, dot, pid = root.rpartition(".")
-    return bool(dot) and pid.isdigit() and os.path.isfile(os.path.join(suite_dir, base + ext))
+    # original while the test runs (see `SharedEngineReplacer.temp_file_path`), and
+    # removes it afterwards. Concurrent `clickhouse-test` invocations share one
+    # queries directory, so another one's suite scan (`os.listdir` in
+    # `get_selected_tests`) can observe such a copy and would otherwise schedule it as
+    # a real test — which then fails either as `FileNotFoundError` once the copy is
+    # gone or as `NO_REFERENCE` for the bogus name. These copies carry a dedicated
+    # marker (`SharedEngineReplacer.TEMP_FILE_MARKER`) that no real test name uses, so
+    # we recognize and skip them at discovery unambiguously, without inferring
+    # "transient copy" from the basename shape and thus without constraining the names
+    # of genuine tests.
+    return f".{SharedEngineReplacer.TEMP_FILE_MARKER}." in case
 
 
 def is_test_from_dir(suite_dir, case):
@@ -5223,7 +5231,7 @@ def is_test_from_dir(suite_dir, case):
     return (
         os.path.isfile(case_file)
         and any(case_file.endswith(suppotred_ext) for suppotred_ext in TEST_FILE_EXTENSIONS)
-        and not is_transient_test_copy(suite_dir, case)
+        and not is_transient_test_copy(case)
     )
 
 


### PR DESCRIPTION
Fix a flaky `Stress test` failure caused by a race in `clickhouse-test`'s suite construction.

When several `clickhouse-test` invocations run concurrently against one shared queries directory, a run that needs query substitutions writes a transient per-PID copy of a test file (`<name>.<pid><ext>`, see `SharedEngineReplacer.temp_file_path`) next to the original and removes it once the test finishes. Another invocation's suite scan enumerates the directory with `os.listdir` in `get_selected_tests` and can observe that copy. Because the copy ends in a supported extension, `is_test_from_dir` accepts it and it is scheduled as a real test. It then fails in one of two ways: if the copy is deleted before the run reads its tags in `load_tags_and_random_settings_limits_from_file` or checks it in `is_valid_utf_8`, the unguarded `open` raises `FileNotFoundError` and aborts the whole run during suite construction; if the copy is still present, it runs as a bogus PID-suffixed test with no reference file and is reported `NO_REFERENCE`.

This surfaced as a flaky `Stress test (arm_asan_ubsan)` failure (`Test script failed`, `script exit code: 1`): one of the 8 parallel `clickhouse-test` instances died with `FileNotFoundError: ... 03745_buffers_input_output_format_roundtrip.4491.sh` in `load_tags_and_random_settings_limits_from_file`, where `4491` is the PID of a `Process-3` worker in a sibling instance. There was no server crash, sanitizer report, or logical error.

The fix recognizes and excludes these transient copies at the single discovery choke point, `is_test_from_dir`, so they never enter the test list. `SharedEngineReplacer` embeds a dedicated infix marker (`SharedEngineReplacer.TEMP_FILE_MARKER`) into the per-PID copies it writes (`<name>.shared_engine_replacer_tmp.<pid><ext>`), and `is_transient_test_copy` skips only the files carrying that marker. The marker is a namespace `clickhouse-test` owns and no real test filename uses, so this recognizes the copies unambiguously without inferring "transient copy" from the basename shape and thus without constraining the names of genuine tests — a real test such as `foo.1.sql` is discovered normally even when `foo.sql` is also present. The copy stays next to the original, so `.sh`/`.sql` tests that resolve helpers or reference files relative to their own location are unaffected. Excluding the copy at discovery also removes the need for a `FileNotFoundError` guard in `load_tags_and_random_settings_limits_from_file`, so the earlier guard is reverted rather than left as a fallback that only masked one symptom.

Found while reviewing the CI report of https://github.com/ClickHouse/ClickHouse/pull/108827 (the failure was unrelated to that PR, which only touches CI tooling).

Related: https://github.com/ClickHouse/ClickHouse/pull/108827

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.452` (included in `26.7` and later)
<!-- ch-version-info:end -->