### PR TITLE
Praktika: prioritize errors over warnings when truncating build logs

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -960,14 +960,27 @@ class Result(MetaClasses.Serializable):
         # Apply truncation if info_lines exceeds MAX_LINES_IN_INFO
         truncated = False
         if len(info_lines) > MAX_LINES_IN_INFO:
-            # For clang-tidy and similar builds, find the first error/warning
-            # and show context around it instead of just the last lines
+            # For clang-tidy and similar builds, find the first error (or, if
+            # there is none, the first warning) and show context around it
+            # instead of just the last lines.
+            # Errors take priority over warnings: a build log often contains
+            # many unrelated warnings (e.g. deprecation warnings from contrib
+            # libraries) before the actual compile error that stopped the
+            # build. Centering the excerpt on the first warning would truncate
+            # away the real error, so scan for the first error first and only
+            # fall back to the first warning when no error is present.
             first_error_idx = None
+            first_warning_idx = None
             for idx, line in enumerate(info_lines):
                 # Match clang-tidy format: "file:line:col: error:" or "file:line:col: warning:"
-                if ": error:" in line or ": warning:" in line:
+                if ": error:" in line:
                     first_error_idx = idx
                     break
+                if first_warning_idx is None and ": warning:" in line:
+                    first_warning_idx = idx
+
+            if first_error_idx is None:
+                first_error_idx = first_warning_idx
 
             if first_error_idx is not None:
                 # Show context around the first error (lines before and after)


### PR DESCRIPTION
When a command log exceeds `MAX_LINES_IN_INFO` (300 lines), the Praktika report shows a truncated excerpt centered on the first line matching `: error:` **or** `: warning:` (`ci/praktika/result.py`).

Build logs frequently contain many unrelated warnings long before the actual compile error that stopped the build — for example, `-Wdeprecated-declarations` warnings emitted while compiling contrib libraries such as LLVM (`'mallinfo' is deprecated`). Because the scan matched the first warning, the excerpt was centered there and the real error was pushed into the truncated tail. The report then showed only irrelevant warnings between `~~~~~ truncated N lines at the beginning ~~~~~` and `~~~~~ truncated M lines at the end ~~~~~`, hiding the cause of the failure.

For example, a failing `Build ClickHouse` job whose real error was:

```
FAILED: src/CMakeFiles/dbms.dir/Interpreters/Context.cpp.o
/ClickHouse/src/Interpreters/Context.cpp:4951:9: error: use of undeclared identifier 'addThrottler'
```

showed only an LLVM `mallinfo` deprecation warning in the report, with both the head and the tail (including the error) truncated away.

This change makes errors take priority over warnings: it scans for the first `: error:` line first and only falls back to the first `: warning:` when no error is present, so the actual compile error is always visible in the truncated excerpt.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.2.26`, `26.5.6.13`, `26.4.5.99`
<!-- ch-version-info:end -->