### PR TITLE
Substitute ALIAS columns in text index arguments

### DIFF
--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -80,6 +80,47 @@ IndexDescription & IndexDescription::operator=(const IndexDescription & other)
     return *this;
 }
 
+namespace
+{
+
+/// Replace ALIAS column references inside index TYPE arguments with their underlying
+/// expressions -- the same substitution initExpressionInfo applies to the index key
+/// expression, but for the arguments (e.g. a text index `preprocessor = lower(col)`).
+///
+/// Arguments are a list of key=value pairs, parsed as `equals(ASTIdentifier key, value)`:
+///
+///   arguments (ASTExpressionList)
+///   +-- equals( "tokenizer",    'asciiCJK'        )   value: children[1]
+///   +-- equals( "preprocessor", lower(alias_col)  )   value: children[1]   <- alias lives here
+///
+/// We must visit ONLY the value side (children[1]) of each pair. Visiting the whole list
+/// would let the aliasing visitor (which rewrites any ASTIdentifier whose name is an alias)
+/// clobber a parameter NAME on children[0] -- e.g. if a column named `tokenizer` were an
+/// alias, the key identifier `tokenizer` would be wrongly rewritten and argument parsing
+/// would break. Non key=value argument forms are left untouched.
+void replaceAliasesInIndexArguments(const ASTPtr & arguments, const ColumnsDescription & columns)
+{
+    if (!arguments)
+        return;
+
+    using ReplaceAliasToExprVisitor = InDepthNodeVisitor<ReplaceAliasByExpressionMatcher, true>;
+    ReplaceAliasToExprVisitor::Data data{columns};
+
+    for (auto & child : arguments->children)
+    {
+        auto * equals_function = child->as<ASTFunction>();
+        if (!equals_function || equals_function->name != "equals" || !equals_function->arguments
+            || equals_function->arguments->children.size() != 2)
+            continue;
+
+        /// children[0] is the parameter name (key) -- never substitute it.
+        /// children[1] is the value expression -- substitute aliases there.
+        ReplaceAliasToExprVisitor{data}.visit(equals_function->arguments->children[1]);
+    }
+}
+
+}
+
 IndexDescription IndexDescription::getIndexFromAST(
     const ASTPtr & definition_ast,
     const ColumnsDescription & columns,
@@ -128,7 +169,18 @@ IndexDescription IndexDescription::getIndexFromAST(
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Skip index '{}' must have at least one column in its expression", result.name);
 
     if (index_type && index_type->arguments)
+    {
         result.arguments = index_type->arguments->clone();
+        /// Only the `text` index has expression-valued arguments (`preprocessor` / `postprocessor`)
+        /// that may reference ALIAS columns -- e.g. `preprocessor = lower(alias_col)`. Other index
+        /// types take positional literal arguments, where an identifier is a value rather than a
+        /// column reference, so alias substitution must not run for them. The index key expression
+        /// is alias-substituted in initExpressionInfo; do the same for the argument VALUES here so
+        /// an argument expression over an ALIAS resolves to the underlying physical columns instead
+        /// of failing later with "Missing columns" during argument validation.
+        if (result.type == "text")
+            replaceAliasesInIndexArguments(result.arguments, columns);
+    }
 
     return result;
 }

--- a/tests/queries/0_stateless/04498_text_index_alias_column_preprocessor.reference
+++ b/tests/queries/0_stateless/04498_text_index_alias_column_preprocessor.reference
@@ -1,0 +1,22 @@
+-- CREATE: preprocessor over an ALIAS column
+-- index metadata keeps the ALIAS name in the argument, key is the expanded expression
+text(tokenizer = \'splitByNonAlpha\', preprocessor = lower(combined))	concat(title, \' \', body)
+-- query results
+1
+1
+1
+1
+1
+1
+1
+0
+-- index is used
+Name: idx
+-- DETACH / ATTACH round-trip (recalculateWithNewColumns)
+1
+-- ALTER ADD INDEX / MATERIALIZE INDEX
+1
+1
+-- ALIAS column shadowing a parameter name does not break argument parsing
+1
+1

--- a/tests/queries/0_stateless/04498_text_index_alias_column_preprocessor.sql
+++ b/tests/queries/0_stateless/04498_text_index_alias_column_preprocessor.sql
@@ -1,0 +1,94 @@
+-- Regression test: a text index whose `preprocessor` argument references an ALIAS
+-- column used to fail validation with "Missing columns: '<alias>'". The ALIAS-to-
+-- expression substitution in IndexDescription::getIndexFromAST only rewrote the index
+-- KEY expression, leaving the TYPE argument VALUES untouched, so at argument-validation
+-- time only the physical source columns existed and `lower(alias_col)` could not resolve.
+-- The fix applies the same alias substitution to the text index argument values.
+
+SET enable_full_text_index = 1;
+
+SELECT '-- CREATE: preprocessor over an ALIAS column';
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    title String,
+    body String,
+    combined ALIAS concat(title, ' ', body),
+    INDEX idx combined TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(combined)) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello', 'World'), ('FOO', 'BAR'), ('quux', 'zoo');
+
+-- The original DDL (with the ALIAS name) must be preserved in the argument: alias substitution
+-- happens on the working argument copy, not on the definition AST used for serialization. The
+-- resolved index KEY expression is the expanded ALIAS `concat(title, ' ', body)`.
+SELECT '-- index metadata keeps the ALIAS name in the argument, key is the expanded expression';
+SELECT type_full, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 'tab' AND name = 'idx';
+
+-- Tokens are lowercased at index time by the preprocessor; the needle is preprocessed too.
+SELECT '-- query results';
+SELECT count() FROM tab WHERE hasToken(combined, 'hello');
+SELECT count() FROM tab WHERE hasToken(combined, 'Hello');
+SELECT count() FROM tab WHERE hasToken(combined, 'world');
+SELECT count() FROM tab WHERE hasToken(combined, 'foo');
+SELECT count() FROM tab WHERE hasToken(combined, 'FOO');
+SELECT count() FROM tab WHERE hasToken(combined, 'bar');
+SELECT count() FROM tab WHERE hasToken(combined, 'quux');
+SELECT count() FROM tab WHERE hasToken(combined, 'xyz');
+
+-- The index is actually built and used for the lookup.
+SELECT '-- index is used';
+SELECT trimLeft(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE hasToken(combined, 'hello')) WHERE explain LIKE '%Name: idx%';
+
+DROP TABLE tab;
+
+SELECT '-- DETACH / ATTACH round-trip (recalculateWithNewColumns)';
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    title String,
+    body String,
+    combined ALIAS concat(title, ' ', body),
+    INDEX idx combined TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(combined)) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello', 'World');
+DETACH TABLE tab;
+ATTACH TABLE tab;
+SELECT count() FROM tab WHERE hasToken(combined, 'hello');
+DROP TABLE tab;
+
+SELECT '-- ALTER ADD INDEX / MATERIALIZE INDEX';
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    title String,
+    body String,
+    combined ALIAS concat(title, ' ', body)
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello', 'World'), ('FOO', 'BAR');
+ALTER TABLE tab ADD INDEX idx combined TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(combined)) GRANULARITY 1;
+ALTER TABLE tab MATERIALIZE INDEX idx SETTINGS mutations_sync = 2;
+SELECT count() FROM tab WHERE hasToken(combined, 'hello');
+SELECT count() FROM tab WHERE hasToken(combined, 'foo');
+DROP TABLE tab;
+
+-- Guard: an ALIAS column named exactly like a parameter key (`tokenizer`) must not clobber
+-- the key. Only the value side of each key=value pair is alias-substituted, so the argument
+-- key `tokenizer` keeps its meaning and parsing still succeeds.
+SELECT '-- ALIAS column shadowing a parameter name does not break argument parsing';
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    title String,
+    body String,
+    combined ALIAS concat(title, ' ', body),
+    tokenizer ALIAS 'shadow',
+    INDEX idx combined TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(combined)) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO tab VALUES ('Hello', 'World'), ('FOO', 'BAR');
+SELECT count() FROM tab WHERE hasToken(combined, 'hello');
+SELECT count() FROM tab WHERE hasToken(combined, 'foo');
+DROP TABLE tab;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/95944

The ALIAS-to-expression substitution in `IndexDescription::getIndexFromAST` only rewrote the index KEY expression (`extractKeyExpressionList`), leaving index TYPE arguments untouched. A `text` index argument that references an ALIAS column — e.g. `preprocessor = lower(combined)` where `combined ALIAS concat(title, ' ', body)` — failed validation, because at argument-validation time only the physical source columns exist:

```sql
SET enable_full_text_index = 1;
CREATE TABLE providers
(
    provider Nullable(String),
    name String ALIAS ifNull(provider, 'default_name'),
    INDEX name_text_idx(name) TYPE text(tokenizer = sparseGrams(3), preprocessor = lower(name))
)
ENGINE = MergeTree ORDER BY tuple();
-- Code: 36. DB::Exception: Preprocessor function must only reference column: ifNull(provider, 'default_name'), also got: name (BAD_ARGUMENTS)
```

This change applies the same alias substitution to the argument VALUES. Only the `text` index has expression-valued arguments (`preprocessor` / `postprocessor`) that may reference columns; every other index type takes positional literal arguments, where an identifier is a value rather than a column reference, so the substitution is scoped to `text`. To avoid clobbering a parameter NAME (a column aliased like `tokenizer` / `preprocessor`), only the value side (`children[1]`) of each `equals(key, value)` argument pair is visited, never the key.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow `ALIAS` columns to be referenced in `text` index `preprocessor` / `postprocessor` arguments (e.g. `preprocessor = lower(alias_col)`), which previously failed validation with a "Missing columns" / "Preprocessor function must only reference column" error.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
