### PR TITLE
Fix use-after-free in Hive unpartitioned read path

### DIFF
--- a/src/Storages/Hive/StorageHive.cpp
+++ b/src/Storages/Hive/StorageHive.cpp
@@ -996,8 +996,13 @@ HiveFiles StorageHive::collectHiveFiles(
         auto file_infos = listDirectory(hive_table_metadata->getTable()->sd.location, hive_table_metadata, fs);
         for (const auto & file_info : file_infos)
         {
+            /// Capture `file_info` by value: `file_infos` is scoped to this `else` block and is destroyed
+            /// at the closing brace below, before the `pool.wait()` that joins the tasks - a task still
+            /// running (or queued) at that point would otherwise read a dangling reference into the freed
+            /// vector. `partitions` in the branch above is a function-scope local and outlives `pool.wait`,
+            /// so its `[&]` capture of `partition` is safe and left unchanged.
             pool.scheduleOrThrowOnError(
-                [&]()
+                [&, file_info]()
                 {
                     auto hive_file = getHiveFileIfNeeded(file_info, {}, filter_actions_dag, hive_table_metadata, context_, prune_level);
                     if (hive_file)


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108094

Fixes a pre-existing use-after-free in `StorageHive::collectHiveFiles` on the read path for a **non-partitioned** `Hive` table.

In that branch, `file_infos` (the result of `listDirectory`) is a local of the `else` block and is destroyed at the block's closing brace, but `pool.wait()` — which joins the worker tasks — runs on the next line, *after* the vector is freed. The tasks capture the range-`for` variable `file_info` (a `const FileInfo &` into `file_infos`) by reference, so a task still executing or queued when the `else` block exits dereferences a dangling reference into the freed `std::vector<FileInfo>` while `pool.wait()` is joining. A multi-threaded read of a non-partitioned `Hive` table can therefore read freed memory (a use-after-free / data race).

The partition branch above is not affected: `partitions` is a function-scope local that outlives `pool.wait()`, so its `[&]` capture of the reference loop variable `partition` is well-defined and is left unchanged.

The fix captures `file_info` by value in the `else`-branch task (`FileInfo` is a small, copyable struct: `path`, `last_modify_time`, `size`), so the closure owns its data and no longer depends on `file_infos` outliving the tasks.

This was found while reviewing the AI report on #108094; it is pre-existing on `master` (independent of that crash fix) and is submitted here as a separate, focused change.

### Changelog category (leave one):
- Not for changelog

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a use-after-free when reading a non-partitioned `Hive` table with multiple threads.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.530` (included in `26.7` and later)
<!-- ch-version-info:end -->