### PR TITLE
Follow up for #105640 perf test for FHT runtime filter

### DIFF
--- a/tests/performance/join_convert_to_fixed_hash_table.xml
+++ b/tests/performance/join_convert_to_fixed_hash_table.xml
@@ -1,6 +1,7 @@
 <test>
     <settings>
         <max_bytes_ratio_before_external_join>0</max_bytes_ratio_before_external_join>
+        <query_plan_join_swap_table>false</query_plan_join_swap_table>
     </settings>
 
     <create_query>CREATE TABLE build_5k (id0 Int64) ENGINE = MergeTree ORDER BY tuple()</create_query>
@@ -33,6 +34,14 @@
     <query>SELECT p.id2, b.id2 FROM probe p INNER JOIN build_50k b ON p.id2 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 0</query>
     <query>SELECT p.id2, b.id2 FROM probe p INNER JOIN build_50k b ON p.id2 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 1</query>
 
+    <!-- INNER JOIN with low selectivity and runtime filter implementation variants.
+         build_5k stays in exact-set mode; build_50k switches to bloomfilter. -->
+    <query>SELECT p.id0, b.id0 FROM probe p INNER JOIN build_5k b ON p.id0 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 0, join_runtime_filter_exact_values_limit = 10000, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+    <query>SELECT p.id0, b.id0 FROM probe p INNER JOIN build_5k b ON p.id0 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 1, join_runtime_filter_exact_values_limit = 10000, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+
+    <query>SELECT p.id2, b.id2 FROM probe p INNER JOIN build_50k b ON p.id2 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 0, join_runtime_filter_exact_values_limit = 10, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+    <query>SELECT p.id2, b.id2 FROM probe p INNER JOIN build_50k b ON p.id2 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 1, join_runtime_filter_exact_values_limit = 10, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+
     <!-- LEFT JOIN with high selectivity -->
     <query>SELECT p.id3, b.id0 FROM probe p LEFT JOIN build_5k b ON p.id3 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 0</query>
     <query>SELECT p.id3, b.id0 FROM probe p LEFT JOIN build_5k b ON p.id3 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 1</query>
@@ -52,6 +61,14 @@
 
     <query>SELECT p.id5, b.id2 FROM probe p INNER JOIN build_50k b ON p.id5 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 0</query>
     <query>SELECT p.id5, b.id2 FROM probe p INNER JOIN build_50k b ON p.id5 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 1</query>
+
+    <!-- INNER JOIN with high selectivity and runtime filter implementation variants.
+         build_5k stays in exact-set mode; build_50k switches to bloomfilter. -->
+    <query>SELECT p.id3, b.id0 FROM probe p INNER JOIN build_5k b ON p.id3 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 0, join_runtime_filter_exact_values_limit = 10000, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+    <query>SELECT p.id3, b.id0 FROM probe p INNER JOIN build_5k b ON p.id3 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 1, join_runtime_filter_exact_values_limit = 10000, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+
+    <query>SELECT p.id5, b.id2 FROM probe p INNER JOIN build_50k b ON p.id5 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 0, join_runtime_filter_exact_values_limit = 10, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
+    <query>SELECT p.id5, b.id2 FROM probe p INNER JOIN build_50k b ON p.id5 = b.id2 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_runtime_filters = 1, enable_join_fixed_hash_table_conversion = 1, join_runtime_filter_from_fixed_hash_table = 1, join_runtime_filter_exact_values_limit = 10, join_runtime_filter_pass_ratio_threshold_for_disabling = 1</query>
 
     <!-- Automatic join algorithm -->
     <query>SELECT p.id0, b.id0 FROM probe p LEFT JOIN build_5k b ON p.id0 = b.id0 FORMAT Null SETTINGS join_algorithm = 'auto', enable_join_fixed_hash_table_conversion = 0</query>


### PR DESCRIPTION
Follow up for https://github.com/ClickHouse/ClickHouse/pull/105640#issuecomment-4723501252 by @rschu1ze 

Extend `tests/performance/join_convert_to_fixed_hash_table.xml` with runtime-filter variants for hash joins whose build side is converted to a fixed hash table.

The added cases compare:
- runtime filter as exact set vs shared FixedHashMap
- runtime filter as bloomfilter vs shared FixedHashMap
- low- and high-selectivity probe-side distributions

The test also pins `query_plan_join_swap_table=false` so the `build_*` tables remain on the hash-build side.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Not for changelog.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.865` (included in `26.7` and later)
<!-- ch-version-info:end -->