### PR TITLE
check_ci.py: treat "already in the queue" as success when enqueuing

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -1057,7 +1057,14 @@ def main():
         "{mergeQueueEntry{position state}}}' "
         f"-f id={pr_node_id}"
     )
-    if not Shell.check(enqueue_cmd, verbose=True):
+    returncode, stdout, stderr = Shell.get_res_stdout_stderr(enqueue_cmd, verbose=True)
+    # GitHub rejects `enqueuePullRequest` with "Pull request is already in the
+    # queue" when the PR is already queued - e.g. the "Merge when ready" button
+    # was clicked on github.com, or a previous run of this tool already enqueued
+    # it. That is the desired end state, so treat it as success instead of
+    # bailing out with an error.
+    already_queued = "already in the queue" in (stdout + stderr).lower()
+    if returncode != 0 and not already_queued:
         print(
             f"ERROR: Failed to add PR #{pr_number} to the merge queue. "
             f"This often happens when mergeStateStatus is UNKNOWN "
@@ -1067,6 +1074,8 @@ def main():
             f"Retry manually:\n  {enqueue_cmd}"
         )
         sys.exit(1)
+    if already_queued:
+        print(f"PR #{pr_number} is already in the merge queue")
 
     # Give GitHub a moment to update the PR's merge state, then verify it
     # actually landed in the queue.

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -1065,6 +1065,12 @@ def main():
     # bailing out with an error.
     already_queued = "already in the queue" in (stdout + stderr).lower()
     if returncode != 0 and not already_queued:
+        # Surface the real gh output so auth/permission/validation/rate-limit
+        # failures stay diagnosable, as the previous verbose Shell.check did.
+        if stdout:
+            print(stdout)
+        if stderr:
+            print(stderr)
         print(
             f"ERROR: Failed to add PR #{pr_number} to the merge queue. "
             f"This often happens when mergeStateStatus is UNKNOWN "


### PR DESCRIPTION
When force-merging a PR with `check_ci`, the `enqueuePullRequest` GraphQL mutation is rejected by GitHub with `UNPROCESSABLE` / `"Pull request is already in the queue"` whenever the PR is *already* queued — for example the "Merge when ready" button was clicked on github.com beforehand, or a previous run of the tool already enqueued it.

In that case the desired end state (the PR sitting in the merge queue) has already been reached, but the tool treated the non-zero exit code of `gh api graphql` as fatal and printed `ERROR: Failed to add PR ...` before exiting with code 1 — even though GitHub actually shows the PR in the merge queue.

This change captures the mutation's output and treats the `"already in the queue"` response as success instead of an error. The subsequent `mergeStateStatus` check still runs and confirms the PR is `QUEUED`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.469` (included in `26.7` and later)
<!-- ch-version-info:end -->