### PR TITLE
Fix flaky test test_keeper_ttl_nodes::test_many_nodes_with_different_ttls

### DIFF
--- a/tests/integration/test_keeper_ttl_nodes/test.py
+++ b/tests/integration/test_keeper_ttl_nodes/test.py
@@ -164,8 +164,14 @@ def test_many_nodes_with_different_ttls():
         node1_zk = get_fake_zk(cluster, "node1")
         node2_zk = get_fake_zk(cluster, "node2")
 
+        # Consecutive nodes' destroy_times differ by this step. Each "still alive" assertion
+        # below runs right after wait_nodes_gone() for the previous node, whose return can
+        # overshoot the target's destroy_time (GC period + Raft commit + poll granularity +
+        # round-trips under load). Keep the step well above that overshoot so an assertion
+        # never races a just-expired node.
+        ttl_step_ms = 3000
         for i in range(10):
-            node1_zk.create(f"/n{i}", str(i).encode(), ttl=1000 * (i + 1))
+            node1_zk.create(f"/n{i}", str(i).encode(), ttl=ttl_step_ms * (i + 1))
 
         wait_nodes_gone([node1_zk, node2_zk], ["/n0"])
         for i in range(1, 10):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/100397
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flakiness in `test_keeper_ttl_nodes::test_many_nodes_with_different_ttls` (added in #100397).

Root cause is test timing, not the Keeper TTL engine. The test created 10 TTL nodes with `destroy_time` spaced only 1000ms apart (`ttl = 1000 * (i + 1)`), then after `wait_nodes_gone()` for one node asserted the next one is still alive. The margin between consecutive nodes' `destroy_time` was ~1s, which under load can be consumed by `wait_nodes_gone` overshoot: the leader GC period (`ttl_gc_period_ms`, 100ms in the test config), the Raft commit round-trip of the `TryRemove`, the 50ms poll granularity in `wait_nodes_gone`, plus client round-trips. When the overshoot approaches 1s the "next" node has already been garbage-collected by the time it is checked, so `assert node1_zk.exists("/n1")` fails with `assert None`.

The Keeper engine itself is correct: a node is never removed before its `destroy_time` (the internal GC `TryRemove` is re-validated deterministically at commit and rejected while `time < destroyTime()`). So the fix belongs in the test: widen the per-node TTL step from 1000ms to 3000ms so every "still alive" assertion keeps a margin well above worst-case overshoot. The test structure and intent are unchanged: it still verifies staggered, ordered, per-node-independent expiry.

Verified locally against a debug build (v26.7.1.1): injecting a 1.2s delay after `wait_nodes_gone(["/n0"])` reproduces the failure deterministically on the old spacing; with the 3000ms step the test passes 15/15 runs (5 + 10) with no failures.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.461` (included in `26.7` and later)
<!-- ch-version-info:end -->