### PR TITLE
Fix wrong access type for PREWARM PRIMARY INDEX CACHE ON CLUSTER

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2733,7 +2733,7 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
         }
         case Type::PREWARM_PRIMARY_INDEX_CACHE:
         {
-            required_access.emplace_back(AccessType::SYSTEM_PREWARM_MARK_CACHE, query.getDatabase(), query.getTable());
+            required_access.emplace_back(AccessType::SYSTEM_PREWARM_PRIMARY_INDEX_CACHE, query.getDatabase(), query.getTable());
             break;
         }
         case Type::SYNC_DATABASE_REPLICA:

--- a/tests/queries/0_stateless/04498_prewarm_primary_index_cache_on_cluster_access.sh
+++ b/tests/queries/0_stateless/04498_prewarm_primary_index_cache_on_cluster_access.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+index_user="index_user_04498_$CLICKHOUSE_DATABASE"
+mark_user="mark_user_04498_$CLICKHOUSE_DATABASE"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $index_user, $mark_user"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS t_04498"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE t_04498 (a UInt64) ENGINE = MergeTree ORDER BY a SETTINGS use_primary_key_cache = 1"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $index_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER, SYSTEM PREWARM PRIMARY INDEX CACHE ON *.* TO $index_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $mark_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER, SYSTEM PREWARM MARK CACHE ON *.* TO $mark_user"
+
+query="SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICKHOUSE_DATABASE.t_04498"
+
+# The ON CLUSTER path must check SYSTEM PREWARM PRIMARY INDEX CACHE, not SYSTEM PREWARM MARK CACHE.
+# Holder of the primary index cache grant is allowed; holder of only the mark cache grant is denied.
+${CLICKHOUSE_CLIENT} --user "$index_user" --query "$query"
+${CLICKHOUSE_CLIENT} --user "$mark_user" --query "$query -- { serverError ACCESS_DENIED }"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER $index_user, $mark_user"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE t_04498"

--- a/tests/queries/0_stateless/04498_prewarm_primary_index_cache_on_cluster_access.sh
+++ b/tests/queries/0_stateless/04498_prewarm_primary_index_cache_on_cluster_access.sh
@@ -21,8 +21,8 @@ query="SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_shard_localhost $CLICK
 
 # The ON CLUSTER path must check SYSTEM PREWARM PRIMARY INDEX CACHE, not SYSTEM PREWARM MARK CACHE.
 # Holder of the primary index cache grant is allowed; holder of only the mark cache grant is denied.
-${CLICKHOUSE_CLIENT} --user "$index_user" --query "$query"
-${CLICKHOUSE_CLIENT} --user "$mark_user" --query "$query -- { serverError ACCESS_DENIED }"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none --user "$index_user" --query "$query"
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none --user "$mark_user" --query "$query -- { serverError ACCESS_DENIED }"
 
 ${CLICKHOUSE_CLIENT} --query "DROP USER $index_user, $mark_user"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE t_04498"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/105133

`getRequiredAccessForDDLOnCluster` required `SYSTEM PREWARM MARK CACHE` for the `PREWARM_PRIMARY_INDEX_CACHE` case (copy-paste from the neighbouring `PREWARM_MARK_CACHE` case), while local execution correctly checks `SYSTEM PREWARM PRIMARY INDEX CACHE`. As a result a user granted only `SYSTEM PREWARM PRIMARY INDEX CACHE` was denied `SYSTEM PREWARM PRIMARY INDEX CACHE ... ON CLUSTER`, and a user with only `SYSTEM PREWARM MARK CACHE` could run it.

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix the access check for `SYSTEM PREWARM PRIMARY INDEX CACHE ... ON CLUSTER`, which incorrectly required the `SYSTEM PREWARM MARK CACHE` privilege instead of `SYSTEM PREWARM PRIMARY INDEX CACHE`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.472` (included in `26.7` and later)
<!-- ch-version-info:end -->