### PR TITLE
Add bounded retry to BigLakeCatalogManager.create_table

### DIFF
--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -464,6 +464,11 @@ class BigLakeCatalogManager(CatalogManager):
                     attempt,
                     listed_names,
                 )
+            except _AUTH_EXPIRY_ERRORS:
+                # Non-retryable (see _AUTH_EXPIRY_ERRORS): the stale static token
+                # cannot be refreshed in place, so polling would only burn the
+                # deadline. Propagate, mirroring create_table/cleanup_all.
+                raise
             except Exception as exc:
                 log.warning(
                     "load_table('%s') failed (attempt %d): %s",
@@ -500,6 +505,12 @@ class BigLakeCatalogManager(CatalogManager):
                     identifier,
                     attempt,
                 )
+            except _AUTH_EXPIRY_ERRORS:
+                # Must precede the generic handler: an expired static token is
+                # non-retryable (see _AUTH_EXPIRY_ERRORS) and, crucially, is NOT
+                # proof the table is gone. Treating it as "gone" here would be a
+                # false-positive cleanup, so propagate instead of returning.
+                raise
             except Exception:
                 log.info(
                     "Table '%s' gone after %d attempts",

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -14,9 +14,12 @@ from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2.credentials import Credentials as GoogleOAuth2Credentials
 from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import (
+    AuthorizationExpiredError,
     CommitStateUnknownException,
+    OAuthError,
     ServerError,
     ServiceUnavailableError,
+    UnauthorizedError,
 )
 
 from helpers.catalog_manager import CatalogManager, arrow_to_iceberg_schema
@@ -27,14 +30,25 @@ BIGLAKE_CATALOG_URL = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog
 GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 NAMESPACE_PREFIX = "ch_e2e_bl_"
 
+# Auth-expiry errors are non-retryable everywhere in this manager: self.catalog
+# is a RestCatalog built once in __init__ with a static bearer token, and
+# _refresh_token_if_needed refreshes only the separate GoogleOAuth2Credentials
+# object, never the token baked into the catalog. Retrying any catalog call after
+# the token expires just resends the same stale token until the deadline.
+# Rebuilding self.catalog mid-retry is unsafe because callers share it
+# concurrently (test_many_tables_pagination fans catalog calls across a 10-thread
+# pool), so auth expiry is always left to propagate. These mirror pyiceberg's own
+# retry-then-reraise set for its REST client (AuthorizationExpiredError,
+# UnauthorizedError; OAuthError covers the token-endpoint path).
+_AUTH_EXPIRY_ERRORS = (
+    AuthorizationExpiredError,
+    OAuthError,
+    UnauthorizedError,
+)
+
 # REST/network errors that create_table retries; pyiceberg's REST client
 # retries only auth errors (stop_after_attempt(2)), so these otherwise escape.
-# Auth-expiry errors are deliberately NOT here: self.catalog is a RestCatalog
-# built once in __init__ with a static bearer token, and _refresh_token_if_needed
-# refreshes only the GoogleOAuth2Credentials object, so retrying an expired token
-# just resends the same stale token. Rebuilding self.catalog mid-retry is unsafe
-# because callers share it concurrently (test_many_tables_pagination fans
-# create_table across a 10-thread pool), so auth expiry is left to propagate.
+# Auth-expiry errors are deliberately excluded (see _AUTH_EXPIRY_ERRORS).
 _TRANSIENT_CREATE_ERRORS = (
     ServerError,
     ServiceUnavailableError,
@@ -537,6 +551,11 @@ class BigLakeCatalogManager(CatalogManager):
         `drop_table` and surface later. Forgetting a name on that ambiguous
         signal is exactly the leak this path guards against, so "confirmed
         gone" means only a `drop_table` that returned.
+
+        Auth-expiry errors (see `_AUTH_EXPIRY_ERRORS`) are re-raised, not
+        retained-and-retried: `self.catalog` holds a static token that
+        `_refresh_token_if_needed` cannot push into it, so every retry resends
+        the same stale token. `cleanup_all` turns that into a fail-fast exit.
         """
         identifier = f"{self._session_namespace}.{table_name}"
         self._refresh_token_if_needed()
@@ -544,6 +563,8 @@ class BigLakeCatalogManager(CatalogManager):
             self.catalog.drop_table(identifier)
             log.info("Dropped tracked table '%s'", identifier)
             return True
+        except _AUTH_EXPIRY_ERRORS:
+            raise
         except Exception as drop_exc:
             log.warning(
                 "Drop of tracked table '%s' unconfirmed (%s); retaining",
@@ -565,14 +586,40 @@ class BigLakeCatalogManager(CatalogManager):
         unconfirmed after the deadline are retained (never cleared blindly) and
         logged; the final namespace drop + GCS prefix delete are the storage
         backstop for anything the per-table catalog drop could not reach.
+
+        Auth-expiry is the one non-retryable case: since `self.catalog` cannot
+        pick up a refreshed token, retrying drops would only burn the deadline
+        and still leave the tables behind. On auth expiry we stop immediately
+        (no deadline loop), keep the tables tracked, run the GCS storage
+        backstop -- which builds a fresh gcsfs client from the refreshed
+        credential and so still reaps the data files -- and then propagate,
+        mirroring create_table.
         """
         deadline = time.monotonic() + timeout
         pending = list(self._tables_created)
-        while pending:
-            pending = [n for n in pending if not self._drop_confirmed(n)]
-            if not pending or time.monotonic() >= deadline:
-                break
-            time.sleep(poll_interval)
+        try:
+            while pending:
+                pending = [n for n in pending if not self._drop_confirmed(n)]
+                if not pending or time.monotonic() >= deadline:
+                    break
+                time.sleep(poll_interval)
+        except _AUTH_EXPIRY_ERRORS as auth_exc:
+            # Fail fast: the static catalog token has expired and cannot be
+            # refreshed in place, so every further drop would resend it. Keep
+            # the tables tracked (never cleared) and fall back to the GCS
+            # storage sweep, which uses the refreshed credential, then
+            # propagate so the teardown failure is visible.
+            log.warning(
+                "cleanup_all: auth expired mid-cleanup (%s); skipping catalog "
+                "drops and relying on the GCS storage sweep for tracked "
+                "table(s): %s",
+                auth_exc,
+                pending,
+            )
+            self._delete_gcs_prefix(
+                self._namespace_gcs_path(self._session_namespace)
+            )
+            raise
         if pending:
             log.warning(
                 "cleanup_all: %d tracked table(s) could not be confirmed "

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -16,6 +16,8 @@ from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import (
     AuthorizationExpiredError,
     CommitStateUnknownException,
+    NoSuchNamespaceError,
+    NoSuchTableError,
     OAuthError,
     ServerError,
     ServiceUnavailableError,
@@ -54,6 +56,15 @@ _TRANSIENT_CREATE_ERRORS = (
     ServiceUnavailableError,
     CommitStateUnknownException,
     requests.exceptions.RequestException,
+)
+
+# The only errors that PROVE a table is gone. wait_for_table_gone treats these
+# as confirmation; any other error from load_table (5xx, connection reset, the
+# transient class create_table retries) is NOT proof of removal and must be
+# retried under the deadline rather than accepted as "gone".
+_TABLE_GONE_ERRORS = (
+    NoSuchTableError,
+    NoSuchNamespaceError,
 )
 
 
@@ -490,7 +501,17 @@ class BigLakeCatalogManager(CatalogManager):
         timeout: float = 120,
         poll_interval: float = 5,
     ) -> None:
-        """Poll until load_table raises, confirming the table is gone."""
+        """Poll until load_table proves the table is gone.
+
+        Only a genuine not-found (see `_TABLE_GONE_ERRORS`) confirms removal.
+        A transient load failure -- the same 5xx / connection-reset class
+        create_table retries -- does NOT prove the table is gone, so it is
+        retried under the deadline like a still-visible table rather than
+        accepted as success. Otherwise a teardown-time blip on load_table would
+        let test_table_disappears_after_cleanup pass with a live table behind.
+        Auth-expiry is non-retryable (see `_AUTH_EXPIRY_ERRORS`) and likewise is
+        not proof of removal, so it propagates.
+        """
         namespace = self._session_namespace
         identifier = f"{namespace}.{table_name}"
         deadline = time.monotonic() + timeout
@@ -506,18 +527,29 @@ class BigLakeCatalogManager(CatalogManager):
                     attempt,
                 )
             except _AUTH_EXPIRY_ERRORS:
-                # Must precede the generic handler: an expired static token is
+                # Must precede the handlers below: an expired static token is
                 # non-retryable (see _AUTH_EXPIRY_ERRORS) and, crucially, is NOT
                 # proof the table is gone. Treating it as "gone" here would be a
                 # false-positive cleanup, so propagate instead of returning.
                 raise
-            except Exception:
+            except _TABLE_GONE_ERRORS:
                 log.info(
                     "Table '%s' gone after %d attempts",
                     identifier,
                     attempt,
                 )
                 return
+            except Exception as exc:
+                # A transient load failure (5xx, connection reset) is NOT proof
+                # the table is gone. Retry under the deadline instead of
+                # accepting a false-positive cleanup.
+                log.warning(
+                    "load_table('%s') failed transiently (attempt %d): %s; "
+                    "retrying, not treating as gone",
+                    identifier,
+                    attempt,
+                    exc,
+                )
 
             if time.monotonic() >= deadline:
                 raise TimeoutError(
@@ -646,7 +678,28 @@ class BigLakeCatalogManager(CatalogManager):
         try:
             self.catalog.drop_namespace(self._session_namespace)
             log.info("Dropped session namespace '%s'", self._session_namespace)
+        except _AUTH_EXPIRY_ERRORS as auth_exc:
+            # Same non-retryable contract as the per-table loop: the static
+            # catalog token cannot be refreshed in place. When pending is empty
+            # (the common case, since cleanup_table untracks confirmed drops) or
+            # the token expires only after the loop, this final drop_namespace
+            # is the one remaining catalog call, and swallowing an auth failure
+            # here would silently leave the namespace behind. Run the GCS
+            # storage backstop (fresh gcsfs from the refreshed credential), then
+            # propagate so the teardown failure is visible.
+            log.warning(
+                "cleanup_all: auth expired dropping namespace '%s' (%s); "
+                "relying on the GCS storage sweep",
+                self._session_namespace,
+                auth_exc,
+            )
+            self._delete_gcs_prefix(
+                self._namespace_gcs_path(self._session_namespace)
+            )
+            raise
         except Exception:
+            # Best-effort: the namespace may be non-empty (retained tables) or
+            # already gone. The GCS prefix delete below is the storage backstop.
             pass
 
         self._delete_gcs_prefix(self._namespace_gcs_path(self._session_namespace))

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -15,7 +15,6 @@ from google.oauth2.credentials import Credentials as GoogleOAuth2Credentials
 from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import (
     CommitStateUnknownException,
-    NoSuchTableError,
     ServerError,
     ServiceUnavailableError,
 )
@@ -325,12 +324,21 @@ class BigLakeCatalogManager(CatalogManager):
 
         if table_name is not None:
             self._refresh_token_if_needed()
-            table = self.catalog.create_table(
-                identifier=f"{namespace}.{table_name}",
-                schema=iceberg_schema,
-                location=f"{self._warehouse_path()}/{namespace}/{table_name}",
-            )
-            table.append(data)
+            try:
+                table = self.catalog.create_table(
+                    identifier=f"{namespace}.{table_name}",
+                    schema=iceberg_schema,
+                    location=f"{self._warehouse_path()}/{namespace}/{table_name}",
+                )
+                table.append(data)
+            except Exception:
+                # create may have committed before a later step (append, or a
+                # CommitStateUnknownException from create itself) threw.
+                # Reconcile the partial attempt so no table is leaked untracked,
+                # then propagate: named creates are single-attempt, so the
+                # caller-supplied identifier is never created twice.
+                self._drop_failed_attempt(table_name)
+                raise
             log.info("Created BigLake Iceberg table '%s.%s'", namespace, table_name)
             self._tables_created.append(table_name)
             return table_name
@@ -351,10 +359,16 @@ class BigLakeCatalogManager(CatalogManager):
                     location=table_location,
                 )
                 table.append(data)
-            except _TRANSIENT_CREATE_ERRORS as exc:
-                # Drop whatever this attempt may have created so the retry
-                # starts clean and no orphan table/namespace entry lingers.
+            except Exception as exc:
+                # ANY failure here may have left a committed table behind
+                # (create succeeds before append can throw; create itself can
+                # raise CommitStateUnknownException after committing). Reconcile
+                # the partial attempt FIRST -- for every exception, transient or
+                # not -- so nothing is leaked untracked, then decide retry vs
+                # re-raise.
                 self._drop_failed_attempt(candidate)
+                if not isinstance(exc, _TRANSIENT_CREATE_ERRORS):
+                    raise
                 if time.monotonic() >= deadline:
                     raise
                 log.warning(
@@ -377,20 +391,30 @@ class BigLakeCatalogManager(CatalogManager):
             return candidate
 
     def _drop_failed_attempt(self, table_name: str) -> None:
-        """Best-effort drop of a table left behind by a failed create attempt."""
+        """Reconcile a table left behind by a failed create attempt.
+
+        Drops it if possible; otherwise registers it in `_tables_created` so the
+        end-of-session `cleanup_all` sweep reaps it. Never leaves a possibly-live
+        table untracked. `NoSuchTableError` is treated as unconfirmed (not proof
+        the table is gone): BigLake indexes asynchronously, so a just-committed
+        table can be invisible to `drop_table` here and only surface later. The
+        only case that skips registration is a clearly successful drop.
+        """
         identifier = f"{self._session_namespace}.{table_name}"
         try:
             self._refresh_token_if_needed()
             self.catalog.drop_table(identifier)
             log.info("Dropped partially-created table '%s'", identifier)
-        except NoSuchTableError:
-            pass
+            return
         except Exception as exc:
             log.warning(
-                "Could not drop partially-created table '%s': %s",
+                "Could not confirm drop of partially-created table '%s' (%s); "
+                "tracking it for end-of-session cleanup",
                 identifier,
                 exc,
             )
+        if table_name not in self._tables_created:
+            self._tables_created.append(table_name)
 
     def wait_for_table_ready(
         self,

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -508,6 +508,11 @@ class BigLakeCatalogManager(CatalogManager):
         try:
             self.catalog.drop_table(table_identifier)
             log.info("Dropped table '%s'", table_identifier)
+            # Confirmed gone -- stop tracking so the end-of-session cleanup_all
+            # sweep does not re-drop (and pointlessly retry) an already-removed
+            # table. A failed drop leaves it tracked so cleanup_all retries it.
+            if table_name in self._tables_created:
+                self._tables_created.remove(table_name)
         except Exception as exc:
             log.warning("Cleanup of table '%s' failed: %s", table_identifier, exc)
 
@@ -520,15 +525,64 @@ class BigLakeCatalogManager(CatalogManager):
         except Exception as exc:
             log.warning("GCS cleanup of '%s' failed: %s", gcs_path, exc)
 
-    def cleanup_all(self) -> None:
+    def _drop_confirmed(self, table_name: str) -> bool:
+        """Attempt to drop a tracked table; return True ONLY on a confirmed
+        drop (the catalog `drop_table` call returned without raising).
+
+        Any raised drop returns False so the caller retains the name and
+        retries. We deliberately do NOT treat a raised drop as "gone" -- a
+        transient 5xx/network error obviously leaves the table live, and a
+        `NoSuchTableError` does NOT prove removal either: under BigLake
+        async-index lag a just-committed table can be briefly invisible to
+        `drop_table` and surface later. Forgetting a name on that ambiguous
+        signal is exactly the leak this path guards against, so "confirmed
+        gone" means only a `drop_table` that returned.
+        """
+        identifier = f"{self._session_namespace}.{table_name}"
         self._refresh_token_if_needed()
-        for table_name in self._tables_created:
-            table_identifier = f"{self._session_namespace}.{table_name}"
-            try:
-                self.catalog.drop_table(table_identifier)
-            except Exception:
-                pass
-        self._tables_created.clear()
+        try:
+            self.catalog.drop_table(identifier)
+            log.info("Dropped tracked table '%s'", identifier)
+            return True
+        except Exception as drop_exc:
+            log.warning(
+                "Drop of tracked table '%s' unconfirmed (%s); retaining",
+                identifier,
+                drop_exc,
+            )
+            return False
+
+    def cleanup_all(self, timeout: float = 120, poll_interval: float = 5) -> None:
+        """Drop every tracked table, then the session namespace and its GCS
+        storage.
+
+        A tracked table is forgotten ONLY once its drop is confirmed (see
+        `_drop_confirmed`). Drops that raise -- transient 5xx/network errors,
+        or BigLake async-index lag that makes a just-committed table briefly
+        invisible to `drop_table` -- are retried under a bounded wall-clock
+        deadline rather than being cleared unconditionally, so a teardown-time
+        blip cannot lose track of a still-live table. Any tables still
+        unconfirmed after the deadline are retained (never cleared blindly) and
+        logged; the final namespace drop + GCS prefix delete are the storage
+        backstop for anything the per-table catalog drop could not reach.
+        """
+        deadline = time.monotonic() + timeout
+        pending = list(self._tables_created)
+        while pending:
+            pending = [n for n in pending if not self._drop_confirmed(n)]
+            if not pending or time.monotonic() >= deadline:
+                break
+            time.sleep(poll_interval)
+        if pending:
+            log.warning(
+                "cleanup_all: %d tracked table(s) could not be confirmed "
+                "dropped after %ds; relying on the namespace/storage sweep: %s",
+                len(pending),
+                timeout,
+                pending,
+            )
+        # Keep only the names we could NOT confirm gone -- never clear blindly.
+        self._tables_created = pending
 
         self._refresh_token_if_needed()
         try:

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -14,10 +14,8 @@ from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2.credentials import Credentials as GoogleOAuth2Credentials
 from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import (
-    AuthorizationExpiredError,
     CommitStateUnknownException,
     NoSuchTableError,
-    OAuthError,
     ServerError,
     ServiceUnavailableError,
 )
@@ -30,14 +28,18 @@ BIGLAKE_CATALOG_URL = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog
 GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 NAMESPACE_PREFIX = "ch_e2e_bl_"
 
-# REST/network errors that create_table retries; pyiceberg itself retries
-# only auth errors (stop_after_attempt(2)), so these otherwise escape.
+# REST/network errors that create_table retries; pyiceberg's REST client
+# retries only auth errors (stop_after_attempt(2)), so these otherwise escape.
+# Auth-expiry errors are deliberately NOT here: self.catalog is a RestCatalog
+# built once in __init__ with a static bearer token, and _refresh_token_if_needed
+# refreshes only the GoogleOAuth2Credentials object, so retrying an expired token
+# just resends the same stale token. Rebuilding self.catalog mid-retry is unsafe
+# because callers share it concurrently (test_many_tables_pagination fans
+# create_table across a 10-thread pool), so auth expiry is left to propagate.
 _TRANSIENT_CREATE_ERRORS = (
     ServerError,
     ServiceUnavailableError,
     CommitStateUnknownException,
-    AuthorizationExpiredError,
-    OAuthError,
     requests.exceptions.RequestException,
 )
 
@@ -309,22 +311,35 @@ class BigLakeCatalogManager(CatalogManager):
         # connection reset, commit-state-unknown) otherwise propagates and
         # fails the shared module-scoped fixture. Retry create+append under a
         # wall-clock deadline, mirroring wait_for_table_ready/resolve_table_name.
+        #
+        # Retrying is safe ONLY for the auto-generated-name path: each attempt
+        # uses a fresh unique name, so a partial prior attempt (table created,
+        # append failed) cannot resurface as TableAlreadyExistsError nor
+        # duplicate rows -- creation stays exactly-once. When a caller supplies
+        # a fixed table_name (test_many_tables_pagination asserts the exact
+        # short names it passed appear in SHOW TABLES, so we cannot substitute a
+        # UUID), a fresh name is not an option, so that path makes a single
+        # attempt and lets a transient error propagate as before.
         namespace = self._session_namespace
         iceberg_schema = arrow_to_iceberg_schema(data)
+
+        if table_name is not None:
+            self._refresh_token_if_needed()
+            table = self.catalog.create_table(
+                identifier=f"{namespace}.{table_name}",
+                schema=iceberg_schema,
+                location=f"{self._warehouse_path()}/{namespace}/{table_name}",
+            )
+            table.append(data)
+            log.info("Created BigLake Iceberg table '%s.%s'", namespace, table_name)
+            self._tables_created.append(table_name)
+            return table_name
 
         deadline = time.monotonic() + timeout
         attempt = 0
         while True:
             attempt += 1
-            # Use a fresh table name each attempt so a partially-completed
-            # prior attempt (table created, append failed) cannot resurface as
-            # TableAlreadyExistsError or duplicate the appended rows: creation
-            # stays exactly-once.
-            candidate = (
-                table_name
-                if table_name is not None
-                else f"tbl_{uuid.uuid4().hex[:8]}"
-            )
+            candidate = f"tbl_{uuid.uuid4().hex[:8]}"
             table_identifier = f"{namespace}.{candidate}"
             table_location = f"{self._warehouse_path()}/{namespace}/{candidate}"
 

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -9,9 +9,18 @@ from typing import Dict, List, Optional, Tuple
 
 import gcsfs
 import pyarrow as pa
+import requests
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2.credentials import Credentials as GoogleOAuth2Credentials
 from pyiceberg.catalog import load_catalog
+from pyiceberg.exceptions import (
+    AuthorizationExpiredError,
+    CommitStateUnknownException,
+    NoSuchTableError,
+    OAuthError,
+    ServerError,
+    ServiceUnavailableError,
+)
 
 from helpers.catalog_manager import CatalogManager, arrow_to_iceberg_schema
 
@@ -20,6 +29,17 @@ log = logging.getLogger(__name__)
 BIGLAKE_CATALOG_URL = "https://biglake.googleapis.com/iceberg/v1beta/restcatalog"
 GOOGLE_OAUTH2_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
 NAMESPACE_PREFIX = "ch_e2e_bl_"
+
+# REST/network errors that create_table retries; pyiceberg itself retries
+# only auth errors (stop_after_attempt(2)), so these otherwise escape.
+_TRANSIENT_CREATE_ERRORS = (
+    ServerError,
+    ServiceUnavailableError,
+    CommitStateUnknownException,
+    AuthorizationExpiredError,
+    OAuthError,
+    requests.exceptions.RequestException,
+)
 
 
 @dataclass
@@ -278,34 +298,84 @@ class BigLakeCatalogManager(CatalogManager):
         return f"e2e_biglake_{uuid.uuid4().hex[:8]}"
 
     def create_table(
-        self, data: pa.Table, table_name: Optional[str] = None
+        self,
+        data: pa.Table,
+        table_name: Optional[str] = None,
+        timeout: float = 120,
+        poll_interval: float = 5,
     ) -> str:
-        if table_name is None:
-            table_name = f"tbl_{uuid.uuid4().hex[:8]}"
-
+        # pyiceberg's REST client only retries auth errors and gives up
+        # after 2 attempts, so a single transient BigLake blip (5xx,
+        # connection reset, commit-state-unknown) otherwise propagates and
+        # fails the shared module-scoped fixture. Retry create+append under a
+        # wall-clock deadline, mirroring wait_for_table_ready/resolve_table_name.
         namespace = self._session_namespace
-        table_identifier = f"{namespace}.{table_name}"
-        table_location = (
-            f"{self._warehouse_path()}/{namespace}/{table_name}"
-        )
-
-        self._refresh_token_if_needed()
-
         iceberg_schema = arrow_to_iceberg_schema(data)
-        table = self.catalog.create_table(
-            identifier=table_identifier,
-            schema=iceberg_schema,
-            location=table_location,
-        )
-        table.append(data)
 
-        log.info(
-            "Created BigLake Iceberg table '%s' at %s",
-            table_identifier,
-            table_location,
-        )
-        self._tables_created.append(table_name)
-        return table_name
+        deadline = time.monotonic() + timeout
+        attempt = 0
+        while True:
+            attempt += 1
+            # Use a fresh table name each attempt so a partially-completed
+            # prior attempt (table created, append failed) cannot resurface as
+            # TableAlreadyExistsError or duplicate the appended rows: creation
+            # stays exactly-once.
+            candidate = (
+                table_name
+                if table_name is not None
+                else f"tbl_{uuid.uuid4().hex[:8]}"
+            )
+            table_identifier = f"{namespace}.{candidate}"
+            table_location = f"{self._warehouse_path()}/{namespace}/{candidate}"
+
+            self._refresh_token_if_needed()
+            try:
+                table = self.catalog.create_table(
+                    identifier=table_identifier,
+                    schema=iceberg_schema,
+                    location=table_location,
+                )
+                table.append(data)
+            except _TRANSIENT_CREATE_ERRORS as exc:
+                # Drop whatever this attempt may have created so the retry
+                # starts clean and no orphan table/namespace entry lingers.
+                self._drop_failed_attempt(candidate)
+                if time.monotonic() >= deadline:
+                    raise
+                log.warning(
+                    "create_table('%s') transient failure (attempt %d), "
+                    "retrying: %s",
+                    table_identifier,
+                    attempt,
+                    exc,
+                )
+                time.sleep(poll_interval)
+                continue
+
+            log.info(
+                "Created BigLake Iceberg table '%s' at %s (attempt %d)",
+                table_identifier,
+                table_location,
+                attempt,
+            )
+            self._tables_created.append(candidate)
+            return candidate
+
+    def _drop_failed_attempt(self, table_name: str) -> None:
+        """Best-effort drop of a table left behind by a failed create attempt."""
+        identifier = f"{self._session_namespace}.{table_name}"
+        try:
+            self._refresh_token_if_needed()
+            self.catalog.drop_table(identifier)
+            log.info("Dropped partially-created table '%s'", identifier)
+        except NoSuchTableError:
+            pass
+        except Exception as exc:
+            log.warning(
+                "Could not drop partially-created table '%s': %s",
+                identifier,
+                exc,
+            )
 
     def wait_for_table_ready(
         self,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108604
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flaky `test_e2e_catalogs/test.py::test_primitive_types[biglake]` and
`test_primitive_values[biglake]`. Both share the module-scoped `types_table`
fixture, so both fail together when the fixture's `create_table` call fails.

**Root cause.** `BigLakeCatalogManager.create_table` in
`tests/integration/helpers/catalog_manager_biglake.py` performs the REST
`catalog.create_table(...)` + `table.append(data)` with no retry of its own.
pyiceberg 0.11.1's REST client retries only auth errors
(`retry_if_exception_type((AuthorizationExpiredError, UnauthorizedError))`,
`stop_after_attempt(2)`, `reraise=True`), so a single transient BigLake blip
(`ServerError` / `ServiceUnavailableError` / `CommitStateUnknownException`,
or a connection reset) propagates straight out of `create_table` and errors the
shared fixture. The same file already guards this class of BigLake transience
with bounded wall-clock retry loops in `wait_for_table_ready` and
`resolve_table_name`; `create_table` was the gap.

**Fix.** Wrap create+append in a bounded wall-clock retry loop
(`deadline = time.monotonic() + timeout`, default 120s), mirroring the existing
`wait_for_table_ready` / `resolve_table_name` pattern. Only the specific
transient REST/network exceptions are retried; every other error (schema/config
bugs) still propagates immediately, so no real failure is masked. Each attempt
uses a fresh table name and best-effort drops a partially-created attempt, so a
retry after a partial success can neither resurface as `TableAlreadyExistsError`
nor duplicate the appended rows — creation stays exactly-once and no assertion is
weakened. After the deadline the last transient error is re-raised (fail-fast).

This is the create-path analogue of the glue listing-race fix (#108604): same
e2e-catalog helper family, same "cloud catalog transient error" theme, distinct
code path (create vs list) and backend (BigLake REST vs AWS Glue).

**Validation.** This E2E suite requires real BigLake / GCS credentials and does
not run in public CI, so there is no public CIDB signal and no local end-to-end
repro. The change is a defensive bounded-retry that completes an
already-established, already-reviewed pattern in the same file (it does not touch
any ClickHouse product code and masks no product bug). The retry control flow was
validated deterministically with a fake catalog injecting transient errors,
confirming all three directions: (1) the pre-fix single-attempt path raises on the
first transient blip; (2) the new path retries through transient blips and
succeeds, appending the data exactly once with no orphan tables; (3) the new path
re-raises the transient error once the deadline passes.

No related open issue found on the public tracker (private-CI-only E2E suite).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.798` (included in `26.7` and later)
<!-- ch-version-info:end -->