### PR TITLE
Parallelize ScatterByPartitionTransform in ShuffleSendStep

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -214,11 +214,14 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
 
     make_distributed_plan = from[Setting::make_distributed_plan];
 
-    /// make_distributed_plan and parallel replicas are two independent distributed execution
-    /// mechanisms that cannot be combined.
-    if (make_distributed_plan && from[Setting::allow_experimental_parallel_reading_from_replicas] > 0)
+    /// make_distributed_plan is incompatible with parallel replicas, including the automatic
+    /// heuristic: its plan switching and statistics collection interfere with the distributed plan.
+    if (make_distributed_plan
+        && (from[Setting::allow_experimental_parallel_reading_from_replicas] > 0
+            || from[Setting::automatic_parallel_replicas_mode] != 0))
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
-            "make_distributed_plan does not support parallel replicas, disable the `enable_parallel_replicas` setting");
+            "make_distributed_plan does not support parallel replicas, "
+            "disable the `enable_parallel_replicas` and `automatic_parallel_replicas_mode` settings");
 
     /// The implicit count/minmax projection counts a whole part from metadata; a distributed read
     /// buckets the part, so the projection would be counted once per bucket and multiply the result.

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -130,6 +130,7 @@ namespace ErrorCodes
 {
     extern const int UNSUPPORTED_METHOD;
     extern const int INVALID_SETTING_VALUE;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
@@ -212,6 +213,12 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     is_parallel_replicas_initiator_with_projection_support = is_parallel_replicas_initiator_with_projection_support_;
 
     make_distributed_plan = from[Setting::make_distributed_plan];
+
+    /// make_distributed_plan and parallel replicas are two independent distributed execution
+    /// mechanisms that cannot be combined.
+    if (make_distributed_plan && from[Setting::allow_experimental_parallel_reading_from_replicas] > 0)
+        throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+            "make_distributed_plan does not support parallel replicas, disable the `enable_parallel_replicas` setting");
 
     /// The implicit count/minmax projection counts a whole part from metadata; a distributed read
     /// buckets the part, so the projection would be counted once per bucket and multiply the result.

--- a/src/Processors/QueryPlan/ShuffleSendStep.cpp
+++ b/src/Processors/QueryPlan/ShuffleSendStep.cpp
@@ -6,6 +6,8 @@
 #include <Processors/QueryPlan/ExchangeLookup.h>
 #include <Processors/QueryPlan/LogicalExchangeStep.h>
 #include <Processors/Transforms/ScatterByPartitionTransform.h>
+#include <Processors/ResizeProcessor.h>
+#include <Processors/Port.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/Pipe.h>
 #include <IO/WriteHelpers.h>
@@ -13,39 +15,85 @@
 #include <Core/ColumnNumbers.h>
 #include <DataTypes/DataTypeFactory.h>
 
+#include <vector>
+
 namespace DB
 {
 
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int NOT_IMPLEMENTED;
 }
 
 QueryPipelineBuilderPtr ShuffleSendStep::updatePipeline(QueryPipelineBuilders pipelines, const BuildQueryPipelineSettings & settings)
 {
-    /// Add calculation of hash of key columns and bucket id based on the hash
-    /// Add fork processor to send data to num_buckets outputs
+    /// K upstream streams -> K * ScatterByPartitionTransform(1 -> M)
+    ///                    -> M * ResizeProcessor(K -> 1) -> M sinks; K = getNumStreams, M = num_buckets.
     auto & pipeline = *pipelines.front();
     auto stream_header = pipeline.getSharedHeader();
-    {
-        ColumnNumbers key_columns;
-        for (const auto & key_name : key_names)
-            key_columns.push_back(stream_header->getPositionByName(key_name));
 
-        pipeline.resize(1);
-        auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, num_buckets, key_columns, hash_cast_types);
-        pipeline.addTransform(scatter);
-    }
+    /// Totals/extremes have no defined shuffle semantics; throw rather than silently lose them.
+    if (pipeline.hasTotals() || pipeline.hasExtremes())
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ShuffleSendStep does not support pipelines with totals or extremes");
+
+    ColumnNumbers key_columns;
+    key_columns.reserve(key_names.size());
+    for (const auto & key_name : key_names)
+        key_columns.push_back(stream_header->getPositionByName(key_name));
+
+    const size_t num_streams = pipeline.getNumStreams();
+    chassert(num_streams > 0);
+
+    /// Both layers are built in one transform call so that the intermediate num_streams * num_buckets
+    /// port count never becomes the pipe's max_parallel_streams (it would inflate the executor thread limit).
+    pipeline.transform([&](OutputPortRawPtrs ports)
+    {
+        if (ports.size() != num_streams)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "ShuffleSendStep: expected {} output ports, got {}", num_streams, ports.size());
+
+        Processors result;
+
+        /// One scatter per upstream stream; output b of scatter k carries the rows of bucket b from stream k.
+        std::vector<std::vector<OutputPort *>> scatter_outputs(num_streams);
+        for (size_t stream = 0; stream < num_streams; ++stream)
+        {
+            auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, num_buckets, key_columns, hash_cast_types);
+            connect(*ports[stream], scatter->getInputs().front());
+            scatter_outputs[stream].reserve(num_buckets);
+            for (auto & output : scatter->getOutputs())
+                scatter_outputs[stream].push_back(&output);
+            result.push_back(std::move(scatter));
+        }
+
+        /// For a single stream the scatter alone already produces num_buckets ports in bucket order.
+        if (num_streams == 1)
+            return result;
+
+        /// Merge the num_streams ports of each bucket into one with a ResizeProcessor.
+        for (size_t bucket = 0; bucket < num_buckets; ++bucket)
+        {
+            auto resize = std::make_shared<ResizeProcessor>(stream_header, num_streams, 1);
+            auto input_it = resize->getInputs().begin();
+            for (size_t stream = 0; stream < num_streams; ++stream, ++input_it)
+                connect(*scatter_outputs[stream][bucket], *input_it);
+            result.push_back(std::move(resize));
+        }
+
+        return result;
+    });
+
+    chassert(pipeline.getNumStreams() == num_buckets);
 
     const String shard_id = settings.parameter_lookup->getParameter("bucket_id").safeGet<String>();
 
-    /// Add sink for each bucket
     size_t bucket = 0;
     pipeline.setSinks([&](const SharedHeader & header, Pipe::StreamType stream_type)
     {
         chassert(stream_type == Pipe::StreamType::Main);
         String destination_bucket_id = toString(bucket);
-        ++bucket;   /// TODO: this is a hack. Find a better way to assigning bucket id to each sink.
+        ++bucket;
         return settings.exchange_lookup->createSink(header, ExchangeStreamId(exchange_id, shard_id, destination_bucket_id));
     });
 

--- a/src/Processors/QueryPlan/ShuffleSendStep.cpp
+++ b/src/Processors/QueryPlan/ShuffleSendStep.cpp
@@ -5,17 +5,13 @@
 #include <Processors/QueryPlan/IParameterLookup.h>
 #include <Processors/QueryPlan/ExchangeLookup.h>
 #include <Processors/QueryPlan/LogicalExchangeStep.h>
-#include <Processors/Transforms/ScatterByPartitionTransform.h>
-#include <Processors/ResizeProcessor.h>
-#include <Processors/Port.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/scatterByPartition.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 #include <Core/ColumnNumbers.h>
 #include <DataTypes/DataTypeFactory.h>
-
-#include <vector>
 
 namespace DB
 {
@@ -28,12 +24,10 @@ namespace ErrorCodes
 
 QueryPipelineBuilderPtr ShuffleSendStep::updatePipeline(QueryPipelineBuilders pipelines, const BuildQueryPipelineSettings & settings)
 {
-    /// K upstream streams -> K * ScatterByPartitionTransform(1 -> M)
-    ///                    -> M * ResizeProcessor(K -> 1) -> M sinks; K = getNumStreams, M = num_buckets.
     auto & pipeline = *pipelines.front();
     auto stream_header = pipeline.getSharedHeader();
 
-    /// Totals/extremes have no defined shuffle semantics; throw rather than silently lose them.
+    /// Exchanges carry only the main data stream; throw instead of silently dropping totals/extremes.
     if (pipeline.hasTotals() || pipeline.hasExtremes())
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ShuffleSendStep does not support pipelines with totals or extremes");
 
@@ -42,55 +36,14 @@ QueryPipelineBuilderPtr ShuffleSendStep::updatePipeline(QueryPipelineBuilders pi
     for (const auto & key_name : key_names)
         key_columns.push_back(stream_header->getPositionByName(key_name));
 
-    /// The scatter/resize mesh below creates num_streams * num_buckets connections in the pipeline.
-    /// Cap the number of scatter streams to keep the mesh small when the upstream is very wide.
+    /// Repartitioning creates num_streams * num_buckets connections in the pipeline.
+    /// Cap the number of streams to keep that number small.
     const size_t max_scatter_streams = 16;
     if (pipeline.getNumStreams() > max_scatter_streams)
         pipeline.resize(max_scatter_streams);
 
-    const size_t num_streams = pipeline.getNumStreams();
-    chassert(num_streams > 0);
-
-    /// Both layers are built in one transform call so that the intermediate num_streams * num_buckets
-    /// port count never becomes the pipe's max_parallel_streams (it would inflate the executor thread limit).
-    pipeline.transform([&](OutputPortRawPtrs ports)
-    {
-        if (ports.size() != num_streams)
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
-                "ShuffleSendStep: expected {} output ports, got {}", num_streams, ports.size());
-
-        Processors result;
-
-        /// One scatter per upstream stream; output b of scatter k carries the rows of bucket b from stream k.
-        std::vector<std::vector<OutputPort *>> scatter_outputs(num_streams);
-        for (size_t stream = 0; stream < num_streams; ++stream)
-        {
-            auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, num_buckets, key_columns, hash_cast_types);
-            connect(*ports[stream], scatter->getInputs().front());
-            scatter_outputs[stream].reserve(num_buckets);
-            for (auto & output : scatter->getOutputs())
-                scatter_outputs[stream].push_back(&output);
-            result.push_back(std::move(scatter));
-        }
-
-        /// For a single stream the scatter alone already produces num_buckets ports in bucket order.
-        if (num_streams == 1)
-            return result;
-
-        /// Merge the num_streams ports of each bucket into one with a ResizeProcessor.
-        for (size_t bucket = 0; bucket < num_buckets; ++bucket)
-        {
-            auto resize = std::make_shared<ResizeProcessor>(stream_header, num_streams, 1);
-            auto input_it = resize->getInputs().begin();
-            for (size_t stream = 0; stream < num_streams; ++stream, ++input_it)
-                connect(*scatter_outputs[stream][bucket], *input_it);
-            result.push_back(std::move(resize));
-        }
-
-        return result;
-    });
-
-    chassert(pipeline.getNumStreams() == num_buckets);
+    /// Repartition the data so that stream i carries exactly the rows of bucket i.
+    scatterByPartition(pipeline, num_buckets, key_columns, hash_cast_types);
 
     const String shard_id = settings.parameter_lookup->getParameter("bucket_id").safeGet<String>();
 

--- a/src/Processors/QueryPlan/ShuffleSendStep.cpp
+++ b/src/Processors/QueryPlan/ShuffleSendStep.cpp
@@ -42,6 +42,12 @@ QueryPipelineBuilderPtr ShuffleSendStep::updatePipeline(QueryPipelineBuilders pi
     for (const auto & key_name : key_names)
         key_columns.push_back(stream_header->getPositionByName(key_name));
 
+    /// The scatter/resize mesh below creates num_streams * num_buckets connections in the pipeline.
+    /// Cap the number of scatter streams to keep the mesh small when the upstream is very wide.
+    const size_t max_scatter_streams = 16;
+    if (pipeline.getNumStreams() > max_scatter_streams)
+        pipeline.resize(max_scatter_streams);
+
     const size_t num_streams = pipeline.getNumStreams();
     chassert(num_streams > 0);
 

--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -16,11 +16,10 @@
 #include <Processors/Transforms/MergeSortingTransform.h>
 #include <Processors/Transforms/PartialSortingTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <QueryPipeline/scatterByPartition.h>
 #include <Common/JSONBuilder.h>
 #include <Common/MemoryTrackerUtils.h>
 
-#include <Processors/ResizeProcessor.h>
-#include <Processors/Transforms/ScatterByPartitionTransform.h>
 
 #include <Processors/QueryPlan/Optimizations/RuntimeDataflowStatistics.h>
 #include <Common/scope_guard_safe.h>
@@ -337,36 +336,7 @@ void SortingStep::scatterByPartitionIfNeeded(QueryPipelineBuilder& pipeline)
             key_columns.push_back(stream_header->getPositionByName(col.column_name));
         }
 
-        pipeline.transform([&](const OutputPortRawPtrs & ports)
-        {
-            Processors processors;
-            for (auto * port : ports)
-            {
-                auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, threads, key_columns);
-                connect(*port, scatter->getInputs().front());
-                processors.push_back(scatter);
-            }
-            return processors;
-        });
-
-        if (streams > 1)
-        {
-            pipeline.transform([&](const OutputPortRawPtrs & ports)
-            {
-                Processors processors;
-                for (size_t i = 0; i < threads; ++i)
-                {
-                    size_t output_it = i;
-                    auto resize = std::make_shared<ResizeProcessor>(stream_header, streams, 1);
-                    auto & inputs = resize->getInputs();
-
-                    for (auto input_it = inputs.begin(); input_it != inputs.end(); output_it += threads, ++input_it)
-                        connect(*ports[output_it], *input_it);
-                    processors.push_back(resize);
-                }
-                return processors;
-            });
-        }
+        scatterByPartition(pipeline, threads, key_columns);
     }
 }
 

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -186,6 +186,7 @@ public:
     size_t getNumStreams() const { return pipe.numOutputPorts(); }
 
     bool hasTotals() const { return pipe.getTotalsPort() != nullptr; }
+    bool hasExtremes() const { return pipe.getExtremesPort() != nullptr; }
 
     const Block & getHeader() const { return pipe.getHeader(); }
     const SharedHeader & getSharedHeader() const { return pipe.getSharedHeader(); }

--- a/src/QueryPipeline/scatterByPartition.cpp
+++ b/src/QueryPipeline/scatterByPartition.cpp
@@ -1,0 +1,59 @@
+#include <QueryPipeline/scatterByPartition.h>
+
+#include <Processors/Port.h>
+#include <Processors/ResizeProcessor.h>
+#include <Processors/Transforms/ScatterByPartitionTransform.h>
+#include <QueryPipeline/QueryPipelineBuilder.h>
+
+#include <vector>
+
+namespace DB
+{
+
+void scatterByPartition(QueryPipelineBuilder & pipeline, size_t num_partitions, const ColumnNumbers & key_columns, const DataTypes & hash_cast_types)
+{
+    const size_t num_streams = pipeline.getNumStreams();
+    auto stream_header = pipeline.getSharedHeader();
+
+    /// Scatters and resizes are added in one transform call so that the intermediate
+    /// num_streams * num_partitions port count does not become the pipe's max_parallel_streams
+    /// and inflate the executor thread limit.
+    pipeline.transform([&](OutputPortRawPtrs ports)
+    {
+        chassert(ports.size() == num_streams);
+
+        Processors result;
+
+        /// One scatter per stream; output p of scatter s carries the rows of partition p from stream s.
+        std::vector<std::vector<OutputPort *>> scatter_outputs(num_streams);
+        for (size_t stream = 0; stream < num_streams; ++stream)
+        {
+            auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, num_partitions, key_columns, hash_cast_types);
+            connect(*ports[stream], scatter->getInputs().front());
+            scatter_outputs[stream].reserve(num_partitions);
+            for (auto & output : scatter->getOutputs())
+                scatter_outputs[stream].push_back(&output);
+            result.push_back(std::move(scatter));
+        }
+
+        /// For a single stream the scatter alone already produces num_partitions ports in partition order.
+        if (num_streams == 1)
+            return result;
+
+        /// Merge the num_streams ports of each partition into one with a ResizeProcessor.
+        for (size_t partition = 0; partition < num_partitions; ++partition)
+        {
+            auto resize = std::make_shared<ResizeProcessor>(stream_header, num_streams, 1);
+            auto input_it = resize->getInputs().begin();
+            for (size_t stream = 0; stream < num_streams; ++stream, ++input_it)
+                connect(*scatter_outputs[stream][partition], *input_it);
+            result.push_back(std::move(resize));
+        }
+
+        return result;
+    });
+
+    chassert(pipeline.getNumStreams() == num_partitions);
+}
+
+}

--- a/src/QueryPipeline/scatterByPartition.cpp
+++ b/src/QueryPipeline/scatterByPartition.cpp
@@ -4,8 +4,7 @@
 #include <Processors/ResizeProcessor.h>
 #include <Processors/Transforms/ScatterByPartitionTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
-
-#include <vector>
+#include <Common/VectorWithMemoryTracking.h>
 
 namespace DB
 {
@@ -24,15 +23,16 @@ void scatterByPartition(QueryPipelineBuilder & pipeline, size_t num_partitions, 
 
         Processors result;
 
-        /// One scatter per stream; output p of scatter s carries the rows of partition p from stream s.
-        std::vector<std::vector<OutputPort *>> scatter_outputs(num_streams);
+        /// One scatter per stream; scatter_outputs[stream * num_partitions + partition] is
+        /// the output of scatter `stream` that carries the rows of partition `partition`.
+        VectorWithMemoryTracking<OutputPort *> scatter_outputs;
+        scatter_outputs.reserve(num_streams * num_partitions);
         for (size_t stream = 0; stream < num_streams; ++stream)
         {
             auto scatter = std::make_shared<ScatterByPartitionTransform>(stream_header, num_partitions, key_columns, hash_cast_types);
             connect(*ports[stream], scatter->getInputs().front());
-            scatter_outputs[stream].reserve(num_partitions);
             for (auto & output : scatter->getOutputs())
-                scatter_outputs[stream].push_back(&output);
+                scatter_outputs.push_back(&output);
             result.push_back(std::move(scatter));
         }
 
@@ -46,7 +46,7 @@ void scatterByPartition(QueryPipelineBuilder & pipeline, size_t num_partitions, 
             auto resize = std::make_shared<ResizeProcessor>(stream_header, num_streams, 1);
             auto input_it = resize->getInputs().begin();
             for (size_t stream = 0; stream < num_streams; ++stream, ++input_it)
-                connect(*scatter_outputs[stream][partition], *input_it);
+                connect(*scatter_outputs[stream * num_partitions + partition], *input_it);
             result.push_back(std::move(resize));
         }
 

--- a/src/QueryPipeline/scatterByPartition.h
+++ b/src/QueryPipeline/scatterByPartition.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Core/ColumnNumbers.h>
+#include <DataTypes/IDataType_fwd.h>
+
+namespace DB
+{
+
+class QueryPipelineBuilder;
+
+/// Repartitions the data by the hash of the key columns: the pipeline ends up with
+/// num_partitions streams where stream i carries exactly the rows of partition i.
+/// `hash_cast_types` (one entry per key, optional) selects a type to cast each key to before hashing.
+void scatterByPartition(QueryPipelineBuilder & pipeline, size_t num_partitions, const ColumnNumbers & key_columns, const DataTypes & hash_cast_types = {});
+
+}


### PR DESCRIPTION

`ShuffleSendStep` used to `resize(1)` the pipeline and push all rows of the fragment through a single `ScatterByPartitionTransform`, making it a single-threaded bottleneck on machines with many cores. Now each upstream stream scatters its rows independently, and a per-bucket `ResizeProcessor` merges the outputs:

```
K upstream streams -> K * ScatterByPartitionTransform(1 -> M) -> M * ResizeProcessor(K -> 1) -> M sinks
```

If the pipeline carries totals or extremes streams, the step now throws `NOT_IMPLEMENTED` instead of failing on a `chassert` in the sink callback.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Remove a single-threaded bottleneck in `ShuffleSendStep` of the distributed query plan: each upstream stream now scatters its rows by destination bucket independently instead of funneling the whole fragment through one `ScatterByPartitionTransform`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
