### PR TITLE
avoid rewrite any join on 1 to cross join

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -1141,6 +1141,14 @@ static QueryPlan::Node chooseJoinOrder(QueryGraphBuilder query_graph_builder, Qu
 
             auto join_operator = std::move(entry->join_operator);
             join_operator.strictness = join_strictness;
+
+            /// The optimizer reconstructs an unconnected Inner pair (e.g. `INNER JOIN ... ON 1`,
+            /// which produces no join edges) as Cross. That is equivalent only for ALL strictness:
+            /// a Cross join ignores strictness, so `ANY INNER JOIN ... ON 1` would degrade to a full
+            /// cartesian product. Restore Inner so that the physical join falls back to the
+            /// constant-key join (`__lhs_const = __rhs_const`) that preserves strictness semantics.
+            if (join_strictness != JoinStrictness::All && join_operator.kind == JoinKind::Cross)
+                join_operator.kind = JoinKind::Inner;
             auto left_rels = entry->left->relations;
             auto right_rels = entry->right->relations;
 

--- a/tests/queries/0_stateless/04490_any_join_constant_condition_reorder.reference
+++ b/tests/queries/0_stateless/04490_any_join_constant_condition_reorder.reference
@@ -1,0 +1,35 @@
+-- ANY INNER JOIN ON constant true: one row per (constant) key
+1	10
+-- plan keeps inner/any with constant key, not cross
+Type: inner | Strictness: any
+Join conditions: 1 = 1
+-- ANY INNER JOIN ON constant false: empty result
+-- ANY LEFT / SEMI / ANTI on constant condition
+1	10
+2	10
+1	10
+2	10
+1	10
+1	20
+-- ALL INNER JOIN ON constant true is still a cartesian product
+1	10
+1	20
+2	10
+2	20
+-- outer join child under ANY INNER ON 1
+2	2	7
+-- comma join child under ANY INNER ON 1
+2	7	1
+-- ANY INNER ON 1 child under comma join
+1	2	7
+1	2	8
+-- chained: ALL INNER then ANY INNER ON 1
+2	2	7
+-- chained: ANY INNER ON 1 then ALL INNER
+1	2	7
+1	2	8
+-- ANY LEFT ON 1 over comma join child
+2	7	1
+2	8	1
+3	7	1
+3	8	1

--- a/tests/queries/0_stateless/04490_any_join_constant_condition_reorder.sql
+++ b/tests/queries/0_stateless/04490_any_join_constant_condition_reorder.sql
@@ -1,0 +1,68 @@
+-- Test for a regression where join order optimization converted `ANY INNER JOIN ... ON 1`
+-- (constant-true condition, empty join expression, hence an unconnected pair in the join graph)
+-- to a CROSS join, silently dropping ANY strictness and returning a full cartesian product.
+-- The correct plan is an inner ANY join on the injected constant key (`1 = 1`).
+
+SET enable_analyzer = 1;
+SET join_algorithm = 'hash';
+SET query_plan_optimize_join_order_limit = 10;
+SET query_plan_optimize_join_order_randomize = 0;
+
+SELECT '-- ANY INNER JOIN ON constant true: one row per (constant) key';
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY INNER JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+
+SELECT '-- plan keeps inner/any with constant key, not cross';
+SELECT extract(explain, 'Type: \\w+ \\| Strictness: \\w+') FROM (
+    EXPLAIN SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY INNER JOIN values('r UInt8', 10, 20) AS r_tbl ON 1
+) WHERE explain LIKE '%Strictness%';
+SELECT extract(explain, 'Join conditions:.*') FROM (
+    EXPLAIN SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY INNER JOIN values('r UInt8', 10, 20) AS r_tbl ON 1
+) WHERE explain LIKE '%Join conditions%';
+
+SELECT '-- ANY INNER JOIN ON constant false: empty result';
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY INNER JOIN values('r UInt8', 10, 20) AS r_tbl ON 0 ORDER BY ALL;
+
+SELECT '-- ANY LEFT / SEMI / ANTI on constant condition';
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY LEFT JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl SEMI LEFT JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANTI LEFT JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl ANY RIGHT JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+
+SELECT '-- ALL INNER JOIN ON constant true is still a cartesian product';
+SELECT * FROM values('l UInt8', 1, 2) AS l_tbl INNER JOIN values('r UInt8', 10, 20) AS r_tbl ON 1 ORDER BY ALL;
+
+-- Compositions of ANY joins with the join graph flattening machinery: an ANY join must
+-- neither absorb child joins into its query graph nor be absorbed into a parent one,
+-- otherwise the original strictness would be re-applied to reconstructed child joins.
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+CREATE TABLE t1 (c Int32) ENGINE = MergeTree ORDER BY c;
+CREATE TABLE t2 (c Int32) ENGINE = MergeTree ORDER BY c;
+CREATE TABLE t3 (c Int32) ENGINE = MergeTree ORDER BY c;
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (2), (3);
+INSERT INTO t3 VALUES (7), (8);
+
+SELECT '-- outer join child under ANY INNER ON 1';
+SELECT * FROM (SELECT t1.c AS a, t2.c AS b FROM t1 RIGHT JOIN t2 ON t1.c = t2.c) AS sq ANY INNER JOIN t3 ON 1 ORDER BY ALL;
+
+SELECT '-- comma join child under ANY INNER ON 1';
+SELECT * FROM (SELECT t2.c AS b, t3.c AS d FROM t2, t3) AS sq ANY INNER JOIN t1 ON 1 ORDER BY ALL;
+
+SELECT '-- ANY INNER ON 1 child under comma join';
+SELECT * FROM (SELECT t1.c AS a, t2.c AS b FROM t1 ANY INNER JOIN t2 ON 1) AS sq, t3 ORDER BY ALL;
+
+SELECT '-- chained: ALL INNER then ANY INNER ON 1';
+SELECT * FROM t1 INNER JOIN t2 ON t1.c = t2.c ANY INNER JOIN t3 ON 1 ORDER BY ALL;
+
+SELECT '-- chained: ANY INNER ON 1 then ALL INNER';
+SELECT * FROM t1 ANY INNER JOIN t2 ON 1 INNER JOIN t3 ON t3.c = t3.c ORDER BY ALL;
+
+SELECT '-- ANY LEFT ON 1 over comma join child';
+SELECT * FROM (SELECT t2.c AS b, t3.c AS d FROM t2, t3) AS sq ANY LEFT JOIN t1 ON 1 ORDER BY ALL;
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Fix unexpected result for `ANY JOIN` with a constant `ON` condition (e.g. `t1 ANY INNER JOIN t2 ON 1`): the query returned the full cartesian product instead of the ANY join result

---

Got changed by https://github.com/ClickHouse/ClickHouse/commit/1564d50b354


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.858` (included in `26.7` and later)
<!-- ch-version-info:end -->