### PR TITLE
Fix flaky test 04344_server_ast_fuzzer_insert_limit

### DIFF
--- a/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
+++ b/tests/queries/0_stateless/04344_server_ast_fuzzer_insert_limit.sql
@@ -42,6 +42,12 @@ SETTINGS min_insert_block_size_rows = 1000000, max_block_size = 1000000, max_row
 -- and the fuzzed CREATE is skipped on re-parse.
 DROP TABLE IF EXISTS t_04344_storage;
 CREATE TABLE t_04344_storage (a UInt64) ENGINE = MergeTree ORDER BY a SETTINGS max_rows_to_read = 0;
+
+-- ast_fuzzer_any_query fuzzes each CREATE into ~30 clones reusing the real table's UUID, contending
+-- its store/<uuid>/ directory. With the CI's synchronous atomic drop a teardown DROP then waits for
+-- the background worker to clear that directory, and under the slowest sanitizer that wait can pass
+-- max_execution_time and fail with TIMEOUT_EXCEEDED. Teardown does not need to wait synchronously.
+SET database_atomic_wait_for_drop_and_detach_synchronously = 0;
 DROP TABLE t_04344_storage;
 
 -- BACKUP carrier: the cap lives in ASTBackupQuery::settings, outside the AST `children`, so a


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108212
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a flaky `Code: 159 TIMEOUT_EXCEEDED` on the cleanup `DROP TABLE` of `04344_server_ast_fuzzer_insert_limit`, seen on `Stateless tests (amd_msan, WasmEdge, parallel, 2/2)`. 2 hits in 30 days (both on PR branches, 0 on master); reruns with the same randomized settings pass.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107087&sha=f3fd77f2195993b30398ef6e21e9cb45cc99e27e&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

**Root cause.** The test sets `ast_fuzzer_any_query = 1`, so the server-side AST fuzzer clones each `CREATE TABLE` seed ~30 times, every clone reusing the real table's UUID and thus contending its `store/<uuid>/` data directory. This slows the background atomic-drop worker for that UUID. The CI test profile forces `database_atomic_wait_for_drop_and_detach_synchronously = 1` (`tests/config/users.d/database_atomic_drop_detach_sync.xml`) with `database_atomic_delay_before_drop_table_sec = 60`, so the trailing cleanup `DROP TABLE` waits in `DatabaseCatalog::waitTableFinallyDropped` for that worker. That wait is charged against the session `SET max_execution_time = 20`, and under the slowest sanitizer (msan + WasmEdge) it can exceed 20s and throw `TIMEOUT_EXCEEDED` on the DROP. The timeout is on cleanup, not on anything the test verifies.

**Fix.** Pin `database_atomic_wait_for_drop_and_detach_synchronously = 0` before the teardown DROPs so they return without waiting for the background worker. The fuzzed SELECT/INSERT queries still run under `max_execution_time = 20` and the fuzzer's own per-context resource caps, so the test still proves the server-side AST fuzzer honors the insert/read limits (reference output `4950 / 4950 / 4950 / 1` is unchanged).

**Validation.** Reproduced the mechanism locally against a server configured like CI (sync drop + 60s finalize delay), holding a table in the drop queue past a small `max_execution_time`:
- without the fix (`sync = 1`): the `DROP` fails with `Code: 159 TIMEOUT_EXCEEDED` at the deadline;
- with the fix (`sync = 0`): the `DROP` returns in ~65 ms.

Full test run against the CI-like server: 15/15 passes, output matches the reference, no `TIMEOUT_EXCEEDED` on any teardown DROP.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.782` (included in `26.7` and later)
<!-- ch-version-info:end -->