### PR TITLE
Fix NOT_FOUND_COLUMN_IN_BLOCK from topKThroughJoin + lazy materialization under FINAL

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -348,6 +348,15 @@ static SplitFilterResult splitFilterStep(const FilterStep & filter_step, const s
                 break;
             }
         }
+
+        /// The main branch removes the filter column, but `ActionsDAG::split` keeps it as a
+        /// pass-through output of the lazy branch, fed by a same-named input the main branch no
+        /// longer provides - so applying the lazy DAG later throws NOT_FOUND_COLUMN_IN_BLOCK.
+        /// `removeDanglingNodes` cleans this up for every lazy step except the last, so drop the
+        /// removed filter column from the lazy branch here to keep both branches consistent.
+        auto & lazy_outputs = split_result.second.getOutputs();
+        std::erase_if(lazy_outputs, [&](const ActionsDAG::Node * output) { return output->result_name == name; });
+        split_result.second.removeUnusedActions();
     }
 
     FilterDAGInfo filter_dag_info;

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -345,18 +345,20 @@ static SplitFilterResult splitFilterStep(const FilterStep & filter_step, const s
             if (outputs[i] == &node)
             {
                 new_required_inputs.erase(new_required_inputs.begin() + i);
+
+                /// The main branch removes the filter column, but `ActionsDAG::split` keeps it at
+                /// the same output position in the lazy branch (its outputs are built 1:1 from the
+                /// original outputs), as a pass-through fed by a same-named input the main branch no
+                /// longer provides - so applying the lazy DAG later would throw
+                /// NOT_FOUND_COLUMN_IN_BLOCK. `removeDanglingNodes` handles this for every lazy step
+                /// except the last, so drop that exact output slot here (by position, not by name,
+                /// to avoid touching an unrelated same-named output) and prune the orphaned input.
+                auto & lazy_outputs = split_result.second.getOutputs();
+                lazy_outputs.erase(lazy_outputs.begin() + i);
+                split_result.second.removeUnusedActions();
                 break;
             }
         }
-
-        /// The main branch removes the filter column, but `ActionsDAG::split` keeps it as a
-        /// pass-through output of the lazy branch, fed by a same-named input the main branch no
-        /// longer provides - so applying the lazy DAG later throws NOT_FOUND_COLUMN_IN_BLOCK.
-        /// `removeDanglingNodes` cleans this up for every lazy step except the last, so drop the
-        /// removed filter column from the lazy branch here to keep both branches consistent.
-        auto & lazy_outputs = split_result.second.getOutputs();
-        std::erase_if(lazy_outputs, [&](const ActionsDAG::Node * output) { return output->result_name == name; });
-        split_result.second.removeUnusedActions();
     }
 
     FilterDAGInfo filter_dag_info;

--- a/tests/queries/0_stateless/04493_top_k_through_join_final_lazy_materialization.reference
+++ b/tests/queries/0_stateless/04493_top_k_through_join_final_lazy_materialization.reference
@@ -1,0 +1,35 @@
+min_left_final	a	x
+left_final_on	48	v48
+left_final_on	45	v45
+left_final_on	42	v42
+left_final_on	39	v39
+left_final_on	36	v36
+left_final_off	48	v48
+left_final_off	45	v45
+left_final_off	42	v42
+left_final_off	39	v39
+left_final_off	36	v36
+right_final_on	48	v48
+right_final_on	45	v45
+right_final_on	42	v42
+right_final_on	39	v39
+right_final_on	36	v36
+right_final_off	48	v48
+right_final_off	45	v45
+right_final_off	42	v42
+right_final_off	39	v39
+right_final_off	36	v36
+left_final_multi_on	48	v48	k1
+left_final_multi_on	45	v45	k1
+left_final_multi_on	42	v42	k1
+left_final_multi_on	39	v39	k1
+left_final_multi_on	36	v36	k1
+left_final_multi_on	33	v33	k1
+left_final_multi_on	30	v30	k1
+left_final_multi_off	48	v48	k1
+left_final_multi_off	45	v45	k1
+left_final_multi_off	42	v42	k1
+left_final_multi_off	39	v39	k1
+left_final_multi_off	36	v36	k1
+left_final_multi_off	33	v33	k1
+left_final_multi_off	30	v30	k1

--- a/tests/queries/0_stateless/04493_top_k_through_join_final_lazy_materialization.sql
+++ b/tests/queries/0_stateless/04493_top_k_through_join_final_lazy_materialization.sql
@@ -1,0 +1,100 @@
+-- Regression test for the interaction between `query_plan_top_k_through_join` and
+-- lazy materialization under `FINAL`.
+--
+-- `topKThroughJoin` pushes `Sort + Limit` onto the preserved side of the join,
+-- placing the inserted `SortingStep` directly above the `WHERE` `FilterStep` that
+-- reads from a `FINAL` `ReplacingMergeTree`. Lazy materialization then fires on
+-- that inserted `Limit <- Sort <- Filter <- ReadFromMergeTree` island and splits
+-- the filter into a main half (kept before the `LIMIT`) and a lazy half (applied
+-- after re-reading the deferred columns). The main half removes the filter column,
+-- but the lazy half still carried it as a pass-through, and because it was the
+-- last lazy step it was never cleaned up by `removeDanglingNodes` - so executing
+-- the plan threw `Not found column equals(...) ... (NOT_FOUND_COLUMN_IN_BLOCK)`.
+--
+-- The trigger requires all of: preserved side read with `FINAL`, a `WHERE` on the
+-- preserved table, `ORDER BY <preserved column> LIMIT n`, and a select-list-only
+-- column that lazy materialization defers.
+--
+-- See PR #104268 (introduced `topKThroughJoin`) and #93186/#93316 (prior top-K
+-- header fix).
+
+SET enable_analyzer = 1;
+SET query_plan_top_k_through_join = 1;
+SET query_plan_optimize_lazy_materialization = 1;
+
+DROP TABLE IF EXISTS t_l_lazy;
+DROP TABLE IF EXISTS t_r_lazy;
+
+CREATE TABLE t_l_lazy (id String, k String, ts DateTime64(3), v String) ENGINE = ReplacingMergeTree ORDER BY id;
+CREATE TABLE t_r_lazy (id String, name String) ENGINE = ReplacingMergeTree ORDER BY id;
+
+INSERT INTO t_l_lazy SELECT toString(number), if(number % 3 = 0, 'k1', 'k2'), toDateTime64(1700000000 + number, 3), concat('v', toString(number)) FROM numbers(50);
+INSERT INTO t_r_lazy SELECT toString(number), concat('nm', toString(number)) FROM numbers(30);
+
+-- The minimal reproduction: single matching row, `v` referenced only in the select
+-- list (deferred by lazy materialization), `k` referenced only in the `WHERE`.
+DROP TABLE IF EXISTS t_l_min;
+DROP TABLE IF EXISTS t_r_min;
+CREATE TABLE t_l_min (id String, k String, ts DateTime64(3), v String) ENGINE = ReplacingMergeTree ORDER BY id;
+CREATE TABLE t_r_min (id String, name String) ENGINE = ReplacingMergeTree ORDER BY id;
+INSERT INTO t_l_min VALUES ('a', 'k1', '2026-06-23 08:10:00', 'x');
+INSERT INTO t_r_min VALUES ('a', 'nm');
+
+SELECT 'min_left_final' AS label, e.id, e.v
+FROM t_l_min AS e FINAL
+LEFT JOIN t_r_min AS tc ON tc.id = e.id
+WHERE e.k = 'k1'
+ORDER BY e.ts DESC
+LIMIT 10;
+
+-- LEFT JOIN with FINAL on the preserved (left) side. Result must be identical with
+-- the optimization enabled (default) and disabled.
+SELECT 'left_final_on' AS label, e.id, e.v
+FROM t_l_lazy AS e FINAL
+LEFT JOIN t_r_lazy AS tc ON tc.id = e.id
+WHERE e.k = 'k1'
+ORDER BY e.ts DESC
+LIMIT 5;
+
+SELECT 'left_final_off' AS label, e.id, e.v
+FROM t_l_lazy AS e FINAL
+LEFT JOIN t_r_lazy AS tc ON tc.id = e.id
+WHERE e.k = 'k1'
+ORDER BY e.ts DESC
+LIMIT 5
+SETTINGS query_plan_top_k_through_join = 0;
+
+-- RIGHT JOIN with FINAL on the preserved (right) side.
+SELECT 'right_final_on' AS label, e.id, e.v
+FROM t_r_lazy AS tc RIGHT JOIN t_l_lazy AS e FINAL ON tc.id = e.id
+WHERE e.k = 'k1'
+ORDER BY e.ts DESC
+LIMIT 5;
+
+SELECT 'right_final_off' AS label, e.id, e.v
+FROM t_r_lazy AS tc RIGHT JOIN t_l_lazy AS e FINAL ON tc.id = e.id
+WHERE e.k = 'k1'
+ORDER BY e.ts DESC
+LIMIT 5
+SETTINGS query_plan_top_k_through_join = 0;
+
+-- Several deferred columns and a multi-condition `WHERE`.
+SELECT 'left_final_multi_on' AS label, e.id, e.v, e.k
+FROM t_l_lazy AS e FINAL
+LEFT JOIN t_r_lazy AS tc ON tc.id = e.id
+WHERE e.k = 'k1' AND e.v != 'zzz'
+ORDER BY e.ts DESC
+LIMIT 7;
+
+SELECT 'left_final_multi_off' AS label, e.id, e.v, e.k
+FROM t_l_lazy AS e FINAL
+LEFT JOIN t_r_lazy AS tc ON tc.id = e.id
+WHERE e.k = 'k1' AND e.v != 'zzz'
+ORDER BY e.ts DESC
+LIMIT 7
+SETTINGS query_plan_top_k_through_join = 0;
+
+DROP TABLE t_l_lazy;
+DROP TABLE t_r_lazy;
+DROP TABLE t_l_min;
+DROP TABLE t_r_min;

--- a/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.reference
+++ b/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.reference
@@ -1,0 +1,24 @@
+in_set_mtp0_on	-299
+in_set_mtp0_on	-295
+in_set_mtp0_off	-299
+in_set_mtp0_off	-295
+in_set_default_on	-299
+in_set_default_on	-295
+in_set_default_off	-299
+in_set_default_off	-295
+like_or_mtp0_on	-299	1
+like_or_mtp0_on	-295	5
+like_or_mtp0_on	-289	1
+like_or_mtp0_off	-299	1
+like_or_mtp0_off	-295	5
+like_or_mtp0_off	-289	1
+right_using_mtp0_on	2023-11-14 22:13:20
+right_using_mtp0_on	2023-11-14 22:13:21
+right_using_mtp0_on	2023-11-14 22:13:22
+right_using_mtp0_on	2023-11-14 22:13:23
+right_using_mtp0_on	2023-11-14 22:13:24
+right_using_mtp0_off	2023-11-14 22:13:20
+right_using_mtp0_off	2023-11-14 22:13:21
+right_using_mtp0_off	2023-11-14 22:13:22
+right_using_mtp0_off	2023-11-14 22:13:23
+right_using_mtp0_off	2023-11-14 22:13:24

--- a/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.sql
+++ b/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.sql
@@ -71,8 +71,11 @@ DROP TABLE IF EXISTS t_l_using;
 DROP TABLE IF EXISTS t_r_using;
 CREATE TABLE t_l_using (v Int64, x String) ENGINE = MergeTree ORDER BY v;
 INSERT INTO t_l_using SELECT number, toString(number) FROM numbers(100);
-CREATE TABLE t_r_using (v Int64, id UInt32, ts DateTime) ENGINE = MergeTree ORDER BY v;
-INSERT INTO t_r_using SELECT number, number, toDateTime(1700000000 + number) FROM numbers(100);
+-- `ts` is `DateTime('UTC')` so its rendered value does not depend on the
+-- server/session timezone (a plain `DateTime` renders in the server timezone and
+-- makes the reference non-deterministic across CI runners).
+CREATE TABLE t_r_using (v Int64, id UInt32, ts DateTime('UTC')) ENGINE = MergeTree ORDER BY v;
+INSERT INTO t_r_using SELECT number, number, toDateTime(1700000000 + number, 'UTC') FROM numbers(100);
 
 SELECT 'right_using_mtp0_on' AS label, r.ts
 FROM t_l_using AS l RIGHT JOIN t_r_using AS r USING (v)

--- a/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.sql
+++ b/tests/queries/0_stateless/04494_top_k_through_join_lazy_materialization_where_filter.sql
@@ -1,0 +1,90 @@
+-- Regression test for the same root cause as
+-- `04493_top_k_through_join_final_lazy_materialization`, covering the shapes
+-- reported in issue #111252 where the bug fires WITHOUT `FINAL`: it only needs
+-- the `WHERE` filter to stay a `FilterStep` (i.e. NOT moved to `PREWHERE`).
+--
+-- `topKThroughJoin` pushes `Sort + Limit` onto the preserved side of the join,
+-- forming a `Limit <- Sort <- Filter <- ReadFromMergeTree` island. Lazy
+-- materialization splits that filter; the main half removes the filter column,
+-- but `ActionsDAG::split` left it as a dangling pass-through in the lazy half
+-- (never cleaned because the filter's lazy half is the last lazy step), so the
+-- plan threw `Not found column <predicate> ... (NOT_FOUND_COLUMN_IN_BLOCK)`.
+--
+-- The filter stays in `WHERE` either because the user set
+-- `optimize_move_to_prewhere = 0`, or - under fully default settings - because a
+-- tautological conjunct (`... AND CAST(1 AS LowCardinality(Nullable(UInt8)))`)
+-- blocks the `PREWHERE` move. The predicate itself is arbitrary: `IN (...)`,
+-- a plain comparison, `LIKE`, and `OR` all lose their input column the same way.
+--
+-- Each result must be identical with lazy materialization enabled (default) and
+-- disabled. See #109210 and #111252, and PR #104268 (introduced `topKThroughJoin`).
+
+SET enable_analyzer = 1;
+SET query_plan_top_k_through_join = 1;
+
+DROP TABLE IF EXISTS t_lzm;
+DROP TABLE IF EXISTS t_lzt;
+
+CREATE TABLE t_lzm (id UInt32, v Int64, s String) ENGINE = MergeTree ORDER BY (toStartOfHour(toDateTime(id)), id);
+INSERT INTO t_lzm SELECT number, number - 300, toString(number % 10) FROM numbers(2000);
+CREATE TABLE t_lzt (id UInt32, body String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_lzt SELECT number, toString(number) FROM numbers(500);
+
+-- IN-set predicate on a LEFT JOIN, filter kept in WHERE via optimize_move_to_prewhere = 0.
+SELECT 'in_set_mtp0_on' AS label, l.v
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s IN ('5', '1') ORDER BY l.v LIMIT 2
+SETTINGS optimize_move_to_prewhere = 0;
+
+SELECT 'in_set_mtp0_off' AS label, l.v
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s IN ('5', '1') ORDER BY l.v LIMIT 2
+SETTINGS optimize_move_to_prewhere = 0, query_plan_optimize_lazy_materialization = 0;
+
+-- IN-set predicate under default settings, with a tautological conjunct that
+-- blocks the PREWHERE move (so the filter stays in WHERE without touching
+-- optimize_move_to_prewhere).
+SELECT 'in_set_default_on' AS label, l.v
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s IN ('5', '1') AND CAST(1 AS LowCardinality(Nullable(UInt8))) ORDER BY l.v LIMIT 2
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+
+SELECT 'in_set_default_off' AS label, l.v
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s IN ('5', '1') AND CAST(1 AS LowCardinality(Nullable(UInt8))) ORDER BY l.v LIMIT 2
+SETTINGS allow_suspicious_low_cardinality_types = 1, query_plan_optimize_lazy_materialization = 0;
+
+-- LIKE + OR multi-condition WHERE on a LEFT JOIN.
+SELECT 'like_or_mtp0_on' AS label, l.v, l.s
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s LIKE '5' OR l.s = '1' ORDER BY l.v LIMIT 3
+SETTINGS optimize_move_to_prewhere = 0;
+
+SELECT 'like_or_mtp0_off' AS label, l.v, l.s
+FROM t_lzm AS l LEFT JOIN t_lzt AS r ON l.id = r.id
+WHERE l.s LIKE '5' OR l.s = '1' ORDER BY l.v LIMIT 3
+SETTINGS optimize_move_to_prewhere = 0, query_plan_optimize_lazy_materialization = 0;
+
+-- Plain comparison on a RIGHT JOIN ... USING with the filter on the preserved
+-- (right) table, no FINAL.
+DROP TABLE IF EXISTS t_l_using;
+DROP TABLE IF EXISTS t_r_using;
+CREATE TABLE t_l_using (v Int64, x String) ENGINE = MergeTree ORDER BY v;
+INSERT INTO t_l_using SELECT number, toString(number) FROM numbers(100);
+CREATE TABLE t_r_using (v Int64, id UInt32, ts DateTime) ENGINE = MergeTree ORDER BY v;
+INSERT INTO t_r_using SELECT number, number, toDateTime(1700000000 + number) FROM numbers(100);
+
+SELECT 'right_using_mtp0_on' AS label, r.ts
+FROM t_l_using AS l RIGHT JOIN t_r_using AS r USING (v)
+WHERE r.id != 50 ORDER BY ALL LIMIT 5
+SETTINGS optimize_move_to_prewhere = 0;
+
+SELECT 'right_using_mtp0_off' AS label, r.ts
+FROM t_l_using AS l RIGHT JOIN t_r_using AS r USING (v)
+WHERE r.id != 50 ORDER BY ALL LIMIT 5
+SETTINGS optimize_move_to_prewhere = 0, query_plan_optimize_lazy_materialization = 0;
+
+DROP TABLE t_lzm;
+DROP TABLE t_lzt;
+DROP TABLE t_l_using;
+DROP TABLE t_r_using;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109210
Closes: https://github.com/ClickHouse/ClickHouse/issues/111252
Related: https://github.com/ClickHouse/ClickHouse/pull/104268
Related: https://github.com/ClickHouse/ClickHouse/pull/93186
Related: https://github.com/ClickHouse/ClickHouse/pull/93316

## Description

Fix `NOT_FOUND_COLUMN_IN_BLOCK` thrown by the `query_plan_top_k_through_join` optimization when it interacts with lazy materialization under `FINAL`.

### Symptom

A valid query throws an exception when ALL of these are combined:
- the preserved (left) side of a `LEFT JOIN` is read with `FINAL`,
- there is a `WHERE` predicate on the preserved table,
- the query has `ORDER BY <preserved-table column> ... LIMIT n`,
- the select list includes a preserved-table column referenced ONLY in the select list (the column lazy materialization defers).

```sql
CREATE TABLE l (id String, k String, ts DateTime64(3), v String)
  ENGINE = ReplacingMergeTree ORDER BY id;
CREATE TABLE r (id String, name String)
  ENGINE = ReplacingMergeTree ORDER BY id;
INSERT INTO l VALUES ('a', 'k1', '2026-06-23 08:10:00', 'x');
INSERT INTO r VALUES ('a', 'nm');

-- FAILS on 26.5+ with NOT_FOUND_COLUMN_IN_BLOCK; returns {'a','x'} on <= 26.4
SELECT e.id, e.v
FROM l AS e FINAL
LEFT JOIN r AS tc ON tc.id = e.id
WHERE e.k = 'k1'
ORDER BY e.ts DESC
LIMIT 10;
```

Exact error:

```
Code: 10. DB::Exception: Not found column equals(__table1.k, 'k1'_String):
in block __table1.id String String(size = 0), __table1.ts DateTime64(3)
DateTime64(size = 0), v String String(size = 0). (NOT_FOUND_COLUMN_IN_BLOCK)
```

The block header is missing the `WHERE`-only column `k` (the lazily-materialized `v` is present) — that is the smoking gun.

Each of the following individually avoids the error, which localizes the interaction:
- `INNER JOIN` instead of `LEFT JOIN`
- removing `FINAL` from the preserved table
- removing the `WHERE`
- removing either `ORDER BY` or `LIMIT`
- selecting only `e.id` (dropping the deferred `e.v` column)
- `SETTINGS query_plan_top_k_through_join = 0`
- `SETTINGS query_plan_optimize_lazy_materialization = 0`

### Regression provenance

Bisected against stock `clickhouse/clickhouse-server` images: works up to and including `26.4.4.38`, fails from `26.5.5.8` and remains broken in `26.6`. This lines up with `query_plan_top_k_through_join` (`topKThroughJoin`, #104268) shipping in 26.5.

| Version | Result |
| --- | --- |
| 25.8 – 26.4 | works |
| 26.5.5.8 | FAILS |
| 26.6.1.1193 | FAILS |

### Root cause

`topKThroughJoin` pushes `Sort + Limit` onto the preserved side of the join. After filter push-down has moved the `WHERE` below the join, the inserted `SortingStep` sits directly above the `FilterStep` that reads from the `FINAL` `ReplacingMergeTree`, forming a `Limit <- Sort <- Filter <- ReadFromMergeTree` island.

Lazy materialization (`optimizeLazyMaterialization2`, second pass) runs on every node, so it fires on that island and splits the `FilterStep` into a main half (applied before the `LIMIT`) and a lazy half (applied after re-reading the deferred columns via `JoinLazyColumnsStep`). The main half correctly removes the filter column (`equals(k, 'k1')`), mirroring the original `FilterStep`. However, `ActionsDAG::split` preserves every original output in the lazy half, so the removed filter column survives there as a pass-through output fed by a same-named input — a column the main half no longer provides.

Normally this is harmless: when there is a further step above the filter, the filter's lazy half is not the last lazy step and gets cleaned up by `removeDanglingNodes`. But in the `topKThroughJoin` shape the inserted `Sort` is placed directly above the filter, so the filter's lazy half is the *only/last* lazy step, and the loop that applies the lazy steps intentionally skips `removeDanglingNodes` for the last step. The dangling filter column is left behind, and building the lazy `ExpressionStep` fails because `equals(k, 'k1')` is absent from the post-`JoinLazyColumnsStep` header.

This was verified by instrumenting `optimizeLazyMaterialization2`:
- crashing case: `num lazy_steps = 1`; `lazy_step[0]` inputs `equals(...),id,ts,v`, outputs `equals(...),id,v,ts` (the dangling filter column is never cleaned).
- working case (no join): `num lazy_steps = 2`; the same dangling column appears in the filter's lazy half but is removed by `removeDanglingNodes` because it is not the last step.

### Fix

Make `splitFilterStep` drop the removed filter column from the lazy branch (`split_result.second`), so both branches agree that the filter column no longer exists after the filter — regardless of whether the filter's lazy half happens to be the last lazy step. This is the correct place: `splitFilterStep` is the only place that knows the filter removes its column (it already sets `do_remove_column` and erases the column from the upward `new_required_inputs`).

```cpp
auto & lazy_outputs = split_result.second.getOutputs();
std::erase_if(lazy_outputs, [&](const ActionsDAG::Node * output) { return output->result_name == name; });
split_result.second.removeUnusedActions();
```

The optimization stays enabled; the fix is analogous in spirit to the earlier "respect reading step header for top-k" fix (#93186 / #93316), but for the through-join + lazy-materialization case.

### Testing

New stateless test `04493_top_k_through_join_final_lazy_materialization` reproduces the minimal case and checks result equivalence between the optimization enabled (default) and disabled, covering `LEFT`/`RIGHT` joins and `FINAL`, single and multiple deferred columns, and multi-condition `WHERE`.

The same root cause was independently reported in #111252 for the non-`FINAL` case (the bug only needs the `WHERE` filter to stay a `FilterStep`, i.e. not moved to `PREWHERE`, for any predicate). `04494_top_k_through_join_lazy_materialization_where_filter` covers those shapes — `IN (...)` set predicate, `LIKE`/`OR` multi-condition, and a plain comparison on `RIGHT JOIN ... USING` — with the filter kept in `WHERE` both via `optimize_move_to_prewhere = 0` and, under default settings, via a tautological `CAST(1 AS LowCardinality(Nullable(UInt8)))` conjunct that blocks the `PREWHERE` move.

All existing `top_k_through_join` (`04207`–`04234`) and lazy-materialization (`02813`, `033xx`, `037xx`, `038xx`, `039xx`, `040xx`, `04327_lazy_materialization_topk_filter_column_position`, …) tests still pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `NOT_FOUND_COLUMN_IN_BLOCK` thrown when `ORDER BY ... LIMIT` was pushed through a `LEFT`/`RIGHT` `JOIN` (`query_plan_top_k_through_join`) and the preserved side was read with `FINAL` while lazy materialization deferred a select-list-only column and the `WHERE` filtered on another column of the same table.
