### PR TITLE
Docs: compact JWT ephemeral-user display name

### DIFF
--- a/docs/en/operations/external-authenticators/jwt.md
+++ b/docs/en/operations/external-authenticators/jwt.md
@@ -93,8 +93,10 @@ Each JWT user receives a deterministic UUID computed from the `iss`, `sub`, and 
 The username, however, is **volatile**. It is constructed as:
 
 ```text
-JWT::<issuer>::<audience>::<subject>::<claims_hash>
+JWT::<subject>::<claims_hash>
 ```
+
+The `<claims_hash>` is a hash derived from the `iss`, `sub`, and `aud` claims together with the `clickhouse:roles` and `clickhouse:grants` claims. The `iss` and `aud` claims participate **only** through this hash; they are no longer inlined into the visible username prefix. This keeps the name compact and readable when `iss`/`aud` are long opaque IDP URLs (for example, Microsoft Entra or Okta), while still guaranteeing that distinct `(iss, sub, aud)` tuples and distinct claim sets map to distinct, stable names.
 
 The `<claims_hash>` portion changes whenever the `clickhouse:roles` or `clickhouse:grants` claims change. This means that tokens with different role or grant sets produce different usernames even for the same identity.
 
@@ -125,7 +127,7 @@ Because the UUID is stable, you can assign settings profiles, quotas, row polici
 Reference the user by their current username:
 
 ```sql
-ALTER SETTINGS PROFILE my_profile ADD TO 'JWT::ClickHouse::my-service-id::jane.doe::<claims-hash>';
+ALTER SETTINGS PROFILE my_profile ADD TO 'JWT::jane.doe::<claims_hash>';
 ```
 
 :::note

--- a/docs/en/operations/external-authenticators/jwt.md
+++ b/docs/en/operations/external-authenticators/jwt.md
@@ -96,7 +96,7 @@ The username, however, is **volatile**. It is constructed as:
 JWT::<subject>::<claims_hash>
 ```
 
-The `<claims_hash>` is a hash derived from the `iss`, `sub`, and `aud` claims together with the `clickhouse:roles` and `clickhouse:grants` claims. The `iss` and `aud` claims participate **only** through this hash; they are no longer inlined into the visible username prefix. This keeps the name compact and readable when `iss`/`aud` are long opaque IDP URLs (for example, Microsoft Entra or Okta), while still guaranteeing that distinct `(iss, sub, aud)` tuples and distinct claim sets map to distinct, stable names.
+The `<claims_hash>` is a hash derived from the `iss`, `sub`, and `aud` claims together with the `clickhouse:roles` and `clickhouse:grants` claims. The `iss` and `aud` claims participate **only** through this hash; they are no longer inlined into the visible username prefix. This keeps the name compact and readable when `iss`/`aud` are long opaque IDP URLs (for example, Microsoft Entra or Okta), while still guaranteeing that distinct `(iss, sub, aud)` tuples and distinct `clickhouse:roles` / `clickhouse:grants` sets map to distinct, stable names. Claims that do not feed the hash (for example `iat`, `exp`, `nbf`, or unrelated custom claims) do not change the username.
 
 The `<claims_hash>` portion changes whenever the `clickhouse:roles` or `clickhouse:grants` claims change. This means that tokens with different role or grant sets produce different usernames even for the same identity.
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Updates the JWT external-authenticator docs to reflect the compact ephemeral-user display name.

The visible username is now `JWT::<subject>::<claims_hash>` (previously `JWT::<issuer>::<audience>::<subject>::<claims_hash>`). The `iss` and `aud` claims are no longer inlined into the name; they still feed the `claims_hash` (and the separate stable user UUID), so distinct `(iss, sub, aud)` tuples and distinct claim sets still map to distinct, stable names. This keeps names readable in `system.users`, `SHOW GRANTS`, `system.session_log`, and access-denied messages when `iss`/`aud` are long opaque IDP URLs (Microsoft Entra, Okta, etc.).

Two edits in `docs/en/operations/external-authenticators/jwt.md`:
- The "Identity and naming" username format block, plus a sentence explaining that `iss`/`aud` participate only via the hash.
- The `ALTER SETTINGS PROFILE` example in "Persistent access assignments".

Docs-only; no code change. No public tracking issue.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.780` (included in `26.7` and later)
<!-- ch-version-info:end -->