### PR TITLE
Enable immediate statistics serialization for CountMinSketch

### DIFF
--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -412,9 +412,27 @@ void ColumnStatistics::serialize(WriteBuffer & buf) const
     /// As the column row count is always useful, save it in any case
     writeIntBinary(rows, buf);
 
-    /// Write each statistics blob with a length prefix, by serializing into a temp buffer first.
+    /// Write each statistics blob with a length prefix. Statistics that can compute their exact
+    /// serialized size can stream directly to the destination; the others keep the temp-buffer
+    /// fallback needed for the V4 prefix.
     for (const auto & [type, stat_ptr] : stats)
     {
+        if (std::optional<UInt64> serialized_size = stat_ptr->getSerializedSize())
+        {
+            writeIntBinary(*serialized_size, buf);
+
+            const auto count_before = buf.count();
+            stat_ptr->serialize(buf);
+            const auto written = static_cast<UInt64>(buf.count() - count_before);
+            if (written != *serialized_size)
+                throw Exception(
+                    ErrorCodes::LOGICAL_ERROR,
+                    "Statistics serialization for type {} wrote {} bytes but declared {} bytes",
+                    statisticsTypeToString(type), written, *serialized_size);
+
+            continue;
+        }
+
         String temp_data;
         WriteBufferFromString temp_buf(temp_data);
         stat_ptr->serialize(temp_buf);

--- a/src/Storages/Statistics/Statistics.h
+++ b/src/Storages/Statistics/Statistics.h
@@ -7,6 +7,8 @@
 
 #include <boost/core/noncopyable.hpp>
 
+#include <optional>
+
 namespace DB
 {
 
@@ -66,6 +68,9 @@ public:
 
     virtual void serialize(WriteBuffer & buf) = 0;
     virtual void deserialize(ReadBuffer & buf, StatisticsFileVersion version) = 0;
+    /// Returns the exact number of bytes written by serialize(), if it can be computed
+    /// without serializing into a temporary buffer.
+    virtual std::optional<UInt64> getSerializedSize() const { return std::nullopt; }
 
     /// Estimate the cardinality of the column.
     /// Throws if the statistics object is not able to do a meaningful estimation.

--- a/src/Storages/Statistics/StatisticsCountMinSketch.cpp
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.cpp
@@ -5,6 +5,9 @@
 #include <IO/WriteHelpers.h>
 #include <Interpreters/convertFieldToType.h>
 
+#include <ostream>
+#include <streambuf>
+
 #if USE_DATASKETCHES
 
 namespace DB
@@ -22,6 +25,39 @@ namespace ErrorCodes
 /// And sketch the size is 152kb.
 static constexpr auto num_hashes = 7uz;
 static constexpr auto num_buckets = 2718uz;
+
+namespace
+{
+
+class StdStreamBufFromWriteBuffer : public std::streambuf
+{
+public:
+    explicit StdStreamBufFromWriteBuffer(WriteBuffer & out_) : out(out_) {}
+
+protected:
+    std::streamsize xsputn(const char * s, std::streamsize count) override
+    {
+        if (count <= 0)
+            return 0;
+
+        out.write(s, static_cast<size_t>(count));
+        return count;
+    }
+
+    int_type overflow(int_type ch) override
+    {
+        if (traits_type::eq_int_type(ch, traits_type::eof()))
+            return traits_type::not_eof(ch);
+
+        out.write(traits_type::to_char_type(ch));
+        return ch;
+    }
+
+private:
+    WriteBuffer & out;
+};
+
+}
 
 StatisticsCountMinSketch::StatisticsCountMinSketch(const SingleStatisticsDescription & description, const DataTypePtr & data_type_)
     : IStatistics(description)
@@ -77,9 +113,17 @@ void StatisticsCountMinSketch::merge(const StatisticsPtr & other_stats)
 
 void StatisticsCountMinSketch::serialize(WriteBuffer & buf)
 {
-    Sketch::vector_bytes bytes = sketch.serialize();
-    writeIntBinary(static_cast<UInt64>(bytes.size()), buf);
-    buf.write(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+    writeIntBinary(static_cast<UInt64>(sketch.get_serialized_size_bytes()), buf);
+
+    StdStreamBufFromWriteBuffer stream_buf(buf);
+    std::ostream stream(&stream_buf);
+    stream.exceptions(std::ios::badbit | std::ios::failbit);
+    sketch.serialize(stream);
+}
+
+std::optional<UInt64> StatisticsCountMinSketch::getSerializedSize() const
+{
+    return sizeof(UInt64) + sketch.get_serialized_size_bytes();
 }
 
 void StatisticsCountMinSketch::deserialize(ReadBuffer & buf, StatisticsFileVersion /*version*/)

--- a/src/Storages/Statistics/StatisticsCountMinSketch.h
+++ b/src/Storages/Statistics/StatisticsCountMinSketch.h
@@ -23,6 +23,7 @@ public:
 
     void serialize(WriteBuffer & buf) override;
     void deserialize(ReadBuffer & buf, StatisticsFileVersion version) override;
+    std::optional<UInt64> getSerializedSize() const override;
 
     String getNameForLogs() const override { return "CMSketch"; }
 private:

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -9,6 +9,9 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <Interpreters/convertFieldToType.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteBufferFromString.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Storages/Statistics/Statistics.h>
 #include <Storages/Statistics/StatisticsMinMax.h>
@@ -18,6 +21,8 @@
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Parsers/parseQuery.h>
 #include <Parsers/ExpressionListParsers.h>
+
+#include "config.h"
 
 using namespace DB;
 
@@ -242,6 +247,71 @@ Float64 estimateRowsFor(Estimator & estimator, const String & expression)
 }
 
 }
+
+#if USE_DATASKETCHES
+TEST(Statistics, CountMinSketchSerializedSizeMatchesPayload)
+{
+    auto data_type = std::make_shared<DataTypeUInt64>();
+    auto column = data_type->createColumn();
+    for (UInt64 value : {1, 2, 3, 3, 5, 8, 13, 13, 13, 21})
+        column->insert(value);
+    const size_t row_count = column->size();
+
+    auto stats = createTestStats({StatisticsType::CountMinSketch}, data_type);
+    stats->build(std::move(column));
+
+    String serialized;
+    WriteBufferFromString out(serialized);
+    stats->serialize(out);
+    out.finalize();
+
+    ReadBufferFromString parser(serialized);
+
+    UInt16 version_raw = 0;
+    readIntBinary(version_raw, parser);
+    ASSERT_EQ(static_cast<StatisticsFileVersion>(version_raw), StatisticsFileVersion::V4);
+
+    UInt64 stat_types_mask = 0;
+    readIntBinary(stat_types_mask, parser);
+    ASSERT_EQ(stat_types_mask, 1ULL << static_cast<UInt8>(StatisticsType::CountMinSketch));
+
+    String stored_type_name;
+    readStringBinary(stored_type_name, parser);
+    ASSERT_EQ(stored_type_name, data_type->getName());
+
+    UInt64 rows = 0;
+    readIntBinary(rows, parser);
+    ASSERT_EQ(rows, row_count);
+
+    UInt64 outer_stat_size = 0;
+    readIntBinary(outer_stat_size, parser);
+    const auto payload_start = parser.count();
+
+    UInt64 sketch_size = 0;
+    readIntBinary(sketch_size, parser);
+    EXPECT_EQ(outer_stat_size, sizeof(UInt64) + sketch_size);
+    EXPECT_EQ(static_cast<UInt64>(serialized.size() - payload_start), outer_stat_size);
+
+    ReadBufferFromString in(serialized);
+    auto deserialized = ColumnStatistics::deserialize(in, data_type);
+    ASSERT_TRUE(deserialized);
+    EXPECT_EQ(in.count(), serialized.size());
+    ASSERT_TRUE(deserialized->getStats().contains(StatisticsType::CountMinSketch));
+    EXPECT_EQ(deserialized->getNumRows(), row_count);
+
+    auto original_existing_estimate = stats->estimateEqual(Field(UInt64(13)));
+    auto deserialized_existing_estimate = deserialized->estimateEqual(Field(UInt64(13)));
+    ASSERT_TRUE(original_existing_estimate.has_value());
+    ASSERT_TRUE(deserialized_existing_estimate.has_value());
+    EXPECT_EQ(*deserialized_existing_estimate, *original_existing_estimate);
+
+    auto original_missing_estimate = stats->estimateEqual(Field(UInt64(4)));
+    auto deserialized_missing_estimate = deserialized->estimateEqual(Field(UInt64(4)));
+    ASSERT_TRUE(original_missing_estimate.has_value());
+    ASSERT_TRUE(deserialized_missing_estimate.has_value());
+    EXPECT_EQ(*deserialized_missing_estimate, *original_missing_estimate);
+}
+#endif
 
 TEST(Statistics, NullableEstimatorWithBasic)
 {


### PR DESCRIPTION
Found during benchmarking `ColumnStatistics`. Related: #109227.

`ColumnStatistics` are currently serialized into a buffer before being written to the part's statistics file. With this change we introduce a mechanism that allows `IStatistics` to report their serialized size and thus allow `ColumnStatistics::serialize()` to decide to skip the additional buffer and instead serialize the on disk represenation directly into the statistics file stream.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

CountMin column statistics are now serialized into the part file without double buffering.