### PR TITLE
AI functions parameter map

### DIFF
--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -23,14 +23,20 @@ All functions are sharing a common infrastructure that provides:
 
 ## Configuration {#configuration}
 
-AI functions reference a **named collection** that stores provider credentials and configuration.
+AI functions reference a **named collection** that stores provider credentials and configuration. Different named collections can be created and used for different functions or functions calls. For example you may want to define a different named collection to use with the text functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) vs the `aiEmbed` function, which require different endpoints and usually use different models.
 
-Example statement to create a named collection with provider credentials:
+Example statement to create a named collection with provider credentials, one with a chat endpoint and another with an embedding endpoint:
 ```sql
-CREATE NAMED COLLECTION ai_credentials AS
+CREATE NAMED COLLECTION ai_text_credentials AS
     provider = 'openai',
     endpoint = 'https://api.openai.com/v1/chat/completions',
     model = 'gpt-4o-mini',
+    api_key = 'sk-...';
+
+CREATE NAMED COLLECTION ai_embedding_credentials AS
+    provider = 'openai',
+    endpoint = 'https://api.openai.com/v1/embeddings',
+    model = 'text-embedding-3-small',
     api_key = 'sk-...';
 ```
 
@@ -74,15 +80,14 @@ SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
 
 Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default.
 
-| Key | Applies to | Description |
-|-----|------------|-------------|
-| `credentials` | all | Named collection to use (see above). |
-| `model` | all | Overrides the collection's `model`. |
-| `max_tokens` | text functions | Overrides the collection's `max_tokens`. |
-| `temperature` | text functions | Sampling temperature. Defaults: `aiGenerate` `0.7`, `aiClassify`/`aiExtract` `0.0`, `aiTranslate` `0.3`. |
-| `system_prompt` | `aiGenerate` | System-level instruction sent with each prompt. |
-| `instructions` | `aiTranslate` | Additional style/dialect instructions. |
-| `dimensions` | `aiEmbed` | Target vector dimensionality (`0` = model's native size). |
+The following parameters are common to all the AI functions:
+
+| Key | Description |
+|-----|-------------|
+| `credentials` | Named collection to use (see above). |
+| `model` | Overrides the collection's `model`. |
+
+Individual functions accept additional, function-specific parameters (such as `max_tokens`, `temperature`, `system_prompt`, `instructions`, and `dimensions`). See each function's reference below for the parameters it accepts and their defaults.
 
 ```sql
 SELECT aiGenerate(body, map('temperature', '0.2', 'system_prompt', 'You are terse.')) FROM articles;

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -23,7 +23,7 @@ All functions are sharing a common infrastructure that provides:
 
 ## Configuration {#configuration}
 
-AI functions reference a **named collection** that stores provider credentials and configuration. The first argument to each function is the name of this collection.
+AI functions reference a **named collection** that stores provider credentials and configuration.
 
 Example statement to create a named collection with provider credentials:
 ```sql
@@ -48,6 +48,45 @@ CREATE NAMED COLLECTION ai_credentials AS
 :::note
 Any OpenAI-compatible API (e.g. vLLM, Ollama, LiteLLM) can be used by setting `provider = 'openai'` and pointing the `endpoint` to your service.
 :::
+
+### Selecting credentials {#selecting-credentials}
+
+A function resolves the named collection to use from, in order:
+
+1. the `credentials` key of its parameter map, when present;
+2. otherwise the applicable default-credentials setting:
+   - [`ai_function_text_default_credentials`](/operations/settings/settings#ai_function_text_default_credentials) for the text functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`);
+   - [`ai_function_embedding_default_credentials`](/operations/settings/settings#ai_function_embedding_default_credentials) for `aiEmbed`.
+
+If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint and model differ from an embeddings one.
+
+```sql
+SET ai_function_text_default_credentials = 'ai_credentials';
+
+-- Uses ai_credentials from the setting:
+SELECT aiGenerate('What is 2 + 2? Reply with just the number.');
+
+-- Overrides the default for this call:
+SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
+```
+
+### Parameter map {#parameter-map}
+
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default.
+
+| Key | Applies to | Description |
+|-----|------------|-------------|
+| `credentials` | all | Named collection to use (see above). |
+| `model` | all | Overrides the collection's `model`. |
+| `max_tokens` | text functions | Overrides the collection's `max_tokens`. |
+| `temperature` | text functions | Sampling temperature. Defaults: `aiGenerate` `0.7`, `aiClassify`/`aiExtract` `0.0`, `aiTranslate` `0.3`. |
+| `system_prompt` | `aiGenerate` | System-level instruction sent with each prompt. |
+| `instructions` | `aiTranslate` | Additional style/dialect instructions. |
+| `dimensions` | `aiEmbed` | Target vector dimensionality (`0` = model's native size). |
+
+```sql
+SELECT aiGenerate(body, map('temperature', '0.2', 'system_prompt', 'You are terse.')) FROM articles;
+```
 
 ### Query-level settings {#query-level-settings}
 

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -67,9 +67,9 @@ A function resolves the named collection to use from, in order:
 If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint and model differ from an embeddings one.
 
 ```sql
-SET ai_function_text_default_credentials = 'ai_credentials';
+SET ai_function_text_default_credentials = 'ai_text_credentials';
 
--- Uses ai_credentials from the setting:
+-- Uses ai_text_credentials from the setting:
 SELECT aiGenerate('What is 2 + 2? Reply with just the number.');
 
 -- Overrides the default for this call:

--- a/docs/reference/functions/regular-functions/ai-functions.mdx
+++ b/docs/reference/functions/regular-functions/ai-functions.mdx
@@ -23,14 +23,20 @@ All functions are sharing a common infrastructure that provides:
 
 ## Configuration {#configuration}
 
-AI functions reference a **named collection** that stores provider credentials and configuration. The first argument to each function is the name of this collection.
+AI functions reference a **named collection** that stores provider credentials and configuration. Different named collections can be created and used for different functions or functions calls. For example you may want to define a different named collection to use with the text functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) vs the `aiEmbed` function, which require different endpoints and usually use different models.
 
-Example statement to create a named collection with provider credentials:
+Example statement to create a named collection with provider credentials, one with a chat endpoint and another with an embedding endpoint:
 ```sql
-CREATE NAMED COLLECTION ai_credentials AS
+CREATE NAMED COLLECTION ai_text_credentials AS
     provider = 'openai',
     endpoint = 'https://api.openai.com/v1/chat/completions',
     model = 'gpt-4o-mini',
+    api_key = 'sk-...';
+
+CREATE NAMED COLLECTION ai_embedding_credentials AS
+    provider = 'openai',
+    endpoint = 'https://api.openai.com/v1/embeddings',
+    model = 'text-embedding-3-small',
     api_key = 'sk-...';
 ```
 
@@ -48,6 +54,44 @@ CREATE NAMED COLLECTION ai_credentials AS
 <Note>
 Any OpenAI-compatible API (e.g. vLLM, Ollama, LiteLLM) can be used by setting `provider = 'openai'` and pointing the `endpoint` to your service.
 </Note>
+
+### Selecting credentials {#selecting-credentials}
+
+A function resolves the named collection to use from, in order:
+
+1. the `credentials` key of its parameter map, when present;
+2. otherwise the applicable default-credentials setting:
+   - [`ai_function_text_default_credentials`](/reference/settings/session-settings#ai_function_text_default_credentials) for the text functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`);
+   - [`ai_function_embedding_default_credentials`](/reference/settings/session-settings#ai_function_embedding_default_credentials) for `aiEmbed`.
+
+If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint and model differ from an embeddings one.
+
+```sql
+SET ai_function_text_default_credentials = 'ai_credentials';
+
+-- Uses ai_credentials from the setting:
+SELECT aiGenerate('What is 2 + 2? Reply with just the number.');
+
+-- Overrides the default for this call:
+SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
+```
+
+### Parameter map {#parameter-map}
+
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default.
+
+The following parameters are common to all the AI functions:
+
+| Key | Description |
+|-----|-------------|
+| `credentials` | Named collection to use (see above). |
+| `model` | Overrides the collection's `model`. |
+
+Individual functions accept additional, function-specific parameters (such as `max_tokens`, `temperature`, `system_prompt`, `instructions`, and `dimensions`). See each function's reference below for the parameters it accepts and their defaults.
+
+```sql
+SELECT aiGenerate(body, map('temperature', '0.2', 'system_prompt', 'You are terse.')) FROM articles;
+```
 
 ### Query-level settings {#query-level-settings}
 

--- a/docs/reference/functions/regular-functions/ai-functions.mdx
+++ b/docs/reference/functions/regular-functions/ai-functions.mdx
@@ -67,9 +67,9 @@ A function resolves the named collection to use from, in order:
 If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint and model differ from an embeddings one.
 
 ```sql
-SET ai_function_text_default_credentials = 'ai_credentials';
+SET ai_function_text_default_credentials = 'ai_text_credentials';
 
--- Uses ai_credentials from the setting:
+-- Uses ai_text_credentials from the setting:
 SELECT aiGenerate('What is 2 + 2? Reply with just the number.');
 
 -- Overrides the default for this call:

--- a/docs/reference/settings/beta-and-experimental-features.mdx
+++ b/docs/reference/settings/beta-and-experimental-features.mdx
@@ -169,6 +169,8 @@ Please note: no additional experimental features are allowed to be enabled in Cl
 | [ai_function_max_api_calls_per_query](/reference/settings/session-settings#ai_function_max_api_calls_per_query) | `0` |
 | [ai_function_throw_on_quota_exceeded](/reference/settings/session-settings#ai_function_throw_on_quota_exceeded) | `1` |
 | [ai_function_embedding_max_batch_size](/reference/settings/session-settings#ai_function_embedding_max_batch_size) | `100` |
+| [ai_function_text_default_credentials](/reference/settings/session-settings#ai_function_text_default_credentials) | `` |
+| [ai_function_embedding_default_credentials](/reference/settings/session-settings#ai_function_embedding_default_credentials) | `` |
 | [allow_commit_order_projection](/reference/settings/merge-tree-settings#allow_commit_order_projection) | `0` |
 | [allow_experimental_replacing_merge_with_cleanup](/reference/settings/merge-tree-settings#allow_experimental_replacing_merge_with_cleanup) | `0` |
 | [allow_experimental_text_index_positions](/reference/settings/merge-tree-settings#allow_experimental_text_index_positions) | `0` |

--- a/docs/reference/settings/session-settings.mdx
+++ b/docs/reference/settings/session-settings.mdx
@@ -171,6 +171,16 @@ Maximal size of block in bytes accumulated during aggregation in order of primar
 
 Number of threads to use for merge intermediate aggregation results in memory efficient mode. When bigger, then more memory is consumed. 0 means - same as 'max_threads'.
 
+## ai_function_embedding_default_credentials {#ai_function_embedding_default_credentials} 
+
+<ExperimentalBadge/>
+
+<SettingsInfoBlock type="String" default_value="" />
+
+<VersionHistory rows={[{"id": "row-1","items": [{"label": "26.7"},{"label": ""},{"label": "New setting"}]}]}/>
+
+Name of the named collection used by `aiEmbed` when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. Kept separate from `ai_function_text_default_credentials` because an embeddings endpoint and model differ from a chat one.
+
 ## ai_function_embedding_max_batch_size {#ai_function_embedding_max_batch_size} 
 
 <ExperimentalBadge/>
@@ -244,6 +254,16 @@ Timeout in seconds for individual HTTP requests made by AI functions (AI chat co
 <VersionHistory rows={[{"id": "row-1","items": [{"label": "26.4"},{"label": "1000"},{"label": "New setting"}]}]}/>
 
 Initial delay in milliseconds before the first retry of a failed AI function API request. The delay doubles on each subsequent attempt (exponential backoff). For example, with default settings: 1000ms, 2000ms, 4000ms.
+
+## ai_function_text_default_credentials {#ai_function_text_default_credentials} 
+
+<ExperimentalBadge/>
+
+<SettingsInfoBlock type="String" default_value="" />
+
+<VersionHistory rows={[{"id": "row-1","items": [{"label": "26.7"},{"label": ""},{"label": "New setting"}]}]}/>
+
+Name of the named collection used by the text AI functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. A chat-completions endpoint and model differ from an embeddings one, so this is separate from `ai_function_embedding_default_credentials`.
 
 ## ai_function_throw_on_error {#ai_function_throw_on_error} 
 

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -3918,9 +3918,9 @@ static const std::vector<std::unordered_set<String>> & swapFuncs
         {"naiveBayesClassifier", "detectCharset", "detectLanguage", "detectLanguageUnknown", "detectLanguageMixed", "detectTonality"},
         /// Word-level NLP (language/extension + word)
         {"stem", "lemmatize", "synonyms"},
-        /// AI functions: text + optional params map (text[, params] → result)
+        /// AI functions: text + optional params map
         {"aiEmbed", "aiGenerate"},
-        /// AI functions: text + semantic_arg + optional params map (text, semantic_arg[, params] → result)
+        /// AI functions: text + a per-function arg (categories / instruction / target_language) + optional params map
         {"aiClassify", "aiExtract", "aiTranslate"},
         /// Geo distance functions (lon1, lat1, lon2, lat2 → Float64)
         {"greatCircleDistance", "geoDistance", "greatCircleAngle"},

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -3918,9 +3918,9 @@ static const std::vector<std::unordered_set<String>> & swapFuncs
         {"naiveBayesClassifier", "detectCharset", "detectLanguage", "detectLanguageUnknown", "detectLanguageMixed", "detectTonality"},
         /// Word-level NLP (language/extension + word)
         {"stem", "lemmatize", "synonyms"},
-        /// AI functions: 2-arg (named_collection, text → result)
+        /// AI functions: text + optional params map (text[, params] → result)
         {"aiEmbed", "aiGenerate"},
-        /// AI functions: 3-arg (named_collection, text, semantic_arg → result)
+        /// AI functions: text + semantic_arg + optional params map (text, semantic_arg[, params] → result)
         {"aiClassify", "aiExtract", "aiTranslate"},
         /// Geo distance functions (lon1, lat1, lon2, lat2 → Float64)
         {"greatCircleDistance", "geoDistance", "greatCircleAngle"},

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8475,6 +8475,12 @@ If true (default), exceeding an AI function quota limit (`ai_function_max_input_
     DECLARE(NonZeroUInt64, ai_function_embedding_max_batch_size, 100, R"(
 Maximum number of texts to include in a single HTTP request made by `aiEmbed`. Texts are grouped into batches of this size to reduce API call overhead. For example, 500 unique texts with a batch size of 100 result in 5 HTTP requests.
 )", EXPERIMENTAL) \
+    DECLARE(String, ai_function_text_default_credentials, "", R"(
+Name of the named collection used by the text AI functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. A chat-completions endpoint and model differ from an embeddings one, so this is separate from `ai_function_embedding_default_credentials`.
+)", EXPERIMENTAL) \
+    DECLARE(String, ai_function_embedding_default_credentials, "", R"(
+Name of the named collection used by `aiEmbed` when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. Kept separate from `ai_function_text_default_credentials` because an embeddings endpoint and model differ from a chat one.
+)", EXPERIMENTAL) \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \
     /* ####################################################### */ \
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"use_streaming_marks_compression", false, false, "New setting to compress marks into in-memory representation one block at a time (streaming) instead of materializing the full plain marks array, reducing peak memory during marks loading for compact parts with many substreams."},
             {"s3_validate_etag_on_read", false, true, "New setting to detect concurrent in-place overwrites of S3/GCS objects during a read by validating the GET response ETag against the listed one. previous_value=false so `compatibility` with versions before 26.7 restores the pre-existing behavior (no validation)."},
+            {"ai_function_text_default_credentials", "", "", "New setting: default named collection for the text AI functions (aiGenerate, aiClassify, aiExtract, aiTranslate) when the call omits credentials."},
+            {"ai_function_embedding_default_credentials", "", "", "New setting: default named collection for aiEmbed when the call omits credentials."},
             {"input_format_csv_missing_nullable_as_empty_string", false, false, "New setting to read a missing value of `Nullable(String)` from CSV as an empty string instead of NULL."},
             {"use_legacy_to_time", true, false, "Use the new `toTime` function (converting values to the `Time` data type) by default instead of the legacy `toTime` (which is still available as `toTimeWithFixedDate`)."},
             {"reserve_memory", 0, 0, "New setting to reserve memory for specific workload before starting a query."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,8 +43,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"use_streaming_marks_compression", false, false, "New setting to compress marks into in-memory representation one block at a time (streaming) instead of materializing the full plain marks array, reducing peak memory during marks loading for compact parts with many substreams."},
             {"s3_validate_etag_on_read", false, true, "New setting to detect concurrent in-place overwrites of S3/GCS objects during a read by validating the GET response ETag against the listed one. previous_value=false so `compatibility` with versions before 26.7 restores the pre-existing behavior (no validation)."},
-            {"ai_function_text_default_credentials", "", "", "New setting: default named collection for the text AI functions (aiGenerate, aiClassify, aiExtract, aiTranslate) when the call omits credentials."},
-            {"ai_function_embedding_default_credentials", "", "", "New setting: default named collection for aiEmbed when the call omits credentials."},
+            {"ai_function_text_default_credentials", "", "", "New setting"},
+            {"ai_function_embedding_default_credentials", "", "", "New setting"},
             {"input_format_csv_missing_nullable_as_empty_string", false, false, "New setting to read a missing value of `Nullable(String)` from CSV as an empty string instead of NULL."},
             {"use_legacy_to_time", true, false, "Use the new `toTime` function (converting values to the `Time` data type) by default instead of the legacy `toTime` (which is still available as `toTimeWithFixedDate`)."},
             {"reserve_memory", 0, 0, "New setting to reserve memory for specific workload before starting a query."},

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -21,6 +21,7 @@
 #include <IO/ConnectionTimeouts.h>
 #include <IO/HTTPCommon.h>
 #include <IO/ReadHelpers.h>
+#include <IO/ReadBufferFromString.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
 #include <limits>
@@ -103,17 +104,13 @@ Field parseAIParamValue(AIParamKind kind, const String & raw, std::string_view n
         }
     }
 
-    /// AIParamKind::UInt
+    /// AIParamKind::UInt. Overflow-checked so a value above UInt64 max is rejected rather than
+    /// silently wrapping (e.g. "18446744073709551616" -> 0); the Int64 cap is applied on top.
     UInt64 value;
-    try
-    {
-        value = parseFromString<UInt64>(raw);
-    }
-    catch (...)
-    {
+    ReadBufferFromString buf(raw);
+    if (!tryReadIntText<ReadIntTextCheckOverflow::CHECK_OVERFLOW>(value, buf) || !buf.eof())
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "AI function parameter '{}' must be a non-negative integer, got '{}'", name, raw);
-    }
     checkUIntFitsInt64(value, name);
     return Field(value);
 }

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -350,7 +350,7 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
     /// `convertToFullColumnIfConst` unwraps the latter into the former, so a single null-map path handles both.
     ColumnPtr prompt_column;
     const ColumnNullable * prompt_nullable = nullptr;
-    if (0 < arguments.size() && arguments[0].type->isNullable())
+    if (arguments[0].type->isNullable())
     {
         prompt_column = arguments[0].column->convertToFullColumnIfConst();
         prompt_nullable = typeid_cast<const ColumnNullable *>(prompt_column.get());

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -105,7 +105,7 @@ Field parseAIParamValue(AIParamKind kind, const String & raw, std::string_view n
         case AIParamKind::UInt:
         {
             /// Special UInt64 handling to avoid potential overflow
-            UInt64 value;
+            UInt64 value = 0;
             ReadBufferFromString buf(raw);
             if (!tryReadIntText<ReadIntTextCheckOverflow::CHECK_OVERFLOW>(value, buf) || !buf.eof())
                 throw Exception(ErrorCodes::BAD_ARGUMENTS,
@@ -152,7 +152,7 @@ bool FunctionBaseAI::isStringToStringMap(const IDataType & type)
     return map_type && isString(map_type->getKeyType()) && isString(map_type->getValueType());
 }
 
-std::vector<AIParamSpec> FunctionBaseAI::commonParams()
+AIParamSpecs FunctionBaseAI::commonParams()
 {
     return {
         /// `credentials` is required, but falls back to the default-credentials setting (handled in resolveAIParams).
@@ -163,7 +163,7 @@ std::vector<AIParamSpec> FunctionBaseAI::commonParams()
     };
 }
 
-std::vector<AIParamSpec> FunctionBaseAI::allParams() const
+AIParamSpecs FunctionBaseAI::allParams() const
 {
     auto spec = commonParams();
     auto extra = functionParams();
@@ -174,7 +174,7 @@ std::vector<AIParamSpec> FunctionBaseAI::allParams() const
 namespace
 {
 
-const Field & getResolvedAIParam(const std::map<String, Field, std::less<>> & values, std::string_view key)
+const Field & getResolvedAIParam(const AIParamValues & values, std::string_view key)
 {
     auto it = values.find(key);
     chassert(it != values.end());
@@ -201,12 +201,12 @@ UInt64 FunctionBaseAI::AIParams::getUInt(std::string_view key) const
 FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
     const ContextPtr & context,
     const ColumnsWithTypeAndName & arguments,
-    const std::vector<AIParamSpec> & spec,
+    const AIParamSpecs & spec,
     const String & default_credentials)
 {
     /// The parameter map, when present, is the last argument (validated as a const Map(String, String)
     /// by getReturnTypeImpl). Read it into a plain string->string map.
-    std::map<String, String, std::less<>> map_values;
+    std::map<String, String, std::less<>> map_values; // STYLE_CHECK_ALLOW_STD_CONTAINERS
     if (!arguments.empty() && isStringToStringMap(*arguments.back().type))
     {
         const auto * map_const = typeid_cast<const ColumnConst *>(arguments.back().column.get());

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -5,6 +5,7 @@
 #include <Common/Exception.h>
 #include <Common/NetException.h>
 #include <Poco/Net/NetException.h>
+#include <algorithm>
 #include <exception>
 #include <thread>
 #include <Common/logger_useful.h>
@@ -14,12 +15,16 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeMap.h>
 #include <IO/ConnectionTimeouts.h>
 #include <IO/HTTPCommon.h>
+#include <IO/ReadHelpers.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
+#include <limits>
 
 namespace ProfileEvents
 {
@@ -44,6 +49,7 @@ namespace Setting
     extern const SettingsUInt64 ai_function_max_output_tokens_per_query;
     extern const SettingsUInt64 ai_function_max_api_calls_per_query;
     extern const SettingsBool ai_function_throw_on_quota_exceeded;
+    extern const SettingsString ai_function_text_default_credentials;
 }
 
 namespace ErrorCodes
@@ -70,6 +76,64 @@ String sanitizeTextForAI(std::string_view input)
     return output;
 }
 
+/// Providers serialize integer fields (`max_tokens`, `dimensions`) as `Int64` (Poco JSON has no
+/// UInt64). Reject values that would silently become negative after the cast.
+void checkUIntFitsInt64(UInt64 value, std::string_view name)
+{
+    if (value > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI function parameter '{}' exceeds maximum ({})",
+            name, std::numeric_limits<Int64>::max());
+}
+
+/// Parse a map value (always a string on the wire) into a `Field` of the parameter's kind.
+Field parseAIParamValue(AIParamKind kind, const String & raw, std::string_view name)
+{
+    if (kind == AIParamKind::String)
+        return Field(raw);
+
+    if (kind == AIParamKind::Float)
+    {
+        try
+        {
+            return Field(parseFromString<Float64>(raw));
+        }
+        catch (...)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI function parameter '{}' must be a number, got '{}'", name, raw);
+        }
+    }
+
+    /// AIParamKind::UInt
+    UInt64 value;
+    try
+    {
+        value = parseFromString<UInt64>(raw);
+    }
+    catch (...)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "AI function parameter '{}' must be a non-negative integer, got '{}'", name, raw);
+    }
+    checkUIntFitsInt64(value, name);
+    return Field(value);
+}
+
+/// Read a parameter's fallback value from the named collection (used when `inherit_from_collection`).
+Field readAIParamFromCollection(AIParamKind kind, const NamedCollectionPtr & collection, std::string_view name)
+{
+    const String key(name);
+    if (kind == AIParamKind::String)
+        return Field(collection->get<String>(key));
+
+    if (kind == AIParamKind::Float)
+        return Field(collection->get<Float64>(key));
+
+    /// AIParamKind::UInt
+    UInt64 value = collection->get<UInt64>(key);
+    checkUIntFitsInt64(value, name);
+    return Field(value);
+}
+
 }
 
 FunctionBaseAI::FunctionBaseAI(ContextPtr context_) : context(context_)
@@ -79,35 +143,108 @@ FunctionBaseAI::FunctionBaseAI(ContextPtr context_) : context(context_)
             "AI functions are experimental. Set `allow_experimental_ai_functions` setting to enable it");
 }
 
-FunctionBaseAI::AINamedCollectionConfig FunctionBaseAI::resolveAINamedCollection(const ContextPtr & context, const ColumnPtr & first_arg)
+bool FunctionBaseAI::isStringToStringMap(const IDataType & type)
 {
-    const auto * col_const = typeid_cast<const ColumnConst *>(first_arg.get());
-    if (!col_const)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "First argument to AI function must be a named collection (constant String)");
+    const auto * map_type = typeid_cast<const DataTypeMap *>(&type);
+    return map_type && isString(map_type->getKeyType()) && isString(map_type->getValueType());
+}
 
-    AINamedCollectionConfig config;
-    config.collection_name = col_const->getValue<String>();
+std::vector<AIParamSpec> FunctionBaseAI::commonParams()
+{
+    return {
+        /// `credentials` is required, but falls back to the default-credentials setting (handled in resolveAIParams).
+        {"credentials", AIParamKind::String, std::nullopt},
+        /// `model` is required, but is normally supplied by the named collection.
+        {"model", AIParamKind::String, std::nullopt, /*inherit_from_collection=*/ true},
+        {"max_tokens", AIParamKind::UInt, Field(DEFAULT_AI_MAX_TOKENS), /*inherit_from_collection=*/ true},
+    };
+}
 
-    context->checkAccess(AccessType::NAMED_COLLECTION, config.collection_name);
+std::vector<AIParamSpec> FunctionBaseAI::allParams() const
+{
+    auto spec = commonParams();
+    auto extra = functionParams();
+    spec.insert(spec.end(), extra.begin(), extra.end());
+    return spec;
+}
 
-    const auto & named_collection = NamedCollectionFactory::instance().get(config.collection_name);
+FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
+    const ContextPtr & context,
+    const ColumnsWithTypeAndName & arguments,
+    const std::vector<AIParamSpec> & spec,
+    const String & default_credentials)
+{
+    /// The parameter map, when present, is the last argument (validated as a const Map(String, String)
+    /// by getReturnTypeImpl). Read it into a plain string->string map.
+    std::map<String, String, std::less<>> map_values;
+    if (!arguments.empty() && isStringToStringMap(*arguments.back().type))
+    {
+        const auto * map_const = typeid_cast<const ColumnConst *>(arguments.back().column.get());
+        if (!map_const)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI function parameter map must be a constant");
 
-    config.provider = named_collection->getOrDefault<String>("provider", "");
-    config.endpoint = named_collection->getOrDefault<String>("endpoint", "");
-    config.model = named_collection->getOrDefault<String>("model", "");
-    config.api_key = named_collection->getOrDefault<String>("api_key", "");
-    config.api_version = named_collection->getOrDefault<String>("api_version", "");
+        const Map & map = (*map_const->getDataColumnPtr())[0].safeGet<Map>();
+        for (const auto & element : map)
+        {
+            const Tuple & kv = element.safeGet<Tuple>();
+            map_values[kv[0].safeGet<String>()] = kv[1].safeGet<String>();
+        }
+    }
 
-    if (config.provider.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'provider'", config.collection_name);
-    if (config.endpoint.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'endpoint'", config.collection_name);
-    if (config.model.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'model'", config.collection_name);
+    /// Reject unknown keys so typos surface immediately instead of being silently ignored.
+    for (const auto & [key, _] : map_values)
+    {
+        bool known = std::any_of(spec.begin(), spec.end(), [&](const AIParamSpec & p) { return p.name == key; });
+        if (!known)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown AI function parameter '{}'", key);
+    }
 
-    context->getRemoteHostFilter().checkURL(Poco::URI(config.endpoint));
+    /// Resolve credentials first: they name the collection everything else is read from.
+    String credentials;
+    if (auto it = map_values.find("credentials"); it != map_values.end())
+        credentials = it->second;
+    else
+        credentials = default_credentials;
 
-    return config;
+    if (credentials.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "AI function requires credentials: pass 'credentials' in the parameter map or set the default-credentials setting");
+
+    context->checkAccess(AccessType::NAMED_COLLECTION, credentials);
+    const auto & collection = NamedCollectionFactory::instance().get(credentials);
+
+    AIParams params;
+    params.collection.collection_name = credentials;
+    params.collection.provider = collection->getOrDefault<String>("provider", "");
+    params.collection.endpoint = collection->getOrDefault<String>("endpoint", "");
+    params.collection.api_key = collection->getOrDefault<String>("api_key", "");
+    params.collection.api_version = collection->getOrDefault<String>("api_version", "");
+
+    if (params.collection.provider.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'provider'", credentials);
+    if (params.collection.endpoint.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'endpoint'", credentials);
+
+    context->getRemoteHostFilter().checkURL(Poco::URI(params.collection.endpoint));
+
+    /// Resolve every declared parameter: map override -> named collection (if inherited) -> default.
+    for (const auto & p : spec)
+    {
+        if (p.name == "credentials")
+            continue;
+
+        if (auto it = map_values.find(p.name); it != map_values.end())
+            params.values.emplace(String(p.name), parseAIParamValue(p.kind, it->second, p.name));
+        else if (p.inherit_from_collection && collection->has(String(p.name)))
+            params.values.emplace(String(p.name), readAIParamFromCollection(p.kind, collection, p.name));
+        else if (p.default_value)
+            params.values.emplace(String(p.name), *p.default_value);
+        else
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "AI named collection '{}' must have '{}', or it must be passed in the parameter map", credentials, p.name);
+    }
+
+    return params;
 }
 
 UInt64 FunctionBaseAI::computeRetryBackoffMs(UInt64 initial_delay_ms, UInt64 attempt)
@@ -158,70 +295,35 @@ bool FunctionBaseAI::isRetriableProviderError(std::exception_ptr exception)
     }
 }
 
-FunctionBaseAI::ResolvedConfig FunctionBaseAI::resolveConfig(const ColumnsWithTypeAndName & arguments) const
-{
-    auto base = resolveAINamedCollection(getContext(), arguments[0].column);
-
-    ResolvedConfig config;
-    config.provider = std::move(base.provider);
-    config.endpoint = std::move(base.endpoint);
-    config.model = std::move(base.model);
-    config.api_key = std::move(base.api_key);
-    config.api_version = std::move(base.api_version);
-    config.temperature = defaultTemperature();
-
-    const auto & named_collection = NamedCollectionFactory::instance().get(base.collection_name);
-    config.max_tokens = named_collection->getOrDefault<UInt64>("max_tokens", DEFAULT_AI_MAX_TOKENS);
-
-    /// Poco JSON does not support UInt64, so providers cast max_tokens to Int64 for serialization.
-    if (config.max_tokens > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}': max_tokens exceeds maximum ({})",
-            base.collection_name, std::numeric_limits<Int64>::max());
-
-    return config;
-}
-
-float FunctionBaseAI::resolveTemperature(const ColumnsWithTypeAndName & arguments, const ResolvedConfig & config) const
-{
-    size_t temp_idx = temperatureArgumentIndex();
-    if (temp_idx < arguments.size() && isNumber(arguments[temp_idx].type))
-    {
-        const auto * col_const = typeid_cast<const ColumnConst *>(arguments[temp_idx].column.get());
-        if (col_const)
-            return static_cast<float>(col_const->getFloat64(0));
-    }
-
-    return config.temperature;
-}
-
 ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const
 {
-    auto config = resolveConfig(arguments);
+    const auto & settings = getContext()->getSettingsRef();
+    auto params = resolveAIParams(getContext(), arguments, allParams(), settings[Setting::ai_function_text_default_credentials]);
+
+    String model = params.getString("model");
+    UInt64 max_tokens = params.getUInt("max_tokens");
+    float temperature = static_cast<float>(params.getFloat("temperature"));
 
     /// Row-independent validation must run before the zero-row fast path so malformed constant
     /// arguments fail consistently regardless of source size.
     checkSanityBeforeExecuteImpl(arguments, result_type, input_rows_count);
-    String system_prompt = sanitizeTextForAI(buildSystemPrompt(arguments));
+    String system_prompt = sanitizeTextForAI(buildSystemPrompt(arguments, params));
     auto response_format = buildResponseFormat(arguments);
-    auto provider = createAIProvider(config.provider, config.endpoint, config.api_key, config.api_version);
+    auto provider = createAIProvider(params.collection.provider, params.collection.endpoint, params.collection.api_key, params.collection.api_version);
 
     if (input_rows_count == 0)
         return result_type->createColumn();
 
     /// A Nullable prompt can arrive as `ColumnNullable` or as `ColumnConst(ColumnNullable)` (e.g. `NULL::Nullable(String)`).
     /// `convertToFullColumnIfConst` unwraps the latter into the former, so a single null-map path handles both.
-    size_t prompt_idx = promptArgumentIndex();
     ColumnPtr prompt_column;
     const ColumnNullable * prompt_nullable = nullptr;
-    if (prompt_idx < arguments.size() && arguments[prompt_idx].type->isNullable())
+    if (PROMPT_ARG_INDEX < arguments.size() && arguments[PROMPT_ARG_INDEX].type->isNullable())
     {
-        prompt_column = arguments[prompt_idx].column->convertToFullColumnIfConst();
+        prompt_column = arguments[PROMPT_ARG_INDEX].column->convertToFullColumnIfConst();
         prompt_nullable = typeid_cast<const ColumnNullable *>(prompt_column.get());
     }
 
-    float temperature = resolveTemperature(arguments, config);
-
-    const auto & settings = getContext()->getSettingsRef();
     UInt64 timeout_sec = settings[Setting::ai_function_request_timeout_sec].value;
     UInt64 max_retries = settings[Setting::ai_function_max_retries].value;
     UInt64 retry_delay_ms = settings[Setting::ai_function_retry_initial_delay_ms].value;
@@ -279,9 +381,9 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
                 ai_request.system_prompt = system_prompt;
                 ai_request.user_message = user_message;
                 ai_request.response_format = response_format;
-                ai_request.model = config.model;
+                ai_request.model = model;
                 ai_request.temperature = temperature;
-                ai_request.max_tokens = config.max_tokens;
+                ai_request.max_tokens = max_tokens;
 
                 /// update api_calls/quotas before call so failed calls are still added to total
                 ++total_api_calls;

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -350,9 +350,9 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
     /// `convertToFullColumnIfConst` unwraps the latter into the former, so a single null-map path handles both.
     ColumnPtr prompt_column;
     const ColumnNullable * prompt_nullable = nullptr;
-    if (PROMPT_ARG_INDEX < arguments.size() && arguments[PROMPT_ARG_INDEX].type->isNullable())
+    if (0 < arguments.size() && arguments[0].type->isNullable())
     {
-        prompt_column = arguments[PROMPT_ARG_INDEX].column->convertToFullColumnIfConst();
+        prompt_column = arguments[0].column->convertToFullColumnIfConst();
         prompt_nullable = typeid_cast<const ColumnNullable *>(prompt_column.get());
     }
 

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -15,7 +15,6 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnConst.h>
-#include <Columns/ColumnMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeMap.h>
@@ -56,6 +55,7 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int SUPPORT_IS_DISABLED;
+    extern const int LOGICAL_ERROR;
 }
 
 namespace
@@ -168,6 +168,34 @@ std::vector<AIParamSpec> FunctionBaseAI::allParams() const
     return spec;
 }
 
+namespace
+{
+
+const Field & getResolvedAIParam(const std::map<String, Field, std::less<>> & values, std::string_view key)
+{
+    auto it = values.find(key);
+    if (it == values.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "AI function parameter '{}' was not resolved", key);
+    return it->second;
+}
+
+}
+
+String FunctionBaseAI::AIParams::getString(std::string_view key) const
+{
+    return getResolvedAIParam(values, key).safeGet<String>();
+}
+
+Float64 FunctionBaseAI::AIParams::getFloat(std::string_view key) const
+{
+    return getResolvedAIParam(values, key).safeGet<Float64>();
+}
+
+UInt64 FunctionBaseAI::AIParams::getUInt(std::string_view key) const
+{
+    return getResolvedAIParam(values, key).safeGet<UInt64>();
+}
+
 FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
     const ContextPtr & context,
     const ColumnsWithTypeAndName & arguments,
@@ -187,7 +215,9 @@ FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
         for (const auto & element : map)
         {
             const Tuple & kv = element.safeGet<Tuple>();
-            map_values[kv[0].safeGet<String>()] = kv[1].safeGet<String>();
+            const String & key = kv[0].safeGet<String>();
+            if (!map_values.emplace(key, kv[1].safeGet<String>()).second)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Duplicate AI function parameter '{}' in the parameter map", key);
         }
     }
 

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <exception>
 #include <thread>
+#include <utility>
 #include <Common/logger_useful.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
 #include <Common/RemoteHostFilter.h>
@@ -56,7 +57,6 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int SUPPORT_IS_DISABLED;
-    extern const int LOGICAL_ERROR;
 }
 
 namespace
@@ -86,49 +86,55 @@ void checkUIntFitsInt64(UInt64 value, std::string_view name)
             name, std::numeric_limits<Int64>::max());
 }
 
-/// Parse a map value (always a string on the wire) into a `Field` of the parameter's kind.
+/// Parse a map value (string) into a `Field` of the parameter's kind.
 Field parseAIParamValue(AIParamKind kind, const String & raw, std::string_view name)
 {
-    if (kind == AIParamKind::String)
-        return Field(raw);
-
-    if (kind == AIParamKind::Float)
+    switch (kind)
     {
-        try
+        case AIParamKind::String:
+            return Field(raw);
+        case AIParamKind::Float:
+            try
+            {
+                return Field(parseFromString<Float64>(raw));
+            }
+            catch (...)
+            {
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI function parameter '{}' must be a number, got '{}'", name, raw);
+            }
+        case AIParamKind::UInt:
         {
-            return Field(parseFromString<Float64>(raw));
-        }
-        catch (...)
-        {
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI function parameter '{}' must be a number, got '{}'", name, raw);
+            /// Special UInt64 handling to avoid potential overflow
+            UInt64 value;
+            ReadBufferFromString buf(raw);
+            if (!tryReadIntText<ReadIntTextCheckOverflow::CHECK_OVERFLOW>(value, buf) || !buf.eof())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "AI function parameter '{}' must be a non-negative integer, got '{}'", name, raw);
+            checkUIntFitsInt64(value, name);
+            return Field(value);
         }
     }
-
-    /// AIParamKind::UInt. Overflow-checked so a value above UInt64 max is rejected rather than
-    /// silently wrapping (e.g. "18446744073709551616" -> 0); the Int64 cap is applied on top.
-    UInt64 value;
-    ReadBufferFromString buf(raw);
-    if (!tryReadIntText<ReadIntTextCheckOverflow::CHECK_OVERFLOW>(value, buf) || !buf.eof())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-            "AI function parameter '{}' must be a non-negative integer, got '{}'", name, raw);
-    checkUIntFitsInt64(value, name);
-    return Field(value);
+    std::unreachable();
 }
 
 /// Read a parameter's fallback value from the named collection (used when `inherit_from_collection`).
 Field readAIParamFromCollection(AIParamKind kind, const NamedCollectionPtr & collection, std::string_view name)
 {
     const String key(name);
-    if (kind == AIParamKind::String)
-        return Field(collection->get<String>(key));
-
-    if (kind == AIParamKind::Float)
-        return Field(collection->get<Float64>(key));
-
-    /// AIParamKind::UInt
-    UInt64 value = collection->get<UInt64>(key);
-    checkUIntFitsInt64(value, name);
-    return Field(value);
+    switch (kind)
+    {
+        case AIParamKind::String:
+            return Field(collection->get<String>(key));
+        case AIParamKind::Float:
+            return Field(collection->get<Float64>(key));
+        case AIParamKind::UInt:
+        {
+            UInt64 value = collection->get<UInt64>(key);
+            checkUIntFitsInt64(value, name);
+            return Field(value);
+        }
+    }
+    std::unreachable();
 }
 
 }
@@ -171,8 +177,7 @@ namespace
 const Field & getResolvedAIParam(const std::map<String, Field, std::less<>> & values, std::string_view key)
 {
     auto it = values.find(key);
-    if (it == values.end())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "AI function parameter '{}' was not resolved", key);
+    chassert(it != values.end());
     return it->second;
 }
 

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -140,9 +140,6 @@ public:
     static bool isRetriableProviderError(std::exception_ptr exception);
 
 protected:
-    /// The per-row text (prompt/`text`) is always the first positional argument.
-    static constexpr size_t PROMPT_ARG_INDEX = 0;
-
     ContextPtr context;
     ContextPtr getContext() const { return context; }
 

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -20,8 +20,9 @@ namespace DB
 
 static constexpr UInt64 DEFAULT_AI_MAX_TOKENS = 1024;
 
-/// Value kind of an AI-function parameter. Map values are always strings on the wire; the kind
-/// tells the resolver how to parse each one (and how to read the same key from a named collection).
+/// Logical type of an AI-function parameter. The parameter map is `Map(String, String)`, so every
+/// value arrives as a `String`; the kind tells the resolver how to parse each one into its real type
+/// (and how to read the same key from a named collection).
 enum class AIParamKind
 {
     String,

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -44,6 +44,11 @@ struct AIParamSpec
     bool inherit_from_collection = false;
 };
 
+/// Small, short-lived config containers (a handful of entries, not user-data-scaled), so the
+/// default allocator is fine and a memory-tracking variant would add nothing.
+using AIParamSpecs = std::vector<AIParamSpec>; // STYLE_CHECK_ALLOW_STD_CONTAINERS
+using AIParamValues = std::map<String, Field, std::less<>>; // STYLE_CHECK_ALLOW_STD_CONTAINERS
+
 class FunctionBaseAI : public IFunction
 {
 public:
@@ -96,7 +101,7 @@ public:
     struct AIParams
     {
         AINamedCollectionConfig collection;
-        std::map<String, Field, std::less<>> values;
+        AIParamValues values;
 
         bool has(std::string_view key) const { return values.contains(key); }
 
@@ -119,11 +124,11 @@ public:
     static AIParams resolveAIParams(
         const ContextPtr & context,
         const ColumnsWithTypeAndName & arguments,
-        const std::vector<AIParamSpec> & spec,
+        const AIParamSpecs & spec,
         const String & default_credentials);
 
     /// Parameters common to every AI function. Function-specific params are appended by `functionParams`.
-    static std::vector<AIParamSpec> commonParams();
+    static AIParamSpecs commonParams();
 
     /// Exponential backoff delay capped at one minute, so adversarial values of
     /// `ai_function_retry_initial_delay_ms` or `ai_function_max_retries` cannot produce a multi-hour
@@ -145,7 +150,7 @@ protected:
 
     /// Function-specific parameters accepted in the trailing `Map(String, String)` argument, on top
     /// of `commonParams`. Each entry carries its own default (or is required). Default: none.
-    virtual std::vector<AIParamSpec> functionParams() const { return {}; }
+    virtual AIParamSpecs functionParams() const { return {}; }
 
     /// Performs additional validation of the input arguments.
     virtual void checkSanityBeforeExecuteImpl(const ColumnsWithTypeAndName & /*arguments*/, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const {}
@@ -164,7 +169,7 @@ protected:
 
 private:
     /// Full parameter spec for this function: `commonParams` followed by `functionParams`.
-    std::vector<AIParamSpec> allParams() const;
+    AIParamSpecs allParams() const;
 };
 
 }

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -6,13 +6,42 @@
 #include <Functions/AI/AIQuotaTracker.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Interpreters/Context.h>
+#include <Core/Field.h>
 
 #include <exception>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string_view>
+#include <vector>
 
 namespace DB
 {
 
 static constexpr UInt64 DEFAULT_AI_MAX_TOKENS = 1024;
+
+/// Value kind of an AI-function parameter. Map values are always strings on the wire; the kind
+/// tells the resolver how to parse each one (and how to read the same key from a named collection).
+enum class AIParamKind
+{
+    String,
+    Float,
+    UInt,
+};
+
+/// Declarative description of one parameter an AI function accepts in its trailing
+/// `Map(String, String)` argument. Each function declares its own params; `FunctionBaseAI`
+/// contributes the common ones (`credentials`, `model`, `max_tokens`).
+struct AIParamSpec
+{
+    std::string_view name;
+    AIParamKind kind;
+    /// `std::nullopt` => required: the resolver throws if the key is absent everywhere.
+    std::optional<Field> default_value;
+    /// When true, a missing map key falls back to the same-named field of the named collection
+    /// before falling back to `default_value` (e.g. `model`, `max_tokens`).
+    bool inherit_from_collection = false;
+};
 
 class FunctionBaseAI : public IFunction
 {
@@ -49,22 +78,48 @@ public:
             return inner;
     }
 
-    /// Fields read from the named collection that every AI function needs. Function-specific knobs
-    /// (max_tokens, temperature, dimensions, …) are layered on top by individual callers.
+    /// Connection fields read from the named collection. `model` is resolved separately as a
+    /// parameter (it may be overridden via the map), so it is not part of the connection config.
     struct AINamedCollectionConfig
     {
         String collection_name;
         String provider;
         String endpoint;
-        String model;
         String api_key;
         String api_version;
     };
 
-    /// Resolve the named-collection argument: cast the first argument to a `ColumnConst`, run the
-    /// `NAMED_COLLECTION` access check, fetch from `NamedCollectionFactory`, and validate that the
-    /// required fields (`provider`, `endpoint`, `model`) are non-empty. `api_key` is optional.
-    static AINamedCollectionConfig resolveAINamedCollection(const ContextPtr & context, const ColumnPtr & first_arg);
+    /// Resolved parameters for one AI-function call: the named-collection connection config plus the
+    /// per-parameter values (map override -> named collection -> declared default). Only keys that
+    /// resolved to a value are present; `has` distinguishes "absent" from "set to empty string".
+    struct AIParams
+    {
+        AINamedCollectionConfig collection;
+        std::map<String, Field, std::less<>> values;
+
+        bool has(std::string_view key) const { return values.contains(key); }
+        String getString(std::string_view key) const { return values.at(String(key)).safeGet<String>(); }
+        Float64 getFloat(std::string_view key) const { return values.at(String(key)).safeGet<Float64>(); }
+        UInt64 getUInt(std::string_view key) const { return values.at(String(key)).safeGet<UInt64>(); }
+    };
+
+    /// Type validator for the optional trailing parameter argument: a `Map(String, String)`.
+    static bool isStringToStringMap(const IDataType & type);
+
+    /// Resolve the trailing `Map(String, String)` argument (if any) against `spec`:
+    ///  - reject any map key not declared in `spec`;
+    ///  - resolve `credentials` (map key -> `default_credentials` -> throw), then load and
+    ///    access-check the named collection and validate `provider`/`endpoint`;
+    ///  - resolve every other spec entry: map override -> (if `inherit_from_collection`) named
+    ///    collection field -> `default_value` -> throw when required and absent.
+    static AIParams resolveAIParams(
+        const ContextPtr & context,
+        const ColumnsWithTypeAndName & arguments,
+        const std::vector<AIParamSpec> & spec,
+        const String & default_credentials);
+
+    /// Parameters common to every AI function. Function-specific params are appended by `functionParams`.
+    static std::vector<AIParamSpec> commonParams();
 
     /// Exponential backoff delay capped at one minute, so adversarial values of
     /// `ai_function_retry_initial_delay_ms` or `ai_function_max_retries` cannot produce a multi-hour
@@ -76,21 +131,23 @@ public:
     static bool isRetriableProviderError(std::exception_ptr exception);
 
 protected:
+    /// The per-row text (prompt/`text`) is always the first positional argument.
+    static constexpr size_t PROMPT_ARG_INDEX = 0;
+
     ContextPtr context;
     ContextPtr getContext() const { return context; }
 
     virtual String functionName() const = 0;
 
-    /// Temperature controls the randomness or noise of the response. The accepted values depend on the AI provider
-    /// (0.0 - 2.0 for OpenAI, 0.0 - 1.0 for Anthropic). Lower is better for more deterministic tasks, while
-    /// a higher value is useful for creative tasks, such as chatting or text generation.
-    virtual float defaultTemperature() const = 0;
+    /// Function-specific parameters accepted in the trailing `Map(String, String)` argument, on top
+    /// of `commonParams`. Each entry carries its own default (or is required). Default: none.
+    virtual std::vector<AIParamSpec> functionParams() const { return {}; }
 
     /// Performs additional validation of the input arguments.
     virtual void checkSanityBeforeExecuteImpl(const ColumnsWithTypeAndName & /*arguments*/, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const {}
 
     /// A system prompt  applies to each request. AI funcs will probably want to provide a default on a per-function basis.
-    virtual String buildSystemPrompt(const ColumnsWithTypeAndName & arguments) const = 0;
+    virtual String buildSystemPrompt(const ColumnsWithTypeAndName & arguments, const AIParams & params) const = 0;
 
     /// The user prompt is appended to the system prompt, this is usually what is contained in each row.
     virtual String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const = 0;
@@ -101,26 +158,9 @@ protected:
 
     virtual String postProcessResponse(const String & raw_response) const { return raw_response; }
 
-    /// Index of the per-row text column in the arguments list.
-    virtual size_t promptArgumentIndex() const = 0;
-
-    /// Index of the temperature argument. Return 0 if the function doesn't accept temperature.
-    virtual size_t temperatureArgumentIndex() const = 0;
-
 private:
-    struct ResolvedConfig
-    {
-        String provider;
-        String endpoint;
-        String model;
-        String api_key;
-        String api_version;
-        float temperature = 0;
-        UInt64 max_tokens = 0;
-    };
-
-    ResolvedConfig resolveConfig(const ColumnsWithTypeAndName & arguments) const;
-    float resolveTemperature(const ColumnsWithTypeAndName & arguments, const ResolvedConfig & config) const;
+    /// Full parameter spec for this function: `commonParams` followed by `functionParams`.
+    std::vector<AIParamSpec> allParams() const;
 };
 
 }

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -98,9 +98,12 @@ public:
         std::map<String, Field, std::less<>> values;
 
         bool has(std::string_view key) const { return values.contains(key); }
-        String getString(std::string_view key) const { return values.at(String(key)).safeGet<String>(); }
-        Float64 getFloat(std::string_view key) const { return values.at(String(key)).safeGet<Float64>(); }
-        UInt64 getUInt(std::string_view key) const { return values.at(String(key)).safeGet<UInt64>(); }
+
+        /// A missing key is a programming error (the spec guarantees resolution): these throw a
+        /// `DB::Exception` rather than `std::map::at`'s `std::out_of_range`.
+        String getString(std::string_view key) const;
+        Float64 getFloat(std::string_view key) const;
+        UInt64 getUInt(std::string_view key) const;
     };
 
     /// Type validator for the optional trailing parameter argument: a `Map(String, String)`.

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -105,8 +105,6 @@ public:
 
         bool has(std::string_view key) const { return values.contains(key); }
 
-        /// A missing key is a programming error (the spec guarantees resolution): these throw a
-        /// `DB::Exception` rather than `std::map::at`'s `std::out_of_range`.
         String getString(std::string_view key) const;
         Float64 getFloat(std::string_view key) const;
         UInt64 getUInt(std::string_view key) const;

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -47,29 +47,27 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors mandatory_args{
-            {"collection", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
             {"categories", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArrayOfStrings), &isColumnConst, "const Array(String)"},
         };
         FunctionArgumentDescriptors optional_args{
-            {"temperature", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), &isColumnConst, "const Number"},
+            {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, prompt_arg_index, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
     }
 
 private:
     static constexpr float default_temp = 0.0f;
-    static constexpr size_t prompt_arg_index = 1;
-    static constexpr size_t categories_arg_index = 2;
-    static constexpr size_t temp_arg_idx = 3;
+    static constexpr size_t categories_arg_index = 1;
 
     String functionName() const override { return name; }
 
-    float defaultTemperature() const override { return default_temp; }
-    size_t promptArgumentIndex() const override { return prompt_arg_index; }
-    size_t temperatureArgumentIndex() const override { return temp_arg_idx; }
+    std::vector<AIParamSpec> functionParams() const override
+    {
+        return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};
+    }
 
     void checkSanityBeforeExecuteImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const override
     {
@@ -81,7 +79,7 @@ private:
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "aiClassify: 'categories' must contain at least one label");
     }
 
-    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments) const override
+    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments, const AIParams &) const override
     {
         const auto & col_categories = assert_cast<const ColumnConst &>(*arguments[categories_arg_index].column);
         auto categories = (*col_categories.getDataColumnPtr())[0].safeGet<Array>();
@@ -103,7 +101,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[prompt_arg_index].column->getDataAt(row));
+        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
     }
 
     /// Builds the OpenAI `response_format` schema object constraining the model to output one of the
@@ -192,19 +190,20 @@ The function sends the text together with a fixed classification prompt and a JS
 constraining the model to return exactly one of the supplied labels. When the response is returned as a JSON
 object of the form `{"category": "..."}`, the label is unwrapped and the label string is returned.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
+Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
+are taken from the `credentials` key of the optional parameter map, or from the
+`ai_function_text_default_credentials` setting when the map omits it.
 )",
-        .syntax = "aiClassify(collection, text, categories[, temperature])",
+        .syntax = "aiClassify(text, categories[, params])",
         .arguments = {
-            {"collection", "Name of a named collection containing provider credentials and configuration.", {"String"}},
             {"text", "Text to classify.", {"String"}},
             {"categories", "Constant list of candidate category labels.", {"Array(String)"}},
-            {"temperature", "Sampling temperature controlling randomness. Default: `0.0`.", {"Float64"}},
+            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
         },
         .returned_value = {"One of the provided category labels, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {
-            {"Classify sentiment", "SELECT aiClassify('ai_credentials', 'I love this product!', ['positive', 'negative', 'neutral'])", "positive"},
-            {"Classify a column", "SELECT body, aiClassify('ai_credentials', body, ['bug', 'question', 'feature']) AS kind FROM issues LIMIT 5", ""},
+            {"Classify sentiment", "SELECT aiClassify('I love this product!', ['positive', 'negative', 'neutral'])", "positive"},
+            {"Classify a column with explicit credentials", "SELECT body, aiClassify(body, ['bug', 'question', 'feature'], map('credentials', 'ai_credentials')) AS kind FROM issues LIMIT 5", ""},
         },
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -203,7 +203,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .returned_value = {"One of the provided category labels, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {
             {"Classify sentiment", "SELECT aiClassify('I love this product!', ['positive', 'negative', 'neutral'])", "positive"},
-            {"Classify a column with explicit credentials", "SELECT body, aiClassify(body, ['bug', 'question', 'feature'], map('credentials', 'ai_credentials')) AS kind FROM issues LIMIT 5", ""},
+            {"Classify a column with explicit credentials", "SELECT body, aiClassify(body, ['bug', 'question', 'feature'], map('credentials', 'ai_text_credentials')) AS kind FROM issues LIMIT 5", ""},
         },
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -198,7 +198,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to classify.", {"String"}},
             {"categories", "Constant list of candidate category labels.", {"Array(String)"}},
-            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.0`).", {"Map(String, String)"}},
         },
         .returned_value = {"One of the provided category labels, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -64,7 +64,7 @@ private:
 
     String functionName() const override { return name; }
 
-    std::vector<AIParamSpec> functionParams() const override
+    AIParamSpecs functionParams() const override
     {
         return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};
     }

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -55,7 +55,7 @@ public:
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, 0, std::make_shared<DataTypeString>());
     }
 
 private:
@@ -101,7 +101,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
+        return String(arguments[0].column->getDataAt(row));
     }
 
     /// Builds the OpenAI `response_format` schema object constraining the model to output one of the

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -198,7 +198,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to classify.", {"String"}},
             {"categories", "Constant list of candidate category labels.", {"Array(String)"}},
-            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.0`).", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `temperature` (sampling temperature controlling randomness; default `0.0`), `max_tokens` (maximum output tokens per call; default `1024`). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}},
         },
         .returned_value = {"One of the provided category labels, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -50,11 +50,11 @@ namespace Setting
     extern const SettingsUInt64 ai_function_max_api_calls_per_query;
     extern const SettingsBool ai_function_throw_on_quota_exceeded;
     extern const SettingsNonZeroUInt64 ai_function_embedding_max_batch_size;
+    extern const SettingsString ai_function_embedding_default_credentials;
 }
 
 namespace ErrorCodes
 {
-    extern const int BAD_ARGUMENTS;
     extern const int NOT_IMPLEMENTED;
     extern const int SUPPORT_IS_DISABLED;
 }
@@ -98,44 +98,45 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors mandatory_args{
-            {"collection", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
         };
         FunctionArgumentDescriptors optional_args{
-            {"dimensions", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNativeUInt), &isColumnConst, "const UInt"},
+            {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeFloat32>());
     }
 
+    /// Parameters accepted in the trailing `Map(String, String)` argument. `aiEmbed` does not inherit
+    /// `FunctionBaseAI`, so it declares its own spec (no `max_tokens`, which embeddings do not use).
+    static std::vector<AIParamSpec> embeddingParams()
+    {
+        return {
+            {"credentials", AIParamKind::String, std::nullopt},
+            {"model", AIParamKind::String, std::nullopt, /*inherit_from_collection=*/ true},
+            {"dimensions", AIParamKind::UInt, Field(UInt64(0))},
+        };
+    }
+
     ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
     {
-        auto nc = FunctionBaseAI::resolveAINamedCollection(getContext(), arguments[0].column);
+        const auto & settings = getContext()->getSettingsRef();
+        auto params = FunctionBaseAI::resolveAIParams(
+            getContext(), arguments, embeddingParams(), settings[Setting::ai_function_embedding_default_credentials]);
 
-        UInt64 dimensions = 0;
-        if (arguments.size() > 2)
-        {
-            const auto * dim_const = typeid_cast<const ColumnConst *>(arguments[2].column.get());
-            chassert(dim_const, "dimensions must be a constant UInt (validated by getReturnTypeImpl)");
-            dimensions = dim_const->getUInt(0);
+        UInt64 dimensions = params.getUInt("dimensions");
+        String model = params.getString("model");
 
-            /// Providers serialize `dimensions` as Int64 (Poco JSON does not support UInt64).
-            /// Reject values that would silently become negative after the cast.
-            if (dimensions > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "aiEmbed: 'dimensions' exceeds maximum ({})",
-                    std::numeric_limits<Int64>::max());
-        }
-
-        auto provider = createAIProvider(nc.provider, nc.endpoint, nc.api_key, nc.api_version);
+        auto provider = createAIProvider(
+            params.collection.provider, params.collection.endpoint, params.collection.api_key, params.collection.api_version);
         if (!provider->supportsEmbeddings())
             throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                "AI provider '{}' does not support embeddings", nc.provider);
+                "AI provider '{}' does not support embeddings", params.collection.provider);
 
         if (input_rows_count == 0)
             return result_type->createColumn();
 
-        const auto & settings = getContext()->getSettingsRef();
         UInt64 timeout_sec = settings[Setting::ai_function_request_timeout_sec].value;
         UInt64 max_retries = settings[Setting::ai_function_max_retries].value;
         UInt64 retry_delay_ms = settings[Setting::ai_function_retry_initial_delay_ms].value;
@@ -206,7 +207,7 @@ public:
             size_t batch_end = std::min(batch_start + max_batch_size, live_rows.size());
 
             AIEmbeddingRequest ai_embedding_request;
-            ai_embedding_request.model = nc.model;
+            ai_embedding_request.model = model;
             ai_embedding_request.dimensions = dimensions;
             ai_embedding_request.inputs.reserve(batch_end - batch_start);
 
@@ -286,7 +287,7 @@ public:
     }
 
 private:
-    static constexpr size_t text_arg_index = 1;
+    static constexpr size_t text_arg_index = 0;
 
     ContextPtr context;
     ContextPtr getContext() const { return context; }
@@ -305,20 +306,24 @@ Within a single block of rows, inputs are grouped into batches of up to
 [`ai_function_embedding_max_batch_size`](/operations/settings/settings#ai_function_embedding_max_batch_size)
 entries per HTTP request to reduce per-call overhead.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
-The optional `dimensions` argument, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
+Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
+are taken from the `credentials` key of the optional parameter map, or from the
+`ai_function_embedding_default_credentials` setting when the map omits it. Note that `aiEmbed` uses a
+separate default-credentials setting from the text functions, since an embeddings endpoint and model
+differ from a chat one.
+
+The optional `dimensions` parameter, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.
 )",
-        .syntax = "aiEmbed(collection, text[, dimensions])",
+        .syntax = "aiEmbed(text[, params])",
         .arguments
-        = {{"collection", "Name of a named collection containing provider credentials and configuration.", {"String"}},
-           {"text", "Text to embed.", {"String"}},
-           {"dimensions", "Optional target dimensionality for the output vector. `0` or omitted means the model's native size.", {"UInt64"}}},
+        = {{"text", "Text to embed.", {"String"}},
+           {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `dimensions`, `model`.", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
-        = {{"Embed a single string", "SELECT aiEmbed('ai_credentials', 'Hello world')", ""},
-           {"With explicit dimensions", "SELECT aiEmbed('ai_credentials', 'Hello world', 256)", ""},
-           {"Embed a column of texts", "SELECT aiEmbed('ai_credentials', title, 256) FROM articles LIMIT 10", ""}},
+        = {{"Embed a single string", "SELECT aiEmbed('Hello world')", ""},
+           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('dimensions', '256'))", ""},
+           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embed_credentials', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
         .introduced_in = {26, 6},
         .category = FunctionDocumentation::Category::AI});
 }

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -318,7 +318,7 @@ requests a vector of the given size; otherwise the model's native size is return
         .syntax = "aiEmbed(text[, params])",
         .arguments
         = {{"text", "Text to embed.", {"String"}},
-           {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_embedding_default_credentials` setting), `model` (overrides the collection's model), `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size).", {"Map(String, String)"}}},
+           {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
         = {{"Embed a single string", "SELECT aiEmbed('Hello world')", ""},

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -110,7 +110,7 @@ public:
 
     /// Parameters accepted in the trailing `Map(String, String)` argument. `aiEmbed` does not inherit
     /// `FunctionBaseAI`, so it declares its own spec (no `max_tokens`, which embeddings do not use).
-    static std::vector<AIParamSpec> embeddingParams()
+    static AIParamSpecs embeddingParams()
     {
         return {
             {"credentials", AIParamKind::String, std::nullopt},

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -321,9 +321,9 @@ requests a vector of the given size; otherwise the model's native size is return
            {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
-        = {{"Embed a single string", "SELECT aiEmbed('Hello world')", ""},
-           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('dimensions', '256'))", ""},
-           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embed_credentials', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
+        = {{"Embed a single string (map parameter can be omitted if the `ai_function_embedding_default_credentials` setting is set)", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials'))", ""},
+           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'dimensions', '256'))", ""},
+           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embedding_credentials', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
         .introduced_in = {26, 6},
         .category = FunctionDocumentation::Category::AI});
 }

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -318,7 +318,7 @@ requests a vector of the given size; otherwise the model's native size is return
         .syntax = "aiEmbed(text[, params])",
         .arguments
         = {{"text", "Text to embed.", {"String"}},
-           {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `dimensions`, `model`.", {"Map(String, String)"}}},
+           {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_embedding_default_credentials` setting), `model` (overrides the collection's model), `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size).", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
         = {{"Embed a single string", "SELECT aiEmbed('Hello world')", ""},

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -35,29 +35,27 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors mandatory_args{
-            {"collection", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
             {"instruction_or_schema", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
         };
         FunctionArgumentDescriptors optional_args{
-            {"temperature", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), &isColumnConst, "const Number"},
+            {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, prompt_arg_index, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
     }
 
 private:
     static constexpr float default_temp = 0.0f;
-    static constexpr size_t prompt_arg_index = 1;
-    static constexpr size_t instruction_arg_index = 2;
-    static constexpr size_t temp_arg_idx = 3;
+    static constexpr size_t instruction_arg_index = 1;
 
     String functionName() const override { return name; }
 
-    float defaultTemperature() const override { return default_temp; }
-    size_t promptArgumentIndex() const override { return prompt_arg_index; }
-    size_t temperatureArgumentIndex() const override { return temp_arg_idx; }
+    std::vector<AIParamSpec> functionParams() const override
+    {
+        return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};
+    }
 
     static bool isJSONSchema(const String & instruction)
     {
@@ -70,7 +68,7 @@ private:
         return String(arguments[instruction_arg_index].column->getDataAt(0));
     }
 
-    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments) const override
+    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments, const AIParams &) const override
     {
         auto instruction = getInstruction(arguments);
         if (isJSONSchema(instruction))
@@ -83,7 +81,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[prompt_arg_index].column->getDataAt(row));
+        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
     }
 
     /// Builds the OpenAI `response_format` schema object. Two shapes depending on `instruction_or_schema`:
@@ -232,19 +230,20 @@ JSON-encoded schema of the form `'{"field_a": "description of field a", "field_b
 In instruction mode, the function returns the extracted value as a plain string, or an empty string if nothing was found.
 In schema mode, the function returns a JSON object string whose keys match the requested schema; missing fields are `null`.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
+Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
+are taken from the `credentials` key of the optional parameter map, or from the
+`ai_function_text_default_credentials` setting when the map omits it.
 )",
-        .syntax = "aiExtract(collection, text, instruction_or_schema[, temperature])",
+        .syntax = "aiExtract(text, instruction_or_schema[, params])",
         .arguments = {
-            {"collection", "Name of a named collection containing provider credentials and configuration.", {"String"}},
             {"text", "Text to extract information from.", {"String"}},
             {"instruction_or_schema", "Free-form extraction instruction, or a constant JSON object describing the fields to extract.", {"const String"}},
-            {"temperature", "Sampling temperature controlling randomness. Default: `0.0`.", {"const Float64"}},
+            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
         },
         .returned_value = {"A single extracted value (instruction mode) or a JSON object string (schema mode). Returns the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {
-            {"Free-form instruction", "SELECT aiExtract('ai_credentials', 'The package arrived late and was damaged.', 'the main complaint')", "late and damaged package"},
-            {"Schema extraction", R"(SELECT aiExtract('ai_credentials', review, '{"sentiment": "positive, negative or neutral", "topic": "main topic of the review"}') FROM reviews LIMIT 5)", ""},
+            {"Free-form instruction", "SELECT aiExtract('The package arrived late and was damaged.', 'the main complaint')", "late and damaged package"},
+            {"Schema extraction", R"(SELECT aiExtract(review, '{"sentiment": "positive, negative or neutral", "topic": "main topic of the review"}') FROM reviews LIMIT 5)", ""},
         },
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -238,7 +238,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to extract information from.", {"String"}},
             {"instruction_or_schema", "Free-form extraction instruction, or a constant JSON object describing the fields to extract.", {"const String"}},
-            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.0`).", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `temperature` (sampling temperature controlling randomness; default `0.0`), `max_tokens` (maximum output tokens per call; default `1024`). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}},
         },
         .returned_value = {"A single extracted value (instruction mode) or a JSON object string (schema mode). Returns the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -52,7 +52,7 @@ private:
 
     String functionName() const override { return name; }
 
-    std::vector<AIParamSpec> functionParams() const override
+    AIParamSpecs functionParams() const override
     {
         return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};
     }

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -43,7 +43,7 @@ public:
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, 0, std::make_shared<DataTypeString>());
     }
 
 private:
@@ -81,7 +81,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
+        return String(arguments[0].column->getDataAt(row));
     }
 
     /// Builds the OpenAI `response_format` schema object. Two shapes depending on `instruction_or_schema`:

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -238,7 +238,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to extract information from.", {"String"}},
             {"instruction_or_schema", "Free-form extraction instruction, or a constant JSON object describing the fields to extract.", {"const String"}},
-            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.0`).", {"Map(String, String)"}},
         },
         .returned_value = {"A single extracted value (instruction mode) or a JSON object string (schema mode). Returns the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -86,7 +86,7 @@ not set, the default is: `)" + String(default_system_prompt) + R"(`
         .syntax = "aiGenerate(prompt[, params])",
         .arguments
         = {{"prompt", "The user prompt or question to send to the model.", {"String"}},
-           {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `system_prompt`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}}},
+           {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.7`), `system_prompt` (constant system-level instruction guiding the model's behavior; default a generic assistant prompt).", {"Map(String, String)"}}},
         .returned_value = {"The generated text response, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples
         = {{"Simple question", "SELECT aiGenerate('What is 2 + 2? Reply with just the number.')", "4"},

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -86,7 +86,7 @@ not set, the default is: `)" + String(default_system_prompt) + R"(`
         .syntax = "aiGenerate(prompt[, params])",
         .arguments
         = {{"prompt", "The user prompt or question to send to the model.", {"String"}},
-           {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.7`), `system_prompt` (constant system-level instruction guiding the model's behavior; default a generic assistant prompt).", {"Map(String, String)"}}},
+           {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `temperature` (sampling temperature controlling randomness; default `0.7`), `max_tokens` (maximum output tokens per call; default `1024`), `system_prompt` (constant system-level instruction guiding the model's behavior; default a generic assistant prompt). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
         .returned_value = {"The generated text response, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples
         = {{"Simple question", "SELECT aiGenerate('What is 2 + 2? Reply with just the number.')", "4"},

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -31,45 +31,37 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors mandatory_args{
-            {"collection", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
             {"prompt", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
         };
         FunctionArgumentDescriptors optional_args{
-            {"system_prompt", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
-            {"temperature", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), &isColumnConst, "const Number"},
+            {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, prompt_arg_index, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
     }
 
 private:
     static constexpr float default_temp = 0.7f;
-    static constexpr size_t prompt_arg_index = 1;
-    static constexpr size_t system_prompt_arg_idx = 2;
-    static constexpr size_t temp_arg_idx = 3;
 
     String functionName() const override { return name; }
 
-    float defaultTemperature() const override { return default_temp; }
-    size_t promptArgumentIndex() const override { return prompt_arg_index; }
-    size_t temperatureArgumentIndex() const override { return temp_arg_idx; }
-
-    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments) const override
+    std::vector<AIParamSpec> functionParams() const override
     {
-        if (arguments.size() > system_prompt_arg_idx)
-        {
-            String system_prompt(arguments[system_prompt_arg_idx].column->getDataAt(0));
-            if (!system_prompt.empty())
-                return system_prompt;
-        }
+        return {
+            {"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))},
+            {"system_prompt", AIParamKind::String, Field(String(default_system_prompt))},
+        };
+    }
 
-        return default_system_prompt;
+    String buildSystemPrompt(const ColumnsWithTypeAndName &, const AIParams & params) const override
+    {
+        return params.getString("system_prompt");
     }
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[prompt_arg_index].column->getDataAt(row));
+        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
     }
 };
 
@@ -82,22 +74,24 @@ REGISTER_FUNCTION(AiGenerate)
 Generates free-form text content from a prompt using an LLM provider.
 
 The function sends the prompt to the configured AI provider and returns the generated text.
-An optional system prompt can be provided to guide the model's behavior (e.g. tone, format, role).
-If no system prompt is given, the default system prompt is: `)" + String(default_system_prompt) + R"(`
 
-The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
+Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
+are taken from the `credentials` key of the optional parameter map, or from the
+`ai_function_text_default_credentials` setting when the map omits it.
+
+The optional parameter map may also set `system_prompt` (an instruction that guides the model's
+behavior, e.g. tone, format, role), `temperature`, `max_tokens`, and `model`. If `system_prompt` is
+not set, the default is: `)" + String(default_system_prompt) + R"(`
 )",
-        .syntax = "aiGenerate(collection, prompt[, system_prompt[, temperature]])",
+        .syntax = "aiGenerate(prompt[, params])",
         .arguments
-        = {{"collection", "Name of a named collection containing provider credentials and configuration.", {"String"}},
-           {"prompt", "The user prompt or question to send to the model.", {"String"}},
-           {"system_prompt", "Optional constant system-level instruction that guides the model's behavior (e.g. persona, output format), sent along with each prompt.", {"String"}},
-           {"temperature", "Sampling temperature controlling randomness. Default: `0.7`.", {"Float64"}}},
+        = {{"prompt", "The user prompt or question to send to the model.", {"String"}},
+           {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `system_prompt`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}}},
         .returned_value = {"The generated text response, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples
-        = {{"Simple question", "SELECT aiGenerate('ai_credentials', 'What is 2 + 2? Reply with just the number.')", "4"},
-           {"With system prompt", "SELECT aiGenerate('ai_credentials', 'Explain ClickHouse', 'You are a database expert. Be concise.')", ""},
-           {"Summarize column values", "SELECT article_title, aiGenerate('ai_credentials', concat('Summarize in one sentence: ', article_body)) AS summary FROM articles LIMIT 5", ""}},
+        = {{"Simple question", "SELECT aiGenerate('What is 2 + 2? Reply with just the number.')", "4"},
+           {"With explicit credentials and system prompt", "SELECT aiGenerate('Explain ClickHouse', map('credentials', 'ai_credentials', 'system_prompt', 'You are a database expert. Be concise.'))", ""},
+           {"Summarize column values", "SELECT article_title, aiGenerate(concat('Summarize in one sentence: ', article_body)) AS summary FROM articles LIMIT 5", ""}},
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});
 

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -46,7 +46,7 @@ private:
 
     String functionName() const override { return name; }
 
-    std::vector<AIParamSpec> functionParams() const override
+    AIParamSpecs functionParams() const override
     {
         return {
             {"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))},

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -38,7 +38,7 @@ public:
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, 0, std::make_shared<DataTypeString>());
     }
 
 private:
@@ -61,7 +61,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
+        return String(arguments[0].column->getDataAt(row));
     }
 };
 

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -90,7 +90,7 @@ not set, the default is: `)" + String(default_system_prompt) + R"(`
         .returned_value = {"The generated text response, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples
         = {{"Simple question", "SELECT aiGenerate('What is 2 + 2? Reply with just the number.')", "4"},
-           {"With explicit credentials and system prompt", "SELECT aiGenerate('Explain ClickHouse', map('credentials', 'ai_credentials', 'system_prompt', 'You are a database expert. Be concise.'))", ""},
+           {"With explicit credentials and system prompt", "SELECT aiGenerate('Explain ClickHouse', map('credentials', 'ai_text_credentials', 'system_prompt', 'You are a database expert. Be concise.'))", ""},
            {"Summarize column values", "SELECT article_title, aiGenerate(concat('Summarize in one sentence: ', article_body)) AS summary FROM articles LIMIT 5", ""}},
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -36,7 +36,7 @@ public:
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, 0, std::make_shared<DataTypeString>());
     }
 
 private:
@@ -73,7 +73,7 @@ private:
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
+        return String(arguments[0].column->getDataAt(row));
     }
 };
 

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -93,7 +93,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to translate.", {"String"}},
             {"target_language", "Target language name or BCP-47 code (e.g. `'French'`, `'es-MX'`).", {"String"}},
-            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `instructions`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.3`), `instructions` (additional style or dialect instructions for the translator).", {"Map(String, String)"}},
         },
         .returned_value = {"The translated text, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -93,7 +93,7 @@ are taken from the `credentials` key of the optional parameter map, or from the
         .arguments = {
             {"text", "Text to translate.", {"String"}},
             {"target_language", "Target language name or BCP-47 code (e.g. `'French'`, `'es-MX'`).", {"String"}},
-            {"params", "Optional constant `Map(String, String)` of parameters. Keys: `credentials` (named collection with provider credentials; defaults to the `ai_function_text_default_credentials` setting), `model` (overrides the collection's model), `max_tokens` (maximum output tokens per call; default `1024`), `temperature` (sampling temperature controlling randomness; default `0.3`), `instructions` (additional style or dialect instructions for the translator).", {"Map(String, String)"}},
+            {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `temperature` (sampling temperature controlling randomness; default `0.3`), `max_tokens` (maximum output tokens per call; default `1024`), `instructions` (additional style or dialect instructions for the translator). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}},
         },
         .returned_value = {"The translated text, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -28,31 +28,30 @@ public:
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
         FunctionArgumentDescriptors mandatory_args{
-            {"collection", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
             {"target_language", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
         };
         FunctionArgumentDescriptors optional_args{
-            {"instructions", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
-            {"temperature", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isNumber), &isColumnConst, "const Number"},
+            {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
         validateFunctionArguments(*this, arguments, mandatory_args, optional_args);
 
-        return wrapReturnTypeForNullablePrompt(arguments, prompt_arg_index, std::make_shared<DataTypeString>());
+        return wrapReturnTypeForNullablePrompt(arguments, PROMPT_ARG_INDEX, std::make_shared<DataTypeString>());
     }
 
 private:
     static constexpr float default_temp = 0.3f;
-    static constexpr size_t prompt_arg_index = 1;
-    static constexpr size_t target_language_arg_index = 2;
-    static constexpr size_t instructions_arg_index = 3;
-    static constexpr size_t temp_arg_idx = 4;
+    static constexpr size_t target_language_arg_index = 1;
 
     String functionName() const override { return name; }
 
-    float defaultTemperature() const override { return default_temp; }
-    size_t promptArgumentIndex() const override { return prompt_arg_index; }
-    size_t temperatureArgumentIndex() const override { return temp_arg_idx; }
+    std::vector<AIParamSpec> functionParams() const override
+    {
+        return {
+            {"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))},
+            {"instructions", AIParamKind::String, Field(String(""))},
+        };
+    }
 
     void checkSanityBeforeExecuteImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & /*result_type*/, size_t /*input_rows_count*/) const override
     {
@@ -61,23 +60,20 @@ private:
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "aiTranslate: 'target_language' must not be empty");
     }
 
-    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments) const override
+    String buildSystemPrompt(const ColumnsWithTypeAndName & arguments, const AIParams & params) const override
     {
         auto target_language = String(arguments[target_language_arg_index].column->getDataAt(0));
         auto prompt = "Translate the following text into " + target_language + ". Return only the translation, nothing else.";
 
-        if (arguments.size() > instructions_arg_index)
-        {
-            auto instructions = String(arguments[instructions_arg_index].column->getDataAt(0));
-            if (!instructions.empty())
-                prompt += " Additional instructions: " + instructions;
-        }
+        auto instructions = params.getString("instructions");
+        if (!instructions.empty())
+            prompt += " Additional instructions: " + instructions;
         return prompt;
     }
 
     String buildUserMessage(const ColumnsWithTypeAndName & arguments, size_t row) const override
     {
-        return String(arguments[prompt_arg_index].column->getDataAt(row));
+        return String(arguments[PROMPT_ARG_INDEX].column->getDataAt(row));
     }
 };
 
@@ -87,22 +83,22 @@ REGISTER_FUNCTION(AiTranslate)
         .description = R"(
 Translates the given text into the specified target language using an LLM provider.
 
-Additional style or dialect instructions may be passed as a fourth argument (e.g. `'keep technical terms untranslated'`).
+Additional style or dialect instructions may be passed via the `instructions` key of the parameter map (e.g. `'keep technical terms untranslated'`).
 
-The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
+Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
+are taken from the `credentials` key of the optional parameter map, or from the
+`ai_function_text_default_credentials` setting when the map omits it.
 )",
-        .syntax = "aiTranslate(collection, text, target_language[, instructions[, temperature]])",
+        .syntax = "aiTranslate(text, target_language[, params])",
         .arguments = {
-            {"collection", "Name of a named collection containing provider credentials and configuration.", {"String"}},
             {"text", "Text to translate.", {"String"}},
             {"target_language", "Target language name or BCP-47 code (e.g. `'French'`, `'es-MX'`).", {"String"}},
-            {"instructions", "Optional constant additional instructions for the translator.", {"String"}},
-            {"temperature", "Sampling temperature controlling randomness. Default: `0.3`.", {"Float64"}},
+            {"params", "Optional constant `Map(String, String)` of parameters: `credentials`, `instructions`, `temperature`, `max_tokens`, `model`.", {"Map(String, String)"}},
         },
         .returned_value = {"The translated text, or the default value for the column type (empty string) if the request failed and `ai_function_throw_on_error` is disabled.", {"String"}},
         .examples = {
-            {"Translate to French", "SELECT aiTranslate('ai_credentials', 'Hello, world!', 'French')", "Bonjour le monde!"},
-            {"Translate to Japanese with style instructions", "SELECT aiTranslate('ai_credentials', body, 'Japanese', 'Use polite form (desu/masu)') FROM articles LIMIT 5", ""},
+            {"Translate to French", "SELECT aiTranslate('Hello, world!', 'French')", "Bonjour le monde!"},
+            {"Translate to Japanese with style instructions", "SELECT aiTranslate(body, 'Japanese', map('instructions', 'Use polite form (desu/masu)')) FROM articles LIMIT 5", ""},
         },
         .introduced_in = {26, 4},
         .category = FunctionDocumentation::Category::AI});

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -45,7 +45,7 @@ private:
 
     String functionName() const override { return name; }
 
-    std::vector<AIParamSpec> functionParams() const override
+    AIParamSpecs functionParams() const override
     {
         return {
             {"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))},

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -195,6 +195,19 @@ def test_generate_content_multiple_rows(started_cluster):
     assert result.strip().split("\n") == ["row1", "row2", "row3"]
 
 
+def test_generate_uses_text_default_credentials(started_cluster):
+    """End-to-end default-credentials path: with no `credentials` in the call, a real (non-empty)
+    request must actually use `ai_function_text_default_credentials`, not just resolve it for the
+    zero-row fast path. The mock echoes the input back, so a wiring bug would show up here."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('row1'), ('row2')")
+    result = instance.query(
+        "SELECT aiGenerate(x) FROM test_input ORDER BY x",
+        settings={**AI_SETTINGS, "ai_function_text_default_credentials": "ai_mock"},
+    )
+    assert result.strip().split("\n") == ["row1", "row2"]
+
+
 def test_generate_content_profile_events(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('a'), ('b'), ('c')")
@@ -481,6 +494,19 @@ def test_embed_basic(started_cluster):
     result = instance.query(
         "SELECT aiEmbed('hello', map('credentials', 'ai_embed'))",
         settings=AI_SETTINGS,
+    )
+    vec = parse_embedding(result)
+    assert len(vec) == 4  # DEFAULT_EMBED_DIM in mock server
+    assert any(v != 0.0 for v in vec)
+
+
+def test_embed_uses_embedding_default_credentials(started_cluster):
+    """End-to-end default-credentials path for embeddings: with no `credentials` in the call, a real
+    (non-empty) request must actually use `ai_function_embedding_default_credentials`. Confirms the
+    embedding default is applied on the request path, not only for the zero-row fast path."""
+    result = instance.query(
+        "SELECT aiEmbed('hello')",
+        settings={**AI_SETTINGS, "ai_function_embedding_default_credentials": "ai_embed"},
     )
     vec = parse_embedding(result)
     assert len(vec) == 4  # DEFAULT_EMBED_DIM in mock server

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -179,7 +179,7 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
 
 def test_generate_content_basic(started_cluster):
     result = instance.query(
-        "SELECT aiGenerate('ai_mock', 'hello world')",
+        "SELECT aiGenerate('hello world', map('credentials', 'ai_mock'))",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "hello world"
@@ -189,7 +189,7 @@ def test_generate_content_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('row1'), ('row2'), ('row3')")
     result = instance.query(
-        "SELECT aiGenerate('ai_mock', x) FROM test_input ORDER BY x",
+        "SELECT aiGenerate(x, map('credentials', 'ai_mock')) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     assert result.strip().split("\n") == ["row1", "row2", "row3"]
@@ -200,7 +200,7 @@ def test_generate_content_profile_events(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('a'), ('b'), ('c')")
     qid = unique_query_id("gen_content_events")
     instance.query(
-        "SELECT aiGenerate('ai_mock', x) FROM test_input",
+        "SELECT aiGenerate(x, map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -218,7 +218,7 @@ def test_generate_content_null_input(started_cluster):
         "INSERT INTO test_input_nullable VALUES (NULL), ('hello'), (NULL)"
     )
     result = instance.query(
-        "SELECT aiGenerate('ai_mock', x) FROM test_input_nullable",
+        "SELECT aiGenerate(x, map('credentials', 'ai_mock')) FROM test_input_nullable",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -228,7 +228,7 @@ def test_generate_content_null_input(started_cluster):
 
 def test_generate_content_error_throw(started_cluster):
     error = instance.query_and_get_error(
-        "SELECT aiGenerate('ai_error', 'hello')",
+        "SELECT aiGenerate('hello', map('credentials', 'ai_error'))",
         settings=AI_SETTINGS,
     )
     assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
@@ -236,7 +236,7 @@ def test_generate_content_error_throw(started_cluster):
 
 def test_generate_content_error_graceful(started_cluster):
     result = instance.query(
-        "SELECT aiGenerate('ai_error', 'hello')",
+        "SELECT aiGenerate('hello', map('credentials', 'ai_error'))",
         settings={**AI_SETTINGS, "ai_function_throw_on_error": 0},
     )
     assert result.strip() == ""
@@ -254,7 +254,7 @@ def test_generate_without_api_key(started_cluster):
     """A named collection that omits `api_key` resolves and runs end-to-end, and the
     provider sends no `Authorization` header (rather than an empty/dummy token)."""
     result = instance.query(
-        "SELECT aiGenerate('ai_no_key', 'no key here')",
+        "SELECT aiGenerate('no key here', map('credentials', 'ai_no_key'))",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "no key here"
@@ -264,7 +264,7 @@ def test_generate_without_api_key(started_cluster):
 def test_generate_with_api_key_sends_auth_header(started_cluster):
     """A keyed collection forwards the key as a `Bearer` `Authorization` header."""
     result = instance.query(
-        "SELECT aiGenerate('ai_mock', 'with key')",
+        "SELECT aiGenerate('with key', map('credentials', 'ai_mock'))",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "with key"
@@ -282,7 +282,7 @@ def test_classify_basic(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('I love this product!')")
     result = instance.query(
-        "SELECT aiClassify('ai_mock', x, ['positive', 'negative', 'neutral']) FROM test_input",
+        "SELECT aiClassify(x, ['positive', 'negative', 'neutral'], map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
     )
     # Mock returns first enum value; postProcessResponse extracts "category" from JSON
@@ -295,7 +295,7 @@ def test_classify_multiple_rows(started_cluster):
         "INSERT INTO test_input VALUES ('great'), ('terrible'), ('okay')"
     )
     result = instance.query(
-        "SELECT aiClassify('ai_mock', x, ['positive', 'negative', 'neutral']) FROM test_input",
+        "SELECT aiClassify(x, ['positive', 'negative', 'neutral'], map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -309,7 +309,7 @@ def test_classify_profile_events(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
     qid = unique_query_id("classify_events")
     instance.query(
-        "SELECT aiClassify('ai_mock', x, ['cat_a', 'cat_b']) FROM test_input",
+        "SELECT aiClassify(x, ['cat_a', 'cat_b'], map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -322,7 +322,7 @@ def test_classify_null_input(started_cluster):
     instance.query("TRUNCATE TABLE test_input_nullable")
     instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('text')")
     result = instance.query(
-        "SELECT aiClassify('ai_mock', x, ['a', 'b']) FROM test_input_nullable",
+        "SELECT aiClassify(x, ['a', 'b'], map('credentials', 'ai_mock')) FROM test_input_nullable",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -342,7 +342,7 @@ def test_extract_simple_instruction(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('The price is $42.99')")
     result = instance.query(
-        "SELECT aiExtract('ai_mock', x, 'the price') FROM test_input",
+        "SELECT aiExtract(x, 'the price', map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
     )
     # Mock returns {"result": "<user_message>"}, postProcess extracts the value
@@ -355,7 +355,7 @@ def test_extract_json_schema(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('John is 30 years old')")
     result = instance.query(
-        """SELECT aiExtract('ai_mock', x, '{"name": "person name", "age": "person age"}') FROM test_input""",
+        """SELECT aiExtract(x, '{"name": "person name", "age": "person age"}', map('credentials', 'ai_mock')) FROM test_input""",
         settings=AI_SETTINGS,
     )
     # Mock returns {"name": "<user_msg>", "age": "<user_msg>"}
@@ -370,7 +370,7 @@ def test_extract_multiple_rows(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('text1'), ('text2'), ('text3')")
     qid = unique_query_id("extract_events")
     instance.query(
-        "SELECT aiExtract('ai_mock', x, 'main topic') FROM test_input",
+        "SELECT aiExtract(x, 'main topic', map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -383,7 +383,7 @@ def test_extract_null_input(started_cluster):
     instance.query("TRUNCATE TABLE test_input_nullable")
     instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('some text')")
     result = instance.query(
-        "SELECT aiExtract('ai_mock', x, 'key info') FROM test_input_nullable",
+        "SELECT aiExtract(x, 'key info', map('credentials', 'ai_mock')) FROM test_input_nullable",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -401,7 +401,7 @@ def test_translate_basic(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('Hello world')")
     result = instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'French') FROM test_input",
+        "SELECT aiTranslate(x, 'French', map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "Hello world"
@@ -411,7 +411,7 @@ def test_translate_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('one'), ('two'), ('three')")
     result = instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'Spanish') FROM test_input ORDER BY x",
+        "SELECT aiTranslate(x, 'Spanish', map('credentials', 'ai_mock')) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     assert result.strip().split("\n") == ["one", "three", "two"]
@@ -421,7 +421,7 @@ def test_translate_with_instructions(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('Hello')")
     result = instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'German', 'Use formal tone') FROM test_input",
+        "SELECT aiTranslate(x, 'German', map('credentials', 'ai_mock', 'instructions', 'Use formal tone')) FROM test_input",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "Hello"
@@ -442,7 +442,7 @@ def test_translate_profile_events(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
     qid = unique_query_id("translate_events")
     instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'Japanese') FROM test_input",
+        "SELECT aiTranslate(x, 'Japanese', map('credentials', 'ai_mock')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -455,7 +455,7 @@ def test_translate_null_input(started_cluster):
     instance.query("TRUNCATE TABLE test_input_nullable")
     instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('hello')")
     result = instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'French') FROM test_input_nullable",
+        "SELECT aiTranslate(x, 'French', map('credentials', 'ai_mock')) FROM test_input_nullable",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -479,7 +479,7 @@ def parse_embedding(s):
 def test_embed_basic(started_cluster):
     """Single-row aiEmbed returns an `Array(Float32)` of the model's native size."""
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', 'hello')",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -492,7 +492,7 @@ def test_embed_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('alpha'), ('beta'), ('gamma')")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input ORDER BY x",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     rows = [parse_embedding(line) for line in result.strip().split("\n")]
@@ -505,7 +505,7 @@ def test_embed_multiple_rows(started_cluster):
 def test_embed_with_dimensions(started_cluster):
     """The `dimensions` argument is forwarded to the provider and honored in the response."""
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', 'hello world', 16)",
+        "SELECT aiEmbed('hello world', map('credentials', 'ai_embed', 'dimensions', '16'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -520,7 +520,7 @@ def test_embed_null_and_empty_input(started_cluster):
     )
     qid = unique_query_id("embed_null_empty")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input_nullable ORDER BY x NULLS FIRST",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input_nullable ORDER BY x NULLS FIRST",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -546,7 +546,7 @@ def test_embed_profile_events_token_accounting(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('abc'), ('de'), ('fghi')")
     qid = unique_query_id("embed_tokens")
     instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -566,7 +566,7 @@ def test_embed_batching(started_cluster):
     )
     qid = unique_query_id("embed_batch")
     instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
         settings={**AI_SETTINGS, "ai_function_embedding_max_batch_size": 2},
         query_id=qid,
     )
@@ -580,7 +580,7 @@ def test_embed_batching(started_cluster):
 def test_embed_error_throw(started_cluster):
     """By default, provider errors propagate as `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER`."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed('ai_embed_error', 'hello')",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_error'))",
         settings=AI_SETTINGS,
     )
     assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
@@ -591,7 +591,7 @@ def test_embed_error_graceful(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed_error', x) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_error')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_throw_on_error": 0,
@@ -605,7 +605,7 @@ def test_embed_error_graceful(started_cluster):
 def test_embed_duplicate_index_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses with duplicate `index` values."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed('ai_embed_dup_index', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_dup_index')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -615,7 +615,7 @@ def test_embed_duplicate_index_rejected(started_cluster):
 def test_embed_wrong_count_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses whose `data` size != number of inputs."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed('ai_embed_wrong_count', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_wrong_count')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -626,7 +626,7 @@ def test_embed_empty_input_table(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     qid = unique_query_id("embed_zero_rows")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -646,7 +646,7 @@ def test_embed_quota_input_tokens_exceeded(started_cluster):
     # Each batch costs `sum(len(text))` input tokens. With batch_size=1 and rows
     # of length 5 ("row_0".."row_3"), the second batch pushes us over a 5-token cap.
     result = instance.query(
-        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_embedding_max_batch_size": 1,
@@ -686,7 +686,7 @@ def test_generate_retries_on_network_error(started_cluster):
     set_flaky(2)
     qid = unique_query_id("gen_retry_net")
     result = instance.query(
-        "SELECT aiGenerate('ai_flaky', 'recover me')",
+        "SELECT aiGenerate('recover me', map('credentials', 'ai_flaky'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -705,7 +705,7 @@ def test_generate_network_error_not_retried_when_disabled(started_cluster):
     set_flaky(10)
     try:
         error = instance.query_and_get_error(
-            "SELECT aiGenerate('ai_flaky', 'no retry')",
+            "SELECT aiGenerate('no retry', map('credentials', 'ai_flaky'))",
             settings={
                 **AI_SETTINGS,
                 "ai_function_max_retries": 0,
@@ -721,7 +721,7 @@ def test_embed_retries_on_network_error(started_cluster):
     set_flaky(2)
     qid = unique_query_id("embed_retry_net")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed_flaky', 'hello')",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_flaky'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -748,7 +748,7 @@ def test_generate_deterministic_http_error_not_retried(started_cluster):
     which never retries 400/401/403/404/405/501. Only a single API call is made."""
     qid = unique_query_id("gen_400_no_retry")
     result = instance.query(
-        "SELECT aiGenerate('ai_bad_request', 'bad request')",
+        "SELECT aiGenerate('bad request', map('credentials', 'ai_bad_request'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -768,7 +768,7 @@ def test_generate_deterministic_http_error_throws(started_cluster):
     """With the default `ai_function_throw_on_error = 1`, the deterministic 400 surfaces as
     `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER` rather than being retried away."""
     error = instance.query_and_get_error(
-        "SELECT aiGenerate('ai_bad_request', 'bad request')",
+        "SELECT aiGenerate('bad request', map('credentials', 'ai_bad_request'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -782,7 +782,7 @@ def test_generate_server_error_is_retried(started_cluster):
     (1 initial attempt + `ai_function_max_retries` retries), matching the url table function."""
     qid = unique_query_id("gen_500_retried")
     result = instance.query(
-        "SELECT aiGenerate('ai_error', 'server error')",
+        "SELECT aiGenerate('server error', map('credentials', 'ai_error'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 2,
@@ -810,7 +810,7 @@ def test_generate_retry_respects_api_call_quota(started_cluster):
     single request is dispatched (the quota stops the retries), not `1 + 5`."""
     qid = unique_query_id("gen_quota_caps_retries")
     result = instance.query(
-        "SELECT aiGenerate('ai_error', 'server error')",
+        "SELECT aiGenerate('server error', map('credentials', 'ai_error'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -834,7 +834,7 @@ def test_embed_retry_respects_api_call_quota(started_cluster):
     retried past `ai_function_max_api_calls_per_query`."""
     qid = unique_query_id("embed_quota_caps_retries")
     result = instance.query(
-        "SELECT aiEmbed('ai_embed_error', 'server error')",
+        "SELECT aiEmbed('server error', map('credentials', 'ai_embed_error'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -36,6 +36,7 @@ result	String
 -- Non-integer max_tokens rejected
 -- Negative max_tokens rejected
 -- Out-of-range max_tokens rejected (exceeds Int64)
+-- Overflowing max_tokens rejected (exceeds UInt64, must not wrap)
 -- Duplicate map key rejected
 -- Non-constant parameter map rejected
 -- Wrong type for parameter argument (not a map)

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -41,6 +41,7 @@ result	String
 -- Non-constant parameter map rejected
 -- Wrong type for parameter argument (not a map)
 -- Wrong map value type (Map(String, Float) not accepted)
+-- Map in the prompt position rejected
 -- Setting defaults
 ai_function_embedding_default_credentials	
 ai_function_embedding_max_batch_size	100

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -34,6 +34,9 @@ result	String
 -- Unknown parameter key rejected
 -- Non-numeric temperature rejected
 -- Non-integer max_tokens rejected
+-- Negative max_tokens rejected
+-- Out-of-range max_tokens rejected (exceeds Int64)
+-- Duplicate map key rejected
 -- Non-constant parameter map rejected
 -- Wrong type for parameter argument (not a map)
 -- Wrong map value type (Map(String, Float) not accepted)

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -3,9 +3,12 @@
 aiGenerate
 -- aiGenerate: too few arguments
 -- aiGenerate: too many arguments
+-- Missing credentials (no default, no map)
 -- Named collection missing provider
 -- Named collection missing endpoint
--- Named collection missing model
+-- Named collection missing model (and none in map)
+-- Model supplied via the parameter map resolves
+0
 -- Named collection without api_key resolves
 0
 -- Named collection without api_key reaches HTTP path
@@ -22,23 +25,20 @@ result	String
 -- Anthropic provider resolves
 0
 -- aiEmbed rejects anthropic provider
--- Custom system prompt accepted
+-- Custom system prompt via map
 0
--- Temperature: Float32
+-- Temperature via map
 0
--- Temperature: Float64
+-- max_tokens and model via map
 0
--- Temperature: zero
-0
--- Temperature: integer literal
-0
--- Temperature without system prompt
--- Temperature without system prompt (integer)
--- Non-constant system prompt
--- Non-constant temperature
--- Wrong type for system prompt (number instead of string)
--- Wrong type for temperature (string instead of number)
+-- Unknown parameter key rejected
+-- Non-numeric temperature rejected
+-- Non-integer max_tokens rejected
+-- Non-constant parameter map rejected
+-- Wrong type for parameter argument (not a map)
+-- Wrong map value type (Map(String, Float) not accepted)
 -- Setting defaults
+ai_function_embedding_default_credentials	
 ai_function_embedding_max_batch_size	100
 ai_function_max_api_calls_per_query	0
 ai_function_max_input_tokens_per_query	1000000
@@ -46,6 +46,7 @@ ai_function_max_output_tokens_per_query	500000
 ai_function_max_retries	0
 ai_function_request_timeout_sec	60
 ai_function_retry_initial_delay_ms	1000
+ai_function_text_default_credentials	
 ai_function_throw_on_error	1
 ai_function_throw_on_quota_exceeded	1
 allow_experimental_ai_functions	0
@@ -92,10 +93,8 @@ result	String
 aiEmbed
 -- aiEmbed: too few arguments
 -- aiEmbed: too many arguments
--- aiEmbed: non-constant dimensions
--- aiEmbed: wrong type for dimensions (signed integer)
--- aiEmbed: wrong type for dimensions (string)
--- aiEmbed: non-constant collection
+-- aiEmbed: non-constant parameter map
+-- aiEmbed: wrong type for parameter argument (not a map)
 -- aiEmbed: return type
 result	Array(Float32)
 -- aiEmbed: return type with dimensions
@@ -112,14 +111,14 @@ result	Array(Float32)
 result	Array(Float32)
 -- aiEmbed: NULL input → []
 0
--- aiEmbed: DEFAULT survives INSERT (no server crash)
+-- aiEmbed: DEFAULT survives INSERT (no exception)
 1	0
--- aiGenerate: DEFAULT survives INSERT (no server crash)
+-- aiGenerate: DEFAULT survives INSERT (no exception)
 1	0
--- aiClassify: DEFAULT survives INSERT (no server crash)
+-- aiClassify: DEFAULT survives INSERT (no exception)
 1	0
--- aiExtract: DEFAULT survives INSERT (no server crash)
+-- aiExtract: DEFAULT survives INSERT (no exception)
 1	0
--- aiTranslate: DEFAULT survives INSERT (no server crash)
+-- aiTranslate: DEFAULT survives INSERT (no exception)
 1	0
 -- Re-disabled blocks function

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -5,8 +5,14 @@
 -- =============================================================================
 -- AI Functions Test Suite
 -- Tests argument validation, error handling, return types, settings behavior,
--- and named collection resolution for `aiGenerate`.
+-- and named collection resolution for the AI functions.
 -- All tests run without a real AI provider or API key.
+--
+-- Signature: each function takes the per-row text first, then any
+-- function-specific mandatory arguments, then an optional trailing
+-- Map(String, String) of parameters (credentials, model, temperature, …).
+-- Credentials come from the map's `credentials` key or, when absent, from
+-- `ai_function_text_default_credentials` / `ai_function_embedding_default_credentials`.
 -- =============================================================================
 
 -- Helper table: a String column with zero rows, used to test function behavior
@@ -20,7 +26,7 @@ CREATE TABLE tab (x String) ENGINE = Memory;
 -- =============================================================================
 
 SELECT '-- Disabled by default';
-SELECT aiGenerate('hello', 'world'); -- { serverError SUPPORT_IS_DISABLED }
+SELECT aiGenerate('hello'); -- { serverError SUPPORT_IS_DISABLED }
 
 SET allow_experimental_ai_functions = 1;
 
@@ -32,13 +38,20 @@ SELECT name FROM system.functions WHERE name = 'aiGenerate';
 -- =============================================================================
 
 SELECT '-- aiGenerate: too few arguments';
-SELECT aiGenerate('a'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiGenerate(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiGenerate: too many arguments';
-SELECT aiGenerate('a', 'b', 'c', 0.7, 'x'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiGenerate('a', map('credentials', 'c'), 'x'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 -- =============================================================================
--- 3. Named collection: missing required fields
+-- 3. Missing credentials
+-- =============================================================================
+
+SELECT '-- Missing credentials (no default, no map)';
+SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }
+
+-- =============================================================================
+-- 4. Named collection: missing required fields
 -- =============================================================================
 
 DROP NAMED COLLECTION IF EXISTS ai_no_provider;
@@ -48,7 +61,7 @@ CREATE NAMED COLLECTION ai_no_provider AS
     api_key = 'fake-key';
 
 SELECT '-- Named collection missing provider';
-SELECT aiGenerate('ai_no_provider', 'hi'); -- { serverError BAD_ARGUMENTS }
+SELECT aiGenerate('hi', map('credentials', 'ai_no_provider')); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_no_provider;
 
@@ -59,7 +72,7 @@ CREATE NAMED COLLECTION ai_no_endpoint AS
     api_key = 'fake-key';
 
 SELECT '-- Named collection missing endpoint';
-SELECT aiGenerate('ai_no_endpoint', 'hi'); -- { serverError BAD_ARGUMENTS }
+SELECT aiGenerate('hi', map('credentials', 'ai_no_endpoint')); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_no_endpoint;
 
@@ -69,8 +82,11 @@ CREATE NAMED COLLECTION ai_no_model AS
     endpoint = 'http://localhost:1/v1/chat/completions',
     api_key = 'fake-key';
 
-SELECT '-- Named collection missing model';
-SELECT aiGenerate('ai_no_model', 'hi'); -- { serverError BAD_ARGUMENTS }
+SELECT '-- Named collection missing model (and none in map)';
+SELECT aiGenerate('hi', map('credentials', 'ai_no_model')); -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- Model supplied via the parameter map resolves';
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_no_model', 'model', 'test-model')) AS result FROM tab);
 
 DROP NAMED COLLECTION ai_no_model;
 
@@ -84,7 +100,7 @@ CREATE NAMED COLLECTION ai_no_api_key AS
     model = 'test-model';
 
 SELECT '-- Named collection without api_key resolves';
-SELECT count() FROM (SELECT aiGenerate('ai_no_api_key', x) AS result FROM tab);
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_no_api_key')) AS result FROM tab);
 
 -- Force the no-key path through provider construction and an actual HTTP request:
 -- `localhost:1` refuses the connection, `ai_function_throw_on_error = 0` swallows it,
@@ -96,7 +112,7 @@ CREATE TABLE _03300_no_api_key_in (x String) ENGINE = Memory;
 INSERT INTO _03300_no_api_key_in VALUES ('hello');
 SET ai_function_throw_on_error = 0;
 SET ai_function_request_timeout_sec = 3;
-SELECT length(aiGenerate('ai_no_api_key', x)) FROM _03300_no_api_key_in;
+SELECT length(aiGenerate(x, map('credentials', 'ai_no_api_key'))) FROM _03300_no_api_key_in;
 SET ai_function_throw_on_error = 1;
 SET ai_function_request_timeout_sec = 60;
 DROP TABLE _03300_no_api_key_in;
@@ -104,14 +120,14 @@ DROP TABLE _03300_no_api_key_in;
 DROP NAMED COLLECTION ai_no_api_key;
 
 -- =============================================================================
--- 4. Named collection: nonexistent collection
+-- 5. Named collection: nonexistent collection
 -- =============================================================================
 
 SELECT '-- Nonexistent named collection';
-SELECT aiGenerate('nonexistent_collection_xyz', 'hello'); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
+SELECT aiGenerate('hello', map('credentials', 'nonexistent_collection_xyz')); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
 
 -- =============================================================================
--- 5. Test collection for remaining tests
+-- 6. Test collection + default credentials for remaining tests
 -- =============================================================================
 
 DROP NAMED COLLECTION IF EXISTS ai_credentials;
@@ -121,20 +137,23 @@ CREATE NAMED COLLECTION ai_credentials AS
     model = 'test-model',
     api_key = 'fake-key';
 
+SET ai_function_text_default_credentials = 'ai_credentials';
+SET ai_function_embedding_default_credentials = 'ai_credentials';
+
 -- =============================================================================
--- 6. Return type verification
+-- 7. Return type verification
 -- =============================================================================
 
 SELECT '-- aiGenerate return type';
 DROP TABLE IF EXISTS _03300_ret_content;
 CREATE TABLE _03300_ret_content ENGINE = Memory AS
-    SELECT aiGenerate('ai_credentials', x) AS result FROM tab;
+    SELECT aiGenerate(x) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_content';
 DROP TABLE IF EXISTS _03300_ret_content;
 
 -- =============================================================================
--- 7. NULL input propagation
+-- 8. NULL input propagation
 -- =============================================================================
 
 DROP TABLE IF EXISTS _03300_null_input;
@@ -144,20 +163,20 @@ INSERT INTO _03300_null_input VALUES (NULL);
 SELECT '-- NULL input returns NULL';
 DROP TABLE IF EXISTS _03300_null_result;
 CREATE TABLE _03300_null_result ENGINE = Memory AS
-    SELECT aiGenerate('ai_credentials', x) AS result FROM _03300_null_input;
+    SELECT aiGenerate(x) AS result FROM _03300_null_input;
 SELECT result IS NULL FROM _03300_null_result;
 DROP TABLE IF EXISTS _03300_null_result;
 DROP TABLE IF EXISTS _03300_null_input;
 
 -- =============================================================================
--- 8. Empty string input: zero rows, should not error
+-- 9. Empty string input: zero rows, should not error
 -- =============================================================================
 
 SELECT '-- Empty string input accepted';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x) AS result FROM tab);
+SELECT count() FROM (SELECT aiGenerate(x) AS result FROM tab);
 
 -- =============================================================================
--- 9. Unknown provider name
+-- 10. Unknown provider name
 -- =============================================================================
 
 DROP NAMED COLLECTION IF EXISTS ai_bad_provider;
@@ -168,16 +187,16 @@ CREATE NAMED COLLECTION ai_bad_provider AS
     api_key = 'fake-key';
 
 SELECT '-- Unknown provider name';
-SELECT aiGenerate('ai_bad_provider', 'hi'); -- { serverError BAD_ARGUMENTS }
+SELECT aiGenerate('hi', map('credentials', 'ai_bad_provider')); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- Unknown provider name on empty input';
-SELECT aiGenerate('ai_bad_provider', x) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
-SELECT aiEmbed('ai_bad_provider', x) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiGenerate(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_bad_provider;
 
 -- =============================================================================
--- 10. Provider name: anthropic
+-- 11. Provider name: anthropic
 -- =============================================================================
 
 DROP NAMED COLLECTION IF EXISTS ai_anthropic;
@@ -188,54 +207,44 @@ CREATE NAMED COLLECTION ai_anthropic AS
     api_key = 'fake-key';
 
 SELECT '-- Anthropic provider resolves';
-SELECT count() FROM (SELECT aiGenerate('ai_anthropic', x) AS result FROM tab);
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_anthropic')) AS result FROM tab);
 
 SELECT '-- aiEmbed rejects anthropic provider';
-SELECT aiEmbed('ai_anthropic', 'hi'); -- { serverError NOT_IMPLEMENTED }
-SELECT aiEmbed('ai_anthropic', x) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed('hi', map('credentials', 'ai_anthropic')); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed(x, map('credentials', 'ai_anthropic')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
 
 DROP NAMED COLLECTION ai_anthropic;
 
 -- =============================================================================
--- 11. Custom system prompt argument
+-- 12. Parameter map: keys and validation
 -- =============================================================================
 
-SELECT '-- Custom system prompt accepted';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x, 'You are a pirate') AS result FROM tab);
+SELECT '-- Custom system prompt via map';
+SELECT count() FROM (SELECT aiGenerate(x, map('system_prompt', 'You are a pirate')) AS result FROM tab);
 
--- =============================================================================
--- 12. Temperature argument
--- =============================================================================
+SELECT '-- Temperature via map';
+SELECT count() FROM (SELECT aiGenerate(x, map('temperature', '0.5')) AS result FROM tab);
 
-SELECT '-- Temperature: Float32';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x, 'system', toFloat32(0.5)) AS result FROM tab);
+SELECT '-- max_tokens and model via map';
+SELECT count() FROM (SELECT aiGenerate(x, map('max_tokens', '128', 'model', 'other-model')) AS result FROM tab);
 
-SELECT '-- Temperature: Float64';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x, 'system', 0.5) AS result FROM tab);
+SELECT '-- Unknown parameter key rejected';
+SELECT aiGenerate('hi', map('bogus', '1')); -- { serverError BAD_ARGUMENTS }
 
-SELECT '-- Temperature: zero';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x, 'system', toFloat32(0.0)) AS result FROM tab);
+SELECT '-- Non-numeric temperature rejected';
+SELECT aiGenerate('hi', map('temperature', 'hot')); -- { serverError BAD_ARGUMENTS }
 
-SELECT '-- Temperature: integer literal';
-SELECT count() FROM (SELECT aiGenerate('ai_credentials', x, 'system', 1) AS result FROM tab);
+SELECT '-- Non-integer max_tokens rejected';
+SELECT aiGenerate('hi', map('max_tokens', '3.5')); -- { serverError BAD_ARGUMENTS }
 
-SELECT '-- Temperature without system prompt';
-SELECT aiGenerate('ai_credentials', x, toFloat32(0.5)) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT '-- Non-constant parameter map rejected';
+SELECT aiGenerate(x, map('credentials', x)) FROM tab; -- { serverError ILLEGAL_COLUMN }
 
-SELECT '-- Temperature without system prompt (integer)';
-SELECT aiGenerate('ai_credentials', x, 1) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT '-- Wrong type for parameter argument (not a map)';
+SELECT aiGenerate(x, 'notamap') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
-SELECT '-- Non-constant system prompt';
-SELECT aiGenerate('ai_credentials', x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
-
-SELECT '-- Non-constant temperature';
-SELECT aiGenerate('ai_credentials', x, 'system', toFloat32(number)) FROM (SELECT x, 0 AS number FROM tab); -- { serverError ILLEGAL_COLUMN }
-
-SELECT '-- Wrong type for system prompt (number instead of string)';
-SELECT aiGenerate('ai_credentials', x, 42) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
-SELECT '-- Wrong type for temperature (string instead of number)';
-SELECT aiGenerate('ai_credentials', x, 'system', 'hot') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT '-- Wrong map value type (Map(String, Float) not accepted)';
+SELECT aiGenerate(x, map('temperature', 0.5)) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 -- =============================================================================
 -- 13. Setting types and defaults
@@ -256,7 +265,9 @@ WHERE name IN (
     'ai_function_max_output_tokens_per_query',
     'ai_function_max_api_calls_per_query',
     'ai_function_throw_on_quota_exceeded',
-    'ai_function_embedding_max_batch_size'
+    'ai_function_embedding_max_batch_size',
+    'ai_function_text_default_credentials',
+    'ai_function_embedding_default_credentials'
 )
 ORDER BY name;
 
@@ -268,37 +279,37 @@ SELECT '-- aiClassify: registered';
 SELECT name FROM system.functions WHERE name = 'aiClassify';
 
 SELECT '-- aiClassify: too few arguments';
-SELECT aiClassify('ai_credentials'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT aiClassify('ai_credentials', 'hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiClassify(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiClassify('hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiClassify: too many arguments';
-SELECT aiClassify('ai_credentials', 'x', ['a', 'b'], 0.0, 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiClassify('x', ['a', 'b'], map('temperature', '0.0'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiClassify: non-constant categories';
-SELECT aiClassify('ai_credentials', x, [x]) FROM tab; -- { serverError ILLEGAL_COLUMN }
+SELECT aiClassify(x, [x]) FROM tab; -- { serverError ILLEGAL_COLUMN }
 
 SELECT '-- aiClassify: wrong type for categories (not array)';
-SELECT aiClassify('ai_credentials', x, 'positive,negative') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT aiClassify(x, 'positive,negative') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 SELECT '-- aiClassify: wrong type for categories (Array of non-String)';
-SELECT aiClassify('ai_credentials', x, [1, 2, 3]) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT aiClassify(x, [1, 2, 3]) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 SELECT '-- aiClassify: empty categories array';
-SELECT aiClassify('ai_credentials', 'test', CAST([], 'Array(String)')); -- { serverError BAD_ARGUMENTS }
+SELECT aiClassify('test', CAST([], 'Array(String)')); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiClassify: return type';
 DROP TABLE IF EXISTS _03300_ret_classify;
 CREATE TABLE _03300_ret_classify ENGINE = Memory AS
-    SELECT aiClassify('ai_credentials', x, ['a', 'b', 'c']) AS result FROM tab;
+    SELECT aiClassify(x, ['a', 'b', 'c']) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_classify';
 DROP TABLE IF EXISTS _03300_ret_classify;
 
 SELECT '-- aiClassify: empty input executes';
-SELECT count() FROM (SELECT aiClassify('ai_credentials', x, ['a', 'b']) AS result FROM tab);
+SELECT count() FROM (SELECT aiClassify(x, ['a', 'b']) AS result FROM tab);
 
 SELECT '-- aiClassify: with temperature';
-SELECT count() FROM (SELECT aiClassify('ai_credentials', x, ['a', 'b'], 0.0) AS result FROM tab);
+SELECT count() FROM (SELECT aiClassify(x, ['a', 'b'], map('temperature', '0.0')) AS result FROM tab);
 
 -- =============================================================================
 -- 15. aiExtract
@@ -308,45 +319,45 @@ SELECT '-- aiExtract: registered';
 SELECT name FROM system.functions WHERE name = 'aiExtract';
 
 SELECT '-- aiExtract: too few arguments';
-SELECT aiExtract('ai_credentials'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT aiExtract('ai_credentials', 'hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiExtract(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiExtract('hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiExtract: too many arguments';
-SELECT aiExtract('ai_credentials', 'x', 'instr', 0.0, 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiExtract('x', 'instr', map('temperature', '0.0'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiExtract: non-constant instruction';
-SELECT aiExtract('ai_credentials', x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
+SELECT aiExtract(x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
 
 SELECT '-- aiExtract: return type';
 DROP TABLE IF EXISTS _03300_ret_extract;
 CREATE TABLE _03300_ret_extract ENGINE = Memory AS
-    SELECT aiExtract('ai_credentials', x, 'main topic') AS result FROM tab;
+    SELECT aiExtract(x, 'main topic') AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_extract';
 DROP TABLE IF EXISTS _03300_ret_extract;
 
 SELECT '-- aiExtract: JSON schema mode accepted';
-SELECT count() FROM (SELECT aiExtract('ai_credentials', x, '{"topic":"main topic","sentiment":"pos/neg"}') AS result FROM tab);
+SELECT count() FROM (SELECT aiExtract(x, '{"topic":"main topic","sentiment":"pos/neg"}') AS result FROM tab);
 
 SELECT '-- aiExtract: malformed JSON schema';
-SELECT aiExtract('ai_credentials', 'hi', '{invalid'); -- { serverError BAD_ARGUMENTS }
+SELECT aiExtract('hi', '{invalid'); -- { serverError BAD_ARGUMENTS }
 
 -- `instruction_or_schema` is a row-independent constant, so a malformed schema must fail
 -- the query even when the source has zero rows.
 SELECT '-- aiExtract: malformed JSON schema on empty input';
-SELECT aiExtract('ai_credentials', x, '{invalid') FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiExtract(x, '{invalid') FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiExtract: JSON schema with non-string value';
-SELECT aiExtract('ai_credentials', 'hi', '{"a":null}'); -- { serverError BAD_ARGUMENTS }
+SELECT aiExtract('hi', '{"a":null}'); -- { serverError BAD_ARGUMENTS }
 
 -- Leading whitespace before the `{` must still be routed to schema mode, otherwise a malformed
 -- JSON would be silently accepted as a free-text instruction.
 SELECT '-- aiExtract: schema mode detection ignores leading whitespace';
-SELECT aiExtract('ai_credentials', 'hi', '   {invalid'); -- { serverError BAD_ARGUMENTS }
-SELECT aiExtract('ai_credentials', 'hi', '\n\t {invalid'); -- { serverError BAD_ARGUMENTS }
+SELECT aiExtract('hi', '   {invalid'); -- { serverError BAD_ARGUMENTS }
+SELECT aiExtract('hi', '\n\t {invalid'); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiExtract: with temperature';
-SELECT count() FROM (SELECT aiExtract('ai_credentials', x, 'main topic', 0.0) AS result FROM tab);
+SELECT count() FROM (SELECT aiExtract(x, 'main topic', map('temperature', '0.0')) AS result FROM tab);
 
 -- =============================================================================
 -- 16. aiTranslate
@@ -356,29 +367,29 @@ SELECT '-- aiTranslate: registered';
 SELECT name FROM system.functions WHERE name = 'aiTranslate';
 
 SELECT '-- aiTranslate: too few arguments';
-SELECT aiTranslate('ai_credentials'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-SELECT aiTranslate('ai_credentials', 'hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiTranslate(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiTranslate('hello'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiTranslate: too many arguments';
-SELECT aiTranslate('ai_credentials', 'x', 'French', 'instr', 0.3, 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiTranslate('x', 'French', map('temperature', '0.3'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiTranslate: non-constant target language';
-SELECT aiTranslate('ai_credentials', x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
+SELECT aiTranslate(x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
 
 SELECT '-- aiTranslate: empty target language';
-SELECT aiTranslate('ai_credentials', 'test', ''); -- { serverError BAD_ARGUMENTS }
-SELECT aiTranslate('ai_credentials', 'test', '   '); -- { serverError BAD_ARGUMENTS }
+SELECT aiTranslate('test', ''); -- { serverError BAD_ARGUMENTS }
+SELECT aiTranslate('test', '   '); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiTranslate: return type';
 DROP TABLE IF EXISTS _03300_ret_translate;
 CREATE TABLE _03300_ret_translate ENGINE = Memory AS
-    SELECT aiTranslate('ai_credentials', x, 'French') AS result FROM tab;
+    SELECT aiTranslate(x, 'French') AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_translate';
 DROP TABLE IF EXISTS _03300_ret_translate;
 
 SELECT '-- aiTranslate: with instructions and temperature';
-SELECT count() FROM (SELECT aiTranslate('ai_credentials', x, 'French', 'keep proper nouns', 0.3) AS result FROM tab);
+SELECT count() FROM (SELECT aiTranslate(x, 'French', map('instructions', 'keep proper nouns', 'temperature', '0.3')) AS result FROM tab);
 
 -- =============================================================================
 -- 17. aiEmbed
@@ -388,27 +399,21 @@ SELECT '-- aiEmbed: registered';
 SELECT name FROM system.functions WHERE name = 'aiEmbed';
 
 SELECT '-- aiEmbed: too few arguments';
-SELECT aiEmbed('ai_credentials'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiEmbed(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiEmbed: too many arguments';
-SELECT aiEmbed('ai_credentials', 'x', 256, 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiEmbed('x', map('dimensions', '256'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
-SELECT '-- aiEmbed: non-constant dimensions';
-SELECT aiEmbed('ai_credentials', x, toUInt64(number)) FROM (SELECT x, 0 AS number FROM tab); -- { serverError ILLEGAL_COLUMN }
+SELECT '-- aiEmbed: non-constant parameter map';
+SELECT aiEmbed(x, map('dimensions', toString(number))) FROM (SELECT x, 0 AS number FROM tab); -- { serverError ILLEGAL_COLUMN }
 
-SELECT '-- aiEmbed: wrong type for dimensions (signed integer)';
-SELECT aiEmbed('ai_credentials', x, -1) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
-SELECT '-- aiEmbed: wrong type for dimensions (string)';
-SELECT aiEmbed('ai_credentials', x, '256') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
-
-SELECT '-- aiEmbed: non-constant collection';
-SELECT aiEmbed(x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
+SELECT '-- aiEmbed: wrong type for parameter argument (not a map)';
+SELECT aiEmbed(x, 256) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
 SELECT '-- aiEmbed: return type';
 DROP TABLE IF EXISTS _03300_ret_embed;
 CREATE TABLE _03300_ret_embed ENGINE = Memory AS
-    SELECT aiEmbed('ai_credentials', x) AS result FROM tab;
+    SELECT aiEmbed(x) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed';
 DROP TABLE IF EXISTS _03300_ret_embed;
@@ -416,24 +421,24 @@ DROP TABLE IF EXISTS _03300_ret_embed;
 SELECT '-- aiEmbed: return type with dimensions';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 CREATE TABLE _03300_ret_embed_dim ENGINE = Memory AS
-    SELECT aiEmbed('ai_credentials', x, 256) AS result FROM tab;
+    SELECT aiEmbed(x, map('dimensions', '256')) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed_dim';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 
 SELECT '-- aiEmbed: empty input executes';
-SELECT count() FROM (SELECT aiEmbed('ai_credentials', x) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x) AS result FROM tab);
 
 SELECT '-- aiEmbed: empty input with dimensions';
-SELECT count() FROM (SELECT aiEmbed('ai_credentials', x, 128) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, map('dimensions', '128')) AS result FROM tab);
 
 -- `dimensions` is a row-independent constant, so an out-of-range value must fail
 -- the query even when the source has zero rows.
 SELECT '-- aiEmbed: out-of-range dimensions on empty input';
-SELECT aiEmbed('ai_credentials', x, 18446744073709551615) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, map('dimensions', '18446744073709551615')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiEmbed: nonexistent named collection';
-SELECT aiEmbed('nonexistent_collection_xyz', 'hello'); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
+SELECT aiEmbed('hello', map('credentials', 'nonexistent_collection_xyz')); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
 
 SELECT '-- aiEmbed: batch size setting default';
 SELECT default FROM system.settings WHERE name = 'ai_function_embedding_max_batch_size';
@@ -447,7 +452,7 @@ DROP TABLE IF EXISTS _03300_embed_null_out;
 CREATE TABLE _03300_embed_null_in (x Nullable(String)) ENGINE = Memory;
 INSERT INTO _03300_embed_null_in VALUES (NULL);
 CREATE TABLE _03300_embed_null_out ENGINE = Memory AS
-    SELECT aiEmbed('ai_credentials', x) AS result FROM _03300_embed_null_in;
+    SELECT aiEmbed(x) AS result FROM _03300_embed_null_in;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_embed_null_out';
 
@@ -466,61 +471,61 @@ DROP TABLE IF EXISTS _03300_embed_null_in;
 SET ai_function_throw_on_error = 0;
 SET ai_function_request_timeout_sec = 3;
 
-SELECT '-- aiEmbed: DEFAULT survives INSERT (no server crash)';
+SELECT '-- aiEmbed: DEFAULT survives INSERT (no exception)';
 DROP TABLE IF EXISTS _03300_embed_default;
 CREATE TABLE _03300_embed_default
 (
     id UInt32,
     doc String,
-    vector Array(Float32) DEFAULT aiEmbed('ai_credentials', doc)
+    vector Array(Float32) DEFAULT aiEmbed(doc)
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_embed_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(vector) FROM _03300_embed_default;
 DROP TABLE _03300_embed_default;
 
-SELECT '-- aiGenerate: DEFAULT survives INSERT (no server crash)';
+SELECT '-- aiGenerate: DEFAULT survives INSERT (no exception)';
 DROP TABLE IF EXISTS _03300_generate_default;
 CREATE TABLE _03300_generate_default
 (
     id UInt32,
     doc String,
-    summary String DEFAULT aiGenerate('ai_credentials', doc)
+    summary String DEFAULT aiGenerate(doc)
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_generate_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(summary) FROM _03300_generate_default;
 DROP TABLE _03300_generate_default;
 
-SELECT '-- aiClassify: DEFAULT survives INSERT (no server crash)';
+SELECT '-- aiClassify: DEFAULT survives INSERT (no exception)';
 DROP TABLE IF EXISTS _03300_classify_default;
 CREATE TABLE _03300_classify_default
 (
     id UInt32,
     doc String,
-    label String DEFAULT aiClassify('ai_credentials', doc, ['positive', 'negative'])
+    label String DEFAULT aiClassify(doc, ['positive', 'negative'])
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_classify_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(label) FROM _03300_classify_default;
 DROP TABLE _03300_classify_default;
 
-SELECT '-- aiExtract: DEFAULT survives INSERT (no server crash)';
+SELECT '-- aiExtract: DEFAULT survives INSERT (no exception)';
 DROP TABLE IF EXISTS _03300_extract_default;
 CREATE TABLE _03300_extract_default
 (
     id UInt32,
     doc String,
-    extracted String DEFAULT aiExtract('ai_credentials', doc, 'main topic')
+    extracted String DEFAULT aiExtract(doc, 'main topic')
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_extract_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(extracted) FROM _03300_extract_default;
 DROP TABLE _03300_extract_default;
 
-SELECT '-- aiTranslate: DEFAULT survives INSERT (no server crash)';
+SELECT '-- aiTranslate: DEFAULT survives INSERT (no exception)';
 DROP TABLE IF EXISTS _03300_translate_default;
 CREATE TABLE _03300_translate_default
 (
     id UInt32,
     doc String,
-    translation String DEFAULT aiTranslate('ai_credentials', doc, 'French')
+    translation String DEFAULT aiTranslate(doc, 'French')
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_translate_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(translation) FROM _03300_translate_default;
@@ -535,7 +540,7 @@ SET ai_function_request_timeout_sec = 60;
 
 SET allow_experimental_ai_functions = 0;
 SELECT '-- Re-disabled blocks function';
-SELECT aiGenerate('ai_credentials', 'hello'); -- { serverError SUPPORT_IS_DISABLED }
+SELECT aiGenerate('hello'); -- { serverError SUPPORT_IS_DISABLED }
 
 SET allow_experimental_ai_functions = 1;
 
@@ -543,5 +548,7 @@ SET allow_experimental_ai_functions = 1;
 -- Cleanup
 -- =============================================================================
 
+SET ai_function_text_default_credentials = '';
+SET ai_function_embedding_default_credentials = '';
 DROP TABLE IF EXISTS tab;
 DROP NAMED COLLECTION ai_credentials;

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -258,6 +258,9 @@ SELECT aiGenerate(x, 'notamap') FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUM
 SELECT '-- Wrong map value type (Map(String, Float) not accepted)';
 SELECT aiGenerate(x, map('temperature', 0.5)) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
+SELECT '-- Map in the prompt position rejected';
+SELECT aiGenerate(map('credentials', 'ai_credentials')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
 -- =============================================================================
 -- 13. Setting types and defaults
 -- =============================================================================

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -237,6 +237,15 @@ SELECT aiGenerate('hi', map('temperature', 'hot')); -- { serverError BAD_ARGUMEN
 SELECT '-- Non-integer max_tokens rejected';
 SELECT aiGenerate('hi', map('max_tokens', '3.5')); -- { serverError BAD_ARGUMENTS }
 
+SELECT '-- Negative max_tokens rejected';
+SELECT aiGenerate('hi', map('max_tokens', '-1')); -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- Out-of-range max_tokens rejected (exceeds Int64)';
+SELECT aiGenerate('hi', map('max_tokens', '18446744073709551615')); -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- Duplicate map key rejected';
+SELECT aiGenerate('hi', map('temperature', '0.1', 'temperature', '0.2')); -- { serverError BAD_ARGUMENTS }
+
 SELECT '-- Non-constant parameter map rejected';
 SELECT aiGenerate(x, map('credentials', x)) FROM tab; -- { serverError ILLEGAL_COLUMN }
 

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -243,6 +243,9 @@ SELECT aiGenerate('hi', map('max_tokens', '-1')); -- { serverError BAD_ARGUMENTS
 SELECT '-- Out-of-range max_tokens rejected (exceeds Int64)';
 SELECT aiGenerate('hi', map('max_tokens', '18446744073709551615')); -- { serverError BAD_ARGUMENTS }
 
+SELECT '-- Overflowing max_tokens rejected (exceeds UInt64, must not wrap)';
+SELECT aiGenerate('hi', map('max_tokens', '18446744073709551616')); -- { serverError BAD_ARGUMENTS }
+
 SELECT '-- Duplicate map key rejected';
 SELECT aiGenerate('hi', map('temperature', '0.1', 'temperature', '0.2')); -- { serverError BAD_ARGUMENTS }
 

--- a/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
+++ b/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
@@ -32,13 +32,13 @@ function check_access_both()
 {
     $CLICKHOUSE_CLIENT --user "$user_name" --password "password" --multiquery --ignore-error -q "
         SET allow_experimental_ai_functions = 1;
-        SELECT aiGenerate('$collection_name', 'hi') FORMAT Null;
+        SELECT aiGenerate('hi', map('credentials', '$collection_name')) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('$collection_name', 'hi') FORMAT Null;
+        SELECT aiEmbed('hi', map('credentials', '$collection_name')) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiGenerate('$collection_name', x) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiGenerate(x, map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('$collection_name', x) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiEmbed(x, map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
     " 2>&1 | awk '
         /ACCESS_DENIED/ { denied = 1; next }
         /^SEP$/ { print (denied ? "ACCESS_DENIED" : "OK"); denied = 0; next }

--- a/tests/queries/0_stateless/04492_ai_functions_default_credentials.reference
+++ b/tests/queries/0_stateless/04492_ai_functions_default_credentials.reference
@@ -1,0 +1,12 @@
+-- No defaults: text function fails
+-- No defaults: aiEmbed fails
+-- Text default set: aiGenerate resolves via default
+0
+-- Text default does not leak into aiEmbed
+-- Embedding default set: aiEmbed resolves via default
+0
+-- Embedding default does not leak into text functions
+-- Map credentials override with no text default
+0
+-- Map credentials override wins over default
+0

--- a/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
+++ b/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
@@ -1,0 +1,76 @@
+-- Tags: no-parallel, no-replicated-database
+-- no-parallel: creates and drops global named collections
+-- no-replicated-database: named collections are server-global, not database-scoped
+
+-- =============================================================================
+-- Default-credentials resolution for AI functions.
+-- The text functions (aiGenerate/aiClassify/aiExtract/aiTranslate) and aiEmbed
+-- use separate default-credentials settings, because a chat-completions endpoint
+-- and model differ from an embeddings one. A per-call `credentials` map key
+-- overrides the default. All tests run without a real AI provider.
+-- =============================================================================
+
+SET allow_experimental_ai_functions = 1;
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (x String) ENGINE = Memory;
+
+DROP NAMED COLLECTION IF EXISTS ai_text_nc;
+DROP NAMED COLLECTION IF EXISTS ai_embed_nc;
+CREATE NAMED COLLECTION ai_text_nc AS
+    provider = 'openai',
+    endpoint = 'http://localhost:1/v1/chat/completions',
+    model = 'chat-model',
+    api_key = 'fake-key';
+CREATE NAMED COLLECTION ai_embed_nc AS
+    provider = 'openai',
+    endpoint = 'http://localhost:1/v1/embeddings',
+    model = 'embed-model',
+    api_key = 'fake-key';
+
+-- Start with no defaults set: bare calls must fail with a clear error.
+SET ai_function_text_default_credentials = '';
+SET ai_function_embedding_default_credentials = '';
+
+SELECT '-- No defaults: text function fails';
+SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }
+SELECT '-- No defaults: aiEmbed fails';
+SELECT aiEmbed('hi'); -- { serverError BAD_ARGUMENTS }
+
+-- Set only the text default. aiGenerate resolves; aiEmbed still has no default.
+SET ai_function_text_default_credentials = 'ai_text_nc';
+
+SELECT '-- Text default set: aiGenerate resolves via default';
+SELECT count() FROM (SELECT aiGenerate(x) AS r FROM tab);
+
+SELECT '-- Text default does not leak into aiEmbed';
+SELECT aiEmbed('hi'); -- { serverError BAD_ARGUMENTS }
+
+-- Set only the embedding default (clear the text one). aiEmbed resolves; text fails.
+SET ai_function_text_default_credentials = '';
+SET ai_function_embedding_default_credentials = 'ai_embed_nc';
+
+SELECT '-- Embedding default set: aiEmbed resolves via default';
+SELECT count() FROM (SELECT aiEmbed(x) AS r FROM tab);
+
+SELECT '-- Embedding default does not leak into text functions';
+SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }
+
+-- The per-call `credentials` map key overrides the default (and works with no default set).
+SELECT '-- Map credentials override with no text default';
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_text_nc')) AS r FROM tab);
+
+-- Map credentials override wins over a set default.
+SET ai_function_text_default_credentials = 'ai_text_nc';
+SELECT '-- Map credentials override wins over default';
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_embed_nc')) AS r FROM tab);
+
+-- =============================================================================
+-- Cleanup
+-- =============================================================================
+
+SET ai_function_text_default_credentials = '';
+SET ai_function_embedding_default_credentials = '';
+DROP NAMED COLLECTION ai_text_nc;
+DROP NAMED COLLECTION ai_embed_nc;
+DROP TABLE tab;


### PR DESCRIPTION
## Description

Reworks how the experimental AI functions (`aiGenerate`, `aiEmbed`, `aiClassify`, `aiExtract`, `aiTranslate`) receive credentials and tunables.

Previously the named collection was a mandatory first positional argument, and each tunable (`system_prompt`, `temperature`, `dimensions`, translate `instructions`) was a separate positional argument. This made a casual call verbose and forced every query to name the collection.

Now:

- The per-row text is the first argument; the named collection is no longer positional.
- Credentials are resolved from a `credentials` key in an optional trailing `Map(String, String)` argument, or — when the map omits it — from a default-credentials setting:
  - `ai_function_text_default_credentials` for the text functions (`aiGenerate`/`aiClassify`/`aiExtract`/`aiTranslate`),
  - `ai_function_embedding_default_credentials` for `aiEmbed`.

  The split exists because a chat-completions endpoint/model differs from an embeddings one, and the named collection's `endpoint` is used verbatim.
- The same map carries the tunables: `model` (overrides the collection), `max_tokens`, `temperature`, `system_prompt` (`aiGenerate`), `instructions` (`aiTranslate`), `dimensions` (`aiEmbed`). Map values are strings; unknown keys and duplicate keys are rejected; integer values are overflow-checked and capped at `Int64` max.

```sql
SET ai_function_text_default_credentials = 'my_nc';

-- casual: use the default
SELECT aiGenerate(body) FROM articles;

-- override per call
SELECT aiGenerate(body, map('temperature', '0.2', 'credentials', 'my_other_nc')) FROM articles;
```

Internally, each function declares its parameters (name, kind, default-or-required, whether it inherits from the named collection) via a small spec, and a single resolver in `FunctionBaseAI` does the parsing, validation and defaulting.

Note: an explicitly empty value is now honored (`map('system_prompt', '')` sends an empty system prompt); the default applies only when the key is absent.

This is a breaking change to the AI function signatures, but they are experimental (guarded by `allow_experimental_ai_functions`) and were introduced only in 26.4/26.6.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

AI functions no longer take the named collection as the first positional argument. Credentials come from the `ai_function_text_default_credentials` / `ai_function_embedding_default_credentials` settings or from a `credentials` key in an optional trailing `Map(String, String)` argument, which also carries tunables (`model`, `max_tokens`, `temperature`, `system_prompt`, `instructions`, `dimensions`).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.641` (included in `26.7` and later)
- Backported to: `26.6.2.137`, `26.5.6.99`
<!-- ch-version-info:end -->