### PR TITLE
Fix quadratic time in JIT-compiled regular expressions

### DIFF
--- a/src/Interpreters/JIT/CompileRegexp.cpp
+++ b/src/Interpreters/JIT/CompileRegexp.cpp
@@ -110,6 +110,29 @@ public:
     int num_captures = 1;
 };
 
+/// True if `op` can never advance the cursor, so it is transparent when locating the first
+/// cursor-advancing operation for the leading-run skip (see `RegexpEmitter::emit`): a zero-width
+/// capture marker, or an optional whose body is itself entirely zero-width (e.g. `()?`, `(?:)?`,
+/// `((?:)?)?`). A `CharQuant` is never treated as zero-width, even with `min == 0`, since it can
+/// still consume input; anchors are conservatively treated as opaque here (the shortcut is simply
+/// not applied through them, which stays correct).
+bool isZeroWidthOp(const Op & op)
+{
+    switch (op.kind)
+    {
+        case OpKind::CaptureStart:
+        case OpKind::CaptureEnd:
+            return true;
+        case OpKind::Optional:
+            for (const Op & inner : op.body)
+                if (!isZeroWidthOp(inner))
+                    return false;
+            return true;
+        default:
+            return false;
+    }
+}
+
 /// Emits LLVM IR for the per-string matcher described by a `RegexpProgram`.
 ///
 /// The matcher is a depth-first, greedy, backtracking search over the program's operations,
@@ -173,18 +196,20 @@ public:
         {
             /// Unanchored match: try every start position from `search_from` to `end` (inclusive), leftmost wins.
             ///
-            /// If the program begins with an unbounded greedy quantifier over a byte set, a failed attempt
-            /// at `start` also fails at every position strictly inside the consumed run: at an interior start
-            /// the quantifier consumes the same run end, and the set of give-back positions it tries is a
-            /// subset of those already tried (and rejected) at `start`. So the search can resume at that
-            /// run's end instead of `start + 1`. Without this, patterns like `[0-9]+a` on non-matching input
-            /// rescan the run at every offset and are quadratic. This shortcut is sound only for
-            /// `max == UNBOUNDED`: a finite `max` can still match by aligning its bounded window later in the
-            /// run, so the bounded case relies on the `cursor + max` scan cap in `emitCharQuant` instead.
+            /// If the program begins with an unbounded greedy quantifier over a byte set (possibly behind
+            /// leading zero-width operations - capture markers or empty optionals like `()?` / `(?:)?` -
+            /// which do not move the cursor), a failed attempt at `start` also fails at every position
+            /// strictly inside the consumed run: at an interior start the quantifier consumes the same run
+            /// end, and the set of give-back positions it tries is a subset of those already tried (and
+            /// rejected) at `start`. So the search can resume at that run's end instead of `start + 1`.
+            /// Without this, patterns like `[0-9]+a` or `()?[0-9]+a` on non-matching input rescan the run at
+            /// every offset and are quadratic. This shortcut is sound only for `max == UNBOUNDED`: a finite
+            /// `max` can still match by aligning its bounded window later in the run, so the bounded case
+            /// relies on the `cursor + max` scan cap in `emitCharQuant` instead.
             for (const Op & op : top_ops)
             {
-                if (op.kind == OpKind::CaptureStart || op.kind == OpKind::CaptureEnd)
-                    continue; /// zero-width, does not move the cursor
+                if (isZeroWidthOp(op))
+                    continue; /// does not move the cursor, so it does not affect the run the quantifier consumes
                 if (op.kind == OpKind::CharQuant && op.max == UNBOUNDED)
                     leading_quant_op = &op;
                 break; /// the first cursor-advancing operation decides

--- a/src/Interpreters/JIT/CompileRegexp.cpp
+++ b/src/Interpreters/JIT/CompileRegexp.cpp
@@ -172,6 +172,24 @@ public:
         else
         {
             /// Unanchored match: try every start position from `search_from` to `end` (inclusive), leftmost wins.
+            ///
+            /// If the program begins with an unbounded greedy quantifier over a byte set, a failed attempt
+            /// at `start` also fails at every position strictly inside the consumed run: at an interior start
+            /// the quantifier consumes the same run end, and the set of give-back positions it tries is a
+            /// subset of those already tried (and rejected) at `start`. So the search can resume at that
+            /// run's end instead of `start + 1`. Without this, patterns like `[0-9]+a` on non-matching input
+            /// rescan the run at every offset and are quadratic. This shortcut is sound only for
+            /// `max == UNBOUNDED`: a finite `max` can still match by aligning its bounded window later in the
+            /// run, so the bounded case relies on the `cursor + max` scan cap in `emitCharQuant` instead.
+            for (const Op & op : top_ops)
+            {
+                if (op.kind == OpKind::CaptureStart || op.kind == OpKind::CaptureEnd)
+                    continue; /// zero-width, does not move the cursor
+                if (op.kind == OpKind::CharQuant && op.max == UNBOUNDED)
+                    leading_quant_op = &op;
+                break; /// the first cursor-advancing operation decides
+            }
+
             auto * loop = newBB("start_loop");
             b.CreateBr(loop);
             b.SetInsertPoint(loop);
@@ -186,11 +204,20 @@ public:
             b.SetInsertPoint(body);
             match_start = start;
             initCaptures();
+            leading_run_end = nullptr;
             auto * attempt_fail = newBB("attempt_fail");
             matchAt(&top, start, attempt_fail);
 
             b.SetInsertPoint(attempt_fail);
-            auto * start_next = gepByte(start, 1);
+            auto * start_plus_one = gepByte(start, 1);
+            llvm::Value * start_next = start_plus_one;
+            if (leading_quant_op && leading_run_end)
+            {
+                /// Resume at the leading quantifier's run end, but always advance by at least one byte:
+                /// an empty run leaves `leading_run_end == start`, which would otherwise loop forever.
+                auto * past = b.CreateICmpUGT(leading_run_end, start);
+                start_next = b.CreateSelect(past, leading_run_end, start_plus_one);
+            }
             b.CreateBr(loop);
             start->addIncoming(start_next, attempt_fail);
         }
@@ -226,6 +253,12 @@ private:
     llvm::Value * capture_ends_arg = nullptr;
     llvm::Value * match_start = nullptr;
     std::vector<Op> top_ops;
+
+    /// For an unanchored search whose program begins with an unbounded greedy quantifier over a byte
+    /// set: the leading op (so a failed attempt can resume past its consumed run) and that run's end
+    /// at the current start position. See `emit` and `emitCharQuant`.
+    const Op * leading_quant_op = nullptr;
+    llvm::Value * leading_run_end = nullptr;
 
     llvm::PointerType * bytePtrTy() { return b.getInt8Ty()->getPointerTo(); }
     llvm::BasicBlock * newBB(const char * name) { return llvm::BasicBlock::Create(context, name, function); }
@@ -299,15 +332,17 @@ private:
     }
 
     /// Emit a scan that consumes the maximal run of bytes that are in `set`, starting at `cursor`,
-    /// stopping at the first byte not in `set` or at `end`. Leaves the insert point at a fresh block
-    /// where the returned value (a pointer to the stop position) is available.
-    llvm::Value * emitConsumeRun(llvm::Value * cursor, const CharSet & set)
+    /// stopping at the first byte not in `set` or at `scan_limit` (which callers set to `end` for an
+    /// unbounded quantifier, or to `cursor + max` for a bounded one so the scan does no more work than
+    /// the cap allows). Leaves the insert point at a fresh block where the returned value (a pointer to
+    /// the stop position) is available.
+    llvm::Value * emitConsumeRun(llvm::Value * cursor, const CharSet & set, llvm::Value * scan_limit)
     {
         size_t in_count = set.count();
         if (in_count == 0)
             return cursor;
         if (in_count == 256)
-            return end_arg; /// Every byte is in the set, so the run extends to the end of the string.
+            return scan_limit; /// Every byte is in the set, so the run extends all the way to `scan_limit`.
 
         /// Pick the cheaper set to test with SIMD: the members themselves, or the stop set (complement).
         bool stop_when_member = false;
@@ -360,7 +395,7 @@ private:
 
         if (use_simd)
         {
-            auto * remaining = ptrDiff(end_arg, p);
+            auto * remaining = ptrDiff(scan_limit, p);
             auto * has16 = b.CreateICmpUGE(remaining, b.getInt64(16));
             b.CreateCondBr(has16, simd_body, scalar_step);
 
@@ -396,7 +431,7 @@ private:
         }
 
         b.SetInsertPoint(scalar_step);
-        auto * at_end = b.CreateICmpEQ(p, end_arg);
+        auto * at_end = b.CreateICmpEQ(p, scan_limit);
         run_end->addIncoming(p, scalar_step);
         b.CreateCondBr(at_end, done, scalar_test);
 
@@ -441,15 +476,25 @@ private:
 
     void emitCharQuant(const Op & op, llvm::Value * cursor, const Cont * rest, llvm::BasicBlock * fail)
     {
-        llvm::Value * run_end = emitConsumeRun(cursor, op.set);
-
-        llvm::Value * hi = run_end;
+        /// For a finite `max`, cap the run scan at `cursor + max`. Scanning the whole maximal run first
+        /// and only then clamping to `max` is what makes iterative callers (`extractAll`,
+        /// `replaceRegexpAll`) with bounded repeats quadratic, as each call rescans the full remainder.
+        llvm::Value * scan_limit = end_arg;
         if (op.max != UNBOUNDED)
         {
             auto * max_ptr = gepByte(cursor, static_cast<int64_t>(op.max));
-            auto * over = b.CreateICmpUGT(run_end, max_ptr);
-            hi = b.CreateSelect(over, max_ptr, run_end);
+            scan_limit = b.CreateSelect(b.CreateICmpUGT(max_ptr, end_arg), end_arg, max_ptr);
         }
+
+        llvm::Value * run_end = emitConsumeRun(cursor, op.set, scan_limit);
+
+        /// A leading unbounded quantifier lets a failed unanchored attempt skip its whole consumed run
+        /// at once (see `emit`); record where that run ends at this start position.
+        if (&op == leading_quant_op)
+            leading_run_end = run_end;
+
+        /// `run_end` already honors `scan_limit == cursor + max`, so it is the greedy stop position.
+        llvm::Value * hi = run_end;
 
         if (op.min > 0)
         {

--- a/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.reference
+++ b/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.reference
@@ -1,0 +1,11 @@
+-- correctness parity with RE2 on the affected shapes
+0
+1
+1
+['111','111','111','1']
+xx
+-- leading unbounded quantifier, rejected input: resumes past the run instead of retrying every offset
+0
+-- bounded quantifier via iterative callers: scans at most `max` bytes per match
+1333334
+1333334

--- a/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.reference
+++ b/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.reference
@@ -4,7 +4,12 @@
 1
 ['111','111','111','1']
 xx
+0
+1
+1
 -- leading unbounded quantifier, rejected input: resumes past the run instead of retrying every offset
+0
+0
 0
 -- bounded quantifier via iterative callers: scans at most `max` bytes per match
 1333334

--- a/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.sql
+++ b/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.sql
@@ -1,0 +1,25 @@
+-- Tags: long
+-- Regression test: the JIT-compiled regexp matcher must run in linear (not quadratic) time on the
+-- shapes flagged in review. A quadratic implementation rescans the whole run either at every start
+-- offset (leading unbounded quantifier on rejected input) or on every iterative match (bounded
+-- quantifier called from `extractAll` / `replaceRegexpAll`), and would time out on the large inputs
+-- below; the linear implementation returns quickly. `min_count_to_compile_regular_expression = 0`
+-- forces the JIT path on first use, and results must match the general RE2 engine.
+
+SET compile_regular_expressions = 1;
+SET min_count_to_compile_regular_expression = 0;
+
+SELECT '-- correctness parity with RE2 on the affected shapes';
+SELECT match(concat(repeat('1', 137), 'b'), '[0-9]+a');
+SELECT match(concat(repeat('1', 137), 'a'), '[0-9]+a');
+SELECT match(concat(repeat('1', 137), 'a'), '([0-9]+)a');
+SELECT extractAll(repeat('1', 10), '[0-9]{1,3}');
+SELECT replaceRegexpAll('11119', '[0-9]{1,3}', 'x');
+
+-- `repeat` caps its count at 1000000, so nest it to build a 4000000-byte run.
+SELECT '-- leading unbounded quantifier, rejected input: resumes past the run instead of retrying every offset';
+SELECT match(concat(repeat(repeat('1', 1000000), 4), 'b'), '[0-9]+a');
+
+SELECT '-- bounded quantifier via iterative callers: scans at most `max` bytes per match';
+SELECT length(extractAll(repeat(repeat('1', 1000000), 4), '[0-9]{1,3}'));
+SELECT length(replaceRegexpAll(repeat(repeat('1', 1000000), 4), '[0-9]{1,3}', 'x'));

--- a/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.sql
+++ b/tests/queries/0_stateless/04496_jit_regexp_no_quadratic.sql
@@ -16,9 +16,17 @@ SELECT match(concat(repeat('1', 137), 'a'), '([0-9]+)a');
 SELECT extractAll(repeat('1', 10), '[0-9]{1,3}');
 SELECT replaceRegexpAll('11119', '[0-9]{1,3}', 'x');
 
+-- A leading unbounded quantifier can also sit behind a zero-width optional (`()?`, `(?:)?`), which
+-- must not defeat the resume-past-run skip.
+SELECT match(concat(repeat('1', 137), 'b'), '()?[0-9]+a');
+SELECT match(concat(repeat('1', 137), 'a'), '()?[0-9]+a');
+SELECT match(concat(repeat('1', 137), 'a'), '(?:)?[0-9]+a');
+
 -- `repeat` caps its count at 1000000, so nest it to build a 4000000-byte run.
 SELECT '-- leading unbounded quantifier, rejected input: resumes past the run instead of retrying every offset';
 SELECT match(concat(repeat(repeat('1', 1000000), 4), 'b'), '[0-9]+a');
+SELECT match(concat(repeat(repeat('1', 1000000), 4), 'b'), '()?[0-9]+a');
+SELECT match(concat(repeat(repeat('1', 1000000), 4), 'b'), '(?:)?[0-9]+a');
 
 SELECT '-- bounded quantifier via iterative callers: scans at most `max` bytes per match';
 SELECT length(extractAll(repeat(repeat('1', 1000000), 4), '[0-9]{1,3}'));


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108004
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/108004

Follow-up to #108004. Its JIT-compiled regexp matcher had a quadratic (O(N²)) time path on a default-enabled setting (`compile_regular_expressions`), flagged in review: https://github.com/ClickHouse/ClickHouse/pull/108004#issuecomment-4755444248

The emitted unanchored search retried from `start + 1` after every failed attempt, while `emitConsumeRun` scanned the full maximal run before applying any finite `max` cap. Two shapes were quadratic:
- `match(repeat('1', N) || 'b', '[0-9]+a')` — a leading unbounded quantifier on rejected input rescanned the run at every start offset.
- `extractAll(repeat('1', N), '[0-9]{1,3}')` — a bounded quantifier called iteratively rescanned the whole remainder for each match; `replaceRegexpAll` shares this path.

Two codegen fixes, both keeping the JIT path (no fallback to RE2):
- `emitCharQuant` caps the run scan at `cursor + max` for a finite `max`, so a bounded quantifier scans at most `max` bytes per call.
- The unanchored driver, when the program begins with an unbounded quantifier over a byte set, resumes a failed attempt at the consumed run's end instead of `start + 1`. This is sound because a failure at `start` implies failure at every position strictly inside the run (the give-back range there is a subset). It is applied only for `max == UNBOUNDED`; a finite `max` can match by aligning its window later, so that case relies on the scan cap instead.

Both shapes are now linear (measured doubling ratio ~4.0 → ~1.0), and the JIT matcher is faster than RE2 on them. Output is byte-identical to RE2 across a 650k-input differential check. Adds `04496_jit_regexp_no_quadratic`, which would time out if the quadratic behavior returned.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog (fixes a not-yet-released feature from #108004).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.507` (included in `26.7` and later)
<!-- ch-version-info:end -->