### PR TITLE
Web UI: hide connection parameters behind a key button when tabs are shown

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5118,7 +5118,15 @@ function syncConnectionUI() {
     connection_key_elem.hidden = !tabsShown;
     if (tabsShown) {
         if (inputs_elem.parentElement !== connection_dropdown_elem) {
+            /// If focus is inside `#inputs` when the tab bar first appears (e.g. the user pressed
+            /// Enter in url/user/password to run the first query — reachable because those fields
+            /// keep `form="controls"` and submit implicitly), moving the subtree into the hidden
+            /// drop-down would strand focus on a hidden element. Move focus to the now-visible 🔑
+            /// button first — as the Escape handler does — so keyboard users keep a visible focus
+            /// target and the inputs stay one key press away behind that button.
+            const refocus = inputs_elem.contains(document.activeElement);
             connection_dropdown_elem.appendChild(inputs_elem);
+            if (refocus) connection_key_elem.focus();
         }
     } else {
         /// Restore the inline position (first child of the form) and make sure the drop-down

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5142,7 +5142,14 @@ connection_key_elem.addEventListener('click', (e) => {
 connection_dropdown_elem.addEventListener('click', (e) => e.stopPropagation());
 document.addEventListener('click', () => closeConnectionDropdown());
 document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && !connection_dropdown_elem.hidden) closeConnectionDropdown();
+    if (e.key === 'Escape' && !connection_dropdown_elem.hidden) {
+        /// Closing hides the subtree that may own focus (a connection input). Return focus to
+        /// the 🔑 button — as the download menu does with its trigger — so keyboard users keep a
+        /// visible focus target and the next Tab continues from the tab bar, not the page top.
+        const refocus = connection_dropdown_elem.contains(document.activeElement);
+        closeConnectionDropdown();
+        if (refocus) connection_key_elem.focus();
+    }
 });
 
 /// Generate the next default title: "Query A" .. "Query Z", "Query AA", ...

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -443,24 +443,30 @@
         #connection-menu
         {
             margin-left: auto;
+            /* Cancel the tab bar's 0.5rem right padding so the key's right edge lines up with
+               the query editor and result tables (the right edge of #main's content). */
+            margin-right: -0.5rem;
             align-self: flex-end;
             position: relative;
             flex-shrink: 0;
         }
 
-        /* Styled like the [+] button so the whole tab bar reads as one row of controls. */
+        /* A borderless, background-less button: just the 🔑 glyph aligned to the right edge. */
         #connection-key
         {
             display: flex;
             align-items: center;
-            justify-content: center;
-            padding: 0.25rem 0.6rem;
+            justify-content: flex-end;
+            /* No right padding: the glyph sits flush at the right edge of the page. */
+            padding: 0.25rem 0 0.25rem 0.6rem;
             cursor: pointer;
             font-size: 100%;
             line-height: 1;
-            background: var(--element-background-color);
-            border: 1px solid var(--border-color);
-            border-bottom: none; /* sits on the strip line like the tabs (no second line) */
+            background: none;
+            border: none;
+            /* On active, brighten the emoji itself rather than painting a button background. */
+            filter: brightness(0.85);
+            transition: filter 0.1s;
         }
 
         #connection-key[hidden]
@@ -470,7 +476,7 @@
 
         #connection-key:hover, #connection-key:focus
         {
-            background: var(--button-color);
+            filter: brightness(1.15);
         }
 
         /* The drop-down panel with the connection parameters. Anchored to the right edge
@@ -481,7 +487,6 @@
             top: 100%;
             right: 0;
             z-index: 3;
-            margin-top: 0.25rem;
             padding: 0.75rem;
             width: min(90vw, 34rem);
             /* The page background, so the inputs look exactly as they do in the inline top bar
@@ -498,23 +503,46 @@
             display: none;
         }
 
-        /* Inside the drop-down the connection inputs keep their inline row layout — the same
-           `#inputs` element is relocated here, so its status dot and event handlers keep working
-           unchanged. The url field is rebalanced so the user/password fields stay usable at the
-           panel's narrower width. */
+        /* Inside the drop-down the same relocated `#inputs` element is laid out in two stories:
+           the url (host) fills the first row, user and password share the second. `flex-wrap`
+           plus a 100% basis on the url forces the wrap; the negative top margin on the second
+           row overlaps the url's bottom border so there is a single seam and no vertical gap
+           (mirroring the horizontal -1px overlap the inputs already use side by side).
+           `position: relative` makes `#inputs` the containing block for the status dot. */
         #connection-dropdown #inputs
         {
+            display: flex;
+            flex-wrap: wrap;
             width: 100%;
+            position: relative;
         }
 
         #connection-dropdown #url
         {
-            width: 60%;
+            flex: 1 1 100%;
+            width: auto;
         }
 
         #connection-dropdown #user, #connection-dropdown #password
         {
-            width: calc(20% + 1px);
+            flex: 1 1 0;
+            width: auto;
+            margin-top: -1px; /* overlap the url's bottom border: one seam, no gap */
+        }
+
+        #connection-dropdown #user
+        {
+            margin-left: 0;
+        }
+
+        /* The connection-status dot sits at the right end of the url (first) row. The inline
+           layout relies on its static position after the url input; in the wrapped two-story
+           layout that position moves to the next row, so pin it explicitly instead. */
+        #connection-dropdown #url_status
+        {
+            top: 0;
+            right: 0;
+            transform: none;
         }
 
         .menu-icon

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -4286,6 +4286,10 @@ function checkCredentials() {
                 updateServerInfoVisibility();
             } else {
                 [user_elem, password_elem].forEach(e => { e.classList.remove('ok'); e.classList.add('fail'); });
+                /// The credentials didn't work — surface the connection settings so they can be
+                /// fixed. Only relevant when they live in the drop-down (tab bar shown); inline
+                /// (single tab) they are already visible, so there is nothing to open.
+                if (!connection_key_elem.hidden) { openConnectionDropdown(); }
             }
         }
     });

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5115,6 +5115,10 @@ function closeConnectionDropdown() {
 /// tab bar's visibility is recomputed.
 function syncConnectionUI() {
     const tabsShown = !tab_bar_elem.hidden;
+    /// Capture whether the 🔑 button owns focus before the next line may hide it: hiding a focused
+    /// element strands keyboard focus, so on the drop-down→inline transition we hand focus to a
+    /// visible control below (the mirror of the inline→drop-down handoff).
+    const keyHadFocus = document.activeElement === connection_key_elem;
     connection_key_elem.hidden = !tabsShown;
     if (tabsShown) {
         if (inputs_elem.parentElement !== connection_dropdown_elem) {
@@ -5135,6 +5139,10 @@ function syncConnectionUI() {
             controls_elem.insertBefore(inputs_elem, controls_elem.firstChild);
         }
         closeConnectionDropdown();
+        /// The `#connection-key` button was just hidden; if it owned focus, hand focus to the
+        /// now-visible inline `url` input — the first connection field the button gated — so
+        /// keyboard focus stays visible and the next Tab continues from the connection row.
+        if (keyHadFocus) url_elem.focus();
     }
     /// The url input's width differs between the inline bar and the drop-down, so the point at
     /// which the hostname reaches the version/uptime indicator changes: recompute its visibility.

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1427,6 +1427,11 @@
             transform: translateX(-100%);
             color: transparent;
             user-select: none;
+            /* The version/uptime indicator floats over the right end of the url input. Give it
+               an opaque background matching the input so a long hostname's text is masked behind
+               it and the version/uptime text stays readable, instead of the two overlapping.
+               The color matches the input, so the box is invisible when nothing is behind it. */
+            background: var(--element-background-color);
         }
 
         #url_status.ok

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5152,6 +5152,17 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
+/// The connection inputs keep `form="controls"`, so native constraint validation (e.g. the
+/// `type="url"` check on `#url`) still runs on submit while they sit in the closed drop-down.
+/// A hidden invalid control blocks the submit with no visible bubble, leaving the Run button
+/// dead. Open the drop-down when a connection field reports invalid, so the browser shows its
+/// validation bubble on a now-visible control. `invalid` does not bubble, so listen in the
+/// capture phase. In the single-tab layout the 🔑 button is hidden and the inputs are already
+/// visible inline, so nothing is opened.
+inputs_elem.addEventListener('invalid', () => {
+    if (!connection_key_elem.hidden && connection_dropdown_elem.hidden) openConnectionDropdown();
+}, true);
+
 /// Generate the next default title: "Query A" .. "Query Z", "Query AA", ...
 /// Skips titles already in use so closing/reopening doesn't produce duplicates.
 function nextDefaultTitle() {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1493,7 +1493,7 @@
         </div>
         <form id="controls">
             <div id="inputs">
-                <input name="url" spellcheck="false" class="monospace shadow" id="url" type="url" value="" placeholder="url" /><span id="url_status"><span id="server_info"></span>●</span><input name="user" spellcheck="false" class="monospace shadow" id="user" type="text" value="" placeholder="user" /><input name="password" class="monospace shadow" id="password" type="password" placeholder="password" />
+                <input name="url" form="controls" spellcheck="false" class="monospace shadow" id="url" type="url" value="" placeholder="url" /><span id="url_status"><span id="server_info"></span>●</span><input name="user" form="controls" spellcheck="false" class="monospace shadow" id="user" type="text" value="" placeholder="user" /><input name="password" form="controls" class="monospace shadow" id="password" type="password" placeholder="password" />
             </div>
             <div id="query_div"><div id="query-backdrop"></div><div id="completion-mirror"></div><textarea autofocus spellcheck="false" autocorrect="false" autocomplete="false" data-gramm="false" class="monospace shadow" id="query"></textarea><div id="completion-overlay"></div></div>
             <div id="query-params"></div>
@@ -5088,7 +5088,10 @@ const tabs_elem = document.getElementById('tabs');
 /// The connection parameters (url/user/password) live in the `#inputs` element. When the tab
 /// bar is shown they clutter the top of every tab, so we relocate that same element into a
 /// drop-down behind a 🔑 button in the top-right corner. Relocating the existing element (rather
-/// than duplicating the inputs) keeps every reference and event listener bound to it valid.
+/// than duplicating the inputs) keeps every reference and event listener bound to it valid. The
+/// three inputs carry `form="controls"`, so once moved out of the form's subtree they still count
+/// as its fields: pressing `Enter` in url/user/password keeps submitting `#controls` (running the
+/// query), matching the inline single-tab layout.
 const inputs_elem = document.getElementById('inputs');
 const controls_elem = document.getElementById('controls');
 const connection_key_elem = document.getElementById('connection-key');

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5094,6 +5094,7 @@ const tabs_elem = document.getElementById('tabs');
 /// query), matching the inline single-tab layout.
 const inputs_elem = document.getElementById('inputs');
 const controls_elem = document.getElementById('controls');
+const connection_menu_elem = document.getElementById('connection-menu');
 const connection_key_elem = document.getElementById('connection-key');
 const connection_dropdown_elem = document.getElementById('connection-dropdown');
 
@@ -5133,14 +5134,25 @@ function syncConnectionUI() {
 }
 
 connection_key_elem.addEventListener('click', (e) => {
+    /// Keep the toggle click from reaching the result-selection handler on `document`.
     e.stopPropagation();
     if (connection_dropdown_elem.hidden) openConnectionDropdown(); else closeConnectionDropdown();
 });
 
-/// Clicks inside the drop-down (typing in the inputs) must not close it; a click anywhere
-/// else does.
+/// A click inside the drop-down (e.g. typing in the inputs) must neither close it nor clear the
+/// result selection, so keep it from bubbling to `document`.
 connection_dropdown_elem.addEventListener('click', (e) => e.stopPropagation());
-document.addEventListener('click', () => closeConnectionDropdown());
+
+/// Close the drop-down on a click anywhere outside `#connection-menu` (which holds the 🔑 button
+/// and the drop-down). Test the target in the capture phase instead of relying on the click
+/// bubbling to `document`: several outside controls in this file (the download menu, the
+/// databases-panel toggles, the terminal toggle, the tab-close button, the per-column toggles)
+/// call `stopPropagation()` in their own bubble-phase click handlers, so a bubbling listener
+/// would never see those clicks and the popover would stay open. A capture-phase listener runs
+/// before all of them, so every outside interaction dismisses it.
+document.addEventListener('click', (e) => {
+    if (!connection_menu_elem.contains(e.target)) closeConnectionDropdown();
+}, true);
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !connection_dropdown_elem.hidden) {
         /// Closing hides the subtree that may own focus (a connection input). Return focus to

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1427,11 +1427,6 @@
             transform: translateX(-100%);
             color: transparent;
             user-select: none;
-            /* The version/uptime indicator floats over the right end of the url input. Give it
-               an opaque background matching the input so a long hostname's text is masked behind
-               it and the version/uptime text stays readable, instead of the two overlapping.
-               The color matches the input, so the box is invisible when nothing is behind it. */
-            background: var(--element-background-color);
         }
 
         #url_status.ok
@@ -4253,6 +4248,32 @@ function formatUptime(t) {
     return days + " day" + (days > 1 ? 's' : '');
 }
 
+/// The version/uptime indicator (`#server_info`) floats over the right end of the url input.
+/// A short hostname leaves it clearly visible, but a long one would overlap it into an illegible
+/// mix. The hostname takes precedence: hide the indicator as soon as the hostname text reaches
+/// it. The connection-status dot (the rest of `#url_status`) is left untouched — `visibility`
+/// keeps the indicator's width, so hiding it does not shift the dot.
+function updateServerInfoVisibility() {
+    const server_info = document.getElementById('server_info');
+    if (!server_info.textContent) { return; } /// nothing shown yet
+    /// Skip while the input is not laid out (e.g. inside a closed drop-down); recomputed on open.
+    if (!url_elem.offsetWidth) { return; }
+
+    /// Width of the hostname text in the input's own font.
+    const style = getComputedStyle(url_elem);
+    const ctx = updateServerInfoVisibility.ctx ||
+        (updateServerInfoVisibility.ctx = document.createElement('canvas').getContext('2d'));
+    ctx.font = `${style.fontSize} ${style.fontFamily}`;
+    const text_width = ctx.measureText(url_elem.value).width;
+
+    const url_rect = url_elem.getBoundingClientRect();
+    const text_end = url_rect.left + parseFloat(style.borderLeftWidth) + parseFloat(style.paddingLeft) + text_width;
+    const indicator_left = document.getElementById('url_status').getBoundingClientRect().left;
+    /// A few pixels of breathing room before they would touch.
+    server_info.style.visibility = (text_end + 4 > indicator_left) ? 'hidden' : 'visible';
+}
+window.addEventListener('resize', updateServerInfoVisibility);
+
 let check_credentials_request_num = 0;
 function checkCredentials() {
     ++check_credentials_request_num;
@@ -4262,6 +4283,7 @@ function checkCredentials() {
             if (json) {
                 [user_elem, password_elem].forEach(e => { e.classList.remove('fail'); e.classList.add('ok'); });
                 document.getElementById('server_info').innerText = `v${json.v}, uptime ${formatUptime(json.t)} `;
+                updateServerInfoVisibility();
             } else {
                 [user_elem, password_elem].forEach(e => { e.classList.remove('ok'); e.classList.add('fail'); });
             }
@@ -5071,6 +5093,8 @@ const connection_dropdown_elem = document.getElementById('connection-dropdown');
 function openConnectionDropdown() {
     connection_dropdown_elem.hidden = false;
     connection_key_elem.setAttribute('aria-expanded', 'true');
+    /// The url input was unmeasurable while the drop-down was display:none; recompute now.
+    updateServerInfoVisibility();
 }
 
 function closeConnectionDropdown() {
@@ -5096,6 +5120,9 @@ function syncConnectionUI() {
         }
         closeConnectionDropdown();
     }
+    /// The url input's width differs between the inline bar and the drop-down, so the point at
+    /// which the hostname reaches the version/uptime indicator changes: recompute its visibility.
+    updateServerInfoVisibility();
 }
 
 connection_key_elem.addEventListener('click', (e) => {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -247,6 +247,12 @@
             gap: 0.25rem;
             position: sticky;
             left: 0;
+            /* Raise the whole bar above #controls (a later sibling that is also `position:
+               sticky`, hence its own stacking context). Without this the connection drop-down
+               — nested in this bar's stacking context — would render behind the query editor,
+               which paints later. The bar and the editor never overlap otherwise, so this only
+               affects the open drop-down. */
+            z-index: 2;
             margin: -0.5rem 0 0.5rem 0; /* negative top bleeds into #main's top padding */
             /* No left padding: the bar's content edge already sits at #main's content
                edge, so the first tab lines up with the query editor and result tables.
@@ -428,6 +434,87 @@
         {
             background: var(--button-color);
             color: var(--button-text-color);
+        }
+
+        /* Holds the 🔑 button and its drop-down; pushed to the far right of the tab bar
+           so the connection settings sit in the top-right corner of the main area.
+           `position: relative` is the containing block for the absolutely positioned
+           drop-down below. */
+        #connection-menu
+        {
+            margin-left: auto;
+            align-self: flex-end;
+            position: relative;
+            flex-shrink: 0;
+        }
+
+        /* Styled like the [+] button so the whole tab bar reads as one row of controls. */
+        #connection-key
+        {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.25rem 0.6rem;
+            cursor: pointer;
+            font-size: 100%;
+            line-height: 1;
+            background: var(--element-background-color);
+            border: 1px solid var(--border-color);
+            border-bottom: none; /* sits on the strip line like the tabs (no second line) */
+        }
+
+        #connection-key[hidden]
+        {
+            display: none;
+        }
+
+        #connection-key:hover, #connection-key:focus
+        {
+            background: var(--button-color);
+        }
+
+        /* The drop-down panel with the connection parameters. Anchored to the right edge
+           of the 🔑 button and floating above the content below it. */
+        #connection-dropdown
+        {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            z-index: 3;
+            margin-top: 0.25rem;
+            padding: 0.75rem;
+            width: min(90vw, 34rem);
+            /* The page background, so the inputs look exactly as they do in the inline top bar
+               (a field on the page color, delineated by its own border) rather than blending
+               into a same-colored panel. The border and shadow below set the panel apart from
+               the content it floats over. */
+            background: var(--background-color);
+            border: 1px solid var(--border-color);
+            box-shadow: 0 0.25rem 1rem var(--shadow-color);
+        }
+
+        #connection-dropdown[hidden]
+        {
+            display: none;
+        }
+
+        /* Inside the drop-down the connection inputs keep their inline row layout — the same
+           `#inputs` element is relocated here, so its status dot and event handlers keep working
+           unchanged. The url field is rebalanced so the user/password fields stay usable at the
+           panel's narrower width. */
+        #connection-dropdown #inputs
+        {
+            width: 100%;
+        }
+
+        #connection-dropdown #url
+        {
+            width: 60%;
+        }
+
+        #connection-dropdown #user, #connection-dropdown #password
+        {
+            width: calc(20% + 1px);
         }
 
         .menu-icon
@@ -1371,6 +1458,10 @@
         <div id="tab-bar" hidden>
             <div id="tabs"></div>
             <button id="tab-add" type="button" title="New query (open a new tab)">+</button>
+            <div id="connection-menu">
+                <button id="connection-key" type="button" title="Connection settings" aria-expanded="false" hidden>🔑</button>
+                <div id="connection-dropdown" hidden></div>
+            </div>
         </div>
         <form id="controls">
             <div id="inputs">
@@ -4935,6 +5026,58 @@ appendTextareaResizer();
 const tab_bar_elem = document.getElementById('tab-bar');
 const tabs_elem = document.getElementById('tabs');
 
+/// The connection parameters (url/user/password) live in the `#inputs` element. When the tab
+/// bar is shown they clutter the top of every tab, so we relocate that same element into a
+/// drop-down behind a 🔑 button in the top-right corner. Relocating the existing element (rather
+/// than duplicating the inputs) keeps every reference and event listener bound to it valid.
+const inputs_elem = document.getElementById('inputs');
+const controls_elem = document.getElementById('controls');
+const connection_key_elem = document.getElementById('connection-key');
+const connection_dropdown_elem = document.getElementById('connection-dropdown');
+
+function openConnectionDropdown() {
+    connection_dropdown_elem.hidden = false;
+    connection_key_elem.setAttribute('aria-expanded', 'true');
+}
+
+function closeConnectionDropdown() {
+    connection_dropdown_elem.hidden = true;
+    connection_key_elem.setAttribute('aria-expanded', 'false');
+}
+
+/// Place the `#inputs` element either inline in `#controls` (no tab bar) or inside the
+/// drop-down behind the 🔑 button (tab bar shown). Called from `renderTabBar` whenever the
+/// tab bar's visibility is recomputed.
+function syncConnectionUI() {
+    const tabsShown = !tab_bar_elem.hidden;
+    connection_key_elem.hidden = !tabsShown;
+    if (tabsShown) {
+        if (inputs_elem.parentElement !== connection_dropdown_elem) {
+            connection_dropdown_elem.appendChild(inputs_elem);
+        }
+    } else {
+        /// Restore the inline position (first child of the form) and make sure the drop-down
+        /// is closed so a later reappearance of the tab bar starts collapsed.
+        if (inputs_elem.parentElement !== controls_elem) {
+            controls_elem.insertBefore(inputs_elem, controls_elem.firstChild);
+        }
+        closeConnectionDropdown();
+    }
+}
+
+connection_key_elem.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (connection_dropdown_elem.hidden) openConnectionDropdown(); else closeConnectionDropdown();
+});
+
+/// Clicks inside the drop-down (typing in the inputs) must not close it; a click anywhere
+/// else does.
+connection_dropdown_elem.addEventListener('click', (e) => e.stopPropagation());
+document.addEventListener('click', () => closeConnectionDropdown());
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !connection_dropdown_elem.hidden) closeConnectionDropdown();
+});
+
 /// Generate the next default title: "Query A" .. "Query Z", "Query AA", ...
 /// Skips titles already in use so closing/reopening doesn't produce duplicates.
 function nextDefaultTitle() {
@@ -5122,6 +5265,7 @@ function renderTabBar() {
     /// (rather than merely `result != null`) also ignores any stale/fabricated result
     /// snapshot that an older build may have persisted to IndexedDB.
     tab_bar_elem.hidden = (tabs.length <= 1 && !(active && active.result && active.result.ran));
+    syncConnectionUI();
 
     tabs_elem.textContent = '';
     for (const tab of tabs) {


### PR DESCRIPTION
Improvement to the Web UI (`play.html`).

When query tabs are shown, the connection parameters (`url`/`user`/`password`) previously took up a row above every tab. This moves them into a drop-down behind a 🔑 button in the top-right corner, so the tab bar and query editor get more room. Clicking the key toggles the drop-down; clicking elsewhere or pressing `Escape` closes it. With a single tab (tab bar hidden) the inputs stay in their original inline position, so nothing changes for the common single-query case.

Details:
- The 🔑 button is borderless and aligned flush with the right edge of the page; on hover/focus the emoji brightens instead of painting a button background.
- The drop-down opens straight below the button and lays the parameters out in two stories: the host (url) on the first row, user and password on the second.
- When a credentials check fails and the parameters live in the drop-down, it opens automatically so they can be fixed.
- A long hostname now takes precedence over the version/uptime indicator: the indicator is hidden as soon as the hostname text would reach it (and shown again when shortened), instead of the two texts overlapping into an illegible mix. The connection-status dot stays in place.

The same `#inputs` element is relocated rather than duplicated, so all existing references and event listeners keep working.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In the Web UI, when query tabs are shown, the connection parameters (host, user, password) are hidden behind a key button in the top-right corner and shown in a drop-down on demand.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.504` (included in `26.7` and later)
<!-- ch-version-info:end -->