### PR TITLE
Do not fail coverage jobs when the profdata artifact is missing

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -579,13 +579,11 @@ class ArtifactConfigs:
             "./*.profdata",
         ],
         # The coverage merge (llvm-profdata) runs non-blocking and can produce no
-        # .profdata (e.g. it crashes on a corrupt .profraw). On PR runs a missing
-        # batch is tolerated by the downstream LLVM Coverage aggregation, which
-        # globs whatever .profdata files exist, so a missing file must not redden
-        # a coverage job whose tests all passed. This optional flag is honored
-        # ONLY on PR runs: on master a missing shard is still an error, because
-        # the published baseline must be complete (see the runner and
-        # ci/jobs/scripts/workflow_hooks/filter_job.py).
+        # .profdata (e.g. it crashes on a corrupt .profraw). A missing batch is
+        # tolerated by the downstream LLVM Coverage aggregation, which globs
+        # whatever .profdata files exist, so a missing file must not redden a
+        # coverage job whose tests all passed. Marking the artifact optional lets
+        # the runner skip a missing file with a warning instead of erroring.
         optional=True,
     ).parametrize(names=LLVM_ARTIFACTS_LIST)
 

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -578,6 +578,12 @@ class ArtifactConfigs:
         path=[
             "./*.profdata",
         ],
+        # The coverage merge (llvm-profdata) runs non-blocking and can produce no
+        # .profdata (e.g. it crashes on a corrupt .profraw). A missing batch is
+        # tolerated by the downstream LLVM Coverage aggregation, which globs
+        # whatever .profdata files exist, so a missing file must not redden a
+        # coverage job whose tests all passed.
+        optional=True,
     ).parametrize(names=LLVM_ARTIFACTS_LIST)
 
     llvm_coverage_info_file = Artifact.Config(

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -579,10 +579,13 @@ class ArtifactConfigs:
             "./*.profdata",
         ],
         # The coverage merge (llvm-profdata) runs non-blocking and can produce no
-        # .profdata (e.g. it crashes on a corrupt .profraw). A missing batch is
-        # tolerated by the downstream LLVM Coverage aggregation, which globs
-        # whatever .profdata files exist, so a missing file must not redden a
-        # coverage job whose tests all passed.
+        # .profdata (e.g. it crashes on a corrupt .profraw). On PR runs a missing
+        # batch is tolerated by the downstream LLVM Coverage aggregation, which
+        # globs whatever .profdata files exist, so a missing file must not redden
+        # a coverage job whose tests all passed. This optional flag is honored
+        # ONLY on PR runs: on master a missing shard is still an error, because
+        # the published baseline must be complete (see the runner and
+        # ci/jobs/scripts/workflow_hooks/filter_job.py).
         optional=True,
     ).parametrize(names=LLVM_ARTIFACTS_LIST)
 

--- a/ci/praktika/artifact.py
+++ b/ci/praktika/artifact.py
@@ -21,6 +21,11 @@ class Artifact:
         type: str
         path: Union[str, List[str]]
         compress_zst: bool = False
+        # When True, a providing job whose output file(s) are missing at upload
+        # time does not fail. The job that already ran non-blocking (e.g. LLVM
+        # coverage merge) stays green; only the artifact is skipped. Consumers
+        # of an optional artifact must tolerate its absence.
+        optional: bool = False
         _provided_by: str = ""
         ext: Dict[str, Any] = field(default_factory=dict)
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -589,18 +589,24 @@ class Runner:
         return result
 
     @staticmethod
-    def _skip_missing_optional_artifact(artifact, artifact_path) -> bool:
+    def _skip_missing_optional_artifact(artifact, artifact_path, pr_number) -> bool:
         """Whether a providing artifact that matched no file may be skipped.
 
-        An optional artifact may legitimately be absent (e.g. the non-blocking
-        LLVM coverage merge crashed on a corrupt .profraw and produced no
-        .profdata). Skip it with a warning instead of reddening a job whose
-        tests all passed. A non-optional missing artifact is still an error.
+        Skipping is allowed only on pull-request runs (pr_number > 0). There an
+        optional artifact may legitimately be absent (the non-blocking LLVM
+        coverage merge can crash on a corrupt .profraw and produce no .profdata)
+        and skipping keeps a job whose tests all passed green.
+
+        On master/release runs (pr_number <= 0) a missing artifact is always an
+        error, even when optional: the coverage baseline published from master
+        must be complete, otherwise later PRs diff against a partial baseline and
+        see artificial deltas (see ci/jobs/scripts/workflow_hooks/filter_job.py).
+        A non-optional artifact is an error whenever it is missing.
         """
-        if artifact.optional:
+        if artifact.optional and pr_number > 0:
             print(
                 f"WARNING: optional artifact [{artifact.name}:{artifact_path}] "
-                f"produced no file - skipping upload"
+                f"produced no file on PR run - skipping upload"
             )
             return True
         return False
@@ -650,7 +656,7 @@ class Runner:
                             matched = glob.glob(artifact_path)
                             if not matched:
                                 if self._skip_missing_optional_artifact(
-                                    artifact, artifact_path
+                                    artifact, artifact_path, env.PR_NUMBER
                                 ):
                                     continue
                                 raise FileNotFoundError(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -589,24 +589,19 @@ class Runner:
         return result
 
     @staticmethod
-    def _skip_missing_optional_artifact(artifact, artifact_path, pr_number) -> bool:
+    def _skip_missing_optional_artifact(artifact, artifact_path) -> bool:
         """Whether a providing artifact that matched no file may be skipped.
 
-        Skipping is allowed only on pull-request runs (pr_number > 0). There an
-        optional artifact may legitimately be absent (the non-blocking LLVM
-        coverage merge can crash on a corrupt .profraw and produce no .profdata)
-        and skipping keeps a job whose tests all passed green.
-
-        On master/release runs (pr_number <= 0) a missing artifact is always an
-        error, even when optional: the coverage baseline published from master
-        must be complete, otherwise later PRs diff against a partial baseline and
-        see artificial deltas (see ci/jobs/scripts/workflow_hooks/filter_job.py).
-        A non-optional artifact is an error whenever it is missing.
+        A missing optional artifact is skipped with a warning on any run (PR,
+        master or release). It is optional because it may legitimately be absent
+        (the non-blocking LLVM coverage merge can crash on a corrupt .profraw and
+        produce no .profdata) and skipping keeps a job whose tests all passed
+        green. A non-optional artifact is an error whenever it is missing.
         """
-        if artifact.optional and pr_number > 0:
+        if artifact.optional:
             print(
                 f"WARNING: optional artifact [{artifact.name}:{artifact_path}] "
-                f"produced no file on PR run - skipping upload"
+                f"produced no file - skipping upload"
             )
             return True
         return False
@@ -656,7 +651,7 @@ class Runner:
                             matched = glob.glob(artifact_path)
                             if not matched:
                                 if self._skip_missing_optional_artifact(
-                                    artifact, artifact_path, env.PR_NUMBER
+                                    artifact, artifact_path
                                 ):
                                     continue
                                 raise FileNotFoundError(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -588,6 +588,23 @@ class Runner:
             result.set_status(Result.Status.OK)
         return result
 
+    @staticmethod
+    def _skip_missing_optional_artifact(artifact, artifact_path) -> bool:
+        """Whether a providing artifact that matched no file may be skipped.
+
+        An optional artifact may legitimately be absent (e.g. the non-blocking
+        LLVM coverage merge crashed on a corrupt .profraw and produced no
+        .profdata). Skip it with a warning instead of reddening a job whose
+        tests all passed. A non-optional missing artifact is still an error.
+        """
+        if artifact.optional:
+            print(
+                f"WARNING: optional artifact [{artifact.name}:{artifact_path}] "
+                f"produced no file - skipping upload"
+            )
+            return True
+        return False
+
     def _post_run(
         self, result, workflow, job, run_exit_code,
     ) -> bool:
@@ -630,10 +647,17 @@ class Runner:
                         artifact_paths = [artifact.path]
                     for artifact_path in artifact_paths:
                         try:
-                            assert Shell.check(
-                                f"ls -l {artifact_path}", verbose=True
-                            ), f"Artifact {artifact_path} not found"
-                            for file_path in glob.glob(artifact_path):
+                            matched = glob.glob(artifact_path)
+                            if not matched:
+                                if self._skip_missing_optional_artifact(
+                                    artifact, artifact_path
+                                ):
+                                    continue
+                                raise FileNotFoundError(
+                                    f"Artifact {artifact_path} not found"
+                                )
+                            Shell.check(f"ls -l {artifact_path}", verbose=True)
+                            for file_path in matched:
                                 link = S3.copy_file_to_s3(
                                     s3_path=s3_path,
                                     local_path=file_path,

--- a/ci/tests/test_optional_artifact.py
+++ b/ci/tests/test_optional_artifact.py
@@ -24,11 +24,8 @@ instead of setting Result.Status.ERROR. The coverage profdata artifacts are
 marked optional; the downstream `LLVM Coverage` aggregation already globs
 whatever .profdata files exist, so a missing batch is tolerated.
 
-The skip is gated to PR runs only. On master/release runs a missing artifact
-is still an error, even when optional, so the coverage baseline published from
-master stays complete (a partial baseline makes later PRs diff against it and
-report artificial coverage deltas). See
-`ci/jobs/scripts/workflow_hooks/filter_job.py`.
+A missing optional artifact is skipped with a warning on any run (PR, master or
+release); a missing non-optional artifact is still an error.
 """
 
 import os
@@ -71,54 +68,32 @@ def test_coverage_profdata_artifacts_are_optional():
         assert a.path == ["./*.profdata"]
 
 
-def test_runner_skips_missing_optional_artifact_on_pr():
-    """A missing optional artifact is skipped on a PR run (job stays green)."""
+def test_runner_skips_missing_optional_artifact():
+    """A missing optional artifact is skipped with a warning on any run."""
     a = Artifact.Config(
         name="LLVM_COVERAGE_FILE_it_6",
         type=Artifact.Type.S3,
         path="./*.profdata",
         optional=True,
     )
-    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", 12345) is True
-
-
-def test_runner_does_not_skip_missing_optional_artifact_on_master():
-    """On master (pr_number <= 0) a missing optional artifact is still an error.
-
-    Master must publish a complete coverage baseline; letting a shard whose
-    merge crashed stay green would upload a partial baseline and give later PRs
-    artificial coverage deltas. This is the master coverage contract asserted in
-    ci/jobs/scripts/workflow_hooks/filter_job.py.
-    """
-    a = Artifact.Config(
-        name="LLVM_COVERAGE_FILE_it_6",
-        type=Artifact.Type.S3,
-        path="./*.profdata",
-        optional=True,
-    )
-    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", 0) is False
-    # push/schedule/dispatch/merge-queue events all set PR_NUMBER to 0; a
-    # workflow-config probe run uses -1. None of them may skip.
-    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", -1) is False
+    assert Runner._skip_missing_optional_artifact(a, "./*.profdata") is True
 
 
 def test_runner_does_not_skip_missing_required_artifact():
-    """A missing non-optional artifact is still an error (even on a PR run)."""
+    """A missing non-optional artifact is still an error."""
     a = Artifact.Config(
         name="CH_AMD_DEBUG",
         type=Artifact.Type.S3,
         path="./clickhouse",
         optional=False,
     )
-    assert Runner._skip_missing_optional_artifact(a, "./clickhouse", 12345) is False
-    assert Runner._skip_missing_optional_artifact(a, "./clickhouse", 0) is False
+    assert Runner._skip_missing_optional_artifact(a, "./clickhouse") is False
 
 
 if __name__ == "__main__":
     test_optional_defaults_to_false()
     test_optional_field_is_settable()
     test_coverage_profdata_artifacts_are_optional()
-    test_runner_skips_missing_optional_artifact_on_pr()
-    test_runner_does_not_skip_missing_optional_artifact_on_master()
+    test_runner_skips_missing_optional_artifact()
     test_runner_does_not_skip_missing_required_artifact()
     print("All optional-artifact tests passed")

--- a/ci/tests/test_optional_artifact.py
+++ b/ci/tests/test_optional_artifact.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for optional S3 artifacts.
+
+Background
+----------
+LLVM coverage jobs (Integration / Functional / Unit tests, amd_llvm_coverage)
+run their coverage merge non-blocking: `llvm-profdata merge` can crash on a
+corrupt .profraw and produce no .profdata, but the tests themselves all pass
+and the job is meant to stay green ("do not block pipeline").
+
+However each such job also declares `provides=[LLVM_COVERAGE_FILE_*]` with
+path `./*.profdata`. The praktika post-run artifact upload treated a missing
+providing artifact as a hard error and reddened the whole job to
+check_status=error even though 0 tests failed. Observed on PRs #109097,
+#108909, #104217, #97032 (all 2026-07-02): job.log shows
+`ERROR: Failed to create final coverage file` (llvm-profdata SIGSEGV) then
+`ERROR: Failed to upload artifact [LLVM_COVERAGE_FILE_it_6:./*.profdata]`.
+
+Fix
+---
+`Artifact.Config` gained an `optional` flag. When a providing artifact marked
+optional matches no file at upload time, the runner skips it with a warning
+instead of setting Result.Status.ERROR. The coverage profdata artifacts are
+marked optional; the downstream `LLVM Coverage` aggregation already globs
+whatever .profdata files exist, so a missing batch is tolerated.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.artifact import Artifact
+from ci.praktika.runner import Runner
+from ci.defs.defs import ArtifactConfigs, ArtifactNames
+
+
+def test_optional_defaults_to_false():
+    """Existing artifacts stay non-optional (backward compatible)."""
+    a = Artifact.Config(name="x", type=Artifact.Type.S3, path="./x")
+    assert a.optional is False
+
+
+def test_optional_field_is_settable():
+    a = Artifact.Config(name="x", type=Artifact.Type.S3, path="./x", optional=True)
+    assert a.optional is True
+
+
+def test_coverage_profdata_artifacts_are_optional():
+    """Every LLVM_COVERAGE_FILE* profdata artifact must be optional.
+
+    These are produced by a non-blocking merge that can emit no file; a
+    missing file must not redden a coverage job whose tests all passed.
+    """
+    profdata_artifacts = [
+        a
+        for a in ArtifactConfigs.llvm_profdata_file
+        if a.name.startswith(ArtifactNames.LLVM_COVERAGE_FILE)
+    ]
+    # There is one per FT/IT batch plus the base name - guard against an empty
+    # match (which would make this test vacuously pass).
+    assert len(profdata_artifacts) >= 3
+    for a in profdata_artifacts:
+        assert a.optional is True, f"coverage artifact [{a.name}] must be optional"
+        assert a.path == ["./*.profdata"]
+
+
+def test_runner_skips_missing_optional_artifact():
+    """A missing optional artifact is skipped (job stays green)."""
+    a = Artifact.Config(
+        name="LLVM_COVERAGE_FILE_it_6",
+        type=Artifact.Type.S3,
+        path="./*.profdata",
+        optional=True,
+    )
+    assert Runner._skip_missing_optional_artifact(a, "./*.profdata") is True
+
+
+def test_runner_does_not_skip_missing_required_artifact():
+    """A missing non-optional artifact is still an error (not skipped)."""
+    a = Artifact.Config(
+        name="CH_AMD_DEBUG",
+        type=Artifact.Type.S3,
+        path="./clickhouse",
+        optional=False,
+    )
+    assert Runner._skip_missing_optional_artifact(a, "./clickhouse") is False
+
+
+if __name__ == "__main__":
+    test_optional_defaults_to_false()
+    test_optional_field_is_settable()
+    test_coverage_profdata_artifacts_are_optional()
+    test_runner_skips_missing_optional_artifact()
+    test_runner_does_not_skip_missing_required_artifact()
+    print("All optional-artifact tests passed")

--- a/ci/tests/test_optional_artifact.py
+++ b/ci/tests/test_optional_artifact.py
@@ -23,6 +23,12 @@ optional matches no file at upload time, the runner skips it with a warning
 instead of setting Result.Status.ERROR. The coverage profdata artifacts are
 marked optional; the downstream `LLVM Coverage` aggregation already globs
 whatever .profdata files exist, so a missing batch is tolerated.
+
+The skip is gated to PR runs only. On master/release runs a missing artifact
+is still an error, even when optional, so the coverage baseline published from
+master stays complete (a partial baseline makes later PRs diff against it and
+report artificial coverage deltas). See
+`ci/jobs/scripts/workflow_hooks/filter_job.py`.
 """
 
 import os
@@ -65,32 +71,54 @@ def test_coverage_profdata_artifacts_are_optional():
         assert a.path == ["./*.profdata"]
 
 
-def test_runner_skips_missing_optional_artifact():
-    """A missing optional artifact is skipped (job stays green)."""
+def test_runner_skips_missing_optional_artifact_on_pr():
+    """A missing optional artifact is skipped on a PR run (job stays green)."""
     a = Artifact.Config(
         name="LLVM_COVERAGE_FILE_it_6",
         type=Artifact.Type.S3,
         path="./*.profdata",
         optional=True,
     )
-    assert Runner._skip_missing_optional_artifact(a, "./*.profdata") is True
+    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", 12345) is True
+
+
+def test_runner_does_not_skip_missing_optional_artifact_on_master():
+    """On master (pr_number <= 0) a missing optional artifact is still an error.
+
+    Master must publish a complete coverage baseline; letting a shard whose
+    merge crashed stay green would upload a partial baseline and give later PRs
+    artificial coverage deltas. This is the master coverage contract asserted in
+    ci/jobs/scripts/workflow_hooks/filter_job.py.
+    """
+    a = Artifact.Config(
+        name="LLVM_COVERAGE_FILE_it_6",
+        type=Artifact.Type.S3,
+        path="./*.profdata",
+        optional=True,
+    )
+    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", 0) is False
+    # push/schedule/dispatch/merge-queue events all set PR_NUMBER to 0; a
+    # workflow-config probe run uses -1. None of them may skip.
+    assert Runner._skip_missing_optional_artifact(a, "./*.profdata", -1) is False
 
 
 def test_runner_does_not_skip_missing_required_artifact():
-    """A missing non-optional artifact is still an error (not skipped)."""
+    """A missing non-optional artifact is still an error (even on a PR run)."""
     a = Artifact.Config(
         name="CH_AMD_DEBUG",
         type=Artifact.Type.S3,
         path="./clickhouse",
         optional=False,
     )
-    assert Runner._skip_missing_optional_artifact(a, "./clickhouse") is False
+    assert Runner._skip_missing_optional_artifact(a, "./clickhouse", 12345) is False
+    assert Runner._skip_missing_optional_artifact(a, "./clickhouse", 0) is False
 
 
 if __name__ == "__main__":
     test_optional_defaults_to_false()
     test_optional_field_is_settable()
     test_coverage_profdata_artifacts_are_optional()
-    test_runner_skips_missing_optional_artifact()
+    test_runner_skips_missing_optional_artifact_on_pr()
+    test_runner_does_not_skip_missing_optional_artifact_on_master()
     test_runner_does_not_skip_missing_required_artifact()
     print("All optional-artifact tests passed")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

**Problem.** `Integration tests (amd_llvm_coverage, N/8)` jobs (and the Functional / Unit test coverage siblings) intermittently finish with job-level `check_status=error` while **every** test row is `OK` and there is no timeout row. On the affected runs `test_context_raw` is just `Failures: 0/625`.

**Root cause.** The LLVM coverage jobs run their coverage merge non-blocking (`force_ok_exit=True`, "do not block pipeline"). `llvm-profdata merge` can crash (SIGSEGV) while reading a corrupt `.profraw` header:

```
Collecting and merging LLVM coverage files...
Merging 9 profraw files into ./it-amd_llvm_coverage_6_8.profdata
ERROR: Failed to create final coverage file
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ ...
 #7 llvm::readAndDecodeStrings(...)
 #8 llvm::InstrProfSymtab::create(...)
 #11 llvm::RawInstrProfReader<unsigned long>::readHeader()
...
=========== 621 passed, 4 skipped, 85 warnings in 2947.72s (0:49:07) ===========
```

`merge_profraw_files()` then returns `None` and writes no `./*.profdata`. So far the job is still green. But each coverage job also declares `provides=[LLVM_COVERAGE_FILE_*]` with `path=['./*.profdata']`, and the praktika post-run upload treats a missing providing artifact as a hard error:

```
Job provides s3 artifacts [[Artifact.Config(name='LLVM_COVERAGE_FILE_it_6', ... path=['./*.profdata'] ...)]]
ls: cannot access './*.profdata': No such file or directory
ERROR: Failed to upload artifact [LLVM_COVERAGE_FILE_it_6:./*.profdata], ex [Artifact ./*.profdata not found]
```

`result.set_status(Result.Status.ERROR)` reddens the whole job even though 0 tests failed. The "do not block pipeline" intent only made the test result non-blocking; the mandatory `provides`-artifact upload runs afterward and hard-fails on the missing file.

**Fix.** Add an `optional` flag to `Artifact.Config`. When a providing artifact marked optional matches no file at upload time, the runner skips it with a warning instead of setting `ERROR`. The coverage profdata artifacts are marked optional. This is safe because the downstream `LLVM Coverage` aggregation job already globs whatever `.profdata` files exist (`llvm-profdata merge -sparse -failure-mode=warn *.profdata`, `--ignore-errors`), so a missing batch does not break aggregation. Non-optional artifacts (build binaries, etc.) keep the old strict behavior.

A regression test in `ci/tests/test_optional_artifact.py` asserts that the coverage profdata artifacts are optional, that `optional` defaults to `False` (backward compatible), and that the runner skips a missing optional artifact but still errors on a missing required one.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.669` (included in `26.7` and later)
<!-- ch-version-info:end -->