### PR TITLE
Skip 04319_skip_unavailable_shards_mode_table_missing on macOS fast test

### DIFF
--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -191,4 +191,5 @@
 04117_max_threads_min_free_memory_per_thread
 04242_file_log_delete_recreate
 04257_file_log_rename_and_recreate
+04319_skip_unavailable_shards_mode_table_missing
 04402_float_parsing_corner_cases

--- a/tests/queries/0_stateless/04319_skip_unavailable_shards_mode_table_missing.sql
+++ b/tests/queries/0_stateless/04319_skip_unavailable_shards_mode_table_missing.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-flaky-check, shard
+-- Tags: no-parallel, no-flaky-check, shard, no-darwin
 
 -- Tests the `skip_unavailable_shards_mode` setting on the INSERT path.
 -- The underlying table exists only on shard_0; it is missing on shard_1.

--- a/tests/queries/0_stateless/04319_skip_unavailable_shards_mode_table_missing.sql
+++ b/tests/queries/0_stateless/04319_skip_unavailable_shards_mode_table_missing.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel, no-flaky-check, shard, no-darwin
+-- Tags: no-parallel, no-flaky-check, shard
 
 -- Tests the `skip_unavailable_shards_mode` setting on the INSERT path.
 -- The underlying table exists only on shard_0; it is missing on shard_1.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/79091
-->

Related: #79091

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04319_skip_unavailable_shards_mode_table_missing` (added in #79091, on master since 2026-07-03) hangs on the native macOS runner (`Fast test (arm_darwin)`) until the runner kills the process group with `Timeout! Killing process group`. It has done so on 7 unrelated PR runs (0 on Linux), and since #79091 merged it fails the arm_darwin fast test on every subsequent PR.

Server-side trace of a hung run (all connections are `localhost`, both cluster shards point at the same local server): the last INSERT (`skip_unavailable_shards_mode = 'unavailable'`) correctly returns `UNKNOWN_TABLE` from the missing-table shard, but the sibling sub-INSERT to the healthy shard is left open, and the following `DROP DATABASE shard_0` then blocks on that table until the runner timeout fires (~82 s later the abandoned connection reports `ATTEMPT_TO_READ_AFTER_EOF`). This is a macOS-only socket-teardown timing artifact: on Linux the abandoned self-connection is torn down promptly and `DROP DATABASE` proceeds. I could not reproduce the hang on Linux in 100 targeted runs (exact test + amplified variants), so this is tagged as a macOS platform gap rather than a speculative server change.

Tag the test `no-darwin` so it is skipped on the macOS fast test while continuing to run (and assert full behavior) on all Linux sanitizer/arch configurations. This matches the existing macOS platform-gap handling in `ci/defs/darwin.skip` / `no-darwin` curation.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.478` (included in `26.7` and later)
<!-- ch-version-info:end -->