### PR TITLE
Backoff for KeeperRequestDispatcher busy-waiting

### DIFF
--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -86,7 +86,8 @@ namespace ErrorCodes
     DECLARE(UInt64, max_request_queue_bytes_size, 100 * 1024 * 1024, "Maximum total bytes in the request queue before blocking new requests", 0) \
     DECLARE(UInt64, max_response_queue_bytes_size, 100 * 1024 * 1024, "Maximum total bytes across all response queues; the dispatch thread throttles at half this limit", 0) \
     DECLARE(Bool, optimize_read_order, true, "Reorder read requests within a batch to group them together for parallel execution, without changing ordering guarantees within each session", 0) \
-    DECLARE(UInt64, dispatch_busy_wait_sleep_us, 100, "Sleep duration in microseconds for busy-wait loops in the dispatch and response threads", 0) \
+    DECLARE(UInt64, dispatch_busy_wait_sleep_us, 100, "Dispatch and response threads periodically poll to check for work to do, sleeping between checks if idle (as opposed to waiting on something like a futex). The sleep duration is dispatch_busy_wait_sleep_us if there was recent activity, gradually backing off to dispatch_busy_wait_long_sleep_us when idle. Reducing these settings reduces request latency by about the same amount but increases cpu usage when the server is idle.", 0) \
+    DECLARE(UInt64, dispatch_busy_wait_long_sleep_us, 10000, "See dispatch_busy_wait_sleep_us", 0) \
     DECLARE(Milliseconds, stream_suspect_retry_delay_ms, 1000, "Delay before reconnecting to the leader after a stream breaks while the new stream is suspected to be unhealthy", 0) \
     DECLARE(Milliseconds, stream_in_flight_drain_timeout_ms, 5000, "Maximum time to wait for in-flight requests to drain after a stream break (e.g. leader change) before dropping them", 0) \
     DECLARE(Bool, nuraft_use_bg_thread_for_snapshot_io, false, "Use a background thread for NuRaft snapshot IO instead of reading snapshot objects synchronously from Raft worker threads.", 0) \

--- a/src/Coordination/KeeperRequestDispatcher.cpp
+++ b/src/Coordination/KeeperRequestDispatcher.cpp
@@ -47,6 +47,7 @@ namespace DB
 
 namespace CoordinationSetting
 {
+    extern const CoordinationSettingsUInt64 dispatch_busy_wait_long_sleep_us;
     extern const CoordinationSettingsUInt64 dispatch_busy_wait_sleep_us;
     extern const CoordinationSettingsUInt64 max_in_flight_request_batches;
     extern const CoordinationSettingsUInt64 max_read_batch_bytes_size;
@@ -149,6 +150,48 @@ static bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & 
     return false;
 }
 
+/// A helper for sleeping while there's no work to do. Sleep duration starts at short_sleep, then
+/// after long_sleep/2 time it exponentially backs off up to long_sleep. So if we get at least one
+/// request every long_sleep/2 the sleeping will add at most short_sleep to request latency.
+/// And if we go idle for >~long_sleep we'll slow down and waste less cpu, but the next request
+/// will get up to long_sleep of added latency.
+struct BusyWaitBackoff
+{
+    std::chrono::microseconds short_sleep;
+    std::chrono::microseconds long_sleep;
+    /// How long to sleep after i idle iterations:
+    ///  i <= backoff_start: short_sleep
+    ///  i >= backoff_start: short_sleep * 2**(i - backoff_start), saturating at long_sleep
+    size_t backoff_start = 0;
+
+    size_t idle_count = 0;
+    std::chrono::microseconds cur_sleep;
+
+    BusyWaitBackoff(UInt64 short_sleep_us, UInt64 long_sleep_us)
+        : short_sleep(short_sleep_us)
+        , long_sleep(std::max(long_sleep_us, short_sleep_us))
+        /// Do short sleeps for half a long sleep duration.
+        , backoff_start(long_sleep_us / std::max(short_sleep_us, UInt64(1)) / 2)
+        , cur_sleep(short_sleep)
+    {
+    }
+
+    /// Reset backoff.
+    void notIdle()
+    {
+        idle_count = 0;
+        cur_sleep = short_sleep;
+    }
+
+    void sleep()
+    {
+        std::this_thread::sleep_for(cur_sleep);
+        idle_count += 1;
+        if (idle_count > backoff_start)
+            /// (max is in case short_sleep is 0)
+            cur_sleep = std::min(std::max(cur_sleep * 2, std::chrono::microseconds(1)), long_sleep);
+    }
+};
 
 KeeperRequestDispatcher::KeeperRequestDispatcher(KeeperServer * server_)
     : server(server_)
@@ -562,6 +605,10 @@ void KeeperRequestDispatcher::dispatchThread()
 
         int64_t operation_timeout_ms = keeper_context->getCoordinationSettings()[CoordinationSetting::operation_timeout_ms].totalMilliseconds();
 
+        BusyWaitBackoff sleep_backoff(
+            keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_sleep_us],
+            keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_long_sleep_us]);
+
         auto last_stuck_check_time = std::chrono::steady_clock::now();
         while (!shutting_down.load())
         {
@@ -645,8 +692,7 @@ void KeeperRequestDispatcher::dispatchThread()
                 ///  Or maybe there are conditions where this breaks and we instead converge to
                 ///  issuing bursts of 100 requests every 5 seconds, with corresponding
                 ///  throughput of 20 requests/s?)
-                std::this_thread::sleep_for(std::chrono::microseconds(
-                    keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_sleep_us]));
+                sleep_backoff.sleep();
                 continue;
             }
 
@@ -656,12 +702,15 @@ void KeeperRequestDispatcher::dispatchThread()
             {
                 /// No requests to process. Busy-wait here too.
                 /// TODO: Perhaps we should replace this with a futex wait to improve throughput on
-                ///       latency-bound workloads. E.g. one client doing blocking requests in a loop.
-                std::chrono::microseconds dispatch_busy_wait_sleep(
-                    keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_sleep_us]);
-                std::this_thread::sleep_for(dispatch_busy_wait_sleep);
+                ///       latency-bound workloads. E.g. one client doing blocking requests in a
+                ///       loop. (The reasoning from long comment above doesn't apply here because
+                ///       this would typically be notified from KeeperTCPHandler threads, which
+                ///       have plenty of cpu to spare.)
+                sleep_backoff.sleep();
                 continue;
             }
+
+            sleep_backoff.notIdle();
 
             /// Pick a batch of requests.
 
@@ -1092,16 +1141,21 @@ void KeeperRequestDispatcher::responseThread()
     {
         DB::setThreadName(ThreadName::KEEPER_RESPONSE);
 
+        BusyWaitBackoff sleep_backoff(
+            keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_sleep_us],
+            keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_long_sleep_us]);
+
         while (!shutting_down.load())
         {
             KeeperResponseForSession response_for_session;
             if (!responses_queue.tryPop(response_for_session))
             {
                 /// Busy-wait.
-                std::this_thread::sleep_for(std::chrono::microseconds(
-                    keeper_context->getCoordinationSettings()[CoordinationSetting::dispatch_busy_wait_sleep_us]));
+                sleep_backoff.sleep();
                 continue;
             }
+
+            sleep_backoff.notIdle();
 
             const UInt64 dequeue_time_us = ZooKeeperOpentelemetrySpans::now();
 

--- a/src/Coordination/KeeperRequestDispatcher.h
+++ b/src/Coordination/KeeperRequestDispatcher.h
@@ -15,9 +15,10 @@ extern template class NonblockingBoundedQueue<DB::KeeperResponseForSession>;
 namespace DB
 {
 
-/// Takes client requests from KeeperTCPHandler (or whoever else calls putRequest), passes them
-/// to nuraft leader, detects when they're committed (or failed), and passes responses back to
-/// KeeperTCPHandler (or whoever registers their response callback by calling registerSession).
+/// KeeperRequestDispatcher takes client requests from KeeperTCPHandler (or whoever else calls
+/// putRequest), passes them to nuraft leader, detects when they're committed (or failed), and
+/// passes responses back to KeeperTCPHandler (or whoever registers their response callback by
+/// calling registerSession).
 ///
 /// Considerations:
 ///  * Forwarding. If nuraft leader is not on this node, requests are sent to the leader node.
@@ -80,6 +81,7 @@ namespace DB
 ///  equally fast because KeeperRequestDispatcher shouldn't be the bottleneck.
 ///  One part where performance may matter is commit callback; we shouldn't waste any time there
 ///  because the commit thread is likely a bottleneck.)
+
 class KeeperRequestDispatcher
 {
 public:


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced Keeper server idle CPU usage.

---

Closes https://github.com/ClickHouse/ClickHouse/issues/107944

Increase sleep duration from 100us to 10ms after 5ms of inactivity.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.566` (included in `26.7` and later)
<!-- ch-version-info:end -->