### PR TITLE
Apply column defaults for inline INSERT into table functions

### DIFF
--- a/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
+++ b/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
@@ -81,16 +81,29 @@ Pipe getSourceFromInputFormat(
     Pipe pipe(format);
 
     const auto * ast_insert_query = ast->as<ASTInsertQuery>();
-    if (context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields] && ast_insert_query->table_id && !input_function)
+    if (context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields] && !input_function)
     {
-        StoragePtr storage = DatabaseCatalog::instance().getTable(ast_insert_query->table_id, context);
-        auto metadata_snapshot = storage->getInMemoryMetadataPtr(context, false);
-        const auto & columns = metadata_snapshot->getColumns();
-        if (columns.hasDefaults())
+        /// Resolve the destination columns. For a plain table the id is in the query;
+        /// for a table function (remote(), file(), ...) the id is empty, but the resolved
+        /// storage columns (including DEFAULTs) are saved in the context by InterpreterInsertQuery.
+        StorageMetadataHandle metadata_snapshot;
+        const ColumnsDescription * columns = nullptr;
+        if (ast_insert_query->table_id)
+        {
+            StoragePtr storage = DatabaseCatalog::instance().getTable(ast_insert_query->table_id, context);
+            metadata_snapshot = storage->getInMemoryMetadataPtr(context, false);
+            columns = &metadata_snapshot->getColumns();
+        }
+        else if (const auto & insertion_columns = context->getInsertionTableColumnsDescription())
+        {
+            columns = insertion_columns.get();
+        }
+
+        if (columns && columns->hasDefaults())
         {
             pipe.addSimpleTransform([&](const SharedHeader & cur_header)
             {
-                return std::make_shared<AddingDefaultsTransform>(cur_header, columns, *format, context);
+                return std::make_shared<AddingDefaultsTransform>(cur_header, *columns, *format, context);
             });
         }
     }

--- a/tests/queries/0_stateless/03816_inline_insert_table_function_defaults.reference
+++ b/tests/queries/0_stateless/03816_inline_insert_table_function_defaults.reference
@@ -1,0 +1,11 @@
+-- remote() table function: explicit NULL -> DEFAULT, matches plain table
+7
+7
+-- file() CSV: explicit NULL -> DEFAULT (Int)
+4	77
+-- file() CSV: Nullable column keeps explicit NULL (null_as_default does not force default)
+4	\N
+-- file() CSV: explicit NULL -> DEFAULT (LowCardinality(String))
+1	x
+-- file() CSV: explicit NULL -> DEFAULT (Array(Int))
+1	[1,2]

--- a/tests/queries/0_stateless/03816_inline_insert_table_function_defaults.sh
+++ b/tests/queries/0_stateless/03816_inline_insert_table_function_defaults.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# When the server parses INSERT ... VALUES inline data itself
+# (send_table_structure_on_insert_with_inline_data = 0, plus async_insert = 0 so the
+# synchronous path is taken), an explicit NULL inserted into a non-Nullable column that
+# has a DEFAULT must be replaced by the default, exactly as for a plain table INSERT and
+# over HTTP (input_format_null_as_default, applied during parsing). Previously the
+# server-side inline path skipped this for INSERT INTO TABLE FUNCTION, because the
+# destination table_id is empty for table functions, so the NULL became 0 instead of the
+# default.
+
+# async_insert 0: the synchronous inline path (the buggy one) is taken.
+# send_table_structure_on_insert_with_inline_data 0: the server parses the inline data.
+# engine_file_truncate_on_insert 1: makes the file() cases idempotent across --test-runs.
+OPT="--async_insert 0 --send_table_structure_on_insert_with_inline_data 0"
+FOPT="$OPT --engine_file_truncate_on_insert 1"
+
+echo '-- remote() table function: explicit NULL -> DEFAULT, matches plain table'
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS t_def"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE t_def (c Int DEFAULT 7) ENGINE = MergeTree ORDER BY tuple()"
+$CLICKHOUSE_CLIENT $OPT --query "INSERT INTO FUNCTION remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}', currentDatabase(), 't_def') VALUES (NULL)"
+$CLICKHOUSE_CLIENT $OPT --query "INSERT INTO TABLE t_def VALUES (NULL)"
+$CLICKHOUSE_CLIENT --query "SELECT c FROM t_def ORDER BY ALL"
+$CLICKHOUSE_CLIENT --query "DROP TABLE t_def"
+
+echo '-- file() CSV: explicit NULL -> DEFAULT (Int)'
+$CLICKHOUSE_CLIENT $FOPT --query "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_int.csv', CSV, 'a Int, b Int DEFAULT 77') VALUES (4, NULL)"
+$CLICKHOUSE_CLIENT --query "SELECT a, b FROM file('${CLICKHOUSE_DATABASE}_int.csv', CSV, 'a Int, b Int DEFAULT 77') ORDER BY ALL"
+
+echo '-- file() CSV: Nullable column keeps explicit NULL (null_as_default does not force default)'
+$CLICKHOUSE_CLIENT $FOPT --query "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_nullable.csv', CSV, 'a Int, b Nullable(Int) DEFAULT 77') VALUES (4, NULL)"
+$CLICKHOUSE_CLIENT --query "SELECT a, b FROM file('${CLICKHOUSE_DATABASE}_nullable.csv', CSV, 'a Int, b Nullable(Int) DEFAULT 77') ORDER BY ALL"
+
+echo '-- file() CSV: explicit NULL -> DEFAULT (LowCardinality(String))'
+$CLICKHOUSE_CLIENT $FOPT --query "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_lc.csv', CSV, 'a Int, s LowCardinality(String) DEFAULT ''x''') VALUES (1, NULL)"
+$CLICKHOUSE_CLIENT --query "SELECT a, s FROM file('${CLICKHOUSE_DATABASE}_lc.csv', CSV, 'a Int, s LowCardinality(String) DEFAULT ''x''') ORDER BY ALL"
+
+echo '-- file() CSV: explicit NULL -> DEFAULT (Array(Int))'
+$CLICKHOUSE_CLIENT $FOPT --query "INSERT INTO FUNCTION file('${CLICKHOUSE_DATABASE}_arr.csv', CSV, 'a Int, arr Array(Int) DEFAULT [1, 2]') VALUES (1, NULL)"
+$CLICKHOUSE_CLIENT --query "SELECT a, arr FROM file('${CLICKHOUSE_DATABASE}_arr.csv', CSV, 'a Int, arr Array(Int) DEFAULT [1, 2]') ORDER BY ALL"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/109253
Related: https://github.com/ClickHouse/ClickHouse/pull/104640
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a bug where column `DEFAULT` values were not applied for `INSERT INTO TABLE FUNCTION` (for example `remote(...)` or `file(...)`) with inline `VALUES` data when the server parses the inline data itself (`send_table_structure_on_insert_with_inline_data = 0`). An explicit `NULL` inserted into a non-`Nullable` column with a `DEFAULT` became `0` instead of the declared default. It now behaves like a plain table `INSERT` and the HTTP protocol.

### Description

Addresses gap 1 of #109253 (table-function defaults). The trailing-comment data-loss gap is not touched here.

Root cause: for inline (non-`SELECT`) `INSERT`, defaults are applied by the `AddingDefaultsTransform` added in `getSourceFromInputFormat` (`src/Processors/Transforms/getSourceFromASTInsertQuery.cpp`). That transform was added only when `ast_insert_query->table_id` is set. `table_id` is empty for table functions, so the transform (which also performs `input_format_null_as_default` during parsing) was skipped and the explicit `NULL` was not converted to the column default. The downstream `InsertDependenciesBuilder::createPreSink` -> `addMissingDefaults` path only fills columns missing from the input header, and its null-as-default is gated to `INSERT ... SELECT`, so it does not cover inline `VALUES`. The asynchronous insert path was unaffected because it adds its own `AddingDefaultsTransform`, which is why the synchronous case (`async_insert = 0`, as CI runs) was the one that reproduced.

Fix: when `table_id` is empty, fall back to the resolved destination columns saved in the context by `InterpreterInsertQuery::setInsertContextValues` (`Context::getInsertionTableColumnsDescription()`), which is populated for table functions as well. The `input()` path stays gated out by `!input_function`.

Verified in both directions on a local debug build (server-side inline path, `async_insert = 0`, `send_table_structure_on_insert_with_inline_data = 0`):

| Case | Before | After |
|---|---|---|
| `remote()` `Int DEFAULT 7`, `VALUES (NULL)` | 0 | 7 |
| `file()` CSV `Int DEFAULT 77`, `VALUES (4, NULL)` | 4, 0 | 4, 77 |
| `file()` CSV `LowCardinality(String) DEFAULT 'x'` | (empty) | x |
| `file()` CSV `Array(Int) DEFAULT [1, 2]` | [] | [1, 2] |
| `file()` CSV `Nullable(Int) DEFAULT 77`, explicit `NULL` | NULL | NULL (unchanged, correct) |

CI report showing the failure this fixes (03667 on PR #104640 head 8ed06ca, `send_table_structure_on_insert_with_inline_data = 0`, 183/183 failing): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104640&sha=8ed06ca93081214a31acef155c8df020fd950600&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.781` (included in `26.7` and later)
- Backported to: `26.6.2.62`
<!-- ch-version-info:end -->