### PR TITLE
Reject quoted type names that start with a digit

### DIFF
--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -249,6 +249,7 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ///  * Array(`x.y`) -> Array(x.y) -> fails to parse
     ///  * `Null` -> Null -> parses as keyword instead of type name
     ///  * DateTime64(`3`) -> DateTime64(3) -> the argument parses back as a numeric literal
+    ///  * Nullable(`true`) -> Nullable(true) -> the argument parses back as a bool literal
     /// Here we check for these cases and reject.
     if (type_name.empty() || isNumericASCII(type_name[0])
         || !std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
@@ -263,6 +264,13 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         String n = type_name;
         boost::to_upper(n);
         if (n == "NOT" || n == "NULL" || n == "DEFAULT" || n == "MATERIALIZED" || n == "EPHEMERAL" || n == "ALIAS" || n == "AUTO" || n == "PRIMARY" || n == "TTL" || n == "COMMENT" || n == "CODEC")
+        {
+            expected.add(pos, "type name");
+            return false;
+        }
+        /// Bareword literals (Bool and inf/nan Float64): in data type argument position
+        /// literals are parsed before nested types, so these names cannot round-trip.
+        if (n == "TRUE" || n == "FALSE" || n == "INF" || n == "INFINITY" || n == "NAN")
         {
             expected.add(pos, "type name");
             return false;

--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -248,8 +248,10 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// unquoted (e.g. UInt64). This introduces problems when the string in the quotes is garbage:
     ///  * Array(`x.y`) -> Array(x.y) -> fails to parse
     ///  * `Null` -> Null -> parses as keyword instead of type name
+    ///  * DateTime64(`3`) -> DateTime64(3) -> the argument parses back as a numeric literal
     /// Here we check for these cases and reject.
-    if (!std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
+    if (type_name.empty() || isNumericASCII(type_name[0])
+        || !std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
     {
         expected.add(pos, "type name");
         return false;

--- a/tests/queries/0_stateless/04498_fuzz_numeric_quoted_type_name.sql
+++ b/tests/queries/0_stateless/04498_fuzz_numeric_quoted_type_name.sql
@@ -1,0 +1,6 @@
+-- Type names starting with a digit cannot survive the formatting round-trip
+-- (`3` formats as 3, which parses back as a literal), so they are rejected.
+create table t (x `3`) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x DateTime64(`3`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x Nullable(`3`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x `3ab`) engine Memory; -- { clientError SYNTAX_ERROR }

--- a/tests/queries/0_stateless/04498_fuzz_numeric_quoted_type_name.sql
+++ b/tests/queries/0_stateless/04498_fuzz_numeric_quoted_type_name.sql
@@ -1,6 +1,11 @@
--- Type names starting with a digit cannot survive the formatting round-trip
--- (`3` formats as 3, which parses back as a literal), so they are rejected.
+-- Quoted type names whose unquoted form parses back as a literal (numbers, true/false,
+-- inf/nan) cannot survive the formatting round-trip, so they are rejected.
 create table t (x `3`) engine Memory; -- { clientError SYNTAX_ERROR }
 create table t (x DateTime64(`3`)) engine Memory; -- { clientError SYNTAX_ERROR }
 create table t (x Nullable(`3`)) engine Memory; -- { clientError SYNTAX_ERROR }
 create table t (x `3ab`) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x Nullable(`true`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x Nullable(`false`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x DateTime64(`inf`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x DateTime64(`Infinity`)) engine Memory; -- { clientError SYNTAX_ERROR }
+create table t (x DateTime64(`nan`)) engine Memory; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject quoted type names that start with a digit (i.e. `DateTime64("3")`)

`DateTime64("3")` parsed into a data type named `3`, which formats back unquoted as `DateTime64(3)` and re-parses as a literal argument, which breaks AST consistency check

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105056&sha=ed38f7aebd220eaad3e5f571f8729b815338b1c6&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29