### PR TITLE
Do not add _block_number/_block_offset to projection parts on merge

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1002,12 +1002,24 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
 
 bool MergeTask::enabledBlockNumberColumn(GlobalRuntimeContextPtr global_ctx)
 {
+    /// `_block_number`/`_block_offset` are per-row columns of the top-level part.
+    /// A projection is a separate sub-part with its own schema; it stores these columns
+    /// only when its own definition references them (then they are already in the
+    /// projection's storage columns). Do not auto-inject them into a projection sub-part,
+    /// otherwise the merged projection part would carry a column the projection metadata
+    /// and insert-produced projection parts do not have.
+    if (global_ctx->parent_part)
+        return false;
+
     return (*global_ctx->data_settings)[MergeTreeSetting::enable_block_number_column]
         && global_ctx->metadata_snapshot->getGroupByTTLs().empty();
 }
 
 bool MergeTask::enabledBlockOffsetColumn(GlobalRuntimeContextPtr global_ctx)
 {
+    if (global_ctx->parent_part)
+        return false;
+
     return (*global_ctx->data_settings)[MergeTreeSetting::enable_block_offset_column]
         && global_ctx->metadata_snapshot->getGroupByTTLs().empty();
 }

--- a/tests/queries/0_stateless/03823_optimize_dry_run_projections.reference
+++ b/tests/queries/0_stateless/03823_optimize_dry_run_projections.reference
@@ -16,3 +16,9 @@ all_2_2_0	p_sum	2
 all_3_3_0	p_sum	2
 profile events projections
 OPTIMIZE TABLE t_dry_run_proj DRY RUN PARTS \'all_1_1_0\', \'all_2_2_0\', \'all_3_3_0\';	Optimize	2	11	6	10
+dry run with block number column
+projection part columns after merge with block number column
+key	UInt64
+sum(value)	AggregateFunction(sum, UInt64)
+check table with block number column
+1

--- a/tests/queries/0_stateless/03823_optimize_dry_run_projections.sql
+++ b/tests/queries/0_stateless/03823_optimize_dry_run_projections.sql
@@ -39,3 +39,34 @@ WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_databa
 ORDER BY event_time_microseconds;
 
 DROP TABLE t_dry_run_proj;
+
+-- OPTIMIZE DRY RUN with enable_block_number_column: the merged projection sub-part must not
+-- gain a _block_number column (the projection metadata does not declare it), otherwise
+-- checkDataPart rejects it as CORRUPTED_DATA.
+DROP TABLE IF EXISTS t_dry_run_proj_bn;
+
+CREATE TABLE t_dry_run_proj_bn (key UInt64, value UInt64, PROJECTION p_sum (SELECT key, sum(value) GROUP BY key))
+ENGINE = MergeTree ORDER BY key SETTINGS enable_block_number_column = 1;
+
+SYSTEM STOP MERGES t_dry_run_proj_bn;
+
+INSERT INTO t_dry_run_proj_bn VALUES (1, 10), (1, 20);
+INSERT INTO t_dry_run_proj_bn VALUES (2, 30), (3, 40);
+INSERT INTO t_dry_run_proj_bn VALUES (2, 50), (4, 60);
+
+SELECT 'dry run with block number column';
+OPTIMIZE TABLE t_dry_run_proj_bn DRY RUN PARTS 'all_1_1_0', 'all_2_2_0', 'all_3_3_0';
+
+-- A real merge must produce a projection part whose columns match the projection metadata.
+SYSTEM START MERGES t_dry_run_proj_bn;
+OPTIMIZE TABLE t_dry_run_proj_bn FINAL;
+
+SELECT 'projection part columns after merge with block number column';
+SELECT DISTINCT column, type FROM system.projection_parts_columns
+WHERE database = currentDatabase() AND table = 't_dry_run_proj_bn' AND active
+ORDER BY column;
+
+SELECT 'check table with block number column';
+CHECK TABLE t_dry_run_proj_bn SETTINGS check_query_single_value_result = 1;
+
+DROP TABLE t_dry_run_proj_bn;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a bug where merging a `MergeTree` table that has projections while the `enable_block_number_column` or `enable_block_offset_column` setting is enabled produced projection parts containing a spurious `_block_number`/`_block_offset` column. The merged projection part then no longer matched the projection definition and the insert-produced projection parts, so `CHECK TABLE` and `OPTIMIZE ... DRY RUN` reported it as corrupted (`CORRUPTED_DATA`).

### Description

No related open issue found. Discovered via CI: `03823_optimize_dry_run_projections` fails deterministically when the randomized MergeTree setting `enable_block_number_column = 1` is picked (0 failures on master over 60 days, but reproducible across unrelated PR runs). CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93694&sha=502e40c1c239c27e8d2588f9ccdec1cfe8539a8c&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

Root cause: `_block_number`/`_block_offset` are per-row columns of the top-level part. When `enable_block_number_column` (or `enable_block_offset_column`) is set, a merge force-added these columns to every merged part via `MergeTask::enabledBlockNumberColumn`/`enabledBlockOffsetColumn`, including projection sub-parts (merges of a projection run as a nested `MergeTask` with `parent_part != nullptr`). A projection is a separate sub-part with its own schema and stores these columns only when its own definition references them; `ProjectionDescription` sets `with_block_number` only when the projection SELECT references `_block_number`, and the INSERT path (`MergeTreeDataWriter`) already skips these columns for projections. The merge path did not, so a merged aggregating-projection part gained a `_block_number` column that the projection metadata and insert-produced parts do not have. `OPTIMIZE ... DRY RUN` then runs `checkDataPart`, which strict-compares the projection part's columns against the declared projection columns and rejects it with `CORRUPTED_DATA`.

Fix: gate the automatic block-number/offset column on top-level part merges only (`parent_part == nullptr`). Projection sub-parts keep these columns only when the projection itself declares them, in which case they are already present in the projection's storage columns and the existing `contains()` early-return in `addMergingColumn`/`addGatheringColumn` makes the force-add a no-op. This makes the merge path consistent with the INSERT path.

Added `enable_block_number_column = 1` coverage to `03823_optimize_dry_run_projections`: without the fix, the merged projection part carries an extra `_block_number` column (test fails); with the fix, the projection part matches its metadata and `CHECK TABLE` passes.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.528` (included in `26.7` and later)
<!-- ch-version-info:end -->