### PR TITLE
Iceberg: deduplicate Avro/JSON boilerplate in writes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -587,9 +587,7 @@ static void writeMetadataFiles(
     }
 
     {
-        std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        Poco::JSON::Stringifier::stringify(metadata_object, oss, 4);
-        std::string json_representation = removeEscapedSlashes(oss.str());
+        std::string json_representation = stringifyJson(metadata_object, 4);
 
         auto buffer_metadata = object_storage->writeObject(
             StoredObject(path_resolver.resolve(generated_metadata_info.path)),

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Compaction.cpp
@@ -587,7 +587,7 @@ static void writeMetadataFiles(
     }
 
     {
-        std::string json_representation = stringifyJson(metadata_object, 4);
+        std::string json_representation = stringifyJSON(metadata_object, 4);
 
         auto buffer_metadata = object_storage->writeObject(
             StoredObject(path_resolver.resolve(generated_metadata_info.path)),

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ExpireSnapshotsExecute.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ExpireSnapshotsExecute.cpp
@@ -773,7 +773,7 @@ ExpireSnapshotsResult expireSnapshots(
 
         updateMetadataForExpiration(metadata, expired_ref_names, partition.retained_snapshots, partition.expired_snapshot_ids);
 
-        std::string json_representation = stringifyJson(metadata, 4);
+        std::string json_representation = stringifyJSON(metadata, 4);
         auto metadata_info = filename_generator.generateMetadataPathWithInfo();
         auto hint_path = filename_generator.generateVersionHint();
         if (!writeMetadataFileAndVersionHint(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ExpireSnapshotsExecute.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ExpireSnapshotsExecute.cpp
@@ -773,9 +773,7 @@ ExpireSnapshotsResult expireSnapshots(
 
         updateMetadataForExpiration(metadata, expired_ref_names, partition.retained_snapshots, partition.expired_snapshot_ids);
 
-        std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        Poco::JSON::Stringifier::stringify(metadata, oss, 4);
-        std::string json_representation = removeEscapedSlashes(oss.str());
+        std::string json_representation = stringifyJson(metadata, 4);
         auto metadata_info = filename_generator.generateMetadataPathWithInfo();
         auto hint_path = filename_generator.generateVersionHint();
         if (!writeMetadataFileAndVersionHint(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -10,7 +10,6 @@
 #include <limits>
 #include <memory>
 #include <optional>
-#include <sstream>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSet.h>
 #include <Core/UUID.h>
@@ -157,9 +156,7 @@ namespace
 {
 String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
 {
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(metadata_object, oss);
-    return removeEscapedSlashes(oss.str());
+    return stringifyJson(metadata_object);
 }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -156,7 +156,7 @@ namespace
 {
 String dumpMetadataObjectToString(const Poco::JSON::Object::Ptr & metadata_object)
 {
-    return stringifyJson(metadata_object);
+    return stringifyJSON(metadata_object);
 }
 }
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -228,11 +228,6 @@ String stringifyJSON(const Poco::Dynamic::Var & json, unsigned indent)
     return removeEscapedSlashes(oss.str());
 }
 
-avro::ValidSchema compileAvroSchema(const String & schema_json)
-{
-    return avro::compileJsonSchemaFromString(schema_json);
-}
-
 static void extendSchemaForPartitions(
     String & schema,
     const std::vector<String> & partition_columns,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -44,6 +44,8 @@
 #include <base/types.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <sys/stat.h>
+#include <Schema.hh>
+#include <Types.hh>
 #include <Poco/Dynamic/Var.h>
 #include <Poco/JSON/Array.h>
 #include <Common/Exception.h>
@@ -219,6 +221,13 @@ String removeEscapedSlashes(const String & json_str)
     return result;
 }
 
+String stringifyJson(const Poco::Dynamic::Var & json, unsigned indent)
+{
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    Poco::JSON::Stringifier::stringify(json, oss, indent);
+    return removeEscapedSlashes(oss.str());
+}
+
 static void extendSchemaForPartitions(
     String & schema,
     const std::vector<String> & partition_columns,
@@ -234,10 +243,7 @@ static void extendSchemaForPartitions(
         partition_fields->add(field);
     }
 
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(partition_fields, oss);
-
-    std::string json_representation = removeEscapedSlashes(oss.str());
+    std::string json_representation = stringifyJson(partition_fields);
 
     std::string from = "#";
     size_t start_pos = schema.find(from);
@@ -245,6 +251,51 @@ static void extendSchemaForPartitions(
     {
         schema.replace(start_pos, from.size(), json_representation);
     }
+}
+
+namespace
+{
+/// Assigns a value into a record field whose optionality depends on the Iceberg format version.
+/// An optional field is an Avro union `["null", T]`; in that case the value goes into the non-null
+/// branch. A required field is a plain scalar. We detect which case applies from the compiled schema
+/// rather than the version number, so the same helper works no matter which version makes the field
+/// optional. The datum type follows the C++ type of `value`; Avro encodes by datum type, so e.g. an
+/// `int` written into a `long` field is wire-compatible.
+void setVersionedField(avro::GenericRecord & rec, const auto & value, const String & field_name)
+{
+    size_t field_index = rec.fieldIndex(field_name);
+    const avro::NodePtr & field_schema = rec.schema()->leafAt(static_cast<UInt32>(field_index));
+
+    if (field_schema->type() == avro::AVRO_UNION)
+    {
+        avro::GenericUnion field(field_schema);
+        field.selectBranch(1);
+        field.datum() = avro::GenericDatum(value);
+        rec.fieldAt(field_index) = avro::GenericDatum(field_schema, field);
+    }
+    else
+    {
+        rec.fieldAt(field_index) = avro::GenericDatum(value);
+    }
+}
+
+/// Returns the schema object from the `schemas` list whose `schema-id` equals the table's `current-schema-id`.
+/// The position in the list is not necessarily equal to the id, so we must match by `schema-id`.
+Poco::JSON::Object::Ptr getCurrentSchema(const Poco::JSON::Object::Ptr & metadata)
+{
+    Int32 current_schema_id = metadata->getValue<Int32>(Iceberg::f_current_schema_id);
+    auto schemas = metadata->getArray(Iceberg::f_schemas);
+    for (size_t i = 0; i < schemas->size(); ++i)
+    {
+        auto schema = schemas->getObject(static_cast<UInt32>(i));
+        if (schema->getValue<Int32>(Iceberg::f_schema_id) == current_schema_id)
+            return schema;
+    }
+    throw Exception(
+        ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
+        "Not found schema with current-schema-id {} in the schemas list",
+        current_schema_id);
+}
 }
 
 void generateManifestFile(
@@ -282,19 +333,14 @@ void generateManifestFile(
     if (root_schema->type() != avro::AVRO_RECORD)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Iceberg manifest file schema must be record");
 
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    int current_schema_id = metadata->getValue<Int32>(Iceberg::f_current_schema_id);
-    Poco::JSON::Stringifier::stringify(metadata->getArray(Iceberg::f_schemas)->getObject(current_schema_id), oss, 4);
-    std::string json_representation = removeEscapedSlashes(oss.str());
+    std::string json_representation = stringifyJson(getCurrentSchema(metadata), 4);
 
     auto adapter = std::make_unique<OutputStreamWriteBufferAdapter>(buf);
     avro::DataFileWriter<avro::GenericDatum> writer(std::move(adapter), schema);
     writer.setMetadata(Iceberg::f_schema, json_representation);
     writer.setMetadata(Iceberg::f_format_version, std::to_string(version));
 
-    std::ostringstream oss_partition_spec; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(partition_spec->getArray(Iceberg::f_fields), oss_partition_spec);
-    writer.setMetadata(Iceberg::f_partition_spec, oss_partition_spec.str());
+    writer.setMetadata(Iceberg::f_partition_spec, stringifyJson(partition_spec->getArray(Iceberg::f_fields)));
     writer.setMetadata(Iceberg::f_partition_spec_id, std::to_string(partition_spec_id));
     writer.setMetadata(Iceberg::f_format_version, std::to_string(version));
     for (size_t file_idx = 0; file_idx < data_file_names.size(); ++file_idx)
@@ -306,34 +352,14 @@ void generateManifestFile(
         manifest.field(Iceberg::f_status) = avro::GenericDatum(1);
         Int64 snapshot_id = new_snapshot->getValue<Int64>(Iceberg::f_metadata_snapshot_id);
 
-        auto set_versioned_field = [&](const auto & value, const String & field_name)
-        {
-            if (version > 1)
-            {
-                size_t field_index = 0;
-                if (!schema.root()->nameIndex(field_name, field_index))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found field {} in schema", field_name);
-
-                const avro::NodePtr & union_schema = schema.root()->leafAt(static_cast<UInt32>(field_index));
-
-                avro::GenericUnion field(union_schema);
-                field.selectBranch(1);
-                field.datum() = avro::GenericDatum(value);
-                manifest.field(field_name) = avro::GenericDatum(union_schema, field);
-            }
-            else
-            {
-                manifest.field(field_name) = avro::GenericDatum(value);
-            }
-        };
-        set_versioned_field(snapshot_id, Iceberg::f_snapshot_id);
+        setVersionedField(manifest, snapshot_id, Iceberg::f_snapshot_id);
 
         if (version > 1)
         {
             Int64 sequence_number = user_defined_sequence_number.value_or(new_snapshot->getValue<Int64>(Iceberg::f_metadata_sequence_number));
 
-            set_versioned_field(sequence_number, Iceberg::f_sequence_number);
-            set_versioned_field(sequence_number, Iceberg::f_file_sequence_number);
+            setVersionedField(manifest, sequence_number, Iceberg::f_sequence_number);
+            setVersionedField(manifest, sequence_number, Iceberg::f_file_sequence_number);
         }
         avro::GenericRecord & data_file = manifest.field(Iceberg::f_data_file).value<avro::GenericRecord>();
         if (version > 1)
@@ -508,38 +534,18 @@ void generateManifestList(
             entry.field(Iceberg::f_min_sequence_number) = new_snapshot->getValue<Int64>(Iceberg::f_metadata_sequence_number);
         }
 
-        auto set_versioned_field = [&](const auto & value, const String & field_name)
-        {
-            if (version == 1)
-            {
-                size_t field_index = 0;
-                if (!schema.root()->nameIndex(field_name, field_index))
-                    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Not found field {} in schema", field_name);
-
-                const avro::NodePtr & union_schema = schema.root()->leafAt(static_cast<UInt32>(field_index));
-
-                avro::GenericUnion field(union_schema);
-                field.selectBranch(1);
-                field.datum() = avro::GenericDatum(value);
-                entry.field(field_name) = avro::GenericDatum(union_schema, field);
-            }
-            else
-            {
-                entry.field(field_name) = value;
-            }
-        };
         entry.field(Iceberg::f_added_snapshot_id) = new_snapshot->getValue<Int64>(Iceberg::f_metadata_snapshot_id);
         auto summary = new_snapshot->getObject(Iceberg::f_summary);
 
         if (version == 1)
         {
-            set_versioned_field(1, Iceberg::f_added_files_count);
-            set_versioned_field(std::stoi(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
-            set_versioned_field(0, Iceberg::f_deleted_files_count);
+            setVersionedField(entry, 1, Iceberg::f_added_files_count);
+            setVersionedField(entry, std::stoi(summary->getValue<String>(Iceberg::f_total_data_files)), Iceberg::f_existing_files_count);
+            setVersionedField(entry, 0, Iceberg::f_deleted_files_count);
             if (summary->has(Iceberg::f_added_position_deletes))
-                set_versioned_field(summary->getValue<Int64>(Iceberg::f_added_position_deletes), Iceberg::f_deleted_rows_count);
+                setVersionedField(entry, summary->getValue<Int64>(Iceberg::f_added_position_deletes), Iceberg::f_deleted_rows_count);
             else
-                set_versioned_field(0, Iceberg::f_deleted_rows_count);
+                setVersionedField(entry, 0, Iceberg::f_deleted_rows_count);
         }
         else
         {
@@ -555,20 +561,24 @@ void generateManifestList(
 
         if (entry_content == Iceberg::FileContentType::DATA)
         {
-            set_versioned_field(
+            setVersionedField(
+                entry,
                 summary->has(Iceberg::f_added_records) ? summary->getValue<Int64>(Iceberg::f_added_records) : 0,
                 Iceberg::f_added_rows_count);
         }
         else
         {
-            set_versioned_field(
+            setVersionedField(
+                entry,
                 summary->has(Iceberg::f_added_position_deletes) ? summary->getValue<Int64>(Iceberg::f_added_position_deletes) : 0,
                 Iceberg::f_added_rows_count);
         }
-        set_versioned_field(
+        setVersionedField(
+            entry,
             0,
             Iceberg::f_existing_rows_count);
-        set_versioned_field(0, Iceberg::f_deleted_rows_count);
+        setVersionedField(entry, 0, Iceberg::f_deleted_rows_count);
+
         writer.write(entry_datum);
     }
 
@@ -1075,9 +1085,7 @@ bool IcebergStorageSink::initializeMetadata()
         }
 
         {
-            std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-            Poco::JSON::Stringifier::stringify(metadata, oss, 4);
-            std::string json_representation = removeEscapedSlashes(oss.str());
+            std::string json_representation = stringifyJson(metadata, 4);
 
             fiu_do_on(FailPoints::iceberg_writes_cleanup,
             {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -221,11 +221,16 @@ String removeEscapedSlashes(const String & json_str)
     return result;
 }
 
-String stringifyJson(const Poco::Dynamic::Var & json, unsigned indent)
+String stringifyJSON(const Poco::Dynamic::Var & json, unsigned indent)
 {
     std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
     Poco::JSON::Stringifier::stringify(json, oss, indent);
     return removeEscapedSlashes(oss.str());
+}
+
+avro::ValidSchema compileAvroSchema(const String & schema_json)
+{
+    return avro::compileJsonSchemaFromString(schema_json);
 }
 
 static void extendSchemaForPartitions(
@@ -243,7 +248,7 @@ static void extendSchemaForPartitions(
         partition_fields->add(field);
     }
 
-    std::string json_representation = stringifyJson(partition_fields);
+    std::string json_representation = stringifyJSON(partition_fields);
 
     std::string from = "#";
     size_t start_pos = schema.find(from);
@@ -333,14 +338,14 @@ void generateManifestFile(
     if (root_schema->type() != avro::AVRO_RECORD)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Iceberg manifest file schema must be record");
 
-    std::string json_representation = stringifyJson(getCurrentSchema(metadata), 4);
+    std::string json_representation = stringifyJSON(getCurrentSchema(metadata), 4);
 
     auto adapter = std::make_unique<OutputStreamWriteBufferAdapter>(buf);
     avro::DataFileWriter<avro::GenericDatum> writer(std::move(adapter), schema);
     writer.setMetadata(Iceberg::f_schema, json_representation);
     writer.setMetadata(Iceberg::f_format_version, std::to_string(version));
 
-    writer.setMetadata(Iceberg::f_partition_spec, stringifyJson(partition_spec->getArray(Iceberg::f_fields)));
+    writer.setMetadata(Iceberg::f_partition_spec, stringifyJSON(partition_spec->getArray(Iceberg::f_fields)));
     writer.setMetadata(Iceberg::f_partition_spec_id, std::to_string(partition_spec_id));
     writer.setMetadata(Iceberg::f_format_version, std::to_string(version));
     for (size_t file_idx = 0; file_idx < data_file_names.size(); ++file_idx)
@@ -1085,7 +1090,7 @@ bool IcebergStorageSink::initializeMetadata()
         }
 
         {
-            std::string json_representation = stringifyJson(metadata, 4);
+            std::string json_representation = stringifyJSON(metadata, 4);
 
             fiu_do_on(FailPoints::iceberg_writes_cleanup,
             {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -44,8 +44,6 @@
 #include <base/types.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <sys/stat.h>
-#include <Schema.hh>
-#include <Types.hh>
 #include <Poco/Dynamic/Var.h>
 #include <Poco/JSON/Array.h>
 #include <Common/Exception.h>
@@ -66,8 +64,10 @@
 #include <Encoder.hh>
 #include <Generic.hh>
 #include <GenericDatum.hh>
+#include <Schema.hh>
 #include <Specific.hh>
 #include <Stream.hh>
+#include <Types.hh>
 #include <ValidSchema.hh>
 
 #include <Poco/JSON/Object.h>
@@ -255,12 +255,6 @@ static void extendSchemaForPartitions(
 
 namespace
 {
-/// Assigns a value into a record field whose optionality depends on the Iceberg format version.
-/// An optional field is an Avro union `["null", T]`; in that case the value goes into the non-null
-/// branch. A required field is a plain scalar. We detect which case applies from the compiled schema
-/// rather than the version number, so the same helper works no matter which version makes the field
-/// optional. The datum type follows the C++ type of `value`; Avro encodes by datum type, so e.g. an
-/// `int` written into a `long` field is wire-compatible.
 void setVersionedField(avro::GenericRecord & rec, const auto & value, const String & field_name)
 {
     size_t field_index = rec.fieldIndex(field_name);
@@ -279,8 +273,6 @@ void setVersionedField(avro::GenericRecord & rec, const auto & value, const Stri
     }
 }
 
-/// Returns the schema object from the `schemas` list whose `schema-id` equals the table's `current-schema-id`.
-/// The position in the list is not necessarily equal to the id, so we must match by `schema-id`.
 Poco::JSON::Object::Ptr getCurrentSchema(const Poco::JSON::Object::Ptr & metadata)
 {
     Int32 current_schema_id = metadata->getValue<Int32>(Iceberg::f_current_schema_id);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -44,6 +44,11 @@ namespace DB
 
 String removeEscapedSlashes(const String & json_str);
 
+/// Serializes a Poco JSON value to text, undoing the `\/` escaping that Poco unconditionally applies
+/// to forward slashes (see `removeEscapedSlashes`). Use this instead of hand-rolling the
+/// `std::ostringstream` + `Stringifier::stringify` + `removeEscapedSlashes` sequence.
+String stringifyJson(const Poco::Dynamic::Var & json, unsigned indent = 0);
+
 void generateManifestFile(
     Poco::JSON::Object::Ptr metadata,
     const std::vector<String> & partition_columns,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -44,9 +44,6 @@ namespace DB
 
 String removeEscapedSlashes(const String & json_str);
 
-/// Serializes a Poco JSON value to text, undoing the `\/` escaping that Poco unconditionally applies
-/// to forward slashes (see `removeEscapedSlashes`). Use this instead of hand-rolling the
-/// Poco stringification + `removeEscapedSlashes` sequence.
 String stringifyJSON(const Poco::Dynamic::Var & json, unsigned indent = 0);
 
 void generateManifestFile(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -46,8 +46,12 @@ String removeEscapedSlashes(const String & json_str);
 
 /// Serializes a Poco JSON value to text, undoing the `\/` escaping that Poco unconditionally applies
 /// to forward slashes (see `removeEscapedSlashes`). Use this instead of hand-rolling the
-/// `std::ostringstream` + `Stringifier::stringify` + `removeEscapedSlashes` sequence.
-String stringifyJson(const Poco::Dynamic::Var & json, unsigned indent = 0);
+/// Poco stringification + `removeEscapedSlashes` sequence.
+String stringifyJSON(const Poco::Dynamic::Var & json, unsigned indent = 0);
+
+/// Compiles an Avro schema from its JSON text. Thin wrapper over the Avro library API,
+/// kept here so the call lives in a single place.
+avro::ValidSchema compileAvroSchema(const String & schema_json);
 
 void generateManifestFile(
     Poco::JSON::Object::Ptr metadata,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -49,10 +49,6 @@ String removeEscapedSlashes(const String & json_str);
 /// Poco stringification + `removeEscapedSlashes` sequence.
 String stringifyJSON(const Poco::Dynamic::Var & json, unsigned indent = 0);
 
-/// Compiles an Avro schema from its JSON text. Thin wrapper over the Avro library API,
-/// kept here so the call lives in a single place.
-avro::ValidSchema compileAvroSchema(const String & schema_json);
-
 void generateManifestFile(
     Poco::JSON::Object::Ptr metadata,
     const std::vector<String> & partition_columns,

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -519,9 +519,7 @@ static bool writeMetadataFiles(
             buffer_manifest_list->finalize();
         }
 
-        std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        Poco::JSON::Stringifier::stringify(metadata, oss, 4);
-        std::string json_representation = removeEscapedSlashes(oss.str());
+        std::string json_representation = stringifyJson(metadata, 4);
 
         fiu_do_on(FailPoints::iceberg_writes_cleanup,
         {
@@ -760,9 +758,7 @@ void alter(
             }
         }
 
-        std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-        Poco::JSON::Stringifier::stringify(metadata, oss, 4);
-        std::string json_representation = removeEscapedSlashes(oss.str());
+        std::string json_representation = stringifyJson(metadata, 4);
 
         auto metadata_info = filename_generator.generateMetadataPathWithInfo();
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -519,7 +519,7 @@ static bool writeMetadataFiles(
             buffer_manifest_list->finalize();
         }
 
-        std::string json_representation = stringifyJson(metadata, 4);
+        std::string json_representation = stringifyJSON(metadata, 4);
 
         fiu_do_on(FailPoints::iceberg_writes_cleanup,
         {
@@ -758,7 +758,7 @@ void alter(
             }
         }
 
-        std::string json_representation = stringifyJson(metadata, 4);
+        std::string json_representation = stringifyJSON(metadata, 4);
 
         auto metadata_info = filename_generator.generateMetadataPathWithInfo();
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -1050,7 +1050,7 @@ std::pair<Poco::JSON::Object::Ptr, String> createEmptyMetadataFile(
     sort_orders->add(sort_order);
     new_metadata_file_content->set(Iceberg::f_sort_orders, sort_orders);
 
-    return {new_metadata_file_content, stringifyJson(new_metadata_file_content, 4)};
+    return {new_metadata_file_content, stringifyJSON(new_metadata_file_content, 4)};
 }
 
 /**

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -1,6 +1,5 @@
 
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <config.h>
@@ -1051,9 +1050,7 @@ std::pair<Poco::JSON::Object::Ptr, String> createEmptyMetadataFile(
     sort_orders->add(sort_order);
     new_metadata_file_content->set(Iceberg::f_sort_orders, sort_orders);
 
-    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
-    Poco::JSON::Stringifier::stringify(new_metadata_file_content, oss, 4);
-    return {new_metadata_file_content, removeEscapedSlashes(oss.str())};
+    return {new_metadata_file_content, stringifyJson(new_metadata_file_content, 4)};
 }
 
 /**


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/105198

Three near-identical `set_versioned_field` lambdas did the same Avro union-branch dance, each keyed off a hand-written `version` check that pointed in different directions. Replace them with one `setVersionedField` that reads optionality from the compiled schema. Fold the `std::ostringstream` + `Stringifier::stringify` + `removeEscapedSlashes` sequence, repeated across seven files, into a single `stringifyJSON`. Also fix `getCurrentSchema` to select the schema by `schema-id` instead of by array position.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.668` (included in `26.7` and later)
<!-- ch-version-info:end -->