### PR TITLE
Fix flaky test 04321_multiple_quotas_per_user

### DIFF
--- a/tests/queries/0_stateless/04321_multiple_quotas_per_user.sh
+++ b/tests/queries/0_stateless/04321_multiple_quotas_per_user.sh
@@ -4,6 +4,11 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Lower the client log level so transient server warnings (e.g. QuotaCache's "Re-chose quotas
+# ... in N ms", emitted when a recompute is slow under load) cannot leak onto stderr and fail
+# the stdout-only assertions below.
+CLICKHOUSE_CLIENT=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=error/")
+
 # A user can be assigned several quotas at once (here, of different key types). All of them must
 # be enforced together: a query is rejected if ANY assigned quota is exceeded. Previously only one
 # quota per user was enforced, chosen non-deterministically, so the others were silently ignored.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/107664


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a flaky failure of `04321_multiple_quotas_per_user` seen on master (`Stateless tests (amd_tsan, parallel)`, commit 882ae8eec3fd078c669d7d7c84fd50b14f2ad443, [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=882ae8eec3fd078c669d7d7c84fd50b14f2ad443&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29)).

The test runs its client queries at the CI-default `send_logs_level=warning`. When `QuotaCache::chooseQuotaToConsume()` recomputes quotas slowly under load (`>= 1000` ms), it emits a Warning-level log (`QuotaCache: Re-chose quotas for N enabled set(s) over M quotas in X ms`). That warning streams onto the client's stderr, and the runner flags any non-empty stderr as a failure. The failing run's diagnostic showed exactly this: correct stdout plus `Reason: having stderror:` with the QuotaCache warning, and all reruns passed (the recompute is fast on an unloaded runner, so it logs at Debug instead).

The fix lowers the client log level to `error` for this test, so transient server warnings cannot leak onto stderr. The assertions depend only on stdout and on the `QUOTA_EXCEEDED` exception text, so this does not weaken the test.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.499` (included in `26.7` and later)
<!-- ch-version-info:end -->