### PR TITLE
Fix server crash on CREATE HYPOTHETICAL INDEX with missing arguments

### DIFF
--- a/src/Interpreters/InterpreterHypotheticalIndexQuery.cpp
+++ b/src/Interpreters/InterpreterHypotheticalIndexQuery.cpp
@@ -102,16 +102,18 @@ BlockIO InterpreterHypotheticalIndexQuery::execute()
     if (index_desc.expression)
         context->checkAccess(AccessType::SELECT, table_id, index_desc.expression->getRequiredColumns());
 
-    /// Reject unsupported types before validate can throw a confusing type-specific error
-    /// get() already throws INCORRECT_QUERY for unknown types, exactly as validate
+    /// validate() must run before get(): index creators assume their arguments were already
+    /// validated and read them unguarded (e.g. set/bloom_filter index.arguments->children[0]),
+    /// so calling get() on an unvalidated user AST can dereference absent arguments.
+    MergeTreeIndexFactory::instance().validate(index_desc, /* attach = */ false, *merge_tree->getSettings());
+
+    /// Well-formed but unimplemented types are rejected here (validate accepts them).
     auto index_helper = MergeTreeIndexFactory::instance().get(metadata, index_desc, *merge_tree->getSettings());
     if (index_helper->isTextIndex() || index_helper->isVectorSimilarityIndex())
         throw Exception(
             ErrorCodes::NOT_IMPLEMENTED,
             "Hypothetical indexes of type '{}' are not supported",
             index_desc.type);
-
-    MergeTreeIndexFactory::instance().validate(index_desc, /* attach = */ false, *merge_tree->getSettings());
 
     /// Old-syntax MergeTree rejects `ALTER TABLE ... ADD INDEX`, so reject it here too.
     if (!merge_tree->is_custom_partitioned)

--- a/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.reference
+++ b/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.reference
@@ -1,0 +1,10 @@
+--- set with no argument ---
+INCORRECT_QUERY
+--- ngrambf_v1 with no arguments ---
+BAD_ARGUMENTS
+--- tokenbf_v1 with no arguments ---
+BAD_ARGUMENTS
+--- server is still alive ---
+1
+--- well-formed set is still accepted ---
+1

--- a/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.reference
+++ b/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.reference
@@ -4,7 +4,13 @@ INCORRECT_QUERY
 BAD_ARGUMENTS
 --- tokenbf_v1 with no arguments ---
 BAD_ARGUMENTS
+--- sparse_grams with no arguments ---
+BAD_ARGUMENTS
+--- vector_similarity with no arguments ---
+INCORRECT_QUERY
 --- server is still alive ---
 1
 --- well-formed set is still accepted ---
 1
+--- well-formed vector_similarity is still 'not supported' ---
+NOT_IMPLEMENTED

--- a/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
+++ b/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
@@ -8,12 +8,13 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "
     DROP TABLE IF EXISTS t_hypo_noargs;
-    CREATE TABLE t_hypo_noargs (a UInt64, b String) ENGINE = MergeTree ORDER BY a;
+    CREATE TABLE t_hypo_noargs (a UInt64, b String, v Array(Float32)) ENGINE = MergeTree ORDER BY a;
 "
 
 # Arg-taking index types with the argument omitted used to reach the index creator
-# (which reads index.arguments->children[0] unguarded) before validation and crash the server.
-# They must now be rejected cleanly by the validator.
+# (which reads its arguments unguarded) before validation and crash the server.
+# They must now be rejected cleanly by the validator. Covers the whole crash family:
+# set/ngrambf_v1/tokenbf_v1/sparse_grams (bloom-filter creators) and vector_similarity.
 
 echo "--- set with no argument ---"
 $CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE set GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
@@ -24,6 +25,12 @@ $CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE ng
 echo "--- tokenbf_v1 with no arguments ---"
 $CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE tokenbf_v1 GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
 
+echo "--- sparse_grams with no arguments ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE sparse_grams GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
+
+echo "--- vector_similarity with no arguments ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (v) TYPE vector_similarity GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
+
 echo "--- server is still alive ---"
 $CLICKHOUSE_CLIENT -q "SELECT 1"
 
@@ -32,5 +39,10 @@ $CLICKHOUSE_CLIENT -q "
     CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE set(100) GRANULARITY 1;
     SELECT count() FROM system.hypothetical_indexes WHERE table = 't_hypo_noargs' AND name = 'hi';
 "
+
+# A well-formed but unsupported type must still pass validation and then be rejected by
+# the explicit "not supported" branch (validate before construct preserves author intent).
+echo "--- well-formed vector_similarity is still 'not supported' ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (v) TYPE vector_similarity('hnsw', 'L2Distance', 3) GRANULARITY 1;" 2>&1 | grep -m1 -oE 'NOT_IMPLEMENTED'
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_noargs;"

--- a/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
+++ b/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database
+# no-replicated-database: hypothetical indexes are session-scoped and not replicated
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS t_hypo_noargs;
+    CREATE TABLE t_hypo_noargs (a UInt64, b String) ENGINE = MergeTree ORDER BY a;
+"
+
+# Arg-taking index types with the argument omitted used to reach the index creator
+# (which reads index.arguments->children[0] unguarded) before validation and crash the server.
+# They must now be rejected cleanly by the validator.
+
+echo "--- set with no argument ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE set GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
+
+echo "--- ngrambf_v1 with no arguments ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE ngrambf_v1 GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
+
+echo "--- tokenbf_v1 with no arguments ---"
+$CLICKHOUSE_CLIENT -q "CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE tokenbf_v1 GRANULARITY 1;" 2>&1 | grep -m1 -oE 'INCORRECT_QUERY|BAD_ARGUMENTS'
+
+echo "--- server is still alive ---"
+$CLICKHOUSE_CLIENT -q "SELECT 1"
+
+echo "--- well-formed set is still accepted ---"
+$CLICKHOUSE_CLIENT -q "
+    CREATE HYPOTHETICAL INDEX hi ON t_hypo_noargs (b) TYPE set(100) GRANULARITY 1;
+    SELECT count() FROM system.hypothetical_indexes WHERE table = 't_hypo_noargs' AND name = 'hi';
+"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_noargs;"

--- a/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
+++ b/tests/queries/0_stateless/04499_hypothetical_index_missing_arguments.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: vector_similarity needs usearch, absent in the ENABLE_LIBRARIES=0 fast build
 # no-replicated-database: hypothetical indexes are session-scoped and not replicated
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/109287
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/109287

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server crash on `CREATE HYPOTHETICAL INDEX ... TYPE set` (and `ngrambf_v1`/`tokenbf_v1`) when the required index argument is omitted. Such statements are now rejected with a clear error.

### Description

`InterpreterHypotheticalIndexQuery::execute()` called `MergeTreeIndexFactory::get()` before `validate()`. `get()` invokes the index creator, and creators assume their arguments were already validated: `setIndexCreator` reads `index.arguments->children[0]` with no guard, and the bloom filter creators do the same. Every other `get()` caller runs on already-validated metadata, so this fresh-user-AST path was the only one that could reach a creator with unvalidated arguments.

A statement that omits a required argument, e.g.:

```sql
CREATE HYPOTHETICAL INDEX hi ON t c0 TYPE set GRANULARITY 1;
```

therefore dereferenced an absent argument list and crashed the server (null `intrusive_ptr` for `set`, `vector` out-of-bounds for `ngrambf_v1`/`tokenbf_v1`).

The fix runs `validate()` before `get()`, restoring the "validate before construct" ordering the creators rely on. Malformed arguments are now rejected with `INCORRECT_QUERY`/`BAD_ARGUMENTS`. Well-formed but unimplemented types (`text`, `vector_similarity`) still pass validation and reach the existing "not supported" message, so the behavior in the existing `04223` test is unchanged.

Crash reproducer (BuzzHouse `amd_tsan`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109194&sha=ea505128ca5f2873ec53d399c23c5e34decd5d24&name_0=PR&name_1=BuzzHouse%20%28amd_tsan%29

New regression test: `04499_hypothetical_index_missing_arguments`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.524` (included in `26.7` and later)
- Backported to: `26.6.2.29`
<!-- ch-version-info:end -->