### PR TITLE
Set Keeper component in StorageMergeTree mutation-file methods

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -447,8 +447,6 @@ void StorageMergeTree::alter(
     ContextPtr local_context,
     AlterLockHolder & table_lock_holder)
 {
-    /// A rolled-back mutation_*.txt (removeFile on pre-commit unwind or explicit rollback below)
-    /// may reach Keeper on a keeper-metadata disk, so the scope must span the whole ALTER path.
     auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::alter");
 
     /// Allow MODIFY_SETTING/RESET_SETTING through even when the table is readonly,
@@ -873,9 +871,6 @@ MergeMutateSelectedEntry::~MergeMutateSelectedEntry()
 StorageMergeTree::PreparedMutationEntry StorageMergeTree::prepareMutationEntry(
     const MutationCommands & commands, ContextPtr query_context)
 {
-    /// Both callers (`startMutation` and `alter`) hold a Keeper component guard spanning the
-    /// commit AND the removeFile rollback of the returned entry, so none is set here.
-
     /// Choose any disk, because when we load mutations we search them at each disk
     /// where storage can be placed. See `loadMutations`.
     auto disk = getStoragePolicy()->getAnyDisk();
@@ -929,8 +924,6 @@ void StorageMergeTree::addPreparedMutationEntry(PreparedMutationEntry prepared)
 
 Int64 StorageMergeTree::startMutation(const MutationCommands & commands, ContextPtr query_context)
 {
-    /// Guard spans addPreparedMutationEntry too: a throw there destructs the unregistered
-    /// entry, whose removeFile may reach Keeper on a keeper-metadata disk.
     auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::startMutation");
 
     /// File I/O (`writeFile` + `sync` + `moveFile`) happens in `prepareMutationEntry`
@@ -1388,7 +1381,6 @@ std::vector<MergeTreeMutationStatus> StorageMergeTree::getMutationsStatus() cons
 
 CancellationCode StorageMergeTree::killMutation(const String & mutation_id)
 {
-    /// MergeTreeMutationEntry disk I/O (removeFile) may reach Keeper on a keeper-metadata disk.
     auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::killMutation");
 
     assertNotReadonly();

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -61,6 +61,7 @@
 #include <Common/FailPoint.h>
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEventsScope.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/escapeForFileName.h>
 
 
@@ -446,6 +447,10 @@ void StorageMergeTree::alter(
     ContextPtr local_context,
     AlterLockHolder & table_lock_holder)
 {
+    /// A rolled-back mutation_*.txt (removeFile on pre-commit unwind or explicit rollback below)
+    /// may reach Keeper on a keeper-metadata disk, so the scope must span the whole ALTER path.
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::alter");
+
     /// Allow MODIFY_SETTING/RESET_SETTING through even when the table is readonly,
     /// so that the `table_readonly` flag can be toggled back.
     bool only_setting_changes = std::all_of(commands.begin(), commands.end(), [](const auto & c)
@@ -868,6 +873,9 @@ MergeMutateSelectedEntry::~MergeMutateSelectedEntry()
 StorageMergeTree::PreparedMutationEntry StorageMergeTree::prepareMutationEntry(
     const MutationCommands & commands, ContextPtr query_context)
 {
+    /// Both callers (`startMutation` and `alter`) hold a Keeper component guard spanning the
+    /// commit AND the removeFile rollback of the returned entry, so none is set here.
+
     /// Choose any disk, because when we load mutations we search them at each disk
     /// where storage can be placed. See `loadMutations`.
     auto disk = getStoragePolicy()->getAnyDisk();
@@ -921,6 +929,10 @@ void StorageMergeTree::addPreparedMutationEntry(PreparedMutationEntry prepared)
 
 Int64 StorageMergeTree::startMutation(const MutationCommands & commands, ContextPtr query_context)
 {
+    /// Guard spans addPreparedMutationEntry too: a throw there destructs the unregistered
+    /// entry, whose removeFile may reach Keeper on a keeper-metadata disk.
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::startMutation");
+
     /// File I/O (`writeFile` + `sync` + `moveFile`) happens in `prepareMutationEntry`
     /// outside the mutex; only the in-memory registration is locked. Holding the
     /// mutex across the file I/O would block merge selection for its full duration.
@@ -1039,6 +1051,8 @@ void StorageMergeTree::waitForMutation(Int64 version, const String & mutation_id
 
 void StorageMergeTree::setMutationCSN(const String & mutation_id, CSN csn)
 {
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::setMutationCSN");
+
     LOG_INFO(log, "Writing CSN {} for mutation {}", csn, mutation_id);
     UInt64 version = MergeTreeMutationEntry::parseFileName(mutation_id);
 
@@ -1374,6 +1388,9 @@ std::vector<MergeTreeMutationStatus> StorageMergeTree::getMutationsStatus() cons
 
 CancellationCode StorageMergeTree::killMutation(const String & mutation_id)
 {
+    /// MergeTreeMutationEntry disk I/O (removeFile) may reach Keeper on a keeper-metadata disk.
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::killMutation");
+
     assertNotReadonly();
 
     LOG_TRACE(log, "Killing mutation {}", mutation_id);
@@ -1440,6 +1457,8 @@ void StorageMergeTree::loadDeduplicationLog()
 
 void StorageMergeTree::loadMutations()
 {
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::loadMutations");
+
     /// Called only from the constructor, before this storage is published to any
     /// database, so no other thread holds a reference and the lock is unnecessary.
     /// Avoiding it also breaks a TSan lock-order edge between `DatabaseAtomic::mutex`
@@ -2139,6 +2158,8 @@ UInt64 StorageMergeTree::getNextMutationVersion(UInt64 data_version, std::unique
 
 size_t StorageMergeTree::clearOldMutations(bool truncate)
 {
+    auto component_guard = Coordination::setCurrentComponent("StorageMergeTree::clearOldMutations");
+
     size_t finished_mutations_to_keep = (*getSettings())[MergeTreeSetting::finished_mutations_to_keep];
     if (!truncate && !finished_mutations_to_keep)
         return 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` (`Current component is empty`) that could be raised by mutation operations such as `KILL MUTATION` on a `MergeTree` table that stores its metadata in Keeper, when the `enforce_keeper_component_tracking` server setting is enabled.

### Description

`StorageMergeTree` methods that perform `MergeTreeMutationEntry` disk I/O (`commit` / `removeFile` / `writeCSN`, and reading entries at load) can reach Keeper when the table's disk stores its metadata in Keeper (`metadata_type='keeper'`). With `enforce_keeper_component_tracking=1`, the ZooKeeper request path requires a thread-local component scope set via `Coordination::setCurrentComponent`. Without it the request raises `LOGICAL_ERROR: Current component is empty, please set it for your scope using Coordination::setCurrentComponent`, which is caught and handled in release builds but aborts the server in debug and sanitizer builds.

One concrete trigger: `KILL MUTATION` on such a table -> `StorageMergeTree::killMutation` -> `MergeTreeMutationEntry::removeFile` -> disk `existsFile` -> Keeper multi request with no component scope up the stack.

`StorageSharedMergeTree` already annotates its Keeper-touching call sites with `setCurrentComponent` guards; `StorageMergeTree` had none. This adds a scoped guard at the entry of every `StorageMergeTree` method that does `MergeTreeMutationEntry` disk I/O: `startMutation`, `setMutationCSN`, `killMutation`, `loadMutations`, `clearOldMutations`. Together these cover all nine mutation-entry I/O sites in the file.

The guards are unconditional, valid public code and a harmless no-op in builds without a keeper-metadata disk (plain disks do not route these operations through Keeper), matching the accepted `StorageSharedMergeTree` guard pattern. No behavior, on-disk format, or setting change.

No related open issue found (checked open/closed issues and open PRs). A targeted regression test would need a keeper-based metadata disk (`metadata_type='keeper'`), whose registration is gated behind a build flag not available in a community build, so this is a source-only fix; the affected path is not reachable on a plain community checkout.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.704` (included in `26.7` and later)
<!-- ch-version-info:end -->