### PR TITLE
Fix flaky test_failed_commit_after_success (s3_queue)

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_5.py
+++ b/tests/integration/test_storage_s3_queue/test_5.py
@@ -24,9 +24,15 @@ AVAILABLE_MODES = ["unordered", "ordered"]
 def s3_queue_setup_teardown(started_cluster):
     instance = started_cluster.instances["instance"]
     instance_2 = started_cluster.instances["instance2"]
+    instance_3 = started_cluster.instances["instance_without_keeper_fault_injection"]
 
     instance.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
     instance_2.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
+    # instance_without_keeper_fault_injection was not reset between tests, so S3Queue
+    # tables leaked from prior tests kept streaming and could consume a process-global
+    # ONCE failpoint (e.g. object_storage_queue_fail_commit_after_success) before the
+    # test that armed it committed. Reset it too so each test starts with no streamers.
+    instance_3.query("DROP DATABASE IF EXISTS default; CREATE DATABASE default;")
 
     minio = started_cluster.minio_client
     objects = list(minio.list_objects(started_cluster.minio_bucket, recursive=True))


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fix flaky `test_storage_s3_queue/test_5.py::test_failed_commit_after_success` (concentrated on `amd_tsan`, ~30 hits across 20 unrelated PRs in 30d).

Root cause (confirmed from a failing-run server log, not a guess): the test arms the process-global ONCE failpoint `object_storage_queue_fail_commit_after_success` and waits up to 100s for its own background commit to hit it. Sibling tests in the same file (`test_deduplication[unordered]`, `test_deduplication_with_multiple_chunks[unordered]`) set `after_processing='keep'` + `s3queue_tracked_file_ttl_sec=1`, so their S3Queue tables re-process and commit forever, and neither test drops its table. The autouse teardown reset only the `instance` and `instance2` databases, not `instance_without_keeper_fault_injection` (the instance all three tests share), so a leftover streamer survived across tests. When it committed during the ~1s window the target had the ONCE failpoint armed, the leftover consumed the failpoint first; the target then committed successfully and its wait timed out with "Failpoint was not triggered". This is why it clustered on the slow `amd_tsan` build and never reproduced in isolation.

In the failing run (PR #108377, commit 067a13c4, `Integration tests (amd_tsan, 2/6)`), the leftover table `test_deduplication_chunks_unordered_*` consumed the failpoint at 15:22:26.527Z, one second before the target's MV was even attached (15:22:27.517Z).

Fix: reset the `default` database on `instance_without_keeper_fault_injection` in the autouse fixture too, so each test starts with no leftover streamers. Test-only change.

Reproduced deterministically locally (a continuously-committing leftover steals the failpoint: target fails without the reset, passes with it).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.515` (included in `26.7` and later)
<!-- ch-version-info:end -->