### PR TITLE
Make `03532_window_function_and_null_source_max_threads` not flaky

### DIFF
--- a/tests/queries/0_stateless/03532_window_function_and_null_source_max_threads.sql
+++ b/tests/queries/0_stateless/03532_window_function_and_null_source_max_threads.sql
@@ -72,7 +72,7 @@ SELECT trimLeft(explain) FROM (
             )
         SELECT lead
         FROM window2
-        SETTINGS max_threads = 20, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0 -- CI may inject False; changes Resize pipeline structure after window functions
+        SETTINGS max_threads = 20, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0, query_plan_optimize_join_order_randomize = 0, join_algorithm = 'parallel_hash' -- pin settings CI may randomize; a plain `hash` join keeps the pipeline single-threaded and changes the Resize structure
 ) WHERE explain LIKE '%Resize%' LIMIT 3;
 
 
@@ -104,7 +104,7 @@ SELECT trimLeft(explain) FROM (
             )
         SELECT lead
         FROM window2
-        SETTINGS max_threads = 2000, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0 -- CI may inject False; changes Resize pipeline structure after window functions
+        SETTINGS max_threads = 2000, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0, query_plan_optimize_join_order_randomize = 0, join_algorithm = 'parallel_hash' -- pin settings CI may randomize; a plain `hash` join keeps the pipeline single-threaded and changes the Resize structure
 ) WHERE explain LIKE '%Resize%' LIMIT 3; -- {serverError LIMIT_EXCEEDED}
 
 
@@ -136,7 +136,7 @@ SELECT trimLeft(explain) FROM (
             )
         SELECT lead
         FROM window2
-        SETTINGS max_threads = 300, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0 -- CI may inject False; changes Resize pipeline structure after window functions
+        SETTINGS max_threads = 300, enable_parallel_replicas=0, query_plan_enable_multithreading_after_window_functions = 1, max_threads_min_free_memory_per_thread = 0, query_plan_optimize_join_order_randomize = 0, join_algorithm = 'parallel_hash' -- pin settings CI may randomize; a plain `hash` join keeps the pipeline single-threaded and changes the Resize structure
 ) WHERE explain LIKE '%Resize%' LIMIT 1;
 
 DROP TABLE empty;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes flaky 03532_window_function_and_null_source_max_threads. Was failing because of randomized settings. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109294&sha=8ff33165d8f5565caf0757b07e8955a91728045c&name_0=PR


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.561` (included in `26.7` and later)
<!-- ch-version-info:end -->