### PR TITLE
Reduce memory usage of the header cache of text index

### DIFF
--- a/src/Common/BitHelpers.h
+++ b/src/Common/BitHelpers.h
@@ -124,7 +124,7 @@ constexpr bool isPowerOf2(T number)
   * The array must be overallocated by one element.
   * The bit range must be pre-filled with zeros.
   */
-inline void writeBits(uint64_t * dest, size_t bit_offset, uint64_t value)
+inline void writeBitsPacked64(uint64_t * dest, size_t bit_offset, uint64_t value)
 {
     size_t mod = bit_offset % 64;
     dest[bit_offset / 64] |= value << mod;
@@ -135,7 +135,7 @@ inline void writeBits(uint64_t * dest, size_t bit_offset, uint64_t value)
 /** Reads a range of bits from a bit-packed array.
   * The array must be overallocated by one element.
   */
-inline uint64_t readBits(const uint64_t * src, size_t bit_offset, size_t num_bits)
+inline uint64_t readBitsPacked64(const uint64_t * src, size_t bit_offset, size_t num_bits)
 {
     size_t mod = bit_offset % 64;
     uint64_t value = src[bit_offset / 64] >> mod;

--- a/src/Common/BitHelpers.h
+++ b/src/Common/BitHelpers.h
@@ -119,3 +119,27 @@ constexpr bool isPowerOf2(T number)
 {
     return number > 0 && (number & (number - 1)) == 0;
 }
+
+/** Writes a value into a bit-packed array at the given bit offset.
+  * The array must be overallocated by one element.
+  * The bit range must be pre-filled with zeros.
+  */
+inline void writeBits(uint64_t * dest, size_t bit_offset, uint64_t value)
+{
+    size_t mod = bit_offset % 64;
+    dest[bit_offset / 64] |= value << mod;
+    if (mod)
+        dest[bit_offset / 64 + 1] |= value >> (64 - mod);
+}
+
+/** Reads a range of bits from a bit-packed array.
+  * The array must be overallocated by one element.
+  */
+inline uint64_t readBits(const uint64_t * src, size_t bit_offset, size_t num_bits)
+{
+    size_t mod = bit_offset % 64;
+    uint64_t value = src[bit_offset / 64] >> mod;
+    if (mod)
+        value |= src[bit_offset / 64 + 1] << (64 - mod);
+    return value & maskLowBits<uint64_t>(static_cast<unsigned char>(num_bits));
+}

--- a/src/Common/BitPackedUInt64Array.cpp
+++ b/src/Common/BitPackedUInt64Array.cpp
@@ -54,7 +54,7 @@ BitPackedUInt64Array::BitPackedUInt64Array(std::span<const UInt64> values)
     {
         const BlockInfo & block = blocks[idx / VALUES_PER_BLOCK];
         size_t bit_offset = block.bit_offset_in_packed_array + (idx % VALUES_PER_BLOCK) * block.bits_per_value;
-        writeBits(packed.data(), bit_offset, values[idx] - block.min_value);
+        writeBitsPacked64(packed.data(), bit_offset, values[idx] - block.min_value);
     }
 }
 
@@ -65,7 +65,7 @@ UInt64 BitPackedUInt64Array::get(size_t idx) const
 
     const BlockInfo & block = blocks[idx / VALUES_PER_BLOCK];
     size_t bit_offset = block.bit_offset_in_packed_array + (idx % VALUES_PER_BLOCK) * block.bits_per_value;
-    return block.min_value + readBits(packed.data(), bit_offset, block.bits_per_value);
+    return block.min_value + readBitsPacked64(packed.data(), bit_offset, block.bits_per_value);
 }
 
 size_t BitPackedUInt64Array::allocatedBytes() const

--- a/src/Common/BitPackedUInt64Array.cpp
+++ b/src/Common/BitPackedUInt64Array.cpp
@@ -1,0 +1,76 @@
+#include <Common/BitPackedUInt64Array.h>
+#include <Common/BitHelpers.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+BitPackedUInt64Array::BitPackedUInt64Array(std::span<const UInt64> values)
+    : num_values(values.size())
+{
+    if (num_values == 0)
+        return;
+
+    size_t num_blocks = (num_values + VALUES_PER_BLOCK - 1) / VALUES_PER_BLOCK;
+    blocks.reserve_exact(num_blocks);
+    blocks.resize_fill(num_blocks);
+
+    /// First pass: calculate the layout of all blocks and the total memory required.
+    size_t packed_bits = 0;
+    for (size_t block_idx = 0; block_idx < num_blocks; ++block_idx)
+    {
+        size_t block_begin = block_idx * VALUES_PER_BLOCK;
+        size_t block_end = std::min(block_begin + VALUES_PER_BLOCK, num_values);
+
+        UInt64 min_value = values[block_begin];
+        UInt64 max_value = values[block_begin];
+
+        for (size_t i = block_begin + 1; i < block_end; ++i)
+        {
+            min_value = std::min(min_value, values[i]);
+            max_value = std::max(max_value, values[i]);
+        }
+
+        BlockInfo & block = blocks[block_idx];
+        block.min_value = min_value;
+        block.bit_offset_in_packed_array = packed_bits;
+        block.bits_per_value = static_cast<UInt8>(sizeof(UInt64) * 8 - getLeadingZeroBits(max_value - min_value));
+
+        packed_bits += (block_end - block_begin) * block.bits_per_value;
+    }
+
+    /// Overallocate by +1 element to let the bit packing/unpacking do less bounds checking.
+    size_t packed_length = (packed_bits + 63) / 64 + 1;
+    packed.reserve_exact(packed_length);
+    packed.resize_fill(packed_length);
+
+    /// Second pass: write out the packed values.
+    for (size_t idx = 0; idx < num_values; ++idx)
+    {
+        const BlockInfo & block = blocks[idx / VALUES_PER_BLOCK];
+        size_t bit_offset = block.bit_offset_in_packed_array + (idx % VALUES_PER_BLOCK) * block.bits_per_value;
+        writeBits(packed.data(), bit_offset, values[idx] - block.min_value);
+    }
+}
+
+UInt64 BitPackedUInt64Array::get(size_t idx) const
+{
+    if (idx >= num_values)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index {} is out of range [0, {})", idx, num_values);
+
+    const BlockInfo & block = blocks[idx / VALUES_PER_BLOCK];
+    size_t bit_offset = block.bit_offset_in_packed_array + (idx % VALUES_PER_BLOCK) * block.bits_per_value;
+    return block.min_value + readBits(packed.data(), bit_offset, block.bits_per_value);
+}
+
+size_t BitPackedUInt64Array::allocatedBytes() const
+{
+    return blocks.allocated_bytes() + packed.allocated_bytes();
+}
+
+}

--- a/src/Common/BitPackedUInt64Array.h
+++ b/src/Common/BitPackedUInt64Array.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <span>
+
+#include <base/types.h>
+#include <Common/PODArray.h>
+
+namespace DB
+{
+
+/** In-memory bit-packed array of UInt64 values with O(1) random access.
+  *
+  * Uses the same technique as MarksInCompressedFile: the values are split into
+  * blocks of VALUES_PER_BLOCK values. For each value, the difference
+  * [value] - [min value in the block] is stored, bit-packed with the number
+  * of bits required for the largest difference in the block.
+  *
+  * It significantly reduces memory usage when values at nearby positions
+  * are close to each other, e.g. for steadily increasing offsets in a file.
+  */
+class BitPackedUInt64Array
+{
+public:
+    BitPackedUInt64Array() = default;
+    explicit BitPackedUInt64Array(std::span<const UInt64> values);
+
+    UInt64 get(size_t idx) const;
+
+    size_t size() const { return num_values; }
+    bool empty() const { return num_values == 0; }
+    size_t allocatedBytes() const;
+
+private:
+    struct BlockInfo
+    {
+        /// Min value in the block.
+        UInt64 min_value = 0;
+        /// Place in `packed` where this block starts.
+        UInt64 bit_offset_in_packed_array = 0;
+        /// How many bits each difference from min_value takes. Can be zero.
+        UInt8 bits_per_value = 0;
+    };
+
+    static constexpr size_t VALUES_PER_BLOCK = 128;
+
+    size_t num_values = 0;
+    PODArray<BlockInfo> blocks;
+    PODArray<UInt64> packed;
+};
+
+}

--- a/src/Common/tests/gtest_bit_packed_uint64_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_uint64_array.cpp
@@ -67,7 +67,7 @@ TEST(BitPackedUInt64Array, BlockBoundaries)
 TEST(BitPackedUInt64Array, IncreasingOffsets)
 {
     /// Emulates offsets in a file: steadily increasing with variable steps.
-    std::mt19937_64 rng(42);
+    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<UInt64> values;
     UInt64 current = 0;
 
@@ -82,7 +82,7 @@ TEST(BitPackedUInt64Array, IncreasingOffsets)
 
 TEST(BitPackedUInt64Array, RandomValues)
 {
-    std::mt19937_64 rng(42);
+    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<UInt64> values;
 
     for (size_t i = 0; i < 10000; ++i)

--- a/src/Common/tests/gtest_bit_packed_uint64_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_uint64_array.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include <Common/BitPackedUInt64Array.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+namespace
+{
+
+void checkRoundTrip(const std::vector<UInt64> & values)
+{
+    BitPackedUInt64Array packed{std::span<const UInt64>(values)};
+
+    ASSERT_EQ(packed.size(), values.size());
+    for (size_t i = 0; i < values.size(); ++i)
+        ASSERT_EQ(packed.get(i), values[i]) << "at index " << i;
+}
+
+}
+
+TEST(BitPackedUInt64Array, Empty)
+{
+    BitPackedUInt64Array packed;
+    EXPECT_EQ(packed.size(), 0u);
+    EXPECT_TRUE(packed.empty());
+
+    BitPackedUInt64Array packed_from_empty{std::span<const UInt64>{}};
+    EXPECT_EQ(packed_from_empty.size(), 0u);
+    EXPECT_TRUE(packed_from_empty.empty());
+}
+
+TEST(BitPackedUInt64Array, SingleValue)
+{
+    checkRoundTrip({0});
+    checkRoundTrip({42});
+    checkRoundTrip({std::numeric_limits<UInt64>::max()});
+}
+
+TEST(BitPackedUInt64Array, AllValuesEqual)
+{
+    /// Zero bits per value.
+    checkRoundTrip(std::vector<UInt64>(1000, 123456789));
+}
+
+TEST(BitPackedUInt64Array, FullWidthValues)
+{
+    /// Differences require all 64 bits.
+    checkRoundTrip({0, std::numeric_limits<UInt64>::max(), 1, std::numeric_limits<UInt64>::max() - 1});
+}
+
+TEST(BitPackedUInt64Array, BlockBoundaries)
+{
+    std::vector<UInt64> values;
+    for (size_t size : {255, 256, 257, 512, 513})
+    {
+        values.clear();
+        for (size_t i = 0; i < size; ++i)
+            values.push_back(i * 1000);
+
+        checkRoundTrip(values);
+    }
+}
+
+TEST(BitPackedUInt64Array, IncreasingOffsets)
+{
+    /// Emulates offsets in a file: steadily increasing with variable steps.
+    std::mt19937_64 rng(42);
+    std::vector<UInt64> values;
+    UInt64 current = 0;
+
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        current += rng() % 100000;
+        values.push_back(current);
+    }
+
+    checkRoundTrip(values);
+}
+
+TEST(BitPackedUInt64Array, RandomValues)
+{
+    std::mt19937_64 rng(42);
+    std::vector<UInt64> values;
+
+    for (size_t i = 0; i < 10000; ++i)
+        values.push_back(rng());
+
+    checkRoundTrip(values);
+}
+
+/// Skipped under debug/sanitizers: LOGICAL_ERROR aborts there, so EXPECT_THROW can't catch it.
+#ifndef DEBUG_OR_SANITIZER_BUILD
+
+TEST(BitPackedUInt64Array, OutOfRangeThrows)
+{
+    BitPackedUInt64Array empty;
+    EXPECT_THROW(empty.get(0), Exception);
+
+    std::vector<UInt64> values{1, 2, 3};
+    BitPackedUInt64Array packed{std::span<const UInt64>(values)};
+    EXPECT_THROW(packed.get(3), Exception);
+}
+
+#endif

--- a/src/Formats/MarkInCompressedFile.cpp
+++ b/src/Formats/MarkInCompressedFile.cpp
@@ -69,8 +69,8 @@ MarksInCompressedFile::MarksInCompressedFile(const PlainArray & marks)
     {
         const auto & mark = marks[idx];
         auto [block, offset] = lookUpMark(idx);
-        writeBits(packed.data(), offset, mark.offset_in_compressed_file - block->min_x);
-        writeBits(
+        writeBitsPacked64(packed.data(), offset, mark.offset_in_compressed_file - block->min_x);
+        writeBitsPacked64(
             packed.data(),
             offset + block->bits_for_x,
             (mark.offset_in_decompressed_block - block->min_y) >> block->trailing_zero_bits_in_y);
@@ -86,8 +86,8 @@ MarkInCompressedFile MarksInCompressedFile::get(size_t idx) const
             idx, num_marks);
 
     auto [block, offset] = lookUpMark(idx);
-    size_t x = block->min_x + readBits(packed.data(), offset, block->bits_for_x);
-    size_t y = block->min_y + (readBits(packed.data(), offset + block->bits_for_x, block->bits_for_y) << block->trailing_zero_bits_in_y);
+    size_t x = block->min_x + readBitsPacked64(packed.data(), offset, block->bits_for_x);
+    size_t y = block->min_y + (readBitsPacked64(packed.data(), offset + block->bits_for_x, block->bits_for_y) << block->trailing_zero_bits_in_y);
     return MarkInCompressedFile{.offset_in_compressed_file = x, .offset_in_decompressed_block = y};
 }
 

--- a/src/Formats/MarkInCompressedFile.cpp
+++ b/src/Formats/MarkInCompressedFile.cpp
@@ -23,27 +23,6 @@ String MarkInCompressedFile::toStringWithRows(size_t rows_num) const
         + DB::toString(rows_num) + ")";
 }
 
-// Write a range of bits in a bit-packed array.
-// The array must be overallocated by one element.
-// The bit range must be pre-filled with zeros.
-static void writeBits(UInt64 * dest, size_t bit_offset, UInt64 value)
-{
-    size_t mod = bit_offset % 64;
-    dest[bit_offset / 64] |= value << mod;
-    if (mod)
-        dest[bit_offset / 64 + 1] |= value >> (64 - mod);
-}
-
-// The array must be overallocated by one element.
-static UInt64 readBits(const UInt64 * src, size_t bit_offset, size_t num_bits)
-{
-    size_t mod = bit_offset % 64;
-    UInt64 value = src[bit_offset / 64] >> mod;
-    if (mod)
-        value |= src[bit_offset / 64 + 1] << (64 - mod);
-    return value & maskLowBits<UInt64>(static_cast<unsigned char>(num_bits));
-}
-
 MarksInCompressedFile::MarksInCompressedFile(const PlainArray & marks)
     : num_marks(marks.size()), blocks((marks.size() + MARKS_PER_BLOCK - 1) / MARKS_PER_BLOCK, BlockInfo{})
 {

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -151,7 +151,8 @@ MergeTreeIndexConditionText::MergeTreeIndexConditionText(
     else
         tokens_cache = std::make_shared<TextIndexTokensCache>(cache_policy, local_cache_max_size, 0, 1.0);
 
-    if (settings[Setting::use_text_index_header_cache])
+    use_global_header_cache = settings[Setting::use_text_index_header_cache];
+    if (use_global_header_cache)
         header_cache = context_->getTextIndexHeaderCache();
     else
         header_cache = std::make_shared<TextIndexHeaderCache>(cache_policy, local_cache_max_size, 0, 1.0);

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -104,6 +104,9 @@ public:
     TextIndexPostingsCachePtr postingsCache() const { return postings_cache; }
     TokensCardinalitiesCachePtr cardinalitiesCache() const { return cardinalities_cache; }
 
+    /// Returns true if the global header cache is used, false if a local per-query cache is used.
+    bool useGlobalHeaderCache() const { return use_global_header_cache; }
+
     TokenizerPtr getTokenizer() const { return tokenizer; }
     MergeTreeIndexTextPreprocessorPtr getPreprocessor() const { return preprocessor; }
     MergeTreeIndexTextPostprocessorPtr getPostprocessor() const { return postprocessor; }
@@ -198,6 +201,7 @@ private:
     TextIndexTokensCachePtr tokens_cache;
     /// Cache for headers of the text index
     TextIndexHeaderCachePtr header_cache;
+    bool use_global_header_cache = false;
     /// Cache for posting lists of tokens (and phrase-search results, keyed with the Phrase discriminator).
     TextIndexPostingsCachePtr postings_cache;
     /// Cache for tokens cardinalities

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -103,8 +103,6 @@ public:
     TextIndexHeaderCachePtr headerCache() const { return header_cache; }
     TextIndexPostingsCachePtr postingsCache() const { return postings_cache; }
     TokensCardinalitiesCachePtr cardinalitiesCache() const { return cardinalities_cache; }
-
-    /// Returns true if the global header cache is used, false if a local per-query cache is used.
     bool useGlobalHeaderCache() const { return use_global_header_cache; }
 
     TokenizerPtr getTokenizer() const { return tokenizer; }
@@ -201,6 +199,7 @@ private:
     TextIndexTokensCachePtr tokens_cache;
     /// Cache for headers of the text index
     TextIndexHeaderCachePtr header_cache;
+    /// Whether the global header cache is used or a local per-query one.
     bool use_global_header_cache = false;
     /// Cache for posting lists of tokens (and phrase-search results, keyed with the Phrase discriminator).
     TextIndexPostingsCachePtr postings_cache;

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -116,18 +116,20 @@ size_t DictionaryBlockBase::upperBound(std::string_view token) const
 }
 
 DictionarySparseIndex::DictionarySparseIndex(ColumnPtr tokens_, ColumnPtr offsets_in_file_)
-    : DictionaryBlockBase(std::move(tokens_)), offsets_in_file(std::move(offsets_in_file_))
+    : DictionaryBlockBase(std::move(tokens_))
 {
+    const auto & offsets_data = assert_cast<const ColumnUInt64 &>(*offsets_in_file_).getData();
+    offsets_in_file = BitPackedUInt64Array(std::span(offsets_data.begin(), offsets_data.end()));
 }
 
 UInt64 DictionarySparseIndex::getOffsetInFile(size_t idx) const
 {
-    return assert_cast<const ColumnUInt64 &>(*offsets_in_file).getData()[idx];
+    return offsets_in_file.get(idx);
 }
 
 size_t DictionarySparseIndex::memoryUsageBytes() const
 {
-    return sizeof(*this) + tokens->allocatedBytes() + offsets_in_file->allocatedBytes();
+    return sizeof(*this) + tokens->allocatedBytes() + offsets_in_file.allocatedBytes();
 }
 
 DictionaryBlock::DictionaryBlock(ColumnPtr tokens_, std::vector<TokenPostingsInfo> token_infos_, UInt64 tokens_format_)
@@ -1113,13 +1115,22 @@ void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & spars
     if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithPositions))
         writeVarUInt(static_cast<UInt64>(has_positions), ostr);
 
-    chassert(sparse_index.tokens->size() == sparse_index.offsets_in_file->size());
+    chassert(sparse_index.tokens->size() == sparse_index.offsets_in_file.size());
     auto serialization_string = SerializationString::create();
     auto serialization_number = SerializationNumber<UInt64>::create();
 
     writeVarUInt(sparse_index.tokens->size(), ostr);
     serialization_string->serializeBinaryBulk(*sparse_index.tokens, ostr, 0, sparse_index.tokens->size());
-    serialization_number->serializeBinaryBulk(*sparse_index.offsets_in_file, ostr, 0, sparse_index.offsets_in_file->size());
+
+    /// Offsets are stored bit-packed in memory, but serialized as plain UInt64 values.
+    auto offsets_column = ColumnUInt64::create();
+    auto & offsets_data = offsets_column->getData();
+    offsets_data.resize(sparse_index.offsets_in_file.size());
+
+    for (size_t i = 0; i < offsets_data.size(); ++i)
+        offsets_data[i] = sparse_index.offsets_in_file.get(i);
+
+    serialization_number->serializeBinaryBulk(*offsets_column, ostr, 0, offsets_column->size());
 }
 
 TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & istr)
@@ -1164,6 +1175,7 @@ TextIndexHeader TextIndexSerialization::deserializeHeader(ReadBuffer & istr)
     readVarUInt(num_sparse_index_tokens, istr);
 
     auto tokens = deserializeTokensRaw(istr, num_sparse_index_tokens);
+    tokens->assumeMutableRef().shrinkToFit();
     auto offsets = ColumnUInt64::create();
 
     auto serialization_number = SerializationNumber<UInt64>::create();

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -116,20 +116,44 @@ size_t DictionaryBlockBase::upperBound(std::string_view token) const
 }
 
 DictionarySparseIndex::DictionarySparseIndex(ColumnPtr tokens_, ColumnPtr offsets_in_file_)
-    : DictionaryBlockBase(std::move(tokens_))
+    : DictionaryBlockBase(std::move(tokens_)), offsets_in_file(std::move(offsets_in_file_))
 {
-    const auto & offsets_data = assert_cast<const ColumnUInt64 &>(*offsets_in_file_).getData();
-    offsets_in_file = BitPackedUInt64Array(std::span(offsets_data.begin(), offsets_data.end()));
 }
 
 UInt64 DictionarySparseIndex::getOffsetInFile(size_t idx) const
 {
-    return offsets_in_file.get(idx);
+    if (const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file))
+        return assert_cast<const ColumnUInt64 &>(**offsets_column).getData()[idx];
+
+    return std::get<BitPackedUInt64Array>(offsets_in_file).get(idx);
 }
 
 size_t DictionarySparseIndex::memoryUsageBytes() const
 {
-    return sizeof(*this) + tokens->allocatedBytes() + offsets_in_file.allocatedBytes();
+    size_t offsets_bytes = 0;
+
+    if (const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file))
+        offsets_bytes = (*offsets_column) ? (*offsets_column)->allocatedBytes() : 0;
+    else
+        offsets_bytes = std::get<BitPackedUInt64Array>(offsets_in_file).allocatedBytes();
+
+    return sizeof(*this) + tokens->allocatedBytes() + offsets_bytes;
+}
+
+void DictionarySparseIndex::optimize()
+{
+    if (tokens)
+    {
+        auto tokens_mut = IColumn::mutate(tokens);
+        tokens_mut->shrinkToFit();
+        tokens = std::move(tokens_mut);
+    }
+
+    if (const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file); offsets_column && *offsets_column)
+    {
+        const auto & offsets_data = assert_cast<const ColumnUInt64 &>(**offsets_column).getData();
+        offsets_in_file = BitPackedUInt64Array(std::span(offsets_data.begin(), offsets_data.end()));
+    }
 }
 
 DictionaryBlock::DictionaryBlock(ColumnPtr tokens_, std::vector<TokenPostingsInfo> token_infos_, UInt64 tokens_format_)
@@ -676,14 +700,21 @@ std::pair<std::vector<size_t>, NameSet> MergeTreeIndexGranuleText::matchTokens(c
 
 std::shared_ptr<TextIndexHeader> MergeTreeIndexGranuleText::loadHeader(MergeTreeIndexReaderStream & header_stream, MergeTreeIndexDeserializationState & state)
 {
+    const auto & condition_text = typeid_cast<const MergeTreeIndexConditionText &>(*state.condition);
+
     const auto load_header = [&]
     {
         header_stream.seekToStart();
-        return std::make_shared<TextIndexHeader>(TextIndexSerialization::deserializeHeader(*header_stream.getDataBuffer()));
+        auto loaded_header = std::make_shared<TextIndexHeader>(TextIndexSerialization::deserializeHeader(*header_stream.getDataBuffer()));
+
+        /// Optimize the memory usage of the sparse index only if the header is put into the global cache.
+        if (condition_text.useGlobalHeaderCache())
+            loaded_header->sparse_index.optimize();
+
+        return loaded_header;
     };
 
     auto header_hash = TextIndexHeaderCache::hash(index_id_for_caches);
-    const auto & condition_text = typeid_cast<const MergeTreeIndexConditionText &>(*state.condition);
     return condition_text.headerCache()->getOrSet(header_hash, load_header);
 }
 
@@ -1115,22 +1146,19 @@ void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & spars
     if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithPositions))
         writeVarUInt(static_cast<UInt64>(has_positions), ostr);
 
-    chassert(sparse_index.tokens->size() == sparse_index.offsets_in_file.size());
+    const auto * offsets_column_ptr = std::get_if<ColumnPtr>(&sparse_index.offsets_in_file);
+    if (!offsets_column_ptr || !*offsets_column_ptr)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Offsets in sparse index of text index must not be bit-packed on serialization");
+
+    const auto & offsets_column = **offsets_column_ptr;
+    chassert(sparse_index.tokens->size() == offsets_column.size());
+
     auto serialization_string = SerializationString::create();
     auto serialization_number = SerializationNumber<UInt64>::create();
 
     writeVarUInt(sparse_index.tokens->size(), ostr);
     serialization_string->serializeBinaryBulk(*sparse_index.tokens, ostr, 0, sparse_index.tokens->size());
-
-    /// Offsets are stored bit-packed in memory, but serialized as plain UInt64 values.
-    auto offsets_column = ColumnUInt64::create();
-    auto & offsets_data = offsets_column->getData();
-    offsets_data.resize(sparse_index.offsets_in_file.size());
-
-    for (size_t i = 0; i < offsets_data.size(); ++i)
-        offsets_data[i] = sparse_index.offsets_in_file.get(i);
-
-    serialization_number->serializeBinaryBulk(*offsets_column, ostr, 0, offsets_column->size());
+    serialization_number->serializeBinaryBulk(offsets_column, ostr, 0, offsets_column.size());
 }
 
 TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & istr)
@@ -1175,7 +1203,6 @@ TextIndexHeader TextIndexSerialization::deserializeHeader(ReadBuffer & istr)
     readVarUInt(num_sparse_index_tokens, istr);
 
     auto tokens = deserializeTokensRaw(istr, num_sparse_index_tokens);
-    tokens->assumeMutableRef().shrinkToFit();
     auto offsets = ColumnUInt64::create();
 
     auto serialization_number = SerializationNumber<UInt64>::create();

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -4,6 +4,7 @@
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/IColumn.h>
+#include <Common/BitPackedUInt64Array.h>
 #include <Common/Logger.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/StringHashMap.h>
@@ -262,7 +263,10 @@ struct DictionarySparseIndex : public DictionaryBlockBase
     UInt64 getOffsetInFile(size_t idx) const;
     size_t memoryUsageBytes() const;
 
-    ColumnPtr offsets_in_file;
+    /// Offsets in the dictionary file to the beginning of each block.
+    /// Stored bit-packed to reduce the memory usage of the text index header cache.
+    /// It doesn't affect the on-disk format, offsets are serialized as plain UInt64 values.
+    BitPackedUInt64Array offsets_in_file;
 };
 
 using DictionarySparseIndexPtr = std::shared_ptr<DictionarySparseIndex>;

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -17,6 +17,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <base/types.h>
 
+#include <variant>
 #include <vector>
 
 #include <roaring/roaring.hh>
@@ -263,10 +264,12 @@ struct DictionarySparseIndex : public DictionaryBlockBase
     UInt64 getOffsetInFile(size_t idx) const;
     size_t memoryUsageBytes() const;
 
+    /// Shrinks the tokens column and bit-packs the offsets to reduce memory usage.
+    void optimize();
+
     /// Offsets in the dictionary file to the beginning of each block.
-    /// Stored bit-packed to reduce the memory usage of the text index header cache.
-    /// It doesn't affect the on-disk format, offsets are serialized as plain UInt64 values.
-    BitPackedUInt64Array offsets_in_file;
+    /// Stored as a raw column after creation and bit-packed after optimize.
+    std::variant<ColumnPtr, BitPackedUInt64Array> offsets_in_file;
 };
 
 using DictionarySparseIndexPtr = std::shared_ptr<DictionarySparseIndex>;

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3631,7 +3631,7 @@ TEST(PostingListCursorTest, TextIndexHeaderPersistsCodecType)
     EXPECT_EQ(sparse_index_data.codec_type, IPostingListCodec::Type::Bitpacking);
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
     EXPECT_EQ(assert_cast<const ColumnString &>(*sparse_index_data.sparse_index.tokens).getDataAt(0), "alpha");
-    EXPECT_EQ(assert_cast<const ColumnUInt64 &>(*sparse_index_data.sparse_index.offsets_in_file).getData()[0], 42u);
+    EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 42u);
 }
 
 TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)
@@ -3655,7 +3655,7 @@ TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)
     EXPECT_EQ(sparse_index_data.codec_type, IPostingListCodec::Type::None);
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
     EXPECT_EQ(assert_cast<const ColumnString &>(*sparse_index_data.sparse_index.tokens).getDataAt(0), "beta");
-    EXPECT_EQ(assert_cast<const ColumnUInt64 &>(*sparse_index_data.sparse_index.offsets_in_file).getData()[0], 7u);
+    EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 7u);
 }
 
 // Section: row_offset beyond UInt32::max must throw — doc IDs are 32-bit, and

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3658,37 +3658,6 @@ TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 7u);
 }
 
-TEST(PostingListCursorTest, TextIndexSparseIndexOptimize)
-{
-    static constexpr size_t num_tokens = 1000;
-
-    auto tokens = ColumnString::create();
-    auto offsets = ColumnUInt64::create();
-
-    for (size_t i = 0; i < num_tokens; ++i)
-    {
-        tokens->insert("token" + std::to_string(i));
-        offsets->insertValue(i * 5000);
-    }
-
-    DictionarySparseIndex sparse_index(tokens->getPtr(), offsets->getPtr());
-    size_t memory_before = sparse_index.memoryUsageBytes();
-
-    for (size_t i = 0; i < num_tokens; ++i)
-        ASSERT_EQ(sparse_index.getOffsetInFile(i), i * 5000);
-
-    sparse_index.optimize();
-
-    for (size_t i = 0; i < num_tokens; ++i)
-        ASSERT_EQ(sparse_index.getOffsetInFile(i), i * 5000);
-
-    EXPECT_LT(sparse_index.memoryUsageBytes(), memory_before);
-
-    /// optimize is idempotent.
-    sparse_index.optimize();
-    EXPECT_EQ(sparse_index.getOffsetInFile(num_tokens - 1), (num_tokens - 1) * 5000);
-}
-
 // Section: row_offset beyond UInt32::max must throw — doc IDs are 32-bit, and
 // `values[i] - row_offset` would otherwise underflow `size_t` and write OOB.
 // Skipped under debug/sanitizers: `LOGICAL_ERROR` aborts there, so `EXPECT_THROW`

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3658,6 +3658,37 @@ TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 7u);
 }
 
+TEST(PostingListCursorTest, TextIndexSparseIndexOptimize)
+{
+    static constexpr size_t num_tokens = 1000;
+
+    auto tokens = ColumnString::create();
+    auto offsets = ColumnUInt64::create();
+
+    for (size_t i = 0; i < num_tokens; ++i)
+    {
+        tokens->insert("token" + std::to_string(i));
+        offsets->insertValue(i * 5000);
+    }
+
+    DictionarySparseIndex sparse_index(tokens->getPtr(), offsets->getPtr());
+    size_t memory_before = sparse_index.memoryUsageBytes();
+
+    for (size_t i = 0; i < num_tokens; ++i)
+        ASSERT_EQ(sparse_index.getOffsetInFile(i), i * 5000);
+
+    sparse_index.optimize();
+
+    for (size_t i = 0; i < num_tokens; ++i)
+        ASSERT_EQ(sparse_index.getOffsetInFile(i), i * 5000);
+
+    EXPECT_LT(sparse_index.memoryUsageBytes(), memory_before);
+
+    /// optimize is idempotent.
+    sparse_index.optimize();
+    EXPECT_EQ(sparse_index.getOffsetInFile(num_tokens - 1), (num_tokens - 1) * 5000);
+}
+
 // Section: row_offset beyond UInt32::max must throw — doc IDs are 32-bit, and
 // `values[i] - row_offset` would otherwise underflow `size_t` and write OOB.
 // Skipped under debug/sanitizers: `LOGICAL_ERROR` aborts there, so `EXPECT_THROW`


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced the memory usage of the text index header cache by 2-2.5 times. More headers of data parts fit into the cache (setting `text_index_header_cache_size`), reducing disk reads for text search queries.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.533` (included in `26.7` and later)
<!-- ch-version-info:end -->