### PR TITLE
Fix flaky test 04061_spilling_hash_join_overflow_limits

### DIFF
--- a/tests/queries/0_stateless/04061_spilling_hash_join_overflow_limits.sql
+++ b/tests/queries/0_stateless/04061_spilling_hash_join_overflow_limits.sql
@@ -5,6 +5,10 @@
 -- join_overflow_mode enforcement.
 
 SET query_plan_optimize_join_order_randomize = 0; -- Pinned because the test asserts on join build side / overflow limits, which depend on join order
+-- Force the right table (t2) to stay the build side. With 'auto', the planner may swap the
+-- tiny left table (t1) to the build side, so the accumulating hash table never exceeds the
+-- overflow limit and no error is thrown.
+SET query_plan_join_swap_table = 'false';
 SET max_block_size = 1000;
 -- ====================================================================
 -- Single-thread path (hash join)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Closes https://github.com/ClickHouse/ClickHouse/issues/109593

Fixes flakiness of `04061_spilling_hash_join_overflow_limits` (seen on master and several unrelated PRs; check `Stateless tests (arm_binary, parallel)`).

The test asserts that `max_rows_in_join` / `max_bytes_in_join` limits are enforced for a 4-row `ANY LEFT JOIN` a 4000-row table. That holds only while the 4000-row right table (`t2`) stays the hash-table build side, so the accumulating side crosses 1000 rows and throws `SET_SIZE_LIMIT_EXCEEDED` (191).

CI randomizes `query_plan_join_swap_table` over `{auto, false}` (tests/clickhouse-test). When the planner swaps the tiny 4-row left table (`t1`) to the build side, the hash table never reaches the limit, no error is thrown, and the query returns a count instead. `EXPLAIN actions=1` confirms the build side flips (`Type: left` vs `Type: right`, join condition order swaps) between `swap=false` and `swap=true`.

A previous fix pinned `query_plan_optimize_join_order_randomize = 0` but left the swap decision free. This pins `query_plan_join_swap_table = 'false'` so the right table is always the build side, which is exactly the scenario the test verifies. Local: 50/50 `clickhouse-test` runs pass with randomization on; without the pin the query returns `4` instead of throwing 191.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.683` (included in `26.7` and later)
<!-- ch-version-info:end -->