### PR TITLE
Reduce peak memory during JSON advanced shared data merge by per-bucket paths columns materialization

### DIFF
--- a/src/DataTypes/Serializations/SerializationObjectHelpers.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectHelpers.cpp
@@ -15,10 +15,11 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-std::vector<std::vector<std::pair<String, ColumnPtr>>> flattenAndBucketSharedDataPaths(const IColumn & shared_data_column, size_t start, size_t end, const DataTypePtr & dynamic_type, size_t num_buckets)
+std::vector<std::pair<String, ColumnPtr>> flattenSharedDataPathsForBucket(
+    const IColumn & shared_data_column, size_t start, size_t end,
+    const DataTypePtr & dynamic_type, size_t target_bucket, size_t num_buckets)
 {
-    /// First, iterate over shared data and collect values of
-    /// all paths that are stored there into separate columns.
+    /// Iterate over shared data and collect values of paths belonging to target_bucket only.
     std::unordered_map<String, MutableColumnPtr> flattened_shared_data_paths;
     const auto [shared_data_paths, shared_data_values, shared_data_offsets] = ColumnObject::getSharedDataPathsValuesAndOffsets(shared_data_column);
     for (size_t i = start; i != end; ++i)
@@ -28,6 +29,10 @@ std::vector<std::vector<std::pair<String, ColumnPtr>>> flattenAndBucketSharedDat
         for (size_t j = offset_start; j != offset_end; ++j)
         {
             std::string path{shared_data_paths->getDataAt(j)};
+            /// Skip paths not belonging to target bucket.
+            if (getSharedDataPathBucket(path, num_buckets) != target_bucket)
+                continue;
+
             auto it = flattened_shared_data_paths.find(path);
             /// If we see this path for the first time, add it to the list and create a column for it.
             if (it == flattened_shared_data_paths.end())
@@ -47,21 +52,19 @@ std::vector<std::vector<std::pair<String, ColumnPtr>>> flattenAndBucketSharedDat
         }
     }
 
-    /// Iterate over collected paths and put them into corresponding buckets.
-    std::vector<std::vector<std::pair<String, ColumnPtr>>> buckets(num_buckets);
-    for (const auto & [path, column] : flattened_shared_data_paths)
-        buckets[getSharedDataPathBucket(path, num_buckets)].emplace_back(path, column->getPtr());
+    /// Collect into a sorted vector.
+    std::vector<std::pair<String, ColumnPtr>> result;
+    result.reserve(flattened_shared_data_paths.size());
+    for (auto & [path, column] : flattened_shared_data_paths)
+        result.emplace_back(std::move(path), column->getPtr());
 
-    /// Keep paths sorted in each bucket for consistency.
-    for (auto & bucket : buckets)
-        std::sort(bucket.begin(), bucket.end());
-
-    return buckets;
+    std::sort(result.begin(), result.end());
+    return result;
 }
 
 std::vector<std::pair<String, ColumnPtr>> flattenPaths(const ColumnObject & object_column)
 {
-    auto all_paths = std::move(flattenAndBucketSharedDataPaths(*object_column.getSharedDataPtr(), 0, object_column.size(), object_column.getDynamicType(), 1)[0]);
+    auto all_paths = flattenSharedDataPathsForBucket(*object_column.getSharedDataPtr(), 0, object_column.size(), object_column.getDynamicType(), 0, 1);
     for (const auto & [path, column] : object_column.getDynamicPaths())
         all_paths.emplace_back(path, column);
     std::sort(all_paths.begin(), all_paths.end());

--- a/src/DataTypes/Serializations/SerializationObjectHelpers.h
+++ b/src/DataTypes/Serializations/SerializationObjectHelpers.h
@@ -13,8 +13,11 @@ namespace DB
 /// separate columns (except typed paths, they are not returned and
 /// should be processed separately).
 std::vector<std::pair<String, ColumnPtr>> flattenPaths(const ColumnObject & object_column);
-/// Flatten paths from shared data and split them into buckets.
-std::vector<std::vector<std::pair<String, ColumnPtr>>> flattenAndBucketSharedDataPaths(const IColumn & shared_data_column, size_t start, size_t end, const DataTypePtr & dynamic_type, size_t num_buckets);
+/// Flatten paths from shared data for a single bucket only.
+/// Only materializes ColumnDynamic columns for paths belonging to target_bucket.
+std::vector<std::pair<String, ColumnPtr>> flattenSharedDataPathsForBucket(
+    const IColumn & shared_data_column, size_t start, size_t end,
+    const DataTypePtr & dynamic_type, size_t target_bucket, size_t num_buckets);
 
 /// Insert data from flattened representation of an Object column to a usual Object column.
 void unflattenAndInsertPaths(const std::vector<String> & flattened_paths, std::vector<ColumnPtr> && flattened_columns, ColumnObject & object_column, size_t num_rows);

--- a/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
+++ b/src/DataTypes/Serializations/SerializationObjectSharedData.cpp
@@ -241,12 +241,22 @@ void SerializationObjectSharedData::serializeBinaryBulkWithMultipleStreams(
     else if (serialization_version.value == SerializationVersion::ADVANCED)
     {
         size_t end = limit && offset + limit < column.size() ? offset + limit : column.size();
-        /// First we need to flatten all paths stored in the shared data and separate them into buckets.
-        auto flattened_paths_buckets = flattenAndBucketSharedDataPaths(column, offset, end, dynamic_type, buckets);
-        /// Second, write paths in each bucket separately.
+        /// Per-bucket path names for the copy section.
+        /// We save them separately because each bucket's flattened columns
+        /// are freed after serialization to reduce peak memory.
+        std::vector<std::vector<String>> bucket_path_names(buckets);
+
+        /// Process each bucket separately to limit peak memory —
+        /// only one bucket's ColumnDynamic columns are alive at a time.
         for (size_t bucket = 0; bucket != buckets; ++bucket)
         {
-            const auto & flattened_paths = flattened_paths_buckets[bucket];
+            auto flattened_paths = flattenSharedDataPathsForBucket(
+                column, offset, end, dynamic_type, bucket, buckets);
+
+            /// Save path names for the copy section.
+            for (const auto & [path, _] : flattened_paths)
+                bucket_path_names[bucket].push_back(path);
+
             settings.path.push_back(Substream::Bucket);
             settings.path.back().bucket = bucket;
 
@@ -479,10 +489,13 @@ void SerializationObjectSharedData::serializeBinaryBulkWithMultipleStreams(
         /// of paths in the total list of paths that we serialized for buckets.
         std::unordered_map<std::string_view, size_t> path_to_index;
         size_t index = 0;
-        for (const auto & [path, _] : flattened_paths_buckets | std::views::join)
+        for (const auto & paths : bucket_path_names)
         {
-            path_to_index[path] = index;
-            ++index;
+            for (const auto & path : paths)
+            {
+                path_to_index[path] = index;
+                ++index;
+            }
         }
 
         auto [indexes_column, indexes_type] = createPathsIndexes(path_to_index, shared_data_tuple_column.getColumn(0), nested_offset, nested_end);


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce peak memory during JSON advanced shared data merge by per-bucket paths columns materialization. Part of https://github.com/ClickHouse/ClickHouse/issues/108992
