### PR TITLE
Web UI: do not colorize empty strings and NULLs in categorical mode

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1637,6 +1637,9 @@ class QueryResultElement extends HTMLElement
     static _vizInstance = null;
     static _loadUplotPromise = null;
 
+    /// The glyph used to render SQL NULL values (superscript "NULL").
+    static _NULL_TEXT = 'ᴺᵁᴸᴸ';
+
     constructor()
     {
         super();
@@ -2199,7 +2202,7 @@ class QueryResultElement extends HTMLElement
         let text;
         if (is_null)
         {
-            text = '\u1D3A\u1D41\u1D38\u1D38';
+            text = QueryResultElement._NULL_TEXT;
         }
         else if (typeof(value) === 'object')
         {
@@ -2590,7 +2593,10 @@ class QueryResultElement extends HTMLElement
             {
                 const cell = row.cells[col_idx];
                 if (!cell) { continue; }
-                const hue = this._hashHue((cell.querySelector('.cell-content') || cell).innerText);
+                const text = (cell.querySelector('.cell-content') || cell).innerText;
+                /// Empty strings and NULLs carry no category, so leave them uncolored.
+                if (text === '' || text === QueryResultElement._NULL_TEXT) { continue; }
+                const hue = this._hashHue(text);
                 cell.style.background = `oklch(var(--viz-cell-lightness) var(--viz-cell-chroma) ${hue})`;
             }
             return;

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2199,6 +2199,10 @@ class QueryResultElement extends HTMLElement
         let is_null = (value === null);
         let is_link = false;
 
+        /// Mark the cell from the original value, so categorical coloring can skip real NULLs
+        /// without relying on the rendered glyph (a string value equal to `_NULL_TEXT` is data).
+        if (is_null) { td.dataset.isNull = ''; }
+
         let text;
         if (is_null)
         {
@@ -2593,9 +2597,12 @@ class QueryResultElement extends HTMLElement
             {
                 const cell = row.cells[col_idx];
                 if (!cell) { continue; }
+                /// Empty strings and NULLs carry no category, so leave them uncolored. NULL is
+                /// detected from the original value (marked in `_renderCell`), not the rendered
+                /// glyph, so a real string value equal to the NULL glyph still gets a color.
+                if (cell.dataset.isNull !== undefined) { continue; }
                 const text = (cell.querySelector('.cell-content') || cell).innerText;
-                /// Empty strings and NULLs carry no category, so leave them uncolored.
-                if (text === '' || text === QueryResultElement._NULL_TEXT) { continue; }
+                if (text === '') { continue; }
                 const hue = this._hashHue(text);
                 cell.style.background = `oklch(var(--viz-cell-lightness) var(--viz-cell-chroma) ${hue})`;
             }

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -2780,8 +2780,16 @@ class QueryResultElement extends HTMLElement
             const name = this._header[idx - 1]?.name;
             if (name !== undefined && this._effectiveColorMode(name) === 'categorical')
             {
-                col_idx = idx;
-                active_text = (cell.querySelector('.cell-content') || cell).innerText;
+                /// Empty strings and NULLs carry no category (mirroring `_applyColumnColor`), so
+                /// selecting one emphasizes nothing. NULL is detected from the original value marked
+                /// in `_renderCell`, not the rendered glyph, so a real string value equal to the NULL
+                /// glyph is still a category.
+                const text = (cell.querySelector('.cell-content') || cell).innerText;
+                if (cell.dataset.isNull === undefined && text !== '')
+                {
+                    col_idx = idx;
+                    active_text = text;
+                }
             }
         }
 
@@ -2808,8 +2816,11 @@ class QueryResultElement extends HTMLElement
         {
             const c = row.cells[col_idx];
             if (!c) { continue; }
+            /// A real NULL peer must not match a real string equal to the NULL glyph, so exclude
+            /// NULL cells from grouping just like `_applyColumnColor` does. Empty cells never match
+            /// here because `active_text` is guaranteed non-empty above.
             const target = c.querySelector('.cell-content') || c;
-            this._setCellEmphasis(c, c !== cell && target.innerText === active_text);
+            this._setCellEmphasis(c, c !== cell && c.dataset.isNull === undefined && target.innerText === active_text);
         }
         this._emphasized_col_idx = col_idx;
         this._emphasized_value = active_text;


### PR DESCRIPTION
In the Web UI (`play.html`), the categorical cell coloring mode assigned a hue to every value, including empty strings and NULLs. Empty strings and NULLs carry no category, so they should stay uncolored. This change skips them so they are rendered without a background color.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In the Web UI, empty strings and NULLs are no longer colorized in the categorical coloring mode.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.517` (included in `26.7` and later)
<!-- ch-version-info:end -->