### PR TITLE
Do not cache the per-arch Bugfix Validation jobs

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -591,18 +591,21 @@ class JobConfigs:
         command="python3 ./ci/jobs/functional_tests.py --options BugfixValidation",
         # some tests can be flaky due to very slow disks - use tmpfs for temporary ClickHouse files
         run_in_docker="clickhouse/stateless-test+--network=host+--privileged+--cgroupns=host+root+--security-opt seccomp=unconfined+--ulimit nofile=1048576:1048576+--tmpfs /tmp/clickhouse:mode=1777",
-        digest_config=Job.CacheDigestConfig(
-            include_paths=[
-                "./ci/jobs/functional_tests.py",
-                "./ci/jobs/scripts/bugfix_validation.py",
-                "./ci/jobs/scripts/clickhouse_proc.py",
-                "./ci/jobs/scripts/functional_tests_results.py",
-                "./tests/queries",
-                "./tests/clickhouse-test",
-                "./tests/config",
-                "./tests/*.txt",
-            ],
-        ),
+        # No digest_config: the Bugfix Validation verdict is intentionally NOT
+        # cacheable. Its inputs are not captured by any set of repository files -
+        # it depends on (1) the PR's source fix and (2) the master-HEAD binary
+        # that the runner downloads at run time from a recent master commit (see
+        # `bugfix_validation.find_master_builds`), and master HEAD advances
+        # independently of the PR. With a digest, a `SKIPPED` no-repro verdict is
+        # pushed as a cache-success record (the cache uses `Result.is_ok`, which
+        # treats SKIPPED as success) and then reused on any later commit whose
+        # test content hashes the same - even after the fix or master HEAD
+        # changed. The job never re-runs, so `new_tests_check.py` fails with "No
+        # per-arch Bugfix Validation job validated the bug". Leaving the job
+        # uncached makes it re-run on every eligible commit; it stays gated to
+        # bug-fix PRs with test changes by `filter_job.py` and runs only the
+        # changed tests, so this is cheap. See ClickHouse/ClickHouse#109229.
+        digest_config=None,
         result_name_for_cidb="Tests",
     ).set_allow_failure(True).parametrize(
         Job.ParamSet(
@@ -811,13 +814,15 @@ class JobConfigs:
         )
         .set_allow_failure(True)
     )
-    # The shared bugfix-validation helper is only used by this job, so add it to
-    # this job's digest (not the common integration config) to avoid leaving the
-    # job cached with stale behavior after the helper changes. Append before
-    # parametrize so both per-arch variants inherit the dependency.
-    bugfix_validation_it_jobs.digest_config.include_paths.append(
-        "./ci/jobs/scripts/bugfix_validation.py"
-    )
+    # No digest_config: the Bugfix Validation verdict is intentionally NOT
+    # cacheable - it depends on the PR's source fix and the run-time-selected
+    # master-HEAD binary, neither of which is a repository file, so no digest can
+    # capture its true inputs. The `common_integration_test_job_config` carries a
+    # digest; clear the (deep-copied) one here so a `SKIPPED` no-repro verdict is
+    # never pushed as a cache-success record and reused on a later commit. See the
+    # matching comment on `bugfix_validation_ft_pr_jobs` and
+    # ClickHouse/ClickHouse#109229.
+    bugfix_validation_it_jobs.digest_config = None
     bugfix_validation_it_jobs = bugfix_validation_it_jobs.parametrize(
         Job.ParamSet(
             parameter="integration tests, amd64",

--- a/ci/tests/test_bugfix_validation_not_cached.py
+++ b/ci/tests/test_bugfix_validation_not_cached.py
@@ -1,0 +1,81 @@
+"""
+Regression test: the per-arch Bugfix Validation jobs must NOT be cacheable.
+
+The Bugfix Validation verdict depends on inputs that are not files in the
+repository - the PR's source fix and the master-HEAD binary that the runner
+downloads at run time (see `bugfix_validation.find_master_builds`), and master
+HEAD advances independently of the PR. No `CacheDigestConfig` can capture those
+inputs, so any cached verdict is unsound.
+
+Concretely, a per-arch job legitimately reports a top-level `SKIPPED` when the
+bug does not reproduce on master HEAD on that arch. The CI cache decides what to
+persist as a reusable "success" with `Result.is_ok`, which treats `SKIPPED` as
+success, so that `SKIPPED` is pushed as a cache-success record. On a later
+commit whose test content hashes to the same digest, the config job reuses it
+("reused from cache") instead of re-running - even after the fix or master HEAD
+changed. The merge-blocking `new_tests_check.py` post-hook uses strict
+`is_success` (a reused `SKIPPED` does not count), so it then fails with "No
+per-arch Bugfix Validation job validated the bug".
+
+Leaving `digest_config` unset makes `calc_job_digest` return the null digest,
+which `hook_cache.py` excludes from both cache lookup and cache push, so the
+job re-runs on every eligible commit (still gated to bug-fix PRs with test
+changes by `filter_job.py`). This test pins that so the digest is not
+reintroduced. See ClickHouse/ClickHouse#109229.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+# `ci/defs/job_configs.py` does `from praktika import ...` rather than
+# `from ci.praktika import ...`, so the `ci/` directory itself must be on the
+# path for `import praktika` to resolve to `ci/praktika`.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ci.defs.job_configs import JobConfigs
+from ci.praktika.digest import Digest
+
+
+def _bugfix_validation_jobs():
+    return list(JobConfigs.bugfix_validation_ft_pr_jobs) + list(
+        JobConfigs.bugfix_validation_it_jobs
+    )
+
+
+def test_all_four_per_arch_jobs_present():
+    """Guard against a rename/refactor silently dropping a per-arch variant."""
+    names = {j.name for j in _bugfix_validation_jobs()}
+    assert names == {
+        "Bugfix validation (functional tests, amd64)",
+        "Bugfix validation (functional tests, aarch64)",
+        "Bugfix validation (integration tests, amd64)",
+        "Bugfix validation (integration tests, aarch64)",
+    }
+
+
+def test_bugfix_validation_jobs_have_no_digest_config():
+    """No `digest_config` => the job is not cacheable (see module docstring)."""
+    for job in _bugfix_validation_jobs():
+        assert (
+            job.digest_config is None
+        ), f"Bugfix Validation job [{job.name}] must not have a digest_config"
+
+
+def test_bugfix_validation_jobs_resolve_to_null_digest():
+    """The null digest is what `hook_cache.py` skips for both lookup and push."""
+    digest = Digest()
+    null = Digest.get_null_digest()
+    for job in _bugfix_validation_jobs():
+        job_digest = digest.calc_job_digest(
+            job_config=job, docker_digests={}, artifact_configs={}
+        )
+        assert (
+            job_digest == null
+        ), f"Bugfix Validation job [{job.name}] must resolve to the null digest"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
The per-arch `Bugfix validation` jobs (functional and integration) were cacheable via a `digest_config`, but their verdict cannot be soundly cached, which makes them get served a stale `SKIPPED` "reused from cache" result and fail the merge-blocking gate.

**What happens.** The runner runs the new regression test on the PR and on a master-HEAD binary that it downloads at run time from a recent master commit (`bugfix_validation.find_master_builds`), then inverts the status. The verdict therefore depends on (1) the PR's source fix and (2) master HEAD — neither of which is a repository file, so no digest can capture the job's true inputs.

When the bug does not reproduce on master HEAD on an arch, the per-arch job legitimately reports a top-level `SKIPPED`. The CI cache decides what to persist as a reusable success with `Result.is_ok`, which treats `SKIPPED` as success, so that `SKIPPED` gets pushed as a cache-success record. On a later commit whose test content hashes to the same digest, the config job reuses it ("reused from cache") instead of re-running — even after the fix or master HEAD changed. Because the merge-blocking `new_tests_check.py` post-hook uses strict `is_success` (a reused `SKIPPED` does not count), it then fails with "No per-arch Bugfix Validation job validated the bug", and the job never re-runs to produce a real verdict.

This was observed on https://github.com/ClickHouse/ClickHouse/pull/109229, where the functional Bugfix Validation jobs showed `SKIPPED` / `reused from cache` and the `new_tests_check.py` post-hook failed even though the PR is a properly-labeled critical bug fix with regression tests.

**Fix.** Drop `digest_config` from all four per-arch jobs. `calc_job_digest` then returns the null digest, which `hook_cache.py` excludes from both cache lookup and cache push, so the jobs re-run on every eligible commit. They stay gated to bug-fix PRs with test changes by `filter_job.py` and run only the changed tests, so this is cheap. A new test `ci/tests/test_bugfix_validation_not_cached.py` pins the jobs as non-cacheable so the digest is not reintroduced.

Related: https://github.com/ClickHouse/ClickHouse/pull/109229

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not cache the per-arch Bugfix Validation CI jobs, so a stale `SKIPPED` result is not reused and the merge-blocking check reflects the current commit.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.503` (included in `26.7` and later)
<!-- ch-version-info:end -->