### PR TITLE
Add optional JWT authentication to the streaming exchange protocol

### DIFF
--- a/src/Server/DistributedQuery/ExchangeServer.cpp
+++ b/src/Server/DistributedQuery/ExchangeServer.cpp
@@ -37,8 +37,9 @@ static constexpr size_t HANDSHAKE_POOL_MAX_THREADS = 64;
 static constexpr size_t HANDSHAKE_POOL_MAX_FREE_THREADS = 0;
 static constexpr size_t HANDSHAKE_POOL_QUEUE_SIZE = 10000;
 
-ExchangeServer::ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_)
+ExchangeServer::ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_, ExchangeConnectionAuthenticator authenticate_connection_)
     : connections(std::move(connections_))
+    , authenticate_connection(std::move(authenticate_connection_))
     , server_socket(Poco::Net::ServerSocket(Poco::Net::SocketAddress(listen_host, port)))
     , accept_thread("ExchangeServer")
     , handshake_pool(
@@ -110,11 +111,11 @@ void ExchangeServer::run()
                 try
                 {
                     handshake_pool.scheduleOrThrowOnError(
-                        [accepted = socket, conns = connections, task_log = log]()
+                        [accepted = socket, conns = connections, task_log = log, auth = authenticate_connection]()
                         {
                             try
                             {
-                                handleConnection(accepted, conns, task_log);
+                                handleConnection(accepted, conns, task_log, auth);
                             }
                             catch (...)
                             {
@@ -166,7 +167,7 @@ namespace
     }
 }
 
-void ExchangeServer::handleConnection(Poco::Net::StreamSocket socket, ExchangeConnectionsPtr connections, LoggerPtr log)
+void ExchangeServer::handleConnection(Poco::Net::StreamSocket socket, ExchangeConnectionsPtr connections, LoggerPtr log, const ExchangeConnectionAuthenticator & authenticate)
 {
     LOG_TRACE(log, "Connection from {}", socket.peerAddress().toString());
 
@@ -233,6 +234,8 @@ void ExchangeServer::handleConnection(Poco::Net::StreamSocket socket, ExchangeCo
         out.finalize();
     };
 
+    /// The protocol version must match exactly. A mismatched peer is rejected after a
+    /// best-effort SinkHello so it gets a precise diagnostic naming both versions.
     if (source_hello.source_version != StreamingExchangeProtocol::PROTOCOL_VERSION)
     {
         try
@@ -249,11 +252,17 @@ void ExchangeServer::handleConnection(Poco::Net::StreamSocket socket, ExchangeCo
             StreamingExchangeProtocol::PROTOCOL_VERSION);
     }
 
-    /// Versions match - body layout is known, parse the rest.
+    /// Version matches, so the body layout is known - parse the rest.
     source_hello.readAfterVersion(body_in);
 
     LOG_TRACE(log, "Query id: {}, stream: {}, peer protocol version: {}",
         source_hello.query_id, source_hello.stream_name, source_hello.source_version);
+
+    /// Authenticate before completing the handshake or registering the connection,
+    /// so an unauthenticated peer is never rendezvoused with a local sink. A failure
+    /// throws and the connection is dropped without a SinkHello.
+    if (authenticate)
+        authenticate(source_hello.jwt_token);
 
     send_sink_hello();
 

--- a/src/Server/DistributedQuery/ExchangeServer.h
+++ b/src/Server/DistributedQuery/ExchangeServer.h
@@ -8,8 +8,17 @@
 #include <Common/Logger.h>
 #include <Common/ThreadPool.h>
 
+#include <functional>
+
 namespace DB
 {
+
+/// Authenticates an incoming exchange connection from the JWT presented in
+/// SourceHello (empty when the peer sent none). Throws to reject the connection
+/// before it is registered. Empty (default, and the case when no authenticator is
+/// configured) means authentication is not enforced and the token is ignored; a
+/// caller can inject a closure that verifies the token.
+using ExchangeConnectionAuthenticator = std::function<void(const String & jwt_token)>;
 
 /// Accepts connections for streaming exchanges used by distributed queries.
 //  Reads first packet from the connections that contains distributed query id and exchange stream id.
@@ -17,7 +26,7 @@ namespace DB
 class ExchangeServer : public Poco::Runnable
 {
 public:
-    ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_);
+    ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_, ExchangeConnectionAuthenticator authenticate_connection_ = {});
     ~ExchangeServer() override;
 
     void start();
@@ -26,12 +35,15 @@ public:
     void run() override;
 
     /// Runs the SourceHello/SinkHello handshake on `socket` and registers the
-    /// resulting connection in `connections` on success. Throws on protocol
-    /// mismatch or transport failure without registering. Exposed for tests.
-    static void handleConnection(Poco::Net::StreamSocket socket, ExchangeConnectionsPtr connections, LoggerPtr log);
+    /// resulting connection in `connections` on success. When `authenticate`
+    /// is set, the SourceHello JWT is checked before registration and a failure
+    /// throws without registering. Throws on protocol mismatch or transport
+    /// failure without registering. Exposed for tests.
+    static void handleConnection(Poco::Net::StreamSocket socket, ExchangeConnectionsPtr connections, LoggerPtr log, const ExchangeConnectionAuthenticator & authenticate);
 
 private:
     ExchangeConnectionsPtr connections;
+    ExchangeConnectionAuthenticator authenticate_connection;
     Poco::Net::ServerSocket server_socket;
     Poco::Thread accept_thread;
     /// Handshakes run on this pool so a slow peer cannot stall the single accept thread and block

--- a/src/Server/DistributedQuery/StreamingExchangeProtocol.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeProtocol.cpp
@@ -25,6 +25,7 @@ void SourceHelloBody::readAfterVersion(ReadBuffer & in)
 {
     readStringBinary(query_id, in);
     readStringBinary(stream_name, in);
+    readStringBinary(jwt_token, in);
 }
 
 void SourceHelloBody::write(WriteBuffer & out) const
@@ -32,6 +33,7 @@ void SourceHelloBody::write(WriteBuffer & out) const
     writeIntBinary(source_version, out);
     writeStringBinary(query_id, out);
     writeStringBinary(stream_name, out);
+    writeStringBinary(jwt_token, out);
 }
 
 void SinkHelloBody::read(ReadBuffer & in)

--- a/src/Server/DistributedQuery/StreamingExchangeProtocol.h
+++ b/src/Server/DistributedQuery/StreamingExchangeProtocol.h
@@ -15,9 +15,11 @@ class WriteBuffer;
 
 namespace StreamingExchangeProtocol
 {
-    /// Wire-format version. Bumped on any change to packet layouts.
-    /// Negotiated in SourceHello/SinkHello; mismatches reject the connection.
-    static constexpr UInt64 PROTOCOL_VERSION = 2;
+    /// Wire-format version, exchanged in SourceHello/SinkHello and required to match
+    /// exactly on both ends. Bumped on any change to packet layouts. Version 3 carries a
+    /// `jwt_token` in `SourceHelloBody` for authenticating the connecting source (empty
+    /// when authentication is not used).
+    static constexpr UInt64 PROTOCOL_VERSION = 3;
 
     /// Sanity cap for the body of a Hello packet.
     static constexpr UInt64 MAX_HELLO_BODY_BYTES = 64 * 1024;
@@ -52,15 +54,16 @@ namespace StreamingExchangeProtocol
         UInt64 bytes_size;  /// Size of the packet body (does not include this header)
     };
 
-    /// Wire format of the SourceHello body. Parsing is split in two phases because
-    /// only the version field is guaranteed to live at a fixed offset across protocol
-    /// versions: peers on a different version may use a different layout for the rest,
-    /// so the version must be read and validated first.
+    /// Wire format of the SourceHello body. The version is read first and must match this
+    /// node's `PROTOCOL_VERSION`; the rest of the body is parsed only after that check, so a
+    /// mismatched peer never has its (possibly differently-laid-out) body parsed further.
     struct SourceHelloBody
     {
         UInt64 source_version = 0;
         String query_id;
         String stream_name;
+        /// Bearer JWT for authenticating the source; empty when the source has no token.
+        String jwt_token;
 
         static UInt64 readVersion(ReadBuffer & in);
         void readAfterVersion(ReadBuffer & in);

--- a/src/Server/DistributedQuery/StreamingExchangeSource.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeSource.cpp
@@ -67,6 +67,7 @@ void StreamingExchangeSource::sendHello()
         .source_version = StreamingExchangeProtocol::PROTOCOL_VERSION,
         .query_id = query_id,
         .stream_name = stream_name,
+        .jwt_token = jwt_token,
     };
     source_hello.write(body);
     body.finalize();
@@ -121,10 +122,12 @@ void StreamingExchangeSource::receiveHello()
     StreamingExchangeProtocol::SinkHelloBody sink_hello;
     sink_hello.read(body_in);
 
+    /// The protocol version must match exactly.
     if (sink_hello.sink_version != StreamingExchangeProtocol::PROTOCOL_VERSION)
         throw Exception(ErrorCodes::PROTOCOL_VERSION_MISMATCH,
             "Streaming exchange protocol version mismatch for stream {}: this node speaks version {}, sink at {}:{} speaks version {}",
-            stream_name, StreamingExchangeProtocol::PROTOCOL_VERSION, host, port, sink_hello.sink_version);
+            stream_name, StreamingExchangeProtocol::PROTOCOL_VERSION,
+            host, port, sink_hello.sink_version);
 }
 
 IProcessor::Status StreamingExchangeSource::prepare()

--- a/src/Server/DistributedQuery/StreamingExchangeSource.h
+++ b/src/Server/DistributedQuery/StreamingExchangeSource.h
@@ -15,12 +15,13 @@ namespace DB
 class StreamingExchangeSource final : public ISource
 {
 public:
-    explicit StreamingExchangeSource(SharedHeader header_, String query_id_, String stream_name_, String host_, UInt16 port_)
+    explicit StreamingExchangeSource(SharedHeader header_, String query_id_, String stream_name_, String host_, UInt16 port_, String jwt_token_ = {})
         : ISource(std::move(header_))
         , host(std::move(host_))
         , port(port_)
         , query_id(std::move(query_id_))
         , stream_name(std::move(stream_name_))
+        , jwt_token(std::move(jwt_token_))
     {
     }
 
@@ -55,6 +56,8 @@ private:
     const UInt16 port;
     const String query_id;
     const String stream_name;
+    /// Bearer JWT presented to the sink in SourceHello (empty when unauthenticated).
+    const String jwt_token;
 
     bool finished_reading = false;  /// All data has been read from socket.
     bool output_finished = false;   /// Output port is finished, do not need to receive more data.

--- a/src/Server/DistributedQuery/tests/gtest_exchange_server_handshake.cpp
+++ b/src/Server/DistributedQuery/tests/gtest_exchange_server_handshake.cpp
@@ -14,6 +14,7 @@
 #include <Common/Exception.h>
 #include <Common/Logger.h>
 #include <Common/logger_useful.h>
+#include <IO/WriteBufferFromString.h>
 #include <Server/DistributedQuery/ExchangeConnections.h>
 #include <Server/DistributedQuery/ExchangeServer.h>
 #include <Server/DistributedQuery/StreamingExchangeProtocol.h>
@@ -24,6 +25,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int PROTOCOL_VERSION_MISMATCH;
+    extern const int AUTHENTICATION_FAILED;
 }
 }
 
@@ -72,7 +74,7 @@ TEST(ExchangeServerHandshake, MismatchedVersionRejectedBeforeParsingBody)
     {
         try
         {
-            ExchangeServer::handleConnection(server_side, connections, log);
+            ExchangeServer::handleConnection(server_side, connections, log, {});
         }
         catch (const Exception & e)
         {
@@ -131,7 +133,7 @@ namespace
         Poco::Net::StreamSocket client(listener.address());
         Poco::Net::StreamSocket server_side = listener.acceptConnection();
         listener.close();
-        return {std::move(client), std::move(server_side)};
+        return {client, server_side};
     }
 }
 
@@ -198,6 +200,132 @@ TEST(ExchangeConnectionsRendezvous, ConnectionAfterReleaseRejected)
     auto future = connections->getConnection("query", "stream");
     EXPECT_TRUE(future->isReady());
     EXPECT_ANY_THROW(future->getSocket());
+}
+
+namespace
+{
+    /// Drive a v3 SourceHello carrying `jwt_token` over `client`, run the server-side
+    /// handshake (with `authenticate`) on `server_side`, and return the error code thrown
+    /// by `handleConnection` (nullopt on success). The token captured by `authenticate`
+    /// is what the source actually serialized into SourceHello.
+    std::optional<int> runJwtHandshake(
+        Poco::Net::StreamSocket client,
+        Poco::Net::StreamSocket server_side,
+        const ExchangeConnectionsPtr & connections,
+        const String & jwt_token,
+        const ExchangeConnectionAuthenticator & authenticate)
+    {
+        using namespace StreamingExchangeProtocol;
+        auto log = getLogger("ExchangeServerHandshakeTest");
+
+        std::optional<int> caught_code;
+        std::thread server_thread([&]
+        {
+            try
+            {
+                ExchangeServer::handleConnection(server_side, connections, log, authenticate);
+            }
+            catch (const Exception & e)
+            {
+                caught_code = e.code();
+            }
+        });
+
+        WriteBufferFromOwnString body;
+        SourceHelloBody source_hello{
+            .source_version = PROTOCOL_VERSION,
+            .query_id = "query",
+            .stream_name = "stream",
+            .jwt_token = jwt_token,
+        };
+        source_hello.write(body);
+        body.finalize();
+        const std::string & body_str = body.str();
+
+        PacketHeader header{.packet_type = PacketType::SourceHello, .bytes_size = body_str.size()};
+        client.sendBytes(&header, sizeof(header));
+        client.sendBytes(body_str.data(), static_cast<int>(body_str.size()));
+
+        server_thread.join();
+        client.close();
+        return caught_code;
+    }
+}
+
+/// A valid token (per the injected authenticator) is accepted, the connection is
+/// registered, and the token the source sent round-trips to the authenticator.
+TEST(ExchangeServerHandshake, ValidJwtAcceptedAndRegistered)
+{
+    auto connections = std::make_shared<ExchangeConnections>();
+    auto [client, server_side] = makeConnectedPair();
+
+    String seen_token;
+    ExchangeConnectionAuthenticator authenticate = [&](const String & token) { seen_token = token; };
+
+    auto code = runJwtHandshake(client, server_side, connections, "good-token", authenticate);
+    EXPECT_FALSE(code.has_value());
+    EXPECT_EQ(seen_token, "good-token");
+
+    auto future = connections->getConnection("query", "stream");
+    EXPECT_TRUE(future->isReady());
+    EXPECT_NO_THROW(future->getSocket());
+}
+
+/// When the authenticator rejects (throws), the connection must NOT be registered.
+TEST(ExchangeServerHandshake, RejectedJwtNotRegistered)
+{
+    auto connections = std::make_shared<ExchangeConnections>();
+    auto [client, server_side] = makeConnectedPair();
+
+    ExchangeConnectionAuthenticator authenticate = [](const String & token)
+    {
+        if (token != "good-token")
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "bad exchange token");
+    };
+
+    auto code = runJwtHandshake(client, server_side, connections, "bad-token", authenticate);
+    ASSERT_TRUE(code.has_value());
+    EXPECT_EQ(*code, ErrorCodes::AUTHENTICATION_FAILED);
+
+    auto future = connections->getConnection("query", "stream");
+    EXPECT_FALSE(future->isReady());
+}
+
+/// Default (empty) authenticator: the token is ignored and the connection is registered,
+/// so a deployment that does not configure authentication is unaffected by the protocol bump.
+TEST(ExchangeServerHandshake, NoAuthenticatorIgnoresToken)
+{
+    auto connections = std::make_shared<ExchangeConnections>();
+    auto [client, server_side] = makeConnectedPair();
+
+    auto code = runJwtHandshake(client, server_side, connections, "whatever", {});
+    EXPECT_FALSE(code.has_value());
+
+    auto future = connections->getConnection("query", "stream");
+    EXPECT_TRUE(future->isReady());
+    EXPECT_NO_THROW(future->getSocket());
+}
+
+/// A require-JWT authenticator rejects a peer that sends an empty token, so enabling auth
+/// closes the door on un-credentialed connections.
+TEST(ExchangeServerHandshake, RequireJwtRejectsTokenlessSource)
+{
+    auto connections = std::make_shared<ExchangeConnections>();
+    auto [client, server_side] = makeConnectedPair();
+
+    ExchangeConnectionAuthenticator require_token = [](const String & token)
+    {
+        if (token.empty())
+            throw Exception(ErrorCodes::AUTHENTICATION_FAILED, "missing exchange token");
+    };
+
+    auto code = runJwtHandshake(client, server_side, connections,
+        /*jwt_token=*/"", require_token);
+    ASSERT_TRUE(code.has_value());
+    EXPECT_EQ(*code, ErrorCodes::AUTHENTICATION_FAILED);
+
+    auto future = connections->getConnection("query", "stream");
+    EXPECT_FALSE(future->isReady());
 }
 
 #endif


### PR DESCRIPTION
The streaming exchange protocol had no per-connection authentication: `ExchangeServer` served any peer that completed the `SourceHello` handshake with a known `query_id`/`stream_name`. Those are coordination identifiers, not secrets, so in a shared deployment they are not a sufficient isolation boundary.

This adds optional JWT authentication to the `SourceHello` handshake (the mechanism only; how the token is produced and verified is supplied by the caller):

- `PROTOCOL_VERSION` is bumped to 3; `SourceHelloBody` gains a trailing `jwt_token` (empty when authentication is not used). Both ends must speak the same protocol version (exact match); a mismatched peer is rejected after a best-effort `SinkHello` so it gets a precise diagnostic naming both versions. No backward-compatibility range is kept — nothing runs this protocol in production yet, so both ends of a deployment are upgraded together.
- `StreamingExchangeSource` carries and sends a caller-supplied token (empty by default).
- `ExchangeServer` accepts an optional authenticator callback that runs before the `SinkHello` reply and before the socket is rendezvoused; a rejection drops the connection without registering it. When no authenticator is set (the default), the token is ignored and behaviour is unchanged.

`ExchangeServer` stays free of any JWT/JWKS dependency — verification and authorization are supplied by the caller's closure.

Tests (`gtest_exchange_server_handshake`): the token round-trips and is accepted/registered; a rejected token is not registered; the default (no authenticator) ignores the token; a mismatched protocol version is rejected before the body is parsed; a require-JWT authenticator rejects a tokenless source.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.766` (included in `26.7` and later)
<!-- ch-version-info:end -->