### PR TITLE
Allowlist DatabasePostgreSQL getTablesIterator and AsyncLoader upgrade-check connection errors

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -427,8 +427,9 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       always activates the `PostgreSQLCleanerTask`, so after the upgrade restart the leftover database's cleaner
 #       task (`removeOutdatedTables`) tries to connect and the connection pool logs `<Error>` for each retry.
 #       Filtered via regex in the secondary pipe below to require the PostgreSQL connection-pool / cleaner-task
-#       context AND the connection-failure symptom together, so real PostgreSQL regressions (auth, protocol,
-#       query errors) are not masked.
+#       context AND a connection failure to the known 04210 fixture host `192.0.2.1:5432` together, so a real
+#       cleaner-task connect failure on a different (persisted) host, or a non-connection PostgreSQL regression
+#       (auth, protocol, query errors), still fails this job.
 #       The same leftover `DatabasePostgreSQL` engine reaches the same unreachable host through two more code
 #       paths that also log the benign connection failure, so they are filtered the same way:
 #       `DatabasePostgreSQL::getTablesIterator` (a `system.tables` scan reads the leftover engine and probes
@@ -533,8 +534,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "RaftInstance: session.*failed to read rpc header from socket.*due to error" \
     | grep -av -e "SystemLog.*Failed to flush system log system\.metric_log.*DEADLOCK_AVOIDED" \
     | grep -av -e "Value passed to 'throwIf' function is non-zero" \
-    | grep -av -e "PostgreSQLConnectionPool: Connection error" \
-    | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
+    | grep -av -e "PostgreSQLConnectionPool: Connection error.*192\.0\.2\.1., port 5432 failed" \
+    | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .192\.0\.2\.1:5432. failed" \
     | grep -av -e "DatabasePostgreSQL::getTablesIterator.*Connection to .192\.0\.2\.1:5432. failed" \
     | grep -av -e "AsyncLoader::worker.*Code: 614.*Connection to .192\.0\.2\.1:5432. failed" \
     | grep -av -e "mysqlxx::Pool.*Failed to connect to MySQL" \

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -435,8 +435,12 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       the pool; it deliberately swallows the error and logs it via `tryLogCurrentException`), and
 #       `AsyncLoader::worker` (the post-upgrade startup asynchronously loads the leftover engine and logs the
 #       same `POSTGRESQL_CONNECTION_FAILURE` (Code: 614) exception). Both matchers require the PostgreSQL
-#       code-path context AND the connection-failure symptom (the `AsyncLoader` one additionally pins the
-#       PostgreSQL-specific `Code: 614`) so non-PostgreSQL async-load or table-iteration errors are not masked.
+#       code-path context AND a connection failure to the known 04210 fixture host `192.0.2.1:5432` together
+#       (the `AsyncLoader` one additionally pins the PostgreSQL-specific `Code: 614`). `PoolWithFailover::get`
+#       builds every `pqxx::broken_connection` into the same `Code: 614` / `Connection to <host_port> failed`
+#       text, so scoping to the fixture host (not any `Connection to .* failed`) keeps genuine connect-time
+#       PostgreSQL regressions on a persisted `DatabasePostgreSQL` (a different host, or a non-614 code)
+#       still failing this job.
 # The MySQL matchers below filter the same class of benign connection failure from a `DatabaseMySQL` engine
 #       that `04210_show_remote_databases_in_system_tables` also creates
 #       (`ENGINE = MySQL('192.0.2.1:3306', ...)`, the same unreachable RFC 5737 host). On the post-upgrade
@@ -531,8 +535,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "Value passed to 'throwIf' function is non-zero" \
     | grep -av -e "PostgreSQLConnectionPool: Connection error" \
     | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
-    | grep -av -e "DatabasePostgreSQL::getTablesIterator.*Connection to .* failed" \
-    | grep -av -e "AsyncLoader::worker.*Code: 614.*Connection to .* failed" \
+    | grep -av -e "DatabasePostgreSQL::getTablesIterator.*Connection to .192\.0\.2\.1:5432. failed" \
+    | grep -av -e "AsyncLoader::worker.*Code: 614.*Connection to .192\.0\.2\.1:5432. failed" \
     | grep -av -e "mysqlxx::Pool.*Failed to connect to MySQL" \
     | grep -av -e "Application: Connection to mysql failed" \
     | grep -av -e "DatabaseMySQL.*Connections to mysql failed" \

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -429,6 +429,14 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       Filtered via regex in the secondary pipe below to require the PostgreSQL connection-pool / cleaner-task
 #       context AND the connection-failure symptom together, so real PostgreSQL regressions (auth, protocol,
 #       query errors) are not masked.
+#       The same leftover `DatabasePostgreSQL` engine reaches the same unreachable host through two more code
+#       paths that also log the benign connection failure, so they are filtered the same way:
+#       `DatabasePostgreSQL::getTablesIterator` (a `system.tables` scan reads the leftover engine and probes
+#       the pool; it deliberately swallows the error and logs it via `tryLogCurrentException`), and
+#       `AsyncLoader::worker` (the post-upgrade startup asynchronously loads the leftover engine and logs the
+#       same `POSTGRESQL_CONNECTION_FAILURE` (Code: 614) exception). Both matchers require the PostgreSQL
+#       code-path context AND the connection-failure symptom (the `AsyncLoader` one additionally pins the
+#       PostgreSQL-specific `Code: 614`) so non-PostgreSQL async-load or table-iteration errors are not masked.
 # The MySQL matchers below filter the same class of benign connection failure from a `DatabaseMySQL` engine
 #       that `04210_show_remote_databases_in_system_tables` also creates
 #       (`ENGINE = MySQL('192.0.2.1:3306', ...)`, the same unreachable RFC 5737 host). On the post-upgrade
@@ -523,6 +531,8 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "Value passed to 'throwIf' function is non-zero" \
     | grep -av -e "PostgreSQLConnectionPool: Connection error" \
     | grep -av -e "DatabasePostgreSQL::removeOutdatedTables.*Connection to .* failed" \
+    | grep -av -e "DatabasePostgreSQL::getTablesIterator.*Connection to .* failed" \
+    | grep -av -e "AsyncLoader::worker.*Code: 614.*Connection to .* failed" \
     | grep -av -e "mysqlxx::Pool.*Failed to connect to MySQL" \
     | grep -av -e "Application: Connection to mysql failed" \
     | grep -av -e "DatabaseMySQL.*Connections to mysql failed" \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104416
-->

Related: #104416

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #108560. That PR allowlisted the benign `DatabasePostgreSQL` cleaner-task (`removeOutdatedTables`) and `DatabaseMySQL` connection errors in the upgrade check. The same leftover `DatabasePostgreSQL` engine, created by `04210_show_remote_databases_in_system_tables` at the intentionally-unreachable RFC 5737 host `192.0.2.1:5432`, reaches that host through two more code paths that also log the benign connection failure at `<Error>` and were NOT covered, so `Upgrade check (amd_release)` stays red across many unrelated PRs (0 on master):

- `DatabasePostgreSQL::getTablesIterator`: a `system.tables` scan probes the connection pool and logs the swallowed error via `tryLogCurrentException`.
- `AsyncLoader::worker`: the post-upgrade startup asynchronously loads the leftover engine and re-logs the `POSTGRESQL_CONNECTION_FAILURE` (`Code: 614`) exception.

This adds two matchers to `tests/docker_scripts/upgrade_runner.sh`, mirroring the existing `removeOutdatedTables` one. Each requires the PostgreSQL code-path context AND the connection-failure symptom together (the `AsyncLoader` matcher additionally pins the PostgreSQL-specific `Code: 614`), so genuine PostgreSQL regressions (auth, protocol, query errors) and unrelated async-load errors are not masked.

Validation (shell-pipeline change, replayed against the authentic failing upgrade log from PR #109302, run `fd7a52338bc8`, 223115 lines):

- Direction 1 (master, unpatched): 30 `<Error>` lines leak, all `DatabasePostgreSQL::getTablesIterator` (matches the reported CI failure).
- Direction 2 (patched): 0 `<Error>` lines remain over the full pipeline.
- Delta: exactly those 30 lines are newly blocked; 0 over-masking (`comm` diff).
- The `AsyncLoader::worker` matcher was validated against real CIDB log lines: it blocks the benign `Code: 614` connection-fail line and preserves genuine `AsyncLoader::worker` errors (`Code: 49`, `Code: 999`) and genuine `getTablesIterator` errors (`Code: 62`, `Code: 516`).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109302&sha=fd7a52338bc87ffe3d77fb2d0a8de40e99fe61e7&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.901` (included in `26.7` and later)
<!-- ch-version-info:end -->