### PR TITLE
Fix TSAN data race in CachedOnDiskReadBufferFromFile::getInfoForLog

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -1815,9 +1815,12 @@ std::string CachedOnDiskReadBufferFromFile::getInfoForLog(
         wb << "bytes_to_predownload: " << state->bytes_to_predownload << ", ";
         if (state->buf)
         {
-            wb << "buf.available: " << state->buf->available() << ", ";
-            wb << "buf.offset: " << state->buf->offset() << ", ";
-            wb << "buf.size: " << state->buf->buffer().size() << ", ";
+            /// NOTE: state->buf can be a remote reader shared between segments (see
+            /// getRemoteReadBuffer), and this logging can run after the buffer was
+            /// released, while another thread already reads through it. So only read
+            /// getFileOffsetOfBufferEnd() here, which is atomic. available()/offset()/
+            /// buffer().size() read working_buffer pointers non-atomically and race
+            /// with SwapHelper in BoundedReadBuffer::nextImpl().
             wb << "buf.buffer_end_offset: " << state->buf->getFileOffsetOfBufferEnd() << ", ";
         }
     }

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -100,7 +100,7 @@ bool ReadBufferFromAzureBlobStorage::nextImpl()
             return false;
 
         if (read_until_position < offset)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read beyond right offset ({} > {})", offset, read_until_position - 1);
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Attempt to read beyond right offset ({} > {})", offset.load(std::memory_order_relaxed), read_until_position - 1);
     }
 
     if (!initialized)
@@ -291,7 +291,7 @@ void ReadBufferFromAzureBlobStorage::initialize(size_t attempt)
             }
 
             ProfileEvents::increment(ProfileEvents::ReadBufferFromAzureRequestsErrors);
-            LOG_DEBUG(log, "Exception caught during Azure Download for file {} at offset {} at attempt {}/{}: {}", path, offset, i + 1, max_single_download_retries, e.Message);
+            LOG_DEBUG(log, "Exception caught during Azure Download for file {} at offset {} at attempt {}/{}: {}", path, offset.load(std::memory_order_relaxed), i + 1, max_single_download_retries, e.Message);
 
             if (i + 1 == max_single_download_retries || !isRetryableAzureException(e))
                 throw;
@@ -411,7 +411,7 @@ size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t ran
             }
 
             ProfileEvents::increment(ProfileEvents::ReadBufferFromAzureRequestsErrors);
-            LOG_DEBUG(log, "Exception caught during Azure Download for file {} at offset {} at attempt {}/{}: {}", path, offset, i + 1, max_single_download_retries, e.Message);
+            LOG_DEBUG(log, "Exception caught during Azure Download for file {} at offset {} at attempt {}/{}: {}", path, offset.load(std::memory_order_relaxed), i + 1, max_single_download_retries, e.Message);
 
             if (i + 1 == max_single_download_retries || !isRetryableAzureException(e))
                 throw;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include "config.h"
 
@@ -42,7 +43,7 @@ public:
 
     bool nextImpl() override;
 
-    size_t getFileOffsetOfBufferEnd() const override { return offset; }
+    size_t getFileOffsetOfBufferEnd() const override { return offset.load(std::memory_order_relaxed); }
 
     String getFileName() const override { return path; }
 
@@ -85,7 +86,11 @@ private:
 
     off_t read_until_position = 0;
 
-    off_t offset = 0;
+    /// atomic is required for CachedOnDiskReadBufferFromFile, which can access
+    /// this variable via getFileOffsetOfBufferEnd() from a thread that logs the
+    /// read info (getInfoForLog) while another thread reads through this shared
+    /// reader. Same reason ReadBufferFromS3/ReadBufferFromWebServer use atomic.
+    std::atomic<off_t> offset = 0;
     size_t total_size{};
     bool initialized = false;
     char * data_ptr;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108838
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a data race in the filesystem cache read path. `CachedOnDiskReadBufferFromFile::getInfoForLog()` read the working buffer pointers (`available`, `offset`, `buffer size`) of a remote reader that can be shared between file segments and used concurrently by another thread, which could race with the buffer swap in `BoundedReadBuffer`.

### Description

TSAN report from `BuzzHouse (amd_tsan)`:

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108838&sha=2586502fbedc5ab52b2531d82464fb0251bac909&name_0=PR&name_1=BuzzHouse%20%28amd_tsan%29

- Read of size 8 by the logging path: `BufferBase::Buffer::end()` <- `available()` <- `CachedOnDiskReadBufferFromFile::getInfoForLog()` (`src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp`).
- Previous write of size 8 by the read path: `std::swap<char*>` <- `BufferBase::Buffer::swap()` <- `SwapHelper::~SwapHelper()` <- `BoundedReadBuffer::nextImpl()`.

Root cause: `getInfoForLog()` logged `state->buf->available()`, `->offset()` and `->buffer().size()`, all of which read the `working_buffer` `char*` pointers non-atomically. `state->buf` can be a remote reader (`BoundedReadBuffer`) that is deliberately shared between file segments (see `getRemoteReadBuffer`), and this logging runs after the buffer is released, while another thread already reads through the shared reader and swaps those pointers via `SwapHelper` in `BoundedReadBuffer::nextImpl()`.

This is the same class of race that PR #55372 fixed for `getFileOffsetOfBufferEnd()` by making it atomic and documenting the contract (the buffer is released before logging, so another thread can already use it). The three remaining working-buffer accessors were left unguarded. This change logs only `getFileOffsetOfBufferEnd()` here, which is atomic, and leaves a NOTE explaining why the other accessors must not be read.
