### PR TITLE
clickhouse-local: use TabSeparated as the default format for served connections

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1808,7 +1808,16 @@ void LocalServer::applyCmdSettings(ContextMutablePtr context)
 
 void LocalServer::applyCmdOptions(ContextMutablePtr context)
 {
-    context->setDefaultFormat(getClientConfiguration().getString("output-format", getClientConfiguration().getString("format", is_interactive ? "PrettyCompact" : "TSV")));
+    /// This sets the default output format for the (global) context, which is used by connections
+    /// served by `clickhouse-local` when it acts as a server (`SYSTEM START LISTEN TCP/HTTP`), as
+    /// well as by internal usages that consult the context's default format. It must match a real
+    /// `clickhouse-server`, which defaults to `TabSeparated`.
+    ///
+    /// Do not use the interactive default (`PrettyCompact`) here: that format is only for rendering
+    /// query results in the terminal and is applied separately via `ClientBase::default_output_format`.
+    /// Otherwise a client connecting over HTTP would receive a `PrettyCompact`-formatted response and
+    /// fail to parse it (for example, the version query used during connection handshake).
+    context->setDefaultFormat(getClientConfiguration().getString("output-format", getClientConfiguration().getString("format", "TSV")));
     applyCmdSettings(context);
 }
 

--- a/tests/queries/0_stateless/04501_local_http_default_format.expect
+++ b/tests/queries/0_stateless/04501_local_http_default_format.expect
@@ -1,0 +1,48 @@
+#!/usr/bin/expect -f
+
+# Test that clickhouse-local, when acting as a server (`SYSTEM START LISTEN HTTP`), serves HTTP
+# connections using the same default output format as clickhouse-server (`TabSeparated`), even when
+# started in interactive mode (where the terminal default is `PrettyCompact`).
+#
+# Previously the interactive default (`PrettyCompact`) leaked into the global context, so an HTTP
+# client received a `PrettyCompact`-formatted response and failed to parse it.
+#
+# We fetch the served response for `SELECT 1` via `LineAsString` and count the returned lines:
+# `TabSeparated` yields exactly one line, while any `Pretty*` format yields several (borders, header).
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+
+log_user 0
+set timeout 60
+match_max 100000
+
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --enable-progress-table-toggle=0 --listen_host 127.0.0.1 --http_port 0"
+expect ":) "
+
+send -- "SYSTEM START LISTEN HTTP\r"
+expect "Ok."
+
+# Build the marker at run time with `concat` so the expected token (`SERVED_HTTP_LINES_1`) never
+# appears in the query text itself: interactive clickhouse-local echoes the typed query back, and a
+# literal token in the query would be matched in that echo before the query even runs. The digit is
+# produced only in the result, where `SERVED_HTTP_LINES_` is followed by the row count. A single line
+# means `TabSeparated`; any `Pretty*` format would produce several lines (borders and header).
+send -- "SELECT concat('SERVED_HTTP_LINES_', toString(count())) FROM url('http://127.0.0.1:' || toString(getServerPort('http_port')) || '/?query=SELECT+1', LineAsString) FORMAT TSV\r"
+expect "SERVED_HTTP_LINES_1"
+
+send -- "exit\r"
+expect eof


### PR DESCRIPTION
When `clickhouse-local` acts as a server (`SYSTEM START LISTEN TCP/HTTP`), connections served over HTTP used the interactive terminal's default output format (`PrettyCompact`) instead of `TabSeparated`, which is what a real `clickhouse-server` uses.

This happened because `LocalServer::applyCmdOptions` set the interactive default on the shared global context, which is also used by the embedded HTTP/TCP listeners. As a result, an HTTP client (for example `clickhouse-connect`) received a `PrettyCompact`-formatted response to the version query performed during the connection handshake and failed to parse it:

```
clickhouse_connect.driver.exceptions.OperationalError: Unexpected response to server version query: '   ┌─version()─┬─timezone()────┐\n1. │ 26.7.1.22 │ Europe/London │\n   └───────────┴───────────────┘'
```

The interactive default is only meant for rendering query results in the terminal and is applied separately via `ClientBase::default_output_format`, so the global (server) default now falls back to `TabSeparated`. An explicit `--format`/`--output-format` is still honored, and the interactive terminal session keeps rendering `PrettyCompact`.

Added an `.expect` test that starts `clickhouse-local` interactively, enables the HTTP listener, and verifies the served default format is `TabSeparated`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`clickhouse-local` acting as a server (after `SYSTEM START LISTEN HTTP`) now serves HTTP connections using the `TabSeparated` default output format, matching `clickhouse-server`, instead of the interactive `PrettyCompact` default. This fixes connecting to `clickhouse-local` over HTTP with drivers such as `clickhouse-connect`. The interactive terminal session still renders results as `PrettyCompact`.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.529` (included in `26.7` and later)
- Backported to: `26.6.2.30`
<!-- ch-version-info:end -->