### PR TITLE
Web UI: resize the progress and stats areas uniformly

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1485,7 +1485,10 @@ class QueryProgressElement extends HTMLElement
                 :host
                 {
                     display: grid;
-                    grid-template-columns: auto 1fr auto;
+                    /* Progress and stats share the available width equally, and both can
+                       shrink below their content size (the zero minimum), so they resize
+                       uniformly when the row is narrow instead of one hogging the space. */
+                    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
                     gap: 1rem;
                     align-items: center;
                 }
@@ -1525,7 +1528,6 @@ class QueryProgressElement extends HTMLElement
                 #stats
                 {
                     color: var(--misc-text-color);
-                    white-space: nowrap;
                 }
 
                 #stats b


### PR DESCRIPTION
In the Web UI (`play.html`), the row containing the run button, the final progress, and the query statistics laid out the `query-progress` element with `grid-template-columns: auto 1fr auto`. This gave the progress area all the flexible width (`1fr`) while the stats area was pinned to its content and set to `white-space: nowrap`.

When the window was narrow, one area collapsed to its minimum and wrapped into many short lines while the other stayed wide, and the stats text could overflow past the copy/download buttons.

This changes the template to `grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr)` and allows the stats text to wrap, so the progress and stats areas share the available width equally and resize uniformly when the row is narrow. Wide layouts render the same as before.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI: resize the final progress and query statistics areas uniformly so they do not wrap awkwardly when the browser window is narrow.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.521` (included in `26.7` and later)
<!-- ch-version-info:end -->