### PR TITLE
Retry transient MinIO InvalidPart on S3 CompleteMultipartUpload

### DIFF
--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -12,6 +12,7 @@
 #include <Interpreters/Context.h>
 #include <IO/LimitSeekableReadBuffer.h>
 #include <IO/S3/getObjectInfo.h>
+#include <IO/S3Common.h>
 #include <IO/SeekableReadBuffer.h>
 #include <IO/StdStreamFromReadBuffer.h>
 #include <IO/ReadBufferFromS3.h>
@@ -220,11 +221,11 @@ namespace
                     break;
                 }
 
-                if ((outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY) && (retries < max_retries))
+                if (isTransientCompleteMultipartUploadError(outcome.GetError()) && (retries < max_retries))
                 {
-                    /// For unknown reason, at least MinIO can respond with NO_SUCH_KEY for put requests
-                    /// BTW, NO_SUCH_UPLOAD is expected error and we shouldn't retry it
-                    LOG_INFO(log, "Multipart upload failed with NO_SUCH_KEY error for Bucket: {}, Key: {}, Upload_id: {}, Parts: {}, will retry", dest_bucket, dest_key, multipart_upload_id, multipart_tags.size());
+                    const auto & error = outcome.GetError();
+                    const String details = error.GetExceptionName().empty() ? error.GetMessage() : error.GetExceptionName();
+                    LOG_INFO(log, "Multipart upload failed with a transient error ({}) for Bucket: {}, Key: {}, Upload_id: {}, Parts: {}, will retry", details, dest_bucket, dest_key, multipart_upload_id, multipart_tags.size());
                     continue; /// will retry
                 }
                 ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);

--- a/src/IO/S3Common.cpp
+++ b/src/IO/S3Common.cpp
@@ -43,6 +43,13 @@ bool S3Exception::isAccessTokenExpiredError() const
     return code == Aws::S3::S3Errors::INVALID_ACCESS_KEY_ID || code == Aws::S3::S3Errors::ACCESS_DENIED || code == Aws::S3::S3Errors::INVALID_SIGNATURE || code == Aws::S3::S3Errors::UNKNOWN;
 }
 
+bool isTransientCompleteMultipartUploadError(const Aws::S3::S3Error & error)
+{
+    return error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY
+        || error.GetExceptionName() == "InvalidPart"
+        || error.GetExceptionName() == "InvalidPartOrder";
+}
+
 }
 
 #endif

--- a/src/IO/S3Common.h
+++ b/src/IO/S3Common.h
@@ -26,6 +26,15 @@ namespace ErrorCodes
 
 struct Settings;
 
+/// MinIO transiently reports a just-uploaded object/part as missing on CompleteMultipartUpload even
+/// though every part was uploaded: NO_SUCH_KEY, or InvalidPart / InvalidPartOrder. These are all
+/// eventual-consistency quirks of the same class and are safe to retry (callers list parts in
+/// ascending order, so a genuine InvalidPartOrder cannot originate here). InvalidPart /
+/// InvalidPartOrder are not in the typed S3Errors enum, so the SDK leaves GetErrorType() == UNKNOWN
+/// and keeps the raw code only in GetExceptionName() -- match by name. NO_SUCH_UPLOAD is a genuine
+/// error handled by DB::S3::Client, not retried here.
+bool isTransientCompleteMultipartUploadError(const Aws::S3::S3Error & error);
+
 class S3Exception : public Exception
 {
 public:

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -659,6 +659,8 @@ bool WriteBufferFromS3::completeMultipartUpload()
     req.SetMultipartUpload(multipart_upload);
 
     size_t max_retry = std::max<UInt64>(request_settings[S3RequestSetting::max_unexpected_write_error_retries].value, 1UL);
+    Aws::S3::S3Errors last_error_type = Aws::S3::S3Errors::NO_SUCH_KEY;
+    String last_error_details;
     for (size_t i = 0; i < max_retry; ++i)
     {
         ProfileEvents::increment(ProfileEvents::S3CompleteMultipartUpload);
@@ -684,25 +686,39 @@ bool WriteBufferFromS3::completeMultipartUpload()
 
         ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
 
-        if (outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY)
+        const auto & error = outcome.GetError();
+        /// MinIO transiently reports a just-uploaded object/part as missing on completion even
+        /// though every part was uploaded: NO_SUCH_KEY, or InvalidPart / InvalidPartOrder. These
+        /// are all eventual-consistency quirks of the same class and are safe to retry (the request
+        /// always lists parts in ascending order, so a genuine InvalidPartOrder cannot originate
+        /// here). InvalidPart / InvalidPartOrder are not in the typed S3Errors enum, so the SDK
+        /// leaves GetErrorType() == UNKNOWN and the raw code only in GetExceptionName() -- match by
+        /// name. NO_SUCH_UPLOAD is a genuine error handled by DB::S3::Client, not retried here.
+        const bool retryable
+            = error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY
+            || error.GetExceptionName() == "InvalidPart"
+            || error.GetExceptionName() == "InvalidPartOrder";
+
+        if (retryable)
         {
-            /// For unknown reason, at least MinIO can respond with NO_SUCH_KEY for put requests
-            /// BTW, NO_SUCH_UPLOAD is expected error and we shouldn't retry it here, DB::S3::Client take care of it
-            LOG_INFO(log, "Multipart upload failed with NO_SUCH_KEY error, will retry. {}, Parts: {}", getVerboseLogDetails(), multipart_tags.size());
+            last_error_type = error.GetErrorType();
+            last_error_details = error.GetExceptionName().empty() ? error.GetMessage() : error.GetExceptionName();
+            LOG_INFO(log, "Multipart upload failed with a transient error ({}), will retry. {}, Parts: {}",
+                     last_error_details, getVerboseLogDetails(), multipart_tags.size());
         }
         else
         {
             throw S3Exception(
-                outcome.GetError().GetErrorType(),
+                error.GetErrorType(),
                 "Message: {}, Key: {}, Bucket: {}, Tags: {}",
-                outcome.GetError().GetMessage(), key, bucket, fmt::join(multipart_tags.begin(), multipart_tags.end(), " "));
+                error.GetMessage(), key, bucket, fmt::join(multipart_tags.begin(), multipart_tags.end(), " "));
         }
     }
 
     throw S3Exception(
-        Aws::S3::S3Errors::NO_SUCH_KEY,
-        "Message: Multipart upload failed with NO_SUCH_KEY error, retries {}, Key: {}, Bucket: {}",
-        max_retry, key, bucket);
+        last_error_type,
+        "Message: Multipart upload failed with a transient error ({}), retries {}, Key: {}, Bucket: {}",
+        last_error_details, max_retry, key, bucket);
 }
 
 S3::PutObjectRequest WriteBufferFromS3::getPutRequest(PartData & data)

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -687,19 +687,7 @@ bool WriteBufferFromS3::completeMultipartUpload()
         ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);
 
         const auto & error = outcome.GetError();
-        /// MinIO transiently reports a just-uploaded object/part as missing on completion even
-        /// though every part was uploaded: NO_SUCH_KEY, or InvalidPart / InvalidPartOrder. These
-        /// are all eventual-consistency quirks of the same class and are safe to retry (the request
-        /// always lists parts in ascending order, so a genuine InvalidPartOrder cannot originate
-        /// here). InvalidPart / InvalidPartOrder are not in the typed S3Errors enum, so the SDK
-        /// leaves GetErrorType() == UNKNOWN and the raw code only in GetExceptionName() -- match by
-        /// name. NO_SUCH_UPLOAD is a genuine error handled by DB::S3::Client, not retried here.
-        const bool retryable
-            = error.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY
-            || error.GetExceptionName() == "InvalidPart"
-            || error.GetExceptionName() == "InvalidPartOrder";
-
-        if (retryable)
+        if (isTransientCompleteMultipartUploadError(error))
         {
             last_error_type = error.GetErrorType();
             last_error_details = error.GetExceptionName().empty() ? error.GetMessage() : error.GetExceptionName();

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -239,7 +239,7 @@ struct Client : DB::S3::Client
     static DB::S3::PocoHTTPClientConfiguration GetClientConfiguration()
     {
         DB::RemoteHostFilter remote_host_filter;
-        return DB::S3::ClientFactory::instance().createClientConfiguration(
+        auto configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
             "some-region",
             remote_host_filter,
             /* s3_max_redirects = */ 100,
@@ -250,6 +250,12 @@ struct Client : DB::S3::Client
             /* for_disk_s3 = */ false,
             /* opt_disk_name = */ {},
             /* request_throttler = */ {});
+        /// createClientConfiguration leaves retryStrategy unset; ClientFactory::create() normally
+        /// fills it in. This mock builds DB::S3::Client directly, bypassing the factory, so replicate
+        /// that here -- otherwise chassert(client_configuration.retryStrategy) in Client::doRequest
+        /// aborts every request in debug/sanitizer builds.
+        configuration.retryStrategy = std::make_shared<DB::S3::Client::RetryStrategy>(configuration.retry_strategy);
+        return configuration;
     }
 
     void setInjectionModel(std::shared_ptr<MockS3::InjectionModel> injections_)
@@ -458,6 +464,31 @@ struct UploadPartFailIngection: InjectionModel
     {
         return Aws::Client::AWSError<Aws::Client::CoreErrors>(Aws::Client::CoreErrors::VALIDATION, "FailInjection", "UploadPartFailIngection", false);
     }
+};
+
+/// Fails the first `fail_times` CompleteMultipartUpload calls with the un-typed MinIO `InvalidPart`
+/// eventual-consistency error, then lets the real mock store handle the rest. The AWS SDK cannot map
+/// <Code>InvalidPart</Code> to a typed model error, so it produces UNKNOWN as the error type and keeps
+/// the raw code only in the exception name -- exactly the shape WriteBufferFromS3 must recognise to
+/// retry (see AWSErrorMarshaller::Marshall).
+struct CompleteMPUInvalidPartOnceIngection : InjectionModel
+{
+    explicit CompleteMPUInvalidPartOnceIngection(size_t fail_times_) : fail_times(fail_times_) {}
+
+    std::optional<Aws::S3::Model::CompleteMultipartUploadOutcome> call(const Aws::S3::Model::CompleteMultipartUploadRequest & /*request*/) override
+    {
+        if (calls++ >= fail_times)
+            return std::nullopt;
+        return Aws::Client::AWSError<Aws::Client::CoreErrors>(
+            Aws::Client::CoreErrors::UNKNOWN,
+            "InvalidPart",
+            "One or more of the specified parts could not be found. The part may not have been uploaded, "
+            "or the specified entity tag may not match the part's entity tag.",
+            false);
+    }
+
+    size_t fail_times;
+    size_t calls = 0;
 };
 
 struct BaseSyncPolicy
@@ -831,6 +862,32 @@ TEST_P(SyncAsync, ExceptionOnCompleteMPU) {
             throw;
         }
       }, DB::S3Exception);
+}
+
+/// A transient MinIO `InvalidPart` on CompleteMultipartUpload must be retried, not surfaced as a
+/// hard failure. Regression test for the `Code: 499 ... InvalidPart` flake at hits_s3 fixture load.
+/// The injection fails the first completion attempt with `InvalidPart` (UNKNOWN type, name only),
+/// then succeeds; the write must finalize and store the object. Without the retry-predicate fix in
+/// WriteBufferFromS3::completeMultipartUpload the first failure is thrown straight through and this
+/// test fails.
+TEST_P(SyncAsync, CompleteMPURetriesInvalidPart) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPUInvalidPartOnceIngection>(/* fail_times= */ 1));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // no single part
+    getSettings()[Setting::s3_min_upload_part_size] = 1; // small parts are ok
+
+    auto buffer = getWriteBuffer("complete_mpu_invalid_part_retry");
+    buffer->write('A');
+
+    getAsyncPolicy().setAutoExecute(true);
+    buffer->finalize();
+
+    /// The completion was attempted twice: once failing with InvalidPart, once succeeding.
+    EXPECT_EQ(client->counters.multiUploadComplete, 2u);
+    EXPECT_EQ(client->counters.multiUploadAbort, 0u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["complete_mpu_invalid_part_retry"].size(), 1u);
 }
 
 TEST_P(SyncAsync, ExceptionOnUploadPart) {

--- a/src/IO/tests/gtest_writebuffer_s3.cpp
+++ b/src/IO/tests/gtest_writebuffer_s3.cpp
@@ -27,7 +27,9 @@
 #include <IO/ReadBufferFromEncryptedFile.h>
 #include <IO/AsyncReadCounters.h>
 #include <IO/ReadBufferFromS3.h>
+#include <IO/ReadBufferFromString.h>
 #include <IO/S3/Client.h>
+#include <IO/S3/copyS3File.h>
 
 #include <Disks/IO/ThreadPoolRemoteFSReader.h>
 #include <Disks/IO/ReadBufferFromRemoteFSGather.h>
@@ -193,6 +195,20 @@ struct EventCounts
 
 struct Client;
 
+/// Read a request body the way the AWS SDK does: block reads of `content_length` bytes via
+/// istream::read (which routes to streambuf::xsgetn). `data << body->rdbuf()` instead reads
+/// char-by-char through sbumpc/uflow, which needs a streambuf get area -- StdStreamBufFromReadBuffer
+/// (used by the copyS3File body path) implements only xsgetn/underflow and leaves the get area empty,
+/// so the rdbuf() form segfaults on it. Reading by content length works for every body stream.
+inline std::string readRequestBody(const std::shared_ptr<Aws::IOStream> & body, size_t content_length)
+{
+    std::string data;
+    data.resize(content_length);
+    body->read(data.data(), static_cast<std::streamsize>(content_length));
+    data.resize(static_cast<size_t>(body->gcount()));
+    return data;
+}
+
 struct InjectionModel
 {
     virtual ~InjectionModel() = default;
@@ -276,10 +292,9 @@ struct Client : DB::S3::Client
         }
 
         auto & bStore = store->GetBucketStore(request.GetBucket());
-        std::stringstream data;
-        data << request.GetBody()->rdbuf();
-        bStore.PutObject(request.GetKey(), data.str());
-        counters.writtenSize += data.str().length();
+        const std::string data = readRequestBody(request.GetBody(), request.GetContentLength());
+        bStore.PutObject(request.GetKey(), data);
+        counters.writtenSize += data.length();
 
         Aws::S3::Model::PutObjectOutcome outcome;
         Aws::S3::Model::PutObjectResult result(outcome.GetResultWithOwnership());
@@ -365,12 +380,11 @@ struct Client : DB::S3::Client
             }
         }
 
-        std::stringstream data;
-        data << request.GetBody()->rdbuf();
-        counters.writtenSize += data.str().length();
+        const std::string data = readRequestBody(request.GetBody(), request.GetContentLength());
+        counters.writtenSize += data.length();
 
         auto & bStore = store->GetBucketStore(request.GetBucket());
-        auto etag = bStore.UploadPart(request.GetUploadId(), data.str());
+        auto etag = bStore.UploadPart(request.GetUploadId(), data);
 
         Aws::S3::Model::UploadPartResult result;
         result.SetETag(etag);
@@ -888,6 +902,51 @@ TEST_P(SyncAsync, CompleteMPURetriesInvalidPart) {
 
     auto & bStore = client->store->GetBucketStore(bucket);
     EXPECT_EQ(bStore.objects["complete_mpu_invalid_part_retry"].size(), 1u);
+}
+
+/// The same transient MinIO `InvalidPart` on CompleteMultipartUpload must also be retried by the
+/// copyDataToS3File / copyS3File helper path (UploadHelper::completeMultipartUpload), which backs
+/// MinIO-backed backups and DiskObjectStorage server-side copies. Injects `InvalidPart` on the first
+/// completion attempt, then succeeds; the copy must finalize and store the object. Without the shared
+/// retry predicate in UploadHelper::completeMultipartUpload the first failure is thrown straight
+/// through and this test fails.
+TEST_F(WBS3Test, CopyDataToS3FileRetriesInvalidPart) {
+    setInjectionModel(std::make_shared<MockS3::CompleteMPUInvalidPartOnceIngection>(/* fail_times= */ 1));
+
+    getSettings()[Setting::s3_max_single_part_upload_size] = 0; // force multipart
+    getSettings()[Setting::s3_min_upload_part_size] = 1; // small parts are ok
+    getSettings()[Setting::s3_check_objects_after_upload] = false;
+
+    S3::S3RequestSettings request_settings;
+    request_settings.updateFromSettings(settings, /* if_changed */ true, /* validate_settings */ false);
+
+    client->resetCounters();
+
+    const String payload = "copy_invalid_part_payload";
+    auto create_read_buffer = [&]() -> std::unique_ptr<SeekableReadBuffer>
+    {
+        return std::make_unique<ReadBufferFromOwnString>(payload);
+    };
+
+    /// Empty schedule => the multipart upload (and completion) runs synchronously on this thread.
+    copyDataToS3File(
+        create_read_buffer,
+        /* offset= */ 0,
+        /* size= */ payload.size(),
+        client,
+        bucket,
+        "copy_data_invalid_part_retry",
+        request_settings,
+        /* blob_storage_log= */ nullptr,
+        /* schedule= */ {},
+        /* object_metadata= */ std::nullopt);
+
+    /// The completion was attempted twice: once failing with InvalidPart, once succeeding.
+    EXPECT_EQ(client->counters.multiUploadComplete, 2u);
+    EXPECT_EQ(client->counters.multiUploadAbort, 0u);
+
+    auto & bStore = client->store->GetBucketStore(bucket);
+    EXPECT_EQ(bStore.objects["copy_data_invalid_part_retry"].size(), payload.size());
 }
 
 TEST_P(SyncAsync, ExceptionOnUploadPart) {


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/93192
-->

Closes: #93192

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a transient `Code: 499 ... InvalidPart` (`S3_ERROR`) failure on S3 multipart uploads (for example `INSERT INTO ... hits_s3`). MinIO can briefly report a just-uploaded part as missing on `CompleteMultipartUpload`; this error is now retried like the already-handled `NoSuchKey`, bounded by `s3_max_unexpected_write_error_retries`.

### Description

`WriteBufferFromS3::completeMultipartUpload()` had a retry loop bounded by `max_unexpected_write_error_retries` that tolerated one known MinIO eventual-consistency quirk, but only `NoSuchKey`. MinIO also transiently reports a just-uploaded part as missing on completion with `InvalidPart` (and can with `InvalidPartOrder`), which is the same class of flake. Those fell into the `else` branch and threw immediately:

```
Code: 499. DB::Exception: Message: Unable to parse ExceptionName: InvalidPart
Message: One or more of the specified parts could not be found. ...
(S3_ERROR) (in query: INSERT INTO test.hits_s3 SELECT * FROM test.hits ...)
```

Root cause of the "Unable to parse ExceptionName" wording: `InvalidPart` / `InvalidPartOrder` are not in the AWS SDK's typed `S3Errors` enum and are not mapped by `S3ErrorMapper`, so `AWSErrorMarshaller::Marshall` leaves `GetErrorType() == UNKNOWN` and keeps the raw code only in `GetExceptionName()`. A fix keyed on the typed enum would not match, so the retry predicate matches by exception name, mirroring the existing `PreconditionFailed` string check in the single-part path.

The retry stays bounded by `max_unexpected_write_error_retries`, logs at INFO like the existing branch, and the terminal throw now reports the actual last error instead of a hardcoded `NoSuchKey`. `InvalidPart` is a `CompleteMultipartUpload`-only error, so the single-part `PutObject` path is intentionally left unchanged. Sorting parts in ascending order is guaranteed by the request builder, so a genuine (non-transient) `InvalidPartOrder` cannot originate here.

Regression test: `src/IO/tests/gtest_writebuffer_s3.cpp` (`WBS3/SyncAsync.CompleteMPURetriesInvalidPart`) injects `InvalidPart` on the first `CompleteMultipartUpload` and asserts the upload then succeeds. It fails on `master` and passes with this change. The test also fills `retryStrategy` in the mock client config (the mock builds `DB::S3::Client` directly, bypassing `ClientFactory::create` which normally sets it), unblocking the whole MockS3 suite under `chassert` in debug/sanitizer builds.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.838` (included in `26.7` and later)
<!-- ch-version-info:end -->