### PR TITLE
Reduce per-block overhead in expression execution for wide inputs

### DIFF
--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -981,6 +981,26 @@ ColumnPtr recursiveRemoveSparse(const ColumnPtr & column)
     return column->convertToFullColumnIfSparse();
 }
 
+bool recursiveHasSparse(const ColumnPtr & column)
+{
+    if (!column)
+        return false;
+
+    if (const auto * column_replicated = typeid_cast<const ColumnReplicated *>(column.get()))
+        return recursiveHasSparse(column_replicated->getNestedColumn());
+
+    if (const auto * column_tuple = typeid_cast<const ColumnTuple *>(column.get()))
+    {
+        for (const auto & element : column_tuple->getColumns())
+            if (recursiveHasSparse(element))
+                return true;
+
+        return false;
+    }
+
+    return column->isSparse();
+}
+
 ColumnPtr removeSpecialRepresentations(const ColumnPtr & column)
 {
     if (!column)

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -265,6 +265,10 @@ private:
 
 ColumnPtr recursiveRemoveSparse(const ColumnPtr & column);
 
+/// Returns true if `recursiveRemoveSparse` would change `column`, i.e. there is a sparse column
+/// either at the top level or nested inside a Tuple or Replicated column. Does not allocate.
+bool recursiveHasSparse(const ColumnPtr & column);
+
 /// Remove all special representations (for now Sparse and Replicated).
 ColumnPtr removeSpecialRepresentations(const ColumnPtr & column);
 

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -249,8 +249,33 @@ void Block::insertUnique(ColumnWithTypeAndName elem)
 
 void Block::erase(const std::set<size_t> & positions)
 {
-    for (auto it = positions.rbegin(); it != positions.rend(); ++it)
-        erase(*it);
+    if (positions.empty())
+        return;
+
+    if (*positions.rbegin() >= data.size())
+        throw Exception(ErrorCodes::POSITION_OUT_OF_BOUND, "Position out of bound in Block::erase(), max position = {}",
+            data.empty() ? 0 : data.size() - 1);
+
+    /// Compact `data` in a single pass, dropping the erased positions, then rebuild the name index once.
+    /// This is O(columns) instead of O(columns * erased) that repeated single-position erases would cost.
+    size_t next = 0;
+    auto pos_it = positions.begin();
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        if (pos_it != positions.end() && *pos_it == i)
+        {
+            ++pos_it;
+            continue;
+        }
+        if (next != i)
+            data[next] = std::move(data[i]);
+        ++next;
+    }
+    data.resize(next);
+
+    index_by_name.clear();
+    for (size_t i = 0; i < data.size(); ++i)
+        index_by_name.emplace(data[i].name, i);
 }
 
 

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -464,10 +464,10 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
     {
-        ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
-
         if (const auto * res_low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(result_type.get()))
         {
+            ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
+
             bool can_be_executed_on_default_arguments = canBeExecutedOnDefaultArguments();
 
             const auto & dictionary_type = res_low_cardinality_type->getDictionaryType();
@@ -497,6 +497,23 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
         }
         else
         {
+            /// Fast path: detect low-cardinality via types only (a column is low-cardinality iff its type
+            /// is), which is cheap for scalar types and lets us avoid copying/converting the (potentially
+            /// very wide) argument list when nothing is low-cardinality.
+            bool has_low_cardinality = false;
+            for (const auto & argument : arguments)
+            {
+                if (recursiveRemoveLowCardinality(argument.type).get() != argument.type.get())
+                {
+                    has_low_cardinality = true;
+                    break;
+                }
+            }
+
+            if (!has_low_cardinality)
+                return executeWithoutLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
+
+            ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
             convertLowCardinalityColumnsToFull(columns_without_low_cardinality);
             result = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, result_type, input_rows_count, dry_run);
         }
@@ -514,6 +531,21 @@ ColumnPtr IExecutableFunction::execute(
 
     if (useDefaultImplementationForReplicatedColumns())
     {
+        /// Fast path: with no replicated columns there is nothing to convert, so skip copying the
+        /// (potentially very wide) argument list and pass it straight through.
+        bool has_replicated_column = false;
+        for (const auto & argument : arguments)
+        {
+            if (typeid_cast<const ColumnReplicated *>(argument.column.get()))
+            {
+                has_replicated_column = true;
+                break;
+            }
+        }
+
+        if (!has_replicated_column)
+            return executeWithoutReplicatedColumns(arguments, result_type, input_rows_count, dry_run);
+
         /// If we have only constants and replicated columns with the same indexes
         /// we can execute function on nested columns and create replicated column
         /// from the result using common indexes.
@@ -593,10 +625,12 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
         size_t num_sparse_columns = 0;
         size_t num_full_columns = 0;
         size_t sparse_column_position = 0;
+        bool has_any_sparse_column = false;
 
         for (size_t i = 0; i < arguments.size(); ++i)
         {
             const auto * column_sparse = checkAndGetColumn<ColumnSparse>(arguments[i].column.get());
+            has_any_sparse_column |= (column_sparse != nullptr);
             /// In rare case, when sparse column doesn't have default values,
             /// it's more convenient to convert it to full before execution of function.
             if (column_sparse && column_sparse->getNumberOfDefaultRows())
@@ -609,6 +643,11 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
                 ++num_full_columns;
             }
         }
+
+        /// Fast path: with no sparse columns there is nothing to convert, so skip copying the
+        /// (potentially very wide) argument list and pass it straight through.
+        if (!has_any_sparse_column)
+            return executeWithoutSparseColumns(arguments, result_type, input_rows_count, dry_run);
 
         auto columns_without_sparse = arguments;
         if (num_sparse_columns == 1 && num_full_columns == 0)

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -630,7 +630,9 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
         for (size_t i = 0; i < arguments.size(); ++i)
         {
             const auto * column_sparse = checkAndGetColumn<ColumnSparse>(arguments[i].column.get());
-            has_any_sparse_column |= (column_sparse != nullptr);
+            /// A sparse column may also be nested inside a Tuple or Replicated column, in which case
+            /// `recursiveRemoveSparse` (used below) still has to convert it, so detect it recursively.
+            has_any_sparse_column |= recursiveHasSparse(arguments[i].column);
             /// In rare case, when sparse column doesn't have default values,
             /// it's more convenient to convert it to full before execution of function.
             if (column_sparse && column_sparse->getNumberOfDefaultRows())

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -852,32 +852,39 @@ void ExpressionActions::execute(
         }
     }
 
-    if (project_inputs)
-    {
-        block.clear();
-    }
-    else if (allow_duplicates_in_input)
-    {
-        /// This case is the same as when the input is projected
-        /// since we do not need any input columns.
-        block.clear();
-    }
-    else
-    {
-        ::sort(execution_context.inputs_pos.rbegin(), execution_context.inputs_pos.rend());
-        for (auto input : execution_context.inputs_pos)
-            if (input >= 0)
-                block.erase(input);
-    }
-
     Block res;
+    res.reserve(result_positions.size() + block.columns());
 
+    /// Note: `result_positions` may reference the same column position more than once
+    /// (e.g. when an output node is requested twice), so keep copying here rather than moving.
     for (auto pos : result_positions)
         if (execution_context.columns[pos].column)
             res.insert(execution_context.columns[pos]);
 
-    for (auto && item : block)
-        res.insert(std::move(item));
+    /// Carry through the input columns that were not consumed as action inputs.
+    /// `project_inputs`/`allow_duplicates_in_input` drop all inputs; otherwise keep the ones whose
+    /// block position was not bound to a required input (i.e. is not present in `inputs_pos`).
+    ///
+    /// Previously the consumed inputs were removed with `Block::erase` one by one. Each such erase is
+    /// O(columns) (a vector shift plus a full rescan of `index_by_name` to fix up positions), so the
+    /// loop was O(columns^2) overall — pathological for very wide inputs, e.g. the hundreds of QBit
+    /// bit-plane sub-columns fed into a single `*DistanceTransposed` call. Build the surviving columns
+    /// in a single pass instead, without ever mutating `block`'s name index.
+    if (!project_inputs && !allow_duplicates_in_input)
+    {
+        std::vector<bool> consumed(block.columns(), false);
+        for (auto input : execution_context.inputs_pos)
+            if (input >= 0)
+                consumed[input] = true;
+
+        size_t pos = 0;
+        for (auto && item : block)
+        {
+            if (!consumed[pos])
+                res.insert(std::move(item));
+            ++pos;
+        }
+    }
 
     block.swap(res);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reduce CPU overhead of expression evaluation for queries with very many columns. The motivating case is vector search over a `QBit` column declared with a small stride (e.g. `QBit(BFloat16, 768, 16)`): each vector is stored as hundreds of `FixedString` bit-plane sub-columns, all of which are passed as arguments to a single `dotProductTransposed`/`*DistanceTransposed` call. Profiling such a query showed that almost all time was spent not in the distance computation but in per-block, per-column bookkeeping.

### Description

Three independent hotspots, each triggered by an expression carrying a very large number of columns:

1. **`ExpressionActions::execute` — `O(columns²)` input removal.** After running the actions, the consumed input columns were removed from the block with `Block::erase` one at a time. Each `Block::eraseImpl` shifts the column vector and rescans the entire `index_by_name` map, so removing *N* inputs is `O(N²)`. This is now a single pass that builds the surviving columns using a `consumed` bitmask, without mutating the block's name index.

2. **`Block::erase(const std::set<size_t> &)` — `O(columns · erased)`.** It called the single-position `erase` in a loop. Replaced with one compaction pass plus a single index rebuild (`O(columns)`).

3. **`IExecutableFunction::execute` — redundant argument-list copies.** The replicated, sparse and low-cardinality layers each did `auto copy = arguments;` *before* checking whether any argument actually needed conversion, plus a `recursiveRemoveLowCardinality` pass. For an argument list with hundreds of columns these copies dominate. Each layer now scans first and passes the original `arguments` through unchanged when no argument is replicated / sparse / low-cardinality (always the case for the `FixedString` bit planes above). Low-cardinality is detected via the argument types (a column is low-cardinality iff its type is), which is cheap and preserves the previous behavior exactly.

The execution core (`executeAction`) already works purely by position; only these boundary steps used names / `Block` operations that scale poorly with the column count.

Results are unchanged. Verified byte-identical output against the unpatched build across LowCardinality, Sparse, nested-LowCardinality, `arrayJoin`, `Nullable`, constant and many-argument expressions, and for `dotProductTransposed`. On a synthetic expression whose cost is dominated by this per-block overhead the change is ~2.2× faster; the end-to-end win on real vector-search queries is best measured by the performance tests / a release build.
