### PR TITLE
Reduce per-block overhead in expression execution (wide inputs + positional ExpressionTransform)

### DIFF
--- a/src/Columns/ColumnSparse.cpp
+++ b/src/Columns/ColumnSparse.cpp
@@ -981,6 +981,26 @@ ColumnPtr recursiveRemoveSparse(const ColumnPtr & column)
     return column->convertToFullColumnIfSparse();
 }
 
+bool recursiveHasSparse(const ColumnPtr & column)
+{
+    if (!column)
+        return false;
+
+    if (const auto * column_replicated = typeid_cast<const ColumnReplicated *>(column.get()))
+        return recursiveHasSparse(column_replicated->getNestedColumn());
+
+    if (const auto * column_tuple = typeid_cast<const ColumnTuple *>(column.get()))
+    {
+        for (const auto & element : column_tuple->getColumns())
+            if (recursiveHasSparse(element))
+                return true;
+
+        return false;
+    }
+
+    return column->isSparse();
+}
+
 ColumnPtr removeSpecialRepresentations(const ColumnPtr & column)
 {
     if (!column)

--- a/src/Columns/ColumnSparse.h
+++ b/src/Columns/ColumnSparse.h
@@ -265,6 +265,10 @@ private:
 
 ColumnPtr recursiveRemoveSparse(const ColumnPtr & column);
 
+/// Returns true if `recursiveRemoveSparse` would change `column`, i.e. there is a sparse column
+/// either at the top level or nested inside a Tuple or Replicated column. Does not allocate.
+bool recursiveHasSparse(const ColumnPtr & column);
+
 /// Remove all special representations (for now Sparse and Replicated).
 ColumnPtr removeSpecialRepresentations(const ColumnPtr & column);
 

--- a/src/Core/Block.cpp
+++ b/src/Core/Block.cpp
@@ -249,8 +249,33 @@ void Block::insertUnique(ColumnWithTypeAndName elem)
 
 void Block::erase(const std::set<size_t> & positions)
 {
-    for (auto it = positions.rbegin(); it != positions.rend(); ++it)
-        erase(*it);
+    if (positions.empty())
+        return;
+
+    if (*positions.rbegin() >= data.size())
+        throw Exception(ErrorCodes::POSITION_OUT_OF_BOUND, "Position out of bound in Block::erase(), max position = {}",
+            data.empty() ? 0 : data.size() - 1);
+
+    /// Compact `data` in a single pass, dropping the erased positions, then rebuild the name index once.
+    /// This is O(columns) instead of O(columns * erased) that repeated single-position erases would cost.
+    size_t next = 0;
+    auto pos_it = positions.begin();
+    for (size_t i = 0; i < data.size(); ++i)
+    {
+        if (pos_it != positions.end() && *pos_it == i)
+        {
+            ++pos_it;
+            continue;
+        }
+        if (next != i)
+            data[next] = std::move(data[i]);
+        ++next;
+    }
+    data.resize(next);
+
+    index_by_name.clear();
+    for (size_t i = 0; i < data.size(); ++i)
+        index_by_name.emplace(data[i].name, i);
 }
 
 

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -464,10 +464,10 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
     ColumnPtr result;
     if (useDefaultImplementationForLowCardinalityColumns())
     {
-        ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
-
         if (const auto * res_low_cardinality_type = typeid_cast<const DataTypeLowCardinality *>(result_type.get()))
         {
+            ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
+
             bool can_be_executed_on_default_arguments = canBeExecutedOnDefaultArguments();
 
             const auto & dictionary_type = res_low_cardinality_type->getDictionaryType();
@@ -497,6 +497,23 @@ ColumnPtr IExecutableFunction::executeWithoutSparseColumns(
         }
         else
         {
+            /// Fast path: detect low-cardinality via types only (a column is low-cardinality iff its type
+            /// is), which is cheap for scalar types and lets us avoid copying/converting the (potentially
+            /// very wide) argument list when nothing is low-cardinality.
+            bool has_low_cardinality = false;
+            for (const auto & argument : arguments)
+            {
+                if (recursiveRemoveLowCardinality(argument.type).get() != argument.type.get())
+                {
+                    has_low_cardinality = true;
+                    break;
+                }
+            }
+
+            if (!has_low_cardinality)
+                return executeWithoutLowCardinalityColumns(arguments, result_type, input_rows_count, dry_run);
+
+            ColumnsWithTypeAndName columns_without_low_cardinality = arguments;
             convertLowCardinalityColumnsToFull(columns_without_low_cardinality);
             result = executeWithoutLowCardinalityColumns(columns_without_low_cardinality, result_type, input_rows_count, dry_run);
         }
@@ -514,6 +531,21 @@ ColumnPtr IExecutableFunction::execute(
 
     if (useDefaultImplementationForReplicatedColumns())
     {
+        /// Fast path: with no replicated columns there is nothing to convert, so skip copying the
+        /// (potentially very wide) argument list and pass it straight through.
+        bool has_replicated_column = false;
+        for (const auto & argument : arguments)
+        {
+            if (typeid_cast<const ColumnReplicated *>(argument.column.get()))
+            {
+                has_replicated_column = true;
+                break;
+            }
+        }
+
+        if (!has_replicated_column)
+            return executeWithoutReplicatedColumns(arguments, result_type, input_rows_count, dry_run);
+
         /// If we have only constants and replicated columns with the same indexes
         /// we can execute function on nested columns and create replicated column
         /// from the result using common indexes.
@@ -593,10 +625,12 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
         size_t num_sparse_columns = 0;
         size_t num_full_columns = 0;
         size_t sparse_column_position = 0;
+        bool has_any_sparse_column = false;
 
         for (size_t i = 0; i < arguments.size(); ++i)
         {
             const auto * column_sparse = checkAndGetColumn<ColumnSparse>(arguments[i].column.get());
+            has_any_sparse_column |= (column_sparse != nullptr);
             /// In rare case, when sparse column doesn't have default values,
             /// it's more convenient to convert it to full before execution of function.
             if (column_sparse && column_sparse->getNumberOfDefaultRows())
@@ -609,6 +643,11 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
                 ++num_full_columns;
             }
         }
+
+        /// Fast path: with no sparse columns there is nothing to convert, so skip copying the
+        /// (potentially very wide) argument list and pass it straight through.
+        if (!has_any_sparse_column)
+            return executeWithoutSparseColumns(arguments, result_type, input_rows_count, dry_run);
 
         auto columns_without_sparse = arguments;
         if (num_sparse_columns == 1 && num_full_columns == 0)

--- a/src/Functions/IFunction.cpp
+++ b/src/Functions/IFunction.cpp
@@ -630,7 +630,9 @@ ColumnPtr IExecutableFunction::executeWithoutReplicatedColumns(
         for (size_t i = 0; i < arguments.size(); ++i)
         {
             const auto * column_sparse = checkAndGetColumn<ColumnSparse>(arguments[i].column.get());
-            has_any_sparse_column |= (column_sparse != nullptr);
+            /// A sparse column may also be nested inside a Tuple or Replicated column, in which case
+            /// `recursiveRemoveSparse` (used below) still has to convert it, so detect it recursively.
+            has_any_sparse_column |= recursiveHasSparse(arguments[i].column);
             /// In rare case, when sparse column doesn't have default values,
             /// it's more convenient to convert it to full before execution of function.
             if (column_sparse && column_sparse->getNumberOfDefaultRows())

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -891,6 +891,101 @@ void ExpressionActions::execute(
     num_rows = execution_context.num_rows;
 }
 
+std::vector<ssize_t> ExpressionActions::getInputPositions(const Block & header) const
+{
+    std::vector<ssize_t> inputs_pos(required_columns.size(), -1);
+
+    for (size_t pos = 0; pos < header.columns(); ++pos)
+    {
+        auto it = input_positions.find(header.getByPosition(pos).name);
+        if (it != input_positions.end())
+        {
+            for (auto input_pos : it->second)
+            {
+                if (inputs_pos[input_pos] < 0)
+                {
+                    inputs_pos[input_pos] = pos;
+                    break;
+                }
+            }
+        }
+    }
+
+    return inputs_pos;
+}
+
+Columns ExpressionActions::executeOnColumns(
+    Columns columns,
+    const Block & header,
+    const std::vector<ssize_t> & input_positions_for_header,
+    size_t & num_rows,
+    bool dry_run,
+    CheckCancelled check_cancelled) const
+{
+    /// Build the inputs positionally from the fixed header; no `Block` (and hence no name index) is created.
+    ColumnsWithTypeAndName inputs;
+    inputs.reserve(columns.size());
+    for (size_t i = 0; i < columns.size(); ++i)
+    {
+        const auto & structure = header.getByPosition(i);
+        inputs.emplace_back(std::move(columns[i]), structure.type, structure.name);
+    }
+
+    ExecutionContext execution_context
+    {
+        .inputs = inputs,
+        .num_rows = num_rows,
+    };
+    /// Fixed header => the input mapping is the same for every chunk and is precomputed by the caller.
+    execution_context.inputs_pos = input_positions_for_header;
+    execution_context.columns.resize(num_columns);
+
+    for (const auto & action : actions)
+    {
+        try
+        {
+            executeAction(action, execution_context, dry_run, /*allow_duplicates_in_input=*/false, settings.enable_lazy_columns_replication);
+            checkLimits(execution_context.columns);
+        }
+        catch (Exception & e)
+        {
+            e.addMessage(fmt::format("while executing '{}'", action.toString()));
+            throw;
+        }
+
+        if (check_cancelled && check_cancelled())
+        {
+            num_rows = 0;
+            auto empty = sample_block.cloneEmptyColumns();
+            return Columns(std::make_move_iterator(empty.begin()), std::make_move_iterator(empty.end()));
+        }
+    }
+
+    Columns res;
+    res.reserve(result_positions.size() + inputs.size());
+
+    /// Result columns first, in `sample_block`/`result_positions` order (a position may repeat).
+    for (auto pos : result_positions)
+        if (execution_context.columns[pos].column)
+            res.push_back(execution_context.columns[pos].column);
+
+    /// Then the input columns that were not consumed as action inputs (unless the inputs are projected away).
+    if (!project_inputs)
+    {
+        std::vector<bool> consumed(inputs.size(), false);
+        for (auto input : execution_context.inputs_pos)
+            if (input >= 0)
+                consumed[input] = true;
+
+        for (size_t i = 0; i < inputs.size(); ++i)
+            if (!consumed[i])
+                res.push_back(inputs[i].column);
+    }
+
+    num_rows = execution_context.num_rows;
+    return res;
+}
+
 void ExpressionActions::execute(Block & block, bool dry_run, bool allow_duplicates_in_input, CheckCancelled check_cancelled) const
 {
     size_t num_rows = block.rows();

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -922,6 +922,16 @@ Columns ExpressionActions::executeOnColumns(
     bool dry_run,
     CheckCancelled check_cancelled) const
 {
+    /// The chunk must match the fixed input header positionally. The block-based path validated this
+    /// implicitly via `Block::cloneWithColumns`; keep the same guard here, because both `header.getByPosition`
+    /// and the cached `input_positions_for_header` index the inputs by position without bounds checks.
+    if (columns.size() != header.columns())
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Cannot execute expression on columns positionally: the input header [{}] has {} columns, "
+            "but {} columns were given",
+            header.dumpStructure(), header.columns(), columns.size());
+
     /// Build the inputs positionally from the fixed header; no `Block` (and hence no name index) is created.
     ColumnsWithTypeAndName inputs;
     inputs.reserve(columns.size());

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -852,32 +852,39 @@ void ExpressionActions::execute(
         }
     }
 
-    if (project_inputs)
-    {
-        block.clear();
-    }
-    else if (allow_duplicates_in_input)
-    {
-        /// This case is the same as when the input is projected
-        /// since we do not need any input columns.
-        block.clear();
-    }
-    else
-    {
-        ::sort(execution_context.inputs_pos.rbegin(), execution_context.inputs_pos.rend());
-        for (auto input : execution_context.inputs_pos)
-            if (input >= 0)
-                block.erase(input);
-    }
-
     Block res;
+    res.reserve(result_positions.size() + block.columns());
 
+    /// Note: `result_positions` may reference the same column position more than once
+    /// (e.g. when an output node is requested twice), so keep copying here rather than moving.
     for (auto pos : result_positions)
         if (execution_context.columns[pos].column)
             res.insert(execution_context.columns[pos]);
 
-    for (auto && item : block)
-        res.insert(std::move(item));
+    /// Carry through the input columns that were not consumed as action inputs.
+    /// `project_inputs`/`allow_duplicates_in_input` drop all inputs; otherwise keep the ones whose
+    /// block position was not bound to a required input (i.e. is not present in `inputs_pos`).
+    ///
+    /// Previously the consumed inputs were removed with `Block::erase` one by one. Each such erase is
+    /// O(columns) (a vector shift plus a full rescan of `index_by_name` to fix up positions), so the
+    /// loop was O(columns^2) overall — pathological for very wide inputs, e.g. the hundreds of QBit
+    /// bit-plane sub-columns fed into a single `*DistanceTransposed` call. Build the surviving columns
+    /// in a single pass instead, without ever mutating `block`'s name index.
+    if (!project_inputs && !allow_duplicates_in_input)
+    {
+        std::vector<bool> consumed(block.columns(), false);
+        for (auto input : execution_context.inputs_pos)
+            if (input >= 0)
+                consumed[input] = true;
+
+        size_t pos = 0;
+        for (auto && item : block)
+        {
+            if (!consumed[pos])
+                res.insert(std::move(item));
+            ++pos;
+        }
+    }
 
     block.swap(res);
 

--- a/src/Interpreters/ExpressionActions.h
+++ b/src/Interpreters/ExpressionActions.h
@@ -113,6 +113,24 @@ public:
     void
     execute(Block & block, bool dry_run = false, bool allow_duplicates_in_input = false, CheckCancelled check_cancelled = nullptr) const;
 
+    /// Positional execution for callers whose input structure is fixed (e.g. ExpressionTransform).
+    ///
+    /// `getInputPositions(header)` precomputes, once, the mapping (required input slot -> position in
+    /// `header`); the result is passed to `executeOnColumns` on every chunk. This avoids the per-chunk
+    /// name lookups and the construction of a `Block` name index (`index_by_name`) on both the input and
+    /// the output, which is significant when the header has very many columns.
+    ///
+    /// `executeOnColumns` consumes `columns` (chunk data, in `header` order) and returns the result
+    /// columns in `getSampleBlock()` order. It assumes `allow_duplicates_in_input == false`.
+    std::vector<ssize_t> getInputPositions(const Block & header) const;
+    Columns executeOnColumns(
+        Columns columns,
+        const Block & header,
+        const std::vector<ssize_t> & input_positions_for_header,
+        size_t & num_rows,
+        bool dry_run = false,
+        CheckCancelled check_cancelled = nullptr) const;
+
     bool hasArrayJoin() const;
     void assertDeterministic() const;
 

--- a/src/Processors/Transforms/ExpressionTransform.cpp
+++ b/src/Processors/Transforms/ExpressionTransform.cpp
@@ -19,6 +19,7 @@ ExpressionTransform::ExpressionTransform(
     SharedHeader header_, ExpressionActionsPtr expression_, RuntimeDataflowStatisticsCacheUpdaterPtr updater_)
     : ISimpleTransform(header_, std::make_shared<const Block>(transformHeader(*header_, expression_->getActionsDAG())), false)
     , expression(std::move(expression_))
+    , input_positions(expression->getInputPositions(*header_))
     , updater(std::move(updater_))
 {
 }
@@ -26,14 +27,22 @@ ExpressionTransform::ExpressionTransform(
 void ExpressionTransform::transform(Chunk & chunk)
 {
     size_t num_rows = chunk.getNumRows();
-    auto block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
 
-    expression->execute(block, num_rows, false, false, [this]() { return isCancelled(); });
-
-    chunk.setColumns(block.getColumns(), num_rows);
-
+    /// The statistics updater needs the full output Block, so fall back to the block-based path when it is set.
     if (updater)
+    {
+        auto block = getInputPort().getHeader().cloneWithColumns(chunk.detachColumns());
+        expression->execute(block, num_rows, false, false, [this]() { return isCancelled(); });
+        chunk.setColumns(block.getColumns(), num_rows);
         updater->recordOutputChunk(chunk, block);
+        return;
+    }
+
+    /// Fast path: run positionally against the fixed input header, avoiding per-chunk Block name-index work.
+    auto columns = expression->executeOnColumns(
+        chunk.detachColumns(), getInputPort().getHeader(), input_positions, num_rows, false, [this]() { return isCancelled(); });
+
+    chunk.setColumns(std::move(columns), num_rows);
 }
 
 void ExpressionTransform::onCancel() noexcept

--- a/src/Processors/Transforms/ExpressionTransform.h
+++ b/src/Processors/Transforms/ExpressionTransform.h
@@ -3,6 +3,8 @@
 #include <Processors/Transforms/ExceptionKeepingTransform.h>
 #include <Core/Block_fwd.h>
 
+#include <vector>
+
 namespace DB
 {
 
@@ -36,6 +38,10 @@ protected:
 
 private:
     ExpressionActionsPtr expression;
+
+    /// Mapping from required input slot to input-header position, precomputed once (the input header is fixed).
+    /// Lets transform() run the expression positionally without rebuilding a Block name index per chunk.
+    std::vector<ssize_t> input_positions;
 
     RuntimeDataflowStatisticsCacheUpdaterPtr updater;
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reduce CPU overhead of expression evaluation for queries with a large number of columns (e.g. vector search over a `QBit` column with a small stride, where each vector expands into hundreds of bit-plane sub-columns that are all fed into a single `*DistanceTransposed` call).

### Description

This PR is a superset of #109378 — it contains all of its commits plus one more (the positional `ExpressionTransform` optimization), and targets `master`.

**Commit 1 — reduce per-block overhead in expression execution for wide inputs** (same as #109378):
* `ExpressionActions::execute` removed consumed input columns with `Block::erase` one by one; each erase shifts the column vector and rescans `index_by_name`, so it was O(columns²). Build the surviving columns in a single pass instead.
* `Block::erase(const std::set<size_t> &)` did repeated single-position erases (O(columns · erased)); do a single compaction pass and one index rebuild (O(columns)).
* `IExecutableFunction::execute` copied the whole argument list up to three times (the replicated, sparse and low-cardinality layers) even when no argument needs conversion. Scan first and pass the arguments through unchanged in that case.

**Commit 2 — run `ExpressionTransform` positionally to avoid per-chunk `Block` reindexing:**
* `ExpressionTransform::transform` rebuilt a `Block` for each chunk via `cloneWithColumns` (building a fresh `index_by_name`), and `ExpressionActions::execute` then matched inputs by name — both proportional to the column count and hashing/copying column names every chunk.
* Since a transform's input header is fixed, the input→required-slot mapping is constant. Precompute it once (`ExpressionActions::getInputPositions`) and add `ExpressionActions::executeOnColumns`, which runs the actions positionally over the chunk's columns and returns the result columns directly, without constructing a `Block` name index on the input or the output. `ExpressionTransform` uses this fast path and falls back to the block-based path when a dataflow-statistics updater is attached.

The execution core (`executeAction`) was already positional; only these boundary steps used name-based `Block` operations.

**Commit 3 — fix a sparse-column regression introduced by Commit 1** (same as #109378):
* The new fast path in `IExecutableFunction::executeWithoutReplicatedColumns` detected sparse arguments only at the top level, whereas the original `convertSparseColumnsToFull` uses `recursiveRemoveSparse`, which also converts sparse columns nested inside `Tuple`/`Replicated`. An all-default `Point` (a `Tuple(Float64, Float64)` with sparse sub-columns) reached `pointInPolygon` unconverted, producing `Unknown numeric column type: DB::ColumnSparse`. Added `recursiveHasSparse` (mirroring `recursiveRemoveSparse`'s recursion) and used it to decide whether any argument needs full conversion.

**Commit 4 — restore the chunk/header arity guard in the positional path:**
* The block-based path validated the chunk against the input header implicitly via `Block::cloneWithColumns`, which throws a `LOGICAL_ERROR` when the column counts differ. The positional `executeOnColumns` indexes both `header.getByPosition` and the cached input-position map by position, and neither bounds-checks, so an arity drift would be undefined behavior instead of a clean exception. Restored the `columns.size() == header.columns()` check at the start of `executeOnColumns`, making the positional path equivalent to the block-based one on the error path as well.

Results are unchanged. Verified byte-identical output against the base build across low-cardinality, sparse, nested-low-cardinality, `arrayJoin` (with row-count changes and survivor replication), projections, duplicate output columns and `dotProductTransposed`. On a synthetic expression whose cost is dominated by this per-block overhead the two optimizations together are ~2.2× faster; the end-to-end effect on real queries is best measured by the performance tests.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.525` (included in `26.7` and later)
<!-- ch-version-info:end -->