### PR TITLE
Potentially faster FixedString compare

### DIFF
--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -182,13 +182,13 @@ Int64 ColumnFixedString::compareTrackAt(size_t p1, size_t p2, const IColumn & rh
     const auto * lhs_data = chars.data() + p1 * n;
     const auto * rhs_data = rhs.chars.data() + p2 * n;
 
-    Int64 res = memcmpSmallAllowOverflow15(lhs_data, rhs_data, n);
+    Int64 res = compare(lhs_data, rhs_data);
 
     if (res < 0)
     {
         const auto * lhs_end = chars.data() + chars.size();
         lhs_data += n;
-        while (lhs_data < lhs_end && (memcmpSmallAllowOverflow15(lhs_data, rhs_data, n) < 0))
+        while (lhs_data < lhs_end && (compare(lhs_data, rhs_data) < 0))
         {
             --res;
             lhs_data += n;
@@ -198,7 +198,7 @@ Int64 ColumnFixedString::compareTrackAt(size_t p1, size_t p2, const IColumn & rh
     {
         const auto * rhs_end = rhs.chars.data() + rhs.chars.size();
         rhs_data += n;
-        while (rhs_data < rhs_end && (memcmpSmallAllowOverflow15(lhs_data, rhs_data, n) > 0))
+        while (rhs_data < rhs_end && (compare(lhs_data, rhs_data) > 0))
         {
             ++res;
             rhs_data += n;
@@ -246,7 +246,7 @@ struct ColumnFixedString::ComparatorBase
 
     ALWAYS_INLINE int compare(size_t lhs, size_t rhs) const
     {
-        int res = memcmpSmallAllowOverflow15(parent.chars.data() + lhs * parent.n, parent.chars.data() + rhs * parent.n, parent.n);
+        int res = parent.compare(parent.chars.data() + lhs * parent.n, parent.chars.data() + rhs * parent.n);
 
         return res;
     }
@@ -271,7 +271,7 @@ size_t ColumnFixedString::getEqualRangeEndAssumeSorted(size_t begin, size_t end,
         return begin;
 
     const UInt8 * ref = chars.data() + begin * n;
-    auto equals = [&](size_t i) { return 0 == memcmpSmallAllowOverflow15(chars.data() + i * n, ref, n); };
+    auto equals = [&](size_t i) { return 0 == compare(chars.data() + i * n, ref); };
 
     /// A fixed-size memcmp is cheap, so use a longer linear probe (the default is 8).
     static constexpr size_t linear_probe = 16;

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -143,6 +143,14 @@ public:
 
     void updateHashFast(SipHash & hash) const override;
 
+    ALWAYS_INLINE int compare(const UInt8 * a, const UInt8 * b) const
+    {
+        if (n & 0x0F)
+            return memcmpSmallAllowOverflow15(a, b, n);
+        else
+            return memcmpSmallMultipleOf16(a, b, n);
+    }
+
 #if !defined(DEBUG_OR_SANITIZER_BUILD)
     int compareAt(size_t p1, size_t p2, const IColumn & rhs_, int /*nan_direction_hint*/) const override
 #else
@@ -151,7 +159,7 @@ public:
     {
         const ColumnFixedString & rhs = assert_cast<const ColumnFixedString &>(rhs_);
         chassert(this->n == rhs.n);
-        return memcmpSmallAllowOverflow15(chars.data() + p1 * n, rhs.chars.data() + p2 * n, n);
+        return compare(chars.data() + p1 * n, rhs.chars.data() + p2 * n);
     }
 
     [[nodiscard]] Int64 compareTrackAt(size_t p1, size_t p2, const IColumn & rhs_, int /*nan_direction_hint*/) const final;

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -147,6 +147,8 @@ public:
     {
         if (n & 0x0F)
             return memcmpSmallAllowOverflow15(a, b, n);
+        else if (n == 16)
+            return memcmp16(a, b);
         else
             return memcmpSmallMultipleOf16(a, b, n);
     }

--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -347,8 +347,16 @@ struct StringComparisonImpl
         else if (a_n == b_n)
         {
             size_t size = a_data.size();
-            for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
-                c[j] = Op::apply(memcmpSmallAllowOverflow15(a_data.data() + i, b_data.data() + i, a_n), 0);
+            if (a_n & 0x0F)
+            {
+                for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
+                    c[j] = Op::apply(memcmpSmallAllowOverflow15(a_data.data() + i, b_data.data() + i, a_n), 0);
+            }
+            else
+            {
+                for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
+                    c[j] = Op::apply(memcmpSmallMultipleOf16(a_data.data() + i, b_data.data() + i, a_n), 0);
+            }
         }
         else
         {
@@ -371,8 +379,16 @@ struct StringComparisonImpl
         else if (a_n == b_size)
         {
             size_t size = a_data.size();
-            for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
-                c[j] = Op::apply(memcmpSmallAllowOverflow15(a_data.data() + i, b_data.data(), a_n), 0);
+            if (a_n & 0x0F)
+            {
+                for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
+                    c[j] = Op::apply(memcmpSmallAllowOverflow15(a_data.data() + i, b_data.data(), a_n), 0);
+            }
+            else
+            {
+                for (size_t i = 0, j = 0; i < size; i += a_n, ++j)
+                    c[j] = Op::apply(memcmpSmallMultipleOf16(a_data.data() + i, b_data.data(), a_n), 0);
+            }
         }
         else
         {

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -57,7 +57,12 @@
     <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; a)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; a)</query>
 
-    <!-- ORDER BY : ColumnFixedString::compareAt and its sort comparator on equal-prefix data. -->
+    <!-- ORDER BY : ColumnFixedString::compareAt and its sort comparator on equal-prefix data.
+         `FixedString(16)` is included here specifically: it is the only surface that reaches the
+         new `n == 16 -> memcmp16` branch of `ColumnFixedString::compare`, since the `<` / `>`
+         queries above go through `StringComparisonImpl`, which dispatches `N == 16` to
+         `memcmpSmallMultipleOf16` rather than to `ColumnFixedString::compare`. -->
+    <query>SELECT a FROM fixstr_cmp_16 ORDER BY a FORMAT Null</query>
     <query>SELECT a FROM fixstr_cmp_32 ORDER BY a FORMAT Null</query>
     <query>SELECT a FROM fixstr_cmp_64 ORDER BY a FORMAT Null</query>
     <query>SELECT a FROM fixstr_cmp_128 ORDER BY a FORMAT Null</query>

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -47,9 +47,9 @@
 
     <!-- string vs constant -->
     <query>WITH toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(0)), 16) AS x SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; x)</query>
-    <query>WITH toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number)), 32) AS x SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; x)</query>
-    <query>WITH toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(number)), 64) AS x SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; x)</query>
-    <query>WITH toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(number)), 128) AS x SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(0)), 32) AS x SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(0)), 64) AS x SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(0)), 128) AS x SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; x)</query>
     
     <!-- ORDER BY : ColumnFixedString::compareAt and its sort comparator on equal-prefix data.
          `FixedString(16)` is included here specifically: it is the only surface that reaches the

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -12,7 +12,8 @@
         fill query and the measured queries are dominated by the comparison itself.
 
         Two comparison surfaces changed by this PR are exercised:
-          - `<` / `>` go through `StringComparisonImpl`;
+          - `<` / `>` go through `StringComparisonImpl`, both its column-vs-column and its
+            column-vs-constant (`WHERE a < '...'`) branches, which this PR changes independently;
           - `ORDER BY` goes through `ColumnFixedString::compareAt` and its sort comparator.
         `=` / `!=` are intentionally not benchmarked: they use `memequalSmallAllowOverflow15`, which
         this PR does not touch.
@@ -37,6 +38,18 @@
     <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &gt; b)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; b)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &gt; b)</query>
+
+    <!-- `<` / `>` against a FixedString constant : StringComparisonImpl vector_constant branch
+         (`WHERE a < '...'`). The constant shares the same `_` prefix, so the compare scans every
+         16-byte block before the difference in the last one, just like the column-vs-column case. -->
+    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(toUInt64(5000000))), 16))</query>
+    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(toUInt64(5000000))), 16))</query>
+    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(toUInt64(5000000))), 32))</query>
+    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(toUInt64(5000000))), 32))</query>
+    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(toUInt64(5000000))), 64))</query>
+    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(toUInt64(5000000))), 64))</query>
+    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(toUInt64(5000000))), 128))</query>
+    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(toUInt64(5000000))), 128))</query>
 
     <!-- Equal strings: the compare scans every 16-byte block before returning 0. -->
     <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; a)</query>

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -45,6 +45,12 @@
     <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; a)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; a)</query>
 
+    <!-- string vs constant -->
+    <query>WITH toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(0)), 16) AS x SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number)), 32) AS x SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(number)), 64) AS x SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; x)</query>
+    <query>WITH toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(number)), 128) AS x SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; x)</query>
+    
     <!-- ORDER BY : ColumnFixedString::compareAt and its sort comparator on equal-prefix data.
          `FixedString(16)` is included here specifically: it is the only surface that reaches the
          new `n == 16 -> memcmp16` branch of `ColumnFixedString::compare`, since the `<` / `>`

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -1,17 +1,56 @@
 <test>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) &lt; toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) &gt; toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) = toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+    <!--
+        This PR routes `FixedString(N)` comparison through `memcmpSmallMultipleOf16` / `memcmp16`
+        when `N` is a multiple of 16. Its advantage over `memcmpSmallAllowOverflow15` only shows up
+        when several 16-byte blocks actually have to be compared, so every stored value shares a long
+        common prefix (a run of `_`) and keeps the varying part (`reinterpretAsFixedString(number)`,
+        8 bytes) in the last 16-byte block. Column `a` holds `number`, column `b` holds `number + 1`,
+        so `a` and `b` are identical except in their final block, and comparing them scans the whole
+        prefix block by block.
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) &lt; toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) &gt; toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) = toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+        The values are materialized in tables so the (heavy) string construction happens once in the
+        fill query and the measured queries are dominated by the comparison itself.
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) &lt; toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) &gt; toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) = toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+        Two comparison surfaces changed by this PR are exercised:
+          - `<` / `>` go through `StringComparisonImpl`;
+          - `ORDER BY` goes through `ColumnFixedString::compareAt` and its sort comparator.
+        `=` / `!=` are intentionally not benchmarked: they use `memequalSmallAllowOverflow15`, which
+        this PR does not touch.
+    -->
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) &lt; toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) &gt; toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) = toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+    <create_query>CREATE TABLE fixstr_cmp_16 (a FixedString(16), b FixedString(16)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_32 (a FixedString(32), b FixedString(32)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_64 (a FixedString(64), b FixedString(64)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_128 (a FixedString(128), b FixedString(128)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+
+    <fill_query>INSERT INTO fixstr_cmp_16 SELECT toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(number)), 16), toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(number + 1)), 16) FROM numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO fixstr_cmp_32 SELECT toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number)), 32), toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number + 1)), 32) FROM numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO fixstr_cmp_64 SELECT toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(number)), 64), toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(number + 1)), 64) FROM numbers(10000000)</fill_query>
+    <fill_query>INSERT INTO fixstr_cmp_128 SELECT toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(number)), 128), toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(number + 1)), 128) FROM numbers(10000000)</fill_query>
+
+    <!-- `<` / `>` : StringComparisonImpl; the shared prefix forces a full multi-block compare. -->
+    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &gt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &gt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &gt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; b)</query>
+    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &gt; b)</query>
+
+    <!-- Equal strings: the compare scans every 16-byte block before returning 0. -->
+    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; a)</query>
+    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; a)</query>
+    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; a)</query>
+    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; a)</query>
+
+    <!-- ORDER BY : ColumnFixedString::compareAt and its sort comparator on equal-prefix data. -->
+    <query>SELECT a FROM fixstr_cmp_32 ORDER BY a FORMAT Null</query>
+    <query>SELECT a FROM fixstr_cmp_64 ORDER BY a FORMAT Null</query>
+    <query>SELECT a FROM fixstr_cmp_128 ORDER BY a FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS fixstr_cmp_16</drop_query>
+    <drop_query>DROP TABLE IF EXISTS fixstr_cmp_32</drop_query>
+    <drop_query>DROP TABLE IF EXISTS fixstr_cmp_64</drop_query>
+    <drop_query>DROP TABLE IF EXISTS fixstr_cmp_128</drop_query>
 </test>

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -1,17 +1,17 @@
 <test>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) < toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) > toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) &lt; toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) &gt; toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
     <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) = toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) < toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) > toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) &lt; toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) &gt; toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
     <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) = toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) < toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) > toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) &lt; toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) &gt; toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
     <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) = toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
 
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) < toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
-    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) > toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) &lt; toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) &gt; toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
     <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) = toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
 </test>

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -1,0 +1,17 @@
+<test>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) < toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) > toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 16) = toFixedString(reinterpretAsFixedString(number + 1), 16))</query>
+
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) < toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) > toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 32) = toFixedString(reinterpretAsFixedString(number + 1), 32))</query>
+
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) < toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) > toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 64) = toFixedString(reinterpretAsFixedString(number + 1), 64))</query>
+
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) < toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) > toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+    <query>SELECT count() FROM numbers(100000000) WHERE NOT ignore(toFixedString( reinterpretAsFixedString(number), 128) = toFixedString(reinterpretAsFixedString(number + 1), 128))</query>
+</test>

--- a/tests/performance/fixed_string_comparison_x16.xml
+++ b/tests/performance/fixed_string_comparison_x16.xml
@@ -19,10 +19,10 @@
         this PR does not touch.
     -->
 
-    <create_query>CREATE TABLE fixstr_cmp_16 (a FixedString(16), b FixedString(16)) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query>CREATE TABLE fixstr_cmp_32 (a FixedString(32), b FixedString(32)) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query>CREATE TABLE fixstr_cmp_64 (a FixedString(64), b FixedString(64)) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query>CREATE TABLE fixstr_cmp_128 (a FixedString(128), b FixedString(128)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_16 (a FixedString(16), b FixedString(16)) ENGINE = Memory</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_32 (a FixedString(32), b FixedString(32)) ENGINE = Memory</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_64 (a FixedString(64), b FixedString(64)) ENGINE = Memory</create_query>
+    <create_query>CREATE TABLE fixstr_cmp_128 (a FixedString(128), b FixedString(128)) ENGINE = Memory</create_query>
 
     <fill_query>INSERT INTO fixstr_cmp_16 SELECT toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(number)), 16), toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(number + 1)), 16) FROM numbers(10000000)</fill_query>
     <fill_query>INSERT INTO fixstr_cmp_32 SELECT toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number)), 32), toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(number + 1)), 32) FROM numbers(10000000)</fill_query>
@@ -38,18 +38,6 @@
     <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &gt; b)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; b)</query>
     <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &gt; b)</query>
-
-    <!-- `<` / `>` against a FixedString constant : StringComparisonImpl vector_constant branch
-         (`WHERE a < '...'`). The constant shares the same `_` prefix, so the compare scans every
-         16-byte block before the difference in the last one, just like the column-vs-column case. -->
-    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(toUInt64(5000000))), 16))</query>
-    <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 8), reinterpretAsFixedString(toUInt64(5000000))), 16))</query>
-    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(toUInt64(5000000))), 32))</query>
-    <query>SELECT count() FROM fixstr_cmp_32 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 24), reinterpretAsFixedString(toUInt64(5000000))), 32))</query>
-    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(toUInt64(5000000))), 64))</query>
-    <query>SELECT count() FROM fixstr_cmp_64 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 56), reinterpretAsFixedString(toUInt64(5000000))), 64))</query>
-    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &lt; toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(toUInt64(5000000))), 128))</query>
-    <query>SELECT count() FROM fixstr_cmp_128 WHERE NOT ignore(a &gt; toFixedString(concat(repeat('_', 120), reinterpretAsFixedString(toUInt64(5000000))), 128))</query>
 
     <!-- Equal strings: the compare scans every 16-byte block before returning 0. -->
     <query>SELECT count() FROM fixstr_cmp_16 WHERE NOT ignore(a &lt; a)</query>


### PR DESCRIPTION
A PR to check if it would be faster to compare FixedStrings(x*16) with `memcmpSmallMultipleOf16`

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
slightly faster FixedString(x*16) compare
