### PR TITLE
Web UI: do not swallow Right/Enter when the completion is a no-op

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -7461,8 +7461,25 @@ query_area.addEventListener('keydown', (e) => {
         }
         return;
     }
+    /// The selected candidate whose full text equals the already-typed word (an "empty
+    /// completion" — same length as the prefix, since every candidate starts with it) would
+    /// accept to a no-op. In that case Right / Enter must keep their native meaning — move the
+    /// caret one character, or insert a newline — instead of being swallowed by a completion
+    /// that changes nothing. This matters e.g. after typing `f()` with the caret between `f`
+    /// and `(`: Right should step into the parens, not "accept" the already-complete `f`.
+    const selectedIsNoop = completionCandidates[completionSelected].length === completionPrefix.length;
+
     /// Plain Enter accepts the completion; Ctrl/Cmd+Enter is left alone so it still runs the query.
-    if (e.key === 'Tab' || e.key === 'ArrowRight' || (e.key === 'Enter' && !e.ctrlKey && !e.metaKey)) {
+    if (e.key === 'ArrowRight' || (e.key === 'Enter' && !e.ctrlKey && !e.metaKey)) {
+        if (selectedIsNoop) {
+            /// Nothing to accept — dismiss the list and let the key act natively.
+            closeCompletions();
+            return;
+        }
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        acceptCompletion(completionSelected);
+    } else if (e.key === 'Tab') {
         e.preventDefault();
         e.stopImmediatePropagation();
         acceptCompletion(completionSelected);


### PR DESCRIPTION
### Description

In the Web UI (`play.html`), the completion list sorts the exact match (the "empty completion" whose full text equals the already-typed word) first, so it is selected by default. Pressing <kbd>Right</kbd> or <kbd>Enter</kbd> then "accepted" that suggestion, which is a no-op, while the key had already been swallowed — so the caret did not move and no newline was inserted. This was misleading: accepting a suggestion that equals the typed word does nothing, yet it stole the key.

Now, when the currently selected suggestion equals the already-typed word, <kbd>Right</kbd> and <kbd>Enter</kbd> keep their native behavior (move the caret / insert a newline) and the completion list is dismissed. This matters e.g. after typing `f()` with the caret between `f` and `(`: <kbd>Right</kbd> now steps into the parens instead of doing nothing.

Genuine completions (a selected extension you navigated to) are accepted as before, and <kbd>Tab</kbd> still accepts unconditionally as the dedicated completion trigger.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI: pressing Right or Enter no longer gets swallowed by autocompletion when the selected suggestion is identical to the already-typed word; the key moves the caret or inserts a newline as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.520` (included in `26.7` and later)
<!-- ch-version-info:end -->