### PR TITLE
Fix flaky tests 03394_distributed_shuffle_join_with_aggregation and _with_in

### DIFF
--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_aggregation.sql
@@ -4,6 +4,9 @@
 SET explain_query_plan_default = 'legacy';
 SET max_rows_to_group_by = 0;
 SET distributed_plan_optimize_exchanges = 1;
+-- Pin off: statistics change the estimated group count, flipping the distributed aggregation
+-- strategy (Shuffle vs partial+merge) and thus the asserted plan.
+SET use_statistics = 0;
 
 DROP TABLE IF EXISTS test;
 CREATE TABLE test(path String, lang String, hits UInt64) ENGINE MergeTree() ORDER BY tuple();

--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_in.sql
@@ -3,6 +3,9 @@
 -- Reset the global max_rows_to_group_by; distributed aggregation rejects a nonzero limit.
 SET explain_query_plan_default = 'legacy';
 SET max_rows_to_group_by = 0;
+-- Pin off: statistics change the estimated group count, flipping the distributed aggregation
+-- strategy (Shuffle vs partial+merge) and thus the asserted plan.
+SET use_statistics = 0;
 
 DROP TABLE IF EXISTS test;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flakiness of `03394_distributed_shuffle_join_with_aggregation` and its sibling `03394_distributed_shuffle_join_with_in`, seen in `Stateless tests` runs under randomized settings (e.g. `amd_tsan`).

No related open issue found (checked GitHub issues for the test name and the flaky signature).

Root cause: the tests assert an exact distributed query plan via `EXPLAIN`. When CI randomization enables statistics (`use_statistics=1` + `materialize_statistics_on_insert=1` + a non-empty `auto_statistics_types`), the cost-based distributed planner reads column NDV / row estimates from the statistics estimator. In `tryMakeDistributedAggregation` (`src/Processors/QueryPlan/Optimizations/makeDistributed.cpp`) this changes the estimated group count and flips the aggregation strategy from `Shuffle` (`Aggregating` + `ShuffleExchange`) to partial+merge (`Aggregating (partial)` + `MergingAggregated` + `ScatterExchange`), so the asserted plan diverges from the reference. Query results are unaffected; only the `EXPLAIN` plan shape changes.

The whole statistics estimator path is gated on `use_statistics` (`estimateReadRowsCount` in `optimizeJoin.cpp`), so pinning `SET use_statistics = 0` makes the plan deterministic regardless of the statistics randomization. This mirrors `03357_join_pk_sharding` and `03279_join_choose_build_table`, which pin the same setting for the same reason (they also assert on the join/plan shape).

CI's own `--diagnose-random-settings` minimizer isolated the culprits on the failing `_with_aggregation` run (public PR #86353, `Stateless tests (amd_tsan, parallel, 2/2)`): `materialize_statistics_on_insert True` + `auto_statistics_types tdigest,minmax,basic` (36/36 fail with the settings, 51/51 pass without). Public report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=86353&sha=d03b55a32fff040b8dac9918793a53b3d868cd29&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29

`_with_in` is structurally identical to `_with_aggregation` (same table, same distributed settings, same `EXPLAIN` plan-shape assertion; only the subquery predicate differs) and shares the same `use_statistics`-gated code path, so it carries the same latent flake. Verified the `_with_in` `EXPLAIN` output is byte-identical with `use_statistics` 0 vs 1 (statistics materialized) and matches the committed `.reference`, so the pin does not change what the test asserts. The distributed shuffle-join plan flip is a property of CI's real multi-replica cluster and is not reproducible on a single node, so both variants are pinned preventively on the same proven code path.

Verified locally: the fixed `_with_aggregation` passes 100/100 under full settings randomization and 10/10 with randomization disabled.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.512` (included in `26.7` and later)
<!-- ch-version-info:end -->