### PR TITLE
Fix flaky test test_dictionaries_postgresql::test_invalidate_query

### DIFF
--- a/tests/integration/test_dictionaries_postgresql/test.py
+++ b/tests/integration/test_dictionaries_postgresql/test.py
@@ -9,6 +9,7 @@ from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import pg_pass
 from helpers.postgres_utility import get_postgres_conn
 from helpers.port_forward import PortForward
+from helpers.test_tools import assert_eq_with_retry
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
@@ -352,52 +353,63 @@ def test_invalidate_query(started_cluster):
     # invalidate query: SELECT value FROM test0 WHERE id = 0
     dict_name = "dict0"
     create_dict(table_name)
+
+    def last_update():
+        # 1970-01-01 00:00:00 means the dictionary was never updated yet.
+        return node1.query(
+            "SELECT toTimeZone(last_successful_update_time, 'UTC') "
+            f"FROM system.dictionaries WHERE name = '{dict_name}'"
+        ).strip()
+
+    def wait_baseline_settled():
+        # SYSTEM RELOAD does a forced full reload but does not run the invalidate
+        # query, so the stored invalidate response is left empty. The first
+        # periodic check then always sees a "modified" source and reloads once
+        # more. Wait until the invalidate baseline settles, i.e.
+        # last_successful_update_time stops advancing across a full check period,
+        # so subsequent "no update" checks are reliable.
+        prev = last_update()
+        while True:
+            time.sleep(7)  # dict lifetime is 1s and the periodic check runs every 5s
+            cur = last_update()
+            if cur == prev:
+                return cur
+            prev = cur
+
+    def dict_get(key):
+        return node1.query(
+            f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64({key}))"
+        ).strip()
+
     node1.query(f"SYSTEM RELOAD DICTIONARY {dict_name}")
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "0\n"
-    )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "1\n"
-    )
+    wait_baseline_settled()
+    assert dict_get(0) == "0"
+    assert dict_get(1) == "1"
 
-    # update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value+1 WHERE id = 0")
-    while True:
-        result = node1.query(
-            f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))"
-        )
-        if result != "0\n":
-            break
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "1\n"
+    # update should happen: the invalidate query result (value at id = 0) changes
+    cursor.execute(f"UPDATE {table_name} SET value = value + 1 WHERE id = 0")
+    assert_eq_with_retry(
+        node1, f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))", "1"
     )
+    settled = wait_baseline_settled()
+    assert dict_get(0) == "1"
 
-    # no update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value*2 WHERE id != 0")
-    time.sleep(5)
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "1\n"
-    )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "1\n"
-    )
+    # no update should happen: the invalidate query result (value at id = 0) is
+    # unchanged, so the dictionary must not reload and pick up the change to
+    # other rows. Verify directly that no reload was triggered.
+    cursor.execute(f"UPDATE {table_name} SET value = value * 2 WHERE id != 0")
+    time.sleep(7)  # more than one periodic check period
+    assert last_update() == settled
+    assert dict_get(0) == "1"
+    assert dict_get(1) == "1"
 
-    # update should happen
-    cursor.execute(f"UPDATE {table_name} SET value=value+1 WHERE id = 0")
-    time.sleep(5)
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))")
-        == "2\n"
+    # update should happen: the invalidate query result (value at id = 0) changes
+    cursor.execute(f"UPDATE {table_name} SET value = value + 1 WHERE id = 0")
+    assert_eq_with_retry(
+        node1, f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(0))", "2"
     )
-    assert (
-        node1.query(f"SELECT dictGetUInt32('{dict_name}', 'value', toUInt64(1))")
-        == "2\n"
-    )
+    assert dict_get(0) == "2"
+    assert dict_get(1) == "2"
 
     node1.query(f"DROP TABLE IF EXISTS {table_name}")
     node1.query(f"DROP DICTIONARY IF EXISTS {dict_name}")


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109367
-->

Related: #109367


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flaky `test_dictionaries_postgresql/test.py::test_invalidate_query`, reported by @serxa on PR #109367.

**Where it was seen:** the failure is not caused by #109367 (Scheduler-only change). It reproduces across 8 unrelated PRs in 30 days, 0 times on master, almost always on slow builds (`amd_asan_ubsan, db disk, old analyzer` and `amd_msan`). Example failing run: [Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/6) on #109367](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109367&sha=a3b75ac70c68bed43d6d0b2abd19360e83c122ba&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29). Assertion: `test.py:385 AssertionError: assert '2\n' == '1\n'`.

**Root cause.** `dict0` is a config-based PostgreSQL dictionary with `LIFETIME(1)` and an `invalidate_query`. `SYSTEM RELOAD DICTIONARY` does a forced full reload but does not run the invalidate query, so the stored invalidate response is left empty. The first periodic check after the forced reload therefore always sees a "modified" source (empty stored response vs the real value) and reloads once more. If that follow-up reload lands after the test has changed the other rows (`value * 2 WHERE id != 0`), the dictionary picks up `value = 2` for `id = 1` and the "no update should happen" assertion fails. The periodic check runs every 5s, so on slow sanitizer / old-analyzer builds it lines up with the fixed `sleep(5)` window often enough to fail.

This is a test timing issue, not a product bug: a forced reload must fully reload, and `invalidate_query` is a best-effort optimization (an extra reload returns fresher data, never wrong data).

**Fix.** After each reload, wait for the invalidate baseline to settle (`last_successful_update_time` stops advancing across a full check period), which drains the guaranteed post-forced-reload reload before the assertion. The "no update should happen" case is then verified directly by asserting `last_successful_update_time` does not advance. The original intent is preserved: a change to the invalidate row (`id = 0`) still triggers a reload, and a change to other rows still does not.

Verified locally on a debug build: reproduced the spurious reload deterministically without the settle step and confirmed it disappears with it; `test_invalidate_query` then passed 25/25 runs and the full `test_dictionaries_postgresql/test.py` suite passed with no regressions.
