### PR TITLE
Fix flaky test 03411_dynamic_resize_filesystem_cache_3

### DIFF
--- a/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
+++ b/tests/queries/0_stateless/03411_dynamic_resize_filesystem_cache_3.sh
@@ -18,10 +18,20 @@ CREATE TABLE ${table_name} (a String) engine=MergeTree() ORDER BY tuple() SETTIN
 INSERT INTO ${table_name} SELECT randomString(10000000);
 "
 
-$CLICKHOUSE_CLIENT --enable_filesystem_cache 1 --query "SELECT * FROM ${table_name} FORMAT Null"
+# `s3_cache` is shared, so a concurrent test dropping the filesystem cache (or eviction) can
+# transiently empty it between the warm-up read and the check. Re-warm and re-check in a short
+# bounded loop so a transient empty instant does not fail the test.
+cache_populated=0
+for _ in {1..10}
+do
+    $CLICKHOUSE_CLIENT --enable_filesystem_cache 1 --query "SELECT * FROM ${table_name} FORMAT Null"
+    cache_populated=$($CLICKHOUSE_CLIENT --query "SELECT current_size > 0 FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
+    [ "$cache_populated" = "1" ] && break
+    sleep 0.5
+done
+echo "$cache_populated"
 
 prev_max_size=$($CLICKHOUSE_CLIENT --query "SELECT max_size FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name'")
-$CLICKHOUSE_CLIENT --query "SELECT current_size > 0 FROM system.filesystem_cache_settings WHERE cache_name = '$disk_name' FORMAT TabSeparated"
 
 config_path=${CLICKHOUSE_CONFIG_DIR}/config.d/storage_conf.xml
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/109331
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109331

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03411_dynamic_resize_filesystem_cache_3` runs in parallel and uses the shared `s3_cache`. It warms the cache with a SELECT and then asserts `current_size > 0`. A concurrent test can drop (name-less `SYSTEM DROP FILESYSTEM CACHE`) or evict the shared cache in the window between the warm-up and the assertion, so the check reads `0` instead of `1`. CI's own randomized-settings diagnosis on the failures confirms it is not a settings issue (reruns with identical settings pass), i.e. a timing race on the shared cache.

Fix: re-warm and re-check in a bounded retry loop (the warm-up SELECT repopulates the cache), so a transient empty-cache moment no longer fails the test. The concurrent dynamic-resize stress that is the actual purpose of the test is unchanged, and the expected output stays `1`.

Reproduced locally on a real `s3_cache`-over-S3 (MinIO) disk: under a concurrent `SYSTEM DROP FILESYSTEM CACHE` aggressor the old single-shot check failed 5/8 runs (`current_size > 0` returned `0`), while the fixed version passed 8/8.
