### PR TITLE
Fix errors during building report (due to lack of space for temporary data)

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -24,10 +24,22 @@ perf_right_config = f"{perf_right}/config"
 perf_left_config = f"{perf_left}/config"
 raw_query_metrics_path = f"{perf_wd}/analyze/raw-query-metrics-upload.tsv"
 
-# Disable cgroup memory correction for report-building clickhouse-local so each
-# process is tracked against its own RSS, not the shared job cgroup (avoids Code 241).
-# Keep in sync with CHPC_REPORT_LOCAL_SERVER_SETTINGS in compare.sh.
-REPORT_LOCAL_SERVER_SETTINGS = ["--", "--memory_worker_use_cgroup=0"]
+# Settings for the report-building clickhouse-local (post-processing, not the
+# measured servers). Keep in sync with CHPC_REPORT_LOCAL_{QUERY,SERVER}_SETTINGS
+# in compare.sh.
+REPORT_LOCAL_QUERY_SETTINGS = [
+    # Keep report aggregations in RAM: report/tmp cannot hold a spill of the
+    # heaviest randomization queries, so spilling only fails with NOT_ENOUGH_SPACE.
+    "--max_bytes_before_external_group_by=0",
+    "--max_bytes_ratio_before_external_group_by=0",
+    "--max_bytes_before_external_sort=0",
+    "--max_bytes_ratio_before_external_sort=0",
+]
+REPORT_LOCAL_SERVER_SETTINGS = [
+    # Track each process against its own RSS, not the job cgroup (MEMORY_LIMIT_EXCEEDED).
+    "--",
+    "--memory_worker_use_cgroup=0",
+]
 
 GET_HISTORICAL_TRESHOLDS_QUERY = """\
 SELECT test, query_index,
@@ -521,7 +533,7 @@ def get_insert_metadata(info, compare_against_release):
 def build_raw_query_metrics_tsv():
     Path(raw_query_metrics_path).unlink(missing_ok=True)
     result = subprocess.run(
-        ["clickhouse-local", "--query", BUILD_RAW_QUERY_METRICS_QUERY, *REPORT_LOCAL_SERVER_SETTINGS],
+        ["clickhouse-local", "--query", BUILD_RAW_QUERY_METRICS_QUERY, *REPORT_LOCAL_QUERY_SETTINGS, *REPORT_LOCAL_SERVER_SETTINGS],
         cwd=perf_wd,
         text=True,
         capture_output=True,
@@ -561,7 +573,7 @@ def build_flamegraph_upload_tsv():
     Path(ch_uploads_dir).mkdir(parents=True, exist_ok=True)
     Path(flamegraph_upload_path).unlink(missing_ok=True)
     result = subprocess.run(
-        ["clickhouse-local", "--query", BUILD_FLAMEGRAPH_UPLOAD_QUERY, *REPORT_LOCAL_SERVER_SETTINGS],
+        ["clickhouse-local", "--query", BUILD_FLAMEGRAPH_UPLOAD_QUERY, *REPORT_LOCAL_QUERY_SETTINGS, *REPORT_LOCAL_SERVER_SETTINGS],
         cwd=perf_wd,
         text=True,
         capture_output=True,

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -36,10 +36,13 @@ export MALLOC_CONF="abort_conf:true,abort:true,narenas:$(nproc --all)"
 # Must match CHServer.JEMALLOC_PROFILER_SAMPLING_RATE in performance_tests.py.
 JEMALLOC_PROFILER_SAMPLING_RATE=16
 
-# Disable cgroup memory correction for report-building clickhouse-local so each
-# process is tracked against its own RSS, not the shared job cgroup (avoids Code 241).
-# Passed after `--` so it word-splits into server settings. Keep in sync with
-# REPORT_LOCAL_SERVER_SETTINGS in performance_tests.py.
+# Settings for the report-building clickhouse-local (post-processing of the perf
+# results, not the measured servers). Keep in sync with
+# REPORT_LOCAL_{QUERY,SERVER}_SETTINGS in performance_tests.py.
+# Keep report aggregations in RAM: report/tmp cannot hold a spill of the
+# heaviest randomization queries, so spilling only fails with NOT_ENOUGH_SPACE.
+CHPC_REPORT_LOCAL_QUERY_SETTINGS="--max_bytes_before_external_group_by=0 --max_bytes_ratio_before_external_group_by=0 --max_bytes_before_external_sort=0 --max_bytes_ratio_before_external_sort=0"
+# Track each process against its own RSS, not the job cgroup (MEMORY_LIMIT_EXCEEDED).
 CHPC_REPORT_LOCAL_SERVER_SETTINGS="--memory_worker_use_cgroup=0"
 
 function wait_for_server # port, pid
@@ -606,7 +609,7 @@ create table query_run_metrics_for_stats engine File(
 create table query_run_metric_names engine File(TSV, 'analyze/query-run-metric-names.tsv')
     as select metric_names from query_run_metric_arrays limit 1
     ;
-" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
 
 # This is a lateral join in bash... please forgive me.
 # We don't have arrayPermute(), so I have to make random permutations with
@@ -625,6 +628,7 @@ do
             --file \"$file\" \
             --structure 'test text, query text, run int, version UInt8, metrics Array(float)' \
             --query \"$(cat "$script_dir/eqmed.sql")\" \
+            $CHPC_REPORT_LOCAL_QUERY_SETTINGS \
             -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS \
             >> \"analyze/query-metric-stats.tsv\"" \
             2>> analyze/errors.log \
@@ -652,7 +656,13 @@ unset IFS
 # --memsuspend:
 #
 #   If the available memory falls below 2 * size, GNU parallel will suspend some of the running jobs.
-parallel -v --joblog analyze/parallel-log.txt --memsuspend 15G --null < analyze/commands.txt 2>> analyze/errors.log
+#
+# With external aggregation disabled, a single heavy job stays in RAM, so bound
+# concurrency by host RAM to avoid MEMORY_LIMIT_EXCEEDED; --memsuspend suspends
+# some jobs anyway if they collectively approach the limit.
+report_jobs=$(( $(awk '/MemTotal/ {print int($2/1024/1024)}' /proc/meminfo) / 15 ))
+[ "$report_jobs" -lt 1 ] && report_jobs=1
+parallel -v -j "$report_jobs" --joblog analyze/parallel-log.txt --memsuspend 15G --null < analyze/commands.txt 2>> analyze/errors.log
 
 clickhouse-local --query "
 -- Join the metric names back to the metric statistics we've calculated, and make
@@ -679,7 +689,7 @@ create table query_metric_stats_denorm engine File(TSVWithNamesAndTypes,
     left array join metric_name, left, right, diff, stat_threshold
     order by test, query_index, metric_name
     ;
-" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
 }
 
 # Analyze results
@@ -1009,7 +1019,7 @@ create table all_query_metrics_tsv engine File(TSV, 'report/all-query-metrics.ts
             and query_display_names.query_index = report_thresholds.query_index
             and query_display_names.query_display_name = report_thresholds.query_display_name
     order by test, query_index;
-" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2)
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2)
 
 # Prepare source data for metrics and flamegraphs for queries that were profiled
 # by perf.py.
@@ -1133,7 +1143,7 @@ create table stacks engine File(TSV, 'report/stacks.$version.tsv') as
     group by test, query_index, trace_type, trace
     order by test, query_index, trace_type, trace
     ;
-" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2) &
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2) &
 done
 wait
 
@@ -1266,7 +1276,7 @@ create table changes engine File(TSV, 'metrics/changes.tsv')
     )
     order by diff desc
     ;
-" -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a metrics/errors.log 1>&2)
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a metrics/errors.log 1>&2)
 
 IFS=$'\n'
 for prefix in $(cut -f1 "metrics/metrics.tsv" | sort | uniq)
@@ -1346,7 +1356,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
             array join map('old', left, 'new', right) as test_desc_
     )
 ;
-    " -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS
+    " $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS
 
     # Upload some run attributes. I use this weird form because it is the same
     # form that can be used for historical data when you only have compare.log.
@@ -1457,6 +1467,13 @@ case "$stage" in
     time upload_results ||:
     ;&
 esac
+
+# A non-empty report/errors.log fails the check. Print it so the cause is in
+# the job log instead of only the results archive.
+if [ -s report/errors.log ]; then
+    echo "### report/errors.log ###"
+    cat report/errors.log
+fi
 
 # Print some final debug info to help debug Weirdness, of which there is plenty.
 jobs


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108804
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #108804

The report build tries to use external aggregation and the disk does not have enough space (Code: 243), so limit memory and disable external aggregation. With spilling off a single job can peak ~30G, so also bound the parallel report jobs by host RAM to avoid Code: 241, and print `report/errors.log` to the job log.


CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109299&sha=34a2cd5d2faf6037651d0a9f6310ba967755e1a8&name_0=PR&name_1=Performance%20Comparison%20%28arm_release%2C%20master_head%2C%204%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.715` (included in `26.7` and later)
<!-- ch-version-info:end -->