### PR TITLE
CI: scope the client docs check to validate + internal links

### DIFF
--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -17,10 +17,13 @@ Steps:
      is one-way, so the checks see exactly what the next sync would produce.
   3. Run the checks from the docs root against the resulting docs.
 
-The check definitions live in ``DEFAULT_CHECKS`` so they are declared once and
-shared: this driver runs them directly, as does the Praktika job
-(``ci/jobs/docs_job_mintlify.py``), which imports the same list. Add a new check
-here and both pick it up.
+The check definitions are declared once here and shared with the Praktika job
+(``ci/jobs/docs_job_mintlify.py``), which imports them. The aggregator job runs
+the full set (``DEFAULT_CHECKS`` plus, when a locale tree changed,
+``LOCALE_CHECKS``); this client driver runs only ``CLIENT_CHECKS`` -- the checks
+a consuming repo can act on for the slice it owns (validate + internal links).
+Redirects, external links, and the locale checks are aggregator-global and are
+left to the aggregator job.
 
 A check can be any shell command, including ``python3 <script>``. Checks run
 from the docs root, so a Python check script committed at
@@ -51,17 +54,31 @@ MINT = "NODE_OPTIONS=--max-old-space-size=8192 mint"
 # the docs (see that script). The external-links check is a non-blocking
 # warning because it depends on third-party sites being reachable.
 LYCHEE = "python3 ../ci/jobs/scripts/docs/lychee_check.py"
+VALIDATE_CHECK = ("Validate docs.json", f"{MINT} validate")
+INTERNAL_LINKS_CHECK = ("Check internal links and anchors", f"{LYCHEE} --mode links .")
+REDIRECTS_CHECK = ("Check redirects", f"{LYCHEE} --mode redirects .")
+EXTERNAL_LINKS_CHECK = ("Check external links (warnings)", f"{LYCHEE} --mode external .")
 DEFAULT_CHECKS = [
-    ("Validate docs.json", f"{MINT} validate"),
-    ("Check internal links and anchors", f"{LYCHEE} --mode links ."),
-    ("Check redirects", f"{LYCHEE} --mode redirects ."),
-    ("Check external links (warnings)", f"{LYCHEE} --mode external ."),
+    VALIDATE_CHECK,
+    INTERNAL_LINKS_CHECK,
+    REDIRECTS_CHECK,
+    EXTERNAL_LINKS_CHECK,
 ]
+
+# The subset a consuming client repo (e.g. clickhouse-connect) runs: only the
+# checks that validate the slice it owns. `mint validate` proves its docs.json
+# fragment and frontmatter are well-formed, and the internal-links check proves
+# its own links and anchors resolve. Redirects, external links, and the locale
+# checks are aggregator-global concerns a client neither owns nor can fix (they
+# depend on the site-wide redirects map, third-party sites, and the translated
+# trees), so the client driver does not run them.
+CLIENT_CHECKS = [VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
 
 # Locale-only checks, kept out of DEFAULT_CHECKS: the Praktika job runs them only
 # when a PR touches the locale folders (top-level or snippets/<locale>/) -- they
-# are large and change independently via the GT translation bot -- while the
-# standalone driver below runs them unconditionally for full local coverage.
+# are large and change independently via the GT translation bot. The client
+# driver below does not run them (they cover the aggregator's translated trees,
+# which a consuming client repo does not own).
 #   - locale-links: markdown link/file resolution for the translated trees
 #     (lychee), fragments skipped.
 #   - locale components: navigation `href`/`to` paths inside localized JSX
@@ -173,10 +190,12 @@ def main(argv=None):
             raise ValueError(f"Invalid --replace '{spec}'. Expected SRC:DEST.")
         replace(parts[0], resolve_replace_dest(docs_root, parts[1]))
 
-    # The driver has no PR diff, so it runs the locale checks unconditionally
-    # (full coverage); the Praktika job gates them on locale-folder changes.
+    # A consuming client repo owns only its docs slice, so it runs just the
+    # checks it can act on (see CLIENT_CHECKS): validate + internal links. The
+    # aggregator-global checks -- redirects, external links, and the locale
+    # checks -- are run by the aggregator's own Praktika job, not here.
     results = [(name, run_check(docs_root, name, command))
-               for name, command in [*DEFAULT_CHECKS, *LOCALE_CHECKS]]
+               for name, command in CLIENT_CHECKS]
 
     print("\n=== Summary ===", flush=True)
     for name, ok in results:


### PR DESCRIPTION
The standalone driver in `mintlify_docs_check.py`, which a consuming client repo (e.g. `clickhouse-connect`) fetches and runs, was executing the full set of checks: `mint validate`, internal links, redirects, external links, and the locale/translation checks. A client owns only its own docs slice, so the aggregator-global checks -- redirects, external links, and the locale checks -- depend on the site-wide redirects map, third-party sites, and the translated trees, none of which a client can fix.

Add `CLIENT_CHECKS` (validate + internal links) and run only that in the client driver. The aggregator's own Praktika job is unchanged and keeps running the full set.

Needed for https://github.com/ClickHouse/clickhouse-connect/pull/778

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.519` (included in `26.7` and later)
<!-- ch-version-info:end -->