### PR TITLE
Fix parallel_hash global JOIN limit not enforced on ARM

### DIFF
--- a/src/Interpreters/ConcurrentHashJoin.cpp
+++ b/src/Interpreters/ConcurrentHashJoin.cpp
@@ -220,7 +220,7 @@ ConcurrentHashJoin::ConcurrentHashJoin(
                         /*use_two_level_maps*/ true);
                     inner_hash_join->data->setMaxJoinedBlockRows(table_join->maxJoinedBlockRows());
                     inner_hash_join->data->setMaxJoinedBlockBytes(table_join->maxJoinedBlockBytes());
-                    inner_hash_join->total_bytes.store(inner_hash_join->data->getTotalByteCount(), std::memory_order_relaxed);
+                    inner_hash_join->total_bytes.store(inner_hash_join->data->getTotalByteCount(), std::memory_order_release);
                     hash_joins[i] = std::move(inner_hash_join);
                 });
         }
@@ -328,9 +328,13 @@ bool ConcurrentHashJoin::addBlockToJoin(const Block & right_block_, bool check_l
                 auto [block, selector] = std::move(dispatched_block).detachData();
                 bool limit_exceeded = !hash_join->data->addBlockToJoin(block, std::move(selector), check_limits);
 
-                /// Update the snapshot of total rows and bytes for the current join instance
-                hash_join->total_rows.store(hash_join->data->getTotalRowCount(), std::memory_order_relaxed);
-                hash_join->total_bytes.store(hash_join->data->getTotalByteCount(), std::memory_order_relaxed);
+                /// Update the snapshot of total rows and bytes for the current join instance.
+                /// Use release ordering so that another thread summing these snapshots in
+                /// getTotalRowCount/getTotalByteCount (with acquire) observes the inserted rows.
+                /// Without this, the lock-free global JOIN limit check can read stale-low totals
+                /// on weak memory models (ARM) and skip the SET_SIZE_LIMIT_EXCEEDED throw.
+                hash_join->total_rows.store(hash_join->data->getTotalRowCount(), std::memory_order_release);
+                hash_join->total_bytes.store(hash_join->data->getTotalByteCount(), std::memory_order_release);
 
                 dispatched_block = {};
                 blocks_left--;
@@ -466,7 +470,7 @@ size_t ConcurrentHashJoin::getTotalRowCount() const
 {
     size_t res = 0;
     for (const auto & hash_join : hash_joins)
-        res += hash_join->total_rows.load(std::memory_order_relaxed);
+        res += hash_join->total_rows.load(std::memory_order_acquire);
     return res;
 }
 
@@ -474,7 +478,7 @@ size_t ConcurrentHashJoin::getTotalByteCount() const
 {
     size_t res = 0;
     for (const auto & hash_join : hash_joins)
-        res += hash_join->total_bytes.load(std::memory_order_relaxed);
+        res += hash_join->total_bytes.load(std::memory_order_acquire);
     return res;
 }
 
@@ -741,8 +745,8 @@ BlocksList ConcurrentHashJoin::releaseSlotBlocks(size_t slot_idx)
     std::lock_guard lock(hash_join->mutex);
     if (!hash_join->data || !hash_join->data->getJoinedData())
         return {};
-    hash_join->total_rows.store(0, std::memory_order_relaxed);
-    hash_join->total_bytes.store(0, std::memory_order_relaxed);
+    hash_join->total_rows.store(0, std::memory_order_release);
+    hash_join->total_bytes.store(0, std::memory_order_release);
     return hash_join->data->releaseJoinedBlocks(/*restructure=*/ false);
 }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Closes: #109400
Related: #108938

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed the global `max_rows_in_join` / `max_bytes_in_join` limit not being enforced for the `parallel_hash` join algorithm on ARM, where a query with `join_overflow_mode = 'throw'` could silently succeed instead of raising `SET_SIZE_LIMIT_EXCEEDED`.

### Description

`ConcurrentHashJoin` enforces the global `max_rows_in_join` / `max_bytes_in_join` limit at the end of `addBlockToJoin` by summing per-instance snapshots via `getTotalRowCount` / `getTotalByteCount`. For `parallel_hash` the right side is split across buckets, so no single instance reaches the limit; only the sum does, so enforcement depends entirely on that summation reading the committed totals.

#108938 made those snapshots lock-free atomics written and read with `memory_order_relaxed`. The previous code took each instance's `mutex` in the getters, and it was that lock/unlock which provided the acquire/release synchronization between a build thread's snapshot store and another thread's summation in the limit check. With relaxed ordering there is no happens-before, so on weak memory models (ARM) the check can observe stale-low totals, compute a sum below the limit, and skip the `throw`. On x86 (TSO) the stores are effectively ordered, so the failure is arm-only.

Fix: publish the snapshots with `memory_order_release` and sum them with `memory_order_acquire`, restoring the exact happens-before the removed `mutex` provided. This is `stlr` / `ldar` on ARM and negligible on x86, far cheaper than the lock contention #108938 removed. The performance win of #108938 is preserved (still lock-free).

Regression coverage already exists: `04061_spilling_hash_join_overflow_limits` test 3 (`parallel_hash` + `max_rows_in_join` + `join_overflow_mode='throw'`), which fails on `arm_binary` on master and passes with this change.

CI failure (master, arm_binary): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e2368f7c094207fee27d342463ae98a6977d79bf&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
