### PR TITLE
Docs: repoint docs "Raise issue" button at the documentation issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > Make sure that `git diff` result is empty and you've just pulled fresh master. Try cleaning up cmake cache. Just in case, official build instructions are published here: https://clickhouse.com/docs/en/development/build/
+        > Thanks for helping us improve the documentation! Please describe what's wrong, missing, or unclear below. If you opened this from the "Raise issue" button on the docs site, the page you were viewing is filled in for you; otherwise, please add a link to the affected page.
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/60_documentation-issue.yaml
@@ -6,6 +6,13 @@ body:
     attributes:
       value: |
         > Make sure that `git diff` result is empty and you've just pulled fresh master. Try cleaning up cmake cache. Just in case, official build instructions are published here: https://clickhouse.com/docs/en/development/build/
+  - type: input
+    id: page
+    attributes:
+      label: Documentation page
+      description: The documentation page this issue is about. Pre-filled when the issue is opened from the "Raise issue" button on the docs site.
+    validations:
+      required: false
   - type: textarea
     attributes:
       label: Company or project name

--- a/docs/_site/customizations/README.mdx
+++ b/docs/_site/customizations/README.mdx
@@ -14,6 +14,8 @@ See Mintlify's docs on [custom scripts](https://www.mintlify.com/docs/customize/
 - `kapa-init.js` — bootstraps the Kapa.ai RAG widget.
 - `navbar-cta.js` — adds the "Get started" CTA to the navbar.
 - `raise-issue-link.js` — repoints Mintlify's default "Raise issue" feedback link at the repository's Documentation issue form (`.github/ISSUE_TEMPLATE/60_documentation-issue.yaml`), pre-filling the current page path.
+- `scroll-reset.js` — restores scroll-to-top on forward client-side navigation, which Next.js skips when an announcement banner is configured. Leaves back/forward (popstate) alone so the browser/router can restore the prior position, and scrolls to the anchor on cross-page hash links.
+- `tab-nav.js` — wires the desktop top-nav tabs (Home / Database / Solutions / Integrations) to their target URLs, keeping navigation within the active locale and base path.
 - `clickhouse-sql-lexer-wasm.js` — exposes ClickHouse's SQL lexer (`src/Parsers/Lexer.cpp` compiled to WebAssembly) as a base64 global. Snapshot from ClickHouse `programs/server/play.html`; re-extract if the upstream lexer/keyword list changes.
 - `clickhouse-sql-highlight.js` — re-highlights `language="sql"` code blocks using the WASM lexer (ClickHouse-native colors, matching play.html / clickhouse-client) in place of Shiki. Must load after `clickhouse-sql-lexer-wasm.js`. Other languages are left as Shiki rendered them.
 

--- a/docs/_site/customizations/README.mdx
+++ b/docs/_site/customizations/README.mdx
@@ -13,6 +13,7 @@ See Mintlify's docs on [custom scripts](https://www.mintlify.com/docs/customize/
 - `inkeep-init.js` — replaces Mintlify's native search (⌘K / navbar search bar) with the Inkeep search modal. Search-only; AI chat stays on Kapa.
 - `kapa-init.js` — bootstraps the Kapa.ai RAG widget.
 - `navbar-cta.js` — adds the "Get started" CTA to the navbar.
+- `raise-issue-link.js` — repoints Mintlify's default "Raise issue" feedback link at the repository's Documentation issue form (`.github/ISSUE_TEMPLATE/60_documentation-issue.yaml`), pre-filling the current page path.
 - `clickhouse-sql-lexer-wasm.js` — exposes ClickHouse's SQL lexer (`src/Parsers/Lexer.cpp` compiled to WebAssembly) as a base64 global. Snapshot from ClickHouse `programs/server/play.html`; re-extract if the upstream lexer/keyword list changes.
 - `clickhouse-sql-highlight.js` — re-highlights `language="sql"` code blocks using the WASM lexer (ClickHouse-native colors, matching play.html / clickhouse-client) in place of Shiki. Must load after `clickhouse-sql-lexer-wasm.js`. Other languages are left as Shiki rendered them.
 

--- a/docs/_site/customizations/raise-issue-link.js
+++ b/docs/_site/customizations/raise-issue-link.js
@@ -1,0 +1,67 @@
+(function () {
+  'use strict';
+
+  // Mintlify renders a default "Raise issue" feedback link that opens a blank
+  // issue (issues/new?title=Issue on docs&body=Path: <page>). Point it at the
+  // repository's Documentation issue form instead, carrying the page path
+  // through so the reporter does not have to type it. The path lands in the
+  // form's `page` field (matched by its `id` in
+  // .github/ISSUE_TEMPLATE/60_documentation-issue.yaml).
+  var FORM = 'https://github.com/ClickHouse/ClickHouse/issues/new';
+  var TEMPLATE = '60_documentation-issue.yaml';
+
+  function pagePathFrom(href) {
+    // Prefer the path Mintlify already encoded in the default link's body
+    // ("Path: /foo"); fall back to the current location.
+    try {
+      var body = new URL(href, window.location.origin).searchParams.get('body') || '';
+      var m = body.match(/Path:\s*(\S+)/);
+      if (m) return m[1];
+    } catch (e) {}
+    return window.location.pathname;
+  }
+
+  function targetHref(path) {
+    return FORM + '?template=' + encodeURIComponent(TEMPLATE) +
+      '&page=' + encodeURIComponent(path);
+  }
+
+  function isDefaultRaiseIssue(href) {
+    // Only touch Mintlify's default "Raise issue" link; leave any other
+    // issues/new links (e.g. in page content) alone. Spaces in the title may be
+    // encoded as %20 or +, or left literal in the attribute.
+    return /\/issues\/new\?/.test(href) &&
+      /title=Issue(%20|\+|\s)on(%20|\+|\s)docs/i.test(href);
+  }
+
+  function rewrite() {
+    var links = document.querySelectorAll('a[href*="/issues/new"]');
+    for (var i = 0; i < links.length; i++) {
+      var href = links[i].getAttribute('href') || '';
+      if (isDefaultRaiseIssue(href)) {
+        links[i].setAttribute('href', targetHref(pagePathFrom(href)));
+      }
+    }
+  }
+
+  // Run now and keep watching: Mintlify is a SPA, so the feedback link is
+  // re-rendered (with a fresh default href) on every client-side navigation.
+  // Rewriting is idempotent -- after the rewrite the href no longer matches
+  // isDefaultRaiseIssue -- so re-running on our own attribute change is a no-op
+  // and cannot loop.
+  function start() {
+    rewrite();
+    new MutationObserver(rewrite).observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['href'],
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3877,6 +3877,9 @@
     },
     {
       "src": "/_site/customizations/clickhouse-sql-highlight.js"
+    },
+    {
+      "src": "/_site/customizations/raise-issue-link.js"
     }
   ],
   "styling": {


### PR DESCRIPTION
Mintlify renders a default "Raise issue" feedback link that opens a blank issue (`issues/new?title=Issue on docs&body=Path: <page>`). Rewrite it client-side to the repository's Documentation issue form, carrying the current page path into the form's `page` field.

- `_site/customizations/raise-issue-link.js` finds Mintlify's default link and repoints its `href` at `issues/new?template=60_documentation-issue.yaml&page=<path>`. It uses a `MutationObserver` because Mintlify is a SPA and re-renders the link on navigation; the rewrite is idempotent and only touches the default link.
- `docs.json` registers the script.
- `60_documentation-issue.yaml` gains a `page` input (id `page`) that the link pre-fills.
- `README.mdx` documents the script.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.527` (included in `26.7` and later)
<!-- ch-version-info:end -->