### PR TITLE
Fail allocations from C on memory limit excess instead of overcommitting

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -48,7 +48,7 @@ MemoryTracker * getMemoryTracker()
 
 using DB::current_thread;
 
-AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit)
+AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, bool * memory_limit_exceeded)
 {
 #ifdef MEMORY_TRACKER_DEBUG_CHECKS
     if (unlikely(memory_tracker_always_throw_logical_error_on_allocation))
@@ -63,7 +63,7 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool enforce_memory_
         if (!current_thread)
         {
             /// total_memory_tracker only, ignore untracked_memory
-            return memory_tracker->allocImpl(size, enforce_memory_limit);
+            return memory_tracker->allocImpl(size, enforce_memory_limit, /*query_tracker=*/ nullptr, /*_sample_probability=*/ -1.0, memory_limit_exceeded);
         }
 
         /// Make sure we do memory tracker calls with the correct level in MemoryTrackerBlockerInThread.
@@ -95,9 +95,19 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool enforce_memory_
             {
                 /// We cannot return the AllocationTrace from here, since its sample_probability was calculated on the (batched) flushed size, which may not match the original allocation size.
                 if (current_untracked_memory > 0)
-                    std::ignore = memory_tracker->allocImpl(current_untracked_memory, enforce_memory_limit, /*query_tracker=*/ nullptr, /*_sample_probability=*/ 0.0);
+                {
+                    std::ignore = memory_tracker->allocImpl(current_untracked_memory, enforce_memory_limit, /*query_tracker=*/ nullptr, /*_sample_probability=*/ 0.0, memory_limit_exceeded);
+                    if (memory_limit_exceeded && *memory_limit_exceeded)
+                    {
+                        current_thread->untracked_memory += previous_untracked_memory;
+                        DB::per_cpu_memory.rollback(current_thread->per_cpu_untracked_memory, previous_per_cpu);
+                        return AllocationTrace(0);
+                    }
+                }
                 else
+                {
                     std::ignore = memory_tracker->free(-current_untracked_memory, /*_sample_probability=*/ 0.0);
+                }
             }
             catch (...)
             {
@@ -127,6 +137,12 @@ AllocationTrace CurrentMemoryTracker::alloc(Int64 size)
 AllocationTrace CurrentMemoryTracker::allocNoThrow(Int64 size)
 {
     return allocImpl(size, /*enforce_memory_limit=*/ false);
+}
+
+AllocationTrace CurrentMemoryTracker::allocFromC(Int64 size, bool & memory_limit_exceeded)
+{
+    memory_limit_exceeded = false;
+    return allocImpl(size, /*enforce_memory_limit=*/ true, &memory_limit_exceeded);
 }
 
 AllocationTrace CurrentMemoryTracker::allocThrow(Int64 size)

--- a/src/Common/CurrentMemoryTracker.h
+++ b/src/Common/CurrentMemoryTracker.h
@@ -16,6 +16,13 @@ struct CurrentMemoryTracker
     /// is `noexcept` and must keep using `allocNoThrow`.
     [[nodiscard]] static AllocationTrace allocThrow(Int64 size);
 
+    /// Like alloc (the memory limit is enforced), but exceeding the limit is
+    /// reported through `memory_limit_exceeded` (with the accounting reverted)
+    /// instead of throwing MEMORY_LIMIT_EXCEEDED. For C allocation functions,
+    /// which cannot throw: the caller must fail the allocation (nullptr/ENOMEM)
+    /// instead of overcommitting.
+    [[nodiscard]] static AllocationTrace allocFromC(Int64 size, bool & memory_limit_exceeded);
+
     /// This function should be called after memory deallocation.
     [[nodiscard]] static AllocationTrace free(Int64 size);
     static void check();
@@ -34,5 +41,5 @@ struct CurrentMemoryTracker
     static UInt64 getMinAllocationSizeBytesToThrow();
 
 private:
-    [[nodiscard]] static AllocationTrace allocImpl(Int64 size, bool enforce_memory_limit);
+    [[nodiscard]] static AllocationTrace allocImpl(Int64 size, bool enforce_memory_limit, bool * memory_limit_exceeded = nullptr);
 };

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -273,7 +273,7 @@ static void incrementAllocationWithoutCheck(Int64 size)
     }
 }
 
-AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, MemoryTracker * query_tracker, double _sample_probability)
+AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, MemoryTracker * query_tracker, double _sample_probability, bool * memory_limit_exceeded)
 {
     if (size < 0)
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Negative size ({}) is passed to MemoryTracker. It is a bug.", size);
@@ -302,7 +302,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
         if (auto * loaded_next = parent.load(std::memory_order_relaxed))
         {
             MemoryTracker * tracker = level == VariableContext::Process ? this : query_tracker;
-            return loaded_next->allocImpl(size, enforce_memory_limit, tracker, _sample_probability);
+            return loaded_next->allocImpl(size, enforce_memory_limit, tracker, _sample_probability, memory_limit_exceeded);
         }
 
         return AllocationTrace(_sample_probability);
@@ -353,6 +353,13 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
             ProfileEvents::increment(ProfileEvents::QueryMemoryLimitExceeded);
             if (level == VariableContext::Global)
                 ProfileEvents::increment(ProfileEvents::GlobalMemoryLimitExceeded);
+
+            if (memory_limit_exceeded)
+            {
+                *memory_limit_exceeded = true;
+                return AllocationTrace(0);
+            }
+
             const auto * description = description_ptr.load(std::memory_order_relaxed);
             throw DB::Exception(
                 DB::ErrorCodes::MEMORY_LIMIT_EXCEEDED,
@@ -456,6 +463,13 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
                 ProfileEvents::increment(ProfileEvents::QueryMemoryLimitExceeded);
                 if (level == VariableContext::Global)
                     ProfileEvents::increment(ProfileEvents::GlobalMemoryLimitExceeded);
+
+                if (memory_limit_exceeded)
+                {
+                    *memory_limit_exceeded = true;
+                    return AllocationTrace(0);
+                }
+
                 const auto * description = description_ptr.load(std::memory_order_relaxed);
                 throw DB::Exception(
                     DB::ErrorCodes::MEMORY_LIMIT_EXCEEDED,
@@ -524,7 +538,7 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool enforce_memory_limit, 
     if (auto * loaded_next = parent.load(std::memory_order_relaxed))
     {
         MemoryTracker * tracker = level == VariableContext::Process ? this : query_tracker;
-        return loaded_next->allocImpl(size, enforce_memory_limit, tracker, _sample_probability);
+        return loaded_next->allocImpl(size, enforce_memory_limit, tracker, _sample_probability, memory_limit_exceeded);
     }
 
     return AllocationTrace(_sample_probability);

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -142,8 +142,13 @@ private:
     int64_t last_corrected_amount = 0;
 
     /// allocImpl(...) and free(...) should not be used directly
+    ///
+    /// If `memory_limit_exceeded` is not nullptr, exceeding the memory limit
+    /// (or an injected fault) is reported through it (with the accounting
+    /// reverted) instead of throwing MEMORY_LIMIT_EXCEEDED — for callers that
+    /// cannot handle exceptions (C API).
     friend struct CurrentMemoryTracker;
-    [[nodiscard]] AllocationTrace allocImpl(Int64 size, bool enforce_memory_limit, MemoryTracker * query_tracker = nullptr, double _sample_probability = -1.0);
+    [[nodiscard]] AllocationTrace allocImpl(Int64 size, bool enforce_memory_limit, MemoryTracker * query_tracker = nullptr, double _sample_probability = -1.0, bool * memory_limit_exceeded = nullptr);
     [[nodiscard]] AllocationTrace free(Int64 size, double _sample_probability = -1.0);
 public:
 

--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -30,7 +30,13 @@ extern "C"
 void * malloc(size_t size)
 {
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded);
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     void * ptr = je_malloc(size);
     if (unlikely(!ptr))
     {
@@ -59,7 +65,13 @@ void * calloc(size_t nmemb, size_t size)
     }
 
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(real_size, trace);
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(real_size, trace, memory_limit_exceeded);
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     void * ptr = je_calloc(nmemb, size);
     if (unlikely(!ptr))
     {
@@ -77,7 +89,13 @@ void * realloc(void * ptr, size_t size)
         old_actual_size = je_sallocx(ptr, 0);
 
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded);
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     void * res = je_realloc(ptr, size);
     if (unlikely(!res))
     {
@@ -106,7 +124,10 @@ int posix_memalign(void ** memptr, size_t alignment, size_t size)
     if (alignment < sizeof(void *) || (alignment & (alignment - 1)) != 0)
         return EINVAL;
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded, static_cast<std::align_val_t>(alignment));
+    if (unlikely(memory_limit_exceeded))
+        return ENOMEM;
     int res = je_posix_memalign(memptr, alignment, size);
     if (unlikely(res != 0))
     {
@@ -125,7 +146,13 @@ void * aligned_alloc(size_t alignment, size_t size)
         return nullptr;
     }
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded, static_cast<std::align_val_t>(alignment));
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     void * res = je_aligned_alloc(alignment, size);
     if (unlikely(!res))
     {
@@ -142,7 +169,13 @@ void * valloc(size_t size)
     void * res = nullptr;
     size_t page_size = getPageSize();
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(page_size));
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded, static_cast<std::align_val_t>(page_size));
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     int err = je_posix_memalign(&res, page_size, size);
     if (unlikely(err != 0))
     {
@@ -171,7 +204,13 @@ void * memalign(size_t alignment, size_t size)
     /// posix_memalign requires alignment >= sizeof(void*); widen valid small powers of two.
     size_t effective_alignment = alignment < sizeof(void *) ? sizeof(void *) : alignment;
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(effective_alignment));
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, memory_limit_exceeded, static_cast<std::align_val_t>(effective_alignment));
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     int err = je_posix_memalign(&res, effective_alignment, size);
     if (unlikely(err != 0))
     {
@@ -196,7 +235,13 @@ void * pvalloc(size_t size)
     }
     rounded_size = rounded_size / page_size * page_size;
     AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(rounded_size, trace, static_cast<std::align_val_t>(page_size));
+    bool memory_limit_exceeded = false;
+    size_t actual_size = Memory::trackMemoryFromC(rounded_size, trace, memory_limit_exceeded, static_cast<std::align_val_t>(page_size));
+    if (unlikely(memory_limit_exceeded))
+    {
+        errno = ENOMEM;
+        return nullptr;
+    }
     int err = je_posix_memalign(&res, page_size, rounded_size);
     if (unlikely(err != 0))
     {

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -136,14 +136,16 @@ inline ALWAYS_INLINE size_t trackMemory(std::size_t size, AllocationTrace & trac
     return actual_size;
 }
 
-/// We cannot throw from C API
+/// We cannot throw from C API, so exceeding the memory limit is reported
+/// through `memory_limit_exceeded` (with the tracked amount reverted) and the
+/// caller must fail the allocation instead of overcommitting.
 template <std::same_as<std::align_val_t>... TAlign>
 requires DB::OptionalArgument<TAlign...>
-inline ALWAYS_INLINE size_t trackMemoryFromC(std::size_t size, AllocationTrace & trace, TAlign... align)
+inline ALWAYS_INLINE size_t trackMemoryFromC(std::size_t size, AllocationTrace & trace, bool & memory_limit_exceeded, TAlign... align)
 {
     [[maybe_unused]] MemoryTrackerUntrackedAllocationsBlockerInThread blocker;
     std::size_t actual_size = getActualAllocationSize(size, align...);
-    trace = CurrentMemoryTracker::allocNoThrow(actual_size);
+    trace = CurrentMemoryTracker::allocFromC(actual_size, memory_limit_exceeded);
     return actual_size;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fail allocations from C on memory limit excess instead of overcommitting

It is possible to have a lot of allocations from C, for i.e. compression (most of the libraries in C, OSS long time default lz4 and Cloud default ZSTD).