### PR TITLE
Split `WhatIfIndexEstimator` into per-concern modules

### DIFF
--- a/src/Storages/MergeTree/WhatIfEmpiricalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfEmpiricalEstimator.cpp
@@ -1,0 +1,283 @@
+#include <Storages/MergeTree/WhatIfEmpiricalEstimator.h>
+
+#include <Interpreters/Context.h>
+#include <Interpreters/ExpressionActions.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/IProcessor.h>
+#include <QueryPipeline/QueryPipeline.h>
+#include <QueryPipeline/SizeLimits.h>
+#include <Storages/MergeTree/AlterConversions.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSequentialSource.h>
+
+#include <Columns/ColumnSparse.h>
+#include <Common/Stopwatch.h>
+#include <Core/Settings.h>
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsUInt64 merge_tree_min_rows_for_seek;
+    extern const SettingsUInt64 merge_tree_min_bytes_for_seek;
+    extern const SettingsUInt64 max_rows_to_read;
+    extern const SettingsUInt64 max_bytes_to_read;
+    extern const SettingsOverflowMode read_overflow_mode;
+}
+
+namespace ErrorCodes
+{
+    extern const int TOO_MANY_ROWS;
+    extern const int TOO_MANY_BYTES;
+}
+
+namespace
+{
+
+/// Expand each baseline mark range to the full skip-index windows it touches (a window is
+/// `granularity` data granules) and merge them into ranges
+MarkRanges skipIndexWindowsOverlapping(const MarkRanges & baseline, size_t granularity, size_t total_marks)
+{
+    MarkRanges windows;
+    if (granularity == 0 || total_marks == 0)
+        return windows;
+
+    for (const auto & range : baseline)
+    {
+        const size_t last = std::min(range.end, total_marks);
+        if (range.begin >= last)
+            continue;
+
+        const size_t begin = range.begin / granularity * granularity;
+        const size_t end = std::min((last - 1) / granularity * granularity + granularity, total_marks);
+        if (!windows.empty() && begin <= windows.back().end)
+            windows.back().end = std::max(windows.back().end, end);
+        else
+            windows.emplace_back(begin, end);
+    }
+    return windows;
+}
+
+}
+
+bool tryEstimateEmpirical(
+    WhatIfIndexEstimator::IndexResult & result,
+    const MergeTreeIndexPtr & index_helper,
+    const MergeTreeIndexConditionPtr & condition,
+    ReadFromMergeTree * read_step,
+    const ReadFromMergeTree::AnalysisResult & analysis,
+    const RangesInDataParts & saved_parts,
+    std::vector<UInt8> * surviving_marks,
+    ContextPtr context)
+{
+    const auto & data = read_step->getMergeTreeData();
+    const auto & storage_snapshot = read_step->getStorageSnapshot();
+    const auto & mutations_snapshot = read_step->getMutationsSnapshot();
+
+    Names index_columns = index_helper->getColumnsRequiredForIndexCalc();
+    if (index_columns.empty())
+        return false;
+
+    /// With non-zero seek gaps a real read coalesces ranges, so our per-granule count would diverge
+    if (context->getSettingsRef()[Setting::merge_tree_min_rows_for_seek] != 0
+        || context->getSettingsRef()[Setting::merge_tree_min_bytes_for_seek] != 0)
+        return false;
+
+    UInt64 total_data_granules = 0;
+    UInt64 skipped_data_granules = 0;
+    Stopwatch watch;
+
+    /// The whole-part scan is not the normal read pipeline, so enforce the query's
+    /// read limits explicitly (max_execution_time is handled by the process-list element)
+    const auto & limit_settings = context->getSettingsRef();
+    const SizeLimits read_limits(
+        limit_settings[Setting::max_rows_to_read],
+        limit_settings[Setting::max_bytes_to_read],
+        limit_settings[Setting::read_overflow_mode]);
+    UInt64 total_rows_read = 0;
+    UInt64 total_bytes_read = 0;
+
+    const size_t skip_index_granularity = index_helper->index.granularity;
+    auto index_expression = index_helper->index.expression;
+
+    /// Position of the next baseline mark, gives every candidate's bitmap the same coordinates
+    size_t baseline_mark_pos = 0;
+
+    for (const auto & part_with_ranges : saved_parts)
+    {
+        auto part = part_with_ranges.data_part;
+        const auto & mark_ranges = part_with_ranges.ranges;
+
+        if (mark_ranges.empty())
+            continue;
+
+        const auto & part_index_granularity = part->index_granularity;
+        const size_t total_marks = part_index_granularity->getMarksCountWithoutFinal();
+
+        std::vector<bool> in_baseline(part->getMarksCount(), false);
+        for (const auto & range : mark_ranges)
+            for (size_t m = range.begin; m < range.end && m < in_baseline.size(); ++m)
+                in_baseline[m] = true;
+
+        /// Read only the skip-index windows overlapping the baseline instead of the whole part
+        const MarkRanges read_ranges = skipIndexWindowsOverlapping(mark_ranges, skip_index_granularity, total_marks);
+        if (read_ranges.empty())
+            continue;
+
+        /// Apply patch parts / on-the-fly mutations so we see the up-to-date values
+        auto alter_conversions = mutations_snapshot
+            ? MergeTreeData::getAlterConversionsForPart(part, mutations_snapshot, context)
+            : std::make_shared<AlterConversions>();
+
+        /// aggregate each skip-index granule and count how many
+        /// baseline granules the candidate would skip. Returns false if a read limit was hit
+        auto scan_range = [&](const MarkRange & read_range) -> bool
+        {
+            RangesInDataPart part_for_read(part);
+
+            Pipe pipe = createMergeTreeSequentialSource(
+                MergeTreeSequentialSourceType::Merge,
+                data,
+                storage_snapshot,
+                std::move(part_for_read),
+                alter_conversions,
+                nullptr,
+                index_columns,
+                MarkRanges{read_range},
+                std::make_shared<std::atomic<size_t>>(0),
+                false,
+                false,
+                false);
+
+            /// Apply the query's execution-speed limits here too (size is the explicit check below)
+            if (auto query_limits = read_step->getQueryInfo().storage_limits)
+            {
+                auto speed_limits = std::make_shared<StorageLimitsList>(*query_limits);
+                for (auto & entry : *speed_limits)
+                {
+                    entry.local_limits.size_limits = {};
+                    entry.leaf_limits = {};
+                    entry.local_limits.speed_limits.max_execution_time = {};
+                }
+                for (const auto & processor : pipe.getProcessors())
+                    processor->setStorageLimits(speed_limits);
+            }
+
+            QueryPipeline pipeline(std::move(pipe));
+            /// Tie the scan to the query so quota / speed / time limits apply
+            pipeline.setProcessListElement(context->getProcessListElement());
+            pipeline.setProgressCallback(context->getProgressCallback());
+            pipeline.setQuota(context->getQuota());
+            /// Carry the query hash so the empirical scan's `read_rows`/`read_bytes` are accounted to the
+            /// query's own bucket under a `KEYED BY normalized_query_hash` quota, not the shared hash-0 one.
+            pipeline.setNormalizedQueryHash(context->getNormalizedQueryHash());
+            PullingPipelineExecutor executor(pipeline);
+
+            auto aggregator = index_helper->createIndexAggregator();
+            size_t current_mark = read_range.begin;
+            size_t rows_remaining_in_mark = current_mark < total_marks
+                ? part_index_granularity->getMarkRows(current_mark)
+                : 0;
+            size_t data_granules_in_window = 0;
+            size_t baseline_marks_in_window = 0;
+            std::vector<size_t> window_baseline_marks;
+
+            auto flush_window = [&]
+            {
+                if (baseline_marks_in_window == 0)
+                    return;
+                auto granule = aggregator->getGranuleAndReset();
+                total_data_granules += baseline_marks_in_window;
+                if (!condition->mayBeTrueOnGranule(granule, {}))
+                    skipped_data_granules += baseline_marks_in_window;
+                else if (surviving_marks)
+                    for (size_t pos : window_baseline_marks)
+                        (*surviving_marks)[pos] = 1;
+            };
+
+            auto on_mark_finished = [&]
+            {
+                ++data_granules_in_window;
+                if (current_mark < in_baseline.size() && in_baseline[current_mark])
+                {
+                    ++baseline_marks_in_window;
+                    if (surviving_marks)
+                        window_baseline_marks.push_back(baseline_mark_pos++);
+                }
+
+                if (data_granules_in_window >= skip_index_granularity)
+                {
+                    flush_window();
+                    aggregator = index_helper->createIndexAggregator();
+                    data_granules_in_window = 0;
+                    baseline_marks_in_window = 0;
+                    window_baseline_marks.clear();
+                }
+
+                ++current_mark;
+                rows_remaining_in_mark = current_mark < total_marks
+                    ? part_index_granularity->getMarkRows(current_mark)
+                    : 0;
+            };
+
+            Block block;
+            while (executor.pull(block))
+            {
+                if (block.rows() == 0)
+                    continue;
+
+                total_rows_read += block.rows();
+                total_bytes_read += block.bytes();
+                /// throw mode raises here; break mode returns false so we don't pass off a partial scan as done
+                if (!read_limits.check(total_rows_read, total_bytes_read, "rows or bytes to read",
+                                       ErrorCodes::TOO_MANY_ROWS, ErrorCodes::TOO_MANY_BYTES))
+                    return false;
+
+                /// Evaluate the index expression so the aggregator sees what a real
+                /// MATERIALIZE INDEX would see (lower(s) instead of raw s)
+                if (index_expression)
+                    index_expression->execute(block);
+
+                /// Index aggregators require full columns, sparse-serialized parts
+                /// would otherwise trip getRawData (matches the real index writer)
+                for (auto & column : block)
+                    column.column = recursiveRemoveSparse(column.column);
+
+                size_t pos = 0;
+                aggregator->update(block, &pos, block.rows());
+
+                if (block.rows() <= rows_remaining_in_mark)
+                    rows_remaining_in_mark -= block.rows();
+                else
+                    rows_remaining_in_mark = 0;
+
+                if (rows_remaining_in_mark == 0 && current_mark < total_marks)
+                    on_mark_finished();
+            }
+
+            if (!aggregator->empty())
+                flush_window();
+            return true;
+        };
+
+        for (const auto & read_range : read_ranges)
+            if (!scan_range(read_range))
+                return false;
+    }
+
+    if (total_data_granules == 0)
+        return false;
+
+    result.skip_ratio = static_cast<double>(skipped_data_granules) / static_cast<double>(total_data_granules);
+    result.estimated_marks = total_data_granules - skipped_data_granules;
+    result.estimate_source = "empirical";
+    result.empirical_status = WhatIfIndexEstimator::IndexResult::Ok;
+    result.sampled_parts = analysis.selected_parts;
+    result.sampled_marks = analysis.selected_marks;
+    result.elapsed_us = watch.elapsedMicroseconds();
+
+    return true;
+}
+
+}

--- a/src/Storages/MergeTree/WhatIfEmpiricalEstimator.h
+++ b/src/Storages/MergeTree/WhatIfEmpiricalEstimator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Interpreters/Context_fwd.h>
+#include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/RangesInDataPart.h>
+#include <Storages/MergeTree/WhatIfIndexEstimator.h>
+
+namespace DB
+{
+
+/// Build the candidate index in memory over the baseline marks and check each granule
+bool tryEstimateEmpirical(
+    WhatIfIndexEstimator::IndexResult & result,
+    const MergeTreeIndexPtr & index_helper,
+    const MergeTreeIndexConditionPtr & condition,
+    ReadFromMergeTree * read_step,
+    const ReadFromMergeTree::AnalysisResult & analysis,
+    const RangesInDataParts & saved_parts,
+    std::vector<UInt8> * surviving_marks,
+    ContextPtr context);
+
+}

--- a/src/Storages/MergeTree/WhatIfFilterAnalysis.cpp
+++ b/src/Storages/MergeTree/WhatIfFilterAnalysis.cpp
@@ -1,0 +1,51 @@
+#include <Storages/MergeTree/WhatIfFilterAnalysis.h>
+
+#include <Functions/IFunction.h>
+
+namespace DB
+{
+
+void collectFilterInputColumns(const ActionsDAG::Node * node, NameSet & out)
+{
+    if (!node)
+        return;
+    if (node->type == ActionsDAG::ActionType::INPUT)
+        out.insert(node->result_name);
+    for (const auto * child : node->children)
+        collectFilterInputColumns(child, out);
+}
+
+bool disjunctionMixesIndexAndOtherColumns(const ActionsDAG::Node * node, const NameSet & index_columns)
+{
+    if (!node)
+        return false;
+
+    if (node->type == ActionsDAG::ActionType::FUNCTION
+        && node->function_base
+        && node->function_base->getName() == "or")
+    {
+        bool branch_has_index = false;
+        bool branch_has_other = false;
+        for (const auto * child : node->children)
+        {
+            NameSet cols;
+            collectFilterInputColumns(child, cols);
+            for (const auto & col : cols)
+            {
+                if (index_columns.contains(col))
+                    branch_has_index = true;
+                else
+                    branch_has_other = true;
+            }
+        }
+        if (branch_has_index && branch_has_other)
+            return true;
+    }
+
+    for (const auto * child : node->children)
+        if (disjunctionMixesIndexAndOtherColumns(child, index_columns))
+            return true;
+    return false;
+}
+
+}

--- a/src/Storages/MergeTree/WhatIfFilterAnalysis.h
+++ b/src/Storages/MergeTree/WhatIfFilterAnalysis.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Core/Names.h>
+#include <Interpreters/ActionsDAG.h>
+
+namespace DB
+{
+
+void collectFilterInputColumns(const ActionsDAG::Node * node, NameSet & out);
+
+/// TODO(yariks5s): an OR with the candidate's column on one side and another column on the other
+/// The real read can combine them (use_skip_indexes_for_disjunctions) we can't, so we bail on those
+bool disjunctionMixesIndexAndOtherColumns(const ActionsDAG::Node * node, const NameSet & index_columns);
+
+}

--- a/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfIndexEstimator.cpp
@@ -2,39 +2,28 @@
 
 #include <Access/Common/AccessFlags.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ExpressionActions.h>
 #include <Interpreters/HypotheticalIndexStore.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
 #include <Interpreters/InterpreterSelectWithUnionQuery.h>
 #include <Interpreters/JoinedTables.h>
-#include <IO/WriteHelpers.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
-#include <Processors/Executors/PullingPipelineExecutor.h>
-#include <Processors/IProcessor.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
-#include <QueryPipeline/QueryPipeline.h>
-#include <QueryPipeline/SizeLimits.h>
-#include <Storages/MergeTree/AlterConversions.h>
 #include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeIndices.h>
-#include <Storages/MergeTree/MergeTreeSequentialSource.h>
-#include <Storages/Statistics/ConditionSelectivityEstimator.h>
+#include <Storages/MergeTree/WhatIfEmpiricalEstimator.h>
+#include <Storages/MergeTree/WhatIfFilterAnalysis.h>
+#include <Storages/MergeTree/WhatIfSettings.h>
+#include <Storages/MergeTree/WhatIfStatisticalEstimator.h>
 
-#include <Columns/ColumnSparse.h>
 #include <Common/Exception.h>
-#include <Common/formatReadable.h>
 #include <Common/quoteString.h>
-#include <Common/Stopwatch.h>
 #include <Core/Settings.h>
-#include <Functions/IFunction.h>
-
-#include <fmt/format.h>
 
 namespace DB
 {
@@ -47,72 +36,16 @@ namespace Setting
     extern const SettingsBool use_skip_indexes_for_disjunctions;
     extern const SettingsString ignore_data_skipping_indices;
     extern const SettingsString force_data_skipping_indices;
-    extern const SettingsUInt64 merge_tree_min_rows_for_seek;
-    extern const SettingsUInt64 merge_tree_min_bytes_for_seek;
-    extern const SettingsUInt64 max_rows_to_read;
-    extern const SettingsUInt64 max_bytes_to_read;
-    extern const SettingsOverflowMode read_overflow_mode;
 }
 
 namespace ErrorCodes
 {
     extern const int INDEX_NOT_USED;
-    extern const int INVALID_SETTING_VALUE;
     extern const int NOT_IMPLEMENTED;
-    extern const int TOO_MANY_ROWS;
-    extern const int TOO_MANY_BYTES;
-    extern const int UNKNOWN_SETTING;
 }
 
 namespace
 {
-
-struct WhatIfSettings
-{
-    bool empirical = true;
-
-    static WhatIfSettings fromAST(const ASTPtr & settings_ast)
-    {
-        WhatIfSettings result;
-        if (!settings_ast)
-            return result;
-
-        const auto * set_query = settings_ast->as<ASTSetQuery>();
-        if (!set_query)
-            return result;
-
-        for (const auto & change : set_query->changes)
-        {
-            if (change.name == "empirical")
-            {
-                if (change.value.getType() != Field::Types::UInt64)
-                    throw Exception(
-                        ErrorCodes::INVALID_SETTING_VALUE,
-                        "Invalid type {} for setting '{}' in EXPLAIN WHATIF, expected an integer 0 or 1",
-                        change.value.getTypeName(),
-                        change.name);
-
-                auto value = change.value.safeGet<UInt64>();
-                if (value > 1)
-                    throw Exception(
-                        ErrorCodes::INVALID_SETTING_VALUE,
-                        "Invalid value {} for setting '{}' in EXPLAIN WHATIF, expected 0 or 1",
-                        value,
-                        change.name);
-
-                result.empirical = value != 0;
-            }
-            else
-            {
-                throw Exception(
-                    ErrorCodes::UNKNOWN_SETTING,
-                    "Unknown setting \"{}\" for EXPLAIN WHATIF query. Supported settings: empirical",
-                    change.name);
-            }
-        }
-        return result;
-    }
-};
 
 void collectReadSteps(const QueryPlan::Node * node, std::vector<ReadFromMergeTree *> & steps)
 {
@@ -193,368 +126,6 @@ void stripWhatIfControlledSettings(IAST * node, std::vector<String> & removed_fo
 
     for (const auto & child : node->children)
         stripWhatIfControlledSettings(child.get(), removed_force);
-}
-
-void collectFilterInputColumns(const ActionsDAG::Node * node, NameSet & out)
-{
-    if (!node)
-        return;
-    if (node->type == ActionsDAG::ActionType::INPUT)
-        out.insert(node->result_name);
-    for (const auto * child : node->children)
-        collectFilterInputColumns(child, out);
-}
-
-/// TODO(yariks5s): an OR with the candidate's column on one side and another column on the other
-/// The real read can combine them (use_skip_indexes_for_disjunctions) we can't, so we bail on those
-bool disjunctionMixesIndexAndOtherColumns(const ActionsDAG::Node * node, const NameSet & index_columns)
-{
-    if (!node)
-        return false;
-
-    if (node->type == ActionsDAG::ActionType::FUNCTION
-        && node->function_base
-        && node->function_base->getName() == "or")
-    {
-        bool branch_has_index = false;
-        bool branch_has_other = false;
-        for (const auto * child : node->children)
-        {
-            NameSet cols;
-            collectFilterInputColumns(child, cols);
-            for (const auto & col : cols)
-            {
-                if (index_columns.contains(col))
-                    branch_has_index = true;
-                else
-                    branch_has_other = true;
-            }
-        }
-        if (branch_has_index && branch_has_other)
-            return true;
-    }
-
-    for (const auto * child : node->children)
-        if (disjunctionMixesIndexAndOtherColumns(child, index_columns))
-            return true;
-    return false;
-}
-
-/// Estimate skip ratio from column statistics (row-level selectivity as upper bound)
-bool tryEstimateWithStatistics(
-    WhatIfIndexEstimator::IndexResult & result,
-    const MergeTreeIndexPtr & index_helper,
-    ReadFromMergeTree * read_step,
-    const ReadFromMergeTree::AnalysisResult & analysis,
-    const RangesInDataParts & parts,
-    const ActionsDAG::Node * filter_node,
-    ContextPtr context)
-{
-    auto metadata = read_step->getStorageMetadata();
-
-    if (!metadata->hasStatistics())
-        return false;
-
-    if (parts.empty())
-        return false;
-
-    /// Only when filter touches just the index's columns, else other columns'
-    /// selectivity leaks into the skip ratio
-    NameSet index_columns_set;
-    for (const auto & col : index_helper->getColumnsRequiredForIndexCalc())
-        index_columns_set.insert(col);
-
-    NameSet filter_input_columns;
-    collectFilterInputColumns(filter_node, filter_input_columns);
-
-    for (const auto & col : filter_input_columns)
-        if (!index_columns_set.contains(col))
-            return false;
-
-    ConditionSelectivityEstimatorBuilder builder(context);
-    bool has_any_stats = false;
-
-    for (const auto & part : parts)
-    {
-        try
-        {
-            auto stats = part.data_part->loadStatistics();
-            if (!stats.empty())
-            {
-                builder.markDataPart(part.data_part);
-                for (const auto & [column_name, stat] : stats)
-                    builder.addStatistics(column_name, stat);
-                has_any_stats = true;
-            }
-        }
-        catch (const Exception &) /// Ok — statistical estimation is best-effort
-        {
-            tryLogCurrentException(__PRETTY_FUNCTION__);
-        }
-    }
-
-    if (!has_any_stats)
-        return false;
-
-    auto estimator = builder.getEstimator();
-    if (!estimator)
-        return false;
-
-    auto profile = estimator->estimateRelationProfile(metadata, filter_node);
-    auto unfiltered = estimator->estimateRelationProfile();
-    if (unfiltered.rows == 0)
-        return false;
-
-    /// Row-level selectivity as upper bound for granule-level skip ratio
-    double selectivity = std::min(1.0, static_cast<double>(profile.rows) / static_cast<double>(unfiltered.rows));
-    result.skip_ratio = 1.0 - selectivity;
-    result.estimated_marks = std::max<UInt64>(1, static_cast<UInt64>(static_cast<double>(analysis.selected_marks) * selectivity));
-    result.estimate_source = "statistical";
-    return true;
-}
-
-/// Expand each baseline mark range to the full skip-index windows it touches (a window is
-/// `granularity` data granules) and merge them into ranges
-MarkRanges skipIndexWindowsOverlapping(const MarkRanges & baseline, size_t granularity, size_t total_marks)
-{
-    MarkRanges windows;
-    if (granularity == 0 || total_marks == 0)
-        return windows;
-
-    for (const auto & range : baseline)
-    {
-        const size_t last = std::min(range.end, total_marks);
-        if (range.begin >= last)
-            continue;
-
-        const size_t begin = range.begin / granularity * granularity;
-        const size_t end = std::min((last - 1) / granularity * granularity + granularity, total_marks);
-        if (!windows.empty() && begin <= windows.back().end)
-            windows.back().end = std::max(windows.back().end, end);
-        else
-            windows.emplace_back(begin, end);
-    }
-    return windows;
-}
-
-/// Build the candidate index in memory over the baseline marks and check each granule
-bool tryEstimateEmpirical(
-    WhatIfIndexEstimator::IndexResult & result,
-    const MergeTreeIndexPtr & index_helper,
-    const MergeTreeIndexConditionPtr & condition,
-    ReadFromMergeTree * read_step,
-    const ReadFromMergeTree::AnalysisResult & analysis,
-    const RangesInDataParts & saved_parts,
-    std::vector<UInt8> * surviving_marks,
-    ContextPtr context)
-{
-    const auto & data = read_step->getMergeTreeData();
-    const auto & storage_snapshot = read_step->getStorageSnapshot();
-    const auto & mutations_snapshot = read_step->getMutationsSnapshot();
-
-    Names index_columns = index_helper->getColumnsRequiredForIndexCalc();
-    if (index_columns.empty())
-        return false;
-
-    /// With non-zero seek gaps a real read coalesces ranges, so our per-granule count would diverge
-    if (context->getSettingsRef()[Setting::merge_tree_min_rows_for_seek] != 0
-        || context->getSettingsRef()[Setting::merge_tree_min_bytes_for_seek] != 0)
-        return false;
-
-    UInt64 total_data_granules = 0;
-    UInt64 skipped_data_granules = 0;
-    Stopwatch watch;
-
-    /// The whole-part scan is not the normal read pipeline, so enforce the query's
-    /// read limits explicitly (max_execution_time is handled by the process-list element)
-    const auto & limit_settings = context->getSettingsRef();
-    const SizeLimits read_limits(
-        limit_settings[Setting::max_rows_to_read],
-        limit_settings[Setting::max_bytes_to_read],
-        limit_settings[Setting::read_overflow_mode]);
-    UInt64 total_rows_read = 0;
-    UInt64 total_bytes_read = 0;
-
-    const size_t skip_index_granularity = index_helper->index.granularity;
-    auto index_expression = index_helper->index.expression;
-
-    /// Position of the next baseline mark, gives every candidate's bitmap the same coordinates
-    size_t baseline_mark_pos = 0;
-
-    for (const auto & part_with_ranges : saved_parts)
-    {
-        auto part = part_with_ranges.data_part;
-        const auto & mark_ranges = part_with_ranges.ranges;
-
-        if (mark_ranges.empty())
-            continue;
-
-        const auto & part_index_granularity = part->index_granularity;
-        const size_t total_marks = part_index_granularity->getMarksCountWithoutFinal();
-
-        std::vector<bool> in_baseline(part->getMarksCount(), false);
-        for (const auto & range : mark_ranges)
-            for (size_t m = range.begin; m < range.end && m < in_baseline.size(); ++m)
-                in_baseline[m] = true;
-
-        /// Read only the skip-index windows overlapping the baseline instead of the whole part
-        const MarkRanges read_ranges = skipIndexWindowsOverlapping(mark_ranges, skip_index_granularity, total_marks);
-        if (read_ranges.empty())
-            continue;
-
-        /// Apply patch parts / on-the-fly mutations so we see the up-to-date values
-        auto alter_conversions = mutations_snapshot
-            ? MergeTreeData::getAlterConversionsForPart(part, mutations_snapshot, context)
-            : std::make_shared<AlterConversions>();
-
-        /// aggregate each skip-index granule and count how many
-        /// baseline granules the candidate would skip. Returns false if a read limit was hit
-        auto scan_range = [&](const MarkRange & read_range) -> bool
-        {
-            RangesInDataPart part_for_read(part);
-
-            Pipe pipe = createMergeTreeSequentialSource(
-                MergeTreeSequentialSourceType::Merge,
-                data,
-                storage_snapshot,
-                std::move(part_for_read),
-                alter_conversions,
-                nullptr,
-                index_columns,
-                MarkRanges{read_range},
-                std::make_shared<std::atomic<size_t>>(0),
-                false,
-                false,
-                false);
-
-            /// Apply the query's execution-speed limits here too (size is the explicit check below)
-            if (auto query_limits = read_step->getQueryInfo().storage_limits)
-            {
-                auto speed_limits = std::make_shared<StorageLimitsList>(*query_limits);
-                for (auto & entry : *speed_limits)
-                {
-                    entry.local_limits.size_limits = {};
-                    entry.leaf_limits = {};
-                    entry.local_limits.speed_limits.max_execution_time = {};
-                }
-                for (const auto & processor : pipe.getProcessors())
-                    processor->setStorageLimits(speed_limits);
-            }
-
-            QueryPipeline pipeline(std::move(pipe));
-            /// Tie the scan to the query so quota / speed / time limits apply
-            pipeline.setProcessListElement(context->getProcessListElement());
-            pipeline.setProgressCallback(context->getProgressCallback());
-            pipeline.setQuota(context->getQuota());
-            /// Carry the query hash so the empirical scan's `read_rows`/`read_bytes` are accounted to the
-            /// query's own bucket under a `KEYED BY normalized_query_hash` quota, not the shared hash-0 one.
-            pipeline.setNormalizedQueryHash(context->getNormalizedQueryHash());
-            PullingPipelineExecutor executor(pipeline);
-
-            auto aggregator = index_helper->createIndexAggregator();
-            size_t current_mark = read_range.begin;
-            size_t rows_remaining_in_mark = current_mark < total_marks
-                ? part_index_granularity->getMarkRows(current_mark)
-                : 0;
-            size_t data_granules_in_window = 0;
-            size_t baseline_marks_in_window = 0;
-            std::vector<size_t> window_baseline_marks;
-
-            auto flush_window = [&]
-            {
-                if (baseline_marks_in_window == 0)
-                    return;
-                auto granule = aggregator->getGranuleAndReset();
-                total_data_granules += baseline_marks_in_window;
-                if (!condition->mayBeTrueOnGranule(granule, {}))
-                    skipped_data_granules += baseline_marks_in_window;
-                else if (surviving_marks)
-                    for (size_t pos : window_baseline_marks)
-                        (*surviving_marks)[pos] = 1;
-            };
-
-            auto on_mark_finished = [&]
-            {
-                ++data_granules_in_window;
-                if (current_mark < in_baseline.size() && in_baseline[current_mark])
-                {
-                    ++baseline_marks_in_window;
-                    if (surviving_marks)
-                        window_baseline_marks.push_back(baseline_mark_pos++);
-                }
-
-                if (data_granules_in_window >= skip_index_granularity)
-                {
-                    flush_window();
-                    aggregator = index_helper->createIndexAggregator();
-                    data_granules_in_window = 0;
-                    baseline_marks_in_window = 0;
-                    window_baseline_marks.clear();
-                }
-
-                ++current_mark;
-                rows_remaining_in_mark = current_mark < total_marks
-                    ? part_index_granularity->getMarkRows(current_mark)
-                    : 0;
-            };
-
-            Block block;
-            while (executor.pull(block))
-            {
-                if (block.rows() == 0)
-                    continue;
-
-                total_rows_read += block.rows();
-                total_bytes_read += block.bytes();
-                /// throw mode raises here; break mode returns false so we don't pass off a partial scan as done
-                if (!read_limits.check(total_rows_read, total_bytes_read, "rows or bytes to read",
-                                       ErrorCodes::TOO_MANY_ROWS, ErrorCodes::TOO_MANY_BYTES))
-                    return false;
-
-                /// Evaluate the index expression so the aggregator sees what a real
-                /// MATERIALIZE INDEX would see (lower(s) instead of raw s)
-                if (index_expression)
-                    index_expression->execute(block);
-
-                /// Index aggregators require full columns, sparse-serialized parts
-                /// would otherwise trip getRawData (matches the real index writer)
-                for (auto & column : block)
-                    column.column = recursiveRemoveSparse(column.column);
-
-                size_t pos = 0;
-                aggregator->update(block, &pos, block.rows());
-
-                if (block.rows() <= rows_remaining_in_mark)
-                    rows_remaining_in_mark -= block.rows();
-                else
-                    rows_remaining_in_mark = 0;
-
-                if (rows_remaining_in_mark == 0 && current_mark < total_marks)
-                    on_mark_finished();
-            }
-
-            if (!aggregator->empty())
-                flush_window();
-            return true;
-        };
-
-        for (const auto & read_range : read_ranges)
-            if (!scan_range(read_range))
-                return false;
-    }
-
-    if (total_data_granules == 0)
-        return false;
-
-    result.skip_ratio = static_cast<double>(skipped_data_granules) / static_cast<double>(total_data_granules);
-    result.estimated_marks = total_data_granules - skipped_data_granules;
-    result.estimate_source = "empirical";
-    result.empirical_status = WhatIfIndexEstimator::IndexResult::Ok;
-    result.sampled_parts = analysis.selected_parts;
-    result.sampled_marks = analysis.selected_marks;
-    result.elapsed_us = watch.elapsedMicroseconds();
-
-    return true;
 }
 
 /// Check applicability, then try empirical → statistical → applicability_only
@@ -940,67 +511,6 @@ WhatIfIndexEstimator::Result WhatIfIndexEstimator::run(
     }
 
     return result;
-}
-
-
-void WhatIfIndexEstimator::Result::format(WriteBuffer & out) const
-{
-    writeCString("Baseline (after PK + partition + existing indexes):\n", out);
-    writeString(fmt::format("  table:       {}.{}\n", database, table), out);
-    writeString(fmt::format("  parts:       {}\n", baseline_parts), out);
-    writeString(fmt::format("  marks:       {}\n", baseline_marks), out);
-    if (baseline_est_bytes > 0)
-        writeString(fmt::format("  est_bytes:   {}\n", ReadableSize(baseline_est_bytes)), out);
-    writeCString("\n", out);
-
-    for (const auto & idx : index_results)
-    {
-        if (!idx.index_type.empty())
-            writeString(fmt::format("With {} ({}, hypothetical):\n", idx.index_name, idx.index_type), out);
-        else
-            writeString(fmt::format("{}:\n", idx.index_name), out);
-
-        if (idx.status == IndexResult::NotApplicable)
-        {
-            writeCString("  status:       not_applicable\n", out);
-            writeString(fmt::format("  reason:       {}\n", idx.not_applicable_reason), out);
-            writeCString("\n", out);
-            continue;
-        }
-
-        writeCString("  status:       applicable\n", out);
-        writeString(fmt::format("  marks:        {}\n", idx.estimated_marks), out);
-
-        if (baseline_marks > 0 && baseline_est_bytes > 0)
-        {
-            UInt64 hypo_bytes = static_cast<UInt64>(
-                static_cast<double>(baseline_est_bytes) * static_cast<double>(idx.estimated_marks) / static_cast<double>(baseline_marks));
-            writeString(fmt::format("  est_bytes:    {}\n", ReadableSize(hypo_bytes)), out);
-        }
-
-        writeString(fmt::format("  skip_ratio:   {:.1f}%\n", idx.skip_ratio * 100.0), out);
-        writeCString("\n", out);
-
-        writeCString("Estimation:\n", out);
-        writeString(fmt::format("  source:           {}\n", idx.estimate_source), out);
-
-        String empirical_status_str;
-        switch (idx.empirical_status)
-        {
-            case IndexResult::Ok: empirical_status_str = "ok"; break;
-            case IndexResult::Unsupported: empirical_status_str = "unsupported"; break;
-            case IndexResult::Disabled: empirical_status_str = "disabled"; break;
-        }
-        writeString(fmt::format("  empirical_status: {}\n", empirical_status_str), out);
-
-        if (idx.empirical_status == IndexResult::Ok)
-        {
-            writeString(fmt::format("  sampled_parts:    {} / {}\n", idx.sampled_parts, idx.total_parts), out);
-            writeString(fmt::format("  sampled_marks:    {} / {}\n", idx.sampled_marks, idx.total_marks), out);
-            writeString(fmt::format("  elapsed_us:       {}\n", idx.elapsed_us), out);
-        }
-        writeCString("\n", out);
-    }
 }
 
 }

--- a/src/Storages/MergeTree/WhatIfResultFormatter.cpp
+++ b/src/Storages/MergeTree/WhatIfResultFormatter.cpp
@@ -1,0 +1,71 @@
+#include <Storages/MergeTree/WhatIfIndexEstimator.h>
+
+#include <IO/WriteHelpers.h>
+#include <Common/formatReadable.h>
+
+#include <fmt/format.h>
+
+namespace DB
+{
+
+void WhatIfIndexEstimator::Result::format(WriteBuffer & out) const
+{
+    writeCString("Baseline (after PK + partition + existing indexes):\n", out);
+    writeString(fmt::format("  table:       {}.{}\n", database, table), out);
+    writeString(fmt::format("  parts:       {}\n", baseline_parts), out);
+    writeString(fmt::format("  marks:       {}\n", baseline_marks), out);
+    if (baseline_est_bytes > 0)
+        writeString(fmt::format("  est_bytes:   {}\n", ReadableSize(baseline_est_bytes)), out);
+    writeCString("\n", out);
+
+    for (const auto & idx : index_results)
+    {
+        if (!idx.index_type.empty())
+            writeString(fmt::format("With {} ({}, hypothetical):\n", idx.index_name, idx.index_type), out);
+        else
+            writeString(fmt::format("{}:\n", idx.index_name), out);
+
+        if (idx.status == IndexResult::NotApplicable)
+        {
+            writeCString("  status:       not_applicable\n", out);
+            writeString(fmt::format("  reason:       {}\n", idx.not_applicable_reason), out);
+            writeCString("\n", out);
+            continue;
+        }
+
+        writeCString("  status:       applicable\n", out);
+        writeString(fmt::format("  marks:        {}\n", idx.estimated_marks), out);
+
+        if (baseline_marks > 0 && baseline_est_bytes > 0)
+        {
+            UInt64 hypo_bytes = static_cast<UInt64>(
+                static_cast<double>(baseline_est_bytes) * static_cast<double>(idx.estimated_marks) / static_cast<double>(baseline_marks));
+            writeString(fmt::format("  est_bytes:    {}\n", ReadableSize(hypo_bytes)), out);
+        }
+
+        writeString(fmt::format("  skip_ratio:   {:.1f}%\n", idx.skip_ratio * 100.0), out);
+        writeCString("\n", out);
+
+        writeCString("Estimation:\n", out);
+        writeString(fmt::format("  source:           {}\n", idx.estimate_source), out);
+
+        String empirical_status_str;
+        switch (idx.empirical_status)
+        {
+            case IndexResult::Ok: empirical_status_str = "ok"; break;
+            case IndexResult::Unsupported: empirical_status_str = "unsupported"; break;
+            case IndexResult::Disabled: empirical_status_str = "disabled"; break;
+        }
+        writeString(fmt::format("  empirical_status: {}\n", empirical_status_str), out);
+
+        if (idx.empirical_status == IndexResult::Ok)
+        {
+            writeString(fmt::format("  sampled_parts:    {} / {}\n", idx.sampled_parts, idx.total_parts), out);
+            writeString(fmt::format("  sampled_marks:    {} / {}\n", idx.sampled_marks, idx.total_marks), out);
+            writeString(fmt::format("  elapsed_us:       {}\n", idx.elapsed_us), out);
+        }
+        writeCString("\n", out);
+    }
+}
+
+}

--- a/src/Storages/MergeTree/WhatIfSettings.cpp
+++ b/src/Storages/MergeTree/WhatIfSettings.cpp
@@ -1,0 +1,58 @@
+#include <Storages/MergeTree/WhatIfSettings.h>
+
+#include <Core/Field.h>
+#include <Parsers/ASTSetQuery.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int INVALID_SETTING_VALUE;
+    extern const int UNKNOWN_SETTING;
+}
+
+WhatIfSettings WhatIfSettings::fromAST(const ASTPtr & settings_ast)
+{
+    WhatIfSettings result;
+    if (!settings_ast)
+        return result;
+
+    const auto * set_query = settings_ast->as<ASTSetQuery>();
+    if (!set_query)
+        return result;
+
+    for (const auto & change : set_query->changes)
+    {
+        if (change.name == "empirical")
+        {
+            if (change.value.getType() != Field::Types::UInt64)
+                throw Exception(
+                    ErrorCodes::INVALID_SETTING_VALUE,
+                    "Invalid type {} for setting '{}' in EXPLAIN WHATIF, expected an integer 0 or 1",
+                    change.value.getTypeName(),
+                    change.name);
+
+            auto value = change.value.safeGet<UInt64>();
+            if (value > 1)
+                throw Exception(
+                    ErrorCodes::INVALID_SETTING_VALUE,
+                    "Invalid value {} for setting '{}' in EXPLAIN WHATIF, expected 0 or 1",
+                    value,
+                    change.name);
+
+            result.empirical = value != 0;
+        }
+        else
+        {
+            throw Exception(
+                ErrorCodes::UNKNOWN_SETTING,
+                "Unknown setting \"{}\" for EXPLAIN WHATIF query. Supported settings: empirical",
+                change.name);
+        }
+    }
+    return result;
+}
+
+}

--- a/src/Storages/MergeTree/WhatIfSettings.h
+++ b/src/Storages/MergeTree/WhatIfSettings.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+
+namespace DB
+{
+
+/// Settings of the `EXPLAIN WHATIF` query itself (the `SETTINGS` clause of the EXPLAIN)
+struct WhatIfSettings
+{
+    bool empirical = true;
+
+    static WhatIfSettings fromAST(const ASTPtr & settings_ast);
+};
+
+}

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
@@ -1,0 +1,82 @@
+#include <Storages/MergeTree/WhatIfStatisticalEstimator.h>
+
+#include <Storages/MergeTree/WhatIfFilterAnalysis.h>
+#include <Storages/Statistics/ConditionSelectivityEstimator.h>
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+bool tryEstimateWithStatistics(
+    WhatIfIndexEstimator::IndexResult & result,
+    const MergeTreeIndexPtr & index_helper,
+    ReadFromMergeTree * read_step,
+    const ReadFromMergeTree::AnalysisResult & analysis,
+    const RangesInDataParts & parts,
+    const ActionsDAG::Node * filter_node,
+    ContextPtr context)
+{
+    auto metadata = read_step->getStorageMetadata();
+
+    if (!metadata->hasStatistics())
+        return false;
+
+    if (parts.empty())
+        return false;
+
+    /// Only when filter touches just the index's columns, else other columns'
+    /// selectivity leaks into the skip ratio
+    NameSet index_columns_set;
+    for (const auto & col : index_helper->getColumnsRequiredForIndexCalc())
+        index_columns_set.insert(col);
+
+    NameSet filter_input_columns;
+    collectFilterInputColumns(filter_node, filter_input_columns);
+
+    for (const auto & col : filter_input_columns)
+        if (!index_columns_set.contains(col))
+            return false;
+
+    ConditionSelectivityEstimatorBuilder builder(context);
+    bool has_any_stats = false;
+
+    for (const auto & part : parts)
+    {
+        try
+        {
+            auto stats = part.data_part->loadStatistics();
+            if (!stats.empty())
+            {
+                builder.markDataPart(part.data_part);
+                for (const auto & [column_name, stat] : stats)
+                    builder.addStatistics(column_name, stat);
+                has_any_stats = true;
+            }
+        }
+        catch (const Exception &) /// Ok — statistical estimation is best-effort
+        {
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+    }
+
+    if (!has_any_stats)
+        return false;
+
+    auto estimator = builder.getEstimator();
+    if (!estimator)
+        return false;
+
+    auto profile = estimator->estimateRelationProfile(metadata, filter_node);
+    auto unfiltered = estimator->estimateRelationProfile();
+    if (unfiltered.rows == 0)
+        return false;
+
+    /// Row-level selectivity as upper bound for granule-level skip ratio
+    double selectivity = std::min(1.0, static_cast<double>(profile.rows) / static_cast<double>(unfiltered.rows));
+    result.skip_ratio = 1.0 - selectivity;
+    result.estimated_marks = std::max<UInt64>(1, static_cast<UInt64>(static_cast<double>(analysis.selected_marks) * selectivity));
+    result.estimate_source = "statistical";
+    return true;
+}
+
+}

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.h
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Interpreters/ActionsDAG.h>
+#include <Interpreters/Context_fwd.h>
+#include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/RangesInDataPart.h>
+#include <Storages/MergeTree/WhatIfIndexEstimator.h>
+
+namespace DB
+{
+
+/// Estimate skip ratio from column statistics (row-level selectivity as upper bound)
+bool tryEstimateWithStatistics(
+    WhatIfIndexEstimator::IndexResult & result,
+    const MergeTreeIndexPtr & index_helper,
+    ReadFromMergeTree * read_step,
+    const ReadFromMergeTree::AnalysisResult & analysis,
+    const RangesInDataParts & parts,
+    const ActionsDAG::Node * filter_node,
+    ContextPtr context);
+
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you do not need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104608
Related: https://github.com/ClickHouse/ClickHouse/pull/108934
-->

`WhatIfIndexEstimator.cpp` had grown to ~1000 lines and mixed several concerns: parsing of `EXPLAIN WHATIF` settings, baseline planning, the empirical scan, the statistical fallback, and result formatting. This PR splits it into per-concern modules under `src/Storages/MergeTree/`:

- `WhatIfSettings` — parsing of the `SETTINGS` clause of `EXPLAIN WHATIF`
- `WhatIfFilterAnalysis` — filter-DAG helpers (`collectFilterInputColumns`, `disjunctionMixesIndexAndOtherColumns`) shared by the applicability check and the statistical estimator
- `WhatIfEmpiricalEstimator` — building the candidate index in memory over the baseline marks and checking each granule
- `WhatIfStatisticalEstimator` — the estimate from column statistics
- `WhatIfResultFormatter` — the text output of `WhatIfIndexEstimator::Result::format`
- `WhatIfIndexEstimator` — keeps only the orchestration: baseline planning, per-index applicability, `FINAL` and `force_data_skipping_indices` handling, and the combined estimate

Related: https://github.com/ClickHouse/ClickHouse/pull/104608
Related: https://github.com/ClickHouse/ClickHouse/pull/108934

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.544` (included in `26.7` and later)
<!-- ch-version-info:end -->