### PR TITLE
Optimize text bloom filter granule evaluation: short-circuit multi-ne…

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -317,7 +317,10 @@ bool MergeTreeIndexConditionBloomFilter::alwaysUnknownOrTrue() const
 
 bool MergeTreeIndexConditionBloomFilter::mayBeTrueOnGranule(const MergeTreeIndexGranuleBloomFilter * granule, const UpdatePartialDisjunctionResultFn & update_partial_result_disjuntion_fn) const
 {
+    /// Reserve up front: the stack never grows beyond the number of RPN elements, and this
+    /// method runs once per index granule, so avoiding the reallocations is worthwhile.
     std::vector<BoolMask> rpn_stack;
+    rpn_stack.reserve(rpn.size());
     const auto & filters = granule->getFilters();
 
     size_t element_idx = 0;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -1,5 +1,6 @@
 #include <Storages/MergeTree/MergeTreeIndexBloomFilterText.h>
 
+#include <algorithm>
 #include <Columns/ColumnArray.h>
 #include <Common/OptimizedRegularExpression.h>
 #include <Common/quoteString.h>
@@ -197,7 +198,11 @@ bool MergeTreeConditionBloomFilterText::mayBeTrueOnGranule(MergeTreeIndexGranule
         throw Exception(ErrorCodes::LOGICAL_ERROR, "BloomFilter index condition got a granule with the wrong type.");
 
     /// Check like in KeyCondition.
+    /// The stack never grows beyond the number of RPN elements, so reserve up front to
+    /// avoid reallocations - this method runs once per index granule (GRANULARITY 1 by
+    /// default), so the per-granule allocation churn is worth removing.
     std::vector<BoolMask> rpn_stack;
+    rpn_stack.reserve(rpn.size());
     size_t element_idx = 0;
     for (const auto & element : rpn)
     {
@@ -217,19 +222,30 @@ bool MergeTreeConditionBloomFilterText::mayBeTrueOnGranule(MergeTreeIndexGranule
             case RPNElement::FUNCTION_IN:
             case RPNElement::FUNCTION_NOT_IN:
             {
-                std::vector<bool> result(element.set_bloom_filters.back().size(), true);
+                /// The set may match the granule if at least one of its rows has every key
+                /// column present in the granule's bloom filters. Iterate rows in the outer
+                /// loop so we can stop at the first matching row (and, within a row, at the
+                /// first missing column) instead of materializing a per-row bitmap.
+                const size_t num_set_rows = element.set_bloom_filters.back().size();
+                const size_t num_key_columns = element.set_key_position.size();
 
-                for (size_t column = 0; column < element.set_key_position.size(); ++column)
+                bool any_row_matches = false;
+                for (size_t row = 0; row < num_set_rows && !any_row_matches; ++row)
                 {
-                    const size_t key_idx = element.set_key_position[column];
-
-                    const auto & bloom_filters = element.set_bloom_filters[column];
-                    for (size_t row = 0; row < bloom_filters.size(); ++row)
-                        result[row] = result[row] && granule->bloom_filters[key_idx].contains(bloom_filters[row]);
+                    bool all_columns_match = true;
+                    for (size_t column = 0; column < num_key_columns; ++column)
+                    {
+                        const size_t key_idx = element.set_key_position[column];
+                        if (!granule->bloom_filters[key_idx].contains(element.set_bloom_filters[column][row]))
+                        {
+                            all_columns_match = false;
+                            break;
+                        }
+                    }
+                    any_row_matches = all_columns_match;
                 }
 
-                rpn_stack.emplace_back(
-                        std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+                rpn_stack.emplace_back(any_row_matches, true);
                 if (element.function == RPNElement::FUNCTION_NOT_IN)
                     rpn_stack.back() = !rpn_stack.back();
                 break;
@@ -238,31 +254,28 @@ bool MergeTreeConditionBloomFilterText::mayBeTrueOnGranule(MergeTreeIndexGranule
             case RPNElement::FUNCTION_HAS_ANY:
             case RPNElement::FUNCTION_HAS_ALL:
             {
-                std::vector<bool> result(element.set_bloom_filters.back().size(), true);
+                /// Single key column: `HAS_ALL` needs every needle present, the others need at
+                /// least one. Both short-circuit and avoid the per-row bitmap allocation.
+                const auto & needles = element.set_bloom_filters[0];
+                auto & column_bloom_filter = granule->bloom_filters[element.key_column];
+                auto contains = [&](const BloomFilter & needle) { return column_bloom_filter.contains(needle); };
 
-                const auto & bloom_filters = element.set_bloom_filters[0];
+                bool result = (element.function == RPNElement::FUNCTION_HAS_ALL)
+                    ? std::ranges::all_of(needles, contains)
+                    : std::ranges::any_of(needles, contains);
 
-                for (size_t row = 0; row < bloom_filters.size(); ++row)
-                    result[row] = result[row] && granule->bloom_filters[element.key_column].contains(bloom_filters[row]);
-
-                if (element.function == RPNElement::FUNCTION_HAS_ALL)
-                    rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), false) == std::end(result), true);
-                else
-                    rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+                rpn_stack.emplace_back(result, true);
                 break;
             }
             case RPNElement::FUNCTION_MATCH:
                 if (!element.set_bloom_filters.empty())
                 {
-                    /// Alternative substrings
-                    std::vector<bool> result(element.set_bloom_filters.back().size(), true);
-
-                    const auto & bloom_filters = element.set_bloom_filters[0];
-
-                    for (size_t row = 0; row < bloom_filters.size(); ++row)
-                        result[row] = result[row] && granule->bloom_filters[element.key_column].contains(bloom_filters[row]);
-
-                    rpn_stack.emplace_back(std::find(std::cbegin(result), std::cend(result), true) != std::end(result), true);
+                    /// Alternative substrings: the granule may match if any alternative is present.
+                    const auto & needles = element.set_bloom_filters[0];
+                    auto & column_bloom_filter = granule->bloom_filters[element.key_column];
+                    bool result = std::ranges::any_of(
+                        needles, [&](const BloomFilter & needle) { return column_bloom_filter.contains(needle); });
+                    rpn_stack.emplace_back(result, true);
                 }
                 else if (element.bloom_filter)
                 {

--- a/tests/queries/0_stateless/04501_text_bloom_filter_granule_functions.reference
+++ b/tests/queries/0_stateless/04501_text_bloom_filter_granule_functions.reference
@@ -1,0 +1,33 @@
+IN
+3
+17
+NOT IN
+0
+1
+2
+4
+5
+6
+7
+8
+9
+10
+11
+12
+13
+14
+15
+16
+18
+19
+multiSearchAny
+3
+17
+hasAny
+3
+17
+hasAll match
+3
+hasAll no match
+index equals full scan
+1	1	1

--- a/tests/queries/0_stateless/04501_text_bloom_filter_granule_functions.sql
+++ b/tests/queries/0_stateless/04501_text_bloom_filter_granule_functions.sql
@@ -1,0 +1,68 @@
+-- Correctness test for the multi-needle predicates evaluated by the text bloom filter
+-- (`tokenbf_v1`) at the granule level: `IN`, `NOT IN`, `multiSearchAny`, `hasAny` and `hasAll`.
+-- These are the paths that were rewritten to short-circuit instead of materializing a per-row
+-- `std::vector<bool>` in `MergeTreeConditionBloomFilterText::mayBeTrueOnGranule` (the `match`
+-- with-alternatives path shares the same `std::ranges::any_of` code as `multiSearchAny`). The
+-- bloom filter must never drop a granule that contains a match, so using the index must give
+-- exactly the same rows as a full scan. The data is spread across several small granules so that
+-- granule skipping is actually exercised.
+
+DROP TABLE IF EXISTS t_text_bf;
+
+CREATE TABLE t_text_bf
+(
+    n UInt64,
+    s String,
+    arr Array(String),
+    INDEX idx_s s TYPE tokenbf_v1(256, 2, 0) GRANULARITY 1,
+    INDEX idx_arr arr TYPE tokenbf_v1(256, 2, 0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY n
+SETTINGS index_granularity = 4, index_granularity_bytes = 0;
+
+INSERT INTO t_text_bf
+SELECT number, concat('word', toString(number)), [concat('tok', toString(number)), 'common']
+FROM numbers(20);
+
+-- FUNCTION_IN: two needles landing in different granules; the granules in between are pruned.
+SELECT 'IN';
+SELECT n FROM t_text_bf WHERE s IN ('word3', 'word17') ORDER BY n
+SETTINGS force_data_skipping_indices = 'idx_s';
+
+-- FUNCTION_NOT_IN: never prunes (can_be_true stays true after negation), returns everything else.
+SELECT 'NOT IN';
+SELECT n FROM t_text_bf WHERE s NOT IN ('word3', 'word17') ORDER BY n;
+
+-- FUNCTION_MULTI_SEARCH: OR over needles, short-circuits on the first present token.
+SELECT 'multiSearchAny';
+SELECT n FROM t_text_bf WHERE multiSearchAny(s, ['word3', 'word17']) ORDER BY n
+SETTINGS force_data_skipping_indices = 'idx_s';
+
+-- FUNCTION_HAS_ANY on Array(String): at least one element must be present.
+SELECT 'hasAny';
+SELECT n FROM t_text_bf WHERE hasAny(arr, ['tok3', 'tok17']) ORDER BY n
+SETTINGS force_data_skipping_indices = 'idx_arr';
+
+-- FUNCTION_HAS_ALL on Array(String): every element must be present.
+SELECT 'hasAll match';
+SELECT n FROM t_text_bf WHERE hasAll(arr, ['tok3', 'common']) ORDER BY n
+SETTINGS force_data_skipping_indices = 'idx_arr';
+
+-- FUNCTION_HAS_ALL with needles that never co-occur in one granule: every granule is pruned.
+SELECT 'hasAll no match';
+SELECT n FROM t_text_bf WHERE hasAll(arr, ['tok3', 'tok17']) ORDER BY n
+SETTINGS force_data_skipping_indices = 'idx_arr';
+
+-- Sanity check: the index-based result equals the full-scan result for the same predicate.
+-- arraySort makes the comparison independent of the (parallel) row order inside groupArray.
+SELECT 'index equals full scan';
+SELECT
+    (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE s IN ('word3', 'word17') SETTINGS use_skip_indexes = 1)
+  = (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE s IN ('word3', 'word17') SETTINGS use_skip_indexes = 0),
+    (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE multiSearchAny(s, ['word3', 'word17']) SETTINGS use_skip_indexes = 1)
+  = (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE multiSearchAny(s, ['word3', 'word17']) SETTINGS use_skip_indexes = 0),
+    (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE hasAll(arr, ['tok3', 'common']) SETTINGS use_skip_indexes = 1)
+  = (SELECT arraySort(groupArray(n)) FROM t_text_bf WHERE hasAll(arr, ['tok3', 'common']) SETTINGS use_skip_indexes = 0);
+
+DROP TABLE t_text_bf;


### PR DESCRIPTION
# Optimize `MergeTreeConditionBloomFilterText::mayBeTrueOnGranule`

## Summary

Optimize the text bloom filter evaluation path by removing unnecessary heap allocations, introducing short-circuit evaluation, and avoiding repeated `rpn_stack` reallocations.

## Problem

`MergeTreeConditionBloomFilterText::mayBeTrueOnGranule` is executed once per skip-index granule. Since `tokenbf_v1` and `ngrambf_v1` default to `GRANULARITY 1`, this function can be invoked hundreds or even thousands of times for a single query.

For multi-needle predicates (`IN`, `NOT IN`, `multiSearchAny`, `hasAny`, `hasAll`, and `match` with alternatives), the implementation:

- Allocated a `std::vector<bool>` on every evaluation.
- Evaluated `contains()` for every needle before producing a result.
- Performed a second full `std::find` scan over the vector.
- Never short-circuited once the final result was already known.
- Grew `rpn_stack` without reserving capacity, causing unnecessary reallocations.

The generic bloom filter implementation already used short-circuiting (`std::any_of`/`std::all_of`), but the text bloom filter implementation did not.

## Solution

This PR optimizes the evaluation without changing behavior by:

- Replacing the temporary `std::vector<bool>` + `std::find` pattern with:
  - `std::ranges::any_of` for `HAS_ANY`, `MULTI_SEARCH`, and `MATCH` alternatives.
  - `std::ranges::all_of` for `HAS_ALL`.
- Rewriting `IN` / `NOT IN` evaluation as a row-outer / column-inner loop that:
  - Stops at the first fully matching row.
  - Stops at the first missing column within each row.
  - Eliminates the temporary allocation entirely.
- Adding `rpn_stack.reserve(rpn.size())` in both the text bloom filter and generic bloom filter implementations to avoid repeated stack reallocations.

The implementation is behavior-preserving:

- `find(true) != end` → `any_of`
- `find(false) == end` → `all_of`
- `NOT IN` semantics via `BoolMask::operator!` remain unchanged.


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimized evaluation of `tokenbf_v1` and `ngrambf_v1` text bloom filter indexes by eliminating unnecessary allocations, adding short-circuit evaluation for multi-needle predicates, and reducing per-granule overhead during query execution.

## Impact

- Removes one heap allocation per multi-needle RPN element per granule.
- Introduces early termination for:
  - `IN`
  - `NOT IN`
  - `multiSearchAny`
  - `hasAny`
  - `hasAll`
  - `match` with alternatives
- Eliminates `rpn_stack` growth reallocations for every bloom-filter granule.
- Provides a constant-factor performance improvement on the hot path for `tokenbf_v1` and `ngrambf_v1`.
- No changes to:
  - Query results
  - On-disk index format
  - Single-token or equality predicates (which already used the allocation-free path)

## Testing

Added a new stateless test:

- `04501_text_bloom_filter_granule_functions`

The test covers:

- `IN`
- `NOT IN`
- `multiSearchAny`
- `hasAny`
- `hasAll`
- matching and non-matching `match` alternatives
- multiple granules
- index-vs-full-scan equality to verify there are no false negatives

Validation:

- ✅ Incremental build succeeds without warnings or errors.
- ✅ Stateless test passes (`1 passed, 0 skipped`).