### PR TITLE
Enable optimize_row_order by default for tables without an ORDER BY key

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1279,6 +1279,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         addSettingsChanges(merge_tree_settings_changes_history, "26.7",
         {
             {"allow_experimental_text_index_positions", false, false, "New setting"},
+            {"optimize_row_order_if_no_order_by", false, true, "New setting to automatically apply the row order optimization (see optimize_row_order) to ordinary MergeTree tables that have no ORDER BY key. Enabled by default; previous_value=false reproduces the pre-26.7 behavior where such tables were not row-order-optimized unless optimize_row_order was set explicitly."},
         });
 
         addSettingsChanges(merge_tree_settings_changes_history, "26.6",

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -95,6 +95,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsUInt64 min_free_disk_bytes_to_perform_insert;
     extern const MergeTreeSettingsFloat min_free_disk_ratio_to_perform_insert;
     extern const MergeTreeSettingsBool optimize_row_order;
+    extern const MergeTreeSettingsBool optimize_row_order_if_no_order_by;
     extern const MergeTreeSettingsFloat ratio_of_defaults_for_sparse_serialization;
     extern const MergeTreeSettingsMergeTreeSerializationInfoVersion serialization_info_version;
     extern const MergeTreeSettingsMergeTreeStringSerializationVersion string_serialization_version;
@@ -776,7 +777,12 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
             ProfileEvents::increment(ProfileEvents::MergeTreeDataWriterBlocksAlreadySorted);
     }
 
-    if ((*data_settings)[MergeTreeSetting::optimize_row_order]
+    /// The row order optimization is applied if it is explicitly enabled via optimize_row_order, or if the
+    /// table has no ORDER BY key (empty sort_description) and optimize_row_order_if_no_order_by is enabled.
+    /// A table without an ORDER BY key imposes no ordering on its rows, so they can be freely re-shuffled
+    /// to improve compressability at no cost, hence the optimization is on by default in that case.
+    if (((*data_settings)[MergeTreeSetting::optimize_row_order]
+            || (sort_description.empty() && (*data_settings)[MergeTreeSetting::optimize_row_order_if_no_order_by]))
         && data.merging_params.mode
             == MergeTreeData::MergingParams::Mode::Ordinary) /// Nobody knows if this optimization messes up specialized MergeTree engines.
     {
@@ -1123,7 +1129,12 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
             ProfileEvents::increment(ProfileEvents::MergeTreeDataProjectionWriterBlocksAlreadySorted);
     }
 
-    if ((*data_settings)[MergeTreeSetting::optimize_row_order]
+    /// The row order optimization is applied if it is explicitly enabled via optimize_row_order, or if the
+    /// table has no ORDER BY key (empty sort_description) and optimize_row_order_if_no_order_by is enabled.
+    /// A table without an ORDER BY key imposes no ordering on its rows, so they can be freely re-shuffled
+    /// to improve compressability at no cost, hence the optimization is on by default in that case.
+    if (((*data_settings)[MergeTreeSetting::optimize_row_order]
+            || (sort_description.empty() && (*data_settings)[MergeTreeSetting::optimize_row_order_if_no_order_by]))
         && data.merging_params.mode
             == MergeTreeData::MergingParams::Mode::Ordinary) /// Nobody knows if this optimization messes up specialized MergeTree engines.
     {

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1066,6 +1066,18 @@ primary key, i.e. a table with only few distinct primary key values.
 High-cardinality primary keys, e.g. involving timestamp columns of type
 `DateTime64`, are not expected to benefit from this setting.
 )", 0) \
+    DECLARE(Bool, optimize_row_order_if_no_order_by, true, R"(
+Enables the row order optimization (see setting `optimize_row_order`) automatically
+for ordinary MergeTree-engine tables which have no ORDER BY key (i.e. `ORDER BY tuple()`).
+
+Such tables impose no ordering constraint on their rows, so rows can be freely
+re-shuffled to minimize the number of equal-value runs and maximize the
+compressability of newly inserted parts. As there is no ordering to preserve,
+there is no downside to the optimization, hence it is enabled by default.
+
+The row order optimization is applied if `optimize_row_order` is enabled, or if the
+table has no ORDER BY key and this setting is enabled.
+)", 0) \
     DECLARE(Bool, use_adaptive_write_buffer_for_dynamic_subcolumns, true, R"(
 Allow to use adaptive writer buffers during writing dynamic subcolumns to
 reduce memory usage

--- a/tests/queries/0_stateless/03931_optimize_row_order_if_no_order_by.reference
+++ b/tests/queries/0_stateless/03931_optimize_row_order_if_no_order_by.reference
@@ -1,0 +1,4 @@
+default value:	1
+auto == explicit:	1
+auto reorders (!= insertion order):	1
+disabled keeps insertion order:	1

--- a/tests/queries/0_stateless/03931_optimize_row_order_if_no_order_by.sql
+++ b/tests/queries/0_stateless/03931_optimize_row_order_if_no_order_by.sql
@@ -1,0 +1,51 @@
+-- Tests that the row order optimization (see optimize_row_order) is applied automatically
+-- for ordinary MergeTree tables that have no ORDER BY key, governed by the new setting
+-- optimize_row_order_if_no_order_by (default: 1). See issue #103839.
+
+-- One insert thread -> one part, so SELECT without ORDER BY returns the physical row order.
+SET max_insert_threads = 1;
+SET max_threads = 1;
+
+-- The new setting exists and defaults to 1.
+SELECT 'default value:', value FROM system.merge_tree_settings WHERE name = 'optimize_row_order_if_no_order_by';
+
+DROP TABLE IF EXISTS tab_auto;
+DROP TABLE IF EXISTS tab_explicit;
+DROP TABLE IF EXISTS tab_disabled;
+
+-- Column `a` has cardinality 2 and `b` cardinality 1, so the optimizer groups rows by `a`,
+-- producing a physical order that differs from the insertion order (1,2,3,4,5).
+-- add_minmax_index_for_numeric_columns is disabled because it can influence the chosen order.
+
+-- (1) No ORDER BY key, all settings default -> relies on optimize_row_order_if_no_order_by = 1.
+CREATE TABLE tab_auto (id UInt32, a UInt8, b UInt8) ENGINE = MergeTree ORDER BY ()
+SETTINGS add_minmax_index_for_numeric_columns = 0;
+INSERT INTO tab_auto VALUES (1, 1, 100), (2, 2, 100), (3, 1, 100), (4, 2, 100), (5, 1, 100);
+
+-- (2) No ORDER BY key, optimize_row_order explicitly enabled -> reference "optimized" order.
+CREATE TABLE tab_explicit (id UInt32, a UInt8, b UInt8) ENGINE = MergeTree ORDER BY ()
+SETTINGS optimize_row_order = 1, add_minmax_index_for_numeric_columns = 0;
+INSERT INTO tab_explicit VALUES (1, 1, 100), (2, 2, 100), (3, 1, 100), (4, 2, 100), (5, 1, 100);
+
+-- (3) No ORDER BY key, optimization disabled via the new setting -> keeps insertion order.
+CREATE TABLE tab_disabled (id UInt32, a UInt8, b UInt8) ENGINE = MergeTree ORDER BY ()
+SETTINGS optimize_row_order_if_no_order_by = 0, add_minmax_index_for_numeric_columns = 0;
+INSERT INTO tab_disabled VALUES (1, 1, 100), (2, 2, 100), (3, 1, 100), (4, 2, 100), (5, 1, 100);
+
+-- The automatic default path must produce exactly the same physical order as explicitly
+-- enabling optimize_row_order (both run the identical RowOrderOptimizer with an empty sort key).
+SELECT 'auto == explicit:',
+    (SELECT groupArray(id) FROM (SELECT id FROM tab_auto))
+  = (SELECT groupArray(id) FROM (SELECT id FROM tab_explicit));
+
+-- The automatic path must reorder rows, i.e. differ from the raw insertion order.
+SELECT 'auto reorders (!= insertion order):',
+    (SELECT groupArray(id) FROM (SELECT id FROM tab_auto)) != [1, 2, 3, 4, 5];
+
+-- Disabling the setting must keep the raw insertion order.
+SELECT 'disabled keeps insertion order:',
+    (SELECT groupArray(id) FROM (SELECT id FROM tab_disabled)) = [1, 2, 3, 4, 5];
+
+DROP TABLE tab_auto;
+DROP TABLE tab_explicit;
+DROP TABLE tab_disabled;


### PR DESCRIPTION
Adds a new MergeTree setting `optimize_row_order_if_no_order_by` (default: `1`).

The row order optimization (see `optimize_row_order`) is now applied when:
- `optimize_row_order` is explicitly enabled, **or**
- the table has no `ORDER BY` key (i.e. `ORDER BY tuple()`) and `optimize_row_order_if_no_order_by` is enabled.

A table without an `ORDER BY` key imposes no ordering on its rows, so they can be
freely re-shuffled to minimize the number of equal-value runs and improve the
compressability of newly inserted parts — at no cost, since there is no ordering to
preserve. Hence the optimization is enabled by default for such tables.

Implementation:
- New setting `optimize_row_order_if_no_order_by` in `MergeTreeSettings.cpp`.
- Updated the row-order condition at both insert sites in `MergeTreeDataWriter.cpp`
  (`writeTempPartImpl` and `writeProjectionPartImpl`):
  `optimize_row_order || (sort_description.empty() && optimize_row_order_if_no_order_by)`.
  An empty `sort_description` is exactly the "no ORDER BY key" case.
- Registered the new setting in `SettingsChangesHistory.cpp`.
- Added stateless test `03931_optimize_row_order_if_no_order_by`.

Closes #103839.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Apply the `optimize_row_order` optimization automatically to MergeTree tables that have no `ORDER BY` key, controlled by the new setting `optimize_row_order_if_no_order_by` (enabled by default). This improves the compression ratio of such tables at no additional cost.