### PR TITLE
Speed up 04417_partition_minmax_pk_pruning_oracle on remote storage

### DIFF
--- a/tests/queries/0_stateless/04417_partition_minmax_pk_pruning_oracle.sql
+++ b/tests/queries/0_stateless/04417_partition_minmax_pk_pruning_oracle.sql
@@ -15,6 +15,11 @@
 -- The result of each variant is folded into one scalar, `cityHash64(count(), sum(cityHash64(...)))`,
 -- so both lost rows and changed rows are detected.
 
+-- `index_granularity` is kept small so partition-minmax pruning stays measurable in the directional
+-- `EXPLAIN ESTIMATE` checks below (a large value would fold each 1200-row partition into one granule and
+-- the `pruning fires` check would go vacuous); it is not 1 because 1-row granules make the many
+-- full-scan oracle subqueries do ~1200 tiny reads per query, which is disproportionately slow on remote storage.
+
 SET optimize_trivial_count_query = 0;
 SET optimize_use_implicit_projections = 0;
 SET use_query_condition_cache = 0;
@@ -23,7 +28,7 @@ SET use_query_condition_cache = 0;
 DROP TABLE IF EXISTS t_pmm_oracle_loaded;
 CREATE TABLE t_pmm_oracle_loaded (event_time UInt32, id UInt32)
 ENGINE = MergeTree PARTITION BY intDiv(event_time, 1000) ORDER BY (id, event_time)
-SETTINGS index_granularity = 1, add_minmax_index_for_numeric_columns = 0, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 1;
+SETTINGS index_granularity = 8, add_minmax_index_for_numeric_columns = 0, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 1;
 INSERT INTO t_pmm_oracle_loaded SELECT number % 1200, number % 10 FROM numbers(1200);
 
 DROP VIEW IF EXISTS matrix_loaded;
@@ -81,7 +86,7 @@ DROP TABLE t_pmm_oracle_loaded;
 DROP TABLE IF EXISTS t_pmm_oracle_dropped;
 CREATE TABLE t_pmm_oracle_dropped (event_time UInt32, id UInt32)
 ENGINE = MergeTree PARTITION BY intDiv(event_time, 1000) ORDER BY (id, event_time)
-SETTINGS index_granularity = 1, add_minmax_index_for_numeric_columns = 0, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 0.01;
+SETTINGS index_granularity = 8, add_minmax_index_for_numeric_columns = 0, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 0.01;
 INSERT INTO t_pmm_oracle_dropped SELECT number % 1200, number % 120 FROM numbers(1200);
 
 DROP VIEW IF EXISTS matrix_dropped;
@@ -139,7 +144,7 @@ DROP TABLE t_pmm_oracle_dropped;
 DROP TABLE IF EXISTS t_pmm_oracle_nullable;
 CREATE TABLE t_pmm_oracle_nullable (event_time UInt32, id Nullable(UInt32))
 ENGINE = MergeTree PARTITION BY intDiv(event_time, 1000) ORDER BY (id, event_time)
-SETTINGS index_granularity = 1, add_minmax_index_for_numeric_columns = 0, allow_nullable_key = 1, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 0.01;
+SETTINGS index_granularity = 8, add_minmax_index_for_numeric_columns = 0, allow_nullable_key = 1, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 0.01;
 INSERT INTO t_pmm_oracle_nullable SELECT number % 1200, if(number % 7 = 0, NULL, number % 120) FROM numbers(1200);
 
 DROP VIEW IF EXISTS matrix_nullable;
@@ -188,7 +193,7 @@ DROP TABLE t_pmm_oracle_nullable;
 DROP TABLE IF EXISTS t_pmm_oracle_reverse;
 CREATE TABLE t_pmm_oracle_reverse (event_time UInt32, id UInt32)
 ENGINE = MergeTree PARTITION BY intDiv(event_time, 1000) ORDER BY (id, event_time DESC)
-SETTINGS index_granularity = 1, add_minmax_index_for_numeric_columns = 0, allow_experimental_reverse_key = 1, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 1;
+SETTINGS index_granularity = 8, add_minmax_index_for_numeric_columns = 0, allow_experimental_reverse_key = 1, primary_key_ratio_of_unique_prefix_values_to_skip_suffix_columns = 1;
 INSERT INTO t_pmm_oracle_reverse SELECT number % 1200, number % 10 FROM numbers(1200);
 
 DROP VIEW IF EXISTS matrix_reverse;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Speeds up the stateless test `04417_partition_minmax_pk_pruning_oracle` so it stops trending toward the 600s timeout on remote-storage + sanitizer configs.

Root cause: the four MergeTree tables were created with `index_granularity = 1` (one row per granule, ~1202 marks over 1200 rows). The test's many full-scan and non-pruned scalar subqueries (4 scenarios x 25 seeds x the full-scan oracle variant) then read almost every 1-row granule. On local disk that is cheap, but on remote object storage each tiny granule read is a network round-trip, so the ~100K tiny reads per run balloon under sanitizer slowdown.

Public CIDB (play.clickhouse.com, `default.checks`, 30d, status OK): `Stateless tests (arm_asan_ubsan, azure, parallel)` p90 195s / p99 277s / max 316s (one max run on public master); `amd_tsan, s3 storage` p99 193s. 21 runs already exceeded 180s. No FAIL yet, but the trajectory is clear.

Fix: coarsen `index_granularity` from 1 to 8 in all four `CREATE TABLE`s. This gives 8x fewer marks (1202 -> 152) and therefore 8x fewer tiny remote reads. The correctness oracle (each variant's `cityHash64(count(), sum(...))` must equal the all-indexes-disabled full scan) is granularity-independent, and the directional `EXPLAIN ESTIMATE` checks keep a non-degenerate margin (A `pruning fires`: 7 < 10 marks; B: 8 < 30), so the optimization is still genuinely exercised and the `.reference` is byte-identical. Predicates, seeds, row count, the 2-partition structure across the 1000 boundary, and the `long` tag are all unchanged.

Verified locally on a debug build at current master: the modified test matches the reference across 40 runs with fresh CI setting randomization each time (0 failures), and each granularity 1/2/4/8/16 was checked to keep the anti-vacuous `pruning fires` checks non-degenerate before choosing 8.

No related open GitHub issue found (there is no auto-flaky issue because the test has not crossed 600s in public CI yet); this is a proactive slow-test fix, so the linkage comment above is left as the unfilled template.

Slowest public master report (316s): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=acab1c85c0ee4eb169f3592d9ee7ebf4abe7623e&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.531` (included in `26.7` and later)
<!-- ch-version-info:end -->