### PR TITLE
Fix ALTER COLUMN on tables with implicit min-max index over virtual columns

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1414,31 +1414,17 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     if (metadata_copy.sampling_key.definition_ast != nullptr)
         metadata_copy.sampling_key.recalculateWithNewAST(metadata_copy.sampling_key.definition_ast, metadata_copy.columns, metadata_copy.virtuals, context);
 
-    /// Changes in columns may lead to changes in secondary indices.
-    /// Implicit min-max indices may cover persistent virtual columns (`_block_number`,
-    /// `_block_offset`), which are absent from `metadata_copy.columns`, so they have to
-    /// be resolved against the virtual columns too.
-    std::optional<ColumnsDescription> columns_with_virtuals;
+    /// Changes in columns may lead to changes in secondary indices
+    const ColumnsDescription columns_with_virtuals(
+        metadata_copy.getSampleBlockWithVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All).getNamesAndTypesList());
     for (auto & index : metadata_copy.secondary_indices)
     {
         try
         {
-            const ColumnsDescription * columns_for_index = &metadata_copy.columns;
-            if (index.isImplicitlyCreated())
-            {
-                if (!columns_with_virtuals)
-                {
-                    columns_with_virtuals = metadata_copy.columns;
-                    for (const auto & virtual_column :
-                         metadata_copy.virtuals.toColumnsDescription(VirtualsKind::All, VirtualsMaterializationPlace::All))
-                        if (!columns_with_virtuals->has(virtual_column.name))
-                            columns_with_virtuals->add(virtual_column);
-                }
-                columns_for_index = &*columns_with_virtuals;
-            }
-
             index = IndexDescription::getIndexFromAST(
-                index.definition_ast, *columns_for_index, index.isImplicitlyCreated(), index.escape_filenames, context);
+                index.definition_ast,
+                index.isImplicitlyCreated() ? columns_with_virtuals : metadata_copy.columns,
+                index.isImplicitlyCreated(), index.escape_filenames, context);
         }
         catch (const Exception & exception)
         {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1414,9 +1414,15 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     if (metadata_copy.sampling_key.definition_ast != nullptr)
         metadata_copy.sampling_key.recalculateWithNewAST(metadata_copy.sampling_key.definition_ast, metadata_copy.columns, metadata_copy.virtuals, context);
 
-    /// Changes in columns may lead to changes in secondary indices
-    const ColumnsDescription columns_with_virtuals(
-        metadata_copy.getSampleBlockWithVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All).getNamesAndTypesList());
+    /// Changes in columns may lead to changes in secondary indices.
+    /// Implicit indices may reference persistent virtual columns (e.g. `_block_number`); resolve them
+    /// against the full column set (incl. alias/ephemeral) plus virtuals, a physical column shadowing
+    /// a virtual of the same name.
+    ColumnsDescription columns_with_virtuals = metadata_copy.columns;
+    for (const auto & virtual_column : metadata_copy.virtuals.toColumnsDescription(VirtualsKind::All, VirtualsMaterializationPlace::All))
+        if (!columns_with_virtuals.has(virtual_column.name))
+            columns_with_virtuals.add(virtual_column);
+
     for (auto & index : metadata_copy.secondary_indices)
     {
         try

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1414,23 +1414,14 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     if (metadata_copy.sampling_key.definition_ast != nullptr)
         metadata_copy.sampling_key.recalculateWithNewAST(metadata_copy.sampling_key.definition_ast, metadata_copy.columns, metadata_copy.virtuals, context);
 
-    /// Changes in columns may lead to changes in secondary indices.
-    /// Implicit indices may reference persistent virtual columns (e.g. `_block_number`); resolve them
-    /// against the full column set (incl. alias/ephemeral) plus virtuals, a physical column shadowing
-    /// a virtual of the same name.
-    ColumnsDescription columns_with_virtuals = metadata_copy.columns;
-    for (const auto & virtual_column : metadata_copy.virtuals.toColumnsDescription(VirtualsKind::All, VirtualsMaterializationPlace::All))
-        if (!columns_with_virtuals.has(virtual_column.name))
-            columns_with_virtuals.add(virtual_column);
-
+    /// Changes in columns may lead to changes in secondary indices
+    const ColumnsDescription columns_with_virtuals = metadata_copy.getColumnsWithVirtuals();
     for (auto & index : metadata_copy.secondary_indices)
     {
         try
         {
             index = IndexDescription::getIndexFromAST(
-                index.definition_ast,
-                index.isImplicitlyCreated() ? columns_with_virtuals : metadata_copy.columns,
-                index.isImplicitlyCreated(), index.escape_filenames, context);
+                index.definition_ast, columns_with_virtuals, index.isImplicitlyCreated(), index.escape_filenames, context);
         }
         catch (const Exception & exception)
         {

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1414,13 +1414,31 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
     if (metadata_copy.sampling_key.definition_ast != nullptr)
         metadata_copy.sampling_key.recalculateWithNewAST(metadata_copy.sampling_key.definition_ast, metadata_copy.columns, metadata_copy.virtuals, context);
 
-    /// Changes in columns may lead to changes in secondary indices
+    /// Changes in columns may lead to changes in secondary indices.
+    /// Implicit min-max indices may cover persistent virtual columns (`_block_number`,
+    /// `_block_offset`), which are absent from `metadata_copy.columns`, so they have to
+    /// be resolved against the virtual columns too.
+    std::optional<ColumnsDescription> columns_with_virtuals;
     for (auto & index : metadata_copy.secondary_indices)
     {
         try
         {
+            const ColumnsDescription * columns_for_index = &metadata_copy.columns;
+            if (index.isImplicitlyCreated())
+            {
+                if (!columns_with_virtuals)
+                {
+                    columns_with_virtuals = metadata_copy.columns;
+                    for (const auto & virtual_column :
+                         metadata_copy.virtuals.toColumnsDescription(VirtualsKind::All, VirtualsMaterializationPlace::All))
+                        if (!columns_with_virtuals->has(virtual_column.name))
+                            columns_with_virtuals->add(virtual_column);
+                }
+                columns_for_index = &*columns_with_virtuals;
+            }
+
             index = IndexDescription::getIndexFromAST(
-                index.definition_ast, metadata_copy.columns, index.isImplicitlyCreated(), index.escape_filenames, context);
+                index.definition_ast, *columns_for_index, index.isImplicitlyCreated(), index.escape_filenames, context);
         }
         catch (const Exception & exception)
         {

--- a/src/Storages/StorageInMemoryMetadata.cpp
+++ b/src/Storages/StorageInMemoryMetadata.cpp
@@ -511,6 +511,15 @@ Block StorageInMemoryMetadata::getSampleBlockWithVirtuals(VirtualsKind kind, Vir
     return res;
 }
 
+ColumnsDescription StorageInMemoryMetadata::getColumnsWithVirtuals() const
+{
+    ColumnsDescription res = columns;
+    for (const auto & virtual_column : virtuals.toColumnsDescription(VirtualsKind::All, VirtualsMaterializationPlace::All))
+        if (!res.has(virtual_column.name))
+            res.add(virtual_column);
+    return res;
+}
+
 Block StorageInMemoryMetadata::getSampleBlock() const
 {
     Block res;

--- a/src/Storages/StorageInMemoryMetadata.h
+++ b/src/Storages/StorageInMemoryMetadata.h
@@ -228,6 +228,10 @@ struct StorageInMemoryMetadata
     /// Block with ordinary + materialized + virtuals.
     Block getSampleBlockWithVirtuals(VirtualsKind kind, VirtualsMaterializationPlace place) const;
 
+    /// All columns (incl. alias/ephemeral) plus virtual columns, a physical column shadowing a
+    /// virtual of the same name. Used to resolve implicit indices over virtual columns.
+    ColumnsDescription getColumnsWithVirtuals() const;
+
     /// Returns whether the column is virtual and not shadowed by a real column.
     bool isVirtualColumn(const String & column_name) const;
 

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
@@ -1,7 +1,5 @@
 auto_minmax_index__block_number	_block_number
-9
-auto_minmax_index__block_offset	_block_offset
-auto_minmax_index__block_number	_block_number
 auto_minmax_index__block_offset	_block_offset
 1
 1
+20

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
@@ -1,0 +1,6 @@
+auto_minmax_index__block_number	_block_number
+9
+auto_minmax_index__block_offset	_block_offset
+auto_minmax_index__block_number	_block_number
+auto_minmax_index__block_offset	_block_offset
+1

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.reference
@@ -4,3 +4,4 @@ auto_minmax_index__block_offset	_block_offset
 auto_minmax_index__block_number	_block_number
 auto_minmax_index__block_offset	_block_offset
 1
+1

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
@@ -1,0 +1,51 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings, no-parallel-replicas
+
+-- The implicit min-max skip index over the persistent virtual columns _block_number / _block_offset
+-- must not prevent column ALTERs (RENAME / ADD / MODIFY) on an unrelated column.
+-- Before the fix, ALTER validation re-resolved the implicit index against physical columns only,
+-- so _block_number could not be resolved and the ALTER threw UNKNOWN_IDENTIFIER.
+
+SET enable_analyzer = 1;
+SET use_skip_indexes = 1;
+
+-- RENAME COLUMN, index over _block_number
+DROP TABLE IF EXISTS t_imv_alter;
+CREATE TABLE t_imv_alter (date1 Date, value1 String)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_number_column = 1, add_minmax_index_for_block_number_column = 1, index_granularity = 1;
+INSERT INTO t_imv_alter SELECT toDate('2018-10-01') + number % 3, toString(number) FROM numbers(9);
+ALTER TABLE t_imv_alter RENAME COLUMN date1 TO renamed_date1;
+SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter' ORDER BY name;
+SELECT count() FROM t_imv_alter;
+
+-- RENAME COLUMN, index over _block_offset
+DROP TABLE IF EXISTS t_imv_alter_off;
+CREATE TABLE t_imv_alter_off (date1 Date, value1 String)
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS enable_block_offset_column = 1, add_minmax_index_for_block_offset_column = 1, index_granularity = 1;
+INSERT INTO t_imv_alter_off SELECT toDate('2018-10-01') + number % 3, toString(number) FROM numbers(9);
+ALTER TABLE t_imv_alter_off RENAME COLUMN date1 TO renamed_date1;
+SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter_off' ORDER BY name;
+
+-- ADD / MODIFY COLUMN, both indices enabled; verify the index still prunes granules afterwards
+DROP TABLE IF EXISTS t_imv_alter_both;
+CREATE TABLE t_imv_alter_both (a UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         add_minmax_index_for_block_number_column = 1, add_minmax_index_for_block_offset_column = 1,
+         index_granularity = 1;
+SYSTEM STOP MERGES t_imv_alter_both;
+INSERT INTO t_imv_alter_both SELECT number FROM numbers(10);
+INSERT INTO t_imv_alter_both SELECT number + 10 FROM numbers(10);
+SYSTEM START MERGES t_imv_alter_both;
+OPTIMIZE TABLE t_imv_alter_both FINAL;
+
+ALTER TABLE t_imv_alter_both ADD COLUMN b Int32;
+ALTER TABLE t_imv_alter_both MODIFY COLUMN a UInt64 CODEC(ZSTD);
+SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter_both' ORDER BY name;
+-- The implicit index must still prune after the column ALTERs.
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_number = 0) WHERE explain ILIKE '%auto_minmax_index__block_number%';
+
+DROP TABLE IF EXISTS t_imv_alter;
+DROP TABLE IF EXISTS t_imv_alter_off;
+DROP TABLE IF EXISTS t_imv_alter_both;

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
@@ -8,50 +8,32 @@
 SET enable_analyzer = 1;
 SET use_skip_indexes = 1;
 
--- RENAME COLUMN, index over _block_number
 DROP TABLE IF EXISTS t_imv_alter;
-CREATE TABLE t_imv_alter (date1 Date, value1 String)
-ENGINE = MergeTree ORDER BY tuple()
-SETTINGS enable_block_number_column = 1, add_minmax_index_for_block_number_column = 1, index_granularity = 1;
-INSERT INTO t_imv_alter SELECT toDate('2018-10-01') + number % 3, toString(number) FROM numbers(9);
-ALTER TABLE t_imv_alter RENAME COLUMN date1 TO renamed_date1;
-SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter' ORDER BY name;
-SELECT count() FROM t_imv_alter;
-
--- RENAME COLUMN, index over _block_offset
-DROP TABLE IF EXISTS t_imv_alter_off;
-CREATE TABLE t_imv_alter_off (date1 Date, value1 String)
-ENGINE = MergeTree ORDER BY tuple()
-SETTINGS enable_block_offset_column = 1, add_minmax_index_for_block_offset_column = 1, index_granularity = 1;
-INSERT INTO t_imv_alter_off SELECT toDate('2018-10-01') + number % 3, toString(number) FROM numbers(9);
-ALTER TABLE t_imv_alter_off RENAME COLUMN date1 TO renamed_date1;
-SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter_off' ORDER BY name;
-
--- ADD / MODIFY COLUMN, both indices enabled; verify the index still prunes granules afterwards
-DROP TABLE IF EXISTS t_imv_alter_both;
-CREATE TABLE t_imv_alter_both (a UInt64)
-ENGINE = MergeTree ORDER BY a
+CREATE TABLE t_imv_alter (id UInt64, s String)
+ENGINE = MergeTree ORDER BY id
 SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
          add_minmax_index_for_block_number_column = 1, add_minmax_index_for_block_offset_column = 1,
          index_granularity = 1;
-SYSTEM STOP MERGES t_imv_alter_both;
-INSERT INTO t_imv_alter_both SELECT number FROM numbers(10);
-INSERT INTO t_imv_alter_both SELECT number + 10 FROM numbers(10);
-SYSTEM START MERGES t_imv_alter_both;
-OPTIMIZE TABLE t_imv_alter_both FINAL;
 
-ALTER TABLE t_imv_alter_both ADD COLUMN b Int32;
-ALTER TABLE t_imv_alter_both MODIFY COLUMN a UInt64 CODEC(ZSTD);
-ALTER TABLE t_imv_alter_both RENAME COLUMN b TO b2;
-SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter_both' ORDER BY name;
+SYSTEM STOP MERGES t_imv_alter;
+INSERT INTO t_imv_alter SELECT number, toString(number) FROM numbers(10);
+INSERT INTO t_imv_alter SELECT number + 10, toString(number) FROM numbers(10);
+SYSTEM START MERGES t_imv_alter;
+OPTIMIZE TABLE t_imv_alter FINAL;
+
+ALTER TABLE t_imv_alter RENAME COLUMN s TO s2;
+ALTER TABLE t_imv_alter ADD COLUMN extra Int32;
+ALTER TABLE t_imv_alter MODIFY COLUMN id UInt64 CODEC(ZSTD);
+
+SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter' ORDER BY name;
+
 -- The implicit indices must still PRUNE granules after the ALTERs, not merely stay attached.
 -- EXPLAIN indexes = 1 prints the index name even when it reads every granule (Granules: N/N),
 -- so a name match alone would pass a regression that stopped pruning. Assert on the Granules line.
 -- 20 rows in two blocks, index_granularity = 1: _block_number = 1 matches one block (10/20 granules read),
 -- _block_offset = 0 matches one row per block (2/20). A stopped-pruning regression reads 20/20 and fails these.
-SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_number = 1) WHERE explain ILIKE '%Granules: 10/20%';
-SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_offset = 0) WHERE explain ILIKE '%Granules: 2/20%';
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter WHERE _block_number = 1) WHERE explain ILIKE '%Granules: 10/20%';
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter WHERE _block_offset = 0) WHERE explain ILIKE '%Granules: 2/20%';
+SELECT count() FROM t_imv_alter;
 
 DROP TABLE IF EXISTS t_imv_alter;
-DROP TABLE IF EXISTS t_imv_alter_off;
-DROP TABLE IF EXISTS t_imv_alter_both;

--- a/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
+++ b/tests/queries/0_stateless/04401_implicit_minmax_block_number_offset_alter_column.sql
@@ -42,9 +42,15 @@ OPTIMIZE TABLE t_imv_alter_both FINAL;
 
 ALTER TABLE t_imv_alter_both ADD COLUMN b Int32;
 ALTER TABLE t_imv_alter_both MODIFY COLUMN a UInt64 CODEC(ZSTD);
+ALTER TABLE t_imv_alter_both RENAME COLUMN b TO b2;
 SELECT name, expr FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = 't_imv_alter_both' ORDER BY name;
--- The implicit index must still prune after the column ALTERs.
-SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_number = 0) WHERE explain ILIKE '%auto_minmax_index__block_number%';
+-- The implicit indices must still PRUNE granules after the ALTERs, not merely stay attached.
+-- EXPLAIN indexes = 1 prints the index name even when it reads every granule (Granules: N/N),
+-- so a name match alone would pass a regression that stopped pruning. Assert on the Granules line.
+-- 20 rows in two blocks, index_granularity = 1: _block_number = 1 matches one block (10/20 granules read),
+-- _block_offset = 0 matches one row per block (2/20). A stopped-pruning regression reads 20/20 and fails these.
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_number = 1) WHERE explain ILIKE '%Granules: 10/20%';
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT * FROM t_imv_alter_both WHERE _block_offset = 0) WHERE explain ILIKE '%Granules: 2/20%';
 
 DROP TABLE IF EXISTS t_imv_alter;
 DROP TABLE IF EXISTS t_imv_alter_off;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/blob/master/tests/queries/0_stateless/01378_alter_rename_with_ttl_zookeeper.sql

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `UNKNOWN_IDENTIFIER` error when running `ALTER TABLE ... RENAME/ADD/MODIFY COLUMN` on a MergeTree table that has an implicit min-max index over the persistent virtual columns `_block_number` or `_block_offset` (enabled by `add_minmax_index_for_block_number_column` / `add_minmax_index_for_block_offset_column`).

### Description

When `enable_block_number_column` / `enable_block_offset_column` are on together with `add_minmax_index_for_block_number_column` / `add_minmax_index_for_block_offset_column`, the table gets an implicit min-max skip index over the persistent virtual columns `_block_number` / `_block_offset` (`auto_minmax_index__block_number`, `auto_minmax_index__block_offset`).

Any `ALTER` on a physical column (RENAME / ADD / MODIFY) then failed, e.g.:

```
Code: 47. DB::Exception: Cannot apply ALTER because it breaks skip index
auto_minmax_index__block_number: Missing columns: '_block_number' ...
available columns: 'value1' 'renamed_date1'. (UNKNOWN_IDENTIFIER)
```

`AlterCommands::apply` re-derives every secondary index from its AST during validation, but resolved them against physical columns only. The implicit indices over virtual columns could not resolve `_block_number` / `_block_offset` and threw, even though the ALTER did not touch those columns. This fix resolves implicitly-created indices against the persistent virtual columns as well, matching how they are created in `StorageInMemoryMetadata::addImplicitIndicesForVirtualColumns`. Explicit indices are unchanged and still resolved against physical columns only, so the guard against ALTERs that genuinely break a user-defined index is intact.

Added a regression test (`04401_implicit_minmax_block_number_offset_alter_column`) covering RENAME/ADD/MODIFY column with the `_block_number`/`_block_offset` implicit index, and asserting the index still prunes granules after the ALTER.

No related open GitHub issue was found; this surfaces as flaky failures of the public stateless test `01378_alter_rename_with_ttl_zookeeper` in PR runs where CI randomization enables these settings, and will become reproducible on master once the virtual min-max index is enabled by default.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.546` (included in `26.7` and later)
<!-- ch-version-info:end -->