### PR TITLE
Remove custom max_execution_time from 03822_variant_distinct_filter

### DIFF
--- a/tests/queries/0_stateless/03822_variant_distinct_filter.sh
+++ b/tests/queries/0_stateless/03822_variant_distinct_filter.sh
@@ -13,7 +13,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# Rely on the test framework's max runtime limit; no custom query timeout.
+# Rely on the test framework's max runtime limit; no custom per-query time cap.
 CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0"
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"

--- a/tests/queries/0_stateless/03822_variant_distinct_filter.sh
+++ b/tests/queries/0_stateless/03822_variant_distinct_filter.sh
@@ -13,20 +13,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# Rely on the test framework's max runtime limit; no custom per-query time cap.
 CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0"
-
-# Ensure the shared table is dropped on every exit path (including when the
-# framework terminates the shell at its runtime limit); the runner's
-# leftover-table check runs before it drops the per-test database.
-cleanup()
-{
-    trap - EXIT INT TERM
-    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct" 2>/dev/null
-}
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"
 $CLICKHOUSE_CLIENT -q "CREATE TABLE test_variant_distinct (v1 Variant(String, UInt64, Array(UInt32)), v2 Variant(String, UInt64, Array(UInt32))) ENGINE = Memory"

--- a/tests/queries/0_stateless/03822_variant_distinct_filter.sh
+++ b/tests/queries/0_stateless/03822_variant_distinct_filter.sh
@@ -16,6 +16,18 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Rely on the test framework's max runtime limit; no custom per-query time cap.
 CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0"
 
+# Ensure the shared table is dropped on every exit path (including when the
+# framework terminates the shell at its runtime limit); the runner's
+# leftover-table check runs before it drops the per-test database.
+cleanup()
+{
+    trap - EXIT INT TERM
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct" 2>/dev/null
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"
 $CLICKHOUSE_CLIENT -q "CREATE TABLE test_variant_distinct (v1 Variant(String, UInt64, Array(UInt32)), v2 Variant(String, UInt64, Array(UInt32))) ENGINE = Memory"
 

--- a/tests/queries/0_stateless/03822_variant_distinct_filter.sh
+++ b/tests/queries/0_stateless/03822_variant_distinct_filter.sh
@@ -13,13 +13,8 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-CH_CLIENT_OPTS="--allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0"
-# max_execution_time guards only the concurrent query loops below: if the COW
-# bug regressed, a corrupted-column query could hang, so cap it. The setup
-# phase must NOT inherit this cap -- a sanitizer host can starve a single
-# trivial INSERT past 10s, failing setup with a spurious TIMEOUT_EXCEEDED.
-CH_CLIENT_SETUP="$CLICKHOUSE_CLIENT $CH_CLIENT_OPTS"
-CH_CLIENT="$CLICKHOUSE_CLIENT $CH_CLIENT_OPTS --max_execution_time=10"
+# Rely on the test framework's max runtime limit; no custom query timeout.
+CH_CLIENT="$CLICKHOUSE_CLIENT --allow_experimental_variant_type=1 --allow_suspicious_types_in_order_by=1 --use_variant_default_implementation_for_comparisons=0"
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_variant_distinct"
 $CLICKHOUSE_CLIENT -q "CREATE TABLE test_variant_distinct (v1 Variant(String, UInt64, Array(UInt32)), v2 Variant(String, UInt64, Array(UInt32))) ENGINE = Memory"
@@ -37,7 +32,7 @@ for i in $(seq 1 10); do
     inserts+="INSERT INTO test_variant_distinct VALUES ([1,2,$i], NULL);"
     inserts+="INSERT INTO test_variant_distinct VALUES (NULL, $i);"
 done
-echo "$inserts" | $CH_CLIENT_SETUP -n
+echo "$inserts" | $CH_CLIENT -n
 
 # Run concurrent queries from multiple connections to trigger the race.
 # The permute optimization (ORDER BY) corrupts shared non-active variant


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108528
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #108528, addressing post-merge review feedback: remove the non-standard `max_execution_time` from `03822_variant_distinct_filter.sh` entirely (setup and query case) and rely on the test framework's max test runtime limit instead of a custom per-query cap.

Background: the 10s cap was a fast-fail guard on the concurrent `ORDER BY`/`DISTINCT` query loops in case the ColumnVariant COW bug regressed and a query hung. The loops are already wall-clock bounded (`SECONDS + 5`), so in the passing case the cap never fired. Removing it means a regressed COW hang surfaces as the framework's TIMEOUT/TOO_LONG (the runner kills the test) instead of a fast `TIMEOUT_EXCEEDED`. Test intent, detecting the COW hang, is preserved; it is just slower to fail. The test runs in ~5s on a debug build, well under the framework limit, so no `long` tag is needed.

Validated locally against a master debug build: 6/6 passes, ~5s each, output matches the reference.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.661` (included in `26.7` and later)
<!-- ch-version-info:end -->