### PR TITLE
Docs: mirror tdigest/countmin stats-cost note into MergeTree source docs

### DIFF
--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -2397,6 +2397,10 @@ EXPLAIN indexes = 1 SELECT count() FROM test_stats WHERE value > 5000;
 
 - `TDigest`
 
+    :::warning
+    Statistics of type `tdigest` have high creation costs and potentially slow down data ingest.
+    :::
+
     [TDigest](https://github.com/tdunning/t-digest) sketches which allow to compute approximate percentiles (e.g. the 90th percentile) for numeric columns.
 
     Syntax: `tdigest`
@@ -2408,6 +2412,10 @@ EXPLAIN indexes = 1 SELECT count() FROM test_stats WHERE value > 5000;
     Syntax: `uniq`
 
 - `CountMin`
+
+    :::warning
+    Statistics of type `countmin` have high creation costs and potentially slow down data ingest.
+    :::
 
     [CountMin](https://en.wikipedia.org/wiki/Count%E2%80%93min_sketch) sketches which provide an approximate count of the frequency of each value in a column.
 


### PR DESCRIPTION
<!--
Linked issues and pull requests.

Related: https://github.com/ClickHouse/ClickHouse/pull/109444
-->

Related: #109444

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Description

Follow-up to #109444, which added the `tdigest`/`countmin` high-creation-cost warning to the website markdown (`docs/en/.../mergetree.md`).

The MergeTree engine description is also embedded in `src/Storages/MergeTree/registerStorageMergeTree.cpp` and exposed through `system.table_engines.description` / `system.documentation`, so the markdown-only change left those surfaces stale. This mirrors the same two `:::warning` notes into that `Documentation{}` block, keeping both surfaces in sync (as requested by @Blargian on #109444).

Wording is identical to what was merged in #109444.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.623` (included in `26.7` and later)
<!-- ch-version-info:end -->