### PR TITLE
Reduce memory usage of the header cache of text index even more

### DIFF
--- a/src/Common/BitPackedStringArray.cpp
+++ b/src/Common/BitPackedStringArray.cpp
@@ -1,0 +1,34 @@
+#include <Common/BitPackedStringArray.h>
+
+namespace DB
+{
+
+BitPackedStringArray::BitPackedStringArray(std::span<const char> chars_, std::span<const UInt64> offsets_)
+{
+    chassert(offsets_.empty() ? chars_.empty() : offsets_.back() == chars_.size());
+
+    chars.reserve_exact(chars_.size());
+    chars.insert(chars_.begin(), chars_.end());
+    offsets = BitPackedUInt64Array(offsets_);
+}
+
+BitPackedStringArray::BitPackedStringArray(const PaddedPODArray<UInt8> & chars_, const PaddedPODArray<UInt64> & offsets_)
+    : BitPackedStringArray(
+        std::span(reinterpret_cast<const char *>(chars_.data()), chars_.size()),
+        std::span(offsets_.data(), offsets_.size()))
+{
+}
+
+std::string_view BitPackedStringArray::get(size_t idx) const
+{
+    size_t begin = idx == 0 ? 0 : offsets.get(idx - 1);
+    size_t end = offsets.get(idx);
+    return {chars.data() + begin, end - begin};
+}
+
+size_t BitPackedStringArray::allocatedBytes() const
+{
+    return chars.allocated_bytes() + offsets.allocatedBytes();
+}
+
+}

--- a/src/Common/BitPackedStringArray.h
+++ b/src/Common/BitPackedStringArray.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <span>
+#include <string_view>
+
+#include <base/types.h>
+#include <Common/BitPackedUInt64Array.h>
+#include <Common/PODArray.h>
+
+namespace DB
+{
+
+/** In-memory array of strings with O(1) random access, decomposed into
+  * a contiguous array of characters and an array of end offsets.
+  *
+  * Compared to ColumnString the offsets are stored bit-packed
+  * (see BitPackedUInt64Array), which significantly reduces
+  * memory usage for short strings.
+  */
+class BitPackedStringArray
+{
+public:
+    BitPackedStringArray() = default;
+    BitPackedStringArray(std::span<const char> chars_, std::span<const UInt64> offsets_);
+    BitPackedStringArray(const PaddedPODArray<UInt8> & chars_, const PaddedPODArray<UInt64> & offsets_);
+
+    std::string_view get(size_t idx) const;
+
+    size_t size() const { return offsets.size(); }
+    bool empty() const { return offsets.empty(); }
+    size_t allocatedBytes() const;
+
+private:
+    PODArray<char> chars;
+    /// End offsets of strings in chars: i-th string is chars[offsets[i - 1], offsets[i]).
+    BitPackedUInt64Array offsets;
+};
+
+}

--- a/src/Common/tests/gtest_bit_packed_string_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_string_array.cpp
@@ -94,7 +94,7 @@ TEST(BitPackedStringArray, BlockBoundaries)
 
 TEST(BitPackedStringArray, RandomStrings)
 {
-    std::mt19937_64 rng(42);
+    std::mt19937_64 rng(42); // NOLINT(cert-msc32-c,cert-msc51-cpp): deterministic seed for reproducible test
     std::vector<std::string> strings;
 
     for (size_t i = 0; i < 10000; ++i)

--- a/src/Common/tests/gtest_bit_packed_string_array.cpp
+++ b/src/Common/tests/gtest_bit_packed_string_array.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include <Common/BitPackedStringArray.h>
+
+using namespace DB;
+
+namespace
+{
+
+void checkRoundTrip(const std::vector<std::string> & strings)
+{
+    /// Concatenated chars and end offsets, the same layout as in ColumnString.
+    std::string chars;
+    std::vector<UInt64> offsets;
+    offsets.reserve(strings.size());
+
+    for (const auto & str : strings)
+    {
+        chars += str;
+        offsets.push_back(chars.size());
+    }
+
+    BitPackedStringArray packed{std::span(chars.data(), chars.size()), std::span(offsets.data(), offsets.size())};
+
+    ASSERT_EQ(packed.size(), strings.size());
+    for (size_t i = 0; i < strings.size(); ++i)
+        ASSERT_EQ(packed.get(i), strings[i]) << "at index " << i;
+}
+
+}
+
+TEST(BitPackedStringArray, Empty)
+{
+    BitPackedStringArray packed;
+    EXPECT_EQ(packed.size(), 0u);
+    EXPECT_TRUE(packed.empty());
+
+    BitPackedStringArray packed_from_empty{std::span<const char>{}, std::span<const UInt64>{}};
+    EXPECT_EQ(packed_from_empty.size(), 0u);
+    EXPECT_TRUE(packed_from_empty.empty());
+}
+
+TEST(BitPackedStringArray, FromPODArrays)
+{
+    PaddedPODArray<UInt8> chars;
+    PaddedPODArray<UInt64> offsets;
+
+    for (std::string_view str : {"ab", "", "xyz"})
+    {
+        chars.insert(str.begin(), str.end());
+        offsets.push_back(chars.size());
+    }
+
+    BitPackedStringArray packed{chars, offsets};
+
+    ASSERT_EQ(packed.size(), 3u);
+    EXPECT_EQ(packed.get(0), "ab");
+    EXPECT_EQ(packed.get(1), "");
+    EXPECT_EQ(packed.get(2), "xyz");
+}
+
+TEST(BitPackedStringArray, SingleString)
+{
+    checkRoundTrip({""});
+    checkRoundTrip({"a"});
+    checkRoundTrip({"hello world"});
+}
+
+TEST(BitPackedStringArray, EmptyStrings)
+{
+    checkRoundTrip({"", "", ""});
+    checkRoundTrip({"", "abc", "", "def", ""});
+}
+
+TEST(BitPackedStringArray, BinaryData)
+{
+    checkRoundTrip({std::string("\x00\x01\x02", 3), std::string("a\x00""b", 3)});
+}
+
+TEST(BitPackedStringArray, BlockBoundaries)
+{
+    std::vector<std::string> strings;
+    for (size_t size : {127, 128, 129, 256, 257})
+    {
+        strings.clear();
+        for (size_t i = 0; i < size; ++i)
+            strings.push_back("token" + std::to_string(i));
+
+        checkRoundTrip(strings);
+    }
+}
+
+TEST(BitPackedStringArray, RandomStrings)
+{
+    std::mt19937_64 rng(42);
+    std::vector<std::string> strings;
+
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        std::string str(rng() % 30, ' ');
+        for (auto & c : str)
+            c = static_cast<char>('a' + rng() % 26);
+        strings.push_back(std::move(str));
+    }
+
+    checkRoundTrip(strings);
+}

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -93,31 +93,54 @@ static_assert(PostingListBuilder::max_small_size <= MAX_CARDINALITY_FOR_RAW_POST
 /// within one index.
 static constexpr bool DEFAULT_POSITIONS = false;
 
-bool DictionaryBlockBase::empty() const
+DictionaryBlock::DictionaryBlock(ColumnPtr tokens_, std::vector<TokenPostingsInfo> token_infos_, UInt64 tokens_format_)
+    : tokens(std::move(tokens_))
+    , token_infos(std::move(token_infos_))
+    , tokens_format(tokens_format_)
+{
+}
+
+bool DictionaryBlock::empty() const
 {
     return !tokens || tokens->empty();
 }
 
-size_t DictionaryBlockBase::size() const
+size_t DictionaryBlock::size() const
 {
     return tokens ? tokens->size() : 0;
 }
 
-size_t DictionaryBlockBase::upperBound(std::string_view token) const
+DictionarySparseIndex::DictionarySparseIndex(ColumnPtr tokens_, ColumnPtr offsets_in_file_)
+    : tokens(std::move(tokens_)), offsets_in_file(std::move(offsets_in_file_))
 {
-    auto range = collections::range(0, tokens->size());
+}
 
-    auto it = std::upper_bound(range.begin(), range.end(), token, [this](std::string_view lhs_ref, size_t rhs_idx)
+size_t DictionarySparseIndex::size() const
+{
+    if (const auto * tokens_column = std::get_if<ColumnPtr>(&tokens))
+        return *tokens_column ? (*tokens_column)->size() : 0;
+
+    return std::get<BitPackedStringArray>(tokens).size();
+}
+
+size_t DictionarySparseIndex::upperBound(std::string_view token) const
+{
+    auto range = collections::range(0, size());
+
+    auto it = std::upper_bound(range.begin(), range.end(), token, [this](std::string_view lhs, size_t rhs_idx)
     {
-        return lhs_ref < assert_cast<const ColumnString &>(*tokens).getDataAt(rhs_idx);
+        return lhs < getToken(rhs_idx);
     });
 
     return it - range.begin();
 }
 
-DictionarySparseIndex::DictionarySparseIndex(ColumnPtr tokens_, ColumnPtr offsets_in_file_)
-    : DictionaryBlockBase(std::move(tokens_)), offsets_in_file(std::move(offsets_in_file_))
+std::string_view DictionarySparseIndex::getToken(size_t idx) const
 {
+    if (const auto * tokens_column = std::get_if<ColumnPtr>(&tokens))
+        return assert_cast<const ColumnString &>(**tokens_column).getDataAt(idx);
+
+    return std::get<BitPackedStringArray>(tokens).get(idx);
 }
 
 UInt64 DictionarySparseIndex::getOffsetInFile(size_t idx) const
@@ -128,25 +151,48 @@ UInt64 DictionarySparseIndex::getOffsetInFile(size_t idx) const
     return std::get<BitPackedUInt64Array>(offsets_in_file).get(idx);
 }
 
+ColumnPtr DictionarySparseIndex::getTokensColumn() const
+{
+    const auto * tokens_column = std::get_if<ColumnPtr>(&tokens);
+    if (!tokens_column || !*tokens_column)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Tokens in sparse index of text index must not be bit-packed here");
+
+    return *tokens_column;
+}
+
+ColumnPtr DictionarySparseIndex::getOffsetsColumn() const
+{
+    const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file);
+    if (!offsets_column || !*offsets_column)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Offsets in sparse index of text index must not be bit-packed here");
+
+    return *offsets_column;
+}
+
 size_t DictionarySparseIndex::memoryUsageBytes() const
 {
+    size_t tokens_bytes = 0;
     size_t offsets_bytes = 0;
+
+    if (const auto * tokens_column = std::get_if<ColumnPtr>(&tokens))
+        tokens_bytes = (*tokens_column) ? (*tokens_column)->allocatedBytes() : 0;
+    else
+        tokens_bytes = std::get<BitPackedStringArray>(tokens).allocatedBytes();
 
     if (const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file))
         offsets_bytes = (*offsets_column) ? (*offsets_column)->allocatedBytes() : 0;
     else
         offsets_bytes = std::get<BitPackedUInt64Array>(offsets_in_file).allocatedBytes();
 
-    return sizeof(*this) + tokens->allocatedBytes() + offsets_bytes;
+    return sizeof(*this) + tokens_bytes + offsets_bytes;
 }
 
 void DictionarySparseIndex::optimize()
 {
-    if (tokens)
+    if (const auto * tokens_column = std::get_if<ColumnPtr>(&tokens); tokens_column && *tokens_column)
     {
-        auto tokens_mut = IColumn::mutate(tokens);
-        tokens_mut->shrinkToFit();
-        tokens = std::move(tokens_mut);
+        const auto & tokens_string = assert_cast<const ColumnString &>(**tokens_column);
+        tokens = BitPackedStringArray(tokens_string.getChars(), tokens_string.getOffsets());
     }
 
     if (const auto * offsets_column = std::get_if<ColumnPtr>(&offsets_in_file); offsets_column && *offsets_column)
@@ -154,13 +200,6 @@ void DictionarySparseIndex::optimize()
         const auto & offsets_data = assert_cast<const ColumnUInt64 &>(**offsets_column).getData();
         offsets_in_file = BitPackedUInt64Array(std::span(offsets_data.begin(), offsets_data.end()));
     }
-}
-
-DictionaryBlock::DictionaryBlock(ColumnPtr tokens_, std::vector<TokenPostingsInfo> token_infos_, UInt64 tokens_format_)
-    : DictionaryBlockBase(std::move(tokens_))
-    , token_infos(std::move(token_infos_))
-    , tokens_format(tokens_format_)
-{
 }
 
 PostingsSerialization::PostingsSerialization(PostingListCodecPtr posting_list_codec_, MergeTreeIndexVersion serialization_version_)
@@ -1146,19 +1185,18 @@ void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & spars
     if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithPositions))
         writeVarUInt(static_cast<UInt64>(has_positions), ostr);
 
-    const auto * offsets_column_ptr = std::get_if<ColumnPtr>(&sparse_index.offsets_in_file);
-    if (!offsets_column_ptr || !*offsets_column_ptr)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Offsets in sparse index of text index must not be bit-packed on serialization");
-
-    const auto & offsets_column = **offsets_column_ptr;
-    chassert(sparse_index.tokens->size() == offsets_column.size());
+    /// Sparse indexes are created with raw columns and bit-packed only by optimize.
+    /// The write path never calls optimize, so expect the raw columns here.
+    auto tokens_column = sparse_index.getTokensColumn();
+    auto offsets_column = sparse_index.getOffsetsColumn();
+    chassert(tokens_column->size() == offsets_column->size());
 
     auto serialization_string = SerializationString::create();
     auto serialization_number = SerializationNumber<UInt64>::create();
 
-    writeVarUInt(sparse_index.tokens->size(), ostr);
-    serialization_string->serializeBinaryBulk(*sparse_index.tokens, ostr, 0, sparse_index.tokens->size());
-    serialization_number->serializeBinaryBulk(offsets_column, ostr, 0, offsets_column.size());
+    writeVarUInt(tokens_column->size(), ostr);
+    serialization_string->serializeBinaryBulk(*tokens_column, ostr, 0, tokens_column->size());
+    serialization_number->serializeBinaryBulk(*offsets_column, ostr, 0, offsets_column->size());
 }
 
 TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & istr)

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -4,6 +4,7 @@
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Columns/IColumn.h>
+#include <Common/BitPackedStringArray.h>
 #include <Common/BitPackedUInt64Array.h>
 #include <Common/Logger.h>
 #include <Common/HashTable/HashMap.h>
@@ -236,39 +237,46 @@ struct TokenPostingsInfo
 using TokenPostingsInfoPtr = std::shared_ptr<TokenPostingsInfo>;
 using TokenToPostingsInfosMap = absl::flat_hash_map<String, TokenPostingsInfoPtr>;
 
-struct DictionaryBlockBase
-{
-    ColumnPtr tokens;
-
-    DictionaryBlockBase() = default;
-    explicit DictionaryBlockBase(ColumnPtr tokens_) : tokens(std::move(tokens_)) {}
-
-    bool empty() const;
-    size_t size() const;
-    size_t upperBound(std::string_view token) const;
-};
-
-struct DictionaryBlock : public DictionaryBlockBase
+struct DictionaryBlock
 {
     DictionaryBlock() = default;
     DictionaryBlock(ColumnPtr tokens_, std::vector<TokenPostingsInfo> token_infos_, UInt64 tokens_format_);
 
+    bool empty() const;
+    size_t size() const;
+
+    ColumnPtr tokens;
     std::vector<TokenPostingsInfo> token_infos;
     UInt64 tokens_format = 0;
 };
 
-struct DictionarySparseIndex : public DictionaryBlockBase
+class DictionarySparseIndex
 {
+public:
     DictionarySparseIndex() = default;
     DictionarySparseIndex(ColumnPtr tokens_, ColumnPtr offsets_in_file_);
+
+    bool empty() const { return size() == 0; }
+    size_t size() const;
+    size_t upperBound(std::string_view token) const;
+
+    std::string_view getToken(size_t idx) const;
     UInt64 getOffsetInFile(size_t idx) const;
     size_t memoryUsageBytes() const;
 
-    /// Shrinks the tokens column and bit-packs the offsets to reduce memory usage.
+    /// Returns the raw tokens column. Throws if tokens were bit-packed by optimize.
+    ColumnPtr getTokensColumn() const;
+    /// Returns the raw offsets column. Throws if offsets were bit-packed by optimize.
+    ColumnPtr getOffsetsColumn() const;
+
+    /// Decomposes the tokens column into chars and bit-packed offsets
+    /// and bit-packs the offsets in file to reduce memory usage.
     void optimize();
 
-    /// Offsets in the dictionary file to the beginning of each block.
-    /// Stored as a raw column after creation and bit-packed after optimize.
+private:
+    /// Tokens and offsets in the dictionary file to the beginning of each block.
+    /// Stored as raw columns after creation and bit-packed after optimize.
+    std::variant<ColumnPtr, BitPackedStringArray> tokens;
     std::variant<ColumnPtr, BitPackedUInt64Array> offsets_in_file;
 };
 

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3630,7 +3630,7 @@ TEST(PostingListCursorTest, TextIndexHeaderPersistsCodecType)
     EXPECT_EQ(sparse_index_data.version, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec));
     EXPECT_EQ(sparse_index_data.codec_type, IPostingListCodec::Type::Bitpacking);
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
-    EXPECT_EQ(assert_cast<const ColumnString &>(*sparse_index_data.sparse_index.tokens).getDataAt(0), "alpha");
+    EXPECT_EQ(sparse_index_data.sparse_index.getToken(0), "alpha");
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 42u);
 }
 
@@ -3654,7 +3654,7 @@ TEST(PostingListCursorTest, TextIndexHeaderInitialVersionDefaultsToNoneCodec)
     EXPECT_EQ(sparse_index_data.version, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::Initial));
     EXPECT_EQ(sparse_index_data.codec_type, IPostingListCodec::Type::None);
     EXPECT_EQ(sparse_index_data.sparse_index.size(), 1u);
-    EXPECT_EQ(assert_cast<const ColumnString &>(*sparse_index_data.sparse_index.tokens).getDataAt(0), "beta");
+    EXPECT_EQ(sparse_index_data.sparse_index.getToken(0), "beta");
     EXPECT_EQ(sparse_index_data.sparse_index.getOffsetInFile(0), 7u);
 }
 

--- a/src/Storages/StorageMergeTreeTextIndex.cpp
+++ b/src/Storages/StorageMergeTreeTextIndex.cpp
@@ -259,7 +259,8 @@ private:
         DataTypes key_types = {string_type};
 
         /// FieldRef can reference a column cell by pointer, avoiding string copies.
-        ColumnsWithTypeAndName ref_columns = {{sparse_index.tokens, string_type, "token"}};
+        /// The sparse index is loaded without a cache here, so tokens are stored as a raw column.
+        ColumnsWithTypeAndName ref_columns = {{sparse_index.getTokensColumn(), string_type, "token"}};
 
         for (size_t i = 0; i < num_blocks; ++i)
         {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

In addition to #109332. In this PR, a bit-packed array is applied to the offsets of `String` column.

Not for a changelog, because the changelog from #109332 will be enough.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.542` (included in `26.7` and later)
<!-- ch-version-info:end -->