### PR TITLE
Web UI: keep login form open while selecting text with the mouse

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5236,8 +5236,19 @@ connection_dropdown_elem.addEventListener('click', (e) => e.stopPropagation());
 /// call `stopPropagation()` in their own bubble-phase click handlers, so a bubbling listener
 /// would never see those clicks and the popover would stay open. A capture-phase listener runs
 /// before all of them, so every outside interaction dismisses it.
+///
+/// A `click` fires on the nearest common ancestor of the `mousedown` and `mouseup` targets, so a
+/// text selection that starts inside an input (e.g. selecting the user name) and is dragged past
+/// the drop-down's border before release lands its `click` on an ancestor outside `#connection-menu`
+/// — which would wrongly dismiss the popover mid-selection. Remember where the pointer went down
+/// (capture phase, so it is unaffected by `stopPropagation()` on inner handlers) and only close
+/// when the interaction both started and ended outside the menu.
+let connection_pointerdown_inside = false;
+document.addEventListener('mousedown', (e) => {
+    connection_pointerdown_inside = connection_menu_elem.contains(e.target);
+}, true);
 document.addEventListener('click', (e) => {
-    if (!connection_menu_elem.contains(e.target)) closeConnectionDropdown();
+    if (!connection_menu_elem.contains(e.target) && !connection_pointerdown_inside) closeConnectionDropdown();
 }, true);
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !connection_dropdown_elem.hidden) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5249,6 +5249,11 @@ document.addEventListener('mousedown', (e) => {
 }, true);
 document.addEventListener('click', (e) => {
     if (!connection_menu_elem.contains(e.target) && !connection_pointerdown_inside) closeConnectionDropdown();
+    /// Consume the latch: it describes only the pointer interaction that produced this `click`.
+    /// A keyboard activation (Space/Enter on a focused control) fires a `click` with no preceding
+    /// `mousedown`, so a stale `true` left over from opening the menu with the mouse must not carry
+    /// over and suppress that outside dismissal.
+    connection_pointerdown_inside = false;
 }, true);
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !connection_dropdown_elem.hidden) {

--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -5248,12 +5248,16 @@ document.addEventListener('mousedown', (e) => {
     connection_pointerdown_inside = connection_menu_elem.contains(e.target);
 }, true);
 document.addEventListener('click', (e) => {
-    if (!connection_menu_elem.contains(e.target) && !connection_pointerdown_inside) closeConnectionDropdown();
-    /// Consume the latch: it describes only the pointer interaction that produced this `click`.
-    /// A keyboard activation (Space/Enter on a focused control) fires a `click` with no preceding
-    /// `mousedown`, so a stale `true` left over from opening the menu with the mouse must not carry
-    /// over and suppress that outside dismissal.
-    connection_pointerdown_inside = false;
+    /// The latch is meaningful only for the pointer press that produced this `click`, and a press
+    /// arms it only when it goes on to emit a `click` (`detail !== 0`). Two kinds of `click` must
+    /// therefore ignore it: a keyboard or synthetic activation (Space/Enter on a focused control, or
+    /// a programmatic `.click()`) reports `detail === 0` and has no preceding `mousedown`; and a
+    /// mouse interaction that ends without a `click` — a right-click's `contextmenu`, a middle-click,
+    /// or a drag released outside the window — leaves a stale latch that no `click` ever consumes.
+    /// In both cases a stale `true` would otherwise wrongly suppress the outside dismissal, so the
+    /// latch counts only for a real pointer `click`.
+    const started_inside = e.detail !== 0 && connection_pointerdown_inside;
+    if (!connection_menu_elem.contains(e.target) && !started_inside) closeConnectionDropdown();
 }, true);
 document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !connection_dropdown_elem.hidden) {


### PR DESCRIPTION
In the Web UI (`play.html`), when the tab bar is shown the connection settings (url/user/password) live in a drop-down behind the 🔑 button. There is a UX problem: opening the login form, selecting the user name with the mouse, and dragging the mouse left just past the form's left border closes the form mid-selection.

A `click` event fires on the nearest common ancestor of its `mousedown` and `mouseup` targets. A drag-selection that starts inside an input and is released outside lands its `click` on an ancestor outside `#connection-menu`, so the capture-phase "click outside → close" handler wrongly dismisses the drop-down.

The fix remembers where the pointer went down (in the capture phase, so inner `stopPropagation()` calls do not hide it) and only closes when the interaction both started and ended outside the menu.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Web UI: fixed the connection settings drop-down closing when selecting text with the mouse and dragging past its border.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.541` (included in `26.7` and later)
<!-- ch-version-info:end -->