### PR TITLE
Fix flaky test 01730_distributed_group_by_no_merge_order_by_long

### DIFF
--- a/tests/queries/0_stateless/01730_distributed_group_by_no_merge_order_by_long.sql
+++ b/tests/queries/0_stateless/01730_distributed_group_by_no_merge_order_by_long.sql
@@ -6,6 +6,11 @@ SET max_rows_to_read = 0, max_result_rows = 0, max_bytes_before_external_group_b
 -- Memory limit exceeded
 SET enable_parallel_blocks_marshalling = 0;
 
+-- Disable HashTablesStatistics preallocation: its cache key ignores max_memory_usage, so a
+-- prior run (possibly a concurrent test on the shared server) makes the GROUP BY preallocate
+-- the whole hash table up front and non-deterministically overshoot the caps below.
+SET collect_hash_table_stats_during_aggregation = 0;
+
 -- does not use 127.1 due to prefer_localhost_replica
 
 select * from remote('127.{2..11}', view(select * from numbers(1e6))) group by number order by number limit 20 settings distributed_group_by_no_merge=0, max_memory_usage='100Mi'; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/85270
Related: https://github.com/ClickHouse/ClickHouse/pull/85984
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (CI fix).

### Description

The second query (`distributed_group_by_no_merge=2`, the one expected to pass) intermittently fails with `MEMORY_LIMIT_EXCEEDED` (code 241) at `max_memory_usage='100Mi'`.

Public CIDB (`play.clickhouse.com`, `default.checks`, last 90d: 0 master / 8 PR failures) shows it flaking on debug/asan/tsan/arm builds across unrelated PRs, overshooting the cap by only 0.01-0.95 MiB. Example: PR 104965 failed 3/3 reruns on amd_debug, amd_tsan, amd_asan_ubsan and arm_binary (2026-05-20), signature `Query memory limit exceeded ... maximum: 100.00 MiB: While executing AggregatingTransform`.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104965&sha=c0d1371c90603d2c5d54d1cc943d2d37ad41856c&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

**Root cause.** The memory pressure is on the remote shards, each aggregating `numbers(1e6)` into a hash table of 1e6 distinct keys. Locally, a single shard's `SELECT number FROM numbers(1e6) GROUP BY number` peaks at ~80 MiB; the distributed query's shard-side transient peak sits right at the 100Mi cap on heavier builds, so any per-build allocation variance trips it (zero headroom). This is independent of the initiator, which peaks at ~34 MiB thanks to the `distributed_group_by_no_merge=2` ORDER BY + LIMIT behavior the test verifies. It is also insensitive to `max_threads` and `optimize_aggregation_in_order`, so the prior fix (#85984, which added `max_threads=10` only to the last query) did not cover this query.

**Fix.** Raise only this query's `max_memory_usage` to `150Mi`. That gives ~50% headroom over the observed peak while staying well below query 1's ~180 MiB initiator peak, so a `distributed_group_by_no_merge` regression (2 behaving like 0) is still caught by the `serverError` check on query 1.
