### PR TITLE
SQLancer++: fix false-positive assertions, result reporting, and attach reproducer logs

### DIFF
--- a/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
+++ b/ci/docker/sqlancer-test/swap-clickhouse-jdbc.py
@@ -25,6 +25,18 @@
    a false-positive oracle mismatch. (`IS TRUE` itself is only accepted since
    https://github.com/ClickHouse/ClickHouse/pull/99997; before that the
    unpatched oracle was a guaranteed `SYNTAX_ERROR`.)
+4. Stop `GeneralQueryPartitioningWhere.check` from turning an `IgnoreMeException`
+   into an `AssertionError`. When the WHERE-stripped baseline query hits an
+   expected (whitelisted) error, `ComparatorHelper.getResultSetFirstColumnAsString`
+   sees a `null` result set and throws `IgnoreMeException` - a "skip this
+   iteration" control-flow signal, not a bug. The upstream oracle catches it in
+   `catch (Exception e)` and, for simple queries (no joins, <= 2 tables),
+   re-throws it as `AssertionError: null` ("You probably triggered an error in
+   the DBMS ..."). Against ClickHouse that fires constantly, so the WHERE oracle
+   (and the QUERY_PARTITIONING composite, which contains it) is a guaranteed
+   false-positive failure. Let the `IgnoreMeException` propagate instead; genuine
+   unexpected errors (a re-thrown `SQLException`, or an `AssertionError` with a
+   message) are unaffected and still reported.
 """
 
 import argparse
@@ -105,6 +117,39 @@ def patch_norec_oracle(repo: pathlib.Path) -> None:
     src.write_text(text.replace(old_postfix, new_postfix))
 
 
+def patch_where_oracle(repo: pathlib.Path) -> None:
+    src = (
+        repo / "src" / "sqlancer" / "general" / "oracle"
+        / "GeneralQueryPartitioningWhere.java"
+    )
+    text = src.read_text()
+    # The baseline (WHERE-stripped) query's catch block escalates any exception
+    # to an AssertionError for simple queries. An IgnoreMeException here is the
+    # benign "expected error, skip this iteration" signal and must propagate
+    # instead - otherwise every whitelisted error on a simple select becomes a
+    # false-positive `AssertionError: null`.
+    anchor = (
+        "        } catch (Exception e) {\n"
+        "            if (select.getJoinList().size() == 0 && select.getFromList().size() <= 2) {\n"
+    )
+    replacement = (
+        "        } catch (Exception e) {\n"
+        "            // ClickHouse patch: an IgnoreMeException means the baseline query hit an\n"
+        "            // expected/whitelisted error and was skipped (null result set); it is a\n"
+        "            // skip-this-iteration signal, not a DBMS bug, so propagate it instead of\n"
+        "            // escalating it into a false-positive AssertionError below.\n"
+        "            if (e instanceof sqlancer.IgnoreMeException) {\n"
+        "                throw e;\n"
+        "            }\n"
+        "            if (select.getJoinList().size() == 0 && select.getFromList().size() <= 2) {\n"
+    )
+    if anchor not in text:
+        sys.exit(f"failed to locate the WHERE-oracle catch block in {src}")
+    if text.count(anchor) != 1:
+        sys.exit(f"expected exactly one WHERE-oracle catch block in {src}")
+    src.write_text(text.replace(anchor, replacement))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("repo", help="Path to the SQLancer++ checkout")
@@ -122,6 +167,7 @@ def main() -> None:
     patch_pom(repo, version)
     patch_jdbc_properties(repo)
     patch_norec_oracle(repo)
+    patch_where_oracle(repo)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/sqlancer_job.sh
+++ b/ci/jobs/sqlancer_job.sh
@@ -240,6 +240,22 @@ else
     RESULT_INFO="Server is not responding before SQLancer run"
 fi
 
+# On failure, attach the per-database reproducer logs as an artifact. With
+# `--log-each-select true` SQLancer writes every statement of each generated
+# database to `logs/<dbms>/databaseN.log` (+ `databaseN-cur.log` for the
+# in-progress one), so the failing database's log is the exact
+# CREATE/INSERT/.../SELECT sequence needed to reproduce the bug - far easier
+# than reconstructing it from the interleaved, multi-threaded stdout. Only on
+# failure and as a single `.tar` (write_result gzips it if it exceeds 10 MB),
+# to avoid uploading a multi-hundred-MB log on clean runs.
+SQLANCER_LOG_DIR="/sqlancer/sqlancer-main/logs"
+if [ "$OVERALL_STATUS" != "OK" ] && [ -d "$SQLANCER_LOG_DIR" ]; then
+    reproducer_archive="$OUTPUT_PATH/sqlancer_reproducer_logs.tar"
+    if tar -C "$(dirname "$SQLANCER_LOG_DIR")" -cf "$reproducer_archive" "$(basename "$SQLANCER_LOG_DIR")"; then
+        ATTACHED_FILES_ARRAY+=("$reproducer_archive")
+    fi
+fi
+
 ls "$OUTPUT_PATH"
 
 if [ -f "$PID_FILE" ]; then

--- a/ci/jobs/sqlancer_pp_job.sh
+++ b/ci/jobs/sqlancer_pp_job.sh
@@ -11,16 +11,36 @@
 # clickhouse-server's HTTP port (8123).
 #
 # Mirrors `sqlancer_job.sh` in shape so the praktika report consumer remains
-# happy: emits a `result.json` with one entry per oracle plus attached log
-# files.
+# happy: emits a `result_<normalized_job_name>.json` with one entry per oracle
+# plus attached log files.
 
 set -exu
+
+# Capture the job start timestamp so the result file can report a real
+# `start_time`/`duration`. Praktika's CIDB inserter rejects a `null` `start_time`
+# (it calls `datetime.utcfromtimestamp(start_time)`, which fails on `None`).
+JOB_START_TIME=$(date +%s)
 
 TMP_PATH=$(readlink -f ./ci/tmp/)
 OUTPUT_PATH="$TMP_PATH/sqlancer_pp_output"
 PID_FILE="$TMP_PATH/clickhouse-server.pid"
 CLICKHOUSE_BIN="$TMP_PATH/clickhouse"
-RESULT_FILE="$TMP_PATH/result.json"
+
+# Praktika reads the job result from `./ci/tmp/result_<normalized_job_name>.json`,
+# where the normalization matches `Utils.normalize_string` in `ci/praktika/utils.py`
+# (see `sqlancer_job.sh`, which does the same). Writing a plain `result.json` here
+# is what made Praktika report ERROR "Job killed or terminated, no Result provided"
+# and drop every oracle result and attached log - the job's real FAIL/OK status
+# was written to a file Praktika never reads. `JOB_NAME` is not propagated into
+# the docker container, so read it from the serialized environment Praktika dumps.
+NORMALIZED_JOB_NAME=$(python3 -c '
+import sys
+sys.path.insert(0, ".")
+from ci.praktika._environment import _Environment
+from ci.praktika.utils import Utils
+print(Utils.normalize_string(_Environment.get().JOB_NAME))
+')
+RESULT_FILE="$TMP_PATH/result_${NORMALIZED_JOB_NAME}.json"
 
 mkdir -p "$OUTPUT_PATH"
 
@@ -142,12 +162,26 @@ done
 
 ATTACHED_FILES_ARRAY+=("$OUTPUT_PATH/clickhouse-server.log" "$OUTPUT_PATH/clickhouse-server.log.err")
 
+# On failure, attach the per-database reproducer logs as an artifact. With
+# `--log-each-select true` SQLancer++ writes every statement of each generated
+# database to `logs/<dbms>/databaseN-cur.log`; the failing database's log is the
+# exact CREATE/INSERT/.../SELECT sequence to reproduce the bug (the oracle's own
+# "Check the *-cur.log" hint points here). Only on failure, and gzip-compressed,
+# to avoid uploading a large log on clean runs.
+SQLANCER_PP_LOG_DIR="/sqlancer-pp/logs"
+if [[ "$OVERALL_STATUS" != "success" && -d "$SQLANCER_PP_LOG_DIR" ]]; then
+    reproducer_archive="$OUTPUT_PATH/sqlancer_pp_reproducer_logs.tar.gz"
+    if tar -C "$(dirname "$SQLANCER_PP_LOG_DIR")" -czf "$reproducer_archive" "$(basename "$SQLANCER_PP_LOG_DIR")"; then
+        ATTACHED_FILES_ARRAY+=("$reproducer_archive")
+    fi
+fi
+
 {
     printf '{\n'
     printf '  "name": "SQLancerPP",\n'
     printf '  "status": "%s",\n' "$OVERALL_STATUS"
-    printf '  "start_time": null,\n'
-    printf '  "duration": null,\n'
+    printf '  "start_time": %d,\n' "$JOB_START_TIME"
+    printf '  "duration": %d,\n' "$(( $(date +%s) - JOB_START_TIME ))"
     printf '  "results": [\n'
 
     for i in "${!TEST_RESULTS[@]}"; do


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/39965
-->

The NightlySQLancer / `SQLancerPP` job had three independent problems, found while investigating run https://github.com/ClickHouse/ClickHouse/actions/runs/28698784006 (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f9dd12e48fbf6bc5cf116e5445206a8e8dbc3866&name_0=NightlySQLancer). Both jobs showed green on GitHub while the praktika report was actually `FAIL`/`ERROR`.

**1. SQLancer++ `WHERE` and `QUERY_PARTITIONING` oracles always failed with `java.lang.AssertionError: null` (false positive).**
When the `WHERE`-stripped baseline query hits an expected/whitelisted ClickHouse error, `SQLQueryAdapter.executeAndGet` returns `null` and `ComparatorHelper` throws `IgnoreMeException` — a "skip this iteration" control-flow signal. `GeneralQueryPartitioningWhere.check` catches it in `catch (Exception e)` and, for simple queries, re-throws it as an `AssertionError` ("You probably triggered an error in the DBMS ..."). Against ClickHouse this fires constantly, so both oracles were guaranteed-red (`QUERY_PARTITIONING` is a composite that contains this oracle). Fixed by patching the oracle in `swap-clickhouse-jdbc.py` — the existing build-time patch mechanism, alongside the `NoREC` fix — to let `IgnoreMeException` propagate. Genuine unexpected errors (a re-thrown `SQLException`, or an `AssertionError` with a message) are unaffected and still reported. Verified locally: the `WHERE` oracle went from exit 255 with many assertions to exit 0 with none.

**2. `sqlancer_pp_job.sh` reporting bug.**
It wrote its result to `result.json` instead of `result_<normalized_job_name>.json`, so praktika never read it and reported `ERROR "Job killed or terminated, no Result provided"`, discarding every oracle status and attached log. It also emitted `null` `start_time`/`duration`, which the CIDB inserter rejects. Both fixed to mirror `sqlancer_job.sh`.

**3. Reproducer logs are now uploaded as artifacts.**
On failure, both `sqlancer_job.sh` and `sqlancer_pp_job.sh` archive SQLancer's per-database logs (`logs/<dbms>/databaseN-cur.log`, written with `--log-each-select`) as a downloadable artifact. Each file is the exact `CREATE`/`INSERT`/.../`SELECT` sequence (with the ClickHouse error inline) that triggered a bug, so reproducing is one click away instead of requiring reconstruction from interleaved multi-threaded stdout.

Note: the `swap-clickhouse-jdbc.py` change takes effect when the `clickhouse/sqlancer-test` image is rebuilt (its digest change triggers Dockers Build).

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.576` (included in `26.7` and later)
<!-- ch-version-info:end -->