### PR TITLE
Faster conversion of signed integers to Int256

### DIFF
--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -372,18 +372,14 @@ struct integer<Bits, Signed>::_impl
 
         self.items[little(0)] = _impl::to_Integral(rhs);
 
+        /// Sign-extend with a value select instead of a branch: a data-dependent branch here
+        /// mispredicts on mixed-sign data and prevents vectorization of columnar conversion loops.
+        base_type extension = 0;
         if constexpr (std::is_signed_v<Integral>)
-        {
-            if (rhs < 0)
-            {
-                for (unsigned i = 1; i < item_count; ++i)
-                    self.items[little(i)] = -1;
-                return;
-            }
-        }
+            extension = rhs < 0 ? base_type(-1) : base_type(0);
 
         for (unsigned i = 1; i < item_count; ++i)
-            self.items[little(i)] = 0;
+            self.items[little(i)] = extension;
     }
 
     template <typename TupleLike, size_t i = 0>
@@ -531,18 +527,13 @@ struct integer<Bits, Signed>::_impl
 
         if constexpr (Bits > Bits2)
         {
+            /// See the rationale in wide_integer_from_builtin.
+            base_type extension = 0;
             if constexpr (std::is_signed_v<Signed2>)
-            {
-                if (rhs < 0)
-                {
-                    for (unsigned i = to_copy; i < item_count; ++i)
-                        self.items[little(i)] = -1;
-                    return;
-                }
-            }
+                extension = rhs < 0 ? base_type(-1) : base_type(0);
 
             for (unsigned i = to_copy; i < item_count; ++i)
-                self.items[little(i)] = 0;
+                self.items[little(i)] = extension;
         }
     }
 

--- a/tests/performance/wide_integer_conversion.xml
+++ b/tests/performance/wide_integer_conversion.xml
@@ -1,0 +1,15 @@
+<test>
+    <!-- Conversion of native integers to 256-bit integers and widening of 128-bit to 256-bit integers.
+         Random 64-bit values give a random sign for the signed cases, which is hostile to a branchy
+         sign extension. The unsigned and 128-bit target queries guard the already fast paths. -->
+
+    <settings>
+        <max_threads>1</max_threads>
+    </settings>
+
+    <query>SELECT count() FROM numbers(50000000) WHERE NOT ignore(toInt256(toInt64(cityHash64(number))))</query>
+    <query>SELECT count() FROM numbers(50000000) WHERE NOT ignore(toInt256(toInt64(bitAnd(cityHash64(number), 4611686018427387903))))</query>
+    <query>SELECT count() FROM numbers(50000000) WHERE NOT ignore(toUInt256(cityHash64(number)))</query>
+    <query>SELECT count() FROM numbers(50000000) WHERE NOT ignore(toInt256(toInt128(toInt64(cityHash64(number)))))</query>
+    <query>SELECT count() FROM numbers(50000000) WHERE NOT ignore(toInt128(toInt64(cityHash64(number))))</query>
+</test>


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109474

`wide_integer_from_builtin` and `wide_integer_from_wide_integer` sign-extend through an `if (rhs < 0)` branch that selects between two separate fill loops. In columnar conversion loops this data-dependent branch mispredicts on mixed-sign data, and the two-loop shape prevents vectorization even when the branch predicts well. Select the extension value (0 or -1) branchlessly instead and use a single fill loop.

Kernel benchmark of the columnar conversion loop (clang 21, x86-64-v3, 64k-element blocks):

| conversion | before | after |
|---|---|---|
| `Int64` to `Int256`, random sign | 10.3 GB/s | 73.9 GB/s |
| `Int64` to `Int256`, positive only | 31.3 GB/s | 73.3 GB/s |
| `Int128` to `Int256`, random sign | 12.2 GB/s | 68.0 GB/s |
| `Int64` to `Int128`, unsigned conversions | unchanged | unchanged |

Absolute numbers are machine-specific, the ratios (up to ~7x on mixed signs, ~2.5x even on single-sign data) are the point. The effect is visible at the query level too: `toInt256(toInt64(cityHash64(number)))` over 100M rows single-threaded takes 6.8x the time of the equivalent unsigned conversion in 26.6.1.

Results are bit-for-bit identical to the previous implementation. This was verified over tens of millions of checks covering all builtin integral source types with boundary values, 128-to-256-bit widening for all signedness combinations (including `Int128` to `UInt256` sign extension and `UInt128` to `Int256` zero extension), narrowing, and constexpr evaluation. The `double` conversion path is untouched.

A performance test covering the mixed-sign, single-sign and unchanged conversion paths is included.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve performance of converting signed native integers to `Int256` and `Int128` to `Int256` (up to 7 times on mixed-sign data) by making the sign extension branchless.