### PR TITLE
Fix OOB segfault in `groupArrayLastMerge`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
+++ b/src/AggregateFunctions/AggregateFunctionGroupArray.cpp
@@ -44,6 +44,7 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
     extern const int BAD_ARGUMENTS;
     extern const int TOO_LARGE_ARRAY_SIZE;
+    extern const int INCORRECT_DATA;
 }
 
 namespace
@@ -342,12 +343,17 @@ public:
                 readBinaryLittleEndian(element, buf);
         }
 
-        if constexpr (Trait::last)
+        if constexpr (Trait::last || Trait::sampler == Sampler::RNG)
+        {
             readBinaryLittleEndian(this->data(place).total_values, buf);
+            if (static_cast<UInt64>(this->data(place).value.size()) != std::min<UInt64>(max_elems, this->data(place).total_values))
+                throw Exception(ErrorCodes::INCORRECT_DATA,
+                    "Malformed {} state: {} stored elements, but total_values = {} with max_elems = {}",
+                    getName(), this->data(place).value.size(), this->data(place).total_values, max_elems);
+        }
 
         if constexpr (Trait::sampler == Sampler::RNG)
         {
-            readBinaryLittleEndian(this->data(place).total_values, buf);
             std::string rng_string;
             readStringBinary(rng_string, buf);
             ReadBufferFromString rng_buf(rng_string);
@@ -691,12 +697,17 @@ public:
                 value[i] = Node::read(buf, arena);
         }
 
-        if constexpr (Trait::last)
+        if constexpr (Trait::last || Trait::sampler == Sampler::RNG)
+        {
             readBinaryLittleEndian(data(place).total_values, buf);
+            if (static_cast<UInt64>(data(place).value.size()) != std::min<UInt64>(max_elems, data(place).total_values))
+                throw Exception(ErrorCodes::INCORRECT_DATA,
+                    "Malformed {} state: {} stored elements, but total_values = {} with max_elems = {}",
+                    getName(), data(place).value.size(), data(place).total_values, max_elems);
+        }
 
         if constexpr (Trait::sampler == Sampler::RNG)
         {
-            readBinaryLittleEndian(data(place).total_values, buf);
             std::string rng_string;
             readStringBinary(rng_string, buf);
             ReadBufferFromString rng_buf(rng_string);

--- a/tests/queries/0_stateless/02520_group_array_last.reference
+++ b/tests/queries/0_stateless/02520_group_array_last.reference
@@ -51,3 +51,48 @@ select * from simple_agg_groupArrayLastArray order by key, value;
 select * from simple_agg_groupArrayLastArray final order by key, value;
 1	[7,8,3,4,5]
 2	[7,8,6,1,2]
+-- Deserializing broken states.
+SELECT
+    CAST(
+        CAST(
+            groupArrayLastState(1)(number) AS String
+        ) AS AggregateFunction(groupArrayLast(42), UInt64)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArrayLastState(1)(toString(number)) AS String
+        ) AS AggregateFunction(groupArrayLast(42), String)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArraySampleState(1)(number) AS String
+        ) AS AggregateFunction(groupArraySample(42), UInt64)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArraySampleState(1)(toString(number)) AS String
+        ) AS AggregateFunction(groupArraySample(42), String)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+WITH (
+    SELECT
+        CAST(
+            CAST(
+                groupArrayLastState(1)(number) AS String
+            ) AS AggregateFunction(groupArrayLast(42), UInt64)
+        )
+    FROM numbers(10)
+) AS s
+SELECT
+    length(groupArrayLastMerge(42)(s))
+FROM numbers(2); -- { serverError INCORRECT_DATA }

--- a/tests/queries/0_stateless/02520_group_array_last.sql
+++ b/tests/queries/0_stateless/02520_group_array_last.sql
@@ -34,3 +34,48 @@ system stop merges simple_agg_groupArrayLastArray;
 insert into simple_agg_groupArrayLastArray values (1, [7,8]), (2, [7,8]);
 select * from simple_agg_groupArrayLastArray order by key, value;
 select * from simple_agg_groupArrayLastArray final order by key, value;
+-- Deserializing broken states.
+SELECT
+    CAST(
+        CAST(
+            groupArrayLastState(1)(number) AS String
+        ) AS AggregateFunction(groupArrayLast(42), UInt64)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArrayLastState(1)(toString(number)) AS String
+        ) AS AggregateFunction(groupArrayLast(42), String)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArraySampleState(1)(number) AS String
+        ) AS AggregateFunction(groupArraySample(42), UInt64)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+SELECT
+    CAST(
+        CAST(
+            groupArraySampleState(1)(toString(number)) AS String
+        ) AS AggregateFunction(groupArraySample(42), String)
+    )
+FROM numbers(2)
+FORMAT Null; -- { serverError INCORRECT_DATA }
+WITH (
+    SELECT
+        CAST(
+            CAST(
+                groupArrayLastState(1)(number) AS String
+            ) AS AggregateFunction(groupArrayLast(42), UInt64)
+        )
+    FROM numbers(10)
+) AS s
+SELECT
+    length(groupArrayLastMerge(42)(s))
+FROM numbers(2); -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a segfault in `groupArrayLastMerge`. Deserialization of aggregated function state is now validated. So a broken state does not lead to OOB. 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.670` (included in `26.7` and later)
- Backported to: `26.6.2.53`, `26.5.6.64`, `26.4.5.152`, `26.3.17.66`, `25.8.29.28`
<!-- ch-version-info:end -->