### PR TITLE
Refuse to make an empty patch release when tweak is 1

### DIFF
--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -286,6 +286,23 @@ class ReleaseInfo:
                 version.with_description(codename)
                 release_branch = f"{version.major}.{version.minor}"
                 release_tag = version.describe
+                # Refuse to make an empty patch release. For a patch release the
+                # tweak equals the number of commits since the previous release
+                # tag (see Git.tweak). A tweak of 1 means the only commit on top
+                # of the previous release is the automated post-release version
+                # bump, so there is nothing to release. Tagging it would produce
+                # a spurious release like v25.8.28.1-lts. Recovery runs
+                # (only-repo/only-docker) rebuild an already-tagged release and
+                # do not tag, so skip the check. This is checked before the
+                # out-of-order check below because "nothing to release" is the
+                # more fundamental condition.
+                if not _skip_out_of_order_check and version.tweak == 1:
+                    raise RuntimeError(
+                        f"Refusing to release ref [{commit_ref}]: computed "
+                        f"version [{version.string}] has tweak 1, which means the "
+                        f"only commit since the previous release is the automated "
+                        f"version bump. There is nothing to release."
+                    )
             Shell.check(
                 f"{GIT_PREFIX} fetch origin {release_branch} --tags",
                 strict=True,
@@ -351,21 +368,6 @@ class ReleaseInfo:
                 f"git rev-list -n1 {previous_release_tag}"
             )
             assert previous_release_sha
-
-            # Refuse to make an empty patch release. For a patch release the
-            # tweak equals the number of commits since the previous release tag
-            # (see Git.tweak). A tweak of 1 means the only commit on top of the
-            # previous release is the automated post-release version bump, so
-            # there is nothing to release. Tagging it would produce a spurious
-            # release like v25.8.28.1-lts. Recovery runs (only-repo/only-docker)
-            # rebuild an already-tagged release and do not tag, so skip the check.
-            if not _skip_out_of_order_check and version.tweak == 1:
-                raise RuntimeError(
-                    f"Refusing to release ref [{commit_ref}]: computed version "
-                    f"[{version.string}] has tweak 1, which means the only commit "
-                    f"since the previous release [{previous_release_tag}] is the "
-                    f"automated version bump. There is nothing to release."
-                )
 
             if GH.is_latest_release_branch(release_branch):
                 print("This is going to be the latest release!")

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -352,6 +352,21 @@ class ReleaseInfo:
             )
             assert previous_release_sha
 
+            # Refuse to make an empty patch release. For a patch release the
+            # tweak equals the number of commits since the previous release tag
+            # (see Git.tweak). A tweak of 1 means the only commit on top of the
+            # previous release is the automated post-release version bump, so
+            # there is nothing to release. Tagging it would produce a spurious
+            # release like v25.8.28.1-lts. Recovery runs (only-repo/only-docker)
+            # rebuild an already-tagged release and do not tag, so skip the check.
+            if not _skip_out_of_order_check and version.tweak == 1:
+                raise RuntimeError(
+                    f"Refusing to release ref [{commit_ref}]: computed version "
+                    f"[{version.string}] has tweak 1, which means the only commit "
+                    f"since the previous release [{previous_release_tag}] is the "
+                    f"automated version bump. There is nothing to release."
+                )
+
             if GH.is_latest_release_branch(release_branch):
                 print("This is going to be the latest release!")
                 latest_release = True

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -236,6 +236,26 @@ class ReleaseInfo:
             print(json.dumps(dataclasses.asdict(self), indent=2), file=f)
         return self
 
+    @staticmethod
+    def _is_empty_patch_release(patch: int, tweak: int) -> bool:
+        """
+        Whether a patch release would be empty and must be refused.
+
+        For a patch release the tweak equals the number of commits since the
+        previous release tag (see `Git.tweak`), so `tweak == 1` means the only
+        commit on top of the previous release is the automated post-release
+        version bump — there is nothing to release (e.g. `v25.8.28.1-lts`).
+
+        The exception is `patch == 1`: that is the first user-facing
+        `stable`/`lts` release of a freshly cut branch. Its previous tag is the
+        non-user-facing `vX.Y.1.1-new`, and the single automated
+        `testing -> stable/lts` version-update commit also yields `tweak == 1`.
+        That release is legitimate and must be allowed. The post-release bump
+        always increments `patch`, so an already-published branch is always at
+        `patch >= 2` on a rerun.
+        """
+        return tweak == 1 and patch != 1
+
     def prepare(
         self,
         commit_ref: str,
@@ -286,17 +306,14 @@ class ReleaseInfo:
                 version.with_description(codename)
                 release_branch = f"{version.major}.{version.minor}"
                 release_tag = version.describe
-                # Refuse to make an empty patch release. For a patch release the
-                # tweak equals the number of commits since the previous release
-                # tag (see Git.tweak). A tweak of 1 means the only commit on top
-                # of the previous release is the automated post-release version
-                # bump, so there is nothing to release. Tagging it would produce
-                # a spurious release like v25.8.28.1-lts. Recovery runs
+                # Refuse to make an empty patch release. Recovery runs
                 # (only-repo/only-docker) rebuild an already-tagged release and
                 # do not tag, so skip the check. This is checked before the
                 # out-of-order check below because "nothing to release" is the
                 # more fundamental condition.
-                if not _skip_out_of_order_check and version.tweak == 1:
+                if not _skip_out_of_order_check and self._is_empty_patch_release(
+                    version.patch, version.tweak
+                ):
                     raise RuntimeError(
                         f"Refusing to release ref [{commit_ref}]: computed "
                         f"version [{version.string}] has tweak 1, which means the "

--- a/tests/ci/test_create_release.py
+++ b/tests/ci/test_create_release.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the pure helpers in `create_release.py`. Run with
+`python -m unittest` from `tests/ci/`, or with
+`pytest tests/ci/test_create_release.py` from the repo root.
+"""
+
+import unittest
+
+from create_release import ReleaseInfo
+
+
+class TestIsEmptyPatchRelease(unittest.TestCase):
+    def test_rejects_empty_rerun(self):
+        # Already-published branch: the only commit since the previous
+        # stable/lts tag is the automated version bump (e.g. v25.8.28.1-lts).
+        self.assertTrue(ReleaseInfo._is_empty_patch_release(patch=28, tweak=1))
+
+    def test_allows_first_release_of_new_branch(self):
+        # First user-facing stable/lts release on a freshly cut branch. Its
+        # previous tag is vX.Y.1.1-new and the single testing -> stable commit
+        # also yields tweak == 1, but the release is legitimate.
+        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=1, tweak=1))
+
+    def test_allows_non_empty_patch_release(self):
+        # Real commits on top of the previous release -> tweak > 1.
+        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=28, tweak=42))
+
+    def test_allows_non_empty_first_release(self):
+        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=1, tweak=2222))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When creating a patch release, the version's `tweak` component equals the number of commits since the previous release tag (see `Git.tweak`). Right after a release, the pipeline pushes an automated "Update autogenerated version to ... and contributors" commit to the release branch. If a patch release is then started on that HEAD without any real changes on top, the computed `tweak` is `1` — the only commit since the previous release is that version bump. Tagging it produces a spurious, empty patch release such as `v25.8.28.1-lts`.

This adds a guard in `ReleaseInfo.prepare`: for a patch release, if the computed `tweak` is `1`, the release is refused with a clear error. Recovery runs (`only-repo`/`only-docker`) rebuild an already-tagged release and do not tag, so the check is skipped there, mirroring the existing out-of-order check.

Related: https://github.com/ClickHouse/ClickHouse/pull/109440

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.639` (included in `26.7` and later)
<!-- ch-version-info:end -->