### PR TITLE
Fix flaky test 04001_join_reorder_through_expression under randomized join order

### DIFF
--- a/tests/queries/0_stateless/04001_join_reorder_through_expression.sql
+++ b/tests/queries/0_stateless/04001_join_reorder_through_expression.sql
@@ -23,6 +23,10 @@ INSERT INTO t3 VALUES (11, 'A'), (21, 'B'), (31, 'C');
 
 SET enable_join_runtime_filters = 0;
 SET query_plan_optimize_join_order_algorithm = 'greedy';
+-- `query_plan_optimize_join_order_randomize` injects random cardinalities/NDVs into the cost model
+-- when non-zero, so the chosen join tree becomes non-deterministic. Pin it off so the EXPLAIN output
+-- is stable under CI-randomized settings.
+SET query_plan_optimize_join_order_randomize = 0;
 SET query_plan_merge_expression_into_join = 1;
 
 EXPLAIN PLAN keep_logical_steps = 1, description = 0


### PR DESCRIPTION
The stateless test `04001_join_reorder_through_expression` asserts a specific join tree via `EXPLAIN PLAN keep_logical_steps = 1`. The CI-randomized setting `query_plan_optimize_join_order_randomize` injects random cardinalities/NDVs into the join-order cost model when non-zero, so the optimizer picks a different (still valid) tree and the `EXPLAIN` output no longer matches the reference.

The randomized-settings diagnosis pins the culprit exactly:

```
Culprit settings: --query_plan_optimize_join_order_randomize 587125
Step 2: Re-running without randomized settings ...
  Runs: 56, Failed: 0, Passed: 56, Other: 0
Result: Passes without randomization. Confirmed: the failure is caused by randomized settings.
```

It reproduces 100% under the randomizer and fails reproducibly on `master` across every architecture (`arm_binary`, `amd_debug`, `amd_tsan`, `amd_asan_ubsan`, `amd_msan`, …) — see the `PR=0` history for this test on play.clickhouse.com.

The fix pins `query_plan_optimize_join_order_randomize = 0` in the test, matching the existing pattern in sibling join-order tests such as `04277_parallel_replicas_join_dp_reorder` and the `03960_join_order_dphyp_*` family, which disable the same randomization because they also check a deterministic `EXPLAIN` join tree.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.560` (included in `26.7` and later)
<!-- ch-version-info:end -->