### PR TITLE
Reject data type names starting with a digit

### DIFF
--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -248,8 +248,13 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// unquoted (e.g. UInt64). This introduces problems when the string in the quotes is garbage:
     ///  * Array(`x.y`) -> Array(x.y) -> fails to parse
     ///  * `Null` -> Null -> parses as keyword instead of type name
+    ///  * Nullable(`255`) -> Nullable(255) -> the unquoted name re-lexes as a number literal
+    ///    (ASTLiteral) instead of a type name (ASTDataType), breaking the AST round-trip check
+    ///    in `executeQuery` (DEBUG/sanitizer builds). See STID 1941-1bfa.
     /// Here we check for these cases and reject.
-    if (!std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
+    if (type_name.empty()
+        || isNumericASCII(type_name.front())
+        || !std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
     {
         expected.add(pos, "type name");
         return false;

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
@@ -17,3 +17,5 @@ Syntax error
 Syntax error
 Syntax error
 Syntax error
+Syntax error
+Syntax error

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
@@ -46,3 +46,10 @@ $CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t3 (a Nullable(multiply((NULL
 # quantileInterpolatedWeighted) must not be mistaken for a MySQL integer type and
 # have its leading (N) group eaten as a display width (which broke the round-trip).
 $CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t (a quantileInterpolatedWeighted(0.8)(a, 1)) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'
+
+# A back-quoted type name starting with a digit (e.g. `255`) is printed unquoted
+# by the formatter and then re-lexes as a number literal (ASTLiteral) instead of
+# a type name (ASTDataType), breaking the AST round-trip. Reject at parse time.
+# See STID 1941-1bfa.
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t4 (\`x\` Nullable(\`255\`)) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t5 (\`x\` Nullable(multiIf(equals(\`255\`, 2147483647), toFixedString('', 2), toFixedString('', 2)))) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix an `Inconsistent AST formatting` logical error (server abort in debug/sanitizer builds) when a back-quoted data type name starts with a digit, e.g. `` Nullable(`255`) ``. Such a name is now rejected at parse time.

### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/109501

Found by the AST fuzzer (STID `1941-1bfa`). A back-quoted type name whose first character is a digit (e.g. `` Nullable(`255`) ``) is printed unquoted by the formatter (`Nullable(255)`). The unquoted name then re-lexes as a number literal (`ASTLiteral`) instead of a type name (`ASTDataType`), so the format-parse-format AST round-trip check in `executeQuery` diverges and aborts debug/sanitizer builds with an `Inconsistent AST formatting` logical error.

Minimal reproducer:
```sql
CREATE TABLE t (`x` Nullable(`255`)) ENGINE = Memory;
```

Root cause: `ParserDataType` accepted any word-char string as a type name, including all-digit names. `ASTDataType::formatImpl` prints the name unquoted, so a digit-leading name does not survive the round trip. Real data type names never start with a digit, so this rejects them at parse time (returning a normal `SYNTAX_ERROR`), alongside the existing rejection of non-word-char names (`` `x.y` ``, `` `Null` ``).

Regression test added to `03210_inconsistent_formatting_of_data_types` (the canonical test for this STID family).

CI report of the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109288&sha=749cbb09b5f36bf574dce5707ca1e496db0840bd&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29
