### PR TITLE
Docs: redirect `/cloud/manage/api/swagger` to the API reference

### DIFF
--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -748,6 +748,10 @@
     "destination": "/api-reference/organization/get-list-of-available-organizations"
   },
   {
+    "source": "/cloud/manage/api/swagger",
+    "destination": "/api-reference/organization/get-list-of-available-organizations"
+  },
+  {
     "source": "/cloud/manage/api/usageCost-api-reference",
     "destination": "/api-reference/organization/get-list-of-available-organizations"
   },


### PR DESCRIPTION
Add a redirect from `/cloud/manage/api/swagger` to `/api-reference/organization/get-list-of-available-organizations`, the same destination the sibling `/cloud/manage/api/*-api-reference` sources already use.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.556` (included in `26.7` and later)
<!-- ch-version-info:end -->