### PR TITLE
docs: point AWS BYOC onboarding Terraform at terraform-byoc-onboarding module

### DIFF
--- a/docs/products/bring-your-own-cloud/onboarding/aws.mdx
+++ b/docs/products/bring-your-own-cloud/onboarding/aws.mdx
@@ -27,14 +27,18 @@ The initial BYOC setup can be performed using either a CloudFormation template o
 
 #### Terraform Module 
 
-[BYOC Terraform module](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz)
+Use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:
 
 ```hcl
 module "clickhouse_onboarding" {
-  source   = "https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz"
-  byoc_env = "production"
+  source      = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  external_id = "<external-id-provided-by-clickhouse>"
 }
 ```
+
+<Note>
+The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
+</Note>
 
 ### Set up BYOC infrastructure 
 
@@ -119,7 +123,7 @@ In ClickHouse BYOC account,
 3. Click the Edit button under the Routes tab.
 4. Click Add another route.
 5. Enter the CIDR range of the target VPC for the Destination.
-6. Select “Peering Connection” and the ID of the peering connection for the Target.
+6. Select "Peering Connection" and the ID of the peering connection for the Target.
 
 <br />
 
@@ -134,7 +138,7 @@ In the peering AWS account,
 3. Click the Edit button under the Routes tab.
 4. Click Add another route.
 5. Enter the CIDR range of the ClickHouse VPC for the Destination.
-6. Select “Peering Connection” and the ID of the peering connection for the Target.
+6. Select "Peering Connection" and the ID of the peering connection for the Target.
 
 <br />
 

--- a/docs/products/bring-your-own-cloud/onboarding/customization-aws.mdx
+++ b/docs/products/bring-your-own-cloud/onboarding/customization-aws.mdx
@@ -45,7 +45,7 @@ Ensure your VPC has working DNS resolution and doesn't block, interfere with, or
 <Step>
 ### Configure your AWS account {#configure-aws-account}
 
-The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml) or a [Terraform module](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz).
+The initial BYOC setup creates a privileged IAM role (`ClickHouseManagementRole`) that enables BYOC controllers from ClickHouse Cloud to manage your infrastructure. This can be performed using either a [CloudFormation template](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/cf-templates/byoc.yaml) or a Terraform module (see below).
 
 When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` parameter to `false` to ensure ClickHouse Cloud doesn't receive permissions to modify your customer-managed VPC.
 
@@ -53,17 +53,21 @@ When deploying for a `BYO-VPC` setup, set the `IncludeVPCWritePermissions` param
 Storage buckets, Kubernetes cluster, and compute resources required for running ClickHouse aren't included in this initial setup. They will be provisioned in a later step. While you control your VPC, ClickHouse Cloud still requires IAM permissions to create and manage the Kubernetes cluster, IAM roles for service accounts, S3 buckets, and other essential resources in your AWS account.
 </Note>
 
-#### Alternative Terraform module {#terraform-module-aws}
+#### Terraform module {#terraform-module-aws}
 
-If you prefer to use Terraform instead of CloudFormation, use the following module:
+If you prefer to use Terraform instead of CloudFormation, use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:
 
 ```hcl
 module "clickhouse_onboarding" {
-  source                     = "https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz"
-  byoc_env                   = "production"
+  source                        = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  external_id                   = "<external-id-provided-by-clickhouse>"
   include_vpc_write_permissions = false
 }
 ```
+
+<Note>
+The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
+</Note>
 </Step>
 <Step>
 ### Set up BYOC infrastructure {#set-up-byoc-infrastructure}

--- a/docs/products/bring-your-own-cloud/onboarding/standard.mdx
+++ b/docs/products/bring-your-own-cloud/onboarding/standard.mdx
@@ -50,18 +50,20 @@ The initial BYOC setup can be performed using a [CloudFormation template (AWS)](
 Storage buckets, VPC/VNet, Kubernetes cluster, and compute resources required for running ClickHouse aren't included in this initial setup. They will be provisioned in the next step.
 </Note>
 
-#### Alternative Terraform Module for AWS {#terraform-module-aws}
+#### Terraform Module for AWS {#terraform-module-aws}
 
-If you prefer to use Terraform instead of CloudFormation for AWS deployments, we also provide a [Terraform module for AWS](https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz).
-
-Usage:
+If you prefer to use Terraform instead of CloudFormation for AWS deployments, use the [terraform-byoc-onboarding](https://github.com/ClickHouse/terraform-byoc-onboarding) module:
 
 ```hcl
 module "clickhouse_onboarding" {
-  source   = "https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz"
-  byoc_env = "production"
+  source      = "github.com/ClickHouse/terraform-byoc-onboarding.git//modules/aws?ref=v1.2.0"
+  external_id = "<external-id-provided-by-clickhouse>"
 }
 ```
+
+<Note>
+The module was previously distributed as a tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz`. That URL remains available but is deprecated — use the GitHub module above.
+</Note>
 </Step>
 <Step>
 ### Set up BYOC infrastructure {#setup-byoc-infrastructure}
@@ -84,7 +86,7 @@ After your BYOC infrastructure has been provisioned, you're ready to launch your
 
 <Image img="/images/cloud/reference/byoc-new-service-1.webp" size="md" alt="BYOC create new service"/>
 
-During service creation, you’ll configure the following options:
+During service creation, you'll configure the following options:
 
 - **Service name**: Enter a clear, descriptive name for your ClickHouse service.
 - **BYOC infrastructure**: Select the BYOC environment, including the cloud account and region, where your service will run.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

---

## Summary

The AWS BYOC onboarding Terraform module is now published at [`ClickHouse/terraform-byoc-onboarding`](https://github.com/ClickHouse/terraform-byoc-onboarding) under `modules/aws`, released as tag `v1.2.0`.

Changes:
- `docs/products/bring-your-own-cloud/onboarding/standard.mdx` — updated the "Terraform Module for AWS" section to use the GitHub module as the primary source; added deprecation note for the S3 tarball URL.
- `docs/products/bring-your-own-cloud/onboarding/aws.mdx` — updated the "Terraform Module" section under "Initialize BYOC setup" similarly.
- `docs/products/bring-your-own-cloud/onboarding/customization-aws.mdx` — updated the "Terraform module" section under "Configure your AWS account" similarly.

The old tarball at `https://s3.us-east-2.amazonaws.com/clickhouse-public-resources.clickhouse.cloud/tf/byoc.tar.gz` remains available but is deprecated. The per-infra tarball (`iam_per_infra.tar.gz`) is unaffected.

Translated (i18n) pages under `docs/{ar,es,fr,ja,ko,pt-BR,ru,zh}/` are intentionally untouched — they regenerate from the English source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)