### PR TITLE
set missing coordination component in system.detached_parts size calculation

### DIFF
--- a/src/Storages/System/StorageSystemDetachedParts.cpp
+++ b/src/Storages/System/StorageSystemDetachedParts.cpp
@@ -16,6 +16,7 @@
 #include <Processors/Sources/SourceFromSingleChunk.h>
 #include <QueryPipeline/Pipe.h>
 #include <IO/SharedThreadPools.h>
+#include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/setThreadName.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
@@ -178,6 +179,8 @@ private:
             /// Passing a reference to worker_state is safe, because the variable outlives runner
             auto worker = [&worker_state] ()
             {
+                auto component_guard = Coordination::setCurrentComponent("DetachedPartsSource::calculatePartSizeOnDisk");
+
                 for (auto id = worker_state.next_task++; id < worker_state.tasks.size(); id = worker_state.next_task++)
                 {
                     auto & task = worker_state.tasks.at(id);

--- a/src/Storages/System/StorageSystemDetachedParts.cpp
+++ b/src/Storages/System/StorageSystemDetachedParts.cpp
@@ -196,6 +196,8 @@ private:
 
     void generateRows(MutableColumns & new_columns, size_t max_rows)
     {
+        auto component_guard = Coordination::setCurrentComponent("DetachedPartsSource::generateRows");
+
         chassert(current_info);
 
         auto rows = std::min(max_rows, detached_parts.size());

--- a/src/Storages/System/StorageSystemDetachedParts.cpp
+++ b/src/Storages/System/StorageSystemDetachedParts.cpp
@@ -178,6 +178,8 @@ private:
             /// Passing a reference to worker_state is safe, because the variable outlives runner
             auto worker = [&worker_state] ()
             {
+                auto component_guard = Coordination::setCurrentComponent("DetachedPartsSource::calculatePartSizeOnDisk");
+
                 for (auto id = worker_state.next_task++; id < worker_state.tasks.size(); id = worker_state.next_task++)
                 {
                     auto & task = worker_state.tasks.at(id);


### PR DESCRIPTION

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109553&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109553](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109553+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1663` (included in `26.8` and later)
<!-- ch-version-info:end -->