### PR TITLE
Fix JSON-as-string setting name in JDBC docs

### DIFF
--- a/docs/integrations/language-clients/java/jdbc.mdx
+++ b/docs/integrations/language-clients/java/jdbc.mdx
@@ -581,7 +581,7 @@ map.put("key3", new HashMap<String, Object>() {{
     put("key5", "value5");
 }});
 ```
-There is more convinient option to read JSON as String by passing server setting `jdbc_read_json_as_string=true` to connection properties.
+There is a more convenient option to read JSON as String by passing the server setting `output_format_binary_write_json_as_string=1` to connection properties.
 This makes driver return JSON values as String and can be used to parse using any JSON library.
 
 ```java


### PR DESCRIPTION
The JDBC integration docs describe reading JSON as String via a `jdbc_read_json_as_string` connection property, but no such property exists — the clickhouse-jdbc driver rejects it as an unknown config property, and the token doesn't appear anywhere in the clickhouse-java source (only in the docs). The code example directly below that sentence already uses the correct setting, `output_format_binary_write_json_as_string`.

This corrects the prose to reference the real setting (and fixes a small typo: convinient → convenient).

### Changelog category (leave one):

- Documentation (changelog entry is not required)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=109554&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109554](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109554+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1068` (included in `26.9` and later)
<!-- ch-version-info:end -->