### PR TITLE
Fix flaky test_retry_loading_parts in test_merge_tree_s3_failover

### DIFF
--- a/tests/integration/test_merge_tree_s3_failover/test.py
+++ b/tests/integration/test_merge_tree_s3_failover/test.py
@@ -313,7 +313,12 @@ def test_retry_loading_parts(cluster):
     node.query("INSERT INTO s3_retry_loading_parts VALUES (42)")
     node.query("DETACH TABLE s3_retry_loading_parts")
 
-    fail_request(cluster, 5)
+    # Fail the 5th GET request to S3 to break the first part-loading attempt.
+    # Use GET method filter to avoid counting background PUT/DELETE requests
+    # (e.g. cleanup, or metadata writes on the shared cluster) that could
+    # consume the fail counter and either land on a non-retryable write or
+    # miss the part-loading read entirely, making the test flaky.
+    fail_request(cluster, 5, "GET")
     node.query("ATTACH TABLE s3_retry_loading_parts")
 
     assert node.contains_in_log(


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107736
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_merge_tree_s3_failover/test.py::test_retry_loading_parts` is flaky. It calls `fail_request(cluster, 5)` without a method filter. The module-shared cluster means background non-GET S3 requests (cleanup of parts from earlier tests, or metadata writes) can occupy the fail-counter window, so the injected `500` lands on a **non-retryable write** under the `s3_no_retries` policy instead of the intended retryable part-loading **GET**. When that happens the `ATTACH` fails hard with `Code: 499. DB::S3Exception` (`WriteBufferFromS3::makeSinglepartUpload`) instead of retrying, and the test fails.

Fix: add a `"GET"` method filter, exactly mirroring the `"PUT"` filters the sibling tests `test_write_failover` and `test_move_failover` already use in this same file (added in commits `90521905b` / `e5731e001` for the identical class of flakiness). Only the part-loading read is now targeted; the `contains_in_log("Failed to load data part ... with retryable error")` assertion is preserved.

The request trace confirms the mechanism: during `ATTACH` the part loader issues a burst of `PUT`s followed by `GET`s; without a method filter the 5th *request* can be a `PUT`.

Reproduction (before fix): with a non-GET request in the counter window during `ATTACH`, `fail_request(cluster, 5)` produces `Code: 499` deterministically. After fix: 25/25 full-module runs pass in random order on the shared cluster; the retryable-error assertion still fires.

CI report showing this signature: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107736&sha=&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%208%2F8%29
