### PR TITLE
Review skill: do not flag docs PRs for skipping Mintlify files during migration

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -103,6 +103,7 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 **Documentation:**
 - Structured ClickHouse surfaces are documented from source registrations: SQL functions and aggregate functions (`FunctionDocumentation`), settings (`DECLARE` doc strings), table functions, table engines, formats, system tables, and similar components. Do not ask for a separate `docs/` page when this source-level documentation is present and adequate.
 - Flag documentation only when source-level structured docs are missing or weak, or when the change needs non-structured user guidance that belongs under `docs/` (guides, tutorials, architecture, operations/admin, integrations).
+- Documentation updates in the /docs directory should be made only to the files in /docs/en. These are used to build the current Docusaurus site. Other files in this repository will be used to build the documentation on Mintlify, but should not be edited yet. Do not flag a PR for editing only `/docs/en` and not the Mintlify files.
 
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Pure formatting (whitespace, brace style, minor naming preferences).


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109232

During the docs migration from Docusaurus to Mintlify, `docs/AGENTS.md` instructs contributors to edit only the legacy `/docs/en` files and to leave the not-yet-published Mintlify files alone. The AI review bot (`ci/jobs/copilot_review_job.py`) follows the review instructions in `.claude/skills/review/SKILL.md`, so it was asking contributors to also update the served `.mdx` reference pages (and regenerate their embedded function sections) — which contradicts the migration policy.

This adds the `docs/AGENTS.md` guidance verbatim to the skill's documentation review section, plus one explicit instruction not to flag a PR for editing only `/docs/en` and not the Mintlify files. The note is temporary and can be removed once Mintlify becomes the default docs site.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.574` (included in `26.7` and later)
<!-- ch-version-info:end -->