### PR TITLE
Docs: add a scoped mint validate for client repo docs checks

### DIFF
--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -24,7 +24,8 @@ the full set (``DEFAULT_CHECKS`` plus, when a locale tree changed,
 a consuming repo can act on for the slice it owns (validate + internal links).
 Redirects, external links, and the locale checks are aggregator-global and are
 left to the aggregator job. With ``--scoped``, ``mint validate`` is replaced by
-``scoped_validate.mjs`` over just the replaced folders.
+``scoped_validate.mjs`` over the replaced folders plus every out-of-scope file
+that imports into them.
 
 A check can be any shell command, including ``python3 <script>``. Checks run
 from the docs root, so a Python check script committed at

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -23,7 +23,9 @@ the full set (``DEFAULT_CHECKS`` plus, when a locale tree changed,
 ``LOCALE_CHECKS``); this client driver runs only ``CLIENT_CHECKS`` -- the checks
 a consuming repo can act on for the slice it owns (validate + internal links).
 Redirects, external links, and the locale checks are aggregator-global and are
-left to the aggregator job.
+left to the aggregator job. With ``--scoped``, the full ``mint validate`` is
+replaced by ``scoped_validate.mjs`` over just the replaced folders, cutting the
+check from minutes to seconds (see that script for the coverage trade-off).
 
 A check can be any shell command, including ``python3 <script>``. Checks run
 from the docs root, so a Python check script committed at
@@ -73,6 +75,21 @@ DEFAULT_CHECKS = [
 # depend on the site-wide redirects map, third-party sites, and the translated
 # trees), so the client driver does not run them.
 CLIENT_CHECKS = [VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
+
+
+# `--scoped` swaps the full `mint validate` for scoped_validate.mjs, which
+# validates docs.json (with `$ref` includes resolved) and runs Mintlify's own
+# per-page processing over just the replaced folders instead of the whole
+# site. Full validate MDX-parses every page of the aggregated site (~13
+# minutes, single-threaded); the scoped check covers everything a client PR
+# can break in seconds -- the aggregator's own CI still runs the full validate
+# before anything deploys. See the header of scoped_validate.mjs for exactly
+# what is and is not covered.
+def scoped_validate_check(scopes):
+    command = "node ../ci/jobs/scripts/docs/scoped_validate.mjs " + " ".join(
+        f"--scope {shlex.quote(scope)}" for scope in scopes
+    )
+    return ("Validate docs.json and the replaced folders (scoped)", command + " .")
 
 # Locale-only checks, kept out of DEFAULT_CHECKS: the Praktika job runs them only
 # when a PR touches the locale folders (top-level or snippets/<locale>/) -- they
@@ -172,8 +189,15 @@ def main(argv=None):
     p.add_argument("--replace", action="append", default=[], metavar="SRC:DEST",
                    help="Replace DEST (relative to docs root) with the local folder "
                         "SRC, wiping DEST first; repeatable.")
+    p.add_argument("--scoped", action="store_true",
+                   help="Validate only the --replace destinations instead of running "
+                        "the full (slow) `mint validate` over the whole site. "
+                        "Requires at least one --replace.")
     p.add_argument("--workdir", help="Where to clone (default: a temp dir).")
     args = p.parse_args(argv)
+
+    if args.scoped and not args.replace:
+        p.error("--scoped requires at least one --replace")
 
     base = args.workdir or tempfile.mkdtemp(prefix="docs-check-")
     clone_dir = os.path.abspath(os.path.join(base, "aggregator"))
@@ -184,18 +208,24 @@ def main(argv=None):
     if not os.path.isfile(os.path.join(docs_root, "docs.json")):
         raise FileNotFoundError(f"No docs.json in docs root: {docs_root}")
 
+    replace_dests = []
     for spec in args.replace:
         parts = spec.split(":")
         if len(parts) != 2:
             raise ValueError(f"Invalid --replace '{spec}'. Expected SRC:DEST.")
         replace(parts[0], resolve_replace_dest(docs_root, parts[1]))
+        replace_dests.append(parts[1])
 
     # A consuming client repo owns only its docs slice, so it runs just the
     # checks it can act on (see CLIENT_CHECKS): validate + internal links. The
     # aggregator-global checks -- redirects, external links, and the locale
-    # checks -- are run by the aggregator's own Praktika job, not here.
+    # checks -- are run by the aggregator's own Praktika job, not here. With
+    # --scoped, the full validate is narrowed to the replaced folders.
+    checks = list(CLIENT_CHECKS)
+    if args.scoped:
+        checks[0] = scoped_validate_check(replace_dests)
     results = [(name, run_check(docs_root, name, command))
-               for name, command in CLIENT_CHECKS]
+               for name, command in checks]
 
     print("\n=== Summary ===", flush=True)
     for name, ok in results:

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -23,9 +23,8 @@ the full set (``DEFAULT_CHECKS`` plus, when a locale tree changed,
 ``LOCALE_CHECKS``); this client driver runs only ``CLIENT_CHECKS`` -- the checks
 a consuming repo can act on for the slice it owns (validate + internal links).
 Redirects, external links, and the locale checks are aggregator-global and are
-left to the aggregator job. With ``--scoped``, the full ``mint validate`` is
-replaced by ``scoped_validate.mjs`` over just the replaced folders, cutting the
-check from minutes to seconds (see that script for the coverage trade-off).
+left to the aggregator job. With ``--scoped``, ``mint validate`` is replaced by
+``scoped_validate.mjs`` over just the replaced folders.
 
 A check can be any shell command, including ``python3 <script>``. Checks run
 from the docs root, so a Python check script committed at
@@ -77,14 +76,9 @@ DEFAULT_CHECKS = [
 CLIENT_CHECKS = [VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
 
 
-# `--scoped` swaps the full `mint validate` for scoped_validate.mjs, which
-# validates docs.json (with `$ref` includes resolved) and runs Mintlify's own
-# per-page processing over just the replaced folders instead of the whole
-# site. Full validate MDX-parses every page of the aggregated site (~13
-# minutes, single-threaded); the scoped check covers everything a client PR
-# can break in seconds -- the aggregator's own CI still runs the full validate
-# before anything deploys. See the header of scoped_validate.mjs for exactly
-# what is and is not covered.
+# Swaps the full `mint validate` (which MDX-parses the whole site, ~13 minutes)
+# for scoped_validate.mjs over just the replaced folders -- see that script's
+# header for what it covers.
 def scoped_validate_check(scopes):
     command = "node ../ci/jobs/scripts/docs/scoped_validate.mjs " + " ".join(
         f"--scope {shlex.quote(scope)}" for scope in scopes
@@ -219,8 +213,7 @@ def main(argv=None):
     # A consuming client repo owns only its docs slice, so it runs just the
     # checks it can act on (see CLIENT_CHECKS): validate + internal links. The
     # aggregator-global checks -- redirects, external links, and the locale
-    # checks -- are run by the aggregator's own Praktika job, not here. With
-    # --scoped, the full validate is narrowed to the replaced folders.
+    # checks -- are run by the aggregator's own Praktika job, not here.
     checks = list(CLIENT_CHECKS)
     if args.scoped:
         checks[0] = scoped_validate_check(replace_dests)

--- a/ci/jobs/scripts/docs/scoped_validate.mjs
+++ b/ci/jobs/scripts/docs/scoped_validate.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+// Scoped replacement for `mint validate`, for client repos that own one slice
+// of the aggregated docs site (e.g. clickhouse-connect owns
+// integrations/language-clients/python).
+//
+// `mint validate` runs Mintlify's prebuild over the WHOLE site: it MDX-parses
+// every page, which takes ~13 minutes for a site this size, single-threaded.
+// A client PR can only change the files inside its slice, and the aggregator
+// repo's own CI still runs the full validate before anything deploys, so a
+// client check only needs to prove:
+//
+//   1. docs.json itself is valid (schema check -- cheap, no page parsing).
+//      The client cannot edit docs.json, but this catches a broken aggregator
+//      snapshot early instead of producing confusing downstream errors.
+//   2. Every docs.json navigation entry pointing INTO the slice resolves to a
+//      file -- catches the client deleting or renaming a page that the
+//      aggregator's navigation still references.
+//   3. Every page inside the slice parses -- the same per-page processing
+//      (frontmatter + MDX parse) that full prebuild runs, via Mintlify's own
+//      `createPage`, so the errors are identical to what `mint validate`
+//      would print for those files.
+//   4. Every `import ... from '/snippets/...'` inside the slice resolves to a
+//      file -- import resolution is otherwise a whole-site prebuild step.
+//
+// Site-wide link/anchor integrity is NOT checked here; the lychee check that
+// runs alongside this script already covers it for the whole site.
+//
+// The Mintlify internals come from the `mint` CLI installed globally in the
+// docs image (clickhouse/docs-builder) -- nothing is downloaded. The packages
+// are pinned by whatever `mint` version the image ships, which is the same
+// version the full check uses, so the two cannot drift apart.
+//
+// Usage: node scoped_validate.mjs --scope <dir-relative-to-docs-root> [--scope ...] [docs-root]
+// Override package resolution for local testing: MINT_PACKAGES_DIR=<node_modules dir>
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readdir, readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+// --- Locate Mintlify's packages inside the installed `mint` CLI ---------------
+//
+// `mint` is installed with `npm install -g mint` in the docs image, which
+// flattens its dependencies under <npm root -g>/mint/node_modules. There is no
+// `exports` map in these packages (plain `main` entries), so createRequire
+// resolution works.
+function importMintlifyPackage(name)
+{
+    const candidates = [];
+    if (process.env.MINT_PACKAGES_DIR)
+        candidates.push(process.env.MINT_PACKAGES_DIR);
+    try
+    {
+        const npmRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim();
+        candidates.push(join(npmRoot, 'mint', 'node_modules'));
+        candidates.push(npmRoot);
+    }
+    catch
+    {
+        // npm missing entirely -- fall through to the error below.
+    }
+    for (const dir of candidates)
+    {
+        try
+        {
+            const resolved = createRequire(join(dir, 'noop.js')).resolve(name);
+            return import(pathToFileURL(resolved).href);
+        }
+        catch
+        {
+            // Not in this candidate dir -- try the next one.
+        }
+    }
+    throw new Error(
+        `Cannot resolve ${name}. Expected a global \`mint\` install ` +
+        `(npm install -g mint) or MINT_PACKAGES_DIR pointing at a node_modules ` +
+        `directory that contains it. Tried: ${candidates.join(', ') || '(nothing)'}`);
+}
+
+// --- Argument parsing ---------------------------------------------------------
+function parseArgs(argv)
+{
+    const scopes = [];
+    let docsRoot = '.';
+    for (let i = 0; i < argv.length; i++)
+    {
+        if (argv[i] === '--scope')
+        {
+            const value = argv[++i];
+            if (!value)
+                throw new Error('--scope requires a value');
+            scopes.push(value.replace(/^\/+|\/+$/g, ''));
+        }
+        else
+        {
+            docsRoot = argv[i];
+        }
+    }
+    if (scopes.length === 0)
+        throw new Error('At least one --scope is required');
+    return { scopes, docsRoot: resolve(docsRoot) };
+}
+
+// --- Navigation walk ----------------------------------------------------------
+//
+// Collect every page reference (plain strings in `pages` arrays and `root`
+// keys) from docs.json navigation. Subtrees carrying an `openapi` key are
+// skipped: their page strings can refer to pages generated from the OpenAPI
+// spec at build time, which have no source file.
+function collectNavPages(node, acc)
+{
+    if (typeof node === 'string')
+    {
+        acc.push(node);
+        return;
+    }
+    if (Array.isArray(node))
+    {
+        for (const item of node)
+            collectNavPages(item, acc);
+        return;
+    }
+    if (node && typeof node === 'object')
+    {
+        if ('openapi' in node)
+            return;
+        for (const [key, value] of Object.entries(node))
+        {
+            if (key === 'pages' || key === 'root')
+                collectNavPages(value, acc);
+            else if (typeof value === 'object' && value !== null)
+                collectNavPages(value, acc);
+        }
+    }
+}
+
+function isInScope(pagePath, scopes)
+{
+    const cleaned = pagePath.replace(/^\/+/, '');
+    return scopes.some(scope => cleaned === scope || cleaned.startsWith(scope + '/'));
+}
+
+// A navigation entry `foo/bar` resolves to foo/bar.mdx or foo/bar.md.
+function navEntryExists(docsRoot, page)
+{
+    const cleaned = page.replace(/^\/+/, '');
+    return ['.mdx', '.md'].some(ext => existsSync(join(docsRoot, cleaned + ext)));
+}
+
+// --- Page discovery -----------------------------------------------------------
+async function listPages(dir)
+{
+    const out = [];
+    for (const entry of await readdir(dir, { withFileTypes: true, recursive: true }))
+    {
+        if (entry.isFile() && /\.mdx?$/.test(entry.name))
+            out.push(join(entry.parentPath, entry.name));
+    }
+    return out;
+}
+
+// Match top-of-file MDX ESM imports of shared snippets, e.g.:
+//   import Thing from '/snippets/foo.mdx';
+// Only absolute /snippets paths are checked: relative imports inside the scope
+// are covered by the per-page parse, and anything else is not a docs snippet.
+const SNIPPET_IMPORT_RE = /^import\s[^;'"]*['"](\/snippets\/[^'"]+)['"]/gm;
+
+async function main()
+{
+    const { scopes, docsRoot } = parseArgs(process.argv.slice(2));
+    const errors = [];
+
+    const docsJsonPath = join(docsRoot, 'docs.json');
+    if (!existsSync(docsJsonPath))
+        throw new Error(`No docs.json in docs root: ${docsRoot}`);
+
+    const [{ validateDocsConfig }, { createPage, getConfigObj }] = await Promise.all([
+        importMintlifyPackage('@mintlify/validation'),
+        importMintlifyPackage('@mintlify/prebuild'),
+    ]);
+
+    // 1. docs.json schema validation. getConfigObj is what full prebuild uses
+    // to load the config: it resolves `$ref` includes (this docs.json pulls
+    // its redirects and parts of its navigation from separate files) before
+    // the schema sees it.
+    const docsConfig = await getConfigObj(docsRoot, 'docs');
+    const configResult = validateDocsConfig(docsConfig);
+    if (!configResult.success)
+    {
+        for (const issue of configResult.error.issues)
+            errors.push(`docs.json: ${issue.path.join('.')}: ${issue.message}`);
+    }
+
+    // 2. Navigation entries inside the scopes must resolve to files.
+    const navPages = [];
+    collectNavPages(docsConfig.navigation, navPages);
+    const scopedNavPages = navPages.filter(page => isInScope(page, scopes));
+    for (const page of scopedNavPages)
+    {
+        if (!navEntryExists(docsRoot, page))
+            errors.push(
+                `docs.json navigation references "${page}" but no such page exists ` +
+                `under the scope (looked for ${page}.mdx and ${page}.md)`);
+    }
+
+    // 3 + 4. Parse every page in the scopes and check its snippet imports.
+    let pageCount = 0;
+    for (const scope of scopes)
+    {
+        const scopeDir = join(docsRoot, scope);
+        if (isAbsolute(scope) || relative(docsRoot, scopeDir).startsWith('..' + sep))
+            throw new Error(`--scope must be a relative path inside the docs root: ${scope}`);
+        if (!existsSync(scopeDir))
+        {
+            errors.push(`Scope directory does not exist in the docs root: ${scope}`);
+            continue;
+        }
+        const pages = await listPages(scopeDir);
+        pageCount += pages.length;
+        await Promise.all(pages.map(async (absPath) =>
+        {
+            const relPath = relative(docsRoot, absPath);
+            const content = await readFile(absPath, 'utf8');
+            // The same per-page processing full prebuild runs: frontmatter
+            // extraction plus the MDX parse. Parse failures arrive via onError
+            // with the same formatted message `mint validate` prints.
+            try
+            {
+                await createPage(relPath, content, docsRoot, [], [], message => errors.push(message.trim()));
+            }
+            catch (error)
+            {
+                errors.push(`${relPath}: ${error.message}`);
+            }
+            for (const match of content.matchAll(SNIPPET_IMPORT_RE))
+            {
+                const snippetPath = match[1];
+                if (!existsSync(join(docsRoot, snippetPath.replace(/^\/+/, ''))))
+                    errors.push(`${relPath}: imports "${snippetPath}" but the file does not exist`);
+            }
+        }));
+    }
+
+    console.log(
+        `Scoped validate: checked docs.json, ${scopedNavPages.length} in-scope navigation ` +
+        `entries, and ${pageCount} pages under: ${scopes.join(', ')}`);
+    if (errors.length > 0)
+    {
+        console.error(`\n${errors.length} error(s):`);
+        for (const error of errors)
+            console.error(`  - ${error}`);
+        process.exit(1);
+    }
+    console.log('scoped validation passed');
+}
+
+main().catch(error =>
+{
+    console.error(error.message);
+    process.exit(1);
+});

--- a/ci/jobs/scripts/docs/scoped_validate.mjs
+++ b/ci/jobs/scripts/docs/scoped_validate.mjs
@@ -9,7 +9,10 @@
 //   2. Navigation entries pointing into the slice resolve to files.
 //   3. Every page inside the slice parses (via Mintlify's own `createPage`,
 //      so the errors match what `mint validate` would print).
-//   4. `import ... from '/snippets/...'` inside the slice resolves to a file.
+//   4. Imports in the slice resolve, via Mintlify's own import pipeline
+//      (`findAndRemoveImports` + `resolveAllImports`): path validity, file
+//      existence, and named-export resolution, followed transitively through
+//      imported snippets.
 //
 // Site-wide link/anchor integrity is left to the lychee check that runs
 // alongside, and the aggregator's own CI still runs the full validate.
@@ -21,7 +24,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 // The Mintlify packages come from the `mint` CLI installed globally in the
@@ -136,10 +139,6 @@ async function listPages(dir)
     return out;
 }
 
-// Only absolute /snippets imports are checked; relative imports inside the
-// scope are covered by the per-page parse.
-const SNIPPET_IMPORT_RE = /^import\s[^;'"]*['"](\/snippets\/[^'"]+)['"]/gm;
-
 async function main()
 {
     const { scopes, docsRoot } = parseArgs(process.argv.slice(2));
@@ -149,10 +148,13 @@ async function main()
     if (!existsSync(docsJsonPath))
         throw new Error(`No docs.json in docs root: ${docsRoot}`);
 
-    const [{ validateDocsConfig }, { createPage, getConfigObj }] = await Promise.all([
+    const [{ validateDocsConfig }, { createPage, getConfigObj, preparseMdxTree }, common] = await Promise.all([
         importMintlifyPackage('@mintlify/validation'),
         importMintlifyPackage('@mintlify/prebuild'),
+        importMintlifyPackage('@mintlify/common'),
     ]);
+    const { findAndRemoveImports, hasImports, resolveAllImports, resolveImportPath,
+            isSnippetExtension, topologicalSort } = common;
 
     // getConfigObj resolves `$ref` includes (the redirects map, per-slice
     // navigation fragments) before the schema sees the config.
@@ -175,6 +177,34 @@ async function main()
                 `under the scope (looked for ${page}.mdx and ${page}.md)`);
     }
 
+    // The import graph reachable from the scope pages. Filenames use the same
+    // leading-slash docs-root-relative form full prebuild uses, which is what
+    // resolveAllImports matches import paths against. A missing entry is left
+    // out so resolveAllImports reports it as a missing file, like full validate.
+    const importedEntries = new Map();
+    async function loadImportedFile(filename)
+    {
+        if (importedEntries.has(filename))
+            return;
+        importedEntries.set(filename, null);
+        const absPath = join(docsRoot, filename);
+        if (!isSnippetExtension(extname(filename).toLowerCase()) || !existsSync(absPath))
+            return;
+        const content = await readFile(absPath, 'utf8');
+        const tree = await preparseMdxTree(content, docsRoot, absPath, message => errors.push(message.trim()));
+        if (!tree)
+            return;
+        const entry = { ...(await findAndRemoveImports(tree)), filename };
+        importedEntries.set(filename, entry);
+        for (const source of Object.keys(entry.importMap))
+        {
+            const resolved = resolveImportPath(source, filename);
+            if (resolved)
+                await loadImportedFile(resolved);
+        }
+    }
+
+    const pagesWithImports = [];
     let pageCount = 0;
     for (const scope of scopes)
     {
@@ -200,18 +230,49 @@ async function main()
             {
                 errors.push(`${relPath}: ${error.message}`);
             }
-            for (const match of content.matchAll(SNIPPET_IMPORT_RE))
-            {
-                const snippetPath = match[1];
-                if (!existsSync(join(docsRoot, snippetPath.replace(/^\/+/, ''))))
-                    errors.push(`${relPath}: imports "${snippetPath}" but the file does not exist`);
-            }
+            // Parse errors were already reported by createPage above.
+            const tree = await preparseMdxTree(content, docsRoot, absPath, () => {});
+            if (!tree)
+                return;
+            const fileWithImports = { ...(await findAndRemoveImports(tree)), filename: '/' + relPath };
+            if (hasImports(fileWithImports))
+                pagesWithImports.push(fileWithImports);
         }));
     }
 
+    for (const page of pagesWithImports)
+        for (const source of Object.keys(page.importMap))
+        {
+            const resolved = resolveImportPath(source, page.filename);
+            if (resolved)
+                await loadImportedFile(resolved);
+        }
+
+    // Resolve imports the way full prebuild does (resolveImportsAndWriteFiles):
+    // snippets first, in reverse topological order so nested imports are
+    // already inlined, then the pages. Every problem -- invalid path, missing
+    // file, unresolvable named export -- arrives via onWarning, which strict
+    // mode turns into failures.
+    const snippetEntries = [...importedEntries.values()].filter(entry => entry !== null);
+    const graph = {};
+    for (const entry of snippetEntries)
+        graph[entry.filename] = Object.keys(entry.importMap)
+            .map(source => resolveImportPath(source, entry.filename))
+            .filter(resolved => resolved !== null);
+    const onWarning = warning => errors.push(warning.message);
+    for (const filename of topologicalSort(graph).reverse())
+    {
+        const entry = importedEntries.get(filename);
+        if (entry && hasImports(entry))
+            entry.tree = await resolveAllImports({ snippets: snippetEntries, fileWithImports: entry, onWarning });
+    }
+    for (const page of pagesWithImports)
+        await resolveAllImports({ snippets: snippetEntries, fileWithImports: page, onWarning });
+
     console.log(
         `Scoped validate: checked docs.json, ${scopedNavPages.length} in-scope navigation ` +
-        `entries, and ${pageCount} pages under: ${scopes.join(', ')}`);
+        `entries, ${pageCount} pages, and ${snippetEntries.length} imported files ` +
+        `under: ${scopes.join(', ')}`);
     if (errors.length > 0)
     {
         console.error(`\n${errors.length} error(s):`);

--- a/ci/jobs/scripts/docs/scoped_validate.mjs
+++ b/ci/jobs/scripts/docs/scoped_validate.mjs
@@ -1,37 +1,21 @@
 #!/usr/bin/env node
 // Scoped replacement for `mint validate`, for client repos that own one slice
 // of the aggregated docs site (e.g. clickhouse-connect owns
-// integrations/language-clients/python).
+// integrations/language-clients/python). Full validate MDX-parses every page
+// of the site (~13 minutes, single-threaded); this checks only what a client
+// PR can break, in seconds:
 //
-// `mint validate` runs Mintlify's prebuild over the WHOLE site: it MDX-parses
-// every page, which takes ~13 minutes for a site this size, single-threaded.
-// A client PR can only change the files inside its slice, and the aggregator
-// repo's own CI still runs the full validate before anything deploys, so a
-// client check only needs to prove:
+//   1. docs.json passes Mintlify's schema validation.
+//   2. Navigation entries pointing into the slice resolve to files.
+//   3. Every page inside the slice parses (via Mintlify's own `createPage`,
+//      so the errors match what `mint validate` would print).
+//   4. `import ... from '/snippets/...'` inside the slice resolves to a file.
 //
-//   1. docs.json itself is valid (schema check -- cheap, no page parsing).
-//      The client cannot edit docs.json, but this catches a broken aggregator
-//      snapshot early instead of producing confusing downstream errors.
-//   2. Every docs.json navigation entry pointing INTO the slice resolves to a
-//      file -- catches the client deleting or renaming a page that the
-//      aggregator's navigation still references.
-//   3. Every page inside the slice parses -- the same per-page processing
-//      (frontmatter + MDX parse) that full prebuild runs, via Mintlify's own
-//      `createPage`, so the errors are identical to what `mint validate`
-//      would print for those files.
-//   4. Every `import ... from '/snippets/...'` inside the slice resolves to a
-//      file -- import resolution is otherwise a whole-site prebuild step.
-//
-// Site-wide link/anchor integrity is NOT checked here; the lychee check that
-// runs alongside this script already covers it for the whole site.
-//
-// The Mintlify internals come from the `mint` CLI installed globally in the
-// docs image (clickhouse/docs-builder) -- nothing is downloaded. The packages
-// are pinned by whatever `mint` version the image ships, which is the same
-// version the full check uses, so the two cannot drift apart.
+// Site-wide link/anchor integrity is left to the lychee check that runs
+// alongside, and the aggregator's own CI still runs the full validate.
 //
 // Usage: node scoped_validate.mjs --scope <dir-relative-to-docs-root> [--scope ...] [docs-root]
-// Override package resolution for local testing: MINT_PACKAGES_DIR=<node_modules dir>
+// MINT_PACKAGES_DIR overrides package resolution (for testing outside the docs image).
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -40,12 +24,11 @@ import { createRequire } from 'node:module';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-// --- Locate Mintlify's packages inside the installed `mint` CLI ---------------
-//
-// `mint` is installed with `npm install -g mint` in the docs image, which
-// flattens its dependencies under <npm root -g>/mint/node_modules. There is no
-// `exports` map in these packages (plain `main` entries), so createRequire
-// resolution works.
+// The Mintlify packages come from the `mint` CLI installed globally in the
+// docs image (`npm install -g mint` flattens them under
+// <npm root -g>/mint/node_modules), so they cannot drift from the version the
+// full check uses. They have plain `main` entries, no `exports` maps, so
+// createRequire resolution works.
 function importMintlifyPackage(name)
 {
     const candidates = [];
@@ -59,7 +42,6 @@ function importMintlifyPackage(name)
     }
     catch
     {
-        // npm missing entirely -- fall through to the error below.
     }
     for (const dir of candidates)
     {
@@ -70,7 +52,6 @@ function importMintlifyPackage(name)
         }
         catch
         {
-            // Not in this candidate dir -- try the next one.
         }
     }
     throw new Error(
@@ -79,7 +60,6 @@ function importMintlifyPackage(name)
         `directory that contains it. Tried: ${candidates.join(', ') || '(nothing)'}`);
 }
 
-// --- Argument parsing ---------------------------------------------------------
 function parseArgs(argv)
 {
     const scopes = [];
@@ -103,12 +83,9 @@ function parseArgs(argv)
     return { scopes, docsRoot: resolve(docsRoot) };
 }
 
-// --- Navigation walk ----------------------------------------------------------
-//
-// Collect every page reference (plain strings in `pages` arrays and `root`
-// keys) from docs.json navigation. Subtrees carrying an `openapi` key are
-// skipped: their page strings can refer to pages generated from the OpenAPI
-// spec at build time, which have no source file.
+// Collect page references (strings in `pages` arrays and `root` keys) from the
+// navigation. Subtrees with an `openapi` key are skipped: their page strings
+// can refer to pages generated from the spec, which have no source file.
 function collectNavPages(node, acc)
 {
     if (typeof node === 'string')
@@ -142,14 +119,12 @@ function isInScope(pagePath, scopes)
     return scopes.some(scope => cleaned === scope || cleaned.startsWith(scope + '/'));
 }
 
-// A navigation entry `foo/bar` resolves to foo/bar.mdx or foo/bar.md.
 function navEntryExists(docsRoot, page)
 {
     const cleaned = page.replace(/^\/+/, '');
     return ['.mdx', '.md'].some(ext => existsSync(join(docsRoot, cleaned + ext)));
 }
 
-// --- Page discovery -----------------------------------------------------------
 async function listPages(dir)
 {
     const out = [];
@@ -161,10 +136,8 @@ async function listPages(dir)
     return out;
 }
 
-// Match top-of-file MDX ESM imports of shared snippets, e.g.:
-//   import Thing from '/snippets/foo.mdx';
-// Only absolute /snippets paths are checked: relative imports inside the scope
-// are covered by the per-page parse, and anything else is not a docs snippet.
+// Only absolute /snippets imports are checked; relative imports inside the
+// scope are covered by the per-page parse.
 const SNIPPET_IMPORT_RE = /^import\s[^;'"]*['"](\/snippets\/[^'"]+)['"]/gm;
 
 async function main()
@@ -181,10 +154,8 @@ async function main()
         importMintlifyPackage('@mintlify/prebuild'),
     ]);
 
-    // 1. docs.json schema validation. getConfigObj is what full prebuild uses
-    // to load the config: it resolves `$ref` includes (this docs.json pulls
-    // its redirects and parts of its navigation from separate files) before
-    // the schema sees it.
+    // getConfigObj resolves `$ref` includes (the redirects map, per-slice
+    // navigation fragments) before the schema sees the config.
     const docsConfig = await getConfigObj(docsRoot, 'docs');
     const configResult = validateDocsConfig(docsConfig);
     if (!configResult.success)
@@ -193,7 +164,6 @@ async function main()
             errors.push(`docs.json: ${issue.path.join('.')}: ${issue.message}`);
     }
 
-    // 2. Navigation entries inside the scopes must resolve to files.
     const navPages = [];
     collectNavPages(docsConfig.navigation, navPages);
     const scopedNavPages = navPages.filter(page => isInScope(page, scopes));
@@ -205,7 +175,6 @@ async function main()
                 `under the scope (looked for ${page}.mdx and ${page}.md)`);
     }
 
-    // 3 + 4. Parse every page in the scopes and check its snippet imports.
     let pageCount = 0;
     for (const scope of scopes)
     {
@@ -223,9 +192,6 @@ async function main()
         {
             const relPath = relative(docsRoot, absPath);
             const content = await readFile(absPath, 'utf8');
-            // The same per-page processing full prebuild runs: frontmatter
-            // extraction plus the MDX parse. Parse failures arrive via onError
-            // with the same formatted message `mint validate` prints.
             try
             {
                 await createPage(relPath, content, docsRoot, [], [], message => errors.push(message.trim()));

--- a/ci/jobs/scripts/docs/scoped_validate.mjs
+++ b/ci/jobs/scripts/docs/scoped_validate.mjs
@@ -9,10 +9,21 @@
 //   2. Navigation entries pointing into the slice resolve to files.
 //   3. Every page inside the slice parses (via Mintlify's own `createPage`,
 //      so the errors match what `mint validate` would print).
-//   4. Imports in the slice resolve, via Mintlify's own import pipeline
+//   4. Every snippet file inside the slice parses, whether or not anything
+//      imports it -- full prebuild parses all snippet files unconditionally,
+//      so a slice of shared components (e.g. snippets/<something>) is covered
+//      even when no in-scope page imports them.
+//   5. Imports resolve, via Mintlify's own import pipeline
 //      (`findAndRemoveImports` + `resolveAllImports`): path validity, file
 //      existence, and named-export resolution, followed transitively through
-//      imported snippets.
+//      imported snippets. This runs for the in-scope pages AND for every
+//      out-of-scope file whose imports (transitively) reach into the slice --
+//      the reverse dependency closure over the site-wide import map that
+//      Mintlify's `categorizeFilePaths` builds -- so deleting an in-scope file
+//      or removing an export that an out-of-scope page imports still fails.
+//      Out-of-scope pages are not themselves re-validated (their content is
+//      not changed by the replacement; any parse error there is pre-existing
+//      aggregator breakage the client cannot fix), only their imports are.
 //
 // Site-wide link/anchor integrity is left to the lychee check that runs
 // alongside, and the aggregator's own CI still runs the full validate.
@@ -22,7 +33,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { readdir, readFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -116,10 +127,12 @@ function collectNavPages(node, acc)
     }
 }
 
-function isInScope(pagePath, scopes)
+// Case-insensitive, because it must also classify entries of Mintlify's
+// fileImportsMap, whose keys and values are lowercased paths.
+function isInScope(pagePath, lowerScopes)
 {
-    const cleaned = pagePath.replace(/^\/+/, '');
-    return scopes.some(scope => cleaned === scope || cleaned.startsWith(scope + '/'));
+    const cleaned = pagePath.toLowerCase().replace(/^\/+/, '');
+    return lowerScopes.some(scope => cleaned === scope || cleaned.startsWith(scope + '/'));
 }
 
 function navEntryExists(docsRoot, page)
@@ -128,31 +141,22 @@ function navEntryExists(docsRoot, page)
     return ['.mdx', '.md'].some(ext => existsSync(join(docsRoot, cleaned + ext)));
 }
 
-async function listPages(dir)
-{
-    const out = [];
-    for (const entry of await readdir(dir, { withFileTypes: true, recursive: true }))
-    {
-        if (entry.isFile() && /\.mdx?$/.test(entry.name))
-            out.push(join(entry.parentPath, entry.name));
-    }
-    return out;
-}
-
 async function main()
 {
     const { scopes, docsRoot } = parseArgs(process.argv.slice(2));
+    const lowerScopes = scopes.map(scope => scope.toLowerCase());
     const errors = [];
 
     const docsJsonPath = join(docsRoot, 'docs.json');
     if (!existsSync(docsJsonPath))
         throw new Error(`No docs.json in docs root: ${docsRoot}`);
 
-    const [{ validateDocsConfig }, { createPage, getConfigObj, preparseMdxTree }, common] = await Promise.all([
+    const [{ validateDocsConfig }, prebuild, common] = await Promise.all([
         importMintlifyPackage('@mintlify/validation'),
         importMintlifyPackage('@mintlify/prebuild'),
         importMintlifyPackage('@mintlify/common'),
     ]);
+    const { categorizeFilePaths, createPage, getConfigObj, getMintIgnore, preparseMdxTree } = prebuild;
     const { findAndRemoveImports, hasImports, resolveAllImports, resolveImportPath,
             isSnippetExtension, topologicalSort } = common;
 
@@ -168,7 +172,7 @@ async function main()
 
     const navPages = [];
     collectNavPages(docsConfig.navigation, navPages);
-    const scopedNavPages = navPages.filter(page => isInScope(page, scopes));
+    const scopedNavPages = navPages.filter(page => isInScope(page, lowerScopes));
     for (const page of scopedNavPages)
     {
         if (!navEntryExists(docsRoot, page))
@@ -177,7 +181,62 @@ async function main()
                 `under the scope (looked for ${page}.mdx and ${page}.md)`);
     }
 
-    // The import graph reachable from the scope pages. Filenames use the same
+    for (const scope of scopes)
+    {
+        if (isAbsolute(scope) || relative(docsRoot, join(docsRoot, scope)).startsWith('..' + sep))
+            throw new Error(`--scope must be a relative path inside the docs root: ${scope}`);
+        if (!existsSync(join(docsRoot, scope)))
+            errors.push(`Scope directory does not exist in the docs root: ${scope}`);
+    }
+
+    // The same site-wide scan full prebuild starts with: classifies every file
+    // (page vs snippet, .mintignore-aware) and extracts every file's import
+    // targets with a cheap line scan (lazyPages), no MDX parsing. All paths it
+    // returns are docs-root-relative with a leading slash; fileImportsMap keys
+    // and values are additionally lowercased.
+    const mintIgnore = await getMintIgnore(docsRoot);
+    const { contentFilenames, snippets, snippetsV2, fileImportsMap } =
+        await categorizeFilePaths(docsRoot, mintIgnore, /*disableOpenApi*/ true, /*lazyPages*/ true);
+    const snippetFilenames = [...snippets, ...snippetsV2];
+
+    // Reverse dependency closure: every out-of-scope file whose imports
+    // (transitively) reach into a scope. Seeds are the import *targets* under
+    // the scopes rather than the files present there, so an import of a file
+    // the replacement deleted still marks its importers as affected.
+    const importersOf = new Map();
+    for (const [file, imports] of fileImportsMap)
+        for (const target of imports)
+        {
+            if (!importersOf.has(target))
+                importersOf.set(target, []);
+            importersOf.get(target).push(file);
+        }
+    const affectedLower = new Set();
+    const queue = [...importersOf.keys()].filter(target => isInScope(target, lowerScopes));
+    while (queue.length > 0)
+    {
+        for (const importer of importersOf.get(queue.pop()) ?? [])
+        {
+            if (affectedLower.has(importer) || isInScope(importer, lowerScopes))
+                continue;
+            affectedLower.add(importer);
+            queue.push(importer);
+        }
+    }
+    const byLower = new Map();
+    for (const filename of [...contentFilenames, ...snippetFilenames])
+        byLower.set(filename.toLowerCase(), filename);
+    const pageSetLower = new Set(contentFilenames.map(filename => filename.toLowerCase()));
+    const affectedPages = [];
+    const affectedSnippets = [];
+    for (const lower of affectedLower)
+    {
+        const original = byLower.get(lower);
+        if (original !== undefined)
+            (pageSetLower.has(lower) ? affectedPages : affectedSnippets).push(original);
+    }
+
+    // The import graph reachable from the scope. Filenames use the same
     // leading-slash docs-root-relative form full prebuild uses, which is what
     // resolveAllImports matches import paths against. A missing entry is left
     // out so resolveAllImports reports it as a missing file, like full validate.
@@ -204,24 +263,17 @@ async function main()
         }
     }
 
+    // In-scope pages get the full page validation; affected out-of-scope pages
+    // only feed the import-resolution pass below (createPage skipped, parse
+    // errors suppressed -- the replacement did not change their content).
+    const scopePages = contentFilenames.filter(filename => isInScope(filename, lowerScopes));
     const pagesWithImports = [];
-    let pageCount = 0;
-    for (const scope of scopes)
+    async function processPage(filename, inScope)
     {
-        const scopeDir = join(docsRoot, scope);
-        if (isAbsolute(scope) || relative(docsRoot, scopeDir).startsWith('..' + sep))
-            throw new Error(`--scope must be a relative path inside the docs root: ${scope}`);
-        if (!existsSync(scopeDir))
+        const relPath = filename.replace(/^\/+/, '');
+        const content = await readFile(join(docsRoot, filename), 'utf8');
+        if (inScope)
         {
-            errors.push(`Scope directory does not exist in the docs root: ${scope}`);
-            continue;
-        }
-        const pages = await listPages(scopeDir);
-        pageCount += pages.length;
-        await Promise.all(pages.map(async (absPath) =>
-        {
-            const relPath = relative(docsRoot, absPath);
-            const content = await readFile(absPath, 'utf8');
             try
             {
                 await createPage(relPath, content, docsRoot, [], [], message => errors.push(message.trim()));
@@ -230,16 +282,27 @@ async function main()
             {
                 errors.push(`${relPath}: ${error.message}`);
             }
-            // Parse errors were already reported by createPage above.
-            const tree = await preparseMdxTree(content, docsRoot, absPath, () => {});
-            if (!tree)
-                return;
-            const fileWithImports = { ...(await findAndRemoveImports(tree)), filename: '/' + relPath };
-            if (hasImports(fileWithImports))
-                pagesWithImports.push(fileWithImports);
-        }));
+        }
+        // In-scope parse errors were already reported by createPage above.
+        const tree = await preparseMdxTree(content, docsRoot, join(docsRoot, filename), () => {});
+        if (!tree)
+            return;
+        const fileWithImports = { ...(await findAndRemoveImports(tree)), filename };
+        if (hasImports(fileWithImports))
+            pagesWithImports.push(fileWithImports);
     }
+    await Promise.all([
+        ...scopePages.map(filename => processPage(filename, true)),
+        ...affectedPages.map(filename => processPage(filename, false)),
+    ]);
 
+    // Snippet files to parse and resolve: everything under the scopes (full
+    // prebuild parses every snippet file, imported or not), plus the affected
+    // out-of-scope ones, plus everything the pages import (loadImportedFile
+    // follows nested imports transitively from all of these).
+    const scopeSnippets = snippetFilenames.filter(filename => isInScope(filename, lowerScopes));
+    for (const filename of [...scopeSnippets, ...affectedSnippets])
+        await loadImportedFile(filename);
     for (const page of pagesWithImports)
         for (const source of Object.keys(page.importMap))
         {
@@ -271,8 +334,9 @@ async function main()
 
     console.log(
         `Scoped validate: checked docs.json, ${scopedNavPages.length} in-scope navigation ` +
-        `entries, ${pageCount} pages, and ${snippetEntries.length} imported files ` +
-        `under: ${scopes.join(', ')}`);
+        `entries, ${scopePages.length} pages and ${scopeSnippets.length} snippet files in ` +
+        `scope, ${affectedPages.length + affectedSnippets.length} out-of-scope importers, ` +
+        `and ${snippetEntries.length} imported files under: ${scopes.join(', ')}`);
     if (errors.length > 0)
     {
         console.error(`\n${errors.length} error(s):`);


### PR DESCRIPTION
Related: https://github.com/ClickHouse/clickhouse-connect/pull/778

The docs check for client repos (driven by `ci/jobs/scripts/docs/mintlify_docs_check.py`, e.g. the `Verify Docs` workflow in clickhouse-connect) ran the full `mint validate`, which MDX-parses every page of the aggregated site on a single thread and accounts for ~13.5 of the job's ~16 minutes — while a client PR can only change the files inside its own docs slice. `--disable-openapi` makes hardly any difference, and a bigger runner would not help since the parse is single-threaded.

## Changes

Add `ci/jobs/scripts/docs/scoped_validate.mjs`, a scoped replacement for `mint validate`. It imports Mintlify's own packages from the `mint` CLI already installed in the `clickhouse/docs-builder` image (nothing is downloaded, and it cannot drift from the version the full check uses) and verifies everything a client PR can break:

- `docs.json` schema validation, loaded via the same `getConfigObj` full prebuild uses, so `$ref` includes (the redirects map, per-slice `navigation.json` fragments) are resolved first.
- Every navigation entry pointing into the slice resolves to a page file — catches deleting or renaming a page the site navigation still references.
- Every page in the slice goes through Mintlify's `createPage` (frontmatter + MDX parse), producing the same error messages `mint validate` prints.
- Every `import ... from '/snippets/...'` in the slice resolves to a file.

`mintlify_docs_check.py` gets a `--scoped` flag that swaps the full validate for this script, scoped to the `--replace` destinations. Site-wide link and anchor integrity remains covered by the lychee check that runs alongside; the aggregator's own Praktika job is unchanged and still runs the full `mint validate` before anything deploys.

## Results

- Scoped validate on the Python client slice: ~2.5 s (vs ~13.5 min for full validate); all 235 pages under `integrations/`: ~3.3 s.
- Full driver end-to-end (sparse clone, replace, scoped validate, lychee): ~20 s locally, so the client job cost becomes mostly container pull + clone.
- Negative tests: a deleted navigation-referenced page, a broken MDX page, and a missing snippet import each fail the check with precise messages; lychee independently flags inbound links from the rest of the site to a deleted page.

After this merges, the clickhouse-connect workflow (which fetches this driver from `master`) can opt in by adding `--scoped` to its invocation.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.582` (included in `26.7` and later)
<!-- ch-version-info:end -->