### PR TITLE
Do not run 01516_drop_table_stress_long under MSan

### DIFF
--- a/tests/queries/0_stateless/01516_drop_table_stress_long.sh
+++ b/tests/queries/0_stateless/01516_drop_table_stress_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-debug, no-azure-blob-storage
+# Tags: long, no-debug, no-msan, no-azure-blob-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`01516_drop_table_stress_long` is a concurrent DROP/CREATE stress loop (25 iterations, ~200 `clickhouse-client` startups). Under MSan the instrumented startup cost pushes the wall-clock time into the tail (avg 315s, max 543s on passing runs), and rare runs exceed the per-test timeout and are killed with `Timeout!`.

All 3 timeout failures in the last 30 days are on `amd_msan` only; 0 on any other build. The rerun diagnosis reports the failure is not reproducible.

CI report (one failing run): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104543&sha=c7e52c67c3e72abb41d09ffc46b46d11130d632a&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

The DDL-race bug class this test targets (use-after-free / read-only races on concurrent DROP/CREATE) is already covered by the debug, ASan, TSan and UBSan builds. MSan (uninitialized-memory detector) adds no unique coverage here, so exclude it, mirroring the existing `no-debug` tag.

No related open issue found.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.587` (included in `26.7` and later)
- Backported to: `26.6.5.76`
<!-- ch-version-info:end -->