### PR TITLE
Do not fail the AST fuzzer job on a server-survived memory limit

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -53,34 +53,53 @@ def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
 # "Received from <host>." A client-side 241 raised under
 # --max_memory_usage_in_client prints "Code: 241. DB::Exception: ..." with no
 # such prefix, so this signature keeps only genuine server-survived limits.
-SERVER_MLE_SIGNATURE = r"Received from.*MEMORY_LIMIT_EXCEEDED"
+# The server error text can appear as the enum "(MEMORY_LIMIT_EXCEEDED)" or the
+# prose "... memory limit exceeded" (the two are printed on separate lines: the
+# "Received from" line carries the prose message, the enum trails on its own
+# line), so match either form -- both are server-origin because of the prefix.
+SERVER_MLE_SIGNATURE = r"Received from.*(?:MEMORY_LIMIT_EXCEEDED|memory limit exceeded)"
 
-# The client prints "Dump of fuzzed AST:\n<query>" before executing each fuzz
+# A client-origin 241 line: "Code: 241" with NO "Received from" on the same line.
+# clickhouse-client raises 241 for its own --max_memory_usage_in_client cap (see
+# tests/queries/0_stateless/02003_memory_limit_in_client.sh) and prints it as
+# "Code: 241. DB::Exception: ..." with no transmission prefix, whereas a server-
+# transmitted 241 always carries "Received from <host>" on that line. Used only
+# in the no-marker fallback below to reject a client/harness 241 that a server
+# limit recovered from earlier in the same read tail must not mask.
+CLIENT_241_SIGNATURE = re.compile(r"^(?!.*Received from).*Code: 241\b", re.MULTILINE)
+
+# The client prints "Fuzzing step <n> out of <m>" to stderr before each fuzz
 # step (programs/client/FuzzLoop.cpp), so the text after the LAST such marker is
 # the terminal query block -- the only step whose outcome sets the exit code.
+# This anchors on stderr, not the "Dump of fuzzed AST:" line: that dump is
+# printed to stdout, which is block-buffered when redirected to a file, so
+# run-fuzzer.sh's "> fuzzer.log 2>&1" flushes the terminal step's dump at process
+# exit -- AFTER its own (unbuffered stderr) exception -- and a dump-based anchor
+# would land on that trailing re-dump, past the evidence.
 # The AST fuzzer swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps going
-# (Client::processASTFuzzerStep), so a 30-minute fuzzer.log accumulates many
-# recovered "Received from ... (MEMORY_LIMIT_EXCEEDED)" lines that did NOT
-# terminate the run; each sits in its own (non-terminal) step block. A fixed
-# line/byte tail can still hold such a swallowed limit together with a later
-# client-side 241 when only a few stack frames separate the two steps, so anchor
-# on the terminal block instead of a fixed-size window.
-DUMP_MARKER = "Dump of fuzzed AST:"
+# (Client::processASTFuzzerStep returns success), so a 30-minute fuzzer.log
+# accumulates many recovered "Received from ... memory limit exceeded" lines that
+# did NOT terminate the run; each sits in its own (non-terminal) step block. A
+# fixed line/byte tail can still hold such a swallowed limit together with a
+# later client-side 241 when only a few stack frames separate the two steps, so
+# anchor on the terminal step block instead of a fixed-size window.
+STEP_MARKER = re.compile(r"^Fuzzing step \d+ out of \d+$", re.MULTILINE)
 
-# Bounded read for the terminal block. A single fuzzed query's dump plus its
+# Bounded read for the terminal block. A single fuzz step's dump plus its
 # transmitted exception is small; 256 KiB comfortably covers the last marker and
 # everything after it without loading a 30-minute log. Everything within a
 # tail-of-file window is by construction after the last marker, so even when the
-# terminal query's dump is larger than this bound the window stays inside the
+# terminal step's output is larger than this bound the window stays inside the
 # terminal block and never leaks an earlier step's swallowed limit.
 TERMINAL_BLOCK_MAX_BYTES = 262144
 
 
 def _terminal_query_block(fuzzer_log: Path) -> str:
-    """Text of fuzzer.log after the last 'Dump of fuzzed AST:' marker.
+    """Text of fuzzer.log after the last 'Fuzzing step <n> out of <m>' marker.
 
     Returns the read tail as-is when no marker is present (the run exited before
-    any fuzz step printed a dump, e.g. a startup/handshake error)."""
+    any AST fuzz step, e.g. a startup/handshake error, or BuzzHouse which does
+    not print step markers)."""
     try:
         size = fuzzer_log.stat().st_size
         if size == 0:
@@ -91,13 +110,30 @@ def _terminal_query_block(fuzzer_log: Path) -> str:
             text = fh.read().decode("utf-8", errors="replace")
     except OSError:
         return ""
-    idx = text.rfind(DUMP_MARKER)
-    return text if idx == -1 else text[idx:]
+    matches = list(STEP_MARKER.finditer(text))
+    return text if not matches else text[matches[-1].start():]
 
 
 def _fuzzer_log_terminal_block_has_server_mle(fuzzer_log: Path) -> bool:
-    """True when a server-origin MEMORY_LIMIT_EXCEEDED is in the terminal block."""
-    return re.search(SERVER_MLE_SIGNATURE, _terminal_query_block(fuzzer_log)) is not None
+    """True when a server-origin MEMORY_LIMIT_EXCEEDED explains the terminal 241.
+
+    The terminal block is anchored on the last 'Fuzzing step' marker (or the
+    whole read tail for a startup/handshake 241 or a BuzzHouse run, which print
+    no marker). It can still hold a server limit the run recovered from earlier
+    followed by a later client/harness 241 -- a recovered query limit then a
+    client-side reconnect/handshake 241 within a step, or the same across a
+    markerless tail. Treat it as benign only when no client-origin 241 line (a
+    "Code: 241" line with no "Received from" prefix) appears AFTER the last
+    server-origin MLE: that later 241 is the real exit cause and must surface,
+    while an earlier recovered client 241 does not veto a genuinely terminal
+    server limit."""
+    block = _terminal_query_block(fuzzer_log)
+    server_mles = [m.start() for m in re.finditer(SERVER_MLE_SIGNATURE, block)]
+    if not server_mles:
+        return False
+    return not any(
+        m.start() > server_mles[-1] for m in CLIENT_241_SIGNATURE.finditer(block)
+    )
 
 
 def _is_benign_memory_limit(
@@ -114,7 +150,7 @@ def _is_benign_memory_limit(
     loop already treats a 241 as "alive, busy".
 
     The evidence must be server-origin (SERVER_MLE_SIGNATURE) AND come from the
-    TERMINAL query block (after the last 'Dump of fuzzed AST:'). clickhouse-client
+    TERMINAL query block (after the last 'Fuzzing step' marker). clickhouse-client
     itself can raise 241 under --max_memory_usage_in_client (a client-side cap;
     see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
     mainEntryClickHouseClient returns that code verbatim -- such a client/harness

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -48,6 +48,22 @@ def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
     return "\n".join(data.decode("utf-8", errors="replace").splitlines()[-max_lines:])
 
 
+def _is_benign_memory_limit(
+    server_died: bool, fuzzer_exit_code: int, fuzzer_log_has_mle: bool
+) -> bool:
+    """True when the fuzzer exited only because the server hit its memory cap.
+
+    A fuzzed query pushes the server over its memory limit; the memory tracker
+    rejects the allocation with Code 241 (MEMORY_LIMIT_EXCEEDED) and the server
+    stays up (server_died=0). clickhouse-client returns the server error code as
+    its exit status, so the fuzzer exits 241. This is the tracker working as
+    intended, not a crash or a finding -- run-fuzzer.sh's liveness loop already
+    treats a 241 as "alive, busy". A genuine unbounded-memory bug crashes the
+    server instead and is caught via server_died / OOM-in-dmesg.
+    """
+    return not server_died and fuzzer_exit_code == 241 and fuzzer_log_has_mle
+
+
 def _read_fuzzer_status(status_path: Path) -> tuple[bool, int, int]:
     """Parse (server_died, server_exit_code, fuzzer_exit_code) from status.tsv.
 
@@ -334,6 +350,17 @@ def run_fuzz_job(check_name: str):
             info.append("Fuzzer killed")
         else:
             info.append("Fuzzer exited with timeout")
+        info.append("\n")
+    elif _is_benign_memory_limit(
+        server_died,
+        fuzzer_exit_code,
+        Shell.check(f"rg --text -q 'MEMORY_LIMIT_EXCEEDED' {fuzzer_log}"),
+    ):
+        # Server hit its memory cap on a fuzzed query but stayed alive; see
+        # _is_benign_memory_limit. Not a crash or a finding.
+        is_failed = False
+        status = Result.Status.OK
+        info.append("Server hit its memory limit (Code 241) but stayed alive")
         info.append("\n")
     elif fuzzer_exit_code in (227,):
         # BuzzHouse exception, it means a query oracle failed, or

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -48,20 +48,36 @@ def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
     return "\n".join(data.decode("utf-8", errors="replace").splitlines()[-max_lines:])
 
 
+# A server-transmitted exception is printed by the client prefixed with
+# "Received from <host>." A client-side 241 raised under
+# --max_memory_usage_in_client prints "Code: 241. DB::Exception: ..." with no
+# such prefix, so this signature keeps only genuine server-survived limits.
+SERVER_MLE_SIGNATURE = r"Received from.*MEMORY_LIMIT_EXCEEDED"
+
+
 def _is_benign_memory_limit(
-    server_died: bool, fuzzer_exit_code: int, fuzzer_log_has_mle: bool
+    server_died: bool, fuzzer_exit_code: int, fuzzer_log_has_server_mle: bool
 ) -> bool:
-    """True when the fuzzer exited only because the server hit its memory cap.
+    """True when the fuzzer exited only because the SERVER hit its memory cap.
 
     A fuzzed query pushes the server over its memory limit; the memory tracker
     rejects the allocation with Code 241 (MEMORY_LIMIT_EXCEEDED) and the server
-    stays up (server_died=0). clickhouse-client returns the server error code as
-    its exit status, so the fuzzer exits 241. This is the tracker working as
-    intended, not a crash or a finding -- run-fuzzer.sh's liveness loop already
-    treats a 241 as "alive, busy". A genuine unbounded-memory bug crashes the
-    server instead and is caught via server_died / OOM-in-dmesg.
+    stays up (server_died=0). The server transmits that exception to the client,
+    which prints it prefixed with "Received from <host>. ... (MEMORY_LIMIT_
+    EXCEEDED)" and exits with the server error code (241). This is the tracker
+    working as intended, not a crash or a finding -- run-fuzzer.sh's liveness
+    loop already treats a 241 as "alive, busy".
+
+    The evidence must be server-origin (SERVER_MLE_SIGNATURE). clickhouse-client
+    itself can raise 241 under --max_memory_usage_in_client (a client-side cap;
+    see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
+    mainEntryClickHouseClient returns that code verbatim -- such a client/harness
+    241 has no "Received from" prefix and must NOT be swallowed, or a real
+    client/harness regression would be masked.
     """
-    return not server_died and fuzzer_exit_code == 241 and fuzzer_log_has_mle
+    return (
+        not server_died and fuzzer_exit_code == 241 and fuzzer_log_has_server_mle
+    )
 
 
 def _read_fuzzer_status(status_path: Path) -> tuple[bool, int, int]:
@@ -354,7 +370,7 @@ def run_fuzz_job(check_name: str):
     elif _is_benign_memory_limit(
         server_died,
         fuzzer_exit_code,
-        Shell.check(f"rg --text -q 'MEMORY_LIMIT_EXCEEDED' {fuzzer_log}"),
+        Shell.check(f"rg --text -q '{SERVER_MLE_SIGNATURE}' {fuzzer_log}"),
     ):
         # Server hit its memory cap on a fuzzed query but stayed alive; see
         # _is_benign_memory_limit. Not a crash or a finding.

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -55,25 +55,53 @@ def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
 # such prefix, so this signature keeps only genuine server-survived limits.
 SERVER_MLE_SIGNATURE = r"Received from.*MEMORY_LIMIT_EXCEEDED"
 
-# Only the LAST queries the fuzzer ran can explain its exit code. The AST fuzzer
-# swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps going (see
-# Client::processASTFuzzerStep in programs/client/FuzzLoop.cpp), so a 30-minute
-# fuzzer.log accumulates many recovered "Received from ... (MEMORY_LIMIT_
-# EXCEEDED)" lines that did NOT terminate the run. The exit-241 is set by the
-# terminal exception the swallow does not cover (e.g. the TCPHandler::receiveHello
-# handshake path). Scan only the tail so a benign 241 is attributed to its actual
-# terminal cause, not a stale earlier limit.
-SERVER_MLE_TAIL_LINES = 50
+# The client prints "Dump of fuzzed AST:\n<query>" before executing each fuzz
+# step (programs/client/FuzzLoop.cpp), so the text after the LAST such marker is
+# the terminal query block -- the only step whose outcome sets the exit code.
+# The AST fuzzer swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps going
+# (Client::processASTFuzzerStep), so a 30-minute fuzzer.log accumulates many
+# recovered "Received from ... (MEMORY_LIMIT_EXCEEDED)" lines that did NOT
+# terminate the run; each sits in its own (non-terminal) step block. A fixed
+# line/byte tail can still hold such a swallowed limit together with a later
+# client-side 241 when only a few stack frames separate the two steps, so anchor
+# on the terminal block instead of a fixed-size window.
+DUMP_MARKER = "Dump of fuzzed AST:"
+
+# Bounded read for the terminal block. A single fuzzed query's dump plus its
+# transmitted exception is small; 256 KiB comfortably covers the last marker and
+# everything after it without loading a 30-minute log. Everything within a
+# tail-of-file window is by construction after the last marker, so even when the
+# terminal query's dump is larger than this bound the window stays inside the
+# terminal block and never leaks an earlier step's swallowed limit.
+TERMINAL_BLOCK_MAX_BYTES = 262144
 
 
-def _fuzzer_log_tail_has_server_mle(fuzzer_log: Path) -> bool:
-    """True when a server-origin MEMORY_LIMIT_EXCEEDED appears in the log tail."""
-    tail = _log_tail(fuzzer_log, max_lines=SERVER_MLE_TAIL_LINES)
-    return re.search(SERVER_MLE_SIGNATURE, tail) is not None
+def _terminal_query_block(fuzzer_log: Path) -> str:
+    """Text of fuzzer.log after the last 'Dump of fuzzed AST:' marker.
+
+    Returns the read tail as-is when no marker is present (the run exited before
+    any fuzz step printed a dump, e.g. a startup/handshake error)."""
+    try:
+        size = fuzzer_log.stat().st_size
+        if size == 0:
+            return ""
+        with open(fuzzer_log, "rb") as fh:
+            if size > TERMINAL_BLOCK_MAX_BYTES:
+                fh.seek(-TERMINAL_BLOCK_MAX_BYTES, os.SEEK_END)
+            text = fh.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+    idx = text.rfind(DUMP_MARKER)
+    return text if idx == -1 else text[idx:]
+
+
+def _fuzzer_log_terminal_block_has_server_mle(fuzzer_log: Path) -> bool:
+    """True when a server-origin MEMORY_LIMIT_EXCEEDED is in the terminal block."""
+    return re.search(SERVER_MLE_SIGNATURE, _terminal_query_block(fuzzer_log)) is not None
 
 
 def _is_benign_memory_limit(
-    server_died: bool, fuzzer_exit_code: int, tail_has_server_mle: bool
+    server_died: bool, fuzzer_exit_code: int, terminal_block_has_server_mle: bool
 ) -> bool:
     """True when the fuzzer exited only because the SERVER hit its memory cap.
 
@@ -86,16 +114,20 @@ def _is_benign_memory_limit(
     loop already treats a 241 as "alive, busy".
 
     The evidence must be server-origin (SERVER_MLE_SIGNATURE) AND come from the
-    fuzzer's last queries (log tail). clickhouse-client itself can raise 241
-    under --max_memory_usage_in_client (a client-side cap; see
-    tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
+    TERMINAL query block (after the last 'Dump of fuzzed AST:'). clickhouse-client
+    itself can raise 241 under --max_memory_usage_in_client (a client-side cap;
+    see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
     mainEntryClickHouseClient returns that code verbatim -- such a client/harness
     241 has no "Received from" prefix. And because the fuzzer swallows earlier
-    server limits and keeps running, only a server MLE in the tail actually
-    explains the exit; a stale earlier one must not swallow a terminal
-    client/harness 241, or a real regression would be masked.
+    server limits and keeps running, only a server MLE in the terminal block
+    actually explains the exit; a swallowed one from an earlier step must not
+    mask a terminal client/harness 241, or a real regression would be missed.
     """
-    return not server_died and fuzzer_exit_code == 241 and tail_has_server_mle
+    return (
+        not server_died
+        and fuzzer_exit_code == 241
+        and terminal_block_has_server_mle
+    )
 
 
 def _read_fuzzer_status(status_path: Path) -> tuple[bool, int, int]:
@@ -388,7 +420,7 @@ def run_fuzz_job(check_name: str):
     elif _is_benign_memory_limit(
         server_died,
         fuzzer_exit_code,
-        _fuzzer_log_tail_has_server_mle(fuzzer_log),
+        _fuzzer_log_terminal_block_has_server_mle(fuzzer_log),
     ):
         # Server hit its memory cap on a fuzzed query but stayed alive; see
         # _is_benign_memory_limit. Not a crash or a finding.

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import random
+import re
 import sys
 import traceback
 from pathlib import Path
@@ -54,9 +55,25 @@ def _log_tail(path: Path, max_lines: int = 50, max_bytes: int = 65536) -> str:
 # such prefix, so this signature keeps only genuine server-survived limits.
 SERVER_MLE_SIGNATURE = r"Received from.*MEMORY_LIMIT_EXCEEDED"
 
+# Only the LAST queries the fuzzer ran can explain its exit code. The AST fuzzer
+# swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps going (see
+# Client::processASTFuzzerStep in programs/client/FuzzLoop.cpp), so a 30-minute
+# fuzzer.log accumulates many recovered "Received from ... (MEMORY_LIMIT_
+# EXCEEDED)" lines that did NOT terminate the run. The exit-241 is set by the
+# terminal exception the swallow does not cover (e.g. the TCPHandler::receiveHello
+# handshake path). Scan only the tail so a benign 241 is attributed to its actual
+# terminal cause, not a stale earlier limit.
+SERVER_MLE_TAIL_LINES = 50
+
+
+def _fuzzer_log_tail_has_server_mle(fuzzer_log: Path) -> bool:
+    """True when a server-origin MEMORY_LIMIT_EXCEEDED appears in the log tail."""
+    tail = _log_tail(fuzzer_log, max_lines=SERVER_MLE_TAIL_LINES)
+    return re.search(SERVER_MLE_SIGNATURE, tail) is not None
+
 
 def _is_benign_memory_limit(
-    server_died: bool, fuzzer_exit_code: int, fuzzer_log_has_server_mle: bool
+    server_died: bool, fuzzer_exit_code: int, tail_has_server_mle: bool
 ) -> bool:
     """True when the fuzzer exited only because the SERVER hit its memory cap.
 
@@ -68,16 +85,17 @@ def _is_benign_memory_limit(
     working as intended, not a crash or a finding -- run-fuzzer.sh's liveness
     loop already treats a 241 as "alive, busy".
 
-    The evidence must be server-origin (SERVER_MLE_SIGNATURE). clickhouse-client
-    itself can raise 241 under --max_memory_usage_in_client (a client-side cap;
-    see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
+    The evidence must be server-origin (SERVER_MLE_SIGNATURE) AND come from the
+    fuzzer's last queries (log tail). clickhouse-client itself can raise 241
+    under --max_memory_usage_in_client (a client-side cap; see
+    tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
     mainEntryClickHouseClient returns that code verbatim -- such a client/harness
-    241 has no "Received from" prefix and must NOT be swallowed, or a real
-    client/harness regression would be masked.
+    241 has no "Received from" prefix. And because the fuzzer swallows earlier
+    server limits and keeps running, only a server MLE in the tail actually
+    explains the exit; a stale earlier one must not swallow a terminal
+    client/harness 241, or a real regression would be masked.
     """
-    return (
-        not server_died and fuzzer_exit_code == 241 and fuzzer_log_has_server_mle
-    )
+    return not server_died and fuzzer_exit_code == 241 and tail_has_server_mle
 
 
 def _read_fuzzer_status(status_path: Path) -> tuple[bool, int, int]:
@@ -370,7 +388,7 @@ def run_fuzz_job(check_name: str):
     elif _is_benign_memory_limit(
         server_died,
         fuzzer_exit_code,
-        Shell.check(f"rg --text -q '{SERVER_MLE_SIGNATURE}' {fuzzer_log}"),
+        _fuzzer_log_tail_has_server_mle(fuzzer_log),
     ):
         # Server hit its memory cap on a fuzzed query but stayed alive; see
         # _is_benign_memory_limit. Not a crash or a finding.

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -11,22 +11,32 @@ failure"), even though run-fuzzer.sh's liveness loop already treats a 241 as
 "server alive, busy".
 
 The benign path is keyed off SERVER-ORIGIN evidence (SERVER_MLE_SIGNATURE) in
-the TERMINAL query block (the text after the last "Dump of fuzzed AST:" the
-client prints before executing a fuzz step), not any MEMORY_LIMIT_EXCEEDED text
-anywhere in fuzzer.log:
+the TERMINAL query block (the text after the last "Fuzzing step <n> out of <m>"
+marker the client prints on stderr before each fuzz step), not any
+MEMORY_LIMIT_EXCEEDED text anywhere in fuzzer.log:
 - clickhouse-client itself can raise 241 under --max_memory_usage_in_client
   (see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
   mainEntryClickHouseClient returns that code verbatim. Such a client-side 241
   has no "Received from" prefix and must NOT be swallowed.
 - The AST fuzzer swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps
   running (Client::processASTFuzzerStep, programs/client/FuzzLoop.cpp), so a
-  30-minute run accumulates many recovered "Received from ... (MEMORY_LIMIT_
-  EXCEEDED)" lines that did NOT terminate it, each in its own (non-terminal)
+  30-minute run accumulates many recovered "Received from ... memory limit
+  exceeded" lines that did NOT terminate it, each in its own (non-terminal)
   step block. A fixed line/byte tail can still hold such a swallowed limit
   together with a later client-side 241 when only a few frames separate the two
-  steps, so the check anchors on the terminal block: only a server MLE after the
-  last dump marker explains the exit; a swallowed earlier one must not mask a
-  terminal client/harness 241, or a real regression would be missed.
+  steps, so the check anchors on the terminal step block: only a server MLE
+  after the last "Fuzzing step" marker explains the exit; a swallowed earlier
+  one must not mask a terminal client/harness 241, or a real regression would be
+  missed.
+
+The anchor is the stderr "Fuzzing step" marker, not the "Dump of fuzzed AST:"
+line, because that dump is printed to stdout: run-fuzzer.sh merges the client's
+streams with "> fuzzer.log 2>&1", and the block-buffered stdout dump of the
+terminal step is flushed at process exit -- AFTER the terminal exception on the
+unbuffered stderr -- so a dump-based anchor lands on that trailing re-dump,
+past the evidence. The server error text is also matched in either its enum
+"(MEMORY_LIMIT_EXCEEDED)" or prose "... memory limit exceeded" form (they print
+on separate lines).
 """
 
 import os
@@ -69,6 +79,15 @@ def _load(name):
     return ns[name]
 
 
+def _assign_src(src, name):
+    # Grab a single-line `NAME = ...` assignment verbatim (used for the compiled
+    # regex constants) so the test exercises the exact pattern the job uses.
+    marker = f"{name} = "
+    start = src.index(marker)
+    end = src.index("\n", start)
+    return src[start:end]
+
+
 def _load_terminal_block_helper():
     # _fuzzer_log_terminal_block_has_server_mle depends on _terminal_query_block,
     # re, and the module constants; exec all of them into one namespace so the
@@ -76,7 +95,8 @@ def _load_terminal_block_helper():
     src = _job_src()
     ns = {"os": os, "re": re, "Path": __import__("pathlib").Path}
     exec(f"{SERVER_MLE_SIGNATURE_SRC}", ns)  # noqa: S102
-    exec(f"DUMP_MARKER = {_load('DUMP_MARKER')!r}", ns)  # noqa: S102
+    exec(_assign_src(src, "CLIENT_241_SIGNATURE"), ns)  # noqa: S102
+    exec(_assign_src(src, "STEP_MARKER"), ns)  # noqa: S102
     exec(  # noqa: S102
         f"TERMINAL_BLOCK_MAX_BYTES = {_load('TERMINAL_BLOCK_MAX_BYTES')}", ns
     )
@@ -119,10 +139,23 @@ _SERVER_MLE_LINE = (
     "Received from localhost:9000. DB::Exception: Memory limit (total) "
     "exceeded: would use 9.32 GiB, maximum: 9.31 GiB. (MEMORY_LIMIT_EXCEEDED)"
 )
+# The prose server form, taken verbatim from the PR #109006 fuzzer.log: the
+# "Received from" line carries the lowercase "(total) memory limit exceeded"
+# message while the enum "(MEMORY_LIMIT_EXCEEDED)" trails on a separate line, so
+# a signature keyed only on the enum token misses this (real) shape entirely.
+_SERVER_MLE_PROSE_LINE = (
+    "Code: 241. DB::Exception: Received from localhost:9000. DB::Exception: "
+    "(total) memory limit exceeded: would use 35.96 GiB (attempt to allocate "
+    "chunk of 0.00 B), current RSS: 44.31 GiB, maximum: 44.29 GiB. Untracked "
+    "memory across all threads: -8.94 MiB.. Stack trace:"
+)
 _CLIENT_MLE_LINE = (
     "Code: 241. DB::Exception: Client memory limit exceeded: would use "
     "10.05 MiB, maximum: 10.00 MiB. (MEMORY_LIMIT_EXCEEDED)"
 )
+# The stderr marker the client prints before each AST fuzz step; the classifier
+# anchors the terminal block on the LAST one of these.
+_STEP = "Fuzzing step 7 out of 1000"
 
 
 # --- SERVER_MLE_SIGNATURE: server-origin evidence only ---
@@ -131,6 +164,12 @@ _CLIENT_MLE_LINE = (
 def test_signature_matches_server_transmitted_241():
     # "Received from <host>. ... (MEMORY_LIMIT_EXCEEDED)" -> server-origin.
     assert _server_mle_matches(_SERVER_MLE_LINE) is True
+
+
+def test_signature_matches_server_transmitted_241_prose_form():
+    # Real logs print the prose "... memory limit exceeded" on the "Received
+    # from" line (enum on a separate line) -> must still match as server-origin.
+    assert _server_mle_matches(_SERVER_MLE_PROSE_LINE) is True
 
 
 def test_signature_ignores_client_side_241():
@@ -170,19 +209,19 @@ _DUMP = "Dump of fuzzed AST:\nSELECT 1"
 _FRAMES = "\n".join(f"  {i}. some_frame_symbol(...)" for i in range(15))
 
 
-def test_terminal_block_matches_server_mle_after_last_dump():
+def test_terminal_block_matches_server_mle_after_last_step():
     # A terminal server-transmitted 241 in the last step block -> benign evidence.
-    log = "\n".join([_DUMP, _SERVER_MLE_LINE] * 3 + [_DUMP, _SERVER_MLE_LINE])
+    log = "\n".join([_STEP, _DUMP, _SERVER_MLE_LINE] * 3 + [_STEP, _SERVER_MLE_LINE])
     assert _terminal_block_has_server_mle(log) is True
 
 
 def test_terminal_block_ignores_server_mle_from_earlier_step():
     # The fuzzer swallows a query-side server MLE on one step and keeps running;
     # a LATER step exits 241 for an unrelated (e.g. client) reason. The swallowed
-    # server MLE sits before the last dump marker -> must NOT count as evidence.
+    # server MLE sits before the last step marker -> must NOT count as evidence.
     log = "\n".join(
-        [_DUMP, _SERVER_MLE_LINE]  # step N: swallowed server limit
-        + [_DUMP, "Query succeeded"]  # terminal step: no server MLE
+        [_STEP, _DUMP, _SERVER_MLE_LINE]  # step N: swallowed server limit
+        + [_STEP, _DUMP, "Query succeeded"]  # terminal step: no server MLE
     )
     assert _terminal_block_has_server_mle(log) is False
 
@@ -190,30 +229,129 @@ def test_terminal_block_ignores_server_mle_from_earlier_step():
 def test_terminal_block_reproduction_from_review():
     # Exact shape the reviewer reproduced: one swallowed server MLE, ~15 stack
     # frames, then a later client-side 241. A fixed 50-line tail wrongly held
-    # both; anchoring on the last dump marker isolates the terminal client 241.
+    # both; anchoring on the last "Fuzzing step" marker isolates the terminal
+    # client 241 in its own step block.
     log = "\n".join(
         [
+            _STEP,  # step N
             _DUMP,
             _SERVER_MLE_LINE,  # swallowed on step N, fuzzer kept going
             _FRAMES,
-            _DUMP,  # terminal step N+1
+            _STEP,  # terminal step N+1
+            _DUMP,
             _CLIENT_MLE_LINE,  # exit-241 was client-side here
         ]
     )
     assert _terminal_block_has_server_mle(log) is False
 
 
+def test_terminal_block_reconnect_path_with_trailing_buffered_dump():
+    # The real PR #109006 shape: the terminal step's server-transmitted 241
+    # (prose form, from the reconnect path) is followed by a trailing
+    # "Dump of fuzzed AST:" -- the terminal step's stdout dump, block-buffered
+    # and flushed at process exit AFTER the stderr exception. A dump-anchored
+    # check would land on that trailing re-dump (no evidence); the "Fuzzing
+    # step" anchor keeps the server MLE in the terminal block -> benign.
+    log = "\n".join(
+        [
+            _STEP,  # terminal step marker (stderr)
+            "Dump of fuzzed AST:",  # step's stdout dump
+            "EXPLAIN WHATIF graph = 1 SELECT 1",
+            _SERVER_MLE_PROSE_LINE,  # reconnect-path server MLE (stderr)
+            _FRAMES,
+            ". (MEMORY_LIMIT_EXCEEDED) (version 26.7.1.1)",
+            "Lost connection to the server.",
+            "Changed settings: max_insert_threads = '1', ...",
+            "No changed MergeTree settings.",
+            "Dump of fuzzed AST:",  # trailing buffered stdout re-dump
+            "EXPLAIN WHATIF graph = 1 SELECT 1",
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is True
+
+
 def test_terminal_block_ignores_client_side_241_at_end():
     # A terminal client-side 241 (no "Received from" prefix) -> not benign.
-    log = "\n".join([_DUMP, _CLIENT_MLE_LINE])
+    log = "\n".join([_STEP, _DUMP, _CLIENT_MLE_LINE])
     assert _terminal_block_has_server_mle(log) is False
 
 
-def test_terminal_block_no_dump_marker_scans_read_tail():
-    # No fuzz step ran (e.g. a startup/handshake 241 before any dump): the whole
-    # read tail is the terminal region, so a server MLE there still counts.
+def test_terminal_block_no_step_marker_scans_read_tail():
+    # No AST fuzz step ran (a startup/handshake 241 before any step, or a
+    # BuzzHouse run that prints no step markers): the whole read tail is the
+    # terminal region, so a server MLE there still counts.
     log = "\n".join(["starting up"] + [_SERVER_MLE_LINE])
     assert _terminal_block_has_server_mle(log) is True
+
+
+# --- no-marker fallback: a later client 241 must not be masked by an earlier
+#     recovered server limit (BuzzHouse prints no "Fuzzing step" markers) ---
+
+
+def test_no_marker_earlier_server_mle_then_client_241_not_benign():
+    # BuzzHouse (no step markers): a server limit recovered from earlier in the
+    # workload, then a terminal client-side 241 (e.g. --max_memory_usage_in_client
+    # or a harness limit). The whole read tail holds both; the later client 241
+    # is the real exit cause and must NOT be masked by the earlier server MLE.
+    log = "\n".join(
+        [
+            "BuzzHouse: running workload",
+            "SELECT 1;",
+            _SERVER_MLE_PROSE_LINE,  # recovered earlier
+            _FRAMES,
+            "INSERT INTO t VALUES (1);",
+            _CLIENT_MLE_LINE,  # terminal client-side 241
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is False
+
+
+def test_no_marker_terminal_server_mle_is_benign():
+    # BuzzHouse (no step markers): a client 241 recovered from earlier, then the
+    # run ends on a server-transmitted limit with no later client 241 -> benign.
+    log = "\n".join(
+        [
+            "BuzzHouse: running workload",
+            "SELECT 1;",
+            _CLIENT_MLE_LINE,  # recovered earlier
+            "INSERT INTO t VALUES (1);",
+            _SERVER_MLE_PROSE_LINE,  # terminal server-transmitted limit
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is True
+
+
+def test_marker_delimited_block_is_authoritative_despite_earlier_client_241():
+    # With a terminal "Fuzzing step" marker the block is authoritative: an AST
+    # fuzz step's server-transmitted 241 stays benign even if an earlier
+    # (pre-marker, hence excluded) part of the log had a client 241.
+    log = "\n".join(
+        [
+            _CLIENT_MLE_LINE,  # earlier, before the terminal step -> excluded
+            _STEP,
+            "Dump of fuzzed AST:",
+            _SERVER_MLE_PROSE_LINE,
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is True
+
+
+def test_marker_delimited_block_later_client_241_not_benign():
+    # Even inside a marker-delimited terminal block, a client-origin 241 that
+    # follows the last server-origin MLE (e.g. a step recovers a query limit,
+    # then a client-side reconnect/handshake 241 sets the exit) is the real exit
+    # cause and must NOT be masked. The ordering check applies to both the marker
+    # and no-marker forms.
+    log = "\n".join(
+        [
+            _STEP,
+            "Dump of fuzzed AST:",
+            _SERVER_MLE_PROSE_LINE,  # recovered server limit on this step
+            _FRAMES,
+            _CLIENT_MLE_LINE,  # later client-side 241 -> the real exit cause
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is False
 
 
 def test_terminal_block_empty_or_missing_log():

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -1,50 +1,100 @@
 """
 Regression test for the memory-limit classification in ci/jobs/ast_fuzzer_job.py.
 
-A fuzzed query can push the server over its memory cap; the memory tracker
+A fuzzed query can push the SERVER over its memory cap; the memory tracker
 rejects the allocation with Code 241 (MEMORY_LIMIT_EXCEEDED) and the server
-stays alive (server_died=0, clean shutdown). clickhouse-client returns the
-server error code as its exit status, so the fuzzer exits 241. Before the fix,
-that landed in the catch-all `else` branch and turned the whole job into a bogus
-ERROR ("Client failure"), even though run-fuzzer.sh's liveness loop already
-treats a 241 as "server alive, busy". These assert the classifier now treats a
-server-survived 241 as OK while a genuine crash / non-241 client failure is not.
+stays alive (server_died=0, clean shutdown). The server transmits that
+exception to the client, which prints it prefixed with "Received from <host>."
+and exits with the server error code (241). Before the fix, that landed in the
+catch-all `else` branch and turned the whole job into a bogus ERROR ("Client
+failure"), even though run-fuzzer.sh's liveness loop already treats a 241 as
+"server alive, busy".
+
+The benign path is keyed off SERVER-ORIGIN evidence (SERVER_MLE_SIGNATURE),
+not any MEMORY_LIMIT_EXCEEDED text: clickhouse-client itself can raise 241
+under --max_memory_usage_in_client (see
+tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
+mainEntryClickHouseClient returns that code verbatim. Such a client-side 241
+has no "Received from" prefix and must NOT be swallowed, or a real
+client/harness regression would be masked.
 """
 
 import os
+import re
 
 _JOB = os.path.join(
     os.path.dirname(__file__), "..", "jobs", "ast_fuzzer_job.py"
 )
 
 
-def _is_benign_memory_limit(*args):
-    # Load the module by path without importing its heavy CI dependencies:
-    # read the source and exec only the target function's def.
+def _load(name):
+    # Load a top-level def/assignment by name from ast_fuzzer_job.py without
+    # importing its heavy CI dependencies: exec only the target snippet.
     src = open(_JOB, encoding="utf-8").read()
     ns = {}
-    # The helper is self-contained (no imports needed); extract and exec it.
-    marker = "def _is_benign_memory_limit("
-    start = src.index(marker)
-    # find the end of the function: next top-level 'def ' after start
-    end = src.index("\ndef ", start + 1)
-    exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
-    return ns["_is_benign_memory_limit"](*args)
+    if name == "SERVER_MLE_SIGNATURE":
+        marker = "SERVER_MLE_SIGNATURE = "
+        start = src.index(marker)
+        end = src.index("\n", start)
+        exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
+    else:
+        marker = f"def {name}("
+        start = src.index(marker)
+        end = src.index("\ndef ", start + 1)
+        exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
+    return ns[name]
+
+
+def _is_benign_memory_limit(*args):
+    return _load("_is_benign_memory_limit")(*args)
+
+
+def _server_mle_matches(log_text):
+    pattern = _load("SERVER_MLE_SIGNATURE")
+    return any(re.search(pattern, line) for line in log_text.splitlines())
+
+
+# Real client output shapes (single line, as clickhouse-client prints them).
+_SERVER_MLE_LINE = (
+    "Received from localhost:9000. DB::Exception: Memory limit (total) "
+    "exceeded: would use 9.32 GiB, maximum: 9.31 GiB. (MEMORY_LIMIT_EXCEEDED)"
+)
+_CLIENT_MLE_LINE = (
+    "Code: 241. DB::Exception: Client memory limit exceeded: would use "
+    "10.05 MiB, maximum: 10.00 MiB. (MEMORY_LIMIT_EXCEEDED)"
+)
+
+
+# --- SERVER_MLE_SIGNATURE: server-origin evidence only ---
+
+
+def test_signature_matches_server_transmitted_241():
+    # "Received from <host>. ... (MEMORY_LIMIT_EXCEEDED)" -> server-origin.
+    assert _server_mle_matches(_SERVER_MLE_LINE) is True
+
+
+def test_signature_ignores_client_side_241():
+    # Client-side 241 (--max_memory_usage_in_client) has no "Received from"
+    # prefix -> must NOT count as benign evidence.
+    assert _server_mle_matches(_CLIENT_MLE_LINE) is False
+
+
+# --- _is_benign_memory_limit: gate on (server_died, exit, server-origin MLE) ---
 
 
 def test_server_survived_memory_limit_is_benign():
-    # 241 + server alive + MLE in log -> benign, job OK.
+    # 241 + server alive + server-origin MLE -> benign, job OK.
     assert _is_benign_memory_limit(False, 241, True) is True
 
 
-def test_memory_limit_without_log_evidence_is_not_benign():
-    # 241 but no MEMORY_LIMIT_EXCEEDED in the log -> treat as a real client
-    # failure (don't guess the cause was memory).
+def test_client_side_241_is_not_benign():
+    # 241 + server alive but NO server-origin MLE (e.g. a client-side cap or a
+    # harness 241) -> not benign; a real client/harness regression must surface.
     assert _is_benign_memory_limit(False, 241, False) is False
 
 
 def test_dead_server_is_not_benign():
-    # Server died -> a crash, never benign, even if the log mentions MLE.
+    # Server died -> a crash, never benign, even with server-origin MLE.
     assert _is_benign_memory_limit(True, 241, True) is False
 
 

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -1,0 +1,55 @@
+"""
+Regression test for the memory-limit classification in ci/jobs/ast_fuzzer_job.py.
+
+A fuzzed query can push the server over its memory cap; the memory tracker
+rejects the allocation with Code 241 (MEMORY_LIMIT_EXCEEDED) and the server
+stays alive (server_died=0, clean shutdown). clickhouse-client returns the
+server error code as its exit status, so the fuzzer exits 241. Before the fix,
+that landed in the catch-all `else` branch and turned the whole job into a bogus
+ERROR ("Client failure"), even though run-fuzzer.sh's liveness loop already
+treats a 241 as "server alive, busy". These assert the classifier now treats a
+server-survived 241 as OK while a genuine crash / non-241 client failure is not.
+"""
+
+import importlib.util
+import os
+
+_JOB = os.path.join(
+    os.path.dirname(__file__), "..", "jobs", "ast_fuzzer_job.py"
+)
+
+
+def _is_benign_memory_limit(*args):
+    # Load the module by path without importing its heavy CI dependencies:
+    # read the source and exec only the target function's def.
+    src = open(_JOB, encoding="utf-8").read()
+    ns = {}
+    # The helper is self-contained (no imports needed); extract and exec it.
+    marker = "def _is_benign_memory_limit("
+    start = src.index(marker)
+    # find the end of the function: next top-level 'def ' after start
+    end = src.index("\ndef ", start + 1)
+    exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
+    return ns["_is_benign_memory_limit"](*args)
+
+
+def test_server_survived_memory_limit_is_benign():
+    # 241 + server alive + MLE in log -> benign, job OK.
+    assert _is_benign_memory_limit(False, 241, True) is True
+
+
+def test_memory_limit_without_log_evidence_is_not_benign():
+    # 241 but no MEMORY_LIMIT_EXCEEDED in the log -> treat as a real client
+    # failure (don't guess the cause was memory).
+    assert _is_benign_memory_limit(False, 241, False) is False
+
+
+def test_dead_server_is_not_benign():
+    # Server died -> a crash, never benign, even if the log mentions MLE.
+    assert _is_benign_memory_limit(True, 241, True) is False
+
+
+def test_other_client_failure_is_not_benign():
+    # A non-241 client failure (e.g. a real finding) stays an error.
+    assert _is_benign_memory_limit(False, 139, True) is False
+    assert _is_benign_memory_limit(False, 0, True) is False

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -11,7 +11,6 @@ treats a 241 as "server alive, busy". These assert the classifier now treats a
 server-survived 241 as OK while a genuine crash / non-241 client failure is not.
 """
 
-import importlib.util
 import os
 
 _JOB = os.path.join(

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -10,39 +10,77 @@ catch-all `else` branch and turned the whole job into a bogus ERROR ("Client
 failure"), even though run-fuzzer.sh's liveness loop already treats a 241 as
 "server alive, busy".
 
-The benign path is keyed off SERVER-ORIGIN evidence (SERVER_MLE_SIGNATURE),
-not any MEMORY_LIMIT_EXCEEDED text: clickhouse-client itself can raise 241
-under --max_memory_usage_in_client (see
-tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
-mainEntryClickHouseClient returns that code verbatim. Such a client-side 241
-has no "Received from" prefix and must NOT be swallowed, or a real
-client/harness regression would be masked.
+The benign path is keyed off SERVER-ORIGIN evidence (SERVER_MLE_SIGNATURE) in
+the LOG TAIL, not any MEMORY_LIMIT_EXCEEDED text anywhere in fuzzer.log:
+- clickhouse-client itself can raise 241 under --max_memory_usage_in_client
+  (see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
+  mainEntryClickHouseClient returns that code verbatim. Such a client-side 241
+  has no "Received from" prefix and must NOT be swallowed.
+- The AST fuzzer swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps
+  running (Client::processASTFuzzerStep, programs/client/FuzzLoop.cpp), so a
+  30-minute run accumulates many recovered "Received from ... (MEMORY_LIMIT_
+  EXCEEDED)" lines that did NOT terminate it. Only a server MLE in the tail
+  (the fuzzer's last queries) can explain the exit code; a stale earlier one
+  must not swallow a terminal client/harness 241, or a real regression would
+  be masked.
 """
 
 import os
 import re
+import tempfile
 
 _JOB = os.path.join(
     os.path.dirname(__file__), "..", "jobs", "ast_fuzzer_job.py"
 )
 
 
+def _job_src():
+    return open(_JOB, encoding="utf-8").read()
+
+
+def _scalar(src, name):
+    marker = f"{name} = "
+    start = src.index(marker)
+    end = src.index("\n", start)
+    ns = {}
+    exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
+    return ns[name]
+
+
+def _def_snippet(src, name):
+    marker = f"def {name}("
+    start = src.index(marker)
+    end = src.index("\ndef ", start + 1)
+    return src[start:end]
+
+
 def _load(name):
     # Load a top-level def/assignment by name from ast_fuzzer_job.py without
     # importing its heavy CI dependencies: exec only the target snippet.
-    src = open(_JOB, encoding="utf-8").read()
+    src = _job_src()
+    if name.isupper():
+        return _scalar(src, name)
     ns = {}
-    if name == "SERVER_MLE_SIGNATURE":
-        marker = "SERVER_MLE_SIGNATURE = "
-        start = src.index(marker)
-        end = src.index("\n", start)
-        exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
-    else:
-        marker = f"def {name}("
-        start = src.index(marker)
-        end = src.index("\ndef ", start + 1)
-        exec(src[start:end], ns)  # noqa: S102 - trusted first-party source
+    exec(_def_snippet(src, name), ns)  # noqa: S102 - trusted first-party source
     return ns[name]
+
+
+def _load_tail_helper():
+    # _fuzzer_log_tail_has_server_mle depends on _log_tail, re, and the two
+    # module constants; exec all of them into one namespace so the real
+    # function runs against a file on disk.
+    src = _job_src()
+    ns = {"os": os, "re": re, "Path": __import__("pathlib").Path}
+    exec(f"{SERVER_MLE_SIGNATURE_SRC}", ns)  # noqa: S102
+    exec(f"SERVER_MLE_TAIL_LINES = {_load('SERVER_MLE_TAIL_LINES')}", ns)  # noqa: S102
+    exec(_def_snippet(src, "_log_tail"), ns)  # noqa: S102
+    exec(_def_snippet(src, "_fuzzer_log_tail_has_server_mle"), ns)  # noqa: S102
+    return ns["_fuzzer_log_tail_has_server_mle"]
+
+
+SERVER_MLE_SIGNATURE_SRC = "SERVER_MLE_SIGNATURE = " + repr(
+    _load("SERVER_MLE_SIGNATURE")
+)
 
 
 def _is_benign_memory_limit(*args):
@@ -52,6 +90,21 @@ def _is_benign_memory_limit(*args):
 def _server_mle_matches(log_text):
     pattern = _load("SERVER_MLE_SIGNATURE")
     return any(re.search(pattern, line) for line in log_text.splitlines())
+
+
+def _tail_has_server_mle(log_text):
+    helper = _load_tail_helper()
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".log", delete=False, encoding="utf-8"
+    ) as fh:
+        fh.write(log_text)
+        path = fh.name
+    try:
+        from pathlib import Path
+
+        return helper(Path(path))
+    finally:
+        os.unlink(path)
 
 
 # Real client output shapes (single line, as clickhouse-client prints them).
@@ -102,3 +155,30 @@ def test_other_client_failure_is_not_benign():
     # A non-241 client failure (e.g. a real finding) stays an error.
     assert _is_benign_memory_limit(False, 139, True) is False
     assert _is_benign_memory_limit(False, 0, True) is False
+
+
+# --- tail scoping: only a server MLE from the fuzzer's LAST queries counts ---
+
+
+def test_tail_matches_server_mle_at_end_of_log():
+    # A terminal server-transmitted 241 at the end of the log -> benign evidence.
+    log = "\n".join(["Dump of fuzzed AST: SELECT 1"] * 10 + [_SERVER_MLE_LINE])
+    assert _tail_has_server_mle(log) is True
+
+
+def test_tail_ignores_stale_server_mle_before_tail():
+    # The fuzzer swallows a query-side server MLE and keeps running for many
+    # more queries; the run then exits 241 for an unrelated (e.g. client) reason.
+    # The stale server MLE is far above the tail -> must NOT count as evidence.
+    log = "\n".join([_SERVER_MLE_LINE] + ["Query succeeded: SELECT 1"] * 200)
+    assert _tail_has_server_mle(log) is False
+
+
+def test_tail_ignores_client_side_241_at_end():
+    # A terminal client-side 241 (no "Received from" prefix) -> not benign.
+    log = "\n".join(["Query succeeded: SELECT 1"] * 10 + [_CLIENT_MLE_LINE])
+    assert _tail_has_server_mle(log) is False
+
+
+def test_tail_empty_or_missing_log():
+    assert _tail_has_server_mle("") is False

--- a/ci/tests/test_ast_fuzzer_memory_limit.py
+++ b/ci/tests/test_ast_fuzzer_memory_limit.py
@@ -11,7 +11,9 @@ failure"), even though run-fuzzer.sh's liveness loop already treats a 241 as
 "server alive, busy".
 
 The benign path is keyed off SERVER-ORIGIN evidence (SERVER_MLE_SIGNATURE) in
-the LOG TAIL, not any MEMORY_LIMIT_EXCEEDED text anywhere in fuzzer.log:
+the TERMINAL query block (the text after the last "Dump of fuzzed AST:" the
+client prints before executing a fuzz step), not any MEMORY_LIMIT_EXCEEDED text
+anywhere in fuzzer.log:
 - clickhouse-client itself can raise 241 under --max_memory_usage_in_client
   (see tests/queries/0_stateless/02003_memory_limit_in_client.sh) and
   mainEntryClickHouseClient returns that code verbatim. Such a client-side 241
@@ -19,10 +21,12 @@ the LOG TAIL, not any MEMORY_LIMIT_EXCEEDED text anywhere in fuzzer.log:
 - The AST fuzzer swallows query-side server MEMORY_LIMIT_EXCEEDED and keeps
   running (Client::processASTFuzzerStep, programs/client/FuzzLoop.cpp), so a
   30-minute run accumulates many recovered "Received from ... (MEMORY_LIMIT_
-  EXCEEDED)" lines that did NOT terminate it. Only a server MLE in the tail
-  (the fuzzer's last queries) can explain the exit code; a stale earlier one
-  must not swallow a terminal client/harness 241, or a real regression would
-  be masked.
+  EXCEEDED)" lines that did NOT terminate it, each in its own (non-terminal)
+  step block. A fixed line/byte tail can still hold such a swallowed limit
+  together with a later client-side 241 when only a few frames separate the two
+  steps, so the check anchors on the terminal block: only a server MLE after the
+  last dump marker explains the exit; a swallowed earlier one must not mask a
+  terminal client/harness 241, or a real regression would be missed.
 """
 
 import os
@@ -65,17 +69,20 @@ def _load(name):
     return ns[name]
 
 
-def _load_tail_helper():
-    # _fuzzer_log_tail_has_server_mle depends on _log_tail, re, and the two
-    # module constants; exec all of them into one namespace so the real
-    # function runs against a file on disk.
+def _load_terminal_block_helper():
+    # _fuzzer_log_terminal_block_has_server_mle depends on _terminal_query_block,
+    # re, and the module constants; exec all of them into one namespace so the
+    # real function runs against a file on disk.
     src = _job_src()
     ns = {"os": os, "re": re, "Path": __import__("pathlib").Path}
     exec(f"{SERVER_MLE_SIGNATURE_SRC}", ns)  # noqa: S102
-    exec(f"SERVER_MLE_TAIL_LINES = {_load('SERVER_MLE_TAIL_LINES')}", ns)  # noqa: S102
-    exec(_def_snippet(src, "_log_tail"), ns)  # noqa: S102
-    exec(_def_snippet(src, "_fuzzer_log_tail_has_server_mle"), ns)  # noqa: S102
-    return ns["_fuzzer_log_tail_has_server_mle"]
+    exec(f"DUMP_MARKER = {_load('DUMP_MARKER')!r}", ns)  # noqa: S102
+    exec(  # noqa: S102
+        f"TERMINAL_BLOCK_MAX_BYTES = {_load('TERMINAL_BLOCK_MAX_BYTES')}", ns
+    )
+    exec(_def_snippet(src, "_terminal_query_block"), ns)  # noqa: S102
+    exec(_def_snippet(src, "_fuzzer_log_terminal_block_has_server_mle"), ns)  # noqa: S102
+    return ns["_fuzzer_log_terminal_block_has_server_mle"]
 
 
 SERVER_MLE_SIGNATURE_SRC = "SERVER_MLE_SIGNATURE = " + repr(
@@ -92,8 +99,8 @@ def _server_mle_matches(log_text):
     return any(re.search(pattern, line) for line in log_text.splitlines())
 
 
-def _tail_has_server_mle(log_text):
-    helper = _load_tail_helper()
+def _terminal_block_has_server_mle(log_text):
+    helper = _load_terminal_block_helper()
     with tempfile.NamedTemporaryFile(
         "w", suffix=".log", delete=False, encoding="utf-8"
     ) as fh:
@@ -157,28 +164,57 @@ def test_other_client_failure_is_not_benign():
     assert _is_benign_memory_limit(False, 0, True) is False
 
 
-# --- tail scoping: only a server MLE from the fuzzer's LAST queries counts ---
+# --- terminal-block scoping: only a server MLE from the LAST fuzz step counts ---
+
+_DUMP = "Dump of fuzzed AST:\nSELECT 1"
+_FRAMES = "\n".join(f"  {i}. some_frame_symbol(...)" for i in range(15))
 
 
-def test_tail_matches_server_mle_at_end_of_log():
-    # A terminal server-transmitted 241 at the end of the log -> benign evidence.
-    log = "\n".join(["Dump of fuzzed AST: SELECT 1"] * 10 + [_SERVER_MLE_LINE])
-    assert _tail_has_server_mle(log) is True
+def test_terminal_block_matches_server_mle_after_last_dump():
+    # A terminal server-transmitted 241 in the last step block -> benign evidence.
+    log = "\n".join([_DUMP, _SERVER_MLE_LINE] * 3 + [_DUMP, _SERVER_MLE_LINE])
+    assert _terminal_block_has_server_mle(log) is True
 
 
-def test_tail_ignores_stale_server_mle_before_tail():
-    # The fuzzer swallows a query-side server MLE and keeps running for many
-    # more queries; the run then exits 241 for an unrelated (e.g. client) reason.
-    # The stale server MLE is far above the tail -> must NOT count as evidence.
-    log = "\n".join([_SERVER_MLE_LINE] + ["Query succeeded: SELECT 1"] * 200)
-    assert _tail_has_server_mle(log) is False
+def test_terminal_block_ignores_server_mle_from_earlier_step():
+    # The fuzzer swallows a query-side server MLE on one step and keeps running;
+    # a LATER step exits 241 for an unrelated (e.g. client) reason. The swallowed
+    # server MLE sits before the last dump marker -> must NOT count as evidence.
+    log = "\n".join(
+        [_DUMP, _SERVER_MLE_LINE]  # step N: swallowed server limit
+        + [_DUMP, "Query succeeded"]  # terminal step: no server MLE
+    )
+    assert _terminal_block_has_server_mle(log) is False
 
 
-def test_tail_ignores_client_side_241_at_end():
+def test_terminal_block_reproduction_from_review():
+    # Exact shape the reviewer reproduced: one swallowed server MLE, ~15 stack
+    # frames, then a later client-side 241. A fixed 50-line tail wrongly held
+    # both; anchoring on the last dump marker isolates the terminal client 241.
+    log = "\n".join(
+        [
+            _DUMP,
+            _SERVER_MLE_LINE,  # swallowed on step N, fuzzer kept going
+            _FRAMES,
+            _DUMP,  # terminal step N+1
+            _CLIENT_MLE_LINE,  # exit-241 was client-side here
+        ]
+    )
+    assert _terminal_block_has_server_mle(log) is False
+
+
+def test_terminal_block_ignores_client_side_241_at_end():
     # A terminal client-side 241 (no "Received from" prefix) -> not benign.
-    log = "\n".join(["Query succeeded: SELECT 1"] * 10 + [_CLIENT_MLE_LINE])
-    assert _tail_has_server_mle(log) is False
+    log = "\n".join([_DUMP, _CLIENT_MLE_LINE])
+    assert _terminal_block_has_server_mle(log) is False
 
 
-def test_tail_empty_or_missing_log():
-    assert _tail_has_server_mle("") is False
+def test_terminal_block_no_dump_marker_scans_read_tail():
+    # No fuzz step ran (e.g. a startup/handshake 241 before any dump): the whole
+    # read tail is the terminal region, so a server MLE there still counts.
+    log = "\n".join(["starting up"] + [_SERVER_MLE_LINE])
+    assert _terminal_block_has_server_mle(log) is True
+
+
+def test_terminal_block_empty_or_missing_log():
+    assert _terminal_block_has_server_mle("") is False


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108212
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

A fuzzed query can push the server over its memory cap. The memory tracker rejects the allocation with `Code 241 (MEMORY_LIMIT_EXCEEDED)` and the server stays alive. `clickhouse-client` returns the server error code as its exit status, so the fuzzer process exits 241 with `server_died=0` and a clean server shutdown.

`run-fuzzer.sh`'s post-fuzz liveness loop already treats a 241 as "server alive, busy", but `ci/jobs/ast_fuzzer_job.py` had no matching branch: `fuzzer_exit_code == 241` fell into the catch-all `else` and turned the whole job into a bogus `ERROR` ("Client failure").

This makes the Python classifier consistent with the shell loop: a server-survived 241 (`server_died == 0` and `MEMORY_LIMIT_EXCEEDED` present in the fuzzer log) is classified `OK`. A genuine unbounded-memory bug crashes the server instead and is still caught via `server_died` / OOM-in-dmesg, so this does not mask real findings.

Adds `ci/tests/test_ast_fuzzer_memory_limit.py` covering: server-survived 241 -> OK; 241 without log evidence -> not benign; dead server -> not benign; non-241 client failure -> not benign.

CI report showing the failure this addresses (AST fuzzer (amd_debug), server RSS 44.56 GiB > 44.46 GiB cap, Code 241 on `SET send_logs_level='fatal'` at `TCPHandler::receiveHello`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107236&sha=0c14f334914a3654b21050598ac4def93be109d6&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
