### PR TITLE
Fix MySQL connect_timeout not taking effect under the query profiler

### DIFF
--- a/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.reference
+++ b/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.reference
@@ -1,0 +1,1 @@
+attach_bounded_by_timeout	1

--- a/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.sh
+++ b/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# Tag justification:
+#   no-fasttest: depends on libmysql (MySQL database engine), not built in fast test.
+#   no-parallel: attaches a MySQL database pointing at an unreachable host; it is visible
+#     in system.tables, so a concurrent unfiltered scan would also try to connect to it.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `MYSQL_OPT_CONNECT_TIMEOUT` must bound the TCP connect even when the thread receives
+# periodic signals: the sampling query profiler interrupts poll with EINTR, and the
+# connector used to restart the poll with the full timeout, resetting the deadline every
+# time. With a blackholed host (192.0.2.1, RFC 5737 TEST-NET-1: SYN packets are dropped,
+# not refused) the connect then lasted until the kernel exhausted SYN retransmissions
+# (~130 s) instead of connect_timeout. The profiler period is set well below
+# connect_timeout so the poll is guaranteed to be interrupted several times.
+
+MYSQL_DB="${CLICKHOUSE_DATABASE}_mysql"
+ATTACH_QUERY_ID="${CLICKHOUSE_DATABASE}_mysql_timeout_attach_${RANDOM}${RANDOM}"
+
+CLICKHOUSE_CLIENT_QUIET=$(echo "${CLICKHOUSE_CLIENT}" | sed "s/--send_logs_level=${CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL}/--send_logs_level=fatal/g")
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE IF EXISTS ${MYSQL_DB}"
+
+${CLICKHOUSE_CLIENT_QUIET} --query_id "${ATTACH_QUERY_ID}" \
+    --query_profiler_real_time_period_ns 100000000 \
+    -q "ATTACH DATABASE ${MYSQL_DB} ENGINE = MySQL('192.0.2.1:3306', 'fake_db', 'user', 'password') SETTINGS connect_timeout = 1, connection_max_tries = 1"
+
+${CLICKHOUSE_CLIENT} -q "
+    SYSTEM FLUSH LOGS query_log;
+    SELECT 'attach_bounded_by_timeout', query_duration_ms < 60000 FROM system.query_log
+    WHERE current_database = currentDatabase() AND query_id = '${ATTACH_QUERY_ID}' AND type = 'QueryFinish';
+"
+
+${CLICKHOUSE_CLIENT_QUIET} -q "DROP DATABASE ${MYSQL_DB}"

--- a/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.sh
+++ b/tests/queries/0_stateless/04507_mysql_connect_timeout_under_profiler.sh
@@ -28,9 +28,13 @@ ${CLICKHOUSE_CLIENT_QUIET} --query_id "${ATTACH_QUERY_ID}" \
     --query_profiler_real_time_period_ns 100000000 \
     -q "ATTACH DATABASE ${MYSQL_DB} ENGINE = MySQL('192.0.2.1:3306', 'fake_db', 'user', 'password') SETTINGS connect_timeout = 1, connection_max_tries = 1"
 
+# The bound is 10x the configured connect_timeout (1 s): the fixed ATTACH takes ~1-2 s
+# (one bounded connection attempt plus attach overhead), the broken one ~135 s, and even
+# a partial regression (e.g. capping the retries instead of decrementing the budget)
+# would exceed 10 s while slow CI machines stay well below it.
 ${CLICKHOUSE_CLIENT} -q "
     SYSTEM FLUSH LOGS query_log;
-    SELECT 'attach_bounded_by_timeout', query_duration_ms < 60000 FROM system.query_log
+    SELECT 'attach_bounded_by_timeout', query_duration_ms < 10000 FROM system.query_log
     WHERE current_database = currentDatabase() AND query_id = '${ATTACH_QUERY_ID}' AND type = 'QueryFinish';
 "
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109472
Related: https://jira.mariadb.org/browse/CONC-834

**Problem.** The MySQL `connect_timeout` setting (and the read/write timeouts) can be silently ignored inside ClickHouse. A connection attempt to an unresponsive MySQL server — one that drops packets instead of refusing the connection — hangs for ~135 seconds (the kernel SYN-retransmission limit) even with `connect_timeout = 1`:

```sql
ATTACH DATABASE m ENGINE = MySQL('192.0.2.1:3306', 'fake_db', 'user', 'password')
SETTINGS connect_timeout = 1, connection_max_tries = 1  -- takes 2m16s instead of ~1s
```

Any query thread touching such a server blocks for minutes while holding locks (e.g. `DatabaseMySQL::mutex`), and stateless test `04210_show_remote_databases_in_system_tables` spent ~135 seconds per run on exactly this.

**Root cause.** `pvio_socket_wait_io_or_timeout` in mariadb-connector-c restarts `poll` with the full original timeout after `EINTR`. ClickHouse query threads receive sampling-profiler timer signals (`query_profiler_real_time_period_ns`, default 1 s) installed without `SA_RESTART`, so whenever the signal period does not exceed the timeout, the poll deadline is reset by every signal and never expires; with a blackholed host the poll returns only when the kernel exhausts SYN retransmissions. Verified with a C repro against the bundled library: no signals → fails in exactly 1.00 s; with a 100 ms periodic signal → 135.32 s and 1353 `EINTR`s, matching the in-server measurement. The connector and the `mysqlxx` option plumbing are otherwise correct.

**Fix.** Bump the `mariadb-connector-c` submodule to a fork commit ([`ClickHouse/mariadb-connector-c@111ec1a5`](https://github.com/ClickHouse/mariadb-connector-c/commit/111ec1a5), branch `eintr-connect-timeout`) that tracks the deadline with `CLOCK_MONOTONIC` and re-polls with the remaining time after `EINTR`, reporting `ETIMEDOUT` once the budget is exhausted. One fix covers all callers of `wait_io_or_timeout`: TCP connect, TLS handshake, and read/write waits. The same defect existed upstream; reported as [CONC-834](https://jira.mariadb.org/browse/CONC-834) and the suggested patch was accepted the same day (Closed/Fixed, fixVersions 3.3.20 and 3.4.10), so the fork patch can be dropped at the next connector version bump.

The regression test `04507_mysql_connect_timeout_under_profiler` attaches a MySQL database pointing at a blackholed TEST-NET-1 address with `connect_timeout = 1` under a 100 ms query profiler and asserts via `system.query_log` that the `ATTACH` is bounded by the timeout (fixed ≈ 2 s, unfixed ≈ 135 s). Side effect: `04210_show_remote_databases_in_system_tables` drops from ~135 s to ~4 s.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the MySQL `connect_timeout`, read and write timeouts not taking effect: a connection attempt to an unresponsive MySQL server could hang for more than two minutes even with `connect_timeout = 1`, because the sampling query profiler's periodic signals kept resetting the MySQL client's internal poll deadline.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.637` (included in `26.7` and later)
<!-- ch-version-info:end -->