### PR TITLE
Support `arrayExists` predicates for text-like indexes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -400,6 +400,8 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
                 }
             }
         }
+        /// When adding a function here (and to `traverseTreeEquals`), decide whether it also
+        /// belongs to `isSupportedArrayExistsElementFunction` below.
         else if (function_name == "equals" ||
                  function_name == "notEquals" ||
                  function_name == "has" ||
@@ -438,40 +440,22 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
     return false;
 }
 
-bool MergeTreeConditionBloomFilterText::traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out)
+/// Functions allowed as `f` in `arrayExists(x -> f(x, const), arr)` (see
+/// `traverseArrayExistsNode`). Must stay a subset of what `traverseTreeEquals` handles
+/// (see also the allowlist in `extractAtomFromTree`), restricted to positive functions of a
+/// single string whose token condition is necessary: a matching element implies its derived
+/// tokens are in the granule bloom filter, because `MergeTreeIndexAggregatorBloomFilterText`
+/// adds the tokens of every array element to it. Excluded:
+///  - negative functions (`notEquals`, `notLike`): their granule condition claims that absent
+///    tokens make `arrayExists` true for every row, which fails for empty arrays;
+///  - functions over whole arrays and maps (`has`, `hasAny`, `hasAll`, `mapContains*`):
+///    `traverseTreeEquals` would misinterpret them as applied to the outer column (and they
+///    are a type error on a `String` element anyway);
+///  - `hasTokenCaseInsensitive*`: they require an index on `lower(column)`, which cannot
+///    exist for an array column.
+bool MergeTreeConditionBloomFilterText::isSupportedArrayExistsElementFunction(const String & function_name)
 {
-    if (function_node.getArgumentsSize() != 2)
-        return false;
-
-    const auto * lambda_dag_node = function_node.getArgumentAt(0).getDAGNode();
-    const auto index_column_argument = function_node.getArgumentAt(1);
-
-    if (!lambda_dag_node)
-        return false;
-
-    auto lambda_body = tryExtractLambdaBodyDAG(*lambda_dag_node);
-    if (!lambda_body || lambda_body->argument_names.size() != 1 || lambda_body->actions.getOutputs().size() != 1)
-        return false;
-
-    const auto & lambda_argument_name = lambda_body->argument_names.front();
-
-    RPNBuilderTreeContext lambda_tree_context(function_node.getTreeContext().getQueryContext());
-    RPNBuilderTreeNode body_node(lambda_body->actions.getOutputs().front(), lambda_tree_context);
-    if (!body_node.isFunction())
-        return false;
-
-    const auto body_function = body_node.toFunctionNode();
-    const auto function_name = body_function.getFunctionName();
-
-    /// Only functions that derive a necessary token condition from the constant are allowed: a
-    /// row-level element match implies that the derived tokens are present in the granule bloom
-    /// filter, because the aggregator feeds tokens of every array element into it. Negative
-    /// functions (`notEquals`, `notLike`) are excluded: their granule condition claims that if
-    /// the tokens are absent, `arrayExists` is true for every row, which fails for empty arrays.
-    /// Functions that expect an array or map lambda argument (`has`, `hasAny`, `mapContains`, ...)
-    /// are excluded because `traverseTreeEquals` would misinterpret them as applied to the outer
-    /// column.
-    const bool is_supported_function = function_name == "equals"
+    return function_name == "equals"
         || function_name == "like"
         || function_name == "startsWith"
         || function_name == "endsWith"
@@ -479,32 +463,41 @@ bool MergeTreeConditionBloomFilterText::traverseArrayExistsNode(const RPNBuilder
         || function_name == "match"
         || function_name == "hasToken"
         || function_name == "hasTokenOrNull";
+}
 
-    if (!is_supported_function || body_function.getArgumentsSize() != 2)
+bool MergeTreeConditionBloomFilterText::traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out)
+{
+    auto element_predicate = tryExtractArrayExistsElementPredicate(function_node);
+    if (!element_predicate)
         return false;
 
-    const auto lhs_argument = body_function.getArgumentAt(0);
-    const auto rhs_argument = body_function.getArgumentAt(1);
+    const auto index_column_argument = function_node.getArgumentAt(1);
+    const auto function_name = element_predicate->body_function.getFunctionName();
+
+    /// `elem IN (constant set)`: a matching element carries all tokens of some set element,
+    /// so a granule with a matching row contains all tokens of at least one set element.
+    /// That is the same condition `tryPrepareSetBloomFilter` derives for `column IN (set)`.
+    /// `notIn` is excluded like the other negative functions: its granule condition is wrong
+    /// for empty arrays.
+    if (function_name == "in" || function_name == "globalIn")
+    {
+        if (!tryPrepareSetBloomFilter(index_column_argument, element_predicate->search_argument, out))
+            return false;
+
+        out.function = RPNElement::FUNCTION_IN;
+        return true;
+    }
+
+    if (!isSupportedArrayExistsElementFunction(function_name))
+        return false;
 
     Field const_value;
     DataTypePtr const_type;
 
-    if (isLambdaArgumentReference(lhs_argument, lambda_argument_name)
-        && rhs_argument.tryGetConstant(const_value, const_type)
-        && traverseTreeEquals(function_name, index_column_argument, const_type, const_value, out))
-    {
-        return true;
-    }
+    if (!element_predicate->search_argument.tryGetConstant(const_value, const_type))
+        return false;
 
-    if (function_name == "equals"
-        && isLambdaArgumentReference(rhs_argument, lambda_argument_name)
-        && lhs_argument.tryGetConstant(const_value, const_type)
-        && traverseTreeEquals(function_name, index_column_argument, const_type, const_value, out))
-    {
-        return true;
-    }
-
-    return false;
+    return traverseTreeEquals(function_name, index_column_argument, const_type, const_value, out);
 }
 
 bool MergeTreeConditionBloomFilterText::traverseTreeEquals(

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.cpp
@@ -375,6 +375,9 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
             }
         }
 
+        if (function_name == "arrayExists" && traverseArrayExistsNode(function_node, out))
+            return true;
+
         if (arguments_size != 2)
             return false;
 
@@ -430,6 +433,75 @@ bool MergeTreeConditionBloomFilterText::extractAtomFromTree(const RPNBuilderTree
                     return true;
             }
         }
+    }
+
+    return false;
+}
+
+bool MergeTreeConditionBloomFilterText::traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out)
+{
+    if (function_node.getArgumentsSize() != 2)
+        return false;
+
+    const auto * lambda_dag_node = function_node.getArgumentAt(0).getDAGNode();
+    const auto index_column_argument = function_node.getArgumentAt(1);
+
+    if (!lambda_dag_node)
+        return false;
+
+    auto lambda_body = tryExtractLambdaBodyDAG(*lambda_dag_node);
+    if (!lambda_body || lambda_body->argument_names.size() != 1 || lambda_body->actions.getOutputs().size() != 1)
+        return false;
+
+    const auto & lambda_argument_name = lambda_body->argument_names.front();
+
+    RPNBuilderTreeContext lambda_tree_context(function_node.getTreeContext().getQueryContext());
+    RPNBuilderTreeNode body_node(lambda_body->actions.getOutputs().front(), lambda_tree_context);
+    if (!body_node.isFunction())
+        return false;
+
+    const auto body_function = body_node.toFunctionNode();
+    const auto function_name = body_function.getFunctionName();
+
+    /// Only functions that derive a necessary token condition from the constant are allowed: a
+    /// row-level element match implies that the derived tokens are present in the granule bloom
+    /// filter, because the aggregator feeds tokens of every array element into it. Negative
+    /// functions (`notEquals`, `notLike`) are excluded: their granule condition claims that if
+    /// the tokens are absent, `arrayExists` is true for every row, which fails for empty arrays.
+    /// Functions that expect an array or map lambda argument (`has`, `hasAny`, `mapContains`, ...)
+    /// are excluded because `traverseTreeEquals` would misinterpret them as applied to the outer
+    /// column.
+    const bool is_supported_function = function_name == "equals"
+        || function_name == "like"
+        || function_name == "startsWith"
+        || function_name == "endsWith"
+        || function_name == "multiSearchAny"
+        || function_name == "match"
+        || function_name == "hasToken"
+        || function_name == "hasTokenOrNull";
+
+    if (!is_supported_function || body_function.getArgumentsSize() != 2)
+        return false;
+
+    const auto lhs_argument = body_function.getArgumentAt(0);
+    const auto rhs_argument = body_function.getArgumentAt(1);
+
+    Field const_value;
+    DataTypePtr const_type;
+
+    if (isLambdaArgumentReference(lhs_argument, lambda_argument_name)
+        && rhs_argument.tryGetConstant(const_value, const_type)
+        && traverseTreeEquals(function_name, index_column_argument, const_type, const_value, out))
+    {
+        return true;
+    }
+
+    if (function_name == "equals"
+        && isLambdaArgumentReference(rhs_argument, lambda_argument_name)
+        && lhs_argument.tryGetConstant(const_value, const_type)
+        && traverseTreeEquals(function_name, index_column_argument, const_type, const_value, out))
+    {
+        return true;
     }
 
     return false;

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -131,6 +131,8 @@ private:
 
     bool extractAtomFromTree(const RPNBuilderTreeNode & node, RPNElement & out);
 
+    bool traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out);
+
     bool traverseTreeEquals(
         const String & function_name,
         const RPNBuilderTreeNode & key_node,

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilterText.h
@@ -131,6 +131,8 @@ private:
 
     bool extractAtomFromTree(const RPNBuilderTreeNode & node, RPNElement & out);
 
+    static bool isSupportedArrayExistsElementFunction(const String & function_name);
+
     bool traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out);
 
     bool traverseTreeEquals(

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -54,6 +54,22 @@ namespace Setting
     extern const SettingsBool reject_expensive_hyperscan_regexps;
 }
 
+namespace
+{
+
+bool isLambdaArgumentReference(const RPNBuilderTreeNode & node, std::string_view lambda_argument_name)
+{
+    const auto * dag_node = node.getDAGNode();
+    if (!dag_node)
+        return false;
+
+    dag_node = getNodeWithoutAlias(dag_node);
+    return dag_node->type == ActionsDAG::ActionType::INPUT
+        && dag_node->result_name == lambda_argument_name;
+}
+
+}
+
 TextSearchQuery::TextSearchQuery(String function_name_, TextSearchMode search_mode_, TextIndexDirectReadMode direct_read_mode_, VectorWithMemoryTracking<String> tokens_, std::vector<OptimizedRegularExpression> patterns_)
     : function_name(std::move(function_name_))
     , search_mode(search_mode_)
@@ -531,6 +547,9 @@ bool MergeTreeIndexConditionText::traverseAtomNode(const RPNBuilderTreeNode & no
         if (traverseJSONSubcolumnKeyNode(function, out))
             return true;
 
+        if (function_name == "arrayExists" && traverseArrayExistsNode(function, out))
+            return true;
+
         if (function_arguments_size != 2)
             return false;
 
@@ -559,6 +578,90 @@ bool MergeTreeIndexConditionText::traverseAtomNode(const RPNBuilderTreeNode & no
                     return true;
             }
         }
+    }
+
+    return false;
+}
+
+bool MergeTreeIndexConditionText::traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const
+{
+    if (function_node.getArgumentsSize() != 2)
+        return false;
+
+    const auto * lambda_dag_node = function_node.getArgumentAt(0).getDAGNode();
+    const auto index_column_argument = function_node.getArgumentAt(1);
+
+    if (!lambda_dag_node)
+        return false;
+
+    auto lambda_body = tryExtractLambdaBodyDAG(*lambda_dag_node);
+    if (!lambda_body || lambda_body->argument_names.size() != 1 || lambda_body->actions.getOutputs().size() != 1)
+        return false;
+
+    const auto & lambda_argument_name = lambda_body->argument_names.front();
+
+    RPNBuilderTreeContext lambda_tree_context(getContext());
+    RPNBuilderTreeNode body_node(lambda_body->actions.getOutputs().front(), lambda_tree_context);
+    if (!body_node.isFunction())
+        return false;
+
+    const auto body_function = body_node.toFunctionNode();
+    const auto function_name = body_function.getFunctionName();
+    if (!isSupportedFunction(function_name) || body_function.getArgumentsSize() != 2)
+        return false;
+
+    /// Functions whose row-level result depends on the tokenizer, preprocessor or postprocessor of
+    /// the index. For plain predicates `optimizeDirectReadFromTextIndex` rewrites the call (injecting
+    /// the tokenizer and processors) so that the row-scan result agrees with the index analysis. That
+    /// rewrite does not reach inside a lambda, so allow these functions only when the index tokenizes
+    /// exactly the way the functions do by default (`splitByNonAlpha`, no processors). The remaining
+    /// supported functions (`equals`, `like`, `startsWith`, ...) derive only a necessary token
+    /// condition from the constant, which holds for any matching element.
+    const bool depends_on_index_transforms = function_name == "hasToken"
+        || function_name == "hasTokenOrNull"
+        || function_name == "hasAnyTokens"
+        || function_name == "hasAllTokens"
+        || function_name == "hasPhrase";
+
+    if (depends_on_index_transforms
+        && (tokenizer->getType() != ITokenizer::Type::SplitByNonAlpha || has_preprocessor || has_postprocessor))
+        return false;
+
+    const auto lhs_argument = body_function.getArgumentAt(0);
+    const auto rhs_argument = body_function.getArgumentAt(1);
+
+    Field const_value;
+    DataTypePtr const_type;
+
+    auto finish = [&]
+    {
+        /// The derived predicate is a safe granule-level condition, but the direct-read virtual
+        /// column is built for the inner text-search predicate, not for the `arrayExists` wrapper.
+        /// Keep the original predicate on the row-scan path: cap the direct read mode at a hint
+        /// so the predicate is never replaced exactly, and preserve `None` where the inner
+        /// function would not use direct read for a plain column either.
+        for (auto & query : out.text_search_queries)
+        {
+            if (query->direct_read_mode != TextIndexDirectReadMode::None)
+                query->direct_read_mode = getHintOrNoneMode();
+        }
+
+        return true;
+    };
+
+    if (isLambdaArgumentReference(lhs_argument, lambda_argument_name)
+        && rhs_argument.tryGetConstant(const_value, const_type)
+        && traverseFunctionNode(body_function, index_column_argument, const_type, const_value, out))
+    {
+        return finish();
+    }
+
+    if (function_name == "equals"
+        && isLambdaArgumentReference(rhs_argument, lambda_argument_name)
+        && lhs_argument.tryGetConstant(const_value, const_type)
+        && traverseFunctionNode(body_function, index_column_argument, const_type, const_value, out))
+    {
+        return finish();
     }
 
     return false;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -216,6 +216,8 @@ bool MergeTreeIndexConditionText::requiresReadingAllTokens(const RPNElement & el
     }
 }
 
+/// When adding a function here, decide whether it also belongs to
+/// `isSupportedArrayExistsElementFunction` below.
 bool MergeTreeIndexConditionText::isSupportedFunction(const String & function_name)
 {
     return function_name == "hasToken"
@@ -239,6 +241,34 @@ bool MergeTreeIndexConditionText::isSupportedFunction(const String & function_na
         || function_name == "multiSearchAny"
         || function_name == "multiSearchAnyUTF8"
         || function_name == "multiMatchAny";
+}
+
+/// Functions allowed as `f` in `arrayExists(x -> f(x, const), arr)` (see
+/// `traverseArrayExistsNode`). To enable a function here:
+///  - its granule condition must be necessary for an element match, i.e. a matching element
+///    implies the derived tokens are present in the granule (`MergeTreeIndexAggregatorText`
+///    adds the tokens of every array element to the granule);
+///  - if its row-level result depends on the tokenizer or pre/postprocessor of the index,
+///    add it to `depends_on_index_transforms` in `traverseArrayExistsNode`.
+/// Functions over whole arrays and maps (`has`, `hasAny`, `hasAll`, `mapContains*`) must stay
+/// excluded: the lambda argument is a single `String` element (a type error for them), and
+/// `traverseFunctionNode` would misinterpret them as applied to the outer column.
+bool MergeTreeIndexConditionText::isSupportedArrayExistsElementFunction(const String & function_name)
+{
+    return function_name == "equals"
+        || function_name == "like"
+        || function_name == "ilike"
+        || function_name == "startsWith"
+        || function_name == "endsWith"
+        || function_name == "match"
+        || function_name == "multiSearchAny"
+        || function_name == "multiSearchAnyUTF8"
+        || function_name == "multiMatchAny"
+        || function_name == "hasToken"
+        || function_name == "hasTokenOrNull"
+        || function_name == "hasAnyTokens"
+        || function_name == "hasAllTokens"
+        || function_name == "hasPhrase";
 }
 
 TextIndexDirectReadMode MergeTreeIndexConditionText::getHintOrNoneMode() const
@@ -569,38 +599,52 @@ bool MergeTreeIndexConditionText::traverseAtomNode(const RPNBuilderTreeNode & no
 
 bool MergeTreeIndexConditionText::traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const
 {
-    if (function_node.getArgumentsSize() != 2)
+    auto element_predicate = tryExtractArrayExistsElementPredicate(function_node);
+    if (!element_predicate)
         return false;
 
-    const auto * lambda_dag_node = function_node.getArgumentAt(0).getDAGNode();
     const auto index_column_argument = function_node.getArgumentAt(1);
-
-    if (!lambda_dag_node)
-        return false;
-
-    auto lambda_body = tryExtractLambdaBodyDAG(*lambda_dag_node);
-    if (!lambda_body || lambda_body->argument_names.size() != 1 || lambda_body->actions.getOutputs().size() != 1)
-        return false;
-
-    const auto & lambda_argument_name = lambda_body->argument_names.front();
-
-    RPNBuilderTreeContext lambda_tree_context(getContext());
-    RPNBuilderTreeNode body_node(lambda_body->actions.getOutputs().front(), lambda_tree_context);
-    if (!body_node.isFunction())
-        return false;
-
-    const auto body_function = body_node.toFunctionNode();
+    const auto & body_function = element_predicate->body_function;
     const auto function_name = body_function.getFunctionName();
-    if (!isSupportedFunction(function_name) || body_function.getArgumentsSize() != 2)
+
+    auto finish = [&]
+    {
+        /// The virtual column answers the token query derived from the lambda, which is only a
+        /// necessary condition for `arrayExists`: tokens can come from different elements, and
+        /// `LIKE`/`match` can have false positives. Use at most hint mode, so the virtual column
+        /// can prefilter rows while `arrayExists` is still evaluated for each row. Keep `None`
+        /// where the inner function would not use direct read for a plain column either.
+        for (auto & query : out.text_search_queries)
+        {
+            if (query->direct_read_mode != TextIndexDirectReadMode::None)
+                query->direct_read_mode = getHintOrNoneMode();
+        }
+
+        return true;
+    };
+
+    /// `elem IN (constant set)`: a matching element carries all tokens of some set element,
+    /// so a granule with a matching row contains all tokens of at least one set element.
+    /// That is the same condition `tryPrepareSetForTextSearch` derives for `column IN (set)`.
+    if (function_name == "in" || function_name == "globalIn")
+    {
+        if (!tryPrepareSetForTextSearch(index_column_argument, element_predicate->search_argument, function_name, out))
+            return false;
+
+        out.function = RPNElement::FUNCTION_HAS_ANY_ELEMENTS;
+        return finish();
+    }
+
+    if (!isSupportedArrayExistsElementFunction(function_name))
         return false;
 
-    /// Functions whose row-level result depends on the tokenizer, preprocessor or postprocessor of
-    /// the index. For plain predicates `optimizeDirectReadFromTextIndex` rewrites the call (injecting
-    /// the tokenizer and processors) so that the row-scan result agrees with the index analysis. That
-    /// rewrite does not reach inside a lambda, so allow these functions only when the index tokenizes
-    /// exactly the way the functions do by default (`splitByNonAlpha`, no processors). The remaining
-    /// supported functions (`equals`, `like`, `startsWith`, ...) derive only a necessary token
-    /// condition from the constant, which holds for any matching element.
+    /// These functions' row-level result depends on the tokenizer and pre/postprocessor of the
+    /// index. For plain predicates `optimizeDirectReadFromTextIndex` injects them into the call
+    /// so that evaluation on rows agrees with the index analysis, but that rewrite does not
+    /// reach inside a lambda. Allow them only when the index tokenizes exactly as the functions
+    /// do by default: `splitByNonAlpha`, no processors. The remaining supported functions
+    /// (`equals`, `like`, `startsWith`, ...) derive only a necessary token condition from the
+    /// constant, which holds for any matching element.
     const bool depends_on_index_transforms = function_name == "hasToken"
         || function_name == "hasTokenOrNull"
         || function_name == "hasAnyTokens"
@@ -611,44 +655,16 @@ bool MergeTreeIndexConditionText::traverseArrayExistsNode(const RPNBuilderFuncti
         && (tokenizer->getType() != ITokenizer::Type::SplitByNonAlpha || has_preprocessor || has_postprocessor))
         return false;
 
-    const auto lhs_argument = body_function.getArgumentAt(0);
-    const auto rhs_argument = body_function.getArgumentAt(1);
-
     Field const_value;
     DataTypePtr const_type;
 
-    auto finish = [&]
-    {
-        /// The derived predicate is a safe granule-level condition, but the direct-read virtual
-        /// column is built for the inner text-search predicate, not for the `arrayExists` wrapper.
-        /// Keep the original predicate on the row-scan path: cap the direct read mode at a hint
-        /// so the predicate is never replaced exactly, and preserve `None` where the inner
-        /// function would not use direct read for a plain column either.
-        for (auto & query : out.text_search_queries)
-        {
-            if (query->direct_read_mode != TextIndexDirectReadMode::None)
-                query->direct_read_mode = getHintOrNoneMode();
-        }
+    if (!element_predicate->search_argument.tryGetConstant(const_value, const_type))
+        return false;
 
-        return true;
-    };
+    if (!traverseFunctionNode(body_function, index_column_argument, const_type, const_value, out))
+        return false;
 
-    if (isLambdaArgumentReference(lhs_argument, lambda_argument_name)
-        && rhs_argument.tryGetConstant(const_value, const_type)
-        && traverseFunctionNode(body_function, index_column_argument, const_type, const_value, out))
-    {
-        return finish();
-    }
-
-    if (function_name == "equals"
-        && isLambdaArgumentReference(rhs_argument, lambda_argument_name)
-        && lhs_argument.tryGetConstant(const_value, const_type)
-        && traverseFunctionNode(body_function, index_column_argument, const_type, const_value, out))
-    {
-        return finish();
-    }
-
-    return false;
+    return finish();
 }
 
 VectorWithMemoryTracking<String> MergeTreeIndexConditionText::stringToTokens(const Field & field) const

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -54,22 +54,6 @@ namespace Setting
     extern const SettingsBool reject_expensive_hyperscan_regexps;
 }
 
-namespace
-{
-
-bool isLambdaArgumentReference(const RPNBuilderTreeNode & node, std::string_view lambda_argument_name)
-{
-    const auto * dag_node = node.getDAGNode();
-    if (!dag_node)
-        return false;
-
-    dag_node = getNodeWithoutAlias(dag_node);
-    return dag_node->type == ActionsDAG::ActionType::INPUT
-        && dag_node->result_name == lambda_argument_name;
-}
-
-}
-
 TextSearchQuery::TextSearchQuery(String function_name_, TextSearchMode search_mode_, TextIndexDirectReadMode direct_read_mode_, VectorWithMemoryTracking<String> tokens_, std::vector<OptimizedRegularExpression> patterns_)
     : function_name(std::move(function_name_))
     , search_mode(search_mode_)

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -139,6 +139,7 @@ private:
     using RPN = std::vector<RPNElement>;
 
     bool traverseAtomNode(const RPNBuilderTreeNode & node, RPNElement & out) const;
+    bool traverseArrayExistsNode(const RPNBuilderFunctionTreeNode & function_node, RPNElement & out) const;
 
     bool traverseFunctionNode(
         const RPNBuilderFunctionTreeNode & function_node,

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -81,6 +81,7 @@ public:
 
     ~MergeTreeIndexConditionText() override = default;
     static bool isSupportedFunction(const String & function_name);
+    static bool isSupportedArrayExistsElementFunction(const String & function_name);
     TextIndexDirectReadMode getDirectReadMode(const String & function_name) const;
 
     bool alwaysUnknownOrTrue() const override;

--- a/src/Storages/MergeTree/MergeTreeIndexSet.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexSet.cpp
@@ -17,6 +17,7 @@
 #include <Functions/IFunctionAdaptors.h>
 #include <Functions/indexHint.h>
 #include <Planner/PlannerActionsVisitor.h>
+#include <Storages/MergeTree/RPNBuilder.h>
 
 namespace DB
 {
@@ -618,9 +619,7 @@ const ActionsDAG::Node * MergeTreeIndexConditionSet::atomFromDAG(const ActionsDA
 {
     /// Function, literal or column
 
-    const auto * node_to_check = &node;
-    while (node_to_check->type == ActionsDAG::ActionType::ALIAS)
-        node_to_check = node_to_check->children[0];
+    const auto * node_to_check = getNodeWithoutAlias(&node);
 
     if (node_to_check->column)
     {
@@ -681,9 +680,7 @@ const ActionsDAG::Node * MergeTreeIndexConditionSet::operatorFromDAG(const Actio
 {
     /// Functions AND, OR, NOT. Replace with bit*.
 
-    const auto * node_to_check = &node;
-    while (node_to_check->type == ActionsDAG::ActionType::ALIAS)
-        node_to_check = node_to_check->children[0];
+    const auto * node_to_check = getNodeWithoutAlias(&node);
 
     if (node_to_check->column)
         return nullptr;
@@ -743,9 +740,7 @@ const ActionsDAG::Node * MergeTreeIndexConditionSet::operatorFromDAG(const Actio
 
 bool MergeTreeIndexConditionSet::checkDAGUseless(const ActionsDAG::Node & node, const ContextPtr & context, std::vector<FutureSetPtr> & sets_to_prepare, bool atomic) const
 {
-    const auto * node_to_check = &node;
-    while (node_to_check->type == ActionsDAG::ActionType::ALIAS)
-        node_to_check = node_to_check->children[0];
+    const auto * node_to_check = getNodeWithoutAlias(&node);
 
     RPNBuilderTreeContext tree_context(context);
     RPNBuilderTreeNode tree_node(node_to_check, tree_context);

--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -54,7 +54,7 @@ void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & o
 /// constant-folded COLUMN nodes that hold a `ColumnConst<ColumnFunction>` (e.g. when all captured
 /// arguments are constants and `removeUnusedActions` collapsed the FUNCTION into a COLUMN).
 void appendLambdaColumnName(
-    const LambdaCapture & capture,
+    const Names & argument_names,
     ActionsDAG capture_dag,
     WriteBuffer & out,
     const ContextPtr & context,
@@ -63,13 +63,13 @@ void appendLambdaColumnName(
 {
     writeString("lambda(tuple(", out);
     bool first = true;
-    for (const auto & arg : capture.lambda_arguments)
+    for (const auto & arg_name : argument_names)
     {
         if (!first)
             writeCString(", ", out);
         first = false;
 
-        writeString(arg.name, out);
+        writeString(arg_name, out);
     }
     writeString("), ", out);
 
@@ -89,47 +89,11 @@ bool tryAppendConstantFunctionColumnName(
     bool use_analyzer,
     bool legacy)
 {
-    const auto * column_const = node.column.get();
-    if (!column_const)
+    auto lambda_body = tryExtractLambdaBodyDAG(node);
+    if (!lambda_body)
         return false;
 
-    const auto * column_function = typeid_cast<const ColumnFunction *>(&column_const->getDataColumn());
-    if (!column_function)
-        return false;
-
-    const auto * function_expression = typeid_cast<const FunctionExpression *>(column_function->getFunction().get());
-    if (!function_expression)
-        return false;
-
-    const auto & capture = function_expression->getCapture();
-    auto capture_dag = function_expression->getAcionsDAG().clone();
-
-    /// Stitch the captured constant columns into the body DAG so the body's input nodes
-    /// are resolved to actual constants. After `ActionsDAGWithInversionPushDown` rewrites
-    /// the constant column names to their AST form, the resulting name will match the one
-    /// produced for the index sample block (which was built via the old analyzer).
-    const auto & captured_columns = column_function->getCapturedColumns();
-    if (!captured_columns.empty())
-    {
-        if (captured_columns.size() != capture.captured_names.size())
-            return false;
-
-        ActionsDAG captured_columns_dag;
-        auto & outputs = captured_columns_dag.getOutputs();
-        outputs.reserve(captured_columns.size());
-        for (size_t i = 0; i < captured_columns.size(); ++i)
-        {
-            const auto & captured = captured_columns[i];
-            auto captured_column_const = assert_cast<const ColumnConst &>(*captured.column).getPtr();
-            const auto & captured_node = captured_columns_dag.addColumn(std::move(captured_column_const), captured.type, captured.name);
-            const auto & alias_node = captured_columns_dag.addAlias(captured_node, capture.captured_names[i]);
-            outputs.push_back(&alias_node);
-        }
-
-        capture_dag = ActionsDAG::merge(std::move(captured_columns_dag), std::move(capture_dag));
-    }
-
-    appendLambdaColumnName(capture, std::move(capture_dag), out, context, use_analyzer, legacy);
+    appendLambdaColumnName(lambda_body->argument_names, std::move(lambda_body->actions), out, context, use_analyzer, legacy);
     return true;
 }
 
@@ -167,21 +131,9 @@ void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & o
             break;
         case ActionsDAG::ActionType::FUNCTION:
         {
-            if (const auto * func_capture = typeid_cast<const ExecutableFunctionCapture *>(node.function.get()))
+            if (auto lambda_body = tryExtractLambdaBodyDAG(node))
             {
-                const auto & capture = func_capture->getCapture();
-                auto capture_dag = func_capture->getActions()->getActionsDAG().clone();
-                if (!node.children.empty())
-                {
-                    auto captured_columns_dag = ActionsDAG::cloneSubDAG(node.children, false);
-                    auto & outputs = captured_columns_dag.getOutputs();
-                    for (size_t i = 0; i < capture->captured_names.size(); ++i)
-                        outputs[i] = &captured_columns_dag.addAlias(*outputs[i], capture->captured_names[i]);
-
-                    capture_dag = ActionsDAG::merge(std::move(captured_columns_dag), std::move(capture_dag));
-                }
-
-                appendLambdaColumnName(*capture, std::move(capture_dag), out, context, use_analyzer, legacy);
+                appendLambdaColumnName(lambda_body->argument_names, std::move(lambda_body->actions), out, context, use_analyzer, legacy);
                 break;
             }
             else
@@ -221,6 +173,8 @@ String getColumnNameWithoutAlias(const ActionsDAG::Node & node, const ContextPtr
     return std::move(out.str());
 }
 
+}
+
 const ActionsDAG::Node * getNodeWithoutAlias(const ActionsDAG::Node * node)
 {
     const ActionsDAG::Node * result = node;
@@ -231,6 +185,87 @@ const ActionsDAG::Node * getNodeWithoutAlias(const ActionsDAG::Node * node)
     return result;
 }
 
+std::optional<DAGLambdaBody> tryExtractLambdaBodyDAG(const ActionsDAG::Node & node)
+{
+    const auto * node_without_alias = getNodeWithoutAlias(&node);
+
+    const LambdaCapture * capture = nullptr;
+    std::optional<ActionsDAG> actions;
+
+    if (node_without_alias->type == ActionsDAG::ActionType::FUNCTION)
+    {
+        const auto * function_capture = typeid_cast<const ExecutableFunctionCapture *>(node_without_alias->function.get());
+        if (!function_capture)
+            return std::nullopt;
+
+        capture = function_capture->getCapture().get();
+        actions = function_capture->getActions()->getActionsDAG().clone();
+
+        if (!node_without_alias->children.empty())
+        {
+            if (node_without_alias->children.size() != capture->captured_names.size())
+                return std::nullopt;
+
+            auto captured_columns_dag = ActionsDAG::cloneSubDAG(node_without_alias->children, false);
+            auto & outputs = captured_columns_dag.getOutputs();
+            for (size_t i = 0; i < capture->captured_names.size(); ++i)
+                outputs[i] = &captured_columns_dag.addAlias(*outputs[i], capture->captured_names[i]);
+
+            actions = ActionsDAG::merge(std::move(captured_columns_dag), std::move(*actions));
+        }
+    }
+    else if (node_without_alias->type == ActionsDAG::ActionType::COLUMN && node_without_alias->column)
+    {
+        const auto * column_function = typeid_cast<const ColumnFunction *>(&node_without_alias->column->getDataColumn());
+        if (!column_function)
+            return std::nullopt;
+
+        const auto * function_expression = typeid_cast<const FunctionExpression *>(column_function->getFunction().get());
+        if (!function_expression)
+            return std::nullopt;
+
+        capture = &function_expression->getCapture();
+        actions = function_expression->getAcionsDAG().clone();
+
+        /// Stitch the captured constant columns into the body DAG so the body's input nodes
+        /// are resolved to actual constants. After `ActionsDAGWithInversionPushDown` rewrites
+        /// the constant column names to their AST form, the resulting name will match the one
+        /// produced for the index sample block (which was built via the old analyzer).
+        const auto & captured_columns = column_function->getCapturedColumns();
+        if (!captured_columns.empty())
+        {
+            if (captured_columns.size() != capture->captured_names.size())
+                return std::nullopt;
+
+            ActionsDAG captured_columns_dag;
+            auto & outputs = captured_columns_dag.getOutputs();
+            outputs.reserve(captured_columns.size());
+            for (size_t i = 0; i < captured_columns.size(); ++i)
+            {
+                const auto & captured = captured_columns[i];
+                const auto * captured_column_const = typeid_cast<const ColumnConst *>(captured.column.get());
+                if (!captured_column_const)
+                    return std::nullopt;
+
+                const auto & captured_node = captured_columns_dag.addColumn(captured_column_const->getPtr(), captured.type, captured.name);
+                const auto & alias_node = captured_columns_dag.addAlias(captured_node, capture->captured_names[i]);
+                outputs.push_back(&alias_node);
+            }
+
+            actions = ActionsDAG::merge(std::move(captured_columns_dag), std::move(*actions));
+        }
+    }
+    else
+    {
+        return std::nullopt;
+    }
+
+    Names argument_names;
+    argument_names.reserve(capture->lambda_arguments.size());
+    for (const auto & lambda_argument : capture->lambda_arguments)
+        argument_names.push_back(lambda_argument.name);
+
+    return DAGLambdaBody{std::move(argument_names), std::move(*actions)};
 }
 
 RPNBuilderTreeContext::RPNBuilderTreeContext(ContextPtr query_context_)

--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -612,6 +612,43 @@ RPNBuilderTreeNode RPNBuilderFunctionTreeNode::getArgumentAt(size_t index) const
     return RPNBuilderTreeNode(dag_node->children[index], tree_context);
 }
 
+std::optional<ArrayExistsElementPredicate> tryExtractArrayExistsElementPredicate(const RPNBuilderFunctionTreeNode & array_exists_node)
+{
+    if (array_exists_node.getArgumentsSize() != 2)
+        return std::nullopt;
+
+    const auto * lambda_dag_node = array_exists_node.getArgumentAt(0).getDAGNode();
+    if (!lambda_dag_node)
+        return std::nullopt;
+
+    auto lambda_body = tryExtractLambdaBodyDAG(*lambda_dag_node);
+    if (!lambda_body || lambda_body->argument_names.size() != 1 || lambda_body->actions.getOutputs().size() != 1)
+        return std::nullopt;
+
+    const auto & lambda_argument_name = lambda_body->argument_names.front();
+
+    auto lambda_tree_context = std::make_unique<RPNBuilderTreeContext>(array_exists_node.getTreeContext().getQueryContext());
+    RPNBuilderTreeNode body_node(lambda_body->actions.getOutputs().front(), *lambda_tree_context);
+    if (!body_node.isFunction())
+        return std::nullopt;
+
+    auto body_function = body_node.toFunctionNode();
+    if (body_function.getArgumentsSize() != 2)
+        return std::nullopt;
+
+    std::optional<size_t> search_argument_index;
+    if (isLambdaArgumentReference(body_function.getArgumentAt(0), lambda_argument_name))
+        search_argument_index = 1;
+    else if (body_function.getFunctionName() == "equals" && isLambdaArgumentReference(body_function.getArgumentAt(1), lambda_argument_name))
+        search_argument_index = 0;
+
+    if (!search_argument_index)
+        return std::nullopt;
+
+    auto search_argument = body_function.getArgumentAt(*search_argument_index);
+    return ArrayExistsElementPredicate{std::move(*lambda_body), std::move(lambda_tree_context), body_function, search_argument};
+}
+
 template <typename RPNElement>
 RPNBuilder<RPNElement>::RPNBuilder(
     const ActionsDAG::Node * filter_actions_dag_node,

--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -268,6 +268,17 @@ std::optional<DAGLambdaBody> tryExtractLambdaBodyDAG(const ActionsDAG::Node & no
     return DAGLambdaBody{std::move(argument_names), std::move(*actions)};
 }
 
+bool isLambdaArgumentReference(const RPNBuilderTreeNode & node, std::string_view lambda_argument_name)
+{
+    const auto * dag_node = node.getDAGNode();
+    if (!dag_node)
+        return false;
+
+    dag_node = getNodeWithoutAlias(dag_node);
+    return dag_node->type == ActionsDAG::ActionType::INPUT
+        && dag_node->result_name == lambda_argument_name;
+}
+
 RPNBuilderTreeContext::RPNBuilderTreeContext(ContextPtr query_context_)
     : query_context(std::move(query_context_))
 {}

--- a/src/Storages/MergeTree/RPNBuilder.h
+++ b/src/Storages/MergeTree/RPNBuilder.h
@@ -171,6 +171,10 @@ protected:
     RPNBuilderTreeContext & tree_context;
 };
 
+/// Whether `node` is a reference to the lambda argument with the given name
+/// (an INPUT node, possibly under aliases).
+bool isLambdaArgumentReference(const RPNBuilderTreeNode & node, std::string_view lambda_argument_name);
+
 /** RPNBuilderFunctionTreeNode is wrapper around RPNBuilderTreeNode with function type.
   * It provide additional functionality that is specific for function.
   */

--- a/src/Storages/MergeTree/RPNBuilder.h
+++ b/src/Storages/MergeTree/RPNBuilder.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <optional>
+
 #include <Core/Block.h>
+#include <Core/Names.h>
 
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/ActionsDAG.h>
@@ -66,6 +69,26 @@ private:
     /// Valid only for AST tree
     PreparedSetsPtr prepared_sets;
 };
+
+/// A lambda body extracted from an `ActionsDAG` node.
+struct DAGLambdaBody
+{
+    /// Lambda arguments in declaration order.
+    Names argument_names;
+    /// Body DAG with captured expressions stitched into its inputs under their captured
+    /// names; the first output is the body result.
+    ActionsDAG actions;
+};
+
+/// Recognizes a lambda in both of its DAG representations:
+///  - a FUNCTION node wrapping `ExecutableFunctionCapture` (captured expressions are the node children);
+///  - a constant-folded COLUMN node holding `ColumnConst` of `ColumnFunction`.
+/// Aliases are unwrapped first. Returns std::nullopt if the node is not a lambda or its
+/// representation is inconsistent.
+std::optional<DAGLambdaBody> tryExtractLambdaBodyDAG(const ActionsDAG::Node & node);
+
+/// Unwraps ALIAS nodes, returning the first non-ALIAS node underneath.
+const ActionsDAG::Node * getNodeWithoutAlias(const ActionsDAG::Node * node);
 
 class RPNBuilderFunctionTreeNode;
 

--- a/src/Storages/MergeTree/RPNBuilder.h
+++ b/src/Storages/MergeTree/RPNBuilder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 
 #include <Core/Block.h>
@@ -80,11 +81,11 @@ struct DAGLambdaBody
     ActionsDAG actions;
 };
 
-/// Recognizes a lambda in both of its DAG representations:
-///  - a FUNCTION node wrapping `ExecutableFunctionCapture` (captured expressions are the node children);
-///  - a constant-folded COLUMN node holding `ColumnConst` of `ColumnFunction`.
-/// Aliases are unwrapped first. Returns std::nullopt if the node is not a lambda or its
-/// representation is inconsistent.
+/// Recognizes a lambda in both of its DAG representations: a FUNCTION node whose function is
+/// `ExecutableFunctionCapture` (captured expressions are the node children) and a
+/// constant-folded COLUMN node that holds a `ColumnConst` of `ColumnFunction`. Aliases are
+/// unwrapped first. Returns std::nullopt if the node is not a lambda or its representation
+/// is inconsistent.
 std::optional<DAGLambdaBody> tryExtractLambdaBodyDAG(const ActionsDAG::Node & node);
 
 /// Unwraps ALIAS nodes, returning the first non-ALIAS node underneath.
@@ -194,6 +195,34 @@ public:
     /// Get function argument at index
     RPNBuilderTreeNode getArgumentAt(size_t index) const;
 };
+
+/** Result of matching the shape `arrayExists(elem -> f(elem, rhs), column)`, where `f` is a
+  * function of two arguments that takes `elem`, the only lambda argument, first. The reversed
+  * form `equals(rhs, elem)` is also recognized; every other function requires the element to
+  * be its first argument (the haystack).
+  *
+  * Lifetime: `body_function` and `search_argument` point into `lambda_body.actions` and
+  * reference `*lambda_tree_context`. Both survive moving the struct (`ActionsDAG` keeps its
+  * nodes in a `std::list`, and the context is heap-allocated), but the struct must outlive
+  * any use of them.
+  */
+struct ArrayExistsElementPredicate
+{
+    /// Owns the DAG the nodes below point into.
+    DAGLambdaBody lambda_body;
+    /// Owns the tree context the nodes below reference.
+    std::unique_ptr<RPNBuilderTreeContext> lambda_tree_context;
+    /// The lambda body `f(elem, rhs)` (or `equals(rhs, elem)`).
+    RPNBuilderFunctionTreeNode body_function;
+    /// The argument of `body_function` other than the element: a constant, a set, etc.
+    /// Not validated here.
+    RPNBuilderTreeNode search_argument;
+};
+
+/// Matches `array_exists_node` against the shape described above. Neither the function nor
+/// `search_argument` is validated: each index decides which functions are sound for it and
+/// what the search argument must look like (constant, set, ...).
+std::optional<ArrayExistsElementPredicate> tryExtractArrayExistsElementPredicate(const RPNBuilderFunctionTreeNode & array_exists_node);
 
 /** RPN Builder build stack of reverse polish notation elements (RPNElements) required for index analysis.
   *

--- a/tests/queries/0_stateless/04501_array_exists_text_index.reference
+++ b/tests/queries/0_stateless/04501_array_exists_text_index.reference
@@ -19,6 +19,32 @@ arrayExists with hasToken uses the text index when the index matches hasToken se
 1
 3
 5
+arrayExists with hasAnyTokens, hasAllTokens and hasPhrase uses the text index
+1
+3
+4
+5
+1
+2
+1
+arrayExists with startsWith and endsWith uses the text index
+4
+3
+arrayExists with ILIKE uses the text index
+1
+3
+5
+arrayExists with multiSearchAny, multiSearchAnyUTF8 and multiMatchAny uses the text index
+1
+2
+1
+2
+1
+arrayExists with IN over a constant set uses the text index
+3
+4
+Granules: 2/6
+negative functions inside the lambda do not use the index
 negated arrayExists stays correct
 2
 4

--- a/tests/queries/0_stateless/04501_array_exists_text_index.reference
+++ b/tests/queries/0_stateless/04501_array_exists_text_index.reference
@@ -1,0 +1,40 @@
+arrayExists with LIKE uses the text index
+1
+3
+5
+2
+5
+0
+the index prunes granules
+Granules: 1/6
+captured constants are recognized
+1
+3
+5
+the original arrayExists predicate is still applied after the index hint
+arrayExists with equals uses the text index
+4
+4
+arrayExists with hasToken uses the text index when the index matches hasToken semantics
+1
+3
+5
+negated arrayExists stays correct
+2
+4
+6
+non-constant lambda predicates do not use the index
+1
+2
+3
+4
+unsupported lambda shapes do not use the index
+token-semantics functions are rejected when the index tokenizer differs from theirs
+1
+1
+2
+LIKE and match prune granules on the ngrams index
+Granules: 1/2
+Granules: 1/2
+token-semantics functions are rejected when the index has a preprocessor
+1

--- a/tests/queries/0_stateless/04501_array_exists_text_index.sql
+++ b/tests/queries/0_stateless/04501_array_exists_text_index.sql
@@ -1,0 +1,120 @@
+-- Tags: no-parallel-replicas, no-azure-blob-storage
+-- Tests that text indexes can be used through simple `arrayExists` lambdas.
+SET explain_query_plan_default = 'legacy';
+SET enable_analyzer = 1;
+-- Otherwise `arrayExists(x -> x = c, arr)` is rewritten to `has(arr, c)` before index
+-- analysis and the equals sections below would not exercise the `arrayExists` path.
+SET optimize_rewrite_array_exists_to_has = 0;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    arr Array(String),
+    needle String,
+    INDEX idx(arr) TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1, text_index_posting_list_block_size = 10000;
+
+INSERT INTO tab VALUES
+    (1, ['abc def foo'], '%foo%'),
+    (2, ['abc def bar'], '%bar%'),
+    (3, ['foo', 'baz'], '%foo%'),
+    (4, ['xyz'], '%xyz%'),
+    (5, ['foo', 'bar'], '%foo bar%'),
+    (6, [], '');
+
+SELECT 'arrayExists with LIKE uses the text index';
+SELECT id FROM tab WHERE arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> x LIKE '%bar%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT count() FROM tab WHERE arrayExists(x -> x LIKE '%missing%', arr) SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'the index prunes granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab WHERE arrayExists(x -> x = 'xyz', arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+
+SELECT 'captured constants are recognized';
+WITH '%foo%' AS pattern SELECT id FROM tab WHERE arrayExists(x -> x LIKE pattern, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'the original arrayExists predicate is still applied after the index hint';
+SELECT id FROM tab WHERE arrayExists(x -> x LIKE '%foo bar%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with equals uses the text index';
+SELECT id FROM tab WHERE arrayExists(x -> x = 'xyz', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> 'xyz' = x, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with hasToken uses the text index when the index matches hasToken semantics';
+SELECT id FROM tab WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'negated arrayExists stays correct';
+SELECT id FROM tab WHERE NOT arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id;
+
+SELECT 'non-constant lambda predicates do not use the index';
+SELECT id FROM tab WHERE arrayExists(x -> x LIKE needle, arr) ORDER BY id;
+SELECT id FROM tab WHERE arrayExists(x -> x LIKE needle, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+SELECT 'unsupported lambda shapes do not use the index';
+SELECT id FROM tab WHERE arrayExists(x -> (x LIKE '%foo%') OR (x = 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists(x -> lower(x) LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists(x -> length(x) > 2, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists((x, y) -> x LIKE '%foo%', arr, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+DROP TABLE tab;
+
+SELECT 'token-semantics functions are rejected when the index tokenizer differs from theirs';
+
+DROP TABLE IF EXISTS tab_ngrams;
+
+CREATE TABLE tab_ngrams
+(
+    id UInt32,
+    arr Array(String),
+    INDEX idx(arr) TYPE text(tokenizer = ngrams(3)) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab_ngrams VALUES (1, ['abc def foo']), (2, ['xyz']);
+
+SELECT id FROM tab_ngrams WHERE arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_ngrams WHERE arrayExists(x -> match(x, 'foo|xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_ngrams WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+SELECT 'LIKE and match prune granules on the ngrams index';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab_ngrams WHERE arrayExists(x -> x LIKE '%foo%', arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab_ngrams WHERE arrayExists(x -> match(x, 'xyz'), arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+
+DROP TABLE tab_ngrams;
+
+SELECT 'token-semantics functions are rejected when the index has a preprocessor';
+
+DROP TABLE IF EXISTS tab_preprocessed;
+
+CREATE TABLE tab_preprocessed
+(
+    id UInt32,
+    arr Array(String),
+    INDEX idx(arr) TYPE text(tokenizer = splitByNonAlpha, preprocessor = lower(arr)) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab_preprocessed VALUES (1, ['ABC DEF FOO']), (2, ['xyz']);
+
+SELECT id FROM tab_preprocessed WHERE arrayExists(x -> x LIKE '%FOO%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_preprocessed WHERE arrayExists(x -> hasToken(x, 'FOO'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+DROP TABLE tab_preprocessed;

--- a/tests/queries/0_stateless/04501_array_exists_text_index.sql
+++ b/tests/queries/0_stateless/04501_array_exists_text_index.sql
@@ -3,7 +3,7 @@
 SET explain_query_plan_default = 'legacy';
 SET enable_analyzer = 1;
 -- Otherwise `arrayExists(x -> x = c, arr)` is rewritten to `has(arr, c)` before index
--- analysis and the equals sections below would not exercise the `arrayExists` path.
+-- analysis and the equals sections below would test `has` instead of `arrayExists`.
 SET optimize_rewrite_array_exists_to_has = 0;
 
 DROP TABLE IF EXISTS tab;
@@ -51,6 +51,40 @@ SELECT id FROM tab WHERE arrayExists(x -> 'xyz' = x, arr) ORDER BY id SETTINGS f
 SELECT 'arrayExists with hasToken uses the text index when the index matches hasToken semantics';
 SELECT id FROM tab WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 
+SELECT 'arrayExists with hasAnyTokens, hasAllTokens and hasPhrase uses the text index';
+SELECT id FROM tab WHERE arrayExists(x -> hasAnyTokens(x, ['foo', 'xyz']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> hasAllTokens(x, ['abc', 'def']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> hasPhrase(x, 'def foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with startsWith and endsWith uses the text index';
+SELECT id FROM tab WHERE arrayExists(x -> startsWith(x, 'xy'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> endsWith(x, 'az'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with ILIKE uses the text index';
+-- `ilike` is evaluated by a dictionary scan, which requires the needle to be at least
+-- `text_index_like_min_pattern_length` characters long (default 4, our needles are 3).
+SELECT id FROM tab WHERE arrayExists(x -> x ILIKE '%FOO%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx', text_index_like_min_pattern_length = 3;
+
+SELECT 'arrayExists with multiSearchAny, multiSearchAnyUTF8 and multiMatchAny uses the text index';
+-- The needles must contain at least one complete token (surrounded by separators),
+-- otherwise the text index bails out and keeps the original predicate.
+SELECT id FROM tab WHERE arrayExists(x -> multiSearchAny(x, [' def ', ' baz ']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> multiSearchAnyUTF8(x, [' def ', ' baz ']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab WHERE arrayExists(x -> multiMatchAny(x, ['c def f']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with IN over a constant set uses the text index';
+SELECT id FROM tab WHERE arrayExists(x -> x IN ('xyz', 'baz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab WHERE arrayExists(x -> x IN ('xyz', 'baz'), arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+
+SELECT 'negative functions inside the lambda do not use the index';
+SELECT id FROM tab WHERE arrayExists(x -> x != 'foo', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists(x -> x NOT LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists(x -> x NOT ILIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab WHERE arrayExists(x -> x NOT IN ('foo', 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
 SELECT 'negated arrayExists stays correct';
 SELECT id FROM tab WHERE NOT arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id;
 
@@ -85,6 +119,9 @@ INSERT INTO tab_ngrams VALUES (1, ['abc def foo']), (2, ['xyz']);
 SELECT id FROM tab_ngrams WHERE arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_ngrams WHERE arrayExists(x -> match(x, 'foo|xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_ngrams WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_ngrams WHERE arrayExists(x -> hasAllTokens(x, ['foo']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+-- The dictionary scan for `ilike` is only supported for the `splitByNonAlpha` and `array` tokenizers.
+SELECT id FROM tab_ngrams WHERE arrayExists(x -> x ILIKE '%FOO%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx', text_index_like_min_pattern_length = 3; -- { serverError INDEX_NOT_USED }
 
 SELECT 'LIKE and match prune granules on the ngrams index';
 SELECT trimLeft(explain) AS explain FROM (
@@ -116,5 +153,6 @@ INSERT INTO tab_preprocessed VALUES (1, ['ABC DEF FOO']), (2, ['xyz']);
 
 SELECT id FROM tab_preprocessed WHERE arrayExists(x -> x LIKE '%FOO%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_preprocessed WHERE arrayExists(x -> hasToken(x, 'FOO'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_preprocessed WHERE arrayExists(x -> hasPhrase(x, 'ABC DEF'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
 
 DROP TABLE tab_preprocessed;

--- a/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.reference
+++ b/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.reference
@@ -1,0 +1,46 @@
+arrayExists with LIKE uses the token bloom filter index
+1
+3
+5
+0
+the index prunes granules
+Granules: 1/6
+captured constants are recognized
+1
+3
+5
+the original arrayExists predicate is still applied after the index check
+arrayExists with equals uses the index (both operand orders)
+4
+4
+arrayExists with hasToken, startsWith, multiSearchAny and match uses the index
+1
+3
+5
+4
+3
+4
+3
+4
+negated arrayExists stays correct (empty arrays match)
+1
+2
+4
+6
+negative functions inside the lambda do not use the index (empty arrays would be pruned wrongly)
+1
+2
+3
+4
+5
+non-constant lambda predicates do not use the index
+1
+2
+3
+4
+unsupported lambda shapes do not use the index
+ngram bloom filter index works through arrayExists too
+1
+1
+LIKE prunes granules on the ngram index
+Granules: 1/3

--- a/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.reference
+++ b/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.reference
@@ -13,15 +13,20 @@ the original arrayExists predicate is still applied after the index check
 arrayExists with equals uses the index (both operand orders)
 4
 4
-arrayExists with hasToken, startsWith, multiSearchAny and match uses the index
+arrayExists with hasToken, startsWith, endsWith, multiSearchAny and match uses the index
 1
 3
 5
 4
 3
+3
 4
 3
 4
+arrayExists with IN over a constant set uses the index
+3
+4
+Granules: 2/6
 negated arrayExists stays correct (empty arrays match)
 1
 2
@@ -33,6 +38,7 @@ negative functions inside the lambda do not use the index (empty arrays would be
 3
 4
 5
+functions not supported by the bloom filter index do not use it
 non-constant lambda predicates do not use the index
 1
 2

--- a/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.sql
+++ b/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.sql
@@ -3,7 +3,7 @@
 SET explain_query_plan_default = 'legacy';
 SET enable_analyzer = 1;
 -- Otherwise `arrayExists(x -> x = c, arr)` is rewritten to `has(arr, c)` before index
--- analysis and the equals sections below would not exercise the `arrayExists` path.
+-- analysis and the equals sections below would test `has` instead of `arrayExists`.
 SET optimize_rewrite_array_exists_to_has = 0;
 
 DROP TABLE IF EXISTS tab_token;
@@ -47,11 +47,19 @@ SELECT 'arrayExists with equals uses the index (both operand orders)';
 SELECT id FROM tab_token WHERE arrayExists(x -> x = 'xyz', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_token WHERE arrayExists(x -> 'xyz' = x, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 
-SELECT 'arrayExists with hasToken, startsWith, multiSearchAny and match uses the index';
+SELECT 'arrayExists with hasToken, startsWith, endsWith, multiSearchAny and match uses the index';
 SELECT id FROM tab_token WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_token WHERE arrayExists(x -> startsWith(x, 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_token WHERE arrayExists(x -> endsWith(x, 'az'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_token WHERE arrayExists(x -> multiSearchAny(x, ['xyz', 'baz']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
 SELECT id FROM tab_token WHERE arrayExists(x -> match(x, 'xyz|baz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with IN over a constant set uses the index';
+SELECT id FROM tab_token WHERE arrayExists(x -> x IN ('xyz', 'baz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab_token WHERE arrayExists(x -> x IN ('xyz', 'baz'), arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
 
 SELECT 'negated arrayExists stays correct (empty arrays match)';
 SELECT id FROM tab_token WHERE NOT arrayExists(x -> x = 'foo', arr) ORDER BY id;
@@ -59,6 +67,15 @@ SELECT id FROM tab_token WHERE NOT arrayExists(x -> x = 'foo', arr) ORDER BY id;
 SELECT 'negative functions inside the lambda do not use the index (empty arrays would be pruned wrongly)';
 SELECT id FROM tab_token WHERE arrayExists(x -> x != 'foo', arr) ORDER BY id;
 SELECT id FROM tab_token WHERE arrayExists(x -> x != 'foo', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> x NOT LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> x NOT IN ('foo', 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+SELECT 'functions not supported by the bloom filter index do not use it';
+SELECT id FROM tab_token WHERE arrayExists(x -> x ILIKE '%FOO%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> multiMatchAny(x, ['xyz', 'baz']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> hasAnyTokens(x, ['foo']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> hasAllTokens(x, ['foo']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> hasPhrase(x, 'abc def'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
 
 SELECT 'non-constant lambda predicates do not use the index';
 SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE needle, arr) ORDER BY id;

--- a/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.sql
+++ b/tests/queries/0_stateless/04502_array_exists_bloom_filter_index.sql
@@ -1,0 +1,99 @@
+-- Tags: no-parallel-replicas
+-- Tests that `tokenbf_v1` and `ngrambf_v1` indexes can be used through simple `arrayExists` lambdas.
+SET explain_query_plan_default = 'legacy';
+SET enable_analyzer = 1;
+-- Otherwise `arrayExists(x -> x = c, arr)` is rewritten to `has(arr, c)` before index
+-- analysis and the equals sections below would not exercise the `arrayExists` path.
+SET optimize_rewrite_array_exists_to_has = 0;
+
+DROP TABLE IF EXISTS tab_token;
+
+CREATE TABLE tab_token
+(
+    id UInt32,
+    arr Array(String),
+    needle String,
+    INDEX idx(arr) TYPE tokenbf_v1(512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab_token VALUES
+    (1, ['abc def foo'], '%foo%'),
+    (2, ['abc def bar'], '%bar%'),
+    (3, ['foo', 'baz'], '%foo%'),
+    (4, ['xyz'], '%xyz%'),
+    (5, ['foo', 'bar'], '%foo bar%'),
+    (6, [], '');
+
+SELECT 'arrayExists with LIKE uses the token bloom filter index';
+SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT count() FROM tab_token WHERE arrayExists(x -> x LIKE '%missing%', arr) SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'the index prunes granules';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab_token WHERE arrayExists(x -> x = 'xyz', arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+
+SELECT 'captured constants are recognized';
+WITH '%foo%' AS pattern SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE pattern, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'the original arrayExists predicate is still applied after the index check';
+SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE '%foo bar%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with equals uses the index (both operand orders)';
+SELECT id FROM tab_token WHERE arrayExists(x -> x = 'xyz', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_token WHERE arrayExists(x -> 'xyz' = x, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'arrayExists with hasToken, startsWith, multiSearchAny and match uses the index';
+SELECT id FROM tab_token WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_token WHERE arrayExists(x -> startsWith(x, 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_token WHERE arrayExists(x -> multiSearchAny(x, ['xyz', 'baz']), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_token WHERE arrayExists(x -> match(x, 'xyz|baz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'negated arrayExists stays correct (empty arrays match)';
+SELECT id FROM tab_token WHERE NOT arrayExists(x -> x = 'foo', arr) ORDER BY id;
+
+SELECT 'negative functions inside the lambda do not use the index (empty arrays would be pruned wrongly)';
+SELECT id FROM tab_token WHERE arrayExists(x -> x != 'foo', arr) ORDER BY id;
+SELECT id FROM tab_token WHERE arrayExists(x -> x != 'foo', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+SELECT 'non-constant lambda predicates do not use the index';
+SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE needle, arr) ORDER BY id;
+SELECT id FROM tab_token WHERE arrayExists(x -> x LIKE needle, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+SELECT 'unsupported lambda shapes do not use the index';
+SELECT id FROM tab_token WHERE arrayExists(x -> (x LIKE '%foo%') OR (x = 'xyz'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists(x -> lower(x) LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+SELECT id FROM tab_token WHERE arrayExists((x, y) -> x LIKE '%foo%', arr, arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx'; -- { serverError INDEX_NOT_USED }
+
+DROP TABLE tab_token;
+
+SELECT 'ngram bloom filter index works through arrayExists too';
+
+DROP TABLE IF EXISTS tab_ngram;
+
+CREATE TABLE tab_ngram
+(
+    id UInt32,
+    arr Array(String),
+    INDEX idx(arr) TYPE ngrambf_v1(3, 512, 3, 0) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab_ngram VALUES (1, ['abc def foo']), (2, ['xyz']), (3, []);
+
+SELECT id FROM tab_ngram WHERE arrayExists(x -> x LIKE '%foo%', arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+SELECT id FROM tab_ngram WHERE arrayExists(x -> hasToken(x, 'foo'), arr) ORDER BY id SETTINGS force_data_skipping_indices = 'idx';
+
+SELECT 'LIKE prunes granules on the ngram index';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes = 1
+    SELECT count() FROM tab_ngram WHERE arrayExists(x -> x LIKE '%foo%', arr)
+) WHERE explain LIKE '%Granules:%' LIMIT 1, 1;
+
+DROP TABLE tab_ngram;


### PR DESCRIPTION
Previously, `text`, `tokenbf_v1`, and `ngrambf_v1` indexes on `Array(String)` columns could not be used for predicates such as `arrayExists(x -> x LIKE '%needle%', arr)`. These predicates had to read every granule even though the index already stores tokens from the array elements.

This PR lets index analysis use `arrayExists` lambdas where the lambda tests the element against a constant, for example `arrayExists(x -> x LIKE '%needle%', arr)` or `arrayExists(x -> x IN ('a', 'b'), arr)`. The index can then check the tokens for `arr` before reading rows. This is safe because any matching element must have added the required tokens to the index granule. The original `arrayExists` expression is still evaluated for rows that pass the index filter.

The supported functions are listed explicitly for each index type. They include positive string predicates such as `equals`, `LIKE`, `ILIKE`, `startsWith`, `endsWith`, `match`, `multiSearchAny`, `hasToken`, and `IN`; the `text` index also supports `hasAnyTokens`, `hasAllTokens`, `hasPhrase`, `multiSearchAnyUTF8`, and `multiMatchAny`. Negative predicates such as `notEquals`, `NOT LIKE`, and `NOT IN` are not supported because they are not valid filters for empty arrays. For `text` indexes, functions whose result depends on tokenization, such as `hasToken`, are supported only when the index uses `splitByNonAlpha` without preprocessors or postprocessors.

Other `arrayExists` lambdas are unchanged: they simply do not use these indexes.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`text`, `tokenbf_v1`, and `ngrambf_v1` indexes can now prune granules for predicates such as `arrayExists(x -> x LIKE '%needle%', arr)` on `Array(String)` columns.