### PR TITLE
Build the toolchain with zlib so clang supports -gz

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1546,7 +1546,10 @@ class JobConfigs:
         run_in_docker=BINARY_DOCKER_COMMAND,
         timeout=8 * 3600,
         digest_config=Job.CacheDigestConfig(
-            include_paths=["./ci/jobs/build_toolchain.py"],
+            include_paths=[
+                "./ci/jobs/build_toolchain.py",
+                "./ci/docker/binary-builder",
+            ],
         ),
     ).parametrize(
         Job.ParamSet(

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1546,10 +1546,7 @@ class JobConfigs:
         run_in_docker=BINARY_DOCKER_COMMAND,
         timeout=8 * 3600,
         digest_config=Job.CacheDigestConfig(
-            include_paths=[
-                "./ci/jobs/build_toolchain.py",
-                "./ci/docker/binary-builder",
-            ],
+            include_paths=["./ci/jobs/build_toolchain.py"],
         ),
     ).parametrize(
         Job.ParamSet(

--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -29,6 +29,7 @@ RUN add-apt-repository ppa:ubuntu-toolchain-r/test --yes \
     && apt-get -o Dpkg::Options::="--force-overwrite" install --yes \
         binutils-dev \
         build-essential \
+        zlib1g-dev \
         python3-boto3 \
         yasm \
         zstd \

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -411,7 +411,10 @@ def main():
             f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f' -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f" -DLLVM_ENABLE_TERMINFO=OFF"
-            f" -DLLVM_ENABLE_ZLIB=OFF"
+            # Enable zlib so the produced clang supports -gz=zlib (compressed debug sections), used
+            # by COMPRESS_DEBUG_SECTIONS in the root CMakeLists. Needs zlib1g-dev in the build image
+            # (binary-builder). Stage 1 is profile-generation only and stays without it.
+            f" -DLLVM_ENABLE_ZLIB=ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DLLVM_BINUTILS_INCDIR=/usr/include"
             f' -DLLVM_BUILTIN_TARGETS="{builtin_targets}"'

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -652,6 +652,15 @@ def main():
             shutil.copy2(ninja_log_saved, f"{ninja_log_dir}/ninja_log")
             print(f"Installed .ninja_log to {ninja_log_dir}/ninja_log")
 
+        # LLVM installs the versioned `clang-21` plus unversioned `clang++`->`clang`->`clang-21`,
+        # but not a versioned `clang++-21`. ClickHouse selects compilers by versioned name, so
+        # without this the C++ compiler resolves to whatever `clang++-21` is elsewhere on PATH (e.g.
+        # a distro one) while C/ASM use this toolchain - a silent mismatch. Add the missing symlink.
+        clangpp21 = f"{STAGE2_INSTALL_DIR}/bin/clang++-21"
+        if not os.path.lexists(clangpp21):
+            os.symlink("clang", clangpp21)
+            print(f"Created symlink {clangpp21} -> clang")
+
         # Strip ELF executables and shared libraries to reduce archive size
         # (relocations from --emit-relocs and LTO symbols are no longer needed).
         # Use "file" to skip scripts (Python, Perl, shell) that strip cannot handle.

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -656,10 +656,10 @@ def main():
         # but not a versioned `clang++-21`. ClickHouse selects compilers by versioned name, so
         # without this the C++ compiler resolves to whatever `clang++-21` is elsewhere on PATH (e.g.
         # a distro one) while C/ASM use this toolchain - a silent mismatch. Add the missing symlink.
-        clangpp21 = f"{STAGE2_INSTALL_DIR}/bin/clang++-21"
-        if not os.path.lexists(clangpp21):
-            os.symlink("clang", clangpp21)
-            print(f"Created symlink {clangpp21} -> clang")
+        clangpp = f"{STAGE2_INSTALL_DIR}/bin/clang++-21"
+        if not os.path.lexists(clangpp):
+            os.symlink("clang", clangpp)
+            print(f"Created symlink {clangpp} -> clang")
 
         # Strip ELF executables and shared libraries to reduce archive size
         # (relocations from --emit-relocs and LTO symbols are no longer needed).

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -200,7 +200,10 @@ def main():
             f" -DCMAKE_CXX_COMPILER=clang++-21"
             f" -DLLVM_ENABLE_LLD=ON"
             f" -DLLVM_ENABLE_TERMINFO=OFF"
-            f" -DLLVM_ENABLE_ZLIB=OFF"
+            # zlib so the instrumented clang can emit -gz=zlib while building ClickHouse for
+            # profile collection - the PGO profile then covers the debug-compression paths that
+            # COMPRESS_DEBUG_SECTIONS now exercises by default. FORCE_ON to fail closed.
+            f" -DLLVM_ENABLE_ZLIB=FORCE_ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DCMAKE_INSTALL_PREFIX={STAGE1_INSTALL_DIR}"
             f" -S {LLVM_SOURCE_DIR}/llvm"
@@ -317,8 +320,8 @@ def main():
                 build_result.info = "Build failed at link step (expected); profraw files collected"
             results.append(build_result)
 
-        # Merge profraw files using system llvm-profdata (stage 1 build lacks zlib
-        # support, but the profraw files may contain zlib-compressed sections)
+        # Merge profraw files with llvm-profdata-21 (it supports the zlib-compressed
+        # profile format the instrumented clang can emit)
         profraw_dir = f"{STAGE1_BUILD_DIR}/profiles/"
         if os.path.isdir(profraw_dir) and os.listdir(profraw_dir):
             results.append(
@@ -413,7 +416,7 @@ def main():
             f" -DLLVM_ENABLE_TERMINFO=OFF"
             # Enable zlib so the produced clang supports -gz=zlib (compressed debug sections), used by
             # COMPRESS_DEBUG_SECTIONS in the root CMakeLists; FORCE_ON so a missing zlib1g-dev fails
-            # the build instead of silently disabling it. Stage 1 (profile-gen) stays without zlib.
+            # the build instead of silently disabling it.
             f" -DLLVM_ENABLE_ZLIB=FORCE_ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DLLVM_BINUTILS_INCDIR=/usr/include"

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -411,10 +411,10 @@ def main():
             f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f' -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f" -DLLVM_ENABLE_TERMINFO=OFF"
-            # Enable zlib so the produced clang supports -gz=zlib (compressed debug sections), used
-            # by COMPRESS_DEBUG_SECTIONS in the root CMakeLists. Needs zlib1g-dev in the build image
-            # (binary-builder). Stage 1 is profile-generation only and stays without it.
-            f" -DLLVM_ENABLE_ZLIB=ON"
+            # Enable zlib so the produced clang supports -gz=zlib (compressed debug sections), used by
+            # COMPRESS_DEBUG_SECTIONS in the root CMakeLists; FORCE_ON so a missing zlib1g-dev fails
+            # the build instead of silently disabling it. Stage 1 (profile-gen) stays without zlib.
+            f" -DLLVM_ENABLE_ZLIB=FORCE_ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DLLVM_BINUTILS_INCDIR=/usr/include"
             f' -DLLVM_BUILTIN_TARGETS="{builtin_targets}"'

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -200,9 +200,6 @@ def main():
             f" -DCMAKE_CXX_COMPILER=clang++-21"
             f" -DLLVM_ENABLE_LLD=ON"
             f" -DLLVM_ENABLE_TERMINFO=OFF"
-            # zlib so the instrumented clang can emit -gz=zlib while building ClickHouse for
-            # profile collection - the PGO profile then covers the debug-compression paths that
-            # COMPRESS_DEBUG_SECTIONS now exercises by default. FORCE_ON to fail closed.
             f" -DLLVM_ENABLE_ZLIB=FORCE_ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DCMAKE_INSTALL_PREFIX={STAGE1_INSTALL_DIR}"
@@ -414,9 +411,6 @@ def main():
             f' -DCMAKE_EXE_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f' -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--emit-relocs,-znow"'
             f" -DLLVM_ENABLE_TERMINFO=OFF"
-            # Enable zlib so the produced clang supports -gz=zlib (compressed debug sections), used by
-            # COMPRESS_DEBUG_SECTIONS in the root CMakeLists; FORCE_ON so a missing zlib1g-dev fails
-            # the build instead of silently disabling it.
             f" -DLLVM_ENABLE_ZLIB=FORCE_ON"
             f" -DLLVM_ENABLE_ZSTD=OFF"
             f" -DLLVM_BINUTILS_INCDIR=/usr/include"


### PR DESCRIPTION
The bundled LLVM toolchain is built with `LLVM_ENABLE_ZLIB=OFF`, so its clang can't do `-gz=zlib`. Enable zlib (`FORCE_ON`) for the stage-2 (shipped) clang and add `zlib1g-dev` to the `binary-builder` image, so [#109306](https://github.com/ClickHouse/ClickHouse/pull/109306)'s `COMPRESS_DEBUG_SECTIONS` auto-detects support and compresses object-file debug sections in CI and default builds (objects ≈ −50%, build dir ≈ −26%; binaries left uncompressed, so symbolization is unaffected).

**Also fixes a compiler-mismatch bug that #109306 surfaced.** LLVM installs the versioned `clang-21` plus unversioned `clang++` → `clang` → `clang-21`, but no versioned `clang++-21`. Since ClickHouse selects compilers by versioned name, CMake finds this toolchain's `clang-21` for C/ASM but falls through `PATH` to a *different* `clang++-21` (the distro's) for C++ — so C and C++ are compiled by two different clang installs. It's normally invisible (both report `Clang 21.1.8`; only the resolved paths `/usr/local/bin/clang-21` vs `/usr/bin/clang++-21` differ), and `-gz` only exposed it because one of the pair had zlib and the other didn't. Symlink `clang++-21` → `clang` before packaging so C and C++ resolve to the same toolchain.

Stage 1 (the instrumented clang used for PGO profile collection) is also built with zlib, so the profile-collection build compiles with `-gz` and the resulting PGO profile covers those code paths.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Built the bundled LLVM toolchain with zlib so the shipped clang accepts `-gz=zlib` (compressed DWARF debug sections), and added the missing `clang++-21` symlink so the toolchain's C and C++ compilers are the same install.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.644` (included in `26.7` and later)
<!-- ch-version-info:end -->