### PR TITLE
Revert onelake_bearer_token PR

### DIFF
--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -83,4 +83,3 @@ SETTINGS
 SHOW TABLES IN database_name;
 SELECT count() from database_name.table_name;
 ```
-To authenticate without sharing a client secret, set `onelake_bearer_token` to a pre-obtained bearer token (scoped to `https://storage.azure.com`) instead of `onelake_client_id`/`onelake_client_secret`. ClickHouse does not refresh the token, so the database must be recreated after it expires.

--- a/src/Databases/DataLake/DataLakeConstants.h
+++ b/src/Databases/DataLake/DataLakeConstants.h
@@ -31,7 +31,6 @@ static inline std::unordered_map<String, ValueMaskingFunc> SETTINGS_TO_HIDE =
     {"storage_aws_secret_access_key", DEFAULT_MASKING_RULE},
     /// OneLake credentials
     {"onelake_client_secret", DEFAULT_MASKING_RULE},
-    {"onelake_bearer_token", DEFAULT_MASKING_RULE},
     /// Google credentials
     {"google_adc_client_secret", DEFAULT_MASKING_RULE},
     {"google_adc_refresh_token", DEFAULT_MASKING_RULE},

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -73,7 +73,6 @@ namespace DatabaseDataLakeSetting
     extern const DatabaseDataLakeSettingsString onelake_tenant_id;
     extern const DatabaseDataLakeSettingsString onelake_client_id;
     extern const DatabaseDataLakeSettingsString onelake_client_secret;
-    extern const DatabaseDataLakeSettingsString onelake_bearer_token;
     extern const DatabaseDataLakeSettingsBool onelake_use_blob_endpoint;
     extern const DatabaseDataLakeSettingsString dlf_access_key_id;
     extern const DatabaseDataLakeSettingsString dlf_access_key_secret;
@@ -208,7 +207,6 @@ void DatabaseDataLake::initialize() const
                 settings[DatabaseDataLakeSetting::onelake_tenant_id].value,
                 settings[DatabaseDataLakeSetting::onelake_client_id].value,
                 settings[DatabaseDataLakeSetting::onelake_client_secret].value,
-                settings[DatabaseDataLakeSetting::onelake_bearer_token].value,
                 settings[DatabaseDataLakeSetting::auth_scope].value,
                 settings[DatabaseDataLakeSetting::oauth_server_uri].value,
                 settings[DatabaseDataLakeSetting::oauth_server_use_request_body].value,
@@ -681,7 +679,6 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
             rest_catalog->getClientId(),
             rest_catalog->getClientSecret(),
             rest_catalog->getTenantId(),
-            rest_catalog->getBearerToken(),
             settings[DatabaseDataLakeSetting::onelake_use_blob_endpoint].value
         );
 #else
@@ -1132,23 +1129,6 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
                                     "To allow its usage, enable setting allow_database_iceberg");
                 }
 
-                if (!args.create_query.attach && catalog_type == DatabaseDataLakeCatalogType::ICEBERG_ONELAKE)
-                {
-                    /// Require exactly one auth method: a bearer token, or a client id + secret pair.
-                    const bool has_bearer = !database_settings[DatabaseDataLakeSetting::onelake_bearer_token].value.empty();
-                    const bool has_client_id = !database_settings[DatabaseDataLakeSetting::onelake_client_id].value.empty();
-                    const bool has_client_secret = !database_settings[DatabaseDataLakeSetting::onelake_client_secret].value.empty();
-
-                    const bool has_client_pair = has_client_id && has_client_secret;
-                    bool has_exactly_one_method = has_bearer != has_client_pair;
-                    bool has_conflicting_fields = has_client_id != has_client_secret;
-
-                    if (!has_exactly_one_method || has_conflicting_fields)
-                        throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                            "OneLake catalog requires exactly one authentication method: either `onelake_bearer_token` "
-                            "or both `onelake_client_id` and `onelake_client_secret`");
-                }
-
                 engine_func->name = "Iceberg";
                 break;
             }
@@ -1302,10 +1282,6 @@ SETTINGS
 SHOW TABLES IN database_name;
 SELECT count() from database_name.table_name;
 ```
-    To authenticate without sharing a client secret, set `onelake_bearer_token` to a pre-obtained
-    bearer token (scoped to https://storage.azure.com) instead of
-    `onelake_client_id`/`onelake_client_secret`. ClickHouse does not refresh the token, so the
-    database must be recreated after it expires.
 )DOCS_MD",
         .syntax = "ENGINE = DataLakeCatalog('catalog_url'[, 'user', 'password']) SETTINGS catalog_type = '...'",
         .related = {}});

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -36,7 +36,6 @@ namespace ErrorCodes
     DECLARE(String, onelake_tenant_id, "", "Tenant id from azure", 0) \
     DECLARE(String, onelake_client_id, "", "Client id from azure", 0) \
     DECLARE(String, onelake_client_secret, "", "Client secret from azure", 0) \
-    DECLARE(String, onelake_bearer_token, "", "Pre-obtained bearer token for OneLake, scoped to https://storage.azure.com. The token is static and not refreshed, so a long-lived database must be recreated once it expires", 0) \
     DECLARE(Bool, onelake_use_blob_endpoint, true, "Use the Blob endpoint (.blob.fabric.microsoft.com) for OneLake. When disabled, the DFS endpoint (.dfs.fabric.microsoft.com) is used instead", 0) \
     DECLARE(String, google_project_id, "", "Google Cloud project ID for BigLake. Required for BigLake catalog. Used in x-goog-user-project header. If not set and google_adc_quota_project_id is provided, it latter will be used", 0) \
     DECLARE(String, google_service_account, "", "Google Cloud service account email for metadata service authentication. Default: 'default'. Only used when ADC credentials are not provided", 0) \

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -188,7 +188,14 @@ RestCatalog::RestCatalog(
     else if (!auth_header_.empty())
     {
         auth_header = parseAuthHeader(auth_header_);
-        validateAuthHeaders(auth_header.value());
+        /// `registerDatabaseDataLake` validates `auth_header` on CREATE only, so that a database
+        /// persisted with a forbidden or malformed header does not block server startup on ATTACH.
+        /// The catalog is built lazily on first use instead; this is where the user-provided
+        /// `auth_header` first becomes a header sent to the catalog, so enforce `http_forbid_headers`
+        /// here, before `loadConfig` issues any request. Mirrors the CREATE-path check: a copy is
+        /// validated and the original parsed header is kept.
+        DB::HTTPHeaderEntries header_to_check{auth_header.value()};
+        getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_to_check);
     }
     config = loadConfig();
 }
@@ -249,18 +256,6 @@ void RestCatalog::parseCatalogConfigurationSettings(const Poco::JSON::Object::Pt
         result.default_base_location = object->get("default-base-location").extract<String>();
 }
 
-void RestCatalog::validateAuthHeaders(const DB::HTTPHeaderEntry & header) const
-{
-    /// `registerDatabaseDataLake` validates `auth_header` on CREATE only, so that a database
-    /// persisted with a forbidden or malformed header does not block server startup on ATTACH.
-    /// The catalog is built lazily on first use instead; this is where the user-provided
-    /// `auth_header` first becomes a header sent to the catalog, so enforce `http_forbid_headers`
-    /// here, before `loadConfig` issues any request. Mirrors the CREATE-path check: a copy is
-    /// validated and the original parsed header is kept.
-    DB::HTTPHeaderEntries header_to_check{header};
-    getContext()->getGlobalContext()->getHTTPHeaderFilter().checkAndNormalizeHeaders(header_to_check);
-}
-
 DB::HTTPHeaderEntries RestCatalog::getAuthHeaders(bool update_token) const
 {
     fiu_do_on(DB::FailPoints::check_database_datalake_negative,
@@ -300,7 +295,6 @@ OneLakeCatalog::OneLakeCatalog(
     const std::string & onelake_tenant_id,
     const std::string & onelake_client_id,
     const std::string & onelake_client_secret,
-    const std::string & bearer_token_,
     const std::string & auth_scope_,
     const std::string & oauth_server_uri_,
     bool oauth_server_use_request_body_,
@@ -308,24 +302,13 @@ OneLakeCatalog::OneLakeCatalog(
     : RestCatalog(warehouse_, base_url_, auth_scope_, oauth_server_uri_, oauth_server_use_request_body_, context_)
     , tenant_id(onelake_tenant_id)
 {
-    if (!bearer_token_.empty())
+    client_id = onelake_client_id;
+    client_secret = onelake_client_secret;
+    update_token_if_expired = true;
+    // Get token before loading config so getAuthHeaders() can work
+    if (!client_id.empty() && !client_secret.empty())
     {
-        /// Pre-obtained token scoped to https://storage.azure.com. Used for both catalog header
-        /// and Azure Blob access. Does not support refresh.
-        bearer_token = bearer_token_;
-        auth_header = DB::HTTPHeaderEntry("Authorization", "Bearer " + bearer_token);
-        validateAuthHeaders(auth_header.value());
-    }
-    else
-    {
-        client_id = onelake_client_id;
-        client_secret = onelake_client_secret;
-        update_token_if_expired = true;
-        // Get token before loading config so getAuthHeaders() can work
-        if (!client_id.empty() && !client_secret.empty())
-        {
-            access_token.set(std::make_unique<AccessToken>(retrieveAccessToken()));
-        }
+        access_token.set(std::make_unique<AccessToken>(retrieveAccessToken()));
     }
     config = loadConfig();
 }
@@ -335,11 +318,6 @@ DB::HTTPHeaderEntries OneLakeCatalog::getAuthHeaders(bool update_token) const
     auto headers = RestCatalog::getAuthHeaders(update_token);
     headers.emplace_back("User-Agent", fmt::format("ClickHouse/{}{} OneLake-Catalog", VERSION_STRING, VERSION_OFFICIAL));
     return headers;
-}
-
-String OneLakeCatalog::getBearerToken() const
-{
-    return bearer_token;
 }
 
 AccessToken RestCatalog::retrieveAccessToken() const

--- a/src/Databases/DataLake/RestCatalog.h
+++ b/src/Databases/DataLake/RestCatalog.h
@@ -164,8 +164,6 @@ protected:
 
     Config loadConfig();
     virtual DB::HTTPHeaderEntries getAuthHeaders(bool update_token) const;
-
-    void validateAuthHeaders(const DB::HTTPHeaderEntry & header) const;
     static void parseCatalogConfigurationSettings(const Poco::JSON::Object::Ptr & object, Config & result);
 
     void sendRequest(
@@ -188,7 +186,6 @@ public:
         const std::string & onelake_tenant_id,
         const std::string & onelake_client_id,
         const std::string & onelake_client_secret,
-        const std::string & bearer_token_,
         const std::string & auth_scope_,
         const std::string & oauth_server_uri_,
         bool oauth_server_use_request_body_,
@@ -201,15 +198,11 @@ public:
 
     String getTenantId() const { return tenant_id; }
 
-    String getBearerToken() const;
-
     DB::HTTPHeaderEntries getAuthHeaders(bool update_token) const override;
 
 protected:
     /// Parameters for OneLake OAuth.
     const std::string tenant_id;
-    /// Set from `onelake_bearer_token`.
-    String bearer_token;
 };
 
 class BigLakeCatalog : public RestCatalog

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -878,27 +878,14 @@ void StorageAzureConfiguration::fromNamedCollection(const NamedCollection & coll
 void StorageAzureConfiguration::fromAST(ASTs & engine_args, ContextPtr context, bool with_structure)
 {
     AzureStorageParsedArguments parsed_arguments;
-    if (is_onelake)
+    if (!onelake_client_id.empty())
     {
         parsed_arguments.initializeForOneLake(engine_args, context, onelake_use_blob_endpoint);
-        if (!onelake_access_token.empty())
-        {
-            /// Pre-obtained bearer token from `onelake_bearer_token`.
-            /// Use epoch as the expiry time. There is no refresh -- the database must be
-            /// recreated with a new token once it expires.
-            parsed_arguments.connection_params.auth_method = std::make_shared<AzureBlobStorage::StaticCredential>(
-                onelake_access_token,
-                std::chrono::system_clock::time_point{}
-            );
-        }
-        else
-        {
-            parsed_arguments.connection_params.auth_method = std::make_shared<Azure::Identity::ClientSecretCredential>(
-                onelake_tenant_id,
-                onelake_client_id,
-                onelake_client_secret
-            );
-        }
+        parsed_arguments.connection_params.auth_method = std::make_shared<Azure::Identity::ClientSecretCredential>(
+            onelake_tenant_id,
+            onelake_client_id,
+            onelake_client_secret
+        );
     }
     else
     {

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -125,14 +125,12 @@ public:
         ContextPtr context,
         bool with_structure) override;
 
-    void setInitializationAsOneLake(const String & client_id_, const String & client_secret_, const String & tenant_id_, const String & access_token_, bool use_blob_endpoint_)
+    void setInitializationAsOneLake(const String & client_id_, const String & client_secret_, const String & tenant_id_, bool use_blob_endpoint_)
     {
         onelake_client_id = client_id_;
         onelake_client_secret = client_secret_;
         onelake_tenant_id = tenant_id_;
-        onelake_access_token = access_token_;
         onelake_use_blob_endpoint = use_blob_endpoint_;
-        is_onelake = true;
     }
 
 protected:
@@ -150,9 +148,7 @@ private:
     String onelake_client_id;
     String onelake_client_secret;
     String onelake_tenant_id;
-    String onelake_access_token;
     bool onelake_use_blob_endpoint = true;
-    bool is_onelake = false;
 
     void initializeFromParsedArguments(const AzureStorageParsedArguments & parsed_arguments);
 };

--- a/tests/integration/helpers/catalog_manager_onelake.py
+++ b/tests/integration/helpers/catalog_manager_onelake.py
@@ -204,51 +204,13 @@ class OneLakeCatalogManager(CatalogManager):
     def make_database_name() -> str:
         return f"e2e_onelake_{uuid.uuid4().hex[:8]}"
 
-    def bearer_token(self) -> str:
-        """Mint a real bearer token scoped to ``https://storage.azure.com``.
-        """
-        return self._credential.get_token(
-            "https://storage.azure.com/.default"
-        ).token
-
-    def create_db_sql_bearer(
-        self, database_name: str, bearer_token: str, **overrides
-    ) -> str:
-        """Build a ``CREATE DATABASE`` SQL string authenticating with a
-        pre-obtained bearer token via ``onelake_bearer_token``.
-        """
-        cfg = self.config
-        u = overrides.get("catalog_url", cfg.catalog_url)
-        w = overrides.get("warehouse", self.warehouse)
-        return (
-            f"CREATE DATABASE {database_name} ENGINE = DataLakeCatalog('{u}')\n"
-            f"SETTINGS\n"
-            f"    catalog_type='onelake',\n"
-            f"    warehouse='{w}',\n"
-            f"    onelake_bearer_token='{bearer_token}'"
-        )
-
-    def create_catalog_bearer(
-        self, node, database_name: str, bearer_token: str
-    ) -> None:
-        """Drop-and-create a DataLakeCatalog database authenticating with a
-        pre-obtained bearer token.
-
-        Assumes ``allow_experimental_database_iceberg`` is enabled in the
-        server's user config."""
-        node.query(
-            f"DROP DATABASE IF EXISTS {database_name};\n"
-            + self.create_db_sql_bearer(database_name, bearer_token)
-        )
-
     def create_db_sql(self, database_name: str, **overrides) -> str:
         """Build a ``CREATE DATABASE`` SQL string.
 
         Uses real credentials by default; pass keyword overrides
         (``tenant_id``, ``client_id``, ``client_secret``,
         ``catalog_url``, ``oauth_server_uri``, ``warehouse``,
-        ``auth_scope``) to substitute individual values. Pass
-        ``bearer_token`` to also emit an ``onelake_bearer_token`` setting.
+        ``auth_scope``) to substitute individual values.
         """
         cfg = self.config
         t = overrides.get("tenant_id", cfg.tenant_id)
@@ -261,17 +223,11 @@ class OneLakeCatalogManager(CatalogManager):
         )
         w = overrides.get("warehouse", self.warehouse)
         a = overrides.get("auth_scope", "https://storage.azure.com/.default")
-        # Optional; lets a test provide both auth methods at once.
-        bearer = overrides.get("bearer_token")
-        bearer_line = (
-            f"    onelake_bearer_token='{bearer}',\n" if bearer is not None else ""
-        )
         return (
             f"CREATE DATABASE {database_name} ENGINE = DataLakeCatalog('{u}')\n"
             f"SETTINGS\n"
             f"    catalog_type='onelake',\n"
             f"    warehouse='{w}',\n"
-            f"{bearer_line}"
             f"    onelake_tenant_id='{t}',\n"
             f"    onelake_client_id='{c}',\n"
             f"    onelake_client_secret='{s}',\n"

--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -1067,97 +1067,6 @@ def test_onelake_show_create_table_no_secret(
     )
 
 
-@only_onelake
-def test_onelake_system_databases_no_bearer_token(node, catalog_manager):
-    """engine_full in system.databases must not expose onelake_bearer_token."""
-
-    token = catalog_manager.bearer_token()
-    db = catalog_manager.make_database_name()
-    catalog_manager.create_catalog_bearer(node, db, token)
-    engine_full = node.query(
-        f"SELECT engine_full FROM system.databases WHERE name = '{db}' "
-        f"FORMAT TSV",
-        settings={"show_data_lake_catalogs_in_system_tables": 1},
-    ).strip()
-    assert engine_full, f"Database {db} not found in system.databases"
-    assert token not in engine_full, (
-        "onelake_bearer_token leaked in engine_full of system.databases"
-    )
-    assert "[HIDDEN]" in engine_full, (
-        f"onelake_bearer_token was not masked in engine_full:\n{engine_full}"
-    )
-
-
-@only_onelake
-def test_onelake_show_create_no_bearer_token(node, catalog_manager):
-    """SHOW CREATE DATABASE must not expose onelake_bearer_token."""
-
-    token = catalog_manager.bearer_token()
-    db = catalog_manager.make_database_name()
-    catalog_manager.create_catalog_bearer(node, db, token)
-    result = node.query(f"SHOW CREATE DATABASE {db}").strip()
-    assert token not in result, (
-        f"onelake_bearer_token leaked in SHOW CREATE DATABASE:\n{result}"
-    )
-    assert "[HIDDEN]" in result, (
-        f"onelake_bearer_token was not masked in SHOW CREATE DATABASE:\n{result}"
-    )
-
-
-@only_onelake
-def test_onelake_show_create_table_no_bearer_token(
-    node, catalog_manager, sales_table,
-):
-    """SHOW CREATE TABLE / system.tables must not expose onelake_bearer_token."""
-
-    token = catalog_manager.bearer_token()
-    db = catalog_manager.make_database_name()
-    catalog_manager.create_catalog_bearer(node, db, token)
-    try:
-        full = catalog_manager.resolve_table_name(node, db, sales_table)
-        result = node.query(f"SHOW CREATE TABLE {db}.`{full}`").strip()
-        assert result, "SHOW CREATE TABLE returned empty result"
-        assert token not in result, (
-            f"onelake_bearer_token leaked in SHOW CREATE TABLE:\n{result}"
-        )
-        system_row = node.query(
-            f"SELECT engine_full FROM system.tables "
-            f"WHERE database = '{db}' AND name = '{full}' "
-            f"FORMAT TSV"
-        ).strip()
-        assert token not in system_row, (
-            f"onelake_bearer_token leaked in system.tables engine_full:\n{system_row}"
-        )
-    finally:
-        node.query(f"DROP DATABASE IF EXISTS {db}")
-
-
-@only_onelake
-def test_onelake_read_with_bearer_token(node, catalog_manager, sales_table):
-    """Read table data authenticating only with onelake_bearer_token.
-
-    Exercises both the catalog Authorization header and the Azure Blob
-    StaticCredential read path (unlike the masking tests, which never
-    query data)."""
-    token = catalog_manager.bearer_token()
-    db = catalog_manager.make_database_name()
-    catalog_manager.create_catalog_bearer(node, db, token)
-    try:
-        full = catalog_manager.resolve_table_name(node, db, sales_table)
-        # count() alone can be served from Iceberg metadata; sum() over a
-        # data column forces an actual data-file read from OneLake blob storage.
-        count = node.query(
-            f"SELECT count() FROM {db}.`{full}` FORMAT TSV"
-        ).strip()
-        assert int(count) == 20
-        total_qty = node.query(
-            f"SELECT sum(quantity) FROM {db}.`{full}` FORMAT TSV"
-        ).strip()
-        assert int(total_qty) == 60
-    finally:
-        node.query(f"DROP DATABASE IF EXISTS {db}")
-
-
 def test_insert_into_table(node, catalog_manager, request):
     """INSERT INTO a catalog table and verify the row count increases."""
     backend = request.node.callspec.params.get("catalog_manager")
@@ -1231,29 +1140,6 @@ def test_onelake_warehouse_wrong_format(node, catalog_manager):
 
     error = node.query_and_get_error(sql)
     assert error, "Expected CREATE DATABASE to fail with malformed warehouse"
-
-
-@only_onelake
-def test_onelake_both_auth_methods_rejected(node, catalog_manager):
-    """Providing both a bearer token and client credentials is rejected."""
-
-    db = catalog_manager.make_database_name()
-    # A dummy token is enough: validation fires before any network call.
-    sql = catalog_manager.create_db_sql(db, bearer_token="dummy_token")
-
-    error = node.query_and_get_error(sql)
-    assert "exactly one" in error, error
-
-
-@only_onelake
-def test_onelake_no_auth_method_rejected(node, catalog_manager):
-    """Providing neither a bearer token nor client credentials is rejected."""
-
-    db = catalog_manager.make_database_name()
-    sql = catalog_manager.create_db_sql(db, client_id="", client_secret="")
-
-    error = node.query_and_get_error(sql)
-    assert "exactly one" in error, error
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Remove `onelake_bearer_token` option for OneLake catalogs. Currently, if the token is expired, the database fails to attach, and the node cannot come up.

Will investigate and remerge with a fix.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.575` (included in `26.7` and later)
<!-- ch-version-info:end -->