### PR TITLE
Add test: `ORDER BY <expression>` (non-plain-column) skip branch in `pushOrderByIntoView` is untested

### DIFF
--- a/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.reference
+++ b/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.reference
@@ -1,0 +1,3 @@
+plain column pushdown sorting steps:	2
+expression ORDER BY sorting steps:	1
+expression ORDER BY result count:	10

--- a/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.sql
+++ b/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.sql
@@ -6,8 +6,8 @@
 
 SET allow_experimental_analyzer = 1;
 
-DROP TABLE IF EXISTS t_obexpr;
 DROP VIEW IF EXISTS v_obexpr;
+DROP TABLE IF EXISTS t_obexpr;
 
 CREATE TABLE t_obexpr (id UInt64, ts DateTime) ENGINE = MergeTree ORDER BY (id, ts);
 INSERT INTO t_obexpr SELECT number, toDateTime(1600000000 + number) FROM numbers(100);

--- a/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.sql
+++ b/tests/queries/0_stateless/04507_view_orderby_expression_no_pushdown.sql
@@ -1,0 +1,26 @@
+-- Tags: no-random-settings
+-- ORDER BY pushdown into a simple VIEW must be skipped when the outer ORDER BY
+-- item is an expression rather than a plain column reference. Pushdown adds an
+-- inner "Sorting for ORDER BY" step inside the view subquery, so a fired pushdown
+-- shows 2 such steps and a skipped one shows only the outer step (1).
+
+SET allow_experimental_analyzer = 1;
+
+DROP TABLE IF EXISTS t_obexpr;
+DROP VIEW IF EXISTS v_obexpr;
+
+CREATE TABLE t_obexpr (id UInt64, ts DateTime) ENGINE = MergeTree ORDER BY (id, ts);
+INSERT INTO t_obexpr SELECT number, toDateTime(1600000000 + number) FROM numbers(100);
+CREATE VIEW v_obexpr AS SELECT id, ts FROM t_obexpr;
+
+SELECT 'plain column pushdown sorting steps:', countIf(explain LIKE '%Sorting (Sorting for ORDER BY)%')
+FROM (EXPLAIN SELECT id FROM v_obexpr ORDER BY ts DESC LIMIT 10 SETTINGS query_plan_optimize_lazy_materialization = 0);
+
+SELECT 'expression ORDER BY sorting steps:', countIf(explain LIKE '%Sorting (Sorting for ORDER BY)%')
+FROM (EXPLAIN SELECT id FROM v_obexpr ORDER BY id % 10 DESC LIMIT 10 SETTINGS query_plan_optimize_lazy_materialization = 0);
+
+SELECT 'expression ORDER BY result count:', count()
+FROM (SELECT id FROM v_obexpr ORDER BY id % 10 DESC LIMIT 10);
+
+DROP VIEW v_obexpr;
+DROP TABLE t_obexpr;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #94102](https://github.com/ClickHouse/ClickHouse/pull/94102).
That PR The PR adds `pushOrderByIntoView` in `src/Planner/PlannerJoinTree.cpp`, a Planner-stage rewrite that pushes an outer query's `ORDER BY`/`LIMIT` into a simple VIEW's inner query AST so that a VIEW over a `Distributed` table can use the merge-sorted-streams optimization instead of a full coordinator s

**1. `ORDER BY <expression>` (non-plain-column) skip branch in `pushOrderByIntoView` is untested**
  `src/Planner/PlannerJoinTree.cpp:1031`
  **Risk:** `PlannerJoinTree.cpp`:1029-1031 computes `col = sort->getExpression()->as<ColumnNode>()` and returns when `!col`. If this `!col` guard were dropped or broken, execution would continue to `col->getColumnSource()` (line 1030) and later `col->getColumnName()` (lines 1137/1168) on a null pointer, causing a SIGSEGV during planning of a very common query shape (`SELECT ... FROM view ORDER BY <expr> LIMIT n`); alternatively an incorrectly-pushed expression sort could truncate the wrong rows per shard …
  **What's unique vs PR tests:** The PR's 04241 test covers ~25 disable/enable cases but every `ORDER BY` in it is a plain column (`ts`, `id`, `x`, `v.ts`). None exercises the `ORDER BY <expression>` guard at line 1030-1031. This test is the only one that drives an expression `ORDER BY` (`id % 10`) through `pushOrderByIntoView` and asserts the pushdown is skipped.
  **Tags:** `-- Tags: no-random-settings` — `no-random-settings`: the assertion counts 'Sorting for ORDER BY' plan steps, which is only deterministic under fixed plan-optimization settings; random settings could alter the plan shape and flake the reference
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/925d91d7-3f6b-44af-a822-f2febe12e490)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.775` (included in `26.7` and later)
<!-- ch-version-info:end -->