### PR TITLE
Add test: Direct reads of RIGHT-kind `Join` engine tables with `ANY`/`SEMI`/`ANTI` strictness (`fillAll` dispatch) untested

### DIFF
--- a/tests/queries/0_stateless/04507_storage_join_right_direct_read.reference
+++ b/tests/queries/0_stateless/04507_storage_join_right_direct_read.reference
@@ -1,0 +1,12 @@
+ANY RIGHT
+1	a
+1	b
+2	c
+SEMI RIGHT
+1	a
+1	b
+2	c
+ANTI RIGHT
+1	a
+1	b
+2	c

--- a/tests/queries/0_stateless/04507_storage_join_right_direct_read.sql
+++ b/tests/queries/0_stateless/04507_storage_join_right_direct_read.sql
@@ -1,0 +1,24 @@
+-- Test direct SELECT reads of RIGHT-kind Join engine tables with ANY/SEMI/ANTI strictness,
+-- which dispatch to fillAll and must emit every stored row (including duplicate keys).
+DROP TABLE IF EXISTS jr_any;
+DROP TABLE IF EXISTS jr_semi;
+DROP TABLE IF EXISTS jr_anti;
+
+CREATE TABLE jr_any (k UInt32, v String) ENGINE = Join(ANY, RIGHT, k);
+INSERT INTO jr_any VALUES (1, 'a'), (1, 'b'), (2, 'c');
+SELECT 'ANY RIGHT';
+SELECT k, v FROM jr_any ORDER BY k, v;
+
+CREATE TABLE jr_semi (k UInt32, v String) ENGINE = Join(SEMI, RIGHT, k);
+INSERT INTO jr_semi VALUES (1, 'a'), (1, 'b'), (2, 'c');
+SELECT 'SEMI RIGHT';
+SELECT k, v FROM jr_semi ORDER BY k, v;
+
+CREATE TABLE jr_anti (k UInt32, v String) ENGINE = Join(ANTI, RIGHT, k);
+INSERT INTO jr_anti VALUES (1, 'a'), (1, 'b'), (2, 'c');
+SELECT 'ANTI RIGHT';
+SELECT k, v FROM jr_anti ORDER BY k, v;
+
+DROP TABLE jr_any;
+DROP TABLE jr_semi;
+DROP TABLE jr_anti;

--- a/tests/queries/0_stateless/04507_storage_join_right_direct_read.sql
+++ b/tests/queries/0_stateless/04507_storage_join_right_direct_read.sql
@@ -1,21 +1,30 @@
 -- Test direct SELECT reads of RIGHT-kind Join engine tables with ANY/SEMI/ANTI strictness,
 -- which dispatch to fillAll and must emit every stored row (including duplicate keys).
+-- Each table is populated with one row per INSERT so StorageJoin::insertBlock forwards each
+-- to a separate HashJoin stored block (fresh block_no per call), forcing the direct read to
+-- resolve refs across more than one {block_no, row_no}.
 DROP TABLE IF EXISTS jr_any;
 DROP TABLE IF EXISTS jr_semi;
 DROP TABLE IF EXISTS jr_anti;
 
 CREATE TABLE jr_any (k UInt32, v String) ENGINE = Join(ANY, RIGHT, k);
-INSERT INTO jr_any VALUES (1, 'a'), (1, 'b'), (2, 'c');
+INSERT INTO jr_any VALUES (1, 'a');
+INSERT INTO jr_any VALUES (1, 'b');
+INSERT INTO jr_any VALUES (2, 'c');
 SELECT 'ANY RIGHT';
 SELECT k, v FROM jr_any ORDER BY k, v;
 
 CREATE TABLE jr_semi (k UInt32, v String) ENGINE = Join(SEMI, RIGHT, k);
-INSERT INTO jr_semi VALUES (1, 'a'), (1, 'b'), (2, 'c');
+INSERT INTO jr_semi VALUES (1, 'a');
+INSERT INTO jr_semi VALUES (1, 'b');
+INSERT INTO jr_semi VALUES (2, 'c');
 SELECT 'SEMI RIGHT';
 SELECT k, v FROM jr_semi ORDER BY k, v;
 
 CREATE TABLE jr_anti (k UInt32, v String) ENGINE = Join(ANTI, RIGHT, k);
-INSERT INTO jr_anti VALUES (1, 'a'), (1, 'b'), (2, 'c');
+INSERT INTO jr_anti VALUES (1, 'a');
+INSERT INTO jr_anti VALUES (1, 'b');
+INSERT INTO jr_anti VALUES (2, 'c');
 SELECT 'ANTI RIGHT';
 SELECT k, v FROM jr_anti ORDER BY k, v;
 


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #107189](https://github.com/ClickHouse/ClickHouse/pull/107189).
PR replaces the pointer-based `RowRef`/`RowRefList` hash-join build-side cell representation with a compact 8-byte index-based encoding: cells hold `{block_no, row_no}` and a per-join `StoredColumnsIndex` resolves `block_no` to the stored block. All map variants, join kinds and strictnesses are affe

**1. Direct reads of RIGHT-kind `Join` engine tables with `ANY`/`SEMI`/`ANTI` strictness (`fillAll` dispatch) untested**
  `src/Storages/StorageJoin.cpp:869`, `src/Storages/StorageJoin.cpp:876`
  **Risk:** `StorageJoin.cpp:869/876/883` select `fillAll` (not `fillOne`) for `KIND == JoinKind::Right` under `Any`/`Semi`/`Anti` strictness; `fillAll` walks `it->getMapped().begin()` and resolves each ref via the new index-based `refWordBlockNo`/`refWordRowNo`. Risk: if the dispatch or block resolution is broken, a direct read of such a table silently returns wrong rows (missing duplicates or reading the wrong stored column) — wrong results with no error.
  **What's unique vs PR tests:** The PR's own 04402_storage_join_emit_non_first_column.sql covers ANY LEFT and ALL INNER direct reads; it never creates a RIGHT-kind Join engine table nor exercises the ANY/SEMI/ANTI + RIGHT fillAll dispatch that this test targets.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/bfd9a4f7-db09-4865-a4cf-b1c59a05e081)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.612` (included in `26.7` and later)
<!-- ch-version-info:end -->