### PR TITLE
Add test: `CountingSet` `keys32`/`keys64` counting-multiset path (INTERSECT ALL / EXCEPT ALL over composite fixed key <= 8 bytes) is untested

### DIFF
--- a/tests/queries/0_stateless/04507_intersect_except_all_packed_composite_key.reference
+++ b/tests/queries/0_stateless/04507_intersect_except_all_packed_composite_key.reference
@@ -1,0 +1,16 @@
+intersect_all_keys32
+1	1
+2	2
+except_all_keys32
+1	1
+1	1
+3	3
+3	3
+intersect_all_keys64
+1	1
+2	2
+except_all_keys64
+1	1
+1	1
+3	3
+3	3

--- a/tests/queries/0_stateless/04507_intersect_except_all_packed_composite_key.sql
+++ b/tests/queries/0_stateless/04507_intersect_except_all_packed_composite_key.sql
@@ -1,0 +1,35 @@
+-- Test INTERSECT ALL / EXCEPT ALL over a composite fixed key that fits in <=4 (keys32)
+-- and <=8 (keys64) bytes. ALL operators use the CountingSetVariants (counting multiset)
+-- path, so this exercises the packed keys32/keys64 methods with occurrence counting.
+
+DROP TABLE IF EXISTS iea_l16;
+DROP TABLE IF EXISTS iea_r16;
+DROP TABLE IF EXISTS iea_l32;
+DROP TABLE IF EXISTS iea_r32;
+
+-- keys32: two UInt16 columns (4 bytes).
+CREATE TABLE iea_l16 (a UInt16, b UInt16) ENGINE = Memory;
+CREATE TABLE iea_r16 (a UInt16, b UInt16) ENGINE = Memory;
+INSERT INTO iea_l16 VALUES (1,1),(1,1),(1,1),(2,2),(3,3),(3,3);
+INSERT INTO iea_r16 VALUES (1,1),(2,2),(2,2),(4,4);
+
+SELECT 'intersect_all_keys32';
+SELECT a, b FROM ((SELECT a, b FROM iea_l16) INTERSECT ALL (SELECT a, b FROM iea_r16)) ORDER BY a, b;
+SELECT 'except_all_keys32';
+SELECT a, b FROM ((SELECT a, b FROM iea_l16) EXCEPT ALL (SELECT a, b FROM iea_r16)) ORDER BY a, b;
+
+-- keys64: two UInt32 columns (8 bytes).
+CREATE TABLE iea_l32 (a UInt32, b UInt32) ENGINE = Memory;
+CREATE TABLE iea_r32 (a UInt32, b UInt32) ENGINE = Memory;
+INSERT INTO iea_l32 VALUES (1,1),(1,1),(1,1),(2,2),(3,3),(3,3);
+INSERT INTO iea_r32 VALUES (1,1),(2,2),(2,2),(4,4);
+
+SELECT 'intersect_all_keys64';
+SELECT a, b FROM ((SELECT a, b FROM iea_l32) INTERSECT ALL (SELECT a, b FROM iea_r32)) ORDER BY a, b;
+SELECT 'except_all_keys64';
+SELECT a, b FROM ((SELECT a, b FROM iea_l32) EXCEPT ALL (SELECT a, b FROM iea_r32)) ORDER BY a, b;
+
+DROP TABLE iea_l16;
+DROP TABLE iea_r16;
+DROP TABLE iea_l32;
+DROP TABLE iea_r32;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #107564](https://github.com/ClickHouse/ClickHouse/pull/107564).
PR #107564 adds packed `keys32` and `keys64` set methods to `SetVariantsTemplate`. (1) `SetVariants.cpp` `chooseMethod` now returns `Type::keys32` for a composite all-fixed key with `keys_bytes <= 4` and `Type::keys64` for `keys_bytes <= 8`, before falling through to the pre-existing `keys128`/`keys

**1. `CountingSet` `keys32`/`keys64` counting-multiset path (INTERSECT ALL / EXCEPT ALL over composite fixed key <= 8 bytes) is untested**
  `src/Interpreters/SetVariants.cpp:151`, `src/Interpreters/SetVariants.h:268`
  **Risk:** `IntersectOrExceptTransform::accumulate`/`filter` call `CountingSetVariants::chooseMethod` for ALL operators (`isAllOperator()`); a composite all-fixed key <= 8 bytes now returns `Type::keys32`/`keys64` (SetVariants.cpp:151-154), instantiating `SetMethodKeysFixed<HashMap<UInt32/UInt64,Count,...>>` (SetVariants.h:268-269). The PR's own test only covers the `NonClearableSet`/`ClearableSet` variants (IN/NOT IN/DISTINCT/INTERSECT DISTINCT/EXCEPT DISTINCT). RISK: if the count mapped-type wiring for …
  **What's unique vs PR tests:** The PR's `04335_packed_composite_key_set.sql` covers `IN`/`NOT IN`/`DISTINCT`/`INTERSECT DISTINCT`/`EXCEPT DISTINCT` — the `NonClearableSet` and `ClearableSet` variants. It never uses `INTERSECT ALL`/`EXCEPT ALL`, so the `CountingSet` (HashMap-with-count) `keys32`/`keys64` specialization and the `addToCounts`/`filterWithCounts` counting path are entirely uncovered by the PR.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/d16aa71d-3711-43e5-ba92-34137d2437f3)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)