### PR TITLE
Add test: Statistical estimator bail-out when filter touches a non-index column is untested

### DIFF
--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
@@ -1,0 +1,8 @@
+--- statistical: filter on index column only ---
+  status:       applicable
+  source:           statistical
+  empirical_status: disabled
+--- statistical: filter touches non-index column, bails to applicability_only ---
+  status:       applicable
+  source:           applicability_only
+  empirical_status: disabled

--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database, no-random-merge-tree-settings
+# no-fasttest: column statistics (tdigest/uniq) require the full build
+# no-replicated-database: hypothetical indexes are session-scoped and not replicated
+# no-random-merge-tree-settings: test requires deterministic index_granularity
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    SET materialize_statistics_on_insert = 1;
+
+    DROP TABLE IF EXISTS t_hypo_stat_mc;
+    CREATE TABLE t_hypo_stat_mc (a UInt64, b UInt64 STATISTICS(tdigest, uniq), c UInt64 STATISTICS(tdigest, uniq))
+    ENGINE = MergeTree ORDER BY a
+    SETTINGS index_granularity = 100, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, auto_statistics_types = '';
+    INSERT INTO t_hypo_stat_mc SELECT number, number % 100, number % 50 FROM numbers(10000);
+"
+
+# Statistical path is used only when the filter touches just the index's columns.
+echo "--- statistical: filter on index column only ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_b ON t_hypo_stat_mc (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM t_hypo_stat_mc WHERE b < 50;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+# Filter references a non-index column (c), so statistical estimation bails to applicability_only.
+echo "--- statistical: filter touches non-index column, bails to applicability_only ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_b ON t_hypo_stat_mc (b) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM t_hypo_stat_mc WHERE b < 50 AND c > 10;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_stat_mc"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #109417](https://github.com/ClickHouse/ClickHouse/pull/109417).
That PR Pure refactor: `WhatIfIndexEstimator.cpp` (~1000 lines) is split into per-concern modules (`WhatIfSettings`, `WhatIfFilterAnalysis`, `WhatIfEmpiricalEstimator`, `WhatIfStatisticalEstimator`, `WhatIfResultFormatter`) with no behavior change; the orchestration (`evaluateIndex`, `run`) stays in `WhatIf

**1. Statistical estimator bail-out when filter touches a non-index column is untested**
  `src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp:38`
  **Risk:** `WhatIfStatisticalEstimator.cpp:36-38` iterates the filter's input columns and returns false as soon as one is not an index column, deliberately avoiding leaking other columns' selectivity into the reported skip ratio. Risk if broken: statistical estimation would run over a multi-column predicate and credit the candidate index for another column's filtering, producing an over-optimistic `skip_ratio`/`marks` in `EXPLAIN WHATIF` output — a misleading index recommendation to the user.
  **What's unique vs PR tests:** PR/existing statistical test (04222) only exercises single-column, index-only filters (WHERE b < 50) which take the `statistical` branch. This test adds the multi-column case where the filter touches a non-index column, exercising the `return false` bail-out at line 38 that flips the source to `applicability_only` — a branch no existing test reaches.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.655` (included in `26.7` and later)
<!-- ch-version-info:end -->