### PR TITLE
fixing a left outer join problem for DpSub - #109617

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/enumeratorChecker.h
+++ b/src/Processors/QueryPlan/Optimizations/enumeratorChecker.h
@@ -88,10 +88,9 @@ EnumeratorCheckerWithCosts<TDPTable, TOptimizer>::accept(const UInt result_subse
     if (!is_buildable(lhs_subset) || !is_buildable(rhs_subset))
         return;
 
-    const UInt32 left_mask = static_cast<UInt32>(lhs_subset);
-    const UInt32 right_mask = static_cast<UInt32>(rhs_subset);
-
-    auto join_kind = optimizer.isValidJoinOrderMask(left_mask, right_mask);
+    /// `UInt` (the DP table `Key`) is the same native integer as the optimizer's `DPsubMask`,
+    /// so the relation subsets are forwarded to the mask helpers without narrowing.
+    auto join_kind = optimizer.isValidJoinOrderMask(lhs_subset, rhs_subset);
     if (!join_kind)
         return;
 
@@ -99,7 +98,7 @@ EnumeratorCheckerWithCosts<TDPTable, TOptimizer>::accept(const UInt result_subse
 
     /// `edge` aliases an internal scratch buffer that the next `collectJoinEdgesMask` call overwrites
     /// it is only read below and copied into the DP entry, so the aliasing is safe.
-    const auto & edge = optimizer.collectJoinEdgesMask(left_mask, right_mask);
+    const auto & edge = optimizer.collectJoinEdgesMask(lhs_subset, rhs_subset);
 
     /// The enumerator only invokes the acceptor for connected pairs, so a `Cross`
     /// kind here is a connected join that should be treated as `Inner` (mirrors the
@@ -107,7 +106,7 @@ EnumeratorCheckerWithCosts<TDPTable, TOptimizer>::accept(const UInt result_subse
     if (kind == JoinKind::Cross)
         kind = JoinKind::Inner;
 
-    auto selectivity = optimizer.computeSelectivityMask(edge, left_mask, right_mask);
+    auto selectivity = optimizer.computeSelectivityMask(edge, lhs_subset, rhs_subset);
     auto plan_cost = computeJoinCost(lhs_subset, rhs_subset, selectivity);
 
     LOG_TEST(logger, "selectivity: {} costs: {}, lhs est. rows: {}, rhs est. rows: {}",

--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -39,17 +39,19 @@ namespace ErrorCodes
     extern const int EXPERIMENTAL_FEATURE_ERROR;
 }
 
-/// Pack a `BitSet` (boost::dynamic_bitset) of relation ids into a native 32-bit mask.
-/// Used by the DPsub hot path, where the relation count is guaranteed below 32 so every
-/// set bit fits, allowing the per-CCP work to run on native integers instead of allocating
-/// a `dynamic_bitset` for every plan it considers.
-static UInt32 toMask(const BitSet & bits)
+/// Pack a `BitSet` (boost::dynamic_bitset) of relation ids into a native integer mask.
+/// Used by the DPsub hot path, where the relation count is guaranteed below the mask width so
+/// every set bit fits, allowing the per-CCP work to run on native integers instead of allocating
+/// a `dynamic_bitset` for every plan it considers. The mask width is chosen by the caller via
+/// `TUInt` (see `JoinOrderOptimizer::DPsubMask`).
+template <std::unsigned_integral TUInt>
+static TUInt toMask(const BitSet & bits)
 {
-    UInt32 mask = 0;
+    TUInt mask = 0;
     for (auto bit : bits)
     {
-        chassert(bit < std::numeric_limits<UInt32>::digits);
-        mask |= (static_cast<UInt32>(1) << bit);
+        chassert(bit < std::numeric_limits<TUInt>::digits);
+        mask |= (static_cast<TUInt>(1) << bit);
     }
     return mask;
 }
@@ -349,16 +351,22 @@ private:
         std::optional<UInt64> left_rows, std::optional<UInt64> right_rows, double selectivity, JoinKind join_kind) const;
     size_t getColumnStats(const BitSet & rels, const String & column_name);
 
+    /// Native integer type used to pack a `BitSet` of relation ids into a single machine word for
+    /// the DPsub hot path. This is the single knob controlling the DPsub mask width: `solveDPsub`
+    /// sets its `dp_table` `Key` (the `Bitvector`) to this type, so widening it here (`UInt64`,
+    /// `UInt128`) lifts the relation-count limit for the whole DPsub pipeline at once.
+    using DPsubMask = UInt32;
+
     /// Native-mask counterparts of the helpers above, used exclusively by the DPsub acceptor.
-    /// They operate on `UInt32` relation masks and the data precomputed by `initDPsubScratch`,
+    /// They operate on `DPsubMask` relation masks and the data precomputed by `initDPsubScratch`,
     /// so the hot enumeration loop never constructs a `BitSet` (which heap-allocates). They are
     /// equivalent to the `BitSet` overloads but bypass per-CCP allocations entirely.
     void initDPsubScratch();
-    std::optional<JoinKind> isValidJoinOrderMask(UInt32 left_mask, UInt32 right_mask) const;
+    std::optional<JoinKind> isValidJoinOrderMask(DPsubMask left_mask, DPsubMask right_mask) const;
     /// Returns the connecting (and, for two-relation joins, the early non-connecting) predicates,
     /// reusing an internal scratch buffer that is overwritten on every call.
-    const std::vector<JoinActionRef *> & collectJoinEdgesMask(UInt32 left_mask, UInt32 right_mask);
-    double computeSelectivityMask(const std::vector<JoinActionRef *> & edges, UInt32 left_mask, UInt32 right_mask);
+    const std::vector<JoinActionRef *> & collectJoinEdgesMask(DPsubMask left_mask, DPsubMask right_mask);
+    double computeSelectivityMask(const std::vector<JoinActionRef *> & edges, DPsubMask left_mask, DPsubMask right_mask);
 
     /// Periodically called from potentially long running optimization to check time limits and send progress
     void checkLimits();
@@ -430,7 +438,7 @@ private:
         UInt64 equiv_generation = 0;              /// bumped on each computeSelectivityMask call
         std::vector<JoinActionRef *> applicable_scratch; /// reused output of collectJoinEdgesMask
     };
-    DPsubMaskData<UInt32> dpsub_data;
+    DPsubMaskData<DPsubMask> dpsub_data;
 
     /** A hyperedge in the join graph connecting a set of left relations to a set of right relations.
     * For simple binary predicates (A.x = B.y), |left| = |right| = 1.
@@ -746,11 +754,11 @@ void JoinOrderOptimizer::initDPsubScratch()
         const auto & edge = edges[i];
         if (!edge)
             continue;
-        dpsub_data.edge_source_mask[i] = toMask(edge.getSourceRelations());
+        dpsub_data.edge_source_mask[i] = toMask<DPsubMask>(edge.getSourceRelations());
         if (auto pin_it = query_graph.pinned.find(edge); pin_it != query_graph.pinned.end())
         {
             dpsub_data.edge_pinned[i] = 1;
-            dpsub_data.edge_pin_mask[i] = toMask(pin_it->second);
+            dpsub_data.edge_pin_mask[i] = toMask<DPsubMask>(pin_it->second);
         }
     }
 
@@ -761,8 +769,8 @@ void JoinOrderOptimizer::initDPsubScratch()
         if (rel >= num_relations)
             continue;
         auto & native = dpsub_data.restriction_by_rel[rel];
-        native.required = toMask(restriction.required_partners);
-        native.forbidden = toMask(restriction.forbidden_partners);
+        native.required = toMask<DPsubMask>(restriction.required_partners);
+        native.forbidden = toMask<DPsubMask>(restriction.forbidden_partners);
         native.kind = restriction.kind;
         native.present = true;
     }
@@ -789,9 +797,9 @@ void JoinOrderOptimizer::initDPsubScratch()
     dpsub_data.equiv_generation = 0;
 }
 
-std::optional<JoinKind> JoinOrderOptimizer::isValidJoinOrderMask(UInt32 left_mask, UInt32 right_mask) const
+std::optional<JoinKind> JoinOrderOptimizer::isValidJoinOrderMask(DPsubMask left_mask, DPsubMask right_mask) const
 {
-    auto check = [&](UInt32 lhs, UInt32 rhs) -> std::optional<JoinKind>
+    auto check = [&](DPsubMask lhs, DPsubMask rhs) -> std::optional<JoinKind>
     {
         if (std::popcount(lhs) == 1)
         {
@@ -834,12 +842,12 @@ std::optional<JoinKind> JoinOrderOptimizer::isValidJoinOrderMask(UInt32 left_mas
     return {};
 }
 
-const std::vector<JoinActionRef *> & JoinOrderOptimizer::collectJoinEdgesMask(UInt32 left_mask, UInt32 right_mask)
+const std::vector<JoinActionRef *> & JoinOrderOptimizer::collectJoinEdgesMask(DPsubMask left_mask, DPsubMask right_mask)
 {
     auto & out = dpsub_data.applicable_scratch;
     out.clear();
 
-    const UInt32 joined = left_mask | right_mask;
+    const DPsubMask joined = left_mask | right_mask;
     const bool two_relations = std::popcount(joined) == 2;
     auto & edges = query_graph.edges;
 
@@ -849,20 +857,38 @@ const std::vector<JoinActionRef *> & JoinOrderOptimizer::collectJoinEdgesMask(UI
         if (!edge)
             continue;
 
-        const UInt32 sources = dpsub_data.edge_source_mask[i];
+        const DPsubMask sources = dpsub_data.edge_source_mask[i];
         if (sources & ~joined) /// edge sources not proper subset of joined relations
             continue;
         if (dpsub_data.edge_pinned[i] && (dpsub_data.edge_pin_mask[i] & ~joined))
             continue;
 
-        if ((sources & left_mask) && (sources & right_mask))
+        /// Relations that must all be present before the predicate is applicable: the relations it
+        /// references (`sources`) plus any relations it is pinned to. For a plain equi-predicate the
+        /// pin is empty, so this is just `sources`. For a single-table conjunct of an outer join's ON
+        /// clause (e.g. `t2.value = 'x'` in `... LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'x'`),
+        /// `sources` is only `{t2}` but the pin is `{t3}`: the predicate belongs to the ON condition of
+        /// the join that brings in `t3`, not to `t2` as a base-table filter. Placing it by `sources`
+        /// alone would push it below (or drop it from) that join, silently changing outer-join
+        /// semantics, since `t2` may already have been NULL-extended (or default-filled) by an
+        /// earlier join.
+        const DPsubMask pin = dpsub_data.edge_pinned[i] ? dpsub_data.edge_pin_mask[i] : 0;
+        const DPsubMask applicable = sources | pin;
+
+        if (std::popcount(applicable) <= 1)
         {
-            /// Predicate connects the two sides
-            out.push_back(&edge);
+            /// Base-relation filter or constant predicate: it becomes applicable as soon as its single
+            /// relation is present, so attach it at the earliest (two-relation) join to filter as low
+            /// as possible.
+            if (two_relations && (edge.fromLeft() || edge.fromRight() || edge.fromNone()))
+                out.push_back(&edge);
         }
-        else if (two_relations && (edge.fromLeft() || edge.fromRight() || edge.fromNone()))
+        else if ((applicable & ~left_mask) && (applicable & ~right_mask))
         {
-            /// Single-table or constant predicate attached at the earliest (two-relation) stage
+            /// The predicate spans the split (a connecting equi-predicate, or a single-table ON-clause
+            /// conjunct pinned to the opposite side): neither side alone contains all the relations it
+            /// needs. This join is the lowest one that makes it applicable, so attach it here — into the
+            /// correct join's ON condition.
             out.push_back(&edge);
         }
     }
@@ -870,7 +896,7 @@ const std::vector<JoinActionRef *> & JoinOrderOptimizer::collectJoinEdgesMask(UI
 }
 
 double JoinOrderOptimizer::computeSelectivityMask(
-    const std::vector<JoinActionRef *> & edges, UInt32 left_mask, UInt32 right_mask)
+    const std::vector<JoinActionRef *> & edges, DPsubMask left_mask, DPsubMask right_mask)
 {
     double selectivity = computeSelectivity(edges);
 
@@ -878,12 +904,12 @@ double JoinOrderOptimizer::computeSelectivityMask(
     /// incident to the left relations. A generation stamp deduplicates classes without allocating
     const UInt64 generation = ++dpsub_data.equiv_generation;
 
-    for (UInt32 remaining = left_mask; remaining;)
+    for (DPsubMask remaining = left_mask; remaining;)
     {
-        const UInt32 rel = std::countr_zero(remaining);
+        const auto rel = std::countr_zero(remaining);
         remaining &= remaining - 1;
 
-        for (UInt32 class_idx : dpsub_data.rel_to_classes[rel])
+        for (auto class_idx : dpsub_data.rel_to_classes[rel])
         {
             if (dpsub_data.class_visited[class_idx] == generation)
                 continue;
@@ -897,7 +923,7 @@ double JoinOrderOptimizer::computeSelectivityMask(
                 auto relation = equiv_member.getSourceRelations().getSingleBit();
                 if (!relation)
                     continue;
-                const UInt32 relation_bit = static_cast<UInt32>(1) << *relation;
+                const DPsubMask relation_bit = static_cast<DPsubMask>(1) << *relation;
                 if (left_mask & relation_bit)
                 {
                     has_left = true;
@@ -1087,7 +1113,11 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::buildPhysicalPlan(const DPTable
 std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solveDPsub()
 {
     const size_t n = query_graph.relation_stats.size();
-    using Bitvector = UInt32; // choose UInt64 or even UInt128 for larger sets
+    /// The DPsub `dp_table` key width. Tied to `DPsubMask` so the native-mask acceptor helpers
+    /// (`isValidJoinOrderMask`, `collectJoinEdgesMask`, `computeSelectivityMask`) and the packed
+    /// scratch in `dpsub_data` all operate on the same integer type. Widen `DPsubMask` (to `UInt64`
+    /// or `UInt128`) to support larger relation sets.
+    using Bitvector = DPsubMask;
     // A budget cap on nr. of connected components considered by DPsub to avoid excessive optimization time on large join graphs.
     // This budget cap is obtained from empirical testing using different queries and join graphs.
     static constexpr UInt32 max_nr_ccps = 50'000;

--- a/tests/queries/0_stateless/04493_dpsub_chained_outer_join_null_side.reference
+++ b/tests/queries/0_stateless/04493_dpsub_chained_outer_join_null_side.reference
@@ -1,0 +1,16 @@
+shared predicate: default
+0	Join_3_Value_0
+1	
+2	
+shared predicate: dpsub
+0	Join_3_Value_0
+1	
+2	
+unshared predicate: default
+0	Join_3_Value_0
+1	
+2	
+unshared predicate: dpsub
+0	Join_3_Value_0
+1	
+2	

--- a/tests/queries/0_stateless/04493_dpsub_chained_outer_join_null_side.sql
+++ b/tests/queries/0_stateless/04493_dpsub_chained_outer_join_null_side.sql
@@ -1,0 +1,51 @@
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+
+CREATE TABLE t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t2 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t3 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t1 VALUES (0, 'Join_1_Value_0'), (1, 'Join_1_Value_1'), (2, 'Join_1_Value_2');
+INSERT INTO t2 VALUES (0, 'Join_2_Value_0'), (1, 'Join_2_Value_1'), (3, 'Join_2_Value_3');
+INSERT INTO t3 VALUES (0, 'Join_3_Value_0'), (1, 'Join_3_Value_1'), (4, 'Join_3_Value_4');
+
+-- The `t2.value = 'Join_2_Value_0'` conjunct in the second ON clause references t2, the
+-- null-supplying side of the first join. Only t1.id = 0 matches t2, so for t1.id in (1, 2)
+-- the second join must not match t3, leaving t3.value empty.
+
+SELECT 'shared predicate: default';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' AND t2.value = 'Join_2_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL;
+
+SELECT 'shared predicate: dpsub';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' AND t2.value = 'Join_2_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+
+SELECT 'unshared predicate: default';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL;
+
+SELECT 'unshared predicate: dpsub';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109617

Fixes wrong results from the DPsub join-order optimizer
(`query_plan_optimize_join_order_algorithm = 'dpsub'`) on chained outer joins
whose later `ON` clause contains a single-relation predicate on a table that is
the null-supplying side of an earlier join, e.g.:

    t1 LEFT JOIN t2 ON t1.id = t2.id ...
       LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'x' AND t3.value = 'y'

`collectJoinEdgesMask` placed each predicate by the relations it references
(`sources`) while ignoring its pin. The conjunct `t2.value = 'x'` references only
`{t2}` but is pinned to `{t3}` (it belongs to the second join's `ON`), so it was
pushed below — or dropped from — that join instead of staying in its `ON`
condition. With `join_use_nulls = 0` the null-supplying key column is then
default-filled (`t2.id = 0`), so the residual `t2.id = t3.id` matched spuriously
and produced extra rows.

The fix places each predicate by its full applicability set (`sources | pin`):
base filters/constants attach at the earliest two-relation join, while any
predicate that spans the split (a connecting equi-predicate or a single-table
`ON`-conjunct pinned to the opposite side) attaches at the lowest join that makes
it applicable — i.e. into the correct join's `ON` condition.

Added regression test `04493_dpsub_chained_outer_join_null_side`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: `query_plan_optimize_join_order_algorithm` is an experimental setting (default `greedy`); the affected `dpsub` algorithm is opt-in and not in a stable release.
