### PR TITLE
Fix wrong results from DPsub join-order optimizer on chained outer joins

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -842,14 +842,32 @@ const std::vector<JoinActionRef *> & JoinOrderOptimizer::collectJoinEdgesMask(UI
         if (dpsub_data.edge_pinned[i] && (dpsub_data.edge_pin_mask[i] & ~joined))
             continue;
 
-        if ((sources & left_mask) && (sources & right_mask))
+        /// Relations that must all be present before the predicate is applicable: the relations it
+        /// references (`sources`) plus any relations it is pinned to. For a plain equi-predicate the
+        /// pin is empty, so this is just `sources`. For a single-table conjunct of an outer join's ON
+        /// clause (e.g. `t2.value = 'x'` in `... LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'x'`),
+        /// `sources` is only `{t2}` but the pin is `{t3}`: the predicate belongs to the ON condition of
+        /// the join that brings in `t3`, not to `t2` as a base-table filter. Placing it by `sources`
+        /// alone would push it below (or drop it from) that join, silently changing outer-join
+        /// semantics, since `t2` may already have been NULL-extended (or default-filled) by an
+        /// earlier join.
+        const UInt32 pin = dpsub_data.edge_pinned[i] ? dpsub_data.edge_pin_mask[i] : 0;
+        const UInt32 applicable = sources | pin;
+
+        if (std::popcount(applicable) <= 1)
         {
-            /// Predicate connects the two sides
-            out.push_back(&edge);
+            /// Base-relation filter or constant predicate: it becomes applicable as soon as its single
+            /// relation is present, so attach it at the earliest (two-relation) join to filter as low
+            /// as possible.
+            if (two_relations && (edge.fromLeft() || edge.fromRight() || edge.fromNone()))
+                out.push_back(&edge);
         }
-        else if (two_relations && (edge.fromLeft() || edge.fromRight() || edge.fromNone()))
+        else if ((applicable & ~left_mask) && (applicable & ~right_mask))
         {
-            /// Single-table or constant predicate attached at the earliest (two-relation) stage
+            /// The predicate spans the split (a connecting equi-predicate, or a single-table ON-clause
+            /// conjunct pinned to the opposite side): neither side alone contains all the relations it
+            /// needs. This join is the lowest one that makes it applicable, so attach it here — into the
+            /// correct join's ON condition.
             out.push_back(&edge);
         }
     }

--- a/tests/queries/0_stateless/04507_dpsub_chained_outer_join_null_side.reference
+++ b/tests/queries/0_stateless/04507_dpsub_chained_outer_join_null_side.reference
@@ -1,0 +1,16 @@
+shared predicate: default
+0	Join_3_Value_0
+1	
+2	
+shared predicate: dpsub
+0	Join_3_Value_0
+1	
+2	
+unshared predicate: default
+0	Join_3_Value_0
+1	
+2	
+unshared predicate: dpsub
+0	Join_3_Value_0
+1	
+2	

--- a/tests/queries/0_stateless/04507_dpsub_chained_outer_join_null_side.sql
+++ b/tests/queries/0_stateless/04507_dpsub_chained_outer_join_null_side.sql
@@ -1,0 +1,51 @@
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP TABLE IF EXISTS t3;
+
+CREATE TABLE t1 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t2 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t3 (id UInt64, value String) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t1 VALUES (0, 'Join_1_Value_0'), (1, 'Join_1_Value_1'), (2, 'Join_1_Value_2');
+INSERT INTO t2 VALUES (0, 'Join_2_Value_0'), (1, 'Join_2_Value_1'), (3, 'Join_2_Value_3');
+INSERT INTO t3 VALUES (0, 'Join_3_Value_0'), (1, 'Join_3_Value_1'), (4, 'Join_3_Value_4');
+
+-- The `t2.value = 'Join_2_Value_0'` conjunct in the second ON clause references t2, the
+-- null-supplying side of the first join. Only t1.id = 0 matches t2, so for t1.id in (1, 2)
+-- the second join must not match t3, leaving t3.value empty.
+
+SELECT 'shared predicate: default';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' AND t2.value = 'Join_2_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL;
+
+SELECT 'shared predicate: dpsub';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0' AND t2.value = 'Join_2_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+
+SELECT 'unshared predicate: default';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL;
+
+SELECT 'unshared predicate: dpsub';
+SELECT t1.id, t3.value
+FROM t1
+LEFT JOIN t2 ON t1.id = t2.id AND t1.value = 'Join_1_Value_0'
+LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'Join_2_Value_0' AND t3.value = 'Join_3_Value_0'
+ORDER BY ALL
+SETTINGS query_plan_optimize_join_order_algorithm = 'dpsub';
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109617

The DPsub join-order optimizer (`query_plan_optimize_join_order_algorithm = 'dpsub'`)
returned wrong results on chained outer joins whose later `ON` clause contains a
single-relation predicate on a table that is the null-supplying side of an earlier
join, e.g. `t1 LEFT JOIN t2 ON ... LEFT JOIN t3 ON t2.id = t3.id AND t2.value = 'x' AND t3.value = 'y'`.

`collectJoinEdgesMask` placed each predicate by the relations it references (`sources`)
while ignoring its pin. `t2.value = 'x'` references only `{t2}` but is pinned to `{t3}`
(it belongs to the second join's `ON`), so it was pushed below — or dropped from — that
join. With `join_use_nulls = 0` the null-supplying key is then default-filled (`t2.id = 0`),
so the residual `t2.id = t3.id` matched spuriously and produced extra rows.

The fix places each predicate by its full applicability set (`sources | pin`) so a
single-table `ON`-conjunct pinned to the opposite side lands in the correct join's `ON`
condition. Added regression test `04507_dpsub_chained_outer_join_null_side`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog: `query_plan_optimize_join_order_algorithm` is an experimental setting (default `greedy`); the affected `dpsub` algorithm is opt-in and not in a stable release.
