### PR TITLE
Fix flaky test_database_delta::test_snapshot_version (Spark DESCRIBE HISTORY timeout)

### DIFF
--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -772,8 +772,13 @@ def test_snapshot_version(started_cluster):
     db_name = f"db_{table_name}"
 
     def get_table_versions():
+        # DESCRIBE HISTORY is read-only, so retry_on_timeout is safe: a
+        # fresh-JVM retry after a transient Unity Catalog HTTP-client hang
+        # cannot corrupt state or duplicate data.
         history = execute_spark_query(
-            node1, f"DESCRIBE HISTORY {schema_name}.{table_name}"
+            node1,
+            f"DESCRIBE HISTORY {schema_name}.{table_name}",
+            retry_on_timeout=True,
         )
         lines = [line.strip() for line in history.splitlines() if line.strip()]
         if "version" in lines[0].lower():


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/109548
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the chronic flaky `test_database_delta/test.py::test_snapshot_version` (timed out after 600s).

Root cause: the `get_table_versions()` helper runs a read-only `DESCRIBE HISTORY` through `execute_spark_query()` **without** `retry_on_timeout`, so it uses a single 600s attempt. A transient Unity Catalog HTTP-client hang (the UC Java client has no per-request timeout, see the jstack root cause recorded when the retry mechanism was added) can consume that whole attempt, and the test fails with `timed out after 600s`. The CI report (Integration tests amd_tsan 5/6, PR #109229) shows exactly this: the hang is inside Spark/Ivy + UC on the `DESCRIBE HISTORY` invocation.

Fix: pass `retry_on_timeout=True` on this read-only call. It is idempotent, so a fresh-JVM retry is safe. This uses the shorter 300s per-attempt budget with 2 attempts (600s total), which still fits the 900s pytest timeout. The non-idempotent `INSERT` calls in the same test are deliberately left un-retried.
