### PR TITLE
Fix flaky 03040_dynamic_type_alters_1_compact_merge_tree

### DIFF
--- a/tests/queries/0_stateless/03040_dynamic_type_alters_1_compact_merge_tree.sql
+++ b/tests/queries/0_stateless/03040_dynamic_type_alters_1_compact_merge_tree.sql
@@ -3,7 +3,8 @@ set allow_experimental_variant_type = 1;
 set use_variant_as_common_type = 1;
 
 drop table if exists test;
-create table test (x UInt64, y UInt64) engine=MergeTree order by x settings min_rows_for_wide_part=100000000, min_bytes_for_wide_part=1000000000;
+-- Pin off background merges: a merge re-decides Dynamic subcolumn placement (flips isDynamicElementInSharedData); mutations below still run.
+create table test (x UInt64, y UInt64) engine=MergeTree order by x settings min_rows_for_wide_part=100000000, min_bytes_for_wide_part=1000000000, max_bytes_to_merge_at_max_space_in_pool=1;
 select 'initial insert';
 insert into test select number, number from numbers(3);
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a flaky failure in `03040_dynamic_type_alters_1_compact_merge_tree` (`result differs with reference`).

The test queries `isDynamicElementInSharedData(d)` right after `ALTER MODIFY COLUMN d Dynamic(max_types=...)`. A background merge racing in before that SELECT re-decides Dynamic subcolumn placement: it promotes the most frequent types (`String`, `UInt64`) out of shared data into typed variants, flipping `isDynamicElementInSharedData` from `true` to `false`. This makes the output nondeterministic.

Reproduced deterministically: running the ALTER sequence and then `OPTIMIZE TABLE ... FINAL` flips `5 String true` / `5 UInt64 true` to `... false`, exactly matching the CI diff at `alter modify column 2`.

Fix: pin `max_bytes_to_merge_at_max_space_in_pool=1` on the table. This disables background merges (any merge exceeds the 1-byte pool limit) while still allowing the test's `mutations_sync=1` ALTERs to run. `SYSTEM STOP MERGES` is not usable here because it also blocks those mutations, which the test depends on.

Verified: 60/60 runs pass with randomization on the fixed test (the failure is a very rare race, 1 genuine hit in 90 days, 0 on master).
