### PR TITLE
Fix rusage race in executable UDF metering with check_exit_code=false

### DIFF
--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -31,6 +31,7 @@
 #include <IO/WriteHelpers.h>
 #include <IO/Operators.h>
 #include <Common/waitForPid.h>
+#include <Common/Stopwatch.h>
 
 
 namespace
@@ -79,6 +80,23 @@ LoggerPtr ShellCommand::getLogger()
     return ::getLogger("ShellCommand");
 }
 
+UInt64 ShellCommand::remainingTerminationTimeoutMs()
+{
+    const UInt64 now_ns = clock_gettime_ns();
+
+    /// Arm the shared deadline once, on the first waiter (cleanup, or the destructor when
+    /// cleanup never ran). Every later waiter subtracts the time already spent so both the
+    /// cleanup poll and the destructor wait draw from one `command_termination_timeout`.
+    if (termination_deadline_ns == 0)
+        termination_deadline_ns
+            = now_ns + config.terminate_in_destructor_strategy.wait_for_normal_exit_before_termination_seconds * 1000000000ULL;
+
+    if (now_ns >= termination_deadline_ns)
+        return 0;
+
+    return (termination_deadline_ns - now_ns) / 1000000ULL;
+}
+
 ShellCommand::~ShellCommand()
 {
     if (do_not_terminate)
@@ -89,7 +107,12 @@ ShellCommand::~ShellCommand()
 
     if (config.terminate_in_destructor_strategy.terminate_in_destructor)
     {
-        size_t try_wait_timeout = config.terminate_in_destructor_strategy.wait_for_normal_exit_before_termination_seconds;
+        /// Draw from the shared deadline: the cleanup-side wait may have already spent
+        /// most of `command_termination_timeout`, so this wait gets only what remains and
+        /// the configured grace period is honored once, not doubled. `waitForPid` is
+        /// second-granular, so round the remainder up to keep at least one poll when any
+        /// budget is left.
+        size_t try_wait_timeout = (remainingTerminationTimeoutMs() + 999) / 1000;
         bool process_terminated_normally = tryWaitProcessWithTimeout(try_wait_timeout);
 
         if (process_terminated_normally)
@@ -484,24 +507,24 @@ bool ShellCommand::tryWaitWithoutStatusCheck()
 {
     /// A child that closed stdout but has only just called `_exit` is not yet a
     /// zombie, so a single `wait4(WNOHANG)` can miss it and lose its `rusage`. Poll
-    /// within the same `command_termination_timeout` window the destructor uses
-    /// (`wait_for_normal_exit_before_termination_seconds`), so a child exiting inside
-    /// that window has its usage collected here rather than by the destructor's
-    /// `waitForPid`, which collects none. A configured timeout of 0 means a single
+    /// until the shared termination deadline (`remainingTerminationTimeoutMs`), collecting the
+    /// child's usage here via `wait4` instead of leaving it to the destructor's
+    /// `waitForPid`, which collects none. The deadline is shared with the destructor,
+    /// so a child that lingers past it is not double-charged: the destructor's own wait
+    /// gets only the time remaining. A configured timeout of 0 means a single
     /// non-blocking attempt, so this never stalls a query beyond the configuration.
-    const UInt64 poll_budget_ms
-        = config.terminate_in_destructor_strategy.wait_for_normal_exit_before_termination_seconds * 1000ULL;
     static constexpr UInt64 poll_step_ms = 5;
 
-    UInt64 waited_ms = 0;
     while (true)
     {
         if (tryWaitImpl(/*blocking=*/false, /*check_exit_status=*/false).is_process_terminated)
             return true;
-        if (waited_ms >= poll_budget_ms)
+
+        const UInt64 remaining_ms = remainingTerminationTimeoutMs();
+        if (remaining_ms == 0)
             return false;
-        sleepForMilliseconds(std::min(poll_step_ms, poll_budget_ms - waited_ms));
-        waited_ms += poll_step_ms;
+
+        sleepForMilliseconds(std::min(poll_step_ms, remaining_ms));
     }
 }
 

--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -19,6 +19,7 @@
 #include <csignal>
 #include <limits>
 
+#include <base/sleep.h>
 #include <Common/logger_useful.h>
 #include <base/errnoToString.h>
 #include <Common/Exception.h>
@@ -480,7 +481,26 @@ bool ShellCommand::waitIfProccesTerminated()
 
 bool ShellCommand::tryReapWithoutStatusCheck()
 {
-    return tryWaitImpl(/*blocking=*/false, /*check_exit_status=*/false).is_process_terminated;
+    /// A child that has closed stdout (so the pipeline is complete) but has only
+    /// just called `_exit` is not yet a reapable zombie the instant cleanup runs, so
+    /// a single non-blocking `wait4(WNOHANG)` can miss it and lose its `rusage` — the
+    /// CPU counters would then read zero. Poll for a short bounded budget so a
+    /// promptly-exiting child is reaped and its usage captured. A child that keeps
+    /// running past the budget is still left to `~ShellCommand`'s bounded
+    /// `command_termination_timeout` + SIGTERM teardown, so cleanup never hangs.
+    static constexpr UInt64 reap_poll_budget_ms = 1000;
+    static constexpr UInt64 reap_poll_step_ms = 5;
+
+    UInt64 waited_ms = 0;
+    while (true)
+    {
+        if (tryWaitImpl(/*blocking=*/false, /*check_exit_status=*/false).is_process_terminated)
+            return true;
+        if (waited_ms >= reap_poll_budget_ms)
+            return false;
+        sleepForMilliseconds(reap_poll_step_ms);
+        waited_ms += reap_poll_step_ms;
+    }
 }
 
 

--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -480,36 +480,28 @@ bool ShellCommand::waitIfProccesTerminated()
 }
 
 
-bool ShellCommand::tryReapWithoutStatusCheck()
+bool ShellCommand::tryWaitWithoutStatusCheck()
 {
-    /// A child that has closed stdout (so the pipeline is complete) but has only
-    /// just called `_exit` is not yet a reapable zombie the instant cleanup runs, so
-    /// a single non-blocking `wait4(WNOHANG)` can miss it and lose its `rusage` — the
-    /// CPU counters would then read zero. Poll for a bounded budget so a
-    /// promptly-exiting child is reaped and its usage captured. A child that keeps
-    /// running past the budget is still left to `~ShellCommand`'s bounded
-    /// `command_termination_timeout` + SIGTERM teardown, so cleanup never hangs.
-    ///
-    /// The budget follows the same `command_termination_timeout` contract as the
-    /// destructor's wait: it is `wait_for_normal_exit_before_termination_seconds`.
-    /// This way a child that exits naturally anywhere inside the configured teardown
-    /// window is reaped here (with its `rusage`) rather than by the destructor's
-    /// `waitForPid`, which does not collect usage. A configured timeout of 0 means
-    /// "do not wait" — a single non-blocking reap, so this path never stalls a query
-    /// beyond what the configuration allows.
-    const UInt64 reap_poll_budget_ms
+    /// A child that closed stdout but has only just called `_exit` is not yet a
+    /// zombie, so a single `wait4(WNOHANG)` can miss it and lose its `rusage`. Poll
+    /// within the same `command_termination_timeout` window the destructor uses
+    /// (`wait_for_normal_exit_before_termination_seconds`), so a child exiting inside
+    /// that window has its usage collected here rather than by the destructor's
+    /// `waitForPid`, which collects none. A configured timeout of 0 means a single
+    /// non-blocking attempt, so this never stalls a query beyond the configuration.
+    const UInt64 poll_budget_ms
         = config.terminate_in_destructor_strategy.wait_for_normal_exit_before_termination_seconds * 1000ULL;
-    static constexpr UInt64 reap_poll_step_ms = 5;
+    static constexpr UInt64 poll_step_ms = 5;
 
     UInt64 waited_ms = 0;
     while (true)
     {
         if (tryWaitImpl(/*blocking=*/false, /*check_exit_status=*/false).is_process_terminated)
             return true;
-        if (waited_ms >= reap_poll_budget_ms)
+        if (waited_ms >= poll_budget_ms)
             return false;
-        sleepForMilliseconds(std::min(reap_poll_step_ms, reap_poll_budget_ms - waited_ms));
-        waited_ms += reap_poll_step_ms;
+        sleepForMilliseconds(std::min(poll_step_ms, poll_budget_ms - waited_ms));
+        waited_ms += poll_step_ms;
     }
 }
 

--- a/src/Common/ShellCommand.cpp
+++ b/src/Common/ShellCommand.cpp
@@ -16,6 +16,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <csignal>
 #include <limits>
 
@@ -484,11 +485,20 @@ bool ShellCommand::tryReapWithoutStatusCheck()
     /// A child that has closed stdout (so the pipeline is complete) but has only
     /// just called `_exit` is not yet a reapable zombie the instant cleanup runs, so
     /// a single non-blocking `wait4(WNOHANG)` can miss it and lose its `rusage` — the
-    /// CPU counters would then read zero. Poll for a short bounded budget so a
+    /// CPU counters would then read zero. Poll for a bounded budget so a
     /// promptly-exiting child is reaped and its usage captured. A child that keeps
     /// running past the budget is still left to `~ShellCommand`'s bounded
     /// `command_termination_timeout` + SIGTERM teardown, so cleanup never hangs.
-    static constexpr UInt64 reap_poll_budget_ms = 1000;
+    ///
+    /// The budget follows the same `command_termination_timeout` contract as the
+    /// destructor's wait: it is `wait_for_normal_exit_before_termination_seconds`.
+    /// This way a child that exits naturally anywhere inside the configured teardown
+    /// window is reaped here (with its `rusage`) rather than by the destructor's
+    /// `waitForPid`, which does not collect usage. A configured timeout of 0 means
+    /// "do not wait" — a single non-blocking reap, so this path never stalls a query
+    /// beyond what the configuration allows.
+    const UInt64 reap_poll_budget_ms
+        = config.terminate_in_destructor_strategy.wait_for_normal_exit_before_termination_seconds * 1000ULL;
     static constexpr UInt64 reap_poll_step_ms = 5;
 
     UInt64 waited_ms = 0;
@@ -498,7 +508,7 @@ bool ShellCommand::tryReapWithoutStatusCheck()
             return true;
         if (waited_ms >= reap_poll_budget_ms)
             return false;
-        sleepForMilliseconds(reap_poll_step_ms);
+        sleepForMilliseconds(std::min(reap_poll_step_ms, reap_poll_budget_ms - waited_ms));
         waited_ms += reap_poll_step_ms;
     }
 }

--- a/src/Common/ShellCommand.h
+++ b/src/Common/ShellCommand.h
@@ -127,10 +127,9 @@ public:
     /// If process terminated, then handle return code.
     bool waitIfProccesTerminated();
 
-    /// Non-blocking reap: if the child has already terminated, collect its `rusage`
-    /// without inspecting the exit status, so a non-zero or signalled exit is not
-    /// raised as an error. Returns whether the child was reaped.
-    bool tryReapWithoutStatusCheck();
+    /// Collect the child's `rusage` without inspecting the exit status, so a non-zero
+    /// or signalled exit is not raised as an error. Returns whether the child was waited.
+    bool tryWaitWithoutStatusCheck();
 
     WriteBufferFromFile in;        /// If the command reads from stdin, do not forget to call in.close() after writing all the data there.
     ReadBufferFromFile out;

--- a/src/Common/ShellCommand.h
+++ b/src/Common/ShellCommand.h
@@ -157,6 +157,17 @@ private:
     /// commands, which never register.
     UInt64 udf_registry_generation = 0;
 
+    /// Absolute monotonic deadline (ns, `clock_gettime_ns`) shared by the cleanup-side
+    /// wait and the destructor-side wait so `command_termination_timeout` bounds their
+    /// SUM, not each separately. Armed lazily by `remainingTerminationTimeoutMs`; 0 means
+    /// not yet armed.
+    UInt64 termination_deadline_ns = 0;
+
+    /// Milliseconds left until the shared termination deadline, arming it on the first
+    /// call from `wait_for_normal_exit_before_termination_seconds`. Returns 0 once the
+    /// deadline has passed, so both wait paths stop at one shared budget.
+    UInt64 remainingTerminationTimeoutMs();
+
     ShellCommand(pid_t pid_, int & in_fd_, int & out_fd_, int & err_fd_, const Config & config);
 
     bool tryWaitProcessWithTimeout(size_t timeout_in_seconds);

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -604,9 +604,10 @@ namespace
                     /// (`check_exit_code=true`, normal completion), `isWaitCalled()` is
                     /// true and `tryReapWithoutStatusCheck` is skipped.
                     ///
-                    /// Non-blocking: a child that closed stdout but keeps running is left
-                    /// to `~ShellCommand`'s bounded `command_termination_timeout` + SIGTERM,
-                    /// so profiling cannot turn cleanup into a query hang.
+                    /// Bounded reap: a child that closed stdout but keeps running past
+                    /// the short poll budget is left to `~ShellCommand`'s bounded
+                    /// `command_termination_timeout` + SIGTERM, so profiling cannot turn
+                    /// cleanup into a query hang.
                     /// No status check: a non-zero exit must not raise
                     /// CHILD_WAS_NOT_EXITED_NORMALLY when `check_exit_code=false`.
                     if (!command->isWaitCalled())

--- a/src/Processors/Sources/ShellCommandSource.cpp
+++ b/src/Processors/Sources/ShellCommandSource.cpp
@@ -599,22 +599,17 @@ namespace
                     /// was provably alive; by cleanup the child has closed stdout and is
                     /// exiting, so its `/proc` mm fields are gone — no useful sample here.
                     ///
-                    /// Attempt a non-blocking reap to capture wait4 rusage for CPU.
-                    /// When `prepare` already reaped the child via its blocking `wait`
-                    /// (`check_exit_code=true`, normal completion), `isWaitCalled()` is
-                    /// true and `tryReapWithoutStatusCheck` is skipped.
-                    ///
-                    /// Bounded reap: a child that closed stdout but keeps running past
-                    /// the short poll budget is left to `~ShellCommand`'s bounded
-                    /// `command_termination_timeout` + SIGTERM, so profiling cannot turn
-                    /// cleanup into a query hang.
-                    /// No status check: a non-zero exit must not raise
-                    /// CHILD_WAS_NOT_EXITED_NORMALLY when `check_exit_code=false`.
+                    /// Capture wait4 rusage for CPU. When `prepare` already waited the child
+                    /// via its blocking `wait` (`check_exit_code=true`), `isWaitCalled()` is
+                    /// true and this is skipped. A child lingering past the poll budget is left
+                    /// to `~ShellCommand`'s bounded `command_termination_timeout` + SIGTERM, so
+                    /// profiling cannot turn cleanup into a query hang. No status check: a
+                    /// non-zero exit must not raise CHILD_WAS_NOT_EXITED_NORMALLY here.
                     if (!command->isWaitCalled())
                     {
                         try
                         {
-                            command->tryReapWithoutStatusCheck();
+                            command->tryWaitWithoutStatusCheck();
                         }
                         catch (...)
                         {
@@ -622,9 +617,9 @@ namespace
                         }
                     }
 
-                    /// Peak memory is independent of the reap: it comes from /proc VmHWM
+                    /// Peak memory is independent of the wait: it comes from /proc VmHWM
                     /// sampled during IO and stamped by recordExecutableElapsed. CPU requires
-                    /// the wait4 rusage and is recorded only when the reap succeeded.
+                    /// the wait4 rusage and is recorded only when the wait succeeded.
                     configuration.sampler->recordExecutableElapsed();
 
                     if (command->wasChildResourceUsageCaptured())

--- a/tests/integration/test_executable_udf_profile_events/test.py
+++ b/tests/integration/test_executable_udf_profile_events/test.py
@@ -478,16 +478,18 @@ def test_peak_memory_reflects_udf_not_server(started_cluster):
 def test_check_exit_code_false_lingering_child_is_bounded_and_flushes_bytes(started_cluster):
     _skip_msan()
     # Invariant: with check_exit_code=false a child that closes stdout and lingers
-    # does not block cleanup (teardown is bounded by command_termination_timeout,
-    # ~3 s, not by the child's 30 s sleep), and its already-observed stdin/stdout
-    # byte counters are still reported even though no wait4 rusage was captured.
+    # is torn down within ONE command_termination_timeout window (3 s here), not the
+    # child's 30 s sleep, and its already-observed stdin/stdout byte counters are still
+    # reported even though no wait4 rusage was captured. The 5 s bound also guards the
+    # cleanup+destructor double-wait: sharing one deadline keeps teardown near 3 s, while
+    # charging the window twice would push it to ~6 s.
     qid = "exec-stdout-linger-1"
     t0 = time.monotonic()
     _run("SELECT sum(test_udf_stdout_close_linger(number)) FROM numbers(50)", qid)
     elapsed = time.monotonic() - t0
-    assert elapsed < 25, (
-        f"Query took {elapsed:.1f}s — must be bounded by command_termination_timeout (~3s) "
-        f"+ teardown, not the child's 30s sleep"
+    assert elapsed < 5, (
+        f"Query took {elapsed:.1f}s — teardown must fit one command_termination_timeout "
+        f"window (~3s), not two (~6s) or the child's 30s sleep"
     )
 
     invocations = _profile_event_value(qid, "ExecutableUserDefinedFunctionInvocations")

--- a/tests/integration/test_executable_udf_profile_events/test.py
+++ b/tests/integration/test_executable_udf_profile_events/test.py
@@ -382,7 +382,7 @@ def test_check_exit_code_false_succeeds_and_meters(started_cluster):
     _skip_msan()
     qid = "exec-nonzero-exit-1"
     # The UDF exits with code 3; check_exit_code=false means the source takes
-    # the tryReapWithoutStatusCheck path, so the query must succeed and rusage
+    # the tryWaitWithoutStatusCheck path, so the query must succeed and rusage
     # must still be populated.
     result = _run(
         "SELECT sum(test_udf_nonzero_exit(number)) FROM numbers(20)",

--- a/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
+++ b/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
@@ -37,11 +37,13 @@ for line in sys.stdin:
 # child is provably still running (not yet a zombie) when cleanup runs its reap:
 # this makes the "reap loses rusage" race deterministic. A single non-blocking
 # wait4(WNOHANG) then returns 0 and loses the rusage, so the reap must poll for a
-# bounded interval to still capture the child's CPU rusage. The delay is above the
-# single-shot failure threshold yet well under both the 1s reap poll budget and
-# command_termination_timeout, so a correct reap succeeds and cleanup never
-# SIGTERM-bounds.
+# bounded interval to still capture the child's CPU rusage. The 2s delay is chosen
+# to sit inside command_termination_timeout (5s here) yet above a 1s window: a
+# reap budget that follows command_termination_timeout captures this child's rusage
+# in cleanup, whereas a shorter fixed budget would give up and let the destructor's
+# waitForPid reap it (which collects no rusage), so a correct reap succeeds and
+# cleanup never SIGTERM-bounds.
 sys.stdout.flush()
 os.close(1)
-time.sleep(0.6)
+time.sleep(2.0)
 os._exit(3)

--- a/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
+++ b/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
@@ -10,6 +10,7 @@ non-blocking, no-status-check path (`tryReapWithoutStatusCheck`), so:
 
 import os
 import sys
+import time
 
 
 def _cpu_work(seed: int) -> int:
@@ -31,6 +32,16 @@ for line in sys.stdin:
     sys.stdout.write(f"{_cpu_work(n)}\n")
     sys.stdout.flush()
 
-# Flush before exiting so all output is visible before the process dies.
+# Flush all output, then close stdout so ClickHouse observes EOF and proceeds to
+# reap the child while this process is still alive. Sleep before exiting so the
+# child is provably still running (not yet a zombie) when cleanup runs its reap:
+# this makes the "reap loses rusage" race deterministic. A single non-blocking
+# wait4(WNOHANG) then returns 0 and loses the rusage, so the reap must poll for a
+# bounded interval to still capture the child's CPU rusage. The delay is above the
+# single-shot failure threshold yet well under both the 1s reap poll budget and
+# command_termination_timeout, so a correct reap succeeds and cleanup never
+# SIGTERM-bounds.
 sys.stdout.flush()
+os.close(1)
+time.sleep(0.6)
 os._exit(3)

--- a/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
+++ b/tests/integration/test_executable_udf_profile_events/user_scripts/udf_nonzero_exit.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
 """executable UDF that does CPU work per row and exits with code 3 after EOF.
 
-Used to validate that with `check_exit_code=false` the source reaps via the
-non-blocking, no-status-check path (`tryReapWithoutStatusCheck`), so:
-  - a non-zero child exit does not raise an exception, and
-  - rusage is still captured (`ExecutableUserDefinedFunctionUserTimeMicroseconds > 0`),
-  - and `CHILD_WAS_NOT_EXITED_NORMALLY` is NOT logged.
+Validates that with `check_exit_code=false` the source takes the no-status-check
+wait path (`tryWaitWithoutStatusCheck`): a non-zero exit raises nothing, rusage is
+still captured (`ExecutableUserDefinedFunctionUserTimeMicroseconds > 0`), and
+`CHILD_WAS_NOT_EXITED_NORMALLY` is not logged.
 """
 
 import os
@@ -32,17 +31,12 @@ for line in sys.stdin:
     sys.stdout.write(f"{_cpu_work(n)}\n")
     sys.stdout.flush()
 
-# Flush all output, then close stdout so ClickHouse observes EOF and proceeds to
-# reap the child while this process is still alive. Sleep before exiting so the
-# child is provably still running (not yet a zombie) when cleanup runs its reap:
-# this makes the "reap loses rusage" race deterministic. A single non-blocking
-# wait4(WNOHANG) then returns 0 and loses the rusage, so the reap must poll for a
-# bounded interval to still capture the child's CPU rusage. The 2s delay is chosen
-# to sit inside command_termination_timeout (5s here) yet above a 1s window: a
-# reap budget that follows command_termination_timeout captures this child's rusage
-# in cleanup, whereas a shorter fixed budget would give up and let the destructor's
-# waitForPid reap it (which collects no rusage), so a correct reap succeeds and
-# cleanup never SIGTERM-bounds.
+# Close stdout so ClickHouse sees EOF and starts cleanup while this process is still
+# alive, then sleep so it is provably still running (not yet a zombie) when the wait
+# runs. A single wait4(WNOHANG) then returns 0 and loses the rusage; the wait must
+# poll to still capture it. The 2s delay sits inside command_termination_timeout (5s)
+# but above a 1s window, so a budget that follows command_termination_timeout captures
+# this child's rusage in cleanup while a fixed 1s budget would miss it.
 sys.stdout.flush()
 os.close(1)
 time.sleep(2.0)

--- a/tests/integration/test_executable_udf_profile_events/user_scripts/udf_stdout_close_linger.py
+++ b/tests/integration/test_executable_udf_profile_events/user_scripts/udf_stdout_close_linger.py
@@ -4,12 +4,12 @@
 Used to validate the `check_exit_code=false` non-blocking-cleanup contract:
   - ClickHouse sees stdout EOF and considers the UDF done, so the pipeline
     completes without waiting for the child process to exit.
-  - `tryReapWithoutStatusCheck` returns false (child still running), so
+  - `tryWaitWithoutStatusCheck` returns false (child still running), so
     `executableFinished` stays false and no wait4 rusage is captured.
-  - Despite no reap, `ExecutableUserDefinedFunctionInputBytes` and
+  - Even so, `ExecutableUserDefinedFunctionInputBytes` and
     `ExecutableUserDefinedFunctionOutputBytes` are still reported because those
     counters are recorded by the pipe buffers as data streams through, independent
-    of child reap status.
+    of child wait status.
 """
 
 import os


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/105618
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a race that made `test_executable_udf_profile_events::test_check_exit_code_false_succeeds_and_meters` flaky (`assert cpu > 0`).

**Failing check:** `Integration tests (arm_binary, distributed plan, 3/4)`.
**CI report:** https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9d5fd8abfb763217edb76704dba9fb9453a6992d&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29

**Root cause.** With `check_exit_code=false`, `ShellCommandSource::cleanup` waits the child via `ShellCommand::tryWaitWithoutStatusCheck`, which did a single `wait4(WNOHANG)`. A child that has closed stdout but only just reached `_exit` is not yet a zombie, so `WNOHANG` returns 0, no `rusage` is collected, and `ExecutableUserDefinedFunctionUserTimeMicroseconds` reads 0.

**Fix.** `tryWaitWithoutStatusCheck` polls `wait4(WNOHANG)` within the configured `command_termination_timeout` window (`wait_for_normal_exit_before_termination_seconds`), so a child exiting in that window has its usage collected here instead of by the destructor's `waitForPid`, which collects none. Timeout 0 means a single non-blocking attempt, so a query is never stalled beyond the configuration. A child lingering past the budget still falls through to the bounded `command_termination_timeout` + SIGTERM teardown (the `..._lingering_child_is_bounded_and_flushes_bytes` invariant is preserved).

**Reproducing test.** `udf_nonzero_exit.py` closes stdout then sleeps 2s (inside the 5s `command_termination_timeout`, above a 1s window) before exiting non-zero, making the lost-usage window deterministic. Verified on a local debug build: without the fix `test_check_exit_code_false_succeeds_and_meters` fails (`UserTime == 0`); with the fix it and the lingering-child test pass, and `CHILD_WAS_NOT_EXITED_NORMALLY` is never logged.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.800` (included in `26.7` and later)
<!-- ch-version-info:end -->