### PR TITLE
Add object_storage_fsync_after_insert to make data-lake writes durable before commit

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7398,6 +7398,9 @@ Defines a rows limit for a single inserted data file in delta lake.
     DECLARE(NonZeroUInt64, delta_lake_insert_max_bytes_in_data_file, 1_GiB, R"(
 Defines a bytes limit for a single inserted data file in delta lake.
 )", 0) \
+    DECLARE(Bool, object_storage_fsync_after_insert, false, R"(
+If enabled, `fsync` (`fdatasync`) each data file written by object storage table engines (`S3`, `File`, `DeltaLake`, `Iceberg`, ...) before the insert completes, so committed data is durable across a hard failure (power loss, container/volume teardown). For data lakes this makes the data files durable before the metadata commit (`_delta_log` for Delta, snapshot for Iceberg) becomes visible. Disabled by default; mirrors the MergeTree `fsync_after_insert` setting.
+)", 0) \
     DECLARE(Bool, allow_experimental_delta_lake_writes, false, R"(
 Enables delta-kernel writes feature.
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.6",
         {
+            {"object_storage_fsync_after_insert", false, false, "New setting to fsync data files written by object storage table engines (S3, File, DeltaLake, Iceberg) before an insert completes, making committed data durable across a hard failure. Disabled by default."},
             {"output_format_image_width", 1024, 1024, "New setting controlling the width of the output image for image output formats such as PNG."},
             {"output_format_image_height", 1024, 1024, "New setting controlling the height of the output image for image output formats such as PNG."},
             {"output_format_image_terminal_mode", "", "", "New setting controlling whether image output formats such as PNG are rendered directly to the terminal using an inline image protocol."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -39,9 +39,12 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// controls new feature and it's 'true' by default, use 'false' as previous_value).
         /// It's used to implement `compatibility` setting (see https://github.com/ClickHouse/ClickHouse/issues/35972)
         /// Note: please check if the key already exists to prevent duplicate entries.
-        addSettingsChanges(settings_changes_history, "26.6",
+        addSettingsChanges(settings_changes_history, "26.7",
         {
             {"object_storage_fsync_after_insert", false, false, "New setting to fsync data files written by object storage table engines (S3, File, DeltaLake, Iceberg) before an insert completes, making committed data durable across a hard failure. Disabled by default."},
+        });
+        addSettingsChanges(settings_changes_history, "26.6",
+        {
             {"output_format_image_width", 1024, 1024, "New setting controlling the width of the output image for image output formats such as PNG."},
             {"output_format_image_height", 1024, 1024, "New setting controlling the height of the output image for image output formats such as PNG."},
             {"output_format_image_terminal_mode", "", "", "New setting controlling whether image output formats such as PNG are rendered directly to the terminal using an inline image protocol."},

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/MultipleFileWriter.cpp
@@ -3,12 +3,18 @@
 #include <Formats/FormatFactory.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Processors/Formats/IOutputFormat.h>
+#include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h>
 
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsBool object_storage_fsync_after_insert;
+}
 
 #if USE_AVRO
 
@@ -84,6 +90,12 @@ void MultipleFileWriter::finalize()
     output_format->flush();
     output_format->finalize();
     buffer->finalize();
+
+    /// Make the data file durable before the Iceberg snapshot commit references it, so a hard
+    /// failure cannot leave a committed-but-truncated data file. Mirrors MergeTree fsync_after_insert.
+    if (context->getSettingsRef()[Setting::object_storage_fsync_after_insert])
+        buffer->sync();
+
     auto buffer_bytes = buffer->count();
     UInt64 file_bytes = 0;
     if (buffer_bytes > 0)

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.cpp
@@ -13,6 +13,7 @@ namespace Setting
 {
     extern const SettingsUInt64 output_format_compression_level;
     extern const SettingsUInt64 output_format_compression_zstd_window_log;
+    extern const SettingsBool object_storage_fsync_after_insert;
 }
 
 namespace ErrorCodes
@@ -61,12 +62,16 @@ StorageObjectStorageSink::StorageObjectStorageSink(
     : SinkToStorage(sample_block_)
     , path(path_)
     , sample_block(sample_block_)
+    , fsync_after_insert(context->getSettingsRef()[Setting::object_storage_fsync_after_insert])
 {
     const auto & settings = context->getSettingsRef();
     const auto chosen_compression_method = chooseCompressionMethod(path, compression_method);
 
     auto buffer = object_storage->writeObject(
         StoredObject(path), WriteMode::Rewrite, std::nullopt, DBMS_DEFAULT_BUFFER_SIZE, context->getWriteSettings());
+
+    /// Keep a non-owning pointer to the file buffer to fdatasync it later (see finalizeBuffers).
+    file_buf = buffer.get();
 
     write_buf = wrapWriteBufferWithCompressionMethod(
         std::move(buffer),
@@ -113,6 +118,12 @@ void StorageObjectStorageSink::finalizeBuffers()
 
     write_buf->finalize();
     result_file_size = write_buf->count();
+
+    /// Make the data file durable before the caller commits it (e.g. DeltaLake `_delta_log`,
+    /// Iceberg snapshot). Without this, a hard failure between finalize() and the metadata
+    /// commit can leave a committed-but-truncated data file. Mirrors MergeTree fsync_after_insert.
+    if (fsync_after_insert && file_buf)
+        file_buf->sync();
 }
 
 void StorageObjectStorageSink::releaseBuffers()

--- a/src/Storages/ObjectStorage/StorageObjectStorageSink.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSink.h
@@ -6,6 +6,8 @@
 
 namespace DB
 {
+class WriteBufferFromFileBase;
+
 class StorageObjectStorageSink final : public SinkToStorage
 {
 public:
@@ -34,6 +36,12 @@ private:
     const String path;
     SharedHeader sample_block;
     std::unique_ptr<WriteBuffer> write_buf;
+    /// Non-owning pointer to the underlying file buffer returned by writeObject(),
+    /// captured before the compression wrap. Used to fdatasync the data file when
+    /// `object_storage_fsync_after_insert` is enabled: compression wrappers inherit
+    /// WriteBuffer::sync() which does not fdatasync, so we must sync the file buffer.
+    WriteBufferFromFileBase * file_buf = nullptr;
+    const bool fsync_after_insert;
     OutputFormatPtr writer;
     std::optional<size_t> result_file_size;
 

--- a/tests/queries/0_stateless/04365_object_storage_fsync_after_insert.reference
+++ b/tests/queries/0_stateless/04365_object_storage_fsync_after_insert.reference
@@ -1,0 +1,3 @@
+fsync_off: no FileSync
+fsync_on: FileSync fired
+50

--- a/tests/queries/0_stateless/04365_object_storage_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04365_object_storage_fsync_after_insert.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-msan
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# When object_storage_fsync_after_insert = 1, a data file written by an object
+# storage sink must be fdatasync'd (FileSync profile event) before the insert
+# completes, so committed data is durable across a hard failure. When the
+# setting is off, no fsync happens (previous behavior). Exercised via the
+# DeltaLakeLocal write path, which is where a lost data-file tail can leave a
+# committed-but-truncated parquet file (issue #109664).
+
+TABLE_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_DATABASE}_fsync_delta"
+
+make_empty_delta_table() {
+    rm -rf "${TABLE_DIR}"
+    mkdir -p "${TABLE_DIR}/_delta_log"
+    cat > "${TABLE_DIR}/_delta_log/00000000000000000000.json" <<EOF
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"00000000-0000-0000-0000-000000000000","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"a\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"b\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1700000000000}}
+EOF
+}
+
+# Count the FileSync profile events emitted while running one insert.
+run_insert() {
+    local fsync="$1"
+    ${CLICKHOUSE_LOCAL} --print-profile-events --profile-events-delay-ms=-1 -q "
+        SET allow_experimental_delta_lake_writes = 1, object_storage_fsync_after_insert = ${fsync};
+        INSERT INTO TABLE FUNCTION deltaLakeLocal('${TABLE_DIR}')
+            SELECT number AS a, toString(number) AS b FROM numbers(50);
+    " 2>&1 | grep -c -E '\bFileSync:'
+}
+
+make_empty_delta_table
+off=$(run_insert 0)
+make_empty_delta_table
+on=$(run_insert 1)
+
+# off: no fdatasync; on: at least one fdatasync of the written data file.
+[ "${off}" -eq 0 ] && echo "fsync_off: no FileSync" || echo "fsync_off: unexpected FileSync (${off})"
+[ "${on}" -ge 1 ] && echo "fsync_on: FileSync fired" || echo "fsync_on: FileSync missing"
+
+# Data is still readable after a durable insert.
+${CLICKHOUSE_LOCAL} -q "SET allow_experimental_delta_lake_writes = 1; SELECT count() FROM deltaLakeLocal('${TABLE_DIR}')"
+
+rm -rf "${TABLE_DIR}"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/109664
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add setting `object_storage_fsync_after_insert` (default `false`). When enabled, data files written by object storage table engines (`S3`, `File`, `DeltaLake`, `Iceberg`) are `fsync`'d before an insert completes, so committed data survives a hard failure (power loss, container/volume teardown). For data lakes this makes the data files durable before the metadata commit (`_delta_log` for Delta, snapshot for Iceberg) becomes visible.


### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/109664

Object storage sinks finalize each data file only to the OS page cache: `StorageObjectStorageSink::finalizeBuffers` calls `write_buf->finalize()`, and `WriteBufferFromFileDescriptor::finalizeImpl` never calls `sync()` (`fdatasync`). `DeltaLakeSink::onFinish` then runs `delta_transaction->commit(files)` (and Iceberg commits its snapshot) while the data bytes are not yet durable. A hard failure between finalize and the metadata commit can leave a committed data file whose tail (e.g. a parquet `PAR1` footer) never reached disk, so a later `SELECT` fails with `Not a Parquet file (wrong magic bytes at the end of file)`. MergeTree already avoids this via `fsync_after_insert`.

Fix, gated behind the new `object_storage_fsync_after_insert` setting (default off, no behavior change):

- `StorageObjectStorageSink`: keep a non-owning pointer to the underlying file buffer (captured before the compression wrap, since compression wrappers inherit `WriteBuffer::sync()` which does not `fdatasync`); after `write_buf->finalize()`, call `file_buf->sync()`. This covers the `File`/`S3` sink and, since `DeltaLakeSink::onFinish` finalizes each data-file sink before `commit`, makes Delta data files durable before the `_delta_log` commit.
- Iceberg `MultipleFileWriter::finalize`: `buffer->sync()` under the same gate, before the snapshot commit references the file.

Read side is intentionally unchanged: a committed corrupt file must keep erroring loudly rather than fail open.

Verified locally on the `DeltaLakeLocal` write path: with the setting on exactly one `FileSync` fires per written data file before the commit; with it off, zero (previous behavior). Regression test: `04365_object_storage_fsync_after_insert`.
