### PR TITLE
Backport #106425 to 26.5: Fix used_privileges leaking across unrelated queries in system.query_log

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -3485,7 +3485,13 @@ void Context::makeQueryContext()
     local_read_query_throttler.reset();
     local_write_query_throttler.reset();
     backups_query_throttler.reset();
-    query_privileges_info = std::make_shared<QueryPrivilegesInfo>(*query_privileges_info);
+    /// A new query starts with an empty set of used/missing privileges.
+    /// We must not copy the contents of the parent's `QueryPrivilegesInfo`: the parent is the session
+    /// (or global) context, whose `query_privileges_info` object is shared between all sessions and queries
+    /// (session contexts are created via `createCopy(global_context)` and never call `makeQueryContext`).
+    /// Copying its contents — and racing with concurrent writers during the copy — leaked privilege strings
+    /// from unrelated earlier queries into `system.query_log.used_privileges`. See issue #105983.
+    query_privileges_info = std::make_shared<QueryPrivilegesInfo>();
     async_read_counters = std::make_shared<AsyncReadCounters>();
     runtime_filter_lookup = createRuntimeFilterLookup();
 }

--- a/src/Interpreters/tests/gtest_context_race.cpp
+++ b/src/Interpreters/tests/gtest_context_race.cpp
@@ -168,6 +168,62 @@ TEST(Context, TableFunctionResultsCopyRace)
     writer.join();
 }
 
+/// Regression test for a cross-query leak in `system.query_log.used_privileges`.
+///
+/// A query context is created via `createCopy(session_or_global_context)` followed by
+/// `makeQueryContext()`. Session contexts are themselves `createCopy(global_context)` and never
+/// call `makeQueryContext`, so the session and global contexts share a single `QueryPrivilegesInfo`
+/// object. `makeQueryContext` used to seed the new query's privileges by *copying the contents* of
+/// that shared parent object (`std::make_shared<QueryPrivilegesInfo>(*query_privileges_info)`).
+///
+/// As a result, any privilege string that ever landed in the shared parent object (and, under
+/// concurrency, partial state observed mid-write) leaked into the `used_privileges` of unrelated
+/// later queries from other sessions and databases. The fix seeds every query with an empty
+/// `QueryPrivilegesInfo`. This test models the scenario deterministically: it pollutes a parent
+/// context's privileges, derives a query context from it, and asserts the query starts clean.
+///
+/// See issue ClickHouse/ClickHouse#105983.
+TEST(Context, MakeQueryContextDoesNotInheritPrivileges)
+{
+    /// Stand in for the shared session/global context whose `QueryPrivilegesInfo` gets polluted.
+    auto parent_context = Context::createCopy(getContext().context);
+    parent_context->addQueryPrivilegesInfo("SELECT(naughty_column) ON some_db.some_table", true);
+    parent_context->addQueryPrivilegesInfo("INSERT ON some_db.some_table", false);
+
+    {
+        const auto & parent_info = parent_context->getQueryPrivilegesInfo();
+        std::lock_guard lock(parent_info.mutex);
+        ASSERT_FALSE(parent_info.used_privileges.empty());
+        ASSERT_FALSE(parent_info.missing_privileges.empty());
+    }
+
+    /// A new query context, as created by `Session::makeQueryContextImpl`.
+    auto query_context = Context::createCopy(parent_context);
+    query_context->makeQueryContext();
+
+    /// The fresh query must not have inherited any of the parent's privilege strings.
+    {
+        const auto & query_info = query_context->getQueryPrivilegesInfo();
+        std::lock_guard lock(query_info.mutex);
+        EXPECT_TRUE(query_info.used_privileges.empty());
+        EXPECT_TRUE(query_info.missing_privileges.empty());
+    }
+
+    /// Privileges checked during the new query must be tracked independently of the parent,
+    /// and must not bleed back into the parent's (shared) object.
+    query_context->addQueryPrivilegesInfo("SELECT ON my_db.my_table", true);
+    {
+        const auto & query_info = query_context->getQueryPrivilegesInfo();
+        std::lock_guard lock(query_info.mutex);
+        EXPECT_EQ(query_info.used_privileges.count("SELECT ON my_db.my_table"), 1u);
+    }
+    {
+        const auto & parent_info = parent_context->getQueryPrivilegesInfo();
+        std::lock_guard lock(parent_info.mutex);
+        EXPECT_EQ(parent_info.used_privileges.count("SELECT ON my_db.my_table"), 0u);
+    }
+}
+
 /// Regression test for a startup race between DNSCacheUpdater and ConfigReloader.
 ///
 /// DNSCacheUpdater::run() can call Context::reloadClusterConfig() before the first


### PR DESCRIPTION
Manual backport of https://github.com/ClickHouse/ClickHouse/pull/106425 to 26.5 (the automated backport was not created).

`used_privileges` (and `missing_privileges`) rows in `system.query_log` could contain privilege strings from completely unrelated earlier queries of a different user, database, and session. `Context::makeQueryContext` seeded a new query's `QueryPrivilegesInfo` by copying the contents of the shared session/global object; a copy-vs-write race against that shared object leaked stray privilege strings into later queries. The fix seeds every query with an empty `QueryPrivilegesInfo`.

This also fixes the flaky failures of `03168_query_log_privileges_not_empty` observed on the 26.5/26.4/26.3/25.8 backport PRs of #108508.

Related: https://github.com/ClickHouse/ClickHouse/issues/105983

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a bug where the `used_privileges` and `missing_privileges` columns of `system.query_log` could contain privilege strings leaked from unrelated earlier queries of a different user, database, or session.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.6.25`
<!-- ch-version-info:end -->