### PR TITLE
Docs: inkeep default docs tab adjustment

### DIFF
--- a/docs/_site/customizations/inkeep-init.js
+++ b/docs/_site/customizations/inkeep-init.js
@@ -31,18 +31,16 @@
   var INKEEP_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@inkeep/cxkit-mintlify@0.5/dist/index.js';
 
   // ── Search tabs ──────────────────────────────────────────────────────────
-  // Catch-all tab. Deliberately NOT named 'All': Inkeep reserves the literal
-  // 'All' as a built-in tab that force-pushes EVERY result into it
-  // (`tabs.includes("All") && bucket.All.push(item)` in the cxkit bundle),
-  // which can't be filtered — so changelogs could never be excluded from it.
-  // We use our own catch-all tag instead and apply it in transformSource to
-  // every source except changelogs.
-  var CATCH_ALL_TAB = 'All results';
   // Row 1 (always visible): the top-level tabs. 'Docs' is first because cxkit
   // uses the FIRST configured tab as the default selected one (its defaultTab
-  // is derived as `tabs[0]`), so the modal opens on Docs results rather than
-  // the catch-all.
-  var ROW1_TABS = ['Docs', CATCH_ALL_TAB, 'Changelogs', 'Blogs', 'Website', 'GitHub'];
+  // is derived as `tabs[0]`), so the modal opens on Docs results.
+  //
+  // There is deliberately NO catch-all tab. If one is ever reintroduced, it
+  // must NOT be named 'All': Inkeep reserves the literal 'All' as a built-in
+  // tab that force-pushes EVERY result into it (`tabs.includes("All") &&
+  // bucket.All.push(item)` in the cxkit bundle), which can't be filtered — so
+  // changelogs could never be excluded from it.
+  var ROW1_TABS = ['Docs', 'Changelogs', 'Blogs', 'Website', 'GitHub'];
   // Row 2 (docs sub-areas): shown only while a docs-context tab is active. A
   // docs source is tagged with BOTH 'Docs' and its sub-area, so selecting
   // 'Docs' shows everything and selecting a sub-area narrows it.
@@ -200,12 +198,9 @@
           } else if (url.indexOf('clickhouse.com') !== -1) {
             tabs.push('Website'); // marketing site (the /docs case is handled above)
           }
-          // Every non-changelog result also belongs to the catch-all tab.
-          // Changelogs are excluded so they only surface under their own tab.
-          // This also captures results that matched none of the branches above
-          // (tabs still empty) — they would otherwise appear in no tab now that
-          // Inkeep's reserved 'All' tab is gone.
-          if (tabs.indexOf('Changelogs') === -1) tabs.unshift(CATCH_ALL_TAB);
+          // No catch-all tab: a result that matched none of the branches above
+          // (tabs still empty) appears in no tab, which is deliberate — every
+          // result must earn a place in one of the named tabs.
           return Object.assign({}, source, { tabs: tabs, url: url });
         },
         // Follow Mintlify's `.dark` class on <html>.

--- a/docs/_site/customizations/inkeep-init.js
+++ b/docs/_site/customizations/inkeep-init.js
@@ -31,15 +31,18 @@
   var INKEEP_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@inkeep/cxkit-mintlify@0.5/dist/index.js';
 
   // ── Search tabs ──────────────────────────────────────────────────────────
-  // Catch-all (default) tab. Deliberately NOT named 'All': Inkeep reserves the
-  // literal 'All' as a built-in tab that force-pushes EVERY result into it
+  // Catch-all tab. Deliberately NOT named 'All': Inkeep reserves the literal
+  // 'All' as a built-in tab that force-pushes EVERY result into it
   // (`tabs.includes("All") && bucket.All.push(item)` in the cxkit bundle),
   // which can't be filtered — so changelogs could never be excluded from it.
   // We use our own catch-all tag instead and apply it in transformSource to
   // every source except changelogs.
   var CATCH_ALL_TAB = 'All results';
-  // Row 1 (always visible): the top-level tabs.
-  var ROW1_TABS = [CATCH_ALL_TAB, 'Docs', 'Changelogs', 'Blogs', 'Website', 'GitHub'];
+  // Row 1 (always visible): the top-level tabs. 'Docs' is first because cxkit
+  // uses the FIRST configured tab as the default selected one (its defaultTab
+  // is derived as `tabs[0]`), so the modal opens on Docs results rather than
+  // the catch-all.
+  var ROW1_TABS = ['Docs', CATCH_ALL_TAB, 'Changelogs', 'Blogs', 'Website', 'GitHub'];
   // Row 2 (docs sub-areas): shown only while a docs-context tab is active. A
   // docs source is tagged with BOTH 'Docs' and its sub-area, so selecting
   // 'Docs' shows everything and selecting a sub-area narrows it.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Adjustments to Inkeep settings based on user feedback.
Get rid of the "All results" tab, which mixes results from docs, blog, github. Replaces it with a single default "docs" tab.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.615` (included in `26.7` and later)
<!-- ch-version-info:end -->