### PR TITLE
Docs: group the Cloud API explorer like the swagger page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2269,7 +2269,173 @@
                       },
                       {
                         "group": "API reference",
-                        "openapi": "https://api.clickhouse.cloud/v1"
+                        "openapi": "https://api.clickhouse.cloud/v1",
+                        "pages": [
+                          {
+                            "group": "Organization",
+                            "pages": [
+                              "GET /v1/organizations",
+                              "GET /v1/organizations/{organizationId}",
+                              "PATCH /v1/organizations/{organizationId}",
+                              "GET /v1/organizations/{organizationId}/activities",
+                              "GET /v1/organizations/{organizationId}/activities/{activityId}",
+                              "GET /v1/organizations/{organizationId}/privateEndpointConfig",
+                              "POST /v1/organizations/{organizationId}/byocInfrastructure",
+                              "DELETE /v1/organizations/{organizationId}/byocInfrastructure/{byocInfrastructureId}",
+                              "PATCH /v1/organizations/{organizationId}/byocInfrastructure/{byocInfrastructureId}",
+                              {
+                                "group": "Billing",
+                                "pages": [
+                                  "GET /v1/organizations/{organizationId}/usageCost"
+                                ]
+                              },
+                              {
+                                "group": "User management",
+                                "pages": [
+                                  "GET /v1/organizations/{organizationId}/members",
+                                  "GET /v1/organizations/{organizationId}/members/{userId}",
+                                  "PATCH /v1/organizations/{organizationId}/members/{userId}",
+                                  "DELETE /v1/organizations/{organizationId}/members/{userId}",
+                                  "GET /v1/organizations/{organizationId}/invitations",
+                                  "POST /v1/organizations/{organizationId}/invitations",
+                                  "GET /v1/organizations/{organizationId}/invitations/{invitationId}",
+                                  "DELETE /v1/organizations/{organizationId}/invitations/{invitationId}"
+                                ]
+                              },
+                              {
+                                "group": "Role management",
+                                "pages": [
+                                  "GET /v1/organizations/{organizationId}/roles",
+                                  "POST /v1/organizations/{organizationId}/roles",
+                                  "GET /v1/organizations/{organizationId}/roles/{roleId}",
+                                  "PATCH /v1/organizations/{organizationId}/roles/{roleId}",
+                                  "DELETE /v1/organizations/{organizationId}/roles/{roleId}"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "Service",
+                            "pages": [
+                              "GET /v1/organizations/{organizationId}/services",
+                              "POST /v1/organizations/{organizationId}/services",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/privateEndpointConfig",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/serviceQueryEndpoint",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/serviceQueryEndpoint",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/serviceQueryEndpoint",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/state",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/scaling",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/replicaScaling",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/password",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/privateEndpoint",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/scalingSchedule",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/scalingSchedule",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/scalingSchedule",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/upgradeWindow",
+                              "PUT /v1/organizations/{organizationId}/services/{serviceId}/upgradeWindow",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/upgradeWindow",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickhouseSettings",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickhouseSettings",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickhouseSettings/schema",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickhouseSettings/{settingName}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/clickhouseSettings/{settingName}",
+                              {
+                                "group": "Backup",
+                                "pages": [
+                                  "GET /v1/organizations/{organizationId}/services/{serviceId}/backups",
+                                  "GET /v1/organizations/{organizationId}/services/{serviceId}/backups/{backupId}",
+                                  "GET /v1/organizations/{organizationId}/services/{serviceId}/backupConfiguration",
+                                  "PATCH /v1/organizations/{organizationId}/services/{serviceId}/backupConfiguration",
+                                  "GET /v1/organizations/{organizationId}/services/{serviceId}/backupBucket",
+                                  "POST /v1/organizations/{organizationId}/services/{serviceId}/backupBucket",
+                                  "PATCH /v1/organizations/{organizationId}/services/{serviceId}/backupBucket",
+                                  "DELETE /v1/organizations/{organizationId}/services/{serviceId}/backupBucket"
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "group": "OpenAPI",
+                            "pages": [
+                              "GET /v1/organizations/{organizationId}/keys",
+                              "POST /v1/organizations/{organizationId}/keys",
+                              "GET /v1/organizations/{organizationId}/keys/{keyId}",
+                              "PATCH /v1/organizations/{organizationId}/keys/{keyId}",
+                              "DELETE /v1/organizations/{organizationId}/keys/{keyId}"
+                            ]
+                          },
+                          {
+                            "group": "Prometheus",
+                            "pages": [
+                              "GET /v1/organizations/{organizationId}/prometheus",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/prometheus",
+                              "GET /v1/organizations/{organizationId}/postgres/prometheus",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/prometheus"
+                            ]
+                          },
+                          {
+                            "group": "ClickPipes",
+                            "pages": [
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipes",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/clickpipes",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}/settings",
+                              "PUT /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}/settings",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}/scaling",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickpipes/{clickPipeId}/state",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipesCdcScaling",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickpipesCdcScaling",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipesReversePrivateEndpoints",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/clickpipesReversePrivateEndpoints",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickpipesReversePrivateEndpoints/{reversePrivateEndpointId}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/clickpipesReversePrivateEndpoints/{reversePrivateEndpointId}",
+                              "PATCH /v1/organizations/{organizationId}/services/{serviceId}/clickpipesReversePrivateEndpoints/{reversePrivateEndpointId}"
+                            ]
+                          },
+                          {
+                            "group": "ClickStack",
+                            "pages": [
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards/{clickStackDashboardId}",
+                              "PUT /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards/{clickStackDashboardId}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards/{clickStackDashboardId}",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/alerts",
+                              "POST /v1/organizations/{organizationId}/services/{serviceId}/clickstack/alerts",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/sources",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/alerts/{clickStackAlertId}",
+                              "PUT /v1/organizations/{organizationId}/services/{serviceId}/clickstack/alerts/{clickStackAlertId}",
+                              "DELETE /v1/organizations/{organizationId}/services/{serviceId}/clickstack/alerts/{clickStackAlertId}",
+                              "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/webhooks"
+                            ]
+                          },
+                          {
+                            "group": "Postgres",
+                            "pages": [
+                              "POST /v1/organizations/{organizationId}/postgres",
+                              "GET /v1/organizations/{organizationId}/postgres",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}",
+                              "DELETE /v1/organizations/{organizationId}/postgres/{postgresId}",
+                              "PATCH /v1/organizations/{organizationId}/postgres/{postgresId}",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/caCertificates",
+                              "POST /v1/organizations/{organizationId}/postgres/{postgresId}/restoredService",
+                              "PATCH /v1/organizations/{organizationId}/postgres/{postgresId}/password",
+                              "PATCH /v1/organizations/{organizationId}/postgres/{postgresId}/state",
+                              "POST /v1/organizations/{organizationId}/postgres/{postgresId}/readReplica",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/config",
+                              "POST /v1/organizations/{organizationId}/postgres/{postgresId}/config",
+                              "PATCH /v1/organizations/{organizationId}/postgres/{postgresId}/config",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/metrics",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/slowQueryPatterns",
+                              "GET /v1/organizations/{organizationId}/postgres/{postgresId}/slowQueryPatterns/{queryId}"
+                            ]
+                          }
+                        ]
                       }
                     ]
                   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2399,6 +2399,7 @@
                           },
                           {
                             "group": "ClickStack",
+                            "tag": "Beta",
                             "pages": [
                               "GET /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards",
                               "POST /v1/organizations/{organizationId}/services/{serviceId}/clickstack/dashboards",
@@ -2416,6 +2417,7 @@
                           },
                           {
                             "group": "Postgres",
+                            "tag": "Beta",
                             "pages": [
                               "POST /v1/organizations/{organizationId}/postgres",
                               "GET /v1/organizations/{organizationId}/postgres",


### PR DESCRIPTION
The Cloud API reference in the explorer was a single flat auto-populated group. Update to use Mintlify's selective endpoints: the 'API reference' group keeps openapi: https://api.clickhouse.cloud/v1 as the inherited default spec and nested groups list each endpoint as a 'METHOD /path' page.

Groups mirror https://clickhouse.com/docs/cloud/manage/api/swagger: Organization (+ Billing, User management, Role management), Service (+ Backup), OpenAPI, Prometheus, ClickPipes, ClickStack, Postgres — 109 endpoints, every operation in the spec listed exactly once.

Note: newly added API endpoints no longer appear automatically; they must be added to docs.json (will follow up with some automation for this)

https://www.mintlify.com/docs/api-playground/openapi-setup

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
