### PR TITLE
Support query parameters as user/role name in most contexts

### DIFF
--- a/src/Access/AccessEntityIO.cpp
+++ b/src/Access/AccessEntityIO.cpp
@@ -23,14 +23,24 @@
 #include <Parsers/Access/ASTCreateUserQuery.h>
 #include <Parsers/Access/ASTGrantQuery.h>
 #include <Parsers/ParserAttachAccessEntity.h>
+#include <Parsers/QueryParameterVisitor.h>
 #include <Parsers/parseQuery.h>
 #include <boost/range/algorithm_ext/push_back.hpp>
+#include <fmt/ranges.h>
 
 namespace DB
 {
 namespace ErrorCodes
 {
     extern const int INCORRECT_ACCESS_ENTITY_DEFINITION;
+}
+
+void checkAccessEntityHasNoQueryParameters(const ASTPtr & query)
+{
+    if (const auto parameter_names = analyzeReceiveQueryParams(query); !parameter_names.empty())
+        throw Exception(ErrorCodes::INCORRECT_ACCESS_ENTITY_DEFINITION,
+            "Query parameters are not allowed in access entity definitions (found {})",
+            fmt::join(parameter_names, ", "));
 }
 
 String serializeAccessEntity(const IAccessEntity & entity)
@@ -65,6 +75,9 @@ static AccessEntityPtr deserializeAccessEntityImpl(const String & definition)
         while (isWhitespaceASCII(*pos) || *pos == ';')
             ++pos;
     }
+
+    for (const auto & query : queries)
+        checkAccessEntityHasNoQueryParameters(query);
 
     /// Interpret the AST to build an access entity.
     std::shared_ptr<User> user;

--- a/src/Access/AccessEntityIO.h
+++ b/src/Access/AccessEntityIO.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <base/types.h>
+#include <Parsers/IAST_fwd.h>
 #include <memory>
 
 namespace DB
@@ -12,5 +13,9 @@ using AccessEntityPtr = std::shared_ptr<const IAccessEntity>;
 String serializeAccessEntity(const IAccessEntity & entity);
 
 AccessEntityPtr deserializeAccessEntity(const String & definition, const String & file_path = "");
+
+/// Access entity definitions (DiskAccessStorage files, grant queries in users.xml) are never passed
+/// through query parameter substitution, so query parameters in them must be rejected.
+void checkAccessEntityHasNoQueryParameters(const ASTPtr & query);
 
 }

--- a/src/Access/RolesOrUsersSet.cpp
+++ b/src/Access/RolesOrUsersSet.cpp
@@ -1,5 +1,6 @@
 #include <Access/RolesOrUsersSet.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Access/AccessControl.h>
 #include <Access/User.h>
 #include <Access/Role.h>
@@ -87,10 +88,10 @@ void RolesOrUsersSet::init(const ASTRolesOrUsersSet & ast, const AccessControl *
         return access_control->getID<Role>(name);
     };
 
-    if (!ast.names.empty() && !all)
+    if (const auto all_names = ast.names ? ast.names->toStrings() : Strings{}; !all_names.empty() && !all)
     {
-        ids.reserve(ast.names.size());
-        for (const String & name : ast.names)
+        ids.reserve(all_names.size());
+        for (const String & name : all_names)
             ids.insert(name_to_id(name));
     }
 
@@ -100,10 +101,10 @@ void RolesOrUsersSet::init(const ASTRolesOrUsersSet & ast, const AccessControl *
         ids.insert(*current_user_id);
     }
 
-    if (!ast.except_names.empty())
+    if (const auto all_except_names = ast.except_names ? ast.except_names->toStrings() : Strings{}; !all_except_names.empty())
     {
-        except_ids.reserve(ast.except_names.size());
-        for (const String & name : ast.except_names)
+        except_ids.reserve(all_except_names.size());
+        for (const String & name : all_except_names)
             except_ids.insert(name_to_id(name));
     }
 
@@ -126,18 +127,26 @@ boost::intrusive_ptr<ASTRolesOrUsersSet> RolesOrUsersSet::toAST() const
 
     if (!ids.empty() && !all)
     {
-        ast->names.reserve(ids.size());
+        Strings names;
+        names.reserve(ids.size());
         for (const UUID & id : ids)
-            ast->names.emplace_back(::DB::toString(id));
-        ::sort(ast->names.begin(), ast->names.end());
+            names.emplace_back(::DB::toString(id));
+        ::sort(names.begin(), names.end());
+        ast->names = make_intrusive<ASTUserNamesWithHost>();
+        for (const auto & name : names)
+            ast->names->children.push_back(make_intrusive<ASTUserNameWithHost>(name));
     }
 
     if (!except_ids.empty())
     {
-        ast->except_names.reserve(except_ids.size());
+        Strings except_names;
+        except_names.reserve(except_ids.size());
         for (const UUID & except_id : except_ids)
-            ast->except_names.emplace_back(::DB::toString(except_id));
-        ::sort(ast->except_names.begin(), ast->except_names.end());
+            except_names.emplace_back(::DB::toString(except_id));
+        ::sort(except_names.begin(), except_names.end());
+        ast->except_names = make_intrusive<ASTUserNamesWithHost>();
+        for (const auto & name : except_names)
+            ast->except_names->children.push_back(make_intrusive<ASTUserNameWithHost>(name));
     }
 
     return ast;
@@ -151,26 +160,34 @@ boost::intrusive_ptr<ASTRolesOrUsersSet> RolesOrUsersSet::toASTWithNames(const A
 
     if (!ids.empty() && !all)
     {
-        ast->names.reserve(ids.size());
+        Strings names;
+        names.reserve(ids.size());
         for (const UUID & id : ids)
         {
             auto name = access_control.tryReadName(id);
             if (name)
-                ast->names.emplace_back(std::move(*name));
+                names.emplace_back(std::move(*name));
         }
-        ::sort(ast->names.begin(), ast->names.end());
+        ::sort(names.begin(), names.end());
+        ast->names = make_intrusive<ASTUserNamesWithHost>();
+        for (const auto & name : names)
+            ast->names->children.push_back(make_intrusive<ASTUserNameWithHost>(name));
     }
 
     if (!except_ids.empty())
     {
-        ast->except_names.reserve(except_ids.size());
+        Strings except_names;
+        except_names.reserve(except_ids.size());
         for (const UUID & except_id : except_ids)
         {
             auto except_name = access_control.tryReadName(except_id);
             if (except_name)
-                ast->except_names.emplace_back(std::move(*except_name));
+                except_names.emplace_back(std::move(*except_name));
         }
-        ::sort(ast->except_names.begin(), ast->except_names.end());
+        ::sort(except_names.begin(), except_names.end());
+        ast->except_names = make_intrusive<ASTUserNamesWithHost>();
+        for (const auto & name : except_names)
+            ast->except_names->children.push_back(make_intrusive<ASTUserNameWithHost>(name));
     }
 
     return ast;

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -1,4 +1,5 @@
 #include <Access/UsersConfigParser.h>
+#include <Access/AccessEntityIO.h>
 #include <Access/Quota.h>
 #include <Access/RowPolicy.h>
 #include <Access/User.h>
@@ -62,6 +63,8 @@ namespace
         if (!ast)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failed to parse grant query. Error: {}", error_message);
 
+        checkAccessEntityHasNoQueryParameters(ast);
+
         auto & query = ast->as<ASTGrantQuery &>();
 
         if (query.roles && query.is_revoke)
@@ -85,10 +88,11 @@ namespace
 
         if (query.roles)
         {
+            const auto role_names = query.roles->names ? query.roles->names->toStrings() : Strings{};
             std::vector<UUID> roles_to_grant;
-            roles_to_grant.reserve(query.roles->size());
+            roles_to_grant.reserve(role_names.size());
 
-            for (const auto & role_name : query.roles->names)
+            for (const auto & role_name : role_names)
             {
                 auto role_id = UsersConfigParser::generateID(AccessEntityType::ROLE, role_name);
                 if (!role_ids_from_users_config.contains(role_id))

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -1,4 +1,5 @@
 #include <Access/UsersConfigParser.h>
+#include <Access/AccessEntityIO.h>
 #include <Access/Quota.h>
 #include <Access/RowPolicy.h>
 #include <Access/User.h>
@@ -62,6 +63,8 @@ namespace
         if (!ast)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Failed to parse grant query. Error: {}", error_message);
 
+        checkAccessEntityHasNoQueryParameters(ast);
+
         auto & query = ast->as<ASTGrantQuery &>();
 
         if (query.roles && query.is_revoke)
@@ -83,10 +86,11 @@ namespace
 
         if (query.roles)
         {
+            const auto role_names = query.roles->names ? query.roles->names->toStrings() : Strings{};
             std::vector<UUID> roles_to_grant;
-            roles_to_grant.reserve(query.roles->size());
+            roles_to_grant.reserve(role_names.size());
 
-            for (const auto & role_name : query.roles->names)
+            for (const auto & role_name : role_names)
             {
                 auto role_id = UsersConfigParser::generateID(AccessEntityType::ROLE, role_name);
                 if (!role_ids_from_users_config.contains(role_id))

--- a/src/Access/tests/gtest_disk_access_storage.cpp
+++ b/src/Access/tests/gtest_disk_access_storage.cpp
@@ -32,6 +32,16 @@ void writeNeedRebuildMarker(const String & directory)
 
 }
 
+TEST(AccessEntityIO, RejectsQueryParameters)
+{
+    EXPECT_THROW(deserializeAccessEntity("ATTACH ROLE {r:Identifier};"), Exception);
+    EXPECT_THROW(deserializeAccessEntity("ATTACH USER {u:Identifier};"), Exception);
+    EXPECT_THROW(deserializeAccessEntity("ATTACH USER u1 IDENTIFIED WITH plaintext_password BY {pw:String};"), Exception);
+    EXPECT_THROW(deserializeAccessEntity("ATTACH USER u1 VALID UNTIL {ts:String};"), Exception);
+    EXPECT_THROW(deserializeAccessEntity("ATTACH USER u1 DEFAULT ROLE {r:Identifier};"), Exception);
+    EXPECT_THROW(deserializeAccessEntity("ATTACH ROLE r1; ATTACH GRANT SELECT ON *.* TO {g:Identifier};"), Exception);
+}
+
 TEST(DiskAccessStorageRecovery, RebuildRemovesTempFiles)
 {
     Poco::TemporaryFile temp_dir;

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -8362,7 +8362,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
                 create_role->settings.reset();
             else
             {
-                create_role->new_name.clear();
+                create_role->new_name.reset();
                 create_role->alter_settings.reset();
             }
         }
@@ -8702,7 +8702,7 @@ void QueryFuzzer::collectFuzzInfoRecurse(ASTPtr ast)
     {
         addColumnLike(ast);
     }
-    else if (typeid_cast<ASTIdentifier *>(ast.get()))
+    else if (const auto * identifier = typeid_cast<ASTIdentifier *>(ast.get()); identifier && !identifier->isParam())
     {
         addColumnLike(ast);
     }

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -7659,7 +7659,7 @@ void QueryFuzzer::collectFuzzInfoRecurse(ASTPtr ast)
     {
         addColumnLike(ast);
     }
-    else if (typeid_cast<ASTIdentifier *>(ast.get()))
+    else if (const auto * identifier = typeid_cast<ASTIdentifier *>(ast.get()); identifier && !identifier->isParam())
     {
         addColumnLike(ast);
     }

--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Interpreters/removeOnClusterClauseIfNeeded.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 
 
 namespace DB
@@ -29,8 +30,8 @@ namespace
             role.setName(override_name);
         else if (!query.new_name.empty())
             role.setName(query.new_name);
-        else if (query.names.size() == 1)
-            role.setName(query.names.front());
+        else if (query.names->size() == 1)
+            role.setName(query.names->toStrings().at(0));
 
         if (override_settings)
             role.settings.applyChanges(*override_settings);
@@ -46,11 +47,12 @@ BlockIO InterpreterCreateRoleQuery::execute()
 {
     const auto updated_query_ptr = removeOnClusterClauseIfNeeded(query_ptr, getContext());
     const auto & query = updated_query_ptr->as<const ASTCreateRoleQuery &>();
+    const Strings names = query.names->toStrings();
 
     auto & access_control = getContext()->getAccessControl();
 
     const auto access_type = query.alter ? AccessType::ALTER_ROLE : AccessType::CREATE_ROLE;
-    for (const auto & name : query.names)
+    for (const auto & name : names)
         getContext()->checkAccess(access_type, name);
 
     if (!query.new_name.empty() && !query.alter)
@@ -87,16 +89,16 @@ BlockIO InterpreterCreateRoleQuery::execute()
         };
         if (query.if_exists)
         {
-            auto ids = storage->find<Role>(query.names);
+            auto ids = storage->find<Role>(names);
             storage->tryUpdate(ids, update_func);
         }
         else
-            storage->update(storage->getIDs<Role>(query.names), update_func);
+            storage->update(storage->getIDs<Role>(names), update_func);
     }
     else
     {
         std::vector<AccessEntityPtr> new_roles;
-        for (const auto & name : query.names)
+        for (const auto & name : names)
         {
             auto new_role = std::make_shared<Role>();
             updateRoleFromQueryImpl(*new_role, query, name, settings_from_query);
@@ -105,7 +107,7 @@ BlockIO InterpreterCreateRoleQuery::execute()
 
         if (!query.storage_name.empty())
         {
-            for (const auto & name : query.names)
+            for (const auto & name : names)
             {
                 if (auto another_storage_ptr = access_control.findExcludingStorage(AccessEntityType::ROLE, name, storage_ptr))
                     throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "Role {} already exists in storage {}", name, another_storage_ptr->getStorageName());

--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Interpreters/removeOnClusterClauseIfNeeded.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 
 
 namespace DB
@@ -27,10 +28,10 @@ namespace
     {
         if (!override_name.empty())
             role.setName(override_name);
-        else if (!query.new_name.empty())
-            role.setName(query.new_name);
-        else if (query.names.size() == 1)
-            role.setName(query.names.front());
+        else if (query.new_name)
+            role.setName(query.new_name->toString());
+        else if (query.names->size() == 1)
+            role.setName(query.names->toStrings().at(0));
 
         if (override_settings)
             role.settings.applyChanges(*override_settings);
@@ -46,15 +47,16 @@ BlockIO InterpreterCreateRoleQuery::execute()
 {
     const auto updated_query_ptr = removeOnClusterClauseIfNeeded(query_ptr, getContext());
     const auto & query = updated_query_ptr->as<const ASTCreateRoleQuery &>();
+    const Strings names = query.names->toStrings();
 
     auto & access_control = getContext()->getAccessControl();
 
     const auto access_type = query.alter ? AccessType::ALTER_ROLE : AccessType::CREATE_ROLE;
-    for (const auto & name : query.names)
+    for (const auto & name : names)
         getContext()->checkAccess(access_type, name);
 
-    if (!query.new_name.empty() && !query.alter)
-        getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name);
+    if (query.new_name && !query.alter)
+        getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name->toString());
 
     std::optional<AlterSettingsProfileElements> settings_from_query;
     if (query.alter_settings)
@@ -87,16 +89,16 @@ BlockIO InterpreterCreateRoleQuery::execute()
         };
         if (query.if_exists)
         {
-            auto ids = storage->find<Role>(query.names);
+            auto ids = storage->find<Role>(names);
             storage->tryUpdate(ids, update_func);
         }
         else
-            storage->update(storage->getIDs<Role>(query.names), update_func);
+            storage->update(storage->getIDs<Role>(names), update_func);
     }
     else
     {
         std::vector<AccessEntityPtr> new_roles;
-        for (const auto & name : query.names)
+        for (const auto & name : names)
         {
             auto new_role = std::make_shared<Role>();
             updateRoleFromQueryImpl(*new_role, query, name, settings_from_query);
@@ -105,7 +107,7 @@ BlockIO InterpreterCreateRoleQuery::execute()
 
         if (!query.storage_name.empty())
         {
-            for (const auto & name : query.names)
+            for (const auto & name : names)
             {
                 if (auto another_storage_ptr = access_control.findExcludingStorage(AccessEntityType::ROLE, name, storage_ptr))
                     throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "Role {} already exists in storage {}", name, another_storage_ptr->getStorageName());

--- a/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
@@ -58,7 +58,7 @@ namespace
         if (override_name)
             user.setName(override_name->toString());
         else if (query.new_name)
-            user.setName(*query.new_name);
+            user.setName(query.new_name->toString());
         else if (query.names->size() == 1)
             user.setName(query.names->toStrings().at(0));
 
@@ -249,7 +249,7 @@ BlockIO InterpreterCreateUserQuery::execute()
         access->checkAccess(query.alter ? AccessType::ALTER_USER : AccessType::CREATE_USER, name);
 
     if (query.new_name && !query.alter)
-        access->checkAccess(AccessType::CREATE_USER, *query.new_name);
+        access->checkAccess(AccessType::CREATE_USER, query.new_name->toString());
 
     bool implicit_no_password_allowed = access_control.isImplicitNoPasswordAllowed();
     bool no_password_allowed = access_control.isNoPasswordAllowed();

--- a/src/Interpreters/Access/InterpreterDropAccessEntityQuery.cpp
+++ b/src/Interpreters/Access/InterpreterDropAccessEntityQuery.cpp
@@ -63,7 +63,7 @@ BlockIO InterpreterDropAccessEntityQuery::execute()
     if (query.type == AccessEntityType::USER)
     {
         auto & definer_dependencies = DefinerDependencies::instance();
-        for (const auto & name : query.names)
+        for (const auto & name : query.names->toStrings())
         {
             std::vector<String> objects;
             for (const auto & uuid : definer_dependencies.getObjectsForDefiner(name))
@@ -86,7 +86,7 @@ BlockIO InterpreterDropAccessEntityQuery::execute()
     else if (query.type == AccessEntityType::MASKING_POLICY)
         do_drop(Strings{query.masking_policy_name->toString()}, query.storage_name);
     else
-        do_drop(query.names, query.storage_name);
+        do_drop(query.names->toStrings(), query.storage_name);
 
     return {};
 }
@@ -100,13 +100,13 @@ AccessRightsElements InterpreterDropAccessEntityQuery::getRequiredAccess() const
     {
         case AccessEntityType::USER:
         {
-            for (const auto & name : query.names)
+            for (const auto & name : query.names->toStrings())
                 res.emplace_back(AccessType::DROP_USER, name);
             return res;
         }
         case AccessEntityType::ROLE:
         {
-            for (const auto & name : query.names)
+            for (const auto & name : query.names->toStrings())
                 res.emplace_back(AccessType::DROP_ROLE, name);
             return res;
         }

--- a/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
@@ -104,7 +104,7 @@ namespace
     ASTPtr getCreateQueryImpl(const Role & role, const AccessControl * access_control, bool attach_mode)
     {
         auto query = make_intrusive<ASTCreateRoleQuery>();
-        query->names.emplace_back(role.getName());
+        query->names = make_intrusive<ASTUserNamesWithHost>(role.getName());
         query->attach = attach_mode;
 
         if (!role.settings.empty())

--- a/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/Access/ASTGrantQuery.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
 #include <Parsers/Access/ASTShowGrantsQuery.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Access/AccessControl.h>
 #include <Access/AccessRights.h>
 #include <Access/CachedAccessChecking.h>
@@ -92,7 +93,7 @@ namespace
         ASTs res;
 
         boost::intrusive_ptr<ASTRolesOrUsersSet> grantees = make_intrusive<ASTRolesOrUsersSet>();
-        grantees->names.push_back(grantee.getName());
+        grantees->names = make_intrusive<ASTUserNamesWithHost>(grantee.getName());
 
         AccessRights access = grantee.access;
         if (final)

--- a/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowGrantsQuery.cpp
@@ -3,6 +3,7 @@
 #include <Parsers/Access/ASTGrantQuery.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
 #include <Parsers/Access/ASTShowGrantsQuery.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Access/AccessControl.h>
 #include <Access/AccessRights.h>
 #include <Access/CachedAccessChecking.h>
@@ -92,7 +93,7 @@ namespace
         ASTs res;
 
         boost::intrusive_ptr<ASTRolesOrUsersSet> grantees = make_intrusive<ASTRolesOrUsersSet>();
-        grantees->names.push_back(grantee.getName());
+        grantees->names = make_intrusive<ASTUserNamesWithHost>(grantee.getName());
 
         AccessRights access_copy;
 

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -16,8 +16,6 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTViewTargets.h>
 #include <Parsers/FieldFromAST.h>
-#include <Parsers/Access/ASTCreateUserQuery.h>
-#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
 #include <Analyzer/Utils.h>
 #include <Common/SettingsChanges.h>
@@ -55,15 +53,6 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
     {
         if (auto * describe_query = dynamic_cast<ASTDescribeQuery *>(ast.get()); describe_query && describe_query->table_expression)
             visitChildren(describe_query->table_expression);
-        else if (auto * create_user_query = dynamic_cast<ASTCreateUserQuery *>(ast.get()))
-        {
-            if (create_user_query->names)
-            {
-                ASTPtr names = create_user_query->names;
-                visitChildren(names);
-            }
-            visitChildren(ast);
-        }
         else if (dynamic_cast<ASTCreateHandlerQuery *>(ast.get()))
         {
             /// The handler's query (the AS clause) is the parameterizable interface of the handler;

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -15,8 +15,6 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTViewTargets.h>
 #include <Parsers/FieldFromAST.h>
-#include <Parsers/Access/ASTCreateUserQuery.h>
-#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
 #include <Analyzer/Utils.h>
 #include <Common/SettingsChanges.h>
@@ -54,15 +52,6 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
     {
         if (auto * describe_query = dynamic_cast<ASTDescribeQuery *>(ast.get()); describe_query && describe_query->table_expression)
             visitChildren(describe_query->table_expression);
-        else if (auto * create_user_query = dynamic_cast<ASTCreateUserQuery *>(ast.get()))
-        {
-            if (create_user_query->names)
-            {
-                ASTPtr names = create_user_query->names;
-                visitChildren(names);
-            }
-            visitChildren(ast);
-        }
         else if (auto * create_query = dynamic_cast<ASTCreateQuery *>(ast.get()))
         {
             if (create_query->isParameterizedView())

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 
@@ -8,15 +9,19 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, WriteBuffer & ostr)
+    void formatNames(const ASTUserNamesWithHost & names, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        ostr << " ";
         bool need_comma = false;
-        for (const String & name : names)
+        for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
                 ostr << ", ";
-            ostr << backQuoteIfNeed(name);
+
+            const auto & user_name = name->as<const ASTUserNameWithHost &>();
+            if (user_name.usernameWasQueryParameter())
+                user_name.format(ostr, settings);
+            else
+                ostr << backQuoteIfNeed(user_name.toString());
         }
     }
 
@@ -48,6 +53,14 @@ String ASTCreateRoleQuery::getID(char) const
 ASTPtr ASTCreateRoleQuery::clone() const
 {
     auto res = make_intrusive<ASTCreateRoleQuery>(*this);
+    res->children.clear();
+
+    if (names)
+    {
+        res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
 
     if (settings)
         res->settings = boost::static_pointer_cast<ASTSettingsProfileElements>(settings->clone());
@@ -78,7 +91,8 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
     else if (or_replace)
         ostr << " OR REPLACE";
 
-    formatNames(names, ostr);
+    ostr << " ";
+    formatNames(*names, ostr, format);
 
     if (!storage_name.empty())
         ostr

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 
@@ -8,21 +9,29 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, WriteBuffer & ostr)
+    void formatNames(const ASTUserNamesWithHost & names, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        ostr << " ";
         bool need_comma = false;
-        for (const String & name : names)
+        for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
                 ostr << ", ";
-            ostr << backQuoteIfNeed(name);
+
+            const auto & user_name = name->as<const ASTUserNameWithHost &>();
+            if (user_name.usernameWasQueryParameter())
+                user_name.format(ostr, settings);
+            else
+                ostr << backQuoteIfNeed(user_name.toString());
         }
     }
 
-    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
+    void formatRenameTo(const ASTUserNameWithHost & new_name, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        ostr << " RENAME TO " << quoteString(new_name);
+        ostr << " RENAME TO ";
+        if (new_name.usernameWasQueryParameter())
+            new_name.format(ostr, settings);
+        else
+            ostr << quoteString(new_name.toString());
     }
 
     void formatSettings(const ASTSettingsProfileElements & settings, WriteBuffer & ostr, const IAST::FormatSettings & format)
@@ -48,6 +57,21 @@ String ASTCreateRoleQuery::getID(char) const
 ASTPtr ASTCreateRoleQuery::clone() const
 {
     auto res = make_intrusive<ASTCreateRoleQuery>(*this);
+    res->children.clear();
+
+    if (names)
+    {
+        res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
+
+    if (new_name)
+    {
+        res->new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name->clone());
+        if (res->new_name->usernameWasQueryParameter())
+            res->children.push_back(res->new_name);
+    }
 
     if (settings)
         res->settings = boost::static_pointer_cast<ASTSettingsProfileElements>(settings->clone());
@@ -78,7 +102,8 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
     else if (or_replace)
         ostr << " OR REPLACE";
 
-    formatNames(names, ostr);
+    ostr << " ";
+    formatNames(*names, ostr, format);
 
     if (!storage_name.empty())
         ostr
@@ -87,8 +112,8 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
 
     formatOnCluster(ostr, format);
 
-    if (!new_name.empty())
-        formatRenameTo(new_name, ostr, format);
+    if (new_name)
+        formatRenameTo(*new_name, ostr, format);
 
     if (alter_settings)
         formatAlterSettings(*alter_settings, ostr, format);

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -7,6 +7,7 @@
 
 namespace DB
 {
+class ASTUserNamesWithHost;
 class ASTSettingsProfileElements;
 class ASTAlterSettingsProfileElements;
 
@@ -33,7 +34,7 @@ public:
     bool if_not_exists = false;
     bool or_replace = false;
 
-    Strings names;
+    boost::intrusive_ptr<ASTUserNamesWithHost> names;
     String new_name;
     String storage_name;
 

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -7,6 +7,8 @@
 
 namespace DB
 {
+class ASTUserNameWithHost;
+class ASTUserNamesWithHost;
 class ASTSettingsProfileElements;
 class ASTAlterSettingsProfileElements;
 
@@ -33,8 +35,8 @@ public:
     bool if_not_exists = false;
     bool or_replace = false;
 
-    Strings names;
-    String new_name;
+    boost::intrusive_ptr<ASTUserNamesWithHost> names;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     String storage_name;
 
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;

--- a/src/Parsers/Access/ASTCreateUserQuery.cpp
+++ b/src/Parsers/Access/ASTCreateUserQuery.cpp
@@ -189,7 +189,11 @@ ASTPtr ASTCreateUserQuery::clone() const
     res->authentication_methods.clear();
 
     if (names)
+    {
         res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
 
     if (roles)
         res->roles = boost::static_pointer_cast<ASTRolesOrUsersSet>(roles->clone());

--- a/src/Parsers/Access/ASTCreateUserQuery.cpp
+++ b/src/Parsers/Access/ASTCreateUserQuery.cpp
@@ -12,9 +12,13 @@ namespace DB
 
 namespace
 {
-    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
+    void formatRenameTo(const ASTUserNameWithHost & new_name, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
-        ostr << " RENAME TO " << quoteString(new_name);
+        ostr << " RENAME TO ";
+        if (new_name.usernameWasQueryParameter())
+            new_name.format(ostr, settings);
+        else
+            ostr << quoteString(new_name.toString());
     }
 
     void formatAuthenticationData(const std::vector<boost::intrusive_ptr<ASTAuthenticationData>> & authentication_methods, WriteBuffer & ostr, const IAST::FormatSettings & settings)
@@ -189,7 +193,18 @@ ASTPtr ASTCreateUserQuery::clone() const
     res->authentication_methods.clear();
 
     if (names)
+    {
         res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
+
+    if (new_name)
+    {
+        res->new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name->clone());
+        if (res->new_name->usernameWasQueryParameter())
+            res->children.push_back(res->new_name);
+    }
 
     if (roles)
         res->roles = boost::static_pointer_cast<ASTRolesOrUsersSet>(roles->clone());

--- a/src/Parsers/Access/ASTCreateUserQuery.h
+++ b/src/Parsers/Access/ASTCreateUserQuery.h
@@ -8,6 +8,7 @@
 
 namespace DB
 {
+class ASTUserNameWithHost;
 class ASTUserNamesWithHost;
 class ASTRolesOrUsersSet;
 class ASTDatabaseOrNone;
@@ -52,7 +53,7 @@ public:
     bool replace_authentication_methods = false;
 
     boost::intrusive_ptr<ASTUserNamesWithHost> names;
-    std::optional<String> new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     String storage_name;
 
     std::vector<boost::intrusive_ptr<ASTAuthenticationData>> authentication_methods;

--- a/src/Parsers/Access/ASTDropAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ASTDropAccessEntityQuery.h>
 #include <Parsers/Access/ASTRowPolicyName.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Access/MaskingPolicy.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
@@ -9,18 +10,23 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, WriteBuffer & ostr)
+    void formatNames(const ASTUserNamesWithHost & names, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         bool need_comma = false;
         for (const auto & name : names)
         {
             if (std::exchange(need_comma, true))
-                ostr << ',';
-            ostr << ' ' << backQuoteIfNeed(name);
+                ostr << ",";
+            ostr << " ";
+
+            const auto & user_name = name->as<const ASTUserNameWithHost &>();
+            if (user_name.usernameWasQueryParameter())
+                user_name.format(ostr, settings);
+            else
+                ostr << backQuoteIfNeed(user_name.toString());
         }
     }
 }
-
 
 String ASTDropAccessEntityQuery::getID(char) const
 {
@@ -37,6 +43,15 @@ ASTPtr ASTDropAccessEntityQuery::clone() const
 
     if (masking_policy_name)
         res->masking_policy_name = std::make_shared<MaskingPolicyName>(*masking_policy_name);
+
+    res->children.clear();
+
+    if (names)
+    {
+        res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
 
     return res;
 }
@@ -59,7 +74,7 @@ void ASTDropAccessEntityQuery::formatImpl(WriteBuffer & ostr, const FormatSettin
         ostr << " " << masking_policy_name->toString();
     }
     else
-        formatNames(names, ostr);
+        formatNames(*names, ostr, settings);
 
     if (!storage_name.empty())
         ostr

--- a/src/Parsers/Access/ASTDropAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.h
@@ -2,6 +2,7 @@
 
 #include <Parsers/IAST.h>
 #include <Parsers/ASTQueryWithOnCluster.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Access/Common/AccessEntityType.h>
 
 
@@ -22,7 +23,7 @@ class ASTDropAccessEntityQuery final : public IAST, public ASTQueryWithOnCluster
 public:
     AccessEntityType type{};
     bool if_exists = false;
-    Strings names;
+    boost::intrusive_ptr<ASTUserNamesWithHost> names;
     String storage_name;
     boost::intrusive_ptr<ASTRowPolicyNames> row_policy_names;
     std::shared_ptr<MaskingPolicyName> masking_policy_name;

--- a/src/Parsers/Access/ASTGrantQuery.cpp
+++ b/src/Parsers/Access/ASTGrantQuery.cpp
@@ -30,12 +30,21 @@ String ASTGrantQuery::getID(char) const
 ASTPtr ASTGrantQuery::clone() const
 {
     auto res = make_intrusive<ASTGrantQuery>(*this);
+    res->children.clear();
 
     if (roles)
+    {
         res->roles = boost::static_pointer_cast<ASTRolesOrUsersSet>(roles->clone());
+        if (res->roles->hasQueryParameters())
+            res->children.push_back(res->roles);
+    }
 
     if (grantees)
+    {
         res->grantees = boost::static_pointer_cast<ASTRolesOrUsersSet>(grantees->clone());
+        if (res->grantees->hasQueryParameters())
+            res->children.push_back(res->grantees);
+    }
 
     return res;
 }

--- a/src/Parsers/Access/ASTRolesOrUsersSet.cpp
+++ b/src/Parsers/Access/ASTRolesOrUsersSet.cpp
@@ -2,6 +2,7 @@
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <unordered_set>
 
 
@@ -9,12 +10,14 @@ namespace DB
 {
 namespace
 {
-    void formatNameOrID(const String & str, bool is_id, WriteBuffer & ostr, const IAST::FormatSettings &)
+    void formatNameOrID(const ASTUserNameWithHost & name, bool is_id, WriteBuffer & ostr, const IAST::FormatSettings & settings)
     {
         if (is_id)
-            ostr << "ID(" << quoteString(str) << ")";
+            ostr << "ID(" << quoteString(name.toString()) << ")";
+        else if (name.usernameWasQueryParameter())
+            name.format(ostr, settings);
         else
-            ostr << backQuoteIfNeed(str);
+            ostr << backQuoteIfNeed(name.toString());
     }
 }
 
@@ -37,11 +40,14 @@ void ASTRolesOrUsersSet::formatImpl(WriteBuffer & ostr, const FormatSettings & s
     }
     else
     {
-        for (const auto & name : names)
+        if (names)
         {
-            if (std::exchange(need_comma, true))
-                ostr << ", ";
-            formatNameOrID(name, id_mode, ostr, settings);
+            for (const auto & name : *names)
+            {
+                if (std::exchange(need_comma, true))
+                    ostr << ", ";
+                formatNameOrID(name->as<const ASTUserNameWithHost &>(), id_mode, ostr, settings);
+            }
         }
 
         if (current_user)
@@ -52,16 +58,19 @@ void ASTRolesOrUsersSet::formatImpl(WriteBuffer & ostr, const FormatSettings & s
         }
     }
 
-    if (except_current_user || !except_names.empty())
+    if (except_current_user || (except_names && !except_names->children.empty()))
     {
         ostr << " EXCEPT ";
         need_comma = false;
 
-        for (const auto & name : except_names)
+        if (except_names)
         {
-            if (std::exchange(need_comma, true))
-                ostr << ", ";
-            formatNameOrID(name, id_mode, ostr, settings);
+            for (const auto & name : *except_names)
+            {
+                if (std::exchange(need_comma, true))
+                    ostr << ", ";
+                formatNameOrID(name->as<const ASTUserNameWithHost &>(), id_mode, ostr, settings);
+            }
         }
 
         if (except_current_user)
@@ -78,22 +87,33 @@ void ASTRolesOrUsersSet::replaceCurrentUserTag(const String & current_user_name)
 {
     if (current_user)
     {
-        names.push_back(current_user_name);
+        if (!names)
+        {
+            names = make_intrusive<ASTUserNamesWithHost>();
+        }
+        names->children.push_back(make_intrusive<ASTUserNameWithHost>(current_user_name));
         current_user = false;
     }
 
     if (except_current_user)
     {
-        except_names.push_back(current_user_name);
+        if (!except_names)
+        {
+            except_names = make_intrusive<ASTUserNamesWithHost>();
+        }
+        except_names->children.push_back(make_intrusive<ASTUserNameWithHost>(current_user_name));
         except_current_user = false;
     }
 }
 
-AccessRightsElements ASTRolesOrUsersSet::collectRequiredGrants(AccessType access_type)
+
+AccessRightsElements ASTRolesOrUsersSet::collectRequiredGrants(AccessType access_type) const
 {
     AccessRightsElements res;
-    std::unordered_set<String> except(except_names.begin(), except_names.end());
-    for (const auto & name: names)
+    const Strings except_all = except_names ? except_names->toStrings() : Strings{};
+    std::unordered_set except(except_all.begin(), except_all.end());
+    const Strings all_names = names ? names->toStrings() : Strings{};
+    for (const auto & name : all_names)
     {
         if (except.contains(name))
             continue;
@@ -103,6 +123,30 @@ AccessRightsElements ASTRolesOrUsersSet::collectRequiredGrants(AccessType access
 
     if (all)
         res.push_back(AccessRightsElement(access_type));
+
+    return res;
+}
+
+
+ASTPtr ASTRolesOrUsersSet::clone() const
+{
+    auto res = make_intrusive<ASTRolesOrUsersSet>(*this);
+
+    res->children.clear();
+
+    if (names)
+    {
+        res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+        if (res->names->hasQueryParameters())
+            res->children.push_back(res->names);
+    }
+
+    if (except_names)
+    {
+        res->except_names = boost::static_pointer_cast<ASTUserNamesWithHost>(except_names->clone());
+        if (res->except_names->hasQueryParameters())
+            res->children.push_back(res->except_names);
+    }
 
     return res;
 }

--- a/src/Parsers/Access/ASTRolesOrUsersSet.h
+++ b/src/Parsers/Access/ASTRolesOrUsersSet.h
@@ -2,12 +2,14 @@
 
 #include <Access/Common/AccessRightsElement.h>
 #include <Parsers/IAST.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 
 
 namespace DB
 {
 
 using Strings = std::vector<String>;
+using ASTUserNamesWithHostPtr = boost::intrusive_ptr<ASTUserNamesWithHost>;
 
 /// Represents a set of users/roles like
 /// {user_name | role_name | CURRENT_USER | ALL | NONE} [,...]
@@ -16,9 +18,9 @@ class ASTRolesOrUsersSet : public IAST
 {
 public:
     bool all = false;
-    Strings names;
+    ASTUserNamesWithHostPtr names;
     bool current_user = false;
-    Strings except_names;
+    ASTUserNamesWithHostPtr except_names;
     bool except_current_user = false;
 
     bool allow_users = true;      /// whether this set can contain names of users
@@ -26,12 +28,17 @@ public:
     bool id_mode = false;         /// whether this set keep UUIDs instead of names
     bool use_keyword_any = false; /// whether the keyword ANY should be used instead of the keyword ALL
 
-    bool empty() const { return names.empty() && !current_user && !all; }
+    bool empty() const { return (!names || names->children.empty()) && !current_user && !all; }
+    bool hasQueryParameters() const
+    {
+        return (names && names->hasQueryParameters())
+            || (except_names && except_names->hasQueryParameters());
+    }
     void replaceCurrentUserTag(const String & current_user_name);
-    AccessRightsElements collectRequiredGrants(AccessType access_type);
+    AccessRightsElements collectRequiredGrants(AccessType access_type) const;
 
     String getID(char) const override { return "RolesOrUsersSet"; }
-    ASTPtr clone() const override { return make_intrusive<ASTRolesOrUsersSet>(*this); }
+    ASTPtr clone() const override;
 
 protected:
     void formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState &, FormatStateStacked) const override;

--- a/src/Parsers/Access/ASTShowGrantsQuery.cpp
+++ b/src/Parsers/Access/ASTShowGrantsQuery.cpp
@@ -27,8 +27,8 @@ void ASTShowGrantsQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSetting
     ostr << "SHOW GRANTS"
                  ;
 
-    if (for_roles->current_user && !for_roles->all && for_roles->names.empty() && for_roles->except_names.empty()
-        && !for_roles->except_current_user)
+    if (for_roles->current_user && !for_roles->all && (!for_roles->names || for_roles->names->children.empty())
+        && (!for_roles->except_names || for_roles->except_names->children.empty()) && !for_roles->except_current_user)
     {
     }
     else

--- a/src/Parsers/Access/ASTUserNameWithHost.cpp
+++ b/src/Parsers/Access/ASTUserNameWithHost.cpp
@@ -60,6 +60,7 @@ void ASTUserNameWithHost::replace(const String name)
     host_pattern.reset();
 
     username = make_intrusive<ASTIdentifier>(name);
+    username_was_query_parameter = false;
     children.emplace_back(username);
 }
 
@@ -73,6 +74,9 @@ ASTUserNameWithHost::ASTUserNameWithHost(ASTPtr && name_, String && host_pattern
 {
     username = std::move(name_);
     children.emplace_back(username);
+
+    if (const auto * identifier = username->as<ASTIdentifier>())
+        username_was_query_parameter = identifier->isParam();
 
     if (!host_pattern_.empty() && host_pattern_ != "%")
     {

--- a/src/Parsers/Access/ASTUserNameWithHost.cpp
+++ b/src/Parsers/Access/ASTUserNameWithHost.cpp
@@ -45,6 +45,7 @@ void ASTUserNameWithHost::replace(const String name)
     host_pattern.reset();
 
     username = make_intrusive<ASTIdentifier>(name);
+    username_was_query_parameter = false;
     children.emplace_back(username);
 }
 
@@ -58,6 +59,9 @@ ASTUserNameWithHost::ASTUserNameWithHost(ASTPtr && name_, String && host_pattern
 {
     username = std::move(name_);
     children.emplace_back(username);
+
+    if (const auto * identifier = username->as<ASTIdentifier>())
+        username_was_query_parameter = identifier->isParam();
 
     if (!host_pattern_.empty() && host_pattern_ != "%")
     {

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -22,6 +22,7 @@ public:
 
     String getHostPattern() const;
     String toString() const;
+    bool usernameWasQueryParameter() const { return username_was_query_parameter; }
 
     String getID(char) const override { return "UserNameWithHost"; }
     ASTPtr clone() const override;
@@ -39,6 +40,7 @@ private:
 
     ASTPtr username;
     ASTPtr host_pattern;
+    bool username_was_query_parameter = false;
 };
 
 
@@ -51,6 +53,14 @@ public:
     size_t size() const { return children.size(); }
     auto begin() const { return children.begin(); }
     auto end() const { return children.end(); }
+
+    bool hasQueryParameters() const
+    {
+        for (const auto & name : children)
+            if (name->as<const ASTUserNameWithHost &>().usernameWasQueryParameter())
+                return true;
+        return false;
+    }
 
     Strings toStrings() const;
     bool getHostPatternIfCommon(String & out_common_host_pattern) const;

--- a/src/Parsers/Access/ASTUserNameWithHost.h
+++ b/src/Parsers/Access/ASTUserNameWithHost.h
@@ -21,6 +21,7 @@ public:
 
     String getHostPattern() const;
     String toString() const;
+    bool usernameWasQueryParameter() const { return username_was_query_parameter; }
 
     String getID(char) const override { return "UserNameWithHost"; }
     ASTPtr clone() const override;
@@ -35,6 +36,7 @@ private:
 
     ASTPtr username;
     ASTPtr host_pattern;
+    bool username_was_query_parameter = false;
 };
 
 
@@ -47,6 +49,14 @@ public:
     size_t size() const { return children.size(); }
     auto begin() const { return children.begin(); }
     auto end() const { return children.end(); }
+
+    bool hasQueryParameters() const
+    {
+        for (const auto & name : children)
+            if (name->as<const ASTUserNameWithHost &>().usernameWasQueryParameter())
+                return true;
+        return false;
+    }
 
     Strings toStrings() const;
     bool getHostPatternIfCommon(String & out_common_host_pattern) const;

--- a/src/Parsers/Access/ParserCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRoleQuery.cpp
@@ -2,8 +2,9 @@
 #include <Parsers/Access/ParserCreateRoleQuery.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/ParserSettingsProfileElement.h>
-#include <Parsers/Access/parseUserName.h>
+#include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
@@ -16,14 +17,19 @@ namespace DB
 {
 namespace
 {
-    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, String & new_name)
+    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & new_name)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!ParserKeyword{Keyword::RENAME_TO}.ignore(pos, expected))
                 return false;
 
-            return parseRoleName(pos, expected, new_name);
+            ASTPtr new_name_ast;
+            if (!ParserUserNameWithHost(/*allow_query_parameter=*/ true, /*parse_host_pattern=*/ false).parse(pos, new_name_ast, expected))
+                return false;
+
+            new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name_ast);
+            return true;
         });
     }
 
@@ -98,11 +104,12 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             or_replace = true;
     }
 
-    Strings names;
-    if (!parseRoleNames(pos, expected, names))
+    ASTPtr names_ast;
+    if (!ParserUserNamesWithHost(/*allow_query_parameter=*/ true, /*parse_host_pattern=*/ false).parse(pos, names_ast, expected))
         return false;
+    auto names = boost::static_pointer_cast<ASTUserNamesWithHost>(names_ast);
 
-    String new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;
     boost::intrusive_ptr<ASTAlterSettingsProfileElements> alter_settings;
     String cluster;
@@ -110,7 +117,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     while (true)
     {
-        if (alter && new_name.empty() && (names.size() == 1) && parseRenameTo(pos, expected, new_name))
+        if (alter && !new_name && (names->size() == 1) && parseRenameTo(pos, expected, new_name))
             continue;
 
         if (alter)
@@ -159,6 +166,12 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->settings = std::move(settings);
     query->alter_settings = std::move(alter_settings);
     query->storage_name = std::move(storage_name);
+
+    if (query->names && query->names->hasQueryParameters())
+        query->children.push_back(query->names);
+
+    if (query->new_name && query->new_name->usernameWasQueryParameter())
+        query->children.push_back(query->new_name);
 
     return true;
 }

--- a/src/Parsers/Access/ParserCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRoleQuery.cpp
@@ -2,7 +2,9 @@
 #include <Parsers/Access/ParserCreateRoleQuery.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/ParserSettingsProfileElement.h>
+#include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
@@ -96,9 +98,10 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             or_replace = true;
     }
 
-    Strings names;
-    if (!parseRoleNames(pos, expected, names))
+    ASTPtr names_ast;
+    if (!ParserUserNamesWithHost(/*allow_query_parameter=*/ true, /*parse_host_pattern=*/ false).parse(pos, names_ast, expected))
         return false;
+    auto names = boost::static_pointer_cast<ASTUserNamesWithHost>(names_ast);
 
     String new_name;
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;
@@ -108,7 +111,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     while (true)
     {
-        if (alter && new_name.empty() && (names.size() == 1) && parseRenameTo(pos, expected, new_name))
+        if (alter && new_name.empty() && (names->size() == 1) && parseRenameTo(pos, expected, new_name))
             continue;
 
         if (alter)
@@ -157,6 +160,9 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->settings = std::move(settings);
     query->alter_settings = std::move(alter_settings);
     query->storage_name = std::move(storage_name);
+
+    if (query->names && query->names->hasQueryParameters())
+        query->children.push_back(query->names);
 
     return true;
 }

--- a/src/Parsers/Access/ParserCreateUserQuery.cpp
+++ b/src/Parsers/Access/ParserCreateUserQuery.cpp
@@ -10,7 +10,6 @@
 #include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/Access/ParserPublicSSHKey.h>
 #include <Parsers/Access/parseAccessRightsElements.h>
-#include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
@@ -39,18 +38,18 @@ namespace ErrorCodes
 
 namespace
 {
-    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, std::optional<String> & new_name)
+    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & new_name)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!ParserKeyword{Keyword::RENAME_TO}.ignore(pos, expected))
                 return false;
 
-            String maybe_new_name;
-            if (!parseUserName(pos, expected, maybe_new_name, /*allow_query_parameter=*/true))
+            ASTPtr new_name_ast;
+            if (!ParserUserNameWithHost(/*allow_query_parameter=*/true).parse(pos, new_name_ast, expected))
                 return false;
 
-            new_name.emplace(std::move(maybe_new_name));
+            new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name_ast);
             return true;
         });
     }
@@ -662,7 +661,7 @@ bool ParserCreateUserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     auto pos_after_parsing_names = pos;
 
-    std::optional<String> new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     std::optional<AllowedClientHosts> hosts;
     std::optional<AllowedClientHosts> add_hosts;
     std::optional<AllowedClientHosts> remove_hosts;
@@ -851,6 +850,12 @@ bool ParserCreateUserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->reset_authentication_methods_to_new = reset_authentication_methods_to_new;
     query->add_identified_with = parsed_add_identified_with;
     query->replace_authentication_methods = parsed_identified_with;
+
+    if (query->names && query->names->hasQueryParameters())
+        query->children.push_back(query->names);
+
+    if (query->new_name && query->new_name->usernameWasQueryParameter())
+        query->children.push_back(query->new_name);
 
     for (const auto & authentication_method : query->authentication_methods)
     {

--- a/src/Parsers/Access/ParserCreateUserQuery.cpp
+++ b/src/Parsers/Access/ParserCreateUserQuery.cpp
@@ -754,6 +754,9 @@ bool ParserCreateUserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->add_identified_with = parsed_add_identified_with;
     query->replace_authentication_methods = parsed_identified_with;
 
+    if (query->names && query->names->hasQueryParameters())
+        query->children.push_back(query->names);
+
     for (const auto & authentication_method : query->authentication_methods)
     {
         query->children.push_back(authentication_method);

--- a/src/Parsers/Access/ParserDropAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ParserDropAccessEntityQuery.cpp
@@ -4,6 +4,8 @@
 #include <Parsers/Access/ASTDropAccessEntityQuery.h>
 #include <Parsers/Access/ParserRowPolicyName.h>
 #include <Parsers/Access/ASTRowPolicyName.h>
+#include <Parsers/Access/ParserUserNameWithHost.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/parseUserName.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
@@ -85,7 +87,7 @@ bool ParserDropAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     if (ParserKeyword{Keyword::IF_EXISTS}.ignore(pos, expected))
         if_exists = true;
 
-    Strings names;
+    boost::intrusive_ptr<ASTUserNamesWithHost> names;
     boost::intrusive_ptr<ASTRowPolicyNames> row_policy_names;
     std::shared_ptr<MaskingPolicyName> masking_policy_name;
     String storage_name;
@@ -93,8 +95,10 @@ bool ParserDropAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
 
     if ((type == AccessEntityType::USER) || (type == AccessEntityType::ROLE))
     {
-        if (!parseUserNames(pos, expected, names, /*allow_query_parameter=*/ false))
+        ASTPtr names_list;
+        if (!ParserUserNamesWithHost(/*allow_query_parameter=*/ true, /*parse_host_pattern=*/ false).parse(pos, names_list, expected))
             return false;
+        names = boost::static_pointer_cast<ASTUserNamesWithHost>(names_list);
     }
     else if (type == AccessEntityType::ROW_POLICY)
     {
@@ -114,8 +118,12 @@ bool ParserDropAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     }
     else
     {
-        if (!parseIdentifiersOrStringLiterals(pos, expected, names))
+        Strings string_names;
+        if (!parseIdentifiersOrStringLiterals(pos, expected, string_names))
             return false;
+        names = make_intrusive<ASTUserNamesWithHost>();
+        for (auto & string_name : string_names)
+            names->children.push_back(make_intrusive<ASTUserNameWithHost>(string_name));
     }
 
     if (ParserKeyword{Keyword::FROM}.ignore(pos, expected))
@@ -134,6 +142,9 @@ bool ParserDropAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     query->row_policy_names = std::move(row_policy_names);
     query->masking_policy_name = std::move(masking_policy_name);
     query->storage_name = std::move(storage_name);
+
+    if (query->names && query->names->hasQueryParameters())
+        query->children.push_back(query->names);
 
     return true;
 }

--- a/src/Parsers/Access/ParserGrantQuery.cpp
+++ b/src/Parsers/Access/ParserGrantQuery.cpp
@@ -61,7 +61,7 @@ namespace
         return IParserBase::wrapParseImpl(pos, [&]
         {
             ParserRolesOrUsersSet roles_p;
-            roles_p.allowRoles().useIDMode(id_mode);
+            roles_p.allowRoles().useIDMode(id_mode).allowQueryParameters();
             if (is_revoke)
                 roles_p.allowAll();
 
@@ -84,7 +84,7 @@ namespace
 
             ASTPtr ast;
             ParserRolesOrUsersSet roles_p;
-            roles_p.allowRoles().allowUsers().allowCurrentUser().allowAll(is_revoke);
+            roles_p.allowRoles().allowUsers().allowCurrentUser().allowAll(is_revoke).allowQueryParameters();
             if (!roles_p.parse(pos, ast, expected))
                 return false;
 
@@ -201,7 +201,11 @@ bool ParserGrantQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     query->cluster = std::move(cluster);
     query->access_rights_elements = std::move(elements);
     query->roles = std::move(roles);
+    if (query->roles && query->roles->hasQueryParameters())
+        query->children.push_back(query->roles);
     query->grantees = std::move(grantees);
+    if (query->grantees && query->grantees->hasQueryParameters())
+        query->children.push_back(query->grantees);
     query->admin_option = admin_option;
     query->replace_access = replace_access;
     query->replace_granted_roles = replace_role;

--- a/src/Parsers/Access/ParserGrantQuery.cpp
+++ b/src/Parsers/Access/ParserGrantQuery.cpp
@@ -59,7 +59,7 @@ namespace
         return IParserBase::wrapParseImpl(pos, [&]
         {
             ParserRolesOrUsersSet roles_p;
-            roles_p.allowRoles().useIDMode(id_mode);
+            roles_p.allowRoles().useIDMode(id_mode).allowQueryParameters();
             if (is_revoke)
                 roles_p.allowAll();
 
@@ -82,7 +82,7 @@ namespace
 
             ASTPtr ast;
             ParserRolesOrUsersSet roles_p;
-            roles_p.allowRoles().allowUsers().allowCurrentUser().allowAll(is_revoke);
+            roles_p.allowRoles().allowUsers().allowCurrentUser().allowAll(is_revoke).allowQueryParameters();
             if (!roles_p.parse(pos, ast, expected))
                 return false;
 
@@ -199,7 +199,11 @@ bool ParserGrantQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     query->cluster = std::move(cluster);
     query->access_rights_elements = std::move(elements);
     query->roles = std::move(roles);
+    if (query->roles && query->roles->hasQueryParameters())
+        query->children.push_back(query->roles);
     query->grantees = std::move(grantees);
+    if (query->grantees && query->grantees->hasQueryParameters())
+        query->children.push_back(query->grantees);
     query->admin_option = admin_option;
     query->replace_access = replace_access;
     query->replace_granted_roles = replace_role;

--- a/src/Parsers/Access/ParserRolesOrUsersSet.cpp
+++ b/src/Parsers/Access/ParserRolesOrUsersSet.cpp
@@ -1,23 +1,23 @@
 #include <Parsers/Access/ParserRolesOrUsersSet.h>
 #include <Parsers/Access/ASTRolesOrUsersSet.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
+#include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
 #include <Parsers/ExpressionListParsers.h>
-#include <boost/range/algorithm/find.hpp>
-
 
 namespace DB
 {
 namespace
 {
-    bool parseNameOrID(IParserBase::Pos & pos, Expected & expected, bool id_mode, String & res)
+    bool parseNameOrID(IParserBase::Pos & pos, Expected & expected, bool id_mode, bool allow_query_parameter, ASTPtr & res)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!id_mode)
-                return parseRoleName(pos, expected, res);
+                return ParserUserNameWithHost(allow_query_parameter, /*parse_host_pattern=*/ false).parse(pos, res, expected);
 
             if (!ParserKeyword{Keyword::ID}.ignore(pos, expected))
                 return false;
@@ -30,7 +30,7 @@ namespace
             if (!ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
                 return false;
 
-            res = std::move(id);
+            res = make_intrusive<ASTUserNameWithHost>(id);
             return true;
         });
     }
@@ -43,13 +43,13 @@ namespace
         bool allow_any,
         bool allow_current_user,
         bool & all,
-        Strings & names,
-        bool & current_user)
+        ASTs & names,
+        bool & current_user,
+        bool allow_query_parameter)
     {
         bool res_all = false;
-        Strings res_names;
+        ASTs res_names;
         bool res_current_user = false;
-        Strings res_with_roles_names;
 
         auto parse_element = [&]
         {
@@ -74,10 +74,10 @@ namespace
                 return true;
             }
 
-            String name;
-            if (parseNameOrID(pos, expected, id_mode, name))
+            ASTPtr name;
+            if (parseNameOrID(pos, expected, id_mode, allow_query_parameter, name))
             {
-                res_names.emplace_back(std::move(name));
+                res_names.push_back(std::move(name));
                 return true;
             }
 
@@ -98,15 +98,16 @@ namespace
         Expected & expected,
         bool id_mode,
         bool allow_current_user,
-        Strings & except_names,
-        bool & except_current_user)
+        ASTs & except_names,
+        bool & except_current_user,
+        bool allow_query_parameter)
     {
         return IParserBase::wrapParseImpl(pos, [&] {
             if (!ParserKeyword{Keyword::EXCEPT}.ignore(pos, expected))
                 return false;
 
             bool unused = false;
-            return parseBeforeExcept(pos, expected, id_mode, false, false, allow_current_user, unused, except_names, except_current_user);
+            return parseBeforeExcept(pos, expected, id_mode, false, false, allow_current_user, unused, except_names, except_current_user, allow_query_parameter);
         });
     }
 }
@@ -115,29 +116,50 @@ namespace
 bool ParserRolesOrUsersSet::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     bool all = false;
-    Strings names;
+    ASTs names;
     bool current_user = false;
-    Strings except_names;
+    ASTs except_names;
     bool except_current_user = false;
 
-    if (!parseBeforeExcept(pos, expected, id_mode, allow_all, allow_any, allow_current_user, all, names, current_user))
+    if (!parseBeforeExcept(pos, expected, id_mode, allow_all, allow_any, allow_current_user, all, names, current_user, allow_query_parameter))
         return false;
 
-    parseExceptAndAfterExcept(pos, expected, id_mode, allow_current_user, except_names, except_current_user);
+    parseExceptAndAfterExcept(pos, expected, id_mode, allow_current_user, except_names, except_current_user, allow_query_parameter);
 
     if (all)
+    {
+        for (const auto & name : names)
+            if (name->as<const ASTUserNameWithHost &>().usernameWasQueryParameter())
+                return false;
+
         names.clear();
+    }
 
     auto result = make_intrusive<ASTRolesOrUsersSet>();
-    result->names = std::move(names);
     result->current_user = current_user;
     result->all = all;
-    result->except_names = std::move(except_names);
     result->except_current_user = except_current_user;
     result->allow_users = allow_users;
     result->allow_roles = allow_roles;
     result->id_mode = id_mode;
     result->use_keyword_any = all && allow_any && !allow_all;
+
+    if (!names.empty())
+    {
+        result->names = make_intrusive<ASTUserNamesWithHost>();
+        result->names->children.swap(names);
+        if (result->names->hasQueryParameters())
+            result->children.push_back(result->names);
+    }
+
+    if (!except_names.empty())
+    {
+        result->except_names = make_intrusive<ASTUserNamesWithHost>();
+        result->except_names->children.swap(except_names);
+        if (result->except_names->hasQueryParameters())
+            result->children.push_back(result->except_names);
+    }
+
     node = result;
     return true;
 }

--- a/src/Parsers/Access/ParserRolesOrUsersSet.h
+++ b/src/Parsers/Access/ParserRolesOrUsersSet.h
@@ -18,6 +18,7 @@ public:
     ParserRolesOrUsersSet & allowCurrentUser(bool allow_current_user_ = true) { allow_current_user = allow_current_user_; return *this; }
     ParserRolesOrUsersSet & allowRoles(bool allow_roles_ = true) { allow_roles = allow_roles_; return *this; }
     ParserRolesOrUsersSet & useIDMode(bool id_mode_ = true) { id_mode = id_mode_; return *this; }
+    ParserRolesOrUsersSet & allowQueryParameters(bool allow_query_parameter_ = true) { allow_query_parameter = allow_query_parameter_; return *this; }
 
 protected:
     const char * getName() const override { return "RolesOrUsersSet"; }
@@ -30,6 +31,7 @@ private:
     bool allow_current_user = false;
     bool allow_roles = false;
     bool id_mode = false;
+    bool allow_query_parameter = false;
 };
 
 }

--- a/src/Parsers/Access/ParserUserNameWithHost.cpp
+++ b/src/Parsers/Access/ParserUserNameWithHost.cpp
@@ -22,7 +22,8 @@ namespace ErrorCodes
 namespace
 {
 bool parseUserNameWithHost(
-    IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & ast, bool allow_query_parameter)
+    IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & ast,
+    bool allow_query_parameter, bool parse_host_pattern)
 {
     return IParserBase::wrapParseImpl(
         pos,
@@ -67,7 +68,17 @@ bool parseUserNameWithHost(
 
             host_pattern = trim(host_pattern, isWhitespaceASCII);
 
-            if (host_pattern.empty() || host_pattern == "%")
+            const auto * name_id = name_ast->as<ASTIdentifier>();
+            if (!parse_host_pattern && (!name_id || !name_id->isParam()))
+            {
+                /// These statements historically stored the name as a String. Preserve that canonical form for
+                /// static names so their formatter continues to quote the whole name, including a folded `@host`.
+                String name = name_id ? getIdentifierName(name_ast) : name_ast->as<ASTLiteral &>().value.safeGet<String>();
+                if (!host_pattern.empty() && host_pattern != "%")
+                    name += "@" + host_pattern;
+                ast = make_intrusive<ASTUserNameWithHost>(std::move(name));
+            }
+            else if (host_pattern.empty() || host_pattern == "%")
                 ast = make_intrusive<ASTUserNameWithHost>(std::move(name_ast));
             else
                 ast = make_intrusive<ASTUserNameWithHost>(std::move(name_ast), std::move(host_pattern));
@@ -81,15 +92,15 @@ bool parseUserNameWithHost(
 bool ParserUserNameWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     boost::intrusive_ptr<ASTUserNameWithHost> res;
-    if (!parseUserNameWithHost(pos, expected, res, allow_query_parameter))
+    if (!parseUserNameWithHost(pos, expected, res, allow_query_parameter, parse_host_pattern))
         return false;
 
     node = res;
     return true;
 }
 
-ParserUserNameWithHost::ParserUserNameWithHost(bool allow_query_parameter_)
-    : allow_query_parameter(allow_query_parameter_)
+ParserUserNameWithHost::ParserUserNameWithHost(bool allow_query_parameter_, bool parse_host_pattern_)
+    : allow_query_parameter(allow_query_parameter_), parse_host_pattern(parse_host_pattern_)
 {
 }
 
@@ -101,7 +112,7 @@ bool ParserUserNamesWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
     auto parse_single_name = [&]
     {
         boost::intrusive_ptr<ASTUserNameWithHost> ast;
-        if (!parseUserNameWithHost(pos, expected, ast, allow_query_parameter))
+        if (!parseUserNameWithHost(pos, expected, ast, allow_query_parameter, parse_host_pattern))
             return false;
 
         names.emplace_back(std::move(ast));
@@ -117,8 +128,8 @@ bool ParserUserNamesWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
     return true;
 }
 
-ParserUserNamesWithHost::ParserUserNamesWithHost(bool allow_query_parameter_)
-    : allow_query_parameter(allow_query_parameter_)
+ParserUserNamesWithHost::ParserUserNamesWithHost(bool allow_query_parameter_, bool parse_host_pattern_)
+    : allow_query_parameter(allow_query_parameter_), parse_host_pattern(parse_host_pattern_)
 {
 }
 

--- a/src/Parsers/Access/ParserUserNameWithHost.cpp
+++ b/src/Parsers/Access/ParserUserNameWithHost.cpp
@@ -22,7 +22,8 @@ namespace ErrorCodes
 namespace
 {
 bool parseUserNameWithHost(
-    IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & ast, bool allow_query_parameter)
+    IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & ast,
+    bool allow_query_parameter, bool parse_host_pattern)
 {
     return IParserBase::wrapParseImpl(
         pos,
@@ -67,7 +68,17 @@ bool parseUserNameWithHost(
 
             boost::algorithm::trim(host_pattern);
 
-            if (host_pattern.empty() || host_pattern == "%")
+            const auto * name_id = name_ast->as<ASTIdentifier>();
+            if (!parse_host_pattern && (!name_id || !name_id->isParam()))
+            {
+                /// These statements historically stored the name as a String. Preserve that canonical form for
+                /// static names so their formatter continues to quote the whole name, including a folded `@host`.
+                String name = name_id ? getIdentifierName(name_ast) : name_ast->as<ASTLiteral &>().value.safeGet<String>();
+                if (!host_pattern.empty() && host_pattern != "%")
+                    name += "@" + host_pattern;
+                ast = make_intrusive<ASTUserNameWithHost>(std::move(name));
+            }
+            else if (host_pattern.empty() || host_pattern == "%")
                 ast = make_intrusive<ASTUserNameWithHost>(std::move(name_ast));
             else
                 ast = make_intrusive<ASTUserNameWithHost>(std::move(name_ast), std::move(host_pattern));
@@ -81,15 +92,15 @@ bool parseUserNameWithHost(
 bool ParserUserNameWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     boost::intrusive_ptr<ASTUserNameWithHost> res;
-    if (!parseUserNameWithHost(pos, expected, res, allow_query_parameter))
+    if (!parseUserNameWithHost(pos, expected, res, allow_query_parameter, parse_host_pattern))
         return false;
 
     node = res;
     return true;
 }
 
-ParserUserNameWithHost::ParserUserNameWithHost(bool allow_query_parameter_)
-    : allow_query_parameter(allow_query_parameter_)
+ParserUserNameWithHost::ParserUserNameWithHost(bool allow_query_parameter_, bool parse_host_pattern_)
+    : allow_query_parameter(allow_query_parameter_), parse_host_pattern(parse_host_pattern_)
 {
 }
 
@@ -101,7 +112,7 @@ bool ParserUserNamesWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
     auto parse_single_name = [&]
     {
         boost::intrusive_ptr<ASTUserNameWithHost> ast;
-        if (!parseUserNameWithHost(pos, expected, ast, allow_query_parameter))
+        if (!parseUserNameWithHost(pos, expected, ast, allow_query_parameter, parse_host_pattern))
             return false;
 
         names.emplace_back(std::move(ast));
@@ -117,8 +128,8 @@ bool ParserUserNamesWithHost::parseImpl(Pos & pos, ASTPtr & node, Expected & exp
     return true;
 }
 
-ParserUserNamesWithHost::ParserUserNamesWithHost(bool allow_query_parameter_)
-    : allow_query_parameter(allow_query_parameter_)
+ParserUserNamesWithHost::ParserUserNamesWithHost(bool allow_query_parameter_, bool parse_host_pattern_)
+    : allow_query_parameter(allow_query_parameter_), parse_host_pattern(parse_host_pattern_)
 {
 }
 

--- a/src/Parsers/Access/ParserUserNameWithHost.h
+++ b/src/Parsers/Access/ParserUserNameWithHost.h
@@ -8,11 +8,12 @@ namespace DB
 
 /** Parses a user name.
   * It can be a simple string or identifier or something like `name@host`.
+  * When `parse_host_pattern` is set (CREATE/ALTER USER), the `@host` part is kept separate from the name.
   */
 class ParserUserNameWithHost : public IParserBase
 {
 public:
-    explicit ParserUserNameWithHost(bool allow_query_parameter);
+    explicit ParserUserNameWithHost(bool allow_query_parameter, bool parse_host_pattern = true);
 
 protected:
     const char * getName() const override { return "UserNameWithHost"; }
@@ -20,13 +21,14 @@ protected:
 
 private:
     bool allow_query_parameter = false;
+    bool parse_host_pattern = true;
 };
 
 
 class ParserUserNamesWithHost : public IParserBase
 {
 public:
-    explicit ParserUserNamesWithHost(bool allow_query_parameter);
+    explicit ParserUserNamesWithHost(bool allow_query_parameter, bool parse_host_pattern = true);
 
 protected:
     const char * getName() const override { return "UserNamesWithHost"; }
@@ -34,6 +36,7 @@ protected:
 
 private:
     bool allow_query_parameter = false;
+    bool parse_host_pattern = true;
 };
 
 }

--- a/src/Storages/System/StorageSystemQuotas.cpp
+++ b/src/Storages/System/StorageSystemQuotas.cpp
@@ -135,12 +135,14 @@ void StorageSystemQuotas::fillData(MutableColumns & res_columns, ContextPtr cont
         auto apply_to_ast = quota->to_roles.toASTWithNames(access_control);
         column_apply_to_all.push_back(apply_to_ast->all);
 
-        for (const auto & role_name : apply_to_ast->names)
-            column_apply_to_list.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->names)
+            for (const auto & role_name : apply_to_ast->names->toStrings())
+                column_apply_to_list.insertData(role_name.data(), role_name.length());
         column_apply_to_list_offsets.push_back(column_apply_to_list.size());
 
-        for (const auto & role_name : apply_to_ast->except_names)
-            column_apply_to_except.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->except_names)
+            for (const auto & role_name : apply_to_ast->except_names->toStrings())
+                column_apply_to_except.insertData(role_name.data(), role_name.length());
         column_apply_to_except_offsets.push_back(column_apply_to_except.size());
 
         if (quota->ipv4_prefix_bits)

--- a/src/Storages/System/StorageSystemRowPolicies.cpp
+++ b/src/Storages/System/StorageSystemRowPolicies.cpp
@@ -131,12 +131,14 @@ void StorageSystemRowPolicies::fillData(MutableColumns & res_columns, ContextPtr
         auto apply_to_ast = apply_to.toASTWithNames(access_control);
         column_apply_to_all.push_back(apply_to_ast->all);
 
-        for (const auto & role_name : apply_to_ast->names)
-            column_apply_to_list.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->names)
+            for (const auto & role_name : apply_to_ast->names->toStrings())
+                column_apply_to_list.insertData(role_name.data(), role_name.length());
         column_apply_to_list_offsets.push_back(column_apply_to_list.size());
 
-        for (const auto & role_name : apply_to_ast->except_names)
-            column_apply_to_except.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->except_names)
+            for (const auto & role_name : apply_to_ast->except_names->toStrings())
+                column_apply_to_except.insertData(role_name.data(), role_name.length());
         column_apply_to_except_offsets.push_back(column_apply_to_except.size());
     };
 

--- a/src/Storages/System/StorageSystemSettingsProfiles.cpp
+++ b/src/Storages/System/StorageSystemSettingsProfiles.cpp
@@ -71,12 +71,14 @@ void StorageSystemSettingsProfiles::fillData(MutableColumns & res_columns, Conte
         auto apply_to_ast = apply_to.toASTWithNames(access_control);
         column_apply_to_all.push_back(apply_to_ast->all);
 
-        for (const auto & role_name : apply_to_ast->names)
-            column_apply_to_list.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->names)
+            for (const auto & role_name : apply_to_ast->names->toStrings())
+                column_apply_to_list.insertData(role_name.data(), role_name.length());
         column_apply_to_list_offsets.push_back(column_apply_to_list.size());
 
-        for (const auto & role_name : apply_to_ast->except_names)
-            column_apply_to_except.insertData(role_name.data(), role_name.length());
+        if (apply_to_ast->except_names)
+            for (const auto & role_name : apply_to_ast->except_names->toStrings())
+                column_apply_to_except.insertData(role_name.data(), role_name.length());
         column_apply_to_except_offsets.push_back(column_apply_to_except.size());
     };
 

--- a/src/Storages/System/StorageSystemUsers.cpp
+++ b/src/Storages/System/StorageSystemUsers.cpp
@@ -461,20 +461,24 @@ void StorageSystemUsers::fillData(MutableColumns & res_columns, ContextPtr conte
 
         auto default_roles_ast = default_roles.toASTWithNames(access_control);
         column_default_roles_all.push_back(default_roles_ast->all);
-        for (const auto & role_name : default_roles_ast->names)
-            column_default_roles_list.insertData(role_name.data(), role_name.length());
+        if (default_roles_ast->names)
+            for (const auto & role_name : default_roles_ast->names->toStrings())
+                column_default_roles_list.insertData(role_name.data(), role_name.length());
         column_default_roles_list_offsets.push_back(column_default_roles_list.size());
-        for (const auto & except_name : default_roles_ast->except_names)
-            column_default_roles_except.insertData(except_name.data(), except_name.length());
+        if (default_roles_ast->except_names)
+            for (const auto & except_name : default_roles_ast->except_names->toStrings())
+                column_default_roles_except.insertData(except_name.data(), except_name.length());
         column_default_roles_except_offsets.push_back(column_default_roles_except.size());
 
         auto grantees_ast = grantees.toASTWithNames(access_control);
         column_grantees_any.push_back(grantees_ast->all);
-        for (const auto & grantee_name : grantees_ast->names)
-            column_grantees_list.insertData(grantee_name.data(), grantee_name.length());
+        if (grantees_ast->names)
+            for (const auto & grantee_name : grantees_ast->names->toStrings())
+                column_grantees_list.insertData(grantee_name.data(), grantee_name.length());
         column_grantees_list_offsets.push_back(column_grantees_list.size());
-        for (const auto & except_name : grantees_ast->except_names)
-            column_grantees_except.insertData(except_name.data(), except_name.length());
+        if (grantees_ast->except_names)
+            for (const auto & except_name : grantees_ast->except_names->toStrings())
+                column_grantees_except.insertData(except_name.data(), except_name.length());
         column_grantees_except_offsets.push_back(column_grantees_except.size());
 
         column_default_database.insertData(default_database.data(), default_database.length());

--- a/src/Storages/System/StorageSystemUsers.cpp
+++ b/src/Storages/System/StorageSystemUsers.cpp
@@ -424,20 +424,24 @@ void StorageSystemUsers::fillData(MutableColumns & res_columns, ContextPtr conte
 
         auto default_roles_ast = default_roles.toASTWithNames(access_control);
         column_default_roles_all.push_back(default_roles_ast->all);
-        for (const auto & role_name : default_roles_ast->names)
-            column_default_roles_list.insertData(role_name.data(), role_name.length());
+        if (default_roles_ast->names)
+            for (const auto & role_name : default_roles_ast->names->toStrings())
+                column_default_roles_list.insertData(role_name.data(), role_name.length());
         column_default_roles_list_offsets.push_back(column_default_roles_list.size());
-        for (const auto & except_name : default_roles_ast->except_names)
-            column_default_roles_except.insertData(except_name.data(), except_name.length());
+        if (default_roles_ast->except_names)
+            for (const auto & except_name : default_roles_ast->except_names->toStrings())
+                column_default_roles_except.insertData(except_name.data(), except_name.length());
         column_default_roles_except_offsets.push_back(column_default_roles_except.size());
 
         auto grantees_ast = grantees.toASTWithNames(access_control);
         column_grantees_any.push_back(grantees_ast->all);
-        for (const auto & grantee_name : grantees_ast->names)
-            column_grantees_list.insertData(grantee_name.data(), grantee_name.length());
+        if (grantees_ast->names)
+            for (const auto & grantee_name : grantees_ast->names->toStrings())
+                column_grantees_list.insertData(grantee_name.data(), grantee_name.length());
         column_grantees_list_offsets.push_back(column_grantees_list.size());
-        for (const auto & except_name : grantees_ast->except_names)
-            column_grantees_except.insertData(except_name.data(), except_name.length());
+        if (grantees_ast->except_names)
+            for (const auto & except_name : grantees_ast->except_names->toStrings())
+                column_grantees_except.insertData(except_name.data(), except_name.length());
         column_grantees_except_offsets.push_back(column_grantees_except.size());
 
         column_default_database.insertData(default_database.data(), default_database.length());

--- a/tests/queries/0_stateless/04648_user_query_parameter_identifier.reference
+++ b/tests/queries/0_stateless/04648_user_query_parameter_identifier.reference
@@ -1,0 +1,19 @@
+1
+1
+0
+2
+0
+1
+0
+3
+0
+1
+1
+0
+2
+0
+1
+0
+REVOKE SELECT ON *.* FROM ALL
+GRANT SELECT ON *.* TO {g:Identifier}
+DROP ROLE IF EXISTS r1, `r2@%.myhost.com`

--- a/tests/queries/0_stateless/04648_user_query_parameter_identifier.sql
+++ b/tests/queries/0_stateless/04648_user_query_parameter_identifier.sql
@@ -1,0 +1,74 @@
+DROP USER IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+
+CREATE USER {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.users WHERE name = currentDatabase();
+ALTER USER {CLICKHOUSE_DATABASE:Identifier} SETTINGS max_threads = 1;
+
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() AND access_type = 'SELECT';
+
+CREATE USER {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name IN (currentDatabase() || '_1', currentDatabase() || '_2') AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier} EXCEPT {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '_1' AND access_type = 'SELECT';
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '_2' AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name IN (currentDatabase() || '_1', currentDatabase() || '_2') AND access_type = 'SELECT';
+
+SELECT count() FROM system.users WHERE name IN (currentDatabase(), currentDatabase() || '_1', currentDatabase() || '_2');
+DROP USER {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.users WHERE name IN (currentDatabase(), currentDatabase() || '_1', currentDatabase() || '_2');
+
+CREATE USER {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.users WHERE name = currentDatabase() || '@192.168.%.%';
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '@192.168.%.%' AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+DROP USER {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.users WHERE name = currentDatabase() || '@192.168.%.%';
+
+GRANT SELECT ON *.* TO {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+REVOKE SELECT ON *.* FROM {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+DROP USER {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+-- Query-parameter substitution must preserve strict identifier formatting.
+SET param_strict_user_04648 = 'user_04648_$';
+SET enforce_strict_identifier_format = 1;
+CREATE USER `user_04648_$`; -- { serverError BAD_ARGUMENTS }
+CREATE USER {strict_user_04648:Identifier}; -- { serverError BAD_ARGUMENTS }
+CREATE ROLE {strict_user_04648:Identifier}; -- { serverError BAD_ARGUMENTS }
+GRANT SELECT ON *.* TO {strict_user_04648:Identifier}; -- { serverError BAD_ARGUMENTS }
+DROP ROLE {strict_user_04648:Identifier}; -- { serverError BAD_ARGUMENTS }
+SET enforce_strict_identifier_format = 0;
+
+DROP USER IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+
+-- The same parameter works as the entity name in CREATE / ALTER / DROP ROLE.
+DROP ROLE IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier};
+CREATE ROLE {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT count() FROM system.roles WHERE name IN (currentDatabase(), currentDatabase() || '_1');
+ALTER ROLE {CLICKHOUSE_DATABASE:Identifier} SETTINGS max_threads = 1;
+DROP ROLE {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT count() FROM system.roles WHERE name IN (currentDatabase(), currentDatabase() || '_1');
+DROP ROLE {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+-- Query parameters work in the granted-role list of GRANT / REVOKE.
+CREATE USER {CLICKHOUSE_DATABASE:Identifier};
+CREATE ROLE {CLICKHOUSE_DATABASE_1:Identifier};
+GRANT {CLICKHOUSE_DATABASE_1:Identifier} TO {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.role_grants WHERE user_name = currentDatabase() AND granted_role_name = currentDatabase() || '_1';
+REVOKE {CLICKHOUSE_DATABASE_1:Identifier} FROM {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.role_grants WHERE user_name = currentDatabase() AND granted_role_name = currentDatabase() || '_1';
+DROP USER {CLICKHOUSE_DATABASE:Identifier};
+DROP ROLE {CLICKHOUSE_DATABASE_1:Identifier};
+
+-- A parameter cannot be silently discarded by ALL.
+SELECT formatQuery('REVOKE SELECT ON *.* FROM ALL, {user:Identifier}'); -- { serverError SYNTAX_ERROR }
+SELECT formatQuery('REVOKE ALL, {role:Identifier} FROM default'); -- { serverError SYNTAX_ERROR }
+
+SELECT formatQuery('REVOKE SELECT ON *.* FROM ALL, role');
+SELECT formatQuery('GRANT SELECT ON *.* TO {g:Identifier}');
+SELECT formatQuery('DROP ROLE IF EXISTS r1@''%'', ''r2@%.myhost.com''');

--- a/tests/queries/0_stateless/05059_user_query_parameter_identifier.reference
+++ b/tests/queries/0_stateless/05059_user_query_parameter_identifier.reference
@@ -1,0 +1,22 @@
+1
+1
+1
+0
+2
+0
+1
+0
+3
+0
+1
+1
+0
+2
+1
+0
+1
+0
+REVOKE SELECT ON *.* FROM ALL
+GRANT SELECT ON *.* TO {g:Identifier}
+DROP ROLE IF EXISTS r1, `r2@%.myhost.com`
+ALTER ROLE r1 RENAME TO \'r2@%.myhost.com\'

--- a/tests/queries/0_stateless/05059_user_query_parameter_identifier.sql
+++ b/tests/queries/0_stateless/05059_user_query_parameter_identifier.sql
@@ -1,0 +1,77 @@
+DROP USER IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+
+CREATE USER {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.users WHERE name = currentDatabase();
+ALTER USER {CLICKHOUSE_DATABASE:Identifier} SETTINGS max_threads = 1;
+ALTER USER {CLICKHOUSE_DATABASE:Identifier} RENAME TO {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT count() FROM system.users WHERE name = currentDatabase() || '_1';
+ALTER USER {CLICKHOUSE_DATABASE_1:Identifier} RENAME TO {CLICKHOUSE_DATABASE:Identifier};
+
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() AND access_type = 'SELECT';
+
+CREATE USER {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name IN (currentDatabase() || '_1', currentDatabase() || '_2') AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier} EXCEPT {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '_1' AND access_type = 'SELECT';
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '_2' AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.grants WHERE user_name IN (currentDatabase() || '_1', currentDatabase() || '_2') AND access_type = 'SELECT';
+
+SELECT count() FROM system.users WHERE name IN (currentDatabase(), currentDatabase() || '_1', currentDatabase() || '_2');
+DROP USER {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.users WHERE name IN (currentDatabase(), currentDatabase() || '_1', currentDatabase() || '_2');
+
+CREATE USER {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.users WHERE name = currentDatabase() || '@192.168.%.%';
+GRANT SELECT ON *.* TO {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.grants WHERE user_name = currentDatabase() || '@192.168.%.%' AND access_type = 'SELECT';
+REVOKE SELECT ON *.* FROM {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+DROP USER {CLICKHOUSE_DATABASE:Identifier}@'192.168.%.%';
+SELECT count() FROM system.users WHERE name = currentDatabase() || '@192.168.%.%';
+
+GRANT SELECT ON *.* TO {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+REVOKE SELECT ON *.* FROM {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+DROP USER {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+-- Query-parameter substitution must preserve strict identifier formatting.
+SET param_strict_user_05059 = 'user_05059_$';
+SET enforce_strict_identifier_format = 1;
+CREATE USER `user_05059_$`; -- { serverError BAD_ARGUMENTS }
+CREATE USER {strict_user_05059:Identifier}; -- { serverError BAD_ARGUMENTS }
+CREATE ROLE {strict_user_05059:Identifier}; -- { serverError BAD_ARGUMENTS }
+GRANT SELECT ON *.* TO {strict_user_05059:Identifier}; -- { serverError BAD_ARGUMENTS }
+DROP ROLE {strict_user_05059:Identifier}; -- { serverError BAD_ARGUMENTS }
+SET enforce_strict_identifier_format = 0;
+
+DROP USER IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+
+-- The same parameter works as the entity name in CREATE / ALTER / DROP ROLE.
+DROP ROLE IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+CREATE ROLE {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier};
+SELECT count() FROM system.roles WHERE name IN (currentDatabase(), currentDatabase() || '_1');
+ALTER ROLE {CLICKHOUSE_DATABASE:Identifier} RENAME TO {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.roles WHERE name = currentDatabase() || '_2';
+ALTER ROLE {CLICKHOUSE_DATABASE_2:Identifier} RENAME TO {CLICKHOUSE_DATABASE:Identifier};
+ALTER ROLE {CLICKHOUSE_DATABASE:Identifier} SETTINGS max_threads = 1;
+DROP ROLE IF EXISTS {CLICKHOUSE_DATABASE:Identifier}, {CLICKHOUSE_DATABASE_1:Identifier}, {CLICKHOUSE_DATABASE_2:Identifier};
+SELECT count() FROM system.roles WHERE name IN (currentDatabase(), currentDatabase() || '_1');
+DROP ROLE {nonexistent_param:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+
+-- Query parameters work in the granted-role list of GRANT / REVOKE.
+CREATE USER {CLICKHOUSE_DATABASE:Identifier};
+CREATE ROLE {CLICKHOUSE_DATABASE_1:Identifier};
+GRANT {CLICKHOUSE_DATABASE_1:Identifier} TO {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.role_grants WHERE user_name = currentDatabase() AND granted_role_name = currentDatabase() || '_1';
+REVOKE {CLICKHOUSE_DATABASE_1:Identifier} FROM {CLICKHOUSE_DATABASE:Identifier};
+SELECT count() FROM system.role_grants WHERE user_name = currentDatabase() AND granted_role_name = currentDatabase() || '_1';
+DROP USER {CLICKHOUSE_DATABASE:Identifier};
+DROP ROLE {CLICKHOUSE_DATABASE_1:Identifier};
+
+SELECT formatQuery('REVOKE SELECT ON *.* FROM ALL, role');
+SELECT formatQuery('GRANT SELECT ON *.* TO {g:Identifier}');
+SELECT formatQuery('DROP ROLE IF EXISTS r1@''%'', ''r2@%.myhost.com''');
+SELECT formatQuery('ALTER ROLE r1 RENAME TO r2@''%.myhost.com''');


### PR DESCRIPTION
Closes #109298

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Query parameters can now be used for primary `USER` and `ROLE` names in `CREATE`, `ALTER`, and `DROP`, and for role and grantee names in `GRANT` and `REVOKE`, e.g. `GRANT {role:Identifier} TO {user:Identifier}`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109696&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109696](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109696+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
