### PR TITLE
Add test: `positions` argument validation in `textIndexValidator` (experimental guard + range check) untested

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -1,6 +1,6 @@
 Must not have no arguments.
 Test single tokenizer argument.
--- tokenizer must be splitByNonAlpha, ngrams, sparseGrams, splitByString or array.
+-- tokenizer must be splitByNonAlpha, ngrams, sparseGrams, splitByString, asciiCJK or array.
 -- tokenizer can be identifier or function.
 Test asciiCJK tokenizer.
 Test ngrams tokenizer.
@@ -24,6 +24,9 @@ Test dictionary_block_frontcoding_compression argument.
 Test posting_list_codec argument.
 -- posting_list_codec must be a string.
 -- posting_list_codec must be none or bitpacking.
+Test positions argument.
+-- positions argument is experimental
+-- positions argument is must be 0 or 1
 Types are incorrect.
 Same argument appears >1 times.
 Non-existing argument.

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -57,7 +57,7 @@ ENGINE = MergeTree
 ORDER BY tuple();
 DROP TABLE tab;
 
-SELECT '-- tokenizer must be splitByNonAlpha, ngrams, sparseGrams, splitByString or array.';
+SELECT '-- tokenizer must be splitByNonAlpha, ngrams, sparseGrams, splitByString, asciiCJK or array.';
 
 CREATE TABLE tab
 (
@@ -515,6 +515,49 @@ CREATE TABLE tab
 )
 ENGINE = MergeTree
 ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+SELECT 'Test positions argument.';
+
+SELECT '-- positions argument is experimental';
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = splitByNonAlpha, positions = 1)
+)
+ENGINE = MergeTree
+ORDER BY tuple(); -- { serverError SUPPORT_IS_DISABLED }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = splitByNonAlpha, positions = 1)
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS allow_experimental_text_index_positions = 1;
+
+DROP TABLE tab;
+
+SELECT '-- positions argument is must be 0 or 1';
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = splitByNonAlpha, positions = 2)
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS allow_experimental_text_index_positions = 1; -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = splitByNonAlpha, positions = 'abc')
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS allow_experimental_text_index_positions = 1; -- { serverError BAD_ARGUMENTS }
 
 SELECT 'Types are incorrect.';
 


### PR DESCRIPTION
[the extremely verbose PR message bla bla bla generated by AI was replaced by this short and sweet banner]

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/103172

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.660` (included in `26.7` and later)
<!-- ch-version-info:end -->