### PR TITLE
Free leftover server ports before starting ClickHouse in stateless test setup

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -450,7 +450,7 @@ profiles:
         previous run holds the ports we are about to bind.
 
         The CI test config sets `listen_try=true`, so if a stale server still
-        holds e.g. 9000/8123/9181/9009 the fresh server does NOT fail to start:
+        holds any listen port the fresh server does NOT fail to start:
         it logs each `Listen ... Address already in use` only as a Warning,
         stays alive, but never listens on the TCP port. wait_ready() then times
         out with Code 210 (Connection refused) and the whole job fails at setup
@@ -498,7 +498,15 @@ profiles:
             # before we launch our own (listen_try=true otherwise turns a port
             # collision into a silent wait_ready timeout). Done once, before any
             # of our replicas start, so it only ever targets stale processes.
-            self._ensure_server_ports_free([9000, 8123, 9181, 9009])
+            # Full stateless-server listen-port set, kept in sync with
+            # wait_server_ports_free() in tests/docker_scripts/stress_tests.lib:
+            #   8123 HTTP        9009 Interserver  9022 SSH    9181 Keeper
+            #   8443 HTTPS       9010 TCP proxy    9100 gRPC   9234 Keeper Raft
+            #   9000 Native TCP  9004 MySQL        9005 PGSQL  9440 Native TLS
+            #                                                  9988 Prometheus
+            self._ensure_server_ports_free(
+                [8123, 8443, 9000, 9004, 9005, 9009, 9010, 9022, 9100, 9181, 9234, 9440, 9988]
+            )
 
         if replica_num == 1:
             pid_file = self.pid_file_replica_1

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -445,10 +445,60 @@ profiles:
             verbose=True,
         )
 
+    def _ensure_server_ports_free(self, ports, timeout_s=45):
+        """Best-effort: make sure no leftover clickhouse-server/keeper from a
+        previous run holds the ports we are about to bind.
+
+        The CI test config sets `listen_try=true`, so if a stale server still
+        holds e.g. 9000/8123/9181/9009 the fresh server does NOT fail to start:
+        it logs each `Listen ... Address already in use` only as a Warning,
+        stays alive, but never listens on the TCP port. wait_ready() then times
+        out with Code 210 (Connection refused) and the whole job fails at setup
+        before any test runs. `clickhouse stop` between stages should release
+        the ports, but does not always (e.g. an ungraceful exit / detached
+        keeper), so this is a safety net. Never raises - a failure here must not
+        mask the real start.
+        """
+
+        def busy_ports():
+            busy = []
+            for p in ports:
+                # `ss -Hlnt 'sport = :P'` prints one line per LISTEN socket on P
+                if Shell.get_output(f"ss -Hlnt 'sport = :{p}'").strip():
+                    busy.append(p)
+            return busy
+
+        busy = busy_ports()
+        if not busy:
+            return
+        print(f"Ports still held before start: {busy} - killing lingering clickhouse server/keeper")
+        # Only clickhouse server/keeper are expected to hold these ports in the
+        # job container; kill them and wait for the OS to release the sockets.
+        Shell.check("pkill -9 -x clickhouse-server", verbose=True)
+        Shell.check("pkill -9 -x clickhouse-keeper", verbose=True)
+        Shell.check("pkill -9 -f 'clickhouse server'", verbose=True)
+        Shell.check("pkill -9 -f 'clickhouse keeper'", verbose=True)
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            busy = busy_ports()
+            if not busy:
+                print("All server ports are free now")
+                return
+            time.sleep(2)
+        print(
+            f"WARNING: ports still held after {timeout_s}s: {busy_ports()} - "
+            "starting anyway (wait_ready will report if the server cannot listen)"
+        )
+
     def start(self, replica_num=0):
         if replica_num == 0:
             # Clear dmesg to avoid false OOM detection from previous CI jobs on the same host
             Shell.check("dmesg --clear", verbose=True)
+            # Release ports held by a leftover server/keeper from a previous run
+            # before we launch our own (listen_try=true otherwise turns a port
+            # collision into a silent wait_ready timeout). Done once, before any
+            # of our replicas start, so it only ever targets stale processes.
+            self._ensure_server_ports_free([9000, 8123, 9181, 9009])
 
         if replica_num == 1:
             pid_file = self.pid_file_replica_1

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -445,6 +445,24 @@ profiles:
             verbose=True,
         )
 
+    # Single source of truth for the stateless-server listen ports is the
+    # CLICKHOUSE_SERVER_PORTS assignment in tests/docker_scripts/stress_tests.lib
+    # (also consumed by wait_server_ports_free there). Parse it instead of
+    # keeping a second hard-coded copy that can silently drift.
+    _STRESS_TESTS_LIB = "tests/docker_scripts/stress_tests.lib"
+
+    @staticmethod
+    def _server_ports():
+        path = Path(ClickHouseProc._STRESS_TESTS_LIB)
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("CLICKHOUSE_SERVER_PORTS="):
+                value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                return [int(p) for p in value.split()]
+        raise RuntimeError(
+            f"CLICKHOUSE_SERVER_PORTS not found in {ClickHouseProc._STRESS_TESTS_LIB}"
+        )
+
     def _ensure_server_ports_free(self, ports, timeout_s=45):
         """Best-effort: make sure no leftover clickhouse-server/keeper from a
         previous run holds the ports we are about to bind.
@@ -498,15 +516,8 @@ profiles:
             # before we launch our own (listen_try=true otherwise turns a port
             # collision into a silent wait_ready timeout). Done once, before any
             # of our replicas start, so it only ever targets stale processes.
-            # Full stateless-server listen-port set, kept in sync with
-            # wait_server_ports_free() in tests/docker_scripts/stress_tests.lib:
-            #   8123 HTTP        9009 Interserver  9022 SSH    9181 Keeper
-            #   8443 HTTPS       9010 TCP proxy    9100 gRPC   9234 Keeper Raft
-            #   9000 Native TCP  9004 MySQL        9005 PGSQL  9440 Native TLS
-            #                                                  9988 Prometheus
-            self._ensure_server_ports_free(
-                [8123, 8443, 9000, 9004, 9005, 9009, 9010, 9022, 9100, 9181, 9234, 9440, 9988]
-            )
+            # Port set is single-sourced from stress_tests.lib (see _server_ports).
+            self._ensure_server_ports_free(self._server_ports())
 
         if replica_num == 1:
             pid_file = self.pid_file_replica_1

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -2,6 +2,7 @@ import glob
 import json as json_module
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
@@ -463,6 +464,17 @@ profiles:
             f"CLICKHOUSE_SERVER_PORTS not found in {ClickHouseProc._STRESS_TESTS_LIB}"
         )
 
+    def _replica_ports(self):
+        # Replicas 1 and 2 (database-replicated mode) do NOT listen on the base
+        # ports - they bind the shifted sets baked into replica_command_1/2
+        # (e.g. 19000/18123/19181..., 29000/28123/29181...). Derive those ports
+        # from the exact commands that launch them so the teardown covers a
+        # replica-1/2 leak too, without a second hard-coded copy that can drift.
+        ports = set()
+        for command in (self.replica_command_1, self.replica_command_2):
+            ports.update(int(p) for p in re.findall(r"--\S*port\S*\s+(\d+)", command))
+        return sorted(ports)
+
     def _ensure_server_ports_free(self, ports, timeout_s=45):
         """Best-effort: make sure no leftover clickhouse-server/keeper from a
         previous run holds the ports we are about to bind.
@@ -517,7 +529,14 @@ profiles:
             # collision into a silent wait_ready timeout). Done once, before any
             # of our replicas start, so it only ever targets stale processes.
             # Port set is single-sourced from stress_tests.lib (see _server_ports).
-            self._ensure_server_ports_free(self._server_ports())
+            # In database-replicated mode replicas 1/2 bind shifted port sets
+            # (19000/18123..., 29000/28123...), so probe those too - a leaked
+            # replica 1/2 leaves the base ports free and would otherwise slip
+            # past the check into the same listen_try-masked wait_ready timeout.
+            ports = self._server_ports()
+            if self.is_db_replicated:
+                ports = sorted(set(ports) | set(self._replica_ports()))
+            self._ensure_server_ports_free(ports)
 
         if replica_num == 1:
             pid_file = self.pid_file_replica_1

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -266,19 +266,25 @@ function wait_server_port_free()
     fi
 }
 
+# Single source of truth for the full stateless-server listen-port set.
+# Parsed by ci/jobs/scripts/clickhouse_proc.py, so keep the assignment on one
+# line in the form  CLICKHOUSE_SERVER_PORTS="..."  (see _server_ports there).
+#   8123  HTTP               9010  TCP with proxy protocol
+#   8443  HTTPS              9022  SSH
+#   9000  Native TCP         9100  gRPC
+#   9004  MySQL compat       9181  Keeper
+#   9005  PostgreSQL compat  9234  Keeper Raft
+#   9009  Interserver HTTP   9440  Native TCP TLS
+#                            9988  Prometheus
+CLICKHOUSE_SERVER_PORTS="8123 8443 9000 9004 9005 9009 9010 9022 9100 9181 9234 9440 9988"
+
 function wait_server_ports_free()
 {
     # Wait for all ClickHouse listen ports to become available.
     # In debug+ThreadFuzzer builds, shutdown is slow and the kernel
     # may still hold sockets from the previous server instance.
-    #   8123  HTTP               9010  TCP with proxy protocol
-    #   8443  HTTPS              9022  SSH
-    #   9000  Native TCP         9100  gRPC
-    #   9004  MySQL compat       9181  Keeper
-    #   9005  PostgreSQL compat  9234  Keeper Raft
-    #   9009  Interserver HTTP   9440  Native TCP TLS
-    #                            9988  Prometheus
-    for port in 8123 8443 9000 9004 9005 9009 9010 9022 9100 9181 9234 9440 9988; do
+    # Port list documented at CLICKHOUSE_SERVER_PORTS above.
+    for port in $CLICKHOUSE_SERVER_PORTS; do
         wait_server_port_free "$port"
     done
 }


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106961
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Free leftover server ports before starting ClickHouse in the stateless functional-test setup, so a stale `clickhouse-server`/`clickhouse-keeper` from a previous run in the same job container cannot silently break the fresh server.

Root cause: the CI test config sets `listen_try=true` (`tests/config/config.d/listen.xml`). When a lingering server still holds `9000`/`8123`/`9181`/`9009`, the fresh server logs each `Listen ... Address already in use` only as a Warning, stays alive, but never listens on the TCP port. `wait_ready()` then times out with `Code: 210. Connection refused (localhost:9000)` and the job fails at setup, before any test runs — reported as an opaque `SETUP FAILURE: clickhouse-server not ready (wait_ready)`. This surfaced as a false-red `Stateless tests (*, flaky check)` verdict (the changed test never executed) and recurs across many unrelated PRs.

Fix: `ClickHouseProc.start()` now runs a best-effort teardown once, before starting replica 0. It checks whether `9000/8123/9181/9009` are held (`ss -Hlnt 'sport = :PORT'`); if so it kills any lingering `clickhouse-server`/`clickhouse-keeper` and waits (up to 45s) for the sockets to be released before launching our own process. It never raises, so a failure here cannot mask a real start error; `wait_ready()` still reports if the server genuinely cannot listen.
