### PR TITLE
Fix ReadBuffer cancellation assert in row-format verbose diagnostics

### DIFF
--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -211,6 +211,13 @@ Chunk IRowInputFormat::read()
                     throw;
                 }
 
+                /// If the parse error was caused by a throwing read that self-canceled the
+                /// buffer (via ReadBuffer::next()'s catch handler), we cannot skip the bad row:
+                /// syncAfterError() reads from the buffer (skipToNextLineOrEOF/ignore/eof), which
+                /// calls next() and trips chassert(!isCanceled()). Rethrow instead of aborting.
+                if (getReadBuffer().isCanceled())
+                    throw;
+
                 syncAfterError();
 
                 /// Rollback all columns in block to initial size (remove values, that was appended to only part of columns).

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -184,7 +184,11 @@ Chunk IRowInputFormat::read()
 
                 /// Logic for possible skipping of errors.
 
-                if (!isParseError(e.code()))
+                /// Skip a bad row only for a genuine parse error that was not thrown from the
+                /// buffer itself. A throwing read self-cancels the buffer (ReadBuffer::next()'s
+                /// catch handler), and syncAfterError() reads from it again
+                /// (skipToNextLineOrEOF/ignore/eof -> next()), tripping chassert(!isCanceled()).
+                if (!isParseError(e.code()) || getReadBuffer().isCanceled())
                     throw;
 
                 if (params.allow_errors_num == 0 && params.allow_errors_ratio == 0)
@@ -210,13 +214,6 @@ Chunk IRowInputFormat::read()
                     e.addMessage("(Input format doesn't allow to skip errors)");
                     throw;
                 }
-
-                /// If the parse error was caused by a throwing read that self-canceled the
-                /// buffer (via ReadBuffer::next()'s catch handler), we cannot skip the bad row:
-                /// syncAfterError() reads from the buffer (skipToNextLineOrEOF/ignore/eof), which
-                /// calls next() and trips chassert(!isCanceled()). Rethrow instead of aborting.
-                if (getReadBuffer().isCanceled())
-                    throw;
 
                 syncAfterError();
 
@@ -245,7 +242,10 @@ Chunk IRowInputFormat::read()
         }
         else
         {
-            if (!isParseError(e.code()))
+            /// Collect verbose diagnostics only for a genuine parse error that was not thrown
+            /// from the buffer itself. A throwing read self-cancels the buffer, and
+            /// getDiagnosticInfo() reads from it (eof() -> next()), tripping chassert(!isCanceled()).
+            if (!isParseError(e.code()) || getReadBuffer().isCanceled())
                 throw;
 
             String verbose_diagnostic;

--- a/src/Processors/Formats/Impl/tests/gtest_row_input_format_diagnostic_on_canceled_buffer.cpp
+++ b/src/Processors/Formats/Impl/tests/gtest_row_input_format_diagnostic_on_canceled_buffer.cpp
@@ -79,3 +79,38 @@ TEST(RowInputFormatDiagnostics, CanceledBufferDoesNotAbort)
     /// Must throw a regular exception, not abort the process.
     EXPECT_THROW(format.read(), Exception);
 }
+
+/// Regression test for the second reachable path to the same "ReadBuffer is canceled"
+/// abort, this time in IRowInputFormat::read()'s error-skipping branch.
+///
+/// With allow_errors_num / allow_errors_ratio set, read() catches the parse error inside
+/// the row loop (before it reaches the diagnostics guard) and calls syncAfterError() to
+/// skip to the next row. For TSV/CSV/template that starts with skipTo*NextLineOrEOF, whose
+/// first buf.eof() calls next() on the now canceled buffer, tripping the same
+/// chassert(!isCanceled()). The fix rethrows when the buffer is already canceled instead
+/// of trying to skip, so a regular exception is thrown rather than aborting.
+TEST(RowInputFormatDiagnostics, CanceledBufferDoesNotAbortWithAllowErrors)
+{
+    Block header;
+    header.insert({ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "a"});
+    header.insert({ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "b"});
+    auto shared_header = std::make_shared<const Block>(header);
+
+    /// One complete row, then a partial row so the parser calls next() mid-row.
+    ThrowingReadBuffer buf("1\t2\n3\t");
+
+    RowInputFormatParams params;
+    params.max_block_size_rows = 100;
+    /// Enable error skipping so read() takes the syncAfterError() path, not the diagnostics one.
+    params.allow_errors_num = 10;
+    params.allow_errors_ratio = 1.0;
+
+    FormatSettings format_settings;
+    TabSeparatedRowInputFormat format(
+        shared_header, buf, params,
+        /* with_names_ = */ false, /* with_types_ = */ false, /* is_raw = */ false,
+        format_settings);
+
+    /// Must throw a regular exception, not abort the process.
+    EXPECT_THROW(format.read(), Exception);
+}

--- a/src/Processors/Formats/Impl/tests/gtest_row_input_format_diagnostic_on_canceled_buffer.cpp
+++ b/src/Processors/Formats/Impl/tests/gtest_row_input_format_diagnostic_on_canceled_buffer.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <Processors/Formats/Impl/TabSeparatedRowInputFormat.h>
+#include <Formats/FormatSettings.h>
+#include <IO/ReadBuffer.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypesNumber.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_READ_ALL_DATA;
+}
+
+namespace
+{
+
+/// A ReadBuffer that serves a fixed payload once, then throws a parse-classified
+/// error from nextImpl(). ReadBuffer::next() catches any throw from nextImpl(),
+/// calls cancel() (setting canceled = true) and rethrows. This models the real
+/// production case where an underlying read fails mid-parse (e.g. a malformed
+/// HTTP chunk header, a truncated fixed-length body) and self-cancels the buffer.
+class ThrowingReadBuffer : public ReadBuffer
+{
+public:
+    explicit ThrowingReadBuffer(std::string payload_)
+        : ReadBuffer(nullptr, 0), payload(std::move(payload_))
+    {
+    }
+
+private:
+    bool nextImpl() override
+    {
+        if (!served)
+        {
+            served = true;
+            BufferBase::set(payload.data(), payload.size(), 0);
+            return true;
+        }
+        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Unexpected EOF (simulated mid-parse failure)");
+    }
+
+    std::string payload;
+    bool served = false;
+};
+
+}
+
+/// Regression test for the "ReadBuffer is canceled. Can't read from it." abort in
+/// RowInputFormatWithDiagnosticInfo::getDiagnosticAndRawDataImpl().
+///
+/// Sequence: a row parse reads a partial row, then next() is called for the rest,
+/// the underlying read throws a parse-classified error and self-cancels the buffer.
+/// IRowInputFormat::read() catches the parse error and calls getDiagnosticInfo() to
+/// enrich the message; the diagnostics code called eof() (-> next()) on the now
+/// canceled buffer, tripping chassert(!isCanceled()) and aborting in assertion-enabled
+/// builds. The fix guards with in->isCanceled() so it must throw a normal exception
+/// instead of aborting.
+TEST(RowInputFormatDiagnostics, CanceledBufferDoesNotAbort)
+{
+    Block header;
+    header.insert({ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "a"});
+    header.insert({ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "b"});
+    auto shared_header = std::make_shared<const Block>(header);
+
+    /// One complete row, then a partial row so the parser calls next() mid-row.
+    ThrowingReadBuffer buf("1\t2\n3\t");
+
+    RowInputFormatParams params;
+    params.max_block_size_rows = 100;
+
+    FormatSettings format_settings;
+    TabSeparatedRowInputFormat format(
+        shared_header, buf, params,
+        /* with_names_ = */ false, /* with_types_ = */ false, /* is_raw = */ false,
+        format_settings);
+
+    /// Must throw a regular exception, not abort the process.
+    EXPECT_THROW(format.read(), Exception);
+}

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -39,10 +39,7 @@ std::pair<String, String> RowInputFormatWithDiagnosticInfo::getDiagnosticAndRawD
     WriteBufferFromOwnString out_diag;
     WriteBufferFromOwnString out_data;
 
-    /// A canceled buffer cannot be read (eof() calls next() which asserts !isCanceled()).
-    /// This happens when the parse error that triggered diagnostics was itself caused by a
-    /// throwing read that self-canceled the buffer via ReadBuffer::next()'s catch handler.
-    if (in->isCanceled() || in->eof())
+    if (in->eof())
         return std::make_pair(
             "Buffer has gone, cannot extract information about what has been parsed.",
             "Buffer has gone, cannot extract information about what has been parsed.");

--- a/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
+++ b/src/Processors/Formats/RowInputFormatWithDiagnosticInfo.cpp
@@ -39,7 +39,10 @@ std::pair<String, String> RowInputFormatWithDiagnosticInfo::getDiagnosticAndRawD
     WriteBufferFromOwnString out_diag;
     WriteBufferFromOwnString out_data;
 
-    if (in->eof())
+    /// A canceled buffer cannot be read (eof() calls next() which asserts !isCanceled()).
+    /// This happens when the parse error that triggered diagnostics was itself caused by a
+    /// throwing read that self-canceled the buffer via ReadBuffer::next()'s catch handler.
+    if (in->isCanceled() || in->eof())
         return std::make_pair(
             "Buffer has gone, cannot extract information about what has been parsed.",
             "Buffer has gone, cannot extract information about what has been parsed.");


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a possible `Logical error: 'ReadBuffer is canceled. Can't read from it.'` when a row-based input format (e.g. `TSV`/`CSV`) failed to parse input and the underlying read had already been canceled (for example a malformed HTTP chunk or a truncated body). Building the verbose parse diagnostics no longer reads from a canceled buffer.


### Description

When a row-format parse fails because an underlying read throws mid-parse, `ReadBuffer::next()` self-cancels the buffer in its `catch (...) { cancel(); throw; }` handler (sets `canceled = true` and rethrows). The failure surfaces as a parse error, so `IRowInputFormat::read()` calls `getDiagnosticInfo()` to enrich the message. `RowInputFormatWithDiagnosticInfo::getDiagnosticAndRawDataImpl()` then called `in->eof()`, and `eof()` calls `next()`, which trips `chassert(!isCanceled())` (`src/IO/ReadBuffer.cpp:107`) and aborts in assertion-enabled builds.

The fix guards the diagnostics entry with `in->isCanceled()` before `eof()`, mirroring the caller-side guard added for `TCPHandler` in #100666. A canceled buffer cannot yield further diagnostics, and re-reading it is exactly what the assertion forbids.

This is a distinct caller of the same assertion family (fuzz issues #84186, #98866, #99258, #100581) not covered by the `TCPHandler` fix (#100666) or the S3 backup upload-retry fix (#108573).

A gtest regression (`RowInputFormatDiagnostics.CanceledBufferDoesNotAbort`) drives a `TabSeparatedRowInputFormat` over a buffer that self-cancels on a parse-classified error mid-row; it aborts without the fix and passes with it. This behavior is not observable from SQL because the abort is a `chassert` in assertion-enabled builds and the exact HTTP framing that reaches the format-level read is timing-sensitive.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.773` (included in `26.7` and later)
<!-- ch-version-info:end -->