### PR TITLE
Rebuild skip indices and projections on APPLY PATCHES

### DIFF
--- a/src/Interpreters/MutationsInterpreter.cpp
+++ b/src/Interpreters/MutationsInterpreter.cpp
@@ -675,6 +675,12 @@ void MutationsInterpreter::prepare(bool dry_run)
     NameSet available_columns_set(available_columns.begin(), available_columns.end());
 
     NameSet updated_columns;
+    /// Columns whose values are changed by materializing patch parts (lightweight
+    /// updates). They arrive as READ_COLUMN commands flagged read_for_patch. Skip
+    /// indices, projections and statistics that depend on them must be rebuilt,
+    /// just like for a classical ALTER UPDATE (see the READ_COLUMN branch below,
+    /// which only rebuilds when the column type changes and so misses patches).
+    NameSet patch_updated_columns;
     bool materialize_ttl_recalculate_only = source.materializeTTLRecalculateOnly();
     bool has_lightweight_delete_materialization = false;
     bool has_rewrite_parts = false;
@@ -689,6 +695,11 @@ void MutationsInterpreter::prepare(bool dry_run)
 
         if (command.type == MutationCommand::REWRITE_PARTS)
             has_rewrite_parts = true;
+
+        /// The _row_exists mask is handled by APPLY_DELETED_MASK, not as a data column.
+        if (command.type == MutationCommand::READ_COLUMN && command.read_for_patch
+            && command.column_name != RowExistsColumn::name)
+            patch_updated_columns.insert(command.column_name);
 
         auto alter = command.ast();
         if (alter && alter->update_assignments)
@@ -774,7 +785,15 @@ void MutationsInterpreter::prepare(bool dry_run)
     };
 
     if (settings.recalculate_dependencies_of_updated_columns)
-        dependencies = getAllColumnDependencies(metadata_snapshot, updated_columns, has_dependency);
+    {
+        /// Patch-updated columns change data without a type change, so they must
+        /// enter dependency analysis to have their skip indices / projections /
+        /// statistics rebuilt. They are excluded from update-column validation
+        /// above because they are not user-issued UPDATEs.
+        NameSet columns_for_dependencies = updated_columns;
+        columns_for_dependencies.insert(patch_updated_columns.begin(), patch_updated_columns.end());
+        dependencies = getAllColumnDependencies(metadata_snapshot, columns_for_dependencies, has_dependency);
+    }
 
     bool need_rebuild_indexes = false;
     bool need_rebuild_indexes_for_update_delete = false;
@@ -1433,7 +1452,11 @@ void MutationsInterpreter::prepare(bool dry_run)
         bool changed = std::any_of(
             index_cols.begin(),
             index_cols.end(),
-            [&](const auto & col) { return updated_columns.contains(col) || changed_columns.contains(col); });
+            [&](const auto & col)
+            {
+                return updated_columns.contains(col) || changed_columns.contains(col)
+                    || patch_updated_columns.contains(col);
+            });
 
         if (changed)
         {
@@ -1467,7 +1490,11 @@ void MutationsInterpreter::prepare(bool dry_run)
         bool changed = std::any_of(
             projection_cols.begin(),
             projection_cols.end(),
-            [&](const auto & col) { return updated_columns.contains(col) || changed_columns.contains(col); });
+            [&](const auto & col)
+            {
+                return updated_columns.contains(col) || changed_columns.contains(col)
+                    || patch_updated_columns.contains(col);
+            });
 
         if (changed)
             materialized_projections.insert(projection.name);
@@ -1478,7 +1505,8 @@ void MutationsInterpreter::prepare(bool dry_run)
         if (column.statistics.empty())
             continue;
 
-        if (updated_columns.contains(column.name) || changed_columns.contains(column.name))
+        if (updated_columns.contains(column.name) || changed_columns.contains(column.name)
+            || patch_updated_columns.contains(column.name))
             materialized_statistics.insert(column.name);
     }
 

--- a/tests/queries/0_stateless/03100_lwu_53_apply_patches_rebuild_indexes.reference
+++ b/tests/queries/0_stateless/03100_lwu_53_apply_patches_rebuild_indexes.reference
@@ -1,0 +1,9 @@
+text skip on 	1
+text skip off	1
+bf skip on 	1
+bf skip off	1
+proj rows	2
+proj use 	a	90
+proj use 	b	10
+proj skip	a	90
+proj skip	b	10

--- a/tests/queries/0_stateless/03100_lwu_53_apply_patches_rebuild_indexes.sql
+++ b/tests/queries/0_stateless/03100_lwu_53_apply_patches_rebuild_indexes.sql
@@ -1,0 +1,73 @@
+SET enable_lightweight_update = 1;
+SET use_query_condition_cache = 0;
+
+-- APPLY PATCHES must rebuild skip indices and projections that depend on a
+-- patch-updated column, otherwise a query using the stale index/projection
+-- returns wrong results.
+
+-- 1. text index
+DROP TABLE IF EXISTS t_lwu_53_text;
+CREATE TABLE t_lwu_53_text
+(
+    id UInt64,
+    s String,
+    INDEX idx_s s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8, min_bytes_for_wide_part = 0, enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_53_text SELECT number, 'nothing here' FROM numbers(100);
+UPDATE t_lwu_53_text SET s = 'magic token' WHERE id = 7;
+ALTER TABLE t_lwu_53_text APPLY PATCHES SETTINGS mutations_sync = 2;
+
+SELECT 'text skip on ', count() FROM t_lwu_53_text WHERE hasToken(s, 'magic') SETTINGS use_skip_indexes = 1;
+SELECT 'text skip off', count() FROM t_lwu_53_text WHERE hasToken(s, 'magic') SETTINGS use_skip_indexes = 0;
+
+DROP TABLE t_lwu_53_text;
+
+-- 2. bloom_filter index
+DROP TABLE IF EXISTS t_lwu_53_bf;
+CREATE TABLE t_lwu_53_bf
+(
+    id UInt64,
+    s String,
+    INDEX idx_s s TYPE bloom_filter(0.001) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 8, min_bytes_for_wide_part = 0, enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_53_bf SELECT number, 'nothing' FROM numbers(100);
+UPDATE t_lwu_53_bf SET s = 'magictoken' WHERE id = 7;
+ALTER TABLE t_lwu_53_bf APPLY PATCHES SETTINGS mutations_sync = 2;
+
+SELECT 'bf skip on ', count() FROM t_lwu_53_bf WHERE s = 'magictoken' SETTINGS use_skip_indexes = 1;
+SELECT 'bf skip off', count() FROM t_lwu_53_bf WHERE s = 'magictoken' SETTINGS use_skip_indexes = 0;
+
+DROP TABLE t_lwu_53_bf;
+
+-- 3. projection over a patch-updated column
+DROP TABLE IF EXISTS t_lwu_53_proj;
+CREATE TABLE t_lwu_53_proj
+(
+    id UInt64,
+    cat String,
+    val UInt64,
+    PROJECTION p (SELECT cat, sum(val) GROUP BY cat)
+)
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, enable_block_number_column = 1, enable_block_offset_column = 1;
+
+INSERT INTO t_lwu_53_proj SELECT number, 'a', 1 FROM numbers(100);
+UPDATE t_lwu_53_proj SET cat = 'b' WHERE id < 10;
+ALTER TABLE t_lwu_53_proj APPLY PATCHES SETTINGS mutations_sync = 2;
+
+-- The projection part must be rebuilt so it holds 2 groups ('a', 'b'),
+-- otherwise a projection-answered query returns stale results once the
+-- spent patch part is dropped.
+SELECT 'proj rows', sum(rows) FROM system.projection_parts
+WHERE table = 't_lwu_53_proj' AND active AND database = currentDatabase();
+
+SELECT 'proj use ', cat, sum(val) FROM t_lwu_53_proj GROUP BY cat ORDER BY cat SETTINGS optimize_use_projections = 1;
+SELECT 'proj skip', cat, sum(val) FROM t_lwu_53_proj GROUP BY cat ORDER BY cat SETTINGS optimize_use_projections = 0;
+
+DROP TABLE t_lwu_53_proj;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/109531

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed stale skip indices (`text`, `bloom_filter`, etc.) and projections after materializing lightweight updates with `ALTER TABLE ... APPLY PATCHES`. Previously the index and projection files that depend on a patch-updated column were left unchanged, so queries using them could return wrong results (e.g. `hasToken` missing an updated row, or a projection returning stale aggregates once the spent patch part was removed).

### Description

Follow-up to #109531, reported by @ EmeraldShift.

`APPLY PATCHES` materialization goes through `MutationsInterpreter::prepare`. The patch-updated columns arrive as `READ_COLUMN` commands flagged `read_for_patch`, but that branch only registers skip-index / projection rebuild dependencies when the column **type** changes. A patch keeps the type unchanged, so nothing was rebuilt; on wide parts the stale index/projection files are hardlinked into the result part with valid checksums, and no later step catches the staleness.

Fix: collect the patch-updated columns (excluding the `_row_exists` mask, which is handled by `APPLY_DELETED_MASK`) and OR them into the dependency analysis and the index / projection / statistics rebuild predicates, exactly like a classical `ALTER UPDATE`.

Verified locally (fails without the fix, passes with it):
- `text` index: after `UPDATE ... SET s = 'magic token'; APPLY PATCHES`, `hasToken(s, 'magic')` returned 0 with `use_skip_indexes = 1` (stale index prunes the granule) and 1 with it off; now returns 1 in both cases.
- `bloom_filter` index: same, wrong result eliminated.
- projection: the projection part was rebuilt (2 groups instead of 1 stale group) so projection-answered queries stay correct after `clearUnusedPatchParts` drops the patch part.

Regression test: `03100_lwu_53_apply_patches_rebuild_indexes`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.772` (included in `26.7` and later)
<!-- ch-version-info:end -->