### PR TITLE
Reject data type names that start with a digit

### DIFF
--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -248,8 +248,11 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     /// unquoted (e.g. UInt64). This introduces problems when the string in the quotes is garbage:
     ///  * Array(`x.y`) -> Array(x.y) -> fails to parse
     ///  * `Null` -> Null -> parses as keyword instead of type name
+    ///  * `8` -> 8 -> parses as a numeric literal instead of a type name
     /// Here we check for these cases and reject.
-    if (!std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
+    if (type_name.empty()
+        || isNumericASCII(type_name[0])
+        || !std::all_of(type_name.begin(), type_name.end(), [](char c) { return isWordCharASCII(c) || c == '$'; }))
     {
         expected.add(pos, "type name");
         return false;

--- a/tests/queries/0_stateless/04507_data_type_name_numeric_roundtrip.reference
+++ b/tests/queries/0_stateless/04507_data_type_name_numeric_roundtrip.reference
@@ -1,0 +1,5 @@
+CREATE TABLE t (`c` Decimal(76, 12)) ENGINE = Memory
+CREATE TABLE t (`c` FixedString(8)) ENGINE = Memory
+CREATE TABLE t (`c` DateTime64(3)) ENGINE = Memory
+CREATE TABLE t (`c` Array(Decimal(10, 2))) ENGINE = Memory
+CREATE TABLE t (`c` UInt64) ENGINE = Memory

--- a/tests/queries/0_stateless/04507_data_type_name_numeric_roundtrip.sql
+++ b/tests/queries/0_stateless/04507_data_type_name_numeric_roundtrip.sql
@@ -1,0 +1,19 @@
+-- A data type name that starts with a digit is only reachable via quoting (e.g. `8`).
+-- The formatter prints type names unquoted, so `8` would round-trip into a numeric literal
+-- instead of a type name, breaking the AST formatting consistency check
+-- ("Inconsistent AST formatting", STID 1941-26fa). Such names must be rejected at parse time.
+
+-- Quoted numeric type name is rejected.
+SELECT formatQuery('CREATE TABLE t (`a` `8`) ENGINE = Memory'); -- { serverError SYNTAX_ERROR }
+
+-- The original fuzzer reproducer: a numeric name nested inside a data type argument.
+SELECT formatQuery('CREATE TABLE t (`a` Nullable(multiply(Decimal(76, 12), `8`))) ENGINE = MergeTree ORDER BY a'); -- { serverError SYNTAX_ERROR }
+
+-- Numeric arguments to a data type are still accepted (the type name is a valid identifier).
+SELECT formatQuerySingleLine('CREATE TABLE t (`c` Decimal(76, 12)) ENGINE = Memory');
+SELECT formatQuerySingleLine('CREATE TABLE t (`c` FixedString(8)) ENGINE = Memory');
+SELECT formatQuerySingleLine('CREATE TABLE t (`c` DateTime64(3)) ENGINE = Memory');
+SELECT formatQuerySingleLine('CREATE TABLE t (`c` Array(Decimal(10, 2))) ENGINE = Memory');
+
+-- A quoted type name that is a valid identifier still round-trips (backticks dropped, but stable).
+SELECT formatQuerySingleLine('CREATE TABLE t (`c` `UInt64`) ENGINE = Memory');


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/108372
Related: https://github.com/ClickHouse/ClickHouse/issues/109158

The AST fuzzer produced a column type like `` Nullable(multiply(Decimal(76, 12), `8`)) `` that triggered an `Inconsistent AST formatting` logical error (STID 1941-26fa) on master.

`ParserDataType` accepts a quoted identifier as a type name, so `` `8` `` parses into an `ASTDataType` named `8`. The formatter prints type names unquoted (there is already a comment about this in `ParserDataType`), so the node becomes a bare `8`, which re-parses as a numeric literal instead of a type name. This breaks the format/parse round-trip consistency check in `executeQueryImpl` that runs in debug/sanitizer builds.

The fix extends the parse-time guard that already rejects other non-round-trippable quoted type names (`` Array(`x.y`) ``, `` `Null` ``) to also reject a name whose first character is a digit: such a name is only reachable via quoting and can never survive unquoted formatting.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=02d808ad2d907c2f4a513b19e0850a6c1c68bf29&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reject data type names that start with a digit (e.g. `` `8` ``), which could not survive AST formatting round-trip and produced an `Inconsistent AST formatting` logical error under the fuzzer.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.692` (included in `26.7` and later)
<!-- ch-version-info:end -->