### PR TITLE
Fix AST fuzzer silently burning the corpus and exiting early with success

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -232,57 +232,104 @@ function fuzz
         exit 1
     fi
 
-    # Allow the fuzzer to run for some time, giving it a grace period of 5m to finish once the time
-    # out triggers. After that, it'll send a SIGKILL to the fuzzer to make sure it finishes within
-    # a reasonable time.
-    # Bound the parser/AST recursion on the client command line, matching the server-side caps in
-    # limit-recursion-settings.xml. The client parses every corpus query locally, and a corpus
-    # `SET compatibility=...` reverts max_parser_backtracks to its pre-24.3 default of 0 (unbounded);
-    # a command-line value survives that revert, unlike a profile value.
-    timeout --verbose --signal TERM --kill-after=5m --preserve-status "${FUZZ_TIME_LIMIT:-30m}" clickhouse-client \
-        --max_memory_usage_in_client=1000000000 \
-        --receive_timeout=10 \
-        --receive_data_timeout_ms=10000 \
-        --stacktrace \
-        --max_parser_backtracks=1000000 \
-        --max_parser_depth=1000 \
-        $FUZZER_ARGS \
-        > fuzzer.log \
-        2>&1 &
-    fuzzer_pid=$!
-    echo "Fuzzer pid is $fuzzer_pid"
+    # Convert FUZZ_TIME_LIMIT (e.g. "30m", "60m", "1800s" or plain seconds) into seconds
+    # so that the remaining budget can be recomputed between fuzzer passes.
+    fuzz_time_limit="${FUZZ_TIME_LIMIT:-30m}"
+    case "$fuzz_time_limit" in
+        *h) fuzz_budget_seconds=$(( ${fuzz_time_limit%h} * 3600 ));;
+        *m) fuzz_budget_seconds=$(( ${fuzz_time_limit%m} * 60 ));;
+        *s) fuzz_budget_seconds=$(( ${fuzz_time_limit%s} ));;
+        *)  fuzz_budget_seconds=$(( fuzz_time_limit ));;
+    esac
 
-    # We need to give timeout some time to execute the underlying command with that many arguments
-    elapsed=0
-    maximum=50
-    while [[ $elapsed -lt $maximum ]]; do
-        if ps -o pid= --ppid "$fuzzer_pid"; then
-            echo "Found underlying PID!"
-            break;
-        else
-            echo "Not found. Trying again..."
-        fi
-        sleep 0.1
-        elapsed=$((elapsed+1))
-    done
-
-    # The fuzzer_pid belongs to the timeout process.
-    actual_fuzzer_pid=$(ps -o pid= --ppid "$fuzzer_pid")
-
-    if [[ "$IS_ASAN" = "1" ]];
-    then
-        echo "ASAN build detected. Not using gdb since it disables LeakSanitizer detections"
-    else
-        echo "Attaching gdb to the fuzzer itself"
-        gdb -batch -command script.gdb -p $actual_fuzzer_pid &
-    fi
-
-    # Wait for the fuzzer to complete.
-    # Note that the 'wait || ...' thing is required so that the script doesn't
-    # exit because of 'set -e' when 'wait' returns nonzero code.
+    fuzz_started_at=$SECONDS
     fuzzer_exit_code=0
-    wait "$fuzzer_pid" || fuzzer_exit_code=$?
-    echo "Fuzzer exit code is $fuzzer_exit_code"
+    fuzz_pass=0
+    : > fuzzer.log
+    while :; do
+        fuzz_pass=$((fuzz_pass+1))
+        remaining_seconds=$(( fuzz_budget_seconds - (SECONDS - fuzz_started_at) ))
+        echo "=== Fuzzer pass $fuzz_pass, remaining time budget: ${remaining_seconds}s ==="
+
+        # Allow the fuzzer to run for some time, giving it a grace period of 5m to finish once the time
+        # out triggers. After that, it'll send a SIGKILL to the fuzzer to make sure it finishes within
+        # a reasonable time.
+        # Bound the parser/AST recursion on the client command line, matching the server-side caps in
+        # limit-recursion-settings.xml. The client parses every corpus query locally, and a corpus
+        # `SET compatibility=...` reverts max_parser_backtracks to its pre-24.3 default of 0 (unbounded);
+        # a command-line value survives that revert, unlike a profile value.
+        timeout --verbose --signal TERM --kill-after=5m --preserve-status "${remaining_seconds}s" clickhouse-client \
+            --max_memory_usage_in_client=1000000000 \
+            --receive_timeout=10 \
+            --receive_data_timeout_ms=10000 \
+            --stacktrace \
+            --max_parser_backtracks=1000000 \
+            --max_parser_depth=1000 \
+            $FUZZER_ARGS \
+            >> fuzzer.log \
+            2>&1 &
+        fuzzer_pid=$!
+        echo "Fuzzer pid is $fuzzer_pid"
+
+        # We need to give timeout some time to execute the underlying command with that many arguments
+        elapsed=0
+        maximum=50
+        while [[ $elapsed -lt $maximum ]]; do
+            if ps -o pid= --ppid "$fuzzer_pid"; then
+                echo "Found underlying PID!"
+                break;
+            else
+                echo "Not found. Trying again..."
+            fi
+            sleep 0.1
+            elapsed=$((elapsed+1))
+        done
+
+        # The fuzzer_pid belongs to the timeout process.
+        actual_fuzzer_pid=$(ps -o pid= --ppid "$fuzzer_pid")
+
+        if [[ "$IS_ASAN" = "1" ]];
+        then
+            echo "ASAN build detected. Not using gdb since it disables LeakSanitizer detections"
+        else
+            echo "Attaching gdb to the fuzzer itself"
+            gdb -batch -command script.gdb -p $actual_fuzzer_pid &
+        fi
+
+        # Wait for the fuzzer to complete.
+        # Note that the 'wait || ...' thing is required so that the script doesn't
+        # exit because of 'set -e' when 'wait' returns nonzero code.
+        fuzzer_exit_code=0
+        wait "$fuzzer_pid" || fuzzer_exit_code=$?
+        echo "Fuzzer exit code is $fuzzer_exit_code"
+
+        # A non-zero exit code is either the time limit (TERM/KILL sent by `timeout`) or a
+        # client/server failure — in both cases stop and let the code below classify it.
+        if [[ "$fuzzer_exit_code" != "0" ]]; then
+            break
+        fi
+        # BuzzHouse enforces its own internal time budget and exits 0 when it is reached.
+        if [[ "$FUZZER_TO_RUN" != "AST Fuzzer" ]]; then
+            break
+        fi
+        # Exit code 0 means the client walked the whole corpus and exited voluntarily. For the
+        # targeted AST fuzzer the corpus is small, so a pass can finish within a couple of
+        # minutes of a 30-minute budget. Each pass starts from a fresh random seed, so rerunning
+        # the corpus explores new mutations instead of throwing away the remaining budget.
+        remaining_seconds=$(( fuzz_budget_seconds - (SECONDS - fuzz_started_at) ))
+        if [[ "$remaining_seconds" -lt 60 ]]; then
+            echo "Fuzzer finished the corpus and only ${remaining_seconds}s of the budget remain, not restarting"
+            break
+        fi
+        # Make sure the server is still accepting queries before restarting: a fuzzer that
+        # exited with code 0 against a dead server would otherwise restart-loop until the budget
+        # runs out and hide the failure.
+        if ! clickhouse-client --receive_timeout=5 --query "SELECT 'fuzzer restart liveness check'"; then
+            echo "Server is not responding, not restarting the fuzzer"
+            break
+        fi
+        echo "Fuzzer finished the corpus with success, restarting it to use the remaining ${remaining_seconds}s of the budget"
+    done
 
     # If the server dies, most often the fuzzer returns Code 210: Connetion
     # refused, and sometimes also code 32: attempt to read after eof. For

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -250,6 +250,14 @@ bool Client::processWithASTFuzzer(std::string_view full_query)
             if (fuzz_step > 0)
             {
                 fuzzer.fuzzMain(ast_to_process);
+
+                /// The fuzzer can substitute fragments that contain {name:type} query parameters
+                /// (e.g. from the column_like pool) and generates values for them. Register the
+                /// values for client-side parameter substitution, like the server-side fuzzer
+                /// does (see executeASTFuzzerQueries); otherwise every such query fails with
+                /// "Substitution ... is not set" before even reaching the server.
+                for (const auto & [name, value] : fuzzer.getLastQueryParameters())
+                    query_parameters.insert_or_assign(name, value);
             }
 
             query_to_execute = ast_to_process->formatForErrorMessage();
@@ -373,6 +381,8 @@ bool Client::processWithASTFuzzer(std::string_view full_query)
         {
             if (!ast_to_process)
                 fmt::print(stderr, "Error while forming new query: {}\n", getCurrentExceptionMessage(true));
+            else
+                fmt::print(stderr, "Client-side exception on processing query '{}': {}\n", query_to_execute, getCurrentExceptionMessage(false));
 
             // Some functions (e.g. protocol parsers) don't throw, but
             // set last_exception instead, so we'll also do it here for
@@ -382,6 +392,15 @@ bool Client::processWithASTFuzzer(std::string_view full_query)
             client_exception
                 = std::make_unique<Exception>(getCurrentExceptionMessageAndPattern(print_stack_trace), getCurrentExceptionCode());
             have_error = true;
+
+            // The exception may mean that the connection to the server was lost (e.g. the server
+            // died and the connection attempt throws). processASTFuzzerStep performs this check
+            // for errors received without throwing, but thrown exceptions bypass it. Without the
+            // check every subsequent step fails instantly the same way, so the fuzzer silently
+            // burns through the rest of the corpus in seconds and exits with code 0 as if all
+            // the queries were fuzzed.
+            if (!tryToReconnect(1, 10))
+                return false;
         }
 
 #if USE_BUZZHOUSE
@@ -467,9 +486,15 @@ bool Client::processWithASTFuzzer(std::string_view full_query)
         }
         catch (...)
         {
+            fmt::print(stderr, "Client-side exception on processing query '{}': {}\n", query_to_execute, getCurrentExceptionMessage(false));
+
             client_exception
                 = std::make_unique<Exception>(getCurrentExceptionMessageAndPattern(print_stack_trace), getCurrentExceptionCode());
             have_error = true;
+
+            // See the comment on the same check in the main fuzzing loop above.
+            if (!tryToReconnect(1, 10))
+                return false;
         }
 
         if (have_error)


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix the AST fuzzer silently burning through its query corpus and exiting early with success, and make the targeted AST fuzzer use its whole time budget by restarting over the corpus.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

The client-side AST fuzzer loop (`Client::processWithASTFuzzer`) swallowed every exception thrown during a fuzzing step: the `catch (...)` handler recorded the error and the loop bottom reset it. When the failure is persistent — most importantly a dead server, where the connection attempt inside `processParsedSingleQuery` throws instantly — the client sprints through the remaining corpus at hundreds of steps per second without contacting the server and exits with code 0, reported as `Fuzzer exited with success` and a green check.

**Evidence**

- `AST fuzzer (amd_debug, targeted)` on PR #109061 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109061&sha=1419f6b7e95c81c812f945c06333998b92d56ad3&name_0=PR&name_1=AST+fuzzer+%28amd_debug%2C+targeted%29)): `fuzzer.log` records 68972 fuzzing steps, of which 52837 ended in a silently swallowed exception (no outcome logged), while `server.log` shows the server received only 209 queries in a 47-second window before dying on the found bug. The remaining ~3 minutes of "fuzzing" never touched the server.
- `AST fuzzer (amd_debug, targeted)` on PR #106250 ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106250&sha=latest&name_0=PR&name_1=AST+fuzzer+%28amd_debug%2C+targeted%29)): a 5-file corpus with ~20 `SELECT` statements — about 20000 fuzzing steps, over an hour of work at the measured debug-build rate of 2–6 steps/s — "completed" in 74 seconds with a live server, and the job passed.
- Per play.clickhouse.com `checks` data, 13–33% of successful targeted AST fuzzer runs per month finish in under 8 minutes of their 30-minute budget, ever since the job was introduced.

**Client fixes** (`programs/client/FuzzLoop.cpp`)

- Print thrown exceptions in the fuzzing-step catch handlers instead of swallowing them silently, so `fuzzer.log` shows what actually happened.
- After a thrown exception, check the connection via `tryToReconnect` (the same check `processASTFuzzerStep` already does for errors received without throwing) and stop fuzzing when the server is gone, instead of uselessly sprinting through the rest of the corpus and masking the failure with exit code 0.
- Register query parameters generated by `QueryFuzzer` (`getLastQueryParameters`) for client-side substitution, mirroring the server-side fuzzer in `executeASTFuzzerQueries`; previously any fuzzed query containing a substituted `{name:type}` parameter failed client-side with `Substitution ... is not set` before reaching the server.

**Job fix** (`ci/jobs/scripts/fuzzer/run-fuzzer.sh`)

- When the AST fuzzer walks the whole corpus and exits 0 with a meaningful part of the `FUZZ_TIME_LIMIT` budget remaining, restart it over the corpus (each pass uses a fresh random seed) instead of ending the job after a couple of minutes. This mainly matters for the targeted variant, whose corpus is a handful of test files. The restart is gated on a server liveness probe, so a dead server still terminates the job and gets classified below; `BuzzHouse` is excluded because it enforces its own internal time budget.

The restart-loop logic was validated with stubbed scenarios (normal restart, budget exhaustion, non-zero exit, dead server), `bash -n`, and `ci/tests/test_fuzzer_liveness_loop.py` still passes. The `FuzzLoop.cpp` change compiles cleanly.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.727` (included in `26.7` and later)
<!-- ch-version-info:end -->