### PR TITLE
Retry reference-binary download in bugfix validation

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -5,7 +5,11 @@ import random
 import subprocess
 from pathlib import Path
 
-from ci.jobs.scripts.bugfix_validation import bugfix_build_types, find_master_builds
+from ci.jobs.scripts.bugfix_validation import (
+    bugfix_build_types,
+    download_master_builds,
+    find_master_builds,
+)
 from ci.jobs.scripts.cidb_cluster import CIDBCluster
 from ci.jobs.scripts.clickhouse_proc import ClickHouseProc
 from ci.jobs.scripts.find_tests import Targeting
@@ -434,18 +438,7 @@ def main():
             build_urls = find_master_builds(build_types)
             assert build_urls, "Could not find master builds in S3"
         if build_urls:
-            for bt, url in build_urls.items():
-                bt_path = bt_paths[bt]
-                if not info.is_local_run or not Path(bt_path).is_file():
-                    # retries: transient S3 5xx must not abort the job; strict
-                    # still fails closed if the artifact is genuinely missing.
-                    Shell.run(
-                        f"wget -nv -O {bt_path} {url}",
-                        verbose=True,
-                        strict=True,
-                        retries=5,
-                    )
-                    Shell.run(f"chmod +x {bt_path}", verbose=True)
+            download_master_builds(build_urls, bt_paths, info.is_local_run)
         Shell.run(
             f"cp {temp_dir}/clickhouse_{build_types[0]} {temp_dir}/clickhouse",
             verbose=True,

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -437,8 +437,13 @@ def main():
             for bt, url in build_urls.items():
                 bt_path = bt_paths[bt]
                 if not info.is_local_run or not Path(bt_path).is_file():
+                    # retries: transient S3 5xx must not abort the job; strict
+                    # still fails closed if the artifact is genuinely missing.
                     Shell.run(
-                        f"wget -nv -O {bt_path} {url}", verbose=True, strict=True
+                        f"wget -nv -O {bt_path} {url}",
+                        verbose=True,
+                        strict=True,
+                        retries=5,
                     )
                     Shell.run(f"chmod +x {bt_path}", verbose=True)
         Shell.run(

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -6,7 +6,11 @@ import time
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from ci.jobs.scripts.bugfix_validation import bugfix_build_types, find_master_builds
+from ci.jobs.scripts.bugfix_validation import (
+    bugfix_build_types,
+    download_master_builds,
+    find_master_builds,
+)
 from ci.jobs.scripts.find_tests import Targeting
 from ci.jobs.scripts.integration_tests_configs import (
     IMAGES_ENV,
@@ -807,14 +811,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
             build_urls = find_master_builds(build_types)
             assert build_urls, "Could not find master builds in S3"
         if build_urls:
-            for bt, url in build_urls.items():
-                bt_path = bt_paths[bt]
-                if not info.is_local_run or not Path(bt_path).is_file():
-                    print(f"NOTE: Downloading {bt} build to [{bt_path}]")
-                    Shell.run(
-                        f"wget -nv -O {bt_path} {url}", verbose=True, strict=True
-                    )
-                    Shell.run(f"chmod +x {bt_path}", verbose=True)
+            download_master_builds(build_urls, bt_paths, info.is_local_run)
         clickhouse_path = f"{temp_path}/clickhouse_{build_types[0]}"
 
     if is_bugfix_validation or is_flaky_check:

--- a/ci/jobs/scripts/bugfix_validation.py
+++ b/ci/jobs/scripts/bugfix_validation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from ci.praktika.info import Info
 from ci.praktika.utils import Shell
 
@@ -35,8 +37,32 @@ def find_master_builds(build_types=None):
             bt: f"https://clickhouse-builds.s3.us-east-1.amazonaws.com/REFs/master/{sha}/build_{bt}/clickhouse"
             for bt in build_types
         }
+        # curl's native --retry only retries transient failures (5xx, timeouts,
+        # refused connections), not a genuine 404, so a partially-built older
+        # commit is still skipped fast while a transient S3 5xx on the newest
+        # commit is retried instead of silently falling back to an older binary.
         if all(
-            Shell.check(f"curl -sfI {url} > /dev/null") for url in urls.values()
+            Shell.check(f"curl -sfI --retry 5 --retry-connrefused {url} > /dev/null")
+            for url in urls.values()
         ):
             return urls
     return None
+
+
+def download_master_builds(build_urls, bt_paths, is_local_run=False):
+    """Download the reference master-HEAD binaries listed in `build_urls`.
+
+    Retries each download so a transient S3 5xx does not abort the whole job;
+    `find_master_builds` already probed that the artifact exists, so a failure
+    here is treated as transient. Still strict: a persistent failure raises
+    after exhausting retries. Shared by the functional- and integration-test
+    bugfix-validation callers so the retry lives in one place.
+    """
+    for bt, url in build_urls.items():
+        bt_path = bt_paths[bt]
+        if not is_local_run or not Path(bt_path).is_file():
+            print(f"NOTE: Downloading {bt} build to [{bt_path}]")
+            Shell.run(
+                f"wget -nv -O {bt_path} {url}", verbose=True, strict=True, retries=5
+            )
+            Shell.run(f"chmod +x {bt_path}", verbose=True)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/105139
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `Bugfix validation (functional tests)` job downloads the master reference ClickHouse binary via a single `wget ... strict=True` with no retry (`ci/jobs/functional_tests.py`). A transient S3 5xx (e.g. `ERROR 503: Service Unavailable`, wget exit code 8) aborts the whole job before any test runs. This is a broad transient class that reddens finish ledgers across unrelated PRs; the `aarch64` variant passing on the same head while `amd64` errors on the download is the tell that it is not code-related.

Fix: use praktika's native `Shell.run` retry (`retries=5`, exponential backoff, 1s->2s->4s->... capped at 60s) around the reference-binary `wget`. It stays `strict`, so a persistently-missing artifact still fails closed and errors clearly after all attempts. Download-robustness only; `aarch64` behavior is unaffected. Same team-approved pattern as #105139 (wget retry for `.deb`/`.tgz`) and #108675 (keeper S3 retry).

Verified both directions locally against `praktika.utils.Shell.run`: a command failing twice then succeeding returns 0 after retries; a persistently-failing command still raises `RuntimeError` under `strict=True` after exhausting all attempts.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109727&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109727](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109727+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
