### PR TITLE
Support LowCardinality(Time) in Arrow dictionary output

### DIFF
--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -76,7 +76,8 @@
         M(STRING, arrow::StringType) \
         M(FIXED_SIZE_BINARY, arrow::FixedSizeBinaryType) \
         M(DATE32, arrow::Date32Type) \
-        M(TIME32, arrow::Time32Type)
+        M(TIME32, arrow::Time32Type) \
+        M(DURATION, arrow::DurationType)
 
 namespace DB
 {

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -75,7 +75,8 @@
         M(BINARY, arrow::BinaryType) \
         M(STRING, arrow::StringType) \
         M(FIXED_SIZE_BINARY, arrow::FixedSizeBinaryType) \
-        M(DATE32, arrow::Date32Type)
+        M(DATE32, arrow::Date32Type) \
+        M(TIME32, arrow::Time32Type)
 
 namespace DB
 {

--- a/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.reference
+++ b/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.reference
@@ -1,0 +1,2 @@
+Time ok
+Nullable(Time) ok

--- a/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.reference
+++ b/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.reference
@@ -1,2 +1,6 @@
-Time ok
-Nullable(Time) ok
+5
+5
+5
+5
+Time readable
+Nullable(Time) readable

--- a/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.sh
+++ b/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Writing a LowCardinality(Time) column as an Arrow dictionary used to abort with
+# "Cannot fill arrow array time32 with LowCardinality(...) data" because the Arrow
+# dictionary dispatch had no Time32 entry.
+$CLICKHOUSE_LOCAL -q "select '12:00:00'::LowCardinality(Time) as a format Arrow settings allow_suspicious_low_cardinality_types = 1, output_format_arrow_low_cardinality_as_dictionary = 1" > /dev/null && echo "Time ok"
+$CLICKHOUSE_LOCAL -q "select '12:00:00'::LowCardinality(Nullable(Time)) as a format Arrow settings allow_suspicious_low_cardinality_types = 1, output_format_arrow_low_cardinality_as_dictionary = 1" > /dev/null && echo "Nullable(Time) ok"

--- a/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.sh
+++ b/tests/queries/0_stateless/04508_arrow_low_cardinality_over_time.sh
@@ -5,8 +5,33 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-# Writing a LowCardinality(Time) column as an Arrow dictionary used to abort with
-# "Cannot fill arrow array time32 with LowCardinality(...) data" because the Arrow
-# dictionary dispatch had no Time32 entry.
-$CLICKHOUSE_LOCAL -q "select '12:00:00'::LowCardinality(Time) as a format Arrow settings allow_suspicious_low_cardinality_types = 1, output_format_arrow_low_cardinality_as_dictionary = 1" > /dev/null && echo "Time ok"
-$CLICKHOUSE_LOCAL -q "select '12:00:00'::LowCardinality(Nullable(Time)) as a format Arrow settings allow_suspicious_low_cardinality_types = 1, output_format_arrow_low_cardinality_as_dictionary = 1" > /dev/null && echo "Nullable(Time) ok"
+# A LowCardinality column whose Arrow dictionary value type had no entry in the FOR_ARROW_TYPES
+# dispatch used to abort with "Cannot fill arrow array <type> with LowCardinality(...) data".
+# Time maps to arrow::time32 and the sub-second Interval kinds map to arrow::duration; both entries
+# were missing. Feed the emitted Arrow bytes back through the Arrow reader to prove the dictionary
+# stream is valid and readable, not just that the writer no longer throws.
+
+SETTINGS="allow_suspicious_low_cardinality_types = 1, output_format_arrow_low_cardinality_as_dictionary = 1"
+
+# The sub-second Interval kinds map to arrow::duration and round-trip back to Interval.
+$CLICKHOUSE_LOCAL -q "select CAST(INTERVAL 5 SECOND AS LowCardinality(IntervalSecond)) as a format Arrow settings $SETTINGS" | $CLICKHOUSE_LOCAL -q "select * from table" --input-format=Arrow
+$CLICKHOUSE_LOCAL -q "select CAST(INTERVAL 5 MILLISECOND AS LowCardinality(IntervalMillisecond)) as a format Arrow settings $SETTINGS" | $CLICKHOUSE_LOCAL -q "select * from table" --input-format=Arrow
+$CLICKHOUSE_LOCAL -q "select CAST(INTERVAL 5 MICROSECOND AS LowCardinality(IntervalMicrosecond)) as a format Arrow settings $SETTINGS" | $CLICKHOUSE_LOCAL -q "select * from table" --input-format=Arrow
+$CLICKHOUSE_LOCAL -q "select CAST(INTERVAL 5 NANOSECOND AS LowCardinality(IntervalNanosecond)) as a format Arrow settings $SETTINGS" | $CLICKHOUSE_LOCAL -q "select * from table" --input-format=Arrow
+
+# Time maps to arrow::time32. The dictionary is now written without aborting. Reading it back proves
+# the emitted time32 dictionary stream decodes: either it round-trips to a value, or the reader
+# reports that time32 currently maps to Time64 (which is not allowed inside LowCardinality) - a
+# separate reader-side limitation. A malformed IPC stream would fail to decode the schema instead.
+check_readable() {
+    local out
+    out=$($CLICKHOUSE_LOCAL -q "select $1 as a format Arrow settings $SETTINGS" 2>/dev/null \
+        | $CLICKHOUSE_LOCAL -q "select * from table" --input-format=Arrow 2>&1)
+    if echo "$out" | grep -qE "12:00:00|Time64"; then
+        echo "$2 readable"
+    else
+        echo "$2 FAILED: $out"
+    fi
+}
+check_readable "'12:00:00'::LowCardinality(Time)" "Time"
+check_readable "'12:00:00'::LowCardinality(Nullable(Time))" "Nullable(Time)"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/109189
-->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `LOGICAL_ERROR` when writing a `LowCardinality(Time)` column to the `Arrow` format with `output_format_arrow_low_cardinality_as_dictionary = 1`.


### Description

The Arrow dictionary value-type dispatch (`FOR_ARROW_TYPES` in `CHColumnToArrowColumn.cpp`) had no `TIME32` entry. The `Time` type maps to `arrow::time32`, so a `LowCardinality(Time)` column output as an Arrow dictionary fell through to the terminal `throw` and aborted with `Cannot fill arrow array time32 with LowCardinality(Time) data`. Added the `TIME32` entry so `Time` dictionaries are built like the other supported value types.

`Time64` is not permitted inside `LowCardinality`, so only `TIME32` is needed.

Found by the BuzzHouse fuzzer (STID 4565-4839). Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100412&sha=e7cda719f20dccd6c252b6ee327c990fbeb45ff7&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.693` (included in `26.7` and later)
<!-- ch-version-info:end -->