### PR TITLE
[CI Proof] `generateNextMetadata` seeds a missing optional `refs` object with a raw `Poco::JSON::Object*`, so `getObject(f_refs)->has(f_main)` throws 'Null pointer'

### DIFF
--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -756,9 +756,9 @@ def test_insert(started_cluster):
     ],
 )
 def test_insert_into_table_without_optional_metadata_arrays(started_cluster, fields_to_remove):
-    # The Iceberg spec marks snapshots / metadata-log / snapshot-log as optional, so external
-    # engines may create empty-table metadata that omits any of them. Inserting into such a table
-    # must still succeed instead of aborting in the metadata write path.
+    # The Iceberg spec marks snapshots / metadata-log / snapshot-log / refs as optional, so
+    # external engines may create empty-table metadata that omits any of them. Inserting into
+    # such a table must still succeed instead of aborting in the metadata write path.
     node = started_cluster.instances["node1"]
 
     test_ref = f"test_insert_no_optional_arrays_{uuid.uuid4()}"

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -752,7 +752,8 @@ def test_insert(started_cluster):
         ["snapshots"],
         ["metadata-log"],
         ["snapshot-log"],
-        ["snapshots", "metadata-log", "snapshot-log"],
+        ["refs"],
+        ["snapshots", "metadata-log", "snapshot-log", "refs"],
     ],
 )
 def test_insert_into_table_without_optional_metadata_arrays(started_cluster, fields_to_remove):


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (requires CI cluster topology or too many iterations to reproduce locally). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** `generateNextMetadata` seeds a missing optional `refs` object with a raw `Poco::JSON::Object*`, so `getObject(f_refs)->has(f_main)` throws 'Null pointer'

**Root cause:** MetadataGenerator.cpp:212 uses `metadata_object->set(Iceberg::f_refs, new Poco::JSON::Object)` (raw pointer) instead of `Poco::JSON::Object::Ptr(new Poco::JSON::Object)`; Poco's getObject requires the `Object::Ptr` type tag and returns null for a raw `Object*`. The PR wrapped the three arrays it added (line 145) but left this pre-existing raw-pointer refs seed, leaving one member of the optional-metadata family broken.

**Affected locations:**
- `src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp:212` — raw-pointer seeding of missing optional `refs` object
- `src/Storages/ObjectStorage/DataLakes/Iceberg/MetadataGenerator.cpp:214` — getObject(f_refs) returns null -> ->has(f_main) throws 'Null pointer'

**Why CI is needed:** INSERT into an external Iceberg table that omits the optional `refs` object aborts with 'Null pointer' — the PR fixes 3 of 4 optional-metadata omission cases but leaves `refs` (an object) broken with the identical type-tag trap it documents.

**Suggested fix:** Change line 212 to `metadata_object->set(Iceberg::f_refs, Poco::JSON::Object::Ptr(new Poco::JSON::Object));` (mirroring the array seeding at line 145 and createEmptyMetadataFile at Utils.cpp:998-1004), and add a `refs` case to the integration test's `fields_to_remove` parametrize list.

## Assumptions
The bot recorded these claims it could not verify directly from source. A maintainer ✅ confirms; ❌ flags a wrong premise (the bot should rework or close the finding).

- [ ] **External engines (e.g. BigLake) can produce empty-table metadata that omits the optional `refs` object.**
  - *Why unverifiable:* No access to a corpus of externally-produced Iceberg metadata files.
  - *Falsifiable test:* Inspect metadata.json emitted by an external engine for an empty V2 table; check whether `refs` is present.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
