### PR TITLE
Add test: `hasTokenOrNull` separator-only needle index-bypass branch untested (`MergeTreeIndexConditionText.cpp`:1048)

### DIFF
--- a/tests/queries/0_stateless/04508_text_index_hastokenornull_separator_only_needle.reference
+++ b/tests/queries/0_stateless/04508_text_index_hastokenornull_separator_only_needle.reference
@@ -1,0 +1,5 @@
+-- separator-only needle: WHERE returns 0 rows
+0
+-- separator-only needle: text index NOT used (bypassed)
+-- valid needle: text index IS used
+Name: idx

--- a/tests/queries/0_stateless/04508_text_index_hastokenornull_separator_only_needle.sql
+++ b/tests/queries/0_stateless/04508_text_index_hastokenornull_separator_only_needle.sql
@@ -1,0 +1,35 @@
+-- Tags: no-fasttest
+-- `hasTokenOrNull` on a `splitByNonAlpha` text index with a separator-only needle bypasses the index
+-- (row-level scan returns NULL per row); a valid needle still uses the index.
+
+DROP TABLE IF EXISTS tab;
+SET use_skip_indexes = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET query_plan_direct_read_from_text_index = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id Int32,
+    text String,
+    INDEX idx(text) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, 'foo bar baz'), (3, 'qux');
+
+SELECT '-- separator-only needle: WHERE returns 0 rows';
+SELECT count() FROM tab WHERE hasTokenOrNull(text, '()');
+
+SELECT '-- separator-only needle: text index NOT used (bypassed)';
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM tab WHERE hasTokenOrNull(text, '()')
+) WHERE explain LIKE '%Name:%';
+
+SELECT '-- valid needle: text index IS used';
+SELECT trim(explain) FROM (
+    EXPLAIN indexes = 1 SELECT count() FROM tab WHERE hasTokenOrNull(text, 'foo')
+) WHERE explain LIKE '%Name:%';
+
+DROP TABLE tab;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #108066](https://github.com/ClickHouse/ClickHouse/pull/108066).
That PR The PR makes `MergeTreeIndexConditionText::traverseFunctionNode` bypass the text index for `hasToken`/`hasTokenOrNull` whenever the index tokenizer is not `splitByNonAlpha` (new early `return false` at line 1011), because those legacy functions assume `splitByNonAlpha` semantics and would otherwise 

**1. `hasTokenOrNull` separator-only needle index-bypass branch untested (`MergeTreeIndexConditionText.cpp`:1048)**
  `src/Storages/MergeTree/MergeTreeIndexConditionText.cpp:1048`
  **Risk:** In `traverseFunctionNode`, `hasTokenOrNull` with a `splitByNonAlpha` index (line 1011 not taken), no pre/postprocessor (line 1019 not taken), and a needle that tokenizes to empty (`tokens.empty()` at 1033) reaches the all-separators check at 1047; a separator-only needle like `'()'` makes `none_of` true → `return false` at 1048, bypassing the index. Risk: if this branch is broken (falls through to `tokens.push_back("")` and uses the index), a separator-only `hasTokenOrNull` would drive granule …
  **What's unique vs PR tests:** The PR only deletes hasToken/hasTokenOrNull cases on NON-splitByNonAlpha indexes and asserts full scans; it adds no coverage for the surviving splitByNonAlpha `hasTokenOrNull` separator-only bypass. Existing separator-only tests (02346_text_index_bug102497) wrap the call in `isNull(...)`, which blocks index pushdown so line 1048 never executes (LLVM-confirmed uncovered). This test is the only one that pushes a direct separator-only `hasTokenOrNull` predicate into the index condition and …
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: text() index type is not available in the FastTest build
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/873da1e7-1dec-4ddb-9dca-fb375c594a33)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)