### PR TITLE
CI: skip unused stateful dataset prep for --no-stateful jobs

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -319,6 +319,14 @@ def main():
         if "ParallelReplicas" in to:
             is_parallel_replicas = True
 
+    # A --no-stateful run filters out every `stateful`-tagged test, i.e. exactly
+    # the tests that use the preloaded test.hits/test.visits datasets. Preparing
+    # those datasets is then wasted work (a multi-minute lazy read of hits_v1/
+    # visits_v1 from the web disk, real AWS S3), so signal prepare_stateful_data
+    # to skip it. Keyed off the actual runner flag, not a specific storage
+    # option, so any --no-stateful job wins.
+    is_no_stateful = "--no-stateful" in runner_options
+
     if is_llvm_coverage:
         # Pin random-by-default fault injection seeds server-side (in the default
         # profile) so coverage is deterministic, instead of injecting them as
@@ -698,6 +706,7 @@ def main():
                 if not CH.prepare_stateful_data(
                     with_s3_storage=is_s3_storage,
                     is_db_replicated=is_database_replicated,
+                    no_stateful=is_no_stateful,
                 ):
                     print(
                         "SETUP FAILURE: "
@@ -901,6 +910,7 @@ def main():
                         if not CH.prepare_stateful_data(
                             with_s3_storage=is_s3_storage,
                             is_db_replicated=is_database_replicated,
+                            no_stateful=is_no_stateful,
                         ):
                             # Prefer the concrete sub-command + ClickHouse error
                             # captured by prepare_stateful_data() over the generic

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -820,7 +820,7 @@ profiles:
                     return False
         return True
 
-    def prepare_stateful_data(self, with_s3_storage, is_db_replicated):
+    def prepare_stateful_data(self, with_s3_storage, is_db_replicated, no_stateful=False):
         self.stateful_setup_error = None
         if is_db_replicated:
             print("Skip stateful data preparation for db replicated")
@@ -837,16 +837,28 @@ trap 'rc=$?; echo "prepare_stateful_data: command [$BASH_COMMAND] at line $LINEN
 
 MAX_EXECUTION_TIME=1800
 
-clickhouse-client --query "SHOW DATABASES"
-clickhouse-client --query "CREATE DATABASE datasets"
-clickhouse-client < ./tests/docker_scripts/create.sql
+# The TPC-H / TPC-DS correctness tests (04033_tpc_ds_*, 04040_tpc_h_*) are NOT
+# tagged `stateful`, so they run even under --no-stateful and their databases
+# must always be prepared. `tpcds` uses a lazy web disk (cheap); `tpch` loads
+# SF1 from S3.
+clickhouse-client --query "CREATE DATABASE test"
 bash ./tests/docker_scripts/create_tpcds.sh
 bash ./tests/docker_scripts/create_tpch.sh
-clickhouse-client --query "SHOW TABLES FROM datasets"
 clickhouse-client --query "SHOW TABLES FROM tpcds"
 clickhouse-client --query "SHOW TABLES FROM tpch"
 
-clickhouse-client --query "CREATE DATABASE test"
+# The hits/visits datasets (and the test.hits_s3 copy) are used ONLY by
+# `stateful`-tagged tests. A --no-stateful job (e.g. s3 storage) filters out
+# exactly those tests, so loading these datasets is wasted work there and is
+# skipped. The slow part is the lazy read of datasets.hits_v1/visits_v1 from
+# the web disk (real AWS S3, us-east-1); the writes into test.hits/test.hits_s3
+# go to the local minio, not real S3. Their consumers are all `stateful`-tagged,
+# so nothing that runs under --no-stateful references test.hits/test.visits/datasets.
+if [[ -z "$NO_STATEFUL" ]]; then
+clickhouse-client --query "SHOW DATABASES"
+clickhouse-client --query "CREATE DATABASE datasets"
+clickhouse-client < ./tests/docker_scripts/create.sql
+clickhouse-client --query "SHOW TABLES FROM datasets"
 clickhouse-client --query "SHOW TABLES FROM test"
 if [[ -n "$USE_S3_STORAGE_FOR_MERGE_TREE" ]] && [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" -eq 1 ]]; then
     clickhouse-client --query "CREATE TABLE test.hits (WatchID UInt64,  JavaEnable UInt8,  Title String,  GoodEvent Int16, EventTime DateTime,  EventDate Date,  CounterID UInt32,  ClientIP UInt32,  ClientIP6 FixedString(16),  RegionID UInt32, UserID UInt64,  CounterClass Int8,  OS UInt8,  UserAgent UInt8,  URL String,  Referer String,  URLDomain String, RefererDomain String,  Refresh UInt8,  IsRobot UInt8,  RefererCategories Array(UInt16),  URLCategories Array(UInt16), URLRegions Array(UInt32),  RefererRegions Array(UInt32),  ResolutionWidth UInt16,  ResolutionHeight UInt16,  ResolutionDepth UInt8, FlashMajor UInt8, FlashMinor UInt8,  FlashMinor2 String,  NetMajor UInt8,  NetMinor UInt8, UserAgentMajor UInt16, UserAgentMinor FixedString(2),  CookieEnable UInt8, JavascriptEnable UInt8,  IsMobile UInt8,  MobilePhone UInt8, MobilePhoneModel String,  Params String,  IPNetworkID UInt32,  TraficSourceID Int8, SearchEngineID UInt16, SearchPhrase String,  AdvEngineID UInt8,  IsArtifical UInt8,  WindowClientWidth UInt16,  WindowClientHeight UInt16, ClientTimeZone Int16,  ClientEventTime DateTime,  SilverlightVersion1 UInt8, SilverlightVersion2 UInt8,  SilverlightVersion3 UInt32, SilverlightVersion4 UInt16,  PageCharset String,  CodeVersion UInt32,  IsLink UInt8,  IsDownload UInt8,  IsNotBounce UInt8, FUniqID UInt64,  HID UInt32,  IsOldCounter UInt8, IsEvent UInt8,  IsParameter UInt8,  DontCountHits UInt8,  WithHash UInt8, HitColor FixedString(1),  UTCEventTime DateTime,  Age UInt8,  Sex UInt8,  Income UInt8,  Interests UInt16,  Robotness UInt8, GeneralInterests Array(UInt16), RemoteIP UInt32,  RemoteIP6 FixedString(16),  WindowName Int32,  OpenerName Int32, HistoryLength Int16,  BrowserLanguage FixedString(2),  BrowserCountry FixedString(2),  SocialNetwork String,  SocialAction String, HTTPError UInt16, SendTiming Int32,  DNSTiming Int32,  ConnectTiming Int32,  ResponseStartTiming Int32,  ResponseEndTiming Int32, FetchTiming Int32,  RedirectTiming Int32, DOMInteractiveTiming Int32,  DOMContentLoadedTiming Int32,  DOMCompleteTiming Int32, LoadEventStartTiming Int32,  LoadEventEndTiming Int32, NSToDOMContentLoadedTiming Int32,  FirstPaintTiming Int32, RedirectCount Int8, SocialSourceNetworkID UInt8,  SocialSourcePage String,  ParamPrice Int64, ParamOrderID String, ParamCurrency FixedString(3),  ParamCurrencyID UInt16, GoalsReached Array(UInt32),  OpenstatServiceName String, OpenstatCampaignID String,  OpenstatAdID String,  OpenstatSourceID String,  UTMSource String, UTMMedium String, UTMCampaign String,  UTMContent String,  UTMTerm String, FromTag String,  HasGCLID UInt8,  RefererHash UInt64, URLHash UInt64,  CLID UInt32,  YCLID UInt64,  ShareService String,  ShareURL String,  ShareTitle String, ParsedParams Nested(Key1 String,  Key2 String, Key3 String, Key4 String, Key5 String,  ValueDouble Float64), IslandID FixedString(16),  RequestNum UInt32,  RequestTry UInt8)
@@ -874,16 +886,40 @@ clickhouse-client --query "CREATE TABLE test.hits_parquet (Title String, URL Str
 clickhouse-client --query "SHOW TABLES FROM test"
 clickhouse-client --query "SELECT count() FROM test.hits"
 clickhouse-client --query "SELECT count() FROM test.visits"
+fi
 """
         if with_s3_storage:
             command = "USE_S3_STORAGE_FOR_MERGE_TREE=1\n" + command
+        if no_stateful:
+            # Skip the hits/visits/test.hits_s3 load (see the NO_STATEFUL guard in
+            # the script): only `stateful`-tagged tests use those tables and a
+            # --no-stateful job filters them out, so the load is pure waste there.
+            command = "NO_STATEFUL=1\n" + command
         # Run via Shell.run (bash, like Shell.check) but keep a log file so that
         # on failure we can surface the failing sub-command + its ClickHouse
         # error tail to the caller. Same success semantics as before
         # (returncode == 0). This is what makes the intermittent msan re-prepare
         # failure diagnosable in CIDB instead of a generic boolean.
         log_file = f"{temp_dir}/prepare_stateful_data.log"
+        # Loading the hits/visits datasets - the lazy read of hits_v1/visits_v1
+        # from the web disk (real AWS S3) plus the local-minio inserts - routinely
+        # takes many minutes. Shell.run streams this step's output to stdout, but the
+        # setup closure runs under Result.from_commands_run's Tee, whose
+        # DualWriter never flushes the block-buffered real stdout. With little
+        # stdout produced during the load, nothing flushes for minutes, so
+        # job.log shows a blank multi-minute gap right after the minio restart
+        # line - which reads like a hung "Restarting clickminio (timeout 60s)"
+        # when it is really data loading. Announce start/end with elapsed time
+        # and flush so the step is attributable in job.log and the gap stops
+        # masquerading as a stuck restart.
+        datasets = "tpch/tpcds" if no_stateful else "tpch/tpcds + hits/visits"
+        print(f"Preparing stateful data ({datasets})...", flush=True)
+        started_at = time.time()
         rc = Shell.run(command, log_file=log_file, verbose=True)
+        print(
+            f"Stateful data preparation finished in {time.time() - started_at:.0f}s (exit {rc})",
+            flush=True,
+        )
         if rc != 0:
             tail = ""
             try:


### PR DESCRIPTION
### Description / motivation

Functional-test env setup shows a multi-minute blank gap in `job.log` right after `Restarting clickminio (timeout 60s)`, which reads like a hung minio restart:

```
[2026-06-01 18:34:43] Restarting clickminio (timeout 60s)
[2026-06-01 18:43:48] Run command: [clickhouse-client --query "insert into system.zookeeper ...]
```

It is **not** the restart. The clean `mc admin service restart --wait` succeeds within its bound (there are no fallback/warning lines anywhere in the log). The ~9 minutes is `prepare_stateful_data` loading the hits/visits datasets — lazily reading `datasets.hits_v1`/`visits_v1` from the **web disk** (real AWS S3, `us-east-1`) and writing `test.hits`/`test.hits_s3` into the **local minio** (the writes are local, not real S3). The step's output goes to a log file and stdout is block-buffered under `Result.from_commands_run`'s `Tee`, so nothing flushes for minutes and the gap looks like a stuck restart.

`prepare_stateful_data` runs on every functional-test job (`has_stateful_tests` is always `True` in CI). But a `--no-stateful` job (the `s3 storage` and `DatabaseReplicated` variants) filters out every `stateful`-tagged test, and those are the **only** consumers of `test.hits` / `test.visits` / `test.hits_s3` / `test.hits_parquet` / `datasets` (verified: 0 non-stateful consumers across `tests/queries/0_stateless`). The TPC-H / TPC-DS correctness tests (`04033_tpc_ds_*`, `04040_tpc_h_*`) are **not** tagged `stateful`, so they still run and their `tpch`/`tpcds` databases must stay.

This PR:
- Gates the hits/visits/datasets section of the prep script behind a `NO_STATEFUL` guard and always creates `tpch`/`tpcds`. `functional_tests.py` derives the flag from the runner options (`--no-stateful in runner_options`), not a specific storage option, so any `--no-stateful` job benefits.
- Makes the step attributable: a flushed start/end banner with elapsed time, so the load no longer masquerades as a stuck `clickminio` restart in `job.log`.

Behavior is unchanged for regular `parallel`/`sequential` stateless jobs (they run `stateful` tests, so they still prepare everything). Verified the generated script with `bash -n` and a stubbed-client run in both modes: `NO_STATEFUL=1` creates only `test` + `tpcds` + `tpch`; the default path is unchanged.

Follow-up (not in this PR): bake `hits_v1`/`visits_v1` into the stateless-test image as a local plain object-storage disk (`object_storage_type=local_blob_storage`, `metadata_type=plain_rewritable`, `table_disk=1`) so reads are local-speed instead of lazy web-disk reads. That needs an offline-generated, hosted dataset image + build validation of the disk DDL, so it is tracked separately.

CI report (source of the log):
https://s3.amazonaws.com/clickhouse-test-reports/PRs/106250/4364e2f746b647512274e6e0185b788c6066e8dc/stateless_tests_amd_tsan_s3_storage_parallel_1_2/job.log

Related: https://github.com/ClickHouse/ClickHouse/pull/106250

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)