### PR TITLE
Fix `remote_url_allow_hosts` checking the wrong port for MySQL dictionary replicas that inherit the top-level `PORT`

### DIFF
--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -168,9 +168,12 @@ void registerDictionarySourceMysql(DictionarySourceFactory & factory)
                         if (replica_key.starts_with("replica"))
                         {
                             const auto replica_prefix = settings_config_prefix + "." + replica_key;
+                            /// A replica without its own port connects to the top-level port
+                            /// (see mysqlxx::Pool), so validate that effective port.
                             global_context->getRemoteHostFilter().checkHostAndPort(
                                 config.getString(replica_prefix + ".host"),
-                                toString(config.getInt(replica_prefix + ".port", 3306)));
+                                toString(config.getInt(replica_prefix + ".port",
+                                    config.getInt(settings_config_prefix + ".port", 3306))));
                         }
                     }
                 }

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -168,8 +168,8 @@ void registerDictionarySourceMysql(DictionarySourceFactory & factory)
                         if (replica_key.starts_with("replica"))
                         {
                             const auto replica_prefix = settings_config_prefix + "." + replica_key;
-                            /// A replica without its own port connects to the top-level port
-                            /// (see mysqlxx::Pool), so validate that effective port.
+                            /// Resolve the port the same way mysqlxx::Pool does, so the checked port
+                            /// always matches the port the connection actually dials.
                             global_context->getRemoteHostFilter().checkHostAndPort(
                                 config.getString(replica_prefix + ".host"),
                                 toString(config.getInt(replica_prefix + ".port",

--- a/tests/integration/test_allowed_url_from_config/configs/config_with_pinned_port.xml
+++ b/tests/integration/test_allowed_url_from_config/configs/config_with_pinned_port.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <remote_url_allow_hosts>
         <host>127.0.0.1:3306</host>
+        <host>127.0.0.1:3308</host>
     </remote_url_allow_hosts>
 </clickhouse>

--- a/tests/integration/test_allowed_url_from_config/configs/config_with_pinned_port.xml
+++ b/tests/integration/test_allowed_url_from_config/configs/config_with_pinned_port.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <remote_url_allow_hosts>
+        <host>127.0.0.1:3306</host>
+    </remote_url_allow_hosts>
+</clickhouse>

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -230,9 +230,9 @@ def test_mysql_dictionary_replica_inherited_port_host_filter(start_cluster):
     """A REPLICA(...) without its own PORT connects to the top-level PORT (mysqlxx::Pool
     falls back to the parent prefix), so the host filter must validate that effective
     port, not the 3306 default."""
-    # node7 allows only 127.0.0.1:3306. 127.0.0.1 (instead of the unroutable 10.0.0.1
-    # used above) makes any dial that passes the filter fail instantly with
-    # connection-refused instead of hanging until the connect timeout.
+    # node7 allows only 127.0.0.1:3306 and 127.0.0.1:3308. 127.0.0.1 (instead of the
+    # unroutable 10.0.0.1 used above) makes any dial that passes the filter fail
+    # instantly with connection-refused instead of hanging until the connect timeout.
     node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_inherited_port")
     node7.query(
         """
@@ -253,8 +253,11 @@ def test_mysql_dictionary_replica_inherited_port_host_filter(start_cluster):
     assert "not allowed" in error, f"Expected host filter error, got: {error}"
     node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_inherited_port")
 
-    # A replica's own PORT takes precedence over the top-level PORT: 127.0.0.1:3306 is
+    # A replica's own PORT takes precedence over the top-level PORT: 127.0.0.1:3308 is
     # allowed, so the filter must pass and the failure is a plain connection error.
+    # 3308 differs from both the denied parent port 3307 and the 3306 default, so a
+    # regression that validated either of those instead of the replica's own port
+    # would fail this case.
     node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_own_port")
     node7.query(
         """
@@ -262,7 +265,7 @@ def test_mysql_dictionary_replica_inherited_port_host_filter(start_cluster):
         PRIMARY KEY id
         SOURCE(MYSQL(
             PORT 3307 USER 'root' PASSWORD 'pass' DB 'test' TABLE 'tbl'
-            REPLICA(PRIORITY 1 HOST '127.0.0.1' PORT 3306)
+            REPLICA(PRIORITY 1 HOST '127.0.0.1' PORT 3308)
         ))
         LAYOUT(FLAT()) LIFETIME(MIN 0 MAX 1)
         """

--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -21,6 +21,9 @@ node5 = cluster.add_instance(
     user_configs=["configs/allow_server_credentials.xml"],
 )
 node6 = cluster.add_instance("node6", main_configs=["configs/config_for_remote.xml"])
+node7 = cluster.add_instance(
+    "node7", main_configs=["configs/config_with_pinned_port.xml"]
+)  # Allows only 127.0.0.1:3306 (port-pinned entry).
 
 
 @pytest.fixture(scope="module")
@@ -221,6 +224,54 @@ def test_mysql_dictionary_replica_host_filter(start_cluster):
     )
     assert "not allowed" in error, f"Expected host filter error, got: {error}"
     node5.query("DROP DICTIONARY IF EXISTS default.test_mysql_replica_filter")
+
+
+def test_mysql_dictionary_replica_inherited_port_host_filter(start_cluster):
+    """A REPLICA(...) without its own PORT connects to the top-level PORT (mysqlxx::Pool
+    falls back to the parent prefix), so the host filter must validate that effective
+    port, not the 3306 default."""
+    # node7 allows only 127.0.0.1:3306. 127.0.0.1 (instead of the unroutable 10.0.0.1
+    # used above) makes any dial that passes the filter fail instantly with
+    # connection-refused instead of hanging until the connect timeout.
+    node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_inherited_port")
+    node7.query(
+        """
+        CREATE DICTIONARY default.test_mysql_inherited_port (id UInt64, val String)
+        PRIMARY KEY id
+        SOURCE(MYSQL(
+            PORT 3307 USER 'root' PASSWORD 'pass' DB 'test' TABLE 'tbl'
+            REPLICA(PRIORITY 1 HOST '127.0.0.1')
+        ))
+        LAYOUT(FLAT()) LIFETIME(MIN 0 MAX 1)
+        """
+    )
+    # The replica inherits the denied top-level port 3307; before the fix the filter
+    # checked the 3306 default, passed, and dialed 127.0.0.1:3307 anyway.
+    error = node7.query_and_get_error(
+        "SELECT dictGet('default.test_mysql_inherited_port', 'val', toUInt64(1))"
+    )
+    assert "not allowed" in error, f"Expected host filter error, got: {error}"
+    node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_inherited_port")
+
+    # A replica's own PORT takes precedence over the top-level PORT: 127.0.0.1:3306 is
+    # allowed, so the filter must pass and the failure is a plain connection error.
+    node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_own_port")
+    node7.query(
+        """
+        CREATE DICTIONARY default.test_mysql_own_port (id UInt64, val String)
+        PRIMARY KEY id
+        SOURCE(MYSQL(
+            PORT 3307 USER 'root' PASSWORD 'pass' DB 'test' TABLE 'tbl'
+            REPLICA(PRIORITY 1 HOST '127.0.0.1' PORT 3306)
+        ))
+        LAYOUT(FLAT()) LIFETIME(MIN 0 MAX 1)
+        """
+    )
+    error = node7.query_and_get_error(
+        "SELECT dictGet('default.test_mysql_own_port', 'val', toUInt64(1))"
+    )
+    assert "not allowed" not in error, f"Filter rejected an allowed replica: {error}"
+    node7.query("DROP DICTIONARY IF EXISTS default.test_mysql_own_port")
 
 
 def test_table_function_remote(start_cluster):


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/99720
Related: https://github.com/ClickHouse/ClickHouse/pull/109304

**Problem**

The `remote_url_allow_hosts` check for DDL-created MySQL dictionary sources (added in #99720) validates the wrong endpoint when a `REPLICA(...)` clause has no `PORT` of its own. For `SOURCE(MYSQL(PORT 3307 ... REPLICA(HOST 'h')))`:

- the filter checks `h:3306` (the hardcoded default),
- the connection pool dials `h:3307` (the top-level `PORT`).

So an allow-list entry pinned to a specific port (`<host>h:3306</host>`) can be bypassed: the dictionary passes validation but connects to a different, disallowed port. Found during the review of the 25.8 backport #109304.

**Root cause**

The check and the connection resolve the replica port from the same configuration with two different rules.

The check side, `registerDictionarySourceMysql` in `src/Dictionaries/MySQLDictionarySource.cpp` (before this fix):

```cpp
global_context->getRemoteHostFilter().checkHostAndPort(
    config.getString(replica_prefix + ".host"),
    toString(config.getInt(replica_prefix + ".port", 3306)));
    //       ^ replica's own PORT, else the hardcoded default 3306
```

The connection side, `mysqlxx::Pool` constructor in `src/Common/mysqlxx/Pool.cpp` (invoked with the parent prefix by `PoolWithFailover.cpp`, right after the check):

```cpp
port = cfg.has(config_name + ".port")
    ? cfg.getInt(config_name + ".port")              // replica's own PORT...
    : cfg.getInt(parent_config_name + ".port", 0);   // ...else the top-level PORT
```

The two rules agree when the replica declares its own `PORT` and diverge exactly when it inherits the parent one: the check validates `3306` while `mysql_real_connect` dials the top-level `PORT`. The host has no such gap — `Pool` reads the replica's `host` with no parent fallback, matching the check.

**Fix**

Make the check resolve the port the same way `mysqlxx::Pool` does — the replica's own `port`, falling back to the top-level `port`:

```cpp
toString(config.getInt(replica_prefix + ".port",
    config.getInt(settings_config_prefix + ".port", 3306)))
```

The pre-existing 3306 default is kept for the case when neither is set (the pool constructor then throws `expected port or socket` before dialing anyway). One expression changed.

Regression test `test_allowed_url_from_config/test.py::test_mysql_dictionary_replica_inherited_port_host_filter` on a new node whose allow-list permits exactly `127.0.0.1:3306`: a replica inheriting the denied top-level `PORT 3307` must be rejected with `not allowed` (before the fix, the filter passed and the pool dialed `127.0.0.1:3307`, verified locally against the unfixed binary), and a replica with its own allowed `PORT 3306` must still pass the filter (its own port takes precedence). The existing #99720 tests keep passing.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the `remote_url_allow_hosts` check for MySQL dictionary sources validating the wrong port when a `REPLICA(...)` clause has no `PORT` of its own: the check used the default port 3306 while the connection used the top-level `PORT`, so an allow-list entry pinned to a specific port could be bypassed.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=109736&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/109736](https://github.com/search?q=head%3Async-upstream%2Fpr%2F109736+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
