### PR TITLE
Docs: Fix announcement banner text color in docs (dark & light mode)

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2628,33 +2628,47 @@ div:has(> img[src*="cloudfront.net/flags/"]) {
    Banner Styling
    ============================================ */
 
-/* Light mode: black background, white text, yellow link */
-html:not(.dark) #banner {
-    background-color: #1a1a1a !important;
-    color: #ffffff !important;
-}
+/* Mintlify paints the banner text via `[&_*]:text-white/95!`, an `!important`
+   utility that lives in Tailwind's `@layer utilities`. For `!important`
+   declarations the cascade reverses layer order and treats un-layered styles
+   as the lowest-priority (implicit final) layer, so an un-layered override —
+   however specific — always loses to that utility and the text stays white.
+   Declaring these rules inside `@layer components` (ordered before `utilities`)
+   makes our `!important` win, so the banner text takes the colors below. */
+@layer components {
+    /* Light mode: black background, white text, yellow link */
+    html:not(.dark) #banner {
+        background-color: #1a1a1a !important;
+        color: #ffffff !important;
+    }
 
-html:not(.dark) #banner a {
-    color: #FAFF69 !important;
-    font-weight: 700 !important;
-}
+    html:not(.dark) #banner *,
+    html:not(.dark) #banner p {
+        color: #ffffff !important;
+    }
 
-/* Dark mode: yellow background, black text, white link */
-html.dark #banner,
-:is(.dark) #banner {
-    background-color: #FAFF69 !important;
-    color: #1a1a1a !important;
-}
+    html:not(.dark) #banner a {
+        color: #FAFF69 !important;
+        font-weight: 700 !important;
+    }
 
-html.dark #banner *,
-:is(.dark) #banner * {
-    color: #1a1a1a !important;
-}
+    /* Dark mode: yellow background, black text, black link */
+    html.dark #banner,
+    :is(.dark) #banner {
+        background-color: #FAFF69 !important;
+        color: #1a1a1a !important;
+    }
 
-html.dark #banner a,
-:is(.dark) #banner a {
-    color: #1a1a1a !important;
-    font-weight: 700 !important;
+    html.dark #banner *,
+    :is(.dark) #banner * {
+        color: #1a1a1a !important;
+    }
+
+    html.dark #banner a,
+    :is(.dark) #banner a {
+        color: #1a1a1a !important;
+        font-weight: 700 !important;
+    }
 }
 
 /* ============================================


### PR DESCRIPTION
The announcement banner in the docs rendered **white text on the yellow background in dark mode**, making it hard to read. The banner styling in `docs/_site/styles.css` already declared the intended colors, but the text color never applied.

Mintlify paints the banner text via the Tailwind utility `[&_*]:text-white/95!`, which compiles to `color:#fffffff2!important` inside `@layer utilities`. For `!important` declarations the cascade reverses layer order and treats un-layered styles as the lowest-priority implicit final layer, so our un-layered `!important` override always lost to that utility regardless of selector specificity, and the text stayed white.

This wraps the banner overrides in `@layer components` (ordered before `utilities`), so our `!important` declarations win the cascade. It also adds an explicit light-mode descendant rule so the link renders yellow, and corrects the misleading dark-mode "white link" comment (the link is black).

Verified against the live banner with a headless browser:
- **Dark mode**: yellow background, black body text, black link.
- **Light mode**: black background, white body text, yellow link.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the documentation announcement banner rendering white text on the yellow background in dark mode.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.650` (included in `26.7` and later)
<!-- ch-version-info:end -->