### PR TITLE
Move AST-fuzzer max_threads cap into the shared limit-recursion-settings.xml

### DIFF
--- a/ci/jobs/scripts/fuzzer/limit-recursion-settings.xml
+++ b/ci/jobs/scripts/fuzzer/limit-recursion-settings.xml
@@ -40,6 +40,17 @@
                     <min>1</min>
                     <max>500000</max>
                 </max_expanded_ast_elements>
+
+                <!--
+                    A fuzzed huge max_threads (e.g. 65535) makes one query request more
+                    pipeline threads than the global pool (max_thread_pool_size=10000),
+                    saturating it (CANNOT_SCHEDULE_TASK), which starves the server-liveness
+                    probe and delays query cancellation. Cap it. Lives here so every
+                    ast_fuzzer_runs user (dedicated AST fuzzer and stress test) gets it.
+                -->
+                <max_threads>
+                    <max>128</max>
+                </max_threads>
             </constraints>
 
             <!-- Server-side backstop: keeps max_parser_backtracks `changed` so a server-side

--- a/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
@@ -27,20 +27,15 @@
                     <max>200</max>
                 </table_function_remote_max_addresses>
 
-                <!-- A fuzzed huge max_threads saturates the global thread pool, starving
-                     the server-liveness probe and delaying query cancellation. Cap it. -->
-                <max_threads>
-                    <max>128</max>
-                </max_threads>
-
                 <!-- Don't waste cycles testing the old interpreter. Spend time in the analyzer instead -->
                 <enable_analyzer>
                     <min>1</min>
                 </enable_analyzer>
 
                 <!-- Recursion-limiting constraints (max_ast_depth, max_parser_depth,
-                     max_parser_backtracks) live in limit-recursion-settings.xml, installed
-                     alongside this file and shared with the stress test. -->
+                     max_parser_backtracks) and the max_threads cap live in
+                     limit-recursion-settings.xml, installed alongside this file and
+                     shared with the stress test. -->
 
             </constraints>
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -160,12 +160,6 @@ EOL
                     <max>200</max>
                 </table_function_remote_max_addresses>
 
-                <!-- A fuzzed huge max_threads saturates the global thread pool, starving
-                     the server-liveness probe and delaying query cancellation. Cap it. -->
-                <max_threads>
-                    <max>128</max>
-                </max_threads>
-
                 <!-- Don't waste cycles testing the old interpreter. Spend time in the analyzer instead -->
                 <enable_analyzer>
                     <min>1</min>


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109256
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #109256 (per @PedroTadim). That PR added the AST-fuzzer `max_threads` `<max>128</max>` cap in two places: `ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml` and the mirrored copy in the stress-path `stress_test_tweaks-users.xml` heredoc in `tests/docker_scripts/stress_tests.lib`.

This moves the cap into `ci/jobs/scripts/fuzzer/limit-recursion-settings.xml`, which is already `cp`'d into `users.d` by every `ast_fuzzer_runs` entry point (`run-fuzzer.sh`, `clickhouse_proc.py`, `stress_runner.sh`), so one shared location covers both the dedicated AST fuzzer and the stress test. The two duplicated constraints are removed.

No behavior change: the effective cap is still 128 for every `ast_fuzzer_runs` user.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.667` (included in `26.7` and later)
<!-- ch-version-info:end -->