### PR TITLE
Set `CH Inc sync` in `Code Review` and unblock on tidy build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -194,7 +194,7 @@ jobs:
 
   code_review:
     runs-on: [self-hosted, pr-style-checker-aarch64]
-    needs: [build_arm_tidy, ci_tests, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
+    needs: [config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'Q29kZSBSZXZpZXc=') }}
     name: "Code Review"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -187,6 +187,9 @@ class JobConfigs:
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="python3 ./ci/jobs/copilot_review_job.py --codex",
         allow_failure=True,
+        post_hooks=[
+            "python3 ./ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py"
+        ],
     )
     ci_tests = Job.Config(
         name=JobNames.CI_TESTS,

--- a/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
+++ b/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
@@ -8,6 +8,10 @@ from ci.praktika.result import Result
 
 def main():
     statuses = GH.get_commit_statuses()
+    if statuses is None:
+        print(f"Failed to fetch commit statuses, skip setting [{SYNC}]")
+        return
+
     if SYNC in statuses:
         print(
             f"Commit status [{SYNC}] already exists with description "

--- a/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
+++ b/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
@@ -1,0 +1,27 @@
+from ci.defs.defs import SYNC
+from ci.praktika.gh import GH
+from ci.praktika.result import Result
+
+# This status is a marker that the sync process can be started. We set it from
+# the `Code Review` job because that job always runs for PRs.
+
+
+def main():
+    statuses = GH.get_commit_statuses()
+    if SYNC in statuses:
+        print(
+            f"Commit status [{SYNC}] already exists with description "
+            f"[{statuses[SYNC].description}], skipping"
+        )
+        return
+
+    GH.post_commit_status(
+        name=SYNC,
+        status=Result.Status.PENDING,
+        description="awaiting",
+        url="",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -905,10 +905,13 @@ class GH:
         return cls.do_command_with_retries(command)
 
     @classmethod
-    def get_commit_statuses(cls, sha="", repo="") -> Dict[str, "GH.CommitStatus"]:
+    def get_commit_statuses(
+        cls, sha="", repo=""
+    ) -> Optional[Dict[str, "GH.CommitStatus"]]:
         """
         Fetch commit statuses for the given commit SHA and return the latest
-        status for each context.
+        status for each context. Returns `None` if the status list cannot be
+        retrieved or parsed.
         """
         repo = repo or _Environment.get().REPOSITORY
         sha = sha or _Environment.get().SHA
@@ -917,9 +920,13 @@ class GH:
             f"gh api repos/{repo}/commits/{sha}/statuses --paginate"
         )
         if not output:
-            return {}
-
-        statuses_list = json.loads(output)
+            print("ERROR: Failed to fetch commit statuses")
+            return None
+        try:
+            statuses_list = json.loads(output)
+        except json.JSONDecodeError as ex:
+            print(f"ERROR: Failed to parse commit statuses: {ex}")
+            return None
         status_map: Dict[str, GH.CommitStatus] = {}
 
         for status in statuses_list:

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -905,6 +905,36 @@ class GH:
         return cls.do_command_with_retries(command)
 
     @classmethod
+    def get_commit_statuses(cls, sha="", repo="") -> Dict[str, "GH.CommitStatus"]:
+        """
+        Fetch commit statuses for the given commit SHA and return the latest
+        status for each context.
+        """
+        repo = repo or _Environment.get().REPOSITORY
+        sha = sha or _Environment.get().SHA
+
+        output = cls.get_output_with_retries(
+            f"gh api repos/{repo}/commits/{sha}/statuses --paginate"
+        )
+        if not output:
+            return {}
+
+        statuses_list = json.loads(output)
+        status_map: Dict[str, GH.CommitStatus] = {}
+
+        for status in statuses_list:
+            context = status["context"]
+            if context not in status_map:
+                status_map[context] = GH.CommitStatus(
+                    state=status["state"],
+                    description=status.get("description", ""),
+                    url=status.get("target_url", ""),
+                    context=context,
+                )
+
+        return status_map
+
+    @classmethod
     def merge_pr(cls, pr=None, repo=None, squash=False, keep_branch=False):
         if not repo:
             repo = _Environment.get().REPOSITORY

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -35,6 +35,11 @@ STYLE_AND_FAST_TESTS = [
     *[j.name for j in JobConfigs.tidy_build_arm_jobs],
 ]
 
+CODE_REVIEW_BLOCKING_JOBS = [
+    JobNames.STYLE_CHECK,
+    JobNames.FAST_TEST,
+]
+
 REGULAR_BUILD_NAMES = [job.name for job in JobConfigs.build_jobs]
 
 PLAIN_FUNCTIONAL_TEST_JOB = [
@@ -47,7 +52,7 @@ workflow = Workflow.Config(
     base_branches=[BASE_BRANCH],
     jobs=[
         JobConfigs.style_check,
-        JobConfigs.code_review.set_run_after(STYLE_AND_FAST_TESTS),
+        JobConfigs.code_review.set_run_after(CODE_REVIEW_BLOCKING_JOBS),
         JobConfigs.docs_job,
         JobConfigs.docs_job_mintlify,
         JobConfigs.fast_test,


### PR DESCRIPTION
Code review should not wait for the tidy build in the PR pipeline, and the `Code Review` job should set the `CH Inc sync` status to `awaiting` when that status does not exist yet. This will serve as a flag to start the sync process (instead of current Style check success status)


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.659` (included in `26.7` and later)
<!-- ch-version-info:end -->