### PR TITLE
Fix ObjectStorageQueue/AzureQueue silently skipping files on an empty listing page with a continuation token

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/ObjectStorageIteratorAsync.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/ObjectStorageIteratorAsync.cpp
@@ -53,24 +53,40 @@ void IObjectStorageIteratorAsync::nextBatch()
 
     try
     {
-        chassert(outcome_future.valid());
-        BatchAndHasNext result = outcome_future.get();
-
-        current_batch = std::move(result.batch);
-        current_batch_iterator = current_batch.begin();
-
-        if (current_batch.empty())
+        /// A single listing request may legitimately return an empty page together with a
+        /// continuation token (e.g. Azure Blob Storage returns fewer/zero results and a
+        /// NextMarker when a listing crosses an internal partition boundary). In that case
+        /// we must keep following the token instead of treating the empty page as the end of
+        /// the listing, otherwise objects that live on a subsequent page are silently skipped.
+        while (true)
         {
-            is_finished = true;
-            has_next_batch = false;
-        }
-        else
-        {
-            accumulated_size.fetch_add(current_batch.size(), std::memory_order_relaxed);
+            chassert(outcome_future.valid());
+            BatchAndHasNext result = outcome_future.get();
 
+            current_batch = std::move(result.batch);
+            current_batch_iterator = current_batch.begin();
             has_next_batch = result.has_next;
+
             if (has_next_batch)
                 outcome_future = scheduleBatch();
+
+            if (!current_batch.empty())
+            {
+                accumulated_size.fetch_add(current_batch.size(), std::memory_order_relaxed);
+                break;
+            }
+
+            /// The page is empty. If there are more pages, keep following the
+            /// continuation token (loop again). Otherwise the listing is finished.
+            /// Note: is_finished is set here (only once there is no buffered page
+            /// left to read) rather than together with has_next_batch, so that
+            /// element-wise callers (isValid()/current()/next()) still observe the
+            /// last non-empty page before the iterator reports itself finished.
+            if (!has_next_batch)
+            {
+                is_finished = true;
+                break;
+            }
         }
     }
     catch (...)

--- a/src/Disks/DiskObjectStorage/ObjectStorages/tests/gtest_object_storage_iterator_async.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/tests/gtest_object_storage_iterator_async.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <Disks/DiskObjectStorage/ObjectStorages/ObjectStorageIteratorAsync.h>
+#include <Common/CurrentMetrics.h>
+#include <Common/setThreadName.h>
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace CurrentMetrics
+{
+    extern const Metric ObjectStorageAzureThreads;
+    extern const Metric ObjectStorageAzureThreadsActive;
+    extern const Metric ObjectStorageAzureThreadsScheduled;
+}
+
+using namespace DB;
+
+namespace
+{
+
+/// An async list iterator whose pages are fully scripted, so we can reproduce a
+/// backend (e.g. Azure Blob Storage) that returns an empty page together with a
+/// continuation token ("there are more pages") in the middle of a listing.
+class ScriptedIteratorAsync : public IObjectStorageIteratorAsync
+{
+public:
+    struct Page
+    {
+        std::vector<std::string> names;   /// object keys returned by this page (may be empty)
+        bool has_next;                    /// whether the backend reports more pages after this one
+    };
+
+    explicit ScriptedIteratorAsync(std::deque<Page> pages_)
+        : IObjectStorageIteratorAsync(
+            CurrentMetrics::ObjectStorageAzureThreads,
+            CurrentMetrics::ObjectStorageAzureThreadsActive,
+            CurrentMetrics::ObjectStorageAzureThreadsScheduled,
+            ThreadName::AZURE_LIST_POOL)
+        , pages(std::move(pages_))
+    {
+    }
+
+    ~ScriptedIteratorAsync() override
+    {
+        if (!deactivated)
+            deactivate();
+    }
+
+private:
+    bool getBatchAndCheckNext(RelativePathsWithMetadata & batch) override
+    {
+        if (pages.empty())
+            return false;
+
+        Page page = pages.front();
+        pages.pop_front();
+
+        for (const auto & name : page.names)
+            batch.emplace_back(std::make_shared<RelativePathWithMetadata>(name));
+
+        return page.has_next;
+    }
+
+    std::deque<Page> pages;
+};
+
+using Pages = std::deque<ScriptedIteratorAsync::Page>;
+
+/// Consume element-wise: for (; isValid(); next()) current(). This path is keyed off
+/// is_finished, so it also guards that the iterator is not marked finished while a
+/// non-empty page is still buffered and unread.
+std::vector<std::string> consumeElementWise(Pages pages)
+{
+    ScriptedIteratorAsync it(std::move(pages));
+    std::vector<std::string> result;
+    while (it.isValid())
+    {
+        result.push_back(it.current()->getPath());
+        it.next();
+    }
+    return result;
+}
+
+/// Consume batch-wise, as StorageObjectStorageSource and ObjectStorageQueueSource do:
+/// via getCurrentBatchAndScheduleNext().
+std::vector<std::string> consumeBatchWise(Pages pages)
+{
+    ScriptedIteratorAsync it(std::move(pages));
+    std::vector<std::string> result;
+    while (auto batch = it.getCurrentBatchAndScheduleNext())
+        for (const auto & object : *batch)
+            result.push_back(object->getPath());
+    return result;
+}
+
+}
+
+/// An empty page that carries a continuation token must not end the listing: the
+/// iterator has to keep following the token. Azure Blob Storage returns such
+/// empty-page-with-marker responses (e.g. at internal partition boundaries), and
+/// treating them as end-of-listing silently skips every object on later pages.
+/// Both consumption APIs must return every object, including the last non-empty page.
+TEST(ObjectStorageIteratorAsync, EmptyPageWithContinuationTokenDoesNotStopListing)
+{
+    auto pages = [] { return Pages{
+        {{}, true},              /// empty page, but more pages follow
+        {{"a", "b"}, true},      /// real objects, still more pages
+        {{}, true},              /// empty intermediate page
+        {{"c"}, false},          /// last objects, no more pages
+    }; };
+    const std::vector<std::string> expected{"a", "b", "c"};
+
+    EXPECT_EQ(consumeBatchWise(pages()), expected);
+    EXPECT_EQ(consumeElementWise(pages()), expected);
+}
+
+/// Sanity check: an empty listing with no continuation token is correctly finished.
+TEST(ObjectStorageIteratorAsync, EmptyListingIsFinished)
+{
+    auto pages = [] { return Pages{{{}, false}}; };
+    EXPECT_TRUE(consumeBatchWise(pages()).empty());
+    EXPECT_TRUE(consumeElementWise(pages()).empty());
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix `ObjectStorageQueue`/`AzureQueue` (and the `azureBlobStorage` table function) silently skipping objects when the object storage returns an empty listing page together with a continuation token. Azure Blob Storage does this (e.g. when a listing crosses an internal partition boundary), and the async list iterator was treating the empty page as the end of the listing and dropping the token. It now follows the continuation token.

### Description

Closes #109751.

`IObjectStorageIteratorAsync::nextBatch()` treated an empty listing page as end-of-listing: on `current_batch.empty()` it set `is_finished = true` / `has_next_batch = false` and never read `result.has_next`, so it discarded the continuation token and never fetched later pages.

Azure Blob Storage's `List Blobs` may legitimately return a page with zero results but a non-empty `NextMarker` — the client must keep following the marker until it is empty. This is documented behavior and happens, for example, when a listing crosses an internal partition boundary in a large container. Because ClickHouse stopped on the first empty page, `AzureQueue` and `azureBlobStorage(...)` silently returned fewer/zero objects than actually exist: the queue "lists forever but processes nothing" (`AzureListObjects` keeps climbing while `ObjectStorageQueueListedFiles` / `ObjectStorageQueueProcessedFiles` stay at 0). It is intermittent because it depends on Azure's partition layout, and can self-recover when the layout changes.

S3/GCS are unaffected: their iterator returns `has_next = IsTruncated`, and `ListObjectsV2` does not return an empty page with `IsTruncated=true` for a prefix that has matching keys, so the empty branch was only reached at true end-of-listing.

Azure docs confirming the empty-page-with-marker behavior:
- List Blobs — https://learn.microsoft.com/en-us/rest/api/storageservices/list-blobs
  - "In certain cases, the service might return fewer results than specified by maxresults, and also return a continuation token."
  - "If the NextMarker is not empty, the list results may or may not be complete ... continue to call List Blobs with subsequent marker values until NextMarker is empty."

**Fix:** in `nextBatch()`, honor `has_next` regardless of whether the page is empty — keep following the continuation token, and only finish when a page is empty **and** there are no more pages.

**Test:** added `src/Disks/DiskObjectStorage/ObjectStorages/tests/gtest_object_storage_iterator_async.cpp` — a scripted iterator that returns an empty page + "has more" followed by real pages (and an empty intermediate page), asserting all objects are returned. With the previous behavior it returns nothing; with the fix it returns all objects.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.747` (included in `26.7` and later)
- Backported to: `26.6.5.68`, `26.3.33.11`
<!-- ch-version-info:end -->