### PR TITLE
Fix Paimon bad error message on unsupported nested type

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Paimon/Types.h
+++ b/src/Storages/ObjectStorage/DataLakes/Paimon/Types.h
@@ -288,7 +288,7 @@ struct DataType
             }
             else
             {
-                throw Exception();
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported Paimon type: {}", real_type);
             }
             return type;
         }

--- a/tests/queries/0_stateless/04401_paimon_unsupported_type_error.reference
+++ b/tests/queries/0_stateless/04401_paimon_unsupported_type_error.reference
@@ -1,0 +1,1 @@
+OK: descriptive error

--- a/tests/queries/0_stateless/04401_paimon_unsupported_type_error.sh
+++ b/tests/queries/0_stateless/04401_paimon_unsupported_type_error.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A Paimon schema whose second field uses an unsupported nested ROW type.
+# Previously the parser threw a bare Exception() with code OK and no message.
+# It must now report a descriptive BAD_ARGUMENTS error.
+TABLE_DIR="${CLICKHOUSE_USER_FILES_UNIQUE}/paimon_unsupported_type"
+rm -rf "${TABLE_DIR}"
+mkdir -p "${TABLE_DIR}/schema"
+
+cat > "${TABLE_DIR}/schema/schema-0" <<'EOF'
+{ "version": 3, "id": 0,
+  "fields": [
+    {"id": 0, "name": "c0", "type": "INT"},
+    {"id": 1, "name": "c1", "type": {"type": "ROW", "fields": [{"id": 2, "name": "f0", "type": "INT"}]}}
+  ],
+  "highestFieldId": 2, "partitionKeys": [], "primaryKeys": [], "options": {}, "timeMillis": 1751900000000 }
+EOF
+
+${CLICKHOUSE_CLIENT} -q "SELECT * FROM paimonLocal('${TABLE_DIR}')" 2>&1 \
+    | grep -q "Unsupported Paimon type: ROW.*(BAD_ARGUMENTS)" && echo "OK: descriptive error"
+
+rm -rf "${TABLE_DIR}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/109758
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/109758

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reading a Paimon table whose schema contains an unsupported nested type (for example a `ROW` field) now reports a clear `BAD_ARGUMENTS` error naming the unsupported type, instead of a bare `DB::Exception. (OK)` with error code 0 and no message.

### Description
`Paimon::DataType::parse` (`src/Storages/ObjectStorage/DataLakes/Paimon/Types.h`) handles object-form types by branching on `ARRAY` / `MAP`; any other object type (such as a nested `ROW`) fell into an `else` that did `throw Exception();`. The default `Exception` constructor uses error code `OK` (0) and an empty message, so `SELECT * FROM paimonLocal(...)` on such a schema failed with `Code: 0. DB::Exception. (OK)`, which is useless to the user.

This now throws `Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported Paimon type: {}", real_type)`, matching the sibling scalar-type branch a few lines above that already reports `Unsupported type: {}`.

Added a parallel-safe stateless regression test (`04401_paimon_unsupported_type_error`) that builds a Paimon schema with a nested `ROW` field under a unique per-test `user_files` path and asserts the descriptive `BAD_ARGUMENTS` error.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.672` (included in `26.7` and later)
<!-- ch-version-info:end -->