### PR TITLE
fix partition pruning for timestamp type

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFilesPruning.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnsDateTime.h>
 #include <Common/DateLUTImpl.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesDecimal.h>
 #include <Common/logger_useful.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
@@ -144,11 +145,15 @@ PruningReturnStatus ManifestFilesPruner::canBePruned(
     {
         const auto & partition_value = entry->parsed_entry->partition_key_value;
         std::vector<FieldRef> index_value(partition_value.begin(), partition_value.end());
-        for (auto & field : index_value)
+        for (size_t i = 0; i < index_value.size(); ++i)
         {
+            auto & field = index_value[i];
+            const auto & type = partition_key->data_types.at(i);
             // NULL_LAST
             if (field.isNull())
                 field = POSITIVE_INFINITY;
+            else if (field.getType() == Field::Types::Int64 && WhichDataType(type).isDateTime64()) /// clickhouse used to write timestamp as simple long in avro
+                field = DecimalField<Decimal64>(field.safeGet<Int64>(), getDecimalScale(*type));
         }
 
         bool can_be_true = partition_key_condition->mayBeTrueInRange(

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -9,8 +9,11 @@
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeCustom.h>
+#include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypesDecimal.h>
+#include <Common/assert_cast.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <IO/CompressionMethod.h>
 #include <Interpreters/Context_fwd.h>
@@ -617,8 +620,15 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
         case TypeIndex::UInt64:
         case TypeIndex::Int64:
         case TypeIndex::DateTime:
-        case TypeIndex::DateTime64:
             return "long";
+        case TypeIndex::DateTime64:
+        {
+            Poco::JSON::Object::Ptr timestamp_type = new Poco::JSON::Object;
+            timestamp_type->set("type", "long");
+            timestamp_type->set("logicalType", "timestamp-micros");
+            timestamp_type->set("adjust-to-utc", assert_cast<const DataTypeDateTime64 &>(*type).hasExplicitTimeZone());
+            return timestamp_type;
+        }
         case TypeIndex::Float32:
             return "float";
         case TypeIndex::Float64:

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -623,6 +623,9 @@ Poco::Dynamic::Var getAvroType(DataTypePtr type)
             return "long";
         case TypeIndex::DateTime64:
         {
+            if (getDecimalScale(*type) != 6)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unsupported type for iceberg {}", type->getName());
+
             Poco::JSON::Object::Ptr timestamp_type = new Poco::JSON::Object;
             timestamp_type->set("type", "long");
             timestamp_type->set("logicalType", "timestamp-micros");

--- a/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.reference
+++ b/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.reference
@@ -1,7 +1,6 @@
 --- full read ---
-2024-01-01 00:00:00.123456	a
-2024-06-15 12:30:00.654321	b
---- equality on the partition column ---
-b
---- monotonic function of the partition column ---
-1
+2024-06-15 12:30:00.654321	a
+--- with prunning ---
+a
+--- without prunning ---
+a

--- a/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.reference
+++ b/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.reference
@@ -1,0 +1,7 @@
+--- full read ---
+2024-01-01 00:00:00.123456	a
+2024-06-15 12:30:00.654321	b
+--- equality on the partition column ---
+b
+--- monotonic function of the partition column ---
+1

--- a/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.sh
+++ b/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option)
+#
+# Regression test: manifests written by ClickHouse declared timestamp partition fields as a
+# bare Avro `long`, without the `timestamp-micros` logical type that Iceberg requires. On
+# read such a value parses into an `Int64` field instead of a `DateTime64` one, so partition
+# pruning compared it against a `Decimal64` predicate constant that never matches: an
+# equality predicate on the partition column silently returned no rows, and a
+# monotonic-function predicate (e.g. `toString`) threw `Bad get: has Int64, requested
+# Decimal64` from the Iceberg iterator.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TABLE="t_${CLICKHOUSE_DATABASE}_${RANDOM}_dt64_pruning"
+TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+
+trap 'rm -rf "${TABLE_PATH}" 2>/dev/null' EXIT
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${TABLE} (t DateTime64(6, 'UTC'), v String)
+    ENGINE = IcebergLocal('${TABLE_PATH}', 'Parquet')
+    PARTITION BY (t)
+"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "
+    INSERT INTO ${TABLE} VALUES ('2024-01-01 00:00:00.123456', 'a'), ('2024-06-15 12:30:00.654321', 'b')
+"
+
+echo "--- full read ---"
+${CLICKHOUSE_CLIENT} --query "SELECT t, v FROM ${TABLE} ORDER BY t FORMAT TSV"
+
+echo "--- equality on the partition column ---"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT v FROM ${TABLE} WHERE t = toDateTime64('2024-06-15 12:30:00.654321', 6, 'UTC') FORMAT TSV"
+
+echo "--- monotonic function of the partition column ---"
+${CLICKHOUSE_CLIENT} --query "
+    SELECT count() FROM ${TABLE} WHERE toString(t) = '2024-06-15 12:30:00.654321' FORMAT TSV"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"

--- a/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.sh
+++ b/tests/queries/0_stateless/04501_iceberg_datetime64_partition_pruning.sh
@@ -5,10 +5,7 @@
 # Regression test: manifests written by ClickHouse declared timestamp partition fields as a
 # bare Avro `long`, without the `timestamp-micros` logical type that Iceberg requires. On
 # read such a value parses into an `Int64` field instead of a `DateTime64` one, so partition
-# pruning compared it against a `Decimal64` predicate constant that never matches: an
-# equality predicate on the partition column silently returned no rows, and a
-# monotonic-function predicate (e.g. `toString`) threw `Bad get: has Int64, requested
-# Decimal64` from the Iceberg iterator.
+# pruning compared it against a `Decimal64` predicate constant that never matches.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -21,23 +18,23 @@ trap 'rm -rf "${TABLE_PATH}" 2>/dev/null' EXIT
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
 ${CLICKHOUSE_CLIENT} --query "
-    CREATE TABLE ${TABLE} (t DateTime64(6, 'UTC'), v String)
+    CREATE TABLE ${TABLE} (t DateTime64, v String)
     ENGINE = IcebergLocal('${TABLE_PATH}', 'Parquet')
     PARTITION BY (t)
 "
 ${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "
-    INSERT INTO ${TABLE} VALUES ('2024-01-01 00:00:00.123456', 'a'), ('2024-06-15 12:30:00.654321', 'b')
+    INSERT INTO ${TABLE} VALUES ('2024-06-15 12:30:00.654321', 'a')
 "
 
 echo "--- full read ---"
 ${CLICKHOUSE_CLIENT} --query "SELECT t, v FROM ${TABLE} ORDER BY t FORMAT TSV"
 
-echo "--- equality on the partition column ---"
+echo "--- with prunning ---"
 ${CLICKHOUSE_CLIENT} --query "
-    SELECT v FROM ${TABLE} WHERE t = toDateTime64('2024-06-15 12:30:00.654321', 6, 'UTC') FORMAT TSV"
+    SELECT v FROM ${TABLE} WHERE t = '2024-06-15 12:30:00.654321' SETTINGS use_iceberg_partition_pruning = 1 FORMAT TSV"
 
-echo "--- monotonic function of the partition column ---"
+echo "--- without prunning ---"
 ${CLICKHOUSE_CLIENT} --query "
-    SELECT count() FROM ${TABLE} WHERE toString(t) = '2024-06-15 12:30:00.654321' FORMAT TSV"
+    SELECT v FROM ${TABLE} WHERE t = '2024-06-15 12:30:00.654321' SETTINGS use_iceberg_partition_pruning = 0 FORMAT TSV"
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed partition pruning returning no rows for Iceberg tables partitioned by a timestamp (DateTime64) column



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.870` (included in `26.7` and later)
- Backported to: `26.6.4.55`
<!-- ch-version-info:end -->