### PR TITLE
Docs: remove the site announcement banner for now

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,10 +9,6 @@
       "light": "#FFFFFF"
     }
   },
-  "banner": {
-    "content": "ClickHouse launches Claude-powered Agents and House Mates partner program at Open House 2026 [Read more →](https://clickhouse.com/blog/clickhouse-tops-250m-arr-and-4000-customers)",
-    "dismissible": true
-  },
   "colors": {
     "dark": "#fdff75",
     "light": "#333431",


### PR DESCRIPTION
Removes the top-of-page announcement banner from `docs/docs.json` (the "Open House 2026" strip). It can be re-added later when there is a new announcement to surface.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.658` (included in `26.7` and later)
<!-- ch-version-info:end -->