### PR TITLE
Revert part of 95079

### DIFF
--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -173,14 +173,12 @@ MergeSelectorApplier::MergeSelectorApplier(
     bool merge_with_ttl_allowed_,
     bool aggressive_,
     IMergeSelector::RangeFilter range_filter_,
-    StorageID storage_id_,
-    bool readonly_)
+    StorageID storage_id_)
     : merge_constraints(std::move(merge_constraints_))
     , merge_with_ttl_allowed(merge_with_ttl_allowed_)
     , aggressive(aggressive_)
     , range_filter(std::move(range_filter_))
     , storage_id(std::move(storage_id_))
-    , readonly(readonly_)
 {
     chassert(!merge_constraints.empty(), "At least one merge constraint should be passed");
 
@@ -215,13 +213,6 @@ MergeSelectorChoices MergeSelectorApplier::chooseMergesFrom(
         .current_time = current_time,
         .aggressive = aggressive,
     };
-
-    /// A read-only table (the `table_readonly` MergeTree setting) does not modify any data on disk and
-    /// wastes no background CPU: no merges of any kind run on it — not regular merges, not recompression,
-    /// and not TTL drop/delete merges. A table with a TTL is never marked read-only (see
-    /// `SystemLog::prepareTable`), so skipping TTL merges here cannot strand expired data.
-    if (readonly)
-        return {};
 
     if (metadata_snapshot->hasAnyTTL() && merge_with_ttl_allowed && can_use_ttl_merges)
         if (auto choices = tryChooseTTLMerge(ctx); !choices.empty())

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.h
@@ -32,18 +32,13 @@ public:
     const bool aggressive = false;
     const IMergeSelector::RangeFilter range_filter = nullptr;
     const StorageID storage_id;
-    /// If true, the table is read-only (the `table_readonly` MergeTree setting): no merges of any kind run —
-    /// neither regular merges, nor recompression, nor TTL drop/delete merges. (Tables with a TTL are never
-    /// marked read-only, so no TTL work is stranded; see `SystemLog::prepareTable`.)
-    const bool readonly = false;
 
     MergeSelectorApplier(
         std::vector<MergeConstraint> && merge_constraints_,
         bool merge_with_ttl_allowed_,
         bool aggressive_,
         IMergeSelector::RangeFilter range_filter_,
-        StorageID storage_id_,
-        bool readonly_ = false);
+        StorageID storage_id_);
 
     MergeSelectorChoices chooseMergesFrom(
         const PartsRanges & ranges,

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7217,13 +7217,7 @@ Pipe MergeTreeData::alterPartition(
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
             "ALTER ... PARTITION operations are not supported on tables with UNIQUE KEY");
 
-    /// A read-only table (the `table_readonly` MergeTree setting, used e.g. for rotated system log tables)
-    /// must reject explicit partition mutations as well. Partition commands are dispatched here directly by
-    /// `InterpreterAlterQuery`, bypassing `StorageMergeTree::alter` / `assertNotReadonly`, so without this
-    /// gate a read-only table could still have its parts dropped, moved, attached, fetched, or replaced.
-    /// Operations that do not modify the table's data (`FREEZE`/`UNFREEZE` of a backup, `FORGET PARTITION`)
-    /// remain allowed, and the `table_readonly` setting itself can always be toggled back via
-    /// `ALTER ... MODIFY/RESET SETTING` (which goes through `alter`, not this path).
+    /// A read-only table must reject explicit partition mutations as well.
     if ((*getSettings())[MergeTreeSetting::table_readonly])
     {
         for (const PartitionCommand & command : commands)
@@ -10338,14 +10332,6 @@ bool MergeTreeData::scheduleDataProcessingJob(BackgroundJobsAssignee & /*assigne
 
 bool MergeTreeData::scheduleDataMovingJob(BackgroundJobsAssignee & assignee)
 {
-    /// A read-only table (the `table_readonly` MergeTree setting, used e.g. for rotated system log tables)
-    /// must not waste background CPU and I/O moving parts between volumes/disks, neither because of the
-    /// storage policy `move_factor` nor because of `TTL ... TO DISK/VOLUME` rules. Explicit
-    /// `ALTER TABLE ... MOVE` commands are rejected separately by `assertNotReadonly`; this only suppresses
-    /// the automatic background moves. The setting is sampled here, immediately before move selection and
-    /// scheduling, so the window against a concurrent `ALTER ... MODIFY SETTING table_readonly = 1` is
-    /// minimal; suppression of an already-selected move is best-effort and a single in-flight move that
-    /// slips through right at the moment the setting is published is harmless (see `scheduleDataProcessingJob`).
     if ((*getSettings())[MergeTreeSetting::table_readonly])
         return false;
 

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -257,13 +257,8 @@ PartitionIdsHint MergeTreeDataMergerMutator::getPartitionsThatMayBeMerged(
                 partition_id, convertMergeConstraintsToString(selector.merge_constraints), ranges_in_partition.size());
     }
 
-    /// A read-only table (the `table_readonly` MergeTree setting) must not run regular merges,
-    /// including forced whole-partition merges (`min_age_to_force_merge_seconds`).
-    if (!selector.readonly)
-    {
-        if (auto best = getBestPartitionToOptimizeEntire(selector.merge_constraints[0].max_size_bytes, context, settings, partitions_stats, log); !best.empty())
-            partitions_hint.insert(std::move(best));
-    }
+    if (auto best = getBestPartitionToOptimizeEntire(selector.merge_constraints[0].max_size_bytes, context, settings, partitions_stats, log); !best.empty())
+        partitions_hint.insert(std::move(best));
 
     LOG_TRACE(log,
             "Checked {} partitions, found {} partitions with parts that may be merged: [{}] "
@@ -287,17 +282,6 @@ std::expected<MergeSelectorChoices, SelectMergeFailure> MergeTreeDataMergerMutat
     const time_t current_time = std::time(nullptr);
     const bool can_use_ttl_merges = !ttl_merges_blocker.isCancelled();
     LogSeriesLimiter series_log(log, 1, /*interval_s_=*/60 * 30);
-
-    /// A read-only table (the `table_readonly` MergeTree setting) runs no merges of any kind. Bail out
-    /// before the candidate scan (`collectAllPossibleRanges` -> `grabAllPossibleRanges` and
-    /// `splitByMergePredicate`) so a rotated log table with many parts does not keep burning background CPU
-    /// on every scheduling pass — the very work this setting is meant to avoid. `MergeSelectorApplier::chooseMergesFrom`
-    /// enforces the same "no merges when read-only" invariant as a secondary guard.
-    if (selector.readonly)
-        return std::unexpected(SelectMergeFailure{
-            .reason = SelectMergeFailure::Reason::CANNOT_SELECT,
-            .explanation = PreformattedMessage::create("Table is in readonly mode"),
-        });
 
     auto collected = collectAllPossibleRanges(parts_collector, metadata_snapshot, storage_policy, current_time, partitions_hint, series_log);
     if (collected.ranges.empty())
@@ -330,8 +314,6 @@ std::expected<MergeSelectorChoices, SelectMergeFailure> MergeTreeDataMergerMutat
         return merge_choices;
     }
 
-    /// Forced whole-partition merges (`min_age_to_force_merge_seconds`). Read-only tables already returned
-    /// above, so no readonly guard is needed here.
     if (auto best = getBestPartitionToOptimizeEntire(selector.merge_constraints[0].max_size_bytes, context, settings, partitions_stats, log); !best.empty())
     {
         return selectAllPartsToMergeWithinPartition(

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -212,7 +212,7 @@ StorageMergeTree::StorageMergeTree(
 
     loadDataParts(LoadingStrictnessLevel::FORCE_RESTORE <= mode, std::nullopt);
 
-    if (mode < LoadingStrictnessLevel::ATTACH && !getDataPartsForInternalUsage().empty() && !isStaticStorage())
+    if (mode < LoadingStrictnessLevel::ATTACH && !getDataPartsForInternalUsage().empty() && !isTableReadonly())
         throw Exception(ErrorCodes::INCORRECT_DATA,
                         "Data directory for table already containing data parts - probably "
                         "it was unclean DROP table or manual intervention. "
@@ -229,8 +229,8 @@ StorageMergeTree::StorageMergeTree(
 
 void StorageMergeTree::startup()
 {
-    /// Do not schedule any background jobs if current storage has static data files.
-    if (isStaticStorage())
+    /// Do not schedule any background jobs if the table is read-only.
+    if (isTableReadonly())
         return;
 
     clearEmptyParts();
@@ -1501,8 +1501,7 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
     TableLockHolder & /* table_lock_holder */,
     std::unique_lock<std::mutex> & lock,
     const MergeTreeTransactionPtr & txn,
-    bool optimize_skip_merged_partitions,
-    bool readonly)
+    bool optimize_skip_merged_partitions)
 {
     /// Merges are disabled for UNIQUE KEY tables: a background merge can outdate
     /// a DELETE's target part between part-resolution and marker publish (the
@@ -1588,8 +1587,7 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
                 /*merge_with_ttl_allowed=*/merge_with_ttl_allowed,
                 /*aggressive=*/aggressive,
                 /*range_filter_=*/nullptr,
-                /*storage_id_=*/getStorageID(),
-                /*readonly_=*/readonly
+                /*storage_id_=*/getStorageID()
             ),
             /*partitions_hint=*/std::nullopt);
 
@@ -1995,7 +1993,8 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
     if (shutdown_called)
         return false;
 
-    chassert(!isStaticStorage());
+    if (isTableReadonly())
+        return false;
 
     FailPointInjection::pauseFailPoint(FailPoints::mt_merge_selecting_task_pause_when_scheduled);
 
@@ -2029,29 +2028,14 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
         if (merger_mutator.merges_blocker.isCancelled())
             return false;
 
-        /// A read-only table (the `table_readonly` MergeTree setting, used e.g. for rotated system log tables)
-        /// performs no modifications on disk and wastes no background CPU: no merges (regular, recompression,
-        /// or TTL), mutations, or part moves run on it. Tables with a TTL are never marked read-only (see
-        /// `SystemLog::prepareTable`), so skipping TTL merges here cannot strand expired data.
-        ///
-        /// Sample the setting here, under `currently_processing_in_background_mutex` and immediately before
-        /// selecting background work, so the window against a concurrent `ALTER ... MODIFY SETTING
-        /// table_readonly = 1` is as small as possible. Suppressing already in-flight background work is
-        /// best-effort: an operation whose selection started just before the setting was published may still
-        /// complete once. That is harmless - the table is abandoned after rotation, the result is correct,
-        /// and explicit user modifications are always rejected synchronously (`assertNotReadonly` for
-        /// writes/mutations/OPTIMIZE, and the `table_readonly` gate in `MergeTreeData::alterPartition` for
-        /// partition commands).
-        const bool table_is_readonly = (*getSettings())[MergeTreeSetting::table_readonly];
-
         {
-            if (auto merge_select_result = selectPartsToMerge(metadata_snapshot, false, {}, false, shared_lock, lock, txn, /*optimize_skip_merged_partitions=*/false, /*readonly=*/table_is_readonly))
+            if (auto merge_select_result = selectPartsToMerge(metadata_snapshot, false, {}, false, shared_lock, lock, txn))
                 merge_entry = std::move(merge_select_result.value());
             else
                 LOG_TRACE(LogFrequencyLimiter(log.load(), 300), "Didn't start merge: {}", merge_select_result.error().explanation.text);
         }
 
-        if (!merge_entry && !table_is_readonly && !current_mutations_by_version.empty())
+        if (!merge_entry && !current_mutations_by_version.empty())
         {
             PreformattedMessage out_reason;
             mutate_entry = selectPartsToMutate(metadata_snapshot, out_reason, shared_lock, lock);
@@ -3583,11 +3567,14 @@ PreparedSetsCachePtr StorageMergeTree::getPreparedSetsCache(Int64 mutation_id)
     return cache;
 }
 
+bool StorageMergeTree::isTableReadonly() const
+{
+    return isStaticStorage() || (*getSettings())[MergeTreeSetting::table_readonly];
+}
+
 void StorageMergeTree::assertNotReadonly() const
 {
-    if (isStaticStorage())
-        throw Exception(ErrorCodes::TABLE_IS_PERMANENTLY_READ_ONLY, "Table is in readonly mode due to static storage");
-    if ((*getSettings())[MergeTreeSetting::table_readonly])
+    if (isTableReadonly())
         throw Exception(ErrorCodes::TABLE_IS_PERMANENTLY_READ_ONLY, "Table is in readonly mode");
 }
 

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -258,8 +258,7 @@ private:
         TableLockHolder & table_lock_holder,
         std::unique_lock<std::mutex> & lock,
         const MergeTreeTransactionPtr & txn,
-        bool optimize_skip_merged_partitions = false,
-        bool readonly = false);
+        bool optimize_skip_merged_partitions = false);
 
     MergeMutateSelectedEntryPtr selectPartsToMutate(
         const StorageMetadataPtr & metadata_snapshot, PreformattedMessage & disable_reason,
@@ -328,6 +327,7 @@ private:
 
     PreparedSetsCachePtr getPreparedSetsCache(Int64 mutation_id);
 
+    bool isTableReadonly() const;
     void assertNotReadonly() const;
 
     friend class MergeTreeSink;

--- a/tests/integration/test_disk_over_web_server/test.py
+++ b/tests/integration/test_disk_over_web_server/test.py
@@ -178,7 +178,7 @@ def test_incorrect_usage(cluster):
     assert "Table is read-only" in result
 
     result = node2.query_and_get_error("OPTIMIZE TABLE test0 FINAL")
-    assert "Table is in readonly mode due to static storage" in result
+    assert "Table is in readonly mode" in result
 
     node2.query("DROP TABLE test0 SYNC")
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes abstraction leaks introduced in https://github.com/ClickHouse/ClickHouse/pull/95079


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.676` (included in `26.7` and later)
<!-- ch-version-info:end -->