### PR TITLE
Move tests/ci/test_* unit tests into ci/tests/ so they run in CI

### DIFF
--- a/ci/jobs/scripts/release_checks.py
+++ b/ci/jobs/scripts/release_checks.py
@@ -3,10 +3,11 @@
 Dependency-light release helpers.
 
 This module is deliberately kept free of the release toolchain's heavy imports
-(`github`, `boto3`, `unidiff`, ...). `create_release.py` drags in that whole
-stack at import time, none of which is shipped in the `CI Tests` docker image,
-so the pure release-decision logic lives here where the `ci/tests/` unit-test
-suite can import and exercise it hermetically.
+(`github`, `boto3`, `unidiff`, ...) and of the `ci.praktika` stack. The release
+driver `tests/ci/create_release.py` drags in the former at import time, none of
+which is shipped in the `CI Tests` docker image, so the pure release-decision
+logic lives here -- importable as `ci.jobs.scripts.release_checks` -- where the
+`ci/tests/` unit-test suite can exercise it hermetically.
 """
 
 

--- a/ci/tests/test_cherry_pick_branches.py
+++ b/ci/tests/test_cherry_pick_branches.py
@@ -1,22 +1,36 @@
 #!/usr/bin/env python3
 """
 Unit tests for the backport branch-selection contract in
-`cherry_pick_branches.py`. Run with `python -m unittest` from `tests/ci/`, or
-with `pytest tests/ci/test_cherry_pick_branches.py` from the repo root.
+`cherry_pick_branches.py`. Run as part of the `ci/tests/` suite with
+`pytest ci/tests/test_cherry_pick_branches.py` from the repo root.
 
 The module under test has no GitHub / git / CI dependencies, so these tests run
 anywhere. Label constants mirror `pr_info.Labels` and are kept local to avoid
 importing the heavyweight `cherry_pick` module.
 """
+import os
+import sys
 import unittest
 
-from cherry_pick_branches import (
-    backport_floor,
-    branch_version,
-    label_version,
-    select_backport_branches,
-    version_key,
+# `cherry_pick_branches` lives under `tests/ci` and imports sibling modules by
+# bare name, so put that directory on `sys.path` only while importing it and
+# remove it again afterwards to avoid leaking it into the rest of the pytest
+# session.
+_CI_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
 )
+sys.path.insert(0, _CI_DIR)
+try:
+    # pylint: disable=import-error
+    from cherry_pick_branches import (
+        backport_floor,
+        branch_version,
+        label_version,
+        select_backport_branches,
+        version_key,
+    )
+finally:
+    sys.path.remove(_CI_DIR)
 
 # Mirror of the label constants used by `cherry_pick.process_pr`.
 MUST_BACKPORT = "pr-must-backport"

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -6,8 +6,21 @@ root.
 """
 
 import os
+import subprocess
 import sys
 import unittest
+
+# FIXME: importing `create_release` pulls in `github_helper`/`get_robot_token`,
+# which do a top-level `from github import ...`, so it needs PyGithub -- not
+# shipped in the CI Tests docker image. Install it on demand as a stopgap.
+# The proper fix is to break the import-time PyGithub dependency of the
+# `create_release` chain (make the `github_helper`/`get_robot_token` imports
+# lazy, as `pr_version_info` already does), or drop PyGithub entirely in favour
+# of praktika's `gh`-CLI wrapper (`ci/praktika/gh.py`). Then remove this block.
+try:
+    import github  # noqa: F401  pylint: disable=unused-import
+except ModuleNotFoundError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "PyGithub"])
 
 # `create_release` lives under `tests/ci` and imports sibling modules by bare
 # name, so put that directory on `sys.path` only while importing it and remove

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -1,33 +1,19 @@
 #!/usr/bin/env python3
 """
-Unit tests for the pure release-decision helpers in `release_checks.py`. Run as
-part of the `ci/tests/` suite with `pytest ci/tests/test_create_release.py` from
-the repo root.
+Unit tests for the pure release-decision helpers in
+`ci/jobs/scripts/release_checks.py`. Run as part of the `ci/tests/` suite with
+`pytest ci/tests/test_create_release.py` from the repo root.
 
 `release_checks` is the dependency-light home of `is_empty_patch_release` (used
-by `create_release.ReleaseInfo.prepare`). It is kept free of the release
-toolchain's heavy imports (`github`, `boto3`, `unidiff`, ...) precisely so this
-test can import it without the packages that the `CI Tests` docker image does
-not ship.
+by `tests/ci/create_release.py`'s `ReleaseInfo.prepare`). It is kept free of the
+release toolchain's heavy imports (`github`, `boto3`, `unidiff`, ...) and of the
+`ci.praktika` stack, so this test imports it as a plain `ci.jobs.scripts` module
+without the packages that the `CI Tests` docker image does not ship.
 """
 
-import os
-import sys
 import unittest
 
-# `release_checks` lives under `tests/ci`, so put that directory on `sys.path`
-# only while importing it and remove it again afterwards to avoid leaking it
-# into the rest of the pytest session, mirroring
-# `ci/tests/test_download_release_packages.py`.
-_CI_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
-)
-sys.path.insert(0, _CI_DIR)
-try:
-    # pylint: disable=import-error
-    from release_checks import is_empty_patch_release
-finally:
-    sys.path.remove(_CI_DIR)
+from ci.jobs.scripts.release_checks import is_empty_patch_release
 
 
 class TestIsEmptyPatchRelease(unittest.TestCase):

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -1,37 +1,31 @@
 #!/usr/bin/env python3
 """
-Unit tests for the pure helpers in `create_release.py`. Run as part of the
-`ci/tests/` suite with `pytest ci/tests/test_create_release.py` from the repo
-root.
+Unit tests for the pure release-decision helpers in `release_checks.py`. Run as
+part of the `ci/tests/` suite with `pytest ci/tests/test_create_release.py` from
+the repo root.
+
+`release_checks` is the dependency-light home of `is_empty_patch_release` (used
+by `create_release.ReleaseInfo.prepare`). It is kept free of the release
+toolchain's heavy imports (`github`, `boto3`, `unidiff`, ...) precisely so this
+test can import it without the packages that the `CI Tests` docker image does
+not ship.
 """
 
 import os
-import subprocess
 import sys
 import unittest
 
-# FIXME: importing `create_release` pulls in `github_helper`/`get_robot_token`,
-# which do a top-level `from github import ...`, so it needs PyGithub -- not
-# shipped in the CI Tests docker image. Install it on demand as a stopgap.
-# The proper fix is to break the import-time PyGithub dependency of the
-# `create_release` chain (make the `github_helper`/`get_robot_token` imports
-# lazy, as `pr_version_info` already does), or drop PyGithub entirely in favour
-# of praktika's `gh`-CLI wrapper (`ci/praktika/gh.py`). Then remove this block.
-try:
-    import github  # noqa: F401  pylint: disable=unused-import
-except ModuleNotFoundError:
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "PyGithub"])
-
-# `create_release` lives under `tests/ci` and imports sibling modules by bare
-# name, so put that directory on `sys.path` only while importing it and remove
-# it again afterwards to avoid leaking it into the rest of the pytest session.
+# `release_checks` lives under `tests/ci`, so put that directory on `sys.path`
+# only while importing it and remove it again afterwards to avoid leaking it
+# into the rest of the pytest session, mirroring
+# `ci/tests/test_download_release_packages.py`.
 _CI_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
 )
 sys.path.insert(0, _CI_DIR)
 try:
     # pylint: disable=import-error
-    from create_release import ReleaseInfo
+    from release_checks import is_empty_patch_release
 finally:
     sys.path.remove(_CI_DIR)
 
@@ -40,20 +34,20 @@ class TestIsEmptyPatchRelease(unittest.TestCase):
     def test_rejects_empty_rerun(self):
         # Already-published branch: the only commit since the previous
         # stable/lts tag is the automated version bump (e.g. v25.8.28.1-lts).
-        self.assertTrue(ReleaseInfo._is_empty_patch_release(patch=28, tweak=1))
+        self.assertTrue(is_empty_patch_release(patch=28, tweak=1))
 
     def test_allows_first_release_of_new_branch(self):
         # First user-facing stable/lts release on a freshly cut branch. Its
         # previous tag is vX.Y.1.1-new and the single testing -> stable commit
         # also yields tweak == 1, but the release is legitimate.
-        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=1, tweak=1))
+        self.assertFalse(is_empty_patch_release(patch=1, tweak=1))
 
     def test_allows_non_empty_patch_release(self):
         # Real commits on top of the previous release -> tweak > 1.
-        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=28, tweak=42))
+        self.assertFalse(is_empty_patch_release(patch=28, tweak=42))
 
     def test_allows_non_empty_first_release(self):
-        self.assertFalse(ReleaseInfo._is_empty_patch_release(patch=1, tweak=2222))
+        self.assertFalse(is_empty_patch_release(patch=1, tweak=2222))
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -1,13 +1,26 @@
 #!/usr/bin/env python3
 """
-Unit tests for the pure helpers in `create_release.py`. Run with
-`python -m unittest` from `tests/ci/`, or with
-`pytest tests/ci/test_create_release.py` from the repo root.
+Unit tests for the pure helpers in `create_release.py`. Run as part of the
+`ci/tests/` suite with `pytest ci/tests/test_create_release.py` from the repo
+root.
 """
 
+import os
+import sys
 import unittest
 
-from create_release import ReleaseInfo
+# `create_release` lives under `tests/ci` and imports sibling modules by bare
+# name, so put that directory on `sys.path` only while importing it and remove
+# it again afterwards to avoid leaking it into the rest of the pytest session.
+_CI_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
+)
+sys.path.insert(0, _CI_DIR)
+try:
+    # pylint: disable=import-error
+    from create_release import ReleaseInfo
+finally:
+    sys.path.remove(_CI_DIR)
 
 
 class TestIsEmptyPatchRelease(unittest.TestCase):

--- a/ci/tests/test_pr_version_info.py
+++ b/ci/tests/test_pr_version_info.py
@@ -1,29 +1,42 @@
 #!/usr/bin/env python3
 """
-Unit tests for the pure helpers in `pr_version_info.py`. Run with
-`python -m unittest` from `tests/ci/`, or with
-`pytest tests/ci/test_pr_version_info.py` from the repo root.
+Unit tests for the pure helpers in `pr_version_info.py`. Run as part of the
+`ci/tests/` suite with `pytest ci/tests/test_pr_version_info.py` from the repo
+root.
 
 `pr_version_info` keeps its GitHub / CIDB imports inside `main()`, so importing
 the helpers here pulls in no heavyweight dependencies.
 """
 
+import os
+import sys
 import unittest
 
-from pr_version_info import (
-    SECTION_END,
-    SECTION_START,
-    MergedPR,
-    has_backport_label,
-    has_ignore_label,
-    original_pr_number_from_backport_ref,
-    partition_merged_prs,
-    release_from_backport_ref,
-    render_issue_section,
-    render_section,
-    upsert_section,
-    version_key,
+# `pr_version_info` lives under `tests/ci` and imports sibling modules by bare
+# name, so put that directory on `sys.path` only while importing it and remove
+# it again afterwards to avoid leaking it into the rest of the pytest session.
+_CI_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "ci")
 )
+sys.path.insert(0, _CI_DIR)
+try:
+    # pylint: disable=import-error
+    from pr_version_info import (
+        SECTION_END,
+        SECTION_START,
+        MergedPR,
+        has_backport_label,
+        has_ignore_label,
+        original_pr_number_from_backport_ref,
+        partition_merged_prs,
+        release_from_backport_ref,
+        render_issue_section,
+        render_section,
+        upsert_section,
+        version_key,
+    )
+finally:
+    sys.path.remove(_CI_DIR)
 
 
 class TestRenderSection(unittest.TestCase):

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -116,6 +116,7 @@ from ci_buddy import CIBuddy
 from ci_utils import GH, Envs, Shell
 from git_helper import GIT_PREFIX, Git
 from pr_info import Labels
+from release_checks import is_empty_patch_release
 from s3_helper import S3Helper
 from ssh import SSHAgent
 from version_helper import (
@@ -236,26 +237,6 @@ class ReleaseInfo:
             print(json.dumps(dataclasses.asdict(self), indent=2), file=f)
         return self
 
-    @staticmethod
-    def _is_empty_patch_release(patch: int, tweak: int) -> bool:
-        """
-        Whether a patch release would be empty and must be refused.
-
-        For a patch release the tweak equals the number of commits since the
-        previous release tag (see `Git.tweak`), so `tweak == 1` means the only
-        commit on top of the previous release is the automated post-release
-        version bump — there is nothing to release (e.g. `v25.8.28.1-lts`).
-
-        The exception is `patch == 1`: that is the first user-facing
-        `stable`/`lts` release of a freshly cut branch. Its previous tag is the
-        non-user-facing `vX.Y.1.1-new`, and the single automated
-        `testing -> stable/lts` version-update commit also yields `tweak == 1`.
-        That release is legitimate and must be allowed. The post-release bump
-        always increments `patch`, so an already-published branch is always at
-        `patch >= 2` on a rerun.
-        """
-        return tweak == 1 and patch != 1
-
     def prepare(
         self,
         commit_ref: str,
@@ -311,7 +292,7 @@ class ReleaseInfo:
                 # do not tag, so skip the check. This is checked before the
                 # out-of-order check below because "nothing to release" is the
                 # more fundamental condition.
-                if not _skip_out_of_order_check and self._is_empty_patch_release(
+                if not _skip_out_of_order_check and is_empty_patch_release(
                     version.patch, version.tweak
                 ):
                     raise RuntimeError(

--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -107,6 +107,7 @@ import argparse
 import dataclasses
 import json
 import os
+import sys
 from contextlib import contextmanager
 from copy import copy
 from pathlib import Path
@@ -116,7 +117,6 @@ from ci_buddy import CIBuddy
 from ci_utils import GH, Envs, Shell
 from git_helper import GIT_PREFIX, Git
 from pr_info import Labels
-from release_checks import is_empty_patch_release
 from s3_helper import S3Helper
 from ssh import SSHAgent
 from version_helper import (
@@ -292,6 +292,16 @@ class ReleaseInfo:
                 # do not tag, so skip the check. This is checked before the
                 # out-of-order check below because "nothing to release" is the
                 # more fundamental condition.
+                #
+                # The guard lives in `ci/jobs/scripts/release_checks.py` so the
+                # `CI Tests` unit suite can exercise it without this module's
+                # release-only dependencies. This script runs from `tests/ci`
+                # with repo root off `sys.path`, so add it and import lazily.
+                repo_root = str(Path(__file__).resolve().parents[2])
+                if repo_root not in sys.path:
+                    sys.path.append(repo_root)
+                from ci.jobs.scripts.release_checks import is_empty_patch_release
+
                 if not _skip_out_of_order_check and is_empty_patch_release(
                     version.patch, version.tweak
                 ):

--- a/tests/ci/release_checks.py
+++ b/tests/ci/release_checks.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Dependency-light release helpers.
+
+This module is deliberately kept free of the release toolchain's heavy imports
+(`github`, `boto3`, `unidiff`, ...). `create_release.py` drags in that whole
+stack at import time, none of which is shipped in the `CI Tests` docker image,
+so the pure release-decision logic lives here where the `ci/tests/` unit-test
+suite can import and exercise it hermetically.
+"""
+
+
+def is_empty_patch_release(patch: int, tweak: int) -> bool:
+    """
+    Whether a patch release would be empty and must be refused.
+
+    For a patch release the tweak equals the number of commits since the
+    previous release tag (see `Git.tweak`), so `tweak == 1` means the only
+    commit on top of the previous release is the automated post-release
+    version bump — there is nothing to release (e.g. `v25.8.28.1-lts`).
+
+    The exception is `patch == 1`: that is the first user-facing
+    `stable`/`lts` release of a freshly cut branch. Its previous tag is the
+    non-user-facing `vX.Y.1.1-new`, and the single automated
+    `testing -> stable/lts` version-update commit also yields `tweak == 1`.
+    That release is legitimate and must be allowed. The post-release bump
+    always increments `patch`, so an already-published branch is always at
+    `patch >= 2` on a rerun.
+    """
+    return tweak == 1 and patch != 1


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109489

The CI unit-test job runs `pytest ci/tests/` (see `ci/jobs/ci_tests_job.py`), so unit tests placed under `tests/ci/` are never executed in CI. Move the three recently added unit-test files there so they actually run:

- `test_create_release.py`
- `test_cherry_pick_branches.py`
- `test_pr_version_info.py`

Each module under test still lives in `tests/ci/` and imports its siblings by bare name, so each test now puts that directory on `sys.path` only for the duration of the import and removes it afterwards, mirroring the existing `ci/tests/test_download_release_packages.py`.

Follow-up to a review comment on #109489.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
