### PR TITLE
Follow RFC in `getClientHTTPHeader`

### DIFF
--- a/src/Access/HTTPAuthClient.h
+++ b/src/Access/HTTPAuthClient.h
@@ -1,11 +1,13 @@
 #pragma once
+
+#include <set>
+
+#include <base/sleep.h>
+#include <Common/HTTPFieldLess.h>
 #include <IO/ConnectionTimeouts.h>
 #include <IO/HTTPCommon.h>
 
-#include <base/sleep.h>
 #include <Poco/Net/HTTPBasicCredentials.h>
-
-#include <set>
 
 namespace DB
 {
@@ -66,28 +68,14 @@ public:
 
     const Poco::URI & getURI() const { return uri; }
 
-    struct ci_less
-    {
-        bool operator()(const std::string & a, const std::string & b) const
-        {
-            return std::lexicographical_compare(
-                a.begin(), a.end(),
-                b.begin(), b.end(),
-                [](unsigned char ac, unsigned char bc)
-                {
-                    return std::tolower(ac) < std::tolower(bc);
-                });
-        }
-    };
-
-    const std::set<String, ci_less> & getForwardHeaders() const { return forward_headers; }
+    const std::set<String, HTTPFieldLess> & getForwardHeaders() const { return forward_headers; }
 
 private:
     const ConnectionTimeouts timeouts;
     const size_t max_tries;
     const size_t retry_initial_backoff_ms;
     const size_t retry_max_backoff_ms;
-    const std::set<String, ci_less> forward_headers;
+    const std::set<String, HTTPFieldLess> forward_headers;
     const Poco::URI uri;
     TResponseParser parser;
 };
@@ -100,7 +88,7 @@ public:
     using HTTPAuthClient<TResponseParser>::HTTPAuthClient;
     using Result = HTTPAuthClient<TResponseParser>::Result;
 
-    Result authenticate(const String & user_name, const String & password, const std::unordered_map<String, String> & headers) const
+    Result authenticate(const String & user_name, const String & password, const std::map<String, String, HTTPFieldLess> & headers) const
     {
         Poco::Net::HTTPRequest request{
             Poco::Net::HTTPRequest::HTTP_GET, this->getURI().getPathAndQuery(), Poco::Net::HTTPRequest::HTTP_1_1};

--- a/src/Common/HTTPFieldLess.h
+++ b/src/Common/HTTPFieldLess.h
@@ -1,28 +1,26 @@
 #pragma once
 
-#include <algorithm>
 #include <string_view>
+
+#include <Common/StringUtils.h>
 
 namespace DB
 {
 
 /// Comparator for HTTP field (header) names.
 /// Per RFC 9110 §5.1, field names are case-insensitive tokens composed of ASCII characters.
-/// Only letters A-Z are folded; punctuation and other valid token characters are left intact,
-/// so distinct names such as `Foo^Bar` and `Foo~Bar` remain distinct.
-/// `is_transparent` enables heterogeneous lookup (find/contains with std::string_view).
+/// Only letters are folded via isAlphaASCII + toLowerIfAlphaASCII; punctuation and other
+/// valid token characters are left intact, so `Foo^Bar` and `Foo~Bar` remain distinct.
 struct HTTPFieldLess
 {
-    using is_transparent = void;
-
     bool operator()(std::string_view a, std::string_view b) const
     {
         return std::lexicographical_compare(
             a.begin(), a.end(), b.begin(), b.end(),
-            [](unsigned char x, unsigned char y)
+            [](char x, char y)
             {
-                auto lower = [](unsigned char c) -> unsigned char { return (c >= 'A' && c <= 'Z') ? c | 0x20 : c; };
-                return lower(x) < lower(y);
+                return (isAlphaASCII(x) ? toLowerIfAlphaASCII(x) : x)
+                     < (isAlphaASCII(y) ? toLowerIfAlphaASCII(y) : y);
             });
     }
 };

--- a/src/Common/HTTPFieldLess.h
+++ b/src/Common/HTTPFieldLess.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <algorithm>
+#include <string_view>
+
+namespace DB
+{
+
+/// Comparator for HTTP field (header) names.
+/// Per RFC 9110 §5.1, field names are case-insensitive tokens composed of ASCII characters.
+/// Only letters A-Z are folded; punctuation and other valid token characters are left intact,
+/// so distinct names such as `Foo^Bar` and `Foo~Bar` remain distinct.
+/// `is_transparent` enables heterogeneous lookup (find/contains with std::string_view).
+struct HTTPFieldLess
+{
+    using is_transparent = void;
+
+    bool operator()(std::string_view a, std::string_view b) const
+    {
+        return std::lexicographical_compare(
+            a.begin(), a.end(), b.begin(), b.end(),
+            [](unsigned char x, unsigned char y)
+            {
+                auto lower = [](unsigned char c) -> unsigned char { return (c >= 'A' && c <= 'Z') ? c | 0x20 : c; };
+                return lower(x) < lower(y);
+            });
+    }
+};
+
+}

--- a/src/Common/tests/gtest_http_field_less.cpp
+++ b/src/Common/tests/gtest_http_field_less.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+#include <Common/HTTPFieldLess.h>
+
+using DB::HTTPFieldLess;
+
+TEST(HTTPFieldLess, LettersAreFolded)
+{
+    HTTPFieldLess less;
+    EXPECT_FALSE(less("Content-Type", "content-type"));
+    EXPECT_FALSE(less("content-type", "Content-Type"));
+    EXPECT_FALSE(less("CONTENT-TYPE", "content-type"));
+    EXPECT_FALSE(less("x-clickhouse-key", "X-ClickHouse-Key"));
+}
+
+TEST(HTTPFieldLess, PunctuationIsNotFolded)
+{
+    HTTPFieldLess less;
+    // '^' (0x5E) and '~' (0x7E) must remain distinct — not collapsed by x|0x20
+    EXPECT_TRUE(less("Foo^Bar", "Foo~Bar") || less("Foo~Bar", "Foo^Bar"));
+    EXPECT_FALSE(less("Foo^Bar", "Foo^Bar")); // irreflexivity
+}
+
+TEST(HTTPFieldLess, MapPreservesOriginalCase)
+{
+    std::map<std::string, int, HTTPFieldLess> m;
+    m["Content-Type"] = 42;
+    // Case-insensitive lookup
+    EXPECT_EQ(m.count("content-type"), 1u);
+    EXPECT_EQ(m.count("CONTENT-TYPE"), 1u);
+    EXPECT_EQ(m.at("content-type"), 42);
+    // Original case is preserved as the stored key
+    EXPECT_EQ(m.begin()->first, "Content-Type");
+}

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7470,7 +7470,7 @@ Traverse frozen data (shadow directory) in addition to actual table data when qu
 If all four arguments to `geoDistance`, `greatCircleDistance`, `greatCircleAngle` functions are Float64, return Float64 and use double precision for internal calculations. In previous ClickHouse versions, the functions always returned Float32.
 )", 0) \
     DECLARE(Bool, allow_get_client_http_header, false, R"(
-Allow to use the function `getClientHTTPHeader` which lets to obtain a value of an the current HTTP request's header. It is not enabled by default for security reasons, because some headers, such as `Cookie`, could contain sensitive info. Note that the `X-ClickHouse-*` and `Authentication` headers are always restricted and cannot be obtained with this function.
+Allow to use the function `getClientHTTPHeader` which lets to obtain a value of the current HTTP request's header. It is not enabled by default for security reasons, because some headers, such as `Cookie`, could contain sensitive info. Note that the `X-ClickHouse-*`, `Authentication` and `Authorization` headers are always restricted and cannot be obtained with this function.
 )", 0) \
     DECLARE(Bool, cast_string_to_dynamic_use_inference, false, R"(
 Use types inference during String to Dynamic conversion

--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -82,14 +82,14 @@ REGISTER_FUNCTION(GetClientHTTPHeader)
     FunctionDocumentation::Description description = R"(
 Gets the value of an HTTP header.
 If there is no such header or the current request is not performed via the HTTP interface, the function returns an empty string.
-Certain HTTP headers (e.g., `Authorization` and `X-ClickHouse-*`) are restricted.
+Certain HTTP headers (e.g., `Authorization`, `Authentication` and `X-ClickHouse-*`) are restricted.
 
 :::note Setting `allow_get_client_http_header` is required
 The function requires the setting `allow_get_client_http_header` to be enabled.
 The setting is not enabled by default for security reasons, because some headers, such as `Cookie`, could contain sensitive info.
 :::
 
-HTTP headers are case-insensitive per RFC 7230.
+HTTP headers are case-insensitive per RFC 9110.
 If the function is used in the context of a distributed query, it returns non-empty result only on the initiator node.
 
 `getClientHTTPHeader` reads the headers of the current request, so it returns a non-empty value only when the query is sent over the HTTP interface.

--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -6,6 +6,7 @@
 #include <Interpreters/Context.h>
 #include <Core/Field.h>
 #include <Core/Settings.h>
+#include <Poco/String.h>
 
 
 namespace DB
@@ -65,7 +66,7 @@ public:
         {
             Field header;
             source->get(row, header);
-            if (auto it = client_info.http_headers.find(header.safeGet<String>()); it != client_info.http_headers.end())
+            if (auto it = client_info.http_headers.find(Poco::toLower(header.safeGet<String>())); it != client_info.http_headers.end())
                 result->insert(it->second);
             else
                 result->insertDefault();
@@ -89,7 +90,7 @@ The function requires the setting `allow_get_client_http_header` to be enabled.
 The setting is not enabled by default for security reasons, because some headers, such as `Cookie`, could contain sensitive info.
 :::
 
-HTTP headers are case sensitive for this function.
+HTTP headers are case-insensitive per RFC 7230.
 If the function is used in the context of a distributed query, it returns non-empty result only on the initiator node.
 
 `getClientHTTPHeader` reads the headers of the current request, so it returns a non-empty value only when the query is sent over the HTTP interface.

--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -6,7 +6,6 @@
 #include <Interpreters/Context.h>
 #include <Core/Field.h>
 #include <Core/Settings.h>
-#include <Poco/String.h>
 
 
 namespace DB
@@ -66,7 +65,7 @@ public:
         {
             Field header;
             source->get(row, header);
-            if (auto it = client_info.http_headers.find(Poco::toLower(header.safeGet<String>())); it != client_info.http_headers.end())
+            if (auto it = client_info.http_headers.find(header.safeGet<String>()); it != client_info.http_headers.end())
                 result->insert(it->second);
             else
                 result->insertDefault();

--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -83,7 +83,7 @@ REGISTER_FUNCTION(GetClientHTTPHeader)
     FunctionDocumentation::Description description = R"(
 Gets the value of an HTTP header.
 If there is no such header or the current request is not performed via the HTTP interface, the function returns an empty string.
-Certain HTTP headers (e.g., `Authentication` and `X-ClickHouse-*`) are restricted.
+Certain HTTP headers (e.g., `Authorization` and `X-ClickHouse-*`) are restricted.
 
 :::note Setting `allow_get_client_http_header` is required
 The function requires the setting `allow_get_client_http_header` to be enabled.

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -496,7 +496,7 @@ void ClientInfo::setFromHTTPRequest(const Poco::Net::HTTPRequest & request)
     {
         /// These headers can contain authentication info and shouldn't be accessible by the user.
         String key_lowercase = Poco::toLower(header.first);
-        if (key_lowercase.starts_with("x-clickhouse") || key_lowercase == "authentication")
+        if (key_lowercase.starts_with("x-clickhouse") || key_lowercase == "authentication" || key_lowercase == "authorization")
             continue;
         http_headers[key_lowercase] = header.second;
     }

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -498,7 +498,7 @@ void ClientInfo::setFromHTTPRequest(const Poco::Net::HTTPRequest & request)
         String key_lowercase = Poco::toLower(header.first);
         if (key_lowercase.starts_with("x-clickhouse") || key_lowercase == "authentication")
             continue;
-        http_headers[header.first] = header.second;
+        http_headers[key_lowercase] = header.second;
     }
 }
 

--- a/src/Interpreters/ClientInfo.cpp
+++ b/src/Interpreters/ClientInfo.cpp
@@ -498,7 +498,7 @@ void ClientInfo::setFromHTTPRequest(const Poco::Net::HTTPRequest & request)
         String key_lowercase = Poco::toLower(header.first);
         if (key_lowercase.starts_with("x-clickhouse") || key_lowercase == "authentication" || key_lowercase == "authorization")
             continue;
-        http_headers[key_lowercase] = header.second;
+        http_headers[header.first] = header.second;
     }
 }
 

--- a/src/Interpreters/ClientInfo.h
+++ b/src/Interpreters/ClientInfo.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <base/types.h>
-#include <Common/OpenTelemetryTracingContext.h>
-
+#include <map>
 #include <time.h>
+#include <base/types.h>
+#include <Common/HTTPFieldLess.h>
+#include <Common/OpenTelemetryTracingContext.h>
 
 namespace Poco::Net
 {
@@ -121,7 +122,7 @@ public:
     HTTPMethod http_method = HTTPMethod::UNKNOWN;
     String http_user_agent;
     String http_referer;
-    std::unordered_map<String, String> http_headers;
+    std::map<String, String, HTTPFieldLess> http_headers;
 
     /// For mysql and postgresql
     UInt64 connection_id = 0;

--- a/tests/queries/0_stateless/03021_get_client_http_header.reference
+++ b/tests/queries/0_stateless/03021_get_client_http_header.reference
@@ -11,6 +11,7 @@ wtf
 -- Some headers cannot be obtained.
 
 
+
 -- The setting matters.
 FUNCTION_NOT_ALLOWED
 -- The setting is not enabled by default.

--- a/tests/queries/0_stateless/03021_get_client_http_header.reference
+++ b/tests/queries/0_stateless/03021_get_client_http_header.reference
@@ -15,9 +15,10 @@ wtf
 FUNCTION_NOT_ALLOWED
 -- The setting is not enabled by default.
 FUNCTION_NOT_ALLOWED
--- Are headers case-sentitive?
+-- Headers are case-insensitive per RFC.
 application/x-www-form-urlencoded
-
+application/x-www-form-urlencoded
+application/x-www-form-urlencoded
 -- Using it from non-HTTP does not make sense.
 
 

--- a/tests/queries/0_stateless/03021_get_client_http_header.sh
+++ b/tests/queries/0_stateless/03021_get_client_http_header.sh
@@ -26,8 +26,8 @@ ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&allow_get_client_http_header=0" -d "SELECT
 echo "-- The setting is not enabled by default."
 ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}" -d "SELECT getClientHTTPHeader(arrayJoin(['Content-Type', 'Accept']))" | grep -o -F 'FUNCTION_NOT_ALLOWED'
 
-echo "-- Are headers case-sentitive?"
-${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&allow_get_client_http_header=1" -d "SELECT getClientHTTPHeader(arrayJoin(['Content-Type', 'content-type']))"
+echo "-- Headers are case-insensitive per RFC."
+${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&allow_get_client_http_header=1" -d "SELECT getClientHTTPHeader(arrayJoin(['Content-Type', 'content-type', 'CONTENT-TYPE']))"
 
 echo "-- Using it from non-HTTP does not make sense."
 ${CLICKHOUSE_CLIENT} --allow_get_client_http_header true --query "SELECT getClientHTTPHeader('Host')"

--- a/tests/queries/0_stateless/03021_get_client_http_header.sh
+++ b/tests/queries/0_stateless/03021_get_client_http_header.sh
@@ -19,6 +19,7 @@ ${CLICKHOUSE_CURL} -H 'Upyachka: wtf' "${CLICKHOUSE_URL}&allow_get_client_http_h
 echo "-- Some headers cannot be obtained."
 ${CLICKHOUSE_CURL} -H 'X-ClickHouse-WTF: Secret' "${CLICKHOUSE_URL}&allow_get_client_http_header=1" -d "SELECT getClientHTTPHeader('X-ClickHouse-WTF')"
 ${CLICKHOUSE_CURL} -H 'Authentication: Secret' "${CLICKHOUSE_URL}&allow_get_client_http_header=1" -d "SELECT getClientHTTPHeader('Authentication')"
+${CLICKHOUSE_CURL} -H 'Authorization: Basic ZGVmYXVsdDo=' "${CLICKHOUSE_URL}&allow_get_client_http_header=1" -d "SELECT getClientHTTPHeader('Authorization')"
 
 echo "-- The setting matters."
 ${CLICKHOUSE_CURL} "${CLICKHOUSE_URL}&allow_get_client_http_header=0" -d "SELECT getClientHTTPHeader(arrayJoin(['Content-Type', 'Accept']))" | grep -o -F 'FUNCTION_NOT_ALLOWED'


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make headers in `getClientHTTPHeader` case-insensitive according to [RFC 9110](https://www.rfc-editor.org/info/rfc9110/#section-5.1). Fixes https://github.com/ClickHouse/ClickHouse/issues/103957 by adding `authorization` to the filtered-out headers.


A follow-up to https://github.com/ClickHouse/ClickHouse/pull/61820 to complete the implementation.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.896` (included in `26.7` and later)
- Backported to: `26.6.2.67`, `26.5.6.39`, `26.4.5.129`, `26.3.17.43`, `25.8.29.19`
<!-- ch-version-info:end -->