### PR TITLE
Fix a query's `max_execution_time` never firing when the timeout watcher was armed for a later deadline

### DIFF
--- a/src/Interpreters/CancellationChecker.cpp
+++ b/src/Interpreters/CancellationChecker.cpp
@@ -170,27 +170,41 @@ void CancellationChecker::workerFunction()
         /// proper timeout for waking up the thread
         if (query_set.empty())
         {
+            armed_deadline = 0;
             cond_var.wait(lock, [&] { return stop_thread || !query_set.empty(); });
         }
         else
         {
             chassert(!query_set.empty());
+            /// `appendTask` may insert a deadline earlier than the one this wait is armed for;
+            /// the wait must be re-armed then, or the notification is swallowed and the new
+            /// deadline fires only when the stale (later) one expires.
+            armed_deadline = query_set.begin()->endtime;
             cond_var.wait_for(
                 lock,
-                std::chrono::milliseconds(query_set.begin()->endtime - now_ms),
+                std::chrono::milliseconds(armed_deadline - now_ms),
                 [&] {
                     /// Use fresh time to avoid spinning when the predicate is re-evaluated after spurious wakeups.
                     UInt64 fresh_now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-                    return stop_thread || (!query_set.empty() && query_set.begin()->endtime <= fresh_now_ms);
+                    return stop_thread
+                        || (!query_set.empty()
+                            && (query_set.begin()->endtime <= fresh_now_ms || query_set.begin()->endtime < armed_deadline));
                 });
         }
     }
+    armed_deadline = 0;
 
     /// `terminateThread` flips `stop_thread` to true to signal exit; clear it here while still
     /// holding the lock so the singleton is left in a re-runnable state. This is mainly relevant
     /// to tests that own the worker thread and may want to spin it up again later; the server
     /// starts the worker exactly once during boot, so for the production code path this is a no-op.
     stop_thread = false;
+}
+
+UInt64 CancellationChecker::getArmedDeadline()
+{
+    std::unique_lock<std::mutex> lock(m);
+    return armed_deadline;
 }
 
 }

--- a/src/Interpreters/CancellationChecker.h
+++ b/src/Interpreters/CancellationChecker.h
@@ -42,6 +42,10 @@ private:
     std::mutex m;
     std::condition_variable cond_var;
 
+    /// The deadline (ms since steady_clock epoch) the worker's wait is currently armed for;
+    /// 0 while the worker is not parked on a deadline. Lets tests synchronize with the wait state.
+    UInt64 armed_deadline = 0;
+
     static void cancelTask(CancellationChecker::QueryToTrack task);
 
     const LoggerPtr log;
@@ -64,5 +68,8 @@ public:
 
     // Worker thread function
     void workerFunction();
+
+    // The deadline the worker is currently sleeping toward, 0 when it is not. For tests.
+    UInt64 getArmedDeadline();
 };
 }

--- a/src/Interpreters/tests/gtest_cancellation_checker.cpp
+++ b/src/Interpreters/tests/gtest_cancellation_checker.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include <base/scope_guard.h>
+
+#include <Core/Settings.h>
+#include <Interpreters/CancellationChecker.h>
+#include <Interpreters/ClientInfo.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
+#include <Parsers/IAST.h>
+#include <QueryPipeline/SizeLimits.h>
+#include <Common/Scheduler/MemoryReservation.h>
+#include <Common/tests/gtest_global_context.h>
+
+using namespace DB;
+
+namespace
+{
+
+QueryStatusPtr makeQueryStatus(const String & query_id)
+{
+    ClientInfo client_info;
+    client_info.current_query_id = query_id;
+    Settings settings;
+    return std::make_shared<QueryStatus>(
+        getContext().context,
+        "SELECT 1",
+        /*normalized_query_hash_*/ 0,
+        client_info,
+        /*priority_handle_*/ QueryPriorities::Handle{},
+        /*query_slot_*/ nullptr,
+        /*memory_reservation_*/ nullptr,
+        /*thread_group_*/ nullptr,
+        IAST::QueryKind::Select,
+        settings,
+        /*watch_start_nanoseconds*/ 0,
+        /*is_internal*/ false);
+}
+
+}
+
+/// The worker arms its wait for the earliest deadline present at wait entry. A deadline appended
+/// later that is earlier than the armed one must re-arm the wait; before the fix the notification
+/// was swallowed by the wake-up predicate and the new deadline fired only when the stale one expired.
+TEST(CancellationChecker, RearmsWaitOnEarlierDeadline)
+{
+    auto & checker = CancellationChecker::getInstance();
+
+    auto long_query = makeQueryStatus("gtest_cancellation_checker_long");
+    auto short_query = makeQueryStatus("gtest_cancellation_checker_short");
+
+    std::thread worker([&] { checker.workerFunction(); });
+    /// Runs on every exit path (including early ASSERT returns, which would otherwise destroy a
+    /// joinable thread and terminate); also drains leftover tasks from the singleton.
+    SCOPE_EXIT({
+        checker.appendDoneTasks(long_query);
+        checker.appendDoneTasks(short_query);
+        checker.terminateThread();
+        worker.join();
+    });
+
+    /// Arm the worker's wait toward a deadline 10 minutes away and wait until the worker has
+    /// actually parked on it, so the buggy interleaving is reproduced deterministically.
+    ASSERT_TRUE(checker.appendTask(long_query, /*timeout=*/600'000, OverflowMode::THROW));
+    for (int i = 0; i < 2000 && checker.getArmedDeadline() == 0; ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    ASSERT_NE(checker.getArmedDeadline(), 0u);
+
+    /// The long query finishes; removal intentionally does not notify the worker, so the stale
+    /// 10-minute arm stays in place.
+    checker.appendDoneTasks(long_query);
+
+    /// A short deadline appended while the worker is armed for the (already removed) long one.
+    ASSERT_TRUE(checker.appendTask(short_query, /*timeout=*/100, OverflowMode::THROW));
+
+    /// 100 ms deadline + 100 ms cancellation grid; poll with a generous bound for sanitizer builds.
+    bool killed = false;
+    for (int i = 0; i < 200 && !killed; ++i)
+    {
+        killed = short_query->isKilled();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    EXPECT_TRUE(killed);
+    EXPECT_FALSE(long_query->isKilled());
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix `max_execution_time` (with `timeout_overflow_mode = 'throw'`) sometimes never cancelling a query: when the internal timeout watcher was already waiting for a query with a later deadline, a query with an earlier deadline registered afterwards could be missed entirely, letting it run long past its time limit.

Closes: https://github.com/ClickHouse/ClickHouse/issues/109767

**Problem**

A throw-mode `max_execution_time` can be missed entirely when another tracked query with a later deadline armed the timeout watcher first. The affected query then runs to completion with `is_cancelled: 0` and no `TIMEOUT_EXCEEDED`. Observed on PR #108357's `amd_tsan` flaky check: an environment-preparation query with `max_execution_time = 1800` armed the watcher; five 8-second deadlines registered afterwards were slept through, and the INSERTs ran 871-880 s to completion — the server log contains zero `Cancelling the task because of the timeout` lines for the whole run. Reproduced locally: an `INSERT` into a `ZSTD(22)` table with `max_execution_time = 2` is cancelled at ~2.1 s when alone, but never cancelled after first registering a query with `max_execution_time = 600`.

**Root cause**

`CancellationChecker::workerFunction` arms `cond_var.wait_for` with the duration to the earliest `endtime` in `query_set` at wait entry. `appendTask` notifies when a new task becomes the earliest, but the wake-up predicate only accepted "the earliest task has already expired" (`query_set.begin()->endtime <= fresh_now_ms`). For an earlier-but-not-yet-due deadline the predicate is false, so `wait_for` swallows the notification and resumes sleeping toward the original later deadline — which may belong to a task already removed by `appendDoneTasks` (removal deliberately never notifies).

**Fix**

Record the deadline the wait is armed for (`armed_deadline`, maintained under the existing mutex) and extend the predicate: also wake when `query_set.begin()->endtime < armed_deadline`. The worker loop then recomputes the wait with the correct, earlier deadline. No locking changes. A read-only `getArmedDeadline` accessor lets the new regression test `CancellationChecker.RearmsWaitOnEarlierDeadline` (`src/Interpreters/tests/gtest_cancellation_checker.cpp`) synchronize with the worker deterministically: it fails in ~10 s on the unfixed predicate and passes in ~250 ms with the fix (verified both ways locally, 10/10 stable).

Related: https://github.com/ClickHouse/ClickHouse/pull/108357

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.890` (included in `26.7` and later)
<!-- ch-version-info:end -->