### PR TITLE
Add regression test for clear error on UPDATE of non-existent column

### DIFF
--- a/tests/queries/0_stateless/04401_update_nonexistent_column_error.sql
+++ b/tests/queries/0_stateless/04401_update_nonexistent_column_error.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS mt_04401;
+CREATE TABLE mt_04401 (d Date) ENGINE = MergeTree ORDER BY tuple();
+
+-- Updating a column that does not exist must report a clear NO_SUCH_COLUMN_IN_TABLE,
+-- not the confusing "Column is updated but not requested to read" it regressed to.
+ALTER TABLE mt_04401 UPDATE n = 2 WHERE 1; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+SET mutations_sync = 1;
+ALTER TABLE mt_04401 UPDATE n = 2 WHERE 1; -- { serverError NO_SUCH_COLUMN_IN_TABLE }
+
+DROP TABLE mt_04401;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/51146
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: #51146

Issue #51146 reported that `ALTER TABLE ... UPDATE` of a non-existent column regressed in 23.5 from the clear `NO_SUCH_COLUMN_IN_TABLE` (`There is no column n in table`) to the confusing `THERE_IS_NO_COLUMN` (`Column n is updated but not requested to read`), which looked like a logical error.

On current master (26.6) the clear `NO_SUCH_COLUMN_IN_TABLE` message is already restored. `MutationsInterpreter::validateUpdateColumns` throws `NO_SUCH_COLUMN_IN_TABLE` for an unknown updated column, and the old `THERE_IS_NO_COLUMN` text is no longer present in the mutation path. Verified locally on both the async (`mutations_sync=0`) and synchronous (`mutations_sync=1`) paths, plus `apply_mutations_on_fly=1`.

Since the fix was never pinned by a test, this PR adds a stateless regression test so the behavior cannot silently regress again. No source change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.687` (included in `26.7` and later)
<!-- ch-version-info:end -->