### PR TITLE
docs: redirect the legacy /en/* locale prefix to /*

### DIFF
--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -1716,8 +1716,8 @@
     "destination": "/concepts/features/dictionaries/best-practices"
   },
   {
-    "source": "/docs/en/cloud/manage/service-types",
-    "destination": "/products/cloud/features/cloud-tiers"
+    "source": "/en/:path*",
+    "destination": "/:path*"
   },
   {
     "source": "/engines",

--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -1,7 +1,7 @@
 [
   {
-    "source": "/docs/en/:path*",
-    "destination": "/docs/:path*"
+    "source": "/en/:path*",
+    "destination": "/:path*"
   },
   {
     "source": "/about",

--- a/docs/_site/redirects.json
+++ b/docs/_site/redirects.json
@@ -1,5 +1,9 @@
 [
   {
+    "source": "/docs/en/:path*",
+    "destination": "/docs/:path*"
+  },
+  {
     "source": "/about",
     "destination": "/resources/about"
   },
@@ -1714,10 +1718,6 @@
   {
     "source": "/dictionary/best-practices",
     "destination": "/concepts/features/dictionaries/best-practices"
-  },
-  {
-    "source": "/en/:path*",
-    "destination": "/:path*"
   },
   {
     "source": "/engines",


### PR DESCRIPTION
The docs are served under `clickhouse.com/docs/` with English at the root, but the legacy Docusaurus site exposed English under an `/en/` locale prefix. Links such as `/docs/en/cloud-quick-start`, `/docs/en/integrations/`, and `/docs/en/manage/security/` are still in the wild and currently 404.

This adds a wildcard redirect `{"source": "/en/:path*", "destination": "/:path*"}` in `docs/_site/redirects.json` that strips the `/en/` prefix; the resulting path is then served directly or follows the existing redirect chain (Mintlify follows redirect chains, which the config already relies on — 22 destinations are themselves redirect sources). It mirrors the existing `/jp/:path* -> /ja/:path*` locale rule.

Verified resolutions:

| Legacy URL | resolves to |
|---|---|
| `/docs/en/cloud-quick-start` | `/get-started/setup/cloud` |
| `/docs/en/integrations/` | `/integrations/home` |
| `/docs/en/manage/security/` | `/concepts/features/security/configuring-ldap` |

Also drops the dead `/docs/en/cloud/manage/service-types` entry: redirect sources are relative to the `/docs` base, so its doubled `/docs` prefix meant it never fired. That real URL is now handled by the new wildcard, chaining through the existing `/cloud/manage/service-types` redirect to `/products/cloud/features/cloud-tiers`.

The `lychee --mode redirects` check skips destinations containing `:` (wildcards) and `en` is not a locale-subdir prefix, so the docs CI is unaffected.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.679` (included in `26.7` and later)
<!-- ch-version-info:end -->