### PR TITLE
Bound each system-table dump with a timeout in Collect logs

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1305,6 +1305,19 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             result.set_label(Result.Label.LOG_CHECK)
         return results
 
+    # Exit codes coreutils `timeout` uses on expiry: 124 when the child dies on
+    # the initial SIGTERM, 128+9 = 137 when a SIGTERM-ignoring child is escalated
+    # with SIGKILL after --kill-after. Both mean the dump exceeded its cap.
+    _TIMEOUT_EXIT_CODES = (124, 137)
+
+    def _annotate_timeout(self, res, stderr):
+        # If `res` is one of timeout's expiry codes, prepend the "timed out"
+        # annotation so a stuck dump is reported as a timeout rather than an
+        # opaque non-zero failure. Returns the (possibly) annotated stderr.
+        if res in self._TIMEOUT_EXIT_CODES:
+            return f"timed out after {self.DUMP_SYSTEM_TABLE_TIMEOUT}s\n{stderr}"
+        return stderr
+
     def dump_system_tables(self):
         # Stop server so we can safely read data with clickhouse-local.
         # Why do we read data with clickhouse-local?
@@ -1355,8 +1368,10 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         command_args_post = "-- --zookeeper.implementation=testkeeper"
 
         # Bound each dump: a single hanging table (e.g. a huge minio_audit_logs
-        # on s3 runs) must not consume the whole 9000s job budget. timeout
-        # returns 124 on expiry, handled by the res != 0 branch below.
+        # on s3 runs) must not consume the whole 9000s job budget. On expiry
+        # timeout sends SIGTERM and returns 124; a dump that ignores SIGTERM is
+        # escalated with SIGKILL after --kill-after and returns 128+9 = 137.
+        # Both are timeouts, annotated by _annotate_timeout below.
         dump_prefix = f"timeout --signal=TERM --kill-after=60 {self.DUMP_SYSTEM_TABLE_TIMEOUT} "
 
         Utils.clean_dir(p_temp_dir / "system_tables")
@@ -1382,10 +1397,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 verbose=True,
             )
             if res != 0:
-                if res == 124:
-                    stderr = (
-                        f"timed out after {self.DUMP_SYSTEM_TABLE_TIMEOUT}s\n{stderr}"
-                    )
+                stderr = self._annotate_timeout(res, stderr)
                 print(f"ERROR: Failed to dump system table: {table}\nError: {stderr}")
                 scraping_system_table.set_info(
                     f"Failed to dump system table: {table}\nError: {stderr}"
@@ -1412,6 +1424,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     verbose=True,
                 )
                 if res != 0:
+                    stderr = self._annotate_timeout(res, stderr)
                     print(
                         f"ERROR: Failed to dump system table from replica 1: {table}\nError: {stderr}"
                     )
@@ -1438,6 +1451,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     verbose=True,
                 )
                 if res != 0:
+                    stderr = self._annotate_timeout(res, stderr)
                     print(
                         f"ERROR: Failed to dump system table from replica 2: {table}\nError: {stderr}"
                     )

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -51,6 +51,9 @@ class ClickHouseProc:
     WD2 = f"{temp_dir}/ft_wd2"
     CH_LOCAL_LOG = f"{temp_dir}/clickhouse-local.log"
     CH_LOCAL_ERR_LOG = f"{temp_dir}/clickhouse-local.err.log"
+    # Per-table wall-clock cap for dump_system_tables (seconds). One stuck dump
+    # must not exhaust the job's 9000s budget and get the whole job SIGKILLed.
+    DUMP_SYSTEM_TABLE_TIMEOUT = 600
 
     def __init__(
         self,
@@ -1351,6 +1354,11 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         #
         command_args_post = "-- --zookeeper.implementation=testkeeper"
 
+        # Bound each dump: a single hanging table (e.g. a huge minio_audit_logs
+        # on s3 runs) must not consume the whole 9000s job budget. timeout
+        # returns 124 on expiry, handled by the res != 0 branch below.
+        dump_prefix = f"timeout --signal=TERM --kill-after=60 {self.DUMP_SYSTEM_TABLE_TIMEOUT} "
+
         Utils.clean_dir(p_temp_dir / "system_tables")
         res = True
 
@@ -1370,10 +1378,14 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         for table in TABLES:
             path_arg = f" --path {self.run_path0}"
             res, stdout, stderr = Shell.get_res_stdout_stderr(
-                f"cd {self.run_path0} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                f"cd {self.run_path0} && {dump_prefix}clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                 verbose=True,
             )
             if res != 0:
+                if res == 124:
+                    stderr = (
+                        f"timed out after {self.DUMP_SYSTEM_TABLE_TIMEOUT}s\n{stderr}"
+                    )
                 print(f"ERROR: Failed to dump system table: {table}\nError: {stderr}")
                 scraping_system_table.set_info(
                     f"Failed to dump system table: {table}\nError: {stderr}"
@@ -1396,7 +1408,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             if self.is_shared_catalog or self.is_db_replicated:
                 path_arg = f" --path {self.run_path1}"
                 res, stdout, stderr = Shell.get_res_stdout_stderr(
-                    f"cd {self.run_path1} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.1.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                    f"cd {self.run_path1} && {dump_prefix}clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.1.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                     verbose=True,
                 )
                 if res != 0:
@@ -1422,7 +1434,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             if self.is_db_replicated:
                 path_arg = f" --path {self.run_path2}"
                 res, stdout, stderr = Shell.get_res_stdout_stderr(
-                    f"cd {self.run_path2} && clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.2.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
+                    f"cd {self.run_path2} && {dump_prefix}clickhouse local {command_args} {path_arg} --query \"select * from system.{table} into outfile '{temp_dir}/system_tables/{table}.2.tsv' format TSVWithNamesAndTypes\" {command_args_post}",
                     verbose=True,
                 )
                 if res != 0:

--- a/ci/tests/test_dump_system_tables_timeout.py
+++ b/ci/tests/test_dump_system_tables_timeout.py
@@ -18,9 +18,10 @@ stuck table is bounded and reported as a failed dump instead of killing the job.
 
 These tests exercise the `timeout` wrapper mechanism (the same coreutil and
 flags the fix builds into `dump_prefix`), proving both directions with a small
-cap: a hanging command is killed within the cap and returns 124; a fast command
+cap: a hanging command is killed within the cap and returns 124; a SIGTERM-
+ignoring command is escalated after --kill-after and returns 137; a fast command
 passes through untouched. They also assert the production code still builds the
-timeout prefix from the class constant.
+timeout prefix from the class constant and classifies both expiry codes.
 """
 
 import subprocess
@@ -31,9 +32,11 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _SRC = _REPO_ROOT / "ci" / "jobs" / "scripts" / "clickhouse_proc.py"
 
 
-def _prefix(timeout_s):
-    # Mirror the exact prefix the fix builds in dump_system_tables.
-    return f"timeout --signal=TERM --kill-after=60 {timeout_s} "
+def _prefix(timeout_s, kill_after_s=60):
+    # Mirror the exact prefix the fix builds in dump_system_tables. The
+    # production code uses --kill-after=60; tests that need to observe the
+    # escalation path pass a small kill_after_s so the test does not wait 60s.
+    return f"timeout --signal=TERM --kill-after={kill_after_s} {timeout_s} "
 
 
 def test_hanging_dump_is_bounded_by_timeout():
@@ -76,6 +79,34 @@ def test_without_timeout_the_dump_runs_unbounded():
     )
 
 
+def test_term_ignoring_dump_is_killed_and_reports_137():
+    # Worst case: a dump that ignores SIGTERM (e.g. a child stuck in an
+    # uninterruptible section, or one that traps TERM). timeout escalates to
+    # SIGKILL after --kill-after and the wrapper exits 128+9 = 137, NOT 124.
+    # The fix must still classify this as a timeout, so 137 is asserted here and
+    # in _annotate_timeout's exit-code set (see the guard test below).
+    cap = 1
+    start = time.monotonic()
+    # Run through the default shell and in the `cd ... && timeout ...` shape used
+    # by dump_system_tables (via Shell.get_res_stdout_stderr), so the wrapping
+    # shell survives and surfaces timeout's 137 exit code (the exit code the
+    # production code inspects), not the raw SIGKILL.
+    res = subprocess.run(
+        "cd . && " + _prefix(cap, kill_after_s=1) + 'sh -c \'trap "" TERM; sleep 30\'',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    elapsed = time.monotonic() - start
+    assert res.returncode == 137, (
+        f"expected escalation exit 137, got {res.returncode}; the TERM-ignoring "
+        "dump was not killed via --kill-after"
+    )
+    assert elapsed < 15, (
+        f"command took {elapsed:.1f}s (>= 15s); --kill-after did not enforce the cap"
+    )
+
+
 def test_fast_dump_passes_through_untouched():
     # A dump that finishes well within the cap must succeed unchanged.
     res = subprocess.run(
@@ -97,5 +128,8 @@ def test_production_code_bounds_each_dump_with_timeout():
     assert "DUMP_SYSTEM_TABLE_TIMEOUT" in src
     assert "timeout --signal=TERM --kill-after=60" in src
     assert "{dump_prefix}clickhouse local" in src
-    # 124 is the exit code coreutils `timeout` returns on expiry.
-    assert "res == 124" in src
+    # Both timeout expiry codes must be classified: 124 (child died on SIGTERM)
+    # and 137 (SIGTERM-ignoring child escalated to SIGKILL via --kill-after).
+    assert "_TIMEOUT_EXIT_CODES = (124, 137)" in src
+    # The annotation helper must be applied to every dump branch (replica 0/1/2).
+    assert src.count("self._annotate_timeout(res, stderr)") == 3

--- a/ci/tests/test_dump_system_tables_timeout.py
+++ b/ci/tests/test_dump_system_tables_timeout.py
@@ -1,0 +1,101 @@
+"""
+Regression test for the per-table wall-clock cap in
+ClickHouseProc.dump_system_tables (ci/jobs/scripts/clickhouse_proc.py).
+
+Background
+----------
+After all functional tests pass, the job's "Collect logs" phase dumps ~12
+system tables one by one with `clickhouse local ... select * from system.<t>
+into outfile ...`. On amd_tsan + s3 runs the JSON-typed `system.minio_audit_logs`
+table can grow huge and `clickhouse local` can hang reading it. Because the dump
+command had NO per-command timeout, a single stuck table consumed the rest of
+the 9000s job budget; the job watchdog then SIGKILLed everything and the job
+finished with a job-level ERROR (exit code 125 / -15) and results:[] - no
+individual test failed. Observed on PRs #107307, #103402, #103706 and on master.
+
+The fix wraps each dump in `timeout --signal=TERM --kill-after=60 <N>` so one
+stuck table is bounded and reported as a failed dump instead of killing the job.
+
+These tests exercise the `timeout` wrapper mechanism (the same coreutil and
+flags the fix builds into `dump_prefix`), proving both directions with a small
+cap: a hanging command is killed within the cap and returns 124; a fast command
+passes through untouched. They also assert the production code still builds the
+timeout prefix from the class constant.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SRC = _REPO_ROOT / "ci" / "jobs" / "scripts" / "clickhouse_proc.py"
+
+
+def _prefix(timeout_s):
+    # Mirror the exact prefix the fix builds in dump_system_tables.
+    return f"timeout --signal=TERM --kill-after=60 {timeout_s} "
+
+
+def test_hanging_dump_is_bounded_by_timeout():
+    # A dump that would hang forever must be killed within the cap and report
+    # timeout's exit code 124 - not run unbounded until the job watchdog fires.
+    cap = 2
+    start = time.monotonic()
+    res = subprocess.run(
+        _prefix(cap) + "sleep 30",
+        shell=True,
+        executable="/bin/bash",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    elapsed = time.monotonic() - start
+    assert res.returncode == 124, (
+        f"expected timeout exit 124, got {res.returncode}; the dump was not bounded"
+    )
+    assert elapsed < 15, (
+        f"command took {elapsed:.1f}s (>= 15s); timeout did not enforce the {cap}s cap"
+    )
+
+
+def test_without_timeout_the_dump_runs_unbounded():
+    # Demonstrate the pre-fix behavior: without the timeout prefix the same
+    # hanging command runs to completion (here a short sleep stands in for a
+    # dump that would hang for the rest of the 9000s budget).
+    start = time.monotonic()
+    res = subprocess.run(
+        "sleep 3",
+        shell=True,
+        executable="/bin/bash",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    elapsed = time.monotonic() - start
+    assert res.returncode == 0
+    assert elapsed >= 3, (
+        f"sleep returned after {elapsed:.1f}s; expected it to run unbounded (>= 3s)"
+    )
+
+
+def test_fast_dump_passes_through_untouched():
+    # A dump that finishes well within the cap must succeed unchanged.
+    res = subprocess.run(
+        _prefix(60) + "echo ok",
+        shell=True,
+        executable="/bin/bash",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert res.returncode == 0
+    assert res.stdout.strip() == "ok"
+
+
+def test_production_code_bounds_each_dump_with_timeout():
+    # Guard against a regression that drops the timeout wrapper: the source must
+    # build the timeout prefix from the class constant and apply it to the dump.
+    src = _SRC.read_text()
+    assert "DUMP_SYSTEM_TABLE_TIMEOUT" in src
+    assert "timeout --signal=TERM --kill-after=60" in src
+    assert "{dump_prefix}clickhouse local" in src
+    # 124 is the exit code coreutils `timeout` returns on expiry.
+    assert "res == 124" in src


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

The "Collect logs" phase of stateless jobs dumps ~12 system tables one by one with `clickhouse local ... select * from system.<table> into outfile ...`. On amd_tsan + s3 runs the JSON-typed `system.minio_audit_logs` table can grow very large and `clickhouse local` can hang reading it. The dump command had no per-command timeout, so a single stuck table consumed the rest of the job's 9000s budget. The job watchdog then SIGKILLed everything and the job finished with a job-level ERROR (exit code 125 / -15) and `results: []` - no individual test failed.

This is the "genuine 9000s timeout" variant of `Stateless tests (amd_tsan, s3 storage, parallel, 2/2)` failures (distinct from the praktika watchdog exit-125 hang fixed by #109096). Signature in all three sampled failures: all tests pass (~6000s), then `dump_system_tables` dumps 10 tables fine and hangs on the 11th (`minio_audit_logs`) until the 9000s watchdog fires.

Sample failures (all end with the timeout firing during the `minio_audit_logs` dump):
- PR #107307 @ 2817cfac: https://s3.amazonaws.com/clickhouse-test-reports/PRs/107307/2817cfac2ebe798bb14a65fd758886c7048be8c5/stateless_tests_amd_tsan_s3_storage_parallel_2_2/job.log
- PR #103402 @ 7e54f8cb, PR #103706 @ 24412db1 (same signature).
- Also seen on master. This job errors at ~2.5% on master (11/436 runs in 14 days).

Fix: wrap each dump in coreutils `timeout --signal=TERM --kill-after=60 600` so one stuck table is bounded and reported as a failed dump (info on the "Scraping system tables" result) instead of exhausting the whole job budget. `timeout` returns 124 on expiry, handled by the existing `res != 0` branch with a clear "timed out after Ns" message. Applied to all three replica dump call sites.

Added `ci/tests/test_dump_system_tables_timeout.py` covering both directions of the timeout wrapper and guarding that the production code keeps building the timeout prefix.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.762` (included in `26.7` and later)
<!-- ch-version-info:end -->