### PR TITLE
Docs: fix homepage navbar collapsing to the left

### DIFF
--- a/docs/_site/customizations/tab-nav.js
+++ b/docs/_site/customizations/tab-nav.js
@@ -117,12 +117,19 @@
   var TOGGLE_ID = 'ch-homepage-toggle';
 
   function findSidebarThemeToggle() {
+    // Current Mintlify builds render a segmented control: a
+    //   <div role="group" aria-label="Theme preference">
+    // wrapping three buttons (system / light / dark). We relocate the whole
+    // group so all three options move together.
+    var group = document.querySelector('#sidebar [role="group"][aria-label="Theme preference"]');
+    if (group) return group;
+    // Older builds rendered a single <button aria-label="Toggle dark mode">.
     var btn = document.querySelector('#sidebar button[aria-label="Toggle dark mode"]');
     if (btn) return btn;
     // Localized UIs translate the aria-label (e.g. "다크 모드 전환"), so fall
-    // back to the toggle's shape: the only sidebar pill button holding the
-    // sun + moon icons.
-    var candidates = document.querySelectorAll('#sidebar button');
+    // back to the control's shape: the only sidebar pill (rounded-full) holding
+    // the theme icons — matches both the segmented group and the legacy button.
+    var candidates = document.querySelectorAll('#sidebar [role="group"], #sidebar button');
     for (var i = 0; i < candidates.length; i++) {
       if (/rounded-full/.test(candidates[i].className)
           && candidates[i].querySelectorAll('svg').length >= 2) {
@@ -141,9 +148,11 @@
       // Restore theme toggle to sidebar before removing wrapper
       var toggleWrapper = document.getElementById(TOGGLE_ID);
       if (toggleWrapper) {
-        var btn = toggleWrapper.querySelector('button');
+        // Move the whole control back — it may be a segmented group (a div with
+        // several buttons), not a single button, so restore firstElementChild.
+        var control = toggleWrapper.firstElementChild;
         var sidebar = document.getElementById('sidebar');
-        if (btn && sidebar) sidebar.appendChild(btn);
+        if (control && sidebar) sidebar.appendChild(control);
         toggleWrapper.parentNode.removeChild(toggleWrapper);
       }
       var logo = document.getElementById(LOGO_ID);


### PR DESCRIPTION
Mintlify replaced the sidebar theme control: the single `button[aria-label="Toggle dark mode"]` is now a segmented `div[role="group"][aria-label="Theme preference"]` wrapping three buttons (system / light / dark), with `rounded-full` on the wrapping `div` and one `svg` per button.

The homepage navbar (`#navbar-transition-maple`) uses `justify-content: flex-start`, so its "space between" layout depends on `tab-nav.js` relocating that control into the navbar with a `margin-right: auto` spacer. `findSidebarThemeToggle` matched neither the new markup (aria-label changed, and the shape fallback looked for a `button` with two icons) nor produced the spacer, so the logo, tabs and CTA all collapsed against the left edge and the theme switcher went missing from the navbar.

Detect the new `[role="group"]` control first (keeping the legacy `button` selector as a fallback), broaden the shape fallback to match the segmented group for localized UIs, and restore the whole control (`firstElementChild`) to the sidebar when navigating away from the homepage instead of tearing a single `button` out of the group.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.688` (included in `26.7` and later)
<!-- ch-version-info:end -->