### PR TITLE
Make RemoteQueryExecutor only send a session's current roles

### DIFF
--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -32,8 +32,6 @@
 #include <Columns/ColumnBLOB.h>
 
 #include <Access/AccessControl.h>
-#include <Access/User.h>
-#include <Access/Role.h>
 
 namespace ProfileEvents
 {
@@ -462,23 +460,18 @@ void RemoteQueryExecutor::sendQueryUnlocked(ClientInfo::QueryKind query_kind, As
     if (extension)
         modified_client_info.collaborate_with_initiator = true;
 
-    // Collect all roles granted on this node and pass those to the remote node
+    // Send the currently active roles (from SET ROLE) to the remote node, so that
+    // row policies on the shard are applied for the correct role set — not all granted roles.
     Strings local_granted_roles;
     if (context->getSettingsRef()[Setting::push_external_roles_in_interserver_queries])
     {
-        auto user = context->getAccessControl().read<User>(modified_client_info.initial_user, false);
-        boost::container::flat_set<String> granted_roles;
-        if (user)
+        const auto & access_control = context->getAccessControl();
+        for (const auto & role_id : context->getCurrentRoles())
         {
-            const auto & access_control = context->getAccessControl();
-            for (const auto & e : user->granted_roles.getElements())
-            {
-                // `tryReadNames` instead of `readNames` because the original user might have a dropped role.
-                auto names = access_control.tryReadNames(e.ids);
-                granted_roles.insert(names.begin(), names.end());
-            }
+            auto name = access_control.tryReadName(role_id);
+            if (name)
+                local_granted_roles.push_back(*name);
         }
-        local_granted_roles.insert(local_granted_roles.end(), granted_roles.begin(), granted_roles.end());
     }
 
     if (distributed_fanout > 0)

--- a/tests/queries/0_stateless/04508_distributed_set_role_row_policy.reference
+++ b/tests/queries/0_stateless/04508_distributed_set_role_row_policy.reference
@@ -1,0 +1,17 @@
+--- SET ROLE role_a on local table: expect workspace_id=1 only ---
+1	ws1_row1
+1	ws1_row2
+--- SET ROLE role_b on local table: expect workspace_id=2 only ---
+2	ws2_row1
+2	ws2_row2
+--- SET ROLE role_a on distributed table: expect workspace_id=1 only ---
+1	ws1_row1
+1	ws1_row2
+--- SET ROLE role_b on distributed table: expect workspace_id=2 only ---
+2	ws2_row1
+2	ws2_row2
+--- Both roles on distributed table: expect all rows ---
+1	ws1_row1
+1	ws1_row2
+2	ws2_row1
+2	ws2_row2

--- a/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
+++ b/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
@@ -25,6 +25,14 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #
 # test_cluster_interserver_secret has two shards over loopback pointing at the
 # same node, so a Distributed read returns each row twice; use DISTINCT.
+#
+# The distributed reads pin serialize_query_plan=0 so the test always exercises
+# the RemoteQueryExecutor path this change fixes. With serialize_query_plan=1
+# (the "distributed plan" test variant) the shard subquery applies no row policy
+# at all -- a separate, pre-existing bypass of row policies through Distributed
+# tables that is unrelated to role propagation and that adding a policy on the
+# Distributed table does not fix.
+# See https://github.com/ClickHouse/ClickHouse/issues/112891
 
 USER="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 ROLE_A="role_a_${CLICKHOUSE_TEST_UNIQUE_NAME}"
@@ -66,13 +74,13 @@ echo "--- SET ROLE role_b on local table: expect workspace_id=2 only ---"
 ${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_B}; SELECT workspace_id, data FROM ${LOCAL_TABLE} ORDER BY workspace_id, data"
 
 echo "--- SET ROLE role_a on distributed table: expect workspace_id=1 only ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0, serialize_query_plan = 0"
 
 echo "--- SET ROLE role_b on distributed table: expect workspace_id=2 only ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0, serialize_query_plan = 0"
 
 echo "--- Both roles on distributed table: expect all rows ---"
-${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}, ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}, ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0, serialize_query_plan = 0"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${DIST_TABLE}"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${LOCAL_TABLE}"

--- a/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
+++ b/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Tags: distributed
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Verify that SET ROLE is respected when querying Distributed tables.
+# Previously, RemoteQueryExecutor sent all granted roles to shards instead of
+# just the currently active roles, causing permissive row policies from all
+# roles to be OR'd together and effectively returning all rows.
+#
+# Three conditions are required to exercise the remote-shard code path where the
+# bug lives; without them the query is served in-process and the bug is hidden:
+#   1. A cluster with an inter-server <secret> (test_cluster_interserver_secret),
+#      so the shard subquery runs as the initial_user and the pushed roles apply.
+#   2. prefer_localhost_replica=0, so the query goes through RemoteQueryExecutor
+#      instead of the in-process localhost shortcut (which keeps SET ROLE).
+#   3. A user with DEFAULT ROLE NONE, so the shard's effective roles come from the
+#      pushed roles rather than from the user's default roles (the shard unions
+#      default_roles with the pushed external_roles).
+#
+# test_cluster_interserver_secret has two shards over loopback pointing at the
+# same node, so a Distributed read returns each row twice; use DISTINCT.
+
+USER="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+ROLE_A="role_a_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+ROLE_B="role_b_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+LOCAL_TABLE="local_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+DIST_TABLE="dist_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+POLICY_A="policy_a_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+POLICY_B="policy_b_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${DIST_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROW POLICY IF EXISTS ${POLICY_A} ON ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROW POLICY IF EXISTS ${POLICY_B} ON ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE IF EXISTS ${ROLE_A}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE IF EXISTS ${ROLE_B}"
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${USER}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${LOCAL_TABLE} (workspace_id UInt32, data String) ENGINE = MergeTree ORDER BY workspace_id"
+${CLICKHOUSE_CLIENT} -q "CREATE TABLE ${DIST_TABLE} AS ${LOCAL_TABLE} ENGINE = Distributed(test_cluster_interserver_secret, currentDatabase(), '${LOCAL_TABLE}')"
+
+${CLICKHOUSE_CLIENT} -q "INSERT INTO ${LOCAL_TABLE} VALUES (1, 'ws1_row1'), (1, 'ws1_row2'), (2, 'ws2_row1'), (2, 'ws2_row2')"
+
+${CLICKHOUSE_CLIENT} -q "CREATE ROLE ${ROLE_A}"
+${CLICKHOUSE_CLIENT} -q "CREATE ROLE ${ROLE_B}"
+# DEFAULT ROLE NONE: roles are only granted, activated per query via SET ROLE.
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${USER} DEFAULT ROLE NONE"
+${CLICKHOUSE_CLIENT} -q "GRANT ${ROLE_A}, ${ROLE_B} TO ${USER}"
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT ON ${CLICKHOUSE_DATABASE}.${LOCAL_TABLE} TO ${ROLE_A}, ${ROLE_B}"
+${CLICKHOUSE_CLIENT} -q "GRANT SELECT ON ${CLICKHOUSE_DATABASE}.${DIST_TABLE} TO ${ROLE_A}, ${ROLE_B}"
+${CLICKHOUSE_CLIENT} -q "GRANT REMOTE ON *.* TO ${USER}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE ROW POLICY ${POLICY_A} ON ${LOCAL_TABLE} USING workspace_id = 1 AS PERMISSIVE TO ${ROLE_A}"
+${CLICKHOUSE_CLIENT} -q "CREATE ROW POLICY ${POLICY_B} ON ${LOCAL_TABLE} USING workspace_id = 2 AS PERMISSIVE TO ${ROLE_B}"
+
+echo "--- SET ROLE role_a on local table: expect workspace_id=1 only ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}; SELECT workspace_id, data FROM ${LOCAL_TABLE} ORDER BY workspace_id, data"
+
+echo "--- SET ROLE role_b on local table: expect workspace_id=2 only ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_B}; SELECT workspace_id, data FROM ${LOCAL_TABLE} ORDER BY workspace_id, data"
+
+echo "--- SET ROLE role_a on distributed table: expect workspace_id=1 only ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+
+echo "--- SET ROLE role_b on distributed table: expect workspace_id=2 only ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+
+echo "--- Both roles on distributed table: expect all rows ---"
+${CLICKHOUSE_CLIENT} --user "${USER}" -q "SET ROLE ${ROLE_A}, ${ROLE_B}; SELECT DISTINCT workspace_id, data FROM ${DIST_TABLE} ORDER BY workspace_id, data SETTINGS prefer_localhost_replica = 0"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${DIST_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROW POLICY ${POLICY_A} ON ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROW POLICY ${POLICY_B} ON ${LOCAL_TABLE}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE ${ROLE_A}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE ${ROLE_B}"
+${CLICKHOUSE_CLIENT} -q "DROP USER ${USER}"

--- a/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
+++ b/tests/queries/0_stateless/04508_distributed_set_role_row_policy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: distributed
+# Tags: no-fasttest, distributed
+# no-fasttest: this test requires that nodes make authenticated connections
+# between each other, but shared secret auth requires encodeSHA256, which is not
+# available in the fast test build.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Update `RemoteQueryExecutor` to only send a session's current roles, instead of all granted roles, down to ClickHouse shard nodes, thus fixing a bug where row policies on shards were not matching policies activated on the initiating node via `SET ROLE`.

This issue especially affects applications where two things are true:

1. multiple roles have been assigned to a single ClickHouse user, each with distinct (non-overlapping) row policies, and SET ROLE is used within the application to change between these roles at query time, e.g. to effect multi-tenant isolation while using a shared connection pool, and
2. roles within this user are used to query a distributed table

Key changes:

* RemoteQueryExecutor: send only the session's current roles, not all granted roles, down to other nodes.
* Add test 04508 to test the bug.

Notes:

* Once the query reaches a shard, `Context::getCurrentRoles` union together both all `external_roles` (sent by `RemoteQueryExecutor`) and the user's default roles. Thus both in the test and for any application using SET ROLE, we ensure the connecting user has `DEFAULT ROLE NONE` or else a default role with no interfering row policies.
* This bug only occurs when the initiating node actually connects to a remote shard, so the test uses `test_cluster_interserver_secret`, whose `<secret>` makes the shard subquery run as the `initial_user`, and sets `prefer_localhost_replica = 0` so the query goes through `RemoteQueryExecutor` rather than the local shortcut.
* Test is verified to fail against the published `clickhouse/clickhouse-server:26.3` (v26.3.17.4-lts, unpatched).
* Test is verified to pass with this patch.
* Repro submitted in Clickhouse Cloud support ticket #00047447 (RunReveal RUN-2549), once updated so the authenticated initial user has `ROLE DEFAULT NONE`, is also verified to pass with this patch.

Related:

* https://github.com/ClickHouse/ClickHouse/issues/28334 (doesn't close, but may obviate need for it)
* https://github.com/ClickHouse/ClickHouse/pull/101791
* https://github.com/ClickHouse/ClickHouse/issues/31080
* https://github.com/ClickHouse/ClickHouse/pull/31262


### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix propagation of user roles to shards so that only active roles, and not all granted roles are used (together with the user's default roles) when querying shards in a distributed table.