### PR TITLE
fix startup_console_log_level removal

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1342,7 +1342,8 @@ try
 
     // If the startup_console_log_level is set in the config, we override the console logger level.
     // Specific loggers can still override it.
-    std::string original_console_log_level_config = config().getString("logger.startup_console_log_level", "");
+    bool console_log_level_was_set = config().has("logger.console_log_level");
+    std::string original_console_log_level_config = config().getString("logger.console_log_level", "");
     bool should_restore_console_log_level = false;
     if (config().has("logger.startup_console_log_level") && !config().getString("logger.startup_console_log_level").empty())
     {
@@ -3447,9 +3448,20 @@ try
 
             if (should_restore_console_log_level)
             {
-                config().setString("logger.console_log_level", original_console_log_level_config);
-                Loggers::updateLevels(config(), logger());
-                LOG_INFO(log, "Restored console logger level to {}", original_console_log_level_config);
+                /// If the level was unset just remove the override so the default can be set via
+                /// Loggers::updateLevels again; otherwise restore the configured value.
+                if (console_log_level_was_set)
+                {
+                    config().setString("logger.console_log_level", original_console_log_level_config);
+                    Loggers::updateLevels(config(), logger());
+                    LOG_INFO(log, "Restored console logger level to {}", original_console_log_level_config);
+                }
+                else
+                {
+                    config().remove("logger.console_log_level");
+                    Loggers::updateLevels(config(), logger());
+                    LOG_INFO(log, "Restored console logger level to logger.level");
+                }
             }
 
             for (auto & server : servers)

--- a/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger_console_set.xml
+++ b/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger_console_set.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <logger>
+        <level>information</level>
+        <console_log_level>warning</console_log_level>
+        <startup_console_log_level>trace</startup_console_log_level>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger_console_unset.xml
+++ b/tests/integration/test_server_startup_and_shutdown_logs/configs/config.d/logger_console_unset.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <logger>
+        <level>information</level>
+        <startup_console_log_level>trace</startup_console_log_level>
+    </logger>
+</clickhouse>

--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -12,6 +12,24 @@ instance = cluster.add_instance(
     stay_alive=True,
 )
 
+# Separate instances validate that the console log level is restored after startup.
+# They use a non-"none" root level so the post-startup "Restored ..." message is itself logged
+# (with level=none it would be suppressed right after the root logger level is restored).
+instance_console_unset = cluster.add_instance(
+    "node_console_unset",
+    main_configs=[
+        "configs/config.d/logger_console_unset.xml",
+    ],
+    stay_alive=True,
+)
+instance_console_set = cluster.add_instance(
+    "node_console_set",
+    main_configs=[
+        "configs/config.d/logger_console_set.xml",
+    ],
+    stay_alive=True,
+)
+
 
 @pytest.fixture(scope="module")
 def started_cluster():
@@ -20,6 +38,22 @@ def started_cluster():
         # Validate on startup we increase the log level.
         assert instance.contains_in_log("Starting root logger in level trace")
         assert instance.contains_in_log("Starting console logger in level trace")
+
+        # The console log level is raised at startup and then restored afterwards.
+        # When console_log_level is unset it reverts to follow logger.level ...
+        assert instance_console_unset.contains_in_log(
+            "Starting console logger in level trace"
+        )
+        assert instance_console_unset.contains_in_log(
+            "Restored console logger level to logger.level"
+        )
+        # ... and when it is explicitly configured it is restored to that value.
+        assert instance_console_set.contains_in_log(
+            "Starting console logger in level trace"
+        )
+        assert instance_console_set.contains_in_log(
+            "Restored console logger level to warning"
+        )
         yield cluster
     finally:
         cluster.shutdown()

--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -13,8 +13,6 @@ instance = cluster.add_instance(
 )
 
 # Separate instances validate that the console log level is restored after startup.
-# They use a non-"none" root level so the post-startup "Restored ..." message is itself logged
-# (with level=none it would be suppressed right after the root logger level is restored).
 instance_console_unset = cluster.add_instance(
     "node_console_unset",
     main_configs=[


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/103472   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/95919


Fixed `logger.startup_console_log_level` not being reverted after startup: the console log level was captured from the wrong config key, so the console stayed at the elevated startup level for the lifetime of the server. Introduced in #95919. Fixes #103472.

Fix
Capture the actual logger.console_log_level before overriding it.
On restore, since an unset console_log_level dynamically follows logger.level (see Loggers::updateLevels):
if console_log_level was explicitly configured, restore that value;
if it was unset, remove the temporary startup override so it falls back to logger.level again (this also avoids restoring an empty string, which would break parseLevel).


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.743` (included in `26.7` and later)
- Backported to: `26.6.2.63`, `26.5.6.35`, `26.4.5.124`, `26.3.17.40`
<!-- ch-version-info:end -->