### PR TITLE
Optimize mutation loading

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -1240,6 +1240,8 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
         {
             std::lock_guard state_lock(state_mutex);
 
+            auto queue_representation = getQueueRepresentation(queue, format_version);
+
             for (const ReplicatedMergeTreeMutationEntryPtr & entry : new_mutations)
             {
                 auto & mutation = mutations_by_znode.emplace(entry->znode_name, MutationStatus(entry, format_version)).first->second;
@@ -1256,9 +1258,8 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
                 LOG_TRACE(log, "Adding mutation {} for {} partitions (data versions: {})",
                           entry->znode_name, entry->block_numbers.size(), entry->getBlockNumbersForLogs());
 
-                /// Initialize `mutation.parts_to_do`. We cannot use only current_parts + virtual_parts here so we
-                /// traverse all the queue and build correct state of parts_to_do.
-                auto queue_representation = getQueueRepresentation(queue, format_version);
+                /// Initialize `mutation.parts_to_do`. We cannot use only current_parts + virtual_parts here,
+                /// so we use queue_representation to get the correct state of parts_to_do.
                 mutation.parts_to_do = getPartNamesToMutate(*entry, current_parts, queue_representation, format_version);
 
                 if (mutation.parts_to_do.size() == 0)


### PR DESCRIPTION
Loading mutations for a RMT can take a lot of time for a big replication queue. For 14347 entries and 58 mutations it took 29 minutes. 
```
2026.07.08 03:20:48.127283 [ 715482 ] {BgSchPool::a5cd0cc1-516a-4679-8ff6-a1bef62f0314} <Debug> table_name (ReplicatedMergeTreeQueue): Having 14347 queue entries to load, 0 entries already loaded
2026.07.08 03:20:48.452300 [ 715482 ] {BgSchPool::a5cd0cc1-516a-4679-8ff6-a1bef62f0314} <Information> table_name (ReplicatedMergeTreeQueue): Loading 58 mutation entries: 0000000000 - 0000000057
2026.07.08 03:48:51.505576 [ 715482 ] {BgSchPool::a5cd0cc1-516a-4679-8ff6-a1bef62f0314} <Debug> table_name (ReplicatedMergeTreeRestartingThread): Table started successfully
```
When the same table had 2 million entries in queue it couldn't load mutations for hours, so there is definitely a dependence between queue size and mutation loading speed. There is a `getQueueRepresentation` call that traverses the queue for each mutation, but the queue is not modified between iterations so it can be moved outside from the cycle.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid redundant traversals of the replication queue when initializing `parts_to_do` for multiple mutations in `ReplicatedMergeTree`. This speeds up loading of `ReplicatedMergeTree` tables with many mutations and queue entries.