### PR TITLE
Bump libarchive from 3.8.7 to 3.8.8

### DIFF
--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -1028,6 +1028,9 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the <stdarg.h> header file. */
 #define HAVE_STDARG_H 1
 
+/* Define to 1 if you have the <stdckdint.h> header file. */
+#define HAVE_STDCKDINT_H 1
+
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bump libarchive from 3.8.7 to 3.8.8


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.718` (included in `26.7` and later)
- Backported to: `26.6.2.57`, `26.5.6.31`, `26.4.5.118`, `26.3.17.36`, `25.8.29.11`
<!-- ch-version-info:end -->