### PR TITLE
Add cloud hook blocks to RestorerFromBackup::createTable

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -42,6 +42,7 @@
 #include <boost/algorithm/string.hpp>
 
 #if CLICKHOUSE_CLOUD
+#include <Backups/BackupsHelper.h>
 #include <Interpreters/SharedDatabaseCatalog.h>
 #endif
 
@@ -754,6 +755,10 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
 
         boost::intrusive_ptr<ASTCreateQuery> create_table_query;
         DatabasePtr database;
+#if CLICKHOUSE_CLOUD
+        String data_path_in_backup;
+        std::optional<ASTs> partitions;
+#endif
 
         {
             std::lock_guard lock{mutex};
@@ -765,7 +770,33 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
 
             create_table_query = boost::static_pointer_cast<ASTCreateQuery>(table_info.create_table_query->clone());
             database = table_info.database;
+#if CLICKHOUSE_CLOUD
+            data_path_in_backup = table_info.data_path_in_backup;
+            partitions = table_info.partitions;
+#endif
         }
+
+#if CLICKHOUSE_CLOUD
+        /// Capture the source table's UUID before it is overwritten below; a mounted table needs it to
+        /// scope its restore revalidation to the source table's per-part locks.
+        String source_table_uuid;
+        if (create_table_query->has_uuid)
+            source_table_uuid = toString(create_table_query->uuid);
+
+        /// For a lightweight restore, resolve the mount provenance to be persisted when the table is
+        /// created (handed to the storage via the create-query context below).
+        auto snapshot_mount_provenance = computeSnapshotMountProvenance(
+            restore_settings, backup, backup_info_for_restore, context, *create_table_query, data_path_in_backup, source_table_uuid);
+
+        /// Partition-filtered mount restore is unimplemented: provenance is persisted in the table-creation
+        /// multi-op, before the PARTITIONS filter runs in the data phase, so a no-match would strand an empty
+        /// mounted table that reopens an unpinned source. Reject up front, before any table is created.
+        if (snapshot_mount_provenance && partitions && !partitions->empty())
+            throw Exception(
+                ErrorCodes::CANNOT_RESTORE_TABLE,
+                "mount_readonly_parts_from_snapshot does not support a PARTITIONS filter. Restore the whole table "
+                "as a mount, or restore the selected partitions without mount_readonly_parts_from_snapshot.");
+#endif
 
         /// Generate a new UUID for a table (the same table on different hosts must use the same UUID, `restore_coordination` will make it so).
         /// The generated UUID will be ignored if the database does not support UUIDs.
@@ -818,6 +849,9 @@ void RestorerFromBackup::createTable(const QualifiedTableName & table_name)
         create_query_context->setSetting("keeper_max_backoff_ms", zookeeper_retries_info.max_backoff_ms);
 
         create_query_context->setUnderRestore(true);
+#if CLICKHOUSE_CLOUD
+        create_query_context->setSnapshotMountProvenanceToPersist(snapshot_mount_provenance);
+#endif
 
         /// We shouldn't use the progress callback copied from the restore context because it was originally set in a
         /// protocol handler (e.g. HTTPHandler) for the "RESTORE ASYNC" query which could have already finished

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1791,7 +1791,7 @@ void Context::setFilesystemCachesPath(const String & path)
     shared->filesystem_caches_path = path;
 }
 
-void Context::setFilesystemCacheUser(const String & user)
+void Context::setFilesystemCacheUser(const String & user) const
 {
     std::lock_guard lock(shared->mutex);
     shared->filesystem_cache_user = user;

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -824,7 +824,7 @@ public:
     void setTempDataOnDisk(TemporaryDataOnDiskScopePtr temp_data_on_disk_);
 
     void setFilesystemCachesPath(const String & path);
-    void setFilesystemCacheUser(const String & user);
+    void setFilesystemCacheUser(const String & user) const;
 
     void setPath(const String & path);
     void setFlagsPath(const String & path);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Adds `#if CLICKHOUSE_CLOUD` hook blocks in `RestorerFromBackup::createTable`, following the existing guarded blocks in this file (e.g. the `SharedDatabaseCatalog` ones). The blocks are compiled out of the open-source build; carrying the same text here keeps the file in sync with the cloud fork so future edits to this function merge cleanly.