### PR TITLE
Docs: keep sidebar scrollbar from touching the search/Ask AI buttons

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -613,9 +613,13 @@ html:not(.dark) .pagination-prev:hover {
     flex: 1 1 auto;
     min-height: 0;
     overflow-y: auto;
-    /* Small breathing room so the first nav item isn't flush against the
-       pinned search row, and so scrolled content doesn't butt the top edge. */
-    padding-top: 0.5rem;
+    /* Gap below the pinned search + Ask AI row. Use margin, not padding: the
+       scroll container's scrollbar track spans its whole padding box, so
+       padding-top would leave the scrollbar flush against — visually touching —
+       the search/Ask AI buttons. A margin pushes the scroll box itself (and
+       therefore the top of its scrollbar) down below that row, so the scrollbar
+       no longer exceeds the first nav item. */
+    margin-top: 0.5rem;
 }
 
 /* Hide the chat assistant textarea and its floating-input wrapper */


### PR DESCRIPTION
The desktop sidebar's scroll container (`#navigation-items`) starts directly below the pinned search + Ask AI row, so its scrollbar track began flush against those buttons. `padding-top` did not help because a scroll container's scrollbar spans its whole padding box.

Switch the gap from `padding-top` to `margin-top`, which pushes the scroll box itself — and therefore the top of its scrollbar — down below the header row, so the scrollbar no longer exceeds the first nav item.

<img width="622" height="790" alt="image" src="https://github.com/user-attachments/assets/fa31c94f-d559-47fe-8d49-497be9875159" />

vs

<img width="584" height="960" alt="image" src="https://github.com/user-attachments/assets/d5ca5faf-3842-4aa2-aefd-5ad9d3f1aa61" />


<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.705` (included in `26.7` and later)
<!-- ch-version-info:end -->