### PR TITLE
Fix flaky test_rabbitmq_mv_combo: keep polling while consumption progresses

### DIFF
--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -767,23 +767,32 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster, db, unique):
         time.sleep(random.uniform(0, 1))
         thread.start()
 
-    # with threadsanitizer the speed of execution is about 8-13k rows per second.
-    # so consumption of 1 mln rows will require about 125 seconds
-    deadline = time.monotonic() + 180
+    # With threadsanitizer the speed of execution is about 8-13k rows per second, so consuming
+    # ~1 mln rows takes ~125s and can exceed a fixed deadline on a loaded runner while still
+    # progressing. Fail only on a genuine stall: reset the no-progress deadline whenever the
+    # total row count increases, so a slow-but-steady run is not abandoned.
+    no_progress_timeout = 180
+    deadline = time.monotonic() + no_progress_timeout
     expected = messages_num * threads_num * NUM_MV
+    prev_result = 0
+    result = 0
     while time.monotonic() < deadline:
         result = 0
         for mv_id in range(NUM_MV):
             result += int(
                 instance.query(f"SELECT count() FROM {db}.combo_{mv_id}")
             )
-        if int(result) == expected:
+        if result == expected:
             break
+        if result > prev_result:
+            deadline = time.monotonic() + no_progress_timeout
+        prev_result = result
         logging.debug(f"Result: {result} / {expected}")
         time.sleep(1)
     else:
         pytest.fail(
-            "Time limit of 180 seconds reached. The result did not match the expected value."
+            f"Time limit of {no_progress_timeout} seconds reached without any RabbitMQ "
+            "consumption progress. The result did not match the expected value."
         )
 
     for thread in threads:


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_rabbitmq_mv_combo` used a fixed 180s wall-clock deadline for the final row-count check. Consuming ~1 mln rows takes ~125s under thread sanitizer (8-13k rows/s), so on a loaded msan/tsan runner the deadline can be reached while consumption is still steadily progressing, producing a spurious `pytest.fail` at `test.py:785`.

Fix: reset the no-progress deadline whenever the total row count across the 5 materialized views increases, so the test only fails on a genuine stall. This mirrors the `check_expected_result_polling` helper already used by the other RabbitMQ streaming tests (added in #106200 / #107813).

CI evidence (test failed initially, passed on retry, `retry_ok`):
- master `Integration tests (amd_msan, 6/8)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8a863a7cc54952795148dcd2eba58fdcd5480ec5&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%206%2F8%29

No related open issue found.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.725` (included in `26.7` and later)
<!-- ch-version-info:end -->