### PR TITLE
Raise keeper-client timeouts in stateless tests to fix sanitizer flakiness

### DIFF
--- a/tests/queries/shell_config.sh
+++ b/tests/queries/shell_config.sh
@@ -110,7 +110,12 @@ export CLICKHOUSE_KEEPER_IDENTITY=${CLICKHOUSE_KEEPER_IDENTITY:=""}
 
 # keeper-client
 
-KEEPER_CLIENT_DEFAULT_ARGS=" --port $CLICKHOUSE_PORT_KEEPER"
+# The default keeper-client timeouts are 10s each. Under heavy sanitizer builds
+# (msan/asan) the keeper handshake or a response can legitimately take longer,
+# which makes keeper-client tests flake with a client-side
+# "Nothing is received in session timeout of 10000 ms" (KEEPER_EXCEPTION).
+# Raise the timeouts so the client waits out a slow-but-alive server.
+KEEPER_CLIENT_DEFAULT_ARGS=" --port $CLICKHOUSE_PORT_KEEPER --connection-timeout 60 --session-timeout 60 --operation-timeout 60"
 
 if [ -n "$CLICKHOUSE_KEEPER_IDENTITY" ] && [ "$CLICKHOUSE_KEEPER_IDENTITY" != "" ]
 then


### PR DESCRIPTION
<!--
Linked issues and pull requests.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The keeper-client stateless tests (`03988_keeper_client_autocomplete`, `03135_keeper_client_find_commands`, and the rest of the family) flake under heavy sanitizer builds with a client-side error:

```
Code: 999. Coordination::Exception: Nothing is received in session timeout of 10000 ms. (KEEPER_EXCEPTION)
```

Root cause: keeper-client uses default connection/session/operation timeouts of 10s each. Under msan/asan (and the WasmEdge variant), the keeper handshake or a response can legitimately take longer than 10s, so the client-side idle deadline in `ZooKeeper::receiveThread()` fires against a slow-but-alive server. CI's own randomized-settings diagnosis re-ran the test and it passed, confirming a transient timing flake, not a regression (30d CIDB: 19 hits across 19 distinct unrelated PRs, 0 on master).

Fix: raise connection/session/operation timeouts to 60s in the shared `KEEPER_CLIENT_DEFAULT_ARGS` in `tests/queries/shell_config.sh`, so every keeper-client stateless test waits out a slow server instead of giving up at 10s. No test relies on the default 10s timeout (none expect a timeout error), and all `03988` assertions still pass, so test intent is preserved.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.771` (included in `26.7` and later)
<!-- ch-version-info:end -->