### PR TITLE
Fix reading Iceberg tables with several partitions on one column

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -5,6 +5,7 @@
 
 #include <compare>
 #include <optional>
+#include <unordered_set>
 
 #include <Interpreters/IcebergMetadataLog.h>
 
@@ -267,6 +268,7 @@ std::shared_ptr<ManifestFileIterator> ManifestFileIterator::create(
     const Poco::JSON::Array::Ptr & partition_specification = partition_spec_json.extract<Poco::JSON::Array::Ptr>();
 
     DB::NamesAndTypesList partition_columns_description;
+    std::unordered_set<String> partition_columns_seen;
     auto partition_key_ast = make_intrusive<ASTFunction>();
     partition_key_ast->name = "tuple";
     partition_key_ast->arguments = make_intrusive<DB::ASTExpressionList>();
@@ -308,7 +310,11 @@ std::shared_ptr<ManifestFileIterator> ManifestFileIterator::create(
             continue;
 
         partition_key_ast->as<ASTFunction>()->arguments->children.emplace_back(std::move(partition_ast));
-        partition_columns_description.emplace_back(numeric_column_name, removeNullable(manifest_file_column_characteristics->type));
+        /// One source column may back several partition fields (e.g. hours(ts) and identity ts).
+        /// The tuple key AST keeps one child per field, but getKeyFromAST resolves identifiers
+        /// against these input columns, which must contain each source column at most once.
+        if (partition_columns_seen.insert(numeric_column_name).second)
+            partition_columns_description.emplace_back(numeric_column_name, removeNullable(manifest_file_column_characteristics->type));
     }
 
     std::optional<DB::KeyDescription> partition_key_description;

--- a/tests/integration/test_storage_iceberg_with_spark/test_multiple_partitions_on_one_column.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_multiple_partitions_on_one_column.py
@@ -1,0 +1,75 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    execute_spark_query_general,
+    get_creation_expression,
+    get_uuid_str,
+)
+
+
+# Regression for issue #83462: reading an Iceberg table partitioned by the same
+# source column more than once (here meta_ts appears in both hours(meta_ts) and
+# an identity partition field) used to throw
+#   Code 44 (ILLEGAL_COLUMN): Cannot add column `<id>`: column with this name already exists
+# while building the partition-pruning key from the manifest partition spec.
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_multiple_partitions_on_one_column(
+    started_cluster_iceberg_with_spark, storage_type
+):
+    instance = started_cluster_iceberg_with_spark.instances["node1"]
+    spark = started_cluster_iceberg_with_spark.spark_session
+    TABLE_NAME = (
+        "test_multiple_partitions_on_one_column_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        return execute_spark_query_general(
+            spark,
+            started_cluster_iceberg_with_spark,
+            storage_type,
+            TABLE_NAME,
+            query,
+        )
+
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME} (
+                col1 STRING,
+                col2 STRING,
+                meta_ts TIMESTAMP,
+                col3 STRING,
+                col4 STRING,
+                col5 STRING
+            )
+            USING iceberg
+            PARTITIONED BY (col1, hours(meta_ts), col2, meta_ts)
+            OPTIONS('format-version'='2')
+        """
+    )
+
+    execute_spark_query(
+        f"""
+        INSERT INTO {TABLE_NAME} VALUES
+        ('val1', 'val2', timestamp('2024-01-01 00:00:00.000000'), 'val3', 'val4', 'val5')
+    """
+    )
+
+    creation_expression = get_creation_expression(
+        storage_type,
+        TABLE_NAME,
+        started_cluster_iceberg_with_spark,
+        table_function=True,
+    )
+
+    # SELECT * forces file iteration, which builds the partition-pruning key.
+    # count() alone is answered from manifest statistics and does not hit the bug.
+    assert (
+        instance.query(
+            f"SELECT col1, col2, col3, col4, col5 FROM {creation_expression} ORDER BY ALL"
+        ).strip()
+        == "val1\tval2\tval3\tval4\tval5"
+    )
+    assert int(instance.query(f"SELECT count() FROM {creation_expression}")) == 1


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/83462
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reading Iceberg tables partitioned by the same source column more than once (for example `PARTITIONED BY (hours(ts), ts)`). Such tables previously failed with `Cannot add column ...: column with this name already exists (ILLEGAL_COLUMN)`.

### Description

When an Iceberg partition spec references the same source column in more than one partition field (e.g. `hours(meta_ts)` and identity `meta_ts`), reading the table threw `Code 44 (ILLEGAL_COLUMN): Cannot add column '3': column with this name already exists`.

While building the partition-pruning key from the manifest partition spec, each partition field added an entry to a `NamesAndTypesList` keyed by the source column id (used as the column name to survive RENAME). Two fields over the same source column produced two entries with the same name, and `ColumnsDescription::add` rejected the duplicate.

The tuple key AST still needs one child per partition field, but the list of input columns that `getKeyFromAST` resolves identifiers against must contain each source column at most once. The fix deduplicates that input-column list by source-column name while keeping the tuple AST intact.

Regression test added in `tests/integration/test_storage_iceberg_with_spark/test_multiple_partitions_on_one_column.py` (s3/azure/local), reproducing the exact spec from the issue.

Closes https://github.com/ClickHouse/ClickHouse/issues/83462
