### PR TITLE
Restore shrink profitability floor for sparse filter columns

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -704,12 +704,10 @@ void MergeTreeRangeReader::ReadResult::optimize(const FilterWithCachedCount & cu
         setFilterConstTrue();
         return;
     }
-    /// Sparse: per-granule tails come from `sparse_indices` cheaply, so always worth shrinking.
-    /// Dense: guess.
-    const bool worth_shrinking = filter.isSparse()
-        ? total_zero_rows_in_tails > 0
-        : 2 * total_zero_rows_in_tails > filter.size();
-    if (worth_shrinking)
+    /// Shrinking a tail ends the current delayed read and forces a fresh seek
+    /// for the next granule, so it only pays off when enough rows are dropped
+    /// to outweigh the extra seek and misaligned filesystem-cache segment.
+    if (2 * total_zero_rows_in_tails > filter.size())
     {
         const NumRows rows_per_granule_previous = rows_per_granule;
         const size_t total_rows_per_granule_previous = total_rows_per_granule;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/63870
Closes: https://github.com/ClickHouse/ClickHouse/issues/109956
Follow up to https://github.com/ClickHouse/ClickHouse/pull/105890

The FWCC sparse-preservation change added an always-shrink branch when `filter.isSparse()`, dropping the dense-path `2 * zeros > size` floor on the grounds that per-granule tail counting is cheap for sparse filters. Cheap to compute isn't cheap to apply: each shrunk tail ends the delayed read and forces a fresh seek for the next granule. On remote storage with a highly sparse column this fragments the read into ~2x as many non-adjacent ranges and misses the filesystem cache segments the earlier run cached, adding ~8x seeks. ClickBench Q10/Q11 lost 15-30% on master 26.7.1.997 (aws hot median).

Use the same profitability floor for sparse and dense filters. Local repro (prod-1, 100M hits): Q11 hot median 256ms → 100ms, `SelectedRanges` 20 → 9.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Regression fix for unreleased sparse-filter shrink policy.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.746` (included in `26.7` and later)
<!-- ch-version-info:end -->