### PR TITLE
Skip set_sync_status_awaiting_hook outside oss repo

### DIFF
--- a/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
+++ b/ci/jobs/scripts/job_hooks/set_sync_status_awaiting_hook.py
@@ -1,5 +1,6 @@
 from ci.defs.defs import SYNC
 from ci.praktika.gh import GH
+from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 # This status is a marker that the sync process can be started. We set it from
@@ -7,6 +8,10 @@ from ci.praktika.result import Result
 
 
 def main():
+    if Info().repo_name != "ClickHouse/ClickHouse":
+        print(f"Not applicable for repo [{Info().repo_name}], skipping")
+        return
+
     statuses = GH.get_commit_statuses()
     if statuses is None:
         print(f"Failed to fetch commit statuses, skip setting [{SYNC}]")


### PR DESCRIPTION
The \`set_sync_status_awaiting_hook.py\` job hook posts a \`sync\` commit status that is only meaningful for the upstream \`ClickHouse/ClickHouse\` repository. Make it a no-op elsewhere (forks, private mirrors), following the same \`Info().repo_name\` guard already used in \`build_master_head_hook.py\` and \`store_data.py\`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.726` (included in `26.7` and later)
<!-- ch-version-info:end -->