### PR TITLE
CI: Pass -Zsanitizer=address to Rust in the combined address,undefined build

### DIFF
--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -146,13 +146,9 @@ elseif (SANITIZE STREQUAL "thread")
     set(RUST_CARGO_BUILD_STD "-Zbuild-std=std,panic_abort,core,alloc")
     list(APPEND RUSTFLAGS "-Zsanitizer=thread")
 elseif (SANITIZE STREQUAL "address" OR SANITIZE STREQUAL "address,undefined")
-    # Rust has no UBSan, so for the combined ASan+UBSan build only ASan is applied.
-    # Besides the sanitizer instrumentation itself, `-Zsanitizer=address` makes cargo expose
-    # `CARGO_CFG_SANITIZE=address` to build scripts, which `wasmtime` translates into
-    # `--cfg asan`. Under that cfg `wasmtime` skips its per-thread `sigaltstack` setup, whose
-    # TLS destructor munmaps the stack without `sigaltstack(SS_DISABLE)` and thereby makes
-    # ASan's `UnsetAlternateSignalStack` unmap the same (by then reused) address range at
-    # thread exit, destroying pages of live heap allocations.
+    # Rust has no UBSan, so the combined ASan+UBSan build applies only ASan. Besides the
+    # instrumentation itself, `-Zsanitizer=address` arms wasmtime's `cfg(asan)` guard, preventing
+    # a stray munmap of live memory at thread exit: https://github.com/bytecodealliance/wasmtime/issues/13857
     set(RUST_CARGO_BUILD_STD "-Zbuild-std=std,panic_abort,core,alloc")
     list(APPEND RUSTFLAGS "-Zsanitizer=address")
 endif()

--- a/contrib/corrosion-cmake/CMakeLists.txt
+++ b/contrib/corrosion-cmake/CMakeLists.txt
@@ -145,7 +145,14 @@ if (SANITIZE STREQUAL "memory")
 elseif (SANITIZE STREQUAL "thread")
     set(RUST_CARGO_BUILD_STD "-Zbuild-std=std,panic_abort,core,alloc")
     list(APPEND RUSTFLAGS "-Zsanitizer=thread")
-elseif (SANITIZE STREQUAL "address")
+elseif (SANITIZE STREQUAL "address" OR SANITIZE STREQUAL "address,undefined")
+    # Rust has no UBSan, so for the combined ASan+UBSan build only ASan is applied.
+    # Besides the sanitizer instrumentation itself, `-Zsanitizer=address` makes cargo expose
+    # `CARGO_CFG_SANITIZE=address` to build scripts, which `wasmtime` translates into
+    # `--cfg asan`. Under that cfg `wasmtime` skips its per-thread `sigaltstack` setup, whose
+    # TLS destructor munmaps the stack without `sigaltstack(SS_DISABLE)` and thereby makes
+    # ASan's `UnsetAlternateSignalStack` unmap the same (by then reused) address range at
+    # thread exit, destroying pages of live heap allocations.
     set(RUST_CARGO_BUILD_STD "-Zbuild-std=std,panic_abort,core,alloc")
     list(APPEND RUSTFLAGS "-Zsanitizer=address")
 endif()


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/104692
Caused by: https://github.com/ClickHouse/ClickHouse/pull/99657
Related: https://github.com/ClickHouse/clickhouse-private/issues/63613
Related: https://github.com/bytecodealliance/wasmtime/issues/13857

### Problem

Sporadic SEGVs at `CompressedReadBufferBase::readCompressedData` on addresses "not mapped to object" keep appearing in ASan CI (https://github.com/ClickHouse/ClickHouse/issues/104692) — across unrelated configurations (s3, azure, db disk, with and without distributed cache), on random columns and queries, surviving multiple read-path fixes. Analyzed occurrence: [CI report](https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=3ad605ded67bd485f48b62b7a8d4e965f186cd8b&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_ubsan%2C%20distributed%20cache%2C%20meta%20in%20keeper%2C%20s3%20storage%2C%20parallel%29).

Additionally, since the switch to combined ASan+UBSan builds all Rust code in sanitizer CI has been silently compiled without any sanitizer.

### Root cause

When https://github.com/ClickHouse/ClickHouse/pull/99657 switched CI to combined builds (`-DSANITIZE=address,undefined`), it added the new value to the C++ flag dispatch in `cmake/sanitize.cmake`:

```cmake
+    elseif (SANITIZE STREQUAL "address,undefined")
+        set (ASAN_UBSAN_FLAGS "-fsanitize=address,undefined -fsanitize-address-use-after-scope ...")
```

but the Rust flag dispatch in `contrib/corrosion-cmake/CMakeLists.txt` was left matching the old value only:

```cmake
if (SANITIZE STREQUAL "memory")
    ...
elseif (SANITIZE STREQUAL "thread")
    ...
elseif (SANITIZE STREQUAL "address")          # <-- "address,undefined" falls through
    set(RUST_CARGO_BUILD_STD "-Zbuild-std=std,panic_abort,core,alloc")
    list(APPEND RUSTFLAGS "-Zsanitizer=address")
endif()
```

so `-Zsanitizer=address` was silently lost for the `asan_ubsan` builds. Without it cargo does not expose `CARGO_CFG_SANITIZE=address`, wasmtime's build script does not emit `--cfg asan`, and wasmtime's own ASan guard in `lazy_per_thread_init` (`crates/wasmtime/src/runtime/vm/sys/unix/signals.rs`) is disarmed — so it installs a per-thread 256 KiB `sigaltstack` on every thread that executes a WASM UDF. That stack's TLS destructor munmaps the memory without `sigaltstack(SS_DISABLE)` (upstream bug: https://github.com/bytecodealliance/wasmtime/issues/13857), leaving a dangling kernel registration, and ASan's `UnsetAlternateSignalStack` unmaps the same — by then reused — address range at thread exit:

```
pool thread T (ran a WASM UDF)                      query thread Q
──────────────────────────────                      ─────────────────────────────
wasmtime lazy_per_thread_init:
  mmap W (260 KiB) + sigaltstack(W)      kernel: T's altstack = W
... minutes later the thread pool reaps T ...
(1) Rust TLS dtor Stack::drop:
    munmap(W) — no SS_DISABLE            kernel: T's altstack = W (dangling)
                                                    ASan secondary allocator reuses the
                                                    freed range for a ~244 KiB prefetch
                                                    buffer; recv() fills it — succeeds,
                                                    pages are mapped at that moment
(2) ASan UnsetAlternateSignalStack:
    queries the stale W and
    UnmapOrDie(W) → munmap #2 destroys
    the pages of the live buffer
T dies                                              Q consumes the prefetch and reads
                                                    byte 0 of the buffer (block checksum
                                                    in readCompressedData zero-copy path)
                                                    → SIGSEGV, SEGV_MAPERR
```

The crash stack always belongs to the first reader of the destroyed buffer, never the culprit — for a MergeTree prefetch buffer that first read is `CompressedReadBufferBase::readCompressedData`, hence the fixed signature on random victims. Established from the decrypted core of the 2026-07-07 occurrence: the faulted buffer was still registered as allocated in ASan's `LargeMmapAllocator` (no `free` involved), exactly one of 2994 live large chunks was damaged, and the destroyed page range measured exactly one wasmtime sigaltstack allocation (guard page + 64×4096 bytes).

### Fix

Match `SANITIZE STREQUAL "address,undefined"` in the same `contrib/corrosion-cmake` dispatch — the single place where the Rust workspace `RUSTFLAGS` are assembled (the MSan/TSan branches live there too). `SANITIZE=address` stays supported: the fuzzer build and local pure-ASan builds still pass it. This restores real ASan instrumentation of Rust code and re-arms wasmtime's `cfg!(asan)` guard, so the custom sigaltstack is not installed at all in ASan builds; the dangling-registration defect itself is reported upstream (https://github.com/bytecodealliance/wasmtime/issues/13857).

Verified locally with `SANITIZE=address,undefined`: the wasmtime build script emits `cargo:rustc-cfg=asan` again, all Rust crates and the full server build and run, and under `strace` executing WASM UDFs no longer allocates the custom signal stack (the `mmap(266240)` fingerprint is gone) while the UDFs keep working.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.742` (included in `26.7` and later)
- Backported to: `26.6.2.59`, `26.5.6.33`, `26.4.5.121`, `26.3.17.38`, `25.8.29.13`
<!-- ch-version-info:end -->