### PR TITLE
ValueRef pilot: persistent project memory + Claude Code discovery skill

### DIFF
--- a/.claude/skills/valueref-pilot/SKILL.md
+++ b/.claude/skills/valueref-pilot/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: valueref-pilot
+description: Resume and continue the long-running "ValueRef pilot" project — reducing reliance on the DB::Field class in the ClickHouse server by introducing a non-owning ValueRef (column pointer + row index). Use whenever the user asks to work on, continue, or check status of the Field/ValueRef refactoring, the "Field pilot", "ValueRef", reducing Field usage/materialization on hot paths, or the project stored under .cursor/projects/valueref-pilot/.
+disable-model-invocation: false
+allowed-tools: Task, Bash, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, AskUserQuestion
+---
+
+# ValueRef pilot — project entry point
+
+This project reduces reliance on `DB::Field` (`src/Core/Field.h`) in the ClickHouse server by
+introducing a lightweight, non-owning `ValueRef` (a `const IColumn*` + row index). All project
+state, context, plans, and history live as git-tracked files under
+`.cursor/projects/valueref-pilot/` — that directory is the single source of truth and is
+tool-neutral (readable from both Cursor and Claude Code).
+
+## What to do when this skill is invoked
+
+1. Read `.cursor/projects/valueref-pilot/AGENT_GUIDE.md` **in full** — it is the operating manual
+   (git/PR conventions, build & test commands, and the memory-update protocol).
+2. Read the newest entry in `.cursor/projects/valueref-pilot/PROGRESS_LOG.md` — "where we left off".
+3. Read `.cursor/projects/valueref-pilot/TASKS.md` — pick the next `TODO`/`IN PROGRESS` task.
+4. Skim `DESIGN.md` (the intended `ValueRef` shape) and consult `INVESTIGATION.md` (background,
+   with file:line references) as needed.
+
+Then continue the work following the guide. Before ending the session, update `TASKS.md` and
+append to `PROGRESS_LOG.md` as instructed in `AGENT_GUIDE.md` §3.
+
+## Hard guardrails (also in AGENT_GUIDE.md §6)
+
+- The goal is **reduction of `Field` on hot paths, not removal.** Do not try to delete `Field`.
+- Do **not** change SQL-literal representation (`ASTLiteral`), the settings `Field` API, or any
+  on-disk/wire format (`partition.dat`, `minmax_*.idx`, skip-index `.idx2`, statistics files,
+  `writeFieldBinary` encodings, partition-ID hashing). These are backward-compatibility surfaces.
+- Follow the repo `AGENTS.md`: never commit to `master`; branch as `cursor/<name>-f766`; no
+  rebase/amend on shared branches; no stacked PRs; Allman braces.

--- a/.cursor/projects/valueref-pilot/AGENT_GUIDE.md
+++ b/.cursor/projects/valueref-pilot/AGENT_GUIDE.md
@@ -1,0 +1,109 @@
+# Agent Guide — how to work on the ValueRef pilot
+
+Read this in full at the start of every session. It is the operating manual. It is written to be
+executable by an agent running in the **Cursor cloud UI** or **Claude Code on a Linux console**;
+the workflow is identical because all state lives in git.
+
+## 0. Orient yourself (every session, in order)
+
+1. Read [`README.md`](./README.md) for the one-paragraph framing.
+2. Read the newest entry in [`PROGRESS_LOG.md`](./PROGRESS_LOG.md) — this is "where we left off".
+3. Read [`TASKS.md`](./TASKS.md) — pick the next `TODO`/`IN PROGRESS` task.
+4. Skim [`DESIGN.md`](./DESIGN.md) so your change matches the intended `ValueRef` shape.
+5. Consult [`INVESTIGATION.md`](./INVESTIGATION.md) when you need background on a specific call
+   site (it has file:line references gathered during the initial survey).
+
+## 1. Golden rules (inherited from the repo `AGENTS.md`)
+
+- **Never commit to `master`.** Create a branch `cursor/<descriptive-name>-f766` for each unit of
+  work. (The `-f766` suffix and `cursor/` prefix are required by the cloud-agent branch policy.
+  A human working directly may use any branch name, but keep PRs targeting `master`.)
+- **Never rebase or amend** on a shared branch — add new commits instead.
+- **No stacked PRs.** Every PR targets `master` directly. If work B depends on unmerged work A,
+  either wait for A to merge or fold both into one PR.
+- **One logical change per commit.** Descriptive messages.
+- **C++ style:** Allman braces (opening brace on its own line). Enforced by CI style check.
+- **Never use `sleep` in C++** to paper over races.
+- **Avoid fallback paths** that silently hide errors; let errors propagate.
+- Wrap literal SQL/type/class/function names in backticks in prose and commit messages; write a
+  function as `f`, not `f()`, when referring to the function itself.
+- Put temporary files (logs, downloads) in a `tmp/` subdirectory of the repo, never `/tmp`.
+
+## 2. Build & test commands
+
+The environment may still be finishing setup. Before building/testing, check
+`/tmp/cursor/async-install/install-user.status` (contains exit code once done) — see the repo
+rules on waiting for background setup.
+
+Builds live in `build_*` directories (e.g. `build`, `build_debug`, `build_asan`). Create one if
+absent. **Do not pass `-j` to ninja and do not use `nproc`** — let ninja decide.
+
+```bash
+# Configure a build (example: default). Only needed once per build dir.
+cmake -B build -S . -G Ninja
+
+# Build a single target and ALWAYS redirect to a log in the build dir.
+ninja -C build unit_tests_dbms > build/build_unit_tests_dbms.log 2>&1
+# Then have a SUBAGENT read the log and return a concise summary (per repo rules).
+```
+
+Unit tests (gtests) are the primary safety net for this project — there is already
+`src/Core/tests/gtest_field.cpp` and many `src/Columns/tests/gtest_column_*.cpp`. Add a
+`gtest_value_ref.cpp` alongside them.
+
+```bash
+# Run the unit test binary, redirecting to a uniquely named log in the build dir.
+./build/src/unit_tests_dbms --gtest_filter='*ValueRef*' > build/test_value_ref.log 2>&1
+```
+
+Stateless SQL tests: add with `./tests/queries/0_stateless/add-test <name>` (`.sql`) or
+`<name>.sh`. Prefer adding new tests over extending existing ones. Do not add `no-*` tags unless
+strictly necessary.
+
+For data-structure size/layout questions (relevant when weighing `ValueRef` vs `Field`), use
+`.claude/tools/cppexpr.sh`, e.g. `.claude/tools/cppexpr.sh -i Core/Field.h 'OUT(sizeof(DB::Field))'`.
+
+## 3. The memory-update protocol (do this before ending every session)
+
+This is the most important habit. If you skip it, the next agent loses continuity.
+
+1. **`TASKS.md`** — update the status of tasks you touched (`TODO` → `IN PROGRESS` → `DONE`), and
+   add any new tasks you discovered. Keep the "Current focus" line at the top accurate.
+2. **`PROGRESS_LOG.md`** — append a new dated entry: what you did, key decisions and their
+   rationale, benchmark numbers, PR/branch links, CI report URLs, and explicit "next step"
+   pointers. Never rewrite old entries; this file is append-only.
+3. If the design changed, revise **`DESIGN.md`** and note the change in the log.
+4. Commit these memory updates (they can share the branch/PR with the code change, or go in a
+   dedicated docs commit).
+
+## 4. PR conventions
+
+- Use `.github/PULL_REQUEST_TEMPLATE.md` as the body template: short description + motivation, the
+  Changelog category (pick one), the Changelog entry, and the Documentation checkbox. Do not
+  invent a custom structure.
+- For an internal refactor with no user-facing behavior change, the appropriate Changelog category
+  is usually **Not for changelog (changelog entry is not required)** — state that explicitly.
+- Create PRs as draft by default. Link related PRs/issues with full URLs (`Related:`, `Closes:`,
+  `Caused by:` on their own lines).
+- Include any CI report URL the user gives you in the commit message.
+
+## 5. Definition of done for a migration step
+
+A call site is "migrated" when:
+1. It no longer constructs a `Field` on the hot path (verified by reading the code, and where
+   feasible by assembly/alloc inspection with the repo tools).
+2. Behavior is identical — covered by existing tests plus a targeted unit test.
+3. A microbenchmark or perf test shows no regression (and ideally an improvement) — attach numbers
+   to the `PROGRESS_LOG.md` entry and the PR.
+4. Memory files updated per §3.
+
+## 6. Safety / scope guardrails
+
+- **Do not attempt to delete `Field`.** The goal is *reduction* on hot paths. `Field` remains the
+  representation for SQL literals, settings, and on-disk/on-wire formats (see `INVESTIGATION.md`
+  §C). Touching those is explicitly out of scope for the pilot.
+- **Do not change any on-disk or wire format** (`partition.dat`, `minmax_*.idx`, skip-index
+  `.idx2`, statistics files, `writeFieldBinary` encodings, partition-ID hashing). These are
+  backward-compatibility surfaces.
+- Prefer additive changes (introduce `ValueRef` and new overloads) over replacing existing APIs,
+  so the change set stays reviewable and revertible.

--- a/.cursor/projects/valueref-pilot/DESIGN.md
+++ b/.cursor/projects/valueref-pilot/DESIGN.md
@@ -1,0 +1,108 @@
+# Design — `ValueRef`
+
+Status: **proposal / not yet implemented**. Revise this file as the design evolves and note
+changes in `PROGRESS_LOG.md`.
+
+## Goal
+
+Provide a lightweight, non-owning reference to a single value that already lives inside an
+`IColumn`, so hot code can compare/inspect/copy a value without materializing a `Field`. This
+directly attacks both problems from `INVESTIGATION.md`:
+
+- No `Field` allocation/branching on the hot path (Problem 2).
+- The reference is `(column, row)`, and the column knows its exact `IDataType`, so type identity is
+  preserved (Problem 1) — no lossy `NearestFieldType` collapse.
+
+## Core shape
+
+```cpp
+/// A non-owning reference to one value stored at row `row` of `column`.
+/// Cheap to copy (a pointer + an index). Valid only while `column` outlives it and is not mutated
+/// in a way that invalidates row `row`.
+struct ValueRef
+{
+    const IColumn * column = nullptr;
+    size_t row = 0;
+
+    ValueRef() = default;
+    ValueRef(const IColumn & column_, size_t row_) : column(&column_), row(row_) {}
+
+    bool isValid() const { return column != nullptr; }
+
+    /// Materialize into a Field only at the boundary where a Field is unavoidable.
+    Field toField() const { return (*column)[row]; }
+    void toField(Field & out) const { column->get(row, out); }
+};
+```
+
+Design intent:
+- **Trivially copyable, 16 bytes.** Never owns memory. Never heap-allocates.
+- **Type-faithful:** `column->getDataType()` / an accompanying `DataTypePtr` gives the true SQL
+  type; there is no `UInt8→UInt64` / `Float32→Float64` collapse.
+- **`toField()` is the escape hatch,** used only at boundaries that genuinely need an owned value
+  (AST literals, serialization, settings). The whole point is to *defer or avoid* that call.
+
+## Operations the pilot needs
+
+The value of `ValueRef` comes from operations that avoid `Field`. Candidate primitives (add
+incrementally, only what a migrated call site needs):
+
+- **Comparison against a column row:** reuse `IColumn::compareAt(row, other_row, other_column,
+  nan_direction_hint)`. A `ValueRef`-to-`ValueRef` compare is
+  `a.column->compareAt(a.row, b.row, *b.column, nan_hint)` when the columns are structurally equal.
+- **Comparison against a `Field`/`ValueRef` for range checks** (for the `KeyCondition` target):
+  needs a `compareAt`-style path that can take the "query constant" side. Investigate whether the
+  constant can be held as a size-1 column (it already is, as `ColumnConst`) so both sides use
+  `compareAt` and no `Field` appears.
+- **Copy into another column:** `dst.insertFrom(*src.column, src.row)` (already exists, `Field`-free).
+- **Null / default checks:** `column->isNullAt(row)`, `column->isDefaultAt(row)`.
+- **Hashing:** `column->updateHashWithValue(row, hash)`.
+
+Observation: most of these primitives **already exist on `IColumn`**. `ValueRef` is largely a thin,
+ergonomic wrapper that makes "operate on a value in place" the easy, default choice instead of
+`operator[]` → `Field`.
+
+## Where it plugs in (pilot candidates, pick ONE first)
+
+1. **`KeyCondition` / `Range` min-max checking (recommended first pilot).**
+   - `INVESTIGATION.md` §D: the code already complains about `Field`/`FieldRef`/`Range` cost for
+     long PKs (`MergeTreeDataSelectExecutor.cpp:1896-1963`).
+   - Approach: let `FieldRef` hold an optional `ValueRef` and route `Range` boundary comparisons
+     through column `compareAt` when both sides are column-backed, materializing a `Field` only for
+     explicit query constants and `±∞` sentinels.
+   - Risk: `Range` algebra + monotonic-function caching is intricate; must not change results.
+
+2. **`SingleValueDataGeneric` aggregate state.**
+   - Today stores a `Field value` and does `column.get(row, value)` (`SingleValueData.cpp`).
+   - `SingleValueDataGenericWithColumn` and `SingleValueReference` already show the column-based
+     alternative; the pilot could widen their use behind `canUseFieldForValueData`.
+   - Lower blast radius than `KeyCondition`, self-contained, easy to benchmark with `min`/`max`/
+     `any` over a generic type.
+
+The recommended sequencing is in `ROADMAP.md`.
+
+## Invariants and hazards
+
+- **Lifetime/validity:** a `ValueRef` is only valid while its column is alive and row `row` is not
+  invalidated (e.g. by `insert`, `popBack`, mutation). Document this at the type and never store a
+  `ValueRef` past the lifetime of its column. This is the main correctness risk versus owning
+  `Field`.
+- **Structural equality for `compareAt`:** columns must be structurally comparable
+  (`structureEquals`) — mirror the debug assertions `IColumn` already uses.
+- **Const/Sparse/LowCardinality/Replicated:** `compareAt` and friends already handle these via
+  their overrides; confirm the wrapper does not bypass them.
+- **Nullability & NaN:** preserve `nan_direction_hint` semantics exactly.
+
+## Explicitly NOT part of this design
+
+- Removing `Field`, changing `ASTLiteral`, the settings API, or any on-disk/wire format
+  (`INVESTIGATION.md` §B, §C).
+- Changing the meaning of `IColumn::operator[]`/`get`/`insert` — we *add* alongside them.
+
+## Success criteria
+
+A `ValueRef` is worth keeping if, on the chosen pilot call site, it:
+1. Removes per-value `Field` construction (verified by reading code + alloc/assembly inspection).
+2. Is behavior-preserving (existing tests + a targeted `gtest_value_ref.cpp` pass).
+3. Shows a measurable perf win (or at minimum no regression) on a representative benchmark, with
+   numbers recorded in `PROGRESS_LOG.md`.

--- a/.cursor/projects/valueref-pilot/INVESTIGATION.md
+++ b/.cursor/projects/valueref-pilot/INVESTIGATION.md
@@ -1,0 +1,148 @@
+# Investigation — the case for reducing `Field`
+
+This file preserves the findings from the initial codebase survey (the "why"). All file:line
+references were accurate as of the commit where this document was first added; verify against the
+current tree if something looks off.
+
+## Background: what `Field` is
+
+`DB::Field` (`src/Core/Field.h`) is a hand-rolled tagged union (~40 bytes with libc++, heap
+storage for `String`/`Array`/`Tuple`/`Map`/`Object`) representing one database value out of ~22
+type tags (`Field::Types::Which`, `src/Core/Field.h:271-305`). `Row = std::vector<Field>`
+(`src/Core/Field.h:669`).
+
+Its own header advises against per-value use:
+
+```260:267:src/Core/Field.h
+/** Discriminated union of several types.
+  * ...
+  * Used to represent a single value of one of several types in memory.
+  * Warning! Prefer to use chunks of columns instead of single values. See IColumn.h
+  */
+```
+
+## Problem 1 — `Field` type tags do NOT correspond to ClickHouse SQL types
+
+The mapping is defined by `NearestFieldTypeImpl` (`src/Core/Field.h:167-238`) and is lossy and
+many-to-one:
+
+- `UInt8`, `UInt16`, `UInt32`, `Date`/`DayNum`, `DateTime`, `bool` → stored as **`UInt64`**
+  (only `bool` gets a distinct `Bool` tag; the rest are indistinguishable).
+- `Int8`, `Int16`, `Int32` → **`Int64`**.
+- `Float32` → **`Float64`** — the header explicitly warns Float32 must not round-trip through
+  `Field` (`src/Core/Field.h:279-282`).
+- Enums → underlying integer type.
+- `DateTime64`/`Time64` → `DecimalField`, blurring them with plain decimals.
+
+Consequence: a `Field` alone cannot reconstruct the SQL type. Every consumer must carry a
+`DataTypePtr` alongside, and there is a coercion ecosystem (`convertFieldToType`) plus special
+bridges (`getFieldFromColumnForASTLiteral` in `src/Analyzer/Utils.cpp` for `DateTime64`,
+`Dynamic`, `Object`) to compensate.
+
+## Problem 2 — `Field` is mostly a value carrier, and an expensive one
+
+`IColumn` bakes `Field` into its interface but flags it as slow:
+
+```179:184:src/Columns/IColumn.h
+    /// Returns value of n-th element in universal Field representation.
+    /// Is used in rare cases, since creation of Field instance is expensive usually.
+    [[nodiscard]] virtual Field operator[](size_t n) const = 0;
+    /// Like the previous one, but avoids extra copying if Field is in a container, for example.
+    virtual void get(size_t n, Field & res) const = 0;
+```
+
+`ColumnArray::get` even hard-caps materialization at `max_array_size_as_field = 1_000_000`
+(`src/Columns/ColumnArray.cpp:40, 132-147`), and `ColumnTuple::get` builds a `Tuple` by calling
+`operator[]` per element.
+
+## Key finding — the "referral type" already exists in embryonic form: `FieldRef`
+
+```14:37:src/Core/Range.h
+/** A field, that can be stored in two representations:
+  * - A standalone field.
+  * - A field with reference to its position in a block.
+  ...
+struct FieldRef : public Field
+{
+    ...
+    ColumnsWithTypeAndName * columns = nullptr;
+    size_t row_idx = 0;
+    size_t column_idx = 0;
+};
+```
+
+But `FieldRef` **inherits from `Field` and copies the value into the `Field` base at
+construction** (`src/Core/Range.cpp:13-16`), so it is a hybrid that still pays the `Field` cost.
+It proves the concept but does not deliver the benefit. A clean `ValueRef` (column pointer + row
+index, no owned value, no `Field` base) is the intended evolution — see `DESIGN.md`.
+
+A second, aggregate-side precedent is `SingleValueReference` (column ref + row number, no `Field`)
+in `src/AggregateFunctions/SingleValueData.*`.
+
+## Map of where `Field` lives (roles, not just counts)
+
+Rough scope: ~4,100 occurrences of the `Field` token across ~880 files under `src/`. They cluster
+into four roles:
+
+### A. Already column-backed / `Field`-free on hot paths (good news — leave alone)
+- **`ColumnConst`** stores a **1-row `IColumn`** (`WrappedPtr data` + count `s`), not a `Field`
+  (`src/Columns/ColumnConst.h:13-22, 64-72`). `getField()`/`getValue<T>()` are the only bridges.
+- **`ConstantNode`/`ConstantValue`** (Analyzer) store a `ColumnConst`; `Field` is ingress/egress
+  only (`src/Analyzer/ConstantValue.h`, `src/Analyzer/ConstantNode.h:56-60`).
+- **`ActionsDAG::Node`** stores `ColumnConstPtr`; equality prefers `IColumn::compareAt`
+  (`src/Interpreters/ActionsDAG.cpp:918-931`).
+- **`ExpressionActions`, `PreparedSets`, input/output formats, the Native protocol** are already
+  column-native.
+- **Aggregate hot paths** use `SingleValueDataFixed`, arena strings, `SingleValueReference`.
+
+### B. Genuine standalone value carriers (no backing column — hard to remove; OUT OF SCOPE)
+- **`ASTLiteral::value`** — first representation of a parsed SQL literal
+  (`src/Parsers/ASTLiteral.h:24-29`).
+- **`convertFieldToType`** — detached-value coercion for `IN`, casts, key analysis, `VALUES`
+  (`src/Interpreters/convertFieldToType.*`).
+- **`evaluateConstantExpression`** — public contract is `std::pair<Field, DataTypePtr>`
+  (`src/Interpreters/evaluateConstantExpression.h:21`).
+- **Settings** — internal storage is typed, but the get/set/constraint API is `Field`-centric
+  (`src/Core/BaseSettings.h:193-199`); `SettingChange{Field value}` flows through ALTER/protocol.
+- **`±∞` sentinels** (`NEGATIVE_INFINITY`/`POSITIVE_INFINITY`), `FieldFromAST`.
+
+### C. On-disk / on-wire (hardest — backward compat; OUT OF SCOPE for the pilot)
+- MergeTree `partition.dat`, `minmax_*.idx`, skip-index `.idx2` deserialize into `Field` via
+  `ISerialization::serializeBinary(Field&)`.
+- Partition-ID hashing via `LegacyFieldVisitorHash` (`src/Storages/MergeTree/MergeTreePartition.cpp`).
+- Column statistics V2+ via `writeFieldBinary`/`readFieldBinary`.
+- Aggregate-function parameter persistence via `writeFieldBinary`
+  (`src/Interpreters/AggregateDescription.cpp`).
+- `ISerialization::serializeBinary(const Field&, ...)` is a required virtual on every data type
+  (`src/DataTypes/Serializations/ISerialization.h:579-590`).
+
+### D. Index/range algebra (central, performance-sensitive — PRIME PILOT TARGET)
+- **`KeyCondition`/`Range`/`Hyperrectangle`** built on `FieldRef`
+  (`src/Core/Range.h`, `src/Storages/MergeTree/KeyCondition.*`).
+- `MergeTreeDataSelectExecutor.cpp:1896-1963` explicitly documents `Field`/`FieldRef`/`Range` as a
+  bottleneck for long primary keys and already works around it by choosing explicit vs referential
+  `FieldRef` and building "sparse arrays" to avoid `Field` where possible.
+
+## Feasibility verdict
+
+- **Full elimination of `Field`: not feasible.** Categories B and C have no column to reference
+  and/or are compatibility surfaces requiring multi-release format migrations.
+- **Reduction on hot paths: feasible and aligned with the code's own direction.** Highest
+  value-to-risk targets:
+  1. Introduce a first-class `ValueRef` (column ptr + row index, no `Field` base).
+  2. Route index-analysis min/max checking (`KeyCondition`, category D) and/or generic aggregate
+     state (`SingleValueDataGeneric`) through it.
+  3. Shrink the `IColumn` `Field` surface by adding column-native comparison/extremes helpers and
+     reducing `getValue<T>()`/`getField()` call sites.
+
+The type-correspondence problem (Problem 1) is best addressed **not** by deleting `Field` but by
+never passing a bare `Field` without its `DataTypePtr` — or by using size-1 `ColumnConst` + type,
+which the `ConstantNode` model already does.
+
+## Open questions to resolve during the pilot
+- Can `FieldRef` be re-based on `ValueRef` (composition) without disturbing the `Range`/
+  `KeyCondition` algebra and its monotonic-function caching?
+- What is the measured cost of `Field` materialization in `KeyCondition::checkInHyperrectangle`
+  for a long PK, and how much does `ValueRef` recover? (Needs a microbenchmark + a perf test.)
+- Which `IColumn` comparison primitives are missing to let consumers avoid `Field` entirely
+  (e.g. `compareAt` against a `ValueRef`)?

--- a/.cursor/projects/valueref-pilot/PROGRESS_LOG.md
+++ b/.cursor/projects/valueref-pilot/PROGRESS_LOG.md
@@ -1,0 +1,42 @@
+# Progress log
+
+Append-only journal. Newest entry on top. Never edit or delete past entries — correct them with a
+new entry. Each entry: date, who/what environment, what changed, decisions + rationale, any
+numbers, and an explicit "next step". See `AGENT_GUIDE.md` §3.
+
+---
+
+## 2026-07-10 — Session 0: project bootstrapped (Cursor cloud agent)
+
+**What happened**
+- Completed the initial investigation into removing/reducing `Field`. Findings captured in
+  `INVESTIGATION.md`. Headline: full removal is infeasible; targeted reduction on hot paths via a
+  non-owning `ValueRef` is the plan.
+- Created this persistent project memory under `.cursor/projects/valueref-pilot/`
+  (`README`, `AGENT_GUIDE`, `INVESTIGATION`, `DESIGN`, `ROADMAP`, `TASKS`, `PROGRESS_LOG`).
+- Added `.claude/skills/valueref-pilot/SKILL.md` so Claude Code on a Linux console auto-discovers
+  the project and is routed into this memory. Both Cursor and Claude read git-tracked files, so
+  the memory itself is tool-neutral; the skill is just the discovery hook for the console agent.
+- Branch: `cursor/valueref-pilot-infrastructure-f766`, off `master`. Draft PR opened (see PR link
+  once created).
+
+**Key decisions**
+- Memory lives in git (not agent-ephemeral) so it survives across sessions and environments.
+- Pilot scope is *reduction*, not removal. `Field` stays for SQL literals, settings, and on-disk/
+  wire formats — these are explicitly out of scope (see `AGENT_GUIDE.md` §6, `INVESTIGATION.md`
+  §B/§C).
+- `ValueRef` = `{const IColumn*, size_t row}`, non-owning, `Field`-free; `toField()` is only an
+  escape hatch. Rationale: preserves exact SQL type (fixes the `NearestFieldType` collapse) and
+  avoids per-value allocation.
+- Recommended first migration target is a single hot call site — `SingleValueDataGeneric`
+  (lower risk) or `KeyCondition` min/max (higher value). Decide at the start of Phase 2.
+
+**Numbers**
+- None yet. `sizeof(DB::Field)` is documented as ~40 bytes (libc++) in `Field.h`; confirm and
+  record `sizeof(ValueRef)` in Phase 1.
+
+**Next step**
+- Push branch and open the draft PR (Phase 0 exit).
+- Then start Phase 1: implement `ValueRef` + `gtest_value_ref.cpp`. See `TASKS.md`.
+
+---

--- a/.cursor/projects/valueref-pilot/README.md
+++ b/.cursor/projects/valueref-pilot/README.md
@@ -1,0 +1,56 @@
+# ValueRef Pilot — reducing reliance on `Field` in the ClickHouse server
+
+This directory is the **persistent memory and control center** for a long-running engineering
+project. Its purpose is to let any agent (running from the Cursor cloud UI, or from a Linux
+console via the API) pick up the work with full context, without re-deriving anything.
+
+If you are an agent starting a session on this project, **read [`AGENT_GUIDE.md`](./AGENT_GUIDE.md)
+first**, then skim the current state in [`TASKS.md`](./TASKS.md) and the latest entry in
+[`PROGRESS_LOG.md`](./PROGRESS_LOG.md).
+
+## The one-paragraph summary
+
+`DB::Field` (`src/Core/Field.h`) is a hand-rolled discriminated union representing a single
+database value. It has two structural problems: (1) it is a *value carrier* that in most cases
+could be replaced by a reference into an existing column row, and (2) its type tags do **not**
+correspond 1:1 to ClickHouse SQL types (e.g. `UInt8`, `Date`, `Enum8`, `bool` all collapse to
+`UInt64`; `Float32` collapses to `Float64`). The project introduces a lightweight **`ValueRef`**
+(a `const IColumn* + row index`, carrying no owned value) and migrates hot, `Field`-materializing
+call sites to it, starting with a measurable pilot. Full removal of `Field` is **out of scope**
+and considered infeasible; **reduction** on hot paths is the goal.
+
+## What lives here
+
+| File | Purpose | Update cadence |
+|------|---------|----------------|
+| [`README.md`](./README.md) | This orientation page. | Rarely. |
+| [`AGENT_GUIDE.md`](./AGENT_GUIDE.md) | Operating manual for agents: workflow, git/PR conventions, build & test commands, how to update this memory. | When process changes. |
+| [`INVESTIGATION.md`](./INVESTIGATION.md) | The "why": findings from the initial codebase investigation, with file:line references. | Append as new facts are learned. |
+| [`DESIGN.md`](./DESIGN.md) | The "what": the `ValueRef` design proposal and API sketch. | Revise as the design evolves. |
+| [`ROADMAP.md`](./ROADMAP.md) | Phased milestones from pilot to broader rollout. | At phase boundaries. |
+| [`TASKS.md`](./TASKS.md) | Granular, checkable task backlog and current status. | Every session. |
+| [`PROGRESS_LOG.md`](./PROGRESS_LOG.md) | Append-only journal: what was done, decisions, benchmark numbers, links to PRs/CI. | Every session. |
+
+## How to work on this from either environment
+
+The project memory here is **tool-neutral** — plain git-tracked markdown that any agent can read.
+Only the *discovery hook* differs per tool:
+
+- **From the Cursor cloud UI:** start an agent and point it at this directory (or just mention the
+  "ValueRef pilot"); it follows `AGENT_GUIDE.md`.
+- **From a Linux console with Claude Code:** the project is registered as a Claude skill at
+  `.claude/skills/valueref-pilot/SKILL.md`, which Claude auto-discovers. Ask Claude to "continue
+  the ValueRef pilot" (or mention `Field`/`ValueRef` work) and it will load that skill and route
+  itself into this directory. You can also just tell it to read
+  `.cursor/projects/valueref-pilot/AGENT_GUIDE.md`.
+- **From any console / API:** `git fetch` and check out the project branch (or `master` once
+  merged), `cd` to the repo, and read this directory. All state is in git; nothing lives only in
+  an agent's ephemeral context.
+
+## Ground rules (see `AGENT_GUIDE.md` for detail)
+
+- Follow the repo's `AGENTS.md` rules (ClickHouse contributor and agent conventions).
+- Never commit to `master`; every unit of work goes on a `cursor/<name>-f766` branch with a PR
+  targeting `master`.
+- Keep this memory current: update `TASKS.md` and append to `PROGRESS_LOG.md` **before ending a
+  session**, so the next agent is never lost.

--- a/.cursor/projects/valueref-pilot/ROADMAP.md
+++ b/.cursor/projects/valueref-pilot/ROADMAP.md
@@ -1,0 +1,69 @@
+# Roadmap
+
+Phased plan from proof-of-concept to (possible) broader rollout. Each phase is a gate: do not
+start the next phase until the current one's exit criteria are met and recorded in
+`PROGRESS_LOG.md`. Granular tasks live in `TASKS.md`.
+
+## Phase 0 — Infrastructure (this phase)
+
+Set up persistent project memory so any agent can resume from either environment.
+
+Exit criteria:
+- [x] Project memory directory created and committed.
+- [x] Claude Code discovery hook (skill) in place.
+- [ ] Branch pushed and draft PR opened.
+
+## Phase 1 — Introduce `ValueRef` (foundation)
+
+Add the `ValueRef` type and a unit test, with **no call-site migrations yet**. Keep it a pure,
+self-contained addition that compiles and is covered by tests.
+
+Scope:
+- Add `ValueRef` (header, likely `src/Columns/ValueRef.h` or `src/Core/`), per `DESIGN.md`.
+- Add `src/Core/tests/gtest_value_ref.cpp` (or under `src/Columns/tests/`) proving: construction,
+  `isValid`, `toField` round-trip equals `operator[]`, and `compareAt`-based comparison matches
+  `Field` comparison across representative column types (number, string, nullable, array, const,
+  low-cardinality).
+
+Exit criteria:
+- Builds; unit test passes; no behavior change anywhere else.
+- `sizeof(ValueRef)` confirmed small (via `.claude/tools/cppexpr.sh`).
+
+## Phase 2 — First migration (measurable pilot)
+
+Migrate exactly **one** hot call site (recommended: `SingleValueDataGeneric` aggregate state, or
+`KeyCondition` min/max checking — see `DESIGN.md` "Where it plugs in"). Choose the lower-risk of
+the two first if uncertain.
+
+Scope:
+- Route the chosen call site through `ValueRef`/column primitives instead of `Field`.
+- Add/extend targeted tests. Ensure existing stateless + gtest suites pass.
+- Build a microbenchmark and/or use an existing perf test to measure before/after.
+
+Exit criteria:
+- Behavior identical (tests green, incl. a fuzz/consistency test vs the `Field` path).
+- Perf: no regression; ideally a measurable improvement. Numbers recorded in `PROGRESS_LOG.md` and
+  the PR.
+
+## Phase 3 — Evaluate & decide
+
+With one real migration and numbers in hand, decide whether the approach generalizes.
+
+Scope:
+- Write an assessment in `PROGRESS_LOG.md`: measured wins, friction, correctness hazards found.
+- Update `DESIGN.md` with lessons.
+- Produce a prioritized list (in `TASKS.md`) of the next N call sites, ranked by
+  (hotness × ease × safety).
+
+Exit criteria:
+- A go/no-go recommendation for broader rollout, backed by data.
+
+## Phase 4+ — Broader rollout (only if Phase 3 says go)
+
+Incrementally migrate additional hot call sites, one reviewable PR each. Candidate areas (all
+column-backed, none touching formats): remaining generic aggregate states, `IColumn` extremes/
+min-max helpers, `Range`/`FieldRef` internals, and reducing `getValue<T>()`/`getField()` usage in
+functions.
+
+Non-goals for every phase: removing `Field`; changing SQL-literal, settings, or on-disk/wire
+representations. See `AGENT_GUIDE.md` §6.

--- a/.cursor/projects/valueref-pilot/TASKS.md
+++ b/.cursor/projects/valueref-pilot/TASKS.md
@@ -1,0 +1,55 @@
+# Tasks
+
+**Current focus:** Phase 0 — stand up project infrastructure. Next actionable work is Phase 1
+(introduce the `ValueRef` type + unit test).
+
+Status legend: `TODO` · `IN PROGRESS` · `DONE` · `BLOCKED` · `DROPPED`.
+Keep this file current every session (see `AGENT_GUIDE.md` §3). When you start a task, set it
+`IN PROGRESS` and put your branch/PR next to it.
+
+## Phase 0 — Infrastructure
+
+- [x] `DONE` Investigate `Field` usage and feasibility (see `INVESTIGATION.md`).
+- [x] `DONE` Create persistent project memory under `.cursor/projects/valueref-pilot/`.
+- [x] `DONE` Add Claude Code discovery skill (`.claude/skills/valueref-pilot/SKILL.md`).
+- [ ] `IN PROGRESS` Push branch `cursor/valueref-pilot-infrastructure-f766` and open draft PR.
+
+## Phase 1 — Introduce `ValueRef`
+
+- [ ] `TODO` Decide final location/namespace for `ValueRef` (candidates: `src/Columns/ValueRef.h`,
+  `src/Core/ValueRef.h`). Record decision in `PROGRESS_LOG.md`.
+- [ ] `TODO` Implement `ValueRef` per `DESIGN.md` (non-owning `{const IColumn*, size_t row}`,
+  `isValid`, `toField`/`toField(Field&)`).
+- [ ] `TODO` Add comparison helper(s) built on `IColumn::compareAt`; define structural-equality
+  precondition and null/NaN handling.
+- [ ] `TODO` Add `gtest_value_ref.cpp`: round-trip vs `operator[]`, and comparison parity vs
+  `Field` across number/string/nullable/array/const/low-cardinality columns.
+- [ ] `TODO` Confirm `sizeof(ValueRef)` via `.claude/tools/cppexpr.sh` and note it in the log.
+- [ ] `TODO` Build `unit_tests_dbms`, run `*ValueRef*`, summarize log via subagent.
+
+## Phase 2 — First migration (pick ONE)
+
+- [ ] `TODO` Choose pilot call site: `SingleValueDataGeneric` (lower risk) **or** `KeyCondition`
+  min/max checking (higher value). Record rationale.
+- [ ] `TODO` Implement the migration behind the chosen call site; keep `Field` path intact where
+  it is still the correct boundary (query constants, `±∞`).
+- [ ] `TODO` Add a consistency test comparing `ValueRef` path vs `Field` path results.
+- [ ] `TODO` Build a microbenchmark and/or select an existing perf test; capture before/after
+  numbers.
+- [ ] `TODO` Run relevant stateless tests; summarize logs via subagent.
+
+## Phase 3 — Evaluate
+
+- [ ] `TODO` Write go/no-go assessment with data in `PROGRESS_LOG.md`; update `DESIGN.md`.
+- [ ] `TODO` Rank next candidate call sites by hotness × ease × safety.
+
+## Backlog / ideas (unscheduled)
+
+- [ ] `TODO` Audit and reduce `ColumnConst::getValue<T>()` / `getField()` call sites in
+  `src/Functions/` that construct a `Field` just to read one scalar.
+- [ ] `TODO` Consider a column-native `getExtremes` variant that avoids `Field` min/max.
+- [ ] `TODO` Explore composing `FieldRef` on top of `ValueRef` (see `DESIGN.md` open question).
+
+## Discovered issues / notes
+
+_(Append findings here as tasks surface. Include file:line and a one-line description.)_


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR sets up the persistent infrastructure for a long-running engineering project: reducing reliance on the `Field` class in the ClickHouse server by introducing a non-owning `ValueRef` (a `const IColumn*` + row index). It contains **no server code changes** — only project documentation and an agent skill, so agents (in the Cursor cloud UI or Claude Code on a Linux console) can resume the work with full context from git.

Motivation: `Field` (`src/Core/Field.h`) is a value-carrying variant whose type tags do not correspond 1:1 to ClickHouse SQL types (e.g. `UInt8`/`Date`/`Enum8`/`bool` all collapse to `UInt64`, `Float32` to `Float64`), and per-value materialization is documented as expensive in `IColumn.h`. In most hot cases a reference into an existing column row can replace it. Full removal of `Field` is out of scope and considered infeasible; the project targets *reduction* on hot paths.

What this adds:
- `.cursor/projects/valueref-pilot/` — tool-neutral, git-tracked project memory: `README`, `AGENT_GUIDE`, `INVESTIGATION` (findings with file:line references), `DESIGN` (the `ValueRef` proposal), `ROADMAP` (phased plan), `TASKS` (backlog + status), and an append-only `PROGRESS_LOG`.
- `.claude/skills/valueref-pilot/SKILL.md` — a discovery hook so Claude Code on a Linux console auto-loads the project and routes into the memory directory.

The memory-update protocol (documented in `AGENT_GUIDE.md`) requires each session to update `TASKS.md` and append to `PROGRESS_LOG.md`, so continuity is preserved across sessions and environments.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-432d04e3-f8e9-4a4d-989f-0fc37df3f766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-432d04e3-f8e9-4a4d-989f-0fc37df3f766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>