### PR TITLE
Fix FIPS-mode crash on `CREATE USER` with an Ed25519 SSH key

### DIFF
--- a/src/Access/AuthenticationData.cpp
+++ b/src/Access/AuthenticationData.cpp
@@ -3,6 +3,7 @@
 #include <Access/Common/AuthenticationType.h>
 #include <Common/Base64.h>
 #include <Common/Exception.h>
+#include <Common/logger_useful.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Access/getValidUntilFromAST.h>
 #include <Interpreters/Context.h>
@@ -514,6 +515,14 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
             const auto & ssh_key = query.children[i]->as<ASTPublicSSHKey &>();
             const auto & key_base64 = ssh_key.key_base64;
             const auto & type = ssh_key.type;
+
+            /// A key unusable in the current FIPS mode must not abort the load, so skip it - it cannot authenticate.
+            if (!SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
+            {
+                LOG_WARNING(getLogger("AuthenticationData"),
+                    "Skipping SSH key of type {}: not usable in FIPS mode", type);
+                continue;
+            }
 
             try
             {

--- a/src/Access/AuthenticationData.cpp
+++ b/src/Access/AuthenticationData.cpp
@@ -21,6 +21,7 @@
 #if USE_SSL
 #    include <openssl/rand.h>
 #    include <openssl/err.h>
+#    include <Common/Crypto/OpenSSLInitializer.h>
 #    include <Common/Crypto/X509Certificate.h>
 #    include <Common/OpenSSLHelpers.h>
 #endif
@@ -516,11 +517,9 @@ AuthenticationData AuthenticationData::fromAST(const ASTAuthenticationData & que
             const auto & key_base64 = ssh_key.key_base64;
             const auto & type = ssh_key.type;
 
-            /// A key unusable in the current FIPS mode must not abort the load, so skip it - it cannot authenticate.
-            if (!SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
+            if (OpenSSLInitializer::instance().isFIPSEnabled() && !SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
             {
-                LOG_WARNING(getLogger("AuthenticationData"),
-                    "Skipping SSH key of type {}: not usable in FIPS mode", type);
+                LOG_WARNING(getLogger("AuthenticationData"), "Skipping SSH key of type {}: not usable in FIPS mode", type);
                 continue;
             }
 

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -299,6 +299,12 @@ namespace
                     else
                         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected base64_key field in {} entry", entry);
 
+                    if (!SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
+                    {
+                        LOG_WARNING(&Poco::Logger::get("UsersConfigParser"),
+                            "Skipping SSH key entry {} for user {} (type {}): not usable in FIPS mode", entry, user_name, type);
+                        continue;
+                    }
 
                     try
                     {

--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -35,6 +35,10 @@
 #include <unordered_set>
 #include <boost/container/flat_set.hpp>
 
+#include "config.h"
+#if USE_SSL
+#    include <Common/Crypto/OpenSSLInitializer.h>
+#endif
 
 namespace DB
 {
@@ -299,7 +303,7 @@ namespace
                     else
                         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected base64_key field in {} entry", entry);
 
-                    if (!SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
+                    if (OpenSSLInitializer::instance().isFIPSEnabled() && !SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(type))
                     {
                         LOG_WARNING(&Poco::Logger::get("UsersConfigParser"),
                             "Skipping SSH key entry {} for user {} (type {}): not usable in FIPS mode", entry, user_name, type);

--- a/src/Access/tests/gtest_users_config_multiple_auth.cpp
+++ b/src/Access/tests/gtest_users_config_multiple_auth.cpp
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #include <Access/AccessControl.h>
 #include <Access/UsersConfigAccessStorage.h>
 #include <Access/User.h>
@@ -7,14 +5,6 @@
 #include <Poco/Util/XMLConfiguration.h>
 #include <gtest/gtest.h>
 #include <sstream>
-
-#if USE_SSH && USE_SSL
-#include <Access/AuthenticationData.h>
-#include <Common/Crypto/OpenSSLInitializer.h>
-#include <Parsers/Access/ASTAuthenticationData.h>
-#include <Parsers/Access/ASTPublicSSHKey.h>
-#include <openssl/evp.h>
-#endif
 
 using namespace DB;
 
@@ -825,103 +815,3 @@ TEST_F(UsersConfigMultipleAuthTest, OTPWithMixedAuthIncludingPassword)
     EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::LDAP);
     EXPECT_EQ(user->authentication_methods[1].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
 }
-
-#if USE_SSH && USE_SSL
-
-namespace
-{
-    /// RAII guard toggling the OpenSSL runtime FIPS property (drives OpenSSLInitializer::isFIPSEnabled()).
-    struct FIPSModeGuard
-    {
-        int previous = 0;
-        explicit FIPSModeGuard(int enable)
-        {
-            previous = EVP_default_properties_is_fips_enabled(nullptr) ? 1 : 0;
-            EVP_default_properties_enable_fips(nullptr, enable);
-        }
-        ~FIPSModeGuard() { EVP_default_properties_enable_fips(nullptr, previous); }
-    };
-}
-
-/// Regression for #50188: a legacy users.xml with an Ed25519 SSH key must still load on a FIPS build.
-/// The key is unusable in FIPS mode, but reloading persisted config must skip it, not abort startup.
-TEST_F(UsersConfigMultipleAuthTest, FIPSEd25519SSHKeyInUsersConfigDoesNotAbort)
-{
-    FIPSModeGuard fips(1);
-    ASSERT_TRUE(OpenSSLInitializer::instance().isFIPSEnabled());
-
-    const std::string xml_config = R"(
-        <clickhouse>
-            <users>
-                <ssh_user>
-                    <ssh_keys>
-                        <ssh_key>
-                            <type>ssh-ed25519</type>
-                            <base64_key>AAAAC3NzaC1lZDI1NTE5AAAAIKQxIaNx90rIr79c5S8cT9fhAsfJK/cCS2dAbyp1xJIj</base64_key>
-                        </ssh_key>
-                    </ssh_keys>
-                </ssh_user>
-                <plain_user>
-                    <password>plaintext_pass</password>
-                </plain_user>
-            </users>
-        </clickhouse>
-    )";
-
-    auto config = createConfigFromXML(xml_config);
-    /// Must not throw: one unusable key does not block the whole config parse.
-    ASSERT_NO_THROW(storage->setConfig(*config));
-
-    /// The unusable key is skipped, so the SSH_KEY method has no usable keys and cannot authenticate.
-    auto ssh_user = storage->tryRead<User>("ssh_user");
-    ASSERT_TRUE(ssh_user);
-    ASSERT_EQ(ssh_user->authentication_methods.size(), 1);
-    const auto & ssh_auth = ssh_user->authentication_methods[0];
-    EXPECT_EQ(ssh_auth.getType(), AuthenticationType::SSH_KEY);
-    EXPECT_TRUE(ssh_auth.getSSHKeys().empty());
-
-    /// Other users in the same config are unaffected.
-    auto plain_user = storage->tryRead<User>("plain_user");
-    ASSERT_TRUE(plain_user);
-    ASSERT_EQ(plain_user->authentication_methods.size(), 1);
-    EXPECT_EQ(plain_user->authentication_methods[0].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
-}
-
-namespace
-{
-    /// CREATE/ALTER USER ... IDENTIFIED WITH ssh_key BY KEY '<base64>' TYPE 'ssh-ed25519', as an AST.
-    ASTPtr makeEd25519SSHKeyAuthAST()
-    {
-        auto auth = make_intrusive<ASTAuthenticationData>();
-        auth->type = AuthenticationType::SSH_KEY;
-        auth->children.push_back(make_intrusive<ASTPublicSSHKey>(
-            "AAAAC3NzaC1lZDI1NTE5AAAAIKQxIaNx90rIr79c5S8cT9fhAsfJK/cCS2dAbyp1xJIj", "ssh-ed25519"));
-        return auth;
-    }
-}
-
-/// Regression for #50188 on the fromAST path (CREATE/ALTER/ATTACH USER, store reload): an ssh-ed25519 key
-/// is skipped under FIPS (unusable, leaving an empty SSH_KEY method) and imported normally otherwise.
-TEST_F(UsersConfigMultipleAuthTest, FIPSEd25519SSHKeyFromASTSkipped)
-{
-    auto auth = makeEd25519SSHKeyAuthAST();
-    const auto & query = auth->as<ASTAuthenticationData &>();
-
-    {
-        FIPSModeGuard fips(1);
-        ASSERT_TRUE(OpenSSLInitializer::instance().isFIPSEnabled());
-        auto auth_data = AuthenticationData::fromAST(query, nullptr, /*validate=*/true);
-        EXPECT_EQ(auth_data.getType(), AuthenticationType::SSH_KEY);
-        EXPECT_TRUE(auth_data.getSSHKeys().empty());
-    }
-
-    {
-        FIPSModeGuard fips(0);
-        ASSERT_FALSE(OpenSSLInitializer::instance().isFIPSEnabled());
-        auto auth_data = AuthenticationData::fromAST(query, nullptr, /*validate=*/true);
-        EXPECT_EQ(auth_data.getType(), AuthenticationType::SSH_KEY);
-        EXPECT_EQ(auth_data.getSSHKeys().size(), 1u);
-    }
-}
-
-#endif

--- a/src/Access/tests/gtest_users_config_multiple_auth.cpp
+++ b/src/Access/tests/gtest_users_config_multiple_auth.cpp
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #include <Access/AccessControl.h>
 #include <Access/UsersConfigAccessStorage.h>
 #include <Access/User.h>
@@ -5,6 +7,14 @@
 #include <Poco/Util/XMLConfiguration.h>
 #include <gtest/gtest.h>
 #include <sstream>
+
+#if USE_SSH && USE_SSL
+#include <Access/AuthenticationData.h>
+#include <Common/Crypto/OpenSSLInitializer.h>
+#include <Parsers/Access/ASTAuthenticationData.h>
+#include <Parsers/Access/ASTPublicSSHKey.h>
+#include <openssl/evp.h>
+#endif
 
 using namespace DB;
 
@@ -815,3 +825,103 @@ TEST_F(UsersConfigMultipleAuthTest, OTPWithMixedAuthIncludingPassword)
     EXPECT_EQ(user->authentication_methods[0].getType(), AuthenticationType::LDAP);
     EXPECT_EQ(user->authentication_methods[1].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
 }
+
+#if USE_SSH && USE_SSL
+
+namespace
+{
+    /// RAII guard toggling the OpenSSL runtime FIPS property (drives OpenSSLInitializer::isFIPSEnabled()).
+    struct FIPSModeGuard
+    {
+        int previous = 0;
+        explicit FIPSModeGuard(int enable)
+        {
+            previous = EVP_default_properties_is_fips_enabled(nullptr) ? 1 : 0;
+            EVP_default_properties_enable_fips(nullptr, enable);
+        }
+        ~FIPSModeGuard() { EVP_default_properties_enable_fips(nullptr, previous); }
+    };
+}
+
+/// Regression for #50188: a legacy users.xml with an Ed25519 SSH key must still load on a FIPS build.
+/// The key is unusable in FIPS mode, but reloading persisted config must skip it, not abort startup.
+TEST_F(UsersConfigMultipleAuthTest, FIPSEd25519SSHKeyInUsersConfigDoesNotAbort)
+{
+    FIPSModeGuard fips(1);
+    ASSERT_TRUE(OpenSSLInitializer::instance().isFIPSEnabled());
+
+    const std::string xml_config = R"(
+        <clickhouse>
+            <users>
+                <ssh_user>
+                    <ssh_keys>
+                        <ssh_key>
+                            <type>ssh-ed25519</type>
+                            <base64_key>AAAAC3NzaC1lZDI1NTE5AAAAIKQxIaNx90rIr79c5S8cT9fhAsfJK/cCS2dAbyp1xJIj</base64_key>
+                        </ssh_key>
+                    </ssh_keys>
+                </ssh_user>
+                <plain_user>
+                    <password>plaintext_pass</password>
+                </plain_user>
+            </users>
+        </clickhouse>
+    )";
+
+    auto config = createConfigFromXML(xml_config);
+    /// Must not throw: one unusable key does not block the whole config parse.
+    ASSERT_NO_THROW(storage->setConfig(*config));
+
+    /// The unusable key is skipped, so the SSH_KEY method has no usable keys and cannot authenticate.
+    auto ssh_user = storage->tryRead<User>("ssh_user");
+    ASSERT_TRUE(ssh_user);
+    ASSERT_EQ(ssh_user->authentication_methods.size(), 1);
+    const auto & ssh_auth = ssh_user->authentication_methods[0];
+    EXPECT_EQ(ssh_auth.getType(), AuthenticationType::SSH_KEY);
+    EXPECT_TRUE(ssh_auth.getSSHKeys().empty());
+
+    /// Other users in the same config are unaffected.
+    auto plain_user = storage->tryRead<User>("plain_user");
+    ASSERT_TRUE(plain_user);
+    ASSERT_EQ(plain_user->authentication_methods.size(), 1);
+    EXPECT_EQ(plain_user->authentication_methods[0].getType(), AuthenticationType::PLAINTEXT_PASSWORD);
+}
+
+namespace
+{
+    /// CREATE/ALTER USER ... IDENTIFIED WITH ssh_key BY KEY '<base64>' TYPE 'ssh-ed25519', as an AST.
+    ASTPtr makeEd25519SSHKeyAuthAST()
+    {
+        auto auth = make_intrusive<ASTAuthenticationData>();
+        auth->type = AuthenticationType::SSH_KEY;
+        auth->children.push_back(make_intrusive<ASTPublicSSHKey>(
+            "AAAAC3NzaC1lZDI1NTE5AAAAIKQxIaNx90rIr79c5S8cT9fhAsfJK/cCS2dAbyp1xJIj", "ssh-ed25519"));
+        return auth;
+    }
+}
+
+/// Regression for #50188 on the fromAST path (CREATE/ALTER/ATTACH USER, store reload): an ssh-ed25519 key
+/// is skipped under FIPS (unusable, leaving an empty SSH_KEY method) and imported normally otherwise.
+TEST_F(UsersConfigMultipleAuthTest, FIPSEd25519SSHKeyFromASTSkipped)
+{
+    auto auth = makeEd25519SSHKeyAuthAST();
+    const auto & query = auth->as<ASTAuthenticationData &>();
+
+    {
+        FIPSModeGuard fips(1);
+        ASSERT_TRUE(OpenSSLInitializer::instance().isFIPSEnabled());
+        auto auth_data = AuthenticationData::fromAST(query, nullptr, /*validate=*/true);
+        EXPECT_EQ(auth_data.getType(), AuthenticationType::SSH_KEY);
+        EXPECT_TRUE(auth_data.getSSHKeys().empty());
+    }
+
+    {
+        FIPSModeGuard fips(0);
+        ASSERT_FALSE(OpenSSLInitializer::instance().isFIPSEnabled());
+        auto auth_data = AuthenticationData::fromAST(query, nullptr, /*validate=*/true);
+        EXPECT_EQ(auth_data.getType(), AuthenticationType::SSH_KEY);
+        EXPECT_EQ(auth_data.getSSHKeys().size(), 1u);
+    }
+}
+
+#endif

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -3,6 +3,8 @@
 # if USE_SSH
 #    include <stdexcept>
 
+#    include <Common/Crypto/OpenSSLInitializer.h>
+
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wreserved-macro-identifier"
 #    pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -29,6 +31,27 @@ struct CStringDeleter
 {
     void operator()(char * ptr) const { std::free(ptr); }
 };
+
+bool isEd25519KeyType(enum ssh_keytypes_e key_type)
+{
+    return key_type == SSH_KEYTYPE_ED25519 || key_type == SSH_KEYTYPE_ED25519_CERT01
+        || key_type == SSH_KEYTYPE_SK_ED25519 || key_type == SSH_KEYTYPE_SK_ED25519_CERT01;
+}
+
+bool isKeyTypeUsableInFIPSBuilds(enum ssh_keytypes_e key_type)
+{
+    /// Ed25519 is not FIPS-approved: importing it in FIPS mode in libssh will cause bad things to happen
+    return !isEd25519KeyType(key_type) || !OpenSSLInitializer::instance().isFIPSEnabled();
+}
+
+void checkIfKeyCanBeUsedInFIPSBuilds(ssh_key key)
+{
+    if (key != nullptr && !isKeyTypeUsableInFIPSBuilds(ssh_key_type(key)))
+    {
+        ssh_key_free(key);
+        throw Exception(ErrorCodes::LIBSSH_ERROR, "Ed25519 SSH keys are not supported in FIPS mode");
+    }
+}
 }
 
 SSHKey SSHKeyFactory::makePrivateKeyFromFile(String filename, String passphrase)
@@ -36,6 +59,7 @@ SSHKey SSHKeyFactory::makePrivateKeyFromFile(String filename, String passphrase)
     ssh_key key = nullptr;
     if (int rc = ssh_pki_import_privkey_file(filename.c_str(), passphrase.c_str(), nullptr, nullptr, &key); rc != SSH_OK)
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't import SSH private key from file");
+    checkIfKeyCanBeUsedInFIPSBuilds(key);
     return SSHKey(key);
 }
 
@@ -44,6 +68,7 @@ SSHKey SSHKeyFactory::makePublicKeyFromFile(String filename)
     ssh_key key = nullptr;
     if (int rc = ssh_pki_import_pubkey_file(filename.c_str(), &key); rc != SSH_OK)
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Can't import SSH public key from file");
+    checkIfKeyCanBeUsedInFIPSBuilds(key);
     return SSHKey(key);
 }
 
@@ -51,9 +76,18 @@ SSHKey SSHKeyFactory::makePublicKeyFromBase64(String base64_key, String type_nam
 {
     ssh_key key = nullptr;
     auto key_type = ssh_key_type_from_name(type_name.c_str());
+    /// Reject before import: libssh's FIPS ed25519 import leaks a pubkey blob in libcrypto builds.
+    if (!isKeyTypeUsableInFIPSBuilds(key_type))
+        throw Exception(ErrorCodes::LIBSSH_ERROR, "Ed25519 SSH keys are not supported in FIPS mode");
     if (int rc = ssh_pki_import_pubkey_base64(base64_key.c_str(), key_type, &key); rc != SSH_OK)
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Bad SSH public key provided");
+    checkIfKeyCanBeUsedInFIPSBuilds(key);
     return SSHKey(key);
+}
+
+bool SSHKeyFactory::isPublicKeyUsableInFIPSBuilds(const String & type_name)
+{
+    return isKeyTypeUsableInFIPSBuilds(ssh_key_type_from_name(type_name.c_str()));
 }
 
 SSHKey::SSHKey(const SSHKey & other)

--- a/src/Common/SSHWrapper.cpp
+++ b/src/Common/SSHWrapper.cpp
@@ -1,10 +1,10 @@
 #include <Common/SSHWrapper.h>
 
-# if USE_SSH
-#    include <stdexcept>
-
+#if USE_SSL
 #    include <Common/Crypto/OpenSSLInitializer.h>
+#endif
 
+#if USE_SSH
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wreserved-macro-identifier"
 #    pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -32,21 +32,17 @@ struct CStringDeleter
     void operator()(char * ptr) const { std::free(ptr); }
 };
 
-bool isEd25519KeyType(enum ssh_keytypes_e key_type)
+bool isKeyTypeUsableInFIPSBuilds(enum ssh_keytypes_e key_type)
 {
+    /// Ed25519 is not FIPS-approved: importing it in FIPS mode in libssh will cause bad things to happen
     return key_type == SSH_KEYTYPE_ED25519 || key_type == SSH_KEYTYPE_ED25519_CERT01
         || key_type == SSH_KEYTYPE_SK_ED25519 || key_type == SSH_KEYTYPE_SK_ED25519_CERT01;
 }
 
-bool isKeyTypeUsableInFIPSBuilds(enum ssh_keytypes_e key_type)
-{
-    /// Ed25519 is not FIPS-approved: importing it in FIPS mode in libssh will cause bad things to happen
-    return !isEd25519KeyType(key_type) || !OpenSSLInitializer::instance().isFIPSEnabled();
-}
-
 void checkIfKeyCanBeUsedInFIPSBuilds(ssh_key key)
 {
-    if (key != nullptr && !isKeyTypeUsableInFIPSBuilds(ssh_key_type(key)))
+    if (key != nullptr
+        && (OpenSSLInitializer::instance().isFIPSEnabled() && !isKeyTypeUsableInFIPSBuilds(ssh_key_type(key))))
     {
         ssh_key_free(key);
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Ed25519 SSH keys are not supported in FIPS mode");
@@ -76,7 +72,6 @@ SSHKey SSHKeyFactory::makePublicKeyFromBase64(String base64_key, String type_nam
 {
     ssh_key key = nullptr;
     auto key_type = ssh_key_type_from_name(type_name.c_str());
-    /// Reject before import: libssh's FIPS ed25519 import leaks a pubkey blob in libcrypto builds.
     if (!isKeyTypeUsableInFIPSBuilds(key_type))
         throw Exception(ErrorCodes::LIBSSH_ERROR, "Ed25519 SSH keys are not supported in FIPS mode");
     if (int rc = ssh_pki_import_pubkey_base64(base64_key.c_str(), key_type, &key); rc != SSH_OK)

--- a/src/Common/SSHWrapper.h
+++ b/src/Common/SSHWrapper.h
@@ -58,6 +58,8 @@ public:
     static SSHKey makePrivateKeyFromFile(String filename, String passphrase);
     static SSHKey makePublicKeyFromFile(String filename);
     static SSHKey makePublicKeyFromBase64(String base64_key, String type_name);
+
+    static bool isPublicKeyUsableInFIPSBuilds(const String & type_name);
 };
 
 }

--- a/tests/queries/0_stateless/03918_ssh_protocol.sh
+++ b/tests/queries/0_stateless/03918_ssh_protocol.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-openssl-fips
+# no-openssl-fips: authenticates with an ssh-ed25519 key, which is not FIPS-approved and rejected at import on FIPS builds.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a crash when creating a user with an Ed25519 SSH public key on a FIPS build.