### PR TITLE
Compile Interpreters/HashJoin through a dedicated ninja job pool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,7 +339,10 @@ add_object_library(clickhouse_planner Planner)
 add_object_library(clickhouse_interpreters Interpreters)
 add_object_library(clickhouse_interpreters_cache Interpreters/Cache)
 add_object_library(clickhouse_interpreters_filecache Interpreters/FileCache)
-add_object_library(clickhouse_interpreters_hash_join Interpreters/HashJoin)
+# Interpreters/HashJoin is compiled as a separate object library (see below,
+# after the `dbms` target is fully configured) so that its compile jobs can be
+# throttled through a dedicated ninja job pool.
+add_headers_and_sources(clickhouse_interpreters_hash_join Interpreters/HashJoin)
 add_object_library(clickhouse_interpreters_access Interpreters/Access)
 add_object_library(clickhouse_interpreters_mysql Interpreters/MySQL)
 add_object_library(clickhouse_interpreters_clusterproxy Interpreters/ClusterProxy)
@@ -905,6 +908,48 @@ if (TARGET ch_rust::wasmtime)
     target_link_libraries(clickhouse_common_io PRIVATE ch_rust::wasmtime)
     target_link_libraries(dbms PRIVATE ch_rust::wasmtime)
 endif()
+
+# The join-instantiation translation units in Interpreters/HashJoin are by far
+# the most memory-hungry compiles of the whole build: with sanitizers each one
+# peaks at ~5 GB. On a cold compiler cache ninja's critical-path scheduling
+# starts all of them at once, which can exceed the builder's memory and get
+# the compilers killed by the OOM killer. Compile them as a separate object
+# library whose job pool bounds how many are in flight simultaneously, sized
+# by physical memory; the rest of the build keeps full parallelism. The pool
+# is only applied to sanitizer/fuzzer builds - elsewhere these units are not
+# outliers enough to matter.
+add_library(clickhouse_interpreters_hash_join OBJECT ${clickhouse_interpreters_hash_join_headers} ${clickhouse_interpreters_hash_join_sources})
+# Inherit the compile environment of `dbms` (snapshotted here, after `dbms` is
+# fully configured; nothing modifies it outside this file). `daemon` and
+# `loggers` are excluded from the inherited link libraries: they mutually link
+# `dbms` (a cycle that is legal among static libraries but not with an object
+# library in the loop), and nothing in Interpreters/HashJoin uses their headers.
+get_target_property(dbms_include_directories dbms INCLUDE_DIRECTORIES)
+get_target_property(dbms_compile_definitions dbms COMPILE_DEFINITIONS)
+get_target_property(dbms_compile_options dbms COMPILE_OPTIONS)
+get_target_property(dbms_link_libraries dbms LINK_LIBRARIES)
+list(REMOVE_ITEM dbms_link_libraries daemon loggers)
+target_include_directories(clickhouse_interpreters_hash_join PRIVATE ${dbms_include_directories})
+if (dbms_compile_definitions)
+    target_compile_definitions(clickhouse_interpreters_hash_join PRIVATE ${dbms_compile_definitions})
+endif ()
+if (dbms_compile_options)
+    target_compile_options(clickhouse_interpreters_hash_join PRIVATE ${dbms_compile_options})
+endif ()
+target_link_libraries(clickhouse_interpreters_hash_join PRIVATE ${dbms_link_libraries})
+target_sources(dbms PRIVATE $<TARGET_OBJECTS:clickhouse_interpreters_hash_join>)
+if (SANITIZE OR SANITIZE_COVERAGE OR ENABLE_FUZZING)
+    set (MAX_HASH_JOIN_COMPILER_MEMORY 8000) # megabytes; ~5 GB peak per TU plus headroom for the rest of the build
+    math (EXPR HASH_JOIN_COMPILE_JOBS "${TOTAL_PHYSICAL_MEMORY} / ${MAX_HASH_JOIN_COMPILER_MEMORY}")
+    if (HASH_JOIN_COMPILE_JOBS LESS 2)
+        set (HASH_JOIN_COMPILE_JOBS 2)
+    elseif (HASH_JOIN_COMPILE_JOBS GREATER NUMBER_OF_LOGICAL_CORES)
+        set (HASH_JOIN_COMPILE_JOBS ${NUMBER_OF_LOGICAL_CORES})
+    endif ()
+    message (STATUS "Limiting concurrent compilation of Interpreters/HashJoin to ${HASH_JOIN_COMPILE_JOBS} jobs")
+    set_property (GLOBAL APPEND PROPERTY JOB_POOLS hash_join_compile_pool=${HASH_JOIN_COMPILE_JOBS})
+    set_target_properties (clickhouse_interpreters_hash_join PROPERTIES JOB_POOL_COMPILE hash_join_compile_pool)
+endif ()
 
 if (ENABLE_TESTS)
     macro (grep_gtest_sources BASE_DIR DST_VAR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,10 +339,14 @@ add_object_library(clickhouse_planner Planner)
 add_object_library(clickhouse_interpreters Interpreters)
 add_object_library(clickhouse_interpreters_cache Interpreters/Cache)
 add_object_library(clickhouse_interpreters_filecache Interpreters/FileCache)
-# Interpreters/HashJoin is compiled as a separate object library (see below,
-# after the `dbms` target is fully configured) so that its compile jobs can be
-# throttled through a dedicated ninja job pool.
-add_headers_and_sources(clickhouse_interpreters_hash_join Interpreters/HashJoin)
+if (SANITIZE OR SANITIZE_COVERAGE OR ENABLE_FUZZING)
+    # Compiled as a separate library with limited concurrency; see the target
+    # definition below, after `dbms` is fully configured.
+    set (LIMIT_HASH_JOIN_COMPILE_CONCURRENCY 1)
+    add_headers_and_sources(clickhouse_interpreters_hash_join Interpreters/HashJoin)
+else ()
+    add_object_library(clickhouse_interpreters_hash_join Interpreters/HashJoin)
+endif ()
 add_object_library(clickhouse_interpreters_access Interpreters/Access)
 add_object_library(clickhouse_interpreters_mysql Interpreters/MySQL)
 add_object_library(clickhouse_interpreters_clusterproxy Interpreters/ClusterProxy)
@@ -909,40 +913,32 @@ if (TARGET ch_rust::wasmtime)
     target_link_libraries(dbms PRIVATE ch_rust::wasmtime)
 endif()
 
-# The join-instantiation translation units in Interpreters/HashJoin are by far
-# the most memory-hungry compiles of the whole build: with sanitizers each one
-# peaks at ~5 GB. On a cold compiler cache ninja's critical-path scheduling
-# starts all of them at once, which can exceed the builder's memory and get
-# the compilers killed by the OOM killer. Compile them as a separate object
-# library whose job pool bounds how many are in flight simultaneously, sized
-# by physical memory; the rest of the build keeps full parallelism. The pool
-# is only applied to sanitizer/fuzzer builds - elsewhere these units are not
-# outliers enough to matter.
-add_library(clickhouse_interpreters_hash_join OBJECT ${clickhouse_interpreters_hash_join_headers} ${clickhouse_interpreters_hash_join_sources})
-# Inherit the compile environment of `dbms` (snapshotted here, after `dbms` is
-# fully configured; nothing modifies it outside this file). `daemon` and
-# `loggers` are excluded from the inherited link libraries: they mutually link
-# `dbms` (a cycle that is legal among static libraries but not with an object
-# library in the loop), and nothing in Interpreters/HashJoin uses their headers.
-get_target_property(dbms_include_directories dbms INCLUDE_DIRECTORIES)
-get_target_property(dbms_compile_definitions dbms COMPILE_DEFINITIONS)
-get_target_property(dbms_compile_options dbms COMPILE_OPTIONS)
-get_target_property(dbms_link_libraries dbms LINK_LIBRARIES)
-list(REMOVE_ITEM dbms_link_libraries daemon loggers)
-target_include_directories(clickhouse_interpreters_hash_join PRIVATE ${dbms_include_directories})
-if (dbms_compile_definitions)
-    target_compile_definitions(clickhouse_interpreters_hash_join PRIVATE ${dbms_compile_definitions})
-endif ()
-if (dbms_compile_options)
-    target_compile_options(clickhouse_interpreters_hash_join PRIVATE ${dbms_compile_options})
-endif ()
-target_link_libraries(clickhouse_interpreters_hash_join PRIVATE ${dbms_link_libraries})
-target_sources(dbms PRIVATE $<TARGET_OBJECTS:clickhouse_interpreters_hash_join>)
-if (SANITIZE OR SANITIZE_COVERAGE OR ENABLE_FUZZING)
-    set (MAX_HASH_JOIN_COMPILER_MEMORY 8000) # megabytes; ~5 GB peak per TU plus headroom for the rest of the build
-    math (EXPR HASH_JOIN_COMPILE_JOBS "${TOTAL_PHYSICAL_MEMORY} / ${MAX_HASH_JOIN_COMPILER_MEMORY}")
-    if (HASH_JOIN_COMPILE_JOBS LESS 2)
-        set (HASH_JOIN_COMPILE_JOBS 2)
+# The join-instantiation translation units in Interpreters/HashJoin are the
+# most memory-hungry compiles of the whole build: with sanitizers each one
+# peaks at ~5 GB, and on a cold compiler cache ninja's critical-path
+# scheduling starts all of them at once, which can exhaust the builder's
+# memory. Compile them as a separate library whose ninja job pool bounds how
+# many are in flight simultaneously, sized by physical memory; the rest of
+# the build keeps full parallelism.
+if (LIMIT_HASH_JOIN_COMPILE_CONCURRENCY)
+    add_library (clickhouse_interpreters_hash_join ${clickhouse_interpreters_hash_join_headers} ${clickhouse_interpreters_hash_join_sources})
+    # The mutual link is a static-library cycle (like `daemon` <-> `dbms`) that
+    # gives the library the public compile environment of `dbms`.
+    target_link_libraries (clickhouse_interpreters_hash_join PRIVATE dbms)
+    target_link_libraries (dbms PUBLIC clickhouse_interpreters_hash_join)
+    if (TARGET ch_contrib::jemalloc)
+        # Reachable through memory-tracking headers, but linked to `dbms` only privately.
+        target_link_libraries (clickhouse_interpreters_hash_join PRIVATE ch_contrib::jemalloc)
+    endif ()
+
+    math (EXPR HASH_JOIN_COMPILE_JOBS "${TOTAL_PHYSICAL_MEMORY} / 8000") # ~5 GB peak per unit, plus headroom for the rest of the build
+    if (HASH_JOIN_COMPILE_JOBS LESS 1)
+        set (HASH_JOIN_COMPILE_JOBS 1)
+    endif ()
+    # A target-specific job pool replaces the global one from cmake/limit_jobs.cmake
+    # for these translation units, so it must not exceed the global compile cap.
+    if (PARALLEL_COMPILE_JOBS AND HASH_JOIN_COMPILE_JOBS GREATER PARALLEL_COMPILE_JOBS)
+        set (HASH_JOIN_COMPILE_JOBS ${PARALLEL_COMPILE_JOBS})
     elseif (HASH_JOIN_COMPILE_JOBS GREATER NUMBER_OF_LOGICAL_CORES)
         set (HASH_JOIN_COMPILE_JOBS ${NUMBER_OF_LOGICAL_CORES})
     endif ()


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109864

## Motivation

The join-instantiation translation units in `Interpreters/HashJoin` (33 files) are the most memory-hungry compiles of the whole build: with sanitizers each one peaks at ~5 GB (measured 4.9 GiB peak RSS for `LeftHashJoinRightAnyMapsAll.cpp` in the `arm_fuzzers` configuration).

Normally this goes unnoticed because these units are sccache hits. On a cold cache, however, ninja's critical-path scheduling (seeded from the toolchain `ninja_log`) starts all of them at once. On the `arm_fuzzers` builder (m8g.8xlarge: 32 cores, 128 GB, ~117 GiB container memory limit), 32 concurrent compile jobs at 3–5 GB each exceed the container limit and the kernel OOM killer terminates the largest compiler processes:

```
FAILED: src/CMakeFiles/dbms.dir/Interpreters/HashJoin/LeftHashJoinRightAnyMapsAll.cpp.o
sccache: Compiler killed by signal 9
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109864&sha=b2a30564a2cd30eaaaf8014aa68e5b49ef751b9a&name_0=PR&name_1=Build%20(arm_fuzzers)

This blocks toolchain updates such as #109864 deterministically: PR builds read the shared sccache bucket in read-only mode, and a new compiler invalidates every cache key, so every retry replays the same cold 32-wide wave and fails at the same file.

## Approach

For sanitizer/fuzzer builds, compile `Interpreters/HashJoin` as a separate static library whose ninja job pool bounds how many of these units are in flight simultaneously. The pool size is derived from physical memory (8 GB per job: ~5 GB peak plus headroom for the rest of the build), i.e. 16 concurrent jobs on a 128 GB builder, and is clamped to the effective global compile cap (`PARALLEL_COMPILE_JOBS`), which a target-specific pool would otherwise override. The rest of the build keeps full parallelism, and non-sanitizer builds keep the sources inside `dbms` exactly as before.

The library inherits the public compile environment of `dbms` through a mutual link — a static-library cycle, which CMake explicitly permits and which already exists between `daemon` and `dbms`. `ch_contrib::jemalloc` is linked explicitly for the configurations where it exists (UBSan): its headers are reachable through the memory-tracking headers, but `dbms` links it only privately.

An alternative would be raising `MAX_COMPILER_MEMORY` (`cmake/limit_jobs.cmake`) for sanitizer builds, but that caps the parallelism of the entire build; the pool throttles only the 33 outlier units.

## Verification

Verified locally on aarch64 (32 cores, 61 GB) with the same PGO+BOLT clang and the exact `arm_fuzzers` cmake configuration: the pool is created with the expected memory-derived depth, all 33 objects are assigned `pool = hash_join_compile_pool` in `build.ninja`, the full dependency closure builds and links (`libclickhouse_interpreters_hash_join.a`, `libdbms.a`), and the peak `HashJoin` compile concurrency measured from `.ninja_log` exactly equals the pool depth. With `-DPARALLEL_COMPILE_JOBS=4` the pool is clamped to 4. A non-sanitizer configure produces no pool and no separate target — the build graph is unchanged.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Compile the join-instantiation translation units in `Interpreters/HashJoin` through a dedicated ninja job pool sized by available memory in sanitizer/fuzzer builds. Each of these units needs ~5 GB to compile under sanitizers; on a cold compiler cache they were all scheduled at once and CI builders ran out of memory (`sccache: Compiler killed by signal 9`).
