### PR TITLE
Recognize arrayJoin aliases (unnest) in the row policy filter guard

### DIFF
--- a/src/Access/RowPolicy.cpp
+++ b/src/Access/RowPolicy.cpp
@@ -2,9 +2,12 @@
 #include <Common/Exception.h>
 #include <Common/quoteString.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/UserDefined/UserDefinedSQLFunctionFactory.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <boost/range/algorithm/equal.hpp>
+
+#include <unordered_set>
 
 
 namespace DB
@@ -17,19 +20,26 @@ namespace ErrorCodes
 
 namespace
 {
-    /// arrayJoin changes the number of rows. Resolve the function name to its canonical form so
-    /// aliases (such as the case-insensitive unnest) are caught too. A call inside a nested
+    /// arrayJoin changes the number of rows. It can hide behind an alias (the case-insensitive
+    /// unnest, caught by resolving to the canonical name) or a SQL UDF that is inlined into the
+    /// filter at read time (caught by descending into the UDF body). A call inside a nested
     /// subquery has its own scope and does not multiply the outer rows, so it is skipped.
-    bool expressionContainsArrayJoin(const ASTPtr & ast)
+    bool expressionContainsArrayJoin(const ASTPtr & ast, std::unordered_set<String> & visited_udfs)
     {
         if (!ast)
             return false;
-        if (const auto * function = ast->as<ASTFunction>();
-            function && getFunctionCanonicalNameIfAny(function->name) == "arrayJoin")
-            return true;
+        if (const auto * function = ast->as<ASTFunction>())
+        {
+            if (getFunctionCanonicalNameIfAny(function->name) == "arrayJoin")
+                return true;
+            if (auto udf_body = UserDefinedSQLFunctionFactory::instance().tryGet(function->name);
+                udf_body && visited_udfs.insert(function->name).second
+                    && expressionContainsArrayJoin(udf_body, visited_udfs))
+                return true;
+        }
         for (const auto & child : ast->children)
         {
-            if (!child->as<ASTSelectQuery>() && expressionContainsArrayJoin(child))
+            if (!child->as<ASTSelectQuery>() && expressionContainsArrayJoin(child, visited_udfs))
                 return true;
         }
         return false;
@@ -38,7 +48,8 @@ namespace
 
 void checkRowPolicyFilterExpression(const ASTPtr & expression)
 {
-    if (expressionContainsArrayJoin(expression))
+    std::unordered_set<String> visited_udfs;
+    if (expressionContainsArrayJoin(expression, visited_udfs))
         throw Exception(ErrorCodes::ILLEGAL_PREWHERE, "arrayJoin is not allowed in a row policy filter expression");
 }
 

--- a/src/Access/RowPolicy.cpp
+++ b/src/Access/RowPolicy.cpp
@@ -1,6 +1,7 @@
 #include <Access/RowPolicy.h>
 #include <Common/Exception.h>
 #include <Common/quoteString.h>
+#include <Functions/FunctionFactory.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <boost/range/algorithm/equal.hpp>
@@ -16,12 +17,15 @@ namespace ErrorCodes
 
 namespace
 {
-    /// `arrayJoin` inside a nested subquery has its own scope and does not multiply the outer rows.
+    /// arrayJoin changes the number of rows. Resolve the function name to its canonical form so
+    /// aliases (such as the case-insensitive unnest) are caught too. A call inside a nested
+    /// subquery has its own scope and does not multiply the outer rows, so it is skipped.
     bool expressionContainsArrayJoin(const ASTPtr & ast)
     {
         if (!ast)
             return false;
-        if (const auto * function = ast->as<ASTFunction>(); function && function->name == "arrayJoin")
+        if (const auto * function = ast->as<ASTFunction>();
+            function && getFunctionCanonicalNameIfAny(function->name) == "arrayJoin")
             return true;
         for (const auto & child : ast->children)
         {

--- a/tests/queries/0_stateless/04509_row_policy_arrayjoin_filter.sql
+++ b/tests/queries/0_stateless/04509_row_policy_arrayjoin_filter.sql
@@ -1,9 +1,10 @@
--- A row policy filter is applied as a per-row predicate at the storage read stage. `arrayJoin`
--- changes the number of rows, which used to abort with 'column->size() == num_rows' (a logical
--- error). It must be rejected instead: when the policy is created, when it is altered, and when
--- it is applied.
+-- A row policy filter is applied as a per-row predicate at the storage read stage. arrayJoin (and
+-- its case-insensitive alias unnest) change the number of rows, which used to abort with the
+-- logical error 'column->size() == num_rows'. Such policies must be rejected: when created, when
+-- altered, and when applied.
 
 DROP ROW POLICY IF EXISTS policy_with_array_join ON row_policy_table;
+DROP ROW POLICY IF EXISTS policy_with_unnest ON row_policy_table;
 DROP ROW POLICY IF EXISTS valid_policy ON row_policy_table;
 DROP TABLE IF EXISTS row_policy_table;
 
@@ -12,6 +13,10 @@ INSERT INTO row_policy_table VALUES (1, 10), (2, 20);
 
 -- Creating a policy whose filter contains arrayJoin is rejected.
 CREATE ROW POLICY policy_with_array_join ON row_policy_table FOR SELECT USING arrayJoin([1, 2]) OR (value = 0) TO ALL; -- { serverError ILLEGAL_PREWHERE }
+
+-- unnest is the case-insensitive alias of arrayJoin and is rejected identically.
+CREATE ROW POLICY policy_with_unnest ON row_policy_table FOR SELECT USING unnest([1, 2]) OR (value = 0) TO ALL; -- { serverError ILLEGAL_PREWHERE }
+CREATE ROW POLICY policy_with_unnest ON row_policy_table FOR SELECT USING UNNEST([1, 2]) OR (value = 0) TO ALL; -- { serverError ILLEGAL_PREWHERE }
 
 -- Altering a valid policy to introduce arrayJoin is rejected too; the original filter is kept.
 CREATE ROW POLICY valid_policy ON row_policy_table FOR SELECT USING value > 0 TO ALL;

--- a/tests/queries/0_stateless/04509_row_policy_arrayjoin_filter.sql
+++ b/tests/queries/0_stateless/04509_row_policy_arrayjoin_filter.sql
@@ -1,11 +1,17 @@
+-- Tags: no-parallel
+-- Reason: creates a global SQL UDF (user-defined functions are not scoped to a database), which
+-- would collide with concurrent runs.
+
 -- A row policy filter is applied as a per-row predicate at the storage read stage. arrayJoin (and
--- its case-insensitive alias unnest) change the number of rows, which used to abort with the
--- logical error 'column->size() == num_rows'. Such policies must be rejected: when created, when
--- altered, and when applied.
+-- its case-insensitive alias unnest, including when hidden behind a SQL UDF wrapper) change the
+-- number of rows, which used to abort with the logical error 'column->size() == num_rows'. Such
+-- policies must be rejected: when created, when altered, and when applied.
 
 DROP ROW POLICY IF EXISTS policy_with_array_join ON row_policy_table;
 DROP ROW POLICY IF EXISTS policy_with_unnest ON row_policy_table;
+DROP ROW POLICY IF EXISTS policy_with_udf ON row_policy_table;
 DROP ROW POLICY IF EXISTS valid_policy ON row_policy_table;
+DROP FUNCTION IF EXISTS row_policy_arrayjoin_udf;
 DROP TABLE IF EXISTS row_policy_table;
 
 CREATE TABLE row_policy_table (id UInt32, value UInt32) ENGINE = MergeTree ORDER BY id;
@@ -17,6 +23,11 @@ CREATE ROW POLICY policy_with_array_join ON row_policy_table FOR SELECT USING ar
 -- unnest is the case-insensitive alias of arrayJoin and is rejected identically.
 CREATE ROW POLICY policy_with_unnest ON row_policy_table FOR SELECT USING unnest([1, 2]) OR (value = 0) TO ALL; -- { serverError ILLEGAL_PREWHERE }
 CREATE ROW POLICY policy_with_unnest ON row_policy_table FOR SELECT USING UNNEST([1, 2]) OR (value = 0) TO ALL; -- { serverError ILLEGAL_PREWHERE }
+
+-- A SQL UDF that expands to arrayJoin is inlined at read time, so a policy using it is rejected too.
+CREATE FUNCTION row_policy_arrayjoin_udf AS (x) -> (unnest([1, 2]) OR x = 0);
+CREATE ROW POLICY policy_with_udf ON row_policy_table FOR SELECT USING row_policy_arrayjoin_udf(value) TO ALL; -- { serverError ILLEGAL_PREWHERE }
+DROP FUNCTION row_policy_arrayjoin_udf;
 
 -- Altering a valid policy to introduce arrayJoin is rejected too; the original filter is kept.
 CREATE ROW POLICY valid_policy ON row_policy_table FOR SELECT USING value > 0 TO ALL;


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/109753, which forbade `arrayJoin` in a row policy filter. That guard matched only the literal name `arrayJoin` and missed its case-insensitive alias `unnest`, so `CREATE ROW POLICY ... USING unnest([...])` was still accepted and reintroduced the `column->size() == num_rows` logical error at read time.

The function name is now resolved to its canonical form via `getFunctionCanonicalNameIfAny`, so any spelling of `unnest` (and any future case-insensitive alias of `arrayJoin`) is caught. The guard runs both at `CREATE`/`ALTER` and at the query-apply choke point `ContextAccess::getRowPolicyFilter`, which every read path routes through (both engines, `StorageMerge`, view inlining, and persisted policies).

Closes: https://github.com/ClickHouse/ClickHouse/issues/109949
Related: https://github.com/ClickHouse/ClickHouse/pull/109753

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reject the `unnest` alias of `arrayJoin` in row policy filters, closing a gap where such a policy could raise a `column->size() == num_rows` logical error at read time.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.856` (included in `26.7` and later)
<!-- ch-version-info:end -->