### PR TITLE
Parse numeric 1/0 as Bool inside containers

### DIFF
--- a/src/DataTypes/Serializations/SerializationBool.cpp
+++ b/src/DataTypes/Serializations/SerializationBool.cpp
@@ -407,9 +407,13 @@ ReturnType deserializeTextQuotedImpl(IColumn & column, ReadBuffer & istr, const 
             col->insert(false);
             break;
         case '1':
+            /// Advance the position like every other branch, otherwise the container reader
+            /// re-reads the same digit and fails with CANNOT_READ_ARRAY_FROM_TEXT.
+            ++istr.position();
             col->insert(true);
             break;
         case '0':
+            ++istr.position();
             col->insert(false);
             break;
         case '\'':

--- a/tests/queries/0_stateless/03158_dynamic_type_from_variant.reference
+++ b/tests/queries/0_stateless/03158_dynamic_type_from_variant.reference
@@ -1,17 +1,17 @@
 false	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
+false	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
+true	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 true	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 2001-01-01 01:01:01.111	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 0	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 s	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
-0	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
-1	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 \N	Variant(Bool, DateTime64(3), IPv6, String, UInt32)
 
 false	Bool
+false	Bool
+true	Bool
 true	Bool
 2001-01-01 01:01:01.111	DateTime64(3)
 0	String
 s	String
-0	UInt32
-1	UInt32
 \N	None

--- a/tests/queries/0_stateless/04510_bool_numeric_in_containers.reference
+++ b/tests/queries/0_stateless/04510_bool_numeric_in_containers.reference
@@ -1,0 +1,14 @@
+[true,false]
+[true,false]
+[true,false,true,false]
+[true,NULL,false]
+(true,false)
+(true,false)
+[true,false]
+[true,false]
+[true,false]
+[true,false,true,false]
+{'a':true,'b':false}
+{'a':true,'b':false}
+{'a':true,'b':false}
+{'a':true,'b':false}

--- a/tests/queries/0_stateless/04510_bool_numeric_in_containers.sql
+++ b/tests/queries/0_stateless/04510_bool_numeric_in_containers.sql
@@ -1,0 +1,19 @@
+-- Numeric 1/0 must parse as Bool inside containers via the text-quoted element path,
+-- just like the word form true/false. Regression test for issue #109882.
+SELECT CAST('[1,0]', 'Array(Bool)');
+SELECT CAST('[true,false]', 'Array(Bool)');
+SELECT CAST('[true,0,1,false]', 'Array(Bool)');
+SELECT CAST('[1,NULL,0]', 'Array(Nullable(Bool))');
+SELECT CAST('(1,0)', 'Tuple(Bool,Bool)');
+SELECT CAST('(true,false)', 'Tuple(Bool,Bool)');
+SELECT [1,0]::Array(Bool);
+
+SELECT * FROM format(CSV, 'x Array(Bool)', '"[1,0]"');
+SELECT * FROM format(CSV, 'x Array(Bool)', '"[true,false]"');
+SELECT * FROM format(CSV, 'x Array(Bool)', '"[true,0,1,false]"');
+
+-- Map(String, Bool) routes values through the same deserializeTextQuoted helper, so pin it too.
+SELECT * FROM format(Values, 'x Map(String, Bool)', $$({'a':1,'b':0})$$);
+SELECT * FROM format(Values, 'x Map(String, Bool)', $$({'a':true,'b':false})$$);
+SELECT * FROM format(CSV, 'x Map(String, Bool)', '"{''a'':1,''b'':0}"');
+SELECT * FROM format(CSV, 'x Map(String, Bool)', '"{''a'':true,''b'':false}"');


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109882

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix parsing of numeric `1`/`0` as `Bool` values inside container types (e.g. `Array(Bool)`, `Tuple(Bool, ...)`). Previously `[1,0]` failed with `CANNOT_READ_ARRAY_FROM_TEXT` while `[true,false]` worked.

### Description
`SerializationBool::deserializeTextQuoted` (the element reader used by `Array`/`Tuple` text parsing and by CSV array elements) handled the numeric forms `1`/`0` by inserting the value **without advancing the read position**, unlike the `true`/`false` and quoted-value branches. The container reader then saw the same digit where it expected a comma or closing bracket:

```
Cannot read array from text, expected comma or end of array, found '1' (CANNOT_READ_ARRAY_FROM_TEXT)
```

Scalar `Bool` was unaffected. The one-line fix advances the position for the `1`/`0` cases like every other branch. Verified `[1,0]`, mixed `[true,0,1,false]`, `Array(Nullable(Bool))`, `Tuple(Bool,Bool)` text, and CSV all parse correctly while `true`/`false`, the quoted `'1'` form, and scalar `Bool` remain unchanged. Regression test added in `04510_bool_numeric_in_containers`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.448` (included in `26.8` and later)
<!-- ch-version-info:end -->