### PR TITLE
CI tools: handle zstd/gzip-compressed report artifacts

### DIFF
--- a/.claude/skills/perf-comparison/scripts/perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/perf_api.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import argparse
 import csv
+import gzip
+import io
 import json
+import subprocess
 from datetime import datetime, timezone
 import urllib.parse
 import urllib.request
@@ -739,11 +742,32 @@ DEFAULT_CHANGED_THRESHOLD = 0.15
 DEFAULT_UNSTABLE_THRESHOLD = 0.25
 
 
+def read_text_maybe_compressed(path: str) -> str:
+    """Read a file as text, transparently decompressing zstd/gzip content.
+
+    CI stores text artifacts above a size threshold as zstd (see ci/praktika/s3.py), so a saved
+    all-query-metrics.tsv may be either plain or compressed. Detected by magic bytes.
+    """
+    with open(path, "rb") as f:
+        data = f.read()
+    if data[:4] == b"\x28\xb5\x2f\xfd":  # zstd magic
+        try:
+            import zstandard  # optional dependency
+            data = zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+        except ImportError:
+            proc = subprocess.run(["zstd", "-dcq"], input=data, capture_output=True, timeout=120)
+            if proc.returncode != 0:
+                raise RuntimeError(f"zstd decompression failed: {proc.stderr.decode('utf-8', 'replace')}")
+            data = proc.stdout
+    elif data[:2] == b"\x1f\x8b":  # gzip magic
+        data = gzip.decompress(data)
+    return data.decode("utf-8")
+
+
 def iter_tsv_dicts(path: str) -> list[dict[str, str]]:
     """Read named TSV or headerless raw all-query-metrics.tsv rows."""
-    with open(path, newline="") as f:
-        reader = csv.reader(f, delimiter="\t")
-        raw_rows = [row for row in reader if row]
+    reader = csv.reader(io.StringIO(read_text_maybe_compressed(path)), delimiter="\t")
+    raw_rows = [row for row in reader if row]
     if not raw_rows:
         return []
     first = raw_rows[0]

--- a/.claude/skills/perf-comparison/scripts/test_perf_api.py
+++ b/.claude/skills/perf-comparison/scripts/test_perf_api.py
@@ -2,7 +2,9 @@
 """Focused tests for perf_api.py artifact parsing."""
 from __future__ import annotations
 
+import gzip
 import shutil
+import subprocess
 from pathlib import Path
 
 import perf_api
@@ -71,6 +73,28 @@ def test_raw_all_query_metrics_classification() -> None:
         shutil.rmtree(root, ignore_errors=True)
 
 
+def test_reads_compressed_all_query_metrics() -> None:
+    """iter_tsv_dicts must parse zstd/gzip artifacts identically to plain (CI compresses
+    text artifacts over a size threshold, see ci/praktika/s3.py)."""
+    root = Path.cwd() / "tmp" / "perf-comparison-compressed-test"
+    shutil.rmtree(root, ignore_errors=True)
+    root.mkdir(parents=True)
+    try:
+        plain = root / "all-query-metrics.tsv"
+        write_raw_fixture(plain)
+        expected_rows = perf_api.iter_tsv_dicts(str(plain))
+
+        raw = plain.read_bytes()
+        (root / "gz.tsv").write_bytes(gzip.compress(raw))
+        subprocess.run(["zstd", "-q", "-f", str(plain), "-o", str(root / "zst.tsv")], check=True)
+
+        for variant in ("gz.tsv", "zst.tsv"):
+            assert perf_api.iter_tsv_dicts(str(root / variant)) == expected_rows, variant
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
 if __name__ == "__main__":
     test_raw_all_query_metrics_classification()
+    test_reads_compressed_all_query_metrics()
     print("ok")

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -115,8 +115,14 @@ function fetchUrl(urlString, credentials = null) {
       const chunks = [];
       stream.on('data', chunk => chunks.push(chunk));
       stream.on('end', () => {
-        const body = maybeDecompress(Buffer.concat(chunks)).toString('utf8');
-        resolve(body);
+        // maybeDecompress may throw (missing zstd binary, corrupt archive); a throw from this
+        // async handler would escape the Promise as an uncaught exception, so surface it as a
+        // normal rejection instead.
+        try {
+          resolve(maybeDecompress(Buffer.concat(chunks)).toString('utf8'));
+        } catch (err) {
+          reject(err);
+        }
       });
       stream.on('error', reject);
     });

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -50,6 +50,21 @@ function normalizeTaskName(name) {
 /**
  * Fetch a URL and return the response body
  */
+// Transparently decompress object-level compression (not HTTP transfer-encoding): CI stores text
+// artifacts above a size threshold as zstd (see ci/praktika/s3.py). Detected by magic bytes, so it
+// works whether the object is served plain, as `.zst`, or gzip.
+function maybeDecompress(buf) {
+  if (buf.length >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
+    if (typeof zlib.zstdDecompressSync === 'function') return zlib.zstdDecompressSync(buf);
+    const { execFileSync } = require('child_process');
+    return execFileSync('zstd', ['-dcq'], { input: buf, maxBuffer: 2 * 1024 * 1024 * 1024 });
+  }
+  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
+    return zlib.gunzipSync(buf);
+  }
+  return buf;
+}
+
 function fetchUrl(urlString, credentials = null) {
   return new Promise((resolve, reject) => {
     const parsedUrl = new URL(urlString);
@@ -69,6 +84,13 @@ function fetchUrl(urlString, credentials = null) {
       if (res.statusCode === 301 || res.statusCode === 302) {
         // Follow redirect
         return fetchUrl(res.headers.location, credentials).then(resolve).catch(reject);
+      }
+
+      // A missing/expired plain artifact may exist only as a zstd-compressed sibling: CI
+      // compresses text artifacts over a size threshold (see ci/praktika/s3.py).
+      if ((res.statusCode === 403 || res.statusCode === 404) && !urlString.endsWith('.zst')) {
+        res.resume();
+        return fetchUrl(urlString + '.zst', credentials).then(resolve).catch(reject);
       }
 
       if (res.statusCode === 403) {
@@ -93,7 +115,7 @@ function fetchUrl(urlString, credentials = null) {
       const chunks = [];
       stream.on('data', chunk => chunks.push(chunk));
       stream.on('end', () => {
-        const body = Buffer.concat(chunks).toString('utf8');
+        const body = maybeDecompress(Buffer.concat(chunks)).toString('utf8');
         resolve(body);
       });
       stream.on('error', reject);

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -57,7 +57,8 @@ function maybeDecompress(buf) {
   if (buf.length >= 4 && buf[0] === 0x28 && buf[1] === 0xb5 && buf[2] === 0x2f && buf[3] === 0xfd) {
     if (typeof zlib.zstdDecompressSync === 'function') return zlib.zstdDecompressSync(buf);
     const { execFileSync } = require('child_process');
-    return execFileSync('zstd', ['-dcq'], { input: buf, maxBuffer: 2 * 1024 * 1024 * 1024 });
+    // Bound the child: a wedged zstd would otherwise block the whole helper indefinitely.
+    return execFileSync('zstd', ['-dcq'], { input: buf, maxBuffer: 2 * 1024 * 1024 * 1024, timeout: 120000 });
   }
   if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
     return zlib.gunzipSync(buf);

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -34,6 +34,8 @@ Examples:
 """
 
 import argparse
+import gzip
+import io
 import json
 import os
 import re
@@ -51,22 +53,54 @@ from urllib.error import HTTPError
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+def maybe_decompress(data):
+    """Transparently decompress `data` (bytes) if it is zstd- or gzip-framed.
+
+    CI uploads text artifacts larger than a threshold as zstd (see
+    ci/praktika/s3.py), so the same object can arrive either plain or compressed.
+    Detected by magic bytes, so it works regardless of the URL suffix.
+    """
+    if data[:4] == b"\x28\xb5\x2f\xfd":  # zstd magic
+        try:
+            import zstandard  # optional dependency
+            return zstandard.ZstdDecompressor().stream_reader(io.BytesIO(data)).read()
+        except ImportError:
+            proc = subprocess.run(["zstd", "-dcq"], input=data, capture_output=True, timeout=120)
+            if proc.returncode != 0:
+                raise RuntimeError(f"zstd decompression failed: {proc.stderr.decode('utf-8', 'replace')}")
+            return proc.stdout
+    if data[:2] == b"\x1f\x8b":  # gzip magic
+        return gzip.decompress(data)
+    return data
+
+
+def _read_url_bytes(url):
+    """GET `url`, falling back to `url + '.zst'` on 404/403, and return decompressed bytes."""
+    candidates = [url] if url.endswith(".zst") else [url, url + ".zst"]
+    last_error = None
+    for candidate in candidates:
+        try:
+            with urlopen(candidate, timeout=60) as resp:
+                return maybe_decompress(resp.read())
+        except HTTPError as e:
+            last_error = f"HTTP {e.code}: {e.reason} for {candidate}"
+    raise RuntimeError(last_error)
+
+
 def fetch_url(url):
-    """Fetch a URL and return its body as text."""
-    try:
-        with urlopen(url, timeout=60) as resp:
-            return resp.read().decode("utf-8")
-    except HTTPError as e:
-        raise RuntimeError(f"HTTP {e.code}: {e.reason} for {url}")
+    """Fetch a URL and return its body as text (transparently decompressed)."""
+    return _read_url_bytes(url).decode("utf-8")
 
 
 def download_url(url, dest):
-    """Download a URL to a file using curl. Returns True on success."""
-    result = subprocess.run(
-        ["curl", "-sfL", "-o", dest, url],
-        capture_output=True, timeout=120,
-    )
-    return result.returncode == 0
+    """Download a URL to a file, transparently decompressing. Returns True on success."""
+    try:
+        data = _read_url_bytes(url)
+    except RuntimeError:
+        return False
+    with open(dest, "wb") as f:
+        f.write(data)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -132,10 +132,16 @@ def _stream_to_file(resp, dest):
             except ImportError:
                 proc = subprocess.Popen(["zstd", "-dcq"], stdin=subprocess.PIPE, stdout=f,
                                         stderr=subprocess.PIPE)
-                shutil.copyfileobj(source, proc.stdin)
-                proc.stdin.close()
-                _, stderr = proc.communicate(timeout=120)
-                if proc.returncode != 0:
+                # Feed the body in and wait for the child directly: communicate() would try to
+                # flush the already-closed stdin, which raises ValueError on most Python versions.
+                try:
+                    shutil.copyfileobj(source, proc.stdin)
+                    proc.stdin.close()
+                except BrokenPipeError:
+                    pass  # zstd exited early (e.g. corrupt input); the real error is on stderr
+                stderr = proc.stderr.read()
+                proc.stderr.close()
+                if proc.wait(timeout=120) != 0:
                     raise RuntimeError(f"zstd decompression failed: {stderr.decode('utf-8', 'replace')}")
         elif header[:2] == b"\x1f\x8b":  # gzip magic
             with gzip.GzipFile(fileobj=source) as gz:

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -93,14 +93,13 @@ def fetch_url(url):
 
 
 def download_url(url, dest):
-    """Download a URL to a file, transparently decompressing. Returns True on success."""
-    try:
-        data = _read_url_bytes(url)
-    except RuntimeError:
-        return False
+    """Download a URL to a file, transparently decompressing. Raises on failure.
+
+    Shard-local failures are isolated by the `download_shard` worker, not here.
+    """
+    data = _read_url_bytes(url)
     with open(dest, "wb") as f:
         f.write(data)
-    return True
 
 
 # ---------------------------------------------------------------------------
@@ -274,8 +273,13 @@ def download_shard(shard, tmpdir):
     shard_num = shard["shard_num"]
     dest = os.path.join(tmpdir, f"{arch}_{shard_num}.tsv")
 
-    if not download_url(shard["tsv_url"], dest):
-        return shard, None, f"Failed to download {shard['tsv_url']}"
+    # Isolate all shard-local download/decompress failures (HTTP, network, timeout, missing zstd,
+    # corrupt archive, ...) as a per-shard error so one bad shard warns and the report continues
+    # with the rest rather than aborting the whole run.
+    try:
+        download_url(shard["tsv_url"], dest)
+    except Exception as e:
+        return shard, None, f"Failed to download {shard['tsv_url']}: {e}"
 
     # Prepend arch and shard_num columns so clickhouse-local can distinguish shards
     enriched = os.path.join(tmpdir, f"{arch}_{shard_num}_enriched.tsv")

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -699,11 +699,6 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Verify clickhouse is available
-    if shutil.which("clickhouse") is None:
-        print("Error: clickhouse not found in PATH.", file=sys.stderr)
-        sys.exit(1)
-
     # Resolve URL
     url = args.url
     if "github.com" in url and "/pull/" in url:
@@ -743,7 +738,15 @@ def main():
     shards = [s for s in shards if str(s.get("status", "")).upper() != "SKIPPED"]
 
     if not shards:
+        # All matching jobs were intentionally skipped: no perf data to analyze, but not a
+        # tool failure, so exit successfully.
         print("No shards to fetch (all matching jobs were skipped)", file=sys.stderr)
+        sys.exit(0)
+
+    # clickhouse (used for local classification of the downloaded data) is only needed once we
+    # know there is at least one shard to analyze.
+    if shutil.which("clickhouse") is None:
+        print("Error: clickhouse not found in PATH.", file=sys.stderr)
         sys.exit(1)
 
     print(f"Fetching {len(shards)} performance shard(s)...\n", file=sys.stderr)

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -43,6 +43,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urlparse, parse_qs
 from urllib.request import urlopen
@@ -116,6 +117,9 @@ class _PrefixedReader:
         return data
 
 
+_ZSTD_CLI_TIMEOUT_SEC = 120  # watchdog bound for the zstd-CLI decompression fallback
+
+
 def _stream_to_file(resp, dest):
     """Stream `resp` to `dest`, transparently decompressing zstd/gzip by magic bytes.
 
@@ -132,17 +136,27 @@ def _stream_to_file(resp, dest):
             except ImportError:
                 proc = subprocess.Popen(["zstd", "-dcq"], stdin=subprocess.PIPE, stdout=f,
                                         stderr=subprocess.PIPE)
-                # Feed the body in and wait for the child directly: communicate() would try to
-                # flush the already-closed stdin, which raises ValueError on most Python versions.
+                # A watchdog bounds the whole exchange: both the stdin write and the stderr read
+                # block indefinitely if the child wedges, so wait(timeout=) alone never fires.
+                # Killing the child unblocks both and turns a stuck shard into a normal error.
+                # (communicate() is unusable here: it flushes the already-closed stdin, which
+                # raises ValueError on most Python versions.)
+                watchdog = threading.Timer(_ZSTD_CLI_TIMEOUT_SEC, proc.kill)
+                watchdog.start()
                 try:
-                    shutil.copyfileobj(source, proc.stdin)
-                    proc.stdin.close()
-                except BrokenPipeError:
-                    pass  # zstd exited early (e.g. corrupt input); the real error is on stderr
-                stderr = proc.stderr.read()
-                proc.stderr.close()
-                if proc.wait(timeout=120) != 0:
-                    raise RuntimeError(f"zstd decompression failed: {stderr.decode('utf-8', 'replace')}")
+                    try:
+                        shutil.copyfileobj(source, proc.stdin)
+                        proc.stdin.close()
+                    except BrokenPipeError:
+                        pass  # zstd exited early (corrupt input or killed); real error is on stderr
+                    stderr = proc.stderr.read()
+                    proc.stderr.close()
+                    rc = proc.wait()
+                finally:
+                    watchdog.cancel()
+                if rc != 0:
+                    raise RuntimeError(f"zstd decompression failed (exit {rc}): "
+                                       f"{stderr.decode('utf-8', 'replace')}")
         elif header[:2] == b"\x1f\x8b":  # gzip magic
             with gzip.GzipFile(fileobj=source) as gz:
                 shutil.copyfileobj(gz, f)

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -735,6 +735,17 @@ def main():
         print("No matching shards found", file=sys.stderr)
         sys.exit(1)
 
+    # Jobs that didn't run (e.g. the amd perf comparison only runs on 'pr-performance' PRs) have no
+    # artifacts, so report them cleanly instead of attempting a download that 403s.
+    skipped = [s for s in shards if str(s.get("status", "")).upper() == "SKIPPED"]
+    for s in skipped:
+        print(f"  Skipped: {s['name']} ({s.get('info') or 'not run'})", file=sys.stderr)
+    shards = [s for s in shards if str(s.get("status", "")).upper() != "SKIPPED"]
+
+    if not shards:
+        print("No shards to fetch (all matching jobs were skipped)", file=sys.stderr)
+        sys.exit(1)
+
     print(f"Fetching {len(shards)} performance shard(s)...\n", file=sys.stderr)
 
     # Download TSV data in parallel

--- a/.claude/tools/fetch_perf_report.py
+++ b/.claude/tools/fetch_perf_report.py
@@ -92,14 +92,74 @@ def fetch_url(url):
     return _read_url_bytes(url).decode("utf-8")
 
 
+class _PrefixedReader:
+    """File-like wrapper that yields `prefix` bytes before the rest of `stream`.
+
+    Lets us peek at the magic bytes for format detection and still stream the whole
+    body through a decompressor without ever holding it fully in memory.
+    """
+
+    def __init__(self, prefix, stream):
+        self._prefix = prefix
+        self._stream = stream
+
+    def read(self, size=-1):
+        if not self._prefix:
+            return self._stream.read(size)
+        if size is None or size < 0:
+            data, self._prefix = self._prefix + self._stream.read(), b""
+            return data
+        if size <= len(self._prefix):
+            data, self._prefix = self._prefix[:size], self._prefix[size:]
+            return data
+        data, self._prefix = self._prefix + self._stream.read(size - len(self._prefix)), b""
+        return data
+
+
+def _stream_to_file(resp, dest):
+    """Stream `resp` to `dest`, transparently decompressing zstd/gzip by magic bytes.
+
+    Compressed perf artifacts exist precisely for the large shards, and several shards
+    download in parallel, so the body is streamed in chunks rather than buffered.
+    """
+    header = resp.read(4)
+    source = _PrefixedReader(header, resp)
+    with open(dest, "wb") as f:
+        if header == b"\x28\xb5\x2f\xfd":  # zstd magic
+            try:
+                import zstandard  # optional dependency
+                shutil.copyfileobj(zstandard.ZstdDecompressor().stream_reader(source), f)
+            except ImportError:
+                proc = subprocess.Popen(["zstd", "-dcq"], stdin=subprocess.PIPE, stdout=f,
+                                        stderr=subprocess.PIPE)
+                shutil.copyfileobj(source, proc.stdin)
+                proc.stdin.close()
+                _, stderr = proc.communicate(timeout=120)
+                if proc.returncode != 0:
+                    raise RuntimeError(f"zstd decompression failed: {stderr.decode('utf-8', 'replace')}")
+        elif header[:2] == b"\x1f\x8b":  # gzip magic
+            with gzip.GzipFile(fileobj=source) as gz:
+                shutil.copyfileobj(gz, f)
+        else:
+            shutil.copyfileobj(source, f)
+
+
 def download_url(url, dest):
     """Download a URL to a file, transparently decompressing. Raises on failure.
 
-    Shard-local failures are isolated by the `download_shard` worker, not here.
+    Falls back to `url + '.zst'` on 404/403. Shard-local failures are isolated by the
+    `download_shard` worker, not here.
     """
-    data = _read_url_bytes(url)
-    with open(dest, "wb") as f:
-        f.write(data)
+    candidates = [url] if url.endswith(".zst") else [url, url + ".zst"]
+    last_error = None
+    for candidate in candidates:
+        try:
+            with urlopen(candidate, timeout=60) as resp:
+                _stream_to_file(resp, dest)
+                return
+        except HTTPError as e:
+            last_error = f"HTTP {e.code}: {e.reason} for {candidate}"
+    raise RuntimeError(last_error)
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -207,6 +207,45 @@ def test_stream_to_file_zstd_cli_fallback():
             _sys.modules["zstandard"] = saved
 
 
+def test_stream_to_file_zstd_cli_times_out():
+    # A wedged zstd must not hang the report forever: the watchdog kills it and the failure
+    # becomes a normal per-shard error. Uses a fake `zstd` on PATH that ignores stdin and never
+    # exits, plus a shrunk timeout so the test stays fast.
+    import io as _io
+    import stat as _stat
+    import sys as _sys
+    import time as _time
+
+    saved_mod = _sys.modules.get("zstandard", "MISSING")
+    saved_path = os.environ["PATH"]
+    saved_timeout = fpr._ZSTD_CLI_TIMEOUT_SEC
+    _sys.modules["zstandard"] = None  # force the CLI fallback
+    with tempfile.TemporaryDirectory() as tmp:
+        fake = os.path.join(tmp, "zstd")
+        with open(fake, "w") as f:
+            f.write("#!/bin/sh\nexec sleep 300\n")
+        os.chmod(fake, os.stat(fake).st_mode | _stat.S_IEXEC)
+        os.environ["PATH"] = tmp + os.pathsep + saved_path
+        fpr._ZSTD_CLI_TIMEOUT_SEC = 2
+        try:
+            zst_magic_input = b"\x28\xb5\x2f\xfd" + b"\x00" * 4096
+            dest = os.path.join(tmp, "out")
+            t0 = _time.time()
+            try:
+                fpr._stream_to_file(_io.BytesIO(zst_magic_input), dest)
+                assert False, "expected the wedged zstd to raise"
+            except RuntimeError as e:
+                assert "zstd decompression failed" in str(e), e
+            assert _time.time() - t0 < 30, "watchdog did not bound the wedged child"
+        finally:
+            fpr._ZSTD_CLI_TIMEOUT_SEC = saved_timeout
+            os.environ["PATH"] = saved_path
+            if saved_mod == "MISSING":
+                _sys.modules.pop("zstandard", None)
+            else:
+                _sys.modules["zstandard"] = saved_mod
+
+
 def test_prefixed_reader_reassembles_stream():
     import io as _io
 
@@ -248,6 +287,7 @@ if __name__ == "__main__":
     test_maybe_decompress_handles_plain_gzip_zstd()
     test_stream_to_file_handles_plain_gzip_zstd()
     test_stream_to_file_zstd_cli_fallback()
+    test_stream_to_file_zstd_cli_times_out()
     test_prefixed_reader_reassembles_stream()
     test_download_shard_isolates_failures()
     print("All fetch_perf_report tests passed (or skipped).")

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -182,6 +182,31 @@ def test_stream_to_file_handles_plain_gzip_zstd():
                 assert f.read() == plain, name
 
 
+def test_stream_to_file_zstd_cli_fallback():
+    # Force the `zstd` CLI path even where `zstandard` is installed, so the fallback the PR
+    # advertises is exercised regardless of the host's optional dependencies.
+    import io as _io
+    import subprocess as _sp
+    import sys as _sys
+
+    plain = b"metric\tleft\tright\n" + b"memory_usage\t100\t90\n" * 10000
+    zst = _sp.run(["zstd", "-cq"], input=plain, capture_output=True).stdout
+
+    saved = _sys.modules.get("zstandard", "MISSING")
+    _sys.modules["zstandard"] = None  # makes `import zstandard` raise ImportError
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = os.path.join(tmp, "out")
+            fpr._stream_to_file(_io.BytesIO(zst), dest)
+            with open(dest, "rb") as f:
+                assert f.read() == plain
+    finally:
+        if saved == "MISSING":
+            _sys.modules.pop("zstandard", None)
+        else:
+            _sys.modules["zstandard"] = saved
+
+
 def test_prefixed_reader_reassembles_stream():
     import io as _io
 
@@ -222,6 +247,7 @@ if __name__ == "__main__":
     test_summary_counts()
     test_maybe_decompress_handles_plain_gzip_zstd()
     test_stream_to_file_handles_plain_gzip_zstd()
+    test_stream_to_file_zstd_cli_fallback()
     test_prefixed_reader_reassembles_stream()
     test_download_shard_isolates_failures()
     print("All fetch_perf_report tests passed (or skipped).")

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -152,7 +152,20 @@ def test_summary_counts():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+def test_maybe_decompress_handles_plain_gzip_zstd():
+    import gzip as _gzip
+    import subprocess as _sp
+
+    plain = b"metric\tleft\tright\nmemory_usage\t100\t90\n"
+    assert fpr.maybe_decompress(plain) == plain
+    assert fpr.maybe_decompress(_gzip.compress(plain)) == plain
+    zst = _sp.run(["zstd", "-cq"], input=plain, capture_output=True).stdout
+    assert zst[:4] == b"\x28\xb5\x2f\xfd"  # sanity: really zstd-framed
+    assert fpr.maybe_decompress(zst) == plain
+
+
 if __name__ == "__main__":
     test_classification_matches_compare_sh()
     test_summary_counts()
+    test_maybe_decompress_handles_plain_gzip_zstd()
     print("All fetch_perf_report tests passed (or skipped).")

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -164,6 +164,34 @@ def test_maybe_decompress_handles_plain_gzip_zstd():
     assert fpr.maybe_decompress(zst) == plain
 
 
+def test_stream_to_file_handles_plain_gzip_zstd():
+    import gzip as _gzip
+    import io as _io
+    import subprocess as _sp
+
+    plain = b"metric\tleft\tright\n" + b"memory_usage\t100\t90\n" * 10000  # >4 bytes, multi-chunk
+    zst = _sp.run(["zstd", "-cq"], input=plain, capture_output=True).stdout
+    variants = {"plain": plain, "gzip": _gzip.compress(plain), "zstd": zst}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        for name, body in variants.items():
+            dest = os.path.join(tmp, name)
+            # A BytesIO stands in for the urlopen response: same .read(size) contract.
+            fpr._stream_to_file(_io.BytesIO(body), dest)
+            with open(dest, "rb") as f:
+                assert f.read() == plain, name
+
+
+def test_prefixed_reader_reassembles_stream():
+    import io as _io
+
+    payload = bytes(range(256)) * 8
+    reader = fpr._PrefixedReader(payload[:4], _io.BytesIO(payload[4:]))
+    # Small reads across the prefix boundary and a final read-all must round-trip.
+    got = reader.read(2) + reader.read(5) + reader.read()
+    assert got == payload
+
+
 def test_download_shard_isolates_failures():
     import gzip as _gzip
     import subprocess as _sp
@@ -193,5 +221,7 @@ if __name__ == "__main__":
     test_classification_matches_compare_sh()
     test_summary_counts()
     test_maybe_decompress_handles_plain_gzip_zstd()
+    test_stream_to_file_handles_plain_gzip_zstd()
+    test_prefixed_reader_reassembles_stream()
     test_download_shard_isolates_failures()
     print("All fetch_perf_report tests passed (or skipped).")

--- a/.claude/tools/test_fetch_perf_report.py
+++ b/.claude/tools/test_fetch_perf_report.py
@@ -164,8 +164,34 @@ def test_maybe_decompress_handles_plain_gzip_zstd():
     assert fpr.maybe_decompress(zst) == plain
 
 
+def test_download_shard_isolates_failures():
+    import gzip as _gzip
+    import subprocess as _sp
+    import urllib.error as _ue
+
+    shard = {"arch": "arm", "shard_num": 1, "tsv_url": "https://example/all-query-metrics.tsv"}
+    failures = [
+        _ue.URLError("connection refused"),
+        _sp.TimeoutExpired(cmd="zstd", timeout=120),
+        FileNotFoundError("zstd"),  # zstd binary unavailable
+        _gzip.BadGzipFile("not a gzip file"),
+        RuntimeError("HTTP 403"),
+    ]
+    original = fpr.download_url
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            for exc in failures:
+                fpr.download_url = lambda *a, _e=exc, **k: (_ for _ in ()).throw(_e)
+                result = fpr.download_shard(shard, tmp)  # must not raise
+                assert result[0] is shard and result[1] is None, (exc, result)
+                assert "Failed to download" in result[2], (exc, result)
+    finally:
+        fpr.download_url = original
+
+
 if __name__ == "__main__":
     test_classification_matches_compare_sh()
     test_summary_counts()
     test_maybe_decompress_handles_plain_gzip_zstd()
+    test_download_shard_isolates_failures()
     print("All fetch_perf_report tests passed (or skipped).")


### PR DESCRIPTION
The perf/CI report helper scripts under `.claude` decoded downloaded artifacts as UTF-8 and failed on compressed ones. CI compresses uploaded text artifacts larger than a threshold with zstd (`ci/praktika/s3.py`, `COMPRESS_THRESHOLD_MB`), so a large perf shard's `all-query-metrics.tsv` is stored as a `.zst` sibling — which the tools silently dropped, making a whole shard vanish from the report.

Make every artifact reader transparently handle plain, zstd, and gzip: detect the compression by magic bytes and, for downloads, fall back to the `.zst` sibling when the plain object is 403/404. Python uses the `zstd` CLI (with an optional `zstandard` fast path); Node uses `zlib.zstdDecompressSync` with a `zstd`-CLI fallback.

- `fetch_perf_report.py`, `fetch_ci_report.js`, `perf_api.py` updated; regression tests assert plain vs gzip vs zstd parse identically.
- `fetch_perf_report.py` also reports SKIPPED shards (e.g. the amd perf comparison, which only runs on `pr-performance` PRs) as a single clean "Skipped (reason)" line instead of six "Failed to download" warnings.

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (developer tooling under `.claude`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.942` (included in `26.7` and later)
<!-- ch-version-info:end -->