### PR TITLE
Support Per-Task Timeouts in PollingQueue

### DIFF
--- a/src/Processors/Executors/ExecutorTasks.cpp
+++ b/src/Processors/Executors/ExecutorTasks.cpp
@@ -173,8 +173,8 @@ size_t ExecutorTasks::pushTasks(Queue & queue, Queue & async_queue, ExecutionThr
 #if defined(OS_LINUX) || defined(OS_DARWIN)
         while (!async_queue.empty() && !finished)
         {
-            auto [fd, events] = async_queue.front()->processor()->scheduleForEvent();
-            async_task_queue.addTask(context.thread_number, async_queue.front(), fd, events);
+            auto [fd, events, timeout_ms] = async_queue.front()->processor()->scheduleForEvent();
+            async_task_queue.addTask(context.thread_number, async_queue.front(), fd, events, timeout_ms);
             async_queue.pop();
         }
 #endif
@@ -240,8 +240,8 @@ size_t ExecutorTasks::fill(Queue & queue, [[maybe_unused]] Queue & async_queue)
 #if defined(OS_LINUX) || defined(OS_DARWIN)
     while (!async_queue.empty())
     {
-        auto [fd, events] = async_queue.front()->processor()->scheduleForEvent();
-        async_task_queue.addTask(next_thread, async_queue.front(), fd, events);
+        auto [fd, events, timeout_ms] = async_queue.front()->processor()->scheduleForEvent();
+        async_task_queue.addTask(next_thread, async_queue.front(), fd, events, timeout_ms);
         async_queue.pop();
 
         ++next_thread;

--- a/src/Processors/Executors/PollingQueue.cpp
+++ b/src/Processors/Executors/PollingQueue.cpp
@@ -3,10 +3,7 @@
 #if defined(OS_LINUX) || defined(OS_DARWIN)
 
 #include <Common/Exception.h>
-#include <Common/ErrnoException.h>
-#include <base/defines.h>
-#include <unistd.h>
-#include <fcntl.h>
+#include <algorithm>
 
 #include <IO/WriteBufferFromString.h>
 #include <IO/Operators.h>
@@ -16,52 +13,101 @@ namespace DB
 
 namespace ErrorCodes
 {
-    extern const int CANNOT_OPEN_FILE;
-    extern const int CANNOT_READ_FROM_SOCKET;
     extern const int LOGICAL_ERROR;
 }
 
+void PollingQueue::Deadlines::arm(Key key, int64_t timeout_ms)
+{
+    cancel(key);
+    index[key] = queue.emplace(Clock::now() + std::chrono::milliseconds(timeout_ms), key);
+}
+
+void PollingQueue::Deadlines::cancel(Key key)
+{
+    if (auto it = index.find(key); it != index.end())
+    {
+        queue.erase(it->second);
+        index.erase(it);
+    }
+}
+
+std::optional<PollingQueue::Clock::time_point> PollingQueue::Deadlines::nextDeadline() const
+{
+    if (queue.empty())
+        return std::nullopt;
+
+    return queue.begin()->first;
+}
+
+std::optional<PollingQueue::Key> PollingQueue::Deadlines::popExpired()
+{
+    if (queue.empty())
+        return std::nullopt;
+
+    auto it = queue.begin();
+    auto [deadline, key] = *it;
+
+    if (deadline > Clock::now())
+        return std::nullopt;
+
+    queue.erase(it);
+    index.erase(key);
+    return key;
+}
 
 PollingQueue::PollingQueue()
 {
-#if defined(OS_LINUX)
-    if (-1 == pipe2(pipe_fd, O_NONBLOCK))
-        throw ErrnoException(ErrorCodes::CANNOT_OPEN_FILE, "Cannot create pipe");
-#else
-    /// macOS has no pipe2; create the pipe and set O_NONBLOCK on both ends.
-    if (-1 == pipe(pipe_fd))
-        throw ErrnoException(ErrorCodes::CANNOT_OPEN_FILE, "Cannot create pipe");
-    for (int pipe_end_fd : pipe_fd)
-    {
-        int flags = fcntl(pipe_end_fd, F_GETFL, 0);
-        if (-1 == flags || -1 == fcntl(pipe_end_fd, F_SETFL, flags | O_NONBLOCK))
-            throw ErrnoException(ErrorCodes::CANNOT_OPEN_FILE, "Cannot make pipe non-blocking");
-    }
-#endif
-
-    epoll.add(pipe_fd[0], pipe_fd);
+    epoll.add(finish_signal.fd(), &finish_signal);
+    epoll.add(timer_signal.getDescriptor(), &timer_signal);
 }
 
-PollingQueue::~PollingQueue()
+void PollingQueue::addTask(size_t thread_number, void * data, int fd, uint32_t events, Int64 timeout_ms)
 {
-    int err = 0;
-    err = close(pipe_fd[0]);  /// NOLINT(clang-analyzer-deadcode.DeadStores)
-    chassert(!err || errno == EINTR);
-    err = close(pipe_fd[1]);  /// NOLINT(clang-analyzer-deadcode.DeadStores)
-    chassert(!err || errno == EINTR);
-}
-
-void PollingQueue::addTask(size_t thread_number, void * data, int fd, uint32_t events)
-{
-    std::uintptr_t key = reinterpret_cast<uintptr_t>(data);
+    Key key = reinterpret_cast<Key>(data);
     if (tasks.contains(key))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Task {} was already added to task queue", key);
 
     tasks[key] = TaskData{thread_number, data, fd};
     epoll.add(fd, data, events);
+
+    if (timeout_ms >= 0)
+    {
+        deadlines.arm(key, timeout_ms);
+        updateTimer();
+    }
 }
 
-static std::string dumpTasks(const std::unordered_map<std::uintptr_t, PollingQueue::TaskData> & tasks)
+PollingQueue::TaskData PollingQueue::popExpiredDeadlineTask()
+{
+    auto expired_key = deadlines.popExpired();
+    if (!expired_key)
+        return {};
+
+    auto task_it = tasks.find(expired_key.value());
+    if (task_it == tasks.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Expired-deadline task {} missing from task map", *expired_key);
+
+    auto res = task_it->second;
+    tasks.erase(task_it);
+    epoll.remove(res.fd);
+    updateTimer();
+    return res;
+}
+
+void PollingQueue::updateTimer()
+{
+    auto next = deadlines.nextDeadline();
+    if (!next)
+    {
+        timer_signal.reset();
+        return;
+    }
+
+    auto us_until_deadline = std::chrono::duration_cast<std::chrono::microseconds>(*next - Clock::now()).count();
+    timer_signal.setRelative(std::max<int64_t>(1, us_until_deadline));
+}
+
+std::string PollingQueue::dumpTasks() const
 {
     WriteBufferFromOwnString res;
     res << "Tasks = [";
@@ -79,52 +125,54 @@ static std::string dumpTasks(const std::unordered_map<std::uintptr_t, PollingQue
 
 PollingQueue::TaskData PollingQueue::getTask(std::unique_lock<std::mutex> & lock, int timeout)
 {
-    if (is_finished)
-        return {};
-
-    lock.unlock();
-
-    epoll_event event{};
-    event.data.ptr = nullptr;
-    size_t num_events = epoll.getManyReady(1, &event, timeout);
-
-    lock.lock();
-
-    if (num_events == 0)
-        return {};
-
-    if (event.data.ptr == pipe_fd)
-        return {};
-
-    void * ptr = event.data.ptr;
-    std::uintptr_t key = reinterpret_cast<uintptr_t>(ptr);
-    auto it = tasks.find(key);
-    if (it == tasks.end())
+    while (true)
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Task {} ({}) was not found in task queue: {}",
-                        key, ptr, dumpTasks(tasks));
+        if (is_finished)
+            return {};
+
+        if (auto expired_task = popExpiredDeadlineTask())
+            return expired_task;
+
+        lock.unlock();
+
+        epoll_event event{};
+        event.data.ptr = nullptr;
+        size_t num_events = epoll.getManyReady(1, &event, timeout);
+
+        lock.lock();
+
+        if (num_events == 0)
+            return {};
+
+        if (event.data.ptr == &finish_signal)
+            return {};
+
+        if (event.data.ptr == &timer_signal)
+        {
+            timer_signal.drain();
+            updateTimer();
+            continue;
+        }
+
+        void * ptr = event.data.ptr;
+        Key key = reinterpret_cast<Key>(ptr);
+        auto it = tasks.find(key);
+        if (it == tasks.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Task {} ({}) was not found in task queue: {}", key, ptr, dumpTasks());
+
+        auto res = it->second;
+        tasks.erase(it);
+        deadlines.cancel(key);
+        epoll.remove(res.fd);
+
+        return res;
     }
-
-    auto res = it->second;
-    tasks.erase(it);
-    epoll.remove(res.fd);
-
-    return res;
 }
 
 void PollingQueue::finish()
 {
     is_finished = true;
-
-    uint64_t buf = 0;
-    while (-1 == write(pipe_fd[1], &buf, sizeof(buf)))
-    {
-        if (errno == EAGAIN)
-            break;
-
-        if (errno != EINTR)
-            throw ErrnoException(ErrorCodes::CANNOT_READ_FROM_SOCKET, "Cannot write to pipe");
-    }
+    finish_signal.notify();
 }
 
 }

--- a/src/Processors/Executors/PollingQueue.h
+++ b/src/Processors/Executors/PollingQueue.h
@@ -1,10 +1,11 @@
 #pragma once
-#include <cstddef>
-#include <cstdint>
-#include <mutex>
-#include <atomic>
-#include <unordered_map>
+
 #include <Common/Epoll.h>
+#include <Common/TimerDescriptor.h>
+#include <Common/WakeupFd.h>
+
+#include <map>
+#include <mutex>
 
 namespace DB
 {
@@ -14,7 +15,24 @@ namespace DB
 /// This queue is used to poll descriptors. Generally, just a wrapper over epoll (kqueue on macOS).
 class PollingQueue
 {
-public:
+    using Clock = std::chrono::steady_clock;
+    using Key = std::uintptr_t;
+
+    class Deadlines
+    {
+    public:
+        void arm(Key key, int64_t timeout_ms);
+        void cancel(Key key);
+
+        std::optional<Clock::time_point> nextDeadline() const;
+        std::optional<Key> popExpired();
+
+    private:
+        using Queue = std::multimap<Clock::time_point, Key>;
+        Queue queue;
+        std::unordered_map<Key, Queue::iterator> index;
+    };
+
     struct TaskData
     {
         size_t thread_num = 0;
@@ -25,23 +43,20 @@ public:
         explicit operator bool() const { return data; }
     };
 
-private:
-    Epoll epoll;
-    int pipe_fd[2]{};
-    std::atomic_bool is_finished = false;
-    std::unordered_map<std::uintptr_t, TaskData> tasks;
-
     TaskData getTask(std::unique_lock<std::mutex> & lock, int timeout);
+    TaskData popExpiredDeadlineTask();
+    void updateTimer();
+
+    std::string dumpTasks() const;
 
 public:
     PollingQueue();
-    ~PollingQueue();
 
     size_t size() const { return tasks.size(); }
     bool empty() const { return tasks.empty(); }
 
     /// Add new task to queue.
-    void addTask(size_t thread_number, void * data, int fd, uint32_t events = EPOLLIN | EPOLLERR);
+    void addTask(size_t thread_number, void * data, int fd, uint32_t events = EPOLLIN | EPOLLERR, int64_t timeout_ms = -1);
 
     /// Wait for any descriptor. If no descriptors in queue, blocks.
     /// Returns ptr which was inserted into queue or nullptr if finished was called.
@@ -55,6 +70,18 @@ public:
 
     /// Interrupt waiting.
     void finish();
+
+private:
+    Epoll epoll;
+    std::unordered_map<Key, TaskData> tasks;
+
+    /// In-Flight timers
+    Deadlines deadlines;
+    TimerDescriptor timer_signal;
+
+    /// Stop semantics
+    std::atomic_bool is_finished = false;
+    WakeupFd finish_signal;
 };
 #else
 class PollingQueue

--- a/src/Processors/Executors/tests/gtest_polling_queue.cpp
+++ b/src/Processors/Executors/tests/gtest_polling_queue.cpp
@@ -1,0 +1,193 @@
+#include <Processors/Executors/PollingQueue.h>
+
+#if defined(OS_LINUX) || defined(OS_DARWIN)
+
+#include <gtest/gtest.h>
+
+#include <Common/Exception.h>
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace DB;
+using namespace std::chrono;
+
+namespace
+{
+
+struct TestPipe
+{
+    int fds[2]{-1, -1};
+
+    TestPipe()
+    {
+        EXPECT_EQ(0, ::pipe(fds));
+        for (int fd : fds)
+            EXPECT_NE(-1, ::fcntl(fd, F_SETFL, ::fcntl(fd, F_GETFL, 0) | O_NONBLOCK));
+    }
+
+    ~TestPipe()
+    {
+        ::close(fds[0]);
+        ::close(fds[1]);
+    }
+
+    int readFd() const { return fds[0]; }
+
+    void makeReady() const
+    {
+        char byte = 0;
+        EXPECT_EQ(1, ::write(fds[1], &byte, 1));
+    }
+};
+
+}
+
+TEST(PollingQueue, ReturnsTaskWhenFdIsReady)
+{
+    PollingQueue queue;
+    TestPipe pipe;
+    std::mutex mutex;
+
+    pipe.makeReady();
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &pipe, pipe.readFd());
+    EXPECT_EQ(queue.size(), 1);
+
+    auto res = queue.wait(lock);
+    EXPECT_EQ(res.data, &pipe);
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(PollingQueue, TryGetReadyTaskDoesNotBlock)
+{
+    PollingQueue queue;
+    TestPipe pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &pipe, pipe.readFd());
+
+    EXPECT_FALSE(queue.tryGetReadyTask(lock));
+
+    pipe.makeReady();
+    auto res = queue.tryGetReadyTask(lock);
+    EXPECT_EQ(res.data, &pipe);
+}
+
+TEST(PollingQueue, ReturnsTaskOnTimeout)
+{
+    PollingQueue queue;
+    TestPipe pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    auto start = steady_clock::now();
+    queue.addTask(0, &pipe, pipe.readFd(), EPOLLIN | EPOLLERR, 50);
+
+    auto res = queue.wait(lock);
+    EXPECT_EQ(res.data, &pipe);
+    EXPECT_GE(steady_clock::now() - start, milliseconds(45));
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(PollingQueue, EarliestDeadlineFiresFirst)
+{
+    PollingQueue queue;
+    TestPipe slow_pipe;
+    TestPipe fast_pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &slow_pipe, slow_pipe.readFd(), EPOLLIN | EPOLLERR, 300);
+    queue.addTask(0, &fast_pipe, fast_pipe.readFd(), EPOLLIN | EPOLLERR, 50);
+
+    EXPECT_EQ(queue.wait(lock).data, &fast_pipe);
+    EXPECT_EQ(queue.wait(lock).data, &slow_pipe);
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(PollingQueue, ReadyFdCancelsDeadline)
+{
+    PollingQueue queue;
+    TestPipe first_pipe;
+    TestPipe second_pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    auto start = steady_clock::now();
+    queue.addTask(0, &first_pipe, first_pipe.readFd(), EPOLLIN | EPOLLERR, 10000);
+    first_pipe.makeReady();
+
+    EXPECT_EQ(queue.wait(lock).data, &first_pipe);
+    EXPECT_LT(steady_clock::now() - start, seconds(10));
+
+    queue.addTask(0, &second_pipe, second_pipe.readFd(), EPOLLIN | EPOLLERR, 50);
+    EXPECT_EQ(queue.wait(lock).data, &second_pipe);
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(PollingQueue, TaskCanBeReAddedAfterTimeout)
+{
+    PollingQueue queue;
+    TestPipe pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &pipe, pipe.readFd(), EPOLLIN | EPOLLERR, 20);
+    EXPECT_EQ(queue.wait(lock).data, &pipe);
+
+    queue.addTask(0, &pipe, pipe.readFd(), EPOLLIN | EPOLLERR, 20);
+    EXPECT_EQ(queue.wait(lock).data, &pipe);
+    EXPECT_TRUE(queue.empty());
+}
+
+TEST(PollingQueue, DeadlineArmedWhileWaiting)
+{
+    PollingQueue queue;
+    TestPipe idle_pipe;
+    TestPipe timed_pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &idle_pipe, idle_pipe.readFd());
+
+    std::thread adder([&]
+    {
+        std::this_thread::sleep_for(milliseconds(100));
+        std::lock_guard guard(mutex);
+        queue.addTask(0, &timed_pipe, timed_pipe.readFd(), EPOLLIN | EPOLLERR, 50);
+    });
+
+    auto res = queue.wait(lock);
+    adder.join();
+
+    EXPECT_EQ(res.data, &timed_pipe);
+    EXPECT_EQ(queue.size(), 1);
+}
+
+TEST(PollingQueue, FinishInterruptsWait)
+{
+    PollingQueue queue;
+    TestPipe pipe;
+    std::mutex mutex;
+
+    std::unique_lock lock(mutex);
+    queue.addTask(0, &pipe, pipe.readFd());
+
+    std::thread finisher([&]
+    {
+        std::this_thread::sleep_for(milliseconds(50));
+        std::lock_guard guard(mutex);
+        queue.finish();
+    });
+
+    EXPECT_FALSE(queue.wait(lock));
+    finisher.join();
+}
+
+#endif

--- a/src/Processors/IProcessor.cpp
+++ b/src/Processors/IProcessor.cpp
@@ -66,9 +66,9 @@ int IProcessor::schedule()
 }
 
 #if defined(OS_LINUX) || defined(OS_DARWIN)
-std::pair<int, uint32_t> IProcessor::scheduleForEvent()
+std::tuple<int, uint32_t, Int64> IProcessor::scheduleForEvent()
 {
-    return {schedule(), EPOLLIN | EPOLLERR};
+    return {schedule(), EPOLLIN | EPOLLERR, -1};
 }
 #endif
 

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -211,12 +211,15 @@ public:
       */
     virtual int schedule();
 
-    /** This method is similar to schedule() but also returns epoll events mask
+    /** This method is similar to schedule() but also returns epoll events mask and an optional timeout.
       * Note that file descriptor returned by schedule() will be polled for read (EPOLLIN event) and errors
       * but for ISink implementations that write data to network or to files it is necessary to poll for write (EPOLLOUT) events as well.
+      *
+      * The third element is a timeout in milliseconds. If non-negative, the processor will be re-dispatched after
+      * the timeout even when the fd has not become readable. A value of -1 means "no timeout" (block until fd fires).
       */
 #if defined(OS_LINUX) || defined(OS_DARWIN)
-    virtual std::pair<int, uint32_t> scheduleForEvent();
+    virtual std::tuple<int, uint32_t, Int64> scheduleForEvent();
 #endif
 
     /* The method is called right after asynchronous job is done

--- a/src/Server/DistributedQuery/StreamingExchangeSink.cpp
+++ b/src/Server/DistributedQuery/StreamingExchangeSink.cpp
@@ -236,7 +236,7 @@ void StreamingExchangeSink::work()
     }
 }
 
-std::pair<int, uint32_t> StreamingExchangeSink::scheduleForEvent()
+std::tuple<int, uint32_t, int64_t> StreamingExchangeSink::scheduleForEvent()
 {
     /// If socket is not ready yet, wait on the eventfd
     if (!socket)
@@ -254,13 +254,14 @@ std::pair<int, uint32_t> StreamingExchangeSink::scheduleForEvent()
         /// EPOLLIN | EPOLLRDHUP wake us on peer-initiated NoMoreDataNeeded / half-close.
         return {
             socket->sockfd(),
-            EPOLLOUT | EPOLLIN | EPOLLRDHUP | EPOLLERR};
+            EPOLLOUT | EPOLLIN | EPOLLRDHUP | EPOLLERR,
+            -1};
     }
 
     int fd = future_connection->getEventFd();
 
     LOG_TEST(log, "Schedule exchange stream sink {} waiting for connection, eventfd: {}", stream_name, fd);
-    return {fd, EPOLLIN | EPOLLERR};
+    return {fd, EPOLLIN | EPOLLERR, -1};
 }
 
 void StreamingExchangeSink::consume(Chunk chunk)

--- a/src/Server/DistributedQuery/StreamingExchangeSink.h
+++ b/src/Server/DistributedQuery/StreamingExchangeSink.h
@@ -28,7 +28,7 @@ public:
     String getName() const override { return "StreamingExchangeSink(" + stream_name + ")"; }
 
     Status prepare() override;
-    std::pair<int, uint32_t> scheduleForEvent() override;
+    std::tuple<int, uint32_t, Int64> scheduleForEvent() override;
 
 private:
     void consume(Chunk chunk) override;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch supports waiting on a file descriptor in epoll with a timeout and wires this feature into `IProcessor::scheduleForEvent`. This can be useful when a processor needs to wait for some event but not indefinitely.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.821` (included in `26.7` and later)
<!-- ch-version-info:end -->