### PR TITLE
Fix flaky test_server_no_logging: poll for async "Restored console logger level" line

### DIFF
--- a/tests/integration/test_server_startup_and_shutdown_logs/test.py
+++ b/tests/integration/test_server_startup_and_shutdown_logs/test.py
@@ -42,14 +42,18 @@ def started_cluster():
         assert instance_console_unset.contains_in_log(
             "Starting console logger in level trace"
         )
-        assert instance_console_unset.contains_in_log(
+        # The "Restored ..." line is logged at the very end of startup, right before
+        # ports are opened. Logging is async by default, so the background writer may
+        # not have flushed it to the log file yet when the instance becomes ready.
+        # Poll for it instead of a one-shot grep.
+        instance_console_unset.wait_for_log_line(
             "Restored console logger level to logger.level"
         )
         # ... and when it is explicitly configured it is restored to that value.
         assert instance_console_set.contains_in_log(
             "Starting console logger in level trace"
         )
-        assert instance_console_set.contains_in_log(
+        instance_console_set.wait_for_log_line(
             "Restored console logger level to warning"
         )
         yield cluster


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/103472
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_server_startup_and_shutdown_logs/test.py::test_server_no_logging` is flaky. Failure on master:

```
File: test_server_startup_and_shutdown_logs/test.py:45 - in started_cluster
    assert instance_console_unset.contains_in_log(
E   AssertionError: assert False
E    +  where False = contains_in_log('Restored console logger level to logger.level')
```

CI report (master, arm_binary): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f5e40f2d86d1715c149223f478bce0460fdd8e29&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

Root cause: the `"Restored console logger level ..."` line is emitted by `LOG_INFO` at the very end of server init (`programs/server/Server.cpp`), right before ports are opened and the instance is declared ready. Logging is async by default (`logger.async=true`), so the background writer thread may not have flushed that final line to the log file yet when the ping handshake succeeds and the fixture runs its one-shot `contains_in_log` grep. The earlier `"Starting console logger in level trace"` checks on the same instances pass reliably because those lines are logged at the start of init, giving the writer the whole init duration to flush.

Fix: use `wait_for_log_line` (polls up to 30s) for the two post-startup `"Restored ..."` assertions. Test intent is unchanged - the same log strings must still appear.

Test-only change. The test/console-log-restore logic was added recently in dbf5f7bb (fix for issue #103472); this addresses the flakiness introduced with the new fixture assertions.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.787` (included in `26.7` and later)
- Backported to: `26.6.2.72`, `26.5.6.43`, `26.4.5.131`, `26.3.17.46`
<!-- ch-version-info:end -->