### PR TITLE
Fix `04401_distributed_with_fill_const_to_scalar` in the distributed plan CI config

### DIFF
--- a/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
+++ b/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
@@ -6,6 +6,14 @@
 -- causing "Bad cast from type DB::FunctionNode to DB::ConstantNode".
 -- optimize_const_name_size = 0 replaces ALL constants with __getScalar calls.
 
+-- WITH FILL sort descriptions do not support query plan serialization yet
+-- (serializeSortDescription throws NOT_IMPLEMENTED), and the `distributed plan`
+-- CI configuration enables serialize_query_plan = 1 server-wide, which would send
+-- the serialized plan to the remote shard. The bug this test covers is in the
+-- planner on the initiator (extractWithFillValue), independent of serialization,
+-- so disable serialize_query_plan here to keep the test meaningful in that config.
+SET serialize_query_plan = 0;
+
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Not for changelog (changelog entry is not required).

### Description

The test `04401_distributed_with_fill_const_to_scalar` runs a distributed `SELECT ... ORDER BY ... WITH FILL` query. In the `distributed plan` CI configuration the server profile sets `serialize_query_plan = 1`, so the query plan is serialized and sent to the remote shard. `serializeSortDescription` (`src/Core/SortDescription.cpp`) throws `NOT_IMPLEMENTED` for `WITH FILL` sort descriptions, so the test failed there with:

```
Code: 48. DB::Exception: WITH FILL is not supported in serialized sort description: While executing Remote. (NOT_IMPLEMENTED)
```

This is a pre-existing serialization limitation, unrelated to what the test covers: the regression being tested is a bad cast in the planner on the initiator (`extractWithFillValue` reading `__getScalar`-replaced constants), which happens regardless of query plan serialization. Disabling `serialize_query_plan` in the test keeps it meaningful in the `distributed plan` config, mirroring the existing `03788_window_function_lag_lead_remote` test which does the same for the analogous `WindowStep` serialization limitation.

The failure reproduces on `master` itself and across many unrelated pull requests in the same CI shard. Verified locally: with `serialize_query_plan = 1` and `prefer_localhost_replica = 0` the query throws the error above, and with `serialize_query_plan = 0` it succeeds with the expected output.

Found via the CI report of https://github.com/ClickHouse/ClickHouse/pull/71030 (report "Stateless tests (amd_asan_ubsan, distributed plan, parallel)").

Related: https://github.com/ClickHouse/ClickHouse/pull/109938

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)