### PR TITLE
Fix 04401_distributed_with_fill_const_to_scalar in the distributed plan shard

### DIFF
--- a/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
+++ b/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
@@ -6,6 +6,11 @@
 -- causing "Bad cast from type DB::FunctionNode to DB::ConstantNode".
 -- optimize_const_name_size = 0 replaces ALL constants with __getScalar calls.
 
+-- serialize_query_plan = 0 because WITH FILL is not supported in serialized sort descriptions
+-- (serializeSortDescription throws NOT_IMPLEMENTED), and the CI `distributed plan` shard turns
+-- serialize_query_plan on globally. This test exercises the query-tree shard rewrite, not query
+-- plan serialization, so the setting is orthogonal to what is being tested here.
+
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;
 
@@ -14,9 +19,9 @@ CREATE TABLE t1 ENGINE = Distributed(test_shard_localhost, currentDatabase(), 't
 
 INSERT INTO t0 VALUES (1), (3), (5);
 
-SELECT c0 FROM t1 ORDER BY c0 WITH FILL TO 6 SETTINGS optimize_const_name_size = 0;
-SELECT c0 FROM t1 ORDER BY c0 WITH FILL FROM 0 TO 6 SETTINGS optimize_const_name_size = 0;
-SELECT c0 FROM t1 ORDER BY c0 WITH FILL FROM 0 TO 6 STEP 2 SETTINGS optimize_const_name_size = 0;
+SELECT c0 FROM t1 ORDER BY c0 WITH FILL TO 6 SETTINGS optimize_const_name_size = 0, serialize_query_plan = 0;
+SELECT c0 FROM t1 ORDER BY c0 WITH FILL FROM 0 TO 6 SETTINGS optimize_const_name_size = 0, serialize_query_plan = 0;
+SELECT c0 FROM t1 ORDER BY c0 WITH FILL FROM 0 TO 6 STEP 2 SETTINGS optimize_const_name_size = 0, serialize_query_plan = 0;
 
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109938
-->

Fixes the stateless test `04401_distributed_with_fill_const_to_scalar` in the CI `distributed plan` shard.

The test (added by #109938) runs distributed `ORDER BY ... WITH FILL` queries. The `distributed plan` shard installs `users.d/distributed_plan.xml`, which enables `serialize_query_plan` globally. `serializeSortDescription` throws `NOT_IMPLEMENTED: WITH FILL is not supported in serialized sort description`, so every `WITH FILL` query fails there. On `master` the test fails ~6/8 times in `Stateless tests (amd_asan_ubsan, distributed plan, parallel)` while staying green in every default-settings shard (`serialize_query_plan` defaults to `0`).

The test targets the query-tree shard rewrite in `buildQueryTreeForShard` (the `Bad cast from type DB::FunctionNode to DB::ConstantNode` fix), which is only exercised with `serialize_query_plan = 0` anyway. This pins the setting to `0` on each query, mirroring the existing opt-out used by other distributed tests (e.g. `02535_max_parallel_replicas_custom_key_rmt`, `03403_parallel_blocks_marshalling_for_distributed`). Results are unchanged, so the reference file stays identical.

Surfaced on the CI report of PR #96823, shard `Stateless tests (amd_asan_ubsan, distributed plan, parallel)`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96823&sha=ca7d00e6093e1544be83e8bb9545138a87b4968e&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.785` (included in `26.7` and later)
<!-- ch-version-info:end -->