### PR TITLE
Speed up drop and shutdown of tables with text indexes

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1826,9 +1826,18 @@ MergeTreeIndexText::MergeTreeIndexText(
     , params(std::move(params_))
     , tokenizer(std::move(tokenizer_))
     , posting_list_codec(std::move(posting_list_codec_))
-    , preprocessor(std::make_shared<MergeTreeIndexTextPreprocessor>(params.preprocessor, index_))
-    , postprocessor(std::make_shared<MergeTreeIndexTextPostprocessor>(params.postprocessor, index_))
 {
+}
+
+void MergeTreeIndexText::buildProcessorsOnce() const
+{
+    callOnce(processors_initialized, [this]
+    {
+        auto new_preprocessor = std::make_shared<MergeTreeIndexTextPreprocessor>(params.preprocessor, index);
+        auto new_postprocessor = std::make_shared<MergeTreeIndexTextPostprocessor>(params.postprocessor, index);
+        preprocessor = std::move(new_preprocessor);
+        postprocessor = std::move(new_postprocessor);
+    });
 }
 
 MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
@@ -1878,11 +1887,13 @@ MergeTreeIndexGranulePtr MergeTreeIndexText::createIndexGranule() const
 
 MergeTreeIndexAggregatorPtr MergeTreeIndexText::createIndexAggregator() const
 {
+    buildProcessorsOnce();
     return std::make_shared<MergeTreeIndexAggregatorText>(index.column_names[0], params, tokenizer.get(), posting_list_codec.get(), preprocessor, postprocessor);
 }
 
 MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const
 {
+    buildProcessorsOnce();
     return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, tokenizer.get(), preprocessor, postprocessor, params.positions);
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -6,6 +6,7 @@
 #include <Columns/IColumn.h>
 #include <Common/BitPackedStringArray.h>
 #include <Common/BitPackedUInt64Array.h>
+#include <Common/callOnce.h>
 #include <Common/Logger.h>
 #include <Common/HashTable/HashMap.h>
 #include <Common/HashTable/StringHashMap.h>
@@ -557,8 +558,15 @@ public:
     MergeTreeIndexTextParams params;
     std::unique_ptr<ITokenizer> tokenizer;
     std::unique_ptr<IPostingListCodec> posting_list_codec;
-    MergeTreeIndexTextPreprocessorPtr preprocessor;
-    MergeTreeIndexTextPostprocessorPtr postprocessor;
+
+private:
+    /// Preprocessor and postprocessor construction analyzes expressions, which is expensive.
+    /// They are built lazily because metadata-only uses of the index object do not need them.
+    void buildProcessorsOnce() const;
+
+    mutable OnceFlag processors_initialized;
+    mutable MergeTreeIndexTextPreprocessorPtr preprocessor;
+    mutable MergeTreeIndexTextPostprocessorPtr postprocessor;
 };
 
 }

--- a/src/Storages/MergeTree/tests/gtest_merge_tree_index_text_lazy_build.cpp
+++ b/src/Storages/MergeTree/tests/gtest_merge_tree_index_text_lazy_build.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <Common/Exception.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+#include <DataTypes/DataTypeString.h>
+#include <Parsers/ParserCreateQuery.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/ColumnsDescription.h>
+#include <Storages/IndicesDescription.h>
+#include <Storages/MergeTree/MergeTreeIndices.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/StorageInMemoryMetadata.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int UNKNOWN_FUNCTION;
+}
+
+using namespace DB;
+
+namespace
+{
+
+MergeTreeIndexPtr createTextIndex(const String & definition)
+{
+    auto context = getContext().context;
+
+    ParserIndexDeclaration parser;
+    ASTPtr ast = parseQuery(parser, definition, 0, 0, 0);
+
+    ColumnsDescription columns{NamesAndTypesList{{"str", std::make_shared<DataTypeString>()}}};
+
+    auto metadata = std::make_shared<StorageInMemoryMetadata>();
+    metadata->setColumns(columns);
+
+    IndicesDescription indices;
+    indices.push_back(IndexDescription::getIndexFromAST(ast, columns, false, false, context));
+    metadata->setSecondaryIndices(indices);
+
+    /// The index object keeps a reference to the description, so pass the metadata-owned one.
+    MergeTreeSettings settings(context->getMergeTreeSettings());
+    return MergeTreeIndexFactory::instance().get(metadata, metadata->getSecondaryIndices().front(), settings);
+}
+
+}
+
+/// Constructing a text index object must not analyze the preprocessor and postprocessor expressions.
+/// Metadata-only paths construct index objects per data part, where such analysis is too expensive.
+TEST(MergeTreeIndexTextTest, LazyPreprocessorBuild)
+{
+    tryRegisterFunctions();
+
+    auto index = createTextIndex(
+        "idx str TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(str)) GRANULARITY 1");
+
+    EXPECT_NO_THROW(index->createIndexAggregator());
+
+    /// An expression with an unknown function fails only on first real use of the index,
+    /// not when the index object is constructed for metadata inspection.
+    auto broken_index = createTextIndex(
+        "idx str TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = unknown_function_12345(str)) GRANULARITY 1");
+
+    EXPECT_FALSE(broken_index->getFileName().empty());
+
+    auto expect_unknown_function = [](auto && callback)
+    {
+        try
+        {
+            callback();
+            ADD_FAILURE() << "Expected UNKNOWN_FUNCTION exception";
+        }
+        catch (const Exception & e)
+        {
+            EXPECT_EQ(e.code(), ErrorCodes::UNKNOWN_FUNCTION);
+        }
+    };
+
+    expect_unknown_function([&] { broken_index->createIndexAggregator(); });
+    /// The null predicate is never used because the lazy build throws first.
+    expect_unknown_function([&] { broken_index->createIndexCondition(nullptr, getContext().context); });
+}


### PR DESCRIPTION
Speed up `DROP TABLE`, `DETACH TABLE`, and server shutdown for tables with `text` indexes: build the `preprocessor` and `postprocessor` expressions lazily on first use instead of in the index object constructor, which runs for every data part on part destruction just to compute cache keys.

Related: https://github.com/ClickHouse/ClickHouse/pull/97772

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up `DROP TABLE`, `DETACH TABLE`, and server shutdown for tables with `text` indexes with `preprocessor` or `postprocessor` arguments.
