### PR TITLE
Resolve secondary index stream names without constructing index objects

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -820,21 +820,10 @@ void IMergeTreeDataPart::loadIndexMarksToCache(MarkCache * index_mark_cache) con
 
     for (const auto & index_description : secondary_indices)
     {
-        auto skip_index = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *storage.getSettings());
-        auto index_name = skip_index->getFileName();
-        auto index_format = skip_index->getDeserializedFormat(checksums, index_name, &getDataPartStorage());
+        auto stream_names = MergeTreeIndexFactory::instance().getStreamNames(index_description, checksums, &getDataPartStorage());
 
-        if (!index_format)
-            continue;
-
-        for (const auto & substream : index_format.substreams)
+        for (const auto & stream_name : stream_names)
         {
-            auto full_stream_name = index_name + substream.suffix;
-            auto stream_name_opt = getStreamNameOrHash(full_stream_name, substream.extension, checksums);
-            /// For packed substreams the per-virtual-file entry is not in checksums; use the
-            /// non-hashed name and rely on the storage overlay to resolve it.
-            String stream_name = stream_name_opt.value_or(full_stream_name);
-
             loaders.emplace_back(std::make_unique<MergeTreeMarksLoader>(
                 info_for_read,
                 index_mark_cache,
@@ -871,19 +860,10 @@ void IMergeTreeDataPart::removeIndexMarksFromCache(MarkCache * index_mark_cache)
 
     for (const auto & index_description : secondary_indices)
     {
-        auto skip_index = MergeTreeIndexFactory::instance().get(metadata_snapshot, index_description, *storage.getSettings());
-        auto index_name = skip_index->getFileName();
-        auto index_format = skip_index->getDeserializedFormat(checksums, index_name, &getDataPartStorage());
+        auto stream_names = MergeTreeIndexFactory::instance().getStreamNames(index_description, checksums, &getDataPartStorage());
 
-        if (!index_format)
-            continue;
-
-        for (const auto & substream : index_format.substreams)
+        for (const auto & stream_name : stream_names)
         {
-            auto full_stream_name = index_name + substream.suffix;
-            auto stream_name_opt = getStreamNameOrHash(full_stream_name, substream.extension, checksums);
-            String stream_name = stream_name_opt.value_or(full_stream_name);
-
             auto marks_file = index_granularity_info.getMarksFilePath(stream_name);
             auto key = MarkCache::hash(getDataPartStorage().getDiskName() + ":" + (fs::path(getRelativePathOfActivePart()) / marks_file).string());
             index_mark_cache->remove(key);

--- a/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexMinMax.cpp
@@ -249,16 +249,24 @@ MergeTreeIndexConditionPtr MergeTreeIndexMinMax::createIndexCondition(
     return std::make_shared<MergeTreeIndexConditionMinMax>(index, filter_dag, context);
 }
 
-MergeTreeIndexFormat MergeTreeIndexMinMax::getDeserializedFormat(
+MergeTreeIndexFormat minmaxIndexFormatDetector(
     const MergeTreeDataPartChecksums & checksums,
     const std::string & relative_path_prefix,
-    const IDataPartStorage * storage) const
+    const IDataPartStorage * storage)
 {
     if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx2", storage))
         return {2, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx2"}}};
     if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
     return {0 /* unknown */, {}};
+}
+
+MergeTreeIndexFormat MergeTreeIndexMinMax::getDeserializedFormat(
+    const MergeTreeDataPartChecksums & checksums,
+    const std::string & relative_path_prefix,
+    const IDataPartStorage * storage) const
+{
+    return minmaxIndexFormatDetector(checksums, relative_path_prefix, storage);
 }
 
 MergeTreeIndexBulkGranulesMinMax::MergeTreeIndexBulkGranulesMinMax(const String & index_name_, const Block & index_sample_block_,

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1846,10 +1846,10 @@ MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
     return substreams;
 }
 
-MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(
+MergeTreeIndexFormat textIndexFormatDetector(
     const MergeTreeDataPartChecksums & checksums,
     const std::string & path_prefix,
-    const IDataPartStorage * storage) const
+    const IDataPartStorage * storage)
 {
     if (!indexFileExistsInChecksums(checksums, path_prefix, ".idx", storage))
         return {0, {}};
@@ -1869,6 +1869,14 @@ MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(
     }
 
     return {1, std::move(substreams)};
+}
+
+MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(
+    const MergeTreeDataPartChecksums & checksums,
+    const std::string & path_prefix,
+    const IDataPartStorage * storage) const
+{
+    return textIndexFormatDetector(checksums, path_prefix, storage);
 }
 
 MergeTreeIndexGranulePtr MergeTreeIndexText::createIndexGranule() const

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -63,15 +63,23 @@ Names IMergeTreeIndex::getColumnsRequiredForIndexCalc() const
     return index.expression->getRequiredColumns();
 }
 
-MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(
+static MergeTreeIndexFormat defaultIndexFormatDetector(
     const MergeTreeDataPartChecksums & checksums,
     const std::string & relative_path_prefix,
-    const IDataPartStorage * storage) const
+    const IDataPartStorage * storage)
 {
     if (indexFileExistsInChecksums(checksums, relative_path_prefix, ".idx", storage))
         return {1, {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}};
 
     return {0 /*unknown*/, {}};
+}
+
+MergeTreeIndexFormat IMergeTreeIndex::getDeserializedFormat(
+    const MergeTreeDataPartChecksums & checksums,
+    const std::string & relative_path_prefix,
+    const IDataPartStorage * storage) const
+{
+    return defaultIndexFormatDetector(checksums, relative_path_prefix, storage);
 }
 
 void IMergeTreeIndexGranule::serializeBinaryWithMultipleStreams(MergeTreeIndexOutputStreams & streams) const
@@ -98,6 +106,51 @@ void MergeTreeIndexFactory::registerValidator(const std::string & index_type, Va
 {
     if (!validators.emplace(index_type, std::move(validator)).second)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeIndexFactory: the Index validator name '{}' is not unique", index_type);
+}
+
+void MergeTreeIndexFactory::registerFormatDetector(const std::string & index_type, FormatDetector detector)
+{
+    if (!format_detectors.emplace(index_type, std::move(detector)).second)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeIndexFactory: the Index format detector name '{}' is not unique", index_type);
+}
+
+Names MergeTreeIndexFactory::getStreamNames(
+    const IndexDescription & index,
+    const MergeTreeDataPartChecksums & checksums,
+    const IDataPartStorage * storage) const
+{
+    auto index_name = getIndexFileName(index.name, index.escape_filenames);
+
+    auto it = format_detectors.find(index.type);
+    auto format = it != format_detectors.end()
+        ? it->second(checksums, index_name, storage)
+        : defaultIndexFormatDetector(checksums, index_name, storage);
+
+    Names stream_names;
+    stream_names.reserve(format.substreams.size());
+
+    for (const auto & substream : format.substreams)
+    {
+        auto full_stream_name = index_name + substream.suffix;
+        if (checksums.files.contains(full_stream_name + substream.extension))
+        {
+            stream_names.push_back(std::move(full_stream_name));
+            continue;
+        }
+
+        auto hash = sipHash128String(full_stream_name);
+        if (checksums.files.contains(hash + substream.extension))
+        {
+            stream_names.push_back(std::move(hash));
+            continue;
+        }
+
+        /// A packed substream has no per-virtual-file checksums entry: keep the
+        /// non-hashed name and rely on the storage overlay to resolve it.
+        stream_names.push_back(std::move(full_stream_name));
+    }
+
+    return stream_names;
 }
 
 std::vector<String> MergeTreeIndexFactory::getAllRegisteredNames() const
@@ -196,6 +249,7 @@ MergeTreeIndexFactory::MergeTreeIndexFactory()
         .syntax = "INDEX name expr TYPE minmax GRANULARITY n",
         .related = {"set"}});
     registerValidator("minmax", minmaxIndexValidator);
+    registerFormatDetector("minmax", minmaxIndexFormatDetector);
 
     registerCreator("set", setIndexCreator, Documentation{
         .description = "Stores up to `max_rows` distinct values of the index expression per granule (0 means unlimited), allowing granules to be skipped for equality and IN conditions.",
@@ -240,6 +294,7 @@ MergeTreeIndexFactory::MergeTreeIndexFactory()
         .syntax = "INDEX name expr TYPE text(tokenizer = splitByNonAlpha) GRANULARITY g",
         .related = {"tokenbf_v1"}});
     registerValidator("text", textIndexValidator);
+    registerFormatDetector("text", textIndexFormatDetector);
 
     /// Index type 'hypothesis' is no longer supported.
     /// To allow loading tables with old indexes, register a dummy index which allows attach but

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -264,6 +264,8 @@ struct IMergeTreeIndex
     /// getDeserializedFormat() should be reimplemented too,
     /// and check all previous extensions for substreams too
     /// (to avoid breaking backward compatibility).
+    /// A matching format detector should also be registered
+    /// in MergeTreeIndexFactory.
     virtual MergeTreeIndexSubstreams getSubstreams() const { return {{MergeTreeIndexSubstream::Type::Regular, "", ".idx"}}; }
 
     /// Returns substreams and version for deserialization. @storage is consulted so that packed
@@ -344,8 +346,24 @@ public:
     MergeTreeIndexPtr get(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & settings) const;
     MergeTreeIndices getMany(StorageMetadataPtr metadata_snapshot, const std::vector<IndexDescription> & indices, const MergeTreeSettings & settings) const;
 
+    /// Per-type equivalent of IMergeTreeIndex::getDeserializedFormat that does not require an index object.
+    using FormatDetector = std::function<MergeTreeIndexFormat(
+        const MergeTreeDataPartChecksums & checksums,
+        const std::string & relative_path_prefix,
+        const IDataPartStorage * storage)>;
+
+    /// On-disk stream names of the index in a part (hash-resolved, without extensions),
+    /// obtained without constructing the index object (which may be expensive, e.g. the
+    /// text index builds expression actions). Unknown index types are probed with the
+    /// default detector instead of throwing, so it is safe on cleanup paths.
+    Names getStreamNames(
+        const IndexDescription & index,
+        const MergeTreeDataPartChecksums & checksums,
+        const IDataPartStorage * storage) const;
+
     void registerCreator(const std::string & index_type, Creator creator, Documentation documentation = {});
     void registerValidator(const std::string & index_type, Validator validator);
+    void registerFormatDetector(const std::string & index_type, FormatDetector detector);
 
     std::vector<String> getAllRegisteredNames() const;
 
@@ -358,14 +376,17 @@ protected:
 private:
     using Creators = std::unordered_map<std::string, Creator>;
     using Validators = std::unordered_map<std::string, Validator>;
+    using FormatDetectors = std::unordered_map<std::string, FormatDetector>;
     using Documentations = std::unordered_map<std::string, Documentation>;
     Creators creators;
     Validators validators;
+    FormatDetectors format_detectors;
     Documentations documentations;
 };
 
 MergeTreeIndexPtr minmaxIndexCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & settings);
 void minmaxIndexValidator(const IndexDescription & index, bool attach, const MergeTreeSettings & settings);
+MergeTreeIndexFormat minmaxIndexFormatDetector(const MergeTreeDataPartChecksums & checksums, const std::string & relative_path_prefix, const IDataPartStorage * storage);
 
 MergeTreeIndexPtr setIndexCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & settings);
 void setIndexValidator(const IndexDescription & index, bool attach, const MergeTreeSettings & settings);
@@ -386,6 +407,7 @@ void ginIndexValidator(const IndexDescription & index, bool attach, const MergeT
 
 MergeTreeIndexPtr textIndexCreator(StorageMetadataPtr metadata_snapshot, const IndexDescription & index, const MergeTreeSettings & settings);
 void textIndexValidator(const IndexDescription & index, bool attach, const MergeTreeSettings & settings);
+MergeTreeIndexFormat textIndexFormatDetector(const MergeTreeDataPartChecksums & checksums, const std::string & relative_path_prefix, const IDataPartStorage * storage);
 
 String getIndexFileName(const String & index_name, bool escape_filename);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Resolve secondary index stream names without constructing index objects

`MergeTreeIndexFactory::get` per part in `clearCaches` made `DETACH` slow: `textIndexCreator` builds `ActionsDAG`. Replace with `MergeTreeIndexFactory::getStreamNames` over per-type format detectors.

On a table with 25K parts and 7 text indexes it can take extra 20 seconds for DETACH - https://pastila.nl/?003e831c/3bbbdcde32385f1838c52be3e3e48a5b#Kz4Twr1lr+vKqpODx9u+XA==GCM