### PR TITLE
Eliminate min/max/any/anyLast of LowCardinality GROUP BY keys

### DIFF
--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -6,7 +6,6 @@
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/LambdaNode.h>
 #include <Analyzer/QueryNode.h>
-#include <Analyzer/UnionNode.h>
 #include <Analyzer/Utils.h>
 
 #include <Core/Settings.h>
@@ -228,9 +227,15 @@ private:
 
     /// Whether a function argument node exposes a well-defined result type that can be compared.
     /// FUNCTION/COLUMN/CONSTANT always do and are the kinds this pass substitutes (an eliminated
-    /// aggregate is replaced by its argument). A QUERY/UNION argument exposes one only when it is a
+    /// aggregate is replaced by its argument). A QUERY argument exposes one only when it is a
     /// correlated scalar subquery; a non-correlated subquery (e.g. an IN subquery) throws from
-    /// getResultType(). ListNode and other kinds have no result type.
+    /// getResultType(). UNION never exposes one here: unlike QueryNode, UnionNode has no
+    /// getResultType() override and always throws UNSUPPORTED_METHOD (even for a correlated scalar
+    /// UNION), so dereferencing it would reintroduce that analyzer failure. This is safe because a
+    /// subquery argument's type is never changed by this pass anyway: a nested query resets the
+    /// filter context (see enterImpl), so any aggregate eliminated inside a subquery projection is
+    /// cast back to its analyzed type and the subquery's result type stays stable. ListNode and
+    /// other kinds have no result type.
     static bool argumentExposesResultType(const IQueryTreeNode & argument_node)
     {
         switch (argument_node.getNodeType())
@@ -241,8 +246,6 @@ private:
                 return true;
             case QueryTreeNodeType::QUERY:
                 return argument_node.as<QueryNode &>().isCorrelated();
-            case QueryTreeNodeType::UNION:
-                return argument_node.as<UnionNode &>().isCorrelated();
             default:
                 return false;
         }

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -4,6 +4,7 @@
 #include <Analyzer/FunctionNode.h>
 #include <Analyzer/HashUtils.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
+#include <Analyzer/LambdaNode.h>
 #include <Analyzer/QueryNode.h>
 #include <Analyzer/UnionNode.h>
 #include <Analyzer/Utils.h>
@@ -41,6 +42,22 @@ public:
     {
         if (!getSettings()[Setting::optimize_aggregators_of_group_by_keys])
             return;
+
+        if (node->getNodeType() == QueryTreeNodeType::LAMBDA)
+        {
+            /// A lambda body is a computation whose type is cached on LambdaNode::result_type and in
+            /// the higher-order parent's DataTypeFunction signature; it is never a storage-pushdown
+            /// predicate, even when the lambda syntactically sits inside a filter section. Treat it
+            /// like a nested-query boundary: save and reset the filter context so an eliminated
+            /// aggregate in the lambda body is cast back to its analyzed type, keeping the lambda body
+            /// type (and the parent higher-order signature) unchanged. group_by_keys_stack is left
+            /// intact - the lambda body still refers to the enclosing query's GROUP BY keys.
+            filter_depth_save_stack.push_back(filter_depth);
+            filter_roots_save_stack.push_back(std::move(active_filter_roots));
+            filter_depth = 0;
+            active_filter_roots.clear();
+            return;
+        }
 
         auto * query_node = node->as<QueryNode>();
         if (!query_node)
@@ -174,6 +191,15 @@ public:
         {
             group_by_keys_stack.pop_back();
             /// Restore the enclosing query's filter context (see enterImpl).
+            filter_depth = filter_depth_save_stack.back();
+            filter_depth_save_stack.pop_back();
+            active_filter_roots = std::move(filter_roots_save_stack.back());
+            filter_roots_save_stack.pop_back();
+        }
+        else if (node->getNodeType() == QueryTreeNodeType::LAMBDA)
+        {
+            /// Restore the filter context saved when entering the lambda (see enterImpl). The
+            /// group_by_keys_stack was not touched, so it is not popped here.
             filter_depth = filter_depth_save_stack.back();
             filter_depth_save_stack.pop_back();
             active_filter_roots = std::move(filter_roots_save_stack.back());

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -42,11 +42,37 @@ public:
         if (!getSettings()[Setting::optimize_aggregators_of_group_by_keys])
             return;
 
-        /// Collect group by keys.
         auto * query_node = node->as<QueryNode>();
         if (!query_node)
+        {
+            /// A filter-section root (WHERE/PREWHERE/HAVING/QUALIFY of the current query) and its
+            /// whole subtree is a predicate position: an eliminated aggregate is left as the bare key
+            /// there so the predicate pushes down to storage and uses skip indexes. Everywhere else
+            /// (projection, ORDER BY, ...) is an output position where the observable type must be
+            /// preserved. Track how deep we are inside a filter subtree of the current query.
+            if (active_filter_roots.contains(node.get()))
+                ++filter_depth;
             return;
+        }
 
+        /// A nested query establishes its own output/filter contexts: its projection is an output
+        /// position even when the whole subquery sits inside the outer query's WHERE. Save and reset
+        /// the filter state so a correlated scalar subquery's projected aggregate is cast back to its
+        /// analyzed type (keeping QueryNode::getResultType() equal to the built header).
+        filter_depth_save_stack.push_back(filter_depth);
+        filter_roots_save_stack.push_back(std::move(active_filter_roots));
+        filter_depth = 0;
+        active_filter_roots.clear();
+        if (query_node->hasPrewhere())
+            active_filter_roots.insert(query_node->getPrewhere().get());
+        if (query_node->hasWhere())
+            active_filter_roots.insert(query_node->getWhere().get());
+        if (query_node->hasHaving())
+            active_filter_roots.insert(query_node->getHaving().get());
+        if (query_node->hasQualify())
+            active_filter_roots.insert(query_node->getQualify().get());
+
+        /// Collect group by keys.
         if (!query_node->hasGroupBy())
         {
             group_by_keys_stack.push_back({});
@@ -97,35 +123,65 @@ public:
         if (!getSettings()[Setting::optimize_aggregators_of_group_by_keys])
             return;
 
+        /// Capture the node identity before any rewrite so a filter-section root that is itself a
+        /// function (e.g. WHERE equals(...)) still has its filter_depth decremented below.
+        const IQueryTreeNode * node_before_rewrite = node.get();
+
         if (node->getNodeType() == QueryTreeNodeType::FUNCTION)
         {
             auto * function_node = node->as<FunctionNode>();
             if (aggregationCanBeEliminated(node, group_by_keys_stack.back()))
             {
-                node = function_node->getArguments().getNodes()[0];
+                /// The aggregate result type always strips LowCardinality from the argument
+                /// (min(LowCardinality(String)) -> String), so replacing the aggregate with the raw
+                /// key would change the node's type from the analyzed type to the key's type.
+                auto original_type = function_node->getResultType();
+                auto & key_node = function_node->getArguments().getNodes()[0];
+
+                if (filter_depth > 0 || original_type->equals(*key_node->getResultType()))
+                {
+                    /// In a filter (WHERE/PREWHERE/HAVING/QUALIFY) subtree, leave the bare key so the
+                    /// predicate operates directly on the key column and pushes down to storage /
+                    /// skip indexes. A type change here is not user-observable. Same bare replacement
+                    /// when the types already match (the plain, non-LowCardinality case) - no cast.
+                    /// The type flip is absorbed by re-resolving the parent ordinary functions below.
+                    node = key_node;
+                }
+                else
+                {
+                    /// In an output position (projection, ORDER BY, correlated-subquery projection,
+                    /// ...) cast the key back to the aggregate's analyzed type so the observable
+                    /// result type is unchanged (e.g. toTypeName(min(s)) stays String, result schemas
+                    /// and type-sensitive expressions are preserved, and a correlated scalar
+                    /// subquery's QueryNode::getResultType() still matches the built header). Parent
+                    /// functions still see the original type, so no re-resolution is needed for them.
+                    node = createCastFunction(key_node, std::move(original_type), getContext());
+                }
             }
-            else if (function_node->isOrdinaryFunction())
+            else if (filter_depth > 0 && function_node->isOrdinaryFunction())
             {
-                /// A child aggregate may have been replaced by its argument, which for a
-                /// LowCardinality group by key has a different type than the eliminated aggregate
-                /// (min(LowCardinality(String)) is String, but the key is LowCardinality(String)).
-                /// Re-resolve this ordinary function against its current argument types so the type
-                /// stays consistent and predicates like `key = 'x'` keep operating directly on the
-                /// key column, letting them push down to storage and use skip indexes.
+                /// A child aggregate in this filter subtree may have been replaced by its bare key,
+                /// whose type differs from the eliminated aggregate (min(LowCardinality(String)) is
+                /// String, but the key is LowCardinality(String)). Re-resolve this ordinary function
+                /// against its current argument types so it natively consumes the key type and the
+                /// predicate keeps pushing down to storage / skip indexes. Cascades upward as parents
+                /// are visited. Only needed in filter subtrees; in output positions the key is cast
+                /// back to the analyzed type, so parents there never see a changed argument type.
                 reresolveIfArgumentTypesChanged(*function_node);
             }
         }
         else if (node->getNodeType() == QueryTreeNodeType::QUERY)
         {
-            /// Projection nodes are rewritten before we leave the query node (post-order visit), so
-            /// a projection column that was an eliminated/re-resolved aggregate may now have a
-            /// different type. Refresh QueryNode::projection_columns so QueryNode::getResultType()
-            /// reports the true post-rewrite type; otherwise a correlated scalar subquery over a
-            /// LowCardinality key would report the stale analyzed type and
-            /// PlannerCorrelatedSubqueries::addStepForResultRenaming would throw on the header mismatch.
-            refreshProjectionColumnTypes(*node->as<QueryNode>());
             group_by_keys_stack.pop_back();
+            /// Restore the enclosing query's filter context (see enterImpl).
+            filter_depth = filter_depth_save_stack.back();
+            filter_depth_save_stack.pop_back();
+            active_filter_roots = std::move(filter_roots_save_stack.back());
+            filter_roots_save_stack.pop_back();
         }
+
+        if (active_filter_roots.contains(node_before_rewrite))
+            --filter_depth;
     }
 
     static bool needChildVisit(VisitQueryTreeNodeType & parent [[maybe_unused]], VisitQueryTreeNodeType & child)
@@ -142,9 +198,11 @@ private:
         bool parents_are_only_deterministic = false;
     };
 
-    /// Whether a function argument node has a well-defined result type that can be compared. Only a
-    /// correlated QUERY/UNION exposes one (see getResultType() on QueryNode/UnionNode); a plain
-    /// (non-correlated) subquery, list, etc. does not.
+    /// Whether a function argument node exposes a well-defined result type that can be compared.
+    /// FUNCTION/COLUMN/CONSTANT always do and are the kinds this pass substitutes (an eliminated
+    /// aggregate is replaced by its argument). A QUERY/UNION argument exposes one only when it is a
+    /// correlated scalar subquery; a non-correlated subquery (e.g. an IN subquery) throws from
+    /// getResultType(). ListNode and other kinds have no result type.
     static bool argumentExposesResultType(const IQueryTreeNode & argument_node)
     {
         switch (argument_node.getNodeType())
@@ -164,8 +222,8 @@ private:
 
     /// Re-resolve an ordinary function if any argument's current result type no longer matches the
     /// type the function was resolved with (a child aggregate was replaced by its differently-typed
-    /// argument, possibly inside a correlated scalar subquery). Cascades upward as parents are
-    /// visited in leaveImpl.
+    /// bare key). Cascades upward as parents are visited in leaveImpl. Used only inside filter
+    /// subtrees, where the bare key is deliberately left in place to keep predicate pushdown.
     void reresolveIfArgumentTypesChanged(FunctionNode & function_node)
     {
         const auto & resolved_argument_types = function_node.getArgumentTypes();
@@ -176,13 +234,6 @@ private:
         bool argument_types_changed = false;
         for (size_t i = 0; i < argument_nodes.size(); ++i)
         {
-            /// Skip arguments that do not expose a result type. FUNCTION/COLUMN/CONSTANT always do
-            /// and may have been substituted by this pass (an eliminated aggregate is replaced by
-            /// its argument). A QUERY/UNION argument exposes a result type only when it is a
-            /// correlated scalar subquery, whose type can also flip if its projection was an
-            /// eliminated aggregate over a LowCardinality key; a non-correlated subquery (e.g. an
-            /// IN subquery) throws from getResultType() and is never rewritten, so skip it. ListNode
-            /// and other kinds have no result type either.
             if (!argumentExposesResultType(*argument_nodes[i]))
                 continue;
 
@@ -195,40 +246,6 @@ private:
 
         if (argument_types_changed)
             resolveOrdinaryFunctionNodeByName(function_node, function_node.getFunctionName(), getContext());
-    }
-
-    /// Re-derive projection column types from the (already rewritten) projection nodes so the query
-    /// node's result-type metadata stays consistent with what the planner will build. Names are kept;
-    /// only types are refreshed. No-op for a query node whose projection types did not change.
-    static void refreshProjectionColumnTypes(QueryNode & query_node)
-    {
-        if (!query_node.isResolved())
-            return;
-
-        const auto & projection_nodes = query_node.getProjection().getNodes();
-        const auto & projection_columns = query_node.getProjectionColumns();
-        if (projection_nodes.size() != projection_columns.size())
-            return;
-
-        NamesAndTypes refreshed_columns = projection_columns;
-        bool changed = false;
-        for (size_t i = 0; i < projection_nodes.size(); ++i)
-        {
-            /// Skip projection nodes without a well-defined result type (e.g. a not-yet-evaluated
-            /// non-correlated scalar subquery) so getResultType() below never throws.
-            if (!argumentExposesResultType(*projection_nodes[i]))
-                continue;
-
-            auto projection_type = projection_nodes[i]->getResultType();
-            if (projection_type && !projection_type->equals(*refreshed_columns[i].type))
-            {
-                refreshed_columns[i].type = std::move(projection_type);
-                changed = true;
-            }
-        }
-
-        if (changed)
-            query_node.resolveProjectionColumns(std::move(refreshed_columns));
     }
 
     bool aggregationCanBeEliminated(QueryTreeNodePtr & node, const QueryTreeNodePtrWithHashSet & group_by_keys)
@@ -304,6 +321,16 @@ private:
     }
 
     GroupByKeysStack group_by_keys_stack;
+
+    /// Roots of the current query's filter sections (WHERE/PREWHERE/HAVING/QUALIFY). filter_depth > 0
+    /// means we are inside one of them, i.e. in a predicate position where an eliminated aggregate is
+    /// left as the bare key so the filter pushes down to storage. Both are per-query: they are saved
+    /// on the stacks below and reset when entering a nested (sub)query, so a correlated subquery's
+    /// projection is treated as an output position even inside the outer query's WHERE.
+    std::unordered_set<const IQueryTreeNode *> active_filter_roots;
+    size_t filter_depth = 0;
+    std::vector<std::unordered_set<const IQueryTreeNode *>> filter_roots_save_stack;
+    std::vector<size_t> filter_depth_save_stack;
 };
 
 }

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -13,6 +13,8 @@
 
 #include <DataTypes/DataTypeLowCardinality.h>
 
+#include <Functions/IFunctionAdaptors.h>
+
 
 namespace DB
 {
@@ -253,7 +255,7 @@ private:
     void reresolveIfArgumentTypesChanged(FunctionNode & function_node)
     {
         const auto & resolved_argument_types = function_node.getArgumentTypes();
-        const auto & argument_nodes = function_node.getArguments().getNodes();
+        auto & argument_nodes = function_node.getArguments().getNodes();
         if (resolved_argument_types.size() != argument_nodes.size())
             return;
 
@@ -270,8 +272,49 @@ private:
             }
         }
 
-        if (argument_types_changed)
-            resolveOrdinaryFunctionNodeByName(function_node, function_node.getFunctionName(), getContext());
+        if (!argument_types_changed)
+            return;
+
+        /// A filter section is a predicate position only for functions that are transparent to
+        /// LowCardinality (they use the default LC implementation: the framework strips LC, computes
+        /// on the nested column and rewraps, so leaving the bare LC key changes only the internal
+        /// representation, not the values, and the predicate still pushes down to skip indexes). A
+        /// function that OBSERVES LowCardinality (useDefaultImplementationForLowCardinalityColumns()
+        /// is false, e.g. toTypeName) would instead change its observable result if re-resolved
+        /// against the bare key type - HAVING toTypeName(min(s)) = 'String' would flip from 'String'
+        /// to 'LowCardinality(String)' and drop the row. For such a function, cast each changed
+        /// argument back to its originally-resolved (LC-stripped) type so the function keeps its
+        /// analyzed signature and result; pushdown below the cast is lost, but an LC-observing
+        /// function does not push down to storage anyway.
+        if (!functionIsTransparentToLowCardinality(function_node))
+        {
+            for (size_t i = 0; i < argument_nodes.size(); ++i)
+            {
+                if (!argumentExposesResultType(*argument_nodes[i]))
+                    continue;
+
+                if (resolved_argument_types[i] && !resolved_argument_types[i]->equals(*argument_nodes[i]->getResultType()))
+                    argument_nodes[i] = createCastFunction(argument_nodes[i], resolved_argument_types[i], getContext());
+            }
+            return;
+        }
+
+        resolveOrdinaryFunctionNodeByName(function_node, function_node.getFunctionName(), getContext());
+    }
+
+    /// Whether the resolved ordinary function computes on the LowCardinality nested column (default
+    /// LC implementation) rather than observing the LowCardinality wrapper. Transparent functions
+    /// (comparisons and most scalar functions) yield the same values on the bare LC key as on the
+    /// LC-stripped type, so re-resolving them against the key preserves both results and pushdown.
+    /// Non-transparent functions (e.g. toTypeName) must not see the key type. Conservatively treat a
+    /// function whose IFunction we cannot reach as non-transparent (fall back to the boundary cast).
+    static bool functionIsTransparentToLowCardinality(const FunctionNode & function_node)
+    {
+        const auto & function_base = function_node.getFunction();
+        const auto * adaptor = typeid_cast<const FunctionToFunctionBaseAdaptor *>(function_base.get());
+        if (!adaptor || !adaptor->getFunction())
+            return false;
+        return adaptor->getFunction()->useDefaultImplementationForLowCardinalityColumns();
     }
 
     bool aggregationCanBeEliminated(QueryTreeNodePtr & node, const QueryTreeNodePtrWithHashSet & group_by_keys)

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -147,6 +147,15 @@ private:
         bool argument_types_changed = false;
         for (size_t i = 0; i < argument_nodes.size(); ++i)
         {
+            /// Only these argument node types expose a result type and can be substituted by this
+            /// pass (an eliminated aggregate is replaced by its FUNCTION/COLUMN argument). Other
+            /// argument kinds (a non-correlated QueryNode/UnionNode from an IN subquery, ListNode,
+            /// etc.) throw from getResultType() and are never rewritten here, so skip them.
+            const auto arg_type = argument_nodes[i]->getNodeType();
+            if (arg_type != QueryTreeNodeType::FUNCTION && arg_type != QueryTreeNodeType::COLUMN
+                && arg_type != QueryTreeNodeType::CONSTANT)
+                continue;
+
             if (!resolved_argument_types[i] || !resolved_argument_types[i]->equals(*argument_nodes[i]->getResultType()))
             {
                 argument_types_changed = true;

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -257,10 +257,21 @@ private:
         if (!function || !function->isAggregateFunction())
             return false;
 
-        if (!(function->getFunctionName() == "min"
-                || function->getFunctionName() == "max"
-                || function->getFunctionName() == "any"
-                || function->getFunctionName() == "anyLast"))
+        /// Every aggregate here returns an actual element of its input column, so over a group where
+        /// the argument is a GROUP BY key (constant within the group) the result equals that key and
+        /// the aggregate can be dropped. Aliases (any_value / first_value -> any, last_value ->
+        /// anyLast, *RespectNulls -> *_respect_nulls) are normalized to these canonical names by name
+        /// resolution before this pass runs, so matching the canonical names covers them too.
+        /// singleValueOrNull is excluded: it returns NULL unless the group has exactly one distinct
+        /// value, so it is not value-preserving; argMin/argMax are two-argument and handled elsewhere.
+        const auto & function_name = function->getFunctionName();
+        if (!(function_name == "min"
+                || function_name == "max"
+                || function_name == "any"
+                || function_name == "anyLast"
+                || function_name == "anyHeavy"
+                || function_name == "any_respect_nulls"
+                || function_name == "anyLast_respect_nulls"))
             return false;
 
         std::vector<NodeWithInfo> candidates;

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -5,8 +5,11 @@
 #include <Analyzer/HashUtils.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/QueryNode.h>
+#include <Analyzer/Utils.h>
 
 #include <Core/Settings.h>
+
+#include <DataTypes/DataTypeLowCardinality.h>
 
 
 namespace DB
@@ -95,8 +98,21 @@ public:
 
         if (node->getNodeType() == QueryTreeNodeType::FUNCTION)
         {
+            auto * function_node = node->as<FunctionNode>();
             if (aggregationCanBeEliminated(node, group_by_keys_stack.back()))
-                node = node->as<FunctionNode>()->getArguments().getNodes()[0];
+            {
+                node = function_node->getArguments().getNodes()[0];
+            }
+            else if (function_node->isOrdinaryFunction())
+            {
+                /// A child aggregate may have been replaced by its argument, which for a
+                /// LowCardinality group by key has a different type than the eliminated aggregate
+                /// (min(LowCardinality(String)) is String, but the key is LowCardinality(String)).
+                /// Re-resolve this ordinary function against its current argument types so the type
+                /// stays consistent and predicates like `key = 'x'` keep operating directly on the
+                /// key column, letting them push down to storage and use skip indexes.
+                reresolveIfArgumentTypesChanged(*function_node);
+            }
         }
         else if (node->getNodeType() == QueryTreeNodeType::QUERY)
         {
@@ -118,6 +134,30 @@ private:
         bool parents_are_only_deterministic = false;
     };
 
+    /// Re-resolve an ordinary function if any argument's current result type no longer matches the
+    /// type the function was resolved with (a child aggregate was replaced by its differently-typed
+    /// argument). Cascades upward as parents are visited in leaveImpl.
+    void reresolveIfArgumentTypesChanged(FunctionNode & function_node)
+    {
+        const auto & resolved_argument_types = function_node.getArgumentTypes();
+        const auto & argument_nodes = function_node.getArguments().getNodes();
+        if (resolved_argument_types.size() != argument_nodes.size())
+            return;
+
+        bool argument_types_changed = false;
+        for (size_t i = 0; i < argument_nodes.size(); ++i)
+        {
+            if (!resolved_argument_types[i] || !resolved_argument_types[i]->equals(*argument_nodes[i]->getResultType()))
+            {
+                argument_types_changed = true;
+                break;
+            }
+        }
+
+        if (argument_types_changed)
+            resolveOrdinaryFunctionNodeByName(function_node, function_node.getFunctionName(), getContext());
+    }
+
     bool aggregationCanBeEliminated(QueryTreeNodePtr & node, const QueryTreeNodePtrWithHashSet & group_by_keys)
     {
         if (group_by_keys.empty())
@@ -138,7 +178,12 @@ private:
         if (function_arguments.size() != 1)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Expected a single argument of function '{}' but received {}", function->getFunctionName(), function_arguments.size());
 
-        if (!function->getResultType()->equals(*function_arguments[0]->getResultType()))
+        /// The aggregate result type must match the argument type up to LowCardinality: aggregate
+        /// functions always strip LowCardinality from their result (min(LowCardinality(String)) ->
+        /// String), so comparing the raw types would make this pass dead for LowCardinality keys.
+        /// The type mismatch introduced by dropping the aggregate is repaired by re-resolving the
+        /// parent ordinary functions in leaveImpl.
+        if (!recursiveRemoveLowCardinality(function->getResultType())->equals(*recursiveRemoveLowCardinality(function_arguments[0]->getResultType())))
             return false;
 
         candidates.push_back({ function_arguments[0], true });

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -5,6 +5,7 @@
 #include <Analyzer/HashUtils.h>
 #include <Analyzer/InDepthQueryTreeVisitor.h>
 #include <Analyzer/QueryNode.h>
+#include <Analyzer/UnionNode.h>
 #include <Analyzer/Utils.h>
 
 #include <Core/Settings.h>
@@ -116,6 +117,13 @@ public:
         }
         else if (node->getNodeType() == QueryTreeNodeType::QUERY)
         {
+            /// Projection nodes are rewritten before we leave the query node (post-order visit), so
+            /// a projection column that was an eliminated/re-resolved aggregate may now have a
+            /// different type. Refresh QueryNode::projection_columns so QueryNode::getResultType()
+            /// reports the true post-rewrite type; otherwise a correlated scalar subquery over a
+            /// LowCardinality key would report the stale analyzed type and
+            /// PlannerCorrelatedSubqueries::addStepForResultRenaming would throw on the header mismatch.
+            refreshProjectionColumnTypes(*node->as<QueryNode>());
             group_by_keys_stack.pop_back();
         }
     }
@@ -134,9 +142,30 @@ private:
         bool parents_are_only_deterministic = false;
     };
 
+    /// Whether a function argument node has a well-defined result type that can be compared. Only a
+    /// correlated QUERY/UNION exposes one (see getResultType() on QueryNode/UnionNode); a plain
+    /// (non-correlated) subquery, list, etc. does not.
+    static bool argumentExposesResultType(const IQueryTreeNode & argument_node)
+    {
+        switch (argument_node.getNodeType())
+        {
+            case QueryTreeNodeType::FUNCTION:
+            case QueryTreeNodeType::COLUMN:
+            case QueryTreeNodeType::CONSTANT:
+                return true;
+            case QueryTreeNodeType::QUERY:
+                return argument_node.as<QueryNode &>().isCorrelated();
+            case QueryTreeNodeType::UNION:
+                return argument_node.as<UnionNode &>().isCorrelated();
+            default:
+                return false;
+        }
+    }
+
     /// Re-resolve an ordinary function if any argument's current result type no longer matches the
     /// type the function was resolved with (a child aggregate was replaced by its differently-typed
-    /// argument). Cascades upward as parents are visited in leaveImpl.
+    /// argument, possibly inside a correlated scalar subquery). Cascades upward as parents are
+    /// visited in leaveImpl.
     void reresolveIfArgumentTypesChanged(FunctionNode & function_node)
     {
         const auto & resolved_argument_types = function_node.getArgumentTypes();
@@ -147,13 +176,14 @@ private:
         bool argument_types_changed = false;
         for (size_t i = 0; i < argument_nodes.size(); ++i)
         {
-            /// Only these argument node types expose a result type and can be substituted by this
-            /// pass (an eliminated aggregate is replaced by its FUNCTION/COLUMN argument). Other
-            /// argument kinds (a non-correlated QueryNode/UnionNode from an IN subquery, ListNode,
-            /// etc.) throw from getResultType() and are never rewritten here, so skip them.
-            const auto arg_type = argument_nodes[i]->getNodeType();
-            if (arg_type != QueryTreeNodeType::FUNCTION && arg_type != QueryTreeNodeType::COLUMN
-                && arg_type != QueryTreeNodeType::CONSTANT)
+            /// Skip arguments that do not expose a result type. FUNCTION/COLUMN/CONSTANT always do
+            /// and may have been substituted by this pass (an eliminated aggregate is replaced by
+            /// its argument). A QUERY/UNION argument exposes a result type only when it is a
+            /// correlated scalar subquery, whose type can also flip if its projection was an
+            /// eliminated aggregate over a LowCardinality key; a non-correlated subquery (e.g. an
+            /// IN subquery) throws from getResultType() and is never rewritten, so skip it. ListNode
+            /// and other kinds have no result type either.
+            if (!argumentExposesResultType(*argument_nodes[i]))
                 continue;
 
             if (!resolved_argument_types[i] || !resolved_argument_types[i]->equals(*argument_nodes[i]->getResultType()))
@@ -165,6 +195,40 @@ private:
 
         if (argument_types_changed)
             resolveOrdinaryFunctionNodeByName(function_node, function_node.getFunctionName(), getContext());
+    }
+
+    /// Re-derive projection column types from the (already rewritten) projection nodes so the query
+    /// node's result-type metadata stays consistent with what the planner will build. Names are kept;
+    /// only types are refreshed. No-op for a query node whose projection types did not change.
+    static void refreshProjectionColumnTypes(QueryNode & query_node)
+    {
+        if (!query_node.isResolved())
+            return;
+
+        const auto & projection_nodes = query_node.getProjection().getNodes();
+        const auto & projection_columns = query_node.getProjectionColumns();
+        if (projection_nodes.size() != projection_columns.size())
+            return;
+
+        NamesAndTypes refreshed_columns = projection_columns;
+        bool changed = false;
+        for (size_t i = 0; i < projection_nodes.size(); ++i)
+        {
+            /// Skip projection nodes without a well-defined result type (e.g. a not-yet-evaluated
+            /// non-correlated scalar subquery) so getResultType() below never throws.
+            if (!argumentExposesResultType(*projection_nodes[i]))
+                continue;
+
+            auto projection_type = projection_nodes[i]->getResultType();
+            if (projection_type && !projection_type->equals(*refreshed_columns[i].type))
+            {
+                refreshed_columns[i].type = std::move(projection_type);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            query_node.resolveProjectionColumns(std::move(refreshed_columns));
     }
 
     bool aggregationCanBeEliminated(QueryTreeNodePtr & node, const QueryTreeNodePtrWithHashSet & group_by_keys)

--- a/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
+++ b/src/Analyzer/Passes/AggregateFunctionOfGroupByKeysPass.cpp
@@ -141,9 +141,11 @@ public:
         if (!getSettings()[Setting::optimize_aggregators_of_group_by_keys])
             return;
 
-        /// Capture the node identity before any rewrite so a filter-section root that is itself a
-        /// function (e.g. WHERE equals(...)) still has its filter_depth decremented below.
+        /// Capture the node identity and type before any rewrite so a filter-section root that is
+        /// itself a function (e.g. WHERE equals(...)) still has its filter_depth decremented below,
+        /// and so the decrement stays gated on the pre-rewrite node type.
         const IQueryTreeNode * node_before_rewrite = node.get();
+        const auto node_type_before_rewrite = node->getNodeType();
 
         if (node->getNodeType() == QueryTreeNodeType::FUNCTION)
         {
@@ -207,7 +209,15 @@ public:
             filter_roots_save_stack.pop_back();
         }
 
-        if (active_filter_roots.contains(node_before_rewrite))
+        /// Decrement symmetrically with enterImpl, which increments filter_depth only for nodes that
+        /// take the non-QUERY, non-LAMBDA branch. A QUERY or LAMBDA node instead saves and resets the
+        /// whole filter context (filter_depth is already restored above), so it never incremented on
+        /// entry; decrementing here for such a node when it is itself the outer filter root (e.g.
+        /// HAVING is directly a correlated scalar subquery) would underflow filter_depth to
+        /// size_t(-1), and the next filter root would wrap it back to 0 and lose the bare-key pushdown.
+        if (node_type_before_rewrite != QueryTreeNodeType::QUERY
+            && node_type_before_rewrite != QueryTreeNodeType::LAMBDA
+            && active_filter_roots.contains(node_before_rewrite))
             --filter_depth;
     }
 

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -110,3 +110,8 @@ Array(String)
 1
 -- type-insensitive predicate in the same HAVING still pushes down (equality on the key)
 x	1
+-- UNION subquery argument of a parent function must not be dereferenced by the pass
+1
+2
+2
+2

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -1,0 +1,34 @@
+-- the aggregate wrappers are eliminated: same single group as the direct predicate
+rare token	8
+rare token	8
+rare token	8
+rare token	8
+rare token	8
+rare token	8
+-- skip-index pruning fires for HAVING min(s) = ... (aggregate pushed down to the text index): 8/128
+Granules: 8/128
+-- skip-index pruning fires for HAVING any(s = ...) too: 8/128
+Granules: 8/128
+-- aggregate is gone from the query tree (no min/max/any/anyLast function remains)
+0
+-- LowCardinality wrapper matrix: result must be identical with the optimization on and off
+0
+1
+2
+3
+4
+0
+1
+2
+0
+1
+2
+3
+4
+5
+6
+0
+1
+2
+3
+4

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -11,6 +11,18 @@ Granules: 8/128
 Granules: 8/128
 -- aggregate is gone from the query tree (no min/max/any/anyLast function remains)
 0
+-- observable result type is preserved: min/max/any/anyLast of a LowCardinality key still
+-- report the aggregate result type (String), not the key type LowCardinality(String)
+String
+String
+String
+String
+-- and it is preserved when the same aggregate is also used in a HAVING predicate (mixed)
+String
+-- the result column schema of a subquery is unchanged (String), so type-sensitive sinks work
+String
+-- pruning is still preserved for that mixed projection+HAVING query: 8/128
+Granules: 8/128
 -- LowCardinality wrapper matrix: result must be identical with the optimization on and off
 0
 1

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -56,3 +56,32 @@ Granules: 8/128
 1	x
 2	m
 3	z
+-- anyHeavy / RESPECT NULLS variants of a LowCardinality key are eliminated too
+-- same single group as the direct predicate (aggregate wrapper eliminated)
+rare token	8
+rare token	8
+rare token	8
+-- observable result type preserved (String, not LowCardinality(String))
+String
+String
+String
+-- aggregate gone from the query tree for anyHeavy
+0
+-- skip-index pruning fires for HAVING anyHeavy(s) = ... just like min(s): 8/128
+Granules: 8/128
+-- wrapper matrix for the newly-covered aggregates: result identical with optimization on and off
+0
+1
+2
+3
+4
+0
+1
+2
+0
+1
+2
+3
+4
+5
+6

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -85,3 +85,17 @@ Granules: 8/128
 4
 5
 6
+-- eliminated aggregate inside a lambda body: LambdaNode result type stays the analyzed type
+10
+10
+10
+['0']
+['1']
+['2']
+-- observable lambda-body type preserved (Array(String), not Array(LowCardinality(String)))
+Array(String)
+Array(String)
+-- nested lambdas over the eliminated key
+10
+10
+10

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -32,3 +32,6 @@ Granules: 8/128
 2
 3
 4
+-- IN subquery must not break: the pass re-resolves ordinary functions but must skip non-column/function arguments (a non-correlated subquery QueryNode has no result type)
+3
+1	2

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -35,3 +35,12 @@ Granules: 8/128
 -- IN subquery must not break: the pass re-resolves ordinary functions but must skip non-column/function arguments (a non-correlated subquery QueryNode has no result type)
 3
 1	2
+-- correlated subquery in WHERE over LowCardinality key (min/max/any/anyLast), opt on == off
+2
+2
+2
+2
+-- correlated subquery in SELECT position over LowCardinality key
+1	x
+2	m
+3	z

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -99,3 +99,14 @@ Array(String)
 10
 10
 10
+-- type-sensitive parent inside HAVING must observe the analyzed type, not the key type
+1
+1
+1
+1
+1
+1
+1
+1
+-- type-insensitive predicate in the same HAVING still pushes down (equality on the key)
+x	1

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -133,3 +133,12 @@ x	1
 1
 -- type-insensitive and type-sensitive parents together in the same QUALIFY
 x	1
+-- correlated scalar subquery as the whole filter root must not underflow the filter depth
+-- correctness across the LC matrix (correlated subquery is the whole HAVING, later QUALIFY min(key))
+x
+x
+1
+-- the later QUALIFY min(s) keeps the bare LowCardinality key (0 = no output cast = pushdown-eligible)
+0
+-- correlated subquery is the whole HAVING, later ORDER BY min(s) still eliminated (observable type String)
+String

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.reference
@@ -23,6 +23,13 @@ String
 String
 -- pruning is still preserved for that mixed projection+HAVING query: 8/128
 Granules: 8/128
+-- QUALIFY is a filter section like HAVING (own clause plumbing, runs after window processing):
+-- a type-insensitive predicate on the key must push down to the skip index just like HAVING
+rare token	8
+rare token	8
+rare token	8
+-- skip-index pruning fires for QUALIFY min(s) = ... just like HAVING: 8/128
+Granules: 8/128
 -- LowCardinality wrapper matrix: result must be identical with the optimization on and off
 0
 1
@@ -115,3 +122,14 @@ x	1
 2
 2
 2
+-- type-sensitive QUALIFY toTypeName(min(key)) must observe the analyzed type across the LC matrix
+1
+1
+1
+1
+1
+1
+1
+1
+-- type-insensitive and type-sensitive parents together in the same QUALIFY
+x	1

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -159,3 +159,19 @@ SELECT anyHeavy(a) AS m FROM t_lc_more_matrix GROUP BY a ORDER BY m;
 SELECT any(b) RESPECT NULLS AS m FROM t_lc_more_matrix GROUP BY b ORDER BY m;
 SELECT anyLast(c) RESPECT NULLS AS m FROM t_lc_more_matrix GROUP BY c ORDER BY m;
 DROP TABLE t_lc_more_matrix;
+
+SELECT '-- eliminated aggregate inside a lambda body: LambdaNode result type stays the analyzed type';
+-- The lambda body min(s) is an output-ish position carried by the higher-order function signature,
+-- not a storage-pushdown predicate, so the eliminated LowCardinality key is cast back to String.
+-- Regression for https://github.com/ClickHouse/ClickHouse/pull/110059 (visitLambda type mismatch).
+DROP TABLE IF EXISTS t_lc_lambda;
+CREATE TABLE t_lc_lambda (s LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t_lc_lambda SELECT toString(number % 3) FROM numbers(30);
+SELECT count() FROM t_lc_lambda GROUP BY s HAVING arrayMap(x -> min(s), [1]) = [s] ORDER BY min(s);
+SELECT arrayMap(x -> max(s), [1]) AS m FROM t_lc_lambda GROUP BY s ORDER BY m;
+SELECT '-- observable lambda-body type preserved (Array(String), not Array(LowCardinality(String)))';
+SELECT DISTINCT toTypeName(arrayMap(x -> any(s), [1])) FROM t_lc_lambda GROUP BY s;
+SELECT DISTINCT toTypeName(arrayMap(x -> anyLast(s), [1])) FROM t_lc_lambda GROUP BY s;
+SELECT '-- nested lambdas over the eliminated key';
+SELECT count() FROM t_lc_lambda GROUP BY s HAVING arrayMap(y -> arrayMap(x -> min(s), [1])[1], [1]) = [s];
+DROP TABLE t_lc_lambda;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -48,6 +48,20 @@ SELECT countIf(explain ILIKE '%function_name: min%' OR explain ILIKE '%function_
     OR explain ILIKE '%function_name: any%' OR explain ILIKE '%function_name: anyLast%')
 FROM (EXPLAIN QUERY TREE SELECT min(s) FROM t_lc_group_key GROUP BY s);
 
+SELECT '-- observable result type is preserved: min/max/any/anyLast of a LowCardinality key still';
+SELECT '-- report the aggregate result type (String), not the key type LowCardinality(String)';
+SELECT DISTINCT toTypeName(min(s)) FROM t_lc_group_key GROUP BY s;
+SELECT DISTINCT toTypeName(max(s)) FROM t_lc_group_key GROUP BY s;
+SELECT DISTINCT toTypeName(any(s)) FROM t_lc_group_key GROUP BY s;
+SELECT DISTINCT toTypeName(anyLast(s)) FROM t_lc_group_key GROUP BY s;
+SELECT '-- and it is preserved when the same aggregate is also used in a HAVING predicate (mixed)';
+SELECT DISTINCT toTypeName(min(s)) FROM t_lc_group_key GROUP BY s HAVING min(s) = 'rare token';
+SELECT '-- the result column schema of a subquery is unchanged (String), so type-sensitive sinks work';
+SELECT DISTINCT toTypeName(m) FROM (SELECT min(s) AS m FROM t_lc_group_key GROUP BY s);
+SELECT '-- pruning is still preserved for that mixed projection+HAVING query: 8/128';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT min(s) AS m, count() FROM t_lc_group_key GROUP BY s HAVING min(s) = 'rare token')
+WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
+
 DROP TABLE t_lc_group_key;
 
 SELECT '-- LowCardinality wrapper matrix: result must be identical with the optimization on and off';
@@ -71,10 +85,10 @@ SELECT s, count() FROM (SELECT toLowCardinality(toString(number % 5)) AS s, numb
 WHERE id IN (SELECT number FROM numbers(10)) GROUP BY s HAVING min(s) = '1' ORDER BY s;
 
 -- Correlated scalar subquery whose projection is an eliminated aggregate over a LowCardinality
--- key: the rewrite flips the subquery result type String -> LowCardinality(String), so both the
--- query node's projection_columns metadata and any parent operator on the subquery must be
--- refreshed. Otherwise the outer `= 'm'` still expects the old type and the query tree validator
--- (or PlannerCorrelatedSubqueries) throws. Result must be identical with the optimization on/off.
+-- key. The subquery projection is an output position, so the key is cast back to the aggregate's
+-- analyzed type; the subquery result type stays String and the outer `= 'm'` predicate is
+-- unchanged (otherwise PlannerCorrelatedSubqueries / the query tree validator would throw on the
+-- header mismatch). Result must be identical with the optimization on/off.
 SET allow_experimental_correlated_subqueries = 1, allow_suspicious_low_cardinality_types = 1;
 DROP TABLE IF EXISTS t_lc_correlated;
 CREATE TABLE t_lc_correlated (id UInt64, s LowCardinality(String), sn LowCardinality(Nullable(String)), u LowCardinality(UInt8))

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -240,3 +240,40 @@ SELECT count() FROM t_lc_qualify_type GROUP BY u QUALIFY toTypeName(min(u)) = 'U
 SELECT '-- type-insensitive and type-sensitive parents together in the same QUALIFY';
 SELECT s, count() FROM t_lc_qualify_type GROUP BY s QUALIFY min(s) = 'x' AND toTypeName(min(s)) = 'String' ORDER BY s;
 DROP TABLE t_lc_qualify_type;
+
+SELECT '-- correlated scalar subquery as the whole filter root must not underflow the filter depth';
+-- enterImpl increments filter_depth only for non-QUERY, non-LAMBDA nodes; a correlated scalar
+-- subquery that is itself the whole HAVING/QUALIFY root saves and resets the filter context instead.
+-- leaveImpl must therefore not decrement filter_depth for such a node, or it underflows to size_t(-1)
+-- and the next filter root wraps back to 0 and loses the bare-key rewrite (and its pushdown) for a
+-- later LC aggregate elimination. Regression for
+-- https://github.com/ClickHouse/ClickHouse/pull/110059: the later QUALIFY min(s) must still be a
+-- type-insensitive predicate on the bare key (result and pushdown-eligibility identical on and off).
+DROP TABLE IF EXISTS t_lc_filter_root;
+DROP TABLE IF EXISTS u_lc_filter_root;
+CREATE TABLE t_lc_filter_root
+    (id UInt64, s LowCardinality(String), sn LowCardinality(Nullable(String)), u LowCardinality(UInt8))
+ENGINE = Memory
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+CREATE TABLE u_lc_filter_root (id UInt64) ENGINE = Memory;
+INSERT INTO t_lc_filter_root VALUES (1, 'x', 'x', 1), (2, 'y', NULL, 2);
+INSERT INTO u_lc_filter_root VALUES (1), (2);
+SET allow_suspicious_low_cardinality_types = 1;
+SET allow_experimental_correlated_subqueries = 1;
+SELECT '-- correctness across the LC matrix (correlated subquery is the whole HAVING, later QUALIFY min(key))';
+SELECT s FROM t_lc_filter_root AS o GROUP BY s, o.id
+    HAVING (SELECT any(u_lc_filter_root.id = o.id) FROM u_lc_filter_root) QUALIFY min(o.s) = 'x' ORDER BY s;
+SELECT sn FROM t_lc_filter_root AS o GROUP BY sn, o.id
+    HAVING (SELECT any(u_lc_filter_root.id = o.id) FROM u_lc_filter_root) QUALIFY min(o.sn) = 'x' ORDER BY sn;
+SELECT u FROM t_lc_filter_root AS o GROUP BY u, o.id
+    HAVING (SELECT any(u_lc_filter_root.id = o.id) FROM u_lc_filter_root) QUALIFY min(o.u) = 1 ORDER BY u;
+SELECT '-- the later QUALIFY min(s) keeps the bare LowCardinality key (0 = no output cast = pushdown-eligible)';
+SELECT countIf(explain LIKE '%_CAST%' AND explain LIKE '%String%') FROM (
+    EXPLAIN QUERY TREE
+    SELECT count() OVER () FROM t_lc_filter_root AS o GROUP BY s, o.id
+        HAVING (SELECT any(u_lc_filter_root.id = o.id) FROM u_lc_filter_root) QUALIFY min(o.s) = 'x');
+SELECT '-- correlated subquery is the whole HAVING, later ORDER BY min(s) still eliminated (observable type String)';
+SELECT DISTINCT toTypeName(min(o.s)) FROM t_lc_filter_root AS o GROUP BY s, o.id
+    HAVING (SELECT any(u_lc_filter_root.id = o.id) FROM u_lc_filter_root) ORDER BY min(o.s);
+DROP TABLE t_lc_filter_root;
+DROP TABLE u_lc_filter_root;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -198,3 +198,17 @@ SELECT count() FROM t_lc_having_type GROUP BY u HAVING toTypeName(min(u)) = 'UIn
 SELECT '-- type-insensitive predicate in the same HAVING still pushes down (equality on the key)';
 SELECT s, count() FROM t_lc_having_type GROUP BY s HAVING min(s) = 'x' AND toTypeName(min(s)) = 'String' ORDER BY s;
 DROP TABLE t_lc_having_type;
+
+SELECT '-- UNION subquery argument of a parent function must not be dereferenced by the pass';
+-- A UNION subquery has no getResultType() (unlike a correlated QueryNode) and throws
+-- UNSUPPORTED_METHOD if dereferenced. reresolveIfArgumentTypesChanged must never call it on a UNION
+-- argument. Regression for https://github.com/ClickHouse/ClickHouse/pull/110059: these queries have
+-- a UNION as a function/IN argument and must run (no UNSUPPORTED_METHOD), with results identical to
+-- the optimization off.
+DROP TABLE IF EXISTS t_lc_union;
+CREATE TABLE t_lc_union (id UInt32, s LowCardinality(String)) ENGINE = Memory;
+INSERT INTO t_lc_union VALUES (1, 'x'), (2, 'y');
+SELECT id FROM t_lc_union WHERE s IN (SELECT min(s) FROM t_lc_union GROUP BY s UNION ALL SELECT 'z') ORDER BY id;
+SELECT id FROM t_lc_union WHERE s = (SELECT min(s) FROM t_lc_union GROUP BY s LIMIT 1) ORDER BY id;
+SELECT count() FROM t_lc_union WHERE s IN (SELECT max(s) FROM t_lc_union GROUP BY s UNION ALL SELECT anyLast(s) FROM t_lc_union GROUP BY s);
+DROP TABLE t_lc_union;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -105,3 +105,57 @@ SELECT '-- correlated subquery in SELECT position over LowCardinality key';
 SELECT id, (SELECT min(s) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY s) AS m FROM t_lc_correlated AS o ORDER BY id;
 
 DROP TABLE t_lc_correlated;
+
+-- The pass eliminates every value-preserving single-argument aggregate it handles, not just
+-- min/max/any/anyLast: anyHeavy and the RESPECT NULLS variants any_respect_nulls /
+-- anyLast_respect_nulls also return an actual element of the group, so over a GROUP BY key they
+-- equal the key and are dropped. Aliases (first_value/last_value/any_value, *RespectNulls) resolve
+-- to these canonical names before the pass runs. singleValueOrNull is intentionally excluded (it
+-- returns NULL unless the group has a single distinct value, so it is not value-preserving).
+SELECT '-- anyHeavy / RESPECT NULLS variants of a LowCardinality key are eliminated too';
+DROP TABLE IF EXISTS t_lc_more_aggs;
+CREATE TABLE t_lc_more_aggs
+(
+    id UInt64,
+    s LowCardinality(String),
+    INDEX s_text s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 64;
+INSERT INTO t_lc_more_aggs
+SELECT number, if(number % 1024 = 42, 'rare token', concat('ordinary token ', toString(number)))
+FROM numbers(8192)
+SETTINGS max_insert_threads = 1;
+
+SELECT '-- same single group as the direct predicate (aggregate wrapper eliminated)';
+SELECT s, count() FROM t_lc_more_aggs GROUP BY s HAVING anyHeavy(s) = 'rare token';
+SELECT s, count() FROM t_lc_more_aggs GROUP BY s HAVING any(s) RESPECT NULLS = 'rare token';
+SELECT s, count() FROM t_lc_more_aggs GROUP BY s HAVING anyLast(s) RESPECT NULLS = 'rare token';
+
+SELECT '-- observable result type preserved (String, not LowCardinality(String))';
+SELECT DISTINCT toTypeName(anyHeavy(s)) FROM t_lc_more_aggs GROUP BY s;
+SELECT DISTINCT toTypeName(any(s) RESPECT NULLS) FROM t_lc_more_aggs GROUP BY s;
+SELECT DISTINCT toTypeName(anyLast(s) RESPECT NULLS) FROM t_lc_more_aggs GROUP BY s;
+
+SELECT '-- aggregate gone from the query tree for anyHeavy';
+SELECT countIf(explain ILIKE '%function_type: aggregate%')
+FROM (EXPLAIN QUERY TREE SELECT anyHeavy(s) FROM t_lc_more_aggs GROUP BY s);
+
+SELECT '-- skip-index pruning fires for HAVING anyHeavy(s) = ... just like min(s): 8/128';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT s, count() FROM t_lc_more_aggs GROUP BY s HAVING anyHeavy(s) = 'rare token')
+WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
+
+DROP TABLE t_lc_more_aggs;
+
+SELECT '-- wrapper matrix for the newly-covered aggregates: result identical with optimization on and off';
+DROP TABLE IF EXISTS t_lc_more_matrix;
+CREATE TABLE t_lc_more_matrix (a LowCardinality(String), b LowCardinality(Nullable(String)), c LowCardinality(UInt8))
+ENGINE = Memory
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO t_lc_more_matrix SELECT toString(number % 5), toString(number % 3), number % 7 FROM numbers(1000);
+SET allow_suspicious_low_cardinality_types = 1;
+SELECT anyHeavy(a) AS m FROM t_lc_more_matrix GROUP BY a ORDER BY m;
+SELECT any(b) RESPECT NULLS AS m FROM t_lc_more_matrix GROUP BY b ORDER BY m;
+SELECT anyLast(c) RESPECT NULLS AS m FROM t_lc_more_matrix GROUP BY c ORDER BY m;
+DROP TABLE t_lc_more_matrix;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -64,3 +64,8 @@ SELECT any(c) AS m FROM t_lc_matrix GROUP BY c ORDER BY m;
 SELECT anyLast(a) AS m FROM t_lc_matrix GROUP BY a ORDER BY m;
 
 DROP TABLE t_lc_matrix;
+
+SELECT '-- IN subquery must not break: the pass re-resolves ordinary functions but must skip non-column/function arguments (a non-correlated subquery QueryNode has no result type)';
+SELECT count() FROM numbers(10) WHERE number IN (SELECT number FROM numbers(3));
+SELECT s, count() FROM (SELECT toLowCardinality(toString(number % 5)) AS s, number AS id FROM numbers(20))
+WHERE id IN (SELECT number FROM numbers(10)) GROUP BY s HAVING min(s) = '1' ORDER BY s;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -62,6 +62,17 @@ SELECT '-- pruning is still preserved for that mixed projection+HAVING query: 8/
 SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT min(s) AS m, count() FROM t_lc_group_key GROUP BY s HAVING min(s) = 'rare token')
 WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
 
+SELECT '-- QUALIFY is a filter section like HAVING (own clause plumbing, runs after window processing):';
+SELECT '-- a type-insensitive predicate on the key must push down to the skip index just like HAVING';
+-- Regression for https://github.com/ClickHouse/ClickHouse/pull/110059: the pass must track the
+-- QUALIFY root as a filter root exactly like HAVING/WHERE/PREWHERE.
+SELECT s, count() FROM t_lc_group_key GROUP BY s QUALIFY s = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s QUALIFY min(s) = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s QUALIFY anyLast(s) = 'rare token';
+SELECT '-- skip-index pruning fires for QUALIFY min(s) = ... just like HAVING: 8/128';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT s, count() FROM t_lc_group_key GROUP BY s QUALIFY min(s) = 'rare token')
+WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
+
 DROP TABLE t_lc_group_key;
 
 SELECT '-- LowCardinality wrapper matrix: result must be identical with the optimization on and off';
@@ -212,3 +223,20 @@ SELECT id FROM t_lc_union WHERE s IN (SELECT min(s) FROM t_lc_union GROUP BY s U
 SELECT id FROM t_lc_union WHERE s = (SELECT min(s) FROM t_lc_union GROUP BY s LIMIT 1) ORDER BY id;
 SELECT count() FROM t_lc_union WHERE s IN (SELECT max(s) FROM t_lc_union GROUP BY s UNION ALL SELECT anyLast(s) FROM t_lc_union GROUP BY s);
 DROP TABLE t_lc_union;
+
+SELECT '-- type-sensitive QUALIFY toTypeName(min(key)) must observe the analyzed type across the LC matrix';
+DROP TABLE IF EXISTS t_lc_qualify_type;
+CREATE TABLE t_lc_qualify_type (s LowCardinality(String), sn LowCardinality(Nullable(String)), u LowCardinality(UInt8))
+ENGINE = Memory
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO t_lc_qualify_type VALUES ('x', 'x', 1), ('y', NULL, 2);
+SET allow_suspicious_low_cardinality_types = 1;
+SELECT count() FROM t_lc_qualify_type GROUP BY s QUALIFY toTypeName(min(s)) = 'String';
+SELECT count() FROM t_lc_qualify_type GROUP BY s
+    QUALIFY toTypeName(max(s)) = 'String' AND toTypeName(any(s)) = 'String'
+        AND toTypeName(anyLast(s)) = 'String' AND toTypeName(anyHeavy(s)) = 'String';
+SELECT count() FROM t_lc_qualify_type GROUP BY sn QUALIFY toTypeName(min(sn)) = 'Nullable(String)';
+SELECT count() FROM t_lc_qualify_type GROUP BY u QUALIFY toTypeName(min(u)) = 'UInt8';
+SELECT '-- type-insensitive and type-sensitive parents together in the same QUALIFY';
+SELECT s, count() FROM t_lc_qualify_type GROUP BY s QUALIFY min(s) = 'x' AND toTypeName(min(s)) = 'String' ORDER BY s;
+DROP TABLE t_lc_qualify_type;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -69,3 +69,25 @@ SELECT '-- IN subquery must not break: the pass re-resolves ordinary functions b
 SELECT count() FROM numbers(10) WHERE number IN (SELECT number FROM numbers(3));
 SELECT s, count() FROM (SELECT toLowCardinality(toString(number % 5)) AS s, number AS id FROM numbers(20))
 WHERE id IN (SELECT number FROM numbers(10)) GROUP BY s HAVING min(s) = '1' ORDER BY s;
+
+-- Correlated scalar subquery whose projection is an eliminated aggregate over a LowCardinality
+-- key: the rewrite flips the subquery result type String -> LowCardinality(String), so both the
+-- query node's projection_columns metadata and any parent operator on the subquery must be
+-- refreshed. Otherwise the outer `= 'm'` still expects the old type and the query tree validator
+-- (or PlannerCorrelatedSubqueries) throws. Result must be identical with the optimization on/off.
+SET allow_experimental_correlated_subqueries = 1, allow_suspicious_low_cardinality_types = 1;
+DROP TABLE IF EXISTS t_lc_correlated;
+CREATE TABLE t_lc_correlated (id UInt64, s LowCardinality(String), sn LowCardinality(Nullable(String)), u LowCardinality(UInt8))
+ENGINE = Memory;
+INSERT INTO t_lc_correlated VALUES (1, 'x', 'x', 1), (2, 'm', 'm', 7), (3, 'z', NULL, 3);
+
+SELECT '-- correlated subquery in WHERE over LowCardinality key (min/max/any/anyLast), opt on == off';
+SELECT id FROM t_lc_correlated AS o WHERE (SELECT min(s) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY s) = 'm' ORDER BY id;
+SELECT id FROM t_lc_correlated AS o WHERE (SELECT max(sn) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY sn) = 'm' ORDER BY id;
+SELECT id FROM t_lc_correlated AS o WHERE (SELECT any(u) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY u) = 7 ORDER BY id;
+SELECT id FROM t_lc_correlated AS o WHERE (SELECT anyLast(s) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY s) = 'm' ORDER BY id;
+
+SELECT '-- correlated subquery in SELECT position over LowCardinality key';
+SELECT id, (SELECT min(s) FROM t_lc_correlated AS i WHERE i.id = o.id GROUP BY s) AS m FROM t_lc_correlated AS o ORDER BY id;
+
+DROP TABLE t_lc_correlated;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -1,0 +1,66 @@
+-- Tags: no-parallel-replicas
+-- optimize_aggregators_of_group_by_keys must eliminate min/max/any/anyLast of a LowCardinality
+-- GROUP BY key just as for a plain key, so a HAVING predicate on the key pushes down to storage
+-- and uses skip indexes. See https://github.com/ClickHouse/ClickHouse/issues/110041
+
+SET enable_analyzer = 1;
+SET optimize_aggregators_of_group_by_keys = 1;
+SET enable_full_text_index = 1;
+SET query_plan_text_index_add_hint = 1;
+SET use_query_condition_cache = 0;
+SET optimize_trivial_count_query = 0;
+
+DROP TABLE IF EXISTS t_lc_group_key;
+
+CREATE TABLE t_lc_group_key
+(
+    id UInt64,
+    s LowCardinality(String),
+    INDEX s_text s TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 64;
+
+INSERT INTO t_lc_group_key
+SELECT number, if(number % 1024 = 42, 'rare token', concat('ordinary token ', toString(number)))
+FROM numbers(8192)
+SETTINGS max_insert_threads = 1;
+
+SELECT '-- the aggregate wrappers are eliminated: same single group as the direct predicate';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING s = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING min(s) = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING max(s) = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING any(s) = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING anyLast(s) = 'rare token';
+SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING any(s = 'rare token');
+
+SELECT '-- skip-index pruning fires for HAVING min(s) = ... (aggregate pushed down to the text index): 8/128';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING min(s) = 'rare token')
+WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
+
+SELECT '-- skip-index pruning fires for HAVING any(s = ...) too: 8/128';
+SELECT trim(explain) FROM (EXPLAIN indexes = 1 SELECT s, count() FROM t_lc_group_key GROUP BY s HAVING any(s = 'rare token'))
+WHERE explain ILIKE '%Granules: %/128%' AND explain ILIKE '%/128%' AND explain NOT ILIKE '%128/128%';
+
+SELECT '-- aggregate is gone from the query tree (no min/max/any/anyLast function remains)';
+SELECT countIf(explain ILIKE '%function_name: min%' OR explain ILIKE '%function_name: max%'
+    OR explain ILIKE '%function_name: any%' OR explain ILIKE '%function_name: anyLast%')
+FROM (EXPLAIN QUERY TREE SELECT min(s) FROM t_lc_group_key GROUP BY s);
+
+DROP TABLE t_lc_group_key;
+
+SELECT '-- LowCardinality wrapper matrix: result must be identical with the optimization on and off';
+DROP TABLE IF EXISTS t_lc_matrix;
+CREATE TABLE t_lc_matrix (a LowCardinality(String), b LowCardinality(Nullable(String)), c LowCardinality(UInt8))
+ENGINE = Memory
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO t_lc_matrix SELECT toString(number % 5), toString(number % 3), number % 7 FROM numbers(1000);
+
+SET allow_suspicious_low_cardinality_types = 1;
+SELECT min(a) AS m FROM t_lc_matrix GROUP BY a ORDER BY m;
+SELECT max(b) AS m FROM t_lc_matrix GROUP BY b ORDER BY m;
+SELECT any(c) AS m FROM t_lc_matrix GROUP BY c ORDER BY m;
+SELECT anyLast(a) AS m FROM t_lc_matrix GROUP BY a ORDER BY m;
+
+DROP TABLE t_lc_matrix;

--- a/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
+++ b/tests/queries/0_stateless/04401_optimize_aggregators_of_group_by_keys_low_cardinality.sql
@@ -175,3 +175,26 @@ SELECT DISTINCT toTypeName(arrayMap(x -> anyLast(s), [1])) FROM t_lc_lambda GROU
 SELECT '-- nested lambdas over the eliminated key';
 SELECT count() FROM t_lc_lambda GROUP BY s HAVING arrayMap(y -> arrayMap(x -> min(s), [1])[1], [1]) = [s];
 DROP TABLE t_lc_lambda;
+
+SELECT '-- type-sensitive parent inside HAVING must observe the analyzed type, not the key type';
+-- A filter section is a predicate position only for functions transparent to LowCardinality
+-- (comparisons run on the nested column, so leaving the bare key preserves values and pushdown). A
+-- function that observes LowCardinality (e.g. toTypeName) would otherwise see LowCardinality(String)
+-- and change its result inside HAVING, dropping rows. Regression for
+-- https://github.com/ClickHouse/ClickHouse/pull/110059: toTypeName(min(s)) = 'String' in HAVING must
+-- stay true (result identical with the optimization on and off).
+DROP TABLE IF EXISTS t_lc_having_type;
+CREATE TABLE t_lc_having_type (s LowCardinality(String), sn LowCardinality(Nullable(String)), u LowCardinality(UInt8))
+ENGINE = Memory
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO t_lc_having_type VALUES ('x', 'x', 1), ('y', NULL, 2);
+SET allow_suspicious_low_cardinality_types = 1;
+SELECT count() FROM t_lc_having_type GROUP BY s HAVING toTypeName(min(s)) = 'String';
+SELECT count() FROM t_lc_having_type GROUP BY s
+    HAVING toTypeName(max(s)) = 'String' AND toTypeName(any(s)) = 'String'
+        AND toTypeName(anyLast(s)) = 'String' AND toTypeName(anyHeavy(s)) = 'String';
+SELECT count() FROM t_lc_having_type GROUP BY sn HAVING toTypeName(min(sn)) = 'Nullable(String)';
+SELECT count() FROM t_lc_having_type GROUP BY u HAVING toTypeName(min(u)) = 'UInt8';
+SELECT '-- type-insensitive predicate in the same HAVING still pushes down (equality on the key)';
+SELECT s, count() FROM t_lc_having_type GROUP BY s HAVING min(s) = 'x' AND toTypeName(min(s)) = 'String' ORDER BY s;
+DROP TABLE t_lc_having_type;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/110041


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `optimize_aggregators_of_group_by_keys` not eliminating `min`/`max`/`any`/`anyLast` of a `LowCardinality` `GROUP BY` key. The optimization was silently dead for `LowCardinality` columns, so a `HAVING` predicate on the key (e.g. `HAVING min(s) = 'x'`) was not pushed down to storage and could not use skip indexes, unlike the same query on a plain column.


### Description

`optimize_aggregators_of_group_by_keys` (on by default) rewrites `min`/`max`/`any`/`anyLast` of a `GROUP BY` key to the key expression itself, so a `HAVING` predicate on the key can be pushed below the aggregation and prune granules via skip indexes.

It never fired for `LowCardinality` keys: the pass required the aggregate's result type to be exactly equal to the argument type, but aggregate functions strip `LowCardinality` from their result (`min(LowCardinality(String))` returns `String`), so the check always failed.

Fix:
- Compare the aggregate result type and the argument type up to `LowCardinality` (`recursiveRemoveLowCardinality`) before deciding the aggregate can be replaced by the key.
- Replacing the aggregate with its argument changes the node type (`String` -> `LowCardinality(String)`), which would break the enclosing function whose resolution was cached against the aggregate's type (and abort with a `LOGICAL_ERROR` in debug/sanitizer builds). So re-resolve the parent ordinary functions in `leaveImpl` when an argument type changed; this cascades upward and keeps predicates like `key = 'x'` operating directly on the key column, so `HAVING` pushes down and skip indexes prune as for a plain key.

Verified locally (issue reproducer): `min(s)` / `any(s = 'x')` of a `LowCardinality(String)` key now eliminate the aggregate, push the `HAVING` predicate down, and prune the text index (8/128 granules, matching the plain-key behavior). Results are unchanged with the optimization on vs off across `LowCardinality(String)`, `LowCardinality(Nullable(String))`, and `LowCardinality(UInt8)`.
