### PR TITLE
Fix flaky 04401_distributed_with_fill_const_to_scalar under distributed plan

### DIFF
--- a/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
+++ b/tests/queries/0_stateless/04401_distributed_with_fill_const_to_scalar.sql
@@ -6,6 +6,13 @@
 -- causing "Bad cast from type DB::FunctionNode to DB::ConstantNode".
 -- optimize_const_name_size = 0 replaces ALL constants with __getScalar calls.
 
+-- Query-plan serialization does not support WITH FILL sort descriptions
+-- (NOT_IMPLEMENTED in serializeSortDescription); the AST-rewrite path this test
+-- covers is orthogonal to it. Pin it off so the test is stable under the
+-- distributed-plan CI job, where prefer_localhost_replica=0 would otherwise send
+-- the localhost shard through the serialized plan path.
+SET serialize_query_plan = 0;
+
 DROP TABLE IF EXISTS t0;
 DROP TABLE IF EXISTS t1;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/109938

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04401_distributed_with_fill_const_to_scalar` (added by #109938) is flaky on the distributed-plan CI job: 31/31 FAIL with randomized `--prefer_localhost_replica 0`, 65/65 PASS without it. ~5% master fail rate, seen across ~16 unrelated PRs on 2026-07-10.

Root cause (deterministic repro isolated locally): the distributed-plan job sets `serialize_query_plan = 1` globally. With `prefer_localhost_replica = 0`, the localhost shard is sent through the serialized query-plan path, which deliberately rejects `WITH FILL` sort descriptions in `serializeSortDescription` (`src/Core/SortDescription.cpp`):

```
Code: 48. DB::Exception: WITH FILL is not supported in serialized sort description: While executing Remote. (NOT_IMPLEMENTED)
```

That query-plan-serialization limitation is orthogonal to what this test covers: the legacy AST-rewrite path where `ReplaceLongConstWithScalarVisitor` turns `WITH FILL` constants into `__getScalar` nodes (the bug #109938 fixed in `buildQueryTreeForShard`).

Fix: pin `SET serialize_query_plan = 0` in the test (same approach as `02947_parallel_replicas_remote`). This avoids the unimplemented plan-serialization path while keeping the genuinely-remote AST-send path exercised under `prefer_localhost_replica = 0`, so the test still guards the #109938 regression.

Verified locally (debug, global `serialize_query_plan=1` + `prefer_localhost_replica=0`):
- Original test: FAILS deterministically (Code 48).
- With fix: PASSES, output matches the reference.

CI report of the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109741&sha=0e350e0a094e&name_0=PR&name_1=Stateless%20tests%20(amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel)
