### PR TITLE
Integrate new keeper storage

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1359,6 +1359,47 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperSnapshotWrittenBytes, "Number of bytes written to snapshot files in Keeper", ValueType::Bytes) \
     M(KeeperSnapshotFileSyncMicroseconds, "Time spent in fsync for Keeper snapshot files", ValueType::Microseconds) \
     \
+    M(KeeperLSMTFlushes, "Number of Keeper LSMT memtable flushes finished successfully", ValueType::Number) \
+    M(KeeperLSMTMerges, "Number of Keeper LSMT merges finished successfully", ValueType::Number) \
+    M(KeeperLSMTFlushExceptions, "Number of exceptions in Keeper LSMT memtable flushes", ValueType::Number) \
+    M(KeeperLSMTMergeExceptions, "Number of exceptions in Keeper LSMT merges", ValueType::Number) \
+    M(KeeperLSMTFileDeletionExceptions, "Number of exceptions in Keeper LSMT file deletions", ValueType::Number) \
+    M(KeeperLSMTFlushWrittenCompressedBytes, "Compressed bytes written to files by Keeper LSMT memtable flushes", ValueType::Bytes) \
+    M(KeeperLSMTFlushWrittenUncompressedBytes, "Uncompressed bytes written to files by Keeper LSMT memtable flushes", ValueType::Bytes) \
+    M(KeeperLSMTMergeWrittenFiles, "Number of output files published by Keeper LSMT merges", ValueType::Number) \
+    M(KeeperLSMTMergeWrittenCompressedBytes, "Compressed bytes in output files published by Keeper LSMT merges", ValueType::Bytes) \
+    M(KeeperLSMTMergeWrittenUncompressedBytes, "Uncompressed bytes in output files published by Keeper LSMT merges", ValueType::Bytes) \
+    M(KeeperLSMTMergeConsumedFiles, "Number of input files fully consumed and dropped by Keeper LSMT merges", ValueType::Number) \
+    M(KeeperLSMTMergeConsumedUncompressedBytes, "Uncompressed bytes in input files fully consumed and dropped by Keeper LSMT merges", ValueType::Bytes) \
+    M(KeeperLSMTUncommittedCreates, "Number of Create entries appended to Keeper LSMT uncommitted memtables", ValueType::Number) \
+    M(KeeperLSMTUncommittedCreateBytes, "Serialized bytes of Create entries appended to Keeper LSMT uncommitted memtables", ValueType::Bytes) \
+    M(KeeperLSMTUncommittedUpdates, "Number of Update entries appended to Keeper LSMT uncommitted memtables", ValueType::Number) \
+    M(KeeperLSMTUncommittedUpdateBytes, "Serialized bytes of Update entries appended to Keeper LSMT uncommitted memtables", ValueType::Bytes) \
+    M(KeeperLSMTUncommittedRemoves, "Number of Remove entries appended to Keeper LSMT uncommitted memtables", ValueType::Number) \
+    M(KeeperLSMTUncommittedRemoveBytes, "Serialized bytes of Remove entries appended to Keeper LSMT uncommitted memtables", ValueType::Bytes) \
+    M(KeeperLSMTCommittedEntryBytes, "Serialized bytes of entries appended to the Keeper LSMT committed memtable", ValueType::Bytes) \
+    M(KeeperLSMTThrottledWrites, "Number of writes delayed because Keeper LSMT background flushes or merges fell behind", ValueType::Number) \
+    M(KeeperLSMTCommittedMemtablesCreated, "Number of committed memtables created by Keeper LSMT", ValueType::Number) \
+    M(KeeperLSMTUncommittedMemtablesCreated, "Number of uncommitted memtables created by Keeper LSMT", ValueType::Number) \
+    M(KeeperLSMTGetUncommittedNodeHits, "Number of Keeper LSMT node lookups that found the node in uncommitted memtables", ValueType::Number) \
+    M(KeeperLSMTGetUncommittedNodeMisses, "Number of Keeper LSMT node lookups that didn't find the node in uncommitted memtables and fell through to committed state", ValueType::Number) \
+    M(KeeperLSMTGetCommittedNodeFromMemory, "Number of Keeper LSMT committed node lookups that found the node's block already in memory", ValueType::Number) \
+    M(KeeperLSMTGetCommittedNodeNonexistent, "Number of Keeper LSMT committed node lookups for nodes that don't exist", ValueType::Number) \
+    M(KeeperLSMTGetCommittedNodeLoadedBlock, "Number of Keeper LSMT committed node lookups that had to load the node's block", ValueType::Number) \
+    M(KeeperLSMTNodeCacheEntriesUpdated, "Number of Keeper LSMT node cache entries re-pointed at a freshly loaded block", ValueType::Number) \
+    M(KeeperLSMTListNamesFromMemtables, "Child names (including tombstones) obtained from memtables by Keeper LSMT list operations", ValueType::Number) \
+    M(KeeperLSMTListNamesFromFiles, "Child names (including tombstones) obtained from files by Keeper LSMT list operations", ValueType::Number) \
+    M(KeeperLSMTListScannedBlocks, "Blocks scanned by Keeper LSMT list operations in files", ValueType::Number) \
+    M(KeeperLSMTListScannedEntries, "Entries scanned by Keeper LSMT list operations in files", ValueType::Number) \
+    M(KeeperLSMTListFilterSkipped, "Number of file scans skipped by Keeper LSMT list operations because the parent paths filter ruled out any children", ValueType::Number) \
+    M(KeeperLSMTListFilterFalsePositives, "Number of file scans not skipped by the Keeper LSMT parent paths filter that found no children", ValueType::Number) \
+    M(KeeperLSMTListFilterTruePositives, "Number of file scans not skipped by the Keeper LSMT parent paths filter that found children", ValueType::Number) \
+    M(KeeperLSMTGetBlockFromWeakPtr, "Number of Keeper LSMT block accesses served by the weak pointer in the file's block info", ValueType::Number) \
+    M(KeeperLSMTGetBlockFromCache, "Number of Keeper LSMT block accesses served by the block cache", ValueType::Number) \
+    M(KeeperLSMTGetBlockLoadedGroup, "Number of Keeper LSMT block accesses that had to load a block group from disk", ValueType::Number) \
+    M(KeeperLSMTLoadedBlocks, "Number of blocks loaded from disk by Keeper LSMT", ValueType::Number) \
+    M(KeeperLSMTLoadedUncompressedBytes, "Uncompressed bytes of blocks loaded from disk by Keeper LSMT", ValueType::Bytes) \
+    \
     M(StorageConnectionsCreated, "Number of created connections for storages", ValueType::Number) \
     M(StorageConnectionsReused, "Number of reused connections for storages", ValueType::Number) \
     M(StorageConnectionsReset, "Number of reset connections for storages", ValueType::Number) \

--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -70,8 +70,8 @@ namespace ErrorCodes
     DECLARE(UInt64, raft_limits_reconnect_limit, 50, "If connection to a peer is silent longer than this limit * (multiplied by heartbeat interval), we re-establish the connection.", 0) \
     DECLARE(UInt64, raft_limits_response_limit, 20, "Total wait time for a response is calculated by multiplying response_limit with heart_beat_interval_ms", 0) \
     DECLARE(Bool, async_replication, true, "Enable async replication. All write and read guarantees are preserved while better performance is achieved.", 0) \
-    DECLARE(Bool, use_new_storage, false, "[Not implemented yet] Use LSM tree storage for nodes. Has about the same performance but lower memory usage.", 0) \
-    DECLARE(Bool, storage_memory_only, false, "LSMT: keep all data in memory, don't write to files", 0) \
+    DECLARE(Bool, use_new_storage, true, "Use LSM tree storage for nodes. Has about the same performance but lower memory usage.", 0) \
+    DECLARE(Bool, storage_memory_only, true, "LSMT: keep all data in memory, don't write to files", 0) \
     DECLARE(UInt64, block_cache_size, 2ul * 1024 * 1024 * 1024, "LSMT: size of the in-memory cache of blocks read from files, in bytes.", 0) \
     DECLARE(UInt64, committed_memtable_size, 64 * 1024 * 1024, "LSMT: rotate the memtable when it exceeds this many bytes.", HOT_RELOAD) \
     DECLARE(UInt64, uncommitted_memtable_size, 16 * 1024 * 1024, "LSMT: rotate the uncommitted-state memtable when it exceeds this many bytes.", HOT_RELOAD) \

--- a/src/Coordination/KeeperAsynchronousMetrics.cpp
+++ b/src/Coordination/KeeperAsynchronousMetrics.cpp
@@ -18,18 +18,10 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
     size_t is_follower = 0;
     size_t is_observer = 0;
     size_t is_standalone = 0;
-    size_t znode_count = 0;
-    size_t watch_count = 0;
-    size_t ephemerals_count = 0;
-    size_t approximate_data_size = 0;
-    size_t key_arena_size = 0;
     size_t open_file_descriptor_count = 0;
     std::optional<size_t> max_file_descriptor_count = 0;
     size_t followers = 0;
     size_t synced_followers = 0;
-    size_t zxid = 0;
-    size_t session_with_watches = 0;
-    size_t paths_watched = 0;
     size_t is_exceeding_mem_soft_limit = 0;
 
     if (keeper_dispatcher.isServerActive())
@@ -40,17 +32,6 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
         is_observer = static_cast<size_t>(keeper_info.is_observer);
         is_follower = static_cast<size_t>(keeper_info.is_follower);
         is_exceeding_mem_soft_limit = static_cast<size_t>(keeper_info.is_exceeding_mem_soft_limit);
-
-        const auto & state_machine = keeper_dispatcher.getStateMachine();
-        const auto storage_stats = state_machine.getStorageStats();
-        zxid = storage_stats.last_committed_zxid;
-        znode_count = storage_stats.nodes_count;
-        watch_count = storage_stats.total_watches_count;
-        ephemerals_count = storage_stats.total_emphemeral_nodes_count;
-        approximate_data_size = storage_stats.approximate_data_size;
-        key_arena_size = 0;
-        session_with_watches = storage_stats.sessions_with_watches_count;
-        paths_watched = storage_stats.watched_paths_count;
 
 #    if defined(__linux__) || defined(__APPLE__)
         open_file_descriptor_count = getCurrentProcessFDCount();
@@ -64,18 +45,20 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
         }
     }
 
+    const auto & state_machine = keeper_dispatcher.getStateMachine();
+    const auto storage_stats = state_machine.getStorageStatsAndAsynchronousMetrics(new_values);
+
     new_values["KeeperIsLeader"] = { is_leader, "1 if ClickHouse Keeper is a leader, 0 otherwise." };
     new_values["KeeperIsFollower"] = { is_follower, "1 if ClickHouse Keeper is a follower, 0 otherwise." };
     new_values["KeeperIsObserver"] = { is_observer, "1 if ClickHouse Keeper is an observer, 0 otherwise." };
     new_values["KeeperIsStandalone"] = { is_standalone, "1 if ClickHouse Keeper is in a standalone mode, 0 otherwise." };
     new_values["KeeperIsExceedingMemorySoftLimitHit"] = { is_exceeding_mem_soft_limit, "1 if ClickHouse Keeper is exceeding the memory soft limit, 0 otherwise." };
 
-    new_values["KeeperZnodeCount"] = { znode_count, "The number of nodes (data entries) in ClickHouse Keeper." };
-    new_values["KeeperWatchCount"] = { watch_count, "The number of watches in ClickHouse Keeper." };
-    new_values["KeeperEphemeralsCount"] = { ephemerals_count, "The number of ephemeral nodes in ClickHouse Keeper." };
+    new_values["KeeperZnodeCount"] = { storage_stats.nodes_count, "The number of nodes (data entries) in ClickHouse Keeper." };
+    new_values["KeeperWatchCount"] = { storage_stats.total_watches_count, "The number of watches in ClickHouse Keeper." };
+    new_values["KeeperEphemeralsCount"] = { storage_stats.total_emphemeral_nodes_count, "The number of ephemeral nodes in ClickHouse Keeper." };
 
-    new_values["KeeperApproximateDataSize"] = { approximate_data_size, "The approximate data size of ClickHouse Keeper, in bytes." };
-    new_values["KeeperKeyArenaSize"] = { key_arena_size, "The size in bytes of the memory arena for keys in ClickHouse Keeper." };
+    new_values["KeeperApproximateDataSize"] = { storage_stats.approximate_data_size, "The approximate data size of ClickHouse Keeper, in bytes." };
     /// TODO: value was incorrectly set to 0 previously for local snapshots
     /// it needs to be fixed and it needs to be atomic to avoid deadlock
     ///new_values["KeeperLatestSnapshotSize"] = { latest_snapshot_size, "The uncompressed size in bytes of the latest snapshot created by ClickHouse Keeper." };
@@ -88,9 +71,9 @@ void updateKeeperInformation(KeeperDispatcher & keeper_dispatcher, AsynchronousM
 
     new_values["KeeperFollowers"] = { followers, "The number of followers of ClickHouse Keeper." };
     new_values["KeeperSyncedFollowers"] = { synced_followers, "The number of followers of ClickHouse Keeper who are also in-sync." };
-    new_values["KeeperZxid"] = { zxid, "The current transaction id number (zxid) in ClickHouse Keeper." };
-    new_values["KeeperSessionWithWatches"] = { session_with_watches, "The number of client sessions of ClickHouse Keeper having watches." };
-    new_values["KeeperPathsWatched"] = { paths_watched, "The number of different paths watched by the clients of ClickHouse Keeper." };
+    new_values["KeeperZxid"] = { storage_stats.last_committed_zxid, "The current transaction id number (zxid) in ClickHouse Keeper." };
+    new_values["KeeperSessionWithWatches"] = { storage_stats.sessions_with_watches_count, "The number of client sessions of ClickHouse Keeper having watches." };
+    new_values["KeeperPathsWatched"] = { storage_stats.watched_paths_count, "The number of different paths watched by the clients of ClickHouse Keeper." };
 
     auto keeper_log_info = keeper_dispatcher.getKeeperLogInfo();
 

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -296,6 +296,47 @@
     M(KeeperSnapshotFileSyncMicroseconds) \
     M(KeeperSnapshotRemoteLoaderErrors) \
 \
+    M(KeeperLSMTFlushes) \
+    M(KeeperLSMTMerges) \
+    M(KeeperLSMTFlushExceptions) \
+    M(KeeperLSMTMergeExceptions) \
+    M(KeeperLSMTFileDeletionExceptions) \
+    M(KeeperLSMTFlushWrittenCompressedBytes) \
+    M(KeeperLSMTFlushWrittenUncompressedBytes) \
+    M(KeeperLSMTMergeWrittenFiles) \
+    M(KeeperLSMTMergeWrittenCompressedBytes) \
+    M(KeeperLSMTMergeWrittenUncompressedBytes) \
+    M(KeeperLSMTMergeConsumedFiles) \
+    M(KeeperLSMTMergeConsumedUncompressedBytes) \
+    M(KeeperLSMTUncommittedCreates) \
+    M(KeeperLSMTUncommittedCreateBytes) \
+    M(KeeperLSMTUncommittedUpdates) \
+    M(KeeperLSMTUncommittedUpdateBytes) \
+    M(KeeperLSMTUncommittedRemoves) \
+    M(KeeperLSMTUncommittedRemoveBytes) \
+    M(KeeperLSMTCommittedEntryBytes) \
+    M(KeeperLSMTThrottledWrites) \
+    M(KeeperLSMTCommittedMemtablesCreated) \
+    M(KeeperLSMTUncommittedMemtablesCreated) \
+    M(KeeperLSMTGetUncommittedNodeHits) \
+    M(KeeperLSMTGetUncommittedNodeMisses) \
+    M(KeeperLSMTGetCommittedNodeFromMemory) \
+    M(KeeperLSMTGetCommittedNodeNonexistent) \
+    M(KeeperLSMTGetCommittedNodeLoadedBlock) \
+    M(KeeperLSMTNodeCacheEntriesUpdated) \
+    M(KeeperLSMTListNamesFromMemtables) \
+    M(KeeperLSMTListNamesFromFiles) \
+    M(KeeperLSMTListScannedBlocks) \
+    M(KeeperLSMTListScannedEntries) \
+    M(KeeperLSMTListFilterSkipped) \
+    M(KeeperLSMTListFilterFalsePositives) \
+    M(KeeperLSMTListFilterTruePositives) \
+    M(KeeperLSMTGetBlockFromWeakPtr) \
+    M(KeeperLSMTGetBlockFromCache) \
+    M(KeeperLSMTGetBlockLoadedGroup) \
+    M(KeeperLSMTLoadedBlocks) \
+    M(KeeperLSMTLoadedUncompressedBytes) \
+\
     M(IOUringSQEsSubmitted) \
     M(IOUringSQEsResubmitsAsync) \
     M(IOUringSQEsResubmitsSync) \

--- a/src/Coordination/KeeperDelta.h
+++ b/src/Coordination/KeeperDelta.h
@@ -13,6 +13,7 @@
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Coordination/ACLMap.h>
 #include <Coordination/KeeperCommon.h>
+#include <Coordination/Storage/Node.h>
 
 namespace DB
 {
@@ -27,6 +28,26 @@ namespace DB
 //    state of that same object from the storage and applying the deltas
 //    in the same order as they are defined
 //  - quickly commit the changes to the storage
+
+struct LSMTDelta
+{
+    /// Pin new_node's block to keep the data pointer valid.
+    /// (Probably not strictly necessary because the data lives in an uncommitted memtable, so
+    ///  shouldn't be invalidated anyway, but feels less sketchy this way.)
+    Coordination::Storage::NodeRef new_node_ref;
+    /// Deserialized node corresponding to new_node_ref.
+    /// Has path depth and hash (even if action is Remove), but the path string is invalid and needs
+    /// to be taken from Delta before use.
+    Coordination::Storage::FullNode new_node;
+    /// (In contrast, rollback speed is not important, so not wasting bytes on FullNode here.)
+    Coordination::Storage::NodeRef old_node_ref;
+    uint64_t old_digest = 0;
+
+    ACLId old_acl_id = 0;
+    int64_t ephemeral_owner = 0;
+    bool has_ttl = false;
+    bool is_container = false;
+};
 
 struct CreateNodeDelta
 {
@@ -86,7 +107,10 @@ struct CloseSessionDelta
 struct KeeperDelta
 {
     using Operation = std::variant<
-        /// Node-related deltas are handled by KeeperStorageImpl.
+        /// KeeperLSMTNodesStorage delta (just one type: overwrite whole node).
+        LSMTDelta,
+
+        /// KeeperMemNodesStorage deltas.
         CreateNodeDelta,
         RemoveNodeDelta,
         UpdateNodeStatDelta,

--- a/src/Coordination/KeeperLSMTNodesStorage.cpp
+++ b/src/Coordination/KeeperLSMTNodesStorage.cpp
@@ -1,0 +1,397 @@
+#include <Coordination/KeeperLSMTNodesStorage.h>
+
+#include <Coordination/Storage/NodeStream.h>
+#include <Coordination/KeeperSnapshotManager.h>
+
+using namespace Coordination::Storage;
+
+namespace DB
+{
+
+KeeperLSMTNodesStorage::KeeperLSMTNodesStorage(KeeperContextPtr keeper_context_, SharedMutex * storage_mutex_)
+    : KeeperNodesStorage(keeper_context_, storage_mutex_), state(keeper_context_, storage_mutex_)
+{
+    state.startup();
+}
+
+void KeeperLSMTNodesStorage::shutdown()
+{
+    state.shutdown();
+}
+
+KeeperLSMTNodesStorage::NodeHolder KeeperLSMTNodesStorage::getCommittedNode(std::string_view path)
+{
+    /// TODO: Change all paths in KeeperNodesStorage interface from string_view to
+    /// NodePath/NodePathWithHash, ideally precalculating hashes during request parsing or batching.
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    NodeHolder node;
+    node.ref = state.getCommittedNode(node_path);
+    if (node.ref)
+        node.ref.readWithKnownPath(node.node, node_path);
+    return node;
+}
+
+KeeperLSMTNodesStorage::UncommittedNodeRef KeeperLSMTNodesStorage::getUncommittedNode(std::string_view path)
+{
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    UncommittedNodeRef node;
+    node.ref = state.getUncommittedNode(node_path);
+    if (node.ref)
+    {
+        node.ref.readWithKnownPath(node.node, node_path);
+        node.node.getOrCalculateDigest(); // precalculate digest for prepare*'s convenience
+    }
+    else
+    {
+        node.node.path = node_path.path;
+        node.node.path_hash = node_path.hash;
+    }
+    return node;
+}
+
+bool KeeperLSMTNodesStorage::getCommittedNodeSimple(std::string_view path, KeeperNodeStats * out_stats, std::string * out_data)
+{
+    NodeRef ref = state.getCommittedNode(NodePath(path).withCalculatedHash());
+    if (!ref)
+        return false;
+    if (!out_stats && !out_data)
+        return true;
+
+    FullNode node;
+    ref.readWithoutPath(node);
+    if (out_stats)
+        *out_stats = node.stats;
+    if (out_data)
+        *out_data = std::string{node.getData()};
+    return true;
+}
+
+bool KeeperLSMTNodesStorage::getUncommittedNodeSimple(std::string_view path, KeeperNodeStats * out_stats, std::string * out_data)
+{
+    NodeRef ref = state.getUncommittedNode(NodePath(path).withCalculatedHash());
+    if (!ref)
+        return false;
+    if (!out_stats && !out_data)
+        return true;
+
+    FullNode node;
+    ref.readWithoutPath(node);
+    if (out_stats)
+        *out_stats = node.stats;
+    if (out_data)
+        *out_data = std::string{node.getData()};
+    return true;
+}
+
+std::vector<std::string> KeeperLSMTNodesStorage::listCommittedChildrenNames(std::string_view path) const
+{
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    Coordination::Storage::ChildrenSet2 set;
+    Arena arena;
+    state.listCommittedChildrenNames(node_path, set, arena);
+
+    std::vector<std::string> res;
+    for (const auto & entry : set.set)
+    {
+        if (entry.action != NodeAction::Remove)
+            res.emplace_back(entry.str());
+    }
+    return res;
+}
+
+bool KeeperLSMTNodesStorage::addCommittedNodeIfNotExists(std::string_view path, const KeeperNodeStats & stats, std::string_view data, bool update_parent_num_children, uint64_t * out_digest)
+{
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    if (state.getCommittedNode(node_path))
+        return false;
+
+    FullNode node;
+    node.action = NodeAction::Create;
+    node.stats = stats;
+    node.setData(data);
+    node.path = node_path.path;
+    node.path_hash = node_path.hash;
+
+    if (out_digest)
+        *out_digest += node.getOrCalculateDigest();
+
+    state.appendCommittedNode(node);
+
+    if (update_parent_num_children && node_path.path.depth > 0)
+    {
+        NodePathWithHash parent_path = node_path.path.parentPath().withCalculatedHash();
+        NodeRef parent_ref = state.getCommittedNode(parent_path);
+        chassert(parent_ref);
+        FullNode parent_node;
+        parent_ref.readWithKnownPath(parent_node, parent_path);
+        if (out_digest)
+            *out_digest -= parent_node.getOrCalculateDigest();
+        parent_node.action = NodeAction::Update;
+        parent_node.stats.increaseNumChildren();
+        parent_node.digest = 0;
+        if (out_digest)
+            *out_digest += parent_node.getOrCalculateDigest();
+        state.appendCommittedNode(parent_node);
+    }
+    return true;
+}
+
+void KeeperLSMTNodesStorage::updateCommittedNode(std::string_view path, std::optional<const KeeperNodeStats *> new_stats, std::optional<std::string_view> new_data, uint64_t * out_digest)
+{
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    NodeRef ref = state.getCommittedNode(node_path);
+    chassert(ref);
+    FullNode node;
+    ref.readWithKnownPath(node, node_path);
+    if (out_digest)
+        *out_digest -= node.getOrCalculateDigest();
+    node.action = NodeAction::Update;
+    if (new_stats)
+        node.stats = **new_stats;
+    if (new_data)
+        node.setData(*new_data);
+    node.digest = 0;
+    if (out_digest)
+        *out_digest += node.getOrCalculateDigest();
+    state.appendCommittedNode(node);
+}
+
+void KeeperLSMTNodesStorage::removeCommittedNode(std::string_view path)
+{
+    NodePathWithHash node_path = NodePath(path).withCalculatedHash();
+    chassert(state.getCommittedNode(node_path));
+
+    FullNode node;
+    node.path = node_path.path;
+    node.path_hash = node_path.hash;
+    node.action = NodeAction::Remove;
+    state.appendCommittedNode(node);
+}
+
+void KeeperLSMTNodesStorage::loadNodesFromSnapshot(KeeperSnapshotReader & reader, KeeperStorage * storage, uint64_t * out_digest)
+{
+    /// TODO: Autodetect long sorted runs, turn them directly into SortedRun-s.
+    auto streams = reader.createStreams(1);
+    chassert(streams.size() == 1);
+    size_t path_size = 0;
+    std::string path_buf;
+    std::string data_buf;
+    while (streams[0]->readNodePathSize(path_size))
+    {
+        state.throttleWrite();
+
+        path_buf.resize(path_size);
+        size_t data_size = 0;
+        streams[0]->readNodePathAndDataSize(path_buf.data(), path_size, data_size);
+        FullNode node;
+        node.action = NodeAction::Create;
+        node.path = NodePath(path_buf);
+        data_buf.resize(data_size);
+        streams[0]->readNodeDataAndStats(node.path.str(), data_buf.data(), data_size, node.stats);
+        node.setData(data_buf);
+
+        if (storage)
+            storage->nodeLoadedFromSnapshot(node.path.str(), node.stats);
+
+        if (out_digest)
+            *out_digest += node.getOrCalculateDigest();
+
+        state.appendCommittedNode(node);
+    }
+
+    reader.finishStreams(std::move(streams));
+}
+
+struct KeeperLSMTNodesStorage::NodeStreamForSnapshot final : public KeeperNodeStreamForSnapshot
+{
+    SnapshotWriterNodeStream stream;
+
+    NodeStreamForSnapshot(const StorageState & state_) : stream(state_)
+    {
+        node_count = stream.getNodeCount();
+    }
+
+    bool next(std::string_view & out_path, std::string_view & out_data, KeeperNodeStats & out_stats) override
+    {
+        stream.next();
+        if (stream.at_end)
+            return false;
+        out_path = stream.node.path.str();
+        out_data = stream.node.getData();
+        out_stats = stream.node.stats;
+        return true;
+    }
+};
+
+std::unique_ptr<KeeperNodeStreamForSnapshot> KeeperLSMTNodesStorage::beginWritingSnapshot()
+{
+    return std::make_unique<NodeStreamForSnapshot>(state);
+}
+
+void KeeperLSMTNodesStorage::finishWritingSnapshot(std::unique_ptr<KeeperNodeStreamForSnapshot> stream)
+{
+    stream->node_count = 0;
+}
+
+void KeeperLSMTNodesStorage::getNodeStorageStats(KeeperStorageStats & out)
+{
+    state.getNodeCountAndDataSize(out.nodes_count, out.approximate_data_size);
+}
+
+void KeeperLSMTNodesStorage::commitDelta(Delta & delta, uint64_t * digest)
+{
+    auto & op = std::get<LSMTDelta>(delta.operation);
+    op.new_node.path.ptr = delta.path.data();
+    if (digest)
+        *digest += op.new_node.getOrCalculateDigest() - op.old_digest;
+    state.appendCommittedNode(op.new_node);
+}
+
+void KeeperLSMTNodesStorage::cleanupUncommittedState(int64_t commit_zxid)
+{
+    state.cleanupUncommittedState(commit_zxid);
+}
+
+void KeeperLSMTNodesStorage::rollbackUncommittedDelta(const Delta & delta)
+{
+    auto & op = std::get<LSMTDelta>(delta.operation);
+
+    /// Instead of un-appending the entry, append another entry that has the opposite effect.
+    /// (Alternatively we could add support for truncating a memtable, but that seems more complex and error-prone.)
+
+    FullNode node;
+    std::string path_buf;
+    if (op.new_node.action == NodeAction::Create)
+    {
+        node.path = op.new_node.path;
+        node.path.ptr = delta.path.data();
+    }
+    else
+    {
+        op.old_node_ref.read(node, path_buf);
+    }
+
+    switch (op.new_node.action)
+    {
+        case NodeAction::Create: node.action = NodeAction::Remove; break;
+        case NodeAction::Update: node.action = NodeAction::Update; break;
+        case NodeAction::Remove: node.action = NodeAction::Create; break;
+    }
+
+    chassert(node.getOrCalculateDigest() == op.old_digest);
+
+    state.appendUncommittedNode(node, delta.zxid);
+}
+
+bool KeeperLSMTNodesStorage::visitUncommittedRecursive(std::string_view root_path, size_t limit, std::function<bool(std::string_view /*path*/, UncommittedNodeRef &&)> check_node)
+{
+    DB::Arena arena; // for paths
+    std::deque<NodePathWithHash> queue;
+
+    {
+        UncommittedNodeRef root_node = getUncommittedNode(root_path);
+        if (!root_node.get())
+            return true;
+
+        NodePathWithHash root_node_path = root_node.node.getPathWithHash();
+        if (!check_node(root_path, std::move(root_node)))
+            return false;
+        queue.push_back(root_node_path);
+    }
+
+    size_t nodes_visited = 1;
+    bool ok = true;
+
+    while (!queue.empty() && ok)
+    {
+        NodePathWithHash node_path = queue.front();
+        queue.pop_front();
+
+        Coordination::Storage::ChildrenSet2 set;
+        state.listUncommittedChildrenNames(node_path, set, arena);
+
+        for (const auto & entry : set.set)
+        {
+            if (entry.action == NodeAction::Remove)
+                continue;
+
+            NodePathWithHash child_path = node_path.path.childPath(entry.str(), arena).withCalculatedHash();
+            UncommittedNodeRef child;
+            child.ref = state.getUncommittedNode(child_path);
+            child.ref.readWithKnownPath(child.node, child_path);
+
+            ++nodes_visited;
+            if (nodes_visited > limit || !check_node(child.node.path.str(), std::move(child)))
+            {
+                ok = false;
+                break;
+            }
+            queue.push_back(child_path);
+        }
+    }
+
+    return ok;
+}
+
+void KeeperLSMTNodesStorage::prepareImpl(std::string_view path, UncommittedNodeRef && node, KeeperStagingTransaction & staging, ACLId old_acl_id, int64_t ephemeral_owner, bool has_ttl, bool is_container)
+{
+    state.throttleWrite();
+
+    chassert((!node.ref) == (node.node.action == NodeAction::Create));
+    chassert((!node.ref) == (node.node.digest == 0));
+    /// Digest must've been calculated by getUncommittedNode, then left unchanged by our caller.
+    uint64_t old_digest = node.node.digest;
+    node.node.path.ptr = path.data();
+    node.node.digest = 0;
+    staging.digest.value += node.node.getOrCalculateDigest() - old_digest;
+    NodeRef new_ref = state.appendUncommittedNode(node.node, staging.zxid);
+    staging.deltas.emplace_back(std::string{path}, staging.zxid, LSMTDelta {new_ref, node.node, node.ref, old_digest, old_acl_id, ephemeral_owner, has_ttl, is_container});
+}
+
+void KeeperLSMTNodesStorage::prepareUpdateNodeStat(
+    std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & new_stats,
+    KeeperStagingTransaction & staging)
+{
+    ACLId old_acl_id = node.node.stats.acl_id;
+    node.node.action = NodeAction::Update;
+    chassert(node.node.stats.getEphemeralOwner() == new_stats.getEphemeralOwner());
+    node.node.stats = new_stats;
+    prepareImpl(path, std::move(node), staging, old_acl_id, new_stats.getEphemeralOwner(), new_stats.isTTL(), new_stats.isContainer());
+}
+
+void KeeperLSMTNodesStorage::prepareUpdateNodeDataAndStat(
+    std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & new_stats,
+    std::string_view new_data, KeeperStagingTransaction & staging)
+{
+    ACLId old_acl_id = node.node.stats.acl_id;
+    node.node.action = NodeAction::Update;
+    chassert(node.node.stats.getEphemeralOwner() == new_stats.getEphemeralOwner());
+    node.node.stats = new_stats;
+    node.node.setData(new_data);
+    prepareImpl(path, std::move(node), staging, old_acl_id, new_stats.getEphemeralOwner(), new_stats.isTTL(), new_stats.isContainer());
+}
+
+void KeeperLSMTNodesStorage::prepareCreateNodeWithoutUpdatingParent(
+    std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & stats,
+    std::string_view data, KeeperStagingTransaction & staging)
+{
+    ACLId old_acl_id = node.node.stats.acl_id;
+    node.node.action = NodeAction::Create;
+    node.node.stats = stats;
+    node.node.setData(data);
+    prepareImpl(path, std::move(node), staging, old_acl_id, stats.getEphemeralOwner(), stats.isTTL(), stats.isContainer());
+}
+
+void KeeperLSMTNodesStorage::prepareRemoveNodeWithoutUpdatingParent(
+    std::string_view path, UncommittedNodeRef && node, KeeperStagingTransaction & staging)
+{
+    ACLId old_acl_id = node.node.stats.acl_id;
+    int64_t ephemeral_owner = node.node.stats.getEphemeralOwner();
+    bool has_ttl = node.node.stats.isTTL();
+    bool is_container = node.node.stats.isContainer();
+    node.node.action = NodeAction::Remove;
+    node.node.stats = {};
+    prepareImpl(path, std::move(node), staging, old_acl_id, ephemeral_owner, has_ttl, is_container);
+}
+
+}

--- a/src/Coordination/KeeperLSMTNodesStorage.cpp
+++ b/src/Coordination/KeeperLSMTNodesStorage.cpp
@@ -3,6 +3,8 @@
 #include <Coordination/Storage/NodeStream.h>
 #include <Coordination/KeeperSnapshotManager.h>
 
+#include <shared_mutex>
+
 using namespace Coordination::Storage;
 
 namespace DB
@@ -236,6 +238,12 @@ void KeeperLSMTNodesStorage::finishWritingSnapshot(std::unique_ptr<KeeperNodeStr
 void KeeperLSMTNodesStorage::getNodeStorageStats(KeeperStorageStats & out)
 {
     state.getNodeCountAndDataSize(out.nodes_count, out.approximate_data_size);
+}
+
+void KeeperLSMTNodesStorage::fillAsynchronousMetrics(AsynchronousMetricValues & new_values)
+{
+    std::shared_lock lock(*storage_mutex);
+    state.fillAsynchronousMetrics(new_values);
 }
 
 void KeeperLSMTNodesStorage::commitDelta(Delta & delta, uint64_t * digest)

--- a/src/Coordination/KeeperLSMTNodesStorage.h
+++ b/src/Coordination/KeeperLSMTNodesStorage.h
@@ -33,6 +33,8 @@ struct KeeperLSMTNodesStorage final : public KeeperNodesStorage
 
     void getNodeStorageStats(KeeperStorageStats & out) override;
 
+    void fillAsynchronousMetrics(AsynchronousMetricValues & new_values) override;
+
     void commitDelta(Delta & delta, uint64_t * digest) override;
     void cleanupUncommittedState(int64_t commit_zxid) override;
     void rollbackUncommittedDelta(const Delta & delta) override;

--- a/src/Coordination/KeeperLSMTNodesStorage.h
+++ b/src/Coordination/KeeperLSMTNodesStorage.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <Coordination/KeeperNodesStorage.h>
+#include <Coordination/KeeperContext.h>
+#include <Coordination/Storage/StorageState.h>
+#include <Coordination/Storage/Node.h>
+
+namespace DB
+{
+
+struct KeeperLSMTNodesStorage final : public KeeperNodesStorage
+{
+    using NodeRef = Coordination::Storage::NodeRef;
+    using FullNode = Coordination::Storage::FullNode;
+    using StorageState = Coordination::Storage::StorageState;
+    using NodeAction = Coordination::Storage::NodeAction;
+
+    /// ========== KeeperNodesStorage virtual methods ==========
+
+    bool getCommittedNodeSimple(std::string_view path, KeeperNodeStats * out_stats, std::string * out_data) override;
+    bool getUncommittedNodeSimple(std::string_view path, KeeperNodeStats * out_stats, std::string * out_data) override;
+
+    std::vector<std::string> listCommittedChildrenNames(std::string_view path) const override;
+
+    bool addCommittedNodeIfNotExists(std::string_view path, const KeeperNodeStats & stats, std::string_view data, bool update_parent_num_children, uint64_t * out_digest) override;
+    void updateCommittedNode(std::string_view path, std::optional<const KeeperNodeStats *> new_stats, std::optional<std::string_view> new_data, uint64_t * out_digest) override;
+    void removeCommittedNode(std::string_view path) override;
+
+    void loadNodesFromSnapshot(KeeperSnapshotReader & reader, KeeperStorage * storage, uint64_t * out_digest) override;
+
+    std::unique_ptr<KeeperNodeStreamForSnapshot> beginWritingSnapshot() override;
+    void finishWritingSnapshot(std::unique_ptr<KeeperNodeStreamForSnapshot> stream) override;
+
+    void getNodeStorageStats(KeeperStorageStats & out) override;
+
+    void commitDelta(Delta & delta, uint64_t * digest) override;
+    void cleanupUncommittedState(int64_t commit_zxid) override;
+    void rollbackUncommittedDelta(const Delta & delta) override;
+
+    void shutdown() override;
+
+    /// ========== Duck-typed interface used by KeeperStorageImpl ==========
+
+    using Node = FullNode;
+    struct NodeHolder;
+    struct UncommittedNodeRef;
+
+    KeeperLSMTNodesStorage(KeeperContextPtr keeper_context_, SharedMutex * storage_mutex_);
+
+    NodeHolder getCommittedNode(std::string_view path);
+    UncommittedNodeRef getUncommittedNode(std::string_view path);
+
+    bool visitUncommittedRecursive(std::string_view root_path, size_t limit, std::function<bool(std::string_view /*path*/, UncommittedNodeRef &&)> check_node);
+
+    void prepareUpdateNodeStat(
+        std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & new_stats,
+        KeeperStagingTransaction & staging);
+    void prepareUpdateNodeDataAndStat(
+        std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & new_stats,
+        std::string_view new_data, KeeperStagingTransaction & staging);
+    void prepareCreateNodeWithoutUpdatingParent(
+        std::string_view path, UncommittedNodeRef && node, const KeeperNodeStats & stats,
+        std::string_view data, KeeperStagingTransaction & staging);
+    void prepareRemoveNodeWithoutUpdatingParent(
+        std::string_view path, UncommittedNodeRef && node, KeeperStagingTransaction & staging);
+
+    /// ========== Implementations ==========
+
+    struct NodeHolder
+    {
+        NodeRef ref;
+        /// NodePath is invalid.
+        FullNode node;
+
+        const Node * get() const { return node.action == NodeAction::Remove ? nullptr : &node; }
+    };
+
+    struct UncommittedNodeRef
+    {
+        NodeRef ref;
+        /// Has digest. Has correct NodePath length and depth but likely invalidated NodePath::ptr.
+        FullNode node;
+
+        const Node * get() const { return node.action == NodeAction::Remove ? nullptr : &node; }
+    };
+
+    struct NodeStreamForSnapshot;
+
+    StorageState state;
+
+    /// Call with node.node mutated, but node.ref and node.node.digest still having the old values.
+    void prepareImpl(std::string_view path, UncommittedNodeRef && node, KeeperStagingTransaction & staging, ACLId old_acl_id, int64_t ephemeral_owner, bool has_ttl, bool is_container);
+};
+
+}

--- a/src/Coordination/KeeperNodesStorage.h
+++ b/src/Coordination/KeeperNodesStorage.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace DB
@@ -19,6 +20,9 @@ namespace DB
 
 class KeeperStorage;
 struct KeeperSnapshotReader;
+
+struct AsynchronousMetricValue;
+using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
 
 /// Iterator over nodes in KeeperStorage, frozen at the moment in time when
 /// KeeperNodeStreamForSnapshot was created. Creation locks storage_mutex but is relatively fast,
@@ -78,6 +82,9 @@ struct KeeperNodesStorage
     /// Assigns just the fields relevant to node storage. Other fields are set by KeeperStorage.
     /// Caller must hold storage_mutex (shared_lock is sufficient).
     virtual void getNodeStorageStats(KeeperStorageStats & out) = 0;
+
+    /// Populate implementation-specific asynchronous metrics. Locks storage_mutex itself.
+    virtual void fillAsynchronousMetrics(AsynchronousMetricValues & /*new_values*/) {}
 
     /// (A little slower than getCommittedNode/getUncommittedNode, so most request processing should
     ///  be a template and use getCommittedNode instead.)

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -1928,6 +1928,16 @@ KeeperStorageStats KeeperStateMachine::getStorageStats() const
     return storage->getStorageStats();
 }
 
+KeeperStorageStats KeeperStateMachine::getStorageStatsAndAsynchronousMetrics(AsynchronousMetricValues & new_values) const
+{
+    /// (Unprofiled because we don't care how long the monitoring threads wait for locks.)
+    std::shared_lock storage_lock(state_machine_storage_mutex);
+    std::lock_guard response_lock(process_and_responses_lock);
+    auto stats = storage->getStorageStats();
+    storage->nodes_storage->fillAsynchronousMetrics(new_values);
+    return stats;
+}
+
 void KeeperStateMachine::dumpWatches(WriteBufferFromOwnString & buf) const
 {
     KEEPER_STORAGE_LOCK_EXCLUSIVE(lock);

--- a/src/Coordination/KeeperStateMachine.h
+++ b/src/Coordination/KeeperStateMachine.h
@@ -23,6 +23,9 @@ using SnapshotsQueue = ConcurrentBoundedQueue<CreateSnapshotTask>;
 struct KeeperStorageStats;
 class KeeperLogStore;
 
+struct AsynchronousMetricValue;
+using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
+
 struct ISnapshotLoader;
 
 struct KeeperSnapshotStatus
@@ -138,6 +141,10 @@ public:
     int64_t getLastProcessedZxid() const;
 
     KeeperStorageStats getStorageStats() const;
+
+    /// Like getStorageStats, but also populates `new_values` with node-storage-specific metrics
+    /// (see KeeperNodesStorage::fillAsynchronousMetrics).
+    KeeperStorageStats getStorageStatsAndAsynchronousMetrics(AsynchronousMetricValues & new_values) const;
 
     void dumpWatches(WriteBufferFromOwnString & buf) const;
     void dumpWatchesByPath(WriteBufferFromOwnString & buf) const;

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -35,6 +35,7 @@
 #include <Coordination/KeeperStorage.h>
 #include <Coordination/KeeperStorageImpl.h>
 #include <Coordination/KeeperMemNodesStorage.h>
+#include <Coordination/KeeperLSMTNodesStorage.h>
 
 #include <limits>
 #include <shared_mutex>
@@ -63,6 +64,7 @@ namespace CoordinationSetting
 {
     extern const CoordinationSettingsUInt64 log_slow_cpu_threshold_ms;
     extern const CoordinationSettingsBool check_node_acl_on_remove;
+    extern const CoordinationSettingsBool use_new_storage;
 }
 
 namespace ErrorCodes
@@ -270,7 +272,11 @@ KeeperStorage::KeeperStorage(
 
 std::unique_ptr<KeeperStorage> KeeperStorage::create(int64_t tick_time_ms, const String & superdigest_, const KeeperContextPtr & keeper_context_, bool initialize_system_nodes)
 {
-    std::unique_ptr<KeeperStorage> res = std::make_unique<KeeperMemoryStorage>(tick_time_ms, superdigest_, keeper_context_);
+    std::unique_ptr<KeeperStorage> res;
+    if (keeper_context_->getCoordinationSettings()[CoordinationSetting::use_new_storage])
+        res = std::make_unique<KeeperLSMTStorage>(tick_time_ms, superdigest_, keeper_context_);
+    else
+        res = std::make_unique<KeeperMemoryStorage>(tick_time_ms, superdigest_, keeper_context_);
     if (initialize_system_nodes)
         res->initializeSystemNodes();
     return res;
@@ -429,6 +435,8 @@ void KeeperStorage::UncommittedState::rollback(int64_t rollback_zxid)
 
 void KeeperStorage::UncommittedState::rollback(std::list<Delta> rollback_deltas)
 {
+    using NodeAction = Coordination::Storage::NodeAction;
+
     // we need to undo ephemeral mapping modifications
     // CreateNodeDelta added ephemeral for session id -> we need to remove it
     // RemoveNodeDelta removed ephemeral for session id -> we need to add it back
@@ -458,6 +466,25 @@ void KeeperStorage::UncommittedState::rollback(std::list<Delta> rollback_deltas)
                     {
                         if (operation.stat.isEphemeral())
                             storage.uncommitted_state.ephemerals[operation.stat.getEphemeralOwner()].emplace(delta.path);
+                    }
+                    else if constexpr (std::same_as<DeltaType, LSMTDelta>)
+                    {
+                        switch (operation.new_node.action)
+                        {
+                            case NodeAction::Create:
+                                if (operation.ephemeral_owner != 0)
+                                    unregisterEphemeralPath(storage.uncommitted_state.ephemerals, operation.ephemeral_owner, delta.path, /*throw_if_missing=*/false);
+                                storage.acl_map.removeUsage(operation.new_node.stats.acl_id);
+                                break;
+                            case NodeAction::Update:
+                                if (operation.old_acl_id != operation.new_node.stats.acl_id)
+                                    storage.acl_map.removeUsage(operation.new_node.stats.acl_id);
+                                break;
+                            case NodeAction::Remove:
+                                if (operation.ephemeral_owner != 0)
+                                    storage.uncommitted_state.ephemerals[operation.ephemeral_owner].emplace(delta.path);
+                                break;
+                        }
                     }
                 },
                 delta.operation);
@@ -560,6 +587,8 @@ uint64_t KeeperStorage::getLastUncommittedLogIdx() const
 
 Coordination::Error KeeperStorage::commit(KeeperStorage::DeltaRange deltas)
 {
+    using NodeAction = Coordination::Storage::NodeAction;
+
     auto digest_on_commit = keeper_context->digestEnabled() && keeper_context->digestEnabledOnCommit();
     uint64_t digest_change = 0;
     uint64_t * digest = digest_on_commit ? &digest_change : nullptr;
@@ -602,6 +631,43 @@ Coordination::Error KeeperStorage::commit(KeeperStorage::DeltaRange deltas)
                         ttl_paths.erase(path);
                     if (operation.stat.isContainer())
                         container_paths.erase(path);
+                    return Coordination::Error::ZOK;
+                }
+                else if constexpr (std::same_as<DeltaType, LSMTDelta>)
+                {
+                    switch (operation.new_node.action)
+                    {
+                        case NodeAction::Create:
+                            if (operation.ephemeral_owner != 0)
+                            {
+                                ++committed_ephemeral_nodes;
+                                std::lock_guard lock(ephemeral_mutex);
+                                committed_ephemerals[operation.ephemeral_owner].emplace(path);
+                            }
+                            if (operation.has_ttl)
+                                ttl_paths.insert(path);
+                            if (operation.is_container)
+                                container_paths.insert(path);
+                            break;
+                        case NodeAction::Update:
+                            if (operation.old_acl_id != operation.new_node.stats.acl_id)
+                                acl_map.removeUsage(operation.old_acl_id);
+                            break;
+                        case NodeAction::Remove:
+                            acl_map.removeUsage(operation.old_acl_id);
+                            if (operation.ephemeral_owner != 0)
+                            {
+                                chassert(committed_ephemeral_nodes != 0);
+                                --committed_ephemeral_nodes;
+                                std::lock_guard lock(ephemeral_mutex);
+                                unregisterEphemeralPath(committed_ephemerals, operation.ephemeral_owner, path, /*throw_if_missing=*/true);
+                            }
+                            if (operation.has_ttl)
+                                ttl_paths.erase(path);
+                            if (operation.is_container)
+                                container_paths.erase(path);
+                            break;
+                    }
                     return Coordination::Error::ZOK;
                 }
                 else if constexpr (std::same_as<DeltaType, ErrorDelta>)

--- a/src/Coordination/KeeperStorageImpl.cpp
+++ b/src/Coordination/KeeperStorageImpl.cpp
@@ -1,6 +1,7 @@
 #include <Coordination/KeeperStorage.h>
 #include <Coordination/KeeperStorageImpl.h>
 #include <Coordination/KeeperMemNodesStorage.h>
+#include <Coordination/KeeperLSMTNodesStorage.h>
 #include <Coordination/KeeperStorage_fwd.h>
 
 #include <algorithm>
@@ -185,6 +186,14 @@ auto callOnConcreteRequestType(Coordination::ZooKeeperRequest & zk_request, F fu
     }
 }
 
+bool isRemoveNodeDelta(const KeeperDelta & delta)
+{
+    if (const auto * op = std::get_if<LSMTDelta>(&delta.operation))
+        return op->new_node.action == Coordination::Storage::NodeAction::Remove;
+    else
+        return std::holds_alternative<RemoveNodeDelta>(delta.operation);
+}
+
 bool takeNodeStatsFromUpdateDelta(std::string_view path, const KeeperStorage::DeltaRange & deltas, Coordination::Stat & out_stat)
 {
     for (auto it = deltas.end(); it != deltas.begin();)
@@ -196,6 +205,14 @@ bool takeNodeStatsFromUpdateDelta(std::string_view path, const KeeperStorage::De
         {
             update_delta->new_stats.setResponseStat(out_stat);
             return true;
+        }
+        if (const auto * lsmt_delta = std::get_if<LSMTDelta>(&it->operation))
+        {
+            if (lsmt_delta->new_node.action == Coordination::Storage::NodeAction::Update)
+            {
+                lsmt_delta->new_node.stats.setResponseStat(out_stat);
+                return true;
+            }
         }
     }
     return false;
@@ -398,26 +415,45 @@ static Coordination::ZooKeeperResponsePtr process(const Coordination::ZooKeeperC
         return response;
     }
 
+    /// Extract information from the Delta that creates the node.
+    bool found_delta = false;
     std::string created_path;
-    auto create_delta_it = std::find_if(
-        deltas.begin(),
-        deltas.end(),
-        [](const auto & delta)
-        { return std::holds_alternative<CreateNodeDelta>(delta.operation); });
-
-    if (create_delta_it != deltas.end())
+    Coordination::Stat * response_stat = nullptr;
+    if (response->getOpNum() == Coordination::OpNum::Create2 ||
+        response->getOpNum() == Coordination::OpNum::CreateTTL ||
+        response->getOpNum() == Coordination::OpNum::CreateContainer)
+        response_stat = &static_cast<Coordination::ZooKeeperCreate2Response &>(*response).zstat;
+    for (const KeeperDelta & delta : deltas)
     {
-        created_path = create_delta_it->path;
-        if (response->getOpNum() == Coordination::OpNum::Create2 ||
-            response->getOpNum() == Coordination::OpNum::CreateTTL ||
-            response->getOpNum() == Coordination::OpNum::CreateContainer)
-            std::get<CreateNodeDelta>(create_delta_it->operation).stat.setResponseStat(static_cast<Coordination::ZooKeeperCreate2Response &>(*response).zstat);
+        if (const auto * lsmt_op = std::get_if<LSMTDelta>(&delta.operation))
+        {
+            if (lsmt_op->new_node.action == Coordination::Storage::NodeAction::Create)
+            {
+                found_delta = true;
+                if (response_stat)
+                    lsmt_op->new_node.stats.setResponseStat(*response_stat);
+            }
+        }
+        else if (const auto * create_op = std::get_if<CreateNodeDelta>(&delta.operation))
+        {
+            found_delta = true;
+            if (response_stat)
+                create_op->stat.setResponseStat(*response_stat);
+        }
+        if (found_delta)
+        {
+            created_path = delta.path;
+            break;
+        }
     }
+
     if (const auto result = storage.commit(std::move(deltas)); result != Coordination::Error::ZOK)
     {
         response->error = result;
         return response;
     }
+    if (!found_delta)
+        onStorageInconsistency("Unexpected deltas for Create request");
 
     response->path_created = std::move(created_path);
     response->error = Coordination::Error::ZOK;
@@ -481,7 +517,7 @@ static std::pair<KeeperResponsesForSessions, Int64> processWatches(
 {
     for (const auto & delta : deltas)
     {
-        if (std::holds_alternative<RemoveNodeDelta>(delta.operation))
+        if (isRemoveNodeDelta(delta))
             return storage.processWatchesImpl(zk_request.getPath(), Coordination::Event::DELETED);
     }
     return {};
@@ -626,7 +662,7 @@ static std::pair<KeeperResponsesForSessions, Int64> processWatches(
     Int64 total_removed_watches = 0;
     for (const auto & delta : deltas)
     {
-        if (std::holds_alternative<RemoveNodeDelta>(delta.operation))
+        if (isRemoveNodeDelta(delta))
         {
             auto [new_responses, removed_watches] = storage.processWatchesImpl(delta.path, Coordination::Event::DELETED);
             responses.insert(responses.end(), std::make_move_iterator(new_responses.begin()), std::make_move_iterator(new_responses.end()));
@@ -674,6 +710,11 @@ static Coordination::Error preprocess(
     bool visited_all = storage.nodes.visitUncommittedRecursive(zk_request.path, zk_request.remove_nodes_limit,
             [&](std::string_view path, typename Storage::UncommittedNodeRef && uncommitted_ref)
             {
+                /// Note: this might be called with storage_mutex locked, make sure to not try to
+                /// lock it again or we'll deadlock.
+                /// (If needed, we could change KeeperLSMTNodesStorage::visitUncommittedRecursive
+                ///  to defer these calls until after unlocking the mutex.)
+
                 if (check_acl && !storage.checkACL(uncommitted_ref.get()->stats.acl_id, Coordination::ACL::Delete, session_id, /*committed=*/false))
                 {
                     error = Coordination::Error::ZNOAUTH;
@@ -1885,7 +1926,7 @@ KeeperResponsesForSessions KeeperStorageImpl<NS>::processRequest(
     {
         for (const auto & delta : deltas)
         {
-            if (std::holds_alternative<RemoveNodeDelta>(delta.operation))
+            if (isRemoveNodeDelta(delta))
             {
                 auto [responses, cnt_removed_watches] = processWatchesImpl(delta.path, Coordination::Event::DELETED);
                 total_watches_count -= cnt_removed_watches;
@@ -2302,5 +2343,6 @@ KeeperStorageImpl<NS>::~KeeperStorageImpl()
 }
 
 template class KeeperStorageImpl<KeeperMemNodesStorage>;
+template class KeeperStorageImpl<KeeperLSMTNodesStorage>;
 
 }

--- a/src/Coordination/KeeperStorage_fwd.h
+++ b/src/Coordination/KeeperStorage_fwd.h
@@ -7,7 +7,9 @@ template<typename NodesStorage>
 class KeeperStorageImpl;
 
 struct KeeperMemNodesStorage;
+struct KeeperLSMTNodesStorage;
 
 using KeeperMemoryStorage = KeeperStorageImpl<KeeperMemNodesStorage>;
+using KeeperLSMTStorage = KeeperStorageImpl<KeeperLSMTNodesStorage>;
 
 }

--- a/src/Coordination/Storage/BackgroundWork.cpp
+++ b/src/Coordination/Storage/BackgroundWork.cpp
@@ -300,6 +300,8 @@ void BackgroundWork::mergeThread()
 
                 for (uint32_t seqno : seqnos_to_lock)
                     merges_in_progress.insert(seqno);
+
+                merges_running.fetch_add(1);
             }
         }
 
@@ -317,6 +319,7 @@ void BackgroundWork::mergeThread()
                 size_t erased = merges_in_progress.erase(seqno);
                 chassert(erased);
             }
+            merges_running.fetch_sub(1);
         };
 
         Stopwatch stopwatch;

--- a/src/Coordination/Storage/BackgroundWork.cpp
+++ b/src/Coordination/Storage/BackgroundWork.cpp
@@ -5,6 +5,7 @@
 #include <Coordination/CoordinationSettings.h>
 #include <Coordination/KeeperContext.h>
 #include <Common/Exception.h>
+#include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/logger_useful.h>
 #include <Disks/IDisk.h>
@@ -15,6 +16,22 @@
 namespace DB::ErrorCodes
 {
     extern const int ABORTED;
+}
+
+namespace ProfileEvents
+{
+    extern const Event KeeperLSMTFlushes;
+    extern const Event KeeperLSMTMerges;
+    extern const Event KeeperLSMTFlushExceptions;
+    extern const Event KeeperLSMTMergeExceptions;
+    extern const Event KeeperLSMTFileDeletionExceptions;
+    extern const Event KeeperLSMTFlushWrittenCompressedBytes;
+    extern const Event KeeperLSMTFlushWrittenUncompressedBytes;
+    extern const Event KeeperLSMTMergeWrittenFiles;
+    extern const Event KeeperLSMTMergeWrittenCompressedBytes;
+    extern const Event KeeperLSMTMergeWrittenUncompressedBytes;
+    extern const Event KeeperLSMTMergeConsumedFiles;
+    extern const Event KeeperLSMTMergeConsumedUncompressedBytes;
 }
 
 namespace DB::CoordinationSetting
@@ -113,6 +130,7 @@ bool BackgroundWork::deleteQueuedFiles() const
         }
         catch (...)
         {
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTFileDeletionExceptions);
             DB::tryLogCurrentException(storage->log, fmt::format("Failed to delete file {}, will retry", path));
 
             /// Put it back; the caller will back off and retry.
@@ -216,6 +234,7 @@ void BackgroundWork::flushThread()
         }
         catch (...)
         {
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTFlushExceptions);
             DB::tryLogCurrentException(storage->log, "Memtable flush failed");
 
             /// Don't retry immediately.
@@ -225,6 +244,10 @@ void BackgroundWork::flushThread()
             flushes_in_progress.erase(memtable->file_seqno);
             continue;
         }
+
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTFlushes);
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTFlushWrittenCompressedBytes, new_run->total_file_size);
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTFlushWrittenUncompressedBytes, new_run->total_block_size);
 
         const double duration = stopwatch.elapsedSeconds();
         LOG_DEBUG(storage->log,
@@ -348,6 +371,10 @@ void BackgroundWork::mergeThread()
                 r->node_count_delta = 0;
             }
 
+            /// A resumed merge's output files were already counted in ProfileEvents by the
+            /// interrupted merge (files get published, and counted, one at a time).
+            size_t counted_output_files = output_run->files.size();
+
             SortedRunWriter writer(output_run, storage);
 
             std::vector<SortedRunNodeStream> input_streams;
@@ -449,8 +476,11 @@ void BackgroundWork::mergeThread()
                 }
 
                 /// Evict newly obsolete files from block cache and mark them for deletion from disk.
+                size_t consumed_bytes = 0;
                 for (SortedFilePtr & f : removed_files)
                 {
+                    consumed_bytes += f->total_block_size;
+
                     f->removeFromBlockCache(storage->block_cache.get());
 
                     /// The file is no longer visible to new readers; delete it from disk when the
@@ -459,6 +489,21 @@ void BackgroundWork::mergeThread()
 
                     f.reset();
                 }
+
+                ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeConsumedFiles, removed_files.size());
+                ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeConsumedUncompressedBytes, consumed_bytes);
+
+                size_t written_compressed_bytes = 0;
+                size_t written_uncompressed_bytes = 0;
+                for (; counted_output_files < output_run->files.size(); ++counted_output_files)
+                {
+                    const SortedFile & f = *output_run->files[counted_output_files];
+                    written_compressed_bytes += f.file_size;
+                    written_uncompressed_bytes += f.total_block_size;
+                    ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeWrittenFiles);
+                }
+                ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeWrittenCompressedBytes, written_compressed_bytes);
+                ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeWrittenUncompressedBytes, written_uncompressed_bytes);
             };
 
             while (true)
@@ -493,11 +538,13 @@ void BackgroundWork::mergeThread()
                 duration);
 
             publish_results(/*is_final=*/ true);
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTMerges);
             unlock_files();
             maybeStartMerge();
         }
         catch (...)
         {
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTMergeExceptions);
             DB::tryLogCurrentException(storage->log, "Merge failed");
 
             /// Don't retry immediately.

--- a/src/Coordination/Storage/BackgroundWork.h
+++ b/src/Coordination/Storage/BackgroundWork.h
@@ -40,6 +40,10 @@ struct BackgroundWork
     std::set<uint32_t> flushes_in_progress;
     std::set<uint32_t> merges_in_progress;
 
+    /// Number of merges currently running. Atomic so that fillAsynchronousMetrics can read it
+    /// without locking `mutex` (which can't be locked while holding storage_mutex).
+    std::atomic<size_t> merges_running{0};
+
     /// If concurrent memtable flushes finish out of order, we hold the results in this reorder
     /// buffer to publish to StorageState in file_seqno order.
     std::map<uint32_t, SortedRunPtr> flushed_files;

--- a/src/Coordination/Storage/Common.h
+++ b/src/Coordination/Storage/Common.h
@@ -16,6 +16,11 @@
 #include <string_view>
 #include <utility>
 
+namespace DB
+{
+    class Arena;
+}
+
 namespace Coordination::Storage
 {
 
@@ -129,8 +134,10 @@ struct NodePath
     NodePath parentPath() const;
 
     /// Path to child znode: "/foo/bar" + "baz" = "/foo/bar/baz".
-    /// Puts the path string into `path_buf`, returns a reference into it.
+    size_t childPathLen(size_t child_name_len) const;
+    NodePath makeChildPath(std::string_view child_name, std::span<char> out) const;
     NodePath childPath(std::string_view child_name, std::string & path_buf) const;
+    NodePath childPath(std::string_view child_name, DB::Arena & arena) const;
 
     /// The last component of the path: "b" for "/a/b". Must not be called on the root path.
     std::string_view baseName() const;

--- a/src/Coordination/Storage/Memtable.cpp
+++ b/src/Coordination/Storage/Memtable.cpp
@@ -142,6 +142,7 @@ NodeRef Memtable::appendNode(FullNode & node, bool strict)
         total_bytes += new_block->capacity;
         blocks.push_back(std::move(new_block));
     }
+    num_entries += 1;
     node_count_delta += nodeCountDelta(node.action);
 
     return ref;
@@ -163,6 +164,7 @@ MemtablePtr Memtable::takeSnapshot() const
     MemtablePtr res = std::make_shared<Memtable>();
     res->file_seqno = file_seqno;
     res->total_bytes = total_bytes;
+    res->num_entries = num_entries;
     res->node_count_delta = node_count_delta;
     res->blocks = blocks;
 

--- a/src/Coordination/Storage/Memtable.h
+++ b/src/Coordination/Storage/Memtable.h
@@ -196,6 +196,7 @@ struct Memtable
     ///          point to these blocks, and we rely on these weak ptrs not expiring.
     std::vector<BlockPtr> blocks;
     size_t total_bytes = 0; // sum of capacities of `blocks`
+    size_t num_entries = 0; // number of nodes/tombstones in all blocks
 
     /// Number of Create-d nodes minus number of Remove-d nodes.
     int64_t node_count_delta = 0;

--- a/src/Coordination/Storage/Node.cpp
+++ b/src/Coordination/Storage/Node.cpp
@@ -71,17 +71,35 @@ NodePath NodePath::parentPath() const
     return NodePath(Coordination::parentNodePath(str()), depth - 1);
 }
 
+size_t NodePath::childPathLen(size_t child_name_len) const
+{
+    return len + child_name_len + (depth > 0);
+}
+
+NodePath NodePath::makeChildPath(std::string_view child_name, std::span<char> out) const
+{
+    chassert(len > 0);
+    chassert((ptr[len - 1] == '/') == (depth == 0));
+    chassert(out.size() == childPathLen(child_name.size()));
+
+    memcpy(out.data(), ptr, len);
+    if (depth > 0)
+        out.data()[len] = '/';
+    memcpy(out.data() + len + (depth > 0), child_name.data(), child_name.size());
+    return NodePath(std::string_view(out.data(), out.size()), depth + 1);
+}
+
 NodePath NodePath::childPath(std::string_view child_name, std::string & path_buf) const
 {
-    path_buf.clear();
-    path_buf.reserve(len + child_name.size() + (depth > 0));
-    path_buf.append(str());
-    if (depth == 0)
-        chassert(str() == "/");
-    if (depth > 0)
-        path_buf.push_back('/');
-    path_buf.append(child_name);
-    return NodePath(path_buf, depth + 1);
+    path_buf.resize(childPathLen(child_name.size()));
+    return makeChildPath(child_name, std::span(path_buf.data(), path_buf.size()));
+}
+
+NodePath NodePath::childPath(std::string_view child_name, DB::Arena & arena) const
+{
+    size_t out_len = childPathLen(child_name.size());
+    char * out = arena.alloc(out_len);
+    return makeChildPath(child_name, std::span(out, out_len));
 }
 
 std::string_view NodePath::baseName() const

--- a/src/Coordination/Storage/NodeStream.cpp
+++ b/src/Coordination/Storage/NodeStream.cpp
@@ -68,6 +68,7 @@ void SortedRunNodeStream::dropConsumedFiles(std::vector<SortedFilePtr> & dropped
         SortedFilePtr file = std::move(sorted_run->files[i]);
         sorted_run->total_block_size -= file->total_block_size;
         sorted_run->total_file_size -= file->file_size;
+        sorted_run->total_entries -= file->num_entries;
         dropped.push_back(std::move(file));
     }
     sorted_run->files.erase(sorted_run->files.begin(), sorted_run->files.begin() + file_idx);

--- a/src/Coordination/Storage/SortedFile.cpp
+++ b/src/Coordination/Storage/SortedFile.cpp
@@ -8,10 +8,12 @@
 #include <Coordination/KeeperContext.h>
 #include <Common/Exception.h>
 #include <Common/PODArray.h>
+#include <Common/ProfileEvents.h>
 #include <Disks/IDisk.h>
 #include <IO/CompressionMethod.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <base/defines.h>
+#include <base/scope_guard.h>
 
 #include <algorithm>
 
@@ -20,6 +22,20 @@
 namespace DB::ErrorCodes
 {
     extern const int CORRUPTED_DATA;
+}
+
+namespace ProfileEvents
+{
+    extern const Event KeeperLSMTListScannedBlocks;
+    extern const Event KeeperLSMTListScannedEntries;
+    extern const Event KeeperLSMTListFilterSkipped;
+    extern const Event KeeperLSMTListFilterFalsePositives;
+    extern const Event KeeperLSMTListFilterTruePositives;
+    extern const Event KeeperLSMTGetBlockFromWeakPtr;
+    extern const Event KeeperLSMTGetBlockFromCache;
+    extern const Event KeeperLSMTGetBlockLoadedGroup;
+    extern const Event KeeperLSMTLoadedBlocks;
+    extern const Event KeeperLSMTLoadedUncompressedBytes;
 }
 
 namespace DB::CoordinationSetting
@@ -43,11 +59,15 @@ BlockPtr SortedFile::getOrLoadBlock(uint32_t block_idx, BlockCache * block_cache
 
     BlockPtr block = info.data.load();
     if (block)
+    {
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTGetBlockFromWeakPtr);
         return block;
+    }
 
     chassert(block_cache); // in memory-only mode load() above succeeds because all blocks are pinned
 
     BlockCacheKey key{.file_id = file_id, .block_idx = block_idx};
+    bool loaded_group = false;
     block = block_cache->get(key);
     if (!block)
     {
@@ -59,10 +79,13 @@ BlockPtr SortedFile::getOrLoadBlock(uint32_t block_idx, BlockCache * block_cache
             --group_start_block_idx;
         }
 
+        /// (Another thread may load the group concurrently, in which case our load_func is not
+        ///  called and we effectively got the block from cache.)
         block = block_cache->getBlockOrLoadGroup(
             key, group_start_block_idx,
-            [&] { return loadBlockGroup(group_start_block_idx); });
+            [&] { loaded_group = true; return loadBlockGroup(group_start_block_idx); });
     }
+    ProfileEvents::increment(loaded_group ? ProfileEvents::KeeperLSMTGetBlockLoadedGroup : ProfileEvents::KeeperLSMTGetBlockFromCache);
 
     /// Note: we update blocks[i].data only for the one requested block, even if we loaded multiple
     /// blocks (loadBlockGroup above). This is intentional. We want the next access to those
@@ -94,7 +117,21 @@ void SortedFile::listChildrenNames(
 {
     if (parent_paths_filter && !parent_paths_filter->findHashPair(
             DB::BloomFilterHashPair {parent_path_hash.items[0], parent_path_hash.items[1]}))
+    {
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTListFilterSkipped);
         return;
+    }
+
+    size_t scanned_blocks = 0;
+    size_t scanned_entries = 0;
+    size_t names_found = 0;
+    SCOPE_EXIT({
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTListScannedBlocks, scanned_blocks);
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTListScannedEntries, scanned_entries);
+        if (parent_paths_filter)
+            ProfileEvents::increment(
+                names_found != 0 ? ProfileEvents::KeeperLSMTListFilterTruePositives : ProfileEvents::KeeperLSMTListFilterFalsePositives);
+    });
 
     auto block_it = std::ranges::partition_point(
         blocks,
@@ -108,6 +145,7 @@ void SortedFile::listChildrenNames(
 
         const uint32_t block_idx = static_cast<uint32_t>(block_it - blocks.begin());
         BlockPtr block = getOrLoadBlock(block_idx, block_cache);
+        scanned_blocks += 1;
 
         NodeRef ref{.block = block};
         NodePath node_path;
@@ -118,12 +156,14 @@ void SortedFile::listChildrenNames(
             ref.offset = offset;
             ref.readPath(node_path, path_buf, serialized_size, action);
             offset += serialized_size;
+            scanned_entries += 1;
 
             if (node_path.compare(range_start) <= 0)
                 continue; /// before the range (range_start is exclusive)
             if (node_path.compare(range_end) >= 0)
                 return; /// past the range (range_end is exclusive)
 
+            names_found += 1;
             out.insert(node_path.baseName(), action, arena_);
         }
     }
@@ -172,6 +212,7 @@ std::vector<BlockPtr> SortedFile::loadBlockGroup(uint32_t start_block_idx) const
         std::move(compressed_reader), DB::CompressionMethod::Zstd);
 
     std::vector<BlockPtr> res;
+    size_t uncompressed_bytes = 0;
     for (uint32_t block_idx = start_block_idx;
          block_idx < blocks.size() && blocks[block_idx].group_offset_in_file == group_info.group_offset_in_file;
          ++block_idx)
@@ -186,8 +227,12 @@ std::vector<BlockPtr> SortedFile::loadBlockGroup(uint32_t start_block_idx) const
 
         block->parseHeader();
 
+        uncompressed_bytes += block->size;
         res.push_back(std::move(block));
     }
+
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTLoadedBlocks, res.size());
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTLoadedUncompressedBytes, uncompressed_bytes);
 
     return res;
 }

--- a/src/Coordination/Storage/SortedFile.h
+++ b/src/Coordination/Storage/SortedFile.h
@@ -60,8 +60,9 @@ struct SortedFile
     uint32_t min_compatible_version = 0;
     DB::KeeperDigestVersion digest_version = DB::KeeperDigestVersion::NO_DIGEST;
 
-    size_t total_block_size = 0;
-    size_t file_size = 0;
+    size_t total_block_size = 0; // uncompressed
+    size_t file_size = 0; // compressed
+    size_t num_entries = 0; // number of nodes/tombstones
 
     /// Number of Create-d nodes minus number of Remove-d nodes.
     int64_t node_count_delta = 0;

--- a/src/Coordination/Storage/SortedRun.cpp
+++ b/src/Coordination/Storage/SortedRun.cpp
@@ -161,6 +161,7 @@ void SortedRunWriter::appendNode(FullNode & node)
     }
 
     file->node_count_delta += nodeCountDelta(node.action);
+    file->num_entries += 1;
 
     if (node.action != NodeAction::Update && node.path.depth != 0)
     {
@@ -303,6 +304,7 @@ void SortedRunWriter::finishFile()
     chassert(!file->blocks.empty()); // a file is created only when a node is appended
     sorted_run->total_block_size += file->total_block_size;
     sorted_run->total_file_size += file->file_size;
+    sorted_run->total_entries += file->num_entries;
     sorted_run->files.push_back(std::move(file));
 }
 

--- a/src/Coordination/Storage/SortedRun.h
+++ b/src/Coordination/Storage/SortedRun.h
@@ -36,8 +36,10 @@ struct SortedRun
     uint32_t min_file_seqno = 0;
     uint32_t max_file_seqno = 0;
 
+    /// Sums across `files`. (No live merge shenanigans like in node_count_delta.)
     size_t total_block_size = 0;
     size_t total_file_size = 0;
+    size_t total_entries = 0;
 
     /// How many nodes (+1) and tombstones (-1) this run "contributes" to the total.
     /// For files not involved in a merge, this is just the sum of node_count_delta in `files`.

--- a/src/Coordination/Storage/StorageState.cpp
+++ b/src/Coordination/Storage/StorageState.cpp
@@ -4,6 +4,7 @@
 #include <Coordination/Storage/Node.h>
 #include <Coordination/CoordinationSettings.h>
 #include <Coordination/KeeperContext.h>
+#include <Common/AsynchronousMetrics.h>
 #include <Common/Exception.h>
 #include <Common/config_version.h>
 #include <Common/logger_useful.h>
@@ -341,6 +342,47 @@ void StorageState::getNodeCountAndDataSize(uint64_t & out_node_count, uint64_t &
     out_node_count = static_cast<uint64_t>(node_count);
 }
 
+void StorageState::fillAsynchronousMetrics(DB::AsynchronousMetricValues & new_values) const
+{
+    new_values["KeeperLSMTUncommittedMemtablesSize"] = { uncommitted_bytes.load(std::memory_order_relaxed), "Bytes in memtables storing uncommitted state." };
+
+    size_t immutable_memtable_bytes = 0;
+    size_t total_entries = 0;
+    for (const auto & m : immutable_memtables)
+    {
+        immutable_memtable_bytes += m->total_bytes;
+        total_entries += m->num_entries;
+    }
+    if (mutable_memtable)
+        total_entries += mutable_memtable->num_entries;
+
+    new_values["KeeperLSMTImmutableMemtablesCount"] = { immutable_memtables.size(), "Number of memtables waiting for flush." };
+    new_values["KeeperLSMTImmutableMemtablesSize"] = { immutable_memtable_bytes, "Bytes in memtables waiting for flush." };
+    new_values["KeeperLSMTMutableMemtableSize"] = { mutable_memtable ? mutable_memtable->total_bytes : 0, "Bytes in current memtable." };
+
+    new_values["KeeperLSMTNodeCacheEntries"] = { node_cache.map.size(), "Number of znodes in node cache." };
+    new_values["KeeperLSMTThrottling"] = { write_throttling_us.load(), "Microseconds of delay added to each write because background flushes or merges fell behind. 0 if background work is keeping up." };
+    new_values["KeeperLSMTMergesInProgress"] = { background ? background->merges_running.load() : 0, "Number of background merges running." };
+
+    size_t total_files = 0;
+    size_t files_compressed_bytes = 0;
+    size_t files_uncompressed_bytes = 0;
+    for (const auto & r : sorted_runs)
+    {
+        total_files += r->files.size();
+        total_entries += r->total_entries;
+        files_compressed_bytes += r->total_file_size;
+        files_uncompressed_bytes += r->total_block_size;
+    }
+
+    new_values["KeeperLSMTSortedRuns"] = { sorted_runs.size(), "Number of sorted runs." };
+    new_values["KeeperLSMTFilesCount"] = { total_files, "Number of files in all sorted runs." };
+    new_values["KeeperLSMTFilesCompressedSize"] = { files_compressed_bytes, "Total size of files in all sorted runs." };
+    new_values["KeeperLSMTFilesUncompressedSize"] = { files_uncompressed_bytes, "Total size of uncompressed blocks in all sorted runs." };
+
+    new_values["KeeperLSMTTotalEntries"] = { total_entries, "Number of entries (nodes and tombstones) in all committed memtables and files." };
+}
+
 NodeRef StorageState::appendUncommittedNode(FullNode & node, int64_t zxid)
 {
     const DB::CoordinationSettings & settings = keeper_context->getCoordinationSettings();
@@ -359,8 +401,10 @@ NodeRef StorageState::appendUncommittedNode(FullNode & node, int64_t zxid)
 
     UncommittedMemtable & u = uncommitted.back();
     u.max_zxid = std::max(u.max_zxid, zxid);
+    const size_t bytes_before = u.memtable->total_bytes;
     /// strict=false: see the comment at Memtable::appendNode.
     NodeRef ref = u.memtable->appendNode(node, /*strict=*/ false);
+    uncommitted_bytes.fetch_add(u.memtable->total_bytes - bytes_before, std::memory_order_relaxed);
     /// Loose model: the last record for a path wins, including Remove tombstones.
     u.nodes[node.getOrCalculatePathHash()] = ref;
     return ref;
@@ -372,6 +416,7 @@ void StorageState::cleanupUncommittedState(int64_t committed_zxid)
     {
         LOG_DEBUG(log, "Removing obsolete uncommitted memtable with max_zxid = {} (committed_zxid = {})", uncommitted.front().max_zxid, committed_zxid);
 
+        uncommitted_bytes.fetch_sub(uncommitted.front().memtable->total_bytes, std::memory_order_relaxed);
         uncommitted.erase(uncommitted.begin());
     }
 }

--- a/src/Coordination/Storage/StorageState.cpp
+++ b/src/Coordination/Storage/StorageState.cpp
@@ -6,6 +6,7 @@
 #include <Coordination/KeeperContext.h>
 #include <Common/AsynchronousMetrics.h>
 #include <Common/Exception.h>
+#include <Common/ProfileEvents.h>
 #include <Common/config_version.h>
 #include <Common/logger_useful.h>
 #include <Common/thread_local_rng.h>
@@ -41,6 +42,28 @@ namespace DB::CoordinationSetting
     extern const CoordinationSettingsUInt64 write_throttling_min_delay_us;
     extern const CoordinationSettingsUInt64 write_throttling_max_delay_us;
     extern const CoordinationSettingsFloat write_throttling_factor;
+}
+
+namespace ProfileEvents
+{
+    extern const Event KeeperLSMTUncommittedCreates;
+    extern const Event KeeperLSMTUncommittedCreateBytes;
+    extern const Event KeeperLSMTUncommittedUpdates;
+    extern const Event KeeperLSMTUncommittedUpdateBytes;
+    extern const Event KeeperLSMTUncommittedRemoves;
+    extern const Event KeeperLSMTUncommittedRemoveBytes;
+    extern const Event KeeperLSMTCommittedEntryBytes;
+    extern const Event KeeperLSMTThrottledWrites;
+    extern const Event KeeperLSMTCommittedMemtablesCreated;
+    extern const Event KeeperLSMTUncommittedMemtablesCreated;
+    extern const Event KeeperLSMTGetUncommittedNodeHits;
+    extern const Event KeeperLSMTGetUncommittedNodeMisses;
+    extern const Event KeeperLSMTGetCommittedNodeFromMemory;
+    extern const Event KeeperLSMTGetCommittedNodeNonexistent;
+    extern const Event KeeperLSMTGetCommittedNodeLoadedBlock;
+    extern const Event KeeperLSMTNodeCacheEntriesUpdated;
+    extern const Event KeeperLSMTListNamesFromMemtables;
+    extern const Event KeeperLSMTListNamesFromFiles;
 }
 
 namespace Coordination::Storage
@@ -127,11 +150,17 @@ NodeRef StorageState::getCommittedNode(const NodePathWithHash & path) const
     const NodeRefCache::Entry * info = nullptr;
     NodeRef node_ref;
     if (node_cache.tryGet(path.hash, node_ref, &info))
+    {
         /// Normal fast path: the node is already in memory
         /// (in memtable, or in block cache, or pinned by SortedFile in memory-only mode).
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTGetCommittedNodeFromMemory);
         return node_ref;
+    }
     if (!info)
+    {
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTGetCommittedNodeNonexistent);
         return NodeRef{}; // the node is not in NodeCache's map and therefore doesn't exist
+    }
 
     /// The block was evicted from the block cache. Memtables keep their blocks alive, so the
     /// node's latest update must be in a file (sorted run).
@@ -166,6 +195,7 @@ NodeRef StorageState::getCommittedNode(const NodePathWithHash & path) const
     /// under its spinlock.
     NodeRef ref{.action = NodeAction::Create, .offset = 0, .block = block};
     std::string path_buf;
+    size_t entries_updated = 0;
     for (uint32_t offset = block->entries_start; offset < block->size;)
     {
         ref.offset = offset;
@@ -184,11 +214,15 @@ NodeRef StorageState::getCommittedNode(const NodePathWithHash & path) const
                 std::lock_guard guard(node_info.block);
                 node_info.block.set(block);
                 node_info.node_offset = offset;
+                entries_updated += 1;
             }
         }
 
         offset += serialized_size;
     }
+
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTGetCommittedNodeLoadedBlock);
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTNodeCacheEntriesUpdated, entries_updated);
 
     /// `info` is still valid: the loop above only updated existing `node_cache` entries.
     std::lock_guard guard(info->block);
@@ -205,8 +239,15 @@ NodeRef StorageState::getUncommittedNode(const NodePathWithHash & path)
     /// Search uncommitted memtables, newest first. The found NodeRef may be a tombstone
     /// (action == Remove) with a non-null block.
     for (auto it = uncommitted.rbegin(); it != uncommitted.rend(); ++it)
+    {
         if (const auto * lookup = it->nodes.find(path.hash))
+        {
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTGetUncommittedNodeHits);
             return lookup->getMapped();
+        }
+    }
+
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTGetUncommittedNodeMisses);
 
     std::shared_lock lock(*storage_mutex);
     return getCommittedNode(path);
@@ -233,6 +274,7 @@ NodeRef StorageState::appendCommittedNode(FullNode & node)
         mutable_memtable->target_block_size = settings[DB::CoordinationSetting::memtable_block_size];
         mutable_memtable->file_seqno = next_file_seqno++;
 
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTCommittedMemtablesCreated);
         LOG_DEBUG(log, "Creating new memtable {}", mutable_memtable->file_seqno);
     }
 
@@ -257,6 +299,8 @@ NodeRef StorageState::appendCommittedNode(FullNode & node)
     }
 
     const NodeRef ref = mutable_memtable->appendNode(node, /*strict=*/ true);
+    /// (The entry we just appended is the last thing in its block.)
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTCommittedEntryBytes, ref.block->size - ref.offset);
 
     /// Update `node_cache`. (We hold storage_mutex exclusively, so no concurrent readers;
     /// no need for the per-entry spinlocks.)
@@ -294,10 +338,15 @@ void StorageState::listCommittedChildrenNames(
     /// memtable removed a child, its listChildrenNames will insert an action=Remove into `out`,
     /// then listChildrenNames in older memtables and files won't insert this child into `out`.
 
+    const size_t names_before_memtables = out.set.size();
+
     if (mutable_memtable)
         mutable_memtable->listChildrenNames(path, out, arena);
     for (auto it = immutable_memtables.rbegin(); it != immutable_memtables.rend(); ++it)
         (*it)->listChildrenNames(path, out, arena);
+
+    const size_t names_before_files = out.set.size();
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTListNamesFromMemtables, names_before_files - names_before_memtables);
 
     if (!sorted_runs.empty())
     {
@@ -318,6 +367,8 @@ void StorageState::listCommittedChildrenNames(
         for (auto it = sorted_runs.rbegin(); it != sorted_runs.rend(); ++it)
             (*it)->listChildrenNames(range_start, range_end, path.hash, out, arena, block_cache.get());
     }
+
+    ProfileEvents::increment(ProfileEvents::KeeperLSMTListNamesFromFiles, out.set.size() - names_before_files);
 }
 
 void StorageState::getNodeCountAndDataSize(uint64_t & out_node_count, uint64_t & out_data_size) const
@@ -367,18 +418,23 @@ void StorageState::fillAsynchronousMetrics(DB::AsynchronousMetricValues & new_va
     size_t total_files = 0;
     size_t files_compressed_bytes = 0;
     size_t files_uncompressed_bytes = 0;
+    size_t parent_paths_filter_bytes = 0;
     for (const auto & r : sorted_runs)
     {
         total_files += r->files.size();
         total_entries += r->total_entries;
         files_compressed_bytes += r->total_file_size;
         files_uncompressed_bytes += r->total_block_size;
+        for (const auto & f : r->files)
+            if (f->parent_paths_filter)
+                parent_paths_filter_bytes += f->parent_paths_filter->getFilterSizeBytes();
     }
 
     new_values["KeeperLSMTSortedRuns"] = { sorted_runs.size(), "Number of sorted runs." };
     new_values["KeeperLSMTFilesCount"] = { total_files, "Number of files in all sorted runs." };
     new_values["KeeperLSMTFilesCompressedSize"] = { files_compressed_bytes, "Total size of files in all sorted runs." };
     new_values["KeeperLSMTFilesUncompressedSize"] = { files_uncompressed_bytes, "Total size of uncompressed blocks in all sorted runs." };
+    new_values["KeeperLSMTParentPathsFilterSize"] = { parent_paths_filter_bytes, "Total size of bloom filters of nodes with children, across all files." };
 
     new_values["KeeperLSMTTotalEntries"] = { total_entries, "Number of entries (nodes and tombstones) in all committed memtables and files." };
 }
@@ -397,6 +453,8 @@ NodeRef StorageState::appendUncommittedNode(FullNode & node, int64_t zxid)
         u.memtable = std::make_shared<Memtable>();
         u.memtable->target_block_size = settings[DB::CoordinationSetting::memtable_block_size];
         uncommitted.push_back(std::move(u));
+
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedMemtablesCreated);
     }
 
     UncommittedMemtable & u = uncommitted.back();
@@ -405,6 +463,24 @@ NodeRef StorageState::appendUncommittedNode(FullNode & node, int64_t zxid)
     /// strict=false: see the comment at Memtable::appendNode.
     NodeRef ref = u.memtable->appendNode(node, /*strict=*/ false);
     uncommitted_bytes.fetch_add(u.memtable->total_bytes - bytes_before, std::memory_order_relaxed);
+
+    /// (The entry we just appended is the last thing in its block.)
+    const size_t entry_bytes = ref.block->size - ref.offset;
+    switch (node.action)
+    {
+        case NodeAction::Create:
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedCreates);
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedCreateBytes, entry_bytes);
+            break;
+        case NodeAction::Update:
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedUpdates);
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedUpdateBytes, entry_bytes);
+            break;
+        case NodeAction::Remove:
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedRemoves);
+            ProfileEvents::increment(ProfileEvents::KeeperLSMTUncommittedRemoveBytes, entry_bytes);
+            break;
+    }
     /// Loose model: the last record for a path wins, including Remove tombstones.
     u.nodes[node.getOrCalculatePathHash()] = ref;
     return ref;
@@ -437,7 +513,10 @@ void StorageState::throttleWrite() const
 {
     int64_t delay_us = write_throttling_us.load(std::memory_order_relaxed);
     if (delay_us != 0)
+    {
+        ProfileEvents::increment(ProfileEvents::KeeperLSMTThrottledWrites);
         std::this_thread::sleep_for(std::chrono::microseconds(delay_us));
+    }
 }
 
 std::string StorageState::makeSortedFilePath(uint32_t min_file_seqno, uint32_t max_file_seqno, size_t file_idx_in_run) const

--- a/src/Coordination/Storage/StorageState.h
+++ b/src/Coordination/Storage/StorageState.h
@@ -13,6 +13,9 @@ namespace DB
 {
 class IDisk;
 using DiskPtr = std::shared_ptr<IDisk>;
+
+struct AsynchronousMetricValue;
+using AsynchronousMetricValues = std::unordered_map<std::string, AsynchronousMetricValue>;
 }
 
 namespace Coordination::Storage
@@ -83,6 +86,11 @@ struct StorageState
     /// its max_zxid gets committed. This vector usually has two elements.
     std::vector<UncommittedMemtable> uncommitted;
 
+    /// Sum of Memtable::total_bytes across `uncommitted`. Duplicates information that's already
+    /// in `uncommitted`, as an atomic, so that fillAsynchronousMetrics can read it without
+    /// holding the mutex that protects uncommitted state.
+    std::atomic<size_t> uncommitted_bytes{};
+
     std::unique_ptr<BackgroundWork> background;
 
     /// How long to sleep before each write, in microseconds.
@@ -119,9 +127,11 @@ struct StorageState
     ///  NodeRefCache lookup, but it's unclear whether this is worth the trouble.)
     void listCommittedChildrenNames(const NodePathWithHash & path, ChildrenSet2 & out, DB::Arena & arena) const;
 
-    /// Very minimal stats.
-    /// TODO: Make AsynchronousMetrics call into StorageState to directly populate the metrics map with lots of stats like number and size of memtables and runs and files, compressed and uncompressed sizes, number of blocks, number of entries and nodes in memtables and files.
+    /// Very minimal stats. Caller must hold storage_mutex.
     void getNodeCountAndDataSize(uint64_t & out_node_count, uint64_t & out_data_size) const;
+
+    /// Various metrics. Caller must hold storage_mutex.
+    void fillAsynchronousMetrics(DB::AsynchronousMetricValues & new_values) const;
 
     /// ========== Operations on uncommitted state. ==========
 

--- a/src/Coordination/Storage/tests/gtest_keeper_storage.cpp
+++ b/src/Coordination/Storage/tests/gtest_keeper_storage.cpp
@@ -325,6 +325,22 @@ TEST(KeeperStorage, BackgroundFlushAndMerge)
         total_node_count_delta += storage.mutable_memtable->node_count_delta;
     EXPECT_EQ(total_node_count_delta, int64_t(2 + (num_k - num_removed) + num_c));
 
+    /// The run's total_entries must stay equal to the sum of per-file num_entries through merges
+    /// and trims.
+    size_t run_entries = 0;
+    for (const SortedFilePtr & file : storage.sorted_runs[0]->files)
+        run_entries += file->num_entries;
+    EXPECT_EQ(storage.sorted_runs[0]->total_entries, run_entries);
+
+    /// Each surviving node contributes one entry to the run or the remaining memtable; a removed
+    /// node contributes zero, one, or two entries (Create and Remove tombstone), depending on
+    /// which of them got combined away.
+    size_t total_entries = run_entries;
+    if (storage.mutable_memtable)
+        total_entries += storage.mutable_memtable->num_entries;
+    EXPECT_GE(total_entries, size_t(2 + (num_k - num_removed) + num_c));
+    EXPECT_LE(total_entries, size_t(2 + num_k + num_removed + num_c));
+
     std::string buf;
     for (int i = 0; i < num_removed; ++i)
         EXPECT_FALSE(bool(storage.getCommittedNode(NodePath(numbered("/a/k", i)).withCalculatedHash())))

--- a/src/Coordination/tests/gtest_coordination_common.cpp
+++ b/src/Coordination/tests/gtest_coordination_common.cpp
@@ -5,12 +5,16 @@
 #include <Coordination/WriteBufferFromNuraftBuffer.h>
 #include <Coordination/KeeperStateMachine.h>
 
-DB::KeeperContextPtr makeKeeperContext(bool /*use_lsmt_storage*/, std::shared_ptr<DB::CoordinationSettings> settings)
+namespace DB::CoordinationSetting
+{
+    extern const CoordinationSettingsBool use_new_storage;
+}
+
+DB::KeeperContextPtr makeKeeperContext(bool use_lsmt_storage, std::shared_ptr<DB::CoordinationSettings> settings)
 {
     if (!settings)
         settings = std::make_shared<DB::CoordinationSettings>();
-    /// TODO: translate use_lsmt_storage into a CoordinationSettings option here so
-    ///       KeeperStorage::create picks the right implementation.
+    (*settings)[DB::CoordinationSetting::use_new_storage] = use_lsmt_storage;
     /// Intentionally minimal: callers add setLocalLogsPreprocessed/disks/digest as they need them.
     return std::make_shared<DB::KeeperContext>(true, settings);
 }
@@ -18,10 +22,8 @@ DB::KeeperContextPtr makeKeeperContext(bool /*use_lsmt_storage*/, std::shared_pt
 INSTANTIATE_TEST_SUITE_P(
     Storage,
     CoordinationTest,
-    ::testing::Values(
-        /*use_lsmt_storage*/ false
-        /// TODO: Add `true` when LSMT storage is integrated.
-    ),
+    /// use_lsmt_storage
+    ::testing::Values(false, true),
     [](const ::testing::TestParamInfo<bool> & param_info) { return param_info.param ? "LSMT" : "Mem"; });
 
 INSTANTIATE_TEST_SUITE_P(
@@ -29,8 +31,8 @@ INSTANTIATE_TEST_SUITE_P(
     CoordinationTestWithCompression,
     ::testing::Values(
         StorageTypeAndCompression{.use_lsmt_storage = false, .enable_compression = false},
-        StorageTypeAndCompression{.use_lsmt_storage = false, .enable_compression = true}
-        /// TODO: StorageTypeAndCompression{.use_lsmt_storage = true, .enable_compression = true}
+        StorageTypeAndCompression{.use_lsmt_storage = false, .enable_compression = true},
+        StorageTypeAndCompression{.use_lsmt_storage = true, .enable_compression = true}
     ),
     [](const ::testing::TestParamInfo<StorageTypeAndCompression> & param_info) { return std::string(param_info.param.use_lsmt_storage ? "LSMT" : "Mem") + (param_info.param.enable_compression ? "Compressed" : "Uncompressed"); });
 


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
 * Keeper can store data on disk in LSM tree now. Use `use_new_storage` and `storage_memory_only` coordination settings to enable.

---

This PR is stacked on top of https://github.com/ClickHouse/ClickHouse/pull/108583 and https://github.com/ClickHouse/ClickHouse/pull/107261