### PR TITLE
Document and test pointInPolygon support for Ring, Polygon, MultiPolygon, and Geometry

### DIFF
--- a/docs/en/sql-reference/functions/geo/coordinates.md
+++ b/docs/en/sql-reference/functions/geo/coordinates.md
@@ -274,10 +274,13 @@ pointInPolygon((x, y), [(a, b), (c, d) ...], ...)
 
 **Input values**
 
-- `(x, y)` — Coordinates of a point on the plane. Data type — [Tuple](../../data-types/tuple.md) — A tuple of two numbers.
-- `[(a, b), (c, d) ...]` — Polygon vertices. Data type — [Array](../../data-types/array.md). Each vertex is represented by a pair of coordinates `(a, b)`. Vertices should be specified in a clockwise or counterclockwise order. The minimum number of vertices is 3. The polygon must be constant.
+- `(x, y)` — Coordinates of a point on the plane. Data type — [Tuple](../../data-types/tuple.md) — A tuple of two numbers, or a [Point](../../data-types/geo.md/#point).
+- `[(a, b), (c, d) ...]` — Polygon vertices. Data type — [Array](../../data-types/array.md) or [Ring](../../data-types/geo.md/#ring). Each vertex is represented by a pair of coordinates `(a, b)`. Vertices should be specified in a clockwise or counterclockwise order. The minimum number of vertices is 3.
 - The function supports polygon with holes (cut-out sections). Data type — [Polygon](../../data-types/geo.md/#polygon). Either pass the entire `Polygon` as the second argument, or pass the outer ring first and then each hole as separate additional arguments.
 - The function also supports multipolygon. Data type — [MultiPolygon](../../data-types/geo.md/#multipolygon). Either pass the entire `MultiPolygon` as the second argument, or list each component polygon as its own argument.
+- The polygon argument can also be a [Geometry](../../data-types/geo.md/#geometry) column holding polygon-shaped values (`Ring`, `Polygon`, or `MultiPolygon`).
+
+The polygon-shaped types ([Ring](../../data-types/geo.md/#ring), [Polygon](../../data-types/geo.md/#polygon), [MultiPolygon](../../data-types/geo.md/#multipolygon) and [Geometry](../../data-types/geo.md/#geometry)) may be passed either as constants or as regular (non-constant) table columns. When the polygon is provided across several separate arguments (an outer ring followed by holes, or several polygons of a multipolygon), all of those arguments must be constant.
 
 **Returned values**
 
@@ -294,6 +297,20 @@ SELECT pointInPolygon((3., 3.), [(6, 0), (8, 4), (5, 8), (0, 2)]) AS res
 ┌─res─┐
 │   1 │
 └─────┘
+```
+
+The polygon can also be given using the named geometric data types, including as a table column:
+
+```sql
+CREATE TABLE poly (id UInt32, shape Polygon) ENGINE = Memory;
+INSERT INTO poly VALUES (1, [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]);
+SELECT id, pointInPolygon((2., 2.), shape) AS res FROM poly;
+```
+
+```text
+┌─id─┬─res─┐
+│  1 │   1 │
+└────┴─────┘
 ```
 
 > **Note**  

--- a/src/Functions/pointInPolygon.cpp
+++ b/src/Functions/pointInPolygon.cpp
@@ -934,13 +934,14 @@ Checks whether the point belongs to the polygon on the plane.
 :::note
 - You can set `validate_polygons = 0` to bypass geometry validation.
 - `pointInPolygon` assumes every polygon is well-formed. If the input is self-intersecting, has mis-ordered rings, or overlapping edges, results become unreliable—especially for points that sit exactly on an edge, a vertex, or inside a self-intersection where the notion of "inside" vs. "outside" is undefined.
+- The polygon-shaped types (`Ring`, `Polygon`, `MultiPolygon`, and `Geometry`) may be passed either as constants or as regular (non-constant) table columns. When the polygon is provided across several separate arguments (an outer ring followed by holes, or several polygons of a multipolygon), all of those arguments must be constant.
 :::
     )";
     FunctionDocumentation::Syntax syntax = "pointInPolygon((x, y), [(a, b), (c, d) ...], ...)";
     FunctionDocumentation::Arguments arguments = {
-        {"(x, y)", "Coordinates of a point on the plane.", {"Tuple(Float64, Float64)"}},
-        {"[(a, b), (c, d) ...]", "Polygon vertices as an array of coordinate pairs. Vertices should be in clockwise or counterclockwise order. Minimum 3 vertices required.", {"Array(Tuple(Float64, Float64))"}},
-        {"...", "Optional. Additional arguments for polygons with holes (as separate arrays) or multipolygons (as separate polygons).", {"Array(Tuple(Float64, Float64))", "Polygon", "MultiPolygon"}}
+        {"(x, y)", "Coordinates of a point on the plane.", {"Tuple(Float64, Float64)", "Point"}},
+        {"[(a, b), (c, d) ...]", "The polygon, either as an array of coordinate pairs or as a named polygon-shaped value. Vertices should be in clockwise or counterclockwise order. Minimum 3 vertices required.", {"Array(Tuple(Float64, Float64))", "Ring", "Polygon", "MultiPolygon", "Geometry"}},
+        {"...", "Optional. Additional arguments for polygons with holes (as separate arrays) or multipolygons (as separate polygons). These additional arguments must be constant.", {"Array(Tuple(Float64, Float64))", "Polygon", "MultiPolygon"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {
         "Returns `1` if the point is inside the polygon, `0` if it is not. If the point is on the polygon boundary, the function may return either `0` or `1`.",
@@ -954,6 +955,17 @@ Checks whether the point belongs to the polygon on the plane.
 ┌─res─┐
 │   1 │
 └─────┘
+            )"
+        },
+        {
+            "Passing the polygon as a named geometric type from a table column",
+            "CREATE TABLE poly (id UInt32, shape Polygon) ENGINE = Memory;\n"
+            "INSERT INTO poly VALUES (1, [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]);\n"
+            "SELECT id, pointInPolygon((2., 2.), shape) AS res FROM poly;",
+            R"(
+┌─id─┬─res─┐
+│  1 │   1 │
+└────┴─────┘
             )"
         }
     };

--- a/src/Functions/pointInPolygon.cpp
+++ b/src/Functions/pointInPolygon.cpp
@@ -941,7 +941,7 @@ Checks whether the point belongs to the polygon on the plane.
     FunctionDocumentation::Arguments arguments = {
         {"(x, y)", "Coordinates of a point on the plane.", {"Tuple(Float64, Float64)", "Point"}},
         {"[(a, b), (c, d) ...]", "The polygon, either as an array of coordinate pairs or as a named polygon-shaped value. Vertices should be in clockwise or counterclockwise order. Minimum 3 vertices required.", {"Array(Tuple(Float64, Float64))", "Ring", "Polygon", "MultiPolygon", "Geometry"}},
-        {"...", "Optional. Additional arguments for polygons with holes (as separate arrays) or multipolygons (as separate polygons). These additional arguments must be constant.", {"Array(Tuple(Float64, Float64))", "Polygon", "MultiPolygon"}}
+        {"...", "Optional. Additional arguments for polygons with holes (each hole as a separate ring) or multipolygons (each component polygon as a separate argument). A whole `MultiPolygon` can only be passed as the sole polygon argument, not as one of several arguments. These additional arguments must be constant.", {"Array(Tuple(Float64, Float64))", "Ring", "Polygon"}}
     };
     FunctionDocumentation::ReturnedValue returned_value = {
         "Returns `1` if the point is inside the polygon, `0` if it is not. If the point is on the polygon boundary, the function may return either `0` or `1`.",

--- a/tests/queries/0_stateless/04511_point_in_polygon_geo_types.reference
+++ b/tests/queries/0_stateless/04511_point_in_polygon_geo_types.reference
@@ -1,0 +1,31 @@
+-- Ring (constant) --
+1
+0
+1
+-- Polygon (constant, with a hole) --
+0
+1
+0
+-- MultiPolygon (constant) --
+1
+1
+0
+-- Ring column --
+1	1
+2	0
+-- Polygon column --
+1	1
+2	0
+-- MultiPolygon column --
+1	1
+2	1
+3	0
+-- Geometry column (mixed Ring, Polygon and MultiPolygon values) --
+1	1
+2	1
+3	1
+1	0
+2	1
+3	0
+-- Geometry from readWKT (constant) --
+1

--- a/tests/queries/0_stateless/04511_point_in_polygon_geo_types.sql
+++ b/tests/queries/0_stateless/04511_point_in_polygon_geo_types.sql
@@ -1,0 +1,56 @@
+-- Tests that pointInPolygon accepts the named geometric data types Ring, Polygon,
+-- MultiPolygon and Geometry, in addition to the raw Array(Tuple(...)) forms, and that
+-- the result matches the equivalent raw representation.
+-- https://github.com/ClickHouse/ClickHouse/issues/109848
+
+SELECT '-- Ring (constant) --';
+SELECT pointInPolygon((3., 3.), [(6, 0), (8, 4), (5, 8), (0, 2)]::Ring);
+SELECT pointInPolygon((100., 100.), [(6, 0), (8, 4), (5, 8), (0, 2)]::Ring);
+-- A named Ring gives the same answer as the raw array of tuples.
+SELECT pointInPolygon((3., 3.), [(6, 0), (8, 4), (5, 8), (0, 2)]::Ring)
+     = pointInPolygon((3., 3.), [(6, 0), (8, 4), (5, 8), (0, 2)]);
+
+SELECT '-- Polygon (constant, with a hole) --';
+-- Outer square (0,0)-(10,10) with a square hole (4,4)-(6,6).
+SELECT pointInPolygon((5., 5.), [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]::Polygon); -- in the hole -> 0
+SELECT pointInPolygon((2., 2.), [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]::Polygon); -- inside, outside the hole -> 1
+SELECT pointInPolygon((20., 20.), [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]::Polygon); -- outside -> 0
+
+SELECT '-- MultiPolygon (constant) --';
+SELECT pointInPolygon((2., 2.), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]::MultiPolygon); -- in the first -> 1
+SELECT pointInPolygon((25., 25.), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]::MultiPolygon); -- in the second -> 1
+SELECT pointInPolygon((15., 15.), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]::MultiPolygon); -- in neither -> 0
+
+SELECT '-- Ring column --';
+DROP TABLE IF EXISTS pip_ring;
+CREATE TABLE pip_ring (id Int32, pt Point, r Ring) ENGINE = Memory;
+INSERT INTO pip_ring VALUES (1, (3, 3), [(6, 0), (8, 4), (5, 8), (0, 2)]), (2, (100, 100), [(6, 0), (8, 4), (5, 8), (0, 2)]);
+SELECT id, pointInPolygon(pt, r) FROM pip_ring ORDER BY id;
+DROP TABLE pip_ring;
+
+SELECT '-- Polygon column --';
+DROP TABLE IF EXISTS pip_poly;
+CREATE TABLE pip_poly (id Int32, pt Point, pg Polygon) ENGINE = Memory;
+INSERT INTO pip_poly VALUES (1, (2, 2), [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]), (2, (5, 5), [[(0, 0), (10, 0), (10, 10), (0, 10)], [(4, 4), (6, 4), (6, 6), (4, 6)]]);
+SELECT id, pointInPolygon(pt, pg) FROM pip_poly ORDER BY id;
+DROP TABLE pip_poly;
+
+SELECT '-- MultiPolygon column --';
+DROP TABLE IF EXISTS pip_mp;
+CREATE TABLE pip_mp (id Int32, pt Point, mpg MultiPolygon) ENGINE = Memory;
+INSERT INTO pip_mp VALUES (1, (2, 2), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]), (2, (25, 25), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]), (3, (15, 15), [[[(0, 0), (10, 0), (10, 10), (0, 10)]], [[(20, 20), (30, 20), (30, 30), (20, 30)]]]);
+SELECT id, pointInPolygon(pt, mpg) FROM pip_mp ORDER BY id;
+DROP TABLE pip_mp;
+
+SELECT '-- Geometry column (mixed Ring, Polygon and MultiPolygon values) --';
+DROP TABLE IF EXISTS pip_geo;
+CREATE TABLE pip_geo (id Int32, geom Geometry) ENGINE = Memory;
+INSERT INTO pip_geo VALUES (1, readWKT('POLYGON((0 0, 10 0, 10 10, 0 10))'));
+INSERT INTO pip_geo VALUES (2, readWKT('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10)), ((20 20, 30 20, 30 30, 20 30)))'));
+INSERT INTO pip_geo VALUES (3, CAST([(0, 0), (10, 0), (10, 10), (0, 10)] AS Ring)::Geometry);
+SELECT id, pointInPolygon((5., 5.), geom) FROM pip_geo ORDER BY id;
+SELECT id, pointInPolygon((25., 25.), geom) FROM pip_geo ORDER BY id;
+DROP TABLE pip_geo;
+
+SELECT '-- Geometry from readWKT (constant) --';
+SELECT pointInPolygon((3., 3.), readWKT('POLYGON((6 0, 8 4, 5 8, 0 2))'));


### PR DESCRIPTION
`pointInPolygon` already accepts the named geometric data types `Ring`, `Polygon`, `MultiPolygon`, and `Geometry`, both as constants and as regular (non-constant) table columns:

- `Ring`, `Polygon`, and `MultiPolygon` are custom-named wrappers over the `Array(Tuple(Float64, Float64))` shapes (depth 1, 2, and 3 respectively) that the function has always supported.
- `Geometry` is a `Variant` of the geometric types, so it is dispatched per row by the default `Variant` implementation; rows holding polygon-shaped values (`Ring`/`Polygon`/`MultiPolygon`) are matched, and non-polygon rows follow the standard `variant_throw_on_type_mismatch` behaviour.

There was no test coverage for the named types, and the documentation mentioned only `Polygon`/`MultiPolygon` (not `Ring` or `Geometry`) and incorrectly stated that the polygon argument "must be constant" — which is only required for the multi-argument form. This pull request adds a stateless test exercising all four types (constant and column forms) and updates the function reference accordingly. No behavior change.

Closes: https://github.com/ClickHouse/ClickHouse/issues/109848

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...