### PR TITLE
Do not stash scale-divergent columns in the function property stress test

### DIFF
--- a/src/Columns/tests/gtest_validate_column_type.cpp
+++ b/src/Columns/tests/gtest_validate_column_type.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/validateColumnType.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypesDecimal.h>
+
+using namespace DB;
+
+/// columnMatchesType is the property fuzzer's validity gate (gtest_functions_stress.cpp).
+/// getDataType() reports only the physical TypeIndex (Decimal64 for any DateTime64 scale), so
+/// without strict_decimal_scale a scale-7 column passes against a DateTime64(3) type, gets
+/// stashed, and is later reused as an argument, surfacing the writeSlice LOGICAL_ERROR in an
+/// innocent consumer (issue #108517). strict_decimal_scale rejects it at the producer's gate.
+
+namespace
+{
+
+ColumnPtr makeDateTime64Column(UInt32 scale, size_t rows)
+{
+    auto col = ColumnDecimal<DateTime64>::create(0, scale);
+    for (size_t i = 0; i < rows; ++i)
+        col->insertDefault();
+    return col;
+}
+
+ColumnPtr makeDateTime64Array(UInt32 element_scale, size_t elements)
+{
+    auto data = ColumnDecimal<DateTime64>::create(0, element_scale);
+    for (size_t i = 0; i < elements; ++i)
+        data->insertDefault();
+
+    auto offsets = ColumnArray::ColumnOffsets::create();
+    offsets->insert(elements);
+    return ColumnArray::create(std::move(data), std::move(offsets));
+}
+
+}
+
+TEST(ValidateColumnType, DecimalScaleDivergence)
+{
+    auto type_dt64_3 = std::make_shared<DataTypeDateTime64>(3);
+
+    auto matching = makeDateTime64Column(3, 4);
+    auto divergent = makeDateTime64Column(7, 4);
+
+    /// Scale is ignored by default, so the divergent column passes (engine callers rely on this).
+    EXPECT_TRUE(columnMatchesType(*matching, *type_dt64_3));
+    EXPECT_TRUE(columnMatchesType(*divergent, *type_dt64_3));
+
+    /// Strict mode compares scale: the matching column still passes, the divergent one is rejected.
+    EXPECT_TRUE(columnMatchesType(*matching, *type_dt64_3, /*strict_decimal_scale=*/ true));
+    EXPECT_FALSE(columnMatchesType(*divergent, *type_dt64_3, /*strict_decimal_scale=*/ true));
+}
+
+TEST(ValidateColumnType, DecimalScaleDivergenceNested)
+{
+    /// The divergence reaches the gate nested inside Array(DateTime64(3)) (the exact #108517 shape).
+    auto array_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeDateTime64>(3));
+
+    auto matching_array = makeDateTime64Array(3, 2);
+    auto divergent_array = makeDateTime64Array(7, 2);
+
+    EXPECT_TRUE(columnMatchesType(*matching_array, *array_type));
+    EXPECT_TRUE(columnMatchesType(*divergent_array, *array_type));
+
+    EXPECT_TRUE(columnMatchesType(*matching_array, *array_type, /*strict_decimal_scale=*/ true));
+    EXPECT_FALSE(columnMatchesType(*divergent_array, *array_type, /*strict_decimal_scale=*/ true));
+}

--- a/src/Columns/validateColumnType.cpp
+++ b/src/Columns/validateColumnType.cpp
@@ -1,6 +1,7 @@
 #include <Columns/validateColumnType.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnDecimal.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
@@ -13,11 +14,50 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeVariant.h>
+#include <DataTypes/DataTypesDecimal.h>
+
+#include <optional>
 
 namespace DB
 {
 
-bool columnMatchesType(const IColumn & column, const IDataType & type)
+namespace
+{
+
+/// A Decimal/DateTime64/Time64 column carries its scale in the column object, but
+/// getDataType() reports only the physical TypeIndex (Decimal32/64/128/256), which is the
+/// same for every scale. So the top-level TypeIndex check passes a scale-7 column against a
+/// DateTime64(3) type. Compare the column's own scale against the type's declared scale.
+bool decimalScaleMatches(const IColumn & col, const IDataType & type)
+{
+    auto type_scale = tryGetDecimalScale(type);
+    if (!type_scale)
+        return true; /// Not a decimal-backed type.
+
+    std::optional<UInt32> col_scale;
+    if (const auto * c32 = typeid_cast<const ColumnDecimal<Decimal32> *>(&col))
+        col_scale = c32->getScale();
+    else if (const auto * c64 = typeid_cast<const ColumnDecimal<Decimal64> *>(&col))
+        col_scale = c64->getScale();
+    else if (const auto * c128 = typeid_cast<const ColumnDecimal<Decimal128> *>(&col))
+        col_scale = c128->getScale();
+    else if (const auto * c256 = typeid_cast<const ColumnDecimal<Decimal256> *>(&col))
+        col_scale = c256->getScale();
+    else if (const auto * cdt = typeid_cast<const ColumnDecimal<DateTime64> *>(&col))
+        col_scale = cdt->getScale();
+    else if (const auto * ctime = typeid_cast<const ColumnDecimal<Time64> *>(&col))
+        col_scale = ctime->getScale();
+
+    /// TypeIndex already matched, so a non-ColumnDecimal here should not happen; do not over-reject.
+    if (!col_scale)
+        return true;
+
+    return *col_scale == *type_scale;
+}
+
+}
+
+bool columnMatchesType(const IColumn & column, const IDataType & type, bool strict_decimal_scale)
 {
     const IColumn * col = &column;
 
@@ -30,17 +70,20 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
     if (col->getDataType() != type.getColumnType())
         return false;
 
+    if (strict_decimal_scale && !decimalScaleMatches(*col, type))
+        return false;
+
     if (const auto * col_array = typeid_cast<const ColumnArray *>(col))
     {
         if (const auto * type_array = typeid_cast<const DataTypeArray *>(&type))
-            return columnMatchesType(col_array->getData(), *type_array->getNestedType());
+            return columnMatchesType(col_array->getData(), *type_array->getNestedType(), strict_decimal_scale);
         return false;
     }
 
     if (const auto * col_nullable = typeid_cast<const ColumnNullable *>(col))
     {
         if (const auto * type_nullable = typeid_cast<const DataTypeNullable *>(&type))
-            return columnMatchesType(col_nullable->getNestedColumn(), *type_nullable->getNestedType());
+            return columnMatchesType(col_nullable->getNestedColumn(), *type_nullable->getNestedType(), strict_decimal_scale);
         return false;
     }
 
@@ -52,7 +95,7 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
             if (col_tuple->tupleSize() != type_elements.size())
                 return false;
             for (size_t i = 0; i < col_tuple->tupleSize(); ++i)
-                if (!columnMatchesType(col_tuple->getColumn(i), *type_elements[i]))
+                if (!columnMatchesType(col_tuple->getColumn(i), *type_elements[i], strict_decimal_scale))
                     return false;
             return true;
         }
@@ -62,14 +105,14 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
     if (const auto * col_map = typeid_cast<const ColumnMap *>(col))
     {
         if (const auto * type_map = typeid_cast<const DataTypeMap *>(&type))
-            return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType());
+            return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType(), strict_decimal_scale);
         return false;
     }
 
     if (const auto * col_lc = typeid_cast<const ColumnLowCardinality *>(col))
     {
         if (const auto * type_lc = typeid_cast<const DataTypeLowCardinality *>(&type))
-            return columnMatchesType(*col_lc->getDictionary().getNestedColumn(), *type_lc->getDictionaryType());
+            return columnMatchesType(*col_lc->getDictionary().getNestedColumn(), *type_lc->getDictionaryType(), strict_decimal_scale);
         return false;
     }
 
@@ -81,7 +124,7 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
             if (col_variant->getVariants().size() != type_variants.size())
                 return false;
             for (size_t i = 0; i < type_variants.size(); ++i)
-                if (!columnMatchesType(col_variant->getVariantByGlobalDiscriminator(i), *type_variants[i]))
+                if (!columnMatchesType(col_variant->getVariantByGlobalDiscriminator(i), *type_variants[i], strict_decimal_scale))
                     return false;
             return true;
         }

--- a/src/Columns/validateColumnType.h
+++ b/src/Columns/validateColumnType.h
@@ -10,6 +10,12 @@ namespace DB
 /// Returns true if the column is compatible with the type, false otherwise.
 /// This goes deeper than comparing top-level TypeIndex values: it recurses
 /// into Array, Nullable, Tuple, and Map to verify nested element types.
-bool columnMatchesType(const IColumn & column, const IDataType & type);
+///
+/// With strict_decimal_scale, a Decimal/DateTime64/Time64 column must also have the
+/// same scale as the type (getDataType() alone is scale-blind: every scale maps to the
+/// same physical TypeIndex). Off by default because a scale-divergent column behaves
+/// correctly almost everywhere; the property fuzzer enables it to detect such a column at
+/// the producing function's gate before stashing and reusing it as another function's input.
+bool columnMatchesType(const IColumn & column, const IDataType & type, bool strict_decimal_scale = false);
 
 }

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -122,6 +122,7 @@ enum Problem
     P_FIELD_COMPARISON_INCONSISTENCY,
     P_VALIDATION_INFRASTRUCTURE,
     P_TIMEOUT_NOT_HONORED,
+    P_SCALE_DIVERGENT_RESULT,
     P_UNEXPECTED_ERROR,
 
     P_COUNT,
@@ -159,6 +160,13 @@ std::pair<String, String> problemInfo(Problem p)
             "iteration ran longer than the configured iteration-too-slow threshold before stopping; "
             "the function is slow and either does not check CurrentThread::isQueryCanceled often enough, "
             "should be made faster, or should reject the offending input shape inside the function itself"};
+        case P_SCALE_DIVERGENT_RESULT: return {"scale_divergent_result",
+            "function returned a Decimal/DateTime64/Time64 column whose scale differs from its declared "
+            "result type. getDataType() is scale-blind so this passes the top-level type check, but the "
+            "column object is structurally inconsistent with its type. Such a column is not stashed for "
+            "reuse (it would surface as a misattributed writeSlice LOGICAL_ERROR in an innocent consumer "
+            "like arrayPushBack, see issue #108517); the producing function should build the result column "
+            "at the declared scale"};
 
         case P_COUNT: std::abort();
     }
@@ -209,7 +217,8 @@ struct Options
     VectorOfStrings ignore_problems = {{"late_typecheck", "const_dependent_checks", "broken_nullable_input", "data_dependent_const",
         "exception_in_prepare", "bulk_success_but_row_error", "bulk_error_but_row_success",
         "broken_determinism", "broken_injectivity", "broken_monotonicity",
-        "field_comparison_inconsistency", "validation_infrastructure", "timeout_not_honored"}};
+        "field_comparison_inconsistency", "validation_infrastructure", "timeout_not_honored",
+        "scale_divergent_result"}};
     VectorOfStrings functions;
     VectorOfStrings skip_functions;
 
@@ -2056,8 +2065,22 @@ struct FunctionsStressTestThread
         }
         FunctionStats & stats = function_stats[operation.function_idx];
 
+        /// A Decimal/DateTime64/Time64 result column whose scale diverges from its declared type is
+        /// structurally inconsistent (getDataType() is scale-blind, so it passes checkAndFixupColumn's
+        /// type check). Reusing it as another function's argument surfaces as a misattributed
+        /// LOGICAL_ERROR in an innocent consumer such as arrayPushBack -> writeSlice (issue #108517).
+        /// Attribute it to the producing function and never stash it for reuse. This is the complete
+        /// cut of the propagation path: generated random arguments are always scale-consistent (built
+        /// via type->createColumn()), so additional_random_values is the only place a divergent column
+        /// can enter as an argument.
+        const bool result_scale_divergent = !columnMatchesType(*result, *result_type, /*strict_decimal_scale=*/ true);
+        if (result_scale_divergent)
+            stats.reportProblem(P_SCALE_DIVERGENT_RESULT, fmt::format(
+                "function returned {} with a scale that diverges from its declared type; {}",
+                result->getName(), operation.describe()));
+
         /// Maybe add result to additional_random_values.
-        if (thread_local_rng() % 8 == 0 && result->byteSize() < (16ul << 10))
+        if (!result_scale_divergent && thread_local_rng() % 8 == 0 && result->byteSize() < (16ul << 10))
         {
             ColumnPtr column = result;
             if (column->size() != options.rows_per_batch)

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1194,6 +1194,11 @@ struct FunctionsStressTestThread
     ColumnsWithTypeAndName valid_args; // rows of `args` on which the function didn't throw
     ColumnPtr result;
 
+    /// Set by checkAndFixupColumn (stress-test path) if any executed column - the bulk result or
+    /// any per-row result before it is merged - had a Decimal/DateTime64/Time64 scale diverging
+    /// from its declared type. Read at the stash site to skip stashing such a producer's result.
+    bool result_scale_divergent = false;
+
     /// Protects `operation`.
     /// Locked by watchdog thread when reading other threads' `operation` values (without mutating them).
     /// Correspondingly, must be locked by this thread when mutating `operation`, but not necessarily
@@ -1445,6 +1450,7 @@ struct FunctionsStressTestThread
             resolver.reset();
             valid_args.clear();
             result.reset();
+            result_scale_divergent = false;
 
             {
                 auto lock = lockMutex();
@@ -1678,6 +1684,22 @@ struct FunctionsStressTestThread
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned unexpected number of rows: {} instead of {}", column->size(), expected_rows);
         if (!columnMatchesType(*column, *data_type))
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned column of unexpected type: {} instead of {}", column->getName(), data_type->getName());
+
+        /// On the stress-test path (stats != nullptr), also detect a Decimal/DateTime64/Time64
+        /// scale that diverges from the declared type. getDataType() is scale-blind, so such a
+        /// column passes the check above; reusing it as another function's argument surfaces as a
+        /// misattributed LOGICAL_ERROR in an innocent consumer (arrayPushBack -> writeSlice, #108517).
+        /// This runs on both the bulk result and every per-row result before it is merged, so a
+        /// per-row divergence (row0 scale 3, row1 scale 7) is caught before insertRangeFrom (a raw
+        /// memcpy that does not rescale) hides it inside a merged column that matches the declared
+        /// scale. Attribute to the producing function and remember so the stash site skips it.
+        if (stats && !columnMatchesType(*column, *data_type, /*strict_decimal_scale=*/ true))
+        {
+            result_scale_divergent = true;
+            stats->reportProblem(P_SCALE_DIVERGENT_RESULT, fmt::format(
+                "function returned {} with a scale that diverges from its declared type; {}",
+                column->getName(), operation.describe()));
+        }
 
         auto apply = [&](IColumn & col)
         {
@@ -2065,20 +2087,17 @@ struct FunctionsStressTestThread
         }
         FunctionStats & stats = function_stats[operation.function_idx];
 
-        /// A Decimal/DateTime64/Time64 result column whose scale diverges from its declared type is
+        /// A Decimal/DateTime64/Time64 column whose scale diverges from its declared type is
         /// structurally inconsistent (getDataType() is scale-blind, so it passes checkAndFixupColumn's
         /// type check). Reusing it as another function's argument surfaces as a misattributed
         /// LOGICAL_ERROR in an innocent consumer such as arrayPushBack -> writeSlice (issue #108517).
-        /// Attribute it to the producing function and never stash it for reuse. This is the complete
-        /// cut of the propagation path: generated random arguments are always scale-consistent (built
-        /// via type->createColumn()), so additional_random_values is the only place a divergent column
-        /// can enter as an argument.
-        const bool result_scale_divergent = !columnMatchesType(*result, *result_type, /*strict_decimal_scale=*/ true);
-        if (result_scale_divergent)
-            stats.reportProblem(P_SCALE_DIVERGENT_RESULT, fmt::format(
-                "function returned {} with a scale that diverges from its declared type; {}",
-                result->getName(), operation.describe()));
-
+        /// result_scale_divergent was set by checkAndFixupColumn on the bulk result and on every
+        /// per-row result before merging, so a per-row divergence is caught even though the merged
+        /// column may end up matching the declared scale. Never stash such a producer's result. This
+        /// is the complete cut of the propagation path: generated random arguments are always
+        /// scale-consistent (built via type->createColumn()), so additional_random_values is the only
+        /// place a divergent column can enter as an argument.
+        ///
         /// Maybe add result to additional_random_values.
         if (!result_scale_divergent && thread_local_rng() % 8 == 0 && result->byteSize() < (16ul << 10))
         {


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/108517
Related: https://github.com/ClickHouse/ClickHouse/pull/96130
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes the chronic `Function writeSlice expects same column types for GenericValueSlice and GenericArraySink` `LOGICAL_ERROR` that the function property stress test (`FunctionsStress.stress` in `gtest_functions_stress.cpp`) keeps surfacing (issue #108517; seen most recently on #96130's `Unit tests (msan, function_prop_fuzzer)` at report https://s3.amazonaws.com/clickhouse-test-reports/PRs/96130/840dde3c3a33b9412f7837fde92cd5c815aef79a/unit_tests_msan_function_prop_fuzzer/unit_tests_msan_function_prop_fuzzer.log , offending query `SELECT arrayPushBack(a, CAST('1900-01-01 00:00:00.0' AS DateTime64(1))) FROM system.one ARRAY JOIN CAST([...] AS Array(Array(LowCardinality(Nullable(Date)))))`).

The error is correct and unreachable from real SQL (the analyzer unifies operands to the least supertype before execution, verified: the exact query above returns results with no error). It is a stress-test artifact. The test validates every function result with `columnMatchesType` before stashing it in `additional_random_values` for reuse as another function's argument. That check compared only `getDataType()`, which for Decimal/DateTime64/Time64 reports the physical `TypeIndex` (`Decimal64` for every scale). A function whose result column carried a scale different from its declared type passed, got stashed, and was reused as an argument to an innocent consumer such as `arrayPushBack`, where the declared-type cast is skipped and the scale-divergent physical column flows straight into GatherUtils, tripping `writeSlice`.

This re-lands the scale-aware detection removed in #108981 (revert of #108551), but not as a hard throw inside the test:
- `columnMatchesType` gains an opt-in `strict_decimal_scale` argument (default off, so the engine callers in `resolveFunction`, `ColumnFunction`, `ExpressionActions`, `ActionsDAG` keep the scale-blind behaviour they rely on).
- The stress test uses it to detect a scale-divergent result, attributes it to the producing function via a new soft, default-ignored problem (`scale_divergent_result`), and never stashes it.

Skipping the stash is the complete cut of the propagation path: generated random arguments are always scale-consistent (built via `type->createColumn()`), so the stash was the only way a divergent column could become an argument. Because the strict check is only a soft, ignored report (not a throw), a newly appearing scale-divergent producer is recorded but cannot redden the whole run, which is exactly the failure mode that caused #108551 to be reverted. The known producers found while #108551 was live (`changeDate`/`timeSlots` in #108994, `reinterpret` in #108878) are already fixed on master; this change makes the harness robust to any remaining or future ones.

Regression coverage: `gtest_validate_column_type` asserts that a scale-7 column labelled `DateTime64(3)` is accepted by the default check and rejected by the strict check, both at top level and nested inside `Array(DateTime64(3))` (the exact #108517 shape).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.816` (included in `26.7` and later)
<!-- ch-version-info:end -->