### PR TITLE
Fix distinct_overflow_mode = 'break': return the partial result and stop reading

### DIFF
--- a/src/Processors/Transforms/DistinctSortedTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedTransform.cpp
@@ -138,7 +138,7 @@ void DistinctSortedTransform::transform(Chunk & chunk)
     const size_t rows = chunk.getNumRows();
     IColumn::Filter filter(rows);
 
-    bool has_new_data = false;
+    size_t new_output_rows = 0;
     switch (data.type)
     {
         case ClearableSetVariants::Type::EMPTY:
@@ -146,7 +146,7 @@ void DistinctSortedTransform::transform(Chunk & chunk)
             // clang-format off
 #define M(NAME) \
         case ClearableSetVariants::Type::NAME: \
-            has_new_data = buildFilter(*data.NAME, column_ptrs, sort_prefix_columns, filter, rows, data); \
+            new_output_rows = buildFilter(*data.NAME, column_ptrs, sort_prefix_columns, filter, rows, data); \
             break;
 
         APPLY_FOR_SET_VARIANTS(M)
@@ -155,22 +155,23 @@ void DistinctSortedTransform::transform(Chunk & chunk)
     }
 
     /// Just go to the next block if there isn't any new record in the current one.
-    if (!has_new_data)
+    if (!new_output_rows)
     {
         chunk.clear();
         return;
     }
 
-    size_t data_total_row_count = data.getTotalRowCount();
+    total_output_rows += new_output_rows;
+
     /// In case of overflow_mode = 'break' `check` returns false instead of throwing.
     /// Stop reading, but still emit the new rows from the current chunk (their keys are
     /// already in the set): 'break' means return a partial result as if the source data
     /// ran out, not discard it.
-    if (!set_size_limits.check(data_total_row_count, data.getTotalByteCount(), "DISTINCT", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED))
+    if (!set_size_limits.check(total_output_rows, data.getTotalByteCount(), "DISTINCT", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED))
         stopReading();
 
     /// Stop reading if we already reached the limit.
-    if (limit_hint && data_total_row_count >= limit_hint)
+    if (limit_hint && total_output_rows >= limit_hint)
         stopReading();
 
     prev_chunk.chunk = std::move(chunk);
@@ -185,7 +186,7 @@ void DistinctSortedTransform::transform(Chunk & chunk)
 }
 
 template <typename Method>
-bool DistinctSortedTransform::buildFilter(
+size_t DistinctSortedTransform::buildFilter(
     Method & method,
     const ColumnRawPtrs & columns,
     const ColumnRawPtrs & clearing_hint_columns,
@@ -203,7 +204,7 @@ bool DistinctSortedTransform::buildFilter(
             method.data.clear();
     }
 
-    bool has_new_data = false;
+    size_t new_rows = 0;
 
     for (size_t run_begin = 0; run_begin < rows;)
     {
@@ -218,7 +219,7 @@ bool DistinctSortedTransform::buildFilter(
         {
             const auto emplace_result = state.emplaceKey(method.data, i, variants.string_pool);
             if (emplace_result.isInserted())
-                has_new_data = true;
+                ++new_rows;
 
             /// Emit the record if there is no such key in the current set yet.
             /// Skip it otherwise.
@@ -227,7 +228,7 @@ bool DistinctSortedTransform::buildFilter(
 
         run_begin = run_end;
     }
-    return has_new_data;
+    return new_rows;
 }
 
 bool DistinctSortedTransform::rowsEqual(const ColumnRawPtrs & lhs, size_t n, const ColumnRawPtrs & rhs, size_t m)

--- a/src/Processors/Transforms/DistinctSortedTransform.cpp
+++ b/src/Processors/Transforms/DistinctSortedTransform.cpp
@@ -162,12 +162,12 @@ void DistinctSortedTransform::transform(Chunk & chunk)
     }
 
     size_t data_total_row_count = data.getTotalRowCount();
+    /// In case of overflow_mode = 'break' `check` returns false instead of throwing.
+    /// Stop reading, but still emit the new rows from the current chunk (their keys are
+    /// already in the set): 'break' means return a partial result as if the source data
+    /// ran out, not discard it.
     if (!set_size_limits.check(data_total_row_count, data.getTotalByteCount(), "DISTINCT", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED))
-    {
         stopReading();
-        chunk.clear();
-        return;
-    }
 
     /// Stop reading if we already reached the limit.
     if (limit_hint && data_total_row_count >= limit_hint)

--- a/src/Processors/Transforms/DistinctSortedTransform.h
+++ b/src/Processors/Transforms/DistinctSortedTransform.h
@@ -44,9 +44,9 @@ protected:
 private:
     static bool rowsEqual(const ColumnRawPtrs & lhs, size_t n, const ColumnRawPtrs & rhs, size_t m);
 
-    /// return true if has new data
+    /// returns the number of new (distinct) rows in the chunk
     template <typename Method>
-    bool buildFilter(
+    size_t buildFilter(
         Method & method,
         const ColumnRawPtrs & key_columns,
         const ColumnRawPtrs & clearing_hint_columns,
@@ -69,6 +69,9 @@ private:
     ClearableSetVariants data;
     Sizes key_sizes;
     UInt64 limit_hint;
+    /// Total number of rows emitted so far. The clearable set is reset on every new sort prefix,
+    /// so its size reflects only the current run and cannot be used to enforce the limits.
+    size_t total_output_rows = 0;
 
     /// Restrictions on the maximum size of the output data.
     SizeLimits set_size_limits;

--- a/src/Processors/Transforms/DistinctTransform.cpp
+++ b/src/Processors/Transforms/DistinctTransform.cpp
@@ -248,8 +248,12 @@ void DistinctTransform::transform(Chunk & chunk)
     if (num_selected == 0)
         return;
 
+    /// In case of overflow_mode = 'break' `check` returns false instead of throwing.
+    /// Stop reading, but still emit the new rows from the current chunk (their keys are
+    /// already in the set): 'break' means return a partial result as if the source data
+    /// ran out, not discard it.
     if (!set_size_limits.check(new_set_size, data.getTotalByteCount(), "DISTINCT", ErrorCodes::SET_SIZE_LIMIT_EXCEEDED))
-        return;
+        stopReading();
 
     if (num_selected == num_rows)
     {

--- a/src/Processors/tests/gtest_distinct_sorted_transform_limits.cpp
+++ b/src/Processors/tests/gtest_distinct_sorted_transform_limits.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <Core/Block.h>
+#include <Core/ColumnWithTypeAndName.h>
+#include <Core/Names.h>
+#include <Core/SortDescription.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Processors/Chunk.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/ISimpleTransform.h>
+#include <Processors/Port.h>
+#include <Processors/Sources/SourceFromChunks.h>
+#include <Processors/Transforms/DistinctSortedTransform.h>
+#include <QueryPipeline/QueryPipeline.h>
+#include <QueryPipeline/QueryPlanResourceHolder.h>
+#include <QueryPipeline/SizeLimits.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+extern const int SET_SIZE_LIMIT_EXCEEDED;
+}
+
+/// Regression tests for cumulative limit accounting in DistinctSortedTransform. The
+/// transform's clearable set is reset on every sort-prefix run, so the set size reflects
+/// only the current run: max_rows_in_distinct / max_bytes_in_distinct / limit_hint checked
+/// against it never trip on a stream of many runs that are each below the limit. They must
+/// be checked against the cumulative count of emitted distinct rows (`total_output_rows`).
+///
+/// This is not reachable from an SQL test: every plan shape places a preliminary DISTINCT
+/// (DistinctSortedStreamTransform, which already counts cumulatively) before the final
+/// DistinctSortedTransform, and the preliminary stage trips the limit first. Hence a
+/// processor-level test: feed the transform sort-prefix runs directly, each below the
+/// limit, and require the limit to trip on their sum.
+
+namespace
+{
+
+/// `transform(Chunk &)` is `protected` in the concrete transform but `public` in the
+/// abstract `ISimpleTransform` base, so the test drives it through the base reference,
+/// which virtual-dispatches to the override (exactly what the pipeline executor does).
+void runTransform(ISimpleTransform & transform, Chunk & chunk)
+{
+    transform.transform(chunk);
+}
+
+SharedHeader makeHeader()
+{
+    Block header{
+        ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), "a"),
+        ColumnWithTypeAndName(std::make_shared<DataTypeUInt64>(), "b"),
+    };
+    return std::make_shared<const Block>(std::move(header));
+}
+
+SortDescription makeSortDescription()
+{
+    SortDescription description;
+    description.push_back(SortColumnDescription("a"));
+    return description;
+}
+
+/// One chunk = one sort-prefix run: "a" (the sort prefix) is `run_key` in every row, "b" is
+/// 0..rows-1, so the run holds `rows` distinct rows. Ascending `run_key` across chunks keeps
+/// the stream sorted, and each new run clears the transform's set.
+Chunk makeRunChunk(UInt64 run_key, UInt64 rows)
+{
+    auto a_column = ColumnUInt64::create();
+    auto b_column = ColumnUInt64::create();
+    for (UInt64 i = 0; i < rows; ++i)
+    {
+        a_column->insertValue(run_key);
+        b_column->insertValue(i);
+    }
+    return Chunk(Columns{std::move(a_column), std::move(b_column)}, rows);
+}
+
+/// source (num_runs runs of run_rows distinct rows each) -> DistinctSortedTransform -> pull.
+/// Returns the total number of rows the transform emitted. Stopping early is the transform's
+/// `stopReading()`: the executor then closes its input and finishes the source, which is the
+/// only externally observable effect of the 'break' overflow mode and of limit_hint.
+size_t countDistinctOutputRows(UInt64 num_runs, UInt64 run_rows, const SizeLimits & set_size_limits, UInt64 limit_hint)
+{
+    auto header = makeHeader();
+
+    Chunks chunks;
+    for (UInt64 run = 0; run < num_runs; ++run)
+        chunks.emplace_back(makeRunChunk(run, run_rows));
+    auto source = std::make_shared<SourceFromChunks>(header, std::move(chunks));
+
+    auto transform
+        = std::make_shared<DistinctSortedTransform>(header, makeSortDescription(), set_size_limits, limit_hint, Names{"a", "b"});
+
+    connect(source->getPort(), transform->getInputPort());
+    auto * output_port = &transform->getOutputPort();
+
+    auto processors = std::make_shared<Processors>();
+    processors->emplace_back(std::move(source));
+    processors->emplace_back(std::move(transform));
+
+    QueryPipeline pipeline(QueryPlanResourceHolder{}, processors, output_port);
+    PullingPipelineExecutor executor(pipeline);
+
+    size_t total_rows = 0;
+    Block block;
+    while (executor.pull(block))
+        total_rows += block.rows();
+    return total_rows;
+}
+
+}
+
+TEST(DistinctSortedTransform, BreakLimitIsCumulativeAcrossSortPrefixRuns)
+{
+    /// 100 runs of 5 distinct rows: no run reaches max_rows = 25, only their sum does.
+    /// 'break' soft-checks at >=, so reading stops on the run that makes the total 25;
+    /// that run is still emitted. Against the per-run set size the limit never trips
+    /// and all 500 rows come out.
+    SizeLimits set_size_limits(/*max_rows_=*/ 25, /*max_bytes_=*/ 0, OverflowMode::BREAK);
+    EXPECT_EQ(countDistinctOutputRows(/*num_runs=*/ 100, /*run_rows=*/ 5, set_size_limits, /*limit_hint=*/ 0), 25u);
+}
+
+TEST(DistinctSortedTransform, LimitHintStopsReadingAcrossSortPrefixRuns)
+{
+    /// Same run layout, no size limits: DISTINCT ... LIMIT 25 passes limit_hint = 25 and
+    /// expects reading to stop once 25 distinct rows have been emitted overall.
+    SizeLimits no_limits;
+    EXPECT_EQ(countDistinctOutputRows(/*num_runs=*/ 100, /*run_rows=*/ 5, no_limits, /*limit_hint=*/ 25), 25u);
+}
+
+TEST(DistinctSortedTransform, ThrowLimitIsCumulativeAcrossSortPrefixRuns)
+{
+    /// 'throw' fails at >, so runs totalling exactly 25 pass and the next one must throw
+    /// even though its own run (and therefore the clearable set) holds only 5 rows.
+    SizeLimits set_size_limits(/*max_rows_=*/ 25, /*max_bytes_=*/ 0, OverflowMode::THROW);
+    DistinctSortedTransform transform(
+        makeHeader(), makeSortDescription(), set_size_limits, /*limit_hint_=*/ 0, Names{"a", "b"});
+
+    for (UInt64 run = 0; run < 5; ++run)
+    {
+        Chunk chunk = makeRunChunk(run, /*rows=*/ 5);
+        ASSERT_NO_THROW(runTransform(transform, chunk));
+        EXPECT_EQ(chunk.getNumRows(), 5u);
+    }
+
+    Chunk crossing_chunk = makeRunChunk(/*run_key=*/ 5, /*rows=*/ 5);
+    try
+    {
+        runTransform(transform, crossing_chunk);
+        FAIL() << "expected SET_SIZE_LIMIT_EXCEEDED on the run that pushes the total to 30 > 25";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::SET_SIZE_LIMIT_EXCEEDED);
+    }
+}

--- a/src/Processors/tests/gtest_distinct_sorted_transform_limits.cpp
+++ b/src/Processors/tests/gtest_distinct_sorted_transform_limits.cpp
@@ -26,9 +26,10 @@ extern const int SET_SIZE_LIMIT_EXCEEDED;
 
 /// Regression tests for cumulative limit accounting in DistinctSortedTransform. The
 /// transform's clearable set is reset on every sort-prefix run, so the set size reflects
-/// only the current run: max_rows_in_distinct / max_bytes_in_distinct / limit_hint checked
-/// against it never trip on a stream of many runs that are each below the limit. They must
-/// be checked against the cumulative count of emitted distinct rows (`total_output_rows`).
+/// only the current run: max_rows_in_distinct / limit_hint checked against it never trip
+/// on a stream of many runs that are each below the limit. They must be checked against
+/// the cumulative count of emitted distinct rows (`total_output_rows`); the byte limit
+/// stays on `data.getTotalByteCount()`, whose allocation does not shrink on clear.
 ///
 /// This is not reachable from an SQL test: every plan shape places a preliminary DISTINCT
 /// (DistinctSortedStreamTransform, which already counts cumulatively) before the final

--- a/tests/queries/0_stateless/04511_distinct_overflow_mode_break.reference
+++ b/tests/queries/0_stateless/04511_distinct_overflow_mode_break.reference
@@ -6,7 +6,11 @@
 30
 -- DistinctTransform: max_bytes_in_distinct also returns a partial non-empty result
 1	1
+-- DistinctSortedTransform is used for distinct over a globally sorted stream
+1
 -- DistinctSortedTransform (distinct over globally sorted stream): the chunk that crosses the limit is returned, not dropped
 30
 -- DistinctSortedStreamTransform (in-order pre-distinct): partial result on limit trip
 3
+-- limits are enforced across sort-prefix runs, not per run
+30

--- a/tests/queries/0_stateless/04511_distinct_overflow_mode_break.reference
+++ b/tests/queries/0_stateless/04511_distinct_overflow_mode_break.reference
@@ -1,0 +1,12 @@
+-- DistinctTransform: the chunk that crosses the limit is returned, not dropped
+30
+-- DistinctTransform: limit tripping on the very first chunk must not produce an empty result
+10
+-- DistinctTransform: reading stops after the limit trips (hangs on infinite source otherwise)
+30
+-- DistinctTransform: max_bytes_in_distinct also returns a partial non-empty result
+1	1
+-- DistinctSortedTransform (distinct over globally sorted stream): the chunk that crosses the limit is returned, not dropped
+30
+-- DistinctSortedStreamTransform (in-order pre-distinct): partial result on limit trip
+3

--- a/tests/queries/0_stateless/04511_distinct_overflow_mode_break.sql
+++ b/tests/queries/0_stateless/04511_distinct_overflow_mode_break.sql
@@ -25,6 +25,9 @@ INSERT INTO t_distinct_break SELECT number % 10, number FROM numbers(1000);
 
 SET optimize_distinct_in_order = 1;
 
+SELECT '-- DistinctSortedTransform is used for distinct over a globally sorted stream';
+SELECT count() > 0 FROM (EXPLAIN PIPELINE SELECT DISTINCT a, b FROM (SELECT a, b FROM t_distinct_break ORDER BY a) SETTINGS query_plan_remove_redundant_sorting = 0) WHERE explain LIKE '%DistinctSortedTransform%';
+
 SELECT '-- DistinctSortedTransform (distinct over globally sorted stream): the chunk that crosses the limit is returned, not dropped';
 -- query_plan_remove_redundant_sorting would drop the inner ORDER BY under count() and the plan would not use DistinctSortedTransform
 SELECT count() FROM (SELECT DISTINCT a, b FROM (SELECT a, b FROM t_distinct_break ORDER BY a)) SETTINGS query_plan_remove_redundant_sorting = 0;
@@ -33,3 +36,13 @@ SELECT '-- DistinctSortedStreamTransform (in-order pre-distinct): partial result
 SELECT count() FROM (SELECT DISTINCT a FROM t_distinct_break) SETTINGS max_rows_in_distinct = 3;
 
 DROP TABLE t_distinct_break;
+
+DROP TABLE IF EXISTS t_distinct_break_runs;
+CREATE TABLE t_distinct_break_runs (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 10;
+-- 100 sort-prefix runs of 5 distinct rows each: no single run reaches the limit, only their sum does
+INSERT INTO t_distinct_break_runs SELECT intDiv(number, 5), number % 5 FROM numbers(500);
+
+SELECT '-- limits are enforced across sort-prefix runs, not per run';
+SELECT count() FROM (SELECT DISTINCT a, b FROM (SELECT a, b FROM t_distinct_break_runs ORDER BY a)) SETTINGS query_plan_remove_redundant_sorting = 0;
+
+DROP TABLE t_distinct_break_runs;

--- a/tests/queries/0_stateless/04511_distinct_overflow_mode_break.sql
+++ b/tests/queries/0_stateless/04511_distinct_overflow_mode_break.sql
@@ -1,0 +1,35 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/110045
+-- distinct_overflow_mode = 'break' must return the partial result accumulated up to the
+-- limit trip (including the chunk that crossed the limit) and stop reading the source.
+
+SET max_threads = 1;
+SET max_block_size = 10;
+SET distinct_overflow_mode = 'break';
+SET max_rows_in_distinct = 25;
+
+SELECT '-- DistinctTransform: the chunk that crosses the limit is returned, not dropped';
+SELECT count() FROM (SELECT DISTINCT number FROM numbers(1000));
+
+SELECT '-- DistinctTransform: limit tripping on the very first chunk must not produce an empty result';
+SELECT count() FROM (SELECT DISTINCT number FROM numbers(1000)) SETTINGS max_rows_in_distinct = 1;
+
+SELECT '-- DistinctTransform: reading stops after the limit trips (hangs on infinite source otherwise)';
+SELECT count() FROM (SELECT DISTINCT number FROM system.numbers);
+
+SELECT '-- DistinctTransform: max_bytes_in_distinct also returns a partial non-empty result';
+SELECT count() > 0, count() < 1000 FROM (SELECT DISTINCT number FROM numbers(1000)) SETTINGS max_rows_in_distinct = 0, max_bytes_in_distinct = 1000;
+
+DROP TABLE IF EXISTS t_distinct_break;
+CREATE TABLE t_distinct_break (a UInt64, b UInt64) ENGINE = MergeTree ORDER BY a SETTINGS index_granularity = 10;
+INSERT INTO t_distinct_break SELECT number % 10, number FROM numbers(1000);
+
+SET optimize_distinct_in_order = 1;
+
+SELECT '-- DistinctSortedTransform (distinct over globally sorted stream): the chunk that crosses the limit is returned, not dropped';
+-- query_plan_remove_redundant_sorting would drop the inner ORDER BY under count() and the plan would not use DistinctSortedTransform
+SELECT count() FROM (SELECT DISTINCT a, b FROM (SELECT a, b FROM t_distinct_break ORDER BY a)) SETTINGS query_plan_remove_redundant_sorting = 0;
+
+SELECT '-- DistinctSortedStreamTransform (in-order pre-distinct): partial result on limit trip';
+SELECT count() FROM (SELECT DISTINCT a FROM t_distinct_break) SETTINGS max_rows_in_distinct = 3;
+
+DROP TABLE t_distinct_break;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110045
Closes: https://github.com/ClickHouse/ClickHouse/issues/89170
Closes: https://github.com/ClickHouse/ClickHouse/issues/57390

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `distinct_overflow_mode = 'break'`: DISTINCT now returns the partial result accumulated up to the limit and stops reading the source, as documented. Previously the chunk that crossed `max_rows_in_distinct` / `max_bytes_in_distinct` was discarded (truncated or empty results) and the query kept reading and inserting into the hash set to the end of the input, which could end in `MEMORY_LIMIT_EXCEEDED`.

### Documentation entry for user-facing changes

The fixed behavior matches the existing documentation of `distinct_overflow_mode = 'break'`: "Stop executing the query and return the partial result, as if the source data ran out." No docs changes needed.

---

**Symptom.** With `distinct_overflow_mode = 'break'`:
- the chunk that crossed the limit was dropped, so results were truncated or even empty when the limit tripped on the first chunk (#57390);
- `DistinctTransform` never stopped reading: the hash set kept growing to the end of the input (the insertion happens before the limit check), ending in `MEMORY_LIMIT_EXCEEDED` on memory-constrained queries (#89170). On an infinite source (`system.numbers`) the query never terminated at all.

Confirmed by automated triage on the issue: reproduces on `master` and every release line tested down to 22.3 — long-standing.

**Root cause.** On failed `SizeLimits::check()`, `DistinctTransform::transform()` just `return`ed (chunk dropped, no `stopReading()`), and `DistinctSortedTransform` called `stopReading()` but cleared the chunk. `SizeLimits::softCheck()` deliberately compares with `>=` — "we check for >= to tell that no more data is needed. Last chunk will be processed" — i.e. the caller is expected to emit the chunk that reached the limit and stop, which `DistinctSortedStreamTransform` already does.

**Fix.** On failed check in break mode, both transforms now call `stopReading()` and still emit the newly-inserted rows of the current chunk (their keys are already in the set). Throw mode is unaffected: `check()` throws before returning `false`.

**Verification.**
- New stateless test `04511_distinct_overflow_mode_break` covers all three transforms (`DistinctTransform`, `DistinctSortedTransform` via a globally sorted stream with `query_plan_remove_redundant_sorting = 0`, `DistinctSortedStreamTransform` via in-order pre-distinct) and both symptoms; the infinite-source case hangs forever without the fix. Transform selection pinned via `EXPLAIN PIPELINE` under both analyzers.
- New unit test `gtest_distinct_sorted_transform_limits` pins the cumulative limit accounting of `DistinctSortedTransform` in isolation: many sort-prefix runs each below the limit, asserting `break` stops reading, `throw` raises `SET_SIZE_LIMIT_EXCEEDED`, and `limit_hint` stops reading — all on the runs' *sum*. Falsified locally: with the limit checks reverted to the per-run set size, all three tests fail (break/limit_hint emit all 500 rows, throw never fires). SQL cannot reach this state: every plan shape places a preliminary in-order DISTINCT (with cumulative accounting) before the final `DistinctSortedTransform`, and the preliminary stage trips the limit first, so the stateless test pins end-to-end behavior while the unit test pins the transform invariant.
- The issue's memory reproducer passes under a `max_memory_usage = 1.2 GB` cap that failed with `MEMORY_LIMIT_EXCEEDED` before the fix; peak memory is now bounded by the distinct set size at the trip point instead of growing with input cardinality.
- Local distinct-related stateless suite: 74/82 pass on a Linux debug build; the 8 failures are environment-only — stateful `test.hits`/`test.visits` datasets and CI-only clusters (including parallel replicas) unavailable locally — those paths are covered by CI on this PR. The new stateless test passed 5 randomized `clickhouse-test` runs and 10 CI-like setting perturbations.
- Behavioral note: `break` results now include the rows of the chunk that reached the limit (they were previously discarded). No existing test pins break-mode DISTINCT row counts.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.825` (included in `26.7` and later)
<!-- ch-version-info:end -->