### PR TITLE
Reject EXPLAIN ANALYZE for streaming (STREAM) queries

### DIFF
--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -1213,7 +1213,7 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                 /// plan the per-step wall-clock registry is populated from. Timing such a query has no
                 /// semantic meaning (a streaming read never completes), so reject it rather than execute it.
                 if (dynamic_cast<const MergeTreeCommitOrderSequentialSource *>(proc_ptr))
-                    throw Exception(ErrorCodes::ILLEGAL_STREAM,
+                    throw Exception(ErrorCodes::NOT_IMPLEMENTED,
                         "EXPLAIN ANALYZE is not supported for streaming (STREAM) queries");
             }
 

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -92,7 +92,6 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
     extern const int BAD_ARGUMENTS;
-    extern const int ILLEGAL_STREAM;
 }
 
 namespace

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -56,6 +56,7 @@
 #include <Core/Settings.h>
 #include <Interpreters/HypotheticalIndexStore.h>
 #include <Storages/MergeTree/WhatIfIndexEstimator.h>
+#include <Storages/MergeTree/Streaming/MergeTreeCommitOrderSequentialSource.h>
 
 #include <Analyzer/QueryTreeBuilder.h>
 #include <Analyzer/QueryTreePassManager.h>
@@ -91,6 +92,7 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
     extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_STREAM;
 }
 
 namespace
@@ -1206,6 +1208,13 @@ QueryPipeline InterpreterExplainQuery::executeImpl()
                     || dynamic_cast<const DelayedSource *>(proc_ptr))
                     throw Exception(ErrorCodes::NOT_IMPLEMENTED,
                         "EXPLAIN ANALYZE doesn't support queries executed in distributed mode");
+
+                /// A STREAM read builds a nested QueryPlan at run time whose steps are not part of the outer
+                /// plan the per-step wall-clock registry is populated from. Timing such a query has no
+                /// semantic meaning (a streaming read never completes), so reject it rather than execute it.
+                if (dynamic_cast<const MergeTreeCommitOrderSequentialSource *>(proc_ptr))
+                    throw Exception(ErrorCodes::ILLEGAL_STREAM,
+                        "EXPLAIN ANALYZE is not supported for streaming (STREAM) queries");
             }
 
             planning_ns += watch.elapsed();

--- a/tests/queries/0_stateless/04422_explain_analyze_stream_read.sql
+++ b/tests/queries/0_stateless/04422_explain_analyze_stream_read.sql
@@ -1,0 +1,23 @@
+-- Tags: no-parallel-replicas, no-darwin
+-- no-darwin: STREAM reads are Linux-only (server raises SUPPORT_IS_DISABLED elsewhere).
+-- EXPLAIN ANALYZE over a STREAM read used to abort the server with a 'clock' logical error in
+-- debug/sanitizer builds: the streaming read builds a nested QueryPlan at run time whose steps are
+-- absent from the per-step wall-clock registry that EXPLAIN ANALYZE populates from the outer plan,
+-- so chassert(clock) fired for the inner processor. EXPLAIN ANALYZE now rejects streaming queries
+-- with a user error (ILLEGAL_STREAM): timing a never-completing streaming read is meaningless.
+
+SET enable_streaming_queries = 1;
+SET max_threads = 1;
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_stream_explain_analyze;
+
+CREATE TABLE t_stream_explain_analyze (a String, b UInt64) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_stream_explain_analyze SELECT toString(number % 100), number FROM numbers(5000);
+INSERT INTO t_stream_explain_analyze SELECT toString(number % 100), number FROM numbers(5000);
+
+EXPLAIN ANALYZE SELECT count() FROM (SELECT DISTINCT a FROM t_stream_explain_analyze STREAM LIMIT 50); -- { serverError ILLEGAL_STREAM }
+EXPLAIN ANALYZE actions = 1, projections = 1, sorting = 1, input_headers = 1 SELECT count() FROM (SELECT DISTINCT * FROM t_stream_explain_analyze STREAM LIMIT 50); -- { serverError ILLEGAL_STREAM }
+
+DROP TABLE t_stream_explain_analyze;

--- a/tests/queries/0_stateless/04422_explain_analyze_stream_read.sql
+++ b/tests/queries/0_stateless/04422_explain_analyze_stream_read.sql
@@ -1,10 +1,6 @@
 -- Tags: no-parallel-replicas, no-darwin
 -- no-darwin: STREAM reads are Linux-only (server raises SUPPORT_IS_DISABLED elsewhere).
--- EXPLAIN ANALYZE over a STREAM read used to abort the server with a 'clock' logical error in
--- debug/sanitizer builds: the streaming read builds a nested QueryPlan at run time whose steps are
--- absent from the per-step wall-clock registry that EXPLAIN ANALYZE populates from the outer plan,
--- so chassert(clock) fired for the inner processor. EXPLAIN ANALYZE now rejects streaming queries
--- with a user error (ILLEGAL_STREAM): timing a never-completing streaming read is meaningless.
+-- EXPLAIN ANALYZE does not support Streaming Queries hence this test is added
 
 SET enable_streaming_queries = 1;
 SET max_threads = 1;
@@ -17,7 +13,7 @@ CREATE TABLE t_stream_explain_analyze (a String, b UInt64) ENGINE = MergeTree OR
 INSERT INTO t_stream_explain_analyze SELECT toString(number % 100), number FROM numbers(5000);
 INSERT INTO t_stream_explain_analyze SELECT toString(number % 100), number FROM numbers(5000);
 
-EXPLAIN ANALYZE SELECT count() FROM (SELECT DISTINCT a FROM t_stream_explain_analyze STREAM LIMIT 50); -- { serverError ILLEGAL_STREAM }
+EXPLAIN ANALYZE SELECT count() FROM (SELECT DISTINCT a FROM t_stream_explain_analyze STREAM LIMIT 50); -- { serverError NOT_IMPLEMENTED }
 EXPLAIN ANALYZE actions = 1, projections = 1, sorting = 1, input_headers = 1 SELECT count() FROM (SELECT DISTINCT * FROM t_stream_explain_analyze STREAM LIMIT 50); -- { serverError ILLEGAL_STREAM }
 
 DROP TABLE t_stream_explain_analyze;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106586
-->


### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`EXPLAIN ANALYZE` now returns an `ILLEGAL_STREAM` error for queries reading a table with the `STREAM` modifier, instead of aborting the server in debug/sanitizer builds. Timing a streaming read has no meaning, since it never completes.

### Description

`EXPLAIN ANALYZE` (added in #106586) builds a per-step wall-clock registry with `StepWallClockRegistry::populateFromPlan(plan)`, walking the outer query plan and registering a clock for every `(step, group)`. At execution, `ExecutionThreadContext::executeTask()` looks up the clock for each processor's query-plan step and asserts it exists with `chassert(clock)`.

A streaming read (`... FROM t STREAM`) is served by `MergeTreeCommitOrderSequentialSource`, which builds a nested `QueryPlan` at run time. Its processors carry step pointers that live only in that inner plan, which `populateFromPlan` never walks, so those inner steps have no registered clock and `chassert(clock)` fired in debug/sanitizer builds.

`EXPLAIN ANALYZE` executes the query and reports per-step timings, but a streaming read never completes, so timing it has no semantic meaning. Following @Fgrtue's review, this rejects such queries with a user-facing `ILLEGAL_STREAM` error in `InterpreterExplainQuery` (in the same pipeline-inspection loop that already rejects distributed execution, so it also catches streaming reads reached through nested sub-plans) and keeps the `chassert(clock)` invariant intact.

Found by the Stress-test AST fuzzer (STID 2508-4031) across `Stress test (amd_tsan)`, `arm_tsan`, `amd_msan`; 0 master hits (release builds caught the exception; only debug/sanitizer builds aborted). Example CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110006&sha=39b6ace5ea65b69a9e6ee774a0d7b69e882a78a7&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29

Reproducer (now returns an error instead of aborting):
```sql
SET enable_streaming_queries = 1, enable_analyzer = 1;
CREATE TABLE t (a String, b UInt64) ENGINE = MergeTree ORDER BY a;
INSERT INTO t SELECT toString(number % 100), number FROM numbers(5000);
EXPLAIN ANALYZE SELECT count() FROM (SELECT DISTINCT a FROM t STREAM LIMIT 50); -- ILLEGAL_STREAM
```
