### PR TITLE
Read ORC in the Hive engine with the native ORC reader

### DIFF
--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -14,6 +14,7 @@
 #include <Common/Exception.h>
 #include <Formats/FormatFactory.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
+#include <Processors/Formats/Impl/NativeORCBlockInputFormat.h>
 #include <Storages/Hive/HiveSettings.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Interpreters/Context.h>
@@ -158,15 +159,13 @@ void HiveORCFile::prepareReader()
     in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, getContext()->getGlobalContext()->getConfigRef(), getContext()->getReadSettings());
     auto format_settings = getFormatSettings(getContext());
     std::atomic<int> is_stopped{0};
-    auto result = arrow::adapters::orc::ORCFileReader::Open(asArrowFile(*in, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES), ArrowMemoryPool::instance());
-    if (!result.ok())
-        throwFromArrowStatus(result.status(), ErrorCodes::BAD_ARGUMENTS, "Failed to open ORC file");
-    reader = std::move(result).ValueOrDie();
+    orc::ReaderOptions options;
+    reader = orc::createReader(asORCInputStream(*in, format_settings, /*use_prefetch=*/false, is_stopped), options);
 }
 
 void HiveORCFile::prepareColumnMapping()
 {
-    const orc::Type & type = reader->GetRawORCReader()->getType();
+    const orc::Type & type = reader->getType();
     size_t count = type.getSubtypeCount();
     for (size_t pos = 0; pos < count; pos++)
     {
@@ -223,7 +222,7 @@ void HiveORCFile::loadFileMinMaxIndexImpl()
         prepareColumnMapping();
     }
 
-    auto statistics = reader->GetRawORCReader()->getStatistics();
+    auto statistics = reader->getStatistics();
     file_minmax_idx = buildMinMaxIndex(statistics.get());
 }
 
@@ -241,7 +240,7 @@ void HiveORCFile::loadSplitMinMaxIndexesImpl()
         prepareColumnMapping();
     }
 
-    auto * raw_reader = reader->GetRawORCReader();
+    auto * raw_reader = reader.get();
     auto stripe_num = raw_reader->getNumberOfStripes();
     auto stripe_stats_num = raw_reader->getNumberOfStripeStatistics();
     if (stripe_num != stripe_stats_num)
@@ -264,7 +263,7 @@ std::optional<size_t> HiveORCFile::getRowsImpl()
         prepareColumnMapping();
     }
 
-    auto * raw_reader = reader->GetRawORCReader();
+    auto * raw_reader = reader.get();
     return raw_reader->getNumberOfRows();
 }
 

--- a/src/Storages/Hive/HiveFile.h
+++ b/src/Storages/Hive/HiveFile.h
@@ -8,7 +8,7 @@
 #include <unordered_set>
 
 #include <boost/algorithm/string/join.hpp>
-#include <arrow/adapters/orc/adapter.h>
+#include <orc/OrcFile.hh>
 #include <parquet/arrow/reader.h>
 
 #include <Core/Field.h>
@@ -236,7 +236,7 @@ private:
     std::optional<size_t> getRowsImpl() override;
 
     std::unique_ptr<ReadBufferFromHDFS> in;
-    std::unique_ptr<arrow::adapters::orc::ORCFileReader> reader;
+    std::unique_ptr<orc::Reader> reader;
     std::map<String, size_t> orc_column_positions;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The Hive engine now reads ORC file metadata (min/max indexes, row counts) with ClickHouse's native ORC reader instead of the Apache Arrow ORC adapter.

### Documentation entry for user-facing changes

No user-facing behavior change.

---

`HiveORCFile` used `arrow::adapters::orc::ORCFileReader` only as a thin wrapper to open the file and obtain the raw `orc::Reader` (via `GetRawORCReader()`). Everything it actually does — building the min/max index from `orc::Statistics`, the column-name mapping, the row count — already uses the native ORC (liborc) API directly.

This opens the `orc::Reader` directly via the same native ORC input stream (`asORCInputStream`) that the ORC input format uses, and drops the Arrow round-trip:

- `HiveORCFile::reader` is now `std::unique_ptr<orc::Reader>` instead of `std::unique_ptr<arrow::adapters::orc::ORCFileReader>`;
- `prepareReader` calls `orc::createReader(asORCInputStream(...))`;
- the four `reader->GetRawORCReader()` sites use the `orc::Reader` directly.

The Parquet side of Hive still uses Arrow, so the Arrow includes remain for it.

### Why

This removes the Hive engine's dependency on the Apache Arrow ORC adapter (`contrib/arrow/.../adapters/orc`). That adapter is the code that heap-buffer-overflows on malformed ORC union tags. Together with removing the Arrow-based ORC input format (#110074), this is the last in-tree consumer, so afterwards the adapter can be dropped from the build entirely (a follow-up).

Part of the series:
1. #110074 — remove the Arrow-based ORC reader
2. #110078 — union support in the native reader
3. #110085 — write Variant as an ORC union
4. **this PR** — read ORC in Hive with the native reader

### Verification

Compiles and links (RelWithDebInfo, `USE_HIVE=1`). Not runtime-tested here — the Hive engine needs a Hive metastore + HDFS, which this environment doesn't have; relying on CI's Hive integration tests. The change is mechanical (the min/max/stats logic is untouched and already native).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.807` (included in `26.7` and later)
<!-- ch-version-info:end -->