### PR TITLE
Fix max_bytes_in_distinct / max_bytes_in_set: count string keys stored in the arena

### DIFF
--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -48,15 +48,18 @@ size_t SetVariantsTemplate<Variant>::getTotalRowCount() const
 template <typename Variant>
 size_t SetVariantsTemplate<Variant>::getTotalByteCount() const
 {
+    /// String keys are stored in the string_pool arena, not in the hash table buffer.
+    size_t bytes = string_pool.allocatedBytes();
     switch (type)
     {
-        case Type::EMPTY: return 0;
+        case Type::EMPTY: break;
 
     #define M(NAME) \
-        case Type::NAME: return (NAME)->data.getBufferSizeInBytes();
+        case Type::NAME: bytes += (NAME)->data.getBufferSizeInBytes(); break;
         APPLY_FOR_SET_VARIANTS(M)
     #undef M
     }
+    return bytes;
 }
 
 template <typename Variant>

--- a/tests/queries/0_stateless/04512_max_bytes_limits_count_string_arena.reference
+++ b/tests/queries/0_stateless/04512_max_bytes_limits_count_string_arena.reference
@@ -1,0 +1,6 @@
+-- DISTINCT, throw: trips on string payload, not only on the hash buffer
+-- DISTINCT, break: stops near the limit instead of retaining the full payload
+1	1
+-- IN set, throw: trips on string payload
+-- fixed-size keys are unaffected: the same limit passes without string keys
+10000

--- a/tests/queries/0_stateless/04512_max_bytes_limits_count_string_arena.sql
+++ b/tests/queries/0_stateless/04512_max_bytes_limits_count_string_arena.sql
@@ -1,0 +1,28 @@
+-- max_bytes_in_distinct / max_bytes_in_set must count string keys, which live in the
+-- string_pool arena, not in the hash table buffer. Before the fix the limits saw only the
+-- ~24-bytes-per-key buffer, so DISTINCT/IN over string keys could hold memory exceeding the
+-- limit by the whole key payload (unbounded in the key length).
+
+SET max_threads = 1;
+SET max_block_size = 8192;
+
+-- 10000 distinct ~1 KB keys = ~10 MB of state vs a 1 MB limit. The hash buffer alone
+-- (2^14 cells) stays well under the limit, so without arena accounting nothing trips.
+
+SELECT '-- DISTINCT, throw: trips on string payload, not only on the hash buffer';
+SELECT count() FROM (SELECT DISTINCT toString(number) || repeat('x', 1000) AS s FROM numbers(10000))
+SETTINGS max_bytes_in_distinct = 1000000, distinct_overflow_mode = 'throw'; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT '-- DISTINCT, break: stops near the limit instead of retaining the full payload';
+-- small blocks so the limit does not trip on the very first chunk and the count stays low
+-- whether or not the chunk that crosses the limit is emitted (see #110075)
+SELECT count() > 0, count() < 5000 FROM (SELECT DISTINCT toString(number) || repeat('x', 1000) AS s FROM numbers(10000))
+SETTINGS max_bytes_in_distinct = 1000000, distinct_overflow_mode = 'break', max_block_size = 256;
+
+SELECT '-- IN set, throw: trips on string payload';
+SELECT count() FROM numbers(10) WHERE toString(number) IN (SELECT toString(number) || repeat('x', 1000) FROM numbers(10000))
+SETTINGS max_bytes_in_set = 1000000, set_overflow_mode = 'throw'; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT '-- fixed-size keys are unaffected: the same limit passes without string keys';
+SELECT count() FROM (SELECT DISTINCT number FROM numbers(10000))
+SETTINGS max_bytes_in_distinct = 1000000, distinct_overflow_mode = 'throw';


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `max_bytes_in_distinct` and `max_bytes_in_set`: string keys are stored in an arena that was not counted by the limit checks, so DISTINCT / IN over string keys could hold memory exceeding the byte limit by the whole key payload (unbounded in the key length). The limits now account for the arena, matching their documentation; queries with string keys close to a byte limit may now trip it earlier (correctly).

### Documentation entry for user-facing changes

The fixed behavior matches the existing documentation: `max_bytes_in_set` — "The maximum number of bytes (of uncompressed data) used by a set in the IN clause"; the `getTotalByteCount()` declaration comment also documents that the string pool must be counted. No docs changes needed.

---

**Symptom.** `SetVariantsTemplate::getTotalByteCount()` returns only the hash-table buffer size (`data.getBufferSizeInBytes()`). For string keys, every consumer — `DistinctTransform`, `DistinctSortedTransform`, `DistinctSortedStreamTransform`, and `Set` (IN) — copies the key payload into the `string_pool` arena, which was not counted. The byte limits only tripped once the ~24-bytes-per-key hash buffer itself crossed the limit:

```sql
-- 1 KB string keys, 10 MB limit, break: retained 139264 rows ≈ 139 MB of key payload
SELECT count() FROM (SELECT DISTINCT toString(number) || repeat('x', 1000) AS s FROM numbers(200000))
SETTINGS max_bytes_in_distinct = 10000000, distinct_overflow_mode = 'break', max_threads = 1, max_block_size = 8192;

-- 100000 distinct 1 KB keys = ~100 MB of state, 10 MB limit: no exception at all (buffer is ~6 MB)
SELECT count() FROM (SELECT DISTINCT toString(number) || repeat('x', 1000) AS s FROM numbers(100000))
SETTINGS max_bytes_in_distinct = 10000000, distinct_overflow_mode = 'throw', max_threads = 1, max_block_size = 8192;

-- Same for the IN set: ~100 MB set, 10 MB limit, throw: passes silently
SELECT count() FROM numbers(10) WHERE toString(number) IN (SELECT toString(number) || repeat('x', 1000) FROM numbers(100000))
SETTINGS max_bytes_in_set = 10000000, set_overflow_mode = 'throw', max_threads = 1;
```

Found while working on #110075 (an orthogonal defect: that PR fixes *what happens* when a DISTINCT limit trips; this PR fixes the byte limit *not tripping* for string keys). Surfaced by the AI review there.

**Root cause.** The declaration comment on `getTotalByteCount()` documents the intended contract — "Counts the size in bytes of the Set buffer *and the size of the `string_pool`*" — but the implementation never included the pool.

**Fix.** `getTotalByteCount()` now adds `string_pool.allocatedBytes()`, following the established pattern of `HashJoin::getTotalByteCount()`, which includes `data->pool.allocatedBytes()` for `max_bytes_in_join`. Fixed-size keys are unaffected (the arena stays at its initial allocation and is dwarfed by the hash buffer).

**Behavior change.** Queries with string keys running close to `max_bytes_in_distinct` / `max_bytes_in_set` will now trip the limit earlier — at the documented boundary instead of an under-counted one. With the repro above: `break` now stops at 8192 rows instead of 139264; both `throw` cases now raise `SET_SIZE_LIMIT_EXCEEDED` with honest byte counts (17.48 MiB / 69.98 MiB vs the 9.54 MiB limit).

**Verification.**
- New stateless test `04512_max_bytes_limits_count_string_arena`: DISTINCT throw/break and IN throw over ~1 KB string keys where the hash buffer alone stays under the limit — fails without the fix (nothing trips), passes with it; plus a fixed-size-key control query pinning that numeric DISTINCT under the same limit is unaffected.
- Existing limit/overflow-mode stateless tests pass on the fixed build (01134_set_overflow_mode, 02382/02383_join_and_filtering_set, 02494_query_cache_bugs, 02581_share_big_sets_between_mutation_tasks, 02841/02861/02907 filter-pushdown, 03359, 03532, 04007, 04201; 04204 needs a CI cluster, 02383's `sed` scripting is GNU-only — both environment, covered by CI here).
- Falsified locally: with the one-line accounting change reverted, the new test fails (no limit trips) and the repro numbers revert to 139264 / no-throw / no-throw.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.974` (included in `26.7` and later)
<!-- ch-version-info:end -->