### PR TITLE
Retry perf dataset downloads and surface failures in the CI report

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -23,6 +23,7 @@ import time
 import xml.etree.ElementTree as ET
 
 from ci.defs.defs import ToolSet
+from ci.jobs.scripts.dataset_download import download_and_extract_datasets
 from ci.praktika.result import Result
 from ci.praktika.utils import MetaClasses, Shell, Utils
 
@@ -215,15 +216,13 @@ def download_datasets():
         "values": "https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar",
         "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar",
     }
-    cmds = []
-    for dataset_path in dataset_paths.values():
-        cmds.append(
-            f'wget -nv -nd -c "{dataset_path}" -O- | tar --extract --verbose -C {PERF_DB_PATH}'
-        )
-    res = Shell.check_parallel(cmds, verbose=True)
-    if res:
-        Shell.check(f"touch {PERF_DB_PATH}/.done")
-    return res
+    errors = download_and_extract_datasets(dataset_paths.values(), PERF_DB_PATH)
+    for error in errors:
+        print(f"ERROR: {error}")
+    if errors:
+        return False
+    Shell.check(f"touch {PERF_DB_PATH}/.done")
+    return True
 
 
 def dump_log_tail(log_path, lines=200):

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 
 from ci.jobs.scripts.cidb_cluster import CIDBCluster
+from ci.jobs.scripts.dataset_download import download_and_extract_datasets
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.settings import Settings
@@ -1183,16 +1184,16 @@ def main():
                 "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch_sf10.tar",
                 "tpcds1": "https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar",
             }
-            cmds = []
-            for dataset_path in dataset_paths.values():
-                cmds.append(
-                    f'wget -nv -nd -c "{dataset_path}" -O- | tar --extract --verbose -C {db_path}'
-                )
-            res = Shell.check_parallel(cmds, verbose=True)
+            stop_watch = Utils.Stopwatch()
+            errors = download_and_extract_datasets(dataset_paths.values(), db_path)
+            res = not errors
             results.append(
                 Result(
                     name="Download datasets",
                     status=Result.Status.OK if res else Result.Status.ERROR,
+                    start_time=stop_watch.start_time,
+                    duration=stop_watch.duration,
+                    info="\n".join(errors),
                 )
             )
             if res:

--- a/ci/jobs/scripts/dataset_download.py
+++ b/ci/jobs/scripts/dataset_download.py
@@ -1,0 +1,40 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+from ci.praktika.utils import Shell
+
+
+def download_and_extract_datasets(dataset_urls, target_dir, retries=5):
+    """Download dataset tarballs in parallel and extract them into target_dir.
+
+    Returns a list of error descriptions, one per dataset that could not be
+    downloaded and extracted; an empty list means success. The caller can put
+    the errors into Result.info so the failure is visible in the CI report
+    without digging through the job log.
+
+    S3 sporadically returns transient errors (e.g. 503 Service Unavailable),
+    and wget retries only network-level errors, not HTTP errors, so a single
+    503 would otherwise fail the whole job. A failed attempt cannot be resumed
+    mid-stream because the body is piped into tar, so rerun the whole pipeline
+    on any failure - extraction into target_dir is idempotent.
+    """
+
+    def download(url):
+        error = ""
+        for attempt in range(1, retries + 1):
+            exit_code, _, error = Shell.get_res_stdout_stderr(
+                f'wget -nv -nd "{url}" -O- | tar --extract -C {target_dir}',
+                verbose=True,
+            )
+            if exit_code == 0:
+                return ""
+            print(
+                f"WARNING: Attempt [{attempt}/{retries}] to download [{url}] failed, err: [{error}]"
+            )
+            if attempt < retries:
+                time.sleep(attempt * 30)
+        return f"Failed to download [{url}] after [{retries}] attempts, last error: [{error}]"
+
+    print(f"Download datasets in parallel: [{len(dataset_urls)}]")
+    with ThreadPoolExecutor(max_workers=len(dataset_urls)) as executor:
+        return [error for error in executor.map(download, dataset_urls) if error]


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/107415

The `Performance Comparison (amd_release, master_head, 2/6)` job on the PR above errored at the `Download datasets` step: S3 answered `503 Service Unavailable` for `hits_10m_single.tar`, `wget` retries only network-level errors (not HTTP errors), so the single 503 killed the whole job. On top of that, the step's `Result` carried no `info`, so the CI report showed a bare `ERROR` and the cause was only findable in `job.log`. This early-setup failure pattern (`Failures: 1/4`) recurs a few times per week across unrelated PRs and master runs, per CIDB; there is no tracking issue for it.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107415&sha=c0ba65e6aa6a1785e890e54d4ea742802c1da7b9&name_0=PR&name_1=Performance%20Comparison%20%28amd_release%2C%20master_head%2C%202%2F6%29

This PR moves the dataset download into a shared helper (`ci/jobs/scripts/dataset_download.py`) that:
- still downloads all datasets in parallel, but retries each `wget | tar` pipeline up to 5 times with increasing backoff. A failed attempt cannot resume mid-stream because the body is piped into `tar`, and extraction into the target directory is idempotent, so the whole pipeline is rerun;
- returns per-dataset error descriptions, which now go into `Result.info` — the CI report shows the actual `wget`/`tar` error instead of a bare `ERROR`.

Both the performance comparison job and the profile collection job (which had a copy of the same fragile pattern) now use the helper. The `-c` (continue) `wget` flag is dropped as a no-op with `-O-`.

Verified with a local HTTP server: successful download extracts correctly; a failing URL is retried the configured number of times and produces an error string containing the server error, while other downloads in the same batch still succeed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.818` (included in `26.7` and later)
<!-- ch-version-info:end -->