### PR TITLE
Fix flaky test_parallel_replicas_protocol backward-compat OPTIMIZE hang

### DIFF
--- a/tests/integration/test_backward_compatibility/test_parallel_replicas_protocol.py
+++ b/tests/integration/test_backward_compatibility/test_parallel_replicas_protocol.py
@@ -89,7 +89,9 @@ def test_backward_compatability(start_cluster):
     # the same data from every replica would rely on cross-version insert deduplication, which the
     # new build (unified hash only) no longer shares with the old replicas.
     nodes[0].query("insert into t select number % 100000 from numbers_mt(1000000) ORDER BY ALL")
-    nodes[0].query("optimize table t final")
+    # No OPTIMIZE FINAL: a single insert is one part, so FINAL is a no-op merge whose MERGE_PARTS entry
+    # the old replicas cannot reproduce byte-identically across versions and can hang for minutes. The
+    # assertions below do not depend on part layout.
     for node in nodes:
         node.query("system sync replica t")
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky integration test `test_backward_compatibility/test_parallel_replicas_protocol.py::test_backward_compatability`, which intermittently fails with the client 600s timeout on `optimize table t final`.

`test_backward_compatability` builds a 3-replica `ReplicatedMergeTree` mixing old release binaries (25.3, `CLICKHOUSE_CI_MIN_TESTED_VERSION`) with the build under test. It inserts once from `nodes[0]` and then ran `optimize table t final`.

With a single insert the table has exactly one part, so `FINAL` only merges a part into itself (server log: `Merging 1 parts: from all_0_0_0 to all_0_0_0`). That no-op merge still creates a `MERGE_PARTS` log entry every replica must execute. The old (25.3) replicas produce a byte-different merge result from the new build (`CHECKSUM_DOESNT_MATCH: Different number of files: 3 compressed (expected 3) and 2 uncompressed ones (expected 3)`), so they discard their own merge and fall back to fetching the canonical part from the new replica. That fetch fallback only fires after a merge-retry backoff that can take minutes, while the synchronous `OPTIMIZE` (`alter_sync=1`) issued from an old replica blocks on its own queue entry and hits the integration client's 600s timeout.

The two parallel-replicas assertions (`sum(a)` and `order by a limit 10`) do not depend on part layout, so the no-op `FINAL` merge serves no purpose. Removing it eliminates the cross-version `MERGE_PARTS` entry entirely; the existing `system sync replica t` loop still guarantees every replica sees the data before the assertions.

Not PR-caused: the failure recurs on master and across unrelated PRs (~0.1% on `Integration tests (arm_binary, distributed plan, 3/4)`); e.g. master run [sha b5bea174](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b5bea1746a44f982c334bd65b6ed695d6973e0fb&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29), 2026-07-10.

Verified with 20 consecutive local runs mixing 25.3 and the current build.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.829` (included in `26.7` and later)
<!-- ch-version-info:end -->