### PR TITLE
Fix flaky test_disable_insertion_and_mutation

### DIFF
--- a/tests/integration/test_disable_insertion_and_mutation/test.py
+++ b/tests/integration/test_disable_insertion_and_mutation/test.py
@@ -82,11 +82,17 @@ def test_disable_insertion_and_mutation(started_cluster):
     writing_node.query("ALTER TABLE my_table delete where 1")
     writing_node.query("ALTER table my_table update value = 'no hello' where 1")
 
-    reading_node.query("ALTER TABLE my_table ADD COLUMN new_column UInt64")
+    # Wait for all replicas to apply the metadata change (alter_sync = 2) so that
+    # the following reads on writing_node do not race the metadata replication.
+    reading_node.query(
+        "ALTER TABLE my_table ADD COLUMN new_column UInt64 SETTINGS alter_sync = 2"
+    )
     writing_node.query("SELECT new_column from my_table")
     reading_node.query("SELECT new_column from my_table")
 
-    reading_node.query("ALter Table my_table MODIFY COLUMN new_column String")
+    reading_node.query(
+        "ALter Table my_table MODIFY COLUMN new_column String SETTINGS alter_sync = 2"
+    )
 
     assert "new_column\tString" in reading_node.query("DESC my_table")
 


### PR DESCRIPTION
The integration test `test_disable_insertion_and_mutation` is flaky.

The test issues `ALTER TABLE ... ADD COLUMN` and `MODIFY COLUMN` on the reading node with the default `alter_sync = 1`, which only waits for the *local* replica to apply the metadata change. The subsequent `SELECT new_column FROM my_table` and `DESC my_table` on the writing node can then run before the metadata change has replicated there, failing with `UNKNOWN_IDENTIFIER: new_column`.

This change uses `alter_sync = 2` on both `ALTER` queries so they wait for all replicas to apply the metadata change before returning, eliminating the race for the reads that follow on the writing node.

The failures cluster on the `arm_binary, distributed plan` integration job; the two most recent occurrences are on `master`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8b6d09cfbd638c3b41942152c6d85137effa75ec&name_0=MasterCI&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.823` (included in `26.7` and later)
<!-- ch-version-info:end -->