### PR TITLE
Fix Bad cast ColumnLowCardinality to ColumnString in identity() with WITH TOTALS

### DIFF
--- a/src/Functions/identity.h
+++ b/src/Functions/identity.h
@@ -37,6 +37,12 @@ public:
     bool isSuitableForConstantFolding() const override { return false; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
+    /// executeImpl returns the argument column verbatim, so the result type must be exactly the argument
+    /// type. The default LowCardinality implementation strips (nested) LowCardinality from the declared
+    /// result type while the passthrough column keeps it, yielding a type/column mismatch that later
+    /// aborts during serialization (e.g. WITH TOTALS const key). Keep the type identical to the column.
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return false; }
+
     DataTypePtr getReturnTypeImpl(const DataTypes & arguments) const override
     {
         return arguments.front();

--- a/src/Functions/identity.h
+++ b/src/Functions/identity.h
@@ -80,6 +80,11 @@ class FunctionIdentity final : public FunctionIdentityBase
 public:
     FunctionIdentity() : FunctionIdentityBase("identity", true) {}
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionIdentity>(); }
+
+    /// Only used as the internal impl of mapKeys/mapValues (FunctionMapToArrayAdapter), whose
+    /// array-subcolumn convention deliberately strips nested LowCardinality. Restore the default
+    /// behavior so the base-class override applies only to user-facing identity()/__scalarSubqueryResult.
+    bool useDefaultImplementationForLowCardinalityColumns() const override { return true; }
 };
 
 

--- a/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.reference
+++ b/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.reference
@@ -1,0 +1,7 @@
+Tuple(\n    `toString(1)` String,\n    `toLowCardinality(\'\')` LowCardinality(String))
+LowCardinality(String)	x
+('1','')	100
+
+('','')	100
+('','')	100
+('1','')	100

--- a/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.sql
+++ b/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.sql
@@ -1,3 +1,7 @@
+-- The Bad-cast abort only happens with the new analyzer, and the declared tuple type name
+-- differs between analyzers (named vs unnamed), so pin the analyzer for a stable reference.
+SET enable_analyzer = 1;
+
 DROP TABLE IF EXISTS t_04515;
 CREATE TABLE t_04515 (key UInt8, value LowCardinality(String)) ENGINE = MergeTree ORDER BY key;
 INSERT INTO t_04515 SELECT number % 3, toString(number) FROM numbers(100);

--- a/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.sql
+++ b/tests/queries/0_stateless/04515_identity_lowcardinality_tuple_totals.sql
@@ -1,0 +1,15 @@
+DROP TABLE IF EXISTS t_04515;
+CREATE TABLE t_04515 (key UInt8, value LowCardinality(String)) ENGINE = MergeTree ORDER BY key;
+INSERT INTO t_04515 SELECT number % 3, toString(number) FROM numbers(100);
+
+-- identity() returns its argument column verbatim, so its result type must equal the argument type.
+-- Previously the default LowCardinality implementation stripped (nested) LowCardinality from the declared
+-- type while the passthrough column kept it, aborting during WITH TOTALS serialization of a constant key.
+SELECT toTypeName(identity((SELECT toString(1), toLowCardinality(''))));
+SELECT toTypeName(identity(toLowCardinality('x'))), identity(toLowCardinality('x'));
+
+-- Regression: must not abort with 'Bad cast from type ColumnLowCardinality to ColumnString'.
+SELECT identity((SELECT toString(1), toLowCardinality(''))) AS k, count(*) FROM t_04515 GROUP BY ALL WITH TOTALS ORDER BY k;
+SELECT identity((SELECT toString(1), toLowCardinality(''))) AS k, count(*) FROM t_04515 GROUP BY ALL WITH ROLLUP ORDER BY k;
+
+DROP TABLE t_04515;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found (searched issues/PRs for "identity LowCardinality totals", "Bad cast ColumnLowCardinality ColumnString" - none). Found by the AST fuzzer.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`Bad cast from type ColumnLowCardinality to ColumnString`) when `identity()` (or a scalar subquery result) wraps a value containing a nested `LowCardinality` and the query uses `WITH TOTALS`/`WITH ROLLUP`.

### Description

`identity()` and the internal `__scalarSubqueryResult` (both `FunctionIdentityBase`) return the argument column verbatim in `executeImpl`, so the declared result type must equal the argument type exactly. They used the default `LowCardinality` implementation, which strips (nested) `LowCardinality` from the *declared* result type while the passthrough *column* keeps the `ColumnLowCardinality`. The regular data path hides the divergence because it materializes columns, but the `WITH TOTALS` constant-key row keeps the raw `ColumnLowCardinality` under a `String` header and aborts during Native serialization.

Fix: disable the default `LowCardinality` implementation for `FunctionIdentityBase`, keeping the declared result type identical to the passthrough column.

Reproducer (aborts before the fix):
```sql
CREATE TABLE t (key UInt8, value LowCardinality(String)) ENGINE = MergeTree ORDER BY key;
SELECT identity((SELECT toString(1), toLowCardinality(''))), count(*) FROM t GROUP BY ALL WITH TOTALS;
```

Found by the AST fuzzer: STID 4350-70e5, check `AST fuzzer (amd_tsan)`, report https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109374&sha=6d35797c5f55c3024f84eaefa3f030d6ca609c02&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29 (surfaced during an unrelated PR run; reproduces on master, not caused by that PR).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.837` (included in `26.7` and later)
<!-- ch-version-info:end -->