### PR TITLE
CI: do not block PRs on amd_llvm_coverage s3-storage job infra failures

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1604,4 +1604,11 @@ class JobConfigs:
         ),
         timeout=3600,
         enable_gh_auth=True,
+        # The coverage shards feed this aggregation via *LLVM_ARTIFACTS_LIST, so a
+        # shard ERROR (e.g. exit 125 during coverage collection) makes the parser's
+        # needs edge report pipeline_status=failure and this job gets skipped, which
+        # native_jobs.py re-materializes as ERROR. allow_failure on the shards only
+        # affects merge accounting, not that skip, so the coverage leg must also be
+        # non-blocking. Coverage is advisory (no blocking test signal), like azure.
+        allow_failure=True,
     )

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -779,6 +779,15 @@ class JobConfigs:
             requires=[ArtifactNames.CH_ARM_BINARY],
         ),
     )
+    # amd_llvm_coverage jobs already force a 0 exit on any test failure (see
+    # is_llvm_coverage / force_ok_exit in ci/jobs/functional_tests.py), so they
+    # carry no blocking test signal. The only way one currently blocks a PR is a
+    # post-run runner hiccup (e.g. the docker daemon connection dropping during
+    # the long coverage collection phase, exit 125). Mark them allow_failure so
+    # that infra noise cannot spuriously block a PR, matching the declared intent.
+    for _job in functional_tests_jobs:
+        if "amd_llvm_coverage" in _job.name:
+            _job.allow_failure = True
     functional_tests_jobs_coverage = common_ft_job_config.parametrize(
         *[
             Job.ParamSet(


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110114
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The `amd_llvm_coverage` stateless jobs already force a `0` exit on any test failure (`is_llvm_coverage` / `force_ok_exit` in `ci/jobs/functional_tests.py`), so they carry no blocking test signal by design.

The only way one of these jobs currently blocks a PR is a post-run runner-level hiccup, e.g. the docker daemon connection dropping during the long coverage collection phase (jemalloc profiling, system-table dumps, profdata merge), which surfaces as exit code 125:

```
level=error msg="Error waiting for container: Canceled: grpc: the client connection is closing: context canceled"
error during connect: Get ".../docker.sock/_ping": write unix @->/run/docker.sock: write: broken pipe
ERROR: Job killed, exit code [125]
```

This is chronic and cross-PR: on the `amd_llvm_coverage ... s3 storage` lanes it recurs across many unrelated PRs (and master) with no individual test failures. Examples on PR #110114 head `4eab62aeb81889843e437cb6ae96da7d297ca0a4` (tests all passed; the `Lost s3 keys` / fatal-log health checks all passed; the job died only in post-run collection):

- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110114&sha=4eab62aeb81889843e437cb6ae96da7d297ca0a4&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110114&sha=4eab62aeb81889843e437cb6ae96da7d297ca0a4&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20AsyncInsert%2C%20s3%20storage%2C%20parallel%29

Mark these jobs `allow_failure` so post-run infra noise cannot spuriously block a PR, matching the job's already-declared non-blocking intent. This mirrors the `azure` functional-test jobs, which use `set_allow_failure(True)` for the same reason. No test signal is hidden (the tests already exit `0`); only the mergeable/blocking status changes.
