### PR TITLE
Docs: fix Galaxy event tracking for Mintlify docs

### DIFF
--- a/docs/_site/customizations/galaxy.js
+++ b/docs/_site/customizations/galaxy.js
@@ -148,12 +148,12 @@
     });
   }
 
-  function post(url, requestBody) {
+  function post(url, requestBody, useBeacon) {
     var json = JSON.stringify(requestBody);
     var blob = new Blob([json], { type: 'application/json;charset=UTF-8' });
     var tooLarge = blob.size > KEEPALIVE_LIMIT_BYTES;
 
-    if (!tooLarge && typeof window.navigator.sendBeacon === 'function') {
+    if (useBeacon && !tooLarge && typeof window.navigator.sendBeacon === 'function') {
       try {
         if (window.navigator.sendBeacon(url, blob)) return Promise.resolve();
       } catch (e) {}
@@ -164,10 +164,14 @@
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       body: json,
       keepalive: !tooLarge,
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error('Galaxy request failed with status ' + response.status);
+      }
     });
   }
 
-  function flushEvents() {
+  function flushEvents(useBeacon) {
     if (flushInFlight || eventsQueue.length === 0) {
       return flushInFlight || Promise.resolve();
     }
@@ -184,7 +188,7 @@
       data: eventsQueue.slice(0, eventCount),
     };
 
-    flushInFlight = post(API_HOST + API_PATH, request)
+    flushInFlight = post(API_HOST + API_PATH, request, useBeacon === true)
       .then(function () {
         eventsQueue.splice(0, eventCount);
       })
@@ -209,7 +213,7 @@
 
   function stopGalaxy() {
     window.clearInterval(flushInterval);
-    void flushEvents();
+    void flushEvents(true);
   }
 
   window.addEventListener('beforeunload', stopGalaxy);
@@ -220,14 +224,8 @@
     if (!event.persisted) stopGalaxy();
   });
 
-  function pageEventPrefix(path) {
-    return path.indexOf('/resources/support-center/knowledge-base/') !== -1
-      ? 'knowledgebase.page.' + path
-      : 'docs.page.' + path;
-  }
-
   function trackPageEvent(action) {
-    track(pageEventPrefix(window.location.pathname) + '.window.' + action, {
+    track('docs.window.' + action, {
       interaction: 'trigger',
     });
   }
@@ -238,6 +236,35 @@
   trackPageEvent('load');
   window.addEventListener('focus', function () { trackPageEvent('focus'); });
   window.addEventListener('blur', function () { trackPageEvent('blur'); });
+
+  // Track clicks declaratively from MDX, including clicks on descendants of
+  // wrappers around Mintlify components:
+  // <div data-galaxy-event="docs.install.download"
+  //      data-galaxy-prop-os="linux">...</div>
+  document.addEventListener('click', function (event) {
+    var target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+
+    var element = target.closest('[data-galaxy-event]');
+    if (!element) return;
+
+    var eventName = element.getAttribute('data-galaxy-event');
+    if (!eventName) return;
+
+    var properties = { interaction: 'click' };
+    var anchor = target.closest('a[href]') ||
+      (element.tagName === 'A' ? element : element.querySelector('a[href]'));
+    if (anchor) properties.href = anchor.getAttribute('href');
+
+    for (var i = 0; i < element.attributes.length; i++) {
+      var attribute = element.attributes[i];
+      if (attribute.name.indexOf('data-galaxy-prop-') === 0) {
+        properties[attribute.name.slice('data-galaxy-prop-'.length)] = attribute.value;
+      }
+    }
+
+    track(eventName, properties);
+  }, true);
 
   function watchPath() {
     var path = window.location.pathname;

--- a/docs/_site/customizations/galaxy.js
+++ b/docs/_site/customizations/galaxy.js
@@ -241,6 +241,17 @@
   // wrappers around Mintlify components:
   // <div data-galaxy-event="docs.install.download"
   //      data-galaxy-prop-os="linux">...</div>
+  function getTrackedHref(anchor) {
+    var href = anchor.getAttribute('href');
+    // Homepage click handlers add the canonical /docs base before navigating.
+    // Record that final destination rather than the unprefixed DOM attribute.
+    if (isCanonicalDocs && href && href.charAt(0) === '/' &&
+        href.indexOf('//') !== 0 && !/^\/docs(?:\/|$)/.test(href)) {
+      return '/docs' + href;
+    }
+    return href;
+  }
+
   document.addEventListener('click', function (event) {
     var target = event.target;
     if (!target || typeof target.closest !== 'function') return;
@@ -254,7 +265,7 @@
     var properties = { interaction: 'click' };
     var anchor = target.closest('a[href]') ||
       (element.tagName === 'A' ? element : element.querySelector('a[href]'));
-    if (anchor) properties.href = anchor.getAttribute('href');
+    if (anchor) properties.href = getTrackedHref(anchor);
 
     for (var i = 0; i < element.attributes.length; i++) {
       var attribute = element.attributes[i];

--- a/docs/_site/customizations/navbar-cta.js
+++ b/docs/_site/customizations/navbar-cta.js
@@ -2,6 +2,7 @@
   'use strict';
 
   var CTA_ID = 'ch-navbar-cta';
+  var CTA_HREF = 'https://clickhouse.cloud/signUp?loc=docs-nav-signUp-cta';
 
   var githubSvg = '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">'
     + '<path fill-rule="evenodd" clip-rule="evenodd" d="M8 1.75C4.27 1.75 1.25 4.77 1.25 8.5c0 2.99 1.93 5.51 4.62 6.4.34.06.46-.14.46-.32 0-.16-.01-.69-.01-1.26-1.7.32-2.14-.6-2.27-.98-.08-.19-.41-.79-.7-.95-.24-.13-.58-.44-.01-.45.53-.01.91.49 1.04.69.61 1.02 1.58.73 1.97.56.06-.44.24-.74.43-.91-1.5-.17-3.07-.75-3.07-3.33 0-.73.26-1.34.69-1.81-.07-.17-.3-.86.07-1.79 0 0 .57-.18 1.86.69.54-.15 1.11-.23 1.69-.23.57 0 1.14.08 1.68.23 1.29-.88 1.86-.69 1.86-.69.37.93.14 1.62.07 1.79.43.47.69 1.07.69 1.81 0 2.59-1.58 3.16-3.08 3.33.25.21.46.62.46 1.25 0 .9-.01 1.63-.01 1.86 0 .18.13.39.47.32 2.67-.9 4.58-3.41 4.58-6.4 0-3.73-3.02-6.75-6.75-6.75Z" fill="currentColor"/>'
@@ -63,11 +64,18 @@
 
     var ctaLink = document.createElement('a');
     ctaLink.className = 'ch-cta-btn';
-    ctaLink.href = 'https://clickhouse.cloud/signUp?loc=docs-nav-signUp-cta';
+    ctaLink.href = CTA_HREF;
     ctaLink.target = '_blank';
     ctaLink.rel = 'noopener noreferrer';
     ctaLink.textContent = 'Get Started';
-    ctaLink.setAttribute('data-galaxy-event', 'docs.navbar.get-started');
+    ctaLink.onclick = function () {
+      if (window.galaxy && typeof window.galaxy.track === 'function') {
+        window.galaxy.track('docs.navbar.get-started', {
+          interaction: 'click',
+          href: CTA_HREF,
+        });
+      }
+    };
     container.appendChild(ctaLink);
 
     mapleNav.appendChild(container);

--- a/docs/_site/customizations/navbar-cta.js
+++ b/docs/_site/customizations/navbar-cta.js
@@ -67,6 +67,7 @@
     ctaLink.target = '_blank';
     ctaLink.rel = 'noopener noreferrer';
     ctaLink.textContent = 'Get Started';
+    ctaLink.setAttribute('data-galaxy-event', 'docs.navbar.get-started');
     container.appendChild(ctaLink);
 
     mapleNav.appendChild(container);

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -32,7 +32,7 @@ export const FullWidthDivider = ({ style }) => {
     return <hr ref={ref} className="ch-usecase-divider" style={style} />;
 };
 
-export const HeroCard = ({ filename, darkFilename: darkFilenameProp, title, description, body, href, links, icon, showArrow, external, arrowBottom, extraClassName, logo, logoInvert, overlayImg, fullWidthImage, imageHeight = 'h-48', imageTop }) => {
+export const HeroCard = ({ filename, darkFilename: darkFilenameProp, title, description, body, href, links, icon, showArrow, external, arrowBottom, extraClassName, logo, logoInvert, overlayImg, fullWidthImage, imageHeight = 'h-48', imageTop, galaxyEvent }) => {
     const assetBase = typeof window !== 'undefined' && window.location.pathname.startsWith('/docs') ? '/docs' : '';
     const withBase = (p) => p && p.startsWith('/') ? assetBase + p : p;
     const darkFilename = darkFilenameProp || (filename ? filename.replace('-light.', '-dark.') : null);
@@ -121,10 +121,10 @@ export const HeroCard = ({ filename, darkFilename: darkFilenameProp, title, desc
 
     const fullClassName = [cardClassName, extraClassName].filter(Boolean).join(' ');
     if (links && links.length > 0) {
-        return <div className={fullClassName}>{content}</div>;
+        return <div className={fullClassName} data-galaxy-event={galaxyEvent}>{content}</div>;
     }
 
-    return <a className={fullClassName} href={href} onClick={(e) => { e.preventDefault(); window.location.href = withBase(href); }}>{content}</a>;
+    return <a className={fullClassName} href={href} data-galaxy-event={galaxyEvent} onClick={(e) => { e.preventDefault(); window.location.href = withBase(href); }}>{content}</a>;
 };
 
 export const IntegrationsBanner = () => {
@@ -134,6 +134,7 @@ export const IntegrationsBanner = () => {
         <a
             className="ch-hero-card ch-integrations-banner flex items-center justify-between gap-4 p-4 rounded-lg no-underline bg-[#f9f9f9] border border-[#e5e7eb] text-inherit"
             href={href}
+            data-galaxy-event="docs.home.integrations"
             onClick={(e) => { e.preventDefault(); window.location.href = assetBase + href; }}
         >
             <div>
@@ -180,6 +181,7 @@ export const McpLink = ({ children }) => {
     return (
         <a
             href="#mcp-setup"
+            data-galaxy-event="docs.home.mcp-server"
             onClick={handleClick}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors no-underline"
         >
@@ -203,6 +205,7 @@ export const QuickstartPill = ({ children }) => {
         <a
             className="inline-flex items-center gap-2 h-9 px-4 rounded-full text-sm text-gray-700 dark:text-zinc-200 bg-gray-950/[0.03] dark:bg-white/[0.04] border border-gray-950/15 dark:border-white/15 hover:border-gray-950/40 dark:hover:border-white/35 transition-colors no-underline"
             href={path}
+            data-galaxy-event="docs.home.quickstart-cloud"
             onClick={(e) => { e.preventDefault(); window.location.href = withBase(path); }}
         >
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" viewBox="0 0 256 256" aria-hidden="true" className="shrink-0 text-gray-500 dark:text-zinc-300"><path d="M215.79,118.17a8,8,0,0,0-5-5.66L153.18,90.9l14.66-73.33a8,8,0,0,0-13.69-7l-112,120a8,8,0,0,0,3,13l57.63,21.61L88.16,238.43a8,8,0,0,0,13.69,7l112-120A8,8,0,0,0,215.79,118.17ZM109.37,214l10.47-52.38a8,8,0,0,0-5-9.06L62,132.71l84.62-90.66L136.16,94.43a8,8,0,0,0,5,9.06l52.8,19.8Z"></path></svg>
@@ -232,6 +235,7 @@ export const AskAILink = ({ children }) => {
         <button
             type="button"
             id="home-assistant-entry"
+            data-galaxy-event="docs.home.ask-ai"
             onClick={openKapa}
             className="inline-flex items-center gap-1.5 text-sm text-gray-500 dark:text-zinc-500 hover:text-gray-900 dark:hover:text-[#fdff75] transition-colors bg-transparent border-0 p-0 cursor-pointer"
         >
@@ -312,7 +316,7 @@ export const PageWrapper = ({ children }) => {
         </div>
 
         <div className="flex items-center justify-center mx-auto mt-8 px-4">
-            <button type="button" id="home-search-entry" className="flex pointer-events-auto items-center text-sm leading-6 h-11 pl-3.5 pr-4 text-gray-500 dark:text-white/50 dark:brightness-[1.1] dark:hover:brightness-[1.25] gap-2 w-full max-w-[560px] bg-gray-950/[0.03] dark:bg-white/[0.03] hover:bg-gray-950/10 dark:hover:bg-white/10 shadow-none border border-gray-950/10 dark:border-white/10 ring-0 dark:ring-0 rounded-lg" aria-label="Open search">
+            <button type="button" id="home-search-entry" data-galaxy-event="docs.home.search" className="flex pointer-events-auto items-center text-sm leading-6 h-11 pl-3.5 pr-4 text-gray-500 dark:text-white/50 dark:brightness-[1.1] dark:hover:brightness-[1.25] gap-2 w-full max-w-[560px] bg-gray-950/[0.03] dark:bg-white/[0.03] hover:bg-gray-950/10 dark:hover:bg-white/10 shadow-none border border-gray-950/10 dark:border-white/10 ring-0 dark:ring-0 rounded-lg" aria-label="Open search">
                 <div className="flex items-center gap-2 min-w-0"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-search min-w-4 flex-none text-gray-700 hover:text-gray-800 dark:text-gray-400 hover:dark:text-gray-200"><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></svg><div className="truncate min-w-0">Search...</div></div>
             </button>
         </div>
@@ -325,6 +329,7 @@ export const PageWrapper = ({ children }) => {
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-4 mt-24">
             <HeroCard
                 title="Get started"
+                galaxyEvent="docs.home.get-started"
                 description="I am new here, I want to get started and learn more"
                 href="/get-started/quickstarts/create-your-first-service-on-cloud"
                 icon={
@@ -344,6 +349,7 @@ export const PageWrapper = ({ children }) => {
             />
             <HeroCard
                 title="Guides"
+                galaxyEvent="docs.home.guides"
                 description="I want to accomplish a specific task with ClickHouse"
                 href="/guides/clickhouse"
                 icon={
@@ -360,6 +366,7 @@ export const PageWrapper = ({ children }) => {
             />
             <HeroCard
                 title="Reference"
+                galaxyEvent="docs.home.reference"
                 description="I know what I want to do - I just need the details"
                 href="/reference/home"
                 icon={
@@ -379,6 +386,7 @@ export const PageWrapper = ({ children }) => {
             />
             <HeroCard
                 title="Our solutions"
+                galaxyEvent="docs.home.solutions"
                 description="I want to explore ClickHouse solutions"
                 href="/products/cloud/getting-started/intro"
                 icon={
@@ -403,24 +411,28 @@ export const PageWrapper = ({ children }) => {
         <div className="grid sm:grid-cols-2 min-[1300px]:grid-cols-4 gap-x-6 gap-y-4 mt-6">
             <HeroCard
                 title="Real-time analytics"
+                galaxyEvent="docs.home.real-time-analytics"
                 description="Deliver instant insights and dashboards at scale. Analyze billions of rows in real time with millisecond results."
                 href="/get-started/use-cases/real-time-analytics"
                 showArrow
             />
             <HeroCard
                 title="Observability"
+                galaxyEvent="docs.home.observability"
                 description="Store and query logs, metrics and traces at scale using ClickStack, the open source observability stack powered by ClickHouse."
                 href="/clickstack/overview"
                 showArrow
             />
             <HeroCard
                 title="Data warehousing"
+                galaxyEvent="docs.home.data-warehousing"
                 description="Analyze and explore data instantly for insights and apps. Scale faster by offloading heavy workloads."
                 href="/get-started/use-cases/data-warehousing"
                 showArrow
             />
             <HeroCard
                 title="Agentic analytics"
+                galaxyEvent="docs.home.agentic-analytics"
                 description="Let AI agents query your real-time data directly to deliver instant, conversational insights and visualizations"
                 href="/get-started/use-cases/agentic-analytics"
                 showArrow
@@ -440,6 +452,7 @@ export const PageWrapper = ({ children }) => {
                         imageTop
                         imageHeight="h-[340px]"
                         title="ClickHouse Cloud"
+                        galaxyEvent="docs.home.clickhouse-cloud"
                         href="/products/cloud/getting-started/cloud-get-started"
                         extraClassName="h-full"
                         body={<>
@@ -461,6 +474,7 @@ export const PageWrapper = ({ children }) => {
                     <HeroCard
                         filename="thumbnail-clickstack-light.webp"
                         title="ClickStack"
+                        galaxyEvent="docs.home.clickstack"
                         description="The all in one observability stack powered by ClickHouse, which gives you lightning-fast queries and powerful aggregations on logs, metrics, traces, session replays and errors."
                         href="/clickstack/overview"
                         extraClassName="flex-1"
@@ -470,6 +484,7 @@ export const PageWrapper = ({ children }) => {
                     <HeroCard
                         filename="thumbnail-postgres-light.webp"
                         title="Managed Postgres"
+                        galaxyEvent="docs.home.managed-postgres"
                         description="Fast, scalable, enterprise-grade Postgres service, natively integrated with ClickHouse. Easily combine Postgres for transactions and ClickHouse for analytics."
                         href="/products/managed-postgres/overview"
                         extraClassName="flex-1"
@@ -485,6 +500,7 @@ export const PageWrapper = ({ children }) => {
                 <HeroCard
                     filename="thumbnail-langfuse-light.webp"
                     title="Langfuse"
+                    galaxyEvent="docs.home.langfuse"
                     description="Open-source LLM engineering platform for observability, metrics, evaluations, and prompt management."
                     href="https://langfuse.com/docs"
                     showArrow
@@ -493,6 +509,7 @@ export const PageWrapper = ({ children }) => {
                 <HeroCard
                     filename="thumbnail-kubernetes-light.webp"
                     title="Kubernetes Operator"
+                    galaxyEvent="docs.home.kubernetes-operator"
                     description="Automates deploying, configuring, and managing ClickHouse and ClickHouse Keeper clusters on Kubernetes."
                     href="/products/kubernetes-operator/overview"
                     showArrow
@@ -500,6 +517,7 @@ export const PageWrapper = ({ children }) => {
                 <HeroCard
                     filename="thumbnail-chdb-light.webp"
                     title="chDB"
+                    galaxyEvent="docs.home.chdb"
                     description="A fast, reliable, and scalable in-process database. Experience the power of ClickHouse, in-process."
                     href="/products/chdb/index"
                     showArrow


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110083

The Mintlify Galaxy adapter encoded the full page path as the event name, causing the Galaxy API to reject paths longer than its 50-character event limit. Routine delivery also used `sendBeacon`, which cannot expose rejected HTTP responses.

This change aligns lifecycle events with the established `namespace.component.event` format (`docs.window.load`, `docs.window.focus`, and `docs.window.blur`), checks routine `fetch` responses while preserving unload beacon delivery, and adds declarative click tracking through `data-galaxy-event` and `data-galaxy-prop-*` attributes. The homepage navigation, calls to action, search, Ask AI, MCP entry point, and cards are instrumented with stable event names and clicked link destinations.

Validated with the Mintlify local preview, rendered DOM inspection of all tagged controls, JavaScript syntax and whitespace checks, a local event-envelope/retry harness, and successful requests to the Galaxy development endpoint.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.833` (included in `26.7` and later)
<!-- ch-version-info:end -->