### PR TITLE
Fix flaky/slow test_s3_glob_scheherazade

### DIFF
--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -796,6 +796,16 @@ def test_s3_glob_scheherazade(started_cluster):
             ),
         )
 
+    # Assert object cardinality directly: the point of scheherazade is that the glob
+    # lists MORE than 1000 separate objects. A row-level count alone would still pass
+    # if partitioned writes coalesced several partitions into fewer objects.
+    night_objects = list(
+        started_cluster.minio_client.list_objects(
+            bucket, prefix="night_", recursive=True
+        )
+    )
+    assert len(night_objects) == 1001
+
     query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/night_*/tale.csv', 'CSV', '{}')".format(
         started_cluster.minio_redirect_host,
         started_cluster.minio_redirect_port,

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -776,33 +776,25 @@ def test_s3_glob_scheherazade(started_cluster):
     bucket = started_cluster.minio_bucket
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
-    values = "(1, 1, 1)"
-    nights_per_job = 1001 // 30
-    jobs = []
-    for night in range(0, 1001, nights_per_job):
 
-        def add_tales(start, end):
-            for i in range(start, end):
-                path = "night_{}/tale.csv".format(i)
-                query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') values {}".format(
-                    started_cluster.minio_ip,
-                    MINIO_INTERNAL_PORT,
-                    bucket,
-                    path,
-                    table_format,
-                    values,
-                )
-                run_query(instance, query)
-
-        jobs.append(
-            threading.Thread(
-                target=add_tales, args=(night, min(night + nights_per_job, 1001))
-            )
+    # Write all 1001 night_<i>/tale.csv objects with one server-side partitioned insert
+    # per batch. column1 carries the night index, so each object gets a distinct value.
+    # Batched to bound the number of concurrently open partition write buffers.
+    batch = 100
+    for start in range(0, 1001, batch):
+        count = min(start + batch, 1001) - start
+        run_query(
+            instance,
+            "insert into table function s3('http://{}:{}/{}/night_{{_partition_id}}/tale.csv', 'CSV', '{}') "
+            "partition by column1 select number, 1, 1 from numbers({}, {}) settings s3_truncate_on_insert=1".format(
+                started_cluster.minio_ip,
+                MINIO_INTERNAL_PORT,
+                bucket,
+                table_format,
+                start,
+                count,
+            ),
         )
-        jobs[-1].start()
-
-    for job in jobs:
-        job.join()
 
     query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/night_*/tale.csv', 'CSV', '{}')".format(
         started_cluster.minio_redirect_host,
@@ -810,7 +802,8 @@ def test_s3_glob_scheherazade(started_cluster):
         bucket,
         table_format,
     )
-    assert run_query(instance, query).splitlines() == ["1001\t1001\t1001\t1001"]
+    # sum(column1) = 0 + 1 + ... + 1000 = 500500 confirms all 1001 distinct files exist.
+    assert run_query(instance, query).splitlines() == ["1001\t500500\t1001\t1001"]
 
 
 def test_s3_enum_glob_should_not_list(started_cluster):

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -886,38 +886,48 @@ def test_s3_glob_many_objects_under_selection(started_cluster):
     bucket = started_cluster.minio_bucket
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
     table_format = "column1 UInt32, column2 UInt32, column3 UInt32"
-    values = "(1, 1, 1)"
-    jobs = []
-    for thread_num in range(16):
 
-        def create_files(thread_num):
-            for f_num in range(thread_num * 63, thread_num * 63 + 63):
-                path = f"folder1/file{f_num}.csv"
-                query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') settings s3_truncate_on_insert=1 values {}".format(
-                    started_cluster.minio_ip,
-                    MINIO_INTERNAL_PORT,
-                    bucket,
-                    path,
-                    table_format,
-                    values,
-                )
-                run_query(instance, query)
+    # Write 1008 folder1/file<i>.csv objects with server-side partitioned inserts.
+    # column1 carries the file index, so each object gets a distinct value and the
+    # file name in the path is _partition_id. Batched to bound the number of
+    # concurrently open partition write buffers.
+    batch = 100
+    for start in range(0, 1008, batch):
+        count = min(start + batch, 1008) - start
+        run_query(
+            instance,
+            "insert into table function s3('http://{}:{}/{}/folder1/file{{_partition_id}}.csv', 'CSV', '{}') "
+            "partition by column1 select number, 1, 1 from numbers({}, {}) settings s3_truncate_on_insert=1".format(
+                started_cluster.minio_ip,
+                MINIO_INTERNAL_PORT,
+                bucket,
+                table_format,
+                start,
+                count,
+            ),
+        )
 
-        jobs.append(threading.Thread(target=create_files, args=(thread_num,)))
-        jobs[-1].start()
-
-    query = "insert into table function s3('http://{}:{}/{}/{}', 'CSV', '{}') settings s3_truncate_on_insert=1 values {}".format(
-        started_cluster.minio_ip,
-        MINIO_INTERNAL_PORT,
-        bucket,
-        "folder2/file0.csv",
-        table_format,
-        values,
+    run_query(
+        instance,
+        "insert into table function s3('http://{}:{}/{}/folder2/file0.csv', 'CSV', '{}') "
+        "settings s3_truncate_on_insert=1 values (1, 1, 1)".format(
+            started_cluster.minio_ip,
+            MINIO_INTERNAL_PORT,
+            bucket,
+            table_format,
+        ),
     )
-    run_query(instance, query)
 
-    for job in jobs:
-        job.join()
+    # Assert object cardinality directly: the point of this test is that the glob
+    # lists MORE than 1000 separate objects under folder1. A row-level count alone
+    # would still pass if partitioned writes coalesced several partitions into
+    # fewer objects.
+    folder1_objects = list(
+        started_cluster.minio_client.list_objects(
+            bucket, prefix="folder1/", recursive=True
+        )
+    )
+    assert len(folder1_objects) == 1008
 
     query = "select count(), sum(column1), sum(column2), sum(column3) from s3('http://{}:{}/{}/folder{{1,2}}/file*.csv', 'CSV', '{}')".format(
         started_cluster.minio_redirect_host,
@@ -925,7 +935,9 @@ def test_s3_glob_many_objects_under_selection(started_cluster):
         bucket,
         table_format,
     )
-    assert run_query(instance, query).splitlines() == ["1009\t1009\t1009\t1009"]
+    # sum(column1) = (0 + 1 + ... + 1007) + 1 = 507528 + 1 = 507529 confirms all
+    # 1008 distinct folder1 files plus the single folder2 file exist.
+    assert run_query(instance, query).splitlines() == ["1009\t507529\t1009\t1009"]
 
 
 def run_s3_mocks(started_cluster):


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/110165
-->

Closes: #110165

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_s3_glob_scheherazade` was slow (~10 min/run) and flaky. It wrote 1001 `night_<i>/tale.csv` objects with 30 Python threads each doing sequential single-row `INSERT ... VALUES` round-trips. Under ASan-server load a writer connection hit `Code: 210 Broken pipe (NETWORK_ERROR)` and the thread died silently (`threading.Thread` swallows the exception, `join()` returns), so the following glob read a partial object set and returned a short `count()` (e.g. 509/779/783 instead of 1001). It is a write-side race, not an S3 listing bug.

Replaces the threaded writer with server-side partitioned inserts, batched to bound the number of concurrently open partition write buffers. All 1001 objects are written without client threads or ~1000 round-trips. `column1` carries the night index, so the assertion is strengthened to `1001	500500	1001	1001` (`sum(column1) = 0+...+1000`), verifying every distinct file exists.

Verified locally: the test passes in ~34s (was ~10 min and failing 3/3 in the flaky check).

Reported from @ alexey-milovidov's investigation on #109310.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.836` (included in `26.7` and later)
<!-- ch-version-info:end -->