### PR TITLE
Fix Vector Search Stress: read public datasets with NOSIGN

### DIFF
--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -291,10 +291,13 @@ class RunTest:
             if configured_select_list is not None:
                 select_list = configured_select_list
 
-            source = f"s3('{url}')"
+            # Public clickhouse-datasets bucket: read with NOSIGN so the query
+            # does not fall back to server-managed credentials (rejected in user
+            # queries by default). NOSIGN is the 2nd positional s3() argument.
+            source = f"s3('{url}', NOSIGN)"
             source_format = self._dataset.get(SOURCE_FORMAT)
             if source_format is not None:
-                source = f"s3('{url}', '{source_format}'"
+                source = f"s3('{url}', NOSIGN, '{source_format}'"
                 source_structure = self._dataset.get(SOURCE_STRUCTURE)
                 if source_structure is not None:
                     source = source + f", '{source_structure}'"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106855
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The weekly `Vector Search Stress` master job fails on all 3 datasets during `load_data()`:

```
Code: 497. DB::Exception: S3 access from user queries is not allowed to use server-managed
credentials ... Provide explicit credentials, use NOSIGN, or enable the setting
`s3_allow_server_credentials_in_user_queries`. (ACCESS_DENIED)
```

Cause: `#106855` (merged 2026-07-07) restricts server-managed S3 credentials in user queries by default. The job reads the public `clickhouse-datasets` bucket via `s3()` without credentials, so the read now falls back to server credentials and is rejected.

Fix: read the public datasets with `NOSIGN` (the 2nd positional `s3()` arg), covering both the plain `s3(url)` and the `s3(url, format, structure)` (cohere `Npy`) paths.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bd4fdad4b12cd2a4ef989171b1b37887f6588a0a&name_0=VectorSearchStress&name_1=Vector%20Search%20Stress

Verified locally on master HEAD (post-#106855): `s3(url)` -> Code 497; `s3(url, NOSIGN)` and `s3(url, NOSIGN, 'Npy', 'vector Array(Float32)')` both read successfully.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.832` (included in `26.7` and later)
<!-- ch-version-info:end -->