### PR TITLE
Allow allocations in NOEXCEPT_SCOPE catch handler

### DIFF
--- a/src/Common/noexcept_scope.h
+++ b/src/Common/noexcept_scope.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Common/Exception.h>
 #include <Common/LockMemoryExceptionInThread.h>
+#include <Common/MemoryTracker.h>
 
 /// It can be used in critical places to exit on unexpected exceptions.
 /// SIGABRT is usually better that broken in-memory state with unpredictable consequences.
@@ -16,6 +17,7 @@
     }                                                          \
     catch (...)                                                \
     {                                                          \
+        ALLOW_ALLOCATIONS_IN_SCOPE;                            \
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);       \
         std::terminate();                                      \
     }                                                          \


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110144
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Run the `NOEXCEPT_SCOPE` catch handler under `ALLOW_ALLOCATIONS_IN_SCOPE` so the real exception is logged before terminate.

CI report (STID 2573-2cd4): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110144&sha=7c516a74c93c6b69606ae441c4a8792afca0b281&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.892` (included in `26.7` and later)
<!-- ch-version-info:end -->