### PR TITLE
CI: fix nightly Cloud API docs authentication

### DIFF
--- a/ci/jobs/cloud_api_docs_nightly.py
+++ b/ci/jobs/cloud_api_docs_nightly.py
@@ -9,6 +9,7 @@ Fail-closed: the PR is only touched when regeneration succeeded and produced a
 real diff; a failed regeneration never pushes a branch or opens a PR.
 """
 
+import os
 import re
 import shlex
 
@@ -59,6 +60,14 @@ def has_changes():
 
 
 def open_or_refresh_pr():
+    repository = os.getenv("GITHUB_REPOSITORY", "")
+    if repository != REPOSITORY:
+        print(
+            "ERROR: the Cloud API docs workflow must run only in "
+            f"{REPOSITORY}, got {repository or '(unset)'}"
+        )
+        return False
+
     prepare = [
         'git config user.name "robot-clickhouse"',
         'git config user.email "robot-clickhouse@users.noreply.github.com"',
@@ -101,13 +110,14 @@ def open_or_refresh_pr():
     # while the drift never reaches reviewers.
     existing = Shell.get_output(
         f"gh pr list --head {BOT_BRANCH} --base master --state open "
-        "--json number --jq '.[].number'"
+        f"--repo {shlex.quote(REPOSITORY)} --json number --jq '.[].number'"
     ).strip()
     if existing:
         print(f"PR #{existing} already open; branch refreshed")
         return True
     return Shell.check(
         f"gh pr create --base master --head {BOT_BRANCH} "
+        f"--repo {shlex.quote(REPOSITORY)} "
         f"--title {shlex.quote(PR_TITLE)} --body {shlex.quote(PR_BODY)}",
         verbose=True,
     )

--- a/ci/jobs/cloud_api_docs_nightly.py
+++ b/ci/jobs/cloud_api_docs_nightly.py
@@ -9,6 +9,7 @@ Fail-closed: the PR is only touched when regeneration succeeded and produced a
 real diff; a failed regeneration never pushes a branch or opens a PR.
 """
 
+import re
 import shlex
 
 from praktika.result import Result
@@ -46,6 +47,8 @@ of the changes that goes into CHANGELOG.md):
 Sync the ClickHouse Cloud API reference documentation from the OpenAPI spec.
 """
 
+TOKENIZED_GITHUB_URL = re.compile(r"(https://x-access-token:)[^@\s]+(@github\.com/)")
+
 
 def regenerate():
     return Shell.check(f"python3 {GENERATOR} --write", verbose=True)
@@ -82,7 +85,13 @@ def open_or_refresh_pr():
         "git -c http.https://github.com/.extraheader= push -f "
         f"{repo_url} {refspec}"
     )
-    if not Shell.check(push, verbose=False):
+    return_code, stdout, stderr = Shell.get_res_stdout_stderr(push, verbose=False)
+    if return_code != 0:
+        output = "\n".join(part for part in (stdout, stderr) if part)
+        output = TOKENIZED_GITHUB_URL.sub(r"\1***\2", output)
+        print("ERROR: failed to push the Cloud API docs bot branch")
+        if output:
+            print(output)
         return False
 
     # A force-push already refreshed any open PR, so a PR is created only when

--- a/ci/jobs/cloud_api_docs_nightly.py
+++ b/ci/jobs/cloud_api_docs_nightly.py
@@ -16,6 +16,7 @@ from praktika.utils import Shell
 
 GENERATOR = "./ci/jobs/scripts/docs/generate_cloud_api_reference.py"
 BOT_BRANCH = "robot/cloud-api-docs"
+REPOSITORY = "ClickHouse/ClickHouse"
 # Paths the generator owns; everything staged into the bot PR lives here.
 DOCS_PATHS = (
     "docs/products/cloud/api-reference docs/_specs/cloud-openapi.json "
@@ -55,15 +56,33 @@ def has_changes():
 
 
 def open_or_refresh_pr():
-    push = [
+    prepare = [
         'git config user.name "robot-clickhouse"',
         'git config user.email "robot-clickhouse@users.noreply.github.com"',
         f"git checkout -B {BOT_BRANCH}",
         f"git add -A {DOCS_PATHS}",
         f"git commit -m {shlex.quote(PR_TITLE)}",
-        f"git push -f origin {BOT_BRANCH}",
     ]
-    if not Shell.check(" && ".join(push), verbose=True):
+    if not Shell.check(" && ".join(prepare), verbose=True):
+        return False
+
+    # actions/checkout persists the workflow GITHUB_TOKEN as an HTTP extraheader,
+    # so a plain `git push origin` ignores the GitHub App token authenticated by
+    # enable_gh_auth and pushes as github-actions[bot]. Clear that extraheader and
+    # use the App token explicitly. Keep the command out of logs because its URL
+    # contains the expanded token.
+    repo_url = (
+        "https://x-access-token:${token}@github.com/"
+        + shlex.quote(REPOSITORY)
+        + ".git"
+    )
+    refspec = shlex.quote(f"{BOT_BRANCH}:refs/heads/{BOT_BRANCH}")
+    push = (
+        'token="$(gh auth token)" && '
+        "git -c http.https://github.com/.extraheader= push -f "
+        f"{repo_url} {refspec}"
+    )
+    if not Shell.check(push, verbose=False):
         return False
 
     # A force-push already refreshed any open PR, so a PR is created only when

--- a/ci/tests/test_cloud_api_docs_nightly.py
+++ b/ci/tests/test_cloud_api_docs_nightly.py
@@ -9,6 +9,7 @@ from ci.jobs import cloud_api_docs_nightly
 
 def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     checks = []
+    pushes = []
 
     def fake_check(command, verbose=False, **_kwargs):
         checks.append((command, verbose))
@@ -17,14 +18,21 @@ def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     monkeypatch.setattr(cloud_api_docs_nightly.Shell, "check", fake_check)
     monkeypatch.setattr(
         cloud_api_docs_nightly.Shell,
+        "get_res_stdout_stderr",
+        lambda command, verbose=False: pushes.append((command, verbose)) or (0, "", ""),
+    )
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
         "get_output",
         lambda *_args, **_kwargs: "123",
     )
 
     assert cloud_api_docs_nightly.open_or_refresh_pr()
-    assert len(checks) == 2
+    assert len(checks) == 1
+    assert len(pushes) == 1
 
-    prepare, push = checks
+    prepare = checks[0]
+    push = pushes[0]
     assert prepare[1] is True
     assert "git commit" in prepare[0]
     assert "git push" not in prepare[0]
@@ -34,3 +42,24 @@ def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     assert "http.https://github.com/.extraheader=" in push[0]
     assert "ClickHouse/ClickHouse.git" in push[0]
     assert "robot/cloud-api-docs:refs/heads/robot/cloud-api-docs" in push[0]
+
+
+def test_failed_push_reports_redacted_stderr(monkeypatch, capsys):
+    monkeypatch.setattr(cloud_api_docs_nightly.Shell, "check", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "get_res_stdout_stderr",
+        lambda *_args, **_kwargs: (
+            128,
+            "",
+            "fatal: unable to access "
+            "https://x-access-token:secret-token@github.com/ClickHouse/ClickHouse.git",
+        ),
+    )
+
+    assert not cloud_api_docs_nightly.open_or_refresh_pr()
+    output = capsys.readouterr().out
+    assert "failed to push the Cloud API docs bot branch" in output
+    assert "fatal: unable to access" in output
+    assert "secret-token" not in output
+    assert "https://x-access-token:***@github.com/ClickHouse/ClickHouse.git" in output

--- a/ci/tests/test_cloud_api_docs_nightly.py
+++ b/ci/tests/test_cloud_api_docs_nightly.py
@@ -9,7 +9,10 @@ from ci.jobs import cloud_api_docs_nightly
 
 def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     checks = []
+    outputs = []
     pushes = []
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", cloud_api_docs_nightly.REPOSITORY)
 
     def fake_check(command, verbose=False, **_kwargs):
         checks.append((command, verbose))
@@ -24,7 +27,7 @@ def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     monkeypatch.setattr(
         cloud_api_docs_nightly.Shell,
         "get_output",
-        lambda *_args, **_kwargs: "123",
+        lambda command, **_kwargs: outputs.append(command) or "123",
     )
 
     assert cloud_api_docs_nightly.open_or_refresh_pr()
@@ -42,9 +45,58 @@ def test_push_uses_app_token_without_verbose_logging(monkeypatch):
     assert "http.https://github.com/.extraheader=" in push[0]
     assert "ClickHouse/ClickHouse.git" in push[0]
     assert "robot/cloud-api-docs:refs/heads/robot/cloud-api-docs" in push[0]
+    assert len(outputs) == 1
+    assert "--repo ClickHouse/ClickHouse" in outputs[0]
+
+
+def test_pr_create_targets_upstream_repository(monkeypatch):
+    checks = []
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", cloud_api_docs_nightly.REPOSITORY)
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "check",
+        lambda command, **_kwargs: checks.append(command) or True,
+    )
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "get_res_stdout_stderr",
+        lambda *_args, **_kwargs: (0, "", ""),
+    )
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "get_output",
+        lambda *_args, **_kwargs: "",
+    )
+
+    assert cloud_api_docs_nightly.open_or_refresh_pr()
+    assert len(checks) == 2
+    assert "gh pr create" in checks[1]
+    assert "--repo ClickHouse/ClickHouse" in checks[1]
+
+
+def test_rejects_non_upstream_repository_before_mutation(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_REPOSITORY", "Blargian/ClickHouse")
+
+    def unexpected_call(*_args, **_kwargs):
+        raise AssertionError("workflow mutated state before validating the repository")
+
+    monkeypatch.setattr(cloud_api_docs_nightly.Shell, "check", unexpected_call)
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "get_res_stdout_stderr",
+        unexpected_call,
+    )
+    monkeypatch.setattr(cloud_api_docs_nightly.Shell, "get_output", unexpected_call)
+
+    assert not cloud_api_docs_nightly.open_or_refresh_pr()
+    output = capsys.readouterr().out
+    assert "must run only in ClickHouse/ClickHouse" in output
+    assert "got Blargian/ClickHouse" in output
 
 
 def test_failed_push_reports_redacted_stderr(monkeypatch, capsys):
+    monkeypatch.setenv("GITHUB_REPOSITORY", cloud_api_docs_nightly.REPOSITORY)
     monkeypatch.setattr(cloud_api_docs_nightly.Shell, "check", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(
         cloud_api_docs_nightly.Shell,

--- a/ci/tests/test_cloud_api_docs_nightly.py
+++ b/ci/tests/test_cloud_api_docs_nightly.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs import cloud_api_docs_nightly
+
+
+def test_push_uses_app_token_without_verbose_logging(monkeypatch):
+    checks = []
+
+    def fake_check(command, verbose=False, **_kwargs):
+        checks.append((command, verbose))
+        return True
+
+    monkeypatch.setattr(cloud_api_docs_nightly.Shell, "check", fake_check)
+    monkeypatch.setattr(
+        cloud_api_docs_nightly.Shell,
+        "get_output",
+        lambda *_args, **_kwargs: "123",
+    )
+
+    assert cloud_api_docs_nightly.open_or_refresh_pr()
+    assert len(checks) == 2
+
+    prepare, push = checks
+    assert prepare[1] is True
+    assert "git commit" in prepare[0]
+    assert "git push" not in prepare[0]
+
+    assert push[1] is False
+    assert 'token="$(gh auth token)"' in push[0]
+    assert "http.https://github.com/.extraheader=" in push[0]
+    assert "ClickHouse/ClickHouse.git" in push[0]
+    assert "robot/cloud-api-docs:refs/heads/robot/cloud-api-docs" in push[0]


### PR DESCRIPTION
## Summary

- push the nightly Cloud API docs bot branch with the GitHub App token authenticated by Praktika
- clear the credential persisted by `actions/checkout` so the read-only `github-actions[bot]` token cannot shadow the App token
- add a focused regression covering the push command, refspec, and non-verbose token handling

## Root cause

The first `NightlyCloudAPIDocs` run successfully regenerated the live OpenAPI spec, but `git push -f origin robot/cloud-api-docs` used the HTTP extraheader persisted by `actions/checkout`. The push therefore authenticated as `github-actions[bot]` instead of the GitHub App configured by `enable_gh_auth=True`, and GitHub rejected it with HTTP 403.

This uses the same explicit App-token push pattern already used by Praktika's workflow regeneration job.

Failed run: https://github.com/ClickHouse/ClickHouse/actions/runs/29184900282

## Validation

- `python3 -m pytest -q ci/tests/test_cloud_api_docs_nightly.py`
- `git diff --check`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.
