### PR TITLE
Remove cross-version-fragile OPTIMIZE FINAL from test_split_topology_rolling_upgrade

### DIFF
--- a/tests/integration/test_backward_compatibility/test_parallel_replicas_protocol.py
+++ b/tests/integration/test_backward_compatibility/test_parallel_replicas_protocol.py
@@ -196,9 +196,13 @@ def test_split_topology_rolling_upgrade(start_cluster):
     split_topology_nodes[0].query(
         "insert into ts select number % 100000 from numbers_mt(1000000) ORDER BY ALL"
     )
+    # No OPTIMIZE FINAL: a single insert is one part, so FINAL is a no-op merge whose MERGE_PARTS
+    # entry the 26.5 replicas cannot reproduce byte-identically across versions and can hang for
+    # minutes, occasionally raising code 341 (log entry not processed, replica shut down). The
+    # assertions below do not depend on part layout. system sync replica already guarantees
+    # every replica sees the same 1M rows.
     for node in split_topology_nodes:
         node.query("system sync replica ts")
-        node.query("optimize table ts final")
 
     split_settings = {
         "cluster_for_parallel_replicas": "parallel_replicas",


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110129
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_split_topology_rolling_upgrade` failed on the `Integration tests (amd_tsan, 1/6)` run with code 341 at the setup step `optimize table ts final`:

```
Code: 341. DB::Exception: Received from 172.16.2.10:9000. DB::Exception:
Log entry log-0000000003 is not precessed on local replica, most likely
because the replica was shut down.
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110152&sha=729886a3f8576eae108e6bd09bc29c4922a39212&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%201%2F6%29

Root cause: the setup does one `insert` then `optimize table ts final`. A single insert produces one part, so FINAL is a no-op merge, but it still enqueues a `MERGE_PARTS` replication log entry. The mixed-version cluster (two 26.5 replicas + the build under test) cannot always reproduce that merge byte-identically across versions, so the entry can block replica sync for minutes and, when a replica restarts, surface as code 341.

The assertions (`order by a limit 10`, `order by a desc limit 10`, `count() group by a`) are part-layout-independent, and the existing `system sync replica ts` loop already guarantees every replica sees the same 1M rows. Removing the OPTIMIZE removes the flakiness without weakening the test.

This mirrors #110129, which removed the identical no-op OPTIMIZE FINAL from the sibling `test_backward_compatability` in the same file.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.841` (included in `26.7` and later)
<!-- ch-version-info:end -->