### PR TITLE
Tag 02835_drop_user_during_session as long

### DIFF
--- a/tests/queries/0_stateless/02835_drop_user_during_session.sh
+++ b/tests/queries/0_stateless/02835_drop_user_during_session.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-debug, no-random-settings, no-random-merge-tree-settings, no-fasttest
+# Tags: long, no-debug, no-random-settings, no-random-merge-tree-settings, no-fasttest
 # no-fasttest: Busy slow wait
+# long: busy-waits on session teardown + session_log flush; can cross the 180s flaky-check backstop on slow sanitizer builds
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/110190
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02835_drop_user_during_session.sh` busy-waits on concurrent session teardown and `system.session_log` flush through unbounded polling loops (`wait_for_queries_start` plus a final `while true` INTERSECT poll). On slow `arm_asan_ubsan` builds a single run can cross the 180s per-run flaky-check wall-clock backstop, producing "runs too long" FAILs. 0 master failures in 60d; all failures were "runs too long" on `arm_asan_ubsan` targeted checks.

The `long` tag exempts the test from the 180s backstop and reduces the flaky-check repeat count, without weakening any assertion or changing what the test checks.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.846` (included in `26.7` and later)
<!-- ch-version-info:end -->