### PR TITLE
Deflake test_startup_with_small_bg_pool_partitioned via is_readonly poll

### DIFF
--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -79,15 +79,37 @@ def test_startup_with_small_bg_pool_partitioned(started_cluster):
         node.start_clickhouse(start_wait_sec=150)
         assert_values()
 
-    # check that we activate it in the end
+    # Check that the table re-activates in the end.
     #
-    # Bound each attempt with `timeout=` so the retry loop can actually fire.
-    # Without it, the first attempt blocks in `subprocess.wait` for
-    # `DEFAULT_QUERY_TIMEOUT` (600s) when the table is still recovering after
-    # fault injection (single background-schedule thread + 0.001 ZK fault
-    # probability + sanitizer overhead), and pytest's 900s test-level timeout
-    # fires before the retry loop can execute even once. With `timeout=15`,
-    # the loop can do up to ~20 attempts within the budget.
+    # Fault injection stays enabled for the rest of this test, and every
+    # injected fault throws `ZSESSIONEXPIRED`, tearing down the whole ClickHouse
+    # Keeper session (not just one request). Combined with
+    # `background_schedule_pool_size=1` - so the attach/restarting task shares a
+    # single thread - and sanitizer/coverage slowdown, re-activation is a
+    # heavy-tailed random process: usually a few seconds, occasionally much
+    # longer. The table becomes writable only once it threads a complete clean
+    # activation sequence between two session-expiry faults.
+    #
+    # Previously we retried the blocking INSERT itself, but an INSERT to a
+    # not-yet-active replica blocks server-side, so each attempt burned its
+    # whole `timeout` even when the table was nowhere near ready, and the retry
+    # budget was occasionally exhausted before activation (issue #101103). Poll
+    # the cheap, local `is_readonly` flag instead - it needs no Keeper
+    # round-trip and returns instantly - so the time budget is spent waiting for
+    # activation rather than blocking inside doomed writes.
+    is_readonly = node.query_with_retry(
+        "SELECT is_readonly FROM system.replicas WHERE table = 'replicated_table_partitioned'",
+        check_callback=lambda x: x.strip() == "0",
+        retry_count=120,
+        sleep_time=3,
+    )
+    assert (
+        is_readonly.strip() == "0"
+    ), f"table did not re-activate after fault injection: is_readonly={is_readonly!r}"
+
+    # Once active, the INSERT should go through. Keep a short retry because a
+    # fault may still transiently expire the session between the check and the
+    # write.
     node.query_with_retry(
         "INSERT INTO replicated_table_partitioned VALUES(20, 30)",
         retry_count=20,


### PR DESCRIPTION
Deflake the integration test `test_replicated_table_attach/test.py::test_startup_with_small_bg_pool_partitioned`.

The final "check that we activate it in the end" step retried a blocking `INSERT` while the replica was still recovering from fault injection. An `INSERT` to a not-yet-active replica blocks server-side, so each retry attempt consumed its whole per-attempt `timeout` even when the table was nowhere near ready, and the retry budget was occasionally exhausted before the table re-activated — surfacing as `QueryTimeoutExceedException: Client timed out!` (and, before the earlier `timeout=15` fix, as a hard pytest-900s hang).

**Root cause of the long tail:** fault injection stays enabled for the rest of the test, and each injected fault throws `ZSESSIONEXPIRED`, tearing down the entire ClickHouse Keeper session rather than failing a single request. The `ReplicatedMergeTreeAttachThread`/`ReplicatedMergeTreeRestartingThread` re-activation task runs on the background schedule pool, which the test sizes to a single thread (`background_schedule_pool_size=1`), and sanitizer/coverage builds slow every attempt down. Re-activation therefore becomes a heavy-tailed random process — usually a few seconds, occasionally past the retry budget.

**Fix:** instead of spending the budget inside doomed writes, poll the cheap, local `is_readonly` flag from `system.replicas`. Selecting only `is_readonly` does not set `with_zk_fields` in `StorageSystemReplicas`, so it needs no Keeper round-trip and returns instantly; the budget is spent purely waiting for activation. Once active, a single retried `INSERT` confirms writes go through (a lingering fault may still transiently expire the session between the check and the write).

CIDB: 0 master failures; residual PR-only timeouts under the heaviest sanitizer configs after the earlier `timeout=15` fix (2026-07-01, 2026-07-02).

Closes: https://github.com/ClickHouse/ClickHouse/issues/101103

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!--
🤖 Generated with [Claude Code](https://claude.com/claude-code)
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.864` (included in `26.7` and later)
<!-- ch-version-info:end -->