### PR TITLE
Don't reuse a canceled zip archive handle

### DIFF
--- a/src/IO/Archives/ZipArchiveReader.cpp
+++ b/src/IO/Archives/ZipArchiveReader.cpp
@@ -157,6 +157,13 @@ namespace
             return *reinterpret_cast<StreamFromReadBuffer *>(ptr);
         }
 
+    public:
+        /// True if the underlying archive read buffer was canceled by a prior mid-stream
+        /// read failure. Such a stream must not be reused (see releaseRawHandle).
+        bool isReadBufferCanceled() const { return read_buffer && read_buffer->isCanceled(); }
+
+    private:
+
         static int testErrorFunc(void *, void * stream)
         {
             auto & strm = get(stream);
@@ -819,6 +826,25 @@ void ZipArchiveReader::releaseRawHandle(RawHandleWithStream handle_info)
 {
     if (!handle_info.handle)
         return;
+
+    /// If a prior read failed mid-stream, ReadBuffer::next() called cancel() on the underlying
+    /// archive buffer and rethrew. The `canceled` flag is terminal: a subsequent read on that
+    /// buffer trips chassert(!isCanceled()) in ReadBuffer::next() (LOGICAL_ERROR in debug builds).
+    /// Both the minizip stream and the buffer are in an undefined state, so this handle must not
+    /// be pooled for reuse. Close it; the next acquireRawHandle() opens a fresh one.
+    auto * stream = reinterpret_cast<StreamFromReadBuffer *>(handle_info.stream);
+    if (stream && stream->isReadBufferCanceled())
+    {
+        try
+        {
+            checkResult(unzClose(handle_info.handle));
+        }
+        catch (...)
+        {
+            tryLogCurrentException("ZipArchiveReader");
+        }
+        return;
+    }
 
     std::lock_guard lock{mutex};
     free_handles.push_back(handle_info);

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -1140,6 +1140,114 @@ TEST(ZipArchiveReaderTest, RethrowsCallbackExceptionAfterOpenSucceeded)
     }
 }
 
+
+/// A `SeekableReadBuffer` whose seeks always succeed but whose reads fail while a flag is
+/// set. A read failure goes through `ReadBuffer::next()`, which calls `cancel()` on this
+/// buffer (setting the terminal `canceled` flag) and rethrows -- exactly how a mid-stream
+/// read failure poisons the underlying archive buffer in production. `seek()` never sets
+/// `canceled`, so failing on read (not seek) is what reproduces the pooled-handle bug.
+class ReadFailingReadBuffer : public SeekableReadBuffer
+{
+public:
+    ReadFailingReadBuffer(const String & data_, std::shared_ptr<std::atomic<bool>> fail_flag_)
+        : SeekableReadBuffer(nullptr, 0)
+        , data(data_)
+        , fail_flag(std::move(fail_flag_))
+    {
+    }
+
+    off_t seek(off_t off, int whence) override
+    {
+        if (whence != SEEK_SET)
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Only SEEK_SET allowed");
+        if (off < 0 || static_cast<size_t>(off) > data.size())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Seek out of bounds");
+        pos = nullptr;
+        working_buffer = Buffer(nullptr, nullptr);
+        position_in_file = off;
+        return off;
+    }
+
+    off_t getPosition() override { return static_cast<off_t>(position_in_file) - available(); }
+
+    bool nextImpl() override
+    {
+        if (fail_flag->load())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Forced read failure");
+        if (position_in_file >= data.size())
+            return false;
+        size_t to_read = std::min<size_t>(data.size() - position_in_file, 1024);
+        buf.resize(to_read);
+        std::copy(data.begin() + position_in_file, data.begin() + position_in_file + to_read, buf.begin());
+        BufferBase::set(buf.data(), to_read, 0);
+        position_in_file += to_read;
+        return true;
+    }
+
+private:
+    const String & data;
+    std::shared_ptr<std::atomic<bool>> fail_flag;
+    std::vector<char> buf;
+    size_t position_in_file = 0;
+};
+
+
+/// Reproducer for the BuzzHouse-found `ReadBuffer is canceled. Can't read from it.`
+/// LOGICAL_ERROR (STID 2508-1f27) on the backup-restore zip path.
+///
+/// `ZipArchiveReader` pools its minizip handles in `free_handles` and reuses them for the
+/// next operation. When a read fails mid-stream, `ReadBuffer::next()` calls `cancel()` on
+/// the underlying archive buffer (setting the terminal `canceled` flag) and rethrows. The
+/// `stored_exception` guards added earlier stop the *current* operation, but the poisoned
+/// handle was still returned to the pool. On the next operation minizip re-reads through
+/// that same buffer, and `ReadBuffer::next()` trips `chassert(!isCanceled())`.
+///
+/// The fix closes (rather than pools) a handle whose underlying buffer is canceled, so the
+/// next operation opens a fresh handle. This test poisons a handle with a failing read, then
+/// does a normal read that must succeed rather than abort.
+TEST(ZipArchiveReaderTest, DoesNotReuseCanceledHandle)
+{
+    String archive_in_memory;
+    {
+        auto writer = createArchiveWriter("archive.zip", std::make_unique<WriteBufferFromString>(archive_in_memory));
+        auto out = writer->writeFile("file.txt");
+        writeString(getRandomASCIIString(16 * 1024), *out);
+        out->finalize();
+        writer->finalize();
+    }
+
+    auto fail_flag = std::make_shared<std::atomic<bool>>(false);
+    auto read_archive_func = [&]() -> std::unique_ptr<SeekableReadBuffer>
+    { return std::make_unique<ReadFailingReadBuffer>(archive_in_memory, fail_flag); };
+
+    auto reader = createArchiveReader("archive.zip", read_archive_func, archive_in_memory.size());
+    ASSERT_TRUE(reader->fileExists("file.txt"));
+
+    /// Step 1: a read fails mid-stream, cancelling the underlying buffer of the pooled handle.
+    fail_flag->store(true);
+    try
+    {
+        auto in = reader->readFile("file.txt", /*throw_on_not_found=*/true);
+        String content;
+        readStringUntilEOF(content, *in);
+        FAIL() << "Expected read failure was not thrown";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::CANNOT_SEEK_THROUGH_FILE) << e.displayText();
+    }
+
+    /// Step 2: recover and read normally. Before the fix this reused the canceled handle and
+    /// aborted with `ReadBuffer is canceled. Can't read from it.`; now a fresh handle is used.
+    fail_flag->store(false);
+    {
+        auto in = reader->readFile("file.txt", /*throw_on_not_found=*/true);
+        String content;
+        readStringUntilEOF(content, *in);
+        EXPECT_EQ(content.size(), 16u * 1024u);
+    }
+}
+
 #endif
 
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `ReadBuffer is canceled. Can't read from it.` logical error (server abort in debug/sanitizer builds) that could occur while reading a zip archive (e.g. during `RESTORE` from a zip backup) after a prior read from the same archive failed mid-stream.


### Description

Found by the BuzzHouse fuzzer (STID 2508-1f27, `BuzzHouse (amd_debug)`): a `RESTORE` from a zip backup aborted with `Logical error: 'ReadBuffer is canceled. Can't read from it.'` (`chassert(!isCanceled())` at `src/IO/ReadBuffer.cpp:107`).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110173&sha=d49ec590f14ff356c6e27aa463aa06b5af5b9e8b&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29

Stack (abbreviated): `ReadBuffer::next()` -> `ZipArchiveReader::StreamFromReadBuffer::readFileFunc` -> minizip `unzLocateFile` -> `ZipArchiveReader::HandleHolder::locateFile` -> `ZipArchiveReader::readFile` -> `BackupImpl::readFile` -> `BackupMetadataFinder::findTableInBackupImpl`.

Root cause: `ZipArchiveReader` pools its minizip handles in `free_handles` and reuses them for the next operation. When a read fails mid-stream, `ReadBuffer::next()` calls `cancel()` on the underlying archive buffer (setting the terminal `canceled` flag) and rethrows. The existing `stored_exception` guards in the stream callbacks (added in a previous fix) correctly abort the current operation, but the poisoned handle was still returned to the pool. On the next operation minizip reads through that same buffer and `ReadBuffer::next()` trips `chassert(!isCanceled())`.

Fix: in `releaseRawHandle`, if the underlying buffer of the handle being released is canceled, close the handle instead of pooling it. Both the minizip stream and the buffer are in an undefined state after a mid-stream failure, so the next `acquireRawHandle()` opens a fresh handle. This is independent of the underlying buffer type (file, S3, in-memory).

Regression test `ZipArchiveReaderTest.DoesNotReuseCanceledHandle` in `gtest_archive_reader_and_writer.cpp` fails a read mid-stream to poison a pooled handle, then does a normal read that must succeed. Without the fix it aborts with the exact production stack; with the fix it passes. Full archive unit-test suite (82 tests) passes.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.853` (included in `26.7` and later)
<!-- ch-version-info:end -->