### PR TITLE
Fix read consistency for tables renamed or exchanged during a query

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1541,25 +1541,25 @@ DatabaseAndTable Context::getOrCacheStorage(const StorageID & id, std::function<
     if (auto it = shard.set.find(id); it != shard.set.end())
     {
         DatabaseAndTable storage = DatabaseCatalog::instance().tryGetByUUID(it->uuid);
-        /// The cache is keyed by qualified name only (see `StorageCache::Shard::set`), so a hit can
-        /// carry a UUID that no longer matches the name we are resolving. Return the cached storage
-        /// only if it is still fresh. Otherwise the entry is stale and must not be reused:
-        ///  - the table no longer exists by its UUID (e.g. a refreshable materialized view's inner
-        ///    table was dropped and recreated), or
-        ///  - the UUID still exists but the name was reassigned to a different table by a rename or
-        ///    exchange within the same query. This happens during `CREATE OR REPLACE`, which creates a
-        ///    temporary table, populates it (caching the temporary name -> temporary UUID here), then
-        ///    atomically swaps it with the target via `EXCHANGE`. After the swap the temporary name
-        ///    refers to the old table that is about to be dropped, but the cache would still hand out
-        ///    the new (now live) table - so dropping by the temporary name would shut down the live
-        ///    table instead and break it (e.g. detaching a materialized view from its source), or
-        ///  - the caller asked for a specific UUID but the cached entry resolves to a different one
-        ///    (a same-name replacement); returning it would silently substitute the wrong table
-        ///    instead of letting the fresh lookup report `UNKNOWN_TABLE`/`TABLE_UUID_MISMATCH`.
-        /// In all cases remove the stale entry and fall through to a fresh lookup by name.
-        if (storage.second
-            && storage.second->getStorageID().getQualifiedName() == id.getQualifiedName()
-            && (!id.hasUUID() || it->uuid == id.uuid))
+        /// The cache is keyed by qualified name only (see `StorageCache::Shard::set`) and pins a name
+        /// to the storage it first resolved to in this query. That is the whole point of the cache: a
+        /// running query must keep seeing the table version it was planned against even if a
+        /// concurrent query renames or exchanges that table underneath it (see
+        /// `03915_exchange_tables_race` - otherwise the query is analyzed for one column type and
+        /// executed against another, raising a `LOGICAL_ERROR`). So a cache hit whose name was since
+        /// reassigned (by a rename/exchange, so the cached UUID now maps to a different qualified
+        /// name, or a different UUID now maps to the requested name) is NOT stale - the pinned UUID is
+        /// exactly what we want to return. Return it as long as it still resolves to a live table;
+        /// only drop the entry when the cached UUID no longer exists at all (e.g. a refreshable
+        /// materialized view's inner table was dropped and recreated with a new UUID), and fall
+        /// through to a fresh lookup by name.
+        ///
+        /// A rename or exchange performed BY THIS query drops the affected names from this cache (see
+        /// `dropStorageCacheEntry`, called from `InterpreterRenameQuery`), so the query's own later
+        /// lookups of those names re-resolve to the current tables. This is what lets
+        /// `CREATE OR REPLACE ... POPULATE` drop the old table by the temporary name after its
+        /// internal `EXCHANGE` instead of shutting down the live one (see #108726).
+        if (storage.second)
             return storage;
 
         shard.set.erase(it);
@@ -1577,6 +1577,15 @@ DatabaseAndTable Context::getOrCacheStorage(const StorageID & id, std::function<
     }
 
     return storage;
+}
+
+void Context::dropStorageCacheEntry(const StorageID & id) const
+{
+    auto & shard = storage_cache.shards[StorageCache::shardIndex(id)];
+    std::lock_guard lock(shard.mutex);
+    /// The set uses name-only equality (`StorageID::DatabaseAndTableNameEqual`), so this erases the
+    /// pinned entry for the qualified name regardless of the UUID it was cached with.
+    shard.set.erase(id);
 }
 
 std::unordered_map<Context::WarningType, PreformattedMessage> Context::getWarnings() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -761,6 +761,11 @@ public:
 
     DatabaseAndTable getOrCacheStorage(const StorageID & id, std::function<DatabaseAndTable()> storage_getter) const;
 
+    /// Remove a qualified name from the per-query storage cache. Called after this query renames or
+    /// exchanges a table so its own later lookups of the affected names re-resolve to the current
+    /// tables instead of the version pinned before the swap.
+    void dropStorageCacheEntry(const StorageID & id) const;
+
     // Get the disk used by databases to store metadata files.
     std::shared_ptr<IDisk> getDatabaseDisk() const;
 

--- a/src/Interpreters/InterpreterRenameQuery.cpp
+++ b/src/Interpreters/InterpreterRenameQuery.cpp
@@ -201,6 +201,20 @@ BlockIO InterpreterRenameQuery::executeToTables(const ASTRenameQuery & rename, c
             NamedCollectionFactory::instance().renameDependencies(from_table_id, to_table_id);
             if (exchange_tables)
                 NamedCollectionFactory::instance().renameDependencies(to_table_id, from_table_id);
+
+            /// The name -> storage mapping just changed. Drop the affected names from this query's
+            /// per-query storage cache so the query's own subsequent lookups resolve to the current
+            /// tables rather than the version pinned before the swap. In particular this lets the
+            /// internal DROP in `CREATE OR REPLACE ... POPULATE` target the old table by the
+            /// temporary name after the internal EXCHANGE (see #108726). Concurrent queries keep
+            /// their own per-query caches and remain isolated from this rename, so a running SELECT
+            /// still reads the version it was planned against (see 03915_exchange_tables_race).
+            if (getContext()->hasQueryContext())
+            {
+                auto query_context = getContext()->getQueryContext();
+                query_context->dropStorageCacheEntry(from_table_id);
+                query_context->dropStorageCacheEntry(to_table_id);
+            }
         }
         catch (...)
         {


### PR DESCRIPTION
The per-query storage cache `Context::getOrCacheStorage` (added in [#97411](https://github.com/ClickHouse/ClickHouse/pull/97411)) pins a table name to the storage first resolved for it within a query, so a running query keeps reading the table version it was planned against even when a concurrent query renames or exchanges that table.

[#108728](https://github.com/ClickHouse/ClickHouse/pull/108728) added two freshness checks to the cache-hit path: reject the hit if the cached storage's current qualified name no longer matches the requested name, and reject it if the requested `StorageID` carries a UUID that differs from the cached one. Both silently defeat the pinning. After a concurrent `EXCHANGE TABLES` renames the pinned storage (and reassigns the name to a different UUID), resolving the original name re-resolves to the swapped table, so the query is analyzed for one column type and executed against another — raising a spurious `LOGICAL_ERROR` (and aborting the server in debug/coverage builds).

This regressed `03915_exchange_tables_race` on `master`. The check `Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DBReplicated, WasmEdge, parallel, 2/3)` started dying with

```
Logical error: 'Arguments of 'multiply' have incorrect data types: 'n' of type 'Int256', '0.123' of type 'Float64''
(query: SELECT n * 0.123 FROM (SELECT * FROM tbl_03007_1))
```

on 2026-07-07 — the day #108728 merged — after 4.5 months with zero occurrences. Only the old analyzer is affected (the new analyzer resolves storages once).

**Fix.** Restore the pinning: a cache hit is reused whenever its cached UUID still resolves to a live table, regardless of the storage's current name or the requested UUID (the pre-#108728 behavior). To keep #108728's fix — `CREATE OR REPLACE ... POPULATE` must drop the old table by the temporary name after its internal `EXCHANGE`, not the live one — a query that renames or exchanges a table now drops the affected names from its own per-query storage cache (`Context::dropStorageCacheEntry`, called from `InterpreterRenameQuery`). So the query's own later lookups re-resolve to the current tables, while concurrent queries keep their own per-query caches and stay isolated.

Regression coverage stays in the existing `03915_exchange_tables_race` (external exchange) and `04492`/`04493_create_or_replace_materialized_view_populate_keeps_subscription` (internal exchange) tests.

Closes: https://github.com/ClickHouse/ClickHouse/issues/110133
Related: https://github.com/ClickHouse/ClickHouse/pull/108728
Related: https://github.com/ClickHouse/ClickHouse/pull/97411
Related: https://github.com/ClickHouse/ClickHouse/pull/110048

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes an unreleased regression from #108728 (master only); no stable release is affected.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)