### PR TITLE
Fix `max_bytes_in_distinct` and `max_bytes_in_set` ignoring the bytes of string keys

### DIFF
--- a/src/Interpreters/SetVariants.cpp
+++ b/src/Interpreters/SetVariants.cpp
@@ -48,12 +48,19 @@ size_t SetVariantsTemplate<Variant>::getTotalRowCount() const
 template <typename Variant>
 size_t SetVariantsTemplate<Variant>::getTotalByteCount() const
 {
+    /// For the `key_string` and `key_fixed_string` methods the hash table holds only `StringRef`
+    /// entries; the key bytes themselves are copied into `string_pool` on insertion. The pool is
+    /// therefore part of the set size — without it, the byte limits (`max_bytes_in_distinct`,
+    /// `max_bytes_in_set`) would see only the fixed-width entries and under-count string keys by
+    /// an unbounded factor. For all other methods the pool stays at its initial allocation.
+    const size_t string_pool_bytes = string_pool.allocatedBytes();
+
     switch (type)
     {
-        case Type::EMPTY: return 0;
+        case Type::EMPTY: return string_pool_bytes;
 
     #define M(NAME) \
-        case Type::NAME: return (NAME)->data.getBufferSizeInBytes();
+        case Type::NAME: return string_pool_bytes + (NAME)->data.getBufferSizeInBytes();
         APPLY_FOR_SET_VARIANTS(M)
     #undef M
     }

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
@@ -46,8 +46,8 @@ Check lifetime_bytes/lifetime_rows for Buffer
 200	100
 402	201
 Check total_bytes/total_rows for Set
-2048	50
-2048	100
+1	50
+1	100
 Check total_bytes/total_rows for Join
 1	50
 1	100

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
@@ -46,8 +46,8 @@ Check lifetime_bytes/lifetime_rows for Buffer
 200	100
 402	201
 Check total_bytes/total_rows for Set
-1	50
-1	100
+2048	50
+2048	100
 Check total_bytes/total_rows for Join
 4096	50
 4096	100

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.reference
@@ -49,8 +49,8 @@ Check total_bytes/total_rows for Set
 1	50
 1	100
 Check total_bytes/total_rows for Join
-1	50
-1	100
+4096	50
+4096	100
 Check total_uncompressed_bytes/total_bytes/total_rows for Materialized views
 0	0	0
 1	1	1

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
@@ -135,10 +135,12 @@ DROP TABLE check_system_tables;
 DROP TABLE check_system_tables_null;
 
 SELECT 'Check total_bytes/total_rows for Set';
+-- total_bytes reports allocated memory (the hash table buffer plus the string pool of the set),
+-- which depends on internal allocation sizes.
 CREATE TABLE check_system_tables Engine=Set() AS SELECT * FROM numbers(50);
-SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes BETWEEN 2048 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 INSERT INTO check_system_tables SELECT number+50 FROM numbers(50);
-SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes BETWEEN 2048 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 DROP TABLE check_system_tables;
 
 SELECT 'Check total_bytes/total_rows for Join';

--- a/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
+++ b/tests/queries/0_stateless/00753_system_columns_and_system_tables_long.sql
@@ -138,16 +138,16 @@ SELECT 'Check total_bytes/total_rows for Set';
 -- total_bytes reports allocated memory (the hash table buffer plus the string pool of the set),
 -- which depends on internal allocation sizes.
 CREATE TABLE check_system_tables Engine=Set() AS SELECT * FROM numbers(50);
-SELECT total_bytes BETWEEN 2048 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 INSERT INTO check_system_tables SELECT number+50 FROM numbers(50);
-SELECT total_bytes BETWEEN 2048 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 DROP TABLE check_system_tables;
 
 SELECT 'Check total_bytes/total_rows for Join';
 CREATE TABLE check_system_tables Engine=Join(ANY, LEFT, number) AS SELECT * FROM numbers(50);
-SELECT total_bytes BETWEEN 4000 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 INSERT INTO check_system_tables SELECT number+50 FROM numbers(50);
-SELECT total_bytes BETWEEN 4000 AND 15000, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
+SELECT total_bytes, total_rows FROM system.tables WHERE name = 'check_system_tables' AND database = currentDatabase();
 DROP TABLE check_system_tables;
 
 -- Build MergeTree table for Materialized view

--- a/tests/queries/0_stateless/04512_max_bytes_in_distinct_and_set_string_keys.reference
+++ b/tests/queries/0_stateless/04512_max_bytes_in_distinct_and_set_string_keys.reference
@@ -1,0 +1,11 @@
+-- DISTINCT over String keys, break: partial result bounded by the byte limit
+1	1
+-- DISTINCT over String keys, throw
+-- DISTINCT over FixedString keys, throw: key_fixed_string also stores keys in the pool
+-- IN set built from String keys, throw (default set_overflow_mode)
+-- IN set built from String keys, break: the probed keys are inserted before the limit trips
+10
+-- multi-column string keys use the hashed method (values not stored): the same limit must not trip
+100
+-- numeric keys are unaffected: a limit far above the fixed allocations does not trip
+1000

--- a/tests/queries/0_stateless/04512_max_bytes_in_distinct_and_set_string_keys.sql
+++ b/tests/queries/0_stateless/04512_max_bytes_in_distinct_and_set_string_keys.sql
@@ -1,0 +1,38 @@
+-- max_bytes_in_distinct and max_bytes_in_set must account for the bytes of string keys.
+-- With the `key_string` / `key_fixed_string` set methods the hash table holds only fixed-width
+-- `StringRef` entries; the key bytes themselves live in the set's `string_pool` arena. The byte
+-- limits are checked against the pool plus the hash table buffer, so with ~1 KB keys a 100 KB
+-- limit must trip after roughly a hundred keys - far before the 1000 distinct input values end.
+-- Multi-column string keys go through the `hashed` method (a 128-bit hash per key, the values
+-- themselves are not stored), so the same limit must NOT trip there.
+
+SET max_threads = 1;
+SET max_block_size = 10;
+
+SELECT '-- DISTINCT over String keys, break: partial result bounded by the byte limit';
+SELECT count() > 0, count() < 500 FROM (SELECT DISTINCT s FROM (SELECT concat(toString(number), repeat('x', 1000)) AS s FROM numbers(1000)))
+SETTINGS distinct_overflow_mode = 'break', max_bytes_in_distinct = 100000;
+
+SELECT '-- DISTINCT over String keys, throw';
+SELECT count() FROM (SELECT DISTINCT s FROM (SELECT concat(toString(number), repeat('x', 1000)) AS s FROM numbers(1000)))
+SETTINGS distinct_overflow_mode = 'throw', max_bytes_in_distinct = 100000; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT '-- DISTINCT over FixedString keys, throw: key_fixed_string also stores keys in the pool';
+SELECT count() FROM (SELECT DISTINCT s FROM (SELECT toFixedString(concat(toString(number), repeat('x', 990)), 1000) AS s FROM numbers(1000)))
+SETTINGS distinct_overflow_mode = 'throw', max_bytes_in_distinct = 100000; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT '-- IN set built from String keys, throw (default set_overflow_mode)';
+SELECT count() FROM numbers(10) WHERE concat(toString(number), repeat('x', 1000)) IN (SELECT concat(toString(number), repeat('x', 1000)) FROM numbers(1000))
+SETTINGS max_bytes_in_set = 100000; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT '-- IN set built from String keys, break: the probed keys are inserted before the limit trips';
+SELECT count() FROM numbers(10) WHERE concat(toString(number), repeat('x', 1000)) IN (SELECT concat(toString(number), repeat('x', 1000)) FROM numbers(1000))
+SETTINGS max_bytes_in_set = 100000, set_overflow_mode = 'break';
+
+SELECT '-- multi-column string keys use the hashed method (values not stored): the same limit must not trip';
+SELECT count() FROM (SELECT DISTINCT s1, s2 FROM (SELECT concat(toString(number), repeat('x', 1000)) AS s1, concat(toString(number), repeat('y', 1000)) AS s2 FROM numbers(100)))
+SETTINGS distinct_overflow_mode = 'throw', max_bytes_in_distinct = 100000;
+
+SELECT '-- numeric keys are unaffected: a limit far above the fixed allocations does not trip';
+SELECT count() FROM (SELECT DISTINCT number FROM numbers(1000))
+SETTINGS distinct_overflow_mode = 'throw', max_bytes_in_distinct = 10000000;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

`SizeLimits::check` for `DISTINCT` and `IN` sets was called with `getTotalByteCount`, which returned only the hash table buffer size and ignored the `string_pool` arena where the actual bytes of `String` / `FixedString` keys are stored. For string keys the limit therefore compared ~16 bytes per key against the budget while the real memory grew unbounded.

```sql
-- 10 KB string keys under a 1 MB byte budget: DISTINCT is expected to stop around 1 MB.
-- Before the fix the limit never tripped (the hash table buffer for 2000 keys is only
-- ~130 KB) and all 19.07 MiB came out; after the fix it stops at 976 KiB (100 keys).
SELECT count(), formatReadableSize(sum(length(s)))
FROM (SELECT DISTINCT randomPrintableASCII(10000) AS s FROM numbers(2000))
SETTINGS max_threads = 1, max_block_size = 100,
         distinct_overflow_mode = 'break', max_bytes_in_distinct = 1000000;

-- The same undercount in throw mode: SET_SIZE_LIMIT_EXCEEDED is expected once the keys
-- exceed 1 MB, but before the fix the query succeeded and returned 2000.
SELECT count()
FROM (SELECT DISTINCT randomPrintableASCII(10000) AS s FROM numbers(2000))
SETTINGS max_block_size = 100, distinct_overflow_mode = 'throw', max_bytes_in_distinct = 1000000;

-- Same for IN sets (default set_overflow_mode = 'throw'): SET_SIZE_LIMIT_EXCEEDED is
-- expected while building the ~19 MB set, but before the fix the set was built in full
-- and the query succeeded.
SELECT count() FROM numbers(10)
WHERE toString(number) IN (SELECT randomPrintableASCII(10000) FROM numbers(2000))
SETTINGS max_block_size = 100, max_bytes_in_set = 1000000;
```


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `max_bytes_in_distinct` and `max_bytes_in_set` not counting the bytes of `String` and `FixedString` keys. The keys themselves are stored in the set's string pool, but only the hash table buffer (about 16 bytes per key) was checked against the limit, so for string keys the limits were exceeded by an unbounded factor before tripping. Queries running close to these limits on string keys now stop or throw where they previously did not.
