### PR TITLE
Fix test_rabbitmq_mv_combo slowdown instead of loosening its timeout

### DIFF
--- a/tests/integration/test_storage_rabbitmq/configs/users.xml
+++ b/tests/integration/test_storage_rabbitmq/configs/users.xml
@@ -2,6 +2,7 @@
     <profiles>
         <default>
             <stream_like_engine_allow_direct_select>1</stream_like_engine_allow_direct_select>
+            <parallel_view_processing>1</parallel_view_processing>
         </default>
     </profiles>
     <users>

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -767,32 +767,23 @@ def test_rabbitmq_mv_combo(rabbitmq_cluster, db, unique):
         time.sleep(random.uniform(0, 1))
         thread.start()
 
-    # With threadsanitizer the speed of execution is about 8-13k rows per second, so consuming
-    # ~1 mln rows takes ~125s and can exceed a fixed deadline on a loaded runner while still
-    # progressing. Fail only on a genuine stall: reset the no-progress deadline whenever the
-    # total row count increases, so a slow-but-steady run is not abandoned.
-    no_progress_timeout = 180
-    deadline = time.monotonic() + no_progress_timeout
+    # with threadsanitizer the speed of execution is about 8-13k rows per second.
+    # so consumption of 1 mln rows will require about 125 seconds
+    deadline = time.monotonic() + 180
     expected = messages_num * threads_num * NUM_MV
-    prev_result = 0
-    result = 0
     while time.monotonic() < deadline:
         result = 0
         for mv_id in range(NUM_MV):
             result += int(
                 instance.query(f"SELECT count() FROM {db}.combo_{mv_id}")
             )
-        if result == expected:
+        if int(result) == expected:
             break
-        if result > prev_result:
-            deadline = time.monotonic() + no_progress_timeout
-        prev_result = result
         logging.debug(f"Result: {result} / {expected}")
         time.sleep(1)
     else:
         pytest.fail(
-            f"Time limit of {no_progress_timeout} seconds reached without any RabbitMQ "
-            "consumption progress. The result did not match the expected value."
+            "Time limit of 180 seconds reached. The result did not match the expected value."
         )
 
     for thread in threads:


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109170
Related: https://github.com/ClickHouse/ClickHouse/pull/109892

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

#109170 correctly made MV fan-out serial by default (`parallel_view_processing=false`), which #109892 papered over by loosening this test's timeout instead of fixing the resulting slowdown. This reverts #109892 and sets `parallel_view_processing=1` in the test's default profile instead — the only place it can be applied to RabbitMQ's internal insert-to-views pipeline. Verified against the CI msan binary: 188s serial vs ~124s with this fix, under the original 180s deadline.

### Documentation entry for a feature (if required):

<!-- ... -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.981` (included in `26.7` and later)
<!-- ch-version-info:end -->