### PR TITLE
Do not abort system.tables for DataLakeCatalog on unresolvable table metadata

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -218,6 +218,7 @@ static struct InitFiu
     ONCE(oom_canary_force_oom_evidence) \
     PAUSEABLE(truncate_database_tables_pause) \
     REGULAR(datalake_try_get_table_return_nullptr) \
+    REGULAR(datalake_try_get_table_throw) \
     REGULAR(datalake_simulate_missing_table_state) \
     PAUSEABLE_ONCE(drop_database_before_exclusive_ddl_lock) \
     PAUSEABLE_ONCE(create_or_replace_before_rename) \

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -131,6 +131,7 @@ namespace FailPoints
 {
     extern const char lightweight_show_tables[];
     extern const char datalake_try_get_table_return_nullptr[];
+    extern const char datalake_try_get_table_throw[];
 }
 
 namespace
@@ -632,6 +633,14 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         return nullptr;
     });
 
+    /// Simulate a per-table metadata resolution failure (throws), so tests can exercise the
+    /// graceful-degradation path in getTablesIteratorWithHint that keeps the table in the
+    /// listing with a null storage object instead of aborting the whole scan.
+    fiu_do_on(FailPoints::datalake_try_get_table_throw,
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Injected metadata resolution failure for table '{}'", name);
+    });
+
     const bool with_vended_credentials = settings[DatabaseDataLakeSetting::vended_credentials].value;
     if (with_vended_credentials)
         table_metadata = table_metadata.withStorageCredentials();
@@ -956,20 +965,23 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
                     }
                     catch (...)
                     {
+                        /// A single table's metadata failing to resolve must not abort the
+                        /// whole listing (e.g. a system.tables scan over the catalog) nor
+                        /// silently omit the table. Keep a row for it with a null storage
+                        /// object: metadata-dependent columns come back as defaults/NULL while
+                        /// the table still appears in the listing. Direct access to that one
+                        /// table (SELECT ... FROM db.table) still surfaces the real error.
                         if (context_->getSettingsRef()[Setting::database_datalake_require_metadata_access])
                         {
                             auto error_code = getCurrentExceptionCode();
                             auto error_message = getCurrentExceptionMessage(true, false, true, true);
-                            auto enhanced_message = fmt::format(
+                            LOG_WARNING(
+                                log,
                                 "Received error {} while fetching table metadata for existing table '{}'. "
-                                "If you want this error to be ignored, use database_datalake_require_metadata_access=0. Error: {}",
+                                "Keeping it in the listing with unresolved metadata. Error: {}",
                                 error_code,
                                 table_name,
                                 error_message);
-                            promise->set_exception(std::make_exception_ptr(Exception::createRuntime(
-                                error_code,
-                                enhanced_message)));
-                            return;
                         }
                         else
                             tryLogCurrentException(log, fmt::format("Ignoring table {}", table_name));
@@ -995,12 +1007,13 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
         if (filter_by_table_name && !filter_by_table_name(table_name))
             continue;
 
+        /// Keep a row even when the storage object could not be resolved (table_ptr is
+        /// null): the table still shows up in listings such as system.tables with default
+        /// values for metadata-dependent columns, instead of being silently dropped or
+        /// aborting the whole listing. See the per-table catch above.
         auto table_ptr = futures[future_index].get();
-        if (table_ptr)
-        {
-            [[maybe_unused]] bool inserted = tables.emplace(table_name, table_ptr).second;
-            chassert(inserted);
-        }
+        [[maybe_unused]] bool inserted = tables.emplace(table_name, table_ptr).second;
+        chassert(inserted);
         future_index++;
     }
     return std::make_unique<DatabaseTablesSnapshotIterator>(tables, getDatabaseName());

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -917,7 +917,13 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIterator(
     const FilterByNameFunction & filter_by_table_name,
     bool skip_not_loaded) const
 {
-    return getTablesIteratorWithHint(context_, filter_by_table_name, skip_not_loaded, /*tables_filter*/ {});
+    /// General-purpose iterator. Consumers such as StorageMerge dereference the storage
+    /// object of every row unconditionally, so a null-storage row would hang or crash them.
+    /// Keep the original contract: propagate the error when metadata access is required,
+    /// otherwise drop the unresolved table. Null-storage rows are confined to
+    /// getTablesIteratorWithHint (system.tables), which null-guards every consumer.
+    return getTablesIteratorImpl(
+        context_, filter_by_table_name, skip_not_loaded, /*tables_filter*/ {}, /*keep_unresolved_tables*/ false);
 }
 
 DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
@@ -925,6 +931,20 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
     const FilterByNameFunction & filter_by_table_name,
     bool skip_not_loaded,
     const TablesFilter & tables_filter) const
+{
+    /// system.tables path: keep a row for a table whose metadata cannot be resolved, with a
+    /// null storage object, so metadata-dependent columns degrade to defaults instead of the
+    /// whole scan aborting. StorageSystemTables null-guards every storage-dependent column.
+    return getTablesIteratorImpl(
+        context_, filter_by_table_name, skip_not_loaded, tables_filter, /*keep_unresolved_tables*/ true);
+}
+
+DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorImpl(
+    ContextPtr context_,
+    const FilterByNameFunction & filter_by_table_name,
+    bool skip_not_loaded,
+    const TablesFilter & tables_filter,
+    bool keep_unresolved_tables) const
 {
     Tables tables;
     DB::Names iceberg_tables;
@@ -955,7 +975,7 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
             futures.emplace_back(promises.back()->get_future());
 
             pool.scheduleOrThrow(
-                [this, table_name, skip_not_loaded, context_, promise=promises.back()]() mutable
+                [this, table_name, skip_not_loaded, context_, keep_unresolved_tables, promise=promises.back()]() mutable
                 {
                     StoragePtr storage = nullptr;
                     try
@@ -965,23 +985,41 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
                     }
                     catch (...)
                     {
-                        /// A single table's metadata failing to resolve must not abort the
-                        /// whole listing (e.g. a system.tables scan over the catalog) nor
-                        /// silently omit the table. Keep a row for it with a null storage
-                        /// object: metadata-dependent columns come back as defaults/NULL while
-                        /// the table still appears in the listing. Direct access to that one
-                        /// table (SELECT ... FROM db.table) still surfaces the real error.
                         if (context_->getSettingsRef()[Setting::database_datalake_require_metadata_access])
                         {
                             auto error_code = getCurrentExceptionCode();
                             auto error_message = getCurrentExceptionMessage(true, false, true, true);
-                            LOG_WARNING(
-                                log,
-                                "Received error {} while fetching table metadata for existing table '{}'. "
-                                "Keeping it in the listing with unresolved metadata. Error: {}",
-                                error_code,
-                                table_name,
-                                error_message);
+                            if (keep_unresolved_tables)
+                            {
+                                /// system.tables path: a single table's metadata failing to
+                                /// resolve must not abort the whole listing nor silently omit
+                                /// the table. Keep a row for it with a null storage object;
+                                /// metadata-dependent columns come back as defaults/NULL. Direct
+                                /// access (SELECT ... FROM db.table) still surfaces the real error.
+                                LOG_WARNING(
+                                    log,
+                                    "Received error {} while fetching table metadata for existing table '{}'. "
+                                    "Keeping it in the listing with unresolved metadata. Error: {}",
+                                    error_code,
+                                    table_name,
+                                    error_message);
+                            }
+                            else
+                            {
+                                /// General-purpose path: consumers dereference the storage
+                                /// unconditionally, so propagate the error rather than hand
+                                /// them a null-storage row.
+                                auto enhanced_message = fmt::format(
+                                    "Received error {} while fetching table metadata for existing table '{}'. "
+                                    "If you want this error to be ignored, use database_datalake_require_metadata_access=0. Error: {}",
+                                    error_code,
+                                    table_name,
+                                    error_message);
+                                promise->set_exception(std::make_exception_ptr(Exception::createRuntime(
+                                    error_code,
+                                    enhanced_message)));
+                                return;
+                            }
                         }
                         else
                             tryLogCurrentException(log, fmt::format("Ignoring table {}", table_name));
@@ -1007,14 +1045,22 @@ DatabaseTablesIteratorPtr DatabaseDataLake::getTablesIteratorWithHint(
         if (filter_by_table_name && !filter_by_table_name(table_name))
             continue;
 
-        /// Keep a row even when the storage object could not be resolved (table_ptr is
-        /// null): the table still shows up in listings such as system.tables with default
-        /// values for metadata-dependent columns, instead of being silently dropped or
-        /// aborting the whole listing. See the per-table catch above.
+        /// futures[future_index].get() rethrows for the general-purpose path when metadata
+        /// access is required (see the per-table catch above), preserving the original
+        /// abort-on-error contract for consumers that dereference the storage unconditionally.
         auto table_ptr = futures[future_index].get();
+        future_index++;
+
+        /// For the system.tables path keep a row even when the storage could not be resolved
+        /// (table_ptr is null), so the table still shows up with default/NULL metadata columns
+        /// instead of being dropped or aborting the scan. For every other consumer drop the
+        /// unresolved table (require_metadata_access=0 case) to keep the iterator's contract
+        /// that every row has a valid storage object.
+        if (!keep_unresolved_tables && !table_ptr)
+            continue;
+
         [[maybe_unused]] bool inserted = tables.emplace(table_name, table_ptr).second;
         chassert(inserted);
-        future_index++;
     }
     return std::make_unique<DatabaseTablesSnapshotIterator>(tables, getDatabaseName());
 }

--- a/src/Databases/DataLake/DatabaseDataLake.h
+++ b/src/Databases/DataLake/DatabaseDataLake.h
@@ -134,6 +134,21 @@ private:
 
     std::string getStorageEndpointForTable(const DataLake::TableMetadata & table_metadata) const;
 
+    /// Shared implementation of getTablesIterator / getTablesIteratorWithHint.
+    /// keep_unresolved_tables controls what happens when a single table's metadata cannot
+    /// be resolved: when true (system.tables path) the table is kept in the listing with a
+    /// null storage object so metadata-dependent columns degrade to defaults instead of the
+    /// whole scan aborting; when false (every other consumer, e.g. StorageMerge, which
+    /// dereferences the storage unconditionally) the original contract is preserved -- the
+    /// error is propagated when database_datalake_require_metadata_access=1 and the table is
+    /// dropped from the listing otherwise. This confines null-storage rows to system.tables.
+    DatabaseTablesIteratorPtr getTablesIteratorImpl(
+        ContextPtr context,
+        const FilterByNameFunction & filter_by_table_name,
+        bool skip_not_loaded,
+        const TablesFilter & tables_filter,
+        bool keep_unresolved_tables) const;
+
     /// Can return nullptr in case of *expected* issues with response from catalog. Sometimes
     /// catalogs can produce completely unexpected responses. In such cases this function may throw.
     StoragePtr tryGetTableImpl(const String & name, ContextPtr context, bool lightweight, bool ignore_if_not_iceberg) const;

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -528,6 +528,10 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
                 for (auto iterator = database->getTablesIterator(table_context); iterator->isValid(); iterator->next())
                 {
                     auto table_ptr = iterator->table();
+                    /// Storage object could not be resolved (e.g. unresolvable DataLakeCatalog
+                    /// metadata); nothing to drop/truncate for it here.
+                    if (!table_ptr)
+                        continue;
 
                     /// Skip tables that don't support truncation (e.g. views)
                     /// when doing TRUNCATE ALL TABLES.
@@ -677,6 +681,9 @@ BlockIO InterpreterDropQuery::executeToDatabaseImpl(const ASTDropQuery & query, 
         for (auto it = database->getTablesIterator(table_context); it->isValid(); it->next())
         {
             const auto & table_ptr = it->table();
+            /// Storage object could not be resolved (e.g. unresolvable DataLakeCatalog metadata).
+            if (!table_ptr)
+                continue;
 
             /// Skip tables that don't support truncation (e.g. views).
             if (!table_ptr->supportsTruncate())

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -456,26 +456,26 @@ protected:
 
     void fillParametralizedViewData(MutableColumns & columns, const StoragePtr & table, size_t & res_index)
     {
-        if (table)
+        /// `table` can be null for an unresolvable table (e.g. a DataLakeCatalog table whose
+        /// metadata cannot be fetched). Always advance `res_index` so the column stays aligned
+        /// with the others; otherwise the whole system.tables scan aborts.
+        const auto metadata_snapshot = table ? table->getInMemoryMetadataPtr(context, false) : nullptr;
+        if (!metadata_snapshot)
         {
-            const auto metadata_snapshot = table->getInMemoryMetadataPtr(context, false);
-            if (!metadata_snapshot)
-            {
-                columns[res_index++]->insertDefault();
-                return;
-            }
-
-            NameToNameMap query_parameters_array = getSelectParamters(metadata_snapshot);
-            if (!query_parameters_array.empty())
-            {
-                Array changes;
-                for (const auto & [key, value] : query_parameters_array)
-                    changes.push_back(Tuple{key, value});
-                columns[res_index++]->insert(changes);
-            }
-            else
-                columns[res_index++]->insertDefault();
+            columns[res_index++]->insertDefault();
+            return;
         }
+
+        NameToNameMap query_parameters_array = getSelectParamters(metadata_snapshot);
+        if (!query_parameters_array.empty())
+        {
+            Array changes;
+            for (const auto & [key, value] : query_parameters_array)
+                changes.push_back(Tuple{key, value});
+            columns[res_index++]->insert(changes);
+        }
+        else
+            columns[res_index++]->insertDefault();
     }
 
 

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -813,7 +813,11 @@ protected:
 
                 if (columns_mask[src_index] || columns_mask[src_index + 1] || columns_mask[src_index + 2])
                 {
-                    ASTPtr ast = database->tryGetCreateTableQuery(table_name, context);
+                    /// Skip the catalog query for a null-storage row (unresolvable DataLakeCatalog
+                    /// table, or one dropped concurrently with the scan): tryGetCreateTableQuery
+                    /// re-enters DatabaseDataLake::getCreateTableQueryImpl, which can throw again
+                    /// and abort the whole scan. A null ast makes the block below emit defaults.
+                    ASTPtr ast = table ? database->tryGetCreateTableQuery(table_name, context) : nullptr;
                     auto * ast_create = ast ? ast->as<ASTCreateQuery>() : nullptr;
 
                     if (ast_create && !context->getSettingsRef()[Setting::show_table_uuid_in_table_create_query_if_not_nil])

--- a/src/Storages/System/StorageSystemTables.cpp
+++ b/src/Storages/System/StorageSystemTables.cpp
@@ -277,13 +277,16 @@ ColumnPtr getFilteredTables(
                 for (; table_it->isValid(); table_it->next())
                 {
                     const auto & table = table_it->table();
-                    if (!table)
-                        continue; /// Table was concurrently dropped and should be skipped
+                    /// A null table means the storage object could not be resolved (concurrent
+                    /// drop, or unresolvable DataLakeCatalog metadata). Keep the name with an
+                    /// empty engine / Nil uuid rather than dropping the row, so predicates on
+                    /// `engine`/`uuid` see it (and it can be filtered out) instead of the table
+                    /// silently vanishing from system.tables.
                     table_column->insert(table_it->name());
                     if (engine_column)
-                        engine_column->insert(table->getName());
+                        engine_column->insert(table ? table->getName() : "");
                     if (uuid_column)
-                        uuid_column->insert(table->getStorageID().uuid);
+                        uuid_column->insert(table ? table->getStorageID().uuid : UUIDHelpers::Nil);
                 }
             }
             else
@@ -702,15 +705,20 @@ protected:
                     continue;
 
                 StoragePtr table = tables_it->table();
-                if (!table)
-                    continue; /// Table was concurrently dropped between iterator snapshot and table() call so we should skip it
+                /// A null table means the storage object could not be resolved: either the table
+                /// was concurrently dropped between the iterator snapshot and this table() call, or
+                /// (for DataLakeCatalog databases) its metadata is unresolvable. We still emit a row
+                /// for it -- with defaults/NULL for every column that needs the opened storage object
+                /// -- so a single broken table neither drops itself from the listing nor aborts the
+                /// whole system.tables scan. Every metadata-dependent column below is guarded on
+                /// `table` being non-null.
 
                 TableLockHolder lock;
 
                 /// The only column that requires us to hold a shared lock is data_paths as rename might alter them (on ordinary tables)
                 /// and it's not protected internally by other mutexes
                 static const size_t DATA_PATHS_INDEX = 5;
-                if (columns_mask[DATA_PATHS_INDEX])
+                if (table && columns_mask[DATA_PATHS_INDEX])
                 {
                     lock = table->tryLockForShare(context->getCurrentQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
                     if (!lock)
@@ -734,8 +742,10 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    chassert(table != nullptr);
-                    res_columns[res_index++]->insert(table->getName());
+                    if (table)
+                        res_columns[res_index++]->insert(table->getName());
+                    else
+                        res_columns[res_index++]->insertDefault();
                 }
 
                 if (columns_mask[src_index++])
@@ -743,13 +753,17 @@ protected:
 
                 if (columns_mask[src_index++])
                 {
-                    chassert(lock != nullptr);
                     Array table_paths_array;
-                    if (auto paths = table->tryGetDataPaths())
+                    /// `lock` is only acquired above when `table` is non-null.
+                    if (table)
                     {
-                        table_paths_array.reserve(paths->size());
-                        for (const String & path : *paths)
-                            table_paths_array.push_back(path);
+                        chassert(lock != nullptr);
+                        if (auto paths = table->tryGetDataPaths())
+                        {
+                            table_paths_array.reserve(paths->size());
+                            for (const String & path : *paths)
+                                table_paths_array.push_back(path);
+                        }
                     }
                     res_columns[res_index++]->insert(table_paths_array);
                     /// We don't need the lock anymore
@@ -921,7 +935,7 @@ protected:
                 {
                     try
                     {
-                        auto total_bytes = table->totalBytes(context_copy);
+                        auto total_bytes = table ? table->totalBytes(context_copy) : std::nullopt;
                         if (total_bytes)
                             res_columns[res_index]->insert(*total_bytes);
                         else
@@ -940,7 +954,7 @@ protected:
                 {
                     try
                     {
-                        auto total_bytes_uncompressed = table->totalBytesUncompressed(context_copy->getSettingsRef());
+                        auto total_bytes_uncompressed = table ? table->totalBytesUncompressed(context_copy->getSettingsRef()) : std::nullopt;
                         if (total_bytes_uncompressed)
                             res_columns[res_index]->insert(*total_bytes_uncompressed);
                         else

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1229,6 +1229,20 @@ def test_system_tables_metadata_unresolvable_does_not_abort_scan(started_cluster
                 f"AND total_rows IS NULL {settings}"
             )
             assert int(result.strip()) >= 1, f"total_rows default, require={require}"
+
+            ## parameterized_view_parameters needs the opened storage too. Selecting it alongside
+            ## other columns must keep the column aligned (defaulted to an empty array), not abort.
+            result = node.query(
+                f"SELECT name, parameterized_view_parameters FROM system.tables "
+                f"WHERE database = '{CATALOG_NAME}' {settings}"
+            )
+            assert table_name in result, f"parameterized_view_parameters scan, require={require}"
+
+            result = node.query(
+                f"SELECT count() FROM system.tables WHERE database = '{CATALOG_NAME}' "
+                f"AND empty(parameterized_view_parameters) {settings}"
+            )
+            assert int(result.strip()) >= 1, f"parameterized_view_parameters default, require={require}"
     finally:
         node.query("SYSTEM DISABLE FAILPOINT datalake_try_get_table_throw")
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1243,6 +1243,21 @@ def test_system_tables_metadata_unresolvable_does_not_abort_scan(started_cluster
                 f"AND empty(parameterized_view_parameters) {settings}"
             )
             assert int(result.strip()) >= 1, f"parameterized_view_parameters default, require={require}"
+
+            ## create_table_query / engine_full / as_select re-enter the catalog metadata query
+            ## for a null-storage row. Selecting them must not re-throw and abort the scan; the
+            ## columns are defaulted to empty strings for the unresolvable table.
+            result = node.query(
+                f"SELECT name, create_table_query, engine_full, as_select FROM system.tables "
+                f"WHERE database = '{CATALOG_NAME}' {settings}"
+            )
+            assert table_name in result, f"create_table_query scan, require={require}"
+
+            result = node.query(
+                f"SELECT count() FROM system.tables WHERE database = '{CATALOG_NAME}' "
+                f"AND create_table_query = '' AND engine_full = '' AND as_select = '' {settings}"
+            )
+            assert int(result.strip()) >= 1, f"create_table_query default, require={require}"
     finally:
         node.query("SYSTEM DISABLE FAILPOINT datalake_try_get_table_throw")
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1130,22 +1130,27 @@ def test_system_tables_with_nullptr_table(started_cluster):
     node.query("SYSTEM ENABLE FAILPOINT datalake_try_get_table_return_nullptr")
 
     try:
-        ## This triggers getFilteredTables with engine_column populated (the crash site).
+        ## getFilteredTables with engine_column populated (a former crash site). The table
+        ## whose storage object could not be resolved is now KEPT in the listing with an empty
+        ## engine, rather than being silently dropped.
         result = node.query(
-            f"SELECT engine FROM system.tables WHERE database = '{CATALOG_NAME}' "
+            f"SELECT name, engine FROM system.tables WHERE database = '{CATALOG_NAME}' "
             f"SETTINGS show_data_lake_catalogs_in_system_tables = 1"
         )
-        ## With the failpoint, all tables return nullptr so we get empty result.
-        assert result.strip() == ""
+        assert table_name in result
+        ## engine is empty for the unresolved table (nothing after the name + tab).
+        assert f"{table_name}\t" in result or f"{table_name}." in result
 
-        ## This triggers the fillData main loop path.
+        ## fillData main loop path: the row is present (not dropped) even though every
+        ## storage-dependent column is defaulted.
         result = node.query(
-            f"SELECT * FROM system.tables WHERE database = '{CATALOG_NAME}' "
+            f"SELECT count() FROM system.tables WHERE database = '{CATALOG_NAME}' "
             f"SETTINGS show_data_lake_catalogs_in_system_tables = 1"
         )
-        assert result.strip() == ""
+        assert int(result.strip()) >= 1
 
-        ## Also test with count() to exercise a different code path.
+        ## A predicate on engine still filters correctly: the unresolved table has an empty
+        ## engine, so it does not match a concrete engine pattern.
         result = node.query(
             f"SELECT count(engine) FROM system.tables WHERE database = '{CATALOG_NAME}' "
             f"AND engine LIKE '%ReplicatedMergeTree' "
@@ -1164,6 +1169,79 @@ def test_system_tables_with_nullptr_table(started_cluster):
         f"SETTINGS show_data_lake_catalogs_in_system_tables = 1"
     )
     assert int(result.strip()) > 0
+
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
+
+
+def test_system_tables_metadata_unresolvable_does_not_abort_scan(started_cluster):
+    """
+    Regression test for https://github.com/ClickHouse/ClickHouse/issues/110032.
+
+    When a table's metadata is unresolvable, a system.tables scan of the whole
+    DataLakeCatalog database must not abort (with database_datalake_require_metadata_access=1)
+    nor silently drop the table (with =0). Either way the table stays listed by name, with
+    default/empty values for the storage-dependent columns.
+    """
+    node = started_cluster.instances["node1"]
+
+    root_namespace = f"clickhouse_{uuid.uuid4()}"
+    namespace = f"{root_namespace}_test_unresolvable"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+
+    table_name = "broken_table"
+    create_table(catalog, namespace, table_name)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    ## Simulate a per-table metadata resolution failure (throws).
+    node.query("SYSTEM ENABLE FAILPOINT datalake_try_get_table_throw")
+
+    try:
+        for require in (1, 0):
+            settings = (
+                f"SETTINGS show_data_lake_catalogs_in_system_tables = 1, "
+                f"database_datalake_require_metadata_access = {require}"
+            )
+
+            ## Name-only fast path always worked; still lists the table.
+            result = node.query(
+                f"SELECT name FROM system.tables WHERE database = '{CATALOG_NAME}' {settings}"
+            )
+            assert table_name in result, f"name-only path, require={require}"
+
+            ## The whole-database scan requesting a storage-dependent column must NOT abort
+            ## and must NOT drop the table -- it is kept with an empty engine.
+            result = node.query(
+                f"SELECT name, engine FROM system.tables WHERE database = '{CATALOG_NAME}' {settings}"
+            )
+            assert table_name in result, f"full scan, require={require}"
+
+            result = node.query(
+                f"SELECT count() FROM system.tables WHERE database = '{CATALOG_NAME}' {settings}"
+            )
+            assert int(result.strip()) >= 1, f"count, require={require}"
+
+            ## total_rows (a per-column stat that needs the opened storage) is defaulted, not fatal.
+            result = node.query(
+                f"SELECT count() FROM system.tables WHERE database = '{CATALOG_NAME}' "
+                f"AND total_rows IS NULL {settings}"
+            )
+            assert int(result.strip()) >= 1, f"total_rows default, require={require}"
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT datalake_try_get_table_throw")
+
+    ## Direct access to the broken table still surfaces the error (query_and_get_error already
+    ## asserts the query failed; here we check it is the injected metadata failure).
+    node.query("SYSTEM ENABLE FAILPOINT datalake_try_get_table_throw")
+    try:
+        assert "Injected metadata resolution failure" in node.query_and_get_error(
+            f"SELECT * FROM {CATALOG_NAME}.`{namespace}.{table_name}` "
+            f"SETTINGS database_datalake_require_metadata_access = 1"
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT datalake_try_get_table_throw")
 
     node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1259,6 +1259,90 @@ def test_system_tables_metadata_unresolvable_does_not_abort_scan(started_cluster
 
     node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
 
+
+def test_merge_over_datalake_with_unresolvable_table_does_not_hang(started_cluster):
+    """
+    Regression test for the StorageMerge consumer of DatabaseDataLake::getTablesIterator.
+
+    Only system.tables (getTablesIteratorWithHint) keeps a row with a null storage object
+    for a table whose metadata is unresolvable. Every other consumer -- StorageMerge in
+    particular -- dereferences the storage object of every iterated row unconditionally
+    (ReadFromMerge::getSelectedTables skips null storage with `continue` without advancing
+    the iterator, so it would loop forever; traverseTablesUntil callers such as
+    supportsPrewhere / totalRows deref the table directly). getTablesIterator therefore must
+    NOT yield null-storage rows: it propagates the error when
+    database_datalake_require_metadata_access=1 and drops the unresolved table otherwise.
+
+    A SELECT through a Merge table over the catalog with one broken table must fail cleanly
+    or return only the resolvable tables' rows, never hang or crash during planning.
+    """
+    node = started_cluster.instances["node1"]
+
+    root_namespace = f"clickhouse_{uuid.uuid4()}"
+    namespace = f"{root_namespace}_test_merge_unresolvable"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+
+    table_name = "broken_table"
+    create_table(catalog, namespace, table_name)
+
+    create_clickhouse_iceberg_database(started_cluster, node, CATALOG_NAME)
+
+    ## An explicitly-created Merge table with a declared structure skips schema inference, so a
+    ## SELECT through it reaches ReadFromMerge::getSelectedTables directly -- the read path the
+    ## bot flagged, where a null-storage iterator row would spin forever (`if (!storage)
+    ## continue;` never advances the iterator). (The merge() table function cannot exercise this
+    ## because it forces schema inference first, which resolves/errors before the read path.)
+    node.query("DROP TABLE IF EXISTS default.merge_over_datalake")
+    node.query(
+        f"CREATE TABLE default.merge_over_datalake (symbol Nullable(String)) "
+        f"ENGINE = Merge('{CATALOG_NAME}', '.*broken_table.*')"
+    )
+
+    node.query("SYSTEM ENABLE FAILPOINT datalake_try_get_table_throw")
+
+    ## Pre-fix, getTablesIterator handed StorageMerge a null-storage iterator row for the
+    ## broken table; ReadFromMerge::getSelectedTables then spun forever (`if (!storage)
+    ## continue;` never advances the iterator), so the SELECT hung. With the fix that row is
+    ## never yielded to StorageMerge -- the error is propagated (require_metadata_access
+    ## defaults to 1 in the storage context) instead. Either way the query must COMPLETE
+    ## within the timeout (a hang would trip the timeout and fail the test) and the server
+    ## must survive. A generous-but-bounded timeout converts the pre-fix hang into a clean
+    ## test failure rather than hanging the whole job.
+    def run_merge_select(require):
+        ## Completes (error or result) within the timeout == no infinite loop; return the
+        ## outcome text for a sanity assertion. A hang raises and fails the test.
+        try:
+            return node.query(
+                "SELECT count() FROM default.merge_over_datalake "
+                f"SETTINGS database_datalake_require_metadata_access = {require}",
+                timeout=60,
+            ).strip()
+        except QueryRuntimeException as e:
+            return str(e)
+
+    try:
+        for require in (1, 0):
+            outcome = run_merge_select(require)
+            ## Either a clean numeric result (unresolved table dropped -> 0 rows) or the
+            ## injected metadata error -- never a hang, never a crash/LOGICAL_ERROR.
+            assert (
+                outcome.isdigit()
+                or "Injected metadata resolution failure" in outcome
+                or "metadata" in outcome
+            ), f"require={require}: {outcome}"
+            assert "LOGICAL_ERROR" not in outcome, f"require={require}: {outcome}"
+
+            ## Server is still alive (i.e. no crash from a null-storage deref).
+            assert node.query("SELECT 1").strip() == "1", f"require={require}"
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT datalake_try_get_table_throw")
+        node.query("DROP TABLE IF EXISTS default.merge_over_datalake")
+
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
+
+
 def test_delete_on_lazy_initialized_table(started_cluster):
     """
     Regression test for https://github.com/ClickHouse/ClickHouse/issues/96806.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/110032


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `system.tables` for a `DataLakeCatalog` (Iceberg/Glue) database aborting the whole query, or silently dropping tables, when a single table's metadata is unresolvable. Such a table now stays listed by name with default/NULL values for the columns that need the opened storage object (`engine`, `total_rows`, etc.), regardless of `database_datalake_require_metadata_access`. Direct access to the broken table still reports the error.


### Description

`system.tables` name-only scans of a `DataLakeCatalog` database always worked (fast path). Requesting any storage-dependent column fell through to `DatabaseDataLake::getTablesIterator`, which resolves each table's storage object. On a per-table failure it either propagated the exception (`database_datalake_require_metadata_access=1`, aborting the entire scan) or set a null storage and the row was then dropped downstream (`=0`, silently omitting the table). One 8-table catalog with one broken table dropped to a single row with no indication.

Fix:
- `DatabaseDataLake::getTablesIteratorWithHint`: a per-table open failure no longer aborts the listing; the table is kept with a null storage object (logged), matching the iterator's existing "must not fail for system.tables" contract.
- `StorageSystemTables`: null-storage rows are no longer dropped and every storage-dependent column is filled with a default/NULL (the main loop was already mostly null-safe; remaining unguarded derefs fixed).
- Null-guarded the iterator consumers in `InterpreterDropQuery` that dereferenced `table()` unconditionally, since the iterator can now yield null rows for DataLake catalogs.

`database_datalake_require_metadata_access` keeps its meaning for direct table access (`SELECT ... FROM db.broken_table` still errors under the default).

Reproduced and verified with a real Iceberg REST catalog via a new `datalake_try_get_table_throw` failpoint: the added regression test fails on master HEAD (whole-scan abort with `Received error 36 ... (BAD_ARGUMENTS)`) and passes with this change, for both setting values.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.913` (included in `26.7` and later)
<!-- ch-version-info:end -->