### PR TITLE
Fix flaky 02346_text_index_bug108519_qcc_skip_index under randomized statistics

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_bug108519_qcc_skip_index.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug108519_qcc_skip_index.sql
@@ -159,7 +159,10 @@ CREATE TABLE tab_disj
     INDEX idx_s s TYPE text(tokenizer = splitByNonAlpha, preprocessor = replaceAll(s, ' ', '')),
     INDEX idx_n n TYPE minmax
 )
-ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
+-- auto_statistics_types = '': randomized materialize_statistics_on_insert would build a minmax
+-- statistic on n that prunes n = 999 before the skip-index QCC path runs, so no entry is written
+-- and the reuse hit below never happens. The skip index must be the only exclusion here.
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, auto_statistics_types = '';
 INSERT INTO tab_disj VALUES ('zzz', 1), ('a b', 2);
 
 -- Populate under the disjunction-enabled profile.
@@ -203,7 +206,10 @@ CREATE TABLE tab_namecol
     INDEX ix_a n TYPE minmax GRANULARITY 1,
     INDEX ix_b n TYPE minmax GRANULARITY 1
 )
-ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1;
+-- auto_statistics_types = '': randomized materialize_statistics_on_insert would build a minmax
+-- statistic on n that prunes n = 999 before the skip-index QCC path runs, so no entry is written
+-- and the reuse hit below never happens. The skip index must be the only exclusion here.
+ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 1, auto_statistics_types = '';
 INSERT INTO tab_namecol VALUES (2), (5);
 
 -- Populate running ix_a (ix_b ignored): n = 999 matches nothing, ix_a drops both granules (sound).


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108548
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #108548, which added `02346_text_index_bug108519_qcc_skip_index`. The test started failing on master across all build types on 2026-07-13 under CI-randomized settings.

Root cause: the `tab_namecol` and `tab_disj` sections use minmax skip indexes on a numeric column `n` with an out-of-range predicate `n = 999`. With the randomized `materialize_statistics_on_insert = 1` and `auto_statistics_types` including `minmax`, a minmax statistic on `n` is built at insert time and prunes the whole part before the skip-index query condition cache path runs. No QCC entry is written, so the reuse query cannot hit and `namecol_reuse_a_reuses_entry` flips from 1 to 0.

The randomized-settings diagnosis in the failing CI report confirms the single culprit: `materialize_statistics_on_insert True` (130/130 fail with it, 184/184 pass without).

Fix: pin `auto_statistics_types = ''` on both tables so the skip index is the only exclusion mechanism, which is what these sections assert. A table-level MergeTree setting is immune to the session-setting randomizer (the client only injects a setting if it is not already present).

Verified both directions on a debug binary with `materialize_statistics_on_insert = 1`: the pre-fix test yields `namecol_reuse_a_reuses_entry 0` (fail), the fixed test matches the reference exactly (pass). Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8b9a8c2d3636ea7a077b4e11d250cd28c0cc47c2&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20sequential%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.867` (included in `26.7` and later)
<!-- ch-version-info:end -->