### PR TITLE
Fix flaky 02346_text_index_bug108519_qcc_skip_index

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_bug108519_qcc_skip_index.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug108519_qcc_skip_index.sql
@@ -18,6 +18,11 @@
 
 SET allow_experimental_full_text_index = 1;
 SET allow_experimental_analyzer = 1;
+-- Disable statistics-based part pruning: with materialize_statistics_on_insert = 1 (randomized by
+-- the test runner) the implicit minmax statistics prune the whole part for the never-matching
+-- predicates below before skip-index analysis runs, so the query condition cache entries this
+-- test asserts on via QueryConditionCacheHits are never written or consulted.
+SET use_statistics_for_part_pruning = 0;
 
 DROP TABLE IF EXISTS tab;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f76b144fcba22d6bedfb5ea7e5f1822456b549fb&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29

Ref https://github.com/ClickHouse/ClickHouse/pull/108511