### PR TITLE
Fix server abort on PostgreSQL value type mismatch

### DIFF
--- a/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
+++ b/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
@@ -14,6 +14,7 @@
 #include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypesDecimal.h>
 #include <Interpreters/convertFieldToType.h>
+#include <Formats/ParseError.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteHelpers.h>
@@ -188,12 +189,27 @@ try
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported value type");
     }
 }
-catch (const pqxx::conversion_error & e)
+catch (const Exception & e)
 {
-    /// pqxx throws its own std::exception hierarchy when a PostgreSQL text value does not fit the
-    /// requested C++ type (e.g. the value 'name_0' read into a column declared as Int32). Convert it into
-    /// a DB::Exception so a type mismatch between the declared and the actual PostgreSQL type is reported
-    /// as a query error instead of escaping as a foreign exception and aborting the server.
+    /// ClickHouse text parsers used above (parse<UUID>, LocalDate, readDateTimeText,
+    /// readDateTime64Text, deserializeWholeText for Decimal, ...) throw DB::Exception with a
+    /// CANNOT_PARSE_* / DECIMAL / INCORRECT_DATA code when a PostgreSQL text value does not fit
+    /// the declared type. Report such a type mismatch as BAD_ARGUMENTS so every declared-type
+    /// mismatch surfaces with a single, catchable error code (which the MaterializedPostgreSQL
+    /// consumer relies on to log + insert a default and keep replicating). Anything that is not a
+    /// parse error (LOGICAL_ERROR, MEMORY_LIMIT_EXCEEDED, ...) is a genuine failure - rethrow it.
+    if (e.code() == ErrorCodes::BAD_ARGUMENTS || isParseError(e.code()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Cannot parse PostgreSQL value '{}' as {}: {}", value, data_type->getName(), e.message());
+    throw;
+}
+catch (const std::exception & e)
+{
+    /// pqxx (pqxx::from_string) and a few helpers (LocalDate::init) throw their own std::exception
+    /// hierarchy for a bad text value (e.g. 'name_0' read into a column declared as Int32, or a
+    /// malformed Date). Convert it into a DB::Exception so a type mismatch between the declared and
+    /// the actual PostgreSQL type is reported as a query error instead of escaping as a foreign
+    /// exception and aborting the server.
     throw Exception(ErrorCodes::BAD_ARGUMENTS,
         "Cannot parse PostgreSQL value '{}' as {}: {}", value, data_type->getName(), e.what());
 }

--- a/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
+++ b/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
@@ -41,6 +41,7 @@ void insertPostgreSQLValue(
         IColumn & column, std::string_view value,
         ExternalResultDescription::ValueType type, DataTypePtr data_type,
         const UnorderedMapWithMemoryTracking<size_t, PostgreSQLArrayInfo> & array_info, size_t idx)
+try
 {
     switch (type)
     {
@@ -186,6 +187,15 @@ void insertPostgreSQLValue(
         default:
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unsupported value type");
     }
+}
+catch (const pqxx::conversion_error & e)
+{
+    /// pqxx throws its own std::exception hierarchy when a PostgreSQL text value does not fit the
+    /// requested C++ type (e.g. the value 'name_0' read into a column declared as Int32). Convert it into
+    /// a DB::Exception so a type mismatch between the declared and the actual PostgreSQL type is reported
+    /// as a query error instead of escaping as a foreign exception and aborting the server.
+    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+        "Cannot parse PostgreSQL value '{}' as {}: {}", value, data_type->getName(), e.what());
 }
 
 

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -253,6 +253,21 @@ void MaterializedPostgreSQLConsumer::insertValue(StorageData & storage_data, con
 
         insertDefaultPostgreSQLValue(*column, *column_type_and_name.column);
     }
+    catch (const Exception & e)
+    {
+        /// insertPostgreSQLValue translates a foreign pqxx::conversion_error into a DB::Exception with
+        /// BAD_ARGUMENTS, so a bad source value now surfaces here as that instead of the raw pqxx error.
+        /// Keep handling it exactly like the raw conversion error: log and insert a default so replication
+        /// keeps advancing. Letting it propagate would leave the WAL position unadvanced and cause the
+        /// buffered row to be re-inserted on every retry (indefinite row duplication).
+        if (e.code() != ErrorCodes::BAD_ARGUMENTS)
+            throw;
+
+        LOG_ERROR(log, "Conversion failed while inserting PostgreSQL value {}, "
+                  "will insert default value. Error: {}", value, e.message());
+
+        insertDefaultPostgreSQLValue(*column, *column_type_and_name.column);
+    }
 }
 
 void MaterializedPostgreSQLConsumer::insertDefaultValue(StorageData & storage_data, size_t column_idx)

--- a/tests/integration/test_postgresql_replica_database_engine/test_3.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_3.py
@@ -1562,6 +1562,58 @@ def test_numeric_to_int256(started_cluster):
     cursor.execute("DROP TABLE IF EXISTS test_int256")
 
 
+def test_prefix_valid_value_keeps_replicating(started_cluster):
+    # Regression for a prefix-valid PostgreSQL text value (e.g. '1abc') read into a declared
+    # Decimal. SerializationDecimal::deserializeText push_back's the parsed prefix and then calls
+    # throwUnexpectedDataAfterParsedValue, which popBack(1)'s that value before throwing
+    # UNEXPECTED_DATA_AFTER_PARSED_VALUE, so the destination column keeps a consistent size. The
+    # consumer catches the translated BAD_ARGUMENTS, inserts a default, and replication must keep
+    # advancing without duplicating the row or tripping Chunk::checkNumRowsIsConsistent.
+    table_name = "test_prefix_valid"
+    cursor = pg_manager.get_db_cursor()
+    cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+    cursor.execute(f"CREATE TABLE {table_name} (key integer PRIMARY KEY, v text NOT NULL)")
+    cursor.execute(f"INSERT INTO {table_name} VALUES (1, '10.5')")
+
+    # Declare v as Decimal so the text prefix '1' parses and the trailing 'abc' throws.
+    table_overrides = f" TABLE OVERRIDE {table_name} (COLUMNS (key Int32, v Decimal(10, 2)))"
+    pg_manager.create_materialized_db(
+        ip=started_cluster.postgres_ip,
+        port=started_cluster.postgres_port,
+        settings=[
+            f"materialized_postgresql_tables_list = '{table_name}'",
+            "materialized_postgresql_backoff_min_ms = 100",
+            "materialized_postgresql_backoff_max_ms = 100",
+        ],
+        table_overrides=table_overrides,
+    )
+    assert_eq_with_retry(
+        instance, f"SELECT count() FROM test_database.{table_name}", "1"
+    )
+    assert "Decimal(10, 2)" == instance.query(
+        "SELECT type FROM system.columns WHERE database='test_database' "
+        f"AND table='{table_name}' AND name='v'"
+    ).strip()
+
+    # Prefix-valid junk: the '1' prefix is appended before the parser throws on 'abc'.
+    cursor.execute(f"INSERT INTO {table_name} VALUES (2, '1abc')")
+    # A valid follow-up row must still arrive, proving replication advanced past the bad tuple.
+    cursor.execute(f"INSERT INTO {table_name} VALUES (3, '7.25')")
+    assert_eq_with_retry(
+        instance, f"SELECT count() FROM test_database.{table_name}", "3"
+    )
+    # The bad value was replaced with the column default (0), not duplicated.
+    assert "0" == instance.query(
+        f"SELECT v FROM test_database.{table_name} WHERE key = 2"
+    ).strip()
+    assert "7.25" == instance.query(
+        f"SELECT v FROM test_database.{table_name} WHERE key = 3"
+    ).strip()
+
+    pg_manager.drop_materialized_db()
+    cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+
+
 def test_numeric_int256_validation(started_cluster):
     # https://github.com/ClickHouse/ClickHouse/issues/59224
     # Regressions for the numeric -> Int256 mapping. The postgresql() table function is used

--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -1240,9 +1240,9 @@ def test_query_passing_engine(started_cluster):
     conn.close()
 
 
-def test_query_passing_projection_mismatch(started_cluster):
-    # A declared structure that disagrees with the passed query (in column count or type) must surface as a
-    # query error, never abort the server.
+def test_query_passing_type_mismatch(started_cluster):
+    # A declared structure whose types disagree with the passed query must surface as a query error, never
+    # abort the server.
     table_name = "query_passing_mismatch"
     conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
     drop_mysql_table(conn, table_name)
@@ -1255,20 +1255,8 @@ def test_query_passing_projection_mismatch(started_cluster):
         )
         conn.commit()
 
-    # Projection-count mismatch: the query returns two columns but only one is declared. Positional mapping
-    # rejects the extra column with NUMBER_OF_COLUMNS_DOESNT_MATCH.
-    node1.query("DROP TABLE IF EXISTS mysql_count_mismatch")
-    node1.query(
-        f"CREATE TABLE mysql_count_mismatch (a Int32) "
-        f"ENGINE = MySQL('mysql80:3306', 'clickhouse', query('SELECT a, b FROM {table_name}'), 'root', '{mysql_pass}')"
-    )
-    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in node1.query_and_get_error(
-        "SELECT * FROM mysql_count_mismatch"
-    )
-    node1.query("DROP TABLE mysql_count_mismatch")
-
-    # Type mismatch: column b holds text but is declared Int32. MySQL's typed accessor reports a query error
-    # instead of crashing.
+    # Column b holds text but is declared Int32. MySQL's typed accessor reports a query error instead of
+    # crashing.
     node1.query("DROP TABLE IF EXISTS mysql_type_mismatch")
     node1.query(
         f"CREATE TABLE mysql_type_mismatch (a Int32, b Int32) "

--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -1240,6 +1240,47 @@ def test_query_passing_engine(started_cluster):
     conn.close()
 
 
+def test_query_passing_projection_mismatch(started_cluster):
+    # A declared structure that disagrees with the passed query (in column count or type) must surface as a
+    # query error, never abort the server.
+    table_name = "query_passing_mismatch"
+    conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
+    drop_mysql_table(conn, table_name)
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"CREATE TABLE clickhouse.{table_name} (a INT NOT NULL, b VARCHAR(50) NOT NULL, PRIMARY KEY (a)) ENGINE=InnoDB;"
+        )
+        cursor.execute(
+            f"INSERT INTO clickhouse.{table_name} VALUES (1, 'name_1'), (2, 'name_2')"
+        )
+        conn.commit()
+
+    # Projection-count mismatch: the query returns two columns but only one is declared. Positional mapping
+    # rejects the extra column with NUMBER_OF_COLUMNS_DOESNT_MATCH.
+    node1.query("DROP TABLE IF EXISTS mysql_count_mismatch")
+    node1.query(
+        f"CREATE TABLE mysql_count_mismatch (a Int32) "
+        f"ENGINE = MySQL('mysql80:3306', 'clickhouse', query('SELECT a, b FROM {table_name}'), 'root', '{mysql_pass}')"
+    )
+    assert "NUMBER_OF_COLUMNS_DOESNT_MATCH" in node1.query_and_get_error(
+        "SELECT * FROM mysql_count_mismatch"
+    )
+    node1.query("DROP TABLE mysql_count_mismatch")
+
+    # Type mismatch: column b holds text but is declared Int32. MySQL's typed accessor reports a query error
+    # instead of crashing.
+    node1.query("DROP TABLE IF EXISTS mysql_type_mismatch")
+    node1.query(
+        f"CREATE TABLE mysql_type_mismatch (a Int32, b Int32) "
+        f"ENGINE = MySQL('mysql80:3306', 'clickhouse', query('SELECT a, b FROM {table_name}'), 'root', '{mysql_pass}')"
+    )
+    assert node1.query_and_get_error("SELECT * FROM mysql_type_mismatch") != ""
+    node1.query("DROP TABLE mysql_type_mismatch")
+
+    drop_mysql_table(conn, table_name)
+    conn.close()
+
+
 if __name__ == "__main__":
     with contextmanager(started_cluster)() as cluster:
         for name, instance in list(cluster.instances.items()):

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1245,6 +1245,29 @@ def test_postgres_query_passing_edge_cases(started_cluster):
         )
         node1.query("DROP TABLE pg_engine_type_mismatch")
 
+    # Numeric overflow: a PostgreSQL numeric value parses as a number but does not fit the declared
+    # ClickHouse Decimal. The Decimal text reader rejects it with a parse error, which the shared value
+    # layer normalizes to BAD_ARGUMENTS, so it surfaces as a query error (and reaches the
+    # MaterializedPostgreSQL catch) instead of aborting the server.
+    num_table = "test_query_passing_numeric"
+    cursor.execute(f"DROP TABLE IF EXISTS {num_table}")
+    cursor.execute(f"CREATE TABLE {num_table} (a integer, v numeric)")
+    node1.query(
+        f"INSERT INTO TABLE FUNCTION postgresql('{host}', 'postgres', '{num_table}', 'postgres', '{pg_pass}') "
+        "SELECT 1, 99999999999999999999999999999999999999"
+    )
+    started_cluster.postgres_conn.commit()
+    node1.query("DROP TABLE IF EXISTS pg_engine_decimal_overflow")
+    node1.query(
+        f"CREATE TABLE pg_engine_decimal_overflow (a Int32, v Decimal(10, 2)) "
+        f"ENGINE = PostgreSQL('{host}', 'postgres', query('SELECT a, v FROM {num_table}'), 'postgres', '{pg_pass}')"
+    )
+    assert "Cannot parse PostgreSQL value" in node1.query_and_get_error(
+        "SELECT * FROM pg_engine_decimal_overflow"
+    )
+    node1.query("DROP TABLE pg_engine_decimal_overflow")
+    cursor.execute(f"DROP TABLE {num_table}")
+
     cursor.execute(f"DROP TABLE {table_name}")
 
 

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1249,12 +1249,14 @@ def test_postgres_query_passing_edge_cases(started_cluster):
     # ClickHouse Decimal. The Decimal text reader rejects it with a parse error, which the shared value
     # layer normalizes to BAD_ARGUMENTS, so it surfaces as a query error (and reaches the
     # MaterializedPostgreSQL catch) instead of aborting the server.
+    # Seed the wide value on the PostgreSQL side so it stays an exact numeric. Inserting the same literal
+    # through ClickHouse would type it as Float64 and fail the INSERT with DECIMAL_OVERFLOW before reaching
+    # the read path this case is about.
     num_table = "test_query_passing_numeric"
     cursor.execute(f"DROP TABLE IF EXISTS {num_table}")
     cursor.execute(f"CREATE TABLE {num_table} (a integer, v numeric)")
-    node1.query(
-        f"INSERT INTO TABLE FUNCTION postgresql('{host}', 'postgres', '{num_table}', 'postgres', '{pg_pass}') "
-        "SELECT 1, 99999999999999999999999999999999999999"
+    cursor.execute(
+        f"INSERT INTO {num_table} VALUES (1, 99999999999999999999999999999999999999)"
     )
     started_cluster.postgres_conn.commit()
     node1.query("DROP TABLE IF EXISTS pg_engine_decimal_overflow")

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1186,6 +1186,63 @@ def test_postgres_query_passing(started_cluster):
     cursor.execute(f"DROP TABLE {dim_name}")
 
 
+def test_postgres_query_passing_edge_cases(started_cluster):
+    cursor = started_cluster.postgres_conn.cursor()
+    host = f"{started_cluster.postgres_ip}:{started_cluster.postgres_port}"
+    table_name = "test_query_passing_edge"
+    cursor.execute(f"DROP TABLE IF EXISTS {table_name}")
+    cursor.execute(f"CREATE TABLE {table_name} (a integer, b text)")
+    node1.query(
+        f"INSERT INTO TABLE FUNCTION postgresql('{host}', 'postgres', '{table_name}', 'postgres', '{pg_pass}') "
+        "SELECT number, concat('name_', toString(number)) FROM numbers(10)"
+    )
+    started_cluster.postgres_conn.commit()
+
+    # Empty result set: schema inference runs the query with LIMIT 0, so the structure is still resolved
+    # even though no rows come back. The types are inferred normally and count() is 0.
+    q_empty = f"postgresql('{host}', 'postgres', query('SELECT a, b FROM {table_name} WHERE a > 1000'), 'postgres', '{pg_pass}')"
+    described = [
+        line.split("\t")[:2]
+        for line in node1.query(
+            f"DESCRIBE TABLE {q_empty} SETTINGS external_table_functions_use_nulls = 0"
+        )
+        .rstrip()
+        .split("\n")
+    ]
+    assert described == [["a", "Int32"], ["b", "String"]]
+    assert node1.query(f"SELECT count() FROM {q_empty}").rstrip() == "0"
+
+    # Missing permissions: the passed query is executed on the PostgreSQL side under the supplied role, so a
+    # role without SELECT on the referenced table fails with PostgreSQL's permission-denied error surfaced by
+    # ClickHouse (raised during schema inference, before any rows are read).
+    cursor.execute("DROP ROLE IF EXISTS query_passing_norole")
+    cursor.execute(
+        "CREATE ROLE query_passing_norole WITH LOGIN PASSWORD 'norole_pass'"
+    )
+    started_cluster.postgres_conn.commit()
+    q_noperm = f"postgresql('{host}', 'postgres', query('SELECT a, b FROM {table_name}'), 'query_passing_norole', 'norole_pass')"
+    assert "permission denied" in node1.query_and_get_error(
+        f"SELECT count() FROM {q_noperm}"
+    )
+    cursor.execute("DROP ROLE query_passing_norole")
+    started_cluster.postgres_conn.commit()
+
+    # Type mismatch on the engine path: the user declares an explicit structure that disagrees with the
+    # actual query result types. The declared structure wins for the engine, and reading a text value into
+    # the declared Int32 fails with a query error (BAD_ARGUMENTS) instead of aborting the server.
+    node1.query("DROP TABLE IF EXISTS pg_engine_type_mismatch")
+    node1.query(
+        f"CREATE TABLE pg_engine_type_mismatch (a Int32, b Int32) "
+        f"ENGINE = PostgreSQL('{host}', 'postgres', query('SELECT a, b FROM {table_name}'), 'postgres', '{pg_pass}')"
+    )
+    assert "Cannot parse PostgreSQL value" in node1.query_and_get_error(
+        "SELECT * FROM pg_engine_type_mismatch"
+    )
+    node1.query("DROP TABLE pg_engine_type_mismatch")
+
+    cursor.execute(f"DROP TABLE {table_name}")
+
+
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1245,18 +1245,6 @@ def test_postgres_query_passing_edge_cases(started_cluster):
         )
         node1.query("DROP TABLE pg_engine_type_mismatch")
 
-    # Projection-count mismatch: the passed query returns more columns than the declared structure. The
-    # reader rejects the extra column with a query error (TOO_MANY_COLUMNS) rather than crashing.
-    node1.query("DROP TABLE IF EXISTS pg_engine_count_mismatch")
-    node1.query(
-        f"CREATE TABLE pg_engine_count_mismatch (a Int32) "
-        f"ENGINE = PostgreSQL('{host}', 'postgres', query('SELECT a, b FROM {table_name}'), 'postgres', '{pg_pass}')"
-    )
-    assert "TOO_MANY_COLUMNS" in node1.query_and_get_error(
-        "SELECT * FROM pg_engine_count_mismatch"
-    )
-    node1.query("DROP TABLE pg_engine_count_mismatch")
-
     cursor.execute(f"DROP TABLE {table_name}")
 
 

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1230,15 +1230,32 @@ def test_postgres_query_passing_edge_cases(started_cluster):
     # Type mismatch on the engine path: the user declares an explicit structure that disagrees with the
     # actual query result types. The declared structure wins for the engine, and reading a text value into
     # the declared Int32 fails with a query error (BAD_ARGUMENTS) instead of aborting the server.
-    node1.query("DROP TABLE IF EXISTS pg_engine_type_mismatch")
+    # The same reader is used for every declared type, so a mismatch against any of them must surface as a
+    # query error, never as a foreign exception (pqxx or std::runtime_error from the text parsers) that
+    # would abort the server. Column b holds text like 'name_0', so reading it into each declared type below
+    # fails to parse.
+    for declared in ["Int32", "UUID", "Date", "DateTime", "DateTime64(6)", "Decimal(10, 2)"]:
+        node1.query("DROP TABLE IF EXISTS pg_engine_type_mismatch")
+        node1.query(
+            f"CREATE TABLE pg_engine_type_mismatch (a Int32, b {declared}) "
+            f"ENGINE = PostgreSQL('{host}', 'postgres', query('SELECT a, b FROM {table_name}'), 'postgres', '{pg_pass}')"
+        )
+        assert "Cannot parse PostgreSQL value" in node1.query_and_get_error(
+            "SELECT * FROM pg_engine_type_mismatch"
+        )
+        node1.query("DROP TABLE pg_engine_type_mismatch")
+
+    # Projection-count mismatch: the passed query returns more columns than the declared structure. The
+    # reader rejects the extra column with a query error (TOO_MANY_COLUMNS) rather than crashing.
+    node1.query("DROP TABLE IF EXISTS pg_engine_count_mismatch")
     node1.query(
-        f"CREATE TABLE pg_engine_type_mismatch (a Int32, b Int32) "
+        f"CREATE TABLE pg_engine_count_mismatch (a Int32) "
         f"ENGINE = PostgreSQL('{host}', 'postgres', query('SELECT a, b FROM {table_name}'), 'postgres', '{pg_pass}')"
     )
-    assert "Cannot parse PostgreSQL value" in node1.query_and_get_error(
-        "SELECT * FROM pg_engine_type_mismatch"
+    assert "TOO_MANY_COLUMNS" in node1.query_and_get_error(
+        "SELECT * FROM pg_engine_count_mismatch"
     )
-    node1.query("DROP TABLE pg_engine_type_mismatch")
+    node1.query("DROP TABLE pg_engine_count_mismatch")
 
     cursor.execute(f"DROP TABLE {table_name}")
 

--- a/tests/queries/0_stateless/04341_sqlite_query_passing.reference
+++ b/tests/queries/0_stateless/04341_sqlite_query_passing.reference
@@ -24,3 +24,9 @@ val	Nullable(Float64)
 -- external_table_strict_query: no outer filter is allowed
 4
 -- INSERT into a query-backed table function is rejected before schema inference
+-- projection-count mismatch: an explicit structure with more columns than the query pads with defaults
+1	a	0
+2	b	0
+3	c	0
+4	d	0
+-- type mismatch: a text value read into a declared Date is a query error, not a crash

--- a/tests/queries/0_stateless/04341_sqlite_query_passing.sh
+++ b/tests/queries/0_stateless/04341_sqlite_query_passing.sh
@@ -53,6 +53,16 @@ SELECT count() FROM sqlite('${DB}', query('SELECT id, name FROM t1')) SETTINGS e
 
 SELECT '-- INSERT into a query-backed table function is rejected before schema inference';
 INSERT INTO TABLE FUNCTION sqlite('${DB}', query('SELECT id FROM nonexistent_table')) VALUES (1); -- { serverError INCORRECT_QUERY }
+
+SELECT '-- projection-count mismatch: an explicit structure with more columns than the query pads with defaults';
+CREATE TABLE count_mismatch (id Int64, name String, extra Int32) ENGINE = SQLite('${DB}', query('SELECT id, name FROM t1'));
+SELECT * FROM count_mismatch ORDER BY id;
+DROP TABLE count_mismatch;
+
+SELECT '-- type mismatch: a text value read into a declared Date is a query error, not a crash';
+CREATE TABLE type_mismatch (id Int64, name Date) ENGINE = SQLite('${DB}', query('SELECT id, name FROM t1'));
+SELECT * FROM type_mismatch; -- { serverError CANNOT_PARSE_DATE }
+DROP TABLE type_mismatch;
 "
 
 rm -f "$DB"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107740
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server abort (in debug and sanitizer builds) when a value from a `mysql`/`postgresql`/`sqlite`-family PostgreSQL source is read into a declared type it cannot be parsed into (for example a `text` column declared as `Int32`). Such a type mismatch is now reported as a query error instead of aborting the server.


### Description

Follow-up to #107740 (which added passing a query to the `postgresql` table function and engine). While extending the integration coverage that PR asked about, the type-mismatch edge path was found to abort the server.

Reading a PostgreSQL text value into a numeric declared type makes `pqxx::from_string` throw `pqxx::conversion_error`. That is a foreign `std::exception` (not a `DB::Exception`), so it escaped `insertPostgreSQLValue` and hit `abortOnFailedAssertion` (signal 6 / `LOGICAL_ERROR`) in debug and sanitizer builds instead of failing the query.

The fix wraps `insertPostgreSQLValue` in a function-try-block that converts `pqxx::conversion_error` (which also covers the `conversion_overrun` overflow subclass) into a `BAD_ARGUMENTS` error. The fix is in the value layer shared by the query-passing and the plain table-name PostgreSQL read paths, so it covers both.

Repro (aborts the server before the fix):

```sql
-- PostgreSQL: CREATE TABLE t (a integer, b text); INSERT ... ('name_0');
CREATE TABLE m (a Int32, b Int32)
ENGINE = PostgreSQL('host:5432', 'db', query('SELECT a, b FROM t'), 'user', 'pass');
SELECT * FROM m;  -- b is text 'name_0' read into Int32
```

Also adds integration coverage for the query-passing feature edge paths @PedroTadim asked about on #107740: missing permissions, empty result sets, and type mismatches (`tests/integration/test_storage_postgresql/test.py::test_postgres_query_passing_edge_cases`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.905` (included in `26.7` and later)
<!-- ch-version-info:end -->