### PR TITLE
Bump `silk` to the latest `clickhouse-public`

### DIFF
--- a/contrib/silk-cmake/CMakeLists.txt
+++ b/contrib/silk-cmake/CMakeLists.txt
@@ -32,7 +32,9 @@ endif()
 set(SILK_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/silk")
 
 # silk-util
-file(GLOB SILK_UTIL_SOURCES "${SILK_SOURCE_DIR}/src/util/*.cpp")
+# CONFIGURE_DEPENDS makes Ninja re-run the glob on each build, so a submodule bump
+# that adds or removes sources reconfigures already-existing build directories.
+file(GLOB SILK_UTIL_SOURCES CONFIGURE_DEPENDS "${SILK_SOURCE_DIR}/src/util/*.cpp")
 add_library(_silk_util STATIC ${SILK_UTIL_SOURCES})
 target_include_directories(_silk_util SYSTEM
     PUBLIC "${SILK_SOURCE_DIR}/include"
@@ -45,7 +47,7 @@ target_link_libraries(_silk_util
 add_library(ch_contrib::silk_util ALIAS _silk_util)
 
 # silk-fibers
-file(GLOB SILK_FIBERS_SOURCES "${SILK_SOURCE_DIR}/src/fibers/*.cpp")
+file(GLOB SILK_FIBERS_SOURCES CONFIGURE_DEPENDS "${SILK_SOURCE_DIR}/src/fibers/*.cpp")
 add_library(_silk_fibers STATIC ${SILK_FIBERS_SOURCES})
 target_include_directories(_silk_fibers SYSTEM
     PUBLIC "${SILK_SOURCE_DIR}/include"


### PR DESCRIPTION
Update `contrib/silk` from e7d5d331a28 to 18b8d9fe3c0 (44 commits from the `clickhouse-public` branch). Notable changes: batched and coalesced mass fiber wakeups, a rewrite of the sleep logic that removes uring timeouts, `FiberSequencer::stop`, MSan/TSan fixes for fiber stack switching, and removal of all submodules from silk's own contrib.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1115` (included in `26.7` and later)
<!-- ch-version-info:end -->