### PR TITLE
Give the server up to 120 seconds to become ready in CI

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -740,7 +740,10 @@ profiles:
 
     def wait_ready(self, replica_num=0):
         res, out, err = 0, "", ""
-        attempts = 30
+        # A debug or sanitizer server can legitimately take over a minute from
+        # fork to listening; the loop below exits early on success and detects a
+        # dead server via proc.poll(), so a generous deadline costs nothing.
+        attempts = 60
         delay = 2
         if replica_num == 1:
             pid_file = self.pid_file_replica_1

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -134,9 +134,12 @@ function fuzz
               --logger.log=server.log 2>&1 | tee -a stderr.log >> server.log 2>&1
       exit "${PIPESTATUS[0]}" ) &
     server_bg_pid=$!
-    for _ in {1..30}
+    # A debug or sanitizer server can take over a minute from fork to listening;
+    # give it the same 120s budget as `wait_ready` in `clickhouse_proc.py`.
+    # A dead server is detected early, so the deadline only affects hung servers.
+    for _ in {1..120}
     do
-        if clickhouse-client --receive_timeout=5 --query "select 1"
+        if clickhouse-client --receive_timeout=5 --query "select 1" || ! kill -0 $server_bg_pid
         then
             break
         fi


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109005

The `wait_ready` deadline in `ci/jobs/scripts/clickhouse_proc.py` (30 attempts × 2s = 60s) is too tight for debug and sanitizer builds. In a flaky-check run on #109005 the amd_debug server listened for connections ~64 seconds after the fork — about 4 seconds past the deadline — and the job failed with `SETUP FAILURE: clickhouse-server not ready (wait_ready)` even though the server started fine ([report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109005&sha=92b35fef52a82ba621462f1218a2e5cb43ef1980&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20flaky%20check%29)).

The loop exits early on success and detects a dead server via `proc.poll`, so raising the deadline to 120s does not slow down healthy runs or runs where the server actually crashed — only genuinely hung servers wait longer before being declared dead.

The AST/BuzzHouse fuzzer bootstrap in `ci/jobs/scripts/fuzzer/run-fuzzer.sh` had the same problem: it gave the server only ~30 seconds to answer `select 1` before the next `clickhouse-client` under `set -e` aborted the job, while the fuzzer jobs run the same `amd_debug` and sanitizer artifacts. It now uses the same 120-second budget and breaks early when the server process died, as `wait_for_server` in `ci/jobs/scripts/perf/compare.sh` does.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.886` (included in `26.7` and later)
<!-- ch-version-info:end -->