### PR TITLE
Fix wrong access type for SYSTEM CLEANUP and VIRTUAL PARTS UPDATE ON CLUSTER

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2886,9 +2886,9 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
         case Type::START_CLEANUP:
         {
             if (!query.table)
-                required_access.emplace_back(AccessType::SYSTEM_PULLING_REPLICATION_LOG);
+                required_access.emplace_back(AccessType::SYSTEM_CLEANUP);
             else
-                required_access.emplace_back(AccessType::SYSTEM_PULLING_REPLICATION_LOG, query.getDatabase(), query.getTable());
+                required_access.emplace_back(AccessType::SYSTEM_CLEANUP, query.getDatabase(), query.getTable());
             break;
         }
         case Type::STOP_FETCHES:
@@ -2937,9 +2937,9 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
         case Type::START_VIRTUAL_PARTS_UPDATE:
         {
             if (!query.table)
-                required_access.emplace_back(AccessType::SYSTEM_PULLING_REPLICATION_LOG);
+                required_access.emplace_back(AccessType::SYSTEM_VIRTUAL_PARTS_UPDATE);
             else
-                required_access.emplace_back(AccessType::SYSTEM_PULLING_REPLICATION_LOG, query.getDatabase(), query.getTable());
+                required_access.emplace_back(AccessType::SYSTEM_VIRTUAL_PARTS_UPDATE, query.getDatabase(), query.getTable());
             break;
         }
         case Type::STOP_REDUCE_BLOCKING_PARTS:

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.reference
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.reference
@@ -1,0 +1,4 @@
+ok
+ok
+ok
+ok

--- a/tests/queries/0_stateless/04499_system_cluster_access_types.sh
+++ b/tests/queries/0_stateless/04499_system_cluster_access_types.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+table="t_04499"
+cleanup_user="cleanup_user_04499_$CLICKHOUSE_DATABASE"
+vparts_user="vparts_user_04499_$CLICKHOUSE_DATABASE"
+# Global (ON *.*) grants: the no-table ON CLUSTER form checks a single global grant on the initiator.
+cleanup_global_user="cleanup_global_user_04499_$CLICKHOUSE_DATABASE"
+vparts_global_user="vparts_global_user_04499_$CLICKHOUSE_DATABASE"
+# Holds only SYSTEM PULLING REPLICATION LOG (the grant the ON CLUSTER path wrongly required before the fix).
+wrong_user="wrong_user_04499_$CLICKHOUSE_DATABASE"
+# Holds SYSTEM PULLING REPLICATION LOG globally (ON *.*): the old grant the no-table branch wrongly required.
+wrong_global_user="wrong_global_user_04499_$CLICKHOUSE_DATABASE"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS $cleanup_user, $vparts_user, $cleanup_global_user, $vparts_global_user, $wrong_user, $wrong_global_user"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS $table"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE $table (a UInt64) ENGINE = MergeTree ORDER BY a"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $cleanup_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $cleanup_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM CLEANUP ON $CLICKHOUSE_DATABASE.$table TO $cleanup_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $vparts_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $vparts_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM VIRTUAL PARTS UPDATE ON $CLICKHOUSE_DATABASE.$table TO $vparts_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $cleanup_global_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $cleanup_global_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM CLEANUP ON *.* TO $cleanup_global_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $vparts_global_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $vparts_global_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM VIRTUAL PARTS UPDATE ON *.* TO $vparts_global_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $wrong_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $wrong_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM PULLING REPLICATION LOG ON $CLICKHOUSE_DATABASE.$table TO $wrong_user"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER $wrong_global_user IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT CLUSTER ON *.* TO $wrong_global_user"
+${CLICKHOUSE_CLIENT} --query "GRANT SYSTEM PULLING REPLICATION LOG ON *.* TO $wrong_global_user"
+
+cluster="test_shard_localhost"
+run() { ${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode none "$@"; }
+
+is_cloud=$(${CLICKHOUSE_CLIENT} --query "SELECT value FROM system.build_options WHERE name = 'CLICKHOUSE_CLOUD'")
+
+# SYSTEM VIRTUAL PARTS UPDATE is a private feature, so only the access check is common to both
+# builds. Assert the grant holder is not denied, and pin the open-source outcome (the command is
+# not implemented there, so it stops at BAD_ARGUMENTS after the access check).
+vparts_allowed() {
+    local out
+    out=$(run --user "$1" --query "$2" 2>&1)
+    if grep -qF ACCESS_DENIED <<< "$out"; then
+        echo "FAIL: access denied: $out"
+    elif [ "$is_cloud" = 1 ] || grep -qF BAD_ARGUMENTS <<< "$out"; then
+        echo "ok"
+    else
+        echo "FAIL: expected BAD_ARGUMENTS on the open-source build: $out"
+    fi
+}
+
+# The ON CLUSTER path must check the dedicated grant, not SYSTEM PULLING REPLICATION LOG.
+
+# Holder of SYSTEM CLEANUP is allowed (command runs on MergeTree).
+run --user "$cleanup_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $cluster $CLICKHOUSE_DATABASE.$table" >/dev/null || exit 1
+echo "ok"
+vparts_allowed "$vparts_user" "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $cluster $CLICKHOUSE_DATABASE.$table"
+
+# Holder of only SYSTEM PULLING REPLICATION LOG is denied both commands.
+run --user "$wrong_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $cluster $CLICKHOUSE_DATABASE.$table -- { serverError ACCESS_DENIED }"
+run --user "$wrong_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $cluster $CLICKHOUSE_DATABASE.$table -- { serverError ACCESS_DENIED }"
+
+# No-table ON CLUSTER form: the patch also switched this branch from the global SYSTEM PULLING
+# REPLICATION LOG grant to the dedicated global SYSTEM CLEANUP / SYSTEM VIRTUAL PARTS UPDATE grant.
+# The no-table check is a single global grant on the initiator, so these need ON *.* grants.
+
+# Holder of global SYSTEM CLEANUP is allowed. START (not STOP) only wakes cleanup threads: idempotent
+# and holds no lock, so it stays parallel-safe despite touching all tables on the host.
+run --user "$cleanup_global_user" --query "SYSTEM START CLEANUP ON CLUSTER $cluster" >/dev/null || exit 1
+echo "ok"
+# START, not STOP: both spellings share one access branch, and START cannot leave updates
+# globally stopped for other tests if the private build does execute the command.
+vparts_allowed "$vparts_global_user" "SYSTEM START VIRTUAL PARTS UPDATE ON CLUSTER $cluster"
+
+# Holder of only global SYSTEM PULLING REPLICATION LOG is now denied both no-table commands.
+# This is the discriminating case: the no-table branch is a single global check, so the old code
+# would have allowed this user via the global SYSTEM PULLING REPLICATION LOG grant; the fix denies it.
+run --user "$wrong_global_user" --query "SYSTEM STOP CLEANUP ON CLUSTER $cluster -- { serverError ACCESS_DENIED }"
+run --user "$wrong_global_user" --query "SYSTEM STOP VIRTUAL PARTS UPDATE ON CLUSTER $cluster -- { serverError ACCESS_DENIED }"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER $cleanup_user, $vparts_user, $cleanup_global_user, $vparts_global_user, $wrong_user, $wrong_global_user"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE $table"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/108956
Related: https://github.com/ClickHouse/ClickHouse/pull/108546


### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SYSTEM STOP/START CLEANUP` and `SYSTEM STOP/START VIRTUAL PARTS UPDATE` `ON CLUSTER` requiring `SYSTEM PULLING REPLICATION LOG` instead of `SYSTEM CLEANUP` / `SYSTEM VIRTUAL PARTS UPDATE`.


### Description

`getRequiredAccessForDDLOnCluster()` required the wrong privilege for the `ON CLUSTER` form of two commands, diverging from the privilege each command needs locally:
- `CLEANUP` used `SYSTEM PULLING REPLICATION LOG` (local execution uses `SYSTEM CLEANUP`).
- `VIRTUAL PARTS UPDATE` used `SYSTEM PULLING REPLICATION LOG` (the dedicated `SYSTEM VIRTUAL PARTS UPDATE` was unused).

Both were copies of the `PULLING REPLICATION LOG` case above them. `SYSTEM VIRTUAL PARTS UPDATE` had no other reader, so the privilege was grantable but never checked.

`VIRTUAL PARTS UPDATE` is a private feature with no executor in this repository, so here it returns `BAD_ARGUMENTS` after the access check. Its access type is kept as it is in the private build. The regression test therefore asserts only what is common to both builds for that command (the grant holder is not denied) and pins the `BAD_ARGUMENTS` outcome to the open-source build, detected via `SELECT value FROM system.build_options WHERE name = 'CLICKHOUSE_CLOUD'`.

`PREWARM PRIMARY INDEX CACHE` from the same issue was fixed separately on master by #109198; this PR covers the two remaining commands.

This tightens the required privilege for the `ON CLUSTER` form: a user must now hold the dedicated grant.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1009` (included in `26.8` and later)
<!-- ch-version-info:end -->