### PR TITLE
Fix INSERT into OneLake DataLakeCatalog table (route ADLS Gen2 writes to the .dfs host)

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -37,7 +37,7 @@ namespace ErrorCodes
     DECLARE(String, onelake_client_id, "", "Client id from azure", 0) \
     DECLARE(String, onelake_client_secret, "", "Client secret from azure", 0) \
     DECLARE(String, onelake_bearer_token, "", "Pre-obtained bearer token for OneLake, scoped to https://storage.azure.com. The token is static and not refreshed, so a long-lived database must be recreated once it expires", 0) \
-    DECLARE(Bool, onelake_use_blob_endpoint, true, "Use the Blob endpoint (.blob.fabric.microsoft.com) for OneLake. When disabled, the DFS endpoint (.dfs.fabric.microsoft.com) is used instead", 0) \
+    DECLARE(Bool, onelake_use_blob_endpoint, true, "Use the Blob endpoint (.blob.fabric.microsoft.com) for OneLake reads; writes use the DFS endpoint (.dfs.fabric.microsoft.com). When disabled, reads use the DFS endpoint too. With remote_url_allow_hosts set, allowlist both hosts or INSERT is rejected", 0) \
     DECLARE(String, google_project_id, "", "Google Cloud project ID for BigLake. Required for BigLake catalog. Used in x-goog-user-project header. If not set and google_adc_quota_project_id is provided, it latter will be used", 0) \
     DECLARE(String, google_service_account, "", "Google Cloud service account email for metadata service authentication. Default: 'default'. Only used when ADC credentials are not provided", 0) \
     DECLARE(String, google_metadata_service, "", "Google Cloud metadata service endpoint for token retrieval. Default: 'metadata.google.internal'. Only used when ADC credentials are not provided", 0) \

--- a/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
+++ b/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.cpp
@@ -4,6 +4,8 @@
 
 #include <base/sleep.h>
 
+#include <Poco/URI.h>
+
 #include <Disks/IO/WriteBufferFromAzureDataLakeStorage.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <IO/AzureBlobStorage/isRetryableAzureException.h>
@@ -48,9 +50,20 @@ String prefixedBlobPath(const AzureBlobStorage::Endpoint & endpoint, const Strin
     return full;
 }
 
+}
+
 String buildAdlsGen2FileUrl(const AzureBlobStorage::Endpoint & endpoint, const String & blob_path_)
 {
     Poco::URI uri(endpoint.getContainerEndpoint());
+
+    /// OneLake serves reads from the Blob host but writes only from the DFS host,
+    /// so retarget the Fabric Blob host to DFS for the write client.
+    const String blob_suffix = ".blob.fabric.microsoft.com";
+    const String dfs_suffix = ".dfs.fabric.microsoft.com";
+    String host = uri.getHost();
+    if (host.ends_with(blob_suffix))
+        uri.setHost(host.substr(0, host.size() - blob_suffix.size()) + dfs_suffix);
+
     String path = uri.getPath();
     if (!path.empty() && path.back() != '/')
         path += '/';
@@ -59,14 +72,13 @@ String buildAdlsGen2FileUrl(const AzureBlobStorage::Endpoint & endpoint, const S
     return uri.toString();
 }
 
-}
-
 constexpr size_t ADLFS_MAX_RETRIES = 10;
 
 bool isAdlsGen2Endpoint(const AzureBlobStorage::Endpoint & endpoint)
 {
-    return endpoint.storage_account_url.contains("dfs.fabric.microsoft.com")
-        || endpoint.storage_account_url.contains("blob.fabric.microsoft.com");
+    /// Only real Microsoft Fabric / OneLake hosts, matched at a label boundary.
+    const String host = Poco::URI(endpoint.storage_account_url).getHost();
+    return host.ends_with(".dfs.fabric.microsoft.com") || host.ends_with(".blob.fabric.microsoft.com");
 }
 
 Azure::Storage::Files::DataLake::DataLakeFileClient makeAdlsGen2FileClient(

--- a/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.h
+++ b/src/Disks/IO/WriteBufferFromAzureDataLakeStorage.h
@@ -75,6 +75,9 @@ Azure::Storage::Files::DataLake::DataLakeFileClient makeAdlsGen2FileClient(
 
 bool isAdlsGen2Endpoint(const AzureBlobStorage::Endpoint & endpoint);
 
+/// Build the ADLS Gen2 (DFS) write URL for a blob path. Exposed for unit testing.
+String buildAdlsGen2FileUrl(const AzureBlobStorage::Endpoint & endpoint, const String & blob_path);
+
 }
 
 #endif

--- a/src/Disks/IO/tests/gtest_adls_gen2_url.cpp
+++ b/src/Disks/IO/tests/gtest_adls_gen2_url.cpp
@@ -1,0 +1,70 @@
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+
+#include <gtest/gtest.h>
+
+#include <Poco/URI.h>
+#include <base/types.h>
+#include <Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.h>
+#include <Disks/IO/WriteBufferFromAzureDataLakeStorage.h>
+
+using namespace DB;
+
+namespace
+{
+
+/// A OneLake endpoint: the host is the Blob endpoint (the default), while writes
+/// must go to the DFS host. Empty account_name keeps getContainerEndpoint from
+/// adding an extra path segment.
+AzureBlobStorage::Endpoint makeOneLakeBlobEndpoint()
+{
+    AzureBlobStorage::Endpoint endpoint;
+    endpoint.storage_account_url = "https://onelake.blob.fabric.microsoft.com";
+    endpoint.account_name = "";
+    endpoint.container_name = "11111111-2222-3333-4444-555555555555";
+    endpoint.prefix = "lakehouse-guid/Tables/dbo/mytable";
+    return endpoint;
+}
+
+}
+
+TEST(AdlsGen2Url, OneLakeBlobEndpointIsGen2)
+{
+    EXPECT_TRUE(isAdlsGen2Endpoint(makeOneLakeBlobEndpoint()));
+}
+
+/// The write URL must target the DFS host; the Blob host does not serve the DFS API.
+TEST(AdlsGen2Url, OneLakeUrlTargetsDfsHost)
+{
+    const String url = buildAdlsGen2FileUrl(makeOneLakeBlobEndpoint(), "data/data-0.parquet");
+    EXPECT_EQ(Poco::URI(url).getHost(), "onelake.dfs.fabric.microsoft.com") << url;
+}
+
+/// A regular Azure account already on a .dfs host is left as-is.
+TEST(AdlsGen2Url, NonFabricDfsHostUnchanged)
+{
+    AzureBlobStorage::Endpoint endpoint;
+    endpoint.storage_account_url = "https://myacct.dfs.core.windows.net";
+    endpoint.container_name = "mycontainer";
+    endpoint.prefix = "path/to/table";
+
+    const String url = buildAdlsGen2FileUrl(endpoint, "data/data-0.parquet");
+    EXPECT_EQ(Poco::URI(url).getHost(), "myacct.dfs.core.windows.net");
+}
+
+/// A host that only contains the Fabric suffix as a substring is not a Fabric
+/// host: not treated as Gen2, not retargeted.
+TEST(AdlsGen2Url, NonFabricLookalikeHostNotRetargeted)
+{
+    AzureBlobStorage::Endpoint endpoint;
+    endpoint.storage_account_url = "https://proxy-blob.fabric.microsoft.com.example.com";
+    endpoint.container_name = "c";
+    endpoint.prefix = "p";
+
+    EXPECT_FALSE(isAdlsGen2Endpoint(endpoint));
+    const String url = buildAdlsGen2FileUrl(endpoint, "data/data-0.parquet");
+    EXPECT_EQ(Poco::URI(url).getHost(), "proxy-blob.fabric.microsoft.com.example.com");
+}
+
+#endif

--- a/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
+++ b/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
@@ -15,6 +15,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/HTTPClientSession.h>
+#include <Poco/String.h>
 #include <Poco/URI.h>
 #include <azure/core/http/policies/policy.hpp>
 
@@ -307,6 +308,21 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
     const auto & headers = request.GetHeaders();
     const auto & method = request.GetMethod().ToString();
     const auto url = request.GetUrl();
+
+    /// Enforce remote_url_allow_hosts on the host actually used: only redirects
+    /// were re-checked before, but the request host can differ from the endpoint
+    /// validated at CREATE time (OneLake writes go to the `.dfs` host, reads to
+    /// `.blob`). Normalize scheme and host as Poco::URI does at CREATE time (the
+    /// scheme resolves the default port; the host is lower-cased) so both agree.
+    {
+        Poco::URI request_uri;
+        request_uri.setScheme(url.GetScheme());
+        std::string request_host = url.GetHost();
+        Poco::toLowerInPlace(request_host);
+        request_uri.setHost(request_host);
+        request_uri.setPort(url.GetPort());
+        remote_host_filter.checkURL(request_uri);
+    }
 
     try
     {

--- a/src/IO/AzureBlobStorage/tests/gtest_poco_azure_http_client_host_filter.cpp
+++ b/src/IO/AzureBlobStorage/tests/gtest_poco_azure_http_client_host_filter.cpp
@@ -1,0 +1,87 @@
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+
+#include <gtest/gtest.h>
+
+#include <IO/AzureBlobStorage/PocoHTTPClient.h>
+#include <Common/RemoteHostFilter.h>
+#include <Common/Exception.h>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/URI.h>
+#include <Poco/Util/XMLConfiguration.h>
+
+#include <sstream>
+
+namespace DB::ErrorCodes
+{
+    extern const int UNACCEPTABLE_URL;
+}
+
+using namespace DB;
+
+/// A write to the `.dfs` host must be rejected when only the `.blob` read host
+/// is allowlisted, i.e. the request-time host check enforces remote_url_allow_hosts.
+TEST(PocoAzureHTTPClientHostFilter, WriteToDisallowedDfsHostIsRejected)
+{
+    const std::string xml =
+        "<clickhouse><remote_url_allow_hosts>"
+        "<host>onelake.blob.fabric.microsoft.com</host>"
+        "</remote_url_allow_hosts></clickhouse>";
+    std::stringstream ss(xml);
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration(ss));
+
+    RemoteHostFilter filter;
+    filter.setValuesFromConfig(*config);
+
+    PocoAzureHTTPClient client(PocoAzureHTTPClientConfiguration{
+        .remote_host_filter = filter,
+        .max_redirects = 10,
+        .for_disk_azure = false,
+        .request_throttler = {},
+        .extra_headers = {},
+    });
+
+    Azure::Core::Http::Request write_request(
+        Azure::Core::Http::HttpMethod::Put,
+        Azure::Core::Url("https://onelake.dfs.fabric.microsoft.com/ws/lh/Tables/dbo/t/data-0.parquet"));
+    Azure::Core::Context context;
+
+    try
+    {
+        client.Send(write_request, context);
+        FAIL() << "write to a non-allowlisted .dfs host must be rejected";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::UNACCEPTABLE_URL);
+    }
+
+    /// Sanity: the allowlisted read host still passes, so it's not a blanket deny.
+    EXPECT_NO_THROW(filter.checkURL(Poco::URI("https://onelake.blob.fabric.microsoft.com/ws/lh")));
+}
+
+/// A `host:443` allowlist entry must accept a request URL with no explicit port:
+/// the scheme lets Poco resolve the default 443 (this breaks if the scheme is dropped).
+TEST(PocoAzureHTTPClientHostFilter, ExplicitDefaultPortAllowlistAcceptsImplicitHttpsPort)
+{
+    const std::string xml =
+        "<clickhouse><remote_url_allow_hosts>"
+        "<host>onelake.dfs.fabric.microsoft.com:443</host>"
+        "</remote_url_allow_hosts></clickhouse>";
+    std::stringstream ss(xml);
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration(ss));
+
+    RemoteHostFilter filter;
+    filter.setValuesFromConfig(*config);
+
+    /// Built exactly as makeRequestInternalImpl does: scheme + host + GetPort()==0.
+    Poco::URI request_uri;
+    request_uri.setScheme("https");
+    request_uri.setHost("onelake.dfs.fabric.microsoft.com");
+    request_uri.setPort(0);
+    EXPECT_NO_THROW(filter.checkURL(request_uri));
+}
+
+#endif

--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -1163,8 +1163,6 @@ def test_insert_into_table(node, catalog_manager, request):
     backend = request.node.callspec.params.get("catalog_manager")
     if backend == "biglake":
         pytest.xfail("INSERT into BigLake DataLakeCatalog does not commit to the catalog")
-    if backend == "onelake":
-        pytest.xfail("INSERT into OneLake raises StorageException during blob upload")
     data = pa.table(
         {
             "id": pa.array([1, 2], type=pa.int64()),
@@ -1188,10 +1186,31 @@ def test_insert_into_table(node, catalog_manager, request):
             f"INSERT INTO {db}.`{full}` VALUES (3, 'three')",
             settings={"allow_insert_into_iceberg": 1},
         )
-        count = node.query(
-            f"SELECT count() FROM {db}.`{full}` FORMAT TSV"
-        ).strip()
+        if backend == "onelake":
+            # OneLake's catalog is eventually consistent, so poll (cache off) for
+            # the new snapshot. Other backends must see it immediately (one-shot).
+            read_settings = {"use_iceberg_metadata_files_cache": 0}
+            deadline = time.monotonic() + 180
+            while True:
+                count = node.query(
+                    f"SELECT count() FROM {db}.`{full}` FORMAT TSV",
+                    settings=read_settings,
+                ).strip()
+                if count == "3" or time.monotonic() >= deadline:
+                    break
+                time.sleep(5)
+        else:
+            read_settings = {}
+            count = node.query(
+                f"SELECT count() FROM {db}.`{full}` FORMAT TSV"
+            ).strip()
         assert int(count) == 3
+        # count() can come from metadata alone, so read a real value too.
+        value = node.query(
+            f"SELECT value FROM {db}.`{full}` WHERE id = 3 FORMAT TSV",
+            settings=read_settings,
+        ).strip()
+        assert value == "three", value
     finally:
         catalog_manager.cleanup_table(table_name)
 


### PR DESCRIPTION
INSERT into a Microsoft Fabric / OneLake `DataLakeCatalog` table failed during the data-file upload with `IncorrectEndpointError` (HTTP 400): OneLake reads use the Blob endpoint, so the ADLS Gen2 (DFS) write client built the file URL against the `.blob` host, which does not serve the DFS filesystem API.

- Route DFS writes to the `.dfs` host in `buildAdlsGen2FileUrl` (reads stay on `.blob`), matching only real Fabric hosts at a domain-label boundary — same tightening in `isAdlsGen2Endpoint`.
- Validate the actual request host against `remote_url_allow_hosts` in `PocoAzureHTTPClient`, so a `.dfs` write can't bypass an allowlist that only lists the `.blob` read host.
- Add gtests for the URL rewrite and the allowlist re-check. The e2e `test_insert_into_table[onelake]` (internal pipeline only) now asserts the INSERT commits and reads back a real value.

**Note for hardened deployments:** OneLake reads use `onelake.blob.fabric.microsoft.com` and writes use `onelake.dfs.fabric.microsoft.com`. If host access is restricted via `remote_url_allow_hosts`, both hosts must be allowlisted — otherwise `CREATE`/reads succeed but `INSERT` is rejected with `UNACCEPTABLE_URL`. This is documented in the `onelake_use_blob_endpoint` setting description. (Not validated at `CREATE` time on purpose, so read-only deployments that only need the `.blob` host are not regressed.)

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `INSERT` into a Microsoft Fabric / OneLake `DataLakeCatalog` table failing with `IncorrectEndpointError` (HTTP 400) by routing ADLS Gen2 (DFS) writes to the `.dfs` endpoint host instead of the `.blob` host. Note: with `remote_url_allow_hosts`, both the `.blob` (read) and `.dfs` (write) Fabric hosts must be allowlisted for `INSERT`.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1226` (included in `26.7` and later)
<!-- ch-version-info:end -->