### PR TITLE
Fix flaky 02907_suggestions_readonly_user: wait for prompt before next command

### DIFF
--- a/tests/queries/0_stateless/02907_suggestions_readonly_user.expect
+++ b/tests/queries/0_stateless/02907_suggestions_readonly_user.expect
@@ -27,9 +27,13 @@ expect ":) "
 
 send -- "DROP USER IF EXISTS $user\r"
 expect "Ok."
+# Wait for the prompt to be redrawn before sending the next command, otherwise
+# the input can race the readline redraw and get lost.
+expect ":) "
 
 send -- "CREATE USER $user\r"
 expect "Ok."
+expect ":) "
 
 send -- "exit\r"
 expect eof
@@ -56,6 +60,7 @@ expect ":) "
 
 send -- "DROP USER $user\r"
 expect "Ok."
+expect ":) "
 
 send -- "exit\r"
 expect eof


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109430
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`02907_suggestions_readonly_user` is an `expect` test that drives an interactive `clickhouse-client`. After a query, it matched the result (`Ok.`) and immediately sent the next command without waiting for the `:) ` prompt to be redrawn. Under sanitizer + parallel CI load the `send` could race the readline redraw, so the input was mangled/lost and a later `expect eof` never completed, timing out the test.

Debuglog from a failing Fast test run (PR #101785): after `expect "Ok."` matched inside the `CREATE USER` result flush, `send exit` landed while the prompt was still being redrawn; the client never processed `exit` and `expect eof` timed out.

Fix: wait for the `:) ` prompt after each command's result before sending the next one. This is the idiom already used by the stable interactive expect tests `02417_repeat_input_commands` and `01945_show_debug_warning`, which always `expect ":) "` between commands. No timeout change is needed once the sequencing is correct.

Verified locally against a debug build: 30/30 passing runs, clean diff vs master (one file, 3 added `expect ":) "`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.881` (included in `26.7` and later)
<!-- ch-version-info:end -->