### PR TITLE
Skip startup access check for s3 disks in test_storage_delta_disks (fix flaky test_single_log_file)

### DIFF
--- a/tests/integration/test_storage_delta_disks/test.py
+++ b/tests/integration/test_storage_delta_disks/test.py
@@ -87,6 +87,7 @@ def generate_cluster_def(common_path, port, azure_container):
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
                 <no_sign_request>0</no_sign_request>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_0_common>
             <disk_s3_1_common>
                 <type>s3</type>
@@ -94,6 +95,7 @@ def generate_cluster_def(common_path, port, azure_container):
                 <access_key_id>minio</access_key_id>
                 <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
                 <no_sign_request>0</no_sign_request>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_1_common>
             <disk_azure_common>
                 <type>object_storage</type>
@@ -109,12 +111,14 @@ def generate_cluster_def(common_path, port, azure_container):
                 <disk>disk_s3_0_common</disk>
                 <path>/tmp/s3_0_cache/</path>
                 <max_size>1000000000</max_size>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_0_with_cache>
             <disk_s3_1_with_cache>
                 <type>cache</type>
                 <disk>disk_s3_1_common</disk>
                 <path>/tmp/s3_1_cache/</path>
                 <max_size>1000000000</max_size>
+                <skip_access_check>true</skip_access_check>
             </disk_s3_1_with_cache>
             <disk_azure_with_cache>
                 <type>cache</type>


### PR DESCRIPTION
<!--
Linked issues and pull requests.
Related: https://github.com/ClickHouse/ClickHouse/pull/109246
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

Fixes flaky `test_storage_delta_disks/test.py::test_single_log_file` (seen on `Integration tests (amd_tsan, 6/6)`, all 8 parameterizations failing at once). Reported by @alexey-milovidov on #109246 (a play.html-only PR, unrelated to the failure).

Root cause: the session-scoped `started_cluster` fixture times out in `cluster.start()`. On the affected node the server actually starts, then aborts during metadata loading because disk `disk_s3_0_with_cache` fails its startup S3 access check with a transient `403 AccessDenied` while writing the probe object (`key .../user_files/...`, MinIO logs "signature check failed ... time skew ... Attempting to adjust the signer", one retry, then gives up). The identical-cred sibling disks `disk_s3_0_common` / `disk_s3_1_common` pass their access checks ~80 ms earlier on the same MinIO, so this is a transient race during the concurrent 3-node TSAN startup burst, not a credentials/config error. The failed session fixture then cascades to all 8 `test_single_log_file` parameterizations as instant setup errors (first after ~333 s = the start timeout, the rest instantly).

Fix: skip the startup access check for the s3 disks, mirroring the azure disks in the same generated config which already set `skip_access_check=true`. This removes the single startup write-probe that intermittently gets the 403; the disks remain fully exercised by the DeltaLake tests themselves.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109246&sha=52be366e5cc6bbd0fe2016d997940ceea424d62f&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.926` (included in `26.7` and later)
<!-- ch-version-info:end -->