### PR TITLE
Fix Rust symbol localization locale

### DIFF
--- a/cmake/localize_rust_c_symbols.sh
+++ b/cmake/localize_rust_c_symbols.sh
@@ -37,6 +37,9 @@
 
 set -eu
 
+# Keep sort and comm on the same portable bytewise ordering.
+export LC_ALL=C
+
 LIB_PATH="${1:-}"
 AR="${2:-}"
 OBJCOPY="${3:-}"


### PR DESCRIPTION
The error was:

```
[128/10486] Localizing C-namespace symbols in delta_kernel_ffi
FAILED: [code=1] contrib/delta-kernel-rs-cmake/CMakeFiles/localize_rust_c_delta_kernel_ffi /home/pablo/ClickHouse/ClickHouse/build/contrib/delta-kernel-rs-cmake/CMakeFiles/localize_rust_c_delta_kernel_ffi
cd /home/pablo/ClickHouse/ClickHouse/build/contrib/delta-kernel-rs-cmake && bash /home/pablo/ClickHouse/ClickHouse/cmake/localize_rust_c_symbols.sh /home/pablo/ClickHouse/ClickHouse/build/contrib/delta-kernel-rs-cmake/libdelta_kernel_ffi.a /usr/bin/llvm-ar-21 /usr/bin/llvm-objcopy /usr/bin/llvm-nm-21 /home/pablo/ClickHouse/ClickHouse/build/contrib/libllvmlibc-cmake/liblibllvmlibc.a /home/pablo/ClickHouse/ClickHouse/build/contrib/compiler-rt-cmake/libclang_rt_builtins.a /home/pablo/ClickHouse/ClickHouse/cmake/linux/../../contrib/sysroot/linux-x86_64/x86_64-linux-gnu/libc/lib/../lib64/libm.so.6
comm: file 1 is not in sorted order
comm: file 2 is not in sorted order
comm: input is not in sorted order
```

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.898` (included in `26.7` and later)
<!-- ch-version-info:end -->