### PR TITLE
Pin merge-tree settings in 04323_text_index_marks_empty_part

### DIFF
--- a/tests/queries/0_stateless/04323_text_index_marks_empty_part.sh
+++ b/tests/queries/0_stateless/04323_text_index_marks_empty_part.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-replicated-database, no-shared-merge-tree, no-object-storage
+# Tags: no-replicated-database, no-shared-merge-tree, no-object-storage, no-random-merge-tree-settings
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/100394
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Test-only fix. `04323_text_index_marks_empty_part` deliberately corrupts a part's `skp_idx_idx.mrk4` (appends one byte) and re-attaches, to exercise the `marks_count == 0` marks-loader early-return added in #106675. It assumes the post-`ALTER DELETE WHERE 1` active part is empty (`marks_count == 0`), so its zero-byte marks file stays a `marks_count == 0` shape after the append and loading tolerates it.

Under CI `--random-merge-tree-settings` (e.g. small `index_granularity`, wide-vs-compact, `replace_long_file_name_to_hash`) the corrupted part can instead be a non-empty part with a real 24-byte marks file. The appended byte makes it 25 bytes and loading throws `Bad size of marks file: 25, must be: 24` (Code 246). In normal runs this fails the test; under the stress test, if the server is killed before the final `DROP TABLE`, the corrupt part survives to restart and aborts server startup (`Cannot start clickhouse-server`).

Reported by @ alexey-milovidov on #100394 stress `arm_debug`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100394&sha=b6921c1e545271d7794c7506a1ea8e0142d159a2&name_0=PR&name_1=Stress%20test%20%28arm_debug%29

Not a marks-writing bug and unrelated to the read-in-order change in #100394: the marks files are written correctly (24 bytes = 1 mark, 0 bytes = 0 marks); the corruption is introduced by the test itself. The same signature has also hit plain `Stateless tests` on unrelated PRs (#108118, #100272), confirming a test-isolation defect.

Fix: pin the merge-tree settings so the intended empty (`marks_count == 0`) part shape is deterministic. The test still exercises the exact bug shape (`marks_count == 0` with a non-empty on-disk marks file) and the reference output is unchanged.
