### PR TITLE
Surface Pre/Post Hooks failure reason in report and CIDB

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -668,7 +668,12 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
             res_.append(Result.from_commands_run(name=name, command=pre_check))
 
         results.append(
-            Result.create_from(name="Pre Hooks", results=res_, stopwatch=sw_)
+            Result.create_from(
+                name="Pre Hooks",
+                results=res_,
+                stopwatch=sw_,
+                with_info_from_results=True,
+            )
         )
         # reread env object in case some new dada (JOB_KV_DATA) has been added in .pre_hooks
         env = _Environment.get()
@@ -996,7 +1001,12 @@ def _finish_workflow(workflow, job_name):
             results_.append(Result.from_commands_run(name=name, command=check))
 
         results.append(
-            Result.create_from(name="Post Hooks", results=results_, stopwatch=sw_)
+            Result.create_from(
+                name="Post Hooks",
+                results=results_,
+                stopwatch=sw_,
+                with_info_from_results=True,
+            )
         )
 
     ready_for_merge_status = Result.Status.OK

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -1075,7 +1075,12 @@ class Runner:
                 else:
                     name = str(check)
                 results_.append(Result.from_commands_run(name=name, command=check))
-            prehook_result = Result.create_from(name="Pre Hooks", results=results_, stopwatch=sw_)
+            prehook_result = Result.create_from(
+                name="Pre Hooks",
+                results=results_,
+                stopwatch=sw_,
+                with_info_from_results=True,
+            )
 
         if res:
             print(f"=== Run script [{job.name}], workflow [{workflow.name}] ===")
@@ -1129,7 +1134,12 @@ class Runner:
                         name = str(check)
                     results_.append(Result.from_commands_run(name=name, command=check))
                 result.results.append(
-                    Result.create_from(name="Post Hooks", results=results_, stopwatch=sw_)
+                    Result.create_from(
+                        name="Post Hooks",
+                        results=results_,
+                        stopwatch=sw_,
+                        with_info_from_results=True,
+                    )
                 )
                 print("=== Post hooks finished ===")
 

--- a/ci/tests/test_result.py
+++ b/ci/tests/test_result.py
@@ -198,3 +198,26 @@ def test_set_error():
     r = Result("t", Result.Status.OK)
     r.set_error()
     assert r.status == Result.Status.ERROR
+
+
+# --- with_info_from_results: hook failure reason must reach the aggregate node ---
+# Regression guard for the "Pre Hooks / Post Hooks" empty test_context_raw bug:
+# CIDB reads Result.info from the aggregate node, so a failing sub-hook's error
+# message (e.g. "ERROR: Change category is missing or invalid") must be lifted
+# into the parent when with_info_from_results=True.
+
+def test_create_from_lifts_child_info_when_requested():
+    subs = [
+        Result("hook_ok", Result.Status.OK),
+        Result("hook_bad", Result.Status.FAIL, info="ERROR: something is wrong"),
+    ]
+    r = Result.create_from(name="Pre Hooks", results=subs, with_info_from_results=True)
+    assert r.status == Result.Status.FAIL
+    assert "ERROR: something is wrong" in r.info
+    assert "hook_bad" in r.info
+
+
+def test_create_from_omits_child_info_by_default():
+    subs = [Result("hook_bad", Result.Status.FAIL, info="ERROR: something is wrong")]
+    r = Result.create_from(name="Pre Hooks", results=subs)
+    assert r.info == ""


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `Pre Hooks` and `Post Hooks` aggregate `Result` nodes (in `ci/praktika/native_jobs.py` for the native `Config Workflow` / `Finish Workflow` jobs, and in `ci/praktika/runner.py` for per-job hooks) were created without `with_info_from_results=True`. A failing sub-hook's error output is captured into that child's `Result.info` (via `from_commands_run`, default `with_info_on_failure=True`), but it was never lifted into the aggregate node.

CIDB inserts `Result.info` of the aggregate node into `test_context_raw`. So a real, common failure like `pr_labels_and_category.py` printing `ERROR: Change category is missing or invalid` produced a `Config Workflow` / `Pre Hooks` row in CIDB with an empty `test_context_raw`, giving no hint of the actual cause. This makes the recurring `Pre Hooks` failures impossible to triage from CIDB alone.

Fix: pass `with_info_from_results=True` at all four `Pre Hooks` / `Post Hooks` aggregation sites so the failing sub-hook's `info` (prefixed with its name) is surfaced in the report and stored in CIDB.

Added a regression test in `ci/tests/test_result.py` asserting that `create_from(..., with_info_from_results=True)` lifts a failing child's info into the parent, and that the default omits it.

No behavior change for passing hooks; purely improves diagnosability of failing ones.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.883` (included in `26.7` and later)
<!-- ch-version-info:end -->