### PR TITLE
Fix flaky 03625_auto_statistics_alter_rmt under virtual-column randomization

### DIFF
--- a/tests/queries/0_stateless/03625_auto_statistics_alter.sql
+++ b/tests/queries/0_stateless/03625_auto_statistics_alter.sql
@@ -20,7 +20,7 @@ SELECT 'no auto statistics';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MODIFY SETTING auto_statistics_types = 'minmax, uniq, tdigest';
@@ -30,7 +30,7 @@ SELECT 'materialized minmax, uniq, tdigest';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MODIFY SETTING auto_statistics_types = 'minmax, uniq, countmin';
@@ -40,7 +40,7 @@ SELECT 'added minmax, uniq, countmin';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MATERIALIZE STATISTICS ALL;
@@ -49,7 +49,7 @@ SELECT 'materialized minmax, uniq, countmin';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics CLEAR STATISTICS ALL;
@@ -58,7 +58,7 @@ SELECT 'cleared statistics';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 DROP TABLE IF EXISTS t_alter_auto_statistics;

--- a/tests/queries/0_stateless/03625_auto_statistics_alter_rmt.sql
+++ b/tests/queries/0_stateless/03625_auto_statistics_alter_rmt.sql
@@ -20,7 +20,7 @@ SELECT 'no auto statistics';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MODIFY SETTING auto_statistics_types = 'minmax, uniq, tdigest';
@@ -30,7 +30,7 @@ SELECT 'materialized minmax, uniq, tdigest';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MODIFY SETTING auto_statistics_types = 'minmax, uniq, countmin';
@@ -40,7 +40,7 @@ SELECT 'added minmax, uniq, countmin';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics MATERIALIZE STATISTICS ALL;
@@ -49,7 +49,7 @@ SELECT 'materialized minmax, uniq, countmin';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 ALTER TABLE t_alter_auto_statistics CLEAR STATISTICS ALL;
@@ -58,7 +58,7 @@ SELECT 'cleared statistics';
 
 SELECT column, type, statistics, estimates.cardinality, estimates.min, estimates.max
 FROM system.parts_columns
-WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1
+WHERE table = 't_alter_auto_statistics' AND database = currentDatabase() AND active = 1 AND column IN ('a', 'b', 'c')
 ORDER BY name, column;
 
 DROP TABLE IF EXISTS t_alter_auto_statistics SYNC;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03625_auto_statistics_alter_rmt` is flaky under CI settings randomization. The test reads every row from `system.parts_columns`. When `enable_block_number_column` / `enable_block_offset_column` is randomized on, the `_block_number` and `_block_offset` virtual columns are materialized as physical columns and show up as extra rows, breaking the reference diff. Those columns carry no statistics and are unrelated to what the test verifies (auto statistics on `a`, `b`, `c`).

Fix: restrict each `system.parts_columns` query to `column IN ('a', 'b', 'c')`. This keeps full settings-randomization coverage (no `no-random-*` tag) and is robust to any virtual column being materialized.

Repro (deterministic): running the test against a `ReplicatedMergeTree` created with `enable_block_number_column=1, enable_block_offset_column=1` fails on `master`/HEAD before this change and passes after. CI diagnosis on the failing runs: "MergeTree settings alone reproduce the failure; Culprit MergeTree settings: --enable_block_offset_column 1" (and `--enable_block_number_column 1`), reproducible across many runs, passing without randomization.

Failing CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109281&sha=c3ed732b353ebb9f9a1833cca225f92ec4af7c35&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.925` (included in `26.7` and later)
<!-- ch-version-info:end -->