### PR TITLE
Run a stateless flaky check in the merge queue

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -222,9 +222,44 @@ jobs:
           . ./ci/tmp/praktika_setup_env.sh
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Build (amd_binary)' --workflow "MergeQueueCI" --ci --timestamp
 
+  stateless_tests_amd_binary_flaky_check:
+    runs-on: [self-hosted, amd-medium]
+    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm]
+    if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhbWRfYmluYXJ5LCBmbGFreSBjaGVjayk=') }}
+    name: "Stateless tests (amd_binary, flaky check)"
+    outputs:
+      data: ${{ steps.run.outputs.DATA }}
+      pipeline_status: ${{ steps.run.outputs.pipeline_status || 'undefined' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Prepare env script
+        run: |
+          rm -rf ./ci/tmp
+          mkdir -p ./ci/tmp
+          cat > ./ci/tmp/praktika_setup_env.sh << 'ENV_SETUP_SCRIPT_EOF'
+          export PYTHONPATH=./ci:.:
+
+          cat > ./ci/tmp/workflow_job.json << 'EOF'
+          ${{ toJson(job) }}
+          EOF
+          cat > ./ci/tmp/workflow_status.json << 'EOF'
+          ${{ toJson(needs) }}
+          EOF
+          ENV_SETUP_SCRIPT_EOF
+
+      - name: Run
+        id: run
+        run: |
+          . ./ci/tmp/praktika_setup_env.sh
+          PYTHONUNBUFFERED=1 python3 -m praktika run 'Stateless tests (amd_binary, flaky check)' --workflow "MergeQueueCI" --ci --timestamp
+
   finish_workflow:
     runs-on: [self-hosted, style-checker-aarch64]
-    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm, fast_test, style_check]
+    needs: [build_amd_binary, config_workflow, dockers_build_amd, dockers_build_arm, fast_test, stateless_tests_amd_binary_flaky_check, style_check]
     if: ${{ always() }}
     name: "Finish Workflow"
     outputs:

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -558,6 +558,21 @@ class JobConfigs:
             requires=[ArtifactNames.CH_AMD_DEBUG],
         ),
     )
+    # Merge-queue drift guard: reruns the PR's new/changed stateless tests on
+    # the merge group state (the PR merged with the current `master`), so a PR
+    # whose last CI run predates test-infrastructure changes on `master` (e.g.
+    # a new randomized setting in `tests/clickhouse-test`) is bounced from the
+    # queue instead of breaking `master`. Runs on the `amd_binary` build the
+    # merge queue produces anyway; merge-queue runs use a reduced iteration
+    # count and time budget (see `ci/jobs/functional_tests.py`) to keep queue
+    # latency bounded.
+    stateless_tests_flaky_mq_jobs = common_ft_job_config.parametrize(
+        Job.ParamSet(
+            parameter="amd_binary, flaky check",
+            runs_on=RunnerLabels.AMD_MEDIUM,
+            requires=[ArtifactNames.CH_AMD_BINARY],
+        ),
+    )
     stateless_tests_targeted_pr_jobs = common_ft_job_config.parametrize(
         Job.ParamSet(
             parameter="arm_asan_ubsan, targeted",

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -468,6 +468,15 @@ def main():
     if args.count:
         print(f"Rerun count set from --count: {args.count}")
         rerun_count = args.count
+    elif is_flaky_check and info.is_merge_queue_event:
+        # The merge-queue flaky check is a drift guard, not a full flakiness
+        # hunt: the PR CI already ran the full flaky check, and this rerun only
+        # needs to catch new tests broken by the current `master` state (e.g. a
+        # setting randomization added to `tests/clickhouse-test` after the PR's
+        # last CI run). A randomized setting drawn with probability 0.4 per run
+        # escapes 20 iterations with probability 0.6^20 ~= 4e-5, so a reduced
+        # count keeps merge-queue latency bounded without losing the signal.
+        rerun_count = 20
     elif is_flaky_check:
         # Large repeat count so the 45-min global_time_limit is the effective stopping
         # condition, not the repeat count.  Tests run in parallel (--jobs N) with fresh
@@ -809,7 +818,9 @@ def main():
 
         global_time_limit = 0
         if is_flaky_check:
-            FLAKY_CHECK_TIME_LIMIT = 45 * 60  # 45 min
+            # The merge-queue run gets a tighter budget: it delays merges
+            # directly, and its reduced rerun_count needs less time anyway.
+            FLAKY_CHECK_TIME_LIMIT = 20 * 60 if info.is_merge_queue_event else 45 * 60
             global_time_limit = max(
                 FLAKY_CHECK_TIME_LIMIT - int(stop_watch.duration), 0
             )

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -821,8 +821,15 @@ def main():
             # The merge-queue run gets a tighter budget: it delays merges
             # directly, and its reduced rerun_count needs less time anyway.
             FLAKY_CHECK_TIME_LIMIT = 20 * 60 if info.is_merge_queue_event else 45 * 60
+            # Floor the budget at a small positive value: `run_tests` interprets
+            # `global_time_limit == 0` as "pass no `--global_time_limit`", i.e. no
+            # cap at all. If setup already consumed the whole budget (more likely
+            # under the tighter merge-queue limit) a `0` here would turn the run
+            # unbounded, defeating the very latency bound it is meant to enforce.
+            # A minimal explicit limit keeps the run bounded while still doing one
+            # quick pass. Mirrors the targeted-check floor below.
             global_time_limit = max(
-                FLAKY_CHECK_TIME_LIMIT - int(stop_watch.duration), 0
+                FLAKY_CHECK_TIME_LIMIT - int(stop_watch.duration), 60
             )
             print(
                 f"Flaky-check time limit: {FLAKY_CHECK_TIME_LIMIT}s"

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -105,6 +105,49 @@ class Targeting:
                     return candidate
         return None
 
+    @classmethod
+    def _tests_owning_data_file(cls, fpath: str):
+        """Map an auxiliary stateless file back to the base names of the tests
+        that own it.
+
+        A data fixture may sit next to its test (`02995_settings_26_4_1.tsv`) or
+        in a subdirectory (`data_parquet/02716_data.parquet`); either way it has
+        no test of its own, so `_derive_test_name` skips it. But such a fixture
+        change still alters the surface of the test that consumes it, and a drift
+        guard that skips it would false-green the very drift it exists to catch.
+
+        Fixtures carry their owning test's five-digit prefix by convention, so
+        the prefix narrows the candidates to the `NNNNN_*` tests at the suite
+        root (a handful of files, never the whole suite). Among those, prefer the
+        ones whose body actually references the fixture by name; fall back to all
+        prefix siblings when the reference is constructed dynamically and cannot
+        be found textually. Return an empty list when the file has no numeric
+        prefix or no test with that prefix exists — there is then genuinely
+        nothing to rerun, and emitting a pattern that matches no test would make
+        `clickhouse-test` exit 1 (the failure mode `PR #104097` fixed).
+        """
+        match = re.match(r"(\d{5})", os.path.basename(fpath))
+        if match is None:
+            return []
+        prefix = match.group(1)
+        test_dir = Path("tests/queries/0_stateless")
+        candidates = {}
+        for ext in cls._TEST_FILE_EXTENSIONS:
+            for test_file in test_dir.glob(f"{prefix}_*{ext}"):
+                candidates[test_file.name[: -len(ext)]] = test_file
+        if not candidates:
+            return []
+        fname = os.path.basename(fpath)
+        referencing = []
+        for base_name, test_file in candidates.items():
+            try:
+                with test_file.open("r", encoding="utf-8", errors="ignore") as f:
+                    if fname in f.read():
+                        referencing.append(base_name)
+            except OSError:
+                continue
+        return sorted(referencing) if referencing else sorted(candidates)
+
     @staticmethod
     def is_functional_test_file(fpath: str) -> bool:
         """A changed path that is itself a stateless functional test source file."""
@@ -223,29 +266,49 @@ class Targeting:
             return result
 
         for fpath in changed_files:
-            if re.match(r"tests/queries/0_stateless/\d{5}", fpath):
-                if not Path(fpath).exists():
-                    print(f"File '{fpath}' was removed — skipping")
-                    continue
-
-                test_base_name = self._derive_test_name(fpath)
-                if test_base_name is None:
-                    # Avoid emitting a regex like `02995_settings_26_4_1.` that
-                    # matches no test — clickhouse-test exits with code 1 when
-                    # "no tests were run", failing the flaky check.
+            if not fpath.startswith("tests/queries/0_stateless/"):
+                if fpath.startswith("tests/queries/"):
+                    # Log any other changed file under tests/queries for future debugging
                     print(
-                        f"File '{fpath}' is not a test source and has no sibling test — skipping"
+                        f"File '{fpath}' changed, but doesn't match expected test pattern"
                     )
+                continue
+
+            if not Path(fpath).exists():
+                print(f"File '{fpath}' was removed — skipping")
+                continue
+
+            # A file directly at the suite root may itself be a test source, or a
+            # supporting file (`.reference`, a `.sql.j2` template, ...) whose sibling
+            # test shares its base name.
+            if Path(fpath).parent == Path("tests/queries/0_stateless"):
+                test_base_name = self._derive_test_name(fpath)
+                if test_base_name is not None:
+                    print(f"Detected changed test: '{test_base_name}' (from '{fpath}')")
+                    # Add '.' suffix to precisely match this test only
+                    result.add(f"{test_base_name}.")
                     continue
 
-                print(f"Detected changed test: '{test_base_name}' (from '{fpath}')")
-                # Add '.' suffix to precisely match this test only
-                result.add(f"{test_base_name}.")
-
-            elif fpath.startswith("tests/queries/"):
-                # Log any other changed file under tests/queries for future debugging
+            # Either a data fixture nested in a subdirectory
+            # (`data_parquet/02716_data.parquet`) or a root-level orphan data file
+            # (`02995_settings_26_4_1.tsv`) with no sibling test. Map it back to the
+            # test(s) that own it so a fixture-only change still reruns the tests
+            # that consume it; otherwise the flaky check — and the merge-queue drift
+            # guard built on it — would silently skip the very test surface the
+            # change affects. Emit only real tests: `_tests_owning_data_file` returns
+            # an empty list when nothing maps, so we never fabricate a no-match
+            # pattern (which would make clickhouse-test exit 1).
+            owning_tests = self._tests_owning_data_file(fpath)
+            if owning_tests:
+                for base_name in owning_tests:
+                    print(
+                        f"Detected changed data file '{fpath}' owned by test '{base_name}'"
+                    )
+                    # Add '.' suffix to precisely match this test only
+                    result.add(f"{base_name}.")
+            else:
                 print(
-                    f"File '{fpath}' changed, but doesn't match expected test pattern"
+                    f"File '{fpath}' is not a test source and has no owning test — skipping"
                 )
 
         return sorted(result)

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -445,7 +445,11 @@ def should_skip_merge_queue_job(job_name):
     deliberately minimal so it cannot skip the build/style/fast-test jobs the
     queue always needs. The skip condition matches the in-job selection in
     `functional_tests.py` (both rely on `Targeting.get_changed_tests`), so the
-    early exit and the config-time skip never disagree.
+    early exit and the config-time skip never disagree. `get_changed_tests`
+    resolves data fixtures (a `.parquet`/`.tsv` under `tests/queries/0_stateless/`,
+    even one nested in a subdirectory) back to the tests that consume them, so a
+    fixture-only PR still reruns the affected test surface instead of being
+    skipped here as "no changed tests".
     """
     global _info_cache
     if _info_cache is None:

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -430,3 +430,34 @@ def should_skip_job(job_name):
                 return True, "Skipped: only CI scripts changed; running amd_asan_ubsan integration batch 1 only"
 
     return False, ""
+
+
+def should_skip_merge_queue_job(job_name):
+    """Config-time filter for the `MergeQueueCI` workflow.
+
+    The merge queue runs a small, fixed set of jobs (style check, fast test, the
+    `amd_binary` build, and the stateless flaky check). Only the flaky check is
+    conditional: it reruns the PR's new/changed stateless tests as a drift guard,
+    so a PR that changes no stateless tests has nothing for it to do. Filter it
+    out here, at config time, so such a PR does not schedule the runner, restore
+    `CH_AMD_BINARY`, and enter the test container only to exit `SKIPPED`. This is
+    the merge-queue counterpart to the `flaky` branch of `should_skip_job`, kept
+    deliberately minimal so it cannot skip the build/style/fast-test jobs the
+    queue always needs. The skip condition matches the in-job selection in
+    `functional_tests.py` (both rely on `Targeting.get_changed_tests`), so the
+    early exit and the config-time skip never disagree.
+    """
+    global _info_cache
+    if _info_cache is None:
+        _info_cache = Info()
+
+    if "flaky" not in job_name.lower() or "stateless" not in job_name.lower():
+        return False, ""
+
+    from ci.jobs.scripts.find_tests import Targeting
+
+    targeter = Targeting(info=_info_cache)
+    targeter.job_type = Targeting.STATELESS_JOB_TYPE
+    if not targeter.get_changed_tests():
+        return True, "Skipped, no new/changed stateless tests to rerun in the merge queue"
+    return False, ""

--- a/ci/jobs/scripts/workflow_hooks/store_data.py
+++ b/ci/jobs/scripts/workflow_hooks/store_data.py
@@ -11,9 +11,13 @@ if __name__ == "__main__":
     info = Info()
 
     # store changed files
+    # Fail-close for PR and merge-queue runs: the merge-queue flaky check
+    # selects tests from this list, so an empty fallback would silently skip
+    # it. Do not fail for master/release CI workflows.
     changed_files = (
-        GH.get_changed_files(strict=info.pr_number) or []
-    )  # do not fail for master/release CI workflow
+        GH.get_changed_files(strict=bool(info.pr_number) or info.is_merge_queue_event)
+        or []
+    )
     info.store_kv_data("changed_files", changed_files)
 
     # hack to get build digest

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -98,6 +98,19 @@ class GH:
         pr_number = info.pr_number
         if pr_number <= 0 and info.is_merge_queue_event:
             pr_number = info.linked_pr_number
+            if pr_number <= 0 and strict:
+                # The linked PR number could not be parsed from the merge group
+                # head ref. Falling back to `repos/{repo}/commits/{sha}` would
+                # reintroduce the 300-entry cap this branch exists to avoid, so a
+                # large PR could silently lose changed test files and turn the
+                # merge-queue flaky check into a false green. Fail closed instead:
+                # a merge-queue run always corresponds to exactly one PR, so a
+                # missing linked PR number is a real fault, not a skip condition.
+                raise RuntimeError(
+                    "Merge-queue run has no linked PR number (could not parse it "
+                    "from the merge group head ref); refusing to fall back to the "
+                    "capped commits API for changed-file detection."
+                )
 
         if pr_number > 0:
             command = (

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -91,9 +91,17 @@ class GH:
         # HEAD, same as deleted files, which were always included.
         jq_both_sides = ".filename, (.previous_filename // empty)"
 
-        if info.pr_number > 0:
+        # In a merge-queue run PR_NUMBER is 0, but the queue entry is built for
+        # exactly one PR (parsed from the merge group head ref). Use that PR's
+        # paginated files list: the merge group SHA is a merge commit, and the
+        # commits API caps a commit's file list at 300 entries.
+        pr_number = info.pr_number
+        if pr_number <= 0 and info.is_merge_queue_event:
+            pr_number = info.linked_pr_number
+
+        if pr_number > 0:
             command = (
-                f"gh api repos/{repo_name}/pulls/{info.pr_number}/files "
+                f"gh api repos/{repo_name}/pulls/{pr_number}/files "
                 f"--paginate --jq '.[] | {jq_both_sides}'"
             )
         else:

--- a/ci/tests/test_find_tests.py
+++ b/ci/tests/test_find_tests.py
@@ -15,6 +15,7 @@ back to that test.
 
 import os
 import sys
+import types
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -76,3 +77,72 @@ def test_unknown_data_file_with_no_sibling_is_skipped():
         )
         is None
     )
+
+
+def test_subdirectory_data_fixture_maps_to_owning_test():
+    # A merge-queue drift guard must not false-green when a PR changes only a
+    # data fixture nested in a subdirectory. `data_parquet/02716_data.parquet`
+    # is consumed by `02716_parquet_invalid_date32.sh`; the prefix-narrowed
+    # content scan reruns exactly that test.
+    owning = Targeting._tests_owning_data_file(
+        "tests/queries/0_stateless/data_parquet/02716_data.parquet"
+    )
+    assert owning == ["02716_parquet_invalid_date32"]
+
+
+def test_orphan_data_file_maps_to_owning_test_by_prefix():
+    # PR #104097 reproducer: `_derive_test_name` returns None for this `.tsv`,
+    # so it used to be skipped. It carries the `02995` prefix of the test that
+    # consumes it, so the flaky check now reruns that test instead of skipping.
+    owning = Targeting._tests_owning_data_file(
+        "tests/queries/0_stateless/02995_settings_26_4_1.tsv"
+    )
+    assert "02995_new_settings_history" in owning
+
+
+def test_data_file_with_no_matching_test_is_skipped():
+    # No test with this prefix exists: emit nothing rather than a pattern that
+    # matches no test (which would make clickhouse-test exit 1).
+    assert (
+        Targeting._tests_owning_data_file(
+            "tests/queries/0_stateless/data_parquet/99999_no_such_test.parquet"
+        )
+        == []
+    )
+
+
+def test_data_file_without_numeric_prefix_is_skipped():
+    # A shared fixture with no owning-test prefix cannot be mapped.
+    assert (
+        Targeting._tests_owning_data_file(
+            "tests/queries/0_stateless/data_parquet/shared_data.parquet"
+        )
+        == []
+    )
+
+
+def _targeting_from_diff(diff_text):
+    info = types.SimpleNamespace(
+        job_name="Stateless tests (flaky check)", is_local_run=False
+    )
+    targeter = Targeting(info=info)
+    targeter._diff_text = diff_text
+    return targeter
+
+
+def test_get_changed_tests_reruns_owning_test_for_fixture_only_diff():
+    # End-to-end reproducer for the merge-queue drift-guard gap: a PR whose only
+    # stateless change is a nested data fixture must still select the test that
+    # consumes it, so neither the config-time skip nor the in-job selection can
+    # false-green the merge queue.
+    diff = "+++ b/tests/queries/0_stateless/data_parquet/02716_data.parquet\n"
+    assert _targeting_from_diff(diff).get_changed_tests() == [
+        "02716_parquet_invalid_date32."
+    ]
+
+
+def test_get_changed_tests_skips_unmappable_fixture():
+    # A fixture that maps to no real test yields no pattern (clickhouse-test
+    # would exit 1 on a zero-match run).
+    diff = "+++ b/tests/queries/0_stateless/data_parquet/99999_no_such_test.parquet\n"
+    assert _targeting_from_diff(diff).get_changed_tests() == []

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -7,6 +7,7 @@ These tests verify that every status is mapped and the mapping is correct.
 
 import os
 import sys
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -204,6 +205,64 @@ def test_to_markdown_no_failures(monkeypatch):
     assert "failures out of" not in md
     # The bullet is still present.
     assert "- Performance Comparison:" in md
+
+
+def _install_fake_get_changed_files_env(monkeypatch, info, shell_out="a.sql\n"):
+    """Stub `Info` and `Shell` in the `GH` module so `get_changed_files` can run
+    without a configured praktika env. Returns the list of shell commands run."""
+    gh_mod = sys.modules[GH.__module__]
+    monkeypatch.setattr(gh_mod, "Info", lambda: info)
+
+    commands = []
+
+    def fake_shell(command):
+        commands.append(command)
+        return 0, shell_out, ""
+
+    monkeypatch.setattr(gh_mod.Shell, "get_res_stdout_stderr", staticmethod(fake_shell))
+    return commands
+
+
+def _merge_queue_info(linked_pr_number):
+    return SimpleNamespace(
+        is_local_run=False,
+        repo_name="ClickHouse/ClickHouse",
+        sha="deadbeef",
+        pr_number=0,
+        is_merge_queue_event=True,
+        linked_pr_number=linked_pr_number,
+    )
+
+
+def test_get_changed_files_merge_queue_missing_linked_pr_fails_closed(monkeypatch):
+    """In a merge-queue run with no parseable linked PR number, a strict call
+    must fail closed rather than silently fall back to the 300-entry-capped
+    commits API (which would drop changed test files and turn the merge-queue
+    flaky check into a false green)."""
+    commands = _install_fake_get_changed_files_env(monkeypatch, _merge_queue_info(0))
+    try:
+        GH.get_changed_files(strict=True)
+        assert False, "Should have raised for a merge-queue run with no linked PR"
+    except RuntimeError as e:
+        assert "linked PR number" in str(e)
+    assert commands == [], "must not query the commits API when failing closed"
+
+
+def test_get_changed_files_merge_queue_missing_linked_pr_non_strict_tolerated(monkeypatch):
+    """A non-strict call keeps the tolerant fallback so master/release-style
+    callers are unaffected."""
+    commands = _install_fake_get_changed_files_env(monkeypatch, _merge_queue_info(0))
+    GH.get_changed_files(strict=False)
+    assert len(commands) == 1 and "commits/deadbeef" in commands[0]
+
+
+def test_get_changed_files_merge_queue_uses_linked_pr_files(monkeypatch):
+    """With a parseable linked PR number the merge-queue run uses that PR's
+    paginated files list, not the commits API."""
+    commands = _install_fake_get_changed_files_env(monkeypatch, _merge_queue_info(12345))
+    GH.get_changed_files(strict=True)
+    assert len(commands) == 1
+    assert "pulls/12345/files" in commands[0] and "--paginate" in commands[0]
 
 
 def test_post_commit_status_converts_transparently(monkeypatch):

--- a/ci/tests/test_merge_queue_flaky_check.py
+++ b/ci/tests/test_merge_queue_flaky_check.py
@@ -1,0 +1,64 @@
+"""
+Tests for the merge-queue stateless flaky-check drift guard added in
+`https://github.com/ClickHouse/ClickHouse/pull/110308`.
+
+The merge queue reruns the PR's new/changed stateless tests against the merge
+group state, catching a semantic conflict with `master` changes that landed
+after the PR's last CI run. Two properties are pinned here:
+
+- `should_skip_merge_queue_job` filters the flaky check at config time on PRs
+  that change no stateless tests (so a non-test PR never schedules the runner
+  and restores the binary only to self-skip), while never touching the
+  build/style/fast-test jobs the queue always needs.
+- the reduced merge-queue budget always yields a positive `--global_time_limit`
+  so the run stays bounded even if setup consumes the whole budget.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from types import SimpleNamespace
+
+import ci.jobs.scripts.workflow_hooks.filter_job as fj
+from ci.jobs.scripts.find_tests import Targeting
+
+FLAKY_CHECK_JOB = "Stateless tests (amd_binary, flaky check)"
+
+
+def _use_dummy_info(monkeypatch):
+    # A minimal stand-in so the hook does not construct a real `Info` (which
+    # needs a configured praktika env). `job_name` is read by `Targeting`.
+    monkeypatch.setattr(fj, "_info_cache", SimpleNamespace(job_name="config"))
+
+
+def test_non_flaky_jobs_are_never_skipped(monkeypatch):
+    _use_dummy_info(monkeypatch)
+    for job in ("Build (amd_binary)", "Style check", "Fast test"):
+        assert fj.should_skip_merge_queue_job(job) == (False, ""), job
+
+
+def test_flaky_check_skipped_when_no_changed_tests(monkeypatch):
+    _use_dummy_info(monkeypatch)
+    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: [])
+    skip, reason = fj.should_skip_merge_queue_job(FLAKY_CHECK_JOB)
+    assert skip is True
+    assert "no new/changed stateless tests" in reason
+
+
+def test_flaky_check_runs_when_tests_changed(monkeypatch):
+    _use_dummy_info(monkeypatch)
+    monkeypatch.setattr(Targeting, "get_changed_tests", lambda self: ["00001_select_1."])
+    assert fj.should_skip_merge_queue_job(FLAKY_CHECK_JOB) == (False, "")
+
+
+def test_merge_queue_budget_stays_positive_when_setup_exhausts_it():
+    # Mirrors the flaky-check budget arithmetic in `ci/jobs/functional_tests.py`.
+    # `run_tests` treats `global_time_limit == 0` as "no cap"; the floor keeps
+    # the merge-queue run bounded even if setup already spent the whole budget.
+    FLAKY_CHECK_TIME_LIMIT = 20 * 60
+    for elapsed in (0, 10 * 60, 20 * 60, 30 * 60):
+        global_time_limit = max(FLAKY_CHECK_TIME_LIMIT - elapsed, 60)
+        assert global_time_limit > 0
+    assert max(FLAKY_CHECK_TIME_LIMIT - 30 * 60, 60) == 60

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -2,6 +2,7 @@ from praktika import Workflow
 
 from ci.defs.defs import DOCKERS, SECRETS, ArtifactConfigs, ArtifactNames
 from ci.defs.job_configs import JobConfigs
+from ci.jobs.scripts.workflow_hooks.filter_job import should_skip_merge_queue_job
 
 workflow = Workflow.Config(
     name="MergeQueueCI",
@@ -30,6 +31,10 @@ workflow = Workflow.Config(
     enable_cidb=True,
     enable_merge_ready_status=True,
     enable_commit_status_on_failure=True,
+    # Config-time skip for the stateless flaky check on PRs that change no
+    # stateless tests, so non-test PRs do not schedule the runner and restore
+    # the binary only for the job to self-skip inside `functional_tests.py`.
+    workflow_filter_hooks=[should_skip_merge_queue_job],
     pre_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/set_dummy_sync_commit_status.py",

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -10,6 +10,11 @@ workflow = Workflow.Config(
         JobConfigs.style_check,
         JobConfigs.fast_test,
         *[job for job in JobConfigs.build_jobs if job.name == "Build (amd_binary)"],
+        # Reruns the PR's new/changed stateless tests against the merge group
+        # state, catching semantic conflicts with `master` changes that landed
+        # after the PR's last CI run (e.g. a new randomized setting in
+        # `tests/clickhouse-test`). Self-skips when the PR changes no tests.
+        *JobConfigs.stateless_tests_flaky_mq_jobs,
     ],
     artifacts=[
         *[


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/108548
Related: https://github.com/ClickHouse/ClickHouse/pull/110260
Related: https://github.com/ClickHouse/ClickHouse/pull/108511

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

A PR's green CI describes the `master` of its last run, not of its merge. #108548 merged on 2026-07-13 with CI last run on 07-01; on 07-03 `master` merged #108511, which added `materialize_statistics_on_insert` to the settings randomizer in `tests/clickhouse-test`. The PR's new test `02346_text_index_bug108519_qcc_skip_index` then failed on `master` whenever the randomized setting was drawn (~40% of runs) and kept `master` red for ~7 hours until #110260 pinned `auto_statistics_types` at the table level. The flaky check would have caught this with near certainty — it just last ran against a `master` that did not have the randomizer yet.

The merge queue already builds the exact merged state (`Build (amd_binary)`) but ran no stateless tests on it. This PR adds `Stateless tests (amd_binary, flaky check)` to `MergeQueueCI`: it reruns the PR's new/changed stateless tests on the merge group state (the PR merged with the current `master`), so a semantic conflict with post-CI `master` changes bounces the PR from the queue instead of breaking `master`. The job self-skips when the PR changes no tests, so non-test PRs pay nothing.

Details:
- Merge-queue runs use a reduced budget: `rerun_count` 20 instead of 50 and a 20-minute instead of 45-minute time limit, since the PR CI already ran the full flaky check and this rerun is a drift guard. A randomized setting drawn with probability 0.4 per run escapes 20 iterations with probability 0.6^20 ≈ 4e-5. `--sequential-test-runs` scales along, as it is derived from `rerun_count`.
- Changed-file detection in merge-queue runs now uses the linked PR's paginated files list: `PR_NUMBER` is 0 in a `merge_group` event (only `LINKED_PR_NUMBER` is parsed from the queue ref), and the previously used commits API caps a merge commit's file list at 300 entries.
- The changed-files fetch in `store_data.py` now fails closed in merge-queue runs (as it already did for PR runs), so a persistent GitHub API failure cannot silently turn the flaky check into a skip. Master/release workflows keep the tolerant behavior.
- `.github/workflows/merge_queue.yml` is regenerated with `praktika yaml`.

A `SKIPPED` result (no tests to run) counts as success for the merge-ready status, same as in PR CI.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.967` (included in `26.7` and later)
<!-- ch-version-info:end -->