### PR TITLE
Read input column values from HTTP request headers

### DIFF
--- a/docs/concepts/features/interfaces/http.mdx
+++ b/docs/concepts/features/interfaces/http.mdx
@@ -275,6 +275,90 @@ $ echo 'DROP TABLE t' | curl 'http://localhost:8123/' --data-binary @-
 
 For successful requests that don't return a data table, an empty response body is returned.
 
+## Mapping HTTP headers to columns {#http-column-mapping}
+
+You can map HTTP request header values to `INSERT` columns using `http_column_` URL parameters.
+The format is `http_column_<Header-Name>=<column_name>`. ClickHouse reads the specified header from the request
+and inserts its value into the corresponding column for every row.
+
+This is useful for webhook receivers and HTTP-based data pipelines where metadata
+(event type, signature, tenant ID, etc.) arrives in headers while the payload is in the request body.
+
+For example, given this table:
+
+```sql
+CREATE TABLE events (
+    event_type LowCardinality(String),
+    signature  String,
+    payload    String
+) ENGINE = MergeTree ORDER BY tuple();
+```
+
+You can insert data with headers mapped to columns:
+
+```bash
+$ curl -sS \
+    -H 'X-Event-Type: push' \
+    -H 'X-Signature: sha256=abc123' \
+    'http://localhost:8123/?query=INSERT+INTO+events+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature' \
+    -d '{"payload":"hello"}'
+```
+
+This inserts a row with `event_type = 'push'`, `signature = 'sha256=abc123'`, and `payload = 'hello'`.
+
+Header names are case-insensitive per RFC 9110, so `http_column_x-event-type` and `http_column_X-Event-Type`
+match the same header. Column names must exist in the target table.
+
+If the specified header is absent from the request, the default value for the column type is inserted.
+
+### Value parsing {#http-column-value-parsing}
+
+Header values are parsed the same way the corresponding column type is read from text, so numeric,
+`Array`, `Map`, `DateTime`, and other types work as long as the header string is a valid text
+representation of the type. Parsing respects the query's format settings (for example
+[`date_time_input_format`](/operations/settings/formats#date_time_input_format)).
+A value that cannot be parsed as the column type raises an error.
+
+Only insertable columns can be targeted. Mapping an `ALIAS` column is always rejected. A `MATERIALIZED`
+column is rejected unless [`insert_allow_materialized_columns`](/operations/settings/settings#insert_allow_materialized_columns)
+is enabled.
+
+### One value per column: body or header, not both {#http-column-one-source}
+
+A column must receive its value from exactly one source, either the request body or an HTTP header,
+never both. ClickHouse enforces this in every case:
+
+- If a column is named in the explicit `INSERT` column list and also mapped with an `http_column_`
+  parameter, the query is rejected with `DUPLICATE_COLUMN`.
+- If the `INSERT` has no explicit column list and a self-describing format (such as `JSONEachRow`,
+  `TSKV`, `CSVWithNames`, or `JSONCompactEachRowWithNames`) carries a field whose name matches a
+  mapped column, the query is rejected as an unknown field. This holds even with
+  [`input_format_skip_unknown_fields`](/operations/settings/formats#input_format_skip_unknown_fields)
+  set to `1`; a mapped column is never silently overwritten by body data.
+
+The match between a body field and a mapped column follows the format's column-name matching mode
+([`input_format_column_name_matching_mode`](/operations/settings/formats#input_format_column_name_matching_mode)),
+so under `auto` or `ignore_case` a differently-cased body field is still detected as a conflict.
+
+### Async inserts {#http-column-async}
+
+The feature works with both synchronous and asynchronous inserts (`async_insert=1`).
+With async inserts, each request's header values are preserved per entry, so rows from
+different requests in the same batch carry their own header values. Requests that map headers
+and requests that do not are never coalesced into the same batch. Header values are validated
+when the request is queued and parsed again against the current column type when the batch is
+flushed, so a schema change while entries are buffered (for example `ALTER TABLE ... MODIFY COLUMN`)
+is handled per entry: an entry whose value no longer fits the new type fails on its own without
+aborting the other entries in the batch, and (with `wait_for_async_insert=1`) the waiting client
+receives that error.
+
+<Note>
+The `http_column_` parameters only affect `INSERT` queries. For `SELECT` queries they are ignored.
+Header values come from the same filtered request-header set that the
+[`getClientHTTPHeader`](/sql-reference/functions/other-functions#getClientHTTPHeader) function reads,
+so restricted headers such as `Authorization` and `X-ClickHouse-*` are stripped and cannot be mapped.
+</Note>
+
 ## Compression {#compression}
 
 Compression can be used to reduce network traffic when transmitting a large amount of data, or for creating dumps that are immediately compressed.
@@ -847,6 +931,33 @@ curl -X POST 'http://localhost:8123/api/events?id=123' \
 <Note>
 In one `predefined_query_handler` only one `query` is supported.
 </Note>
+
+#### Mapping request headers to INSERT columns {#predefined-handler-http-column-mapping}
+
+`predefined_query_handler` can map HTTP request header values directly to `INSERT` columns using a
+`<header_column_mappings>` block, the static-config equivalent of the `http_column_<Header-Name>=<column_name>`
+URL parameter available in the dynamic handler. Each entry maps a header name to a target column;
+when a header maps to the same column more than once, the first declared mapping wins.
+
+```xml
+<http_handlers>
+    <rule>
+        <methods>POST</methods>
+        <url>/ingest_events</url>
+        <handler>
+            <type>predefined_query_handler</type>
+            <query>INSERT INTO events (payload) FORMAT JSONEachRow</query>
+            <header_column_mappings>
+                <X-Event-Type>event_type</X-Event-Type>
+                <X-Signature>signature</X-Signature>
+            </header_column_mappings>
+        </handler>
+    </rule>
+</http_handlers>
+```
+
+See [Mapping HTTP headers to columns](#http-column-mapping) for the full description of the feature,
+including value parsing, the body-or-header invariant, and async insert behavior.
 
 ### dynamic_query_handler {#dynamic_query_handler}
 

--- a/docs/concepts/features/interfaces/http.mdx
+++ b/docs/concepts/features/interfaces/http.mdx
@@ -309,7 +309,7 @@ This inserts a row with `event_type = 'push'`, `signature = 'sha256=abc123'`, an
 Header names are case-insensitive per RFC 9110, so `http_column_x-event-type` and `http_column_X-Event-Type`
 match the same header. Column names must exist in the target table.
 
-If the specified header is absent from the request, the default value for the column type is inserted.
+If the specified header is absent from the request, ClickHouse rejects the query with `BAD_QUERY_PARAMETER`. Every mapped header must be present, mirroring the behaviour of query parameters (`param_*`).
 
 ### Value parsing {#http-column-value-parsing}
 

--- a/src/Core/HTTPHeaderColumns.h
+++ b/src/Core/HTTPHeaderColumns.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <base/types.h>
+#include <unordered_map>
+#include <vector>
+
+namespace DB
+{
+
+/// One HTTP-header-to-INSERT-column mapping: the target column and the resolved
+/// header value.
+struct HTTPHeaderColumn
+{
+    String column_name;
+    String value;
+};
+
+/// Ordered set of HTTP-header-to-column mappings, kept in declaration order (URL
+/// params for the dynamic handler, config order for the predefined handler). A side
+/// index gives O(1) first-wins insert and O(1) lookup while iteration still yields
+/// declaration order, so the expanded query column list, the async batch key, and
+/// the per-entry values all share one canonical order without sorting.
+class HTTPHeaderColumns
+{
+public:
+    /// The first declaration wins: a repeated column is ignored and order is preserved.
+    void add(const String & column_name, const String & value)
+    {
+        if (!index.emplace(column_name, entries.size()).second)
+            return;
+        entries.push_back({column_name, value});
+    }
+
+    bool contains(const String & column_name) const { return index.contains(column_name); }
+
+    /// Value for a column, or nullptr if the column is not mapped. The pointer is
+    /// valid only until the next add() (which may reallocate); in practice all adds
+    /// happen at request parse time and all lookups later, so it is never held across one.
+    const String * find(const String & column_name) const
+    {
+        auto it = index.find(column_name);
+        return it == index.end() ? nullptr : &entries[it->second].value;
+    }
+
+    bool empty() const { return entries.empty(); }
+    size_t size() const { return entries.size(); }
+
+    void reserve(size_t n)
+    {
+        entries.reserve(n);
+        index.reserve(n);
+    }
+
+    auto begin() const { return entries.begin(); }
+    auto end() const { return entries.end(); }
+
+private:
+    std::vector<HTTPHeaderColumn> entries;
+    std::unordered_map<String, size_t> index;
+};
+
+}

--- a/src/Formats/ColumnMapping.cpp
+++ b/src/Formats/ColumnMapping.cpp
@@ -35,7 +35,7 @@ void addColumnsInternal(
         std::optional<size_t> column_idx = find(name);
         if (!column_idx.has_value())
         {
-            if (settings.skip_unknown_fields)
+            if (settings.skip_unknown_fields && !settings.isHTTPColumnName(name))
             {
                 column_indexes_for_input_fields.push_back(std::nullopt);
                 continue;

--- a/src/Formats/FormatFactory.cpp
+++ b/src/Formats/FormatFactory.cpp
@@ -306,6 +306,13 @@ FormatSettings getFormatSettings(const ContextPtr & context, const Settings & se
     format_settings.schema.is_server = context->hasGlobalContext() && (context->getGlobalContext()->getApplicationType() == Context::ApplicationType::SERVER);
     format_settings.schema.output_format_schema = settings[Setting::output_format_schema];
     format_settings.skip_unknown_fields = settings[Setting::input_format_skip_unknown_fields];
+    /// Columns mapped from HTTP headers via http_column_* must never be silently skipped
+    /// from the body even when skip_unknown_fields = 1: the body and the header are
+    /// mutually exclusive sources, so a body field that matches a mapped column is always
+    /// an error. Populate the set here so every format constructed from this context
+    /// inherits the restriction automatically.
+    for (const auto & [col_name, _] : context->getHTTPHeaderColumns())
+        format_settings.http_column_names.insert(col_name);
     format_settings.template_settings.resultset_format = settings[Setting::format_template_resultset];
     format_settings.template_settings.row_between_delimiter = settings[Setting::format_template_rows_between_delimiter];
     format_settings.template_settings.row_format = settings[Setting::format_template_row];

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -639,6 +639,27 @@ struct FormatSettings
     /// (http_column_* URL params) to enforce "body or header, not both":
     /// a body field that matches a mapped column is always an error.
     NameSet http_column_names = {};
+
+    /// Returns true when name matches a protected http_column_* target,
+    /// respecting the active column-name case-sensitivity mode.
+    bool isHTTPColumnName(std::string_view name) const noexcept
+    {
+        if (http_column_names.empty())
+            return false;
+        if (http_column_names.contains(String(name)))
+            return true;
+        /// AUTO and IGNORE_CASE modes match columns case-insensitively, so also
+        /// check the lowercase spelling to catch body fields like EVENT_TYPE when
+        /// the mapped column is event_type.
+        if (input_format_column_matching_case_sensitivity != InputFormatColumnMatchingCaseSensitivity::MATCH_CASE)
+        {
+            String lower(name);
+            std::transform(lower.begin(), lower.end(), lower.begin(),
+                           [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+            return http_column_names.contains(lower);
+        }
+        return false;
+    }
 };
 
 }

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -648,15 +648,22 @@ struct FormatSettings
             return false;
         if (http_column_names.contains(String(name)))
             return true;
-        /// AUTO and IGNORE_CASE modes match columns case-insensitively, so also
-        /// check the lowercase spelling to catch body fields like EVENT_TYPE when
-        /// the mapped column is event_type.
+        /// AUTO and IGNORE_CASE modes match columns case-insensitively. The stored
+        /// set keeps the original spellings, so compare lowercase on both sides to
+        /// catch e.g. body field EVENT_TYPE against mapped column event_type.
         if (input_format_column_matching_case_sensitivity != InputFormatColumnMatchingCaseSensitivity::MATCH_CASE)
         {
-            String lower(name);
-            std::transform(lower.begin(), lower.end(), lower.begin(),
-                           [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
-            return http_column_names.contains(lower);
+            auto to_lower = [](std::string_view s)
+            {
+                String r(s);
+                std::transform(r.begin(), r.end(), r.begin(),
+                               [](unsigned char c){ return static_cast<char>(std::tolower(c)); });
+                return r;
+            };
+            const String lname = to_lower(name);
+            for (const auto & col : http_column_names)
+                if (to_lower(col) == lname)
+                    return true;
         }
         return false;
     }

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -634,6 +634,11 @@ struct FormatSettings
         bool validate_geometry = true;
     } geojson{};
 
+    /// Column names that must never be silently skipped as unknown fields, even
+    /// when skip_unknown_fields = true. Used by HTTP header column injection
+    /// (http_column_* URL params) to enforce "body or header, not both":
+    /// a body field that matches a mapped column is always an error.
+    NameSet http_column_names = {};
 };
 
 }

--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -298,7 +298,7 @@ Block NativeReader::read()
             }
             else
             {
-                if (format_settings && !format_settings->skip_unknown_fields)
+                if (format_settings && (!format_settings->skip_unknown_fields || format_settings->isHTTPColumnName(column.name)))
                     throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown column with name {} found while reading data in Native format", column.name);
                 use_in_result = false;
             }

--- a/src/Formats/parseColumnFromString.h
+++ b/src/Formats/parseColumnFromString.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Columns/IColumn.h>
+#include <DataTypes/IDataType.h>
+#include <Formats/FormatSettings.h>
+#include <IO/ReadBufferFromString.h>
+
+namespace DB
+{
+
+/// Parse one value's whole-text representation into a single-row column of the
+/// given type. Throws when the text does not fit the type. Shared by the paths
+/// that turn HTTP request header strings into typed INSERT column values: the
+/// sync transform, async push-time validation, and async flush-time parsing all
+/// deserialize the same way, so keeping one helper prevents them from drifting.
+inline MutableColumnPtr parseColumnValueFromString(
+    const DataTypePtr & type, const String & text, const FormatSettings & format_settings)
+{
+    auto column = type->createColumn();
+    ReadBufferFromString buf(text);
+    type->getDefaultSerialization()->deserializeWholeText(*column, buf, format_settings);
+    return column;
+}
+
+}

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1407,7 +1407,23 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     if (format_header.columns() == 0 && injected_column_infos.empty())
         format_header = header;  /// No injection: use the full header as-is.
 
-    auto format = getInputFormatFromASTInsertQuery(key.query, false, format_header, insert_context, nullptr);
+    /// The flush-time insert_context does not carry the http_column_* mapping, so the
+    /// FormatSettings guard that rejects a body field duplicating a mapped column would
+    /// be lost for async inserts. Populate it on a copy used only for format creation
+    /// (not for the pipeline, which already expanded the column list at push time and
+    /// would otherwise re-expand and fail with DUPLICATE_COLUMN).
+    ContextPtr format_context = insert_context;
+    if (!injected_column_infos.empty())
+    {
+        auto ctx = Context::createCopy(insert_context);
+        NameToNameMap http_cols;
+        for (const auto & info : injected_column_infos)
+            http_cols.emplace(header.getByPosition(info.header_col_idx).name, String{});
+        ctx->setHTTPHeaderColumns(std::move(http_cols));
+        format_context = ctx;
+    }
+
+    auto format = getInputFormatFromASTInsertQuery(key.query, false, format_header, format_context, nullptr);
     std::shared_ptr<ISimpleTransform> adding_defaults_transform;
 
     if (insert_context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields] && insert_context->hasInsertionTableColumnsDescription())

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -642,16 +642,14 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             const auto & str_value = http_header_columns.at(col_name);
             const auto & col_type = insertable_block.getByName(col_name).type;
 
-            /// Validate that the string value parses correctly against the current
-            /// column type. The parsed result is discarded; only the raw string is
-            /// stored so that a later ALTER TABLE ... MODIFY COLUMN does not break
-            /// the batch (flush time re-parses from the string using the live type).
-            {
-                auto tmp_col = col_type->createColumn();
-                ReadBufferFromString buf(str_value);
-                col_type->getDefaultSerialization()->deserializeWholeText(*tmp_col, buf, format_settings);
-            }
-            entry->http_header_column_values.emplace_back(col_name, str_value);
+            /// Parse the header value once at push time so that type errors
+            /// (e.g. "not-a-number" for UInt64) surface immediately to the client.
+            /// The resulting 1-row column is stored directly; flush time reuses it
+            /// without re-parsing.
+            auto parsed = col_type->createColumn();
+            ReadBufferFromString buf(str_value);
+            col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
+            entry->http_header_column_values.emplace_back(col_name, std::move(parsed));
         }
     }
 
@@ -1508,16 +1506,26 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         /// using the correct header-injected value for this entry's rows.
         if (!injected_column_infos.empty())
         {
-            const FormatSettings fmt_settings = getFormatSettings(insert_context);
             Columns const_cols;
             const_cols.reserve(injected_column_infos.size());
             for (const auto & info : injected_column_infos)
             {
-                const auto & raw_value = entry->http_header_column_values[info.entry_parsed_idx].second;
-                auto col = info.type->createColumn();
-                ReadBufferFromString buf(raw_value);
-                info.type->getDefaultSerialization()->deserializeWholeText(*col, buf, fmt_settings);
-                const_cols.push_back(std::move(col));
+                const ColumnPtr & stored_col = entry->http_header_column_values[info.entry_parsed_idx].second;
+                /// Handle schema drift (ALTER TABLE ... MODIFY COLUMN during buffering):
+                /// if the push-time column type differs from the flush-time type, convert
+                /// via Field so the DEFAULT expression sees the right type.
+                if (stored_col->getDataType() != info.type->getTypeId())
+                {
+                    Field value;
+                    stored_col->get(0, value);
+                    auto converted = info.type->createColumn();
+                    converted->insert(value);
+                    const_cols.push_back(std::move(converted));
+                }
+                else
+                {
+                    const_cols.push_back(stored_col);
+                }
             }
             executor.setConstantColumnsForDefaults(std::move(const_cols));
         }
@@ -1556,23 +1564,29 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         {
             if (inj_idx < injected_column_infos.size() && injected_column_infos[inj_idx].header_col_idx == col_idx)
             {
-                /// Injected column: parse each entry's raw string against the live
-                /// flush-time column type. This survives ALTER TABLE ... MODIFY COLUMN
-                /// on a mapped column while requests are buffered.
+                /// Injected column: use the pre-parsed 1-row column stored at push
+                /// time — no re-parsing. For schema drift (ALTER TABLE during buffering)
+                /// fall back to Field-based conversion.
                 const auto & info = injected_column_infos[inj_idx++];
-                const auto & serialization = info.type->getDefaultSerialization();
-                const FormatSettings fmt_settings = getFormatSettings(insert_context);
                 auto new_col = info.type->createColumn();
                 new_col->reserve(total_rows);
                 size_t ei = 0;
                 for (const auto & entry : data->entries)
                 {
-                    const auto & raw_value = entry->http_header_column_values[info.entry_parsed_idx].second;
-                    auto tmp_col = info.type->createColumn();
-                    ReadBufferFromString buf(raw_value);
-                    serialization->deserializeWholeText(*tmp_col, buf, fmt_settings);
-                    for (size_t row = 0; row < entry_num_rows[ei++]; ++row)
-                        new_col->insertFrom(*tmp_col, 0);
+                    const ColumnPtr & stored_col = entry->http_header_column_values[info.entry_parsed_idx].second;
+                    ColumnPtr col_to_use = stored_col;
+                    if (stored_col->getDataType() != info.type->getTypeId())
+                    {
+                        /// Schema drift: convert the stored value to the current column
+                        /// type via Field (handles common numeric promotions; throws on
+                        /// incompatible types — same behaviour as a raw-string re-parse).
+                        Field value;
+                        stored_col->get(0, value);
+                        auto converted = info.type->createColumn();
+                        converted->insert(value);
+                        col_to_use = std::move(converted);
+                    }
+                    new_col->insertManyFrom(*col_to_use, 0, entry_num_rows[ei++]);
                 }
                 result_columns.push_back(std::move(new_col));
             }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -98,14 +98,12 @@ namespace Setting
 
 namespace ErrorCodes
 {
-    extern const int DUPLICATE_COLUMN;
     extern const int TIMEOUT_EXCEEDED;
     extern const int UNKNOWN_EXCEPTION;
     extern const int UNKNOWN_FORMAT;
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SETTING_VALUE;
-    extern const int NO_SUCH_COLUMN_IN_TABLE;
 }
 
 static const NameSet settings_to_skip
@@ -432,38 +430,8 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
     const auto & http_header_columns = query_context->getHTTPHeaderColumns();
     if (!http_header_columns.empty())
     {
-        const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
-
-        for (const auto & [col_name, _] : http_header_columns)
-        {
-            if (!insertable_sample.has(col_name))
-                throw Exception(
-                    ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-                    "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
-                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
-                    col_name, insert_query.table_id.getFullTableName());
-        }
-
-        /// Same as the sync path: only modify the column list when the user provided an
-        /// explicit one. A null list means "all table columns" and getSampleBlock already
-        /// includes the http_column columns in the full schema.
-        if (insert_query.columns)
-        {
-            NameSet existing_columns;
-            for (const auto & child : insert_query.columns->children)
-                existing_columns.insert(child->getColumnName());
-
-            for (const auto & [col_name, _] : http_header_columns)
-            {
-                if (existing_columns.contains(col_name))
-                    throw Exception(
-                        ErrorCodes::DUPLICATE_COLUMN,
-                        "http_column mapping conflicts with column '{}' already listed in the INSERT column list. "
-                        "A column must come from either the request body or an HTTP header, not both.",
-                        col_name);
-                insert_query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
-            }
-        }
+        InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
+            insert_query, metadata_snapshot, http_header_columns);
     }
 
     auto sample_block = InterpreterInsertQuery::getSampleBlock(

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -98,6 +98,7 @@ namespace Setting
 
 namespace ErrorCodes
 {
+    extern const int DUPLICATE_COLUMN;
     extern const int TIMEOUT_EXCEEDED;
     extern const int UNKNOWN_EXCEPTION;
     extern const int UNKNOWN_FORMAT;
@@ -432,12 +433,6 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
     if (!http_header_columns.empty())
     {
         const auto & table_columns = metadata_snapshot->getColumns();
-        if (!insert_query.columns)
-            insert_query.columns = make_intrusive<ASTExpressionList>();
-
-        NameSet existing_columns;
-        for (const auto & child : insert_query.columns->children)
-            existing_columns.insert(child->getColumnName());
 
         for (const auto & [col_name, _] : http_header_columns)
         {
@@ -446,8 +441,27 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
                     ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
                     "http_column mapping references column '{}' which does not exist in table '{}'",
                     col_name, insert_query.table_id.getFullTableName());
-            if (!existing_columns.contains(col_name))
+        }
+
+        /// Same as the sync path: only modify the column list when the user provided an
+        /// explicit one. A null list means "all table columns" and getSampleBlock already
+        /// includes the http_column columns in the full schema.
+        if (insert_query.columns)
+        {
+            NameSet existing_columns;
+            for (const auto & child : insert_query.columns->children)
+                existing_columns.insert(child->getColumnName());
+
+            for (const auto & [col_name, _] : http_header_columns)
+            {
+                if (existing_columns.contains(col_name))
+                    throw Exception(
+                        ErrorCodes::DUPLICATE_COLUMN,
+                        "http_column mapping conflicts with column '{}' already listed in the INSERT column list. "
+                        "A column must come from either the request body or an HTTP header, not both.",
+                        col_name);
                 insert_query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+            }
         }
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -17,6 +17,7 @@
 #include <IO/ConcatReadBuffer.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/ReadBufferFromString.h>
+#include <IO/WriteBufferFromString.h>
 #include <IO/WriteBufferFromStringWithMemoryTracking.h>
 #include <IO/copyData.h>
 #include <Interpreters/ExpressionActions.h>
@@ -1454,6 +1455,22 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     /// Track per-entry row counts for column replication after the loop.
     std::vector<size_t> entry_num_rows;
 
+    /// Re-parses a stored 1-row column through text serialization to adapt it to a
+    /// new flush-time type after schema drift (ALTER TABLE ... MODIFY COLUMN).
+    /// This mirrors how body columns are re-parsed by the format at flush time,
+    /// so text-compatible changes (e.g. String -> Array(String)) succeed where
+    /// Field-based conversion would fail.
+    const FormatSettings fmt_settings_for_drift = getFormatSettings(insert_context);
+    auto reparse_for_drift = [&](const ColumnPtr & col, const DataTypePtr & from_type, const DataTypePtr & to_type) -> ColumnPtr
+    {
+        WriteBufferFromOwnString str_buf;
+        from_type->getDefaultSerialization()->serializeText(*col, 0, str_buf, fmt_settings_for_drift);
+        auto new_col = to_type->createColumn();
+        ReadBufferFromString read_buf(str_buf.str());
+        to_type->getDefaultSerialization()->deserializeWholeText(*new_col, read_buf, fmt_settings_for_drift);
+        return new_col;
+    };
+
     for (const auto & entry : data->entries)
     {
         current_entry = entry;
@@ -1471,27 +1488,43 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         /// using the correct header-injected value for this entry's rows.
         if (!injected_column_infos.empty())
         {
+            /// Build constant columns for AddingDefaultsTransform. If schema drift
+            /// causes a conversion failure, fail this entry in isolation and skip it.
+            std::exception_ptr defaults_conversion_exception;
             Columns const_cols;
             const_cols.reserve(injected_column_infos.size());
             for (const auto & info : injected_column_infos)
             {
                 const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
                 const ColumnPtr & stored_col = stored.col;
-                /// Handle schema drift (ALTER TABLE ... MODIFY COLUMN during buffering):
-                /// if the push-time column type differs from the flush-time type, convert
-                /// via Field so the DEFAULT expression sees the right type.
                 if (!stored.push_time_type->equals(*info.type))
                 {
-                    Field value;
-                    stored_col->get(0, value);
-                    auto converted = info.type->createColumn();
-                    converted->insert(value);
-                    const_cols.push_back(std::move(converted));
+                    try
+                    {
+                        const_cols.push_back(reparse_for_drift(stored_col, stored.push_time_type, info.type));
+                    }
+                    catch (...)
+                    {
+                        /// Capture inside the catch — std::current_exception() is null after.
+                        defaults_conversion_exception = std::current_exception();
+                        break;
+                    }
                 }
                 else
                 {
                     const_cols.push_back(stored_col);
                 }
+            }
+
+            if (defaults_conversion_exception)
+            {
+                LOG_ERROR(logger, "Failed http_column schema-drift conversion for defaults in entry {}, skipping.",
+                    entry->query_id);
+                entry->finish(defaults_conversion_exception);
+                entry_num_rows.push_back(0);
+                add_to_async_insert_log(entry, "schema drift in defaults conversion", 0, bytes->size());
+                entry->resetChunk();
+                continue;
             }
             executor.setConstantColumnsForDefaults(std::move(const_cols));
         }
@@ -1501,9 +1534,6 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
         total_rows += num_rows;
         entry_num_rows.push_back(num_rows);
-
-        /// it is ok if total_rows is 0 here or async_dedup_token is empty
-        deduplication_info->setUserToken(entry->async_dedup_token, num_rows);
 
         add_to_async_insert_log(entry, current_exception, num_rows, num_bytes);
         current_exception.clear();
@@ -1553,11 +1583,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                     {
                         try
                         {
-                            Field value;
-                            stored.col->get(0, value);
-                            auto converted = info.type->createColumn();
-                            converted->insert(value);
-                            col_to_use = std::move(converted);
+                            col_to_use = reparse_for_drift(stored.col, stored.push_time_type, info.type);
                         }
                         catch (...) // Ok: mark entry invalid; handled below after the loop
                         {
@@ -1605,7 +1631,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             col = std::move(new_col);
         }
 
-        /// Finish failed entries with an exception.
+        /// Finish entries whose schema-drift conversion failed.
         size_t ei2 = 0;
         for (const auto & entry : data->entries)
         {
@@ -1621,6 +1647,18 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             ++ei2;
         }
         total_rows = valid_rows;
+    }
+
+    /// Register dedup tokens only for entries whose rows actually reached the result.
+    /// Failed entries (schema drift) are excluded so their tokens remain retryable.
+    {
+        size_t ei = 0;
+        for (const auto & entry : data->entries)
+        {
+            if (entry_valid[ei])
+                deduplication_info->setUserToken(entry->async_dedup_token, entry_num_rows[ei]);
+            ++ei;
+        }
     }
 
     Chunk chunk(std::move(result_columns), total_rows);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -104,6 +104,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SETTING_VALUE;
+    extern const int NO_SUCH_COLUMN_IN_TABLE;
 }
 
 static const NameSet settings_to_skip
@@ -412,6 +413,34 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
 
     auto table = interpreter.getTable(insert_query);
     const auto metadata_snapshot = table->getInMemoryMetadataPtr(query_context, false);
+
+    /// If http_column_* URL params mapped HTTP headers to column names, add those
+    /// columns to the INSERT's column list so getSampleBlock includes them in the
+    /// pipeline header. This tells the pipeline that these columns are client-provided,
+    /// skipping DEFAULT expressions. The actual values are injected per-entry at flush.
+    const auto & http_header_columns = query_context->getHTTPHeaderColumns();
+    if (!http_header_columns.empty())
+    {
+        const auto & table_columns = metadata_snapshot->getColumns();
+        if (!insert_query.columns)
+            insert_query.columns = make_intrusive<ASTExpressionList>();
+
+        NameSet existing_columns;
+        for (const auto & child : insert_query.columns->children)
+            existing_columns.insert(child->getColumnName());
+
+        for (const auto & [col_name, _] : http_header_columns)
+        {
+            if (!table_columns.has(col_name))
+                throw Exception(
+                    ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
+                    "http_column mapping references column '{}' which does not exist in table '{}'",
+                    col_name, insert_query.table_id.getFullTableName());
+            if (!existing_columns.contains(col_name))
+                insert_query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+        }
+    }
+
     auto sample_block = InterpreterInsertQuery::getSampleBlock(
         insert_query,
         table,
@@ -546,6 +575,9 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
     /// Query parameters make sense only for format Values.
     if (insert_query.format == "Values")
         entry->query_parameters = query_context->getQueryParameters();
+
+    /// Store HTTP header-to-column mappings per entry for injection at flush time.
+    entry->http_header_columns = query_context->getHTTPHeaderColumns();
 
     const auto & client_info = query_context->getClientInfo();
     InsertQuery key{
@@ -1332,6 +1364,15 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
 
+    /// Track per-entry row counts for http_header_column injection.
+    struct EntryRowInfo
+    {
+        size_t num_rows;
+        const NameToNameMap * http_header_columns;
+    };
+    std::vector<EntryRowInfo> entry_row_infos;
+    bool has_http_header_columns = false;
+
     for (const auto & entry : data->entries)
     {
         current_entry = entry;
@@ -1349,6 +1390,16 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
         total_rows += num_rows;
 
+        if (!entry->http_header_columns.empty())
+        {
+            has_http_header_columns = true;
+            entry_row_infos.push_back({num_rows, &entry->http_header_columns});
+        }
+        else
+        {
+            entry_row_infos.push_back({num_rows, nullptr});
+        }
+
         /// it is ok if total_rows is 0 here or async_dedup_token is empty
         deduplication_info->setUserToken(entry->async_dedup_token, num_rows);
 
@@ -1359,7 +1410,52 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     LOG_DEBUG(logger, "Processed {} rows with parsing them for {} entries", total_rows, data->entries.size());
 
-    Chunk chunk(executor.getResultColumns(), total_rows);
+    auto result_columns = executor.getResultColumns();
+
+    /// Overwrite columns that were mapped from HTTP headers (http_column_* URL params).
+    /// The format + AddingDefaultsTransform filled these with defaults; replace them
+    /// with the actual per-entry header values so each row carries its request's headers.
+    if (has_http_header_columns)
+    {
+        for (size_t col_idx = 0; col_idx < header.columns(); ++col_idx)
+        {
+            const auto & col_name = header.getByPosition(col_idx).name;
+
+            /// Check if any entry has this column in its http_header_columns.
+            /// All entries that use http_column_* share the same column names
+            /// (the URL pattern is the same), so checking the first non-null suffices.
+            bool is_injected = false;
+            for (const auto & info : entry_row_infos)
+            {
+                if (info.http_header_columns && info.http_header_columns->contains(col_name))
+                {
+                    is_injected = true;
+                    break;
+                }
+            }
+            if (!is_injected)
+                continue;
+
+            /// Build a replacement column with per-entry header values.
+            auto new_col = header.getByPosition(col_idx).type->createColumn();
+            new_col->reserve(total_rows);
+            for (const auto & info : entry_row_infos)
+            {
+                String value;
+                if (info.http_header_columns)
+                {
+                    auto it = info.http_header_columns->find(col_name);
+                    if (it != info.http_header_columns->end())
+                        value = it->second;
+                }
+                for (size_t row = 0; row < info.num_rows; ++row)
+                    new_col->insert(value);
+            }
+            result_columns[col_idx] = std::move(new_col);
+        }
+    }
+
+    Chunk chunk(std::move(result_columns), total_rows);
     chunk.getChunkInfos().add(std::move(deduplication_info));
     return chunk;
 }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -14,6 +14,7 @@
 #include <Core/DeduplicateInsert.h>
 #include <Core/ServerSettings.h>
 #include <Formats/FormatFactory.h>
+#include <Formats/parseColumnFromString.h>
 #include <IO/ConcatReadBuffer.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/ReadBufferFromString.h>
@@ -610,11 +611,7 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             /// (e.g. "not-a-number" for UInt64) surface immediately to the client.
             /// We store only the raw string; flush time re-parses against the
             /// then-current column type, which handles schema drift naturally.
-            {
-                auto validate = col_type->createColumn();
-                ReadBufferFromString buf(str_value);
-                col_type->getDefaultSerialization()->deserializeWholeText(*validate, buf, format_settings);
-            }
+            parseColumnValueFromString(col_type, str_value, format_settings);
             entry->http_header_column_values.push_back({col_name, str_value});
         }
     }
@@ -1498,9 +1495,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                 const auto & raw = entry->http_header_column_values[info.entry_parsed_idx].raw_value;
                 try
                 {
-                    auto col = info.type->createColumn();
-                    ReadBufferFromString buf(raw);
-                    info.type->getDefaultSerialization()->deserializeWholeText(*col, buf, fmt_settings);
+                    auto col = parseColumnValueFromString(info.type, raw, fmt_settings);
                     ep.injected.push_back({std::move(col), info.type, header.getByPosition(info.header_col_idx).name});
                 }
                 catch (...)

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -123,7 +123,8 @@ AsynchronousInsertQueue::InsertQuery::InsertQuery(
     const String & initial_user_,
     const String & authenticated_user_,
     const Settings & settings_,
-    AsynchronousInsertQueueDataKind data_kind_)
+    AsynchronousInsertQueueDataKind data_kind_,
+    Names http_header_column_names_)
     : query(query_->clone())
     , query_str(query->formatWithSecretsOneLine())
     , user_id(user_id_)
@@ -133,6 +134,7 @@ AsynchronousInsertQueue::InsertQuery::InsertQuery(
     , authenticated_user(authenticated_user_)
     , settings(std::make_unique<Settings>(settings_))
     , data_kind(data_kind_)
+    , http_header_column_names(std::move(http_header_column_names_))
 {
     SipHash siphash;
 
@@ -171,6 +173,12 @@ AsynchronousInsertQueue::InsertQuery::InsertQuery(
         }
     }
 
+    for (const auto & col_name : http_header_column_names)
+    {
+        siphash.update(col_name.size());
+        siphash.update(col_name);
+    }
+
     hash = siphash.get128();
 }
 
@@ -185,6 +193,7 @@ AsynchronousInsertQueue::InsertQuery::InsertQuery(const InsertQuery & other)
     authenticated_user = other.authenticated_user;
     settings = std::make_unique<Settings>(*other.settings);
     data_kind = other.data_kind;
+    http_header_column_names = other.http_header_column_names;
     hash = other.hash;
     setting_changes = other.setting_changes;
 }
@@ -203,6 +212,7 @@ AsynchronousInsertQueue::InsertQuery::operator=(const InsertQuery & other)
         authenticated_user = other.authenticated_user;
         settings = std::make_unique<Settings>(*other.settings);
         data_kind = other.data_kind;
+        http_header_column_names = other.http_header_column_names;
         hash = other.hash;
         setting_changes = other.setting_changes;
     }
@@ -576,8 +586,27 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
     if (insert_query.format == "Values")
         entry->query_parameters = query_context->getQueryParameters();
 
-    /// Store HTTP header-to-column mappings per entry for injection at flush time.
-    entry->http_header_columns = query_context->getHTTPHeaderColumns();
+    /// Parse HTTP header values into typed columns at push time.
+    /// Errors (e.g. "not-a-number" for UInt64) surface immediately to the client.
+    const auto & http_header_columns = query_context->getHTTPHeaderColumns();
+    Names http_col_names;
+    if (!http_header_columns.empty())
+    {
+        auto table = DatabaseCatalog::instance().getTable(insert_query.table_id, query_context);
+        auto metadata = table->getInMemoryMetadataPtr(query_context, false);
+        FormatSettings format_settings;
+        http_col_names.reserve(http_header_columns.size());
+        for (const auto & [col_name, str_value] : http_header_columns)
+        {
+            const auto & col_type = metadata->getColumns().get(col_name).type;
+            auto parsed = col_type->createColumn();
+            ReadBufferFromString buf(str_value);
+            col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
+            entry->parsed_http_header_columns.emplace_back(col_name, std::move(parsed));
+            http_col_names.push_back(col_name);
+        }
+        std::sort(http_col_names.begin(), http_col_names.end());
+    }
 
     const auto & client_info = query_context->getClientInfo();
     InsertQuery key{
@@ -588,7 +617,8 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         client_info.initial_user,
         client_info.authenticated_user,
         settings,
-        data_kind};
+        data_kind,
+        std::move(http_col_names)};
     InsertDataPtr data_to_process;
     std::future<ResultProgress> progress_future;
 
@@ -1364,14 +1394,33 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
 
-    /// Track per-entry row counts for http_header_column injection.
-    struct EntryRowInfo
+    /// Build a lookup: header column name → position in entry's parsed_http_header_columns
+    /// and column index in the pipeline header. Built once before the entry loop.
+    struct InjectedColumnInfo
     {
-        size_t num_rows;
-        const NameToNameMap * http_header_columns;
+        size_t header_col_idx;   /// Position in the pipeline header / result_columns.
+        size_t entry_parsed_idx; /// Position in entry->parsed_http_header_columns.
+        DataTypePtr type;
     };
-    std::vector<EntryRowInfo> entry_row_infos;
-    bool has_http_header_columns = false;
+    std::vector<InjectedColumnInfo> injected_column_infos;
+    if (!data->entries.empty() && !data->entries.front()->parsed_http_header_columns.empty())
+    {
+        /// Map column names from the first entry's parsed columns to header positions.
+        /// All entries share the same column name set (enforced by the batching key).
+        const auto & first_parsed = data->entries.front()->parsed_http_header_columns;
+        for (size_t parsed_idx = 0; parsed_idx < first_parsed.size(); ++parsed_idx)
+        {
+            const auto & col_name = first_parsed[parsed_idx].first;
+            if (header.has(col_name))
+            {
+                size_t header_idx = header.getPositionByName(col_name);
+                injected_column_infos.push_back({header_idx, parsed_idx, header.getByPosition(header_idx).type});
+            }
+        }
+    }
+
+    /// Track per-entry row counts for column replication after the loop.
+    std::vector<size_t> entry_num_rows;
 
     for (const auto & entry : data->entries)
     {
@@ -1389,16 +1438,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         size_t num_rows = executor.execute(*buffer, num_bytes);
 
         total_rows += num_rows;
-
-        if (!entry->http_header_columns.empty())
-        {
-            has_http_header_columns = true;
-            entry_row_infos.push_back({num_rows, &entry->http_header_columns});
-        }
-        else
-        {
-            entry_row_infos.push_back({num_rows, nullptr});
-        }
+        entry_num_rows.push_back(num_rows);
 
         /// it is ok if total_rows is 0 here or async_dedup_token is empty
         deduplication_info->setUserToken(entry->async_dedup_token, num_rows);
@@ -1413,55 +1453,22 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     auto result_columns = executor.getResultColumns();
 
     /// Overwrite columns that were mapped from HTTP headers (http_column_* URL params).
-    /// The format + AddingDefaultsTransform filled these with defaults; replace them
-    /// with the actual per-entry header values so each row carries its request's headers.
-    if (has_http_header_columns)
+    /// Values were pre-parsed at push time, so just replicate per-entry.
+    if (!injected_column_infos.empty())
     {
-        for (size_t col_idx = 0; col_idx < header.columns(); ++col_idx)
+        for (const auto & info : injected_column_infos)
         {
-            const auto & col_name = header.getByPosition(col_idx).name;
-
-            /// Check if any entry has this column in its http_header_columns.
-            /// All entries that use http_column_* share the same column names
-            /// (the URL pattern is the same), so checking the first non-null suffices.
-            bool is_injected = false;
-            for (const auto & info : entry_row_infos)
-            {
-                if (info.http_header_columns && info.http_header_columns->contains(col_name))
-                {
-                    is_injected = true;
-                    break;
-                }
-            }
-            if (!is_injected)
-                continue;
-
-            /// Build a replacement column with per-entry header values.
-            /// Deserialize each value through the column type's text serialization
-            /// so that non-String types (UInt64, Array, etc.) are parsed correctly.
-            const auto & col_type = header.getByPosition(col_idx).type;
-            const auto & serialization = col_type->getDefaultSerialization();
-            auto new_col = col_type->createColumn();
+            auto new_col = info.type->createColumn();
             new_col->reserve(total_rows);
-            for (const auto & info : entry_row_infos)
+            size_t entry_idx = 0;
+            for (const auto & entry : data->entries)
             {
-                String value;
-                if (info.http_header_columns)
-                {
-                    auto it = info.http_header_columns->find(col_name);
-                    if (it != info.http_header_columns->end())
-                        value = it->second;
-                }
-                /// Parse the string value into the target column type.
-                MutableColumnPtr parsed = col_type->createColumn();
-                ReadBufferFromString buf(value);
-                FormatSettings format_settings;
-                serialization->deserializeWholeText(*parsed, buf, format_settings);
-
-                for (size_t row = 0; row < info.num_rows; ++row)
-                    new_col->insertFrom(*parsed, 0);
+                const auto & parsed_col = entry->parsed_http_header_columns[info.entry_parsed_idx].second;
+                size_t num_rows = entry_num_rows[entry_idx++];
+                for (size_t row = 0; row < num_rows; ++row)
+                    new_col->insertFrom(*parsed_col, 0);
             }
-            result_columns[col_idx] = std::move(new_col);
+            result_columns[info.header_col_idx] = std::move(new_col);
         }
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1535,10 +1535,12 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         if (!entry_parsed.empty() && entry_parsed[ei].exc)
         {
             LOG_ERROR(logger, "Failed http_column parsing for entry {}, skipping.", entry->query_id);
+            /// Capture the byte count before finish(): finish() calls resetChunk()
+            /// internally, which destroys the chunk storage that bytes points into.
+            const size_t entry_bytes = bytes->size();
             entry->finish(entry_parsed[ei].exc);
             entry_num_rows.push_back(0);
-            add_to_async_insert_log(entry, "http_column parse error at flush time", 0, bytes->size());
-            entry->resetChunk();
+            add_to_async_insert_log(entry, "http_column parse error at flush time", 0, entry_bytes);
             ++ei;
             continue;
         }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1437,7 +1437,11 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                 continue;
 
             /// Build a replacement column with per-entry header values.
-            auto new_col = header.getByPosition(col_idx).type->createColumn();
+            /// Deserialize each value through the column type's text serialization
+            /// so that non-String types (UInt64, Array, etc.) are parsed correctly.
+            const auto & col_type = header.getByPosition(col_idx).type;
+            const auto & serialization = col_type->getDefaultSerialization();
+            auto new_col = col_type->createColumn();
             new_col->reserve(total_rows);
             for (const auto & info : entry_row_infos)
             {
@@ -1448,8 +1452,14 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                     if (it != info.http_header_columns->end())
                         value = it->second;
                 }
+                /// Parse the string value into the target column type.
+                MutableColumnPtr parsed = col_type->createColumn();
+                ReadBufferFromString buf(value);
+                FormatSettings format_settings;
+                serialization->deserializeWholeText(*parsed, buf, format_settings);
+
                 for (size_t row = 0; row < info.num_rows; ++row)
-                    new_col->insert(value);
+                    new_col->insertFrom(*parsed, 0);
             }
             result_columns[col_idx] = std::move(new_col);
         }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1312,7 +1312,7 @@ try
         if (key.data_kind == AsynchronousInsertQueueDataKind::Parsed)
             chunk = processEntriesWithParsing(key, data, *header, insert_context, log, add_entry_to_asynchronous_insert_log);
         else
-            chunk = processPreprocessedEntries(data, *header, insert_context, log, add_entry_to_asynchronous_insert_log);
+            chunk = processPreprocessedEntries(key, data, *header, insert_context, log, add_entry_to_asynchronous_insert_log);
 
         ProfileEvents::increment(ProfileEvents::AsyncInsertRows, chunk.getNumRows());
 
@@ -1621,12 +1621,19 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
 template <typename LogFunc>
 Chunk AsynchronousInsertQueue::processPreprocessedEntries(
+    const InsertQuery & key,
     const InsertDataPtr & data,
     const Block & header,
     const ContextPtr & context_,
     LoggerPtr logger,
     LogFunc && add_to_async_insert_log)
 {
+    /// http_column_* injection is only supported on the Parsed path. Preprocessed entries
+    /// arrive as already-complete blocks (e.g. from native protocol clients) and have no
+    /// per-entry raw header strings to inject. A non-empty column name list here means
+    /// something pushed an entry onto the wrong queue shard.
+    chassert(key.http_header_column_names.empty());
+
     size_t total_rows = 0;
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
     auto result_columns = header.cloneEmptyColumns();

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -591,18 +591,13 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
         const auto format_settings = getFormatSettings(query_context);
 
-        /// Collect and sort column names for deterministic order across all entries
-        /// in a batch. The flush loop indexes by position (entry_parsed_idx), so
-        /// unordered NameToNameMap iteration would cause cross-column value swaps.
+        /// The mapping is already in declaration order. Use it as-is so the batch key
+        /// (http_col_names), the per-entry values, and the query expansion all share
+        /// one canonical order. The flush loop indexes by position, so values and
+        /// names must be pushed in lockstep here.
         http_col_names.reserve(http_header_columns.size());
-        for (const auto & [col_name, _] : http_header_columns)
-            http_col_names.push_back(col_name);
-        std::sort(http_col_names.begin(), http_col_names.end());
-
-        for (const auto & col_name : http_col_names)
+        for (const auto & [col_name, str_value] : http_header_columns)
         {
-
-            const auto & str_value = http_header_columns.at(col_name);
             /// expandInsertQueryWithHTTPHeaderColumns already validated insertability;
             /// here we just retrieve the type for parsing.
             const auto & col_type = metadata->getColumns().get(col_name).type;
@@ -612,7 +607,10 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             /// We store only the raw string; flush time re-parses against the
             /// then-current column type, which handles schema drift naturally.
             parseColumnValueFromString(col_type, str_value, format_settings);
-            entry->http_header_column_values.push_back({col_name, str_value});
+            /// Store only the value; its position matches http_col_names, so the
+            /// column name is recovered from the key at flush.
+            entry->http_header_column_values.push_back(str_value);
+            http_col_names.push_back(col_name);
         }
     }
 
@@ -1381,15 +1379,15 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     };
     std::vector<InjectedColumnInfo> injected_column_infos;
     Block format_header;  /// Body-only block passed to the format and AddingDefaultsTransform.
-    if (!data->entries.empty() && !data->entries.front()->http_header_column_values.empty())
+    if (!key.http_header_column_names.empty())
     {
-        const auto & first_values = data->entries.front()->http_header_column_values;
-
-        /// Build column-name → position map for the first entry (all entries in a
-        /// batch have the same names in the same order, enforced by the batching key).
+        /// The batch key carries the sorted injected-column names, and each entry's
+        /// http_header_column_values is positionally aligned to that list. So the
+        /// injected column set is authoritative from the key alone, without inspecting
+        /// any entry, and the position doubles as entry_parsed_idx.
         std::unordered_map<String, size_t> injected_name_to_idx;
-        for (size_t i = 0; i < first_values.size(); ++i)
-            injected_name_to_idx.emplace(first_values[i].col_name, i);
+        for (size_t i = 0; i < key.http_header_column_names.size(); ++i)
+            injected_name_to_idx.emplace(key.http_header_column_names[i], i);
 
         for (size_t i = 0; i < header.columns(); ++i)
         {
@@ -1413,9 +1411,12 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     if (!injected_column_infos.empty())
     {
         auto ctx = Context::createCopy(insert_context);
-        NameToNameMap http_cols;
+        /// Only the column names matter here (they feed the FormatSettings guard);
+        /// values are irrelevant, so leave them empty.
+        HTTPHeaderColumns http_cols;
+        http_cols.reserve(injected_column_infos.size());
         for (const auto & info : injected_column_infos)
-            http_cols.emplace(header.getByPosition(info.header_col_idx).name, String{});
+            http_cols.add(header.getByPosition(info.header_col_idx).name, String{});
         ctx->setHTTPHeaderColumns(std::move(http_cols));
         format_context = ctx;
     }
@@ -1492,7 +1493,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             ep.injected.reserve(injected_column_infos.size());
             for (const auto & info : injected_column_infos)
             {
-                const auto & raw = entry->http_header_column_values[info.entry_parsed_idx].raw_value;
+                const auto & raw = entry->http_header_column_values[info.entry_parsed_idx];
                 try
                 {
                     auto col = parseColumnValueFromString(info.type, raw, fmt_settings);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -17,7 +17,6 @@
 #include <IO/ConcatReadBuffer.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/ReadBufferFromString.h>
-#include <IO/WriteBufferFromString.h>
 #include <IO/WriteBufferFromStringWithMemoryTracking.h>
 #include <IO/copyData.h>
 #include <Interpreters/ExpressionActions.h>
@@ -105,7 +104,6 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SETTING_VALUE;
-    extern const int TYPE_MISMATCH;
 }
 
 static const NameSet settings_to_skip
@@ -608,14 +606,16 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             /// here we just retrieve the type for parsing.
             const auto & col_type = metadata->getColumns().get(col_name).type;
 
-            /// Parse the header value once at push time so that type errors
+            /// Validate the header value at push time so that type errors
             /// (e.g. "not-a-number" for UInt64) surface immediately to the client.
-            /// The resulting 1-row column is stored directly; flush time reuses it
-            /// without re-parsing.
-            auto parsed = col_type->createColumn();
-            ReadBufferFromString buf(str_value);
-            col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
-            entry->http_header_column_values.push_back({col_name, std::move(parsed), col_type});
+            /// We store only the raw string; flush time re-parses against the
+            /// then-current column type, which handles schema drift naturally.
+            {
+                auto validate = col_type->createColumn();
+                ReadBufferFromString buf(str_value);
+                col_type->getDefaultSerialization()->deserializeWholeText(*validate, buf, format_settings);
+            }
+            entry->http_header_column_values.push_back({col_name, str_value});
         }
     }
 
@@ -1415,25 +1415,10 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         const auto & columns = *insert_context->getInsertionTableColumnsDescription();
         if (columns.hasDefaults())
         {
-            /// Pass the injected columns directly to AddingDefaultsTransform so it
-            /// appends them internally (same as the sync path in getSourceFromInputFormat).
-            /// This keeps num_body_columns = format_header.columns() correct inside
-            /// transform(), preventing out-of-bounds BlockMissingValues access when
-            /// injected columns have DEFAULT/MATERIALIZED expressions.
-            ColumnsWithTypeAndName injected_for_defaults;
-            injected_for_defaults.reserve(injected_column_infos.size());
-            /// Use the first entry's stored 1-row columns; updated per-entry below.
-            if (!data->entries.empty())
-            {
-                for (const auto & info : injected_column_infos)
-                {
-                    const auto & stored = data->entries.front()->http_header_column_values[info.entry_parsed_idx];
-                    injected_for_defaults.push_back({stored.col, info.type, header.getByPosition(info.header_col_idx).name});
-                }
-            }
+            /// Injected columns are set per-entry via setInjectedColumns() before
+            /// each executor.execute() call, so we start with an empty list here.
             adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(
-                std::make_shared<const Block>(format_header), columns, *format, insert_context,
-                std::move(injected_for_defaults));
+                std::make_shared<const Block>(format_header), columns, *format, insert_context);
         }
     }
 
@@ -1450,6 +1435,14 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         return 0;
     };
 
+    /// Keep a raw pointer before moving the shared_ptr into the executor so we can
+    /// call setInjectedColumns() per entry without a use-after-move.
+    /// The executor holds the shared_ptr and keeps the object alive.
+    AddingDefaultsTransform * defaults_transform_ptr =
+        adding_defaults_transform
+            ? static_cast<AddingDefaultsTransform *>(adding_defaults_transform.get())
+            : nullptr;
+
     StreamingFormatExecutor executor(
         format_header,
         format,
@@ -1460,25 +1453,52 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
 
-    /// Track per-entry row counts for column replication after the loop.
+    /// Track per-entry row counts for result assembly.
     std::vector<size_t> entry_num_rows;
+    entry_num_rows.reserve(data->entries.size());
 
-    /// Re-parses a stored 1-row column through text serialization to adapt it to a
-    /// new flush-time type after schema drift (ALTER TABLE ... MODIFY COLUMN).
-    /// This mirrors how body columns are re-parsed by the format at flush time,
-    /// so text-compatible changes (e.g. String -> Array(String)) succeed where
-    /// Field-based conversion would fail.
-    const FormatSettings fmt_settings_for_drift = getFormatSettings(insert_context);
-    auto reparse_for_drift = [&](const ColumnPtr & col, const DataTypePtr & from_type, const DataTypePtr & to_type) -> ColumnPtr
+    /// Pre-parse all injected column raw values against flush-time types before the
+    /// executor loop. Parsing at flush time handles schema drift naturally: if the
+    /// column type changed (ALTER TABLE during buffering), the raw string is parsed
+    /// against the new type directly — no explicit drift detection or re-serialization
+    /// needed. Failed entries are skipped from the executor entirely, so no
+    /// post-loop compaction of body columns is ever needed.
+    struct EntryParsed
     {
-        WriteBufferFromOwnString str_buf;
-        from_type->getDefaultSerialization()->serializeText(*col, 0, str_buf, fmt_settings_for_drift);
-        auto new_col = to_type->createColumn();
-        ReadBufferFromString read_buf(str_buf.str());
-        to_type->getDefaultSerialization()->deserializeWholeText(*new_col, read_buf, fmt_settings_for_drift);
-        return new_col;
+        ColumnsWithTypeAndName injected; /// one element per injected_column_infos, 1 row each
+        std::exception_ptr exc;          /// set when any injected column fails to parse
     };
+    std::vector<EntryParsed> entry_parsed;
+    const FormatSettings fmt_settings = getFormatSettings(insert_context);
+    if (!injected_column_infos.empty())
+    {
+        entry_parsed.reserve(data->entries.size());
+        for (const auto & entry : data->entries)
+        {
+            EntryParsed ep;
+            ep.injected.reserve(injected_column_infos.size());
+            for (const auto & info : injected_column_infos)
+            {
+                const auto & raw = entry->http_header_column_values[info.entry_parsed_idx].raw_value;
+                try
+                {
+                    auto col = info.type->createColumn();
+                    ReadBufferFromString buf(raw);
+                    info.type->getDefaultSerialization()->deserializeWholeText(*col, buf, fmt_settings);
+                    ep.injected.push_back({std::move(col), info.type, header.getByPosition(info.header_col_idx).name});
+                }
+                catch (...)
+                {
+                    ep.exc = std::current_exception();
+                    ep.injected.clear();
+                    break;
+                }
+            }
+            entry_parsed.push_back(std::move(ep));
+        }
+    }
 
+    size_t ei = 0;
     for (const auto & entry : data->entries)
     {
         current_entry = entry;
@@ -1488,44 +1508,28 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "Expected entry with data kind Parsed. Got: {}", entry->chunk.getDataKind());
 
-        auto buffer = std::make_unique<ReadBufferFromString>(*bytes);
-        executor.setQueryParameters(entry->query_parameters);
-
-        /// Update AddingDefaultsTransform with this entry's per-entry injected column
-        /// values so DEFAULT expressions (e.g. `b DEFAULT a + 1`) use the correct value.
-        /// The transform now handles injection internally (format_header only, injected
-        /// appended inside transform()), so we only need to update the per-entry values.
-        if (!injected_column_infos.empty() && adding_defaults_transform)
+        /// Skip entries whose injected column values failed to parse against the
+        /// current flush-time type (e.g. incompatible ALTER TABLE during buffering).
+        if (!entry_parsed.empty() && entry_parsed[ei].exc)
         {
-            std::exception_ptr defaults_conversion_exception;
-            ColumnsWithTypeAndName per_entry_injected;
-            per_entry_injected.reserve(injected_column_infos.size());
-            for (const auto & info : injected_column_infos)
-            {
-                const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
-                ColumnPtr col_to_use = stored.col;
-                if (!stored.push_time_type->equals(*info.type))
-                {
-                    try { col_to_use = reparse_for_drift(stored.col, stored.push_time_type, info.type); }
-                    catch (...) { defaults_conversion_exception = std::current_exception(); break; }
-                }
-                per_entry_injected.push_back({col_to_use, info.type, header.getByPosition(info.header_col_idx).name});
-            }
-
-            if (defaults_conversion_exception)
-            {
-                LOG_ERROR(logger, "Failed http_column schema-drift conversion for defaults in entry {}, skipping.",
-                    entry->query_id);
-                entry->finish(defaults_conversion_exception);
-                entry_num_rows.push_back(0);
-                add_to_async_insert_log(entry, "schema drift in defaults conversion", 0, bytes->size());
-                entry->resetChunk();
-                continue;
-            }
-            static_cast<AddingDefaultsTransform &>(*adding_defaults_transform)
-                .setInjectedColumns(std::move(per_entry_injected));
+            LOG_ERROR(logger, "Failed http_column parsing for entry {}, skipping.", entry->query_id);
+            entry->finish(entry_parsed[ei].exc);
+            entry_num_rows.push_back(0);
+            add_to_async_insert_log(entry, "http_column parse error at flush time", 0, bytes->size());
+            entry->resetChunk();
+            ++ei;
+            continue;
         }
 
+        executor.setQueryParameters(entry->query_parameters);
+
+        /// Supply this entry's injected column values to AddingDefaultsTransform so
+        /// DEFAULT expressions that reference them (e.g. `b DEFAULT a + 1`) evaluate
+        /// with the correct per-entry value.
+        if (!entry_parsed.empty() && defaults_transform_ptr)
+            defaults_transform_ptr->setInjectedColumns(entry_parsed[ei].injected);
+
+        auto buffer = std::make_unique<ReadBufferFromString>(*bytes);
         size_t num_bytes = bytes->size();
         size_t num_rows = executor.execute(*buffer, num_bytes);
 
@@ -1535,19 +1539,15 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         add_to_async_insert_log(entry, current_exception, num_rows, num_bytes);
         current_exception.clear();
         entry->resetChunk();
+        ++ei;
     }
 
     LOG_DEBUG(logger, "Processed {} rows with parsing them for {} entries", total_rows, data->entries.size());
 
     auto body_columns = executor.getResultColumns();  /// Matches format_header.
 
-    /// Track which entries are still valid after injected-column schema-drift conversion.
-    /// Entries that fail to convert are finished with an exception and excluded from the result.
-    /// Initialized to true; the injected-column loop below may set entries to false.
-    std::vector<bool> entry_valid(data->entries.size(), true);
-
     /// Build the full result matching the pipeline header by interleaving body columns
-    /// (from the executor) and injected columns (pre-parsed per-entry at push time).
+    /// (from the executor) and injected columns (parsed per-entry above).
     MutableColumns result_columns;
     if (injected_column_infos.empty())
     {
@@ -1557,104 +1557,38 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     {
         result_columns.reserve(header.columns());
         size_t body_idx = 0;
-        size_t inj_idx = 0;
+        size_t inj_counter = 0;
         for (size_t col_idx = 0; col_idx < header.columns(); ++col_idx)
         {
-            if (inj_idx < injected_column_infos.size() && injected_column_infos[inj_idx].header_col_idx == col_idx)
+            if (inj_counter < injected_column_infos.size()
+                && injected_column_infos[inj_counter].header_col_idx == col_idx)
             {
-                /// Injected column: use the pre-parsed 1-row column stored at push
-                /// time — no re-parsing. For schema drift (ALTER TABLE during buffering)
-                /// attempt Field-based conversion. Uses IDataType::equals() so parametric
-                /// changes within the same TypeIndex family (e.g. FixedString(4) -> FixedString(2))
-                /// are detected and handled; TypeIndex alone would miss such differences.
-                const auto & info = injected_column_infos[inj_idx++];
-                auto new_col = info.type->createColumn();
+                const size_t local_inj = inj_counter++;
+                auto new_col = injected_column_infos[local_inj].type->createColumn();
                 new_col->reserve(total_rows);
-                size_t ei = 0;
-                for (const auto & entry : data->entries)
+                for (size_t ep_idx = 0; ep_idx < entry_parsed.size(); ++ep_idx)
                 {
-                    if (!entry_valid[ei]) { ++ei; continue; }
-                    const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
-                    ColumnPtr col_to_use = stored.col;
-                    if (!stored.push_time_type->equals(*info.type))
-                    {
-                        try
-                        {
-                            col_to_use = reparse_for_drift(stored.col, stored.push_time_type, info.type);
-                        }
-                        catch (...) // Ok: mark entry invalid; handled below after the loop
-                        {
-                            entry_valid[ei] = false;
-                        }
-                    }
-                    if (entry_valid[ei])
-                        new_col->insertManyFrom(*col_to_use, 0, entry_num_rows[ei]);
-                    ++ei;
+                    if (entry_num_rows[ep_idx] > 0)
+                        new_col->insertManyFrom(*entry_parsed[ep_idx].injected[local_inj].column, 0, entry_num_rows[ep_idx]);
                 }
                 result_columns.push_back(std::move(new_col));
             }
             else
             {
-                /// Body column: take directly from the executor result.
                 result_columns.push_back(std::move(body_columns[body_idx++]));
             }
         }
     }
 
-    /// Finish entries that failed schema-drift conversion and compact result columns
-    /// to exclude their rows, preserving per-entry failure isolation.
-    bool any_failed = false;
-    for (size_t ei = 0; ei < data->entries.size(); ++ei)
-        if (!entry_valid[ei]) { any_failed = true; break; }
-
-    if (any_failed)
+    /// Register dedup tokens only for entries that actually contributed rows.
+    /// Entries that failed parsing are skipped so their tokens remain retryable.
     {
-        size_t valid_rows = 0;
-        for (size_t ei = 0; ei < data->entries.size(); ++ei)
-            if (entry_valid[ei]) valid_rows += entry_num_rows[ei];
-
-        /// Rebuild every result column keeping only rows from valid entries.
-        for (auto & col : result_columns)
-        {
-            auto new_col = col->cloneEmpty();
-            new_col->reserve(valid_rows);
-            size_t row_offset = 0;
-            for (size_t ei = 0; ei < data->entries.size(); ++ei)
-            {
-                if (entry_valid[ei])
-                    new_col->insertRangeFrom(*col, row_offset, entry_num_rows[ei]);
-                row_offset += entry_num_rows[ei];
-            }
-            col = std::move(new_col);
-        }
-
-        /// Finish entries whose schema-drift conversion failed.
-        size_t ei2 = 0;
+        size_t dedup_ei = 0;
         for (const auto & entry : data->entries)
         {
-            if (!entry_valid[ei2] && !entry->isFinished())
-            {
-                LOG_ERROR(logger,
-                    "http_column schema drift for entry {}: type changed while buffered, entry dropped.",
-                    entry->query_id);
-                entry->finish(std::make_exception_ptr(
-                    Exception(ErrorCodes::TYPE_MISMATCH,
-                        "http_column value type changed (ALTER TABLE during async buffering)")));
-            }
-            ++ei2;
-        }
-        total_rows = valid_rows;
-    }
-
-    /// Register dedup tokens only for entries whose rows actually reached the result.
-    /// Failed entries (schema drift) are excluded so their tokens remain retryable.
-    {
-        size_t ei = 0;
-        for (const auto & entry : data->entries)
-        {
-            if (entry_valid[ei])
-                deduplication_info->setUserToken(entry->async_dedup_token, entry_num_rows[ei]);
-            ++ei;
+            if (entry_num_rows[dedup_ei] > 0)
+                deduplication_info->setUserToken(entry->async_dedup_token, entry_num_rows[dedup_ei]);
+            ++dedup_ei;
         }
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -606,7 +606,17 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
     Names http_col_names;
     if (!http_header_columns.empty())
     {
-        auto table = DatabaseCatalog::instance().getTable(insert_query.table_id, query_context);
+        /// Use InterpreterInsertQuery::getTable so that both regular tables and
+        /// INSERT INTO FUNCTION targets are resolved through the same path.
+        auto insert_context_for_table = Context::createCopy(query_context);
+        InterpreterInsertQuery interpreter_for_table(
+            query,
+            insert_context_for_table,
+            query_context->getSettingsRef()[Setting::insert_allow_materialized_columns],
+            /* no_squash */ false,
+            /* no_destination */ false,
+            /* async_insert */ false);
+        auto table = interpreter_for_table.getTable(insert_query);
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
         const auto format_settings = getFormatSettings(query_context);
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -594,18 +594,27 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
     {
         auto table = DatabaseCatalog::instance().getTable(insert_query.table_id, query_context);
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
-        FormatSettings format_settings;
+        const auto format_settings = getFormatSettings(query_context);
+
+        /// Collect and sort column names so that parsed_http_header_columns has a
+        /// deterministic order across all entries in a batch. This is required because
+        /// the flush loop indexes entries by position (entry_parsed_idx), and unordered
+        /// iteration of http_header_columns (std::unordered_map) could produce different
+        /// orderings for different requests, causing cross-column value swaps.
         http_col_names.reserve(http_header_columns.size());
-        for (const auto & [col_name, str_value] : http_header_columns)
+        for (const auto & [col_name, _] : http_header_columns)
+            http_col_names.push_back(col_name);
+        std::sort(http_col_names.begin(), http_col_names.end());
+
+        for (const auto & col_name : http_col_names)
         {
+            const auto & str_value = http_header_columns.at(col_name);
             const auto & col_type = metadata->getColumns().get(col_name).type;
             auto parsed = col_type->createColumn();
             ReadBufferFromString buf(str_value);
             col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
             entry->parsed_http_header_columns.emplace_back(col_name, std::move(parsed));
-            http_col_names.push_back(col_name);
         }
-        std::sort(http_col_names.begin(), http_col_names.end());
     }
 
     const auto & client_info = query_context->getClientInfo();

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1415,17 +1415,25 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         const auto & columns = *insert_context->getInsertionTableColumnsDescription();
         if (columns.hasDefaults())
         {
-            /// When there are injected columns, build an extended header for
-            /// AddingDefaultsTransform that appends the injected columns after
-            /// the body columns. This lets DEFAULT expressions that reference
-            /// injected columns (e.g. `b DEFAULT a + 1` where `a` is from a
-            /// header) evaluate correctly. The injected columns are appended
-            /// at the end so body column positions match BlockMissingValues indices.
-            Block defaults_header = format_header;
-            for (const auto & info : injected_column_infos)
-                defaults_header.insert(header.getByPosition(info.header_col_idx));
+            /// Pass the injected columns directly to AddingDefaultsTransform so it
+            /// appends them internally (same as the sync path in getSourceFromInputFormat).
+            /// This keeps num_body_columns = format_header.columns() correct inside
+            /// transform(), preventing out-of-bounds BlockMissingValues access when
+            /// injected columns have DEFAULT/MATERIALIZED expressions.
+            ColumnsWithTypeAndName injected_for_defaults;
+            injected_for_defaults.reserve(injected_column_infos.size());
+            /// Use the first entry's stored 1-row columns; updated per-entry below.
+            if (!data->entries.empty())
+            {
+                for (const auto & info : injected_column_infos)
+                {
+                    const auto & stored = data->entries.front()->http_header_column_values[info.entry_parsed_idx];
+                    injected_for_defaults.push_back({stored.col, info.type, header.getByPosition(info.header_col_idx).name});
+                }
+            }
             adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(
-                std::make_shared<const Block>(defaults_header), columns, *format, insert_context);
+                std::make_shared<const Block>(format_header), columns, *format, insert_context,
+                std::move(injected_for_defaults));
         }
     }
 
@@ -1483,37 +1491,25 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         auto buffer = std::make_unique<ReadBufferFromString>(*bytes);
         executor.setQueryParameters(entry->query_parameters);
 
-        /// For each entry, update the per-entry injected constant columns so that
-        /// AddingDefaultsTransform can evaluate DEFAULT expressions (e.g. `b DEFAULT a+1`)
-        /// using the correct header-injected value for this entry's rows.
-        if (!injected_column_infos.empty())
+        /// Update AddingDefaultsTransform with this entry's per-entry injected column
+        /// values so DEFAULT expressions (e.g. `b DEFAULT a + 1`) use the correct value.
+        /// The transform now handles injection internally (format_header only, injected
+        /// appended inside transform()), so we only need to update the per-entry values.
+        if (!injected_column_infos.empty() && adding_defaults_transform)
         {
-            /// Build constant columns for AddingDefaultsTransform. If schema drift
-            /// causes a conversion failure, fail this entry in isolation and skip it.
             std::exception_ptr defaults_conversion_exception;
-            Columns const_cols;
-            const_cols.reserve(injected_column_infos.size());
+            ColumnsWithTypeAndName per_entry_injected;
+            per_entry_injected.reserve(injected_column_infos.size());
             for (const auto & info : injected_column_infos)
             {
                 const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
-                const ColumnPtr & stored_col = stored.col;
+                ColumnPtr col_to_use = stored.col;
                 if (!stored.push_time_type->equals(*info.type))
                 {
-                    try
-                    {
-                        const_cols.push_back(reparse_for_drift(stored_col, stored.push_time_type, info.type));
-                    }
-                    catch (...)
-                    {
-                        /// Capture inside the catch — std::current_exception() is null after.
-                        defaults_conversion_exception = std::current_exception();
-                        break;
-                    }
+                    try { col_to_use = reparse_for_drift(stored.col, stored.push_time_type, info.type); }
+                    catch (...) { defaults_conversion_exception = std::current_exception(); break; }
                 }
-                else
-                {
-                    const_cols.push_back(stored_col);
-                }
+                per_entry_injected.push_back({col_to_use, info.type, header.getByPosition(info.header_col_idx).name});
             }
 
             if (defaults_conversion_exception)
@@ -1526,7 +1522,8 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                 entry->resetChunk();
                 continue;
             }
-            executor.setConstantColumnsForDefaults(std::move(const_cols));
+            static_cast<AddingDefaultsTransform &>(*adding_defaults_transform)
+                .setInjectedColumns(std::move(per_entry_injected));
         }
 
         size_t num_bytes = bytes->size();

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1450,7 +1450,19 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     {
         const auto & columns = *insert_context->getInsertionTableColumnsDescription();
         if (columns.hasDefaults())
-            adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(std::make_shared<const Block>(format_header), columns, *format, insert_context);
+        {
+            /// When there are injected columns, build an extended header for
+            /// AddingDefaultsTransform that appends the injected columns after
+            /// the body columns. This lets DEFAULT expressions that reference
+            /// injected columns (e.g. `b DEFAULT a + 1` where `a` is from a
+            /// header) evaluate correctly. The injected columns are appended
+            /// at the end so body column positions match BlockMissingValues indices.
+            Block defaults_header = format_header;
+            for (const auto & info : injected_column_infos)
+                defaults_header.insert(header.getByPosition(info.header_col_idx));
+            adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(
+                std::make_shared<const Block>(defaults_header), columns, *format, insert_context);
+        }
     }
 
     auto on_error = [&](const MutableColumns & result_columns, const ColumnCheckpoints & checkpoints, Exception & e)
@@ -1490,6 +1502,25 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
         auto buffer = std::make_unique<ReadBufferFromString>(*bytes);
         executor.setQueryParameters(entry->query_parameters);
+
+        /// For each entry, update the per-entry injected constant columns so that
+        /// AddingDefaultsTransform can evaluate DEFAULT expressions (e.g. `b DEFAULT a+1`)
+        /// using the correct header-injected value for this entry's rows.
+        if (!injected_column_infos.empty())
+        {
+            const FormatSettings fmt_settings = getFormatSettings(insert_context);
+            Columns const_cols;
+            const_cols.reserve(injected_column_infos.size());
+            for (const auto & info : injected_column_infos)
+            {
+                const auto & raw_value = entry->http_header_column_values[info.entry_parsed_idx].second;
+                auto col = info.type->createColumn();
+                ReadBufferFromString buf(raw_value);
+                info.type->getDefaultSerialization()->deserializeWholeText(*col, buf, fmt_settings);
+                const_cols.push_back(std::move(col));
+            }
+            executor.setConstantColumnsForDefaults(std::move(const_cols));
+        }
 
         size_t num_bytes = bytes->size();
         size_t num_rows = executor.execute(*buffer, num_bytes);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -431,7 +431,8 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
     if (!http_header_columns.empty())
     {
         InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
-            insert_query, metadata_snapshot, http_header_columns);
+            insert_query, metadata_snapshot, http_header_columns,
+            query_context->getSettingsRef()[Setting::insert_allow_materialized_columns]);
     }
 
     auto sample_block = InterpreterInsertQuery::getSampleBlock(
@@ -588,7 +589,7 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         auto table = interpreter_for_table.getTable(insert_query);
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
         const auto format_settings = getFormatSettings(query_context);
-        const Block insertable_block = metadata->getSampleBlockInsertable();
+        const bool allow_materialized = query_context->getSettingsRef()[Setting::insert_allow_materialized_columns];
 
         /// Collect and sort column names for deterministic order across all entries
         /// in a batch. The flush loop indexes by position (entry_parsed_idx), so
@@ -600,15 +601,11 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
 
         for (const auto & col_name : http_col_names)
         {
-            if (!insertable_block.has(col_name))
-                throw Exception(
-                    ErrorCodes::BAD_ARGUMENTS,
-                    "http_column mapping references column '{}' which is not insertable in table '{}'. "
-                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
-                    col_name, insert_query.table_id.getFullTableName());
 
             const auto & str_value = http_header_columns.at(col_name);
-            const auto & col_type = insertable_block.getByName(col_name).type;
+            /// expandInsertQueryWithHTTPHeaderColumns already validated insertability;
+            /// here we just retrieve the type for parsing.
+            const auto & col_type = metadata->getColumns().get(col_name).type;
 
             /// Parse the header value once at push time so that type errors
             /// (e.g. "not-a-number" for UInt64) surface immediately to the client.

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -103,6 +103,7 @@ namespace ErrorCodes
     extern const int UNKNOWN_EXCEPTION;
     extern const int UNKNOWN_FORMAT;
     extern const int BAD_ARGUMENTS;
+    extern const int BAD_QUERY_PARAMETER;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SETTING_VALUE;
 }
@@ -606,7 +607,16 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             /// (e.g. "not-a-number" for UInt64) surface immediately to the client.
             /// We store only the raw string; flush time re-parses against the
             /// then-current column type, which handles schema drift naturally.
-            parseColumnValueFromString(col_type, str_value, format_settings);
+            try
+            {
+                parseColumnValueFromString(col_type, str_value, format_settings);
+            }
+            catch (const Exception & e)
+            {
+                throw Exception(ErrorCodes::BAD_QUERY_PARAMETER,
+                    "http_column parameter for column '{}' contains value '{}' that cannot be parsed as {}: {}",
+                    col_name, str_value, col_type->getName(), e.message());
+            }
             /// Store only the value; its position matches http_col_names, so the
             /// column name is recovered from the key at flush.
             entry->http_header_column_values.push_back(str_value);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -104,6 +104,7 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int INVALID_SETTING_VALUE;
+    extern const int TYPE_MISMATCH;
 }
 
 static const NameSet settings_to_skip
@@ -589,7 +590,6 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         auto table = interpreter_for_table.getTable(insert_query);
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
         const auto format_settings = getFormatSettings(query_context);
-        const bool allow_materialized = query_context->getSettingsRef()[Setting::insert_allow_materialized_columns];
 
         /// Collect and sort column names for deterministic order across all entries
         /// in a batch. The flush loop indexes by position (entry_parsed_idx), so
@@ -614,7 +614,7 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
             auto parsed = col_type->createColumn();
             ReadBufferFromString buf(str_value);
             col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
-            entry->http_header_column_values.emplace_back(col_name, std::move(parsed));
+            entry->http_header_column_values.push_back({col_name, std::move(parsed), col_type});
         }
     }
 
@@ -1391,7 +1391,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         /// batch have the same names in the same order, enforced by the batching key).
         std::unordered_map<String, size_t> injected_name_to_idx;
         for (size_t i = 0; i < first_values.size(); ++i)
-            injected_name_to_idx.emplace(first_values[i].first, i);
+            injected_name_to_idx.emplace(first_values[i].col_name, i);
 
         for (size_t i = 0; i < header.columns(); ++i)
         {
@@ -1475,11 +1475,12 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             const_cols.reserve(injected_column_infos.size());
             for (const auto & info : injected_column_infos)
             {
-                const ColumnPtr & stored_col = entry->http_header_column_values[info.entry_parsed_idx].second;
+                const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
+                const ColumnPtr & stored_col = stored.col;
                 /// Handle schema drift (ALTER TABLE ... MODIFY COLUMN during buffering):
                 /// if the push-time column type differs from the flush-time type, convert
                 /// via Field so the DEFAULT expression sees the right type.
-                if (stored_col->getDataType() != info.type->getTypeId())
+                if (!stored.push_time_type->equals(*info.type))
                 {
                     Field value;
                     stored_col->get(0, value);
@@ -1513,6 +1514,11 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     auto body_columns = executor.getResultColumns();  /// Matches format_header.
 
+    /// Track which entries are still valid after injected-column schema-drift conversion.
+    /// Entries that fail to convert are finished with an exception and excluded from the result.
+    /// Initialized to true; the injected-column loop below may set entries to false.
+    std::vector<bool> entry_valid(data->entries.size(), true);
+
     /// Build the full result matching the pipeline header by interleaving body columns
     /// (from the executor) and injected columns (pre-parsed per-entry at push time).
     MutableColumns result_columns;
@@ -1531,27 +1537,36 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
             {
                 /// Injected column: use the pre-parsed 1-row column stored at push
                 /// time — no re-parsing. For schema drift (ALTER TABLE during buffering)
-                /// fall back to Field-based conversion.
+                /// attempt Field-based conversion. Uses IDataType::equals() so parametric
+                /// changes within the same TypeIndex family (e.g. FixedString(4) -> FixedString(2))
+                /// are detected and handled; TypeIndex alone would miss such differences.
                 const auto & info = injected_column_infos[inj_idx++];
                 auto new_col = info.type->createColumn();
                 new_col->reserve(total_rows);
                 size_t ei = 0;
                 for (const auto & entry : data->entries)
                 {
-                    const ColumnPtr & stored_col = entry->http_header_column_values[info.entry_parsed_idx].second;
-                    ColumnPtr col_to_use = stored_col;
-                    if (stored_col->getDataType() != info.type->getTypeId())
+                    if (!entry_valid[ei]) { ++ei; continue; }
+                    const auto & stored = entry->http_header_column_values[info.entry_parsed_idx];
+                    ColumnPtr col_to_use = stored.col;
+                    if (!stored.push_time_type->equals(*info.type))
                     {
-                        /// Schema drift: convert the stored value to the current column
-                        /// type via Field (handles common numeric promotions; throws on
-                        /// incompatible types — same behaviour as a raw-string re-parse).
-                        Field value;
-                        stored_col->get(0, value);
-                        auto converted = info.type->createColumn();
-                        converted->insert(value);
-                        col_to_use = std::move(converted);
+                        try
+                        {
+                            Field value;
+                            stored.col->get(0, value);
+                            auto converted = info.type->createColumn();
+                            converted->insert(value);
+                            col_to_use = std::move(converted);
+                        }
+                        catch (...) // Ok: mark entry invalid; handled below after the loop
+                        {
+                            entry_valid[ei] = false;
+                        }
                     }
-                    new_col->insertManyFrom(*col_to_use, 0, entry_num_rows[ei++]);
+                    if (entry_valid[ei])
+                        new_col->insertManyFrom(*col_to_use, 0, entry_num_rows[ei]);
+                    ++ei;
                 }
                 result_columns.push_back(std::move(new_col));
             }
@@ -1561,6 +1576,51 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
                 result_columns.push_back(std::move(body_columns[body_idx++]));
             }
         }
+    }
+
+    /// Finish entries that failed schema-drift conversion and compact result columns
+    /// to exclude their rows, preserving per-entry failure isolation.
+    bool any_failed = false;
+    for (size_t ei = 0; ei < data->entries.size(); ++ei)
+        if (!entry_valid[ei]) { any_failed = true; break; }
+
+    if (any_failed)
+    {
+        size_t valid_rows = 0;
+        for (size_t ei = 0; ei < data->entries.size(); ++ei)
+            if (entry_valid[ei]) valid_rows += entry_num_rows[ei];
+
+        /// Rebuild every result column keeping only rows from valid entries.
+        for (auto & col : result_columns)
+        {
+            auto new_col = col->cloneEmpty();
+            new_col->reserve(valid_rows);
+            size_t row_offset = 0;
+            for (size_t ei = 0; ei < data->entries.size(); ++ei)
+            {
+                if (entry_valid[ei])
+                    new_col->insertRangeFrom(*col, row_offset, entry_num_rows[ei]);
+                row_offset += entry_num_rows[ei];
+            }
+            col = std::move(new_col);
+        }
+
+        /// Finish failed entries with an exception.
+        size_t ei2 = 0;
+        for (const auto & entry : data->entries)
+        {
+            if (!entry_valid[ei2] && !entry->isFinished())
+            {
+                LOG_ERROR(logger,
+                    "http_column schema drift for entry {}: type changed while buffered, entry dropped.",
+                    entry->query_id);
+                entry->finish(std::make_exception_ptr(
+                    Exception(ErrorCodes::TYPE_MISMATCH,
+                        "http_column value type changed (ALTER TABLE during async buffering)")));
+            }
+            ++ei2;
+        }
+        total_rows = valid_rows;
     }
 
     Chunk chunk(std::move(result_columns), total_rows);

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -432,14 +432,15 @@ void AsynchronousInsertQueue::preprocessInsertQuery(const ASTPtr & query, const 
     const auto & http_header_columns = query_context->getHTTPHeaderColumns();
     if (!http_header_columns.empty())
     {
-        const auto & table_columns = metadata_snapshot->getColumns();
+        const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
 
         for (const auto & [col_name, _] : http_header_columns)
         {
-            if (!table_columns.has(col_name))
+            if (!insertable_sample.has(col_name))
                 throw Exception(
                     ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-                    "http_column mapping references column '{}' which does not exist in table '{}'",
+                    "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
+                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
                     col_name, insert_query.table_id.getFullTableName());
         }
 
@@ -619,12 +620,11 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
         auto table = interpreter_for_table.getTable(insert_query);
         auto metadata = table->getInMemoryMetadataPtr(query_context, false);
         const auto format_settings = getFormatSettings(query_context);
+        const Block insertable_block = metadata->getSampleBlockInsertable();
 
-        /// Collect and sort column names so that parsed_http_header_columns has a
-        /// deterministic order across all entries in a batch. This is required because
-        /// the flush loop indexes entries by position (entry_parsed_idx), and unordered
-        /// iteration of http_header_columns (std::unordered_map) could produce different
-        /// orderings for different requests, causing cross-column value swaps.
+        /// Collect and sort column names for deterministic order across all entries
+        /// in a batch. The flush loop indexes by position (entry_parsed_idx), so
+        /// unordered NameToNameMap iteration would cause cross-column value swaps.
         http_col_names.reserve(http_header_columns.size());
         for (const auto & [col_name, _] : http_header_columns)
             http_col_names.push_back(col_name);
@@ -632,12 +632,26 @@ AsynchronousInsertQueue::PushResult AsynchronousInsertQueue::pushDataChunk(ASTPt
 
         for (const auto & col_name : http_col_names)
         {
+            if (!insertable_block.has(col_name))
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "http_column mapping references column '{}' which is not insertable in table '{}'. "
+                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
+                    col_name, insert_query.table_id.getFullTableName());
+
             const auto & str_value = http_header_columns.at(col_name);
-            const auto & col_type = metadata->getColumns().get(col_name).type;
-            auto parsed = col_type->createColumn();
-            ReadBufferFromString buf(str_value);
-            col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
-            entry->parsed_http_header_columns.emplace_back(col_name, std::move(parsed));
+            const auto & col_type = insertable_block.getByName(col_name).type;
+
+            /// Validate that the string value parses correctly against the current
+            /// column type. The parsed result is discarded; only the raw string is
+            /// stored so that a later ALTER TABLE ... MODIFY COLUMN does not break
+            /// the batch (flush time re-parses from the string using the live type).
+            {
+                auto tmp_col = col_type->createColumn();
+                ReadBufferFromString buf(str_value);
+                col_type->getDefaultSerialization()->deserializeWholeText(*tmp_col, buf, format_settings);
+            }
+            entry->http_header_column_values.emplace_back(col_name, str_value);
         }
     }
 
@@ -1400,26 +1414,27 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     /// The injected columns are appended after the executor loop.
     struct InjectedColumnInfo
     {
-        size_t header_col_idx;   /// Position in the full pipeline header.
-        size_t entry_parsed_idx; /// Position in entry->parsed_http_header_columns.
+        size_t header_col_idx = 0;   /// Position in the full pipeline header.
+        size_t entry_parsed_idx = 0; /// Position in entry->http_header_column_values.
         DataTypePtr type;
     };
     std::vector<InjectedColumnInfo> injected_column_infos;
     Block format_header;  /// Body-only block passed to the format and AddingDefaultsTransform.
-    if (!data->entries.empty() && !data->entries.front()->parsed_http_header_columns.empty())
+    if (!data->entries.empty() && !data->entries.front()->http_header_column_values.empty())
     {
-        const auto & first_parsed = data->entries.front()->parsed_http_header_columns;
+        const auto & first_values = data->entries.front()->http_header_column_values;
 
-        /// Collect injected column names for fast lookup.
-        std::unordered_map<String, size_t> injected_name_to_parsed_idx;
-        for (size_t i = 0; i < first_parsed.size(); ++i)
-            injected_name_to_parsed_idx.emplace(first_parsed[i].first, i);
+        /// Build column-name → position map for the first entry (all entries in a
+        /// batch have the same names in the same order, enforced by the batching key).
+        std::unordered_map<String, size_t> injected_name_to_idx;
+        for (size_t i = 0; i < first_values.size(); ++i)
+            injected_name_to_idx.emplace(first_values[i].first, i);
 
         for (size_t i = 0; i < header.columns(); ++i)
         {
             const auto & col_name = header.getByPosition(i).name;
-            auto it = injected_name_to_parsed_idx.find(col_name);
-            if (it != injected_name_to_parsed_idx.end())
+            auto it = injected_name_to_idx.find(col_name);
+            if (it != injected_name_to_idx.end())
                 injected_column_infos.push_back({i, it->second, header.getByPosition(i).type});
             else
                 format_header.insert(header.getByPosition(i));
@@ -1510,16 +1525,23 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         {
             if (inj_idx < injected_column_infos.size() && injected_column_infos[inj_idx].header_col_idx == col_idx)
             {
-                /// Injected column: replicate per-entry pre-parsed value.
+                /// Injected column: parse each entry's raw string against the live
+                /// flush-time column type. This survives ALTER TABLE ... MODIFY COLUMN
+                /// on a mapped column while requests are buffered.
                 const auto & info = injected_column_infos[inj_idx++];
+                const auto & serialization = info.type->getDefaultSerialization();
+                const FormatSettings fmt_settings = getFormatSettings(insert_context);
                 auto new_col = info.type->createColumn();
                 new_col->reserve(total_rows);
                 size_t ei = 0;
                 for (const auto & entry : data->entries)
                 {
-                    const auto & parsed_col = entry->parsed_http_header_columns[info.entry_parsed_idx].second;
+                    const auto & raw_value = entry->http_header_column_values[info.entry_parsed_idx].second;
+                    auto tmp_col = info.type->createColumn();
+                    ReadBufferFromString buf(raw_value);
+                    serialization->deserializeWholeText(*tmp_col, buf, fmt_settings);
                     for (size_t row = 0; row < entry_num_rows[ei++]; ++row)
-                        new_col->insertFrom(*parsed_col, 0);
+                        new_col->insertFrom(*tmp_col, 0);
                 }
                 result_columns.push_back(std::move(new_col));
             }

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1361,14 +1361,48 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     InsertData::EntryPtr current_entry;
     String current_exception;
 
-    auto format = getInputFormatFromASTInsertQuery(key.query, false, header, insert_context, nullptr);
+    /// Build a body-only header: the full pipeline header minus http_column_* columns.
+    /// The format only reads columns from the body; positional formats (TSV, CSV, etc.)
+    /// must not see the injected columns or they expect them in the body.
+    /// The injected columns are appended after the executor loop.
+    struct InjectedColumnInfo
+    {
+        size_t header_col_idx;   /// Position in the full pipeline header.
+        size_t entry_parsed_idx; /// Position in entry->parsed_http_header_columns.
+        DataTypePtr type;
+    };
+    std::vector<InjectedColumnInfo> injected_column_infos;
+    Block format_header;  /// Body-only block passed to the format and AddingDefaultsTransform.
+    if (!data->entries.empty() && !data->entries.front()->parsed_http_header_columns.empty())
+    {
+        const auto & first_parsed = data->entries.front()->parsed_http_header_columns;
+
+        /// Collect injected column names for fast lookup.
+        std::unordered_map<String, size_t> injected_name_to_parsed_idx;
+        for (size_t i = 0; i < first_parsed.size(); ++i)
+            injected_name_to_parsed_idx.emplace(first_parsed[i].first, i);
+
+        for (size_t i = 0; i < header.columns(); ++i)
+        {
+            const auto & col_name = header.getByPosition(i).name;
+            auto it = injected_name_to_parsed_idx.find(col_name);
+            if (it != injected_name_to_parsed_idx.end())
+                injected_column_infos.push_back({i, it->second, header.getByPosition(i).type});
+            else
+                format_header.insert(header.getByPosition(i));
+        }
+    }
+    if (format_header.columns() == 0 && injected_column_infos.empty())
+        format_header = header;  /// No injection: use the full header as-is.
+
+    auto format = getInputFormatFromASTInsertQuery(key.query, false, format_header, insert_context, nullptr);
     std::shared_ptr<ISimpleTransform> adding_defaults_transform;
 
     if (insert_context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields] && insert_context->hasInsertionTableColumnsDescription())
     {
         const auto & columns = *insert_context->getInsertionTableColumnsDescription();
         if (columns.hasDefaults())
-            adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(std::make_shared<const Block>(header), columns, *format, insert_context);
+            adding_defaults_transform = std::make_shared<AddingDefaultsTransform>(std::make_shared<const Block>(format_header), columns, *format, insert_context);
     }
 
     auto on_error = [&](const MutableColumns & result_columns, const ColumnCheckpoints & checkpoints, Exception & e)
@@ -1385,7 +1419,7 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
     };
 
     StreamingFormatExecutor executor(
-        header,
+        format_header,
         format,
         std::move(on_error),
         data->size_in_bytes,
@@ -1393,31 +1427,6 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         std::move(adding_defaults_transform));
 
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
-
-    /// Build a lookup: header column name → position in entry's parsed_http_header_columns
-    /// and column index in the pipeline header. Built once before the entry loop.
-    struct InjectedColumnInfo
-    {
-        size_t header_col_idx;   /// Position in the pipeline header / result_columns.
-        size_t entry_parsed_idx; /// Position in entry->parsed_http_header_columns.
-        DataTypePtr type;
-    };
-    std::vector<InjectedColumnInfo> injected_column_infos;
-    if (!data->entries.empty() && !data->entries.front()->parsed_http_header_columns.empty())
-    {
-        /// Map column names from the first entry's parsed columns to header positions.
-        /// All entries share the same column name set (enforced by the batching key).
-        const auto & first_parsed = data->entries.front()->parsed_http_header_columns;
-        for (size_t parsed_idx = 0; parsed_idx < first_parsed.size(); ++parsed_idx)
-        {
-            const auto & col_name = first_parsed[parsed_idx].first;
-            if (header.has(col_name))
-            {
-                size_t header_idx = header.getPositionByName(col_name);
-                injected_column_infos.push_back({header_idx, parsed_idx, header.getByPosition(header_idx).type});
-            }
-        }
-    }
 
     /// Track per-entry row counts for column replication after the loop.
     std::vector<size_t> entry_num_rows;
@@ -1450,25 +1459,42 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
 
     LOG_DEBUG(logger, "Processed {} rows with parsing them for {} entries", total_rows, data->entries.size());
 
-    auto result_columns = executor.getResultColumns();
+    auto body_columns = executor.getResultColumns();  /// Matches format_header.
 
-    /// Overwrite columns that were mapped from HTTP headers (http_column_* URL params).
-    /// Values were pre-parsed at push time, so just replicate per-entry.
-    if (!injected_column_infos.empty())
+    /// Build the full result matching the pipeline header by interleaving body columns
+    /// (from the executor) and injected columns (pre-parsed per-entry at push time).
+    MutableColumns result_columns;
+    if (injected_column_infos.empty())
     {
-        for (const auto & info : injected_column_infos)
+        result_columns = std::move(body_columns);
+    }
+    else
+    {
+        result_columns.reserve(header.columns());
+        size_t body_idx = 0;
+        size_t inj_idx = 0;
+        for (size_t col_idx = 0; col_idx < header.columns(); ++col_idx)
         {
-            auto new_col = info.type->createColumn();
-            new_col->reserve(total_rows);
-            size_t entry_idx = 0;
-            for (const auto & entry : data->entries)
+            if (inj_idx < injected_column_infos.size() && injected_column_infos[inj_idx].header_col_idx == col_idx)
             {
-                const auto & parsed_col = entry->parsed_http_header_columns[info.entry_parsed_idx].second;
-                size_t num_rows = entry_num_rows[entry_idx++];
-                for (size_t row = 0; row < num_rows; ++row)
-                    new_col->insertFrom(*parsed_col, 0);
+                /// Injected column: replicate per-entry pre-parsed value.
+                const auto & info = injected_column_infos[inj_idx++];
+                auto new_col = info.type->createColumn();
+                new_col->reserve(total_rows);
+                size_t ei = 0;
+                for (const auto & entry : data->entries)
+                {
+                    const auto & parsed_col = entry->parsed_http_header_columns[info.entry_parsed_idx].second;
+                    for (size_t row = 0; row < entry_num_rows[ei++]; ++row)
+                        new_col->insertFrom(*parsed_col, 0);
+                }
+                result_columns.push_back(std::move(new_col));
             }
-            result_columns[info.header_col_idx] = std::move(new_col);
+            else
+            {
+                /// Body column: take directly from the executor result.
+                result_columns.push_back(std::move(body_columns[body_idx++]));
+            }
         }
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -98,6 +98,10 @@ public:
         std::unique_ptr<Settings> settings;
 
         AsynchronousInsertQueueDataKind data_kind;
+        /// Column names injected from HTTP headers via http_column_* URL params.
+        /// Part of the batching key so that requests with header-mapped columns
+        /// are never coalesced with requests that provide those columns in the body.
+        Names http_header_column_names;
         UInt128 hash{};
 
         InsertQuery(
@@ -108,7 +112,8 @@ public:
             const String & initial_user_,
             const String & authenticated_user_,
             const Settings & settings_,
-            AsynchronousInsertQueueDataKind data_kind_);
+            AsynchronousInsertQueueDataKind data_kind_,
+            Names http_header_column_names_ = {});
 
         InsertQuery(const InsertQuery & other);
         InsertQuery & operator=(const InsertQuery & other);
@@ -116,7 +121,7 @@ public:
         StorageID getStorageID() const;
 
     private:
-        auto toTupleCmp() const { return std::tie(data_kind, query_str, user_id, current_roles, current_user, initial_user, authenticated_user, setting_changes); }
+        auto toTupleCmp() const { return std::tie(data_kind, query_str, user_id, current_roles, current_user, initial_user, authenticated_user, setting_changes, http_header_column_names); }
 
         std::vector<SettingChange> setting_changes;
     };
@@ -171,7 +176,10 @@ private:
             MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
             NameToNameMap query_parameters;
-            NameToNameMap http_header_columns;  /// column_name -> header_value, from http_column_* URL params
+            /// Pre-parsed single-row columns from http_column_* URL params.
+            /// Parsed at push time so type errors surface immediately to the client.
+            /// At flush time the values are just replicated for each entry's row count.
+            std::vector<std::pair<String, ColumnPtr>> parsed_http_header_columns;
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -180,7 +180,10 @@ private:
             /// 1-row typed columns in sorted column-name order. Parsed once at push time
             /// so type errors surface immediately to the client. At flush time the stored
             /// column is used directly, avoiding per-entry re-parsing.
-            struct HTTPHeaderColumnValue { String col_name; ColumnPtr col; DataTypePtr push_time_type; };
+            /// Raw header value stored at push time; parsed against the current column
+            /// type at flush time so schema drift is handled naturally without any
+            /// explicit drift detection or round-trip re-serialization.
+            struct HTTPHeaderColumnValue { String col_name; String raw_value; };
             std::vector<HTTPHeaderColumnValue> http_header_column_values;
 
             Entry(

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -336,6 +336,7 @@ private:
 
     template <typename LogFunc>
     static Chunk processPreprocessedEntries(
+        const InsertQuery & key,
         const InsertDataPtr & data,
         const Block & header,
         const ContextPtr & context_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -176,15 +176,15 @@ private:
             MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
             NameToNameMap query_parameters;
-            /// HTTP header values from http_column_* URL params, stored as pre-parsed
-            /// 1-row typed columns in sorted column-name order. Parsed once at push time
-            /// so type errors surface immediately to the client. At flush time the stored
-            /// column is used directly, avoiding per-entry re-parsing.
-            /// Raw header value stored at push time; parsed against the current column
-            /// type at flush time so schema drift is handled naturally without any
-            /// explicit drift detection or round-trip re-serialization.
-            struct HTTPHeaderColumnValue { String col_name; String raw_value; };
-            std::vector<HTTPHeaderColumnValue> http_header_column_values;
+            /// Raw HTTP header values for the injected columns, positionally aligned
+            /// to InsertQuery::http_header_column_names. Both are kept in URL parameter
+            /// declaration order (the order the http_column_* params appear in the
+            /// request URL). Declaration order defines the batch key: two requests with
+            /// the same mappings in different URL order land in different batches. This
+            /// is intentional — declaration order is stable per client and avoids a sort
+            /// on every push. The injected column set is part of the batch key, so it is
+            /// the same for every entry in a batch and need not be stored per entry.
+            std::vector<String> http_header_column_values;
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -176,10 +176,12 @@ private:
             MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
             NameToNameMap query_parameters;
-            /// Pre-parsed single-row columns from http_column_* URL params.
-            /// Parsed at push time so type errors surface immediately to the client.
-            /// At flush time the values are just replicated for each entry's row count.
-            std::vector<std::pair<String, ColumnPtr>> parsed_http_header_columns;
+            /// HTTP header values from http_column_* URL params, stored as raw strings
+            /// in sorted column-name order. Validated (parsed + discarded) at push time
+            /// so type errors surface immediately. Re-parsed at flush time against the
+            /// live table schema so that ALTER TABLE ... MODIFY COLUMN during buffering
+            /// does not break the batch.
+            std::vector<std::pair<String, String>> http_header_column_values;
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -180,7 +180,8 @@ private:
             /// 1-row typed columns in sorted column-name order. Parsed once at push time
             /// so type errors surface immediately to the client. At flush time the stored
             /// column is used directly, avoiding per-entry re-parsing.
-            std::vector<std::pair<String, ColumnPtr>> http_header_column_values;
+            struct HTTPHeaderColumnValue { String col_name; ColumnPtr col; DataTypePtr push_time_type; };
+            std::vector<HTTPHeaderColumnValue> http_header_column_values;
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -176,12 +176,11 @@ private:
             MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
             NameToNameMap query_parameters;
-            /// HTTP header values from http_column_* URL params, stored as raw strings
-            /// in sorted column-name order. Validated (parsed + discarded) at push time
-            /// so type errors surface immediately. Re-parsed at flush time against the
-            /// live table schema so that ALTER TABLE ... MODIFY COLUMN during buffering
-            /// does not break the batch.
-            std::vector<std::pair<String, String>> http_header_column_values;
+            /// HTTP header values from http_column_* URL params, stored as pre-parsed
+            /// 1-row typed columns in sorted column-name order. Parsed once at push time
+            /// so type errors surface immediately to the client. At flush time the stored
+            /// column is used directly, avoiding per-entry re-parsing.
+            std::vector<std::pair<String, ColumnPtr>> http_header_column_values;
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/AsynchronousInsertQueue.h
+++ b/src/Interpreters/AsynchronousInsertQueue.h
@@ -171,6 +171,7 @@ private:
             MemoryTracker * const user_memory_tracker;
             const std::chrono::time_point<std::chrono::system_clock> create_time;
             NameToNameMap query_parameters;
+            NameToNameMap http_header_columns;  /// column_name -> header_value, from http_column_* URL params
 
             Entry(
                 DataChunk && chunk_,

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -7454,19 +7454,19 @@ void Context::addQueryParameters(const NameToNameMap & parameters)
         query_parameters.insert_or_assign(name, value);
 }
 
-const NameToNameMap & Context::getHTTPHeaderColumns() const
+const HTTPHeaderColumns & Context::getHTTPHeaderColumns() const
 {
     return http_header_columns;
 }
 
-void Context::setHTTPHeaderColumns(NameToNameMap mapping)
+void Context::setHTTPHeaderColumns(HTTPHeaderColumns mapping)
 {
     http_header_columns = std::move(mapping);
 }
 
 void Context::addHTTPHeaderColumn(const String & column_name, const String & header_value)
 {
-    http_header_columns.emplace(column_name, header_value);  /// first wins; emplace is a no-op on duplicate key
+    http_header_columns.add(column_name, header_value);
 }
 
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1352,7 +1352,9 @@ ContextData::ContextData(const ContextData &o) :
     runtime_filter_lookup(o.runtime_filter_lookup),
     kitchen_sink(o.kitchen_sink),
     query_parameters(o.query_parameters),
-    http_header_columns(o.http_header_columns),
+    /// http_header_columns intentionally not copied: they are request-scoped
+    /// (set by the HTTP handler from URL params) and must not bleed into
+    /// sub-contexts such as distributed local shard execution.
     host_context(o.host_context),
     metadata_transaction(o.metadata_transaction),
     merge_tree_transaction(o.merge_tree_transaction),

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1352,6 +1352,7 @@ ContextData::ContextData(const ContextData &o) :
     runtime_filter_lookup(o.runtime_filter_lookup),
     kitchen_sink(o.kitchen_sink),
     query_parameters(o.query_parameters),
+    http_header_columns(o.http_header_columns),
     host_context(o.host_context),
     metadata_transaction(o.metadata_transaction),
     merge_tree_transaction(o.merge_tree_transaction),
@@ -7461,6 +7462,11 @@ const NameToNameMap & Context::getHTTPHeaderColumns() const
 void Context::setHTTPHeaderColumns(NameToNameMap mapping)
 {
     http_header_columns = std::move(mapping);
+}
+
+void Context::addHTTPHeaderColumn(const String & column_name, const String & header_value)
+{
+    http_header_columns.emplace(column_name, header_value);  /// first wins; emplace is a no-op on duplicate key
 }
 
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -7453,6 +7453,16 @@ void Context::addQueryParameters(const NameToNameMap & parameters)
         query_parameters.insert_or_assign(name, value);
 }
 
+const NameToNameMap & Context::getHTTPHeaderColumns() const
+{
+    return http_header_columns;
+}
+
+void Context::setHTTPHeaderColumns(NameToNameMap mapping)
+{
+    http_header_columns = std::move(mapping);
+}
+
 
 IHostContextPtr & Context::getHostContext()
 {

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -2,6 +2,7 @@
 
 #include <base/types.h>
 #include <Core/Block_fwd.h>
+#include <Core/HTTPHeaderColumns.h>
 #include <Common/Exception.h>
 #include <Common/MultiVersion.h>
 #include <Common/ThreadPool_fwd.h>
@@ -682,9 +683,9 @@ protected:
     NameToNameMap query_parameters;   /// Dictionary with query parameters for prepared statements.
                                                      /// (key=name, value)
 
-    NameToNameMap http_header_columns;  /// HTTP header values mapped to INSERT columns via
-                                        /// http_column_<Header>=<column> URL params.
-                                        /// (key=column_name, value=header_value)
+    HTTPHeaderColumns http_header_columns;  /// HTTP header values mapped to INSERT columns via
+                                            /// http_column_<Header>=<column> URL params, kept in
+                                            /// declaration order (first declaration wins per column).
 
     IHostContextPtr host_context;  /// Arbitrary object that may used to attach some host specific information to query context,
                                    /// when using ClickHouse as a library in some project. For example, it may contain host
@@ -1810,8 +1811,8 @@ public:
     void addQueryParameters(const NameToNameMap & parameters);
 
     /// HTTP header-to-column mappings for INSERT (set by http_column_* URL params).
-    const NameToNameMap & getHTTPHeaderColumns() const;
-    void setHTTPHeaderColumns(NameToNameMap mapping);
+    const HTTPHeaderColumns & getHTTPHeaderColumns() const;
+    void setHTTPHeaderColumns(HTTPHeaderColumns mapping);
     /// Add one mapping; first occurrence wins (duplicates silently ignored).
     void addHTTPHeaderColumn(const String & column_name, const String & header_value);
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -682,6 +682,10 @@ protected:
     NameToNameMap query_parameters;   /// Dictionary with query parameters for prepared statements.
                                                      /// (key=name, value)
 
+    NameToNameMap http_header_columns;  /// HTTP header values mapped to INSERT columns via
+                                        /// http_column_<Header>=<column> URL params.
+                                        /// (key=column_name, value=header_value)
+
     IHostContextPtr host_context;  /// Arbitrary object that may used to attach some host specific information to query context,
                                    /// when using ClickHouse as a library in some project. For example, it may contain host
                                    /// logger, some query identification information, profiling guards, etc. This field is
@@ -1804,6 +1808,10 @@ public:
 
     /// Overrides values of existing parameters.
     void addQueryParameters(const NameToNameMap & parameters);
+
+    /// HTTP header-to-column mappings for INSERT (set by http_column_* URL params).
+    const NameToNameMap & getHTTPHeaderColumns() const;
+    void setHTTPHeaderColumns(NameToNameMap mapping);
 
 
     IHostContextPtr & getHostContext();

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1812,6 +1812,8 @@ public:
     /// HTTP header-to-column mappings for INSERT (set by http_column_* URL params).
     const NameToNameMap & getHTTPHeaderColumns() const;
     void setHTTPHeaderColumns(NameToNameMap mapping);
+    /// Add one mapping; first occurrence wins (duplicates silently ignored).
+    void addHTTPHeaderColumn(const String & column_name, const String & header_value);
 
 
     IHostContextPtr & getHostContext();

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -755,6 +755,46 @@ std::optional<QueryPipeline> InterpreterInsertQuery::buildInsertSelectPipelinePa
 }
 
 
+void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
+    ASTInsertQuery & query,
+    const StorageMetadataPtr & metadata_snapshot,
+    const NameToNameMap & http_header_columns)
+{
+    const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
+
+    for (const auto & [col_name, _] : http_header_columns)
+    {
+        if (!insertable_sample.has(col_name))
+            throw Exception(
+                ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
+                "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
+                "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
+                col_name, query.table_id.getFullTableName());
+    }
+
+    /// Only modify the explicit column list when the user provided one.
+    /// A null list means \"all table columns\": getSampleBlock already returns the
+    /// full schema including the http_column columns, so no modification is needed.
+    if (query.columns)
+    {
+        NameSet existing_columns;
+        for (const auto & child : query.columns->children)
+            existing_columns.insert(child->getColumnName());
+
+        for (const auto & [col_name, _] : http_header_columns)
+        {
+            if (existing_columns.contains(col_name))
+                throw Exception(
+                    ErrorCodes::DUPLICATE_COLUMN,
+                    "http_column mapping conflicts with column '{}' already listed in the INSERT column list. "
+                    "A column must come from either the request body or an HTTP header, not both.",
+                    col_name);
+            query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+        }
+    }
+}
+
+
 QueryPipeline InterpreterInsertQuery::buildInsertPipeline(ASTInsertQuery & query, StoragePtr table)
 {
     auto context = getContext();
@@ -1087,39 +1127,7 @@ BlockIO InterpreterInsertQuery::execute()
                 "http_column_* URL parameters are not supported with INSERT ... SELECT. "
                 "Use getClientHTTPHeader() in the SELECT clause instead");
 
-        const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
-
-        for (const auto & [col_name, _] : http_header_columns)
-        {
-            if (!insertable_sample.has(col_name))
-                throw Exception(
-                    ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-                    "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
-                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
-                    col_name, query.table_id.getFullTableName());
-        }
-
-        /// When the user provides an explicit column list, the http_column columns must not
-        /// appear in it: a column must come from either the body or a header, not both.
-        /// When query.columns is null (all table columns), getSampleBlock already returns the
-        /// full schema including the http_column columns, so no modification is needed.
-        if (query.columns)
-        {
-            NameSet existing_columns;
-            for (const auto & child : query.columns->children)
-                existing_columns.insert(child->getColumnName());
-
-            for (const auto & [col_name, _] : http_header_columns)
-            {
-                if (existing_columns.contains(col_name))
-                    throw Exception(
-                        ErrorCodes::DUPLICATE_COLUMN,
-                        "http_column mapping conflicts with column '{}' already listed in the INSERT column list. "
-                        "A column must come from either the request body or an HTTP header, not both.",
-                        col_name);
-                query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
-            }
-        }
+        expandInsertQueryWithHTTPHeaderColumns(query, metadata_snapshot, http_header_columns);
     }
 
     auto query_sample_block = getSampleBlock(query, table, metadata_snapshot, context, no_destination, allow_materialized);

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -783,11 +783,31 @@ void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
                     : " (MATERIALIZED columns require insert_allow_materialized_columns=1)");
     }
 
-    /// Only modify the explicit column list when the user provided one.
-    /// A null list means \"all table columns\": getSampleBlock already returns the
-    /// full schema including the http_column columns, so no modification is needed.
-    if (query.columns)
+    if (!query.columns)
     {
+        /// No explicit column list. Synthesize one with all insertable body columns
+        /// (minus the http_column_*-mapped ones) followed by the mapped columns.
+        /// This enforces the "body or header, not both" invariant consistently with
+        /// the explicit-list path: the format only ever sees the body columns, so a
+        /// body field matching a mapped column is treated as unknown by the format
+        /// regardless of input_format_skip_unknown_fields.
+        query.columns = make_intrusive<ASTExpressionList>();
+        for (const auto & col : columns_desc)
+        {
+            if (http_header_columns.contains(col.name))
+                continue;
+            const auto kind = col.default_desc.kind;
+            const bool is_body_col = (kind == ColumnDefaultKind::Default || kind == ColumnDefaultKind::Ephemeral)
+                || (allow_materialized && kind == ColumnDefaultKind::Materialized);
+            if (is_body_col)
+                query.columns->children.push_back(make_intrusive<ASTIdentifier>(col.name));
+        }
+        for (const auto & [col_name, _] : http_header_columns)
+            query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+    }
+    else
+    {
+        /// Explicit list: check for conflicts and append mapped columns.
         NameSet existing_columns;
         for (const auto & child : query.columns->children)
             existing_columns.insert(child->getColumnName());

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -1064,6 +1064,14 @@ BlockIO InterpreterInsertQuery::execute()
     const auto & http_header_columns = context->getHTTPHeaderColumns();
     if (!http_header_columns.empty())
     {
+        /// http_column_* is only supported for pure FORMAT inserts.
+        /// INSERT ... SELECT already has getClientHTTPHeader for reading headers.
+        if (query.select)
+            throw Exception(
+                ErrorCodes::NOT_IMPLEMENTED,
+                "http_column_* URL parameters are not supported with INSERT ... SELECT. "
+                "Use getClientHTTPHeader() in the SELECT clause instead");
+
         const auto & table_columns = metadata_snapshot->getColumns();
         if (!query.columns)
             query.columns = make_intrusive<ASTExpressionList>();

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -769,7 +769,7 @@ void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
             throw Exception(
                 ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
                 "http_column mapping references column '{}' which does not exist in table '{}'.",
-                col_name, query.table_id.getFullTableName());
+                col_name, query.table_id.empty() ? "(table function)" : query.table_id.getFullTableName());
 
         const auto kind = columns_desc.get(col_name).default_desc.kind;
         const bool insertable = (kind == ColumnDefaultKind::Default || kind == ColumnDefaultKind::Ephemeral)
@@ -778,7 +778,7 @@ void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
             throw Exception(
                 ErrorCodes::ILLEGAL_COLUMN,
                 "http_column mapping references column '{}' in table '{}' which is not insertable{}.",
-                col_name, query.table_id.getFullTableName(),
+                col_name, query.table_id.empty() ? "(table function)" : query.table_id.getFullTableName(),
                 kind == ColumnDefaultKind::Alias ? " (ALIAS columns are never insertable)"
                     : " (MATERIALIZED columns require insert_allow_materialized_columns=1)");
     }

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -11,6 +11,7 @@
 #include <Core/ServerSettings.h>
 #include <Core/DeduplicateInsert.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <Formats/FormatFactory.h>
 #include <Interpreters/ApplyWithAliasVisitor.h>
 #include <Interpreters/ApplyWithSubqueryVisitor.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -835,14 +836,26 @@ QueryPipeline InterpreterInsertQuery::buildInsertPipeline(ASTInsertQuery & query
                 chain.getInputSharedHeader()));
     }
 
-    /// For http_column_* mappings: inject a transform that replaces the mapped columns
-    /// with the HTTP header values from the originating request. For the sync path all
-    /// rows share the same header values, so one constant-fill transform suffices.
+    /// For http_column_* mappings: inject an expanding transform that adds the http_column
+    /// columns to the block before addMissingDefaults sees it. addMissingDefaults then
+    /// treats these columns as client-provided and skips evaluating their DEFAULT expressions.
+    /// The transform uses a body-only input header so positional formats (TSV, CSV, Values)
+    /// only see the columns present in the body, not the injected ones.
     const auto & http_header_columns = context->getHTTPHeaderColumns();
     if (!http_header_columns.empty())
     {
+        /// full_header: what the chain expects (body cols + http_column cols).
+        /// format_header: body-only block that the format source will produce.
+        const Block & full_header = *chain.getInputSharedHeader();
+        Block format_header;
+        for (size_t i = 0; i < full_header.columns(); ++i)
+        {
+            const auto & col = full_header.getByPosition(i);
+            if (!http_header_columns.contains(col.name))
+                format_header.insert(col);
+        }
         chain.addSource(std::make_shared<HTTPHeaderColumnsTransform>(
-            *chain.getInputSharedHeader(), http_header_columns));
+            format_header, full_header, http_header_columns, getFormatSettings(context)));
     }
 
     auto counting = std::make_shared<CountingTransform>(chain.getInputSharedHeader(), context->getQuota(), context->getNormalizedQueryHash());
@@ -862,7 +875,9 @@ QueryPipeline InterpreterInsertQuery::buildInsertPipeline(ASTInsertQuery & query
 
     if (query.hasInlinedData() && !async_insert)
     {
-        auto format = getInputFormatFromASTInsertQuery(query_ptr, true, *query_sample_block, context, nullptr);
+        /// Use the pipeline's current input header (body-only after HTTPHeaderColumnsTransform
+        /// was added above) so that the format source produces only body columns.
+        auto format = getInputFormatFromASTInsertQuery(query_ptr, true, *pipeline.getSharedHeader(), context, nullptr);
 
         if (settings[Setting::enable_parsing_to_custom_serialization])
             format->setSerializationHints(table->getSerializationHints());

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -25,6 +25,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/InsertDependenciesBuilder.h>
 #include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTInsertQuery.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/ASTSelectWithUnionQuery.h>
@@ -36,6 +37,7 @@
 #include <Processors/Transforms/PlanSquashingTransform.h>
 #include <Processors/Transforms/ApplySquashingTransform.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
+#include <Processors/Transforms/HTTPHeaderColumnsTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
@@ -833,6 +835,16 @@ QueryPipeline InterpreterInsertQuery::buildInsertPipeline(ASTInsertQuery & query
                 chain.getInputSharedHeader()));
     }
 
+    /// For http_column_* mappings: inject a transform that replaces the mapped columns
+    /// with the HTTP header values from the originating request. For the sync path all
+    /// rows share the same header values, so one constant-fill transform suffices.
+    const auto & http_header_columns = context->getHTTPHeaderColumns();
+    if (!http_header_columns.empty())
+    {
+        chain.addSource(std::make_shared<HTTPHeaderColumnsTransform>(
+            *chain.getInputSharedHeader(), http_header_columns));
+    }
+
     auto counting = std::make_shared<CountingTransform>(chain.getInputSharedHeader(), context->getQuota(), context->getNormalizedQueryHash());
     counting->setProcessListElement(context->getProcessListElement());
     counting->setProgressCallback(context->getProgressCallback());
@@ -1043,6 +1055,35 @@ BlockIO InterpreterInsertQuery::execute()
 
     table->updateExternalDynamicMetadataIfExists(context);
     auto metadata_snapshot = table->getInMemoryMetadataPtr(context, false);
+
+    /// If http_column_* URL params mapped HTTP headers to column names, add those
+    /// columns to the INSERT's column list so getSampleBlock includes them in the
+    /// pipeline header. This tells the pipeline that these columns are client-provided,
+    /// skipping DEFAULT expressions. For the sync path the actual values are injected
+    /// via a transform added in buildInsertPipeline.
+    const auto & http_header_columns = context->getHTTPHeaderColumns();
+    if (!http_header_columns.empty())
+    {
+        const auto & table_columns = metadata_snapshot->getColumns();
+        if (!query.columns)
+            query.columns = make_intrusive<ASTExpressionList>();
+
+        NameSet existing_columns;
+        for (const auto & child : query.columns->children)
+            existing_columns.insert(child->getColumnName());
+
+        for (const auto & [col_name, _] : http_header_columns)
+        {
+            if (!table_columns.has(col_name))
+                throw Exception(
+                    ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
+                    "http_column mapping references column '{}' which does not exist in table '{}'",
+                    col_name, query.table_id.getFullTableName());
+            if (!existing_columns.contains(col_name))
+                query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+        }
+    }
+
     auto query_sample_block = getSampleBlock(query, table, metadata_snapshot, context, no_destination, allow_materialized);
     /// For table functions we check access while executing
     /// getTable() -> ITableFunction::execute().

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -758,18 +758,29 @@ std::optional<QueryPipeline> InterpreterInsertQuery::buildInsertSelectPipelinePa
 void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
     ASTInsertQuery & query,
     const StorageMetadataPtr & metadata_snapshot,
-    const NameToNameMap & http_header_columns)
+    const NameToNameMap & http_header_columns,
+    bool allow_materialized)
 {
-    const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
+    const auto & columns_desc = metadata_snapshot->getColumns();
 
     for (const auto & [col_name, _] : http_header_columns)
     {
-        if (!insertable_sample.has(col_name))
+        if (!columns_desc.has(col_name))
             throw Exception(
                 ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-                "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
-                "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
+                "http_column mapping references column '{}' which does not exist in table '{}'.",
                 col_name, query.table_id.getFullTableName());
+
+        const auto kind = columns_desc.get(col_name).default_desc.kind;
+        const bool insertable = (kind == ColumnDefaultKind::Default || kind == ColumnDefaultKind::Ephemeral)
+            || (allow_materialized && kind == ColumnDefaultKind::Materialized);
+        if (!insertable)
+            throw Exception(
+                ErrorCodes::ILLEGAL_COLUMN,
+                "http_column mapping references column '{}' in table '{}' which is not insertable{}.",
+                col_name, query.table_id.getFullTableName(),
+                kind == ColumnDefaultKind::Alias ? " (ALIAS columns are never insertable)"
+                    : " (MATERIALIZED columns require insert_allow_materialized_columns=1)");
     }
 
     /// Only modify the explicit column list when the user provided one.
@@ -1127,7 +1138,7 @@ BlockIO InterpreterInsertQuery::execute()
                 "http_column_* URL parameters are not supported with INSERT ... SELECT. "
                 "Use getClientHTTPHeader() in the SELECT clause instead");
 
-        expandInsertQueryWithHTTPHeaderColumns(query, metadata_snapshot, http_header_columns);
+        expandInsertQueryWithHTTPHeaderColumns(query, metadata_snapshot, http_header_columns, allow_materialized);
     }
 
     auto query_sample_block = getSampleBlock(query, table, metadata_snapshot, context, no_destination, allow_materialized);

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -837,6 +837,9 @@ QueryPipeline InterpreterInsertQuery::buildInsertPipeline(ASTInsertQuery & query
     {
         auto mutable_context = Context::createCopy(context);
         mutable_context->setSetting("enable_parallel_replicas", Field{0});
+        /// http_header_columns are request-scoped and not copied by createCopy;
+        /// restore them explicitly so HTTPHeaderColumnsTransform is still added.
+        mutable_context->setHTTPHeaderColumns(context->getHTTPHeaderColumns());
         context = mutable_context;
     }
 

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -1088,12 +1088,6 @@ BlockIO InterpreterInsertQuery::execute()
                 "Use getClientHTTPHeader() in the SELECT clause instead");
 
         const auto & table_columns = metadata_snapshot->getColumns();
-        if (!query.columns)
-            query.columns = make_intrusive<ASTExpressionList>();
-
-        NameSet existing_columns;
-        for (const auto & child : query.columns->children)
-            existing_columns.insert(child->getColumnName());
 
         for (const auto & [col_name, _] : http_header_columns)
         {
@@ -1102,8 +1096,28 @@ BlockIO InterpreterInsertQuery::execute()
                     ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
                     "http_column mapping references column '{}' which does not exist in table '{}'",
                     col_name, query.table_id.getFullTableName());
-            if (!existing_columns.contains(col_name))
+        }
+
+        /// When the user provides an explicit column list, the http_column columns must not
+        /// appear in it: a column must come from either the body or a header, not both.
+        /// When query.columns is null (all table columns), getSampleBlock already returns the
+        /// full schema including the http_column columns, so no modification is needed.
+        if (query.columns)
+        {
+            NameSet existing_columns;
+            for (const auto & child : query.columns->children)
+                existing_columns.insert(child->getColumnName());
+
+            for (const auto & [col_name, _] : http_header_columns)
+            {
+                if (existing_columns.contains(col_name))
+                    throw Exception(
+                        ErrorCodes::DUPLICATE_COLUMN,
+                        "http_column mapping conflicts with column '{}' already listed in the INSERT column list. "
+                        "A column must come from either the request body or an HTTP header, not both.",
+                        col_name);
                 query.columns->children.push_back(make_intrusive<ASTIdentifier>(col_name));
+            }
         }
     }
 

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -758,7 +758,7 @@ std::optional<QueryPipeline> InterpreterInsertQuery::buildInsertSelectPipelinePa
 void InterpreterInsertQuery::expandInsertQueryWithHTTPHeaderColumns(
     ASTInsertQuery & query,
     const StorageMetadataPtr & metadata_snapshot,
-    const NameToNameMap & http_header_columns,
+    const HTTPHeaderColumns & http_header_columns,
     bool allow_materialized)
 {
     const auto & columns_desc = metadata_snapshot->getColumns();

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -1087,14 +1087,15 @@ BlockIO InterpreterInsertQuery::execute()
                 "http_column_* URL parameters are not supported with INSERT ... SELECT. "
                 "Use getClientHTTPHeader() in the SELECT clause instead");
 
-        const auto & table_columns = metadata_snapshot->getColumns();
+        const Block insertable_sample = metadata_snapshot->getSampleBlockInsertable();
 
         for (const auto & [col_name, _] : http_header_columns)
         {
-            if (!table_columns.has(col_name))
+            if (!insertable_sample.has(col_name))
                 throw Exception(
                     ErrorCodes::NO_SUCH_COLUMN_IN_TABLE,
-                    "http_column mapping references column '{}' which does not exist in table '{}'",
+                    "http_column mapping references column '{}' which does not exist or is not insertable in table '{}'. "
+                    "MATERIALIZED, ALIAS and other non-insertable columns are not supported.",
                     col_name, query.table_id.getFullTableName());
         }
 

--- a/src/Interpreters/InterpreterInsertQuery.h
+++ b/src/Interpreters/InterpreterInsertQuery.h
@@ -65,7 +65,8 @@ public:
     static void expandInsertQueryWithHTTPHeaderColumns(
         ASTInsertQuery & query,
         const StorageMetadataPtr & metadata_snapshot,
-        const NameToNameMap & http_header_columns);
+        const NameToNameMap & http_header_columns,
+        bool allow_materialized = false);
 
     static void setInsertContextValues(ContextMutablePtr context_, const ASTInsertQuery & insert_query, const StoragePtr & table);
 

--- a/src/Interpreters/InterpreterInsertQuery.h
+++ b/src/Interpreters/InterpreterInsertQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Names.h>
 #include <QueryPipeline/BlockIO.h>
 #include <IO/ReadBuffer.h>
 #include <Interpreters/IInterpreter.h>
@@ -56,6 +57,15 @@ public:
     bool supportsTransactions() const override { return true; }
 
     static bool shouldAddSquashingForStorage(const StoragePtr & table, ContextPtr context);
+
+    /// Validates http_column_* mappings against the table schema and, when the INSERT
+    /// has an explicit column list, appends the mapped column names to it so that
+    /// getSampleBlock includes them in the pipeline header (treating them as client-provided).
+    /// Throws if any mapped column is non-insertable or conflicts with the explicit list.
+    static void expandInsertQueryWithHTTPHeaderColumns(
+        ASTInsertQuery & query,
+        const StorageMetadataPtr & metadata_snapshot,
+        const NameToNameMap & http_header_columns);
 
     static void setInsertContextValues(ContextMutablePtr context_, const ASTInsertQuery & insert_query, const StoragePtr & table);
 

--- a/src/Interpreters/InterpreterInsertQuery.h
+++ b/src/Interpreters/InterpreterInsertQuery.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/HTTPHeaderColumns.h>
 #include <Core/Names.h>
 #include <QueryPipeline/BlockIO.h>
 #include <IO/ReadBuffer.h>
@@ -65,7 +66,7 @@ public:
     static void expandInsertQueryWithHTTPHeaderColumns(
         ASTInsertQuery & query,
         const StorageMetadataPtr & metadata_snapshot,
-        const NameToNameMap & http_header_columns,
+        const HTTPHeaderColumns & http_header_columns,
         bool allow_materialized = false);
 
     static void setInsertContextValues(ContextMutablePtr context_, const ASTInsertQuery & insert_query, const StoragePtr & table);

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -1,3 +1,4 @@
+#include <Columns/ColumnConst.h>
 #include <Columns/IColumn.h>
 #include <Processors/Executors/StreamingFormatExecutor.h>
 #include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
@@ -153,12 +154,7 @@ size_t StreamingFormatExecutor::insertChunk(Chunk chunk, size_t num_bytes)
             /// column positions match the BlockMissingValues indices from the format.
             auto cols = chunk.detachColumns();
             for (const auto & const_col : constant_cols_for_defaults)
-            {
-                auto full_col = const_col->cloneEmpty();
-                for (size_t row = 0; row < chunk_rows; ++row)
-                    full_col->insertFrom(*const_col, 0);
-                cols.push_back(std::move(full_col));
-            }
+                cols.push_back(ColumnConst::create(const_col, chunk_rows));
             chunk.setColumns(std::move(cols), chunk_rows);
             adding_defaults_transform->transform(chunk);
 

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -1,4 +1,3 @@
-#include <Columns/ColumnConst.h>
 #include <Columns/IColumn.h>
 #include <Processors/Executors/StreamingFormatExecutor.h>
 #include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
@@ -144,30 +143,7 @@ size_t StreamingFormatExecutor::insertChunk(Chunk chunk, size_t num_bytes)
 {
     size_t chunk_rows = chunk.getNumRows();
     if (adding_defaults_transform)
-    {
-        if (!constant_cols_for_defaults.empty())
-        {
-            /// Temporarily append the per-entry injected constant columns so that
-            /// AddingDefaultsTransform can evaluate DEFAULT expressions that reference
-            /// them (e.g. `b DEFAULT a + 1` where `a` comes from an HTTP header).
-            /// The injected columns are appended AFTER body columns so that body
-            /// column positions match the BlockMissingValues indices from the format.
-            auto cols = chunk.detachColumns();
-            for (const auto & const_col : constant_cols_for_defaults)
-                cols.push_back(ColumnConst::create(const_col, chunk_rows));
-            chunk.setColumns(std::move(cols), chunk_rows);
-            adding_defaults_transform->transform(chunk);
-
-            /// Strip the injected columns back out before accumulation.
-            auto result_cols = chunk.detachColumns();
-            result_cols.resize(result_cols.size() - constant_cols_for_defaults.size());
-            chunk.setColumns(std::move(result_cols), chunk_rows);
-        }
-        else
-        {
-            adding_defaults_transform->transform(chunk);
-        }
-    }
+        adding_defaults_transform->transform(chunk);
 
     preallocateResultColumns(num_bytes, chunk);
 

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -143,7 +143,35 @@ size_t StreamingFormatExecutor::insertChunk(Chunk chunk, size_t num_bytes)
 {
     size_t chunk_rows = chunk.getNumRows();
     if (adding_defaults_transform)
-        adding_defaults_transform->transform(chunk);
+    {
+        if (!constant_cols_for_defaults.empty())
+        {
+            /// Temporarily append the per-entry injected constant columns so that
+            /// AddingDefaultsTransform can evaluate DEFAULT expressions that reference
+            /// them (e.g. `b DEFAULT a + 1` where `a` comes from an HTTP header).
+            /// The injected columns are appended AFTER body columns so that body
+            /// column positions match the BlockMissingValues indices from the format.
+            auto cols = chunk.detachColumns();
+            for (const auto & const_col : constant_cols_for_defaults)
+            {
+                auto full_col = const_col->cloneEmpty();
+                for (size_t row = 0; row < chunk_rows; ++row)
+                    full_col->insertFrom(*const_col, 0);
+                cols.push_back(std::move(full_col));
+            }
+            chunk.setColumns(std::move(cols), chunk_rows);
+            adding_defaults_transform->transform(chunk);
+
+            /// Strip the injected columns back out before accumulation.
+            auto result_cols = chunk.detachColumns();
+            result_cols.resize(result_cols.size() - constant_cols_for_defaults.size());
+            chunk.setColumns(std::move(result_cols), chunk_rows);
+        }
+        else
+        {
+            adding_defaults_transform->transform(chunk);
+        }
+    }
 
     preallocateResultColumns(num_bytes, chunk);
 

--- a/src/Processors/Executors/StreamingFormatExecutor.h
+++ b/src/Processors/Executors/StreamingFormatExecutor.h
@@ -44,14 +44,6 @@ public:
     /// Sets query parameters for input format if applicable.
     void setQueryParameters(const NameToNameMap & parameters);
 
-    /// Sets per-entry constant columns that are temporarily appended to each chunk
-    /// before AddingDefaultsTransform runs, then stripped back out. This lets
-    /// DEFAULT expressions (e.g. `b DEFAULT a + 1`) correctly reference columns
-    /// that are injected from HTTP headers rather than parsed from the body.
-    /// AddingDefaultsTransform must be constructed with a header that includes
-    /// these columns appended after the body columns.
-    void setConstantColumnsForDefaults(Columns cols) { constant_cols_for_defaults = std::move(cols); }
-
 private:
     void preallocateResultColumns(size_t num_bytes, const Chunk & chunk);
 
@@ -59,10 +51,6 @@ private:
     const InputFormatPtr format;
     const ErrorCallback on_error;
     const SimpleTransformPtr adding_defaults_transform;
-
-    /// Per-entry single-row columns for DEFAULT expression evaluation.
-    /// Set via setConstantColumnsForDefaults(); empty when no injection is needed.
-    Columns constant_cols_for_defaults;
 
     InputPort port;
     MutableColumns result_columns;

--- a/src/Processors/Executors/StreamingFormatExecutor.h
+++ b/src/Processors/Executors/StreamingFormatExecutor.h
@@ -44,6 +44,14 @@ public:
     /// Sets query parameters for input format if applicable.
     void setQueryParameters(const NameToNameMap & parameters);
 
+    /// Sets per-entry constant columns that are temporarily appended to each chunk
+    /// before AddingDefaultsTransform runs, then stripped back out. This lets
+    /// DEFAULT expressions (e.g. `b DEFAULT a + 1`) correctly reference columns
+    /// that are injected from HTTP headers rather than parsed from the body.
+    /// AddingDefaultsTransform must be constructed with a header that includes
+    /// these columns appended after the body columns.
+    void setConstantColumnsForDefaults(Columns cols) { constant_cols_for_defaults = std::move(cols); }
+
 private:
     void preallocateResultColumns(size_t num_bytes, const Chunk & chunk);
 
@@ -51,6 +59,10 @@ private:
     const InputFormatPtr format;
     const ErrorCallback on_error;
     const SimpleTransformPtr adding_defaults_transform;
+
+    /// Per-entry single-row columns for DEFAULT expression evaluation.
+    /// Set via setConstantColumnsForDefaults(); empty when no injection is needed.
+    Columns constant_cols_for_defaults;
 
     InputPort port;
     MutableColumns result_columns;

--- a/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
@@ -795,7 +795,7 @@ static void skipBSONField(ReadBuffer & in, BSONType type)
 
 void BSONEachRowRowInputFormat::skipUnknownField(BSONType type, const String & key_name)
 {
-    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(key_name))
+    if (!format_settings.skip_unknown_fields || format_settings.isHTTPColumnName(key_name))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing BSONEachRow format: {}", key_name);
 
     skipBSONField(*in, type);

--- a/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/BSONEachRowRowInputFormat.cpp
@@ -795,7 +795,7 @@ static void skipBSONField(ReadBuffer & in, BSONType type)
 
 void BSONEachRowRowInputFormat::skipUnknownField(BSONType type, const String & key_name)
 {
-    if (!format_settings.skip_unknown_fields)
+    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(key_name))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing BSONEachRow format: {}", key_name);
 
     skipBSONField(*in, type);

--- a/src/Processors/Formats/Impl/FormRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/FormRowInputFormat.cpp
@@ -77,7 +77,7 @@ void FormRowInputFormat::readFormData(MutableColumns & columns)
 
         if (!it)
         {
-            if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
+            if (!format_settings.skip_unknown_fields || format_settings.isHTTPColumnName(name_ref))
                 throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing Form format: {}", name_ref);
 
             /// Skip the value if key is not found.

--- a/src/Processors/Formats/Impl/FormRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/FormRowInputFormat.cpp
@@ -77,7 +77,7 @@ void FormRowInputFormat::readFormData(MutableColumns & columns)
 
         if (!it)
         {
-            if (!format_settings.skip_unknown_fields)
+            if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
                 throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing Form format: {}", name_ref);
 
             /// Skip the value if key is not found.

--- a/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
@@ -168,7 +168,7 @@ Chunk JSONColumnsBlockInputFormatBase::read()
             auto idx = name_to_index.get(*column_name);
             if (idx == CaseAwareBlockNameMap::NOT_FOUND)
             {
-                if (!format_settings.skip_unknown_fields)
+                if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(*column_name))
                     throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown column found in input data: {}", *column_name);
 
                 reader->skipColumn();

--- a/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
+++ b/src/Processors/Formats/Impl/JSONColumnsBlockInputFormatBase.cpp
@@ -168,7 +168,7 @@ Chunk JSONColumnsBlockInputFormatBase::read()
             auto idx = name_to_index.get(*column_name);
             if (idx == CaseAwareBlockNameMap::NOT_FOUND)
             {
-                if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(*column_name))
+                if (!format_settings.skip_unknown_fields || format_settings.isHTTPColumnName(*column_name))
                     throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown column found in input data: {}", *column_name);
 
                 reader->skipColumn();

--- a/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -122,7 +122,7 @@ std::string_view JSONEachRowRowInputFormat::readColumnName(ReadBuffer & buf)
 
 void JSONEachRowRowInputFormat::skipUnknownField(std::string_view name_ref)
 {
-    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
+    if (!format_settings.skip_unknown_fields || format_settings.isHTTPColumnName(name_ref))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing JSONEachRow format: {}", name_ref);
 
     skipJSONField(*in, name_ref, format_settings.json);

--- a/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowRowInputFormat.cpp
@@ -122,7 +122,7 @@ std::string_view JSONEachRowRowInputFormat::readColumnName(ReadBuffer & buf)
 
 void JSONEachRowRowInputFormat::skipUnknownField(std::string_view name_ref)
 {
-    if (!format_settings.skip_unknown_fields)
+    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing JSONEachRow format: {}", name_ref);
 
     skipJSONField(*in, name_ref, format_settings.json);

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -128,7 +128,7 @@ bool TSKVRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
                 auto * it = name_map.find(name_ref);
                 if (!it)
                 {
-                    if (!format_settings.skip_unknown_fields)
+                    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
                         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing TSKV format: {}", name_ref);
 
                     /// If the key is not found, skip the value.

--- a/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/TSKVRowInputFormat.cpp
@@ -128,7 +128,7 @@ bool TSKVRowInputFormat::readRow(MutableColumns & columns, RowReadExtension & ex
                 auto * it = name_map.find(name_ref);
                 if (!it)
                 {
-                    if (!format_settings.skip_unknown_fields || format_settings.http_column_names.contains(String(name_ref)))
+                    if (!format_settings.skip_unknown_fields || format_settings.isHTTPColumnName(name_ref))
                         throw Exception(ErrorCodes::INCORRECT_DATA, "Unknown field found while parsing TSKV format: {}", name_ref);
 
                     /// If the key is not found, skip the value.

--- a/src/Processors/Transforms/AddingDefaultsTransform.cpp
+++ b/src/Processors/Transforms/AddingDefaultsTransform.cpp
@@ -141,12 +141,14 @@ AddingDefaultsTransform::AddingDefaultsTransform(
     SharedHeader header,
     const ColumnsDescription & columns_,
     IInputFormat & input_format_,
-    ContextPtr context_)
+    ContextPtr context_,
+    ColumnsWithTypeAndName injected_columns_)
     : ISimpleTransform(header, header, true)
     , columns(columns_)
     , column_defaults(columns.getDefaults())
     , input_format(input_format_)
     , context(context_)
+    , injected_columns(std::move(injected_columns_))
 {
 }
 
@@ -164,20 +166,44 @@ void AddingDefaultsTransform::transform(Chunk & chunk)
     size_t num_rows = chunk.getNumRows();
     auto res = header.cloneWithColumns(chunk.detachColumns());
 
-    /// Identify columns that need defaults computed
+    /// Temporarily append header-injected columns so DEFAULT expressions that reference
+    /// them (e.g. `b DEFAULT a + 1` where `a` comes from an HTTP header) evaluate against
+    /// the real value. Appended at the end, so body-column positions used against
+    /// BlockMissingValues stay aligned. Stripped before output via output_columns below.
+    const size_t num_body_columns = res.columns();
+    for (const auto & injected : injected_columns)
+    {
+        if (!res.has(injected.name))
+            res.insert({ColumnConst::create(injected.column, num_rows), injected.type, injected.name});
+    }
+
+    /// Identify columns that need defaults computed.
+    /// Skip columns at position >= num_body_columns: those are injected columns appended
+    /// temporarily for DEFAULT evaluation; they have no entry in block_missing_values
+    /// (which only covers the body columns) and must not be accessed there.
     std::vector<std::pair<String, size_t>> columns_needing_defaults;
     for (const auto & [col_name, col_default] : column_defaults)
     {
         if (!res.has(col_name))
             continue;
         size_t column_idx = res.getPositionByName(col_name);
+        if (column_idx >= num_body_columns)
+            continue;  /// injected column — no block_missing_values entry
         if (block_missing_values->hasDefaultBits(column_idx))
             columns_needing_defaults.emplace_back(col_name, column_idx);
     }
 
+    /// Returns the body columns only (drops any appended injected columns).
+    auto body_columns = [&]()
+    {
+        Columns cols = res.getColumns();
+        cols.resize(num_body_columns);
+        return cols;
+    };
+
     if (columns_needing_defaults.empty())
     {
-        chunk.setColumns(res.getColumns(), num_rows);
+        chunk.setColumns(body_columns(), num_rows);
         return;
     }
 
@@ -325,7 +351,7 @@ void AddingDefaultsTransform::transform(Chunk & chunk)
         }
     }
 
-    chunk.setColumns(res.getColumns(), num_rows);
+    chunk.setColumns(body_columns(), num_rows);
 }
 
 }

--- a/src/Processors/Transforms/AddingDefaultsTransform.h
+++ b/src/Processors/Transforms/AddingDefaultsTransform.h
@@ -28,6 +28,10 @@ public:
 
     String getName() const override { return "AddingDefaultsTransform"; }
 
+    /// Updates the injected columns used for DEFAULT expression evaluation.
+    /// Called per-entry in the async path so each entry uses its own header values.
+    void setInjectedColumns(ColumnsWithTypeAndName cols) { injected_columns = std::move(cols); }
+
 protected:
     void transform(Chunk & chunk) override;
 
@@ -37,7 +41,7 @@ private:
     IInputFormat & input_format;
     ContextPtr context;
     /// Single-row value columns for header-injected columns (name, type, 1-row column).
-    const ColumnsWithTypeAndName injected_columns;
+    ColumnsWithTypeAndName injected_columns;
 };
 
 }

--- a/src/Processors/Transforms/AddingDefaultsTransform.h
+++ b/src/Processors/Transforms/AddingDefaultsTransform.h
@@ -13,11 +13,18 @@ class IInputFormat;
 class AddingDefaultsTransform final : public ISimpleTransform
 {
 public:
+    /// injected_columns_ - extra columns not produced by the format but available for
+    /// DEFAULT expression evaluation (e.g. columns injected from HTTP request headers via
+    /// http_column_*). Each holds a single-row value column. They are temporarily appended
+    /// to the working block so DEFAULT expressions can reference them, then stripped so the
+    /// output matches the format header. Appended at the end to keep the format's
+    /// BlockMissingValues indices for the body columns aligned.
     AddingDefaultsTransform(
         SharedHeader header,
         const ColumnsDescription & columns_,
         IInputFormat & input_format_,
-        ContextPtr context_);
+        ContextPtr context_,
+        ColumnsWithTypeAndName injected_columns_ = {});
 
     String getName() const override { return "AddingDefaultsTransform"; }
 
@@ -29,6 +36,8 @@ private:
     const ColumnDefaults column_defaults;
     IInputFormat & input_format;
     ContextPtr context;
+    /// Single-row value columns for header-injected columns (name, type, 1-row column).
+    const ColumnsWithTypeAndName injected_columns;
 };
 
 }

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -7,32 +7,50 @@
 namespace DB
 {
 
-/// Replaces specified columns in each chunk with constant values parsed from strings.
-/// Used by the http_column_* feature to inject HTTP header values into INSERT columns.
-/// For the sync INSERT path, all rows in a single request carry the same header values.
-/// The string values are deserialized through the column type's text serialization,
-/// so non-String types (UInt64, Array, etc.) are parsed correctly.
+/// Injects HTTP header values as INSERT columns for the sync path.
+///
+/// This is an expanding transform: input is the body-only block (columns the format
+/// parsed from the HTTP body), output is the full block (body columns + http_column_*
+/// mapped columns). The injected columns are placed at their correct positions in the
+/// output so the downstream chain (addMissingDefaults, constraints, sink) receives a
+/// complete block and does NOT evaluate DEFAULT expressions for the injected columns.
+///
+/// Using the format-only block as input lets positional formats (TSV, CSV, Values,
+/// RowBinary) work correctly: they see only the body columns and read the exact number
+/// of fields they expect.
 class HTTPHeaderColumnsTransform : public ISimpleTransform
 {
 public:
+    /// input_header  - block the format produces (body columns only).
+    /// output_header - full pipeline block (body + http_column_* columns).
+    /// http_header_columns - column_name -> header_value from the URL params.
+    /// format_settings - query/session format settings for value deserialization.
     HTTPHeaderColumnsTransform(
-        const Block & header_,
-        const NameToNameMap & http_header_columns_)
-        : ISimpleTransform(header_, header_, false)
+        const Block & input_header,
+        const Block & output_header,
+        const NameToNameMap & http_header_columns,
+        const FormatSettings & format_settings)
+        : ISimpleTransform(input_header, output_header, false)
     {
-        /// Precompute column indices and pre-parse values for the injected columns.
-        for (size_t i = 0; i < header_.columns(); ++i)
+        col_sources.reserve(output_header.columns());
+        for (size_t i = 0; i < output_header.columns(); ++i)
         {
-            auto it = http_header_columns_.find(header_.getByPosition(i).name);
-            if (it != http_header_columns_.end())
+            const auto & col_name = output_header.getByPosition(i).name;
+            if (input_header.has(col_name))
             {
-                const auto & col_type = header_.getByPosition(i).type;
-                /// Parse the string value into the target column type once.
-                auto parsed_col = col_type->createColumn();
-                ReadBufferFromString buf(it->second);
-                FormatSettings format_settings;
-                col_type->getDefaultSerialization()->deserializeWholeText(*parsed_col, buf, format_settings);
-                injected_columns.push_back({i, std::move(parsed_col), col_type});
+                /// Body column: pass through from input at the corresponding position.
+                col_sources.push_back({false, input_header.getPositionByName(col_name), nullptr, nullptr});
+            }
+            else
+            {
+                /// Injected column: parse the header value once.
+                auto it = http_header_columns.find(col_name);
+                const String & str_value = (it != http_header_columns.end()) ? it->second : "";
+                const auto & col_type = output_header.getByPosition(i).type;
+                auto parsed = col_type->createColumn();
+                ReadBufferFromString buf(str_value);
+                col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
+                col_sources.push_back({true, 0, std::move(parsed), col_type});
             }
         }
     }
@@ -42,32 +60,38 @@ public:
 protected:
     void transform(Chunk & chunk) override
     {
-        if (injected_columns.empty())
-            return;
-
         size_t num_rows = chunk.getNumRows();
-        auto columns = chunk.detachColumns();
+        auto input_columns = chunk.detachColumns();
 
-        for (const auto & inj : injected_columns)
+        Columns output_columns;
+        output_columns.reserve(col_sources.size());
+        for (const auto & src : col_sources)
         {
-            auto new_col = inj.type->createColumn();
-            new_col->reserve(num_rows);
-            for (size_t row = 0; row < num_rows; ++row)
-                new_col->insertFrom(*inj.parsed_value, 0);
-            columns[inj.index] = std::move(new_col);
+            if (!src.is_injected)
+            {
+                output_columns.push_back(std::move(input_columns[src.input_idx]));
+            }
+            else
+            {
+                auto new_col = src.type->createColumn();
+                new_col->reserve(num_rows);
+                for (size_t row = 0; row < num_rows; ++row)
+                    new_col->insertFrom(*src.parsed_value, 0);
+                output_columns.push_back(std::move(new_col));
+            }
         }
-
-        chunk.setColumns(std::move(columns), num_rows);
+        chunk.setColumns(std::move(output_columns), num_rows);
     }
 
 private:
-    struct InjectedColumn
+    struct ColSource
     {
-        size_t index;
-        ColumnPtr parsed_value;  /// Single pre-parsed value to replicate into each chunk.
-        DataTypePtr type;
+        bool is_injected;
+        size_t input_idx;      /// Position in the input (body) block; valid when !is_injected.
+        ColumnPtr parsed_value; /// Pre-parsed single-row column; valid when is_injected.
+        DataTypePtr type;       /// Column type; valid when is_injected.
     };
-    std::vector<InjectedColumn> injected_columns;
+    std::vector<ColSource> col_sources;
 };
 
 }

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/ColumnConst.h>
+#include <Common/Exception.h>
 #include <Core/HTTPHeaderColumns.h>
 #include <Formats/FormatSettings.h>
 #include <Formats/parseColumnFromString.h>
@@ -8,6 +9,12 @@
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int BAD_QUERY_PARAMETER;
+}
+
 
 /// Injects HTTP header values as INSERT columns for the sync path.
 ///
@@ -35,23 +42,38 @@ public:
         : ISimpleTransform(input_header, output_header, false)
     {
         col_sources.reserve(output_header.columns());
+        size_t body_col_idx = 0;
         for (size_t i = 0; i < output_header.columns(); ++i)
         {
             const auto & col_name = output_header.getByPosition(i).name;
-            if (input_header.has(col_name))
+            if (http_header_columns.contains(col_name))
             {
-                /// Body column: pass through from input at the corresponding position.
-                col_sources.push_back({false, input_header.getPositionByName(col_name), nullptr, nullptr});
+                /// Injected column: parse the header value once.
+                /// find() is guaranteed non-null here: contains() was just true.
+                const String & str_value = *http_header_columns.find(col_name);
+                const auto & col_type = output_header.getByPosition(i).type;
+                MutableColumnPtr parsed;
+                try
+                {
+                    parsed = parseColumnValueFromString(col_type, str_value, format_settings);
+                }
+                catch (const DB::Exception & e)
+                {
+                    throw DB::Exception(DB::ErrorCodes::BAD_QUERY_PARAMETER,
+                        "http_column parameter for column '{}' contains value '{}' that cannot be parsed as {}: {}",
+                        col_name, str_value, col_type->getName(), e.message());
+                }
+                col_sources.push_back({true, 0, std::move(parsed), col_type});
             }
             else
             {
-                /// Injected column: parse the header value once. A missing column
-                /// contributes an empty value.
-                const String * mapped = http_header_columns.find(col_name);
-                const String str_value = mapped ? *mapped : String{};
-                const auto & col_type = output_header.getByPosition(i).type;
-                auto parsed = parseColumnValueFromString(col_type, str_value, format_settings);
-                col_sources.push_back({true, 0, std::move(parsed), col_type});
+                /// Body column: match by name for FORMAT inserts, or by position for
+                /// INSERT...SELECT (where SELECT output columns have anonymous names).
+                size_t input_pos = input_header.has(col_name)
+                    ? input_header.getPositionByName(col_name)
+                    : body_col_idx;
+                col_sources.push_back({false, input_pos, nullptr, nullptr});
+                ++body_col_idx;
             }
         }
     }

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <base/defines.h>
 #include <Columns/ColumnConst.h>
 #include <Common/Exception.h>
 #include <Core/HTTPHeaderColumns.h>
@@ -30,10 +31,10 @@ namespace ErrorCodes
 class HTTPHeaderColumnsTransform : public ISimpleTransform
 {
 public:
-    /// input_header  - block the format produces (body columns only).
-    /// output_header - full pipeline block (body + http_column_* columns).
+    /// input_header        - block the format produces (body columns only).
+    /// output_header       - full pipeline block (body + http_column_* columns).
     /// http_header_columns - column_name -> header_value from the URL params.
-    /// format_settings - query/session format settings for value deserialization.
+    /// format_settings     - query/session format settings for value deserialization.
     HTTPHeaderColumnsTransform(
         const Block & input_header,
         const Block & output_header,
@@ -67,11 +68,12 @@ public:
             }
             else
             {
-                /// Body column: match by name for FORMAT inserts, or by position for
-                /// INSERT...SELECT (where SELECT output columns have anonymous names).
+                /// Body column: match by name so named formats (JSONEachRow, TSVWithNames,
+                /// etc.) land in the right slot regardless of declaration order.
                 size_t input_pos = input_header.has(col_name)
                     ? input_header.getPositionByName(col_name)
                     : body_col_idx;
+                chassert(input_pos < input_header.columns());
                 col_sources.push_back({false, input_pos, nullptr, nullptr});
                 ++body_col_idx;
             }
@@ -92,6 +94,7 @@ protected:
         {
             if (!src.is_injected)
             {
+                chassert(src.input_idx < input_columns.size());
                 output_columns.push_back(std::move(input_columns[src.input_idx]));
             }
             else

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Columns/ColumnConst.h>
+#include <Core/HTTPHeaderColumns.h>
 #include <Formats/FormatSettings.h>
 #include <Formats/parseColumnFromString.h>
 #include <Processors/ISimpleTransform.h>
@@ -29,7 +30,7 @@ public:
     HTTPHeaderColumnsTransform(
         const Block & input_header,
         const Block & output_header,
-        const NameToNameMap & http_header_columns,
+        const HTTPHeaderColumns & http_header_columns,
         const FormatSettings & format_settings)
         : ISimpleTransform(input_header, output_header, false)
     {
@@ -44,9 +45,10 @@ public:
             }
             else
             {
-                /// Injected column: parse the header value once.
-                auto it = http_header_columns.find(col_name);
-                const String & str_value = (it != http_header_columns.end()) ? it->second : "";
+                /// Injected column: parse the header value once. A missing column
+                /// contributes an empty value.
+                const String * mapped = http_header_columns.find(col_name);
+                const String str_value = mapped ? *mapped : String{};
                 const auto & col_type = output_header.getByPosition(i).type;
                 auto parsed = parseColumnValueFromString(col_type, str_value, format_settings);
                 col_sources.push_back({true, 0, std::move(parsed), col_type});

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Columns/ColumnConst.h>
 #include <Formats/FormatSettings.h>
 #include <IO/ReadBufferFromString.h>
 #include <Processors/ISimpleTransform.h>
@@ -73,11 +74,7 @@ protected:
             }
             else
             {
-                auto new_col = src.type->createColumn();
-                new_col->reserve(num_rows);
-                for (size_t row = 0; row < num_rows; ++row)
-                    new_col->insertFrom(*src.parsed_value, 0);
-                output_columns.push_back(std::move(new_col));
+                output_columns.push_back(ColumnConst::create(src.parsed_value, num_rows));
             }
         }
         chunk.setColumns(std::move(output_columns), num_rows);

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include <Formats/FormatSettings.h>
+#include <IO/ReadBufferFromString.h>
 #include <Processors/ISimpleTransform.h>
 
 namespace DB
 {
 
-/// Replaces specified columns in each chunk with constant values.
+/// Replaces specified columns in each chunk with constant values parsed from strings.
 /// Used by the http_column_* feature to inject HTTP header values into INSERT columns.
 /// For the sync INSERT path, all rows in a single request carry the same header values.
+/// The string values are deserialized through the column type's text serialization,
+/// so non-String types (UInt64, Array, etc.) are parsed correctly.
 class HTTPHeaderColumnsTransform : public ISimpleTransform
 {
 public:
@@ -16,12 +20,20 @@ public:
         const NameToNameMap & http_header_columns_)
         : ISimpleTransform(header_, header_, false)
     {
-        /// Precompute column indices and values for the injected columns.
+        /// Precompute column indices and pre-parse values for the injected columns.
         for (size_t i = 0; i < header_.columns(); ++i)
         {
             auto it = http_header_columns_.find(header_.getByPosition(i).name);
             if (it != http_header_columns_.end())
-                injected_columns.push_back({i, it->second, header_.getByPosition(i).type});
+            {
+                const auto & col_type = header_.getByPosition(i).type;
+                /// Parse the string value into the target column type once.
+                auto parsed_col = col_type->createColumn();
+                ReadBufferFromString buf(it->second);
+                FormatSettings format_settings;
+                col_type->getDefaultSerialization()->deserializeWholeText(*parsed_col, buf, format_settings);
+                injected_columns.push_back({i, std::move(parsed_col), col_type});
+            }
         }
     }
 
@@ -36,13 +48,13 @@ protected:
         size_t num_rows = chunk.getNumRows();
         auto columns = chunk.detachColumns();
 
-        for (const auto & [col_idx, value, type] : injected_columns)
+        for (const auto & inj : injected_columns)
         {
-            auto new_col = type->createColumn();
+            auto new_col = inj.type->createColumn();
             new_col->reserve(num_rows);
             for (size_t row = 0; row < num_rows; ++row)
-                new_col->insert(value);
-            columns[col_idx] = std::move(new_col);
+                new_col->insertFrom(*inj.parsed_value, 0);
+            columns[inj.index] = std::move(new_col);
         }
 
         chunk.setColumns(std::move(columns), num_rows);
@@ -52,7 +64,7 @@ private:
     struct InjectedColumn
     {
         size_t index;
-        String value;
+        ColumnPtr parsed_value;  /// Single pre-parsed value to replicate into each chunk.
         DataTypePtr type;
     };
     std::vector<InjectedColumn> injected_columns;

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -2,7 +2,7 @@
 
 #include <Columns/ColumnConst.h>
 #include <Formats/FormatSettings.h>
-#include <IO/ReadBufferFromString.h>
+#include <Formats/parseColumnFromString.h>
 #include <Processors/ISimpleTransform.h>
 
 namespace DB
@@ -48,9 +48,7 @@ public:
                 auto it = http_header_columns.find(col_name);
                 const String & str_value = (it != http_header_columns.end()) ? it->second : "";
                 const auto & col_type = output_header.getByPosition(i).type;
-                auto parsed = col_type->createColumn();
-                ReadBufferFromString buf(str_value);
-                col_type->getDefaultSerialization()->deserializeWholeText(*parsed, buf, format_settings);
+                auto parsed = parseColumnValueFromString(col_type, str_value, format_settings);
                 col_sources.push_back({true, 0, std::move(parsed), col_type});
             }
         }

--- a/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
+++ b/src/Processors/Transforms/HTTPHeaderColumnsTransform.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Processors/ISimpleTransform.h>
+
+namespace DB
+{
+
+/// Replaces specified columns in each chunk with constant values.
+/// Used by the http_column_* feature to inject HTTP header values into INSERT columns.
+/// For the sync INSERT path, all rows in a single request carry the same header values.
+class HTTPHeaderColumnsTransform : public ISimpleTransform
+{
+public:
+    HTTPHeaderColumnsTransform(
+        const Block & header_,
+        const NameToNameMap & http_header_columns_)
+        : ISimpleTransform(header_, header_, false)
+    {
+        /// Precompute column indices and values for the injected columns.
+        for (size_t i = 0; i < header_.columns(); ++i)
+        {
+            auto it = http_header_columns_.find(header_.getByPosition(i).name);
+            if (it != http_header_columns_.end())
+                injected_columns.push_back({i, it->second, header_.getByPosition(i).type});
+        }
+    }
+
+    String getName() const override { return "HTTPHeaderColumnsTransform"; }
+
+protected:
+    void transform(Chunk & chunk) override
+    {
+        if (injected_columns.empty())
+            return;
+
+        size_t num_rows = chunk.getNumRows();
+        auto columns = chunk.detachColumns();
+
+        for (const auto & [col_idx, value, type] : injected_columns)
+        {
+            auto new_col = type->createColumn();
+            new_col->reserve(num_rows);
+            for (size_t row = 0; row < num_rows; ++row)
+                new_col->insert(value);
+            columns[col_idx] = std::move(new_col);
+        }
+
+        chunk.setColumns(std::move(columns), num_rows);
+    }
+
+private:
+    struct InjectedColumn
+    {
+        size_t index;
+        String value;
+        DataTypePtr type;
+    };
+    std::vector<InjectedColumn> injected_columns;
+};
+
+}

--- a/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
+++ b/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
@@ -8,6 +8,8 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/EmptyReadBuffer.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
+#include <Formats/FormatFactory.h>
+#include <IO/ReadBufferFromString.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
 #include <Storages/IStorage.h>
 #include <QueryPipeline/Pipe.h>
@@ -101,9 +103,30 @@ Pipe getSourceFromInputFormat(
 
         if (columns && columns->hasDefaults())
         {
+            /// If http_column_* URL params inject columns, pass them to AddingDefaultsTransform
+            /// so DEFAULT expressions that reference an injected column (e.g. `b DEFAULT a + 1`
+            /// where `a` comes from a header) evaluate against the real header value instead of
+            /// the column's own default. The values are parsed once here into single-row columns.
+            ColumnsWithTypeAndName injected_columns;
+            const auto & http_header_columns = context->getHTTPHeaderColumns();
+            if (!http_header_columns.empty())
+            {
+                const auto format_settings = getFormatSettings(context);
+                for (const auto & [col_name, str_value] : http_header_columns)
+                {
+                    if (!columns->has(col_name))
+                        continue;
+                    const auto & col_type = columns->get(col_name).type;
+                    auto value = col_type->createColumn();
+                    ReadBufferFromString buf(str_value);
+                    col_type->getDefaultSerialization()->deserializeWholeText(*value, buf, format_settings);
+                    injected_columns.push_back({std::move(value), col_type, col_name});
+                }
+            }
+
             pipe.addSimpleTransform([&](const SharedHeader & cur_header)
             {
-                return std::make_shared<AddingDefaultsTransform>(cur_header, *columns, *format, context);
+                return std::make_shared<AddingDefaultsTransform>(cur_header, *columns, *format, context, injected_columns);
             });
         }
     }

--- a/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
+++ b/src/Processors/Transforms/getSourceFromASTInsertQuery.cpp
@@ -9,7 +9,7 @@
 #include <IO/EmptyReadBuffer.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
 #include <Formats/FormatFactory.h>
-#include <IO/ReadBufferFromString.h>
+#include <Formats/parseColumnFromString.h>
 #include <Processors/Transforms/AddingDefaultsTransform.h>
 #include <Storages/IStorage.h>
 #include <QueryPipeline/Pipe.h>
@@ -117,9 +117,7 @@ Pipe getSourceFromInputFormat(
                     if (!columns->has(col_name))
                         continue;
                     const auto & col_type = columns->get(col_name).type;
-                    auto value = col_type->createColumn();
-                    ReadBufferFromString buf(str_value);
-                    col_type->getDefaultSerialization()->deserializeWholeText(*value, buf, format_settings);
+                    auto value = parseColumnValueFromString(col_type, str_value, format_settings);
                     injected_columns.push_back({std::move(value), col_type, col_name});
                 }
             }

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -266,6 +266,8 @@ void HTTPHandler::processQuery(
 
     bool has_external_data = startsWith(request.getContentType(), "multipart/form-data");
 
+    static constexpr std::string_view HTTP_COLUMN_PREFIX = "http_column_";
+
     auto param_could_be_skipped = [&] (const String & name)
     {
         /// Empty parameter appears when URL like ?&a=b or a=b&&c=d. Just skip them for user's convenience.
@@ -279,6 +281,10 @@ void HTTPHandler::processQuery(
             "database", "default_format"};
 
         if (reserved_param_names.contains(name))
+            return true;
+
+        /// http_column_* params are processed separately (header-to-column mapping).
+        if (name.starts_with(HTTP_COLUMN_PREFIX))
             return true;
 
         if (has_external_data)
@@ -297,6 +303,26 @@ void HTTPHandler::processQuery(
 
         return false;
     };
+
+    /// Parse http_column_* params: map HTTP request header values to INSERT columns.
+    /// URL param format: http_column_<Header-Name>=<column_name>
+    /// The header value is resolved from the current request and stored on the context
+    /// so that both sync and async INSERT paths can inject it as column data.
+    {
+        NameToNameMap http_header_columns;
+        for (const auto & [key, value] : params)
+        {
+            if (key.starts_with(HTTP_COLUMN_PREFIX))
+            {
+                String header_name(key.substr(HTTP_COLUMN_PREFIX.size()));
+                String column_name = value;
+                String header_value = request.get(header_name, "");
+                http_header_columns.emplace(column_name, header_value);
+            }
+        }
+        if (!http_header_columns.empty())
+            context->setHTTPHeaderColumns(std::move(http_header_columns));
+    }
 
     /// Settings can be overridden in the query.
     SettingsChanges settings_changes;

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -83,6 +83,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int BAD_QUERY_PARAMETER;
 
     extern const int NO_ELEMENTS_IN_CONFIG;
 
@@ -850,16 +851,26 @@ DynamicQueryHandler::DynamicQueryHandler(
 {
 }
 
-/// Resolve one header->column mapping from the request and register it on the
-/// context. Header values come from ClientInfo::http_headers (already filtered
-/// for sensitive headers); a missing header contributes an empty value. Shared by
-/// the dynamic http_column_* handler and the predefined header_column_mappings.
+/// Resolve one http_column_* mapping: validate both names, look up the header
+/// value, and register it on the context. Throws BAD_QUERY_PARAMETER for any
+/// invalid input (empty names, absent header) — mirrors param_* semantics.
+/// Shared by the dynamic handler and the predefined header_column_mappings.
 static void addHTTPHeaderColumnFromRequest(
     const ContextMutablePtr & context, const String & header_name, const String & column_name)
 {
+    if (header_name.empty())
+        throw Exception(ErrorCodes::BAD_QUERY_PARAMETER,
+            "http_column_ parameter has an empty header name.");
+    if (column_name.empty())
+        throw Exception(ErrorCodes::BAD_QUERY_PARAMETER,
+            "http_column_ parameter for header '{}' has an empty column name.", header_name);
     const auto & http_headers = context->getClientInfo().http_headers;
     auto it = http_headers.find(header_name);
-    context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
+    if (it == http_headers.end())
+        throw Exception(ErrorCodes::BAD_QUERY_PARAMETER,
+            "HTTP header '{}' required by http_column parameter for column '{}' is absent from the request.",
+            header_name, column_name);
+    context->addHTTPHeaderColumn(column_name, it->second);
 }
 
 bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
@@ -880,12 +891,9 @@ bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const s
     if (startsWith(key, HTTP_COLUMN_PREFIX))
     {
         /// Map an HTTP request header value to an INSERT column.
-        /// Behaviour mirrors param_*: first occurrence wins, empty header/column names are ignored.
-        /// Header values are sourced from ClientInfo::http_headers (already filtered for sensitive headers).
         const String header_name = key.substr(strlen(HTTP_COLUMN_PREFIX));
         const String & column_name = value;
-        if (!header_name.empty() && !column_name.empty())
-            addHTTPHeaderColumnFromRequest(context, header_name, column_name);
+        addHTTPHeaderColumnFromRequest(context, header_name, column_name);
         return true;
     }
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -925,12 +925,14 @@ PredefinedQueryHandler::PredefinedQueryHandler(
     const std::string & predefined_query_,
     const CompiledRegexPtr & url_regexp_,
     const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regexp_,
-    const HTTPResponseHeaderSetup & http_response_headers_override_)
+    const HTTPResponseHeaderSetup & http_response_headers_override_,
+    NameToNameMap header_column_mappings_)
     : HTTPHandler(server_, connection_config, "PredefinedQueryHandler", http_response_headers_override_)
     , receive_params(receive_params_)
     , predefined_query(predefined_query_)
     , url_regexp(url_regexp_)
     , header_name_with_capture_regexp(header_name_with_regexp_)
+    , header_column_mappings(std::move(header_column_mappings_))
 {
 }
 
@@ -1001,6 +1003,19 @@ void PredefinedQueryHandler::customizeContext(HTTPServerRequest & request, Conte
         copyDataMaxBytes(body, value, settings[Setting::http_max_request_param_data_size]);
         context->setQueryParameter("_request_body", value.str());
     }
+
+    /// Resolve config-declared header→column mappings.
+    /// Values are sourced from ClientInfo::http_headers (already filtered for sensitive headers).
+    /// First occurrence wins — same semantics as http_column_* in the dynamic handler.
+    if (!header_column_mappings.empty())
+    {
+        const auto & http_headers = context->getClientInfo().http_headers;
+        for (const auto & [header_name, column_name] : header_column_mappings)
+        {
+            auto it = http_headers.find(header_name);
+            context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
+        }
+    }
 }
 
 std::string PredefinedQueryHandler::getQuery(HTTPServerRequest & request, HTMLForm & params, ContextMutablePtr context)
@@ -1068,6 +1083,22 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         http_response_headers_override.value().insert(common_headers.begin(), common_headers.end());
     }
 
+    /// Parse optional <header_column_mappings> block.
+    /// Each child tag is treated as <HeaderName>column_name</HeaderName>.
+    NameToNameMap header_column_mappings;
+    const std::string mappings_key = config_prefix + ".handler.header_column_mappings";
+    if (config.has(mappings_key))
+    {
+        Poco::Util::AbstractConfiguration::Keys header_names;
+        config.keys(mappings_key, header_names);
+        for (const auto & header_name : header_names)
+        {
+            const String column_name = config.getString(mappings_key + "." + header_name);
+            if (!header_name.empty() && !column_name.empty())
+                header_column_mappings.emplace(header_name, column_name);
+        }
+    }
+
     auto creator = [
         &server,
         analyze_receive_params,
@@ -1075,7 +1106,8 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         url_regexp = regexps.url_regexp,
         headers_name_with_regexp = std::move(regexps.headers_name_with_regexp),
         http_response_headers_override,
-        connection_config]
+        connection_config,
+        hdr_col_mappings = std::move(header_column_mappings)]
         -> std::unique_ptr<PredefinedQueryHandler>
     {
         return std::make_unique<PredefinedQueryHandler>(
@@ -1085,7 +1117,8 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
             predefined_query,
             url_regexp,
             headers_name_with_regexp,
-            http_response_headers_override);
+            http_response_headers_override,
+            hdr_col_mappings);
     };
     auto factory = std::make_shared<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>>(std::move(creator));
     factory->addFiltersFromConfig(config, config_prefix);

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -306,9 +306,10 @@ void HTTPHandler::processQuery(
 
     /// Parse http_column_* params: map HTTP request header values to INSERT columns.
     /// URL param format: http_column_<Header-Name>=<column_name>
-    /// The header value is resolved from the current request and stored on the context
-    /// so that both sync and async INSERT paths can inject it as column data.
+    /// Values are sourced from ClientInfo::http_headers (populated by authenticateUserByHTTP),
+    /// which already filters out sensitive headers (Authorization, X-ClickHouse-*).
     {
+        const auto & http_headers = context->getClientInfo().http_headers;
         NameToNameMap http_header_columns;
         for (const auto & [key, value] : params)
         {
@@ -316,7 +317,8 @@ void HTTPHandler::processQuery(
             {
                 String header_name(key.substr(HTTP_COLUMN_PREFIX.size()));
                 String column_name = value;
-                String header_value = request.get(header_name, "");
+                auto it = http_headers.find(header_name);
+                String header_value = (it != http_headers.end()) ? it->second : "";
                 http_header_columns.emplace(column_name, header_value);
             }
         }

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -49,6 +49,7 @@
 #include <Poco/Util/LayeredConfiguration.h>
 
 #include <algorithm>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <memory>
 #include <optional>
@@ -1099,15 +1100,29 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     /// Each child tag is treated as <HeaderName>column_name</HeaderName>.
     /// Stored as a vector to preserve declaration order; first occurrence wins
     /// when two entries target the same column.
+    ///
+    /// config.keys() returns Poco-escaped names: dots become `\.` and repeated
+    /// siblings become `Name[N]`. We use the escaped key for value lookup, but
+    /// unescape it before storing as the runtime header name so that a tag like
+    /// <X.Trace-Id> correctly looks up "X.Trace-Id" in the request headers.
     std::vector<std::pair<String, String>> header_column_mappings;
     const std::string mappings_key = config_prefix + ".handler.header_column_mappings";
     if (config.has(mappings_key))
     {
-        Poco::Util::AbstractConfiguration::Keys header_names;
-        config.keys(mappings_key, header_names);
-        for (const auto & header_name : header_names)
+        Poco::Util::AbstractConfiguration::Keys escaped_names;
+        config.keys(mappings_key, escaped_names);
+        for (const auto & escaped_name : escaped_names)
         {
-            const String column_name = config.getString(mappings_key + "." + header_name);
+            const String column_name = config.getString(mappings_key + "." + escaped_name);
+
+            /// Unescape the Poco-encoded tag name to recover the real XML element
+            /// name: strip any trailing `[N]` index (repeated siblings), then
+            /// replace `\.` escape sequences with literal dots.
+            String header_name = escaped_name;
+            if (auto bracket = header_name.rfind('['); bracket != String::npos)
+                header_name.resize(bracket);
+            boost::replace_all(header_name, "\\.", ".");
+
             if (!header_name.empty() && !column_name.empty())
                 header_column_mappings.emplace_back(header_name, column_name);
         }

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -59,6 +59,9 @@
 
 namespace DB
 {
+
+static constexpr char HTTP_COLUMN_PREFIX[] = "http_column_";
+
 namespace Setting
 {
     extern const SettingsBool add_http_cors_header;
@@ -266,8 +269,6 @@ void HTTPHandler::processQuery(
 
     bool has_external_data = startsWith(request.getContentType(), "multipart/form-data");
 
-    static constexpr std::string_view HTTP_COLUMN_PREFIX = "http_column_";
-
     auto param_could_be_skipped = [&] (const String & name)
     {
         /// Empty parameter appears when URL like ?&a=b or a=b&&c=d. Just skip them for user's convenience.
@@ -281,10 +282,6 @@ void HTTPHandler::processQuery(
             "database", "default_format"};
 
         if (reserved_param_names.contains(name))
-            return true;
-
-        /// http_column_* params are processed separately (header-to-column mapping).
-        if (name.starts_with(HTTP_COLUMN_PREFIX))
             return true;
 
         if (has_external_data)
@@ -303,28 +300,6 @@ void HTTPHandler::processQuery(
 
         return false;
     };
-
-    /// Parse http_column_* params: map HTTP request header values to INSERT columns.
-    /// URL param format: http_column_<Header-Name>=<column_name>
-    /// Values are sourced from ClientInfo::http_headers (populated by authenticateUserByHTTP),
-    /// which already filters out sensitive headers (Authorization, X-ClickHouse-*).
-    {
-        const auto & http_headers = context->getClientInfo().http_headers;
-        NameToNameMap http_header_columns;
-        for (const auto & [key, value] : params)
-        {
-            if (key.starts_with(HTTP_COLUMN_PREFIX))
-            {
-                String header_name(key.substr(HTTP_COLUMN_PREFIX.size()));
-                String column_name = value;
-                auto it = http_headers.find(header_name);
-                String header_value = (it != http_headers.end()) ? it->second : "";
-                http_header_columns.emplace(column_name, header_value);
-            }
-        }
-        if (!http_header_columns.empty())
-            context->setHTTPHeaderColumns(std::move(http_header_columns));
-    }
 
     /// Settings can be overridden in the query.
     SettingsChanges settings_changes;
@@ -887,6 +862,22 @@ bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const s
 
         if (!context->getQueryParameters().contains(parameter_name))
             context->setQueryParameter(parameter_name, value);
+        return true;
+    }
+
+    if (startsWith(key, HTTP_COLUMN_PREFIX))
+    {
+        /// Map an HTTP request header value to an INSERT column.
+        /// Behaviour mirrors param_*: first occurrence wins, empty header/column names are ignored.
+        /// Header values are sourced from ClientInfo::http_headers (already filtered for sensitive headers).
+        const String header_name = key.substr(strlen(HTTP_COLUMN_PREFIX));
+        const String & column_name = value;
+        if (!header_name.empty() && !column_name.empty())
+        {
+            const auto & http_headers = context->getClientInfo().http_headers;
+            auto it = http_headers.find(header_name);
+            context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
+        }
         return true;
     }
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -850,6 +850,18 @@ DynamicQueryHandler::DynamicQueryHandler(
 {
 }
 
+/// Resolve one header->column mapping from the request and register it on the
+/// context. Header values come from ClientInfo::http_headers (already filtered
+/// for sensitive headers); a missing header contributes an empty value. Shared by
+/// the dynamic http_column_* handler and the predefined header_column_mappings.
+static void addHTTPHeaderColumnFromRequest(
+    const ContextMutablePtr & context, const String & header_name, const String & column_name)
+{
+    const auto & http_headers = context->getClientInfo().http_headers;
+    auto it = http_headers.find(header_name);
+    context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
+}
+
 bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const std::string & key, const std::string & value)
 {
     if (key == param_name)
@@ -873,11 +885,7 @@ bool DynamicQueryHandler::customizeQueryParam(ContextMutablePtr context, const s
         const String header_name = key.substr(strlen(HTTP_COLUMN_PREFIX));
         const String & column_name = value;
         if (!header_name.empty() && !column_name.empty())
-        {
-            const auto & http_headers = context->getClientInfo().http_headers;
-            auto it = http_headers.find(header_name);
-            context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
-        }
+            addHTTPHeaderColumnFromRequest(context, header_name, column_name);
         return true;
     }
 
@@ -1009,12 +1017,8 @@ void PredefinedQueryHandler::customizeContext(HTTPServerRequest & request, Conte
     /// First occurrence wins — same semantics as http_column_* in the dynamic handler.
     if (!header_column_mappings.empty())
     {
-        const auto & http_headers = context->getClientInfo().http_headers;
         for (const auto & [header_name, column_name] : header_column_mappings)
-        {
-            auto it = http_headers.find(header_name);
-            context->addHTTPHeaderColumn(column_name, it != http_headers.end() ? it->second : "");
-        }
+            addHTTPHeaderColumnFromRequest(context, header_name, column_name);
     }
 }
 

--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -926,7 +926,7 @@ PredefinedQueryHandler::PredefinedQueryHandler(
     const CompiledRegexPtr & url_regexp_,
     const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regexp_,
     const HTTPResponseHeaderSetup & http_response_headers_override_,
-    NameToNameMap header_column_mappings_)
+    std::vector<std::pair<String, String>> header_column_mappings_)
     : HTTPHandler(server_, connection_config, "PredefinedQueryHandler", http_response_headers_override_)
     , receive_params(receive_params_)
     , predefined_query(predefined_query_)
@@ -1085,7 +1085,9 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
 
     /// Parse optional <header_column_mappings> block.
     /// Each child tag is treated as <HeaderName>column_name</HeaderName>.
-    NameToNameMap header_column_mappings;
+    /// Stored as a vector to preserve declaration order; first occurrence wins
+    /// when two entries target the same column.
+    std::vector<std::pair<String, String>> header_column_mappings;
     const std::string mappings_key = config_prefix + ".handler.header_column_mappings";
     if (config.has(mappings_key))
     {
@@ -1095,7 +1097,7 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
         {
             const String column_name = config.getString(mappings_key + "." + header_name);
             if (!header_name.empty() && !column_name.empty())
-                header_column_mappings.emplace(header_name, column_name);
+                header_column_mappings.emplace_back(header_name, column_name);
         }
     }
 

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -195,10 +195,11 @@ private:
     std::string predefined_query;
     CompiledRegexPtr url_regexp;
     std::unordered_map<String, CompiledRegexPtr> header_name_with_capture_regexp;
-    /// Config-declared header→column mappings for INSERT queries.
-    /// Key: HTTP header name, Value: target INSERT column name.
-    /// Resolved at request time and stored in the query context as http_header_columns.
-    NameToNameMap header_column_mappings;
+    /// Config-declared header→column mappings for INSERT queries, in declaration order.
+    /// Each pair is (HTTP header name, target INSERT column name).
+    /// Stored as a vector to preserve config order; first occurrence wins when multiple
+    /// entries target the same column.
+    std::vector<std::pair<String, String>> header_column_mappings;
 
 public:
     PredefinedQueryHandler(
@@ -209,7 +210,7 @@ public:
         const CompiledRegexPtr & url_regexp_,
         const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regexp_,
         const HTTPResponseHeaderSetup & http_response_headers_override_ = std::nullopt,
-        NameToNameMap header_column_mappings_ = {});
+        std::vector<std::pair<String, String>> header_column_mappings_ = {});
 
     void customizeContext(HTTPServerRequest & request, ContextMutablePtr context, ReadBuffer & body) override;
 

--- a/src/Server/HTTPHandler.h
+++ b/src/Server/HTTPHandler.h
@@ -195,6 +195,10 @@ private:
     std::string predefined_query;
     CompiledRegexPtr url_regexp;
     std::unordered_map<String, CompiledRegexPtr> header_name_with_capture_regexp;
+    /// Config-declared header→column mappings for INSERT queries.
+    /// Key: HTTP header name, Value: target INSERT column name.
+    /// Resolved at request time and stored in the query context as http_header_columns.
+    NameToNameMap header_column_mappings;
 
 public:
     PredefinedQueryHandler(
@@ -204,7 +208,8 @@ public:
         const std::string & predefined_query_,
         const CompiledRegexPtr & url_regexp_,
         const std::unordered_map<String, CompiledRegexPtr> & header_name_with_regexp_,
-        const HTTPResponseHeaderSetup & http_response_headers_override_ = std::nullopt);
+        const HTTPResponseHeaderSetup & http_response_headers_override_ = std::nullopt,
+        NameToNameMap header_column_mappings_ = {});
 
     void customizeContext(HTTPServerRequest & request, ContextMutablePtr context, ReadBuffer & body) override;
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -978,3 +978,46 @@ def test_predefined_handler_header_column_mappings():
             "SELECT event_type, signature, payload FROM http_column_test"
         )
         assert result == "\t\tno-headers\n"
+
+
+def test_predefined_handler_header_column_mappings_async():
+    """predefined_query_handler with <header_column_mappings> works correctly
+    with async inserts: the header value is injected per-entry and survives
+    async buffering until flush. Reuses the sync-handler config."""
+    with contextlib.closing(
+        SimpleCluster(
+            ClickHouseCluster(__file__),
+            "predefined_handler_http_columns_async",
+            "test_predefined_handler_http_columns",
+        )
+    ) as cluster:
+        cluster.instance.query(
+            "CREATE TABLE http_column_test "
+            "(event_type String, signature String, payload String) "
+            "ENGINE = MergeTree ORDER BY tuple()"
+        )
+
+        # Two requests with different header values; wait_for_async_insert=1 ensures
+        # each is flushed and visible before we query.
+        response = cluster.instance.http_request(
+            "ingest_events",
+            method="POST",
+            headers={"X-Event-Type": "push", "X-Signature": "sig1"},
+            params={"async_insert": "1", "wait_for_async_insert": "1"},
+            data=b'{"payload":"first"}',
+        )
+        assert response.status_code == 200, response.content
+
+        response = cluster.instance.http_request(
+            "ingest_events",
+            method="POST",
+            headers={"X-Event-Type": "release", "X-Signature": "sig2"},
+            params={"async_insert": "1", "wait_for_async_insert": "1"},
+            data=b'{"payload":"second"}',
+        )
+        assert response.status_code == 200, response.content
+
+        result = cluster.instance.query(
+            "SELECT event_type, signature, payload FROM http_column_test ORDER BY payload"
+        )
+        assert result == "push\tsig1\tfirst\nrelease\tsig2\tsecond\n"

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -933,3 +933,48 @@ def test_catch_all_handler():
             response = cluster.instance.http_request(path, method="GET")
             assert response.status_code == 200, f"{path} -> {response.status_code}"
             assert response.content == b"catch-all matched", path
+
+
+def test_predefined_handler_header_column_mappings():
+    """predefined_query_handler with <header_column_mappings> injects HTTP header
+    values as INSERT columns without exposing them as URL parameters."""
+    with contextlib.closing(
+        SimpleCluster(
+            ClickHouseCluster(__file__),
+            "predefined_handler_http_columns",
+            "test_predefined_handler_http_columns",
+        )
+    ) as cluster:
+        cluster.instance.query(
+            "CREATE TABLE http_column_test "
+            "(event_type String, signature String, payload String) "
+            "ENGINE = MergeTree ORDER BY tuple()"
+        )
+
+        # Inject two header values into separate INSERT columns.
+        response = cluster.instance.http_request(
+            "ingest_events",
+            method="POST",
+            headers={"X-Event-Type": "push", "X-Signature": "sha256=abc"},
+            data=b'{"payload":"hello"}',
+        )
+        assert response.status_code == 200, response.content
+
+        result = cluster.instance.query(
+            "SELECT event_type, signature, payload FROM http_column_test"
+        )
+        assert result == "push\tsha256=abc\thello\n"
+
+        # A missing header produces an empty string.
+        cluster.instance.query("TRUNCATE TABLE http_column_test")
+        response = cluster.instance.http_request(
+            "ingest_events",
+            method="POST",
+            data=b'{"payload":"no-headers"}',
+        )
+        assert response.status_code == 200, response.content
+
+        result = cluster.instance.query(
+            "SELECT event_type, signature, payload FROM http_column_test"
+        )
+        assert result == "\t\tno-headers\n"

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -965,19 +965,14 @@ def test_predefined_handler_header_column_mappings():
         )
         assert result == "push\tsha256=abc\thello\n"
 
-        # A missing header produces an empty string.
-        cluster.instance.query("TRUNCATE TABLE http_column_test")
+        # A missing mapped header is rejected with BAD_QUERY_PARAMETER.
         response = cluster.instance.http_request(
             "ingest_events",
             method="POST",
             data=b'{"payload":"no-headers"}',
         )
-        assert response.status_code == 200, response.content
-
-        result = cluster.instance.query(
-            "SELECT event_type, signature, payload FROM http_column_test"
-        )
-        assert result == "\t\tno-headers\n"
+        assert response.status_code == 500, response.content
+        assert b"BAD_QUERY_PARAMETER" in response.content, response.content
 
 
 def test_predefined_handler_header_column_mappings_async():

--- a/tests/integration/test_http_handlers_config/test_predefined_handler_http_columns/config.xml
+++ b/tests/integration/test_http_handlers_config/test_predefined_handler_http_columns/config.xml
@@ -1,0 +1,17 @@
+
+<clickhouse>
+    <http_handlers>
+        <rule>
+            <methods>POST</methods>
+            <url>/ingest_events</url>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>INSERT INTO http_column_test (payload) FORMAT JSONEachRow</query>
+                <header_column_mappings>
+                    <X-Event-Type>event_type</X-Event-Type>
+                    <X-Signature>signature</X-Signature>
+                </header_column_mappings>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -57,10 +57,14 @@ release	sig2	batch2
 DUPLICATE_COLUMN
 --- error: non-existent column
 NO_SUCH_COLUMN_IN_TABLE
---- error: MATERIALIZED column
-NO_SUCH_COLUMN_IN_TABLE
---- error: ALIAS column
-NO_SUCH_COLUMN_IN_TABLE
+--- error: MATERIALIZED column without insert_allow_materialized_columns
+ILLEGAL_COLUMN
+--- error: ALIAS column is never insertable
+ILLEGAL_COLUMN
+--- sync: MATERIALIZED column allowed with insert_allow_materialized_columns=1
+mat-test	42
+--- async: MATERIALIZED column allowed with insert_allow_materialized_columns=1
+mat-test	42
 --- sync: non-String column types
 42	['a','b']	3.14	typed
 --- async: non-String column types

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -16,3 +16,7 @@ star	multi1
 star	multi2
 --- error: non-existent column
 NO_SUCH_COLUMN_IN_TABLE
+--- sync: non-String column types
+42	['important','urgent']	3.14	typed-test
+--- async: non-String column types
+100	['async']	2.72	async-typed

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -103,3 +103,14 @@ ab	dedup-valid
 --- async: schema drift with wait_for_async_insert=1, waiter receives error
 TYPE_MISMATCH
 0
+--- sync: FORMAT Native body-column conflict is rejected
+INCORRECT_DATA
+--- sync: absent mapped header is rejected
+BAD_QUERY_PARAMETER
+0
+--- sync: empty header name is rejected
+BAD_QUERY_PARAMETER
+0
+--- sync: empty column name is rejected
+BAD_QUERY_PARAMETER
+0

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -87,11 +87,12 @@ remote-event	remote
 7	8	default-no-list
 --- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives
 ab	short-valid
---- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse
-['a','b']	text-compat
 --- async: failed dedup token remains retryable after schema drift
 ab	dedup-valid
 ab	dedup-retry
+ab	dedup-valid
+--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse
+['a','b']	text-compat
 --- async: schema drift with wait_for_async_insert=1, waiter receives error
 TYPE_MISMATCH
 0

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -8,7 +8,7 @@ release	sha256=def456	row3
 issues	case-test
 --- sync: missing header produces empty string
 	no-header
---- async: header-to-column mapping with batching
+--- async: different header values per request coalesce into one batch
 push	sig1	async1
 release	sig2	async2
 --- async: multiple rows per entry

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -1,5 +1,7 @@
 --- sync: no explicit column list (body provides remaining columns)
 push	s	no-list
+--- sync: no explicit column list, body also contains a header-mapped field (header wins)
+from-header	conflict-test
 --- sync: basic header-to-column mapping
 push	sha256=abc123	hello
 --- sync: multiple rows
@@ -26,6 +28,8 @@ Cannot parse
 NOT_IMPLEMENTED
 --- async: no explicit column list (body provides remaining columns)
 push	s	no-list
+--- async: no explicit column list, body also contains a header-mapped field (header wins)
+from-header	conflict-test
 --- async: basic header-to-column mapping
 push	sha256=abc123	hello
 --- async: multiple rows

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -1,7 +1,7 @@
 --- sync: no explicit column list (body provides remaining columns)
 push	s	no-list
---- sync: no explicit column list, body also contains a header-mapped field (header wins)
-from-header	conflict-test
+--- sync: no explicit column list, body also contains a header-mapped field is an error
+INCORRECT_DATA
 --- sync: basic header-to-column mapping
 push	sha256=abc123	hello
 --- sync: multiple rows
@@ -28,8 +28,8 @@ Cannot parse
 NOT_IMPLEMENTED
 --- async: no explicit column list (body provides remaining columns)
 push	s	no-list
---- async: no explicit column list, body also contains a header-mapped field (header wins)
-from-header	conflict-test
+--- async: no explicit column list, body also contains a header-mapped field is an error
+INCORRECT_DATA
 --- async: basic header-to-column mapping
 push	sha256=abc123	hello
 --- async: multiple rows

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -57,6 +57,10 @@ NOT_IMPLEMENTED
 --- async: different header values per request coalesce into one batch
 push	sig1	batch1
 release	sig2	batch2
+--- error: CSVWithNames body header contains http_column_* target (skip_unknown_fields=1 must not bypass)
+INCORRECT_DATA
+--- error: case-insensitive body field matches http_column_* target
+INCORRECT_DATA
 --- error: column listed in both INSERT list and http_column_*
 DUPLICATE_COLUMN
 --- error: non-existent column

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -89,6 +89,8 @@ remote-event	remote
 --- async: DEFAULT expression referencing injected column (no explicit column list)
 7	8	default-no-list
 5	6	default-test
+--- sync: bad header value with input_format_defaults_for_omitted_fields=1
+BAD_QUERY_PARAMETER
 --- async: multi-header middle-entry failure isolation (alter)
 --- async: multi-header middle-entry failure isolation (results)
 aa	first	entry1

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -22,6 +22,14 @@ star	multi2
 DUPLICATE_COLUMN
 --- error: non-existent column
 NO_SUCH_COLUMN_IN_TABLE
+--- error: MATERIALIZED column (sync)
+NO_SUCH_COLUMN_IN_TABLE
+--- error: ALIAS column (sync)
+NO_SUCH_COLUMN_IN_TABLE
+--- error: MATERIALIZED column (async)
+NO_SUCH_COLUMN_IN_TABLE
+--- error: ALIAS column (async)
+NO_SUCH_COLUMN_IN_TABLE
 --- sync: non-String column types
 42	['important','urgent']	3.14	typed-test
 --- async: non-String column types

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -38,3 +38,7 @@ NO_SUCH_COLUMN_IN_TABLE
 push	remote-sync
 --- async: INSERT INTO FUNCTION remote()
 release	remote-async
+--- sync: DEFAULT expression referencing injected column
+5	6	sync-default
+--- async: DEFAULT expression referencing injected column
+10	11	async-default

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -85,6 +85,9 @@ remote-event	remote
 5	6	default-test
 --- async: DEFAULT expression referencing injected column (no explicit column list)
 7	8	default-no-list
+--- async: multi-header middle-entry failure isolation
+aa	first	entry1
+bb	third	entry3
 --- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives
 ab	short-valid
 --- async: failed dedup token remains retryable after schema drift

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -10,16 +10,16 @@ release	sha256=def456	row2
 release	sha256=def456	row3
 --- sync: case-insensitive header name
 issues	case-test
---- sync: missing header produces empty string
-	no-header
+--- sync: missing header is rejected
+BAD_QUERY_PARAMETER
 --- sync: positional format (TSV) - body-only columns, header injected separately
 tsv-push	hello-tsv
---- sync: filtered header (Authorization) produces empty string
-	filtered
---- sync: empty header name is ignored (no mapping applied)
-body-value	empty-hdr
---- sync: empty column name is ignored (no mapping applied)
-body-value2	empty-col
+--- sync: filtered header (Authorization) is rejected
+BAD_QUERY_PARAMETER
+--- sync: empty header name is rejected
+BAD_QUERY_PARAMETER
+--- sync: empty column name is rejected
+BAD_QUERY_PARAMETER
 --- sync: duplicate http_column_* to same column, first wins
 first	dup
 --- sync: type parse error surfaces immediately
@@ -38,16 +38,16 @@ release	sha256=def456	row2
 release	sha256=def456	row3
 --- async: case-insensitive header name
 issues	case-test
---- async: missing header produces empty string
-	no-header
+--- async: missing header is rejected
+BAD_QUERY_PARAMETER
 --- async: positional format (TSV) - body-only columns, header injected separately
 tsv-push	hello-tsv
---- async: filtered header (Authorization) produces empty string
-	filtered
---- async: empty header name is ignored (no mapping applied)
-body-value	empty-hdr
---- async: empty column name is ignored (no mapping applied)
-body-value2	empty-col
+--- async: filtered header (Authorization) is rejected
+BAD_QUERY_PARAMETER
+--- async: empty header name is rejected
+BAD_QUERY_PARAMETER
+--- async: empty column name is rejected
+BAD_QUERY_PARAMETER
 --- async: duplicate http_column_* to same column, first wins
 first	dup
 --- async: type parse error surfaces immediately
@@ -106,11 +106,5 @@ TYPE_MISMATCH
 --- sync: FORMAT Native body-column conflict is rejected
 INCORRECT_DATA
 --- sync: absent mapped header is rejected
-BAD_QUERY_PARAMETER
-0
---- sync: empty header name is rejected
-BAD_QUERY_PARAMETER
-0
---- sync: empty column name is rejected
 BAD_QUERY_PARAMETER
 0

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -26,3 +26,7 @@ NO_SUCH_COLUMN_IN_TABLE
 42	['important','urgent']	3.14	typed-test
 --- async: non-String column types
 100	['async']	2.72	async-typed
+--- sync: INSERT INTO FUNCTION remote()
+push	remote-sync
+--- async: INSERT INTO FUNCTION remote()
+release	remote-async

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -87,3 +87,11 @@ remote-event	remote
 7	8	default-no-list
 --- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives
 ab	short-valid
+--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse
+['a','b']	text-compat
+--- async: failed dedup token remains retryable after schema drift
+ab	dedup-valid
+ab	dedup-retry
+--- async: schema drift with wait_for_async_insert=1, waiter receives error
+TYPE_MISMATCH
+0

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -10,35 +10,66 @@ release	sha256=def456	row3
 issues	case-test
 --- sync: missing header produces empty string
 	no-header
+--- sync: positional format (TSV) - body-only columns, header injected separately
+tsv-push	hello-tsv
+--- sync: filtered header (Authorization) produces empty string
+	filtered
+--- sync: empty header name is ignored (no mapping applied)
+body-value	empty-hdr
+--- sync: empty column name is ignored (no mapping applied)
+body-value2	empty-col
+--- sync: duplicate http_column_* to same column, first wins
+first	dup
+--- sync: type parse error surfaces immediately
+Cannot parse
+--- sync: INSERT ... SELECT rejected
+NOT_IMPLEMENTED
 --- async: no explicit column list (body provides remaining columns)
-push	s	no-list-async
+push	s	no-list
+--- async: basic header-to-column mapping
+push	sha256=abc123	hello
+--- async: multiple rows
+release	sha256=def456	row1
+release	sha256=def456	row2
+release	sha256=def456	row3
+--- async: case-insensitive header name
+issues	case-test
+--- async: missing header produces empty string
+	no-header
+--- async: positional format (TSV) - body-only columns, header injected separately
+tsv-push	hello-tsv
+--- async: filtered header (Authorization) produces empty string
+	filtered
+--- async: empty header name is ignored (no mapping applied)
+body-value	empty-hdr
+--- async: empty column name is ignored (no mapping applied)
+body-value2	empty-col
+--- async: duplicate http_column_* to same column, first wins
+first	dup
+--- async: type parse error surfaces immediately
+Cannot parse
+--- async: INSERT ... SELECT rejected
+NOT_IMPLEMENTED
 --- async: different header values per request coalesce into one batch
-push	sig1	async1
-release	sig2	async2
---- async: multiple rows per entry
-star	multi1
-star	multi2
+push	sig1	batch1
+release	sig2	batch2
 --- error: column listed in both INSERT list and http_column_*
 DUPLICATE_COLUMN
 --- error: non-existent column
 NO_SUCH_COLUMN_IN_TABLE
---- error: MATERIALIZED column (sync)
+--- error: MATERIALIZED column
 NO_SUCH_COLUMN_IN_TABLE
---- error: ALIAS column (sync)
-NO_SUCH_COLUMN_IN_TABLE
---- error: MATERIALIZED column (async)
-NO_SUCH_COLUMN_IN_TABLE
---- error: ALIAS column (async)
+--- error: ALIAS column
 NO_SUCH_COLUMN_IN_TABLE
 --- sync: non-String column types
-42	['important','urgent']	3.14	typed-test
+42	['a','b']	3.14	typed
 --- async: non-String column types
-100	['async']	2.72	async-typed
+42	['a','b']	3.14	typed
 --- sync: INSERT INTO FUNCTION remote()
-push	remote-sync
+remote-event	remote
 --- async: INSERT INTO FUNCTION remote()
-release	remote-async
+remote-event	remote
 --- sync: DEFAULT expression referencing injected column
-5	6	sync-default
+5	6	default-test
 --- async: DEFAULT expression referencing injected column
-10	11	async-default
+5	6	default-test

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -23,7 +23,7 @@ BAD_QUERY_PARAMETER
 --- sync: duplicate http_column_* to same column, first wins
 first	dup
 --- sync: type parse error surfaces immediately
-Cannot parse
+BAD_QUERY_PARAMETER
 --- sync: INSERT ... SELECT rejected
 NOT_IMPLEMENTED
 --- async: no explicit column list (body provides remaining columns)
@@ -51,7 +51,7 @@ BAD_QUERY_PARAMETER
 --- async: duplicate http_column_* to same column, first wins
 first	dup
 --- async: type parse error surfaces immediately
-Cannot parse
+BAD_QUERY_PARAMETER
 --- async: INSERT ... SELECT rejected
 NOT_IMPLEMENTED
 --- async: different header values per request coalesce into one batch
@@ -82,18 +82,21 @@ remote-event	remote
 --- async: INSERT INTO FUNCTION remote()
 remote-event	remote
 --- sync: DEFAULT expression referencing injected column (explicit column list)
-5	6	default-test
 --- sync: DEFAULT expression referencing injected column (no explicit column list)
 7	8	default-no-list
---- async: DEFAULT expression referencing injected column (explicit column list)
 5	6	default-test
+--- async: DEFAULT expression referencing injected column (explicit column list)
 --- async: DEFAULT expression referencing injected column (no explicit column list)
 7	8	default-no-list
---- async: multi-header middle-entry failure isolation
+5	6	default-test
+--- async: multi-header middle-entry failure isolation (alter)
+--- async: multi-header middle-entry failure isolation (results)
 aa	first	entry1
 bb	third	entry3
+--- async: schema drift same TypeIndex (FixedString shrink) (alter)
 --- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives
 ab	short-valid
+--- async: failed dedup token remains retryable after schema drift (alter)
 --- async: failed dedup token remains retryable after schema drift
 ab	dedup-valid
 ab	dedup-retry
@@ -101,7 +104,7 @@ ab	dedup-valid
 --- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse
 ['a','b']	text-compat
 --- async: schema drift with wait_for_async_insert=1, waiter receives error
-TYPE_MISMATCH
+TOO_LARGE_STRING_SIZE
 0
 --- sync: FORMAT Native body-column conflict is rejected
 INCORRECT_DATA

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -85,3 +85,5 @@ remote-event	remote
 5	6	default-test
 --- async: DEFAULT expression referencing injected column (no explicit column list)
 7	8	default-no-list
+--- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives
+ab	short-valid

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -1,3 +1,5 @@
+--- sync: no explicit column list (body provides remaining columns)
+push	s	no-list
 --- sync: basic header-to-column mapping
 push	sha256=abc123	hello
 --- sync: multiple rows
@@ -8,12 +10,16 @@ release	sha256=def456	row3
 issues	case-test
 --- sync: missing header produces empty string
 	no-header
+--- async: no explicit column list (body provides remaining columns)
+push	s	no-list-async
 --- async: different header values per request coalesce into one batch
 push	sig1	async1
 release	sig2	async2
 --- async: multiple rows per entry
 star	multi1
 star	multi2
+--- error: column listed in both INSERT list and http_column_*
+DUPLICATE_COLUMN
 --- error: non-existent column
 NO_SUCH_COLUMN_IN_TABLE
 --- sync: non-String column types

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -73,7 +73,11 @@ mat-test	42
 remote-event	remote
 --- async: INSERT INTO FUNCTION remote()
 remote-event	remote
---- sync: DEFAULT expression referencing injected column
+--- sync: DEFAULT expression referencing injected column (explicit column list)
 5	6	default-test
---- async: DEFAULT expression referencing injected column
+--- sync: DEFAULT expression referencing injected column (no explicit column list)
+7	8	default-no-list
+--- async: DEFAULT expression referencing injected column (explicit column list)
 5	6	default-test
+--- async: DEFAULT expression referencing injected column (no explicit column list)
+7	8	default-no-list

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.reference
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.reference
@@ -1,0 +1,18 @@
+--- sync: basic header-to-column mapping
+push	sha256=abc123	hello
+--- sync: multiple rows
+release	sha256=def456	row1
+release	sha256=def456	row2
+release	sha256=def456	row3
+--- sync: case-insensitive header name
+issues	case-test
+--- sync: missing header produces empty string
+	no-header
+--- async: header-to-column mapping with batching
+push	sig1	async1
+release	sig2	async2
+--- async: multiple rows per entry
+star	multi1
+star	multi2
+--- error: non-existent column
+NO_SUCH_COLUMN_IN_TABLE

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -482,3 +482,68 @@ echo "${drift_response}" | expect_match 'TYPE_MISMATCH|type.mismatch'
 # No rows must have been inserted.
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
+
+# --- FORMAT Native: body-or-header guard ---
+# A column mapped via http_column_* must not be silently dropped from the Native
+# body even when input_format_skip_unknown_fields=1. The insert must fail with
+# INCORRECT_DATA so the header value cannot win without the caller noticing.
+echo "--- sync: FORMAT Native body-column conflict is rejected"
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.t_native;
+    CREATE TABLE ${CLICKHOUSE_DATABASE}.t_native
+        (event_type String, payload String)
+        ENGINE = MergeTree ORDER BY tuple();
+"
+native_payload=$(${CLICKHOUSE_CLIENT} -q "SELECT 'body-value' AS event_type, 'p' AS payload FORMAT Native")
+curl -sS \
+    -H 'X-Event-Type: header-value' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_native+(payload)+FORMAT+Native"\
+"&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
+    --data-binary "${native_payload}" 2>&1 | expect_match 'INCORRECT_DATA'
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.t_native"
+
+# --- absent header is a hard error ---
+# http_column_* mirrors param_*: if the referenced header is absent from the
+# request, ClickHouse must reject it with BAD_QUERY_PARAMETER rather than
+# silently inserting an empty/default value.
+echo "--- sync: absent mapped header is rejected"
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.t_absent;
+    CREATE TABLE ${CLICKHOUSE_DATABASE}.t_absent
+        (code UInt64, payload String)
+        ENGINE = MergeTree ORDER BY tuple();
+"
+# No X-Code header sent — must error, not insert with default 0.
+curl -sS \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_absent+(payload)+FORMAT+JSONEachRow"\
+"&http_column_X-Code=code" \
+    -d '{"payload":"p"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_absent"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.t_absent"
+
+# --- empty http_column_ names are rejected ---
+# http_column_=col  (empty header name) and
+# http_column_X-Foo=  (empty column name) are both malformed parameters;
+# ClickHouse rejects them with BAD_QUERY_PARAMETER, consistent with the
+# general rule that every http_column_ field must be non-empty.
+echo "--- sync: empty header name is rejected"
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.t_empty;
+    CREATE TABLE ${CLICKHOUSE_DATABASE}.t_empty (payload String)
+        ENGINE = MergeTree ORDER BY tuple();
+"
+curl -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_empty+FORMAT+JSONEachRow"\
+"&http_column_=event_type" \
+    -d '{"payload":"p"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_empty"
+
+echo "--- sync: empty column name is rejected"
+curl -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_empty+FORMAT+JSONEachRow"\
+"&http_column_X-Event-Type=" \
+    -d '{"payload":"p"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_empty"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.t_empty"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -14,7 +14,7 @@ run_modes() {
     for mode in sync async; do
         if [ "$mode" = "async" ]; then
             INSERT_EXTRA="&async_insert=1&wait_for_async_insert=0"
-            flush() { ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"; }
+            flush() { ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"; }
         else
             INSERT_EXTRA=""
             flush() { :; }
@@ -181,7 +181,7 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
     -d '{"payload":"batch2"}'
 
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t ORDER BY payload"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
@@ -316,8 +316,13 @@ run_modes do_default_tests
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
 # ── Async schema drift and per-entry failure isolation ────────────────────────
-# Entries are buffered with a large busy timeout so they stay in the queue until
-# we ALTER the column type and call SYSTEM FLUSH ASYNC INSERT QUEUE manually.
+# Entries are buffered until we ALTER the column type and call
+# SYSTEM FLUSH ASYNC INSERT QUEUE manually. A large fixed busy timeout with the
+# adaptive timeout disabled keeps entries in the queue even when the flaky check
+# randomizes async insert settings; otherwise an early flush could materialize
+# 'abcd' before the ALTER and make the ALTER itself fail with TOO_LARGE_STRING_SIZE.
+ASYNC_BUF="async_insert=1&wait_for_async_insert=0&async_insert_use_adaptive_busy_timeout=0&async_insert_busy_timeout_min_ms=300000&async_insert_busy_timeout_max_ms=300000"
+ASYNC_BUF_WAIT="async_insert=1&wait_for_async_insert=1&async_insert_use_adaptive_busy_timeout=0&async_insert_busy_timeout_min_ms=300000&async_insert_busy_timeout_max_ms=300000"
 
 # Test 0: multi-header, middle-entry failure isolation.
 # Three entries, two mapped headers (code FixedString(4) + tag String).
@@ -331,21 +336,21 @@ ${CLICKHOUSE_CLIENT} -q "
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: aa' -H 'X-Tag: first' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
     -d '{"payload":"entry1"}'
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: abcd' -H 'X-Tag: second' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
     -d '{"payload":"entry2"}'
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: bb' -H 'X-Tag: third' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
     -d '{"payload":"entry3"}'
 
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
 echo "--- async: multi-header middle-entry failure isolation"
 ${CLICKHOUSE_CLIENT} -q "SELECT code, tag, payload FROM t ORDER BY payload"
@@ -361,16 +366,16 @@ ${CLICKHOUSE_CLIENT} -q "
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: ab' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"short-valid"}'
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: abcd' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"exact-valid"}'
 
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
 echo "--- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives"
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
@@ -385,16 +390,16 @@ ${CLICKHOUSE_CLIENT} -q "
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: ab' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&insert_deduplication_token=token-valid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&insert_deduplication_token=token-valid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"dedup-valid"}'
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: abcd' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"dedup-invalid"}'
 
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
 echo "--- async: failed dedup token remains retryable after schema drift"
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
@@ -416,11 +421,11 @@ ${CLICKHOUSE_CLIENT} -q "
 
 ${CLICKHOUSE_CURL} -sS \
     -H "X-Tags: ['a','b']" \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t_tags+(payload)+FORMAT+JSONEachRow&http_column_X-Tags=tags" \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t_tags+(payload)+FORMAT+JSONEachRow&http_column_X-Tags=tags" \
     -d '{"payload":"text-compat"}'
 
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_tags MODIFY COLUMN tags Array(String)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t_tags"
 
 echo "--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse"
 ${CLICKHOUSE_CLIENT} -q "SELECT tags, payload FROM t_tags"
@@ -433,14 +438,14 @@ ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 drift_response=$(
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Code: abcd' \
-        "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+        "${CLICKHOUSE_URL}&${ASYNC_BUF_WAIT}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
         -d '{"payload":"drift-waiter"}' 2>&1
 ) &
 drift_pid=$!
 
 # Entry is now queued; shrink column to invalidate the buffered value.
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(1)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 wait "${drift_pid}"
 
 echo "--- async: schema drift with wait_for_async_insert=1, waiter receives error"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -7,247 +7,267 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Helper: build mode-specific URL params and optional flush call.
+# Usage: insert_url <extra_params>
+# Side effect: sets $INSERT_EXTRA (URL params string) and defines flush()
+run_modes() {
+    for mode in sync async; do
+        if [ "$mode" = "async" ]; then
+            INSERT_EXTRA="&async_insert=1&wait_for_async_insert=0"
+            flush() { ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"; }
+        else
+            INSERT_EXTRA=""
+            flush() { :; }
+        fi
+        "$@"
+    done
+}
+
+# ── Main table ─────────────────────────────────────────────────────────────────
 ${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS test_http_columns;
-    CREATE TABLE test_http_columns (
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (
         event_type LowCardinality(String),
-        signature String,
-        payload String
+        signature  String,
+        payload    String
     ) ENGINE = MergeTree ORDER BY tuple();
 "
 
-echo "--- sync: no explicit column list (body provides remaining columns)"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"no-list","signature":"s"}'
+do_basic_tests() {
+    echo "--- ${mode}: no explicit column list (body provides remaining columns)"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: push' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+        -d '{"payload":"no-list","signature":"s"}'
+    # Note: both sync and async use same payload value for consistent reference output
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+    echo "--- ${mode}: basic header-to-column mapping"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: push' \
+        -H 'X-Signature: sha256=abc123' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+        -d '{"payload":"hello"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t ORDER BY payload"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-echo "--- sync: basic header-to-column mapping"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    -H 'X-Signature: sha256=abc123' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"hello"}'
-
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
-
-echo "--- sync: multiple rows"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: release' \
-    -H 'X-Signature: sha256=def456' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"row1"}
+    echo "--- ${mode}: multiple rows"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: release' \
+        -H 'X-Signature: sha256=def456' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+        -d '{"payload":"row1"}
 {"payload":"row2"}
 {"payload":"row3"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t ORDER BY payload"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+    echo "--- ${mode}: case-insensitive header name"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'x-event-type: issues' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+        -d '{"payload":"case-test"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-echo "--- sync: case-insensitive header name"
-${CLICKHOUSE_CURL} -sS \
-    -H 'x-event-type: issues' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"case-test"}'
+    echo "--- ${mode}: missing header produces empty string"
+    ${CLICKHOUSE_CURL} -sS \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+        -d '{"payload":"no-header"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+    echo "--- ${mode}: positional format (TSV) - body-only columns, header injected separately"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: tsv-push' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+TSV&http_column_X-Event-Type=event_type" \
+        -d 'hello-tsv'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-echo "--- sync: missing header produces empty string"
-${CLICKHOUSE_CURL} -sS \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"no-header"}'
+    echo "--- ${mode}: filtered header (Authorization) produces empty string"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'Authorization: Bearer secret-token' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_Authorization=event_type" \
+        -d '{"payload":"filtered"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+    echo "--- ${mode}: empty header name is ignored (no mapping applied)"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: ignored' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(event_type,payload)+FORMAT+JSONEachRow&http_column_=event_type" \
+        -d '{"event_type":"body-value","payload":"empty-hdr"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-echo "--- async: no explicit column list (body provides remaining columns)"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"no-list-async","signature":"s"}'
+    echo "--- ${mode}: empty column name is ignored (no mapping applied)"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: ignored' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(event_type,payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=" \
+        -d '{"event_type":"body-value2","payload":"empty-col"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+    echo "--- ${mode}: duplicate http_column_* to same column, first wins"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-A: first' \
+        -H 'X-B: second' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-A=event_type&http_column_X-B=event_type" \
+        -d '{"payload":"dup"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+
+    echo "--- ${mode}: type parse error surfaces immediately"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Count: not-a-number' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count" \
+        -d '{"payload":"type-err"}' 2>&1 | grep -o 'CANNOT_PARSE_TEXT\|Cannot parse'
+
+    echo "--- ${mode}: INSERT ... SELECT rejected"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: push' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+SELECT+%27x%27&http_column_X-Event-Type=event_type" \
+        2>&1 | grep -o 'NOT_IMPLEMENTED'
+}
+
+# ── Typed table (for type-error test) ─────────────────────────────────────────
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS typed;
+    CREATE TABLE typed (count UInt64, payload String) ENGINE = MergeTree ORDER BY tuple();
+"
+
+run_modes do_basic_tests
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE typed"
+
+# ── Async-only: batching with different headers per entry ──────────────────────
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (event_type String, signature String, payload String)
+    ENGINE = MergeTree ORDER BY tuple();
+"
 
 echo "--- async: different header values per request coalesce into one batch"
-# Two fire-and-forget requests, then explicit flush. Each row must carry its own
-# request's header values to verify per-entry injection works correctly.
 ${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    -H 'X-Signature: sig1' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"async1"}'
+    -H 'X-Event-Type: push' -H 'X-Signature: sig1' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"batch1"}'
 
 ${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: release' \
-    -H 'X-Signature: sig2' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"async2"}'
+    -H 'X-Event-Type: release' -H 'X-Signature: sig2' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"batch2"}'
 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
-echo "--- async: multiple rows per entry"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: star' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"multi1"}
-{"payload":"multi2"}'
-
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns ORDER BY payload"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
-
-echo "--- error: column listed in both INSERT list and http_column_*"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(event_type,payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"conflict"}' 2>&1 | grep -o 'DUPLICATE_COLUMN'
-
-echo "--- error: non-existent column"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=no_such_column" \
-    -d '{"payload":"err"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
-
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns"
-
-# MATERIALIZED and ALIAS columns are not insertable and must be rejected.
+# ── Error cases (format-independent, run once) ─────────────────────────────────
 ${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS test_http_columns_non_insertable;
-    CREATE TABLE test_http_columns_non_insertable (
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (
         payload   String,
         mat_col   UInt64 MATERIALIZED length(payload),
         alias_col String ALIAS payload
     ) ENGINE = MergeTree ORDER BY tuple();
 "
 
-echo "--- error: MATERIALIZED column (sync)"
+echo "--- error: column listed in both INSERT list and http_column_*"
 ${CLICKHOUSE_CURL} -sS \
-    -H 'X-Val: 42' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=mat_col" \
+    -H 'X-E: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=payload" \
+    -d '{"payload":"conflict"}' 2>&1 | grep -o 'DUPLICATE_COLUMN'
+
+echo "--- error: non-existent column"
+${CLICKHOUSE_CURL} -sS \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=no_col" \
     -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
 
-echo "--- error: ALIAS column (sync)"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Val: hello' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=alias_col" \
+echo "--- error: MATERIALIZED column"
+${CLICKHOUSE_CURL} -sS -H 'X-V: 1' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=mat_col" \
     -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
 
-echo "--- error: MATERIALIZED column (async)"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Val: 42' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=mat_col" \
+echo "--- error: ALIAS column"
+${CLICKHOUSE_CURL} -sS -H 'X-V: hi' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=alias_col" \
     -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
 
-echo "--- error: ALIAS column (async)"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Val: hello' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=alias_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_non_insertable"
-
-# Test non-String column types: values are deserialized through the column type's
-# text serialization, so UInt64, Array, Date, etc. should parse correctly.
+# ── Non-String types ───────────────────────────────────────────────────────────
 ${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS test_http_columns_typed;
-    CREATE TABLE test_http_columns_typed (
-        count UInt64,
-        tags Array(String),
-        rate Float64,
-        payload String
-    ) ENGINE = MergeTree ORDER BY tuple();
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (count UInt64, tags Array(String), rate Float64, payload String)
+    ENGINE = MergeTree ORDER BY tuple();
 "
 
-echo "--- sync: non-String column types"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Count: 42' \
-    -H "X-Tags: ['important','urgent']" \
-    -H 'X-Rate: 3.14' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
-    -d '{"payload":"typed-test"}'
+do_typed_tests() {
+    echo "--- ${mode}: non-String column types"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Count: 42' \
+        -H "X-Tags: ['a','b']" \
+        -H 'X-Rate: 3.14' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
+        -d '{"payload":"typed"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+}
 
-${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_typed"
+run_modes do_typed_tests
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
-echo "--- async: non-String column types"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Count: 100' \
-    -H "X-Tags: ['async']" \
-    -H 'X-Rate: 2.72' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
-    -d '{"payload":"async-typed"}'
-
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
-
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_typed"
-
-# Test INSERT INTO FUNCTION remote() -- verifies that table functions are supported
-# and resolved correctly (not broken by direct DatabaseCatalog lookup).
+# ── INSERT INTO FUNCTION remote() ─────────────────────────────────────────────
 ${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS test_http_columns_remote;
-    CREATE TABLE test_http_columns_remote (
-        event_type String,
-        payload    String
-    ) ENGINE = MergeTree ORDER BY tuple();
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (event_type String, payload String) ENGINE = MergeTree ORDER BY tuple();
 "
 
-echo "--- sync: INSERT INTO FUNCTION remote()"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),test_http_columns_remote)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"remote-sync"}'
+do_remote_tests() {
+    echo "--- ${mode}: INSERT INTO FUNCTION remote()"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: remote-event' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),t)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+        -d '{"payload":"remote"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+}
 
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns_remote"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_remote"
+run_modes do_remote_tests
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
-echo "--- async: INSERT INTO FUNCTION remote()"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-Event-Type: release' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),test_http_columns_remote)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-    -d '{"payload":"remote-async"}'
-
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns_remote"
-
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_remote"
-
-# Test DEFAULT expressions that reference an http_column_* injected column.
-# With input_format_defaults_for_omitted_fields=1, the DEFAULT expression
-# `b DEFAULT a + 1` must use the injected value of `a`, not zero.
+# ── DEFAULT expression referencing injected column ────────────────────────────
 ${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS test_http_columns_defaults;
-    CREATE TABLE test_http_columns_defaults (
-        a UInt64,
-        b UInt64 DEFAULT a + 1,
-        payload String
-    ) ENGINE = MergeTree ORDER BY tuple();
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (a UInt64, b UInt64 DEFAULT a + 1, payload String)
+    ENGINE = MergeTree ORDER BY tuple();
 "
 
-echo "--- sync: DEFAULT expression referencing injected column"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-A: 5' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_defaults+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
-    -d '{"payload":"sync-default"}'
+do_default_tests() {
+    echo "--- ${mode}: DEFAULT expression referencing injected column"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-A: 5' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
+        -d '{"payload":"default-test"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+}
 
-${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM test_http_columns_defaults"
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_defaults"
-
-echo "--- async: DEFAULT expression referencing injected column"
-${CLICKHOUSE_CURL} -sS \
-    -H 'X-A: 10' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_defaults+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
-    -d '{"payload":"async-default"}'
-
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM test_http_columns_defaults"
-
-${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_defaults"
+run_modes do_default_tests
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -72,7 +72,7 @@ do_basic_tests() {
         -H 'X-Event-Type: from-header' \
         "${CLICKHOUSE_URL}${CONFLICT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
         -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}' \
-        | expect_match 'INCORRECT_DATA|Unknown field'
+        | expect_match 'INCORRECT_DATA'
 
     echo "--- ${mode}: basic header-to-column mapping"
     ${CLICKHOUSE_CURL} -sS \
@@ -121,7 +121,7 @@ do_basic_tests() {
 
     echo "--- ${mode}: filtered header (Authorization) is rejected"
     ${CLICKHOUSE_CURL} -sS \
-        -H 'Authorization: Bearer secret-token' \
+        -H 'Authorization: Basic ZGVmYXVsdDo=' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_Authorization=event_type" \
         -d '{"payload":"filtered"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
@@ -151,7 +151,7 @@ do_basic_tests() {
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Count: not-a-number' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count" \
-        -d '{"payload":"type-err"}' 2>&1 | expect_match 'CANNOT_PARSE_TEXT|Cannot parse'
+        -d '{"payload":"type-err"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
     echo "--- ${mode}: INSERT ... SELECT rejected"
     ${CLICKHOUSE_CURL} -sS \
@@ -215,14 +215,14 @@ ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+CSVWithNames&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
     --data-binary $'event_type,payload\nfrom-body,conflict' \
-    | expect_match 'INCORRECT_DATA|Unknown field'
+    | expect_match 'INCORRECT_DATA'
 
 echo "--- error: case-insensitive body field matches http_column_* target"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1&input_format_column_name_matching_mode=ignore_case" \
     -d '{"EVENT_TYPE":"from-body","payload":"conflict"}' \
-    | expect_match 'INCORRECT_DATA|Unknown field'
+    | expect_match 'INCORRECT_DATA'
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_conflict"
 
 echo "--- error: column listed in both INSERT list and http_column_*"
@@ -232,7 +232,7 @@ ${CLICKHOUSE_CURL} -sS \
     -d '{"payload":"conflict"}' 2>&1 | expect_match 'DUPLICATE_COLUMN'
 
 echo "--- error: non-existent column"
-${CLICKHOUSE_CURL} -sS \
+${CLICKHOUSE_CURL} -sS -H 'X-E: val' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=no_col" \
     -d '{"payload":"x"}' 2>&1 | expect_match 'NO_SUCH_COLUMN_IN_TABLE'
 
@@ -293,8 +293,11 @@ do_remote_tests() {
     echo "--- ${mode}: INSERT INTO FUNCTION remote()"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: remote-event' \
-        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),t)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+FUNCTION+remote('127.0.0.1:${CLICKHOUSE_PORT_TCP}',currentDatabase(),t)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
         -d '{"payload":"remote"}'
+    flush
+    # The remote() call itself may be queued asynchronously on the receiving side,
+    # so flush a second time to drain that entry too.
     flush
     ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
@@ -324,7 +327,7 @@ do_default_tests() {
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
         -d '{"payload":"default-no-list"}'
     flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM t ORDER BY payload"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 }
 
@@ -341,12 +344,16 @@ ASYNC_BUF="async_insert=1&wait_for_async_insert=0&async_insert_use_adaptive_busy
 ASYNC_BUF_WAIT="async_insert=1&wait_for_async_insert=1&async_insert_use_adaptive_busy_timeout=0&async_insert_busy_timeout_min_ms=300000&async_insert_busy_timeout_max_ms=300000"
 
 # Test 0: multi-header, middle-entry failure isolation.
-# Three entries, two mapped headers (code FixedString(4) + tag String).
-# After ALTER, the middle entry's code value ('abcd', 4 bytes) no longer fits
-# FixedString(2). Entries 1 and 3 must survive with their own header values.
+# Three entries, two mapped headers (code String + tag String).
+# After ALTER to FixedString(2), the middle entry's code value ('abcd', 4 chars)
+# no longer fits. Entries 1 and 3 must survive with their own header values.
+# String (not FixedString(4)) is used as the initial type because ALTER to a
+# smaller FixedString checks the metadata sample block (which is 4 null bytes
+# for FixedString(4) and can't fit in FixedString(2)), making the ALTER itself
+# fail even on an empty table. String's default '' fits any FixedString.
 ${CLICKHOUSE_CLIENT} -q "
     DROP TABLE IF EXISTS t;
-    CREATE TABLE t (code FixedString(4), tag String, payload String)
+    CREATE TABLE t (code String, tag String, payload String)
     ENGINE = MergeTree ORDER BY tuple();
 "
 
@@ -365,19 +372,20 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
     -d '{"payload":"entry3"}'
 
+echo "--- async: multi-header middle-entry failure isolation (alter)"
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
-echo "--- async: multi-header middle-entry failure isolation"
+echo "--- async: multi-header middle-entry failure isolation (results)"
 ${CLICKHOUSE_CLIENT} -q "SELECT code, tag, payload FROM t ORDER BY payload"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
-# Test 1: FixedString(4) -> FixedString(2) shrink.
-# Both entries are enqueued before the ALTER; the one with the 4-byte value must
-# fail in isolation while the 2-byte entry survives.
+# Test 1: String -> FixedString(2) drift.
+# Both entries are enqueued before the ALTER; the one with the 4-char value must
+# fail in isolation while the 2-char entry survives.
 ${CLICKHOUSE_CLIENT} -q "
     DROP TABLE IF EXISTS t;
-    CREATE TABLE t (code FixedString(4), payload String) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE t (code String, payload String) ENGINE = MergeTree ORDER BY tuple();
 "
 
 ${CLICKHOUSE_CURL} -sS \
@@ -390,6 +398,7 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&${ASYNC_BUF}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"exact-valid"}'
 
+echo "--- async: schema drift same TypeIndex (FixedString shrink) (alter)"
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
@@ -397,11 +406,10 @@ echo "--- async: schema drift same TypeIndex (FixedString shrink) - valid entry 
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
 
 # Test 2: Dedup — a failed entry's token must remain retryable.
-# Recreate the table with FixedString(4) so push-time validation passes for 'abcd'.
 # Both entries are enqueued BEFORE the ALTER that invalidates 'abcd'.
 ${CLICKHOUSE_CLIENT} -q "
     DROP TABLE IF EXISTS t;
-    CREATE TABLE t (code FixedString(4), payload String) ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE t (code String, payload String) ENGINE = MergeTree ORDER BY tuple();
 "
 
 ${CLICKHOUSE_CURL} -sS \
@@ -414,6 +422,7 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&${ASYNC_BUF}&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"dedup-invalid"}'
 
+echo "--- async: failed dedup token remains retryable after schema drift (alter)"
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
 
@@ -449,24 +458,37 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_tags"
 
 # Test 4: waiter with wait_for_async_insert=1 must receive an error, not silent success,
 # when schema drift makes the buffered value unparseable at flush time.
-${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+# Recreate t with code String so ALTER to FixedString(1) succeeds on an empty
+# table (String default '' fits FixedString(1); FixedString(N) default is N null
+# bytes which would fail the metadata sample-block cast check for any N > 1).
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (code String, payload String) ENGINE = MergeTree ORDER BY tuple();
+"
 
-drift_response=$(
-    ${CLICKHOUSE_CURL} -sS \
-        -H 'X-Code: abcd' \
-        "${CLICKHOUSE_URL}&${ASYNC_BUF_WAIT}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
-        -d '{"payload":"drift-waiter"}' 2>&1
-) &
-drift_pid=$!
+# Run ALTER+FLUSH in background: wait until the entry is queued, then shrink
+# the column to invalidate the buffered value and trigger the flush.
+{
+    for _ in $(seq 1 100); do
+        ${CLICKHOUSE_CLIENT} -q \
+            "SELECT count() FROM system.asynchronous_inserts WHERE database=currentDatabase() AND table='t'" \
+            2>/dev/null | grep -q '^[1-9]' && break
+        sleep 0.1
+    done
+    ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(1)"
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
+} &
 
-# Entry is now queued; shrink column to invalidate the buffered value.
-${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(1)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE ${CLICKHOUSE_DATABASE}.t"
-wait "${drift_pid}"
+# curl runs in the foreground; it blocks until the flush above resolves the wait.
+drift_response=$(${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: abcd' \
+    "${CLICKHOUSE_URL}&${ASYNC_BUF_WAIT}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"drift-waiter"}')
+wait
 
 echo "--- async: schema drift with wait_for_async_insert=1, waiter receives error"
 # Waiter must have received an error (TYPE_MISMATCH or similar).
-echo "${drift_response}" | expect_match 'TYPE_MISMATCH|type.mismatch'
+echo "${drift_response}" | expect_match 'BAD_QUERY_PARAMETER|TOO_LARGE_STRING_SIZE'
 # No rows must have been inserted.
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -44,6 +44,18 @@ do_basic_tests() {
     ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
+    echo "--- ${mode}: no explicit column list, body also contains a header-mapped field (header wins)"
+    # Body provides event_type='from-body', but http_column also maps event_type from header.
+    # Since event_type is excluded from format_header, the body value is silently discarded
+    # and the header value wins. input_format_skip_unknown_fields=1 prevents a parse error.
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Event-Type: from-header' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
+        -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+
     echo "--- ${mode}: basic header-to-column mapping"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: push' \

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -307,6 +307,38 @@ ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 # Entries are buffered with a large busy timeout so they stay in the queue until
 # we ALTER the column type and call SYSTEM FLUSH ASYNC INSERT QUEUE manually.
 
+# Test 0: multi-header, middle-entry failure isolation.
+# Three entries, two mapped headers (code FixedString(4) + tag String).
+# After ALTER, the middle entry's code value ('abcd', 4 bytes) no longer fits
+# FixedString(2). Entries 1 and 3 must survive with their own header values.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (code FixedString(4), tag String, payload String)
+    ENGINE = MergeTree ORDER BY tuple();
+"
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: aa' -H 'X-Tag: first' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    -d '{"payload":"entry1"}'
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: abcd' -H 'X-Tag: second' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    -d '{"payload":"entry2"}'
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: bb' -H 'X-Tag: third' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code&http_column_X-Tag=tag" \
+    -d '{"payload":"entry3"}'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+
+echo "--- async: multi-header middle-entry failure isolation"
+${CLICKHOUSE_CLIENT} -q "SELECT code, tag, payload FROM t ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
+
 # Test 1: FixedString(4) -> FixedString(2) shrink.
 # Both entries are enqueued before the ALTER; the one with the 4-byte value must
 # fail in isolation while the 2-byte entry survives.

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -336,3 +336,76 @@ echo "--- async: schema drift same TypeIndex (FixedString shrink) - valid entry 
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 # 'ab' must be inserted; 'abcd' must fail in isolation (not in result).
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
+
+# Dedup regression: failed entry's token must remain retryable.
+# Queue two entries with distinct dedup tokens before the schema change.
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: ab' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&insert_deduplication_token=token-valid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"dedup-valid"}'
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: abcd' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"dedup-invalid"}'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+
+# Schema drift regression: text-compatible but Field-incompatible type change.
+# String -> Array(String): Field conversion would fail, but text re-parsing succeeds.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (tags String, payload String) ENGINE = MergeTree ORDER BY tuple();
+"
+
+${CLICKHOUSE_CURL} -sS \
+    -H "X-Tags: ['a','b']" \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Tags=tags" \
+    -d '{"payload":"text-compat"}'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN tags Array(String)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+
+echo "--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse"
+${CLICKHOUSE_CLIENT} -q "SELECT tags, payload FROM t"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
+
+echo "--- async: failed dedup token remains retryable after schema drift"
+# Only the valid entry ('ab') must be in the table.
+${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
+
+# Retry the previously-failed entry with the same token — must succeed now.
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: ab' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"dedup-retry"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
+
+# Regression: waiter with wait_for_async_insert=1 must receive an exception, not silent
+# 0-row success, when schema drift invalidates the buffered header value during defaults
+# evaluation (input_format_defaults_for_omitted_fields=1 path).
+# HTTP enqueue is synchronous: by the time the curl process is backgrounded, the entry
+# is already queued, so there is no race between enqueue and the ALTER below.
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+
+drift_response=$(
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-Code: abcd' \
+        "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+        -d '{"payload":"drift-waiter"}' 2>&1
+) &
+drift_pid=$!
+
+# Entry is now queued; shrink column to invalidate the buffered value.
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(1)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+wait "${drift_pid}"
+
+echo "--- async: schema drift with wait_for_async_insert=1, waiter receives error"
+# Waiter must have received an error (TYPE_MISMATCH or similar).
+echo "${drift_response}" | grep -oE 'TYPE_MISMATCH|type.mismatch' | head -1 || echo 'ERROR_RECEIVED'
+# No rows must have been inserted.
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -271,11 +271,18 @@ ${CLICKHOUSE_CLIENT} -q "
 "
 
 do_default_tests() {
-    echo "--- ${mode}: DEFAULT expression referencing injected column"
+    echo "--- ${mode}: DEFAULT expression referencing injected column (explicit column list)"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-A: 5' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
         -d '{"payload":"default-test"}'
+    flush
+
+    echo "--- ${mode}: DEFAULT expression referencing injected column (no explicit column list)"
+    ${CLICKHOUSE_CURL} -sS \
+        -H 'X-A: 7' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
+        -d '{"payload":"default-no-list"}'
     flush
     ${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -95,3 +95,38 @@ ${CLICKHOUSE_CURL} -sS \
     -d '{"payload":"err"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns"
+
+# Test non-String column types: values are deserialized through the column type's
+# text serialization, so UInt64, Array, Date, etc. should parse correctly.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS test_http_columns_typed;
+    CREATE TABLE test_http_columns_typed (
+        count UInt64,
+        tags Array(String),
+        rate Float64,
+        payload String
+    ) ENGINE = MergeTree ORDER BY tuple();
+"
+
+echo "--- sync: non-String column types"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Count: 42' \
+    -H "X-Tags: ['important','urgent']" \
+    -H 'X-Rate: 3.14' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
+    -d '{"payload":"typed-test"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_typed"
+
+echo "--- async: non-String column types"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Count: 100' \
+    -H "X-Tags: ['async']" \
+    -H 'X-Rate: 2.72' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
+    -d '{"payload":"async-typed"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_typed"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -118,6 +118,42 @@ ${CLICKHOUSE_CURL} -sS \
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns"
 
+# MATERIALIZED and ALIAS columns are not insertable and must be rejected.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS test_http_columns_non_insertable;
+    CREATE TABLE test_http_columns_non_insertable (
+        payload   String,
+        mat_col   UInt64 MATERIALIZED length(payload),
+        alias_col String ALIAS payload
+    ) ENGINE = MergeTree ORDER BY tuple();
+"
+
+echo "--- error: MATERIALIZED column (sync)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Val: 42' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=mat_col" \
+    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+
+echo "--- error: ALIAS column (sync)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Val: hello' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=alias_col" \
+    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+
+echo "--- error: MATERIALIZED column (async)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Val: 42' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=mat_col" \
+    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+
+echo "--- error: ALIAS column (async)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Val: hello' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_non_insertable+(payload)+FORMAT+JSONEachRow&http_column_X-Val=alias_col" \
+    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_non_insertable"
+
 # Test non-String column types: values are deserialized through the column type's
 # text serialization, so UInt64, Array, Date, etc. should parse correctly.
 ${CLICKHOUSE_CLIENT} -q "

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -304,20 +304,17 @@ run_modes do_default_tests
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
 # ── Async schema drift and per-entry failure isolation ────────────────────────
-# Tests two async-specific behaviours:
-# 1. Same-TypeIndex parametric change (FixedString(4) -> FixedString(2)): the current
-#    TypeIndex comparison treats both as the same type; the value must be converted or
-#    the entry must fail gracefully rather than silently corrupting data.
-# 2. Per-entry failure isolation: an entry whose header value becomes invalid after the
-#    schema change must fail on its own without aborting the valid entries in the same batch.
+# Entries are buffered with a large busy timeout so they stay in the queue until
+# we ALTER the column type and call SYSTEM FLUSH ASYNC INSERT QUEUE manually.
+
+# Test 1: FixedString(4) -> FixedString(2) shrink.
+# Both entries are enqueued before the ALTER; the one with the 4-byte value must
+# fail in isolation while the 2-byte entry survives.
 ${CLICKHOUSE_CLIENT} -q "
     DROP TABLE IF EXISTS t;
-    CREATE TABLE t (code FixedString(4), payload String)
-    ENGINE = MergeTree ORDER BY tuple();
+    CREATE TABLE t (code FixedString(4), payload String) ENGINE = MergeTree ORDER BY tuple();
 "
 
-# Use a large busy timeout so entries stay buffered until we explicitly flush.
-# Enqueue two entries before the schema change.
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: ab' \
     "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
@@ -328,17 +325,20 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
     -d '{"payload":"exact-valid"}'
 
-# Shrink the column: 'abcd' (4 bytes) no longer fits in FixedString(2).
-# 'ab' (2 bytes) is still valid.
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 
 echo "--- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-# 'ab' must be inserted; 'abcd' must fail in isolation (not in result).
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
 
-# Dedup regression: failed entry's token must remain retryable.
-# Queue two entries with distinct dedup tokens before the schema change.
+# Test 2: Dedup — a failed entry's token must remain retryable.
+# Recreate the table with FixedString(4) so push-time validation passes for 'abcd'.
+# Both entries are enqueued BEFORE the ALTER that invalidates 'abcd'.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (code FixedString(4), payload String) ENGINE = MergeTree ORDER BY tuple();
+"
+
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: ab' \
     "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&insert_deduplication_token=token-valid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
@@ -352,30 +352,10 @@ ${CLICKHOUSE_CURL} -sS \
 ${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 
-# Schema drift regression: text-compatible but Field-incompatible type change.
-# String -> Array(String): Field conversion would fail, but text re-parsing succeeds.
-${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS t;
-    CREATE TABLE t (tags String, payload String) ENGINE = MergeTree ORDER BY tuple();
-"
-
-${CLICKHOUSE_CURL} -sS \
-    -H "X-Tags: ['a','b']" \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Tags=tags" \
-    -d '{"payload":"text-compat"}'
-
-${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN tags Array(String)"
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
-
-echo "--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse"
-${CLICKHOUSE_CLIENT} -q "SELECT tags, payload FROM t"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
-
 echo "--- async: failed dedup token remains retryable after schema drift"
-# Only the valid entry ('ab') must be in the table.
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
 
-# Retry the previously-failed entry with the same token — must succeed now.
+# Retry the previously-failed entry with the same token and a value that fits — must succeed.
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Code: ab' \
     "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&insert_deduplication_token=token-invalid&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
@@ -383,11 +363,27 @@ ${CLICKHOUSE_CURL} -sS \
 
 ${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"
 
-# Regression: waiter with wait_for_async_insert=1 must receive an exception, not silent
-# 0-row success, when schema drift invalidates the buffered header value during defaults
-# evaluation (input_format_defaults_for_omitted_fields=1 path).
-# HTTP enqueue is synchronous: by the time the curl process is backgrounded, the entry
-# is already queued, so there is no race between enqueue and the ALTER below.
+# Test 3: String -> Array(String) (text-compatible, Field-incompatible) drift.
+# Uses a separate table dropped at the end.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t_tags;
+    CREATE TABLE t_tags (tags String, payload String) ENGINE = MergeTree ORDER BY tuple();
+"
+
+${CLICKHOUSE_CURL} -sS \
+    -H "X-Tags: ['a','b']" \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t_tags+(payload)+FORMAT+JSONEachRow&http_column_X-Tags=tags" \
+    -d '{"payload":"text-compat"}'
+
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t_tags MODIFY COLUMN tags Array(String)"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+
+echo "--- async: text-compatible schema drift (String->Array(String)) succeeds via text re-parse"
+${CLICKHOUSE_CLIENT} -q "SELECT tags, payload FROM t_tags"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_tags"
+
+# Test 4: waiter with wait_for_async_insert=1 must receive an error, not silent success,
+# when schema drift makes the buffered value unparseable at flush time.
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
 drift_response=$(

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -7,6 +7,23 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Assert that stdin contains an expected token and print it. If nothing matches
+# (the insert unexpectedly succeeded, or failed with a different message), print
+# a visible NO_MATCH marker so the reference diff fails instead of silently
+# passing on empty output (a plain `grep | head -1` would hide it).
+expect_match() {
+    local pattern="$1"
+    local input
+    input=$(cat)
+    local m
+    m=$(printf '%s' "$input" | grep -oE "$pattern" | head -1)
+    if [ -n "$m" ]; then
+        printf '%s\n' "$m"
+    else
+        printf 'NO_MATCH\n'
+    fi
+}
+
 # Helper: build mode-specific URL params and optional flush call.
 # Usage: insert_url <extra_params>
 # Side effect: sets $INSERT_EXTRA (URL params string) and defines flush()
@@ -55,7 +72,7 @@ do_basic_tests() {
         -H 'X-Event-Type: from-header' \
         "${CLICKHOUSE_URL}${CONFLICT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
         -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}' \
-        | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+        | expect_match 'INCORRECT_DATA|Unknown field'
 
     echo "--- ${mode}: basic header-to-column mapping"
     ${CLICKHOUSE_CURL} -sS \
@@ -146,13 +163,13 @@ do_basic_tests() {
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Count: not-a-number' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count" \
-        -d '{"payload":"type-err"}' 2>&1 | grep -o 'CANNOT_PARSE_TEXT\|Cannot parse'
+        -d '{"payload":"type-err"}' 2>&1 | expect_match 'CANNOT_PARSE_TEXT|Cannot parse'
 
     echo "--- ${mode}: INSERT ... SELECT rejected"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: push' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+SELECT+%27x%27&http_column_X-Event-Type=event_type" \
-        2>&1 | grep -o 'NOT_IMPLEMENTED'
+        2>&1 | expect_match 'NOT_IMPLEMENTED'
 }
 
 # ── Typed table (for type-error test) ─────────────────────────────────────────
@@ -210,36 +227,36 @@ ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+CSVWithNames&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
     --data-binary $'event_type,payload\nfrom-body,conflict' \
-    | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+    | expect_match 'INCORRECT_DATA|Unknown field'
 
 echo "--- error: case-insensitive body field matches http_column_* target"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1&input_format_column_name_matching_mode=ignore_case" \
     -d '{"EVENT_TYPE":"from-body","payload":"conflict"}' \
-    | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+    | expect_match 'INCORRECT_DATA|Unknown field'
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_conflict"
 
 echo "--- error: column listed in both INSERT list and http_column_*"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-E: push' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=payload" \
-    -d '{"payload":"conflict"}' 2>&1 | grep -o 'DUPLICATE_COLUMN'
+    -d '{"payload":"conflict"}' 2>&1 | expect_match 'DUPLICATE_COLUMN'
 
 echo "--- error: non-existent column"
 ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=no_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+    -d '{"payload":"x"}' 2>&1 | expect_match 'NO_SUCH_COLUMN_IN_TABLE'
 
 echo "--- error: MATERIALIZED column without insert_allow_materialized_columns"
 ${CLICKHOUSE_CURL} -sS -H 'X-V: 1' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=mat_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'ILLEGAL_COLUMN'
+    -d '{"payload":"x"}' 2>&1 | expect_match 'ILLEGAL_COLUMN'
 
 echo "--- error: ALIAS column is never insertable"
 ${CLICKHOUSE_CURL} -sS -H 'X-V: hi' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=alias_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'ILLEGAL_COLUMN'
+    -d '{"payload":"x"}' 2>&1 | expect_match 'ILLEGAL_COLUMN'
 
 do_materialized_tests() {
     echo "--- ${mode}: MATERIALIZED column allowed with insert_allow_materialized_columns=1"
@@ -461,7 +478,7 @@ wait "${drift_pid}"
 
 echo "--- async: schema drift with wait_for_async_insert=1, waiter receives error"
 # Waiter must have received an error (TYPE_MISMATCH or similar).
-echo "${drift_response}" | grep -oE 'TYPE_MISMATCH|type.mismatch' | head -1 || echo 'ERROR_RECEIVED'
+echo "${drift_response}" | expect_match 'TYPE_MISMATCH|type.mismatch'
 # No rows must have been inserted.
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM t"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -219,3 +219,35 @@ ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns_remote"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_remote"
+
+# Test DEFAULT expressions that reference an http_column_* injected column.
+# With input_format_defaults_for_omitted_fields=1, the DEFAULT expression
+# `b DEFAULT a + 1` must use the injected value of `a`, not zero.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS test_http_columns_defaults;
+    CREATE TABLE test_http_columns_defaults (
+        a UInt64,
+        b UInt64 DEFAULT a + 1,
+        payload String
+    ) ENGINE = MergeTree ORDER BY tuple();
+"
+
+echo "--- sync: DEFAULT expression referencing injected column"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-A: 5' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns_defaults+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
+    -d '{"payload":"sync-default"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM test_http_columns_defaults"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_defaults"
+
+echo "--- async: DEFAULT expression referencing injected column"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-A: 10' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_defaults+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
+    -d '{"payload":"async-default"}'
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SELECT a, b, payload FROM test_http_columns_defaults"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_defaults"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -16,6 +16,15 @@ ${CLICKHOUSE_CLIENT} -q "
     ) ENGINE = MergeTree ORDER BY tuple();
 "
 
+echo "--- sync: no explicit column list (body provides remaining columns)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"no-list","signature":"s"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
 echo "--- sync: basic header-to-column mapping"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
@@ -55,6 +64,16 @@ ${CLICKHOUSE_CURL} -sS \
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
 
+echo "--- async: no explicit column list (body provides remaining columns)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"no-list-async","signature":"s"}'
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
 echo "--- async: different header values per request coalesce into one batch"
 # Two fire-and-forget requests, then explicit flush. Each row must carry its own
 # request's header values to verify per-entry injection works correctly.
@@ -84,6 +103,12 @@ ${CLICKHOUSE_CURL} -sS \
 ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns ORDER BY payload"
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- error: column listed in both INSERT list and http_column_*"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(event_type,payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"conflict"}' 2>&1 | grep -o 'DUPLICATE_COLUMN'
 
 echo "--- error: non-existent column"
 ${CLICKHOUSE_CURL} -sS \

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -302,3 +302,37 @@ do_default_tests() {
 
 run_modes do_default_tests
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
+
+# ── Async schema drift and per-entry failure isolation ────────────────────────
+# Tests two async-specific behaviours:
+# 1. Same-TypeIndex parametric change (FixedString(4) -> FixedString(2)): the current
+#    TypeIndex comparison treats both as the same type; the value must be converted or
+#    the entry must fail gracefully rather than silently corrupting data.
+# 2. Per-entry failure isolation: an entry whose header value becomes invalid after the
+#    schema change must fail on its own without aborting the valid entries in the same batch.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t;
+    CREATE TABLE t (code FixedString(4), payload String)
+    ENGINE = MergeTree ORDER BY tuple();
+"
+
+# Use a large busy timeout so entries stay buffered until we explicitly flush.
+# Enqueue two entries before the schema change.
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: ab' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"short-valid"}'
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Code: abcd' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&async_insert_busy_timeout_ms=60000&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Code=code" \
+    -d '{"payload":"exact-valid"}'
+
+# Shrink the column: 'abcd' (4 bytes) no longer fits in FixedString(2).
+# 'ab' (2 bytes) is still valid.
+${CLICKHOUSE_CLIENT} -q "ALTER TABLE t MODIFY COLUMN code FixedString(2)"
+
+echo "--- async: schema drift same TypeIndex (FixedString shrink) - valid entry survives"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+# 'ab' must be inserted; 'abcd' must fail in isolation (not in result).
+${CLICKHOUSE_CLIENT} -q "SELECT code, payload FROM t ORDER BY payload"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -44,17 +44,15 @@ do_basic_tests() {
     ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-    echo "--- ${mode}: no explicit column list, body also contains a header-mapped field (header wins)"
-    # Body provides event_type='from-body', but http_column also maps event_type from header.
-    # Since event_type is excluded from format_header, the body value is silently discarded
-    # and the header value wins. input_format_skip_unknown_fields=1 prevents a parse error.
+    echo "--- ${mode}: no explicit column list, body also contains a header-mapped field is an error"
+    # Body provides event_type='from-body' but http_column also maps event_type from header.
+    # Even with input_format_skip_unknown_fields=1, the body field is never silently dropped:
+    # http_column_* mapped columns are forbidden unknown fields and always raise an error.
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: from-header' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
-        -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}'
-    flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
-    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+        -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}' \
+        | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
 
     echo "--- ${mode}: basic header-to-column mapping"
     ${CLICKHOUSE_CURL} -sS \

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -48,9 +48,12 @@ do_basic_tests() {
     # Body provides event_type='from-body' but http_column also maps event_type from header.
     # Even with input_format_skip_unknown_fields=1, the body field is never silently dropped:
     # http_column_* mapped columns are forbidden unknown fields and always raise an error.
+    # Use wait_for_async_insert=1 in async mode so the flush-time rejection reaches the client.
+    CONFLICT_EXTRA=""
+    [ "$mode" = "async" ] && CONFLICT_EXTRA="&async_insert=1&wait_for_async_insert=1"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: from-header' \
-        "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
+        "${CLICKHOUSE_URL}${CONFLICT_EXTRA}&query=INSERT+INTO+t+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
         -d '{"event_type":"from-body","payload":"conflict-test","signature":"s"}' \
         | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
 
@@ -195,19 +198,27 @@ ${CLICKHOUSE_CLIENT} -q "
     ) ENGINE = MergeTree ORDER BY tuple();
 "
 
+# A dedicated table that actually has the mapped column, so these cases reach the
+# format's unknown-field guard instead of failing earlier with NO_SUCH_COLUMN.
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS t_conflict;
+    CREATE TABLE t_conflict (event_type String, payload String) ENGINE = MergeTree ORDER BY tuple();
+"
+
 echo "--- error: CSVWithNames body header contains http_column_* target (skip_unknown_fields=1 must not bypass)"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+CSVWithNames&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+CSVWithNames&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
     --data-binary $'event_type,payload\nfrom-body,conflict' \
     | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
 
 echo "--- error: case-insensitive body field matches http_column_* target"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1&input_format_column_name_matching_mode=ignore_case" \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t_conflict+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1&input_format_column_name_matching_mode=ignore_case" \
     -d '{"EVENT_TYPE":"from-body","payload":"conflict"}' \
     | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_conflict"
 
 echo "--- error: column listed in both INSERT list and http_column_*"
 ${CLICKHOUSE_CURL} -sS \

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -332,6 +332,19 @@ do_default_tests() {
 }
 
 run_modes do_default_tests
+
+# Sync-only: a bad header value with input_format_defaults_for_omitted_fields=1
+# must still produce BAD_QUERY_PARAMETER. The table has b DEFAULT a+1, so
+# columns->hasDefaults() is true and getSourceFromASTInsertQuery also parses the
+# header value. HTTPHeaderColumnsTransform is constructed first, so its
+# BAD_QUERY_PARAMETER wrap fires before the raw parse in getSourceFromInputFormat.
+echo "--- sync: bad header value with input_format_defaults_for_omitted_fields=1"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-A: not-a-number' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-A=a&input_format_defaults_for_omitted_fields=1" \
+    -d '{"payload":"x"}' \
+    | expect_match 'BAD_QUERY_PARAMETER'
+
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 
 # ── Async schema drift and per-entry failure isolation ────────────────────────

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -196,15 +196,27 @@ ${CLICKHOUSE_CURL} -sS \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-E=no_col" \
     -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
 
-echo "--- error: MATERIALIZED column"
+echo "--- error: MATERIALIZED column without insert_allow_materialized_columns"
 ${CLICKHOUSE_CURL} -sS -H 'X-V: 1' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=mat_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+    -d '{"payload":"x"}' 2>&1 | grep -o 'ILLEGAL_COLUMN'
 
-echo "--- error: ALIAS column"
+echo "--- error: ALIAS column is never insertable"
 ${CLICKHOUSE_CURL} -sS -H 'X-V: hi' \
     "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-V=alias_col" \
-    -d '{"payload":"x"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+    -d '{"payload":"x"}' 2>&1 | grep -o 'ILLEGAL_COLUMN'
+
+do_materialized_tests() {
+    echo "--- ${mode}: MATERIALIZED column allowed with insert_allow_materialized_columns=1"
+    ${CLICKHOUSE_CURL} -sS -H 'X-Mat: 42' \
+        "${CLICKHOUSE_URL}${INSERT_EXTRA}&insert_allow_materialized_columns=1&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Mat=mat_col" \
+        -d '{"payload":"mat-test"}'
+    flush
+    ${CLICKHOUSE_CLIENT} -q "SELECT payload, mat_col FROM t"
+    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+}
+
+run_modes do_materialized_tests
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t"
 

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Test http_column_* URL params: map HTTP request headers to INSERT columns.
+# Works for both sync and async inserts.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS test_http_columns;
+    CREATE TABLE test_http_columns (
+        event_type LowCardinality(String),
+        signature String,
+        payload String
+    ) ENGINE = MergeTree ORDER BY tuple();
+"
+
+echo "--- sync: basic header-to-column mapping"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    -H 'X-Signature: sha256=abc123' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"hello"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- sync: multiple rows"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: release' \
+    -H 'X-Signature: sha256=def456' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"row1"}
+{"payload":"row2"}
+{"payload":"row3"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- sync: case-insensitive header name"
+${CLICKHOUSE_CURL} -sS \
+    -H 'x-event-type: issues' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"case-test"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- sync: missing header produces empty string"
+${CLICKHOUSE_CURL} -sS \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"no-header"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- async: header-to-column mapping with batching"
+# Send two async inserts with different header values. They should batch together
+# but each row must carry its own request's header values.
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    -H 'X-Signature: sig1' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"async1"}' &
+pid1=$!
+
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: release' \
+    -H 'X-Signature: sig2' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"async2"}' &
+pid2=$!
+
+wait $pid1
+wait $pid2
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- async: multiple rows per entry"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: star' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"multi1"}
+{"payload":"multi2"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns ORDER BY payload"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
+
+echo "--- error: non-existent column"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=no_such_column" \
+    -d '{"payload":"err"}' 2>&1 | grep -o 'NO_SUCH_COLUMN_IN_TABLE'
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -105,13 +105,10 @@ do_basic_tests() {
     ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-    echo "--- ${mode}: missing header produces empty string"
+    echo "--- ${mode}: missing header is rejected"
     ${CLICKHOUSE_CURL} -sS \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
-        -d '{"payload":"no-header"}'
-    flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
-    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+        -d '{"payload":"no-header"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
     echo "--- ${mode}: positional format (TSV) - body-only columns, header injected separately"
     ${CLICKHOUSE_CURL} -sS \
@@ -122,32 +119,23 @@ do_basic_tests() {
     ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
     ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
 
-    echo "--- ${mode}: filtered header (Authorization) produces empty string"
+    echo "--- ${mode}: filtered header (Authorization) is rejected"
     ${CLICKHOUSE_CURL} -sS \
         -H 'Authorization: Bearer secret-token' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_Authorization=event_type" \
-        -d '{"payload":"filtered"}'
-    flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
-    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+        -d '{"payload":"filtered"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
-    echo "--- ${mode}: empty header name is ignored (no mapping applied)"
+    echo "--- ${mode}: empty header name is rejected"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: ignored' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(event_type,payload)+FORMAT+JSONEachRow&http_column_=event_type" \
-        -d '{"event_type":"body-value","payload":"empty-hdr"}'
-    flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
-    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+        -d '{"event_type":"body-value","payload":"empty-hdr"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
-    echo "--- ${mode}: empty column name is ignored (no mapping applied)"
+    echo "--- ${mode}: empty column name is rejected"
     ${CLICKHOUSE_CURL} -sS \
         -H 'X-Event-Type: ignored' \
         "${CLICKHOUSE_URL}${INSERT_EXTRA}&query=INSERT+INTO+t+(event_type,payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=" \
-        -d '{"event_type":"body-value2","payload":"empty-col"}'
-    flush
-    ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM t"
-    ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE t"
+        -d '{"event_type":"body-value2","payload":"empty-col"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
 
     echo "--- ${mode}: duplicate http_column_* to same column, first wins"
     ${CLICKHOUSE_CURL} -sS \
@@ -521,29 +509,3 @@ curl -sS \
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_absent"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.t_absent"
 
-# --- empty http_column_ names are rejected ---
-# http_column_=col  (empty header name) and
-# http_column_X-Foo=  (empty column name) are both malformed parameters;
-# ClickHouse rejects them with BAD_QUERY_PARAMETER, consistent with the
-# general rule that every http_column_ field must be non-empty.
-echo "--- sync: empty header name is rejected"
-${CLICKHOUSE_CLIENT} -q "
-    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.t_empty;
-    CREATE TABLE ${CLICKHOUSE_DATABASE}.t_empty (payload String)
-        ENGINE = MergeTree ORDER BY tuple();
-"
-curl -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_empty+FORMAT+JSONEachRow"\
-"&http_column_=event_type" \
-    -d '{"payload":"p"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
-${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_empty"
-
-echo "--- sync: empty column name is rejected"
-curl -sS \
-    -H 'X-Event-Type: push' \
-    "${CLICKHOUSE_URL}&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.t_empty+FORMAT+JSONEachRow"\
-"&http_column_X-Event-Type=" \
-    -d '{"payload":"p"}' 2>&1 | expect_match 'BAD_QUERY_PARAMETER'
-${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_empty"
-${CLICKHOUSE_CLIENT} -q "DROP TABLE ${CLICKHOUSE_DATABASE}.t_empty"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -195,6 +195,20 @@ ${CLICKHOUSE_CLIENT} -q "
     ) ENGINE = MergeTree ORDER BY tuple();
 "
 
+echo "--- error: CSVWithNames body header contains http_column_* target (skip_unknown_fields=1 must not bypass)"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+CSVWithNames&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1" \
+    --data-binary $'event_type,payload\nfrom-body,conflict' \
+    | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+
+echo "--- error: case-insensitive body field matches http_column_* target"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+t+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&input_format_skip_unknown_fields=1&input_format_column_name_matching_mode=ignore_case" \
+    -d '{"EVENT_TYPE":"from-body","payload":"conflict"}' \
+    | grep -oE 'INCORRECT_DATA|Unknown field' | head -1
+
 echo "--- error: column listed in both INSERT list and http_column_*"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-E: push' \

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -153,3 +153,33 @@ ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_typed"
+
+# Test INSERT INTO FUNCTION remote() -- verifies that table functions are supported
+# and resolved correctly (not broken by direct DatabaseCatalog lookup).
+${CLICKHOUSE_CLIENT} -q "
+    DROP TABLE IF EXISTS test_http_columns_remote;
+    CREATE TABLE test_http_columns_remote (
+        event_type String,
+        payload    String
+    ) ENGINE = MergeTree ORDER BY tuple();
+"
+
+echo "--- sync: INSERT INTO FUNCTION remote()"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: push' \
+    "${CLICKHOUSE_URL}&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),test_http_columns_remote)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"remote-sync"}'
+
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns_remote"
+${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns_remote"
+
+echo "--- async: INSERT INTO FUNCTION remote()"
+${CLICKHOUSE_CURL} -sS \
+    -H 'X-Event-Type: release' \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+FUNCTION+remote('127.0.0.1',currentDatabase(),test_http_columns_remote)+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    -d '{"payload":"remote-async"}'
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns_remote"
+
+${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_remote"

--- a/tests/queries/0_stateless/04516_http_column_header_mapping.sh
+++ b/tests/queries/0_stateless/04516_http_column_header_mapping.sh
@@ -55,36 +55,33 @@ ${CLICKHOUSE_CURL} -sS \
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns"
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
 
-echo "--- async: header-to-column mapping with batching"
-# Send two async inserts with different header values. They should batch together
-# but each row must carry its own request's header values.
+echo "--- async: different header values per request coalesce into one batch"
+# Two fire-and-forget requests, then explicit flush. Each row must carry its own
+# request's header values to verify per-entry injection works correctly.
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: push' \
     -H 'X-Signature: sig1' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"async1"}' &
-pid1=$!
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"async1"}'
 
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: release' \
     -H 'X-Signature: sig2' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
-    -d '{"payload":"async2"}' &
-pid2=$!
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type&http_column_X-Signature=signature" \
+    -d '{"payload":"async2"}'
 
-wait $pid1
-wait $pid2
-
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, signature, payload FROM test_http_columns ORDER BY payload"
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
 
 echo "--- async: multiple rows per entry"
 ${CLICKHOUSE_CURL} -sS \
     -H 'X-Event-Type: star' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns+(payload)+FORMAT+JSONEachRow&http_column_X-Event-Type=event_type" \
     -d '{"payload":"multi1"}
 {"payload":"multi2"}'
 
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT event_type, payload FROM test_http_columns ORDER BY payload"
 ${CLICKHOUSE_CLIENT} -q "TRUNCATE TABLE test_http_columns"
 
@@ -124,9 +121,10 @@ ${CLICKHOUSE_CURL} -sS \
     -H 'X-Count: 100' \
     -H "X-Tags: ['async']" \
     -H 'X-Rate: 2.72' \
-    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
+    "${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=0&query=INSERT+INTO+test_http_columns_typed+(payload)+FORMAT+JSONEachRow&http_column_X-Count=count&http_column_X-Tags=tags&http_column_X-Rate=rate" \
     -d '{"payload":"async-typed"}'
 
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
 ${CLICKHOUSE_CLIENT} -q "SELECT count, tags, rate, payload FROM test_http_columns_typed"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE test_http_columns_typed"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
 Closes https://github.com/ClickHouse/ClickHouse/issues/64792

### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add processing `http_column_Header-Name=column_name` in URL parameters and `<header_column_mappings>` in `predefined_query_handler` configuration. Provided values from `Header-Name` headers are processed and injected into `INSERT` queries as `column_name`.