### PR TITLE
Docs: use `Steps` components for procedural guides

### DIFF
--- a/docs/chdb/install/bun.mdx
+++ b/docs/chdb/install/bun.mdx
@@ -11,7 +11,8 @@ chDB-bun provides experimental FFI (Foreign Function Interface) bindings for chD
 
 ## Installation {#installation}
 
-### Step 1: Install system dependencies {#install-system-dependencies}
+<Steps>
+<Step title="Install system dependencies" id="install-system-dependencies">
 
 First, install the required system dependencies:
 
@@ -25,7 +26,8 @@ curl -sL https://lib.chdb.io | bash
 
 You'll need either `gcc` or `clang` installed on your system:
 
-### Step 2: Install chDB-bun {#install-chdb-bun}
+</Step>
+<Step title="Install chDB-bun" id="install-chdb-bun">
 
 ```bash
 # Install from the GitHub repository
@@ -37,6 +39,9 @@ cd chdb-bun
 bun install
 bun run build
 ```
+
+</Step>
+</Steps>
 
 ## Usage {#usage}
 

--- a/docs/chdb/install/c.mdx
+++ b/docs/chdb/install/c.mdx
@@ -11,7 +11,8 @@ chDB provides a native C/C++ API for embedding ClickHouse functionality directly
 
 ## Installation {#installation}
 
-### Step 1: Install libchdb {#install-libchdb}
+<Steps>
+<Step title="Install libchdb" id="install-libchdb">
 
 Install the chDB library on your system:
 
@@ -19,7 +20,8 @@ Install the chDB library on your system:
 curl -sL https://lib.chdb.io | bash
 ```
 
-### Step 2: Include headers {#include-headers}
+</Step>
+<Step title="Include headers" id="include-headers">
 
 Include the chDB header in your project:
 
@@ -27,7 +29,8 @@ Include the chDB header in your project:
 #include <chdb.h>
 ```
 
-### Step 3: Link library {#link-library}
+</Step>
+<Step title="Link library" id="link-library">
 
 Compile and link your application with chDB:
 
@@ -38,6 +41,9 @@ gcc -o myapp myapp.c -lchdb
 # C++ compilation  
 g++ -o myapp myapp.cpp -lchdb
 ```
+
+</Step>
+</Steps>
 
 ## C Examples {#c-examples}
 

--- a/docs/chdb/install/go.mdx
+++ b/docs/chdb/install/go.mdx
@@ -11,7 +11,8 @@ chDB-go provides Go bindings for chDB, enabling you to run ClickHouse queries di
 
 ## Installation {#installation}
 
-### Step 1: Install libchdb {#install-libchdb}
+<Steps>
+<Step title="Install libchdb" id="install-libchdb">
 
 First, install the chDB library:
 
@@ -19,7 +20,8 @@ First, install the chDB library:
 curl -sL https://lib.chdb.io | bash
 ```
 
-### Step 2: Install chdb-go {#install-chdb-go}
+</Step>
+<Step title="Install chdb-go" id="install-chdb-go">
 
 Install the Go package:
 
@@ -32,6 +34,9 @@ Or add it to your `go.mod`:
 ```bash
 go get github.com/chdb-io/chdb-go
 ```
+
+</Step>
+</Steps>
 
 ## Usage {#usage}
 

--- a/docs/concepts/features/security/ssl-user-auth.mdx
+++ b/docs/concepts/features/security/ssl-user-auth.mdx
@@ -23,7 +23,8 @@ If you use AWS NLB with the MySQL interface, you have to ask AWS support to enab
 > I would like to be able to configure our NLB proxy protocol v2 as below `proxy_protocol_v2.client_to_server.header_placement,Value=on_first_ack`.
 </Note>
 
-## 1. Create SSL user certificates {#1-create-ssl-user-certificates}
+<Steps>
+<Step title="Create SSL user certificates" id="1-create-ssl-user-certificates">
 
 <Note>
 This example uses self-signed certificates with a self-signed CA. For production environments, create a CSR and submit to your PKI team or certificate provider to obtain a proper certificate.
@@ -50,7 +51,8 @@ This example uses self-signed certificates with a self-signed CA. For production
     openssl x509 -req -in chnode1_cert_user.csr -out chnode1_cert_user.crt -CA marsnet_ca.crt -CAkey marsnet_ca.key -days 365
     ```
 
-## 2. Create a SQL user and grant permissions {#2-create-a-sql-user-and-grant-permissions}
+</Step>
+<Step title="Create a SQL user and grant permissions" id="2-create-a-sql-user-and-grant-permissions">
 
 <Note>
 For details on how to enable SQL users and set roles, refer to [Defining SQL Users and Roles](/concepts/features/security/access-rights) user guide.
@@ -88,7 +90,8 @@ For details on how to enable SQL users and set roles, refer to [Defining SQL Use
     ```
 </Note>
 
-## 3. Testing {#3-testing}
+</Step>
+<Step title="Testing" id="3-testing">
 
 1. Copy the user certificate, user key and CA certificate to a remote node.
 
@@ -112,7 +115,8 @@ For details on how to enable SQL users and set roles, refer to [Defining SQL Use
     Note that the password passed to clickhouse-client is ignored when a certificate is specified in the config.
 </Note>
 
-## 4. Testing HTTP {#4-testing-http}
+</Step>
+<Step title="Testing HTTP" id="4-testing-http">
 
 1. Copy the user certificate, user key and CA certificate to a remote node.
 
@@ -134,6 +138,9 @@ For details on how to enable SQL users and set roles, refer to [Defining SQL Use
 <Note>
     Notice that no password was specified, the certificate is used in lieu of a password and is how ClickHouse will authenticate the user.
 </Note>
+
+</Step>
+</Steps>
 
 ## Summary {#summary}
 

--- a/docs/guides/oss/deployment-and-scaling/keeper/index.mdx
+++ b/docs/guides/oss/deployment-and-scaling/keeper/index.mdx
@@ -731,7 +731,8 @@ See also the ClickHouse Cloud [Prometheus integration](/products/cloud/features/
 
 This guide provides simple and minimal settings to configure ClickHouse Keeper with an example on how to test distributed operations. This example is performed using 3 nodes on Linux.
 
-### 1. Configure nodes with Keeper settings {#1-configure-nodes-with-keeper-settings}
+<Steps>
+<Step title="Configure nodes with Keeper settings" id="1-configure-nodes-with-keeper-settings">
 
 1. Install 3 ClickHouse instances on 3 hosts (`chnode1`, `chnode2`, `chnode3`). (View the [Quick Start](/get-started/setup/install) for details on installing ClickHouse.)
 
@@ -835,7 +836,8 @@ This guide provides simple and minimal settings to configure ClickHouse Keeper w
     └────────────┴───────┴───────┴───────┴─────────────────────┴─────────────────────┴─────────┴──────────┴──────────┴────────────────┴────────────┴─────────────┴───────┴─────────────┘
     ```
 
-### 2.  Configure a cluster in ClickHouse {#2--configure-a-cluster-in-clickhouse}
+</Step>
+<Step title="Configure a cluster in ClickHouse" id="2--configure-a-cluster-in-clickhouse">
 
 1. Let's configure a simple cluster with 2 shards and only one replica on 2 of the nodes. The third node will be used to achieve a quorum for the requirement in ClickHouse Keeper. Update the configuration on `chnode1` and `chnode2`. The following cluster defines 1 shard on each node for a total of 2 shards with no replication. In this example, some of the data will be on node and some will be on the other node:
     ```xml
@@ -882,7 +884,8 @@ This guide provides simple and minimal settings to configure ClickHouse Keeper w
     └───────────────┘
     ```
 
-### 3. Create and test distributed table {#3-create-and-test-distributed-table}
+</Step>
+<Step title="Create and test distributed table" id="3-create-and-test-distributed-table">
 
 1.  Create a new database on the new cluster using ClickHouse client on `chnode1`. The `ON CLUSTER` clause automatically creates the database on both nodes.
     ```sql
@@ -980,6 +983,9 @@ This guide provides simple and minimal settings to configure ClickHouse Keeper w
 
     4 rows in set. Elapsed: 0.018 sec.
     ```
+
+</Step>
+</Steps>
 
 ### Summary {#summary}
 

--- a/docs/guides/oss/deployment-and-scaling/separation-storage-compute.mdx
+++ b/docs/guides/oss/deployment-and-scaling/separation-storage-compute.mdx
@@ -25,7 +25,8 @@ Please note that implementing and managing a separation of storage and compute a
 Don't configure any AWS/GCS life cycle policy. This isn't supported and could lead to broken tables.
 </Warning>
 
-## 1. Use S3 as a ClickHouse disk {#1-use-s3-as-a-clickhouse-disk}
+<Steps>
+<Step title="Use S3 as a ClickHouse disk" id="1-use-s3-as-a-clickhouse-disk">
 
 ### Creating a disk {#creating-a-disk}
 
@@ -88,7 +89,8 @@ You can now restart the ClickHouse server to have the changes take effect:
 service clickhouse-server restart
 ```
 
-## 2. Create a table backed by S3 {#2-create-a-table-backed-by-s3}
+</Step>
+<Step title="Create a table backed by S3" id="2-create-a-table-backed-by-s3">
 
 To test that we've configured the S3 disk properly, we can attempt to create and query a table.
 
@@ -156,7 +158,8 @@ If everything worked successfully, you're now using ClickHouse with separated st
 
 <Image img="/images/guides/s3_bucket_example.webp" size="md" alt="S3 bucket example using separation of compute and storage" border/>
 
-## 3. Implementing replication for fault tolerance (optional) {#3-implementing-replication-for-fault-tolerance-optional}
+</Step>
+<Step title="Implementing replication for fault tolerance (optional)" id="3-implementing-replication-for-fault-tolerance-optional">
 
 <Warning>
 Don't configure any AWS/GCS life cycle policy. This isn't supported and could lead to broken tables.
@@ -166,6 +169,9 @@ For fault tolerance, you can use multiple ClickHouse server nodes distributed ac
 
 Replication with S3 disks can be accomplished by using the `ReplicatedMergeTree` table engine. See the following guide for details:
 - [Replicating a single shard across two AWS regions using S3 Object Storage](/integrations/connectors/data-ingestion/AWS/integrating-s3-with-clickhouse#s3-multi-region).
+
+</Step>
+</Steps>
 
 ## Further reading {#further-reading}
 

--- a/docs/integrations/clickpipes/dynamodb.mdx
+++ b/docs/integrations/clickpipes/dynamodb.mdx
@@ -21,21 +21,24 @@ Data will be ingested into a `ReplacingMergeTree`. This table engine is commonly
 * [Change Data Capture (CDC) with PostgreSQL and ClickHouse - Part 1](https://clickhouse.com/blog/clickhouse-postgresql-change-data-capture-cdc-part-1?loc=docs-rockest-migrations)
 * [Change Data Capture (CDC) with PostgreSQL and ClickHouse - Part 2](https://clickhouse.com/blog/clickhouse-postgresql-change-data-capture-cdc-part-2?loc=docs-rockest-migrations)
 
-## 1. Set up Kinesis stream {#1-set-up-kinesis-stream}
+<Steps>
+<Step title="Set up Kinesis stream" id="1-set-up-kinesis-stream">
 
 First, you will want to enable a Kinesis stream on your DynamoDB table to capture changes in real-time. We want to do this before we create the snapshot to avoid missing any data.
 Find the AWS guide located [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/kds.html).
 
 <Image img="/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-kinesis-stream.webp" size="lg" alt="DynamoDB Kinesis Stream" border/>
 
-## 2. Create the snapshot {#2-create-the-snapshot}
+</Step>
+<Step title="Create the snapshot" id="2-create-the-snapshot">
 
 Next, we will create a snapshot of the DynamoDB table. This can be achieved through an AWS export to S3. Find the AWS guide located [here](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/S3DataExport.HowItWorks.html).
 **You will want to do a "Full export" in the DynamoDB JSON format.**
 
 <Image img="/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-s3-export.webp" size="md" alt="DynamoDB S3 Export" border/>
 
-## 3. Load the snapshot into ClickHouse {#3-load-the-snapshot-into-clickhouse}
+</Step>
+<Step title="Load the snapshot into ClickHouse" id="3-load-the-snapshot-into-clickhouse">
 
 ### Create necessary tables {#create-necessary-tables}
 
@@ -111,7 +114,8 @@ https://{bucket}.s3.amazonaws.com/{prefix}/AWSDynamoDB/{export-id}/data/*
 
 Once created, data will begin populating in the snapshot and destination tables. You don't need to wait for the snapshot load to finish before moving on to the next step.
 
-## 4. Create the Kinesis ClickPipe {#4-create-the-kinesis-clickpipe}
+</Step>
+<Step title="Create the Kinesis ClickPipe" id="4-create-the-kinesis-clickpipe">
 
 Now we can set up the Kinesis ClickPipe to capture real-time changes from the Kinesis stream. Follow the Kinesis ClickPipe guide [here](/integrations/clickpipes/kinesis/overview), but use the following settings:
 
@@ -124,7 +128,8 @@ Now we can set up the Kinesis ClickPipe to capture real-time changes from the Ki
 
 <Image img="/images/integrations/data-ingestion/dbms/dynamodb/dynamodb-map-columns.webp" size="md" alt="DynamoDB Map Columns" border/>
 
-## 5. Cleanup (optional) {#5-cleanup-optional}
+</Step>
+<Step title="Cleanup (optional)" id="5-cleanup-optional">
 
 Once the snapshot ClickPipe has finished, you can delete the snapshot table and materialized view.
 
@@ -133,3 +138,5 @@ DROP TABLE IF EXISTS "default"."snapshot";
 DROP TABLE IF EXISTS "default"."snapshot_clickpipes_error";
 DROP VIEW IF EXISTS "default"."snapshot_mv";
 ```
+</Step>
+</Steps>

--- a/docs/integrations/clickpipes/mongodb/table-resync.mdx
+++ b/docs/integrations/clickpipes/mongodb/table-resync.mdx
@@ -14,15 +14,20 @@ There are scenarios where it would be useful to have specific tables of a pipe b
 
 While resyncing individual tables with a button click is a work-in-progress, this guide will share steps on how you can achieve this today in the MongoDB ClickPipe.
 
-### 1. Remove the table from the pipe {#removing-table}
+<Steps>
+<Step title="Remove the table from the pipe" id="removing-table">
 
 This can be followed by following the [table removal guide](/integrations/clickpipes/mongodb/remove-table).
 
-### 2. Truncate or drop the table on ClickHouse {#truncate-drop-table}
+</Step>
+<Step title="Truncate or drop the table on ClickHouse" id="truncate-drop-table">
 
 This step is to avoid data duplication when we add this table again in the next step. You can do this by heading over to the **SQL Console** tab in ClickHouse Cloud and running a query.
 Note that we have validation to block table addition if the table already exists in ClickHouse and isn't empty.
 
-### 3. Add the table to the ClickPipe again {#add-table-again}
+</Step>
+<Step title="Add the table to the ClickPipe again" id="add-table-again">
 
 This can be followed by following the [table addition guide](/integrations/clickpipes/mongodb/add-table).
+</Step>
+</Steps>

--- a/docs/integrations/clickpipes/mysql/source/aurora.mdx
+++ b/docs/integrations/clickpipes/mysql/source/aurora.mdx
@@ -18,7 +18,8 @@ This step-by-step guide shows you how to configure Amazon Aurora MySQL to replic
 
 The binary log is a set of log files that contain information about data modifications made to a MySQL server instance, and binary log files are required for replication. To configure binary log retention in Aurora MySQL, you must [enable binary logging](#enable-binlog-logging) and [increase the binlog retention interval](#binlog-retention-interval).
 
-### 1. Enable binary logging via automated backup {#enable-binlog-logging}
+<Steps>
+<Step title="Enable binary logging via automated backup" id="enable-binlog-logging">
 
 The automated backups feature determines whether binary logging is turned on or off for MySQL. Automated backups can be configured for your instance in the RDS Console by navigating to **Modify** > **Additional configuration** > **Backup** and selecting the **Enable automated backups** checkbox (if not selected already).
 
@@ -26,7 +27,8 @@ The automated backups feature determines whether binary logging is turned on or 
 
 We recommend setting the **Backup retention period** to a reasonably long value, depending on the replication use case.
 
-### 2. Increase the binlog retention interval {#binlog-retention-interval}
+</Step>
+<Step title="Increase the binlog retention interval" id="binlog-retention-interval">
 
 <Warning>
 If ClickPipes tries to resume replication and the required binlog files have been purged due to the configured binlog retention value, the ClickPipe will enter an errored state and a resync is required.
@@ -41,6 +43,9 @@ mysql=> call mysql.rds_set_configuration('binlog retention hours', 72);
 ```
 
 If this configuration isn't set or is set to a low interval, it can lead to gaps in the binary logs, compromising ClickPipes' ability to resume replication. 
+
+</Step>
+</Steps>
 
 ## Configure binlog settings {#binlog-settings}
 

--- a/docs/integrations/clickpipes/mysql/source/rds-maria.mdx
+++ b/docs/integrations/clickpipes/mysql/source/rds-maria.mdx
@@ -21,7 +21,8 @@ We also recommend going through the MySQL FAQs [here](/integrations/clickpipes/m
 ## Enable binary log retention {#enable-binlog-retention-rds}
 The binary log is a set of log files that contain information about data modifications made to a MySQL server instance. Binary log files are required for replication. Both of the steps below must be followed:
 
-### 1. Enable binary logging via automated backup {#enable-binlog-logging-rds}
+<Steps>
+<Step title="Enable binary logging via automated backup" id="enable-binlog-logging-rds">
 
 The automated backups feature determines whether binary logging is turned on or off for MySQL. It can be set in the AWS console:
 
@@ -29,7 +30,8 @@ The automated backups feature determines whether binary logging is turned on or 
 
 Setting backup retention to a reasonably long value depending on the replication use-case is advisable.
 
-### 2. Binlog retention hours {#binlog-retention-hours-rds}
+</Step>
+<Step title="Binlog retention hours" id="binlog-retention-hours-rds">
 Amazon RDS for MariaDB has a different method of setting binlog retention duration, which is the amount of time a binlog file containing changes is kept. If some changes aren't read before the binlog file is removed, replication will be unable to continue. The default value of binlog retention hours is NULL, which means binary logs aren't retained.
 
 To specify the number of hours to retain binary logs on a DB instance, use the mysql.rds_set_configuration function with a binlog retention period long enough for replication to occur. `24 hours` is the recommended minimum.
@@ -37,6 +39,9 @@ To specify the number of hours to retain binary logs on a DB instance, use the m
 ```text
 mysql=> call mysql.rds_set_configuration('binlog retention hours', 24);
 ```
+
+</Step>
+</Steps>
 
 ## Configure binlog settings in the parameter group {#binlog-parameter-group-rds}
 

--- a/docs/integrations/clickpipes/mysql/source/rds.mdx
+++ b/docs/integrations/clickpipes/mysql/source/rds.mdx
@@ -18,7 +18,8 @@ This step-by-step guide shows you how to configure Amazon RDS MySQL to replicate
 
 The binary log is a set of log files that contain information about data modifications made to an MySQL server instance, and binary log files are required for replication. To configure binary log retention in RDS MySQL, you must [enable binary logging](#enable-binlog-logging) and [increase the binlog retention interval](#binlog-retention-interval).
 
-### 1. Enable binary logging via automated backup {#enable-binlog-logging}
+<Steps>
+<Step title="Enable binary logging via automated backup" id="enable-binlog-logging">
 
 The automated backups feature determines whether binary logging is turned on or off for MySQL. Automated backups can be configured for your instance in the RDS Console by navigating to **Modify** > **Additional configuration** > **Backup** and selecting the **Enable automated backups** checkbox (if not selected already).
 
@@ -26,7 +27,8 @@ The automated backups feature determines whether binary logging is turned on or 
 
 We recommend setting the **Backup retention period** to a reasonably long value, depending on the replication use case.
 
-### 2. Increase the binlog retention interval {#binlog-retention-interval}
+</Step>
+<Step title="Increase the binlog retention interval" id="binlog-retention-interval">
 
 <Warning>
 If ClickPipes tries to resume replication and the required binlog files have been purged due to the configured binlog retention value, the ClickPipe will enter an errored state and a resync is required.
@@ -41,6 +43,9 @@ mysql=> call mysql.rds_set_configuration('binlog retention hours', 72);
 ```
 
 If this configuration isn't set or is set to a low interval, it can lead to gaps in the binary logs, compromising ClickPipes' ability to resume replication. 
+
+</Step>
+</Steps>
 
 ## Configure binlog settings {#binlog-settings}
 

--- a/docs/integrations/clickpipes/mysql/table-resync.mdx
+++ b/docs/integrations/clickpipes/mysql/table-resync.mdx
@@ -14,15 +14,20 @@ There are scenarios where it would be useful to have specific tables of a pipe b
 
 While resyncing individual tables with a button click is a work-in-progress, this guide will share steps on how you can achieve this today in the MySQL ClickPipe.
 
-### 1. Remove the table from the pipe {#removing-table}
+<Steps>
+<Step title="Remove the table from the pipe" id="removing-table">
 
 This can be followed by following the [table removal guide](/integrations/clickpipes/mysql/remove-table).
 
-### 2. Truncate or drop the table on ClickHouse {#truncate-drop-table}
+</Step>
+<Step title="Truncate or drop the table on ClickHouse" id="truncate-drop-table">
 
 This step is to avoid data duplication when we add this table again in the next step. You can do this by heading over to the **SQL Console** tab in ClickHouse Cloud and running a query.
 Note that we have validation to block table addition if the table already exists in ClickHouse and isn't empty.
 
-### 3. Add the table to the ClickPipe again {#add-table-again}
+</Step>
+<Step title="Add the table to the ClickPipe again" id="add-table-again">
 
 This can be followed by following the [table addition guide](/integrations/clickpipes/mysql/add-table).
+</Step>
+</Steps>

--- a/docs/integrations/clickpipes/postgres/connecting-to-postgresql.mdx
+++ b/docs/integrations/clickpipes/postgres/connecting-to-postgresql.mdx
@@ -23,7 +23,8 @@ Check out our [Managed Postgres](/products/managed-postgres/overview) service. B
 The `PostgreSQL` table engine allows **SELECT** and **INSERT** operations on data stored on the remote PostgreSQL server from ClickHouse.
 This article is to illustrate basic methods of integration using one table.
 
-### 1. Setting up PostgreSQL {#1-setting-up-postgresql}
+<Steps>
+<Step title="Setting up PostgreSQL" id="1-setting-up-postgresql">
 1.  In `postgresql.conf`, add the following entry to enable PostgreSQL to listen on the network interfaces:
   ```text
   listen_addresses = '*'
@@ -77,7 +78,8 @@ If you're using this feature in ClickHouse Cloud, you may need the to allow the 
 Check the ClickHouse [Cloud Endpoints API](/products/cloud/guides/sql-console/query-endpoints) for egress traffic details.
 </Note>
 
-### 2. Define a Table in ClickHouse {#2-define-a-table-in-clickhouse}
+</Step>
+<Step title="Define a Table in ClickHouse" id="2-define-a-table-in-clickhouse">
 1. Login to the `clickhouse-client`:
   ```bash
   clickhouse-client --user default --password ClickHouse123!
@@ -111,7 +113,8 @@ Check the ClickHouse [Cloud Endpoints API](/products/cloud/guides/sql-console/qu
   View the [PostgreSQL table engine](/reference/engines/table-engines/integrations/postgresql) doc page for a complete list of parameters.
 </Note>
 
-### 3 Test the Integration {#3-test-the-integration}
+</Step>
+<Step title="Test the Integration" id="3-test-the-integration">
 1. In ClickHouse, view initial rows:
   ```sql
   SELECT * FROM db_in_ch.table1
@@ -179,6 +182,9 @@ Check the ClickHouse [Cloud Endpoints API](/products/cloud/guides/sql-console/qu
 This example demonstrated the basic integration between PostgreSQL and ClickHouse using the `PostrgeSQL` table engine.
 Check out the [doc page for the PostgreSQL table engine](/reference/engines/table-engines/integrations/postgresql) for more features, such as specifying schemas, returning only a subset of columns, and connecting to multiple replicas. Also check out the [ClickHouse and PostgreSQL - a match made in data heaven - part 1](https://clickhouse.com/blog/migrating-data-between-clickhouse-postgres) blog.
 
+</Step>
+</Steps>
+
 ## Using the MaterializedPostgreSQL database engine {#using-the-materializedpostgresql-database-engine}
 <CloudNotSupportedBadge />
 <ExperimentalBadge />
@@ -188,7 +194,8 @@ This article is to illustrate basic methods of integration using one database, o
 
 ***In the following procedures, the PostgreSQL CLI (psql) and the ClickHouse CLI (clickhouse-client) are used. The PostgreSQL server is installed on linux. The following has minimum settings if the postgresql database is new test install***
 
-### 1. In PostgreSQL {#1-in-postgresql}
+<Steps>
+<Step title="In PostgreSQL" id="1-in-postgresql">
 1.  In `postgresql.conf`, set minimum listen levels, replication wal level and replication slots:
 
 add the following entries:
@@ -250,7 +257,8 @@ _*for demonstration purposes, this is using clear text password authentication m
  psql -U clickhouse_user -W -d db1 -h <your_postgresql_host>
 ```
 
-### 2. In ClickHouse {#2-in-clickhouse}
+</Step>
+<Step title="In ClickHouse" id="2-in-clickhouse">
 1. log into the ClickHouse CLI
 ```bash
 clickhouse-client --user default --password ClickHouse123!
@@ -301,7 +309,8 @@ Query id: df2381ac-4e30-4535-b22e-8be3894aaafc
 └────┴─────────┘
 ```
 
-### 3. Test basic replication {#3-test-basic-replication}
+</Step>
+<Step title="Test basic replication" id="3-test-basic-replication">
 1. In PostgreSQL, add new rows:
 ```sql
 INSERT INTO table1
@@ -336,9 +345,12 @@ Query id: b0729816-3917-44d3-8d1a-fed912fb59ce
 └────┴─────────┘
 ```
 
-### 4. Summary {#4-summary}
+</Step>
+<Step title="Summary" id="4-summary">
 This integration guide focused on a simple example on how to replicate a database with a table, however, there exist more advanced options which include replicating the whole database or adding new tables and schemas to the existing replications. Although DDL commands aren't supported for this replication, the engine can be set to detect changes and reload the tables when there are structural changes made.
 
 <Info>
 For more features available for advanced options, please see the [reference documentation](/reference/engines/database-engines/materialized-postgresql).
 </Info>
+</Step>
+</Steps>

--- a/docs/integrations/clickpipes/postgres/table-resync.mdx
+++ b/docs/integrations/clickpipes/postgres/table-resync.mdx
@@ -14,11 +14,13 @@ There are scenarios where it would be useful to have specific tables of a pipe b
 
 While resyncing individual tables with a button click is a work-in-progress, this guide will share steps on how you can achieve this today in the Postgres ClickPipe.
 
-### 1. Remove the table from the pipe {#removing-table}
+<Steps>
+<Step title="Remove the table from the pipe" id="removing-table">
 
 This can be followed by following the [table removal guide](/integrations/clickpipes/postgres/remove-table).
 
-### 2. Truncate or drop the table on ClickHouse {#truncate-drop-table}
+</Step>
+<Step title="Truncate or drop the table on ClickHouse" id="truncate-drop-table">
 
 This step is to avoid data duplication when we add this table again in the next step. You can do this by heading over to the **SQL Console** tab in ClickHouse Cloud and running a query.
 Note that we have validation to block table addition if the table already exists in ClickHouse and isn't empty.
@@ -29,6 +31,9 @@ Alternatively, if you need to keep the old table you can simply rename it. This 
 RENAME TABLE table_A TO table_A_bak;
 ```
 
-### 3. Add the table to the ClickPipe again {#add-table-again}
+</Step>
+<Step title="Add the table to the ClickPipe again" id="add-table-again">
 
 This can be followed by following the [table addition guide](/integrations/clickpipes/postgres/add-table).
+</Step>
+</Steps>

--- a/docs/integrations/connectors/data-ingestion/kafka/confluent/kafka-connect-http.mdx
+++ b/docs/integrations/connectors/data-ingestion/kafka/confluent/kafka-connect-http.mdx
@@ -21,10 +21,12 @@ Below we describe a simple installation, pulling messages from a single Kafka to
 
 ### Quick start steps {#quick-start-steps}
 
-#### 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-#### 2. Run Kafka Connect and the HTTP sink connector {#2-run-kafka-connect-and-the-http-sink-connector}
+</Step>
+<Step title="Run Kafka Connect and the HTTP sink connector" id="2-run-kafka-connect-and-the-http-sink-connector">
 
 You have two options:
 
@@ -37,7 +39,8 @@ If you use the confluent-hub installation method, your local configuration files
   The following examples are using Confluent Cloud.
 </Note>
 
-#### 3. Create destination table in ClickHouse {#3-create-destination-table-in-clickhouse}
+</Step>
+<Step title="Create destination table in ClickHouse" id="3-create-destination-table-in-clickhouse">
 
 Before the connectivity test, let's start by creating a test table in ClickHouse Cloud, this table will receive the data from Kafka:
 
@@ -54,7 +57,8 @@ CREATE TABLE default.my_table
 ORDER BY tuple()
 ```
 
-#### 4. Configure HTTP Sink {#4-configure-http-sink}
+</Step>
+<Step title="Configure HTTP Sink" id="4-configure-http-sink">
 Create a Kafka topic and an instance of HTTP Sink Connector:
 <Image img="/images/integrations/data-ingestion/kafka/confluent/create_http_sink.webp" size="sm" alt="Confluent Cloud interface showing how to create an HTTP Sink connector" border/>
 
@@ -87,13 +91,17 @@ Configure HTTP Sink Connector:
 
 <Image img="/images/integrations/data-ingestion/kafka/confluent/http_advanced.webp" size="sm" alt="Confluent Cloud interface showing advanced configuration options for the HTTP Sink connector" border/>
 
-#### 5. Testing the connectivity {#5-testing-the-connectivity}
+</Step>
+<Step title="Testing the connectivity" id="5-testing-the-connectivity">
 Create an message in a topic configured by your HTTP Sink
 <Image img="/images/integrations/data-ingestion/kafka/confluent/create_message_in_topic.webp" size="md" alt="Confluent Cloud interface showing how to create a test message in a Kafka topic" border/>
 
 <br/>
 
 and verify the created message's been written to your ClickHouse instance.
+
+</Step>
+</Steps>
 
 ### Troubleshooting {#troubleshooting}
 #### HTTP Sink doesn't batch messages {#http-sink-doesnt-batch-messages}
@@ -118,7 +126,8 @@ Set `input_format_json_read_objects_as_strings=1` setting in URL as encoded stri
 
 Note that this example preserves the Array fields of the Github dataset. We assume you have an empty github topic in the examples and use [kcat](https://github.com/edenhill/kcat) for message insertion to Kafka.
 
-##### 1. Prepare configuration {#1-prepare-configuration}
+<Steps>
+<Step title="Prepare configuration" id="1-prepare-configuration">
 
 Follow [these instructions](https://docs.confluent.io/cloud/current/cp-component/connect-cloud-config.html#set-up-a-local-connect-worker-with-cp-install) for setting up Connect relevant to your installation type, noting the differences between a standalone and distributed cluster. If using Confluent Cloud, the distributed setup is relevant.
 
@@ -148,7 +157,8 @@ A full list of settings, including how to configure a proxy, retries, and advanc
 
 Example configuration files for the Github sample data can be found [here](https://github.com/ClickHouse/clickhouse-docs/tree/main/docs/integrations/data-ingestion/kafka/code/connectors/http_sink), assuming Connect is run in standalone mode and Kafka is hosted in Confluent Cloud.
 
-##### 2. Create the ClickHouse table {#2-create-the-clickhouse-table}
+</Step>
+<Step title="Create the ClickHouse table" id="2-create-the-clickhouse-table">
 
 Ensure the table has been created. An example for a minimal github dataset using a standard MergeTree is shown below.
 
@@ -184,7 +194,8 @@ CREATE TABLE github
 
 ```
 
-##### 3. Add data to Kafka {#3-add-data-to-kafka}
+</Step>
+<Step title="Add data to Kafka" id="3-add-data-to-kafka">
 
 Insert messages to Kafka. Below we use [kcat](https://github.com/edenhill/kcat) to insert 10k messages.
 
@@ -202,3 +213,5 @@ SELECT count() FROM default.github;
 | 10000 |
 
 ```
+</Step>
+</Steps>

--- a/docs/integrations/connectors/data-ingestion/kafka/kafka-connect-jdbc.mdx
+++ b/docs/integrations/connectors/data-ingestion/kafka/kafka-connect-jdbc.mdx
@@ -26,7 +26,8 @@ The JDBC Connector is distributed under the [Confluent Community License](https:
 #### Gather your connection details {#gather-your-connection-details}
 <ConnectionDetails />
 
-#### 1. Install Kafka Connect and Connector {#1-install-kafka-connect-and-connector}
+<Steps>
+<Step title="Install Kafka Connect and Connector" id="1-install-kafka-connect-and-connector">
 
 We assume you have downloaded the Confluent package and installed it locally. Follow the installation instructions for installing the connector as documented [here](https://docs.confluent.io/kafka-connect-jdbc/current/#install-the-jdbc-connector).
 
@@ -34,7 +35,8 @@ If you use the confluent-hub installation method, your local configuration files
 
 For sending data to ClickHouse from Kafka, we use the Sink component of the connector.
 
-#### 2. Download and install the JDBC Driver {#2-download-and-install-the-jdbc-driver}
+</Step>
+<Step title="Download and install the JDBC Driver" id="2-download-and-install-the-jdbc-driver">
 
 Download and install the ClickHouse JDBC driver `clickhouse-jdbc-<version>-shaded.jar` from [here](https://github.com/ClickHouse/clickhouse-java/releases). Install this into Kafka Connect following the details [here](https://docs.confluent.io/kafka-connect-jdbc/current/#installing-jdbc-drivers). Other drivers may work but haven't been tested.
 
@@ -43,7 +45,8 @@ Download and install the ClickHouse JDBC driver `clickhouse-jdbc-<version>-shade
 Common Issue: the docs suggest copying the jar to `share/java/kafka-connect-jdbc/`. If you experience issues with Connect finding the driver, copy the driver to `share/confluent-hub-components/confluentinc-kafka-connect-jdbc/lib/`. Or modify `plugin.path` to include the driver - see below.
 </Note>
 
-#### 3. Prepare configuration {#3-prepare-configuration}
+</Step>
+<Step title="Prepare configuration" id="3-prepare-configuration">
 
 Follow [these instructions](https://docs.confluent.io/cloud/current/cp-component/connect-cloud-config.html#set-up-a-local-connect-worker-with-cp-install) for setting up a Connect relevant to your installation type, noting the differences between a standalone and distributed cluster. If using Confluent Cloud the distributed setup is relevant.
 
@@ -73,7 +76,8 @@ If using our sample dataset for testing, ensure the following are set:
 
 Example configuration files for the Github sample data can be found [here](https://github.com/ClickHouse/kafka-samples/tree/main/github_events/jdbc_sink), assuming Connect is run in standalone mode and Kafka is hosted in Confluent Cloud.
 
-#### 4. Create the ClickHouse table {#4-create-the-clickhouse-table}
+</Step>
+<Step title="Create the ClickHouse table" id="4-create-the-clickhouse-table">
 
 Ensure the table has been created, dropping it if it already exists from previous examples. An example compatible with the reduced Github dataset is shown below. Not the absence of any Array or Map types that aren't currently not supported:
 
@@ -105,7 +109,8 @@ CREATE TABLE github
 ) ENGINE = MergeTree ORDER BY (event_type, repo_name, created_at)
 ```
 
-#### 5. Start Kafka Connect {#5-start-kafka-connect}
+</Step>
+<Step title="Start Kafka Connect" id="5-start-kafka-connect">
 
 Start Kafka Connect in either [standalone](https://docs.confluent.io/cloud/current/cp-component/connect-cloud-config.html#standalone-cluster) or [distributed](https://docs.confluent.io/cloud/current/cp-component/connect-cloud-config.html#distributed-cluster) mode.
 
@@ -113,7 +118,8 @@ Start Kafka Connect in either [standalone](https://docs.confluent.io/cloud/curre
 ./bin/connect-standalone connect.properties.ini github-jdbc-sink.properties.ini
 ```
 
-#### 6. Add data to Kafka {#6-add-data-to-kafka}
+</Step>
+<Step title="Add data to Kafka" id="6-add-data-to-kafka">
 
 Insert messages to Kafka using the [script and config](https://github.com/ClickHouse/kafka-samples/tree/main/producer) provided. You will need to modify github.config to include your Kafka credentials. The script is currently configured for use with Confluent Cloud.
 
@@ -138,6 +144,9 @@ SELECT count() FROM default.github;
 | :--- |
 | 10000 |
 ```
+
+</Step>
+</Steps>
 
 ### Recommended further reading {#recommended-further-reading}
 

--- a/docs/integrations/connectors/data-ingestion/kafka/kafka-table-engine.mdx
+++ b/docs/integrations/connectors/data-ingestion/kafka/kafka-table-engine.mdx
@@ -31,11 +31,13 @@ To persist this data from a read of the table engine, we need a means of capturi
 
 #### Steps {#steps}
 
-##### 1. Prepare {#1-prepare}
+<Steps>
+<Step title="Prepare" id="1-prepare">
 
 If you have data populated on a target topic, you can adapt the following for use in your dataset. Alternatively, a sample Github dataset is provided [here](https://datasets-documentation.s3.eu-west-3.amazonaws.com/kafka/github_all_columns.ndjson). This dataset is used in the examples below and uses a reduced schema and subset of the rows (specifically, we limit to Github events concerning the [ClickHouse repository](https://github.com/ClickHouse/ClickHouse)), compared to the full dataset available [here](https://ghe.clickhouse.tech/), for brevity. This is still sufficient for most of the queries [published with the dataset](https://ghe.clickhouse.tech/) to work.
 
-##### 2. Configure ClickHouse {#2-configure-clickhouse}
+</Step>
+<Step title="Configure ClickHouse" id="2-configure-clickhouse">
 
 This step is required if you're connecting to a secure Kafka. These settings can't be passed through the SQL DDL commands and must be configured in the ClickHouse config.xml. We assume you're connecting to a SASL secured instance. This is the simplest method when interacting with Confluent Cloud.
 
@@ -64,7 +66,8 @@ Once you've created the database, you'll need to switch over to it:
 USE KafkaEngine;
 ```
 
-##### 3. Create the destination table {#3-create-the-destination-table}
+</Step>
+<Step title="Create the destination table" id="3-create-the-destination-table">
 
 Prepare your destination table. In the example below we use the reduced GitHub schema for purposes of brevity. Note that although we use a MergeTree table engine, this example could easily be adapted for any member of the [MergeTree family](/reference/engines/table-engines/mergetree-family/index).
 
@@ -99,7 +102,8 @@ CREATE TABLE github
 ) ENGINE = MergeTree ORDER BY (event_type, repo_name, created_at)
 ```
 
-##### 4. Create and populate the topic {#4-create-and-populate-the-topic}
+</Step>
+<Step title="Create and populate the topic" id="4-create-and-populate-the-topic">
 
 Next, we're going to create a topic. There are several tools that we can use to do this. If we're running Kafka locally on our machine or inside a Docker container, [RPK](https://docs.redpanda.com/current/get-started/rpk-install/) works well. We can create a topic called `github` with 5 partitions by running the following command:
 
@@ -137,7 +141,8 @@ kcat -P \
 
 The dataset contains 200,000 rows, so it should be ingested in just a few seconds. If you want to work with a larger dataset, take a look at [the large datasets section](https://github.com/ClickHouse/kafka-samples/tree/main/producer#large-datasets) of the [ClickHouse/kafka-samples](https://github.com/ClickHouse/kafka-samples) GitHub repository.
 
-##### 5. Create the Kafka table engine {#5-create-the-kafka-table-engine}
+</Step>
+<Step title="Create the Kafka table engine" id="5-create-the-kafka-table-engine">
 
 The below example creates a table engine with the same schema as the merge tree table. This isn't strictly required, as you can have an alias or ephemeral columns in the target table. The settings are important; however - note the use of `JSONEachRow` as the data type for consuming JSON from a Kafka topic. The values `github` and `clickhouse` represent the name of the topic and consumer group names, respectively. The topics can actually be a list of values.
 
@@ -176,7 +181,8 @@ CREATE TABLE github_queue
 
 We discuss engine settings and performance tuning below. At this point, a simple select on the table `github_queue` should read some rows.  Note that this will move the consumer offsets forward, preventing these rows from being re-read without a [reset](#common-operations). Note the limit and required parameter `stream_like_engine_allow_direct_select.`
 
-##### 6. Create the materialized view {#6-create-the-materialized-view}
+</Step>
+<Step title="Create the materialized view" id="6-create-the-materialized-view">
 
 The materialized view will connect the two previously created tables, reading data from the Kafka table engine and inserting it into the target merge tree table. We can do a number of data transformations. We will do a simple read and insert. The use of * assumes column names are identical (case sensitive).
 
@@ -188,7 +194,8 @@ FROM github_queue;
 
 At the point of creation, the materialized view connects to the Kafka engine and commences reading: inserting rows into the target table. This process will continue indefinitely, with subsequent message inserts into Kafka being consumed. Feel free to re-run the insertion script to insert further messages to Kafka.
 
-##### 7. Confirm rows have been inserted {#7-confirm-rows-have-been-inserted}
+</Step>
+<Step title="Confirm rows have been inserted" id="7-confirm-rows-have-been-inserted">
 
 Confirm data exists in the target table:
 
@@ -202,6 +209,9 @@ You should see 200,000 rows:
 │  200000 │
 └─────────┘
 ```
+
+</Step>
+</Steps>
 
 #### Common operations {#common-operations}
 
@@ -330,7 +340,8 @@ Our initial objective is best illustrated:
 
 We assume you have the tables and views created under steps for [Kafka to ClickHouse](#kafka-to-clickhouse) and that the topic has been fully consumed.
 
-##### 1. Inserting rows directly {#1-inserting-rows-directly}
+<Steps>
+<Step title="Inserting rows directly" id="1-inserting-rows-directly">
 
 First, confirm the count of the target table.
 
@@ -364,7 +375,8 @@ You should see 100 additional rows:
 └─────────┘
 ```
 
-##### 2. Using materialized views {#2-using-materialized-views}
+</Step>
+<Step title="Using materialized views" id="2-using-materialized-views">
 
 We can utilize materialized views to push messages to a Kafka engine (and a topic) when documents are inserted into a table. When rows are inserted into the GitHub table, a materialized view is triggered, which causes the rows to be inserted back into a Kafka engine and into a new topic. Again this is best illustrated:
 
@@ -447,6 +459,9 @@ wc -l
 ```
 
 Although an elaborate example, this illustrates the power of materialized views when used in conjunction with the Kafka engine.
+
+</Step>
+</Steps>
 
 ### Clusters and performance {#clusters-and-performance}
 

--- a/docs/integrations/connectors/data-ingestion/streamkap/sql-server-clickhouse.mdx
+++ b/docs/integrations/connectors/data-ingestion/streamkap/sql-server-clickhouse.mdx
@@ -47,11 +47,12 @@ Make sure you have:
 - ClickHouse server address, port, username, and password. IP access lists in ClickHouse determine what services can connect to your ClickHouse database.[Follow the instructions here.](https://www.google.com/url?q=https://docs.streamkap.com/docs/clickhouse&sa=D&source=editors&ust=1760992472359060&usg=AOvVaw3H1XqqwvqAso_TQPNBKEhD)
 - The tables you want to stream—start with one for now
 
-## Setting Up SQL Server as a Source {#setting-up-sql-server-as-a-source}
+<Steps>
+<Step title="Creating a SQL Server Source in Streamkap" id="step-1-creating-a-sql-server-source-in-streamkap">
+<a id="setting-up-sql-server-as-a-source"></a>
 
 Let’s get into it!
 
-### Step 1: Creating a SQL Server Source in Streamkap {#step-1-creating-a-sql-server-source-in-streamkap}
 
 We’ll start by setting up the source connection. This is how Streamkap knows where to fetch changes from.
 
@@ -74,11 +75,12 @@ Here’s how you do it:
 
 When you set this up, Streamkap will connect to your SQL Server and detect tables. For this demo, we’ll pick a table with some data already streaming in, like events or transactions.
 
-## Creating a ClickHouse Destination {#creating-a-clickhouse-destination}
+</Step>
+<Step title="Add a ClickHouse Destination in Streamkap" id="step-2-add-a-clickhouse-destination-in-streamkap">
+<a id="creating-a-clickhouse-destination"></a>
 
 Now let’s wire up the destination where we’ll send all this data.
 
-### Step 2: Add a ClickHouse Destination in Streamkap {#step-2-add-a-clickhouse-destination-in-streamkap}
 
 Similar to the source, we’ll create a destination using our ClickHouse connection details.
 
@@ -108,11 +110,12 @@ ClickHouse and SQL Server sometimes don’t have the same columns—especially w
 
 Just select “schema evolution” in your destination settings. You can always tweak this later as needed.
 
-## Building the Streaming Pipeline {#building-the-streaming-pipeline}
+</Step>
+<Step title="Set up the Pipeline in Streamkap" id="step-3-set-up-the-pipeline-in-streamkap">
+<a id="building-the-streaming-pipeline"></a>
 
 With the source and destination set, it’s time for the fun part—streaming your data!
 
-### Step 3: Set up the Pipeline in Streamkap {#step-3-set-up-the-pipeline-in-streamkap}
 
 #### Pipeline Setup {#pipeline-setup}
 
@@ -142,11 +145,12 @@ For a lot of analytics cases, you might just want to start with streaming change
 
 Just pick “don’t backfill” for now unless you have a specific need.
 
-## Streaming in Action: What to Expect {#streaming-in-action-what-to-expect}
+</Step>
+<Step title="Watch the Data Stream" id="step-4-watch-the-data-stream">
+<a id="streaming-in-action-what-to-expect"></a>
 
 Now your pipeline is set up and active!
 
-### Step 4: Watch the Data Stream {#step-4-watch-the-data-stream}
 
 Here’s what happens:
 
@@ -164,6 +168,9 @@ SELECT COUNT(*) FROM analytics.events; |
 ```
 
 Expect some lag in heavy-load scenarios, but most use cases see near-real-time streaming.
+
+</Step>
+</Steps>
 
 ## Under the Hood: What’s Streamkap Actually Doing? {#under-the-hood-whats-streamkap-actually-doing}
 

--- a/docs/integrations/connectors/data-ingestion/streamkap/streamkap-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-ingestion/streamkap/streamkap-and-clickhouse.mdx
@@ -46,14 +46,16 @@ This guide provides a high-level overview of setting up a Streamkap pipeline to 
 - Your ClickHouse cluster connection details: Hostname, Port, Username, and Password.
 - A source database (e.g., PostgreSQL, SQL Server) configured to allow CDC. You can find detailed setup guides in the Streamkap documentation.
 
-### Step 1: Configure the Source in Streamkap {#configure-clickhouse-source}
+<Steps>
+<Step title="Configure the Source in Streamkap" id="configure-clickhouse-source">
 1. Log into your Streamkap account.
 2. In the sidebar, navigate to **Connectors** and select the **Sources** tab.
 3. Click **+ Add** and select your source database type (e.g., SQL Server RDS).
 4. Fill in the connection details, including the endpoint, port, database name, and user credentials.
 5. Save the connector.
 
-### Step 2: Configure the ClickHouse Destination {#configure-clickhouse-dest}
+</Step>
+<Step title="Configure the ClickHouse Destination" id="configure-clickhouse-dest">
 1. In the **Connectors** section, select the **Destinations** tab.
 2. Click **+ Add** and choose **ClickHouse** from the list.
 3. Enter the connection details for your ClickHouse service:
@@ -63,7 +65,8 @@ This guide provides a high-level overview of setting up a Streamkap pipeline to 
    - **Database:** The target database name in ClickHouse
 4. Save the destination.
 
-### Step 3: Create and Run the Pipeline {#run-pipeline}
+</Step>
+<Step title="Create and Run the Pipeline" id="run-pipeline">
 1. Navigate to **Pipelines** in the sidebar and click **+ Create**.
 2. Select the Source and Destination you just configured.
 3. Choose the schemas and tables you wish to stream.
@@ -71,13 +74,17 @@ This guide provides a high-level overview of setting up a Streamkap pipeline to 
 
 Once created, the pipeline will become active. Streamkap will first take a snapshot of the existing data and then begin streaming any new changes as they occur.
 
-### Step 4: Verify the Data in ClickHouse {#verify-data-clickhoouse}
+</Step>
+<Step title="Verify the Data in ClickHouse" id="verify-data-clickhoouse">
 
 Connect to your ClickHouse cluster and run a query to see the data arriving in the target table.
 
 ```sql
 SELECT * FROM your_table_name LIMIT 10;
 ```
+
+</Step>
+</Steps>
 
 ## How it Works with ClickHouse {#how-it-works-with-clickhouse}
 

--- a/docs/integrations/connectors/data-integrations/integrations/retool.mdx
+++ b/docs/integrations/connectors/data-integrations/integrations/retool.mdx
@@ -17,10 +17,12 @@ import PartnerBadge from "/snippets/components/PartnerBadge/PartnerBadge.jsx";
 
 <PartnerBadge/>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Create a ClickHouse resource {#2-create-a-clickhouse-resource}
+</Step>
+<Step title="Create a ClickHouse resource" id="2-create-a-clickhouse-resource">
 
 Login to your Retool account and navigate to the _Resources_ tab. Choose "Create New" -> "Resource":
 
@@ -49,3 +51,5 @@ After that, test your connection:
 <br/>
 
 Now, you should be able to proceed to your app using your ClickHouse resource.
+</Step>
+</Steps>

--- a/docs/integrations/connectors/data-sources/mysql.mdx
+++ b/docs/integrations/connectors/data-sources/mysql.mdx
@@ -25,7 +25,8 @@ For ClickHouse Cloud, you can also use the [MySQL ClickPipe](/integrations/click
 
 The `MySQL` table engine allows you to connect ClickHouse to MySQL. **SELECT** and **INSERT** statements can be made in either ClickHouse or in the MySQL table. This article illustrates the basic methods of how to use the `MySQL` table engine.
 
-### 1. Configure MySQL {#1-configure-mysql}
+<Steps>
+<Step title="Configure MySQL" id="1-configure-mysql">
 
 1.  Create a database in MySQL:
   ```sql
@@ -65,7 +66,8 @@ If you're using this feature in ClickHouse Cloud, you may need the to allow the 
 Check the ClickHouse [Cloud Endpoints API](/products/cloud/guides/sql-console/query-endpoints) for egress traffic details.
 </Note>
 
-### 2. Define a Table in ClickHouse {#2-define-a-table-in-clickhouse}
+</Step>
+<Step title="Define a Table in ClickHouse" id="2-define-a-table-in-clickhouse">
 
 1. Now let's create a ClickHouse table that uses the `MySQL` table engine:
   ```sql
@@ -90,7 +92,8 @@ The minimum parameters are:
 View the [MySQL table engine](/reference/engines/table-engines/integrations/mysql) doc page for a complete list of parameters.
 </Note>
 
-### 3. Test the Integration {#3-test-the-integration}
+</Step>
+<Step title="Test the Integration" id="3-test-the-integration">
 
 1. In MySQL, insert a sample row:
   ```sql
@@ -148,6 +151,9 @@ You should see the new row:
   +------+---------+
   5 rows in set (0.01 sec)
   ```
+
+</Step>
+</Steps>
 
 ### Summary {#summary}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/chartbrew-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/chartbrew-and-clickhouse.mdx
@@ -30,11 +30,13 @@ In this guide, you will connect Chartbrew to ClickHouse, run a SQL query, and cr
 If you don't have a dataset to work with, you can add one of the examples. This guide uses the [UK Price Paid](/get-started/sample-datasets/uk-price-paid) dataset.
 </Tip>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-## 2. Connect Chartbrew to ClickHouse {#2-connect-chartbrew-to-clickhouse}
+</Step>
+<Step title="Connect Chartbrew to ClickHouse" id="2-connect-chartbrew-to-clickhouse">
 
 1. Log in to [Chartbrew](https://chartbrew.com/login) and go to the **Connections** tab.
 2. Click **Create connection** and select **ClickHouse** from the available database options.
@@ -57,7 +59,8 @@ If you don't have a dataset to work with, you can add one of the examples. This 
 
    <Image img="/images/integrations/data-visualization/chartbrew_04.webp" size="lg" alt="ClickHouse JSON schema in Chartbrew" />
 
-## 3. Create a dataset and run a SQL query {#3-create-a-dataset-and-run-a-sql-query}
+</Step>
+<Step title="Create a dataset and run a SQL query" id="3-create-a-dataset-and-run-a-sql-query">
 
   1. Click on the **Create dataset** button or navigate to the **Datasets** tab to create one.
   2. Select the ClickHouse connection you created earlier.
@@ -83,7 +86,8 @@ If you don't have a dataset to work with, you can add one of the examples. This 
 
 Once the data is retrieved, click **Configure dataset** to set up the visualization parameters.
 
-## 4. Create a visualization {#4-create-a-visualization}
+</Step>
+<Step title="Create a visualization" id="4-create-a-visualization">
    
   1. Define a metric (numerical value) and dimension (categorical value) for your visualization.
   2. Preview the dataset to ensure the query results are structured correctly.
@@ -96,7 +100,8 @@ Once the data is retrieved, click **Configure dataset** to set up the visualizat
 
   <Image img="/images/integrations/data-visualization/chartbrew_01.webp" size="lg" alt="Chartbrew dashboard with ClickHouse data" />
 
-## 5. Automate data updates {#5-automate-data-updates}
+</Step>
+<Step title="Automate data updates" id="5-automate-data-updates">
    
   To keep your dashboard up-to-date, you can schedule automatic data updates:
 
@@ -105,6 +110,9 @@ Once the data is retrieved, click **Configure dataset** to set up the visualizat
   3. Save the settings to enable automatic refresh.
 
   <Image img="/images/integrations/data-visualization/chartbrew_09.webp" size="lg" alt="Chartbrew dataset refresh settings" />
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/databrain-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/databrain-and-clickhouse.mdx
@@ -30,11 +30,13 @@ This guide will walk you through the steps to connect Databrain with your ClickH
 
 ## Steps to connect Databrain to ClickHouse {#steps-to-connect-databrain-to-clickhouse}
 
-### 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-### 2. Allow Databrain IP addresses (if required) {#2-allow-databrain-ip-addresses}
+</Step>
+<Step title="Allow Databrain IP addresses (if required)" id="2-allow-databrain-ip-addresses">
 
 If your ClickHouse instance has IP filtering enabled, you'll need to whitelist Databrain's IP addresses. 
 
@@ -47,7 +49,8 @@ For ClickHouse Cloud users:
 Refer to [Databrain's IP whitelisting documentation](https://docs.usedatabrain.com/guides/datasources/allow-access-to-our-ip) for the current list of IP addresses to whitelist.
 </Tip>
 
-### 3. Add ClickHouse as a data source in Databrain {#3-add-clickhouse-as-a-data-source}
+</Step>
+<Step title="Add ClickHouse as a data source in Databrain" id="3-add-clickhouse-as-a-data-source">
 
 1. Log in to your Databrain account and navigate to the workspace where you want to add the data source.
 
@@ -74,7 +77,8 @@ Refer to [Databrain's IP whitelisting documentation](https://docs.usedatabrain.c
 
 7. Once the connection is successful, click **Save** or **Connect** to add the data source.
 
-### 4. Configure user permissions {#4-configure-user-permissions}
+</Step>
+<Step title="Configure user permissions" id="4-configure-user-permissions">
 
 Ensure the ClickHouse user you're connecting with has the necessary permissions:
 
@@ -87,6 +91,9 @@ GRANT SELECT ON your_database.* TO your_databrain_user;
 ```
 
 Replace `your_databrain_user` and `your_database` with your actual username and database name.
+
+</Step>
+</Steps>
 
 ## Using Databrain with ClickHouse {#using-databrain-with-clickhouse}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/draxlr-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/draxlr-and-clickhouse.mdx
@@ -19,10 +19,12 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
 
 Draxlr offers an intuitive interface for connecting to your ClickHouse database, enabling your team to explore, visualize, and publish insights within minutes. This guide will walk you through the steps to establish a successful connection.
 
-## 1. Get your ClickHouse credentials {#1-get-your-clickhouse-credentials}
+<Steps>
+<Step title="Get your ClickHouse credentials" id="1-get-your-clickhouse-credentials">
 <ConnectionDetails />
 
-## 2.  Connect Draxlr to ClickHouse {#2--connect-draxlr-to-clickhouse}
+</Step>
+<Step title="Connect Draxlr to ClickHouse" id="2--connect-draxlr-to-clickhouse">
 
 1. Click on the **Connect a Database** button on the navbar.
 
@@ -38,7 +40,8 @@ Draxlr offers an intuitive interface for connecting to your ClickHouse database,
 
 6. Click on the **Next** button and wait for the connection to be established. You will see the tables page if the connection is successful.
 
-## 4. Explore your data {#4-explore-your-data}
+</Step>
+<Step title="Explore your data" id="4-explore-your-data">
 
 1. Click on one of the tables in the list.
 
@@ -52,7 +55,8 @@ Draxlr offers an intuitive interface for connecting to your ClickHouse database,
 
   <Image size="md" img="/images/integrations/data-visualization/draxlr_05.webp" alt="Draxlr graph visualization options for ClickHouse data" border />
 
-## 4. Using SQL queries {#4-using-sql-queries}
+</Step>
+<Step title="Using SQL queries" id="4-using-sql-queries">
 
 1. Click on the Explore button on the navbar.
 
@@ -62,7 +66,8 @@ Draxlr offers an intuitive interface for connecting to your ClickHouse database,
 
 3. Click on the **Execute Query** button to see the results.
 
-## 4. Saving you query {#4-saving-you-query}
+</Step>
+<Step title="Saving you query" id="4-saving-you-query">
 
 1. After executing your query, click on the **Save Query** button.
 
@@ -74,7 +79,8 @@ Draxlr offers an intuitive interface for connecting to your ClickHouse database,
 
 4. Click on the **Save** button to save the query.
 
-## 5. Building dashboards {#5-building-dashboards}
+</Step>
+<Step title="Building dashboards" id="5-building-dashboards">
 
 1. Click on the **Dashboards** button on the navbar.
 
@@ -85,6 +91,9 @@ Draxlr offers an intuitive interface for connecting to your ClickHouse database,
 3. To add a new widget, click on the **Add** button on the top right corner.
 
 4. You can select a query from the list of saved queries and choose the visualization type then click on the **Add Dashboard Item** button.
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 To know more about Draxlr you can visit [Draxlr documentation](https://draxlr.notion.site/draxlr/Draxlr-Docs-d228b23383f64d00a70836ff9643a928) site.

--- a/docs/integrations/connectors/data-visualization/community-integrations/embeddable-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/embeddable-and-clickhouse.mdx
@@ -21,10 +21,12 @@ The end result is the ability to deliver fast, interactive customer-facing analy
 
 Built-in row-level security means that every user only ever sees exactly the data they're allowed to see. And two levels of fully-configurable caching mean you can deliver fast, real time analytics at scale.
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Create a ClickHouse connection type {#2-create-a-clickhouse-connection-type}
+</Step>
+<Step title="Create a ClickHouse connection type" id="2-create-a-clickhouse-connection-type">
 
 You add a database connection using Embeddable API. This connection is used to connect to your ClickHouse service. You can add a connection using the following API call:
 
@@ -70,3 +72,5 @@ The `credentials` is a JavaScript object containing the necessary credentials ex
 Embeddable strongly encourage you to create a read-only database user for each connection (Embeddable will only ever read from your database, not write).
 
 In order to support connecting to different databases for prod, qa, test, etc (or to support different databases for different customers) you can assign each connection to an environment (see [Environments API](https://docs.embeddable.com/data/environments)).
+</Step>
+</Steps>

--- a/docs/integrations/connectors/data-visualization/community-integrations/explo-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/explo-and-clickhouse.mdx
@@ -32,10 +32,12 @@ In this guide you will connect your data from ClickHouse to Explo and visualize 
 If you don't have a dataset to work with you can add one of the examples.  This guide uses the [UK Price Paid](/get-started/sample-datasets/uk-price-paid) dataset, so you might choose that one.  There are several others to look at in the same documentation category.
 </Tip>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2.  Connect Explo to ClickHouse {#2--connect-explo-to-clickhouse}
+</Step>
+<Step title="Connect Explo to ClickHouse" id="2--connect-explo-to-clickhouse">
 
 1. Sign up for an Explo account.
 
@@ -68,7 +70,8 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 54.211.43.19, 52.55.98.121, 3.214.169.94, and 54.156.141.148
 `
 
-## 3. Create a Dashboard {#3-create-a-dashboard}
+</Step>
+<Step title="Create a Dashboard" id="3-create-a-dashboard">
 
 1. Navigate to **Dashboard** tab on the left side nav bar.
 
@@ -82,7 +85,8 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 
 <Image img="/images/integrations/data-visualization/explo_09.webp" size="md" alt="Explo Dashboard" border />
 
-## 4. Run a SQL query {#4-run-a-sql-query}
+</Step>
+<Step title="Run a SQL query" id="4-run-a-sql-query">
 
 1. Get your table name from the right hand sidebar under your schema title. You should then put the following command into your dataset editor:
 `
@@ -96,7 +100,8 @@ LIMIT 100
 
 <Image img="/images/integrations/data-visualization/explo_11.webp" size="md" alt="Explo Dashboard" border />
 
-## 5. Build a Chart {#5-build-a-chart}
+</Step>
+<Step title="Build a Chart" id="5-build-a-chart">
 
 1. From the left hand side, drag the bar chart icon onto the screen.
 
@@ -117,6 +122,9 @@ LIMIT 100
 5. We now have average price of homes broken down by price!
 
 <Image img="/images/integrations/data-visualization/explo_15.webp" size="md" alt="Explo Dashboard" />
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/hashboard-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/hashboard-and-clickhouse.mdx
@@ -32,11 +32,13 @@ This guide will walk you through the steps to connect Hashboard with your ClickH
 
 ## Steps to connect Hashboard to ClickHouse {#steps-to-connect-hashboard-to-clickhouse}
 
-### 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-### 2. Add a new database connection in Hashboard {#2-add-a-new-database-connection-in-hashboard}
+</Step>
+<Step title="Add a new database connection in Hashboard" id="2-add-a-new-database-connection-in-hashboard">
 
 1. Navigate to your [Hashboard project](https://hashboard.com/app).
 2. Open the Settings page by clicking the gear icon in the side navigation bar.
@@ -47,6 +49,9 @@ This guide will walk you through the steps to connect Hashboard with your ClickH
 7. Click "Add"
 
 Your ClickHouse database is now be connected to Hashboard and you can proceed by building [Data Models](https://docs.hashboard.com/docs/data-modeling/add-data-model), [Explorations](https://docs.hashboard.com/docs/visualizing-data/explorations), [Metrics](https://docs.hashboard.com/docs/metrics), and [Dashboards](https://docs.hashboard.com/docs/dashboards). See the corresponding Hashboard documentation for more detail on these features.
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/luzmo-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/luzmo-and-clickhouse.mdx
@@ -17,7 +17,8 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
 
 <CommunityMaintainedBadge/>
 
-## 1. Setup a ClickHouse connection {#1-setup-a-clickhouse-connection}
+<Steps>
+<Step title="Setup a ClickHouse connection" id="1-setup-a-clickhouse-connection">
 
 To make a connection to ClickHouse, navigate to the **Connections page**, select **New Connection**, then select the ClickHouse from the New Connection modal.
 
@@ -34,7 +35,8 @@ You'll be asked to provide a **host**, **username** and **password**:
 
 Please refer to the examples in our developer documentation to find out how to [create a connection to ClickHouse](https://developer.luzmo.com/api/createAccount?exampleSection=AccountCreateClickhouseRequestBody) via our API.
 
-## 2. Add datasets {#2-add-datasets}
+</Step>
+<Step title="Add datasets" id="2-add-datasets">
 
 Once you have connected your ClickHouse you can add datasets as explained [here](https://academy.luzmo.com/article/ldx3iltg). You can select one or multiple datasets as available in your ClickHouse and [link](https://academy.luzmo.com/article/gkrx48x5) them in Luzmo to ensure they can be used together in a dashboard. Also make sure to check out this article on [Preparing your data for analytics](https://academy.luzmo.com/article/u492qov0).
 
@@ -43,6 +45,9 @@ To find out how to add datasets using our API, please refer to [this example in 
 You can now use your datasets to build beautiful (embedded) dashboards, or even power an AI Data Analyst ([Luzmo IQ](https://luzmo.com/iq)) that can answer your clients' questions.
 
 <Image img="/images/integrations/data-visualization/luzmo_03.webp" size="md" alt="Luzmo dashboard example showing multiple visualizations of data from ClickHouse" border />
+
+</Step>
+</Steps>
 
 ## Usage notes {#usage-notes}
 

--- a/docs/integrations/connectors/data-visualization/community-integrations/mitzu-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/community-integrations/mitzu-and-clickhouse.mdx
@@ -37,29 +37,34 @@ This dataset is available in ClickHouse Cloud or [can be loaded with these instr
 
 This guide is just a brief overview of how to use Mitzu. You can find more detailed information in the [Mitzu documentation](https://docs.mitzu.io/).
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-## 2. Sign in or sign up to Mitzu {#2-sign-in-or-sign-up-to-mitzu}
+</Step>
+<Step title="Sign in or sign up to Mitzu" id="2-sign-in-or-sign-up-to-mitzu">
 
 As a first step, head to [https://app.mitzu.io](https://app.mitzu.io) to sign up.
 
 <Image size="lg" img="/images/integrations/data-visualization/mitzu_01.webp" alt="Mitzu sign-in page with email and password fields" border />
 
-## 3. Configure your workspace {#3-configure-your-workspace}
+</Step>
+<Step title="Configure your workspace" id="3-configure-your-workspace">
 
 After creating an organization, follow the `Set up your workspace` onboarding guide in the left sidebar. Then, click on the `Connect Mitzu with your data warehouse` link.
 
 <Image size="lg" img="/images/integrations/data-visualization/mitzu_02.webp" alt="Mitzu workspace setup page showing onboarding steps" border />
 
-## 4. Connect Mitzu to ClickHouse {#4-connect-mitzu-to-clickhouse}
+</Step>
+<Step title="Connect Mitzu to ClickHouse" id="4-connect-mitzu-to-clickhouse">
 
 First, select ClickHouse as the connection type and set the connection details. Then, click the `Test connection & Save` button to save the settings.
 
 <Image size="lg" img="/images/integrations/data-visualization/mitzu_03.webp" alt="Mitzu connection setup page for ClickHouse with configuration form" border />
 
-## 5. Configure event tables {#5-configure-event-tables}
+</Step>
+<Step title="Configure event tables" id="5-configure-event-tables">
 
 Once the connection is saved, select the `Event tables` tab and click the `Add table` button. In the modal, select your database and the tables you want to add to Mitzu.
 
@@ -80,7 +85,8 @@ Use the checkboxes to select at least one table and click on the `Configure tabl
 <br/>
 Once all tables are configured, click on the `Save & update event catalog` button, and  Mitzu will find all events and their properties from the above-defined table. This step may take up to a few minutes, depending on the size of your dataset.
 
-## 4. Run segmentation queries {#4-run-segmentation-queries}
+</Step>
+<Step title="Run segmentation queries" id="4-run-segmentation-queries">
 
 User segmentation in Mitzu is as easy as in Amplitude, Mixpanel, or PostHog.
 
@@ -97,7 +103,8 @@ Filtering is done as you would expect: pick a property (ClickHouse column) and s
 You can choose any event or user property for breakdowns (see below for how to integrate user properties).
 </Tip>
 
-## 5. Run funnel queries {#5-run-funnel-queries}
+</Step>
+<Step title="Run funnel queries" id="5-run-funnel-queries">
 
 Select up to 9 steps for a funnel. Choose the time window within which your users can complete the funnel.
 Get immediate conversion rate insights without writing a single line of SQL code.
@@ -112,7 +119,8 @@ Get immediate conversion rate insights without writing a single line of SQL code
 Pick `Funnel trends` to visualize funnel trends over time.
 </Tip>
 
-## 6. Run retention queries {#6-run-retention-queries}
+</Step>
+<Step title="Run retention queries" id="6-run-retention-queries">
 
 Select up to 2 steps for a retention rate calculation. Choose the retention window for the recurring window for
 Get immediate conversion rate insights without writing a single line of SQL code.
@@ -127,7 +135,8 @@ Get immediate conversion rate insights without writing a single line of SQL code
 Pick `Weekly cohort retention` to visualize how your retention rates change over time.
 </Tip>
 
-## 7. Run journey queries {#7-run-journey-queries}
+</Step>
+<Step title="Run journey queries" id="7-run-journey-queries">
 Select up to 9 steps for a funnel. Choose the time window within which your users can finish the journey. The Mitzu journey chart gives you a visual map of every path users take through the selected events.
 
 <Image size="lg" img="/images/integrations/data-visualization/mitzu_09.webp" alt="Mitzu journey visualization showing user path flow between events" border />
@@ -141,12 +150,14 @@ You can select a property for the segment `Break down` to distinguish users with
 
 <br/>
 
-## 8. Run revenue queries {#8-run-revenue-queries}
+</Step>
+<Step title="Run revenue queries" id="8-run-revenue-queries">
 If revenue settings are configured, Mitzu can calculate the total MRR and subscription count based on your payment events.
 
 <Image size="lg" img="/images/integrations/data-visualization/mitzu_10.webp" alt="Mitzu revenue analysis dashboard showing MRR metrics" border />
 
-## 9. SQL native {#9-sql-native}
+</Step>
+<Step title="SQL native" id="9-sql-native">
 
 Mitzu is SQL Native, which means it generates native SQL code from your chosen configuration on the Explore page.
 
@@ -159,6 +170,9 @@ Mitzu is SQL Native, which means it generates native SQL code from your chosen c
 
 If you encounter a limitation with Mitzu UI, copy the SQL code and continue your work in a BI tool.
 </Tip>
+
+</Step>
+</Steps>
 
 ## Mitzu support {#mitzu-support}
 

--- a/docs/integrations/connectors/data-visualization/grafana/index.mdx
+++ b/docs/integrations/connectors/data-visualization/grafana/index.mdx
@@ -34,10 +34,12 @@ Grafana requires a plugin to connect to ClickHouse, which is easily installed wi
 </Frame>
 </div>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Making a read-only user {#2-making-a-read-only-user}
+</Step>
+<Step title="Making a read-only user" id="2-making-a-read-only-user">
 
 When connecting ClickHouse to a data visualization tool like Grafana, it is recommended to make a read-only user to protect your data from unwanted modifications.
 
@@ -48,7 +50,8 @@ To configure a read-only user, follow these steps:
 2. Ensure the `readonly` user has enough permission to modify the `max_execution_time` setting required by the underlying [clickhouse-go client](https://github.com/ClickHouse/clickhouse-go).
 3. If you're using a public ClickHouse instance, it isn't recommended to set `readonly=2` in the `readonly` profile. Instead, leave `readonly=1` and set the constraint type of `max_execution_time` to [changeable_in_readonly](/concepts/features/configuration/settings/constraints-on-settings) to allow modification of this setting.
 
-## 3.  Install the ClickHouse plugin for Grafana {#3--install-the-clickhouse-plugin-for-grafana}
+</Step>
+<Step title="Install the ClickHouse plugin for Grafana" id="3--install-the-clickhouse-plugin-for-grafana">
 
 Before Grafana can connect to ClickHouse, you need to install the appropriate Grafana plugin. Assuming you're logged in to Grafana, follow these steps:
 
@@ -62,7 +65,8 @@ Before Grafana can connect to ClickHouse, you need to install the appropriate Gr
 
     <Image size="md" img="/images/integrations/data-visualization/grafana/install.webp" alt="Install the ClickHouse plugin" border />
 
-## 4. Define a ClickHouse data source {#4-define-a-clickhouse-data-source}
+</Step>
+<Step title="Define a ClickHouse data source" id="4-define-a-clickhouse-data-source">
 
 1. Once the installation is complete, click the **Add new data source** button. (You can also add a data source from the **Data sources** tab on the **Connections** page.)
 
@@ -86,13 +90,17 @@ For more settings, check the [plugin configuration](/integrations/connectors/dat
 
     <Image size="md" img="/images/integrations/data-visualization/grafana/valid_ds.webp" alt="Select Save & test" border />
 
-## 5. Next steps {#5-next-steps}
+</Step>
+<Step title="Next steps" id="5-next-steps">
 
 Your data source is now ready to use! Learn more about how to build queries with the [query builder](/integrations/connectors/data-visualization/grafana/query-builder).
 
 For more details on configuration, check the [plugin configuration](/integrations/connectors/data-visualization/grafana/config) documentation.
 
 If you're looking for more information that isn't included in these docs, check the [plugin repository on GitHub](https://github.com/grafana/clickhouse-datasource).
+
+</Step>
+</Steps>
 
 ## Upgrading plugin versions {#upgrading-plugin-versions}
 

--- a/docs/integrations/connectors/data-visualization/looker-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/looker-and-clickhouse.mdx
@@ -19,10 +19,12 @@ import PartnerBadge from "/snippets/components/PartnerBadge/PartnerBadge.jsx";
 
 Looker can connect to ClickHouse Cloud or on-premise deployment via the official ClickHouse data source.
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Create a ClickHouse data source {#2-create-a-clickhouse-data-source}
+</Step>
+<Step title="Create a ClickHouse data source" id="2-create-a-clickhouse-data-source">
 
 Navigate to Admin -> Database -> Connections and click the "Add Connection" button in the top right corner.
 
@@ -46,7 +48,10 @@ Test your connection first, and, once it is done, connect to your new ClickHouse
 
 Now you should be able to attach ClickHouse Datasource to your Looker project.
 
-## 3. Known limitations {#3-known-limitations}
+</Step>
+</Steps>
+
+## Known limitations {#3-known-limitations}
 
 1. The following data types are handled as strings by default:
    * Array - serialization doesn't work as expected due to the JDBC driver limitations

--- a/docs/integrations/connectors/data-visualization/metabase-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/metabase-and-clickhouse.mdx
@@ -34,10 +34,12 @@ In this guide you will ask some questions of your ClickHouse data with Metabase 
 If you don't have a dataset to work with you can add one of the examples.  This guide uses the [UK Price Paid](/get-started/sample-datasets/uk-price-paid) dataset, so you might choose that one.  There are several others to look at in the same documentation category.
 </Tip>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2.  Download the ClickHouse plugin for Metabase {#2--download-the-clickhouse-plugin-for-metabase}
+</Step>
+<Step title="Download the ClickHouse plugin for Metabase" id="2--download-the-clickhouse-plugin-for-metabase">
 
 1. If you don't have a `plugins` folder, create one as a subfolder of where you have `metabase.jar` saved.
 
@@ -49,7 +51,8 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 
 5. Access Metabase at <a href="http://localhost:3000/" target="_blank">http://hostname:3000</a>. On the initial startup, you will see a welcome screen and have to work your way through a list of questions. If prompted to select a database, select "**I'll add my data later**":
 
-## 3.  Connect Metabase to ClickHouse {#3--connect-metabase-to-clickhouse}
+</Step>
+<Step title="Connect Metabase to ClickHouse" id="3--connect-metabase-to-clickhouse">
 
 1. Click on the gear icon in the top-right corner and select **Admin Settings** to visit your <a href="http://localhost:3000/admin/settings/setup" target="_blank">Metabase admin page</a>.
 
@@ -67,7 +70,8 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 
 6. Click the **Save** button and Metabase will scan your database for tables.
 
-## 4. Run a SQL query {#4-run-a-sql-query}
+</Step>
+<Step title="Run a SQL query" id="4-run-a-sql-query">
 
 1. Exit the **Admin settings** by clicking the **Exit admin** button in the top-right corner.
 
@@ -79,7 +83,8 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 
     <Image size="md" img="/images/integrations/data-visualization/metabase_04.webp" alt="Metabase SQL editor showing a query on UK price paid data" border />
 
-## 5. Ask a question {#5-ask-a-question}
+</Step>
+<Step title="Ask a question" id="5-ask-a-question">
 
 1. Click on **+ New** and select **Question**. Notice you can build a question by starting with a database and table. For example, the following question is being asked of a table named `uk_price_paid` in the `default` database. Here is a simple question that calculates the average price by town, within the county of Greater Manchester:
 
@@ -92,6 +97,9 @@ If you don't have a dataset to work with you can add one of the examples.  This 
 3. Below the results, click the **Visualization** button to change the visualization to a bar chart (or any of the other options available):
 
     <Image size="md" img="/images/integrations/data-visualization/metabase_08.webp" alt="Metabase pie chart visualization of average prices by town in Greater Manchester" border />
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/data-visualization/omni-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/omni-and-clickhouse.mdx
@@ -19,11 +19,13 @@ import PartnerBadge from "/snippets/components/PartnerBadge/PartnerBadge.jsx";
 
 Omni can connect to ClickHouse Cloud or on-premise deployment via the official ClickHouse data source.
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-## 2. Create a ClickHouse data source {#2-create-a-clickhouse-data-source}
+</Step>
+<Step title="Create a ClickHouse data source" id="2-create-a-clickhouse-data-source">
 
 Navigate to Admin -> Connections and click the "Add Connection" button in the top right corner.
 
@@ -36,3 +38,5 @@ Select `ClickHouse`. Enter your credentials in the form.
 <br/>
 
 Now you should can query and visualize data from ClickHouse in Omni.
+</Step>
+</Steps>

--- a/docs/integrations/connectors/data-visualization/superset-and-clickhouse.mdx
+++ b/docs/integrations/connectors/data-visualization/superset-and-clickhouse.mdx
@@ -34,10 +34,12 @@ In this guide you will build a dashboard in Superset with data from a ClickHouse
 If you don't have a dataset to work with you can add one of the examples. This guide uses the [UK Price Paid](/get-started/sample-datasets/uk-price-paid) dataset, so you might choose that one. There are several others to look at in the same documentation category.
 </Tip>
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Install the Driver {#2-install-the-driver}
+</Step>
+<Step title="Install the Driver" id="2-install-the-driver">
 
 1. Superset uses the `clickhouse-connect` driver to connect to ClickHouse. The details of `clickhouse-connect` are at <a href="https://pypi.org/project/clickhouse-connect/" target="_blank">https://pypi.org/project/clickhouse-connect/</a> and it can be installed with the following command:
 
@@ -53,7 +55,8 @@ If you don't have a dataset to work with you can add one of the examples. This g
 
 2. Start (or restart) Superset.
 
-## 3. Connect Superset to ClickHouse {#3-connect-superset-to-clickhouse}
+</Step>
+<Step title="Connect Superset to ClickHouse" id="3-connect-superset-to-clickhouse">
 
 1. Within Superset, select **Data** from the top menu and then **Databases** from the drop-down menu. Add a new database by clicking the **+ Database** button:
 
@@ -75,7 +78,8 @@ If you don't have a dataset to work with you can add one of the examples. This g
 
 4. Click the **CONNECT** and then **FINISH** buttons to complete the setup wizard, and you should see your database in the list of databases.
 
-## 4. Add a Dataset {#4-add-a-dataset}
+</Step>
+<Step title="Add a Dataset" id="4-add-a-dataset">
 
 1. To interact with your ClickHouse data with Superset, you need to define a **_dataset_**. From the top menu in Superset, select **Data**, then **Datasets** from the drop-down menu.
 
@@ -86,7 +90,8 @@ If you don't have a dataset to work with you can add one of the examples. This g
 
 3. Click the **ADD** button at the bottom of the dialog window and your table appears in the list of datasets. You're ready to build a dashboard and analyze your ClickHouse data!
 
-## 5.  Creating charts and a dashboard in Superset {#5--creating-charts-and-a-dashboard-in-superset}
+</Step>
+<Step title="Creating charts and a dashboard in Superset" id="5--creating-charts-and-a-dashboard-in-superset">
 
 If you're familiar with Superset, then you will feel right at home with this next section. If you're new to Superset, well...it's like a lot of the other cool visualization tools out there in the world - it doesn't take long to get started, but the details and nuances get learned over time as you use the tool.
 
@@ -120,3 +125,5 @@ If you're familiar with Superset, then you will feel right at home with this nex
 
 <Image size="md" img="/images/integrations/data-visualization/superset_12.webp" alt="Completed Superset dashboard with multiple visualizations of UK property price data from ClickHouse" border />
 <br/>
+</Step>
+</Steps>

--- a/docs/integrations/connectors/sql-clients/datagrip.mdx
+++ b/docs/integrations/connectors/sql-clients/datagrip.mdx
@@ -22,10 +22,12 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
 
 DataGrip is available at https://www.jetbrains.com/datagrip/
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 <ConnectionDetails />
 
-## 2. Load the ClickHouse driver {#2-load-the-clickhouse-driver}
+</Step>
+<Step title="Load the ClickHouse driver" id="2-load-the-clickhouse-driver">
 
 1. Launch DataGrip, and on the **Data Sources** tab in the **Data Sources and Drivers** dialog, click the **+** icon
 
@@ -46,7 +48,8 @@ DataGrip is available at https://www.jetbrains.com/datagrip/
 
 <Image img="/images/integrations/sql-clients/datagrip-1.webp" size="lg" border alt="DataGrip Drivers tab showing ClickHouse driver installation" />
 
-## 3. Connect to ClickHouse {#3-connect-to-clickhouse}
+</Step>
+<Step title="Connect to ClickHouse" id="3-connect-to-clickhouse">
 
 - Specify your database connection details, and click **Test Connection**. 
 In step one you gathered your connection details - fill in the host URL, port, username, password, and database name, then test the connection.
@@ -64,6 +67,9 @@ For more details on JDBC URL settings, please refer to the [ClickHouse JDBC driv
 </Tip>
 
 <Image img="/images/integrations/sql-clients/datagrip-7.webp" border alt="DataGrip connection details form with ClickHouse settings" />
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/sql-clients/dbeaver.mdx
+++ b/docs/integrations/connectors/sql-clients/dbeaver.mdx
@@ -23,7 +23,8 @@ DBeaver is available in multiple offerings. In this guide [DBeaver Community](ht
 Please use DBeaver version 23.1.0 or above for improved support of `Nullable` columns in ClickHouse.
 </Note>
 
-## 1. Gather your ClickHouse details {#1-gather-your-clickhouse-details}
+<Steps>
+<Step title="Gather your ClickHouse details" id="1-gather-your-clickhouse-details">
 
 DBeaver uses JDBC over HTTP(S) to connect to ClickHouse; you need:
 
@@ -32,11 +33,13 @@ DBeaver uses JDBC over HTTP(S) to connect to ClickHouse; you need:
 - username
 - password
 
-## 2. Download DBeaver {#2-download-dbeaver}
+</Step>
+<Step title="Download DBeaver" id="2-download-dbeaver">
 
 DBeaver is available at https://dbeaver.io/download/
 
-## 3. Add a database {#3-add-a-database}
+</Step>
+<Step title="Add a database" id="3-add-a-database">
 
 - Either use the **Database > New Database Connection** menu or the **New Database Connection** icon in the **Database Navigator** to bring up the **Connect to a database** dialog:
 
@@ -64,7 +67,8 @@ If DBeaver detects that you don't have the ClickHouse driver installed it will o
 
 <Image img="/images/integrations/sql-clients/dbeaver-test-connection.webp" size="md" border alt="Test the connection" />
 
-## 4. Query ClickHouse {#4-query-clickhouse}
+</Step>
+<Step title="Query ClickHouse" id="4-query-clickhouse">
 
 Open a query editor and run a query.
 
@@ -75,6 +79,9 @@ Open a query editor and run a query.
 - An example query against `system.query_log`:
 
 <Image img="/images/integrations/sql-clients/dbeaver-query-log-select.webp" size="md" border alt="A sample query" />
+
+</Step>
+</Steps>
 
 ## Next steps {#next-steps}
 

--- a/docs/integrations/connectors/sql-clients/dbvisualizer.mdx
+++ b/docs/integrations/connectors/sql-clients/dbvisualizer.mdx
@@ -21,17 +21,20 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
 
 DbVisualizer is available at https://www.dbvis.com/download/
 
-## 1. Gather your connection details {#1-gather-your-connection-details}
+<Steps>
+<Step title="Gather your connection details" id="1-gather-your-connection-details">
 
 <ConnectionDetails />
 
-## 2. Built-in JDBC driver management {#2-built-in-jdbc-driver-management}
+</Step>
+<Step title="Built-in JDBC driver management" id="2-built-in-jdbc-driver-management">
 
 DbVisualizer has the most up-to-date JDBC drivers for ClickHouse included. It has full JDBC driver management built right in that points to the latest releases as well as historical versions for the drivers.
 
 <Image img="/images/integrations/sql-clients/dbvisualizer-driver-manager.webp" size="lg" border alt="DbVisualizer driver manager interface showing ClickHouse JDBC driver configuration" />
 
-## 3. Connect to ClickHouse {#3-connect-to-clickhouse}
+</Step>
+<Step title="Connect to ClickHouse" id="3-connect-to-clickhouse">
 
 To connect a database with DbVisualizer, you must first create and setup a Database Connection.
 
@@ -55,6 +58,9 @@ To connect a database with DbVisualizer, you must first create and setup a Datab
 See [Fixing Connection Issues](https://www.dbvis.com/docs/ug/troubleshooting/fixing-connection-issues/) for some tips if you have problems connecting to the database.
 
 </Tip>
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/integrations/connectors/sql-clients/marimo.mdx
+++ b/docs/integrations/connectors/sql-clients/marimo.mdx
@@ -20,7 +20,8 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
 
 <Image img="/images/integrations/sql-clients/marimo/clickhouse-connect.webp" size="md" border alt="Connect to ClickHouse" />
 
-## 1. Install marimo with SQL support {#install-marimo-sql}
+<Steps>
+<Step title="Install marimo with SQL support" id="install-marimo-sql">
 
 ```shell
 pip install "marimo[sql]" clickhouse_connect
@@ -28,7 +29,8 @@ marimo edit clickhouse_demo.py
 ```
 This should open up a web browser running on localhost.
 
-## 2. Connecting to ClickHouse. {#connect-to-clickhouse}
+</Step>
+<Step title="Connecting to ClickHouse." id="connect-to-clickhouse">
 
 Navigate to the datasources panel on the left side of the marimo editor and click on 'Add database'.
 
@@ -42,7 +44,8 @@ You will then have a cell that can be run to establish a connection.
 
 <Image img="/images/integrations/sql-clients/marimo/run-cell.webp" size="md" border alt="Run the cell to connect to ClickHouse" />
 
-## 3. Run SQL {#run-sql}
+</Step>
+<Step title="Run SQL" id="run-sql">
 
 Once you have set up a connection, you can create a new SQL cell and choose the clickhouse engine. 
 
@@ -115,3 +118,5 @@ marimo's reactive execution model extends into SQL queries, so changes to your S
 You can also toggle App View to have a clean interface for exploring your data.
 
 <Image img="/images/integrations/sql-clients/marimo/run-app-view.webp" size="md" border alt="Run app view" />
+</Step>
+</Steps>

--- a/docs/integrations/connectors/sql-clients/qstudio.mdx
+++ b/docs/integrations/connectors/sql-clients/qstudio.mdx
@@ -21,7 +21,8 @@ QStudio is a free SQL GUI, it allows running SQL scripts, easy browsing of table
 
 QStudio connects to ClickHouse using JDBC.
 
-## 1. Gather your ClickHouse details {#1-gather-your-clickhouse-details}
+<Steps>
+<Step title="Gather your ClickHouse details" id="1-gather-your-clickhouse-details">
 
 QStudio uses JDBC over HTTP(S) to connect to ClickHouse; you need:
 
@@ -32,11 +33,13 @@ QStudio uses JDBC over HTTP(S) to connect to ClickHouse; you need:
 
 <ConnectionDetails />
 
-## 2. Download QStudio {#2-download-qstudio}
+</Step>
+<Step title="Download QStudio" id="2-download-qstudio">
 
 QStudio is available at https://www.timestored.com/qstudio/download/
 
-## 3. Add a database {#3-add-a-database}
+</Step>
+<Step title="Add a database" id="3-add-a-database">
 
 - When you first open QStudio click on the menu options **Server->Add Server** or on the add server button on the toolbar.
 - Then set the details:
@@ -53,7 +56,8 @@ QStudio is available at https://www.timestored.com/qstudio/download/
 
 If QStudio detects that you don't have the ClickHouse JDBC driver installed, it will offer to download them for you:
 
-## 4. Query ClickHouse {#4-query-clickhouse}
+</Step>
+<Step title="Query ClickHouse" id="4-query-clickhouse">
 
 - Open a query editor and run a query. You can run queries by
 - Ctrl + e - Runs highlighted text
@@ -62,6 +66,9 @@ If QStudio detects that you don't have the ClickHouse JDBC driver installed, it 
 - An example query:
 
 <Image img="/images/integrations/sql-clients/qstudio-running-query.webp" size="lg" border alt="QStudio interface showing sample SQL query execution against ClickHouse database" />
+
+</Step>
+</Steps>
 
 ## Next steps {#next-steps}
 

--- a/docs/integrations/connectors/sql-clients/tablum.mdx
+++ b/docs/integrations/connectors/sql-clients/tablum.mdx
@@ -22,13 +22,15 @@ import CommunityMaintainedBadge from "/snippets/components/CommunityMaintainedBa
   You can install a self-hosted version of TABLUM.IO on your Linux server in docker.
 </Note>
 
-## 1. Sign up or sign in to the service {#1-sign-up-or-sign-in-to-the-service}
+<Steps>
+<Step title="Sign up or sign in to the service" id="1-sign-up-or-sign-in-to-the-service">
 
   First, sign up to TABLUM.IO using your email or use a quick-login via accounts in Google or Facebook.
 
 <Image img="/images/integrations/sql-clients/tablum-ch-0.webp" size="md" border alt="TABLUM.IO login page" />
 
-## 2. Add a ClickHouse connector {#2-add-a-clickhouse-connector}
+</Step>
+<Step title="Add a ClickHouse connector" id="2-add-a-clickhouse-connector">
 
 Gather your ClickHouse connection details, navigate to the **Connector** tab, and fill in the host URL, port, username, password, database name, and connector's name. After completing these fields, click on **Test connection** button to validate the details and then click on  **Save connector for me** to make it persistent.
 
@@ -42,13 +44,15 @@ Typically, the port is 8443 when using TLS or 8123 when not using TLS.
 
 <Image img="/images/integrations/sql-clients/tablum-ch-1.webp" size="lg" border alt="Adding a ClickHouse connector in TABLUM.IO" />
 
-## 3. Select the connector {#3-select-the-connector}
+</Step>
+<Step title="Select the connector" id="3-select-the-connector">
 
 Navigate to the **Dataset** tab. Select recently created ClickHouse connector in the dropdown. In the right panel, you will see the list of available tables and schemas.
 
 <Image img="/images/integrations/sql-clients/tablum-ch-2.webp" size="lg" border alt="Selecting the ClickHouse connector in TABLUM.IO" />
 
-## 4. Input a SQL query and run it {#4-input-a-sql-query-and-run-it}
+</Step>
+<Step title="Input a SQL query and run it" id="4-input-a-sql-query-and-run-it">
 
 Type a query in the SQL Console and press **Run Query**. The results will be displayed as a spreadsheet.
 
@@ -64,6 +68,9 @@ With TABLUM.IO you can
 * run queries on any loaded data regardless of the data source,
 * share the results as a new ClickHouse database.
 </Note>
+
+</Step>
+</Steps>
 
 ## Learn more {#learn-more}
 

--- a/docs/products/bring-your-own-cloud/onboarding/aws.mdx
+++ b/docs/products/bring-your-own-cloud/onboarding/aws.mdx
@@ -86,10 +86,12 @@ Create a support ticket with the following information:
 
 To create or delete VPC peering for ClickHouse BYOC, follow the steps:
 
-#### Step 1: Enable private load balancer for ClickHouse BYOC 
+<Steps>
+<Step title="Enable private load balancer for ClickHouse BYOC" id="step-1-enable-private-load-balancer-for-clickhouse-byoc">
 Contact ClickHouse Support to enable Private Load Balancer.
 
-#### Step 2 Create a peering connection 
+</Step>
+<Step title="Create a peering connection" id="step-2-create-a-peering-connection">
 1. Navigate to the VPC Dashboard in ClickHouse BYOC account.
 2. Select Peering Connections.
 3. Click Create Peering Connection
@@ -103,7 +105,8 @@ Contact ClickHouse Support to enable Private Load Balancer.
 
 <br />
 
-#### Step 3 Accept the peering connection request 
+</Step>
+<Step title="Accept the peering connection request" id="step-3-accept-the-peering-connection-request">
 Go to the peering account, in the (VPC -> Peering connections -> Actions -> Accept request) page customer can approve this VPC peering request.
 
 <br />
@@ -112,7 +115,8 @@ Go to the peering account, in the (VPC -> Peering connections -> Actions -> Acce
 
 <br />
 
-#### Step 4 Add destination to ClickHouse VPC route tables 
+</Step>
+<Step title="Add destination to ClickHouse VPC route tables" id="step-4-add-destination-to-clickhouse-vpc-route-tables">
 In ClickHouse BYOC account,
 1. Select Route Tables in the VPC Dashboard.
 2. Search for the ClickHouse VPC ID. Edit each route table attached to the private subnets.
@@ -127,7 +131,8 @@ In ClickHouse BYOC account,
 
 <br />
 
-#### Step 5 Add destination to the target VPC route tables 
+</Step>
+<Step title="Add destination to the target VPC route tables" id="step-5-add-destination-to-the-target-vpc-route-tables">
 In the peering AWS account,
 1. Select Route Tables in the VPC Dashboard.
 2. Search for the target VPC ID.
@@ -142,7 +147,8 @@ In the peering AWS account,
 
 <br />
 
-#### Step 6: Edit security group to allow peered VPC access 
+</Step>
+<Step title="Edit security group to allow peered VPC access" id="step-6-edit-security-group-to-allow-peered-vpc-access">
 In the ClickHouse BYOC account, you need to update the Security Group settings to allow traffic from your peered VPC. Please contact ClickHouse Support to request the addition of inbound rules that include the CIDR ranges of your peered VPC.
 
 ---
@@ -153,6 +159,9 @@ To access ClickHouse privately, a private load balancer and endpoint are provisi
 - **Private endpoint**: `h5ju65kv87-private.mhp0y4dmph.us-west-2.aws.byoc.clickhouse.cloud`
 
 Optional, after verifying that peering is working, you can request the removal of the public load balancer for ClickHouse BYOC.
+
+</Step>
+</Steps>
 
 ## Upgrade process 
 

--- a/docs/products/kubernetes-operator/guides/tls.mdx
+++ b/docs/products/kubernetes-operator/guides/tls.mdx
@@ -46,7 +46,8 @@ webhook rejects a cluster that enables TLS without it, and rejects `required: tr
 unless `enabled: true`.
 </Note>
 
-## Step 1 — Bootstrap a CA with cert-manager {#step-1-ca}
+<Steps>
+<Step title="Bootstrap a CA with cert-manager" id="step-1-ca">
 
 The most reproducible setup is a self-signed CA that then signs the server
 certificate. This gives you a stable `ca.crt` that clients can trust.
@@ -93,7 +94,8 @@ In production, replace the self-signed bootstrap with your real issuer (a
 corporate CA, Vault, ACME, etc.). Only Step 2 changes — the cluster wiring is
 identical.
 
-## Step 2 — Issue the server certificate {#step-2-cert}
+</Step>
+<Step title="Issue the server certificate" id="step-2-cert">
 
 Request a leaf certificate from the CA issuer. The `dnsNames` must cover how
 clients address the pods. The operator creates a single **headless** Service named
@@ -134,7 +136,8 @@ kubectl -n <namespace> get secret clickhouse-cert -o jsonpath='{.data}' | jq 'ke
 # ["ca.crt","tls.crt","tls.key"]
 ```
 
-## Step 3 — Enable TLS on the cluster {#step-3-enable}
+</Step>
+<Step title="Enable TLS on the cluster" id="step-3-enable">
 
 Point the cluster at the Secret:
 
@@ -178,7 +181,8 @@ even when TLS is off, so toggling `tls.enabled` later never collides with a
 [Configuration → `additionalPorts`](/products/kubernetes-operator/guides/configuration#additional-ports).
 </Note>
 
-## Step 4 — Connect over TLS {#step-4-connect}
+</Step>
+<Step title="Connect over TLS" id="step-4-connect">
 
 With `required: true`, clients must use the secure ports and trust the CA. Address
 a specific replica pod through the headless Service (or your own `ClusterIP`
@@ -207,6 +211,9 @@ Pull `ca.crt` straight from the Secret for local testing:
 kubectl -n <namespace> get secret clickhouse-cert \
   -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 ```
+
+</Step>
+</Steps>
 
 ## Encrypting Keeper traffic {#keeper-tls}
 

--- a/docs/products/managed-postgres/migrations/clickhouse-cloud.mdx
+++ b/docs/products/managed-postgres/migrations/clickhouse-cloud.mdx
@@ -22,7 +22,8 @@ ClickHouse Cloud includes a built-in import wizard that migrates your external P
 ## Considerations before migrating {#considerations}
 - **DDL propagation**: continuous replication (CDC) captures DML operations and `ADD COLUMN`. Other DDL changes such as `DROP COLUMN` and `ALTER COLUMN` aren't propagated and must be applied manually on the target.
 
-## Step 1: Connect to your source database {#step-1-connect}
+<Steps>
+<Step title="Connect to your source database" id="step-1-connect">
 Open the [ClickHouse Cloud console](https://clickhouse.cloud) and select your Managed Postgres service.
 
 <Image img="/images/managed-postgres/pgpg/servicecard.webp" alt="Managed Postgres service card in the ClickHouse Cloud services list" size="lg" border />
@@ -49,7 +50,8 @@ Choose an ingestion method:
 
 Click **Next**.
 
-## Step 2: Export your database schema {#step-2-export-schema}
+</Step>
+<Step title="Export your database schema" id="step-2-export-schema">
 The wizard displays a `pg_dump` command pre-filled with your source connection details. Run it in a terminal:
 
 <Image img="/images/managed-postgres/pgpg/nextexport.webp" alt="Step 2: pg_dump command for schema export" size="lg" border />
@@ -69,7 +71,8 @@ This creates `pg.sql` in your current directory.
 
 Click **Next**.
 
-## Step 3: Import the schema into your Managed Postgres service {#step-3-import-schema}
+</Step>
+<Step title="Import the schema into your Managed Postgres service" id="step-3-import-schema">
 Select the destination database from the dropdown, or click **Create a new database** to provision one.
 
 The wizard displays a `psql` command to apply the schema dump to your Managed Postgres service. Run it in a terminal:
@@ -89,7 +92,8 @@ psql \
 
 Click **Next**.
 
-## Step 4: Configure ingestion settings {#step-4-ingestion-settings}
+</Step>
+<Step title="Configure ingestion settings" id="step-4-ingestion-settings">
 Specify the publication to use for logical replication. If you leave this blank, a publication is created automatically.
 
 Expand **Advanced replication settings** to tune throughput:
@@ -106,12 +110,16 @@ Expand **Advanced replication settings** to tune throughput:
 
 Click **Next**.
 
-## Step 5: Select tables {#step-5-select-tables}
+</Step>
+<Step title="Select tables" id="step-5-select-tables">
 Select the tables you want to replicate. Tables are grouped by schema. Select individual tables or expand a schema to pick all of them.
 
 <Image img="/images/managed-postgres/pgpg/tablepicker.webp" alt="Step 5: table picker grouped by schema with Create migration button" size="lg" border />
 
 Click **Create migration**.
+
+</Step>
+</Steps>
 
 ## Monitor the migration {#monitor}
 After creating the migration, you'll see it listed in **Data sources** with a **Running** status.

--- a/docs/products/managed-postgres/migrations/clickpipes.mdx
+++ b/docs/products/managed-postgres/migrations/clickpipes.mdx
@@ -37,7 +37,8 @@ ClickHouse Cloud now offers ClickPipes to migrate your external PostgreSQL datab
 If you run into issues during migration, check the [Managed Postgres Migrations FAQ](/products/managed-postgres/migrations/faq) for common errors and solutions.
 </Note>
 
-## Step 1: Connect to your source database {#step-1-connect}
+<Steps>
+<Step title="Connect to your source database" id="step-1-connect">
 
 Open the [ClickHouse Cloud console](https://clickhouse.cloud) and select your Managed Postgres service.
 
@@ -65,7 +66,8 @@ Choose an ingestion method:
 
 Click **Next**.
 
-## Step 2: Export your database schema {#step-2-export-schema}
+</Step>
+<Step title="Export your database schema" id="step-2-export-schema">
 
 The wizard displays a `pg_dump` command pre-filled with your source connection details. Run it in a terminal:
 
@@ -86,7 +88,8 @@ This creates `pg.sql` in your current directory.
 
 Click **Next**.
 
-## Step 3: Import the schema into your Managed Postgres service {#step-3-import-schema}
+</Step>
+<Step title="Import the schema into your Managed Postgres service" id="step-3-import-schema">
 
 Select the destination database from the dropdown, or click **Create a new database** to provision one.
 
@@ -107,7 +110,8 @@ psql \
 
 Click **Next**.
 
-## Step 4: Configure ingestion settings {#step-4-ingestion-settings}
+</Step>
+<Step title="Configure ingestion settings" id="step-4-ingestion-settings">
 
 Specify the publication to use for logical replication. If you leave this blank, a publication is created automatically.
 
@@ -125,13 +129,17 @@ Expand **Advanced replication settings** to tune throughput:
 
 Click **Next**.
 
-## Step 5: Select tables {#step-5-select-tables}
+</Step>
+<Step title="Select tables" id="step-5-select-tables">
 
 Select the tables you want to replicate. Tables are grouped by schema. Select individual tables or expand a schema to pick all of them.
 
 <Image img="/images/managed-postgres/pgpg/tablepicker.webp" alt="Step 5: table picker grouped by schema with Create migration button" size="lg" border />
 
 Click **Create migration**.
+
+</Step>
+</Steps>
 
 ## Monitor the migration {#monitor}
 

--- a/docs/resources/develop-contribute/contribute/backports.mdx
+++ b/docs/resources/develop-contribute/contribute/backports.mdx
@@ -123,7 +123,7 @@ For each original PR number `N` and release branch `release/X.Y`:
 When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this — for the named release and for every newer active release branch it expands to. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
 
 </Step>
-<Step title="Cherry-pick stage (`ReleaseBranch.create_cherrypick`)" id="cherry-pick-stage">
+<Step title={<>Cherry-pick stage (<code>ReleaseBranch.create_cherrypick</code>)</>} id="cherry-pick-stage">
 
 For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 
@@ -143,7 +143,7 @@ For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 If the cherry-pick PR is mergeable (no conflicts), the bot merges it automatically via the GitHub API and proceeds immediately to the backport stage.
 
 </Step>
-<Step title="Backport stage (`ReleaseBranch.create_backport`)" id="backport-stage">
+<Step title={<>Backport stage (<code>ReleaseBranch.create_backport</code>)</>} id="backport-stage">
 
 After the cherry-pick PR is merged:
 

--- a/docs/resources/develop-contribute/contribute/backports.mdx
+++ b/docs/resources/develop-contribute/contribute/backports.mdx
@@ -103,11 +103,13 @@ For each original PR number `N` and release branch `release/X.Y`:
 
 ### Step-by-Step Process {#step-by-step-process}
 
-#### 1. Discover active releases {#discover-active-releases}
+<Steps>
+<Step title="Discover active releases" id="discover-active-releases">
 
 `BackportPRs.receive_release_prs` queries GitHub for all open PRs with the `release` label. The head refs of these PRs are the release branch names (e.g. `release/25.3`). From these it derives the set of version-specific labels to search for: every `v{VER}-must-backport` label that exists in the repository whose version is not newer than the newest active release. Older labels are included even when their release is no longer active (a label newer than every active release is skipped, since it could not expand to any active branch), so a PR labelled for an end-of-life release is still found as long as a newer release is active.
 
-#### 2. Find PRs to backport {#find-prs-to-backport}
+</Step>
+<Step title="Find PRs to backport" id="find-prs-to-backport">
 
 `BackportPRs.receive_prs_for_backport` uses the GitHub search API to find merged PRs that:
 - carry at least one backport label (`pr-must-backport`, `pr-must-backport-force`, `pr-critical-bugfix`, or a version-specific label), and
@@ -115,11 +117,13 @@ For each original PR number `N` and release branch `release/X.Y`:
 - were merged after the oldest commit date found on any release branch, and
 - were updated within the last 90 days (to keep the search query efficient).
 
-#### 3. Rolling-out branch handling {#rolling-out-branch-handling}
+</Step>
+<Step title="Rolling-out branch handling" id="rolling-out-branch-handling">
 
 When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this — for the named release and for every newer active release branch it expands to. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
 
-#### 4. Cherry-pick stage (`ReleaseBranch.create_cherrypick`) {#cherry-pick-stage}
+</Step>
+<Step title="Cherry-pick stage (`ReleaseBranch.create_cherrypick`)" id="cherry-pick-stage">
 
 For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 
@@ -133,11 +137,13 @@ For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 6. Propagate `pr-bugfix` or `pr-critical-bugfix` from the original PR if applicable.
 7. Assignees are **not** set at this point; they are only added when conflicts are detected.
 
-#### 5. Auto-merge of conflict-free cherry-pick PRs {#auto-merge-conflict-free-cherry-pick-prs}
+</Step>
+<Step title="Auto-merge of conflict-free cherry-pick PRs" id="auto-merge-conflict-free-cherry-pick-prs">
 
 If the cherry-pick PR is mergeable (no conflicts), the bot merges it automatically via the GitHub API and proceeds immediately to the backport stage.
 
-#### 6. Backport stage (`ReleaseBranch.create_backport`) {#backport-stage}
+</Step>
+<Step title="Backport stage (`ReleaseBranch.create_backport`)" id="backport-stage">
 
 After the cherry-pick PR is merged:
 
@@ -149,13 +155,18 @@ After the cherry-pick PR is merged:
 6. Label the PR `pr-backport` (and `pr-bugfix` / `pr-critical-bugfix` if applicable).
 7. Assign the PR to the original PR's author, merger, and existing assignees (excluding robot accounts).
 
-#### 7. Completion {#completion}
+</Step>
+<Step title="Completion" id="completion">
 
 When all release branches for a given original PR are backported, the bot adds `pr-backports-created` to the original PR.
 
-#### 8. Pre-check {#pre-check}
+</Step>
+<Step title="Pre-check" id="pre-check">
 
 Before starting any work on a PR, `ReleaseBranch.pre_check` runs `git merge-base --is-ancestor` to verify the merge commit is not already reachable from the release branch. If it is, the PR is considered already backported and skipped.
+
+</Step>
+</Steps>
 
 ### Stale Cherry-pick PR Handling {#stale-cherry-pick-pr-handling}
 


### PR DESCRIPTION
### Summary

- Convert procedural numbered headings to Mintlify `<Steps>` and `<Step>` components across 45 documentation pages.
- Cover SQL clients, visualization integrations, ClickPipes, Kafka, Streamkap, chDB installation, BYOC, Kubernetes, Managed Postgres, and operational guides.
- Preserve existing explicit and generated anchors so inbound links continue to resolve.
- Leave non-procedural numbered content such as comparisons, scenarios, best practices, alert types, and academic sections unchanged.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use Mintlify Steps components for numbered procedural guides.

### Validation

- `node ci/jobs/scripts/docs/scoped_validate.mjs --scope integrations --scope products --scope chdb --scope resources --scope guides --scope concepts docs`
- `python3 ci/jobs/scripts/docs/lychee_check.py --mode links docs`
- `git diff --check`


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.873` (included in `26.7` and later)
<!-- ch-version-info:end -->