### PR TITLE
Fix server abort on PRQL parser panic at the Rust FFI boundary

### DIFF
--- a/rust/workspace/prql/src/lib.rs
+++ b/rust/workspace/prql/src/lib.rs
@@ -15,7 +15,12 @@ fn set_output(result: String, out: *mut *mut u8, out_size: *mut u64) {
 }
 
 /// Converts a PRQL query from a raw C string to SQL, returning an error code if the conversion fails.
-pub unsafe extern "C" fn prql_to_sql_impl(
+///
+/// This must be a plain Rust `fn`, not `extern "C"`. `prqlc::compile` can panic on some
+/// inputs; a panic that unwinds out of an `extern "C"` frame is a nounwind abort (SIGABRT)
+/// that the `catch_unwind` in `prql_to_sql` cannot intercept. Keeping this frame as a normal
+/// Rust fn lets the panic unwind into `catch_unwind` and be converted to an error code.
+unsafe fn prql_to_sql_impl(
     query: *const u8,
     size: u64,
     out: *mut *mut u8,
@@ -105,5 +110,13 @@ mod tests {
         // panic is caught. When we upgrade prqlc, it won't be a panic any
         // longer.
         assert!(run_compile("x -> y").1 == 1);
+    }
+
+    #[test]
+    fn test_prql_panic_is_caught() {
+        // `prqlc::compile` panics (`todo!()` in `type_intersection`) when `append`
+        // combines pipelines whose column types have no defined intersection. The
+        // panic must be caught and turned into an error code, never abort the process.
+        assert!(run_compile("from t | select {a=1} | append (from u | select {a=[1]})").1 == 1);
     }
 }


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107582
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server abort when parsing certain PRQL queries (`SET dialect = 'prql'`). A panic inside the `prqlc` compiler was aborting the process instead of being reported as a query error.


### Description

Found by the AST fuzzer on PR #107582 (unrelated to that PR): `AST fuzzer (amd_debug, targeted, old_compatibility)`, head `347442f0fa447f7b769ebb736c856b3ab7700f6c`, `Received signal 6` (STID 2781-2f11).
Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107582&sha=347442f0fa447f7b769ebb736c856b3ab7700f6c&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%2C%20old_compatibility%29

**Root cause.** `prqlc::compile` can panic on some inputs (e.g. a `todo!()` in `type_intersection`, `prqlc-0.13.13/src/semantic/resolver/types.rs:399`, reached via `append` combining pipelines whose column types have no defined intersection). The bridge in `rust/workspace/prql/src/lib.rs` wraps the compile call in `std::panic::catch_unwind`, but the wrapped `prql_to_sql_impl` was itself declared `extern "C"`. A panic that reaches an `extern "C"` frame is a nounwind abort (`panic_in_cleanup` -> SIGABRT), so the process aborted at that inner boundary *before* the outer `catch_unwind` could run. The stack from the report is: `prql_to_sql` -> `core::panicking::panic_in_cleanup` -> `panic_nounwind_fmt` -> abort, reached from `ParserPRQLQuery::parseImpl`.

**Fix.** Make `prql_to_sql_impl` a plain Rust `fn` (drop `extern "C"`). The panic then unwinds normally into `catch_unwind` in `prql_to_sql`, which returns error code 1; `ParserPRQLQuery::parseImpl` raises it as `SYNTAX_ERROR` instead of crashing the server.

**Reproducer** (before this PR: server aborts with signal 6; after: `Code: 62. DB::Exception: PRQL syntax error` and the server stays up):
```sql
SET dialect = 'prql';
from t | select {a=1} | append (from u | select {a=[1]})
```

**Validation.** Added a Rust unit test `test_prql_panic_is_caught` in the bridge crate that asserts the panicking input returns an error code (aborts without the fix, passes with it). Verified end-to-end on a local debug build: the query now returns `SYNTAX_ERROR` and a subsequent `SELECT` succeeds (server alive).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.907` (included in `26.7` and later)
<!-- ch-version-info:end -->