### PR TITLE
Skip benign LSan ptrace warning in clickhouse-test

### DIFF
--- a/ci/tests/test_lsan_ptrace_probe_filter.py
+++ b/ci/tests/test_lsan_ptrace_probe_filter.py
@@ -1,7 +1,7 @@
 """
-Regression tests for the LSan `TestPTrace()` sanitizer-log filter in tests/clickhouse-test.
+Regression tests for the LSan `TestPTrace` sanitizer-log filter in tests/clickhouse-test.
 
-compiler-rt's `TestPTrace()` (contrib/llvm-project/compiler-rt/lib/sanitizer_common/
+compiler-rt's `TestPTrace` (contrib/llvm-project/compiler-rt/lib/sanitizer_common/
 sanitizer_stoptheworld_linux_libcdep.cpp) forks a short-lived child that issues one throwaway
 `ptrace` call to find out whether `ptrace` is blocked before the stop-the-world tracer attaches to
 the real threads.  If that child dies from a signal, LSan prints two lines back to back:
@@ -14,8 +14,8 @@ test carries the kills-processes-by-cmdline tag (only such a test can kill the p
 inherits the client's argv), and the reported signal is not SIGSYS (which is how seccomp kills the
 child when it really denies the ptrace call).
 
-The tag is load-bearing rather than cosmetic.  TestPTrace() ignores the result of its
-internal_waitpid() and reads a possibly untouched wstatus, so an EINTR-interrupted wait reports a
+The tag is load-bearing rather than cosmetic.  `TestPTrace` ignores the result of its
+`internal_waitpid` and reads a possibly untouched `wstatus`, so an EINTR-interrupted wait reports a
 stale signal number: with a SIGINT raced against a genuinely seccomp-blocked probe, 812 of 2000
 real blocks reported a stale non-SIGSYS signal, versus 0 of 2000 without the race.  Requiring the
 tag confines that upstream misreport to the one test that already tolerates it and leaves every
@@ -43,7 +43,7 @@ KILLS_PROCESSES_BY_CMDLINE_TAG = _ct["KILLS_PROCESSES_BY_CMDLINE_TAG"]
 RunnerTestCase = _ct["TestCase"]
 RunnerTestSuite = _ct["TestSuite"]
 
-# compiler-rt's Report() prefixes every line with ==PID==.
+# compiler-rt's `Report` prefixes every line with ==PID==.
 _PID = 4242
 _WARNING = f"=={_PID}=={LSAN_PTRACE_WARNING}. LeakSanitizer may hang."
 _UAF = f"=={_PID}==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000010"

--- a/ci/tests/test_lsan_ptrace_probe_filter.py
+++ b/ci/tests/test_lsan_ptrace_probe_filter.py
@@ -18,8 +18,8 @@ The tag is load-bearing rather than cosmetic.  `TestPTrace` ignores the result o
 `internal_waitpid` and reads a possibly untouched `wstatus`, so an EINTR-interrupted wait reports a
 stale signal number: with a SIGINT raced against a genuinely seccomp-blocked probe, 812 of 2000
 real blocks reported a stale non-SIGSYS signal, versus 0 of 2000 without the race.  Requiring the
-tag confines that upstream misreport to the one test that already tolerates it and leaves every
-other test's diagnostics untouched.
+tag bounds that upstream misreport: outside the tagged test nothing is ever dropped, so a real
+block is always reported, while inside it a real block the upstream bug misreports can be dropped.
 
 `02435_rollback_cancelled_queries` only reaches the benign case through a timing race, so it
 cannot pin this behaviour.  These tests drive the runner's own filtering path so that the intended
@@ -34,7 +34,7 @@ _CLICKHOUSE_TEST = str(
     Path(__file__).resolve().parent.parent.parent / "tests" / "clickhouse-test"
 )
 
-# runpy.run_path handles the missing .py extension and the hyphen in the name.
+# `runpy.run_path` handles the missing .py extension and the hyphen in the name.
 _ct = runpy.run_path(_CLICKHOUSE_TEST)
 find_benign_lsan_ptrace_probe_lines = _ct["find_benign_lsan_ptrace_probe_lines"]
 LSAN_PTRACE_WARNING = _ct["LSAN_PTRACE_WARNING"]
@@ -45,7 +45,13 @@ RunnerTestSuite = _ct["TestSuite"]
 
 # compiler-rt's `Report` prefixes every line with ==PID==.
 _PID = 4242
-_WARNING = f"=={_PID}=={LSAN_PTRACE_WARNING}. LeakSanitizer may hang."
+# Spelled out rather than built from LSAN_PTRACE_WARNING: these fixtures must fail if the runner's
+# matcher drifts away from what compiler-rt actually prints, so they must not reuse that constant.
+# Verbatim from sanitizer_stoptheworld_linux_libcdep.cpp, where the two format strings concatenate.
+_WARNING = (
+    f"=={_PID}==WARNING: ptrace appears to be blocked (is seccomp enabled?). "
+    "LeakSanitizer may hang."
+)
 _UAF = f"=={_PID}==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000010"
 
 
@@ -78,7 +84,7 @@ def _kept(lines, tmp_path, extra_log_lines=None, tagged=True):
     """Lines that survive the real sanitizer-log filtering in `TestCase.process_result_impl`.
 
     The filter is not reimplemented here: sanitizer logs are written where the runner looks for
-    them and the production method is called, so disconnecting the filter from the runner fails
+    them and `process_result_impl` is called, so disconnecting the filter from the runner fails
     these tests too.
     """
     case = RunnerTestCase.__new__(RunnerTestCase)
@@ -115,7 +121,7 @@ def test_benign_probe_killed_by_sigint_is_dropped(tmp_path):
 
 def test_benign_probe_killed_by_the_signals_seen_in_ci_is_dropped(tmp_path):
     # The only signals this pair has ever carried in CI (180 days: 13 hits with 42, 5 with 36,
-    # zero with SIGSYS), both real-time signals rather than the SIGINT/SIGKILL thread_cancel
+    # zero with SIGSYS), both real-time signals rather than the SIGINT/SIGKILL `thread_cancel`
     # sends: WTERMSIG reports whatever signal reaped the probe, so the check must not be narrowed
     # to the signals a test sends directly.
     for sig in (42, 36):
@@ -131,7 +137,7 @@ def test_repeated_benign_pairs_are_dropped(tmp_path):
     assert _kept(_benign_pair(signal.SIGKILL) + _benign_pair(signal.SIGINT), tmp_path) == []
 
 
-def test_real_seccomp_block_is_kept(tmp_path):
+def test_correctly_reported_seccomp_block_is_kept_in_a_tagged_test(tmp_path):
     lines = _real_seccomp_pair()
     assert _kept(lines, tmp_path) == lines
 
@@ -200,6 +206,22 @@ def test_empty_log_has_nothing_to_drop(tmp_path):
 def test_helper_drops_nothing_without_the_tag(tmp_path):
     assert find_benign_lsan_ptrace_probe_lines(_benign_pair(), False) == set()
     assert find_benign_lsan_ptrace_probe_lines(_benign_pair(), True) == {0, 1}
+
+
+def test_matcher_matches_what_compiler_rt_prints(tmp_path):
+    # The fixtures spell the upstream line out, so this is what ties the runner's matcher to it: if
+    # LSAN_PTRACE_WARNING drifts to something compiler-rt never prints, the benign case stops being
+    # recognised here even though the helper would still be self-consistent.
+    assert LSAN_PTRACE_WARNING in _WARNING
+    assert _kept(_benign_pair(), tmp_path) == []
+
+
+def test_unrelated_warning_with_a_child_exit_is_kept(tmp_path):
+    # Near miss: a different sanitizer warning followed by a child-exit line must not be treated as
+    # the probe pair, or an overbroad matcher would silently swallow it.
+    other = f"=={_PID}==WARNING: unrelated sanitizer warning, not the ptrace probe"
+    lines = [other, _child_exit(signal.SIGKILL)]
+    assert _kept(lines, tmp_path) == lines
 
 
 def test_suite_loader_reads_the_tag_from_the_test_file():

--- a/ci/tests/test_lsan_ptrace_probe_filter.py
+++ b/ci/tests/test_lsan_ptrace_probe_filter.py
@@ -1,0 +1,215 @@
+"""
+Regression tests for the LSan `TestPTrace()` sanitizer-log filter in tests/clickhouse-test.
+
+compiler-rt's `TestPTrace()` (contrib/llvm-project/compiler-rt/lib/sanitizer_common/
+sanitizer_stoptheworld_linux_libcdep.cpp) forks a short-lived child that issues one throwaway
+`ptrace` call to find out whether `ptrace` is blocked before the stop-the-world tracer attaches to
+the real threads.  If that child dies from a signal, LSan prints two lines back to back:
+
+    WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
+    Child exited with signal N.
+
+Both spellings are ambiguous on their own, so the filter requires two conditions together: the
+test carries the kills-processes-by-cmdline tag (only such a test can kill the probe child, which
+inherits the client's argv), and the reported signal is not SIGSYS (which is how seccomp kills the
+child when it really denies the ptrace call).
+
+The tag is load-bearing rather than cosmetic.  TestPTrace() ignores the result of its
+internal_waitpid() and reads a possibly untouched wstatus, so an EINTR-interrupted wait reports a
+stale signal number: with a SIGINT raced against a genuinely seccomp-blocked probe, 812 of 2000
+real blocks reported a stale non-SIGSYS signal, versus 0 of 2000 without the race.  Requiring the
+tag confines that upstream misreport to the one test that already tolerates it and leaves every
+other test's diagnostics untouched.
+
+`02435_rollback_cancelled_queries` only reaches the benign case through a timing race, so it
+cannot pin this behaviour.  These tests drive the runner's own filtering path so that the intended
+suppression, the preservation of a real diagnostic, and the tag scoping all stay verified.
+"""
+
+import runpy
+import signal
+from pathlib import Path
+
+_CLICKHOUSE_TEST = str(
+    Path(__file__).resolve().parent.parent.parent / "tests" / "clickhouse-test"
+)
+
+# runpy.run_path handles the missing .py extension and the hyphen in the name.
+_ct = runpy.run_path(_CLICKHOUSE_TEST)
+find_benign_lsan_ptrace_probe_lines = _ct["find_benign_lsan_ptrace_probe_lines"]
+LSAN_PTRACE_WARNING = _ct["LSAN_PTRACE_WARNING"]
+KILLS_PROCESSES_BY_CMDLINE_TAG = _ct["KILLS_PROCESSES_BY_CMDLINE_TAG"]
+# Aliased away from a Test* name so pytest does not try to collect it as a test class.
+RunnerTestCase = _ct["TestCase"]
+RunnerTestSuite = _ct["TestSuite"]
+
+# compiler-rt's Report() prefixes every line with ==PID==.
+_PID = 4242
+_WARNING = f"=={_PID}=={LSAN_PTRACE_WARNING}. LeakSanitizer may hang."
+_UAF = f"=={_PID}==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000010"
+
+
+def _child_exit(sig):
+    return f"=={_PID}==Child exited with signal {int(sig)}."
+
+
+def _benign_pair(sig=signal.SIGKILL):
+    return [_WARNING, _child_exit(sig)]
+
+
+def _real_seccomp_pair():
+    # Verified against a real SECCOMP_SET_MODE_FILTER policy for SYS_ptrace: SECCOMP_RET_KILL_THREAD,
+    # SECCOMP_RET_KILL_PROCESS and SECCOMP_RET_TRAP all report WTERMSIG == SIGSYS.
+    return [_WARNING, _child_exit(signal.SIGSYS)]
+
+
+class _Args:
+    """Stub runner args: anything this test does not care about reads as falsy."""
+
+    def __init__(self, tmp_path):
+        self.debug_log_file = str(tmp_path / "case.debuglog")
+        self.testcase_database = "test_db"
+
+    def __getattr__(self, name):
+        return None
+
+
+def _kept(lines, tmp_path, extra_log_lines=None, tagged=True):
+    """Lines that survive the real sanitizer-log filtering in TestCase.process_result_impl.
+
+    The filter is not reimplemented here: sanitizer logs are written where the runner looks for
+    them and the production method is called, so disconnecting the filter from the runner fails
+    these tests too.
+    """
+    case = RunnerTestCase.__new__(RunnerTestCase)
+    case.fatal_sanitizer_prefix = str(tmp_path / "case.stderr-fatal")
+    case.stdout_file = str(tmp_path / "case.stdout")
+    case.stderr_file = str(tmp_path / "case.stderr")
+    case.testcase_args = _Args(tmp_path)
+    case.args = case.testcase_args
+    case.name = "probe_case"
+    case.suite = None
+    case.tags = {KILLS_PROCESSES_BY_CMDLINE_TAG} if tagged else set()
+    # reference_file=None with a falsy --record makes process_result_impl return right after the
+    # sanitizer-log filtering, so the returned description carries exactly the filter's output.
+    case.reference_file = None
+
+    for index, content in enumerate([lines] + list(extra_log_lines or [])):
+        path = f"{case.fatal_sanitizer_prefix}.{_PID + index}"
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("".join(f"{line}\n" for line in content))
+
+    description = RunnerTestCase.process_result_impl(case, None, 0.0).description or ""
+    reported = [line for line in description.splitlines() if line.startswith(f"=={_PID}==")]
+    assert ("Path:" in description) == bool(reported), description
+    return reported
+
+
+def test_benign_probe_killed_by_sigkill_is_dropped(tmp_path):
+    assert _kept(_benign_pair(signal.SIGKILL), tmp_path) == []
+
+
+def test_benign_probe_killed_by_sigint_is_dropped(tmp_path):
+    assert _kept(_benign_pair(signal.SIGINT), tmp_path) == []
+
+
+def test_benign_probe_killed_by_the_signals_seen_in_ci_is_dropped(tmp_path):
+    # The only signals this pair has ever carried in CI (180 days: 13 hits with 42, 5 with 36,
+    # zero with SIGSYS), both real-time signals rather than the SIGINT/SIGKILL thread_cancel
+    # sends: WTERMSIG reports whatever signal reaped the probe, so the check must not be narrowed
+    # to the signals a test sends directly.
+    for sig in (42, 36):
+        assert _kept(_benign_pair(sig), tmp_path) == [], sig
+
+
+def test_benign_probe_killed_by_any_non_sigsys_signal_is_dropped(tmp_path):
+    for sig in (signal.SIGTERM, signal.SIGSEGV, signal.SIGABRT, signal.SIGRTMIN, 42, 64):
+        assert _kept(_benign_pair(sig), tmp_path) == [], sig
+
+
+def test_repeated_benign_pairs_are_dropped(tmp_path):
+    assert _kept(_benign_pair(signal.SIGKILL) + _benign_pair(signal.SIGINT), tmp_path) == []
+
+
+def test_real_seccomp_block_is_kept(tmp_path):
+    lines = _real_seccomp_pair()
+    assert _kept(lines, tmp_path) == lines
+
+
+def test_real_seccomp_block_is_kept_after_a_benign_pair(tmp_path):
+    # The decision is per occurrence: a benign pair earlier in the same log must not hide a
+    # genuine seccomp block later in it.
+    assert _kept(_benign_pair() + _real_seccomp_pair(), tmp_path) == _real_seccomp_pair()
+
+
+def test_real_seccomp_block_is_kept_before_a_benign_pair(tmp_path):
+    assert _kept(_real_seccomp_pair() + _benign_pair(), tmp_path) == _real_seccomp_pair()
+
+
+def test_warning_without_a_child_exit_line_is_kept(tmp_path):
+    assert _kept([_WARNING], tmp_path) == [_WARNING]
+
+
+def test_warning_as_the_last_line_is_kept(tmp_path):
+    # Guards the index + 1 lookahead against running off the end of the log.
+    assert _kept([_UAF, _WARNING], tmp_path) == [_UAF, _WARNING]
+
+
+def test_child_exit_without_the_warning_is_kept(tmp_path):
+    lines = [_child_exit(signal.SIGSEGV)]
+    assert _kept(lines, tmp_path) == lines
+
+
+def test_non_adjacent_warning_and_child_exit_are_kept(tmp_path):
+    # Only a back-to-back pair is the probe; anything in between means these lines are unrelated.
+    lines = [_WARNING, _UAF, _child_exit(signal.SIGKILL)]
+    assert _kept(lines, tmp_path) == lines
+
+
+def test_real_diagnostic_next_to_a_benign_pair_is_kept(tmp_path):
+    assert _kept(_benign_pair() + [_UAF], tmp_path) == [_UAF]
+
+
+def test_real_diagnostic_in_another_log_file_is_kept(tmp_path):
+    # The runner globs several sanitizer logs per test; a benign pair in one must not affect
+    # what is reported from the others.
+    assert _kept(_benign_pair(), tmp_path, extra_log_lines=[[_UAF]]) == [_UAF]
+
+
+def test_benign_pair_alone_produces_no_report(tmp_path):
+    assert _kept([], tmp_path, extra_log_lines=[_benign_pair()]) == []
+
+
+def test_untagged_test_keeps_the_pair(tmp_path):
+    # Without the tag nothing is dropped, whatever the signal: a test that does not kill by
+    # /proc/*/cmdline cannot produce the benign case, and this is what keeps an EINTR-mangled
+    # signal number from hiding a real seccomp block elsewhere.
+    for sig in (signal.SIGKILL, signal.SIGINT, 42, 36):
+        assert _kept(_benign_pair(sig), tmp_path, tagged=False) == _benign_pair(sig), sig
+
+
+def test_untagged_test_keeps_a_real_seccomp_block(tmp_path):
+    assert _kept(_real_seccomp_pair(), tmp_path, tagged=False) == _real_seccomp_pair()
+
+
+def test_empty_log_has_nothing_to_drop(tmp_path):
+    assert _kept([], tmp_path) == []
+    assert find_benign_lsan_ptrace_probe_lines([], True) == set()
+
+
+def test_helper_drops_nothing_without_the_tag(tmp_path):
+    assert find_benign_lsan_ptrace_probe_lines(_benign_pair(), False) == set()
+    assert find_benign_lsan_ptrace_probe_lines(_benign_pair(), True) == {0, 1}
+
+
+def test_suite_loader_reads_the_tag_from_the_test_file():
+    # End to end: the tag has to survive the runner's own suite loader, not just be spelled
+    # correctly in the test file, and it must not leak onto other tests.
+    suite_dir = str(Path(_CLICKHOUSE_TEST).parent / "queries" / "0_stateless")
+    tagged = "02435_rollback_cancelled_queries.sh"
+    untagged = "02434_cancel_insert_when_client_dies.sh"
+    all_tags, _, _ = RunnerTestSuite.read_test_tags_and_random_settings_limits(
+        suite_dir, [tagged, untagged]
+    )
+    assert KILLS_PROCESSES_BY_CMDLINE_TAG in all_tags[tagged]
+    assert KILLS_PROCESSES_BY_CMDLINE_TAG not in all_tags[untagged]

--- a/ci/tests/test_lsan_ptrace_probe_filter.py
+++ b/ci/tests/test_lsan_ptrace_probe_filter.py
@@ -10,7 +10,7 @@ the real threads.  If that child dies from a signal, LSan prints two lines back 
     Child exited with signal N.
 
 Both spellings are ambiguous on their own, so the filter requires two conditions together: the
-test carries the kills-processes-by-cmdline tag (only such a test can kill the probe child, which
+test carries the `kills-processes-by-cmdline` tag (only such a test can kill the probe child, which
 inherits the client's argv), and the reported signal is not SIGSYS (which is how seccomp kills the
 child when it really denies the ptrace call).
 
@@ -75,7 +75,7 @@ class _Args:
 
 
 def _kept(lines, tmp_path, extra_log_lines=None, tagged=True):
-    """Lines that survive the real sanitizer-log filtering in TestCase.process_result_impl.
+    """Lines that survive the real sanitizer-log filtering in `TestCase.process_result_impl`.
 
     The filter is not reimplemented here: sanitizer logs are written where the runner looks for
     them and the production method is called, so disconnecting the filter from the runner fails

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -157,15 +157,18 @@ def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
     untouched.
 
     Second, the reported signal must not be `SIGSYS`, which is how seccomp kills the child when it
-    really denies the `ptrace` call. The signal alone is not enough to decide: `TestPTrace` ignores
-    the result of its `internal_waitpid` and reads a possibly untouched `wstatus`, so a wait
-    interrupted by `EINTR` reports a stale signal number - measured on a seccomp-blocked probe
-    raced with `SIGINT`, 812 of 2000 real blocks were reported with a stale non-`SIGSYS` signal,
-    and 2000 of 2000 reported `SIGSYS` without the race. Requiring the tag as well confines that
-    upstream misreport to the one test that already tolerates it.
+    really denies the `ptrace` call. It cannot be narrowed further than that: `WTERMSIG` reports
+    whatever signal reaped the child, not what the test sent, and in CI this pair has carried
+    signal 42 and signal 36.
 
-    Note the signal cannot be narrowed further: `WTERMSIG` reports whatever signal reaped the
-    child, not what the test sent, and in CI this pair has carried signal 42 and signal 36.
+    The signal is not a reliable discriminator on its own, which is why the tag is required too.
+    `TestPTrace` ignores the result of its `internal_waitpid` and reads a possibly untouched
+    `wstatus`, so a wait interrupted by `EINTR` reports a stale signal number: measured on a
+    seccomp-blocked probe raced with `SIGINT`, 812 of 2000 real blocks were reported with a stale
+    non-`SIGSYS` signal, versus 0 of 2000 without the race. The guarantee this gives is therefore
+    scoped, not absolute - outside the tagged test nothing is ever dropped, so a real block is
+    always reported, while inside it a real block that the upstream bug misreports can be dropped.
+    That is the trade the tag exists to bound.
     """
     if not kills_processes_by_cmdline:
         return set()

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -135,6 +135,50 @@ IGNORED_SANITIZER_ERRORS = [
     # "LLVM ERROR: IO failure on output stream: Broken pipe",
 ]
 
+LSAN_PTRACE_WARNING = "WARNING: ptrace appears to be blocked (is seccomp enabled?)"
+LSAN_PTRACE_CHILD_EXIT_RE = re.compile(r"Child exited with signal (\d+)\.")
+
+# Tag for a test that signals every process it finds by grepping /proc/*/cmdline for its own mark.
+# Such a test also hits sanitizer-internal forks, which inherit the client's argv.
+KILLS_PROCESSES_BY_CMDLINE_TAG = "kills-processes-by-cmdline"
+
+
+def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
+    """Return indexes of LSan TestPTrace() lines that are safe to drop from a sanitizer log.
+
+    TestPTrace() forks a short-lived child that issues one throwaway ptrace call to find out
+    whether ptrace is blocked, and prints these two lines back to back if that child dies from a
+    signal. Neither line can be whitelisted on its own, because the same pair also reports a real
+    seccomp ptrace block, so two conditions must hold together.
+
+    First, only a test that signals processes it found in /proc/*/cmdline can produce the benign
+    case: the probe child inherits the client's argv, so it matches such a test's own mark. That is
+    what the kills-processes-by-cmdline tag marks, and it keeps every other test's diagnostics
+    untouched.
+
+    Second, the reported signal must not be SIGSYS, which is how seccomp kills the child when it
+    really denies the ptrace call. The signal alone is not enough to decide: TestPTrace() ignores
+    the result of its internal_waitpid() and reads a possibly untouched wstatus, so a wait
+    interrupted by EINTR reports a stale signal number - measured on a seccomp-blocked probe raced
+    with SIGINT, 812 of 2000 real blocks were reported with a stale non-SIGSYS signal, and 2000 of
+    2000 reported SIGSYS without the race. Requiring the tag as well confines that upstream
+    misreport to the one test that already tolerates it.
+
+    Note the signal cannot be narrowed further: WTERMSIG reports whatever signal reaped the child,
+    not what the test sent, and in CI this pair has carried signal 42 and signal 36.
+    """
+    if not kills_processes_by_cmdline:
+        return set()
+
+    benign = set()
+    for index, line in enumerate(lines):
+        if LSAN_PTRACE_WARNING not in line or index + 1 >= len(lines):
+            continue
+        match = LSAN_PTRACE_CHILD_EXIT_RE.search(lines[index + 1])
+        if match and int(match.group(1)) != signal.SIGSYS:
+            benign.update((index, index + 1))
+    return benign
+
 MAX_RETRIES = 3
 
 TEST_FILE_EXTENSIONS = [".sql", ".sql.j2", ".sh", ".py", ".expect"]
@@ -3037,7 +3081,14 @@ class TestCase:
             with open(path, "rb") as stream:
                 content = str(stream.read(), errors="replace", encoding="utf-8")
 
-                def ignore_sanitizer_line(line):
+                lines = content.splitlines()
+                benign_ptrace_probe_lines = find_benign_lsan_ptrace_probe_lines(
+                    lines, KILLS_PROCESSES_BY_CMDLINE_TAG in self.tags
+                )
+
+                def ignore_sanitizer_line(index, line):
+                    if index in benign_ptrace_probe_lines:
+                        return True
                     return any(
                         filter(
                             lambda exception: exception in line,
@@ -3046,10 +3097,9 @@ class TestCase:
                     )
 
                 content = "\n".join(
-                    filter(
-                        lambda line: not ignore_sanitizer_line(line),
-                        content.splitlines(),
-                    )
+                    line
+                    for index, line in enumerate(lines)
+                    if not ignore_sanitizer_line(index, line)
                 ).strip()
                 if content:
                     stderr += f"Path: {path}\n"

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -144,9 +144,9 @@ KILLS_PROCESSES_BY_CMDLINE_TAG = "kills-processes-by-cmdline"
 
 
 def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
-    """Return indexes of LSan TestPTrace() lines that are safe to drop from a sanitizer log.
+    """Return indexes of LSan TestPTrace lines that are safe to drop from a sanitizer log.
 
-    TestPTrace() forks a short-lived child that issues one throwaway ptrace call to find out
+    TestPTrace forks a short-lived child that issues one throwaway ptrace call to find out
     whether ptrace is blocked, and prints these two lines back to back if that child dies from a
     signal. Neither line can be whitelisted on its own, because the same pair also reports a real
     seccomp ptrace block, so two conditions must hold together.
@@ -157,8 +157,8 @@ def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
     untouched.
 
     Second, the reported signal must not be SIGSYS, which is how seccomp kills the child when it
-    really denies the ptrace call. The signal alone is not enough to decide: TestPTrace() ignores
-    the result of its internal_waitpid() and reads a possibly untouched wstatus, so a wait
+    really denies the ptrace call. The signal alone is not enough to decide: TestPTrace ignores
+    the result of its internal_waitpid and reads a possibly untouched wstatus, so a wait
     interrupted by EINTR reports a stale signal number - measured on a seccomp-blocked probe raced
     with SIGINT, 812 of 2000 real blocks were reported with a stale non-SIGSYS signal, and 2000 of
     2000 reported SIGSYS without the race. Requiring the tag as well confines that upstream

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -144,28 +144,28 @@ KILLS_PROCESSES_BY_CMDLINE_TAG = "kills-processes-by-cmdline"
 
 
 def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
-    """Return indexes of LSan TestPTrace lines that are safe to drop from a sanitizer log.
+    """Return indexes of LSan `TestPTrace` lines that are safe to drop from a sanitizer log.
 
-    TestPTrace forks a short-lived child that issues one throwaway ptrace call to find out
-    whether ptrace is blocked, and prints these two lines back to back if that child dies from a
+    `TestPTrace` forks a short-lived child that issues one throwaway `ptrace` call to find out
+    whether `ptrace` is blocked, and prints these two lines back to back if that child dies from a
     signal. Neither line can be whitelisted on its own, because the same pair also reports a real
-    seccomp ptrace block, so two conditions must hold together.
+    seccomp `ptrace` block, so two conditions must hold together.
 
-    First, only a test that signals processes it found in /proc/*/cmdline can produce the benign
+    First, only a test that signals processes it found in `/proc/*/cmdline` can produce the benign
     case: the probe child inherits the client's argv, so it matches such a test's own mark. That is
-    what the kills-processes-by-cmdline tag marks, and it keeps every other test's diagnostics
+    what the `kills-processes-by-cmdline` tag marks, and it keeps every other test's diagnostics
     untouched.
 
-    Second, the reported signal must not be SIGSYS, which is how seccomp kills the child when it
-    really denies the ptrace call. The signal alone is not enough to decide: TestPTrace ignores
-    the result of its internal_waitpid and reads a possibly untouched wstatus, so a wait
-    interrupted by EINTR reports a stale signal number - measured on a seccomp-blocked probe raced
-    with SIGINT, 812 of 2000 real blocks were reported with a stale non-SIGSYS signal, and 2000 of
-    2000 reported SIGSYS without the race. Requiring the tag as well confines that upstream
-    misreport to the one test that already tolerates it.
+    Second, the reported signal must not be `SIGSYS`, which is how seccomp kills the child when it
+    really denies the `ptrace` call. The signal alone is not enough to decide: `TestPTrace` ignores
+    the result of its `internal_waitpid` and reads a possibly untouched `wstatus`, so a wait
+    interrupted by `EINTR` reports a stale signal number - measured on a seccomp-blocked probe
+    raced with `SIGINT`, 812 of 2000 real blocks were reported with a stale non-`SIGSYS` signal,
+    and 2000 of 2000 reported `SIGSYS` without the race. Requiring the tag as well confines that
+    upstream misreport to the one test that already tolerates it.
 
-    Note the signal cannot be narrowed further: WTERMSIG reports whatever signal reaped the child,
-    not what the test sent, and in CI this pair has carried signal 42 and signal 36.
+    Note the signal cannot be narrowed further: `WTERMSIG` reports whatever signal reaped the
+    child, not what the test sent, and in CI this pair has carried signal 42 and signal 36.
     """
     if not kills_processes_by_cmdline:
         return set()
@@ -178,6 +178,7 @@ def find_benign_lsan_ptrace_probe_lines(lines, kills_processes_by_cmdline):
         if match and int(match.group(1)) != signal.SIGSYS:
             benign.update((index, index + 1))
     return benign
+
 
 MAX_RETRIES = 3
 

--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Tags: long, no-random-settings, no-ordinary-database, no-fasttest, no-azure-blob-storage
+# Tags: long, no-random-settings, no-ordinary-database, no-fasttest, no-azure-blob-storage, kills-processes-by-cmdline
 # long: The test inserts 4M+ rows across the initial setup, 20s parallel insert/select/cancel phase,
 #     and final verification. On the encrypted-S3 + ASan+UBSan + meta-in-keeper flaky-check variant
 #     it consistently exceeds the 180s default budget, so we use the 600s budget instead.
 # no-fasttest: The test is slow (too many small blocks)
 # no-azure-blob-storage: The test uploads many parts to Azure (5k+), and it runs in parallel with other tests.
 #     As a result, they may interfere, and some queries won't be able to finish in 30 seconds timeout leading to a test failure.
+# kills-processes-by-cmdline: thread_cancel signals every process matching $TEST_MARK in
+#     /proc/*/cmdline, which also hits sanitizer-internal forks that inherited the client's argv.
 # shellcheck disable=SC2009
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)

--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -6,7 +6,7 @@
 # no-fasttest: The test is slow (too many small blocks)
 # no-azure-blob-storage: The test uploads many parts to Azure (5k+), and it runs in parallel with other tests.
 #     As a result, they may interfere, and some queries won't be able to finish in 30 seconds timeout leading to a test failure.
-# kills-processes-by-cmdline: thread_cancel signals every process matching $TEST_MARK in
+# kills-processes-by-cmdline: `thread_cancel` signals every process matching $TEST_MARK in
 #     /proc/*/cmdline, which also hits sanitizer-internal forks that inherited the client's argv.
 # shellcheck disable=SC2009
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/105474


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Replaces the closed #105474. Per review feedback there: do not disable LSan, skip the benign warning instead.

`02435_rollback_cancelled_queries` signals every process whose `/proc/*/cmdline` matches its test mark. LSan's at-exit stop-the-world first calls `TestPTrace`, which forks a short-lived child that issues one throwaway `ptrace` call to find out whether `ptrace` is blocked before the tracer attaches to the real threads. That child inherits the client's argv, so it matches the kill loop and dies from the signal, and LSan prints two lines to the sanitizer log and keeps going:

```
WARNING: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.
Child exited with signal N.
```

The runner treats that as a fatal stderr finding. Leak detection itself is unaffected.

Neither line can be whitelisted on its own, because `TestPTrace` prints the same pair when seccomp really does block `ptrace`. The signal number is the first discriminator: seccomp kills the child with `SIGSYS`, verified against a real `SECCOMP_SET_MODE_FILTER` policy for `SYS_ptrace` where `SECCOMP_RET_KILL_THREAD`, `SECCOMP_RET_KILL_PROCESS` and `SECCOMP_RET_TRAP` all report `WTERMSIG == SIGSYS`, while `SECCOMP_RET_ERRNO` lets the child exit normally so nothing is printed at all.

Over 180 days this pair has appeared in CI with signal 42 (13 hits) and signal 36 (5 hits), never with `SIGSYS`. Both are real-time signals rather than the `SIGINT`/`SIGKILL` the test sends, which is consistent with `WTERMSIG` reporting whatever signal actually reaped the child: an externally killed probe child reports its killing signal verbatim, and only a seccomp denial yields `SIGSYS`. So the check cannot be narrowed to a specific observed signal either. (`#105474` guessed that LSan itself falls back to `SIGRTMIN+2`; `compiler-rt` contains no `SIGRTMIN` code at all, so that was wrong.)

The signal alone is still not enough. `TestPTrace` ignores the result of its `internal_waitpid` and reads a possibly untouched `wstatus`, so a wait interrupted by `EINTR` reports a stale signal number, and `02435` sends `SIGINT` to every marked process while the client installs its handler with `sa_flags = 0`. Racing a `SIGINT` against a genuinely seccomp-blocked probe, 812 of 2000 real blocks were reported with a stale non-`SIGSYS` signal; without the race, 0 of 2000. A signal-only global filter could therefore suppress a real diagnostic. `TestPTrace`'s sibling wait on the tracer thread does retry `EINTR`; this one does not, which is an upstream bug either way.

So the fix requires two conditions together. The two lines are dropped only as an adjacent pair, only when the reported signal is not `SIGSYS`, and only for a test tagged `kills-processes-by-cmdline` - a new tag on `02435_rollback_cancelled_queries`, since only a test that signals processes it found in `/proc/*/cmdline` can kill the probe child at all. That confines the upstream misreport to the one test that already tolerates it. Consequences:

- every other test's sanitizer log is untouched, so a real `ptrace` block elsewhere is always reported;
- within the tagged test, a correctly reported seccomp block is still surfaced, including when a benign pair precedes it in the same log. A real block that the `EINTR` bug above misreports as a non-`SIGSYS` signal can be dropped there; bounding that to the one test which already tolerates it is exactly what the tag buys;
- a `Child exited with signal N` line without the warning directly above it is always kept;
- the warning is kept when no child-exit line follows it.

A tag rather than a hardcoded test name keeps the runner free of test identifiers, so it does not rot when the test is renamed or split, and a future test that signals processes this way only needs the tag. `02435` is the only candidate today anyway: the three other tests that kill by `/proc/*/cmdline` (`02434_cancel_insert_when_client_dies` and the `04365`/`04366` variants) are tagged `no-asan, no-msan, no-tsan`, so no sanitizer runs there.

`02435_rollback_cancelled_queries` only reaches the benign case through a timing race, so it cannot pin this behaviour. `ci/tests/test_lsan_ptrace_probe_filter.py` drives the runner's own filtering path and covers all three directions: benign pairs are dropped (`SIGKILL`, `SIGINT`, the signals 42 and 36 seen in CI, repeated pairs); a `SIGSYS` pair, a bare warning, a warning as the last line, a child-exit line without the warning, a non-adjacent combination and an unrelated ASan report are preserved; and an untagged test keeps everything. It also asserts that the runner's own suite loader reads the new tag from the test file.
