### PR TITLE
Add test: Batched no-key `uniqCombined` over FixedString columns (ColumnFixedString branch) is untested

### DIFF
--- a/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.reference
+++ b/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.reference
@@ -2,3 +2,7 @@ fixedstring cardinality, no key
 100	100	100	100
 fixedstring matches uniqExact
 1	1
+fixedstring with embedded null cardinality, no key
+100	100	100	100
+fixedstring with embedded null matches uniqExact
+1	1

--- a/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.reference
+++ b/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.reference
@@ -1,0 +1,4 @@
+fixedstring cardinality, no key
+100	100	100	100
+fixedstring matches uniqExact
+1	1

--- a/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.sql
+++ b/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.sql
@@ -10,3 +10,18 @@ SELECT 'fixedstring matches uniqExact';
 SELECT uniqCombined(s) = uniqExact(s), uniqCombined64(s) = uniqExact(s) FROM t_uniq_fs;
 
 DROP TABLE t_uniq_fs;
+
+-- Values that share the same prefix up to the first \0 padding byte and differ only afterwards
+-- (bytes are 'p' \0 <distinct> \0 \0 ...). A regression that hashes FixedString as a NUL-terminated
+-- string, or ignores bytes past the first zero, would collapse all rows to one value here.
+DROP TABLE IF EXISTS t_uniq_fs_nul;
+CREATE TABLE t_uniq_fs_nul (s FixedString(8)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_uniq_fs_nul SELECT toFixedString(char(112, 0, number % 100 + 1), 8) FROM numbers(5000);
+
+SELECT 'fixedstring with embedded null cardinality, no key';
+SELECT uniqCombined(s), uniqCombined64(s), uniqCombined(12)(s), uniqCombined64(12)(s) FROM t_uniq_fs_nul;
+
+SELECT 'fixedstring with embedded null matches uniqExact';
+SELECT uniqCombined(s) = uniqExact(s), uniqCombined64(s) = uniqExact(s) FROM t_uniq_fs_nul;
+
+DROP TABLE t_uniq_fs_nul;

--- a/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.sql
+++ b/tests/queries/0_stateless/04539_uniq_combined_fixed_string_no_key.sql
@@ -1,0 +1,12 @@
+-- Test uniqCombined/uniqCombined64 batched no-key path over FixedString columns.
+DROP TABLE IF EXISTS t_uniq_fs;
+CREATE TABLE t_uniq_fs (s FixedString(8)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_uniq_fs SELECT toFixedString(concat('s', toString(number % 100)), 8) FROM numbers(5000);
+
+SELECT 'fixedstring cardinality, no key';
+SELECT uniqCombined(s), uniqCombined64(s), uniqCombined(12)(s), uniqCombined64(12)(s) FROM t_uniq_fs;
+
+SELECT 'fixedstring matches uniqExact';
+SELECT uniqCombined(s) = uniqExact(s), uniqCombined64(s) = uniqExact(s) FROM t_uniq_fs;
+
+DROP TABLE t_uniq_fs;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #109794](https://github.com/ClickHouse/ClickHouse/pull/109794).
PR #109794 optimizes `uniqCombined`/`uniqCombined64` for aggregation WITHOUT a key. It (1) switches the String specialization type parameter from `String` to `std::string_view`, (2) overrides `addBatchSinglePlace`, `addBatchSinglePlaceNotNull` and `addManyDefaults` in `AggregateFunctionUniqCombined`

**1. Batched no-key `uniqCombined` over FixedString columns (ColumnFixedString branch) is untested**
  `src/AggregateFunctions/AggregateFunctionUniqCombined.h:237`, `src/AggregateFunctions/AggregateFunctionUniqCombined.h:238`
  **Risk:** `addBatchImpl` (AggregateFunctionUniqCombined.h:231) first tries `typeid_cast<const ColumnString *>`; when the column is a `FixedString` this fails and execution enters the else branch at 237-238 that `assert_cast<const ColumnFixedString &>` and hashes `getDataAt(row)`. RISK: if the dispatch or the cast were wrong, FixedString aggregation without a key would throw a LOGICAL_ERROR exception or hash the wrong bytes -> wrong distinct counts.
  **What's unique vs PR tests:** The PR's 04511 test aggregates only variable String columns (the typeid_cast<ColumnString> branch); the FixedString sibling branch at 237-238 is never exercised.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1185` (included in `26.7` and later)
<!-- ch-version-info:end -->