### PR TITLE
Fix wrong data read from stale projection parts after the projection's columns change

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -989,6 +989,7 @@ std::optional<String> optimizeUseAggregateProjections(
                     reader,
                     empty_mutations_snapshot,
                     required_column_names,
+                    metadata,
                     *parent_reading_select_result,
                     projection_query_info,
                     context);

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -566,6 +566,7 @@ std::optional<String> optimizeUseNormalProjections(
             reader,
             empty_mutations_snapshot,
             required_columns,
+            metadata,
             *parent_reading_select_result,
             projection_query_info,
             context);

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -440,13 +440,11 @@ void filterPartsAndCollectProjectionCandidates(
     RangesInDataParts projection_parts;
     std::unordered_set<const IMergeTreeDataPart *> valid_parts;
 
-    /// A drifted projection part can lack a column the current metadata expects (see
-    /// projectionPartHasRequiredColumns). Evaluating the filter over such a part here would default-fill
-    /// the missing column and prune the wrong parent rows, so route those parts to a parent read instead.
-    /// Only the filter inputs actually read from the projection part matter (filter-DAG inputs the
-    /// projection provides); the mark estimate below is index-based and safe on its own. A drifted part
-    /// keyed on the missing column cannot currently reach this path (a projection sort/INDEX column may
-    /// not be an ALIAS, which is the only known drift source), so this guard is defensive.
+    /// Route a drifted projection part (see projectionPartHasRequiredColumns) to a parent read rather
+    /// than evaluating the filter over it, which would prune the wrong parent rows. Only the filter
+    /// inputs the projection provides matter; the index-based mark estimate below is safe on its own.
+    /// Defensive: such a part cannot currently reach here (a projection sort/INDEX column may not be an
+    /// ALIAS, the only known drift source).
     const auto parent_metadata = reading.getStorageMetadata();
     Names filter_required_columns;
     if (projection_query_info.filter_actions_dag)

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -313,11 +313,45 @@ size_t filterPartsByProjection(
     return filtered_parts;
 }
 
+static bool projectionPartHasRequiredColumns(
+    const IMergeTreeDataPart & projection_part,
+    const IMergeTreeDataPart & parent_part,
+    const ProjectionDescription & projection,
+    const StorageMetadataPtr & parent_metadata,
+    const Names & required_column_names)
+{
+    /// The projection's column set is re-derived from its query at every table load, so it can drift
+    /// from what an existing projection part stores (e.g. an ALIAS column selected by the projection
+    /// was re-pointed by ALTER, changing the materialized source column or the aggregate-state column
+    /// name). Reading a column the projection part lacks would fill defaults and return wrong data,
+    /// so such parts must be read from the parent instead. The only legitimate absence is a parent
+    /// TABLE column the parent part lacks too: it was added after the part was written, and the
+    /// default fill is then correct and identical on either read path (see 04412).
+    const auto & parent_table_columns = parent_metadata->getColumns();
+
+    for (const auto & name : required_column_names)
+    {
+        if (projection_part.tryGetColumn(name))
+            continue;
+
+        /// Virtual columns are provided by the reading step, never stored in the part.
+        if (projection.metadata->virtuals.has(name))
+            continue;
+
+        if (parent_part.tryGetColumn(name)
+            || !parent_table_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, name))
+            return false;
+    }
+
+    return true;
+}
+
 bool analyzeProjectionCandidate(
     ProjectionCandidate & candidate,
     const MergeTreeDataSelectExecutor & reader,
     MergeTreeData::MutationsSnapshotPtr empty_mutations_snapshot,
     const Names & required_column_names,
+    const StorageMetadataPtr & parent_metadata,
     ReadFromMergeTree::AnalysisResult & parent_reading_select_result,
     const SelectQueryInfo & projection_query_info,
     const ContextPtr & context)
@@ -328,7 +362,9 @@ bool analyzeProjectionCandidate(
     {
         const auto & created_projections = part_with_ranges.data_part->getProjectionParts();
         auto it = created_projections.find(candidate.projection->name);
-        if (it != created_projections.end() && !it->second->is_broken)
+        if (it != created_projections.end() && !it->second->is_broken
+            && projectionPartHasRequiredColumns(
+                *it->second, *part_with_ranges.data_part, *candidate.projection, parent_metadata, required_column_names))
         {
             projection_parts.push_back(RangesInDataPart(
                 it->second,

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -427,11 +427,31 @@ void filterPartsAndCollectProjectionCandidates(
     RangesInDataParts projection_parts;
     std::unordered_set<const IMergeTreeDataPart *> valid_parts;
 
+    /// A drifted projection part can lack a column the current metadata expects (see
+    /// projectionPartHasRequiredColumns). Evaluating the filter over such a part here would default-fill
+    /// the missing column and prune the wrong parent rows, so route those parts to a parent read instead.
+    /// Only the filter inputs actually read from the projection part matter (filter-DAG inputs the
+    /// projection provides); the mark estimate below is index-based and safe on its own. A drifted part
+    /// keyed on the missing column cannot currently reach this path (a projection sort/INDEX column may
+    /// not be an ALIAS, which is the only known drift source), so this guard is defensive.
+    const auto parent_metadata = reading.getStorageMetadata();
+    Names filter_required_columns;
+    if (projection_query_info.filter_actions_dag)
+    {
+        for (const auto & name : projection_query_info.filter_actions_dag->getRequiredColumnsNames())
+        {
+            if (projection.sample_block.has(name))
+                filter_required_columns.push_back(name);
+        }
+    }
+
     for (const auto & part_with_ranges : parent_reading_select_result.parts_with_ranges)
     {
         const auto & created_projections = part_with_ranges.data_part->getProjectionParts();
         auto it = created_projections.find(projection.name);
-        if (it != created_projections.end() && !it->second->is_broken)
+        if (it != created_projections.end() && !it->second->is_broken
+            && projectionPartHasRequiredColumns(
+                *it->second, *part_with_ranges.data_part, projection, parent_metadata, filter_required_columns))
         {
             RangesInDataPart projection_part(
                 it->second,

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -313,6 +313,21 @@ size_t filterPartsByProjection(
     return filtered_parts;
 }
 
+/// The projection's column set is re-derived from its query at every table load, so it can drift
+/// from what an existing projection part stores (e.g. an ALIAS column selected by the projection
+/// was re-pointed by ALTER, changing the materialized source column or the aggregate-state column
+/// name). Reading a column the projection part lacks would fill defaults and return wrong data.
+/// For each required column there are four cases:
+///   (1) the projection part stores the column:
+///       usable, keep checking.
+///   (2) the column is virtual:
+///       usable, it is synthesized by the reading step and never stored.
+///   (3) the projection part lacks it, and either the parent part still stores it or it is not a
+///       parent TABLE column at all (a drifted alias-derived or aggregate-state column):
+///       drift, read from the parent instead.
+///   (4) the projection part lacks it, the parent part lacks it too, and it is a parent TABLE column:
+///       legitimate, the column was added after the part was written, so the default fill is correct
+///       and identical on either read path (see 04412).
 static bool projectionPartHasRequiredColumns(
     const IMergeTreeDataPart & projection_part,
     const IMergeTreeDataPart & parent_part,
@@ -320,27 +335,25 @@ static bool projectionPartHasRequiredColumns(
     const StorageMetadataPtr & parent_metadata,
     const Names & required_column_names)
 {
-    /// The projection's column set is re-derived from its query at every table load, so it can drift
-    /// from what an existing projection part stores (e.g. an ALIAS column selected by the projection
-    /// was re-pointed by ALTER, changing the materialized source column or the aggregate-state column
-    /// name). Reading a column the projection part lacks would fill defaults and return wrong data,
-    /// so such parts must be read from the parent instead. The only legitimate absence is a parent
-    /// TABLE column the parent part lacks too: it was added after the part was written, and the
-    /// default fill is then correct and identical on either read path (see 04412).
     const auto & parent_table_columns = parent_metadata->getColumns();
 
     for (const auto & name : required_column_names)
     {
+        /// (1) Stored by the projection part.
         if (projection_part.tryGetColumn(name))
             continue;
 
-        /// Virtual columns are provided by the reading step, never stored in the part.
+        /// (2) Virtual column, provided by the reading step.
         if (projection.metadata->virtuals.has(name))
             continue;
 
+        /// (3) Drift: the parent part still stores the column, or it is not a stored table column,
+        /// so the projection part is stale for it and must not be read.
         if (parent_part.tryGetColumn(name)
             || !parent_table_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, name))
             return false;
+
+        /// (4) Legitimate late-added table column, missing from both parts; the default fill matches.
     }
 
     return true;

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.h
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.h
@@ -74,6 +74,7 @@ bool analyzeProjectionCandidate(
     const MergeTreeDataSelectExecutor & reader,
     MergeTreeData::MutationsSnapshotPtr empty_mutations_snapshot,
     const Names & required_column_names,
+    const StorageMetadataPtr & parent_metadata,
     ReadFromMergeTree::AnalysisResult & parent_reading_select_result,
     const SelectQueryInfo & projection_query_info,
     const ContextPtr & context);

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1210,13 +1210,11 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::prepareProjectionsToMergeAndRe
             continue;
         }
 
-        /// The projection's column set is re-derived from its query at every table load, so an existing
-        /// projection part may lack a column the current metadata expects (e.g. an ALIAS column selected
-        /// by the projection was re-pointed by ALTER, changing the materialized source column or the
-        /// aggregate-state column name). Merging such a part directly would bake default values for the
-        /// missing column into the merged projection part; rebuild from the parent data instead. The only
-        /// legitimate absence is a parent TABLE column the parent part lacks too: it was added after the
-        /// part was written, and the default fill is then correct on either path.
+        /// An existing projection part may lack a column the current metadata expects (e.g. an ALIAS
+        /// selected by the projection was re-pointed by ALTER; see projectionPartHasRequiredColumns).
+        /// Merging it directly would bake default values into the merged part, so rebuild from the parent
+        /// instead. A parent TABLE column the parent part also lacks is a legitimate late-add and does
+        /// not count.
         const auto projection_columns = projection.metadata->getColumns().getAllPhysical();
         const auto & parent_table_columns = global_ctx->metadata_snapshot->getColumns();
         bool projection_part_misses_column = false;

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -1210,15 +1210,47 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::prepareProjectionsToMergeAndRe
             continue;
         }
 
+        /// The projection's column set is re-derived from its query at every table load, so an existing
+        /// projection part may lack a column the current metadata expects (e.g. an ALIAS column selected
+        /// by the projection was re-pointed by ALTER, changing the materialized source column or the
+        /// aggregate-state column name). Merging such a part directly would bake default values for the
+        /// missing column into the merged projection part; rebuild from the parent data instead. The only
+        /// legitimate absence is a parent TABLE column the parent part lacks too: it was added after the
+        /// part was written, and the default fill is then correct on either path.
+        const auto projection_columns = projection.metadata->getColumns().getAllPhysical();
+        const auto & parent_table_columns = global_ctx->metadata_snapshot->getColumns();
+        bool projection_part_misses_column = false;
+
         MergeTreeData::DataPartsVector projection_parts;
         for (const auto & part : global_ctx->future_part->parts)
         {
             auto it = part->getProjectionParts().find(projection.name);
             if (it != part->getProjectionParts().end() && !it->second->is_broken)
+            {
+                for (const auto & column : projection_columns)
+                {
+                    if (!it->second->tryGetColumn(column.name)
+                        && (part->tryGetColumn(column.name)
+                            || !parent_table_columns.hasColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column.name)))
+                    {
+                        projection_part_misses_column = true;
+                        break;
+                    }
+                }
+
                 projection_parts.push_back(it->second);
+            }
         }
 
-        if (projection_parts.size() == global_ctx->future_part->parts.size())
+        if (projection_part_misses_column && mode != DeduplicateMergeProjectionMode::IGNORE)
+        {
+            LOG_DEBUG(
+                ctx->log,
+                "Projection {} will be rebuilt because some projection parts miss columns the projection now expects",
+                projection.name);
+            global_ctx->projections_to_rebuild.push_back(&projection);
+        }
+        else if (projection_parts.size() == global_ctx->future_part->parts.size())
         {
             global_ctx->projections_to_merge.push_back(&projection);
             global_ctx->projections_to_merge_parts[projection.name].assign(projection_parts.begin(), projection_parts.end());

--- a/tests/queries/0_stateless/04516_projection_part_column_drift.reference
+++ b/tests/queries/0_stateless/04516_projection_part_column_drift.reference
@@ -1,0 +1,18 @@
+part columns before drift	p	a
+part columns before drift	p	b
+read after drift	1	501
+mixed read	1	501
+mixed read	2	601
+read after merge	1	501
+read after merge	2	601
+1	501
+2	601
+part columns after merge	p	a
+part columns after merge	p	d
+added column via projection	1	42
+agg read after drift	1	501
+agg read after merge	1	501
+agg read after merge	2	601
+1	501
+2	601
+virtual via projection	1	100	1

--- a/tests/queries/0_stateless/04516_projection_part_column_drift.sql
+++ b/tests/queries/0_stateless/04516_projection_part_column_drift.sql
@@ -3,6 +3,12 @@
 -- ALIAS column selected by the projection). Reading or merging such a part must not fill the
 -- missing column with defaults: reads fall back to the parent part, merges rebuild the projection.
 
+-- The projections here select an ALIAS column, so building them on INSERT requires the alias to be
+-- resolved. Under optimize_respect_aliases=0 that resolution is skipped and every INSERT fails with
+-- UNKNOWN_IDENTIFIER, independently of the drift this test exercises (reproduces on master too), so
+-- pin the setting away from the randomized value.
+-- Random settings limits: optimize_respect_aliases=(1, 1)
+
 DROP TABLE IF EXISTS t_proj_column_drift;
 
 CREATE TABLE t_proj_column_drift

--- a/tests/queries/0_stateless/04516_projection_part_column_drift.sql
+++ b/tests/queries/0_stateless/04516_projection_part_column_drift.sql
@@ -1,0 +1,127 @@
+-- Projection metadata is re-derived from the projection query at every table load, so an existing
+-- projection part may lack a column the current metadata expects (e.g. after ALTER re-points an
+-- ALIAS column selected by the projection). Reading or merging such a part must not fill the
+-- missing column with defaults: reads fall back to the parent part, merges rebuild the projection.
+
+DROP TABLE IF EXISTS t_proj_column_drift;
+
+CREATE TABLE t_proj_column_drift
+(
+    a UInt64,
+    b UInt64,
+    d UInt64,
+    c UInt64 ALIAS b + 1,
+    PROJECTION p (SELECT a, c ORDER BY a)
+)
+ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_proj_column_drift (a, b, d) VALUES (1, 100, 500);
+
+-- the projection part stores the alias source `b`
+SELECT 'part columns before drift', name, column FROM system.projection_parts_columns
+WHERE database = currentDatabase() AND table = 't_proj_column_drift' AND active ORDER BY name, column;
+
+-- re-point the alias: the part still stores {a, b}, but the re-derived metadata now expects {a, d}
+ALTER TABLE t_proj_column_drift MODIFY COLUMN c UInt64 ALIAS d + 1;
+
+-- the drifted part must be served from the parent (c = 501, not 1 from a default-filled d)
+SELECT 'read after drift', a, c FROM t_proj_column_drift ORDER BY a;
+
+-- forcing the projection cannot use the drifted part
+SELECT a, c FROM t_proj_column_drift ORDER BY a
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1; -- { serverError PROJECTION_NOT_USED }
+
+-- a part written after the alter is not drifted; the mixed read stays correct
+INSERT INTO t_proj_column_drift (a, b, d) VALUES (2, 200, 600);
+
+SELECT 'mixed read', a, c FROM t_proj_column_drift ORDER BY a;
+
+-- merging a drifted part must rebuild the projection from the parent data instead of
+-- baking default values for the missing column into the merged projection part
+OPTIMIZE TABLE t_proj_column_drift FINAL;
+
+SELECT 'read after merge', a, c FROM t_proj_column_drift ORDER BY a;
+
+SELECT a, c FROM t_proj_column_drift ORDER BY a
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+SELECT 'part columns after merge', name, column FROM system.projection_parts_columns
+WHERE database = currentDatabase() AND table = 't_proj_column_drift' AND active ORDER BY name, column;
+
+DROP TABLE t_proj_column_drift;
+
+-- must-not-act control (the #108569 scenario): a column added to the table after the part was
+-- written is missing from BOTH the projection part and the parent part; the default fill is then
+-- correct and the projection must still be usable
+DROP TABLE IF EXISTS t_proj_added_column;
+
+CREATE TABLE t_proj_added_column
+(
+    a UInt64,
+    PROJECTION p (SELECT * ORDER BY a)
+)
+ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_proj_added_column VALUES (1);
+
+ALTER TABLE t_proj_added_column ADD COLUMN e UInt64 DEFAULT 42;
+
+SELECT 'added column via projection', a, e FROM t_proj_added_column ORDER BY a
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_added_column;
+
+-- aggregate projection drift: the state column name embeds the expanded alias
+-- (`sum(plus(b, 1))`), so re-pointing the alias leaves the part without the state column the
+-- metadata now expects (`sum(plus(d, 1))`); the parent never stores aggregate states, so the
+-- absence must still count as drift
+DROP TABLE IF EXISTS t_proj_agg_drift;
+
+CREATE TABLE t_proj_agg_drift
+(
+    a UInt64,
+    b UInt64,
+    d UInt64,
+    c UInt64 ALIAS b + 1,
+    PROJECTION p (SELECT a, sum(c) GROUP BY a)
+)
+ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_proj_agg_drift (a, b, d) VALUES (1, 100, 500);
+
+ALTER TABLE t_proj_agg_drift MODIFY COLUMN c UInt64 ALIAS d + 1;
+
+SELECT 'agg read after drift', a, sum(c) FROM t_proj_agg_drift GROUP BY a ORDER BY a;
+
+SELECT a, sum(c) FROM t_proj_agg_drift GROUP BY a ORDER BY a
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1; -- { serverError PROJECTION_NOT_USED }
+
+INSERT INTO t_proj_agg_drift (a, b, d) VALUES (2, 200, 600);
+
+OPTIMIZE TABLE t_proj_agg_drift FINAL;
+
+SELECT 'agg read after merge', a, sum(c) FROM t_proj_agg_drift GROUP BY a ORDER BY a;
+
+SELECT a, sum(c) FROM t_proj_agg_drift GROUP BY a ORDER BY a
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_agg_drift;
+
+-- virtual-column control: virtuals are provided by the reading step, not stored in the part;
+-- requiring one must not disqualify the projection
+DROP TABLE IF EXISTS t_proj_virtual;
+
+CREATE TABLE t_proj_virtual
+(
+    a UInt64,
+    b UInt64,
+    PROJECTION p (SELECT a, b ORDER BY b)
+)
+ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO t_proj_virtual VALUES (1, 100);
+
+SELECT 'virtual via projection', a, b, _part != '' FROM t_proj_virtual WHERE b = 100
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
+
+DROP TABLE t_proj_virtual;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/103723
Related: https://github.com/ClickHouse/ClickHouse/pull/104680

## Problem

A plain `SELECT a, c FROM t ORDER BY a` can silently return wrong data when the table has a projection selecting an `ALIAS` column and some projection parts were written before the projection's column set changed. Two native triggers:

- **Upgrade**: for `PROJECTION p (SELECT a, c ORDER BY a)` with `c UInt64 ALIAS b + 1`, parts written by ≤26.2 store only `{a}`, while 26.3+ re-derive the projection columns as `{a, b}` (the alias source is materialized). After upgrading to ≥26.5 — where the planner also selects normal projections for sorting without a filter (#103723, #104680) — reading `c` through such a part fills the missing `b` with the type default and returns `c = 1` instead of the real value, until the part is rewritten by a merge.
- **`ALTER`**: `ALTER TABLE t MODIFY COLUMN c UInt64 ALIAS d + 1` is allowed without a projection rebuild; existing projection parts keep `{a, b}` while the re-derived metadata expects `{a, d}` — same wrong read on any single version ≥26.5.

Worse, a background merge that merges projection parts directly reads the same default fill and **bakes the wrong values permanently** into the merged projection part (`OPTIMIZE FINAL` → base read right, projection read wrong forever). Aggregate projections break the same way: the state column name embeds the expanded alias (`sum(plus(b, 1))`), so a re-pointed alias leaves old parts without the state column the metadata now expects, and reads return default aggregate states.

## Root cause

Projection metadata is re-derived from the projection query text at every table load, so the *believed* column set of a projection is version- and metadata-dependent, while the *stored* column set of each projection part is frozen at write time. Neither the read path (`analyzeProjectionCandidate`) nor the merge path (`prepareProjectionsToMergeAndRebuild`) checked that a projection part actually stores the columns the current metadata expects; the missing-column default fill that is correct for base-table `ALTER ADD COLUMN` semantics is unsound when the parent part has real values for the column (or when the column is an aggregate state that can be recomputed only from parent data).

## Solution

A column may be missing from a projection part legitimately only when it is a parent-**table** column that the parent **part** also lacks — i.e. it was added by `ALTER ADD COLUMN` after the part was written, and the default fill is then correct and identical on either read path (that behavior, from #108569, is preserved and covered by a control case). Any other absence counts as drift:

- `analyzeProjectionCandidate` sends parent parts whose projection part is stale for any required column to the base-table bucket (covers normal and aggregate projection candidates; virtual columns are exempt since the reading step provides them, never the part).
- `prepareProjectionsToMergeAndRebuild` rebuilds the projection from the merged parent data instead of merging drifted projection parts directly (skipped under `deduplicate_merge_projection_mode = 'ignore'`, mirroring the expired-columns rule), so merges self-heal drifted projections.

The new stateless test covers the normal-projection drift (auto read, forced read → `PROJECTION_NOT_USED`, mixed old/new parts), the merge rebuild (values and rebuilt column set), the aggregate-projection drift, the `ALTER ADD COLUMN` must-not-act control, and a virtual-column control. Each guard clause was verified load-bearing by reverting it individually and observing exactly the matching assertions fail.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix silently wrong query results when a projection part written before the projection's column set changed (for example, after upgrading across versions that materialize an `ALIAS` column's source differently, or after `ALTER TABLE ... MODIFY COLUMN` re-points an `ALIAS` column used by a projection) was read through the projection or merged: the missing column was filled with default values instead of the real data. Such parts are now read from the base table, and merges rebuild the projection from the base data.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.5.14`
<!-- ch-version-info:end -->