### PR TITLE
Add setting `send_header_and_column_defaults_for_insert`

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -128,6 +128,7 @@ namespace Setting
 {
     extern const SettingsBool allow_settings_after_format_in_insert;
     extern const SettingsBool async_insert;
+    extern const SettingsBool send_header_and_column_defaults_for_insert;
     extern const SettingsBool send_table_structure_on_insert_with_inline_data;
     extern const SettingsDialect dialect;
     extern const SettingsNonZeroUInt64 max_block_size;
@@ -1998,6 +1999,16 @@ void ClientBase::processInsertQuery(String query, ASTPtr parsed_query)
     if (isEmbeeddedClient() && parsed_insert_query.infile)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Reading from INFILE is disabled when you are running client embedded into server.");
 
+    /// The client parses the INSERT data itself and needs the table structure from the server for that,
+    /// but with `send_header_and_column_defaults_for_insert = 0` the server will not send it.
+    /// INSERT queries with inline data don't reach this point: they are sent as-is and parsed by the server.
+    /// INSERT SELECT with the `input` function doesn't need this structure: the server sends the structure
+    /// of the `input` function separately, regardless of the setting.
+    if (!parsed_insert_query.select && !client_context->getSettingsRef()[Setting::send_header_and_column_defaults_for_insert])
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "INSERT without inline data requires receiving the table structure from the server, "
+            "which is disabled by the setting 'send_header_and_column_defaults_for_insert'");
+
     query_interrupt_handler.start();
     SCOPE_EXIT({ query_interrupt_handler.stop(); });
 
@@ -2532,11 +2543,16 @@ void ClientBase::processParsedSingleQuery(
         if (insert && insert->select)
             insert->tryFindInputFunction(input_function);
 
-        /// When the user explicitly requested inline insert data mode (via `--inline-insert-data` or
-        /// `send_table_structure_on_insert_with_inline_data = 0`), it takes precedence over `async_insert`
-        /// on the client side: both paths send the data inline with the query, and the explicit user choice
-        /// determines which client-side flow (and rejection message) applies.
-        bool is_inline_insert_data = (inline_insert_data || !client_context->getSettingsRef()[Setting::send_table_structure_on_insert_with_inline_data])
+        /// When the user explicitly requested inline insert data mode (via `--inline-insert-data`,
+        /// `send_table_structure_on_insert_with_inline_data = 0` or `send_header_and_column_defaults_for_insert = 0`),
+        /// it takes precedence over `async_insert` on the client side: both paths send the data inline
+        /// with the query, and the explicit user choice determines which client-side flow
+        /// (and rejection message) applies. With `send_header_and_column_defaults_for_insert = 0`
+        /// the server does not send the table structure, so the client cannot parse the data itself
+        /// and must send it inline for the server to parse.
+        bool is_inline_insert_data = (inline_insert_data
+            || !client_context->getSettingsRef()[Setting::send_table_structure_on_insert_with_inline_data]
+            || !client_context->getSettingsRef()[Setting::send_header_and_column_defaults_for_insert])
             && insert && insert->hasInlinedData() && !insert->select;
 
         /// Update async_insert after applying settings from server

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6698,6 +6698,11 @@ Only has an effect in ClickHouse Cloud. Number of granules in stripe of compact 
     DECLARE(Bool, send_table_structure_on_insert_with_inline_data, true, R"(
 If disabled and the INSERT query contains inline data, the server will not send the table structure and column defaults back to the client over the native protocol. Instead, the server will parse the inline data itself. This can improve performance for many small inserts over the native protocol.
 )", 0) \
+    DECLARE(Bool, send_header_and_column_defaults_for_insert, true, R"(
+If disabled, the server will not send the header block and column defaults for the insertion table to the client over the native protocol before receiving the INSERT data. This saves a round-trip and egress traffic on every INSERT, which is significant for small inserts into tables with many columns.
+
+Disable it only from clients that already know the structure of the insertion table and send the data in that structure (for example, drivers using the `Native` format), because the server will not send anything for the client to wait for. `clickhouse-client` needs the structure from the server to parse the INSERT data on the client side, so with this setting disabled it only supports INSERT queries with inline data (which are sent as-is and parsed by the server).
+)", 0) \
     \
     DECLARE(Bool, async_insert, true, R"(
 If true, data from INSERT query is stored in queue and later flushed to table in background. If wait_for_async_insert is false, INSERT query is processed almost instantly, otherwise client will wait until data will be flushed to table

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -43,6 +43,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         {
             {"dictionary_lazy_load", "auto", "auto", "New setting overriding the server setting `dictionaries_lazy_load` for an individual dictionary."},
             {"discard_query_data", false, false, "New setting to skip sending query result rows to the client over the native TCP protocol."},
+            {"send_header_and_column_defaults_for_insert", true, true, "New setting to control whether the server sends the header block and column defaults for the insertion table to the client before receiving INSERT data over the native protocol."},
             {"optimize_trivial_count_with_sparsity_filter", false, false, "New (experimental) setting to serve `SELECT count() FROM t WHERE <pred>` from per-column `num_defaults` / `num_rows` recorded in `serialization.json` when `<pred>` partitions rows into defaults vs non-defaults."},
             {"merge_tree_generic_exclusion_search_max_steps", 0, 0, "New setting to limit the number of steps of the generic exclusion search over the primary key index."},
             {"use_streaming_marks_compression", false, false, "New setting to compress marks into in-memory representation one block at a time (streaming) instead of materializing the full plain marks array, reducing peak memory during marks loading for compact parts with many substreams."},

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -108,6 +108,7 @@ namespace Setting
     extern const SettingsBool partial_result_on_first_cancel;
     extern const SettingsUInt64 poll_interval;
     extern const SettingsSeconds receive_timeout;
+    extern const SettingsBool send_header_and_column_defaults_for_insert;
     extern const SettingsLogsLevel send_logs_level;
     extern const SettingsBool send_profile_events;
     extern const SettingsString send_logs_source_regexp;
@@ -1333,18 +1334,22 @@ void TCPHandler::startInsertQuery(QueryState & state)
 {
     std::lock_guard lock(*callback_mutex);
 
-    /// Send ColumnsDescription for insertion table
-    if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA)
+    if (state.query_context->getSettingsRef()[Setting::send_header_and_column_defaults_for_insert])
     {
-        if (state.query_context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields])
+        /// Send ColumnsDescription for insertion table
+        if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA)
         {
-            if (state.query_context->hasInsertionTableColumnsDescription())
-                sendTableColumns(state, *state.query_context->getInsertionTableColumnsDescription());
+            if (state.query_context->getSettingsRef()[Setting::input_format_defaults_for_omitted_fields])
+            {
+                if (state.query_context->hasInsertionTableColumnsDescription())
+                    sendTableColumns(state, *state.query_context->getInsertionTableColumnsDescription());
+            }
         }
+
+        /// Send block to the client - table structure.
+        sendData(state, state.io.pipeline.getHeader());
     }
 
-    /// Send block to the client - table structure.
-    sendData(state, state.io.pipeline.getHeader());
     sendLogs(state);
 
     /// Update flag after reading external tables

--- a/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.python
+++ b/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.python
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+
+# Checks which packets the server sends for an INSERT over the native protocol
+# depending on the `send_header_and_column_defaults_for_insert` setting.
+# With the setting disabled, the server must not send `TableColumns` and the header
+# block before receiving the INSERT data, and the client can pipeline the data
+# right after the query without waiting for the server.
+
+import os
+import socket
+import struct
+import sys
+import uuid
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "127.0.0.1")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT_TCP", "900000"))
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
+CLIENT_NAME = "simple native protocol"
+CLIENT_TCP_PROTOCOL_VERSION = 54449
+
+
+def writeVarUInt(x, ba):
+    for _ in range(0, 9):
+        byte = x & 0x7F
+        if x > 0x7F:
+            byte |= 0x80
+
+        ba.append(byte)
+
+        x >>= 7
+        if x == 0:
+            return
+
+
+def writeStringBinary(s, ba):
+    b = bytes(s, "utf-8")
+    writeVarUInt(len(s), ba)
+    ba.extend(b)
+
+
+def readStrict(s, size=1):
+    res = bytearray()
+    while size:
+        cur = s.recv(size)
+        if not cur:
+            raise RuntimeError("Socket is closed")
+        size -= len(cur)
+        res.extend(cur)
+
+    return res
+
+
+def readUInt(s, size=1):
+    res = readStrict(s, size)
+    val = 0
+    for i in range(len(res)):
+        val += res[i] << (i * 8)
+    return val
+
+
+def readUInt8(s):
+    return readUInt(s)
+
+
+def readUInt32(s):
+    return readUInt(s, 4)
+
+
+def readVarUInt(s):
+    x = 0
+    for i in range(9):
+        byte = readStrict(s)[0]
+        x |= (byte & 0x7F) << (7 * i)
+
+        if not byte & 0x80:
+            return x
+
+    return x
+
+
+def readStringBinary(s):
+    size = readVarUInt(s)
+    s = readStrict(s, size)
+    return s.decode("utf-8")
+
+
+def sendHello(s):
+    ba = bytearray()
+    writeVarUInt(0, ba)  # Hello
+    writeStringBinary(CLIENT_NAME, ba)
+    writeVarUInt(21, ba)
+    writeVarUInt(9, ba)
+    writeVarUInt(CLIENT_TCP_PROTOCOL_VERSION, ba)
+    writeStringBinary(CLICKHOUSE_DATABASE, ba)  # database
+    writeStringBinary("default", ba)  # user
+    writeStringBinary("", ba)  # pwd
+    s.sendall(ba)
+
+
+def receiveHello(s):
+    p_type = readVarUInt(s)
+    assert p_type == 0  # Hello
+    readStringBinary(s)  # server name
+    readVarUInt(s)  # major
+    readVarUInt(s)  # minor
+    readVarUInt(s)  # revision
+    readStringBinary(s)  # timezone
+    readStringBinary(s)  # display name
+    readVarUInt(s)  # version patch
+
+
+def serializeClientInfo(ba, query_id):
+    writeStringBinary("default", ba)  # initial_user
+    writeStringBinary(query_id, ba)  # initial_query_id
+    writeStringBinary("127.0.0.1:9000", ba)  # initial_address
+    ba.extend([0] * 8)  # initial_query_start_time_microseconds
+    ba.append(1)  # TCP
+    writeStringBinary("os_user", ba)  # os_user
+    writeStringBinary("client_hostname", ba)  # client_hostname
+    writeStringBinary(CLIENT_NAME, ba)  # client_name
+    writeVarUInt(21, ba)
+    writeVarUInt(9, ba)
+    writeVarUInt(CLIENT_TCP_PROTOCOL_VERSION, ba)
+    writeStringBinary("", ba)  # quota_key
+    writeVarUInt(0, ba)  # distributed_depth
+    writeVarUInt(1, ba)  # client_version_patch
+    ba.append(0)  # No telemetry
+
+
+def sendQuery(s, query, settings):
+    ba = bytearray()
+    query_id = uuid.uuid4().hex
+    writeVarUInt(1, ba)  # query
+    writeStringBinary(query_id, ba)
+
+    ba.append(1)  # INITIAL_QUERY
+
+    # client info
+    serializeClientInfo(ba, query_id)
+
+    # settings serialized as strings with flags
+    for name, value in settings.items():
+        writeStringBinary(name, ba)
+        writeVarUInt(0, ba)  # flags
+        writeStringBinary(value, ba)
+    writeStringBinary("", ba)  # end of settings
+
+    writeStringBinary("", ba)  # No interserver secret
+    writeVarUInt(2, ba)  # Stage - Complete
+    ba.append(0)  # No compression
+    writeStringBinary(query, ba)  # query, finally
+    s.sendall(ba)
+
+
+def serializeBlockInfo(ba):
+    writeVarUInt(1, ba)  # field 1
+    ba.append(0)  # is_overflows
+    writeVarUInt(2, ba)  # field 2
+    ba.extend(struct.pack("<i", -1))  # bucket_num
+    writeVarUInt(0, ba)  # end of fields
+
+
+def sendEmptyBlock(s):
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)
+    serializeBlockInfo(ba)
+    writeVarUInt(0, ba)  # columns
+    writeVarUInt(0, ba)  # rows
+    s.sendall(ba)
+
+
+def sendOneRowBlock(s, value):
+    ba = bytearray()
+    writeVarUInt(2, ba)  # Data
+    writeStringBinary("", ba)
+    serializeBlockInfo(ba)
+    writeVarUInt(1, ba)  # columns
+    writeVarUInt(1, ba)  # rows
+    writeStringBinary("x", ba)
+    writeStringBinary("UInt64", ba)
+    ba.extend(struct.pack("<Q", value))
+    s.sendall(ba)
+
+
+def readBlockInfo(s):
+    while True:
+        field_num = readVarUInt(s)
+        if field_num == 0:
+            break
+        if field_num == 1:
+            readUInt8(s)  # is_overflows
+        elif field_num == 2:
+            readStrict(s, 4)  # bucket_num
+        else:
+            raise RuntimeError("Unknown block info field {}".format(field_num))
+
+
+def readHeaderBlock(s):
+    readStringBinary(s)  # external table name
+    readBlockInfo(s)
+    num_columns = readVarUInt(s)
+    num_rows = readVarUInt(s)
+    assert num_rows == 0, num_rows
+    columns = []
+    for _ in range(num_columns):
+        name = readStringBinary(s)
+        type_name = readStringBinary(s)
+        columns.append("{} {}".format(name, type_name))
+    return columns
+
+
+def readException(s):
+    code = readUInt32(s)
+    readStringBinary(s)  # name
+    text = readStringBinary(s)
+    readStringBinary(s)  # trace
+    assert readUInt8(s) == 0  # has_nested
+    return "code {}: {}".format(code, text.replace("DB::Exception:", ""))
+
+
+def main():
+    send_header = sys.argv[1]
+    value = int(sys.argv[2])
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(30)
+        s.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+        sendHello(s)
+        receiveHello(s)
+
+        sendQuery(
+            s,
+            "INSERT INTO {}.test_04512 (x) VALUES".format(CLICKHOUSE_DATABASE),
+            {
+                "send_header_and_column_defaults_for_insert": send_header,
+                "input_format_defaults_for_omitted_fields": "1",
+            },
+        )
+
+        # Pipeline everything without waiting for the server:
+        # end of external tables, then the INSERT data, then end of data.
+        sendEmptyBlock(s)
+        sendOneRowBlock(s, value)
+        sendEmptyBlock(s)
+
+        got_table_columns = False
+        got_header = False
+        while True:
+            packet_type = readVarUInt(s)
+            if packet_type == 1:  # Data
+                got_header = True
+                readHeaderBlock(s)
+            elif packet_type == 2:  # Exception
+                raise RuntimeError(readException(s))
+            elif packet_type == 3:  # Progress
+                for _ in range(5):
+                    readVarUInt(s)
+            elif packet_type == 11:  # TableColumns
+                got_table_columns = True
+                readStringBinary(s)  # external table name
+                readStringBinary(s)  # columns description
+            elif packet_type == 5:  # End of stream
+                break
+            else:
+                raise RuntimeError("Unexpected packet {}".format(packet_type))
+
+        expected = send_header == "1"
+        assert got_table_columns == expected, got_table_columns
+        assert got_header == expected, got_header
+
+        print(
+            "setting={} table_columns={} header={}".format(
+                send_header, int(got_table_columns), int(got_header)
+            )
+        )
+
+        s.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.reference
+++ b/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.reference
@@ -1,0 +1,8 @@
+1
+setting=1 table_columns=1 header=1
+setting=0 table_columns=0 header=0
+1	hello
+2	y_default
+3	y_default
+100	y_default
+200	y_default

--- a/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.sh
+++ b/tests/queries/0_stateless/04512_send_header_and_column_defaults_for_insert.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test the `send_header_and_column_defaults_for_insert` setting.
+# When it is disabled, the server does not send the header block and column defaults
+# to the client before receiving the INSERT data over the native protocol.
+# `clickhouse-client` with the setting disabled sends INSERT queries with inline data
+# as-is (the server parses the data), and rejects INSERT queries with external data,
+# because it cannot parse them without the structure from the server.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS test_04512"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE test_04512 (x UInt64, y String DEFAULT 'y_default') ENGINE = MergeTree ORDER BY x"
+
+# Inline data is sent as-is and parsed by the server; column defaults are applied by the server.
+$CLICKHOUSE_CLIENT --send_header_and_column_defaults_for_insert 0 --query "INSERT INTO test_04512 VALUES (1, 'hello')"
+$CLICKHOUSE_CLIENT --send_header_and_column_defaults_for_insert 0 --query "INSERT INTO test_04512 (x) VALUES (2)"
+$CLICKHOUSE_CLIENT --send_header_and_column_defaults_for_insert 0 --query "INSERT INTO test_04512 FORMAT JSONEachRow {\"x\": 3}"
+
+# INSERT with external data (from stdin) is rejected, because the client needs
+# the table structure from the server to parse it.
+$CLICKHOUSE_CLIENT --send_header_and_column_defaults_for_insert 0 --query "INSERT INTO test_04512 FORMAT TSV" <<<"4	stdin" 2>&1 | grep -F -c "requires receiving the table structure from the server"
+
+# Raw native protocol: with the setting disabled the server must send neither
+# `TableColumns` nor the header block, and the INSERT must still succeed.
+python3 "$CUR_DIR"/04512_send_header_and_column_defaults_for_insert.python 1 100
+python3 "$CUR_DIR"/04512_send_header_and_column_defaults_for_insert.python 0 200
+
+$CLICKHOUSE_CLIENT --query "SELECT * FROM test_04512 ORDER BY x"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE test_04512"


### PR DESCRIPTION
Changelog category (leave one):
- Improvement

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Add setting `send_header_and_column_defaults_for_insert`. When disabled, the server does not send the header block and column defaults to the client before receiving INSERT data over the native protocol, saving a round-trip and egress traffic per INSERT.

For every INSERT over the native protocol the server sends the insertion table's header block and column defaults to the client before receiving data. For small inserts into wide tables this wastes egress bandwidth and adds a round-trip of latency per insert. This adds the setting prescribed in the issue: when disabled, `TCPHandler::startInsertQuery` sends neither, so clients that already know the table structure (e.g. drivers sending `Native` blocks) can pipeline data immediately. Default is `true` (no behavior change). `clickhouse-client` with the setting disabled sends INSERT queries with inline data as-is for the server to parse (reusing the `send_table_structure_on_insert_with_inline_data` path) and rejects INSERTs with external data with a clear error, since it cannot parse them without the structure. Includes a raw-native-protocol test asserting the packets are absent and the insert succeeds.

Closes: https://github.com/ClickHouse/ClickHouse/issues/75719
