### PR TITLE
Store minio audit/server log tables on local disk, not S3

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -563,14 +563,26 @@ profiles:
         # False). Every step MUST stay non-strict: a strict=True step would
         # raise before we can record the reason and signal failure. Record the
         # concrete failing sub-step so it reaches CIDB test_context_raw.
+        # storage_policy = 'default' pins these diagnostic tables to local disk.
+        # On s3 storage runs the default merge_tree policy is S3
+        # (s3_storage_policy_for_merge_tree_by_default.xml), which would put the
+        # audit log on S3, so (1) every audit-event insert writes parts to S3 and
+        # thereby generates more audit events (a feedback loop that inflates the
+        # table), and (2) the post-run `select * ... into outfile` dump reads all
+        # of it back from S3 - on amd_tsan this JSON-typed table grew to ~700k
+        # rows / ~1.5 GB and the dump blew past the DUMP_SYSTEM_TABLE_TIMEOUT cap,
+        # failing the "Scraping system tables" check. These are diagnostics ABOUT
+        # S3 activity; there is no reason to store them ON S3. 'default' is a
+        # local policy on every stateless config (no config remaps it), so this
+        # is a no-op on non-s3 runs.
         setup_steps = [
             (
                 "create system.minio_audit_logs table",
-                'clickhouse-client --enable_json_type=1 --query "CREATE TABLE system.minio_audit_logs (log JSON(time DateTime64(9))) ENGINE = MergeTree ORDER BY tuple()"',
+                'clickhouse-client --enable_json_type=1 --query "CREATE TABLE system.minio_audit_logs (log JSON(time DateTime64(9))) ENGINE = MergeTree ORDER BY tuple() SETTINGS storage_policy = \'default\'"',
             ),
             (
                 "create system.minio_server_logs table",
-                'clickhouse-client --enable_json_type=1 --query "CREATE TABLE system.minio_server_logs (log JSON(time DateTime64(9))) ENGINE = MergeTree ORDER BY tuple()"',
+                'clickhouse-client --enable_json_type=1 --query "CREATE TABLE system.minio_server_logs (log JSON(time DateTime64(9))) ENGINE = MergeTree ORDER BY tuple() SETTINGS storage_policy = \'default\'"',
             ),
             (
                 "set clickminio logger_webhook config",

--- a/ci/tests/test_minio_log_tables_local_storage.py
+++ b/ci/tests/test_minio_log_tables_local_storage.py
@@ -1,0 +1,59 @@
+"""
+Guard test for the storage placement of the MinIO webhook log tables created in
+ClickHouseProc.create_minio_log_tables (ci/jobs/scripts/clickhouse_proc.py).
+
+Background
+----------
+`system.minio_audit_logs` and `system.minio_server_logs` are diagnostic tables
+that capture the MinIO audit/server webhook stream during a run. They are plain
+`ENGINE = MergeTree` tables, so on s3 storage runs they would inherit the
+overridden default merge_tree policy (s3_storage_policy_for_merge_tree_by_default
+.xml sets <merge_tree><storage_policy>s3</storage_policy>) and live ON S3. That is
+doubly bad for a table that records S3 activity:
+
+  * every audit-event insert writes parts to S3, which generates more audit
+    events - a feedback loop that inflates the table, and
+  * the post-run `select * ... into outfile` dump in dump_system_tables reads it
+    all back from S3. On amd_tsan the JSON-typed audit table grew to ~700k rows /
+    ~1.5 GB and the dump exceeded DUMP_SYSTEM_TABLE_TIMEOUT, turning the
+    "Scraping system tables" step red (observed on master, e.g. commit 961ded3).
+
+The fix pins both tables to the local `default` policy with an explicit
+`SETTINGS storage_policy = 'default'`. `default` is a local policy on every
+stateless config (nothing remaps it), so the dump reads locally and the audit
+insert path no longer feeds itself over S3. This test guards against a future
+edit dropping that setting and silently putting the tables back on S3.
+"""
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SRC = _REPO_ROOT / "ci" / "jobs" / "scripts" / "clickhouse_proc.py"
+
+
+def _create_statements(src):
+    # Every `CREATE TABLE system.minio_*_logs ...` SQL string built in the
+    # source, up to the closing double quote of the clickhouse-client --query.
+    return re.findall(r"CREATE TABLE system\.minio_\w+_logs[^\"]*", src)
+
+
+def test_minio_log_tables_are_pinned_to_local_storage():
+    src = _SRC.read_text()
+    statements = _create_statements(src)
+    # Both the audit and server log tables must be created.
+    assert len(statements) == 2, (
+        f"expected 2 minio log table CREATE statements, found {len(statements)}: {statements}"
+    )
+    for stmt in statements:
+        # The captured text is a Python source fragment, so the SQL string
+        # quotes are backslash-escaped (\\'default\\'); drop the backslashes to
+        # compare against the SQL as clickhouse-client will see it.
+        sql = stmt.replace("\\", "")
+        # A CREATE that ends at `ORDER BY tuple()` with no storage_policy would
+        # inherit the s3-overridden default on s3 runs. Require the local pin
+        # right after the ORDER BY, so the placement is explicit and local.
+        assert re.search(r"ORDER BY tuple\(\)\s+SETTINGS\s+storage_policy = 'default'", sql), (
+            "minio log table must be pinned to the local 'default' storage policy "
+            f"so its dump is not read back from S3; got: {sql}"
+        )


### PR DESCRIPTION
The `Scraping system tables` step of stateless jobs fails on **amd_tsan + s3 storage** runs with:

```
Failed to dump system table: minio_audit_logs
Error: timed out after 600s
```

`system.minio_audit_logs` and `system.minio_server_logs` capture the MinIO audit/server webhook stream, but they are plain `ENGINE = MergeTree` tables, so on s3 storage runs they inherit the overridden default merge_tree policy (`s3_storage_policy_for_merge_tree_by_default.xml` sets `<merge_tree><storage_policy>s3</storage_policy>`) and live **on S3**. That is doubly bad for tables that record S3 activity:

- every audit-event insert writes parts to S3, which itself generates more audit events — a feedback loop that inflates the table, and
- the post-run `select * ... into outfile` dump in `dump_system_tables` reads it all back from S3. On amd_tsan the `JSON`-typed audit table grew to ~700k rows / ~1.5 GB and the dump blew past the `DUMP_SYSTEM_TABLE_TIMEOUT` (600s) cap, so the bounded dump was killed and `Scraping system tables` went red.

On master this only ever fired on runs that already had another failing test (the failure-reproduction/minimization storm hammers S3, tipping the table over the cap), so it never turned a green run red — but it added a confusing extra `FAIL` and wasted up to ~20 min per affected run.

**Fix:** pin both tables to the local `default` storage policy with an explicit `SETTINGS storage_policy = 'default'`. The dump then reads locally and the audit insert path no longer feeds itself over S3. These are diagnostics *about* S3 activity; there is no reason to store them *on* S3. `default` is a local policy on every stateless config (nothing remaps it), so this is a no-op on non-s3 runs.

Verified with `clickhouse local`: with the default merge_tree policy overridden to a non-default policy, a plain `CREATE` lands on the override while `SETTINGS storage_policy = 'default'` lands on local storage. A guard test (`ci/tests/test_minio_log_tables_local_storage.py`) prevents a future edit from silently putting the tables back on S3.

CI report (one of several; amd_tsan s3 storage sequential 2/2 on master):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=961ded3e6c262b07d1b0b33e74ce60b9fad99682&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20sequential%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)