### PR TITLE
Record the backup id in the backup metadata

### DIFF
--- a/src/Backups/BackupFactory.h
+++ b/src/Backups/BackupFactory.h
@@ -41,6 +41,7 @@ public:
         size_t data_file_name_prefix_length = 3;
         std::shared_ptr<IBackupCoordination> backup_coordination;
         std::optional<UUID> backup_uuid;
+        String backup_id;
         bool deduplicate_files = true;
         bool allow_s3_native_copy = true;
         bool allow_azure_native_copy = true;

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -174,6 +174,7 @@ BackupImpl::BackupImpl(
     , data_file_name_prefix_length(params.data_file_name_prefix_length)
     , coordination(params.backup_coordination)
     , uuid(params.backup_uuid)
+    , backup_id(params.backup_id)
     , version(CURRENT_BACKUP_VERSION)
     , base_backup_info(params.base_backup_info)
     , log(getLogger("BackupImpl"))
@@ -433,6 +434,8 @@ void BackupImpl::writeBackupMetadata()
     *out << "<deduplicate_files>" << params.deduplicate_files << "</deduplicate_files>";
     *out << "<timestamp>" << toString(LocalDateTime{timestamp}) << "</timestamp>";
     *out << "<uuid>" << toString(*uuid) << "</uuid>";
+    if (!backup_id.empty())
+        *out << "<backup_id>" << xml << backup_id << "</backup_id>";
     if (data_file_name_generator != BackupDataFileNameGeneratorType::FirstFileName)
         *out << "<data_file_name_generator>" << SettingFieldBackupDataFileNameGeneratorTypeTraits::toString(data_file_name_generator)
              << "</data_file_name_generator>";
@@ -580,6 +583,8 @@ void BackupImpl::readBackupMetadata()
 
     timestamp = parse<::LocalDateTime>(getString(config_root, "timestamp")).to_time_t();
     uuid = parse<UUID>(getString(config_root, "uuid"));
+    if (config_root->getNodeByPath("backup_id"))
+        backup_id = getString(config_root, "backup_id");
 
     if (config_root->getNodeByPath("base_backup") && !base_backup_info)
     {

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -65,6 +65,7 @@ public:
     std::map<String, String> getEngineSettings() const override;
     time_t getTimestamp() const override { return timestamp; }
     UUID getUUID() const override { return *uuid; }
+    const String & getBackupId() const override { return backup_id; }
     BackupPtr getBaseBackup() const override;
     size_t getNumFiles() const override;
     UInt64 getTotalSize() const override;
@@ -158,6 +159,7 @@ private:
     std::unordered_map<String, BackupFileInfo> lightweight_snapshot_file_infos TSA_GUARDED_BY(mutex);
 
     std::optional<UUID> uuid;
+    String backup_id; /// Set from params on write, from the manifest on read; empty for legacy backups without the field.
     time_t timestamp = 0;
     size_t num_files = 0;
     UInt64 total_size = 0;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -494,7 +494,7 @@ struct BackupsWorker::BackupStarter
         backup_coordination->startup();
 
         chassert(!backup);
-        backup = backups_worker.openBackupForWriting(backup_info, backup_settings, backup_id, backup_coordination, backup_context);
+        backup = backups_worker.openBackupForWriting(backup_info, backup_settings, backup_coordination, backup_context);
 
         backups_worker.doBackup(backup, backup_query, backup_id, backup_settings, backup_coordination, backup_context,
                                 on_cluster, cluster);
@@ -608,7 +608,6 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startMakingBackup(cons
 BackupMutablePtr BackupsWorker::openBackupForWriting(
     const BackupInfo & backup_info,
     const BackupSettings & backup_settings,
-    const String & backup_id,
     std::shared_ptr<IBackupCoordination> backup_coordination,
     const ContextPtr & context) const
 {
@@ -629,7 +628,7 @@ BackupMutablePtr BackupsWorker::openBackupForWriting(
     backup_create_params.data_file_name_prefix_length = *backup_settings.data_file_name_prefix_length;
     backup_create_params.backup_coordination = backup_coordination;
     backup_create_params.backup_uuid = backup_settings.backup_uuid;
-    backup_create_params.backup_id = backup_id;
+    backup_create_params.backup_id = backup_settings.id.empty() ? toString(*backup_settings.backup_uuid) : backup_settings.id;
     backup_create_params.deduplicate_files = backup_settings.deduplicate_files;
     backup_create_params.allow_s3_native_copy = backup_settings.allow_s3_native_copy;
     backup_create_params.allow_azure_native_copy = backup_settings.allow_azure_native_copy;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -494,7 +494,7 @@ struct BackupsWorker::BackupStarter
         backup_coordination->startup();
 
         chassert(!backup);
-        backup = backups_worker.openBackupForWriting(backup_info, backup_settings, backup_coordination, backup_context);
+        backup = backups_worker.openBackupForWriting(backup_info, backup_settings, backup_id, backup_coordination, backup_context);
 
         backups_worker.doBackup(backup, backup_query, backup_id, backup_settings, backup_coordination, backup_context,
                                 on_cluster, cluster);
@@ -608,6 +608,7 @@ std::pair<BackupOperationID, BackupStatus> BackupsWorker::startMakingBackup(cons
 BackupMutablePtr BackupsWorker::openBackupForWriting(
     const BackupInfo & backup_info,
     const BackupSettings & backup_settings,
+    const String & backup_id,
     std::shared_ptr<IBackupCoordination> backup_coordination,
     const ContextPtr & context) const
 {
@@ -628,6 +629,7 @@ BackupMutablePtr BackupsWorker::openBackupForWriting(
     backup_create_params.data_file_name_prefix_length = *backup_settings.data_file_name_prefix_length;
     backup_create_params.backup_coordination = backup_coordination;
     backup_create_params.backup_uuid = backup_settings.backup_uuid;
+    backup_create_params.backup_id = backup_id;
     backup_create_params.deduplicate_files = backup_settings.deduplicate_files;
     backup_create_params.allow_s3_native_copy = backup_settings.allow_s3_native_copy;
     backup_create_params.allow_azure_native_copy = backup_settings.allow_azure_native_copy;

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -628,6 +628,8 @@ BackupMutablePtr BackupsWorker::openBackupForWriting(
     backup_create_params.data_file_name_prefix_length = *backup_settings.data_file_name_prefix_length;
     backup_create_params.backup_coordination = backup_coordination;
     backup_create_params.backup_uuid = backup_settings.backup_uuid;
+    /// The logical backup id, not BackupStarter's `-internal-` suffixed infos-map key -- internal ON CLUSTER
+    /// workers never write a manifest (writeBackupMetadata asserts !is_internal_backup), so this is the id readers see.
     backup_create_params.backup_id = backup_settings.id.empty() ? toString(*backup_settings.backup_uuid) : backup_settings.id;
     backup_create_params.deduplicate_files = backup_settings.deduplicate_files;
     backup_create_params.allow_s3_native_copy = backup_settings.allow_s3_native_copy;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -86,6 +86,7 @@ private:
     BackupMutablePtr openBackupForWriting(
         const BackupInfo & backup_info,
         const BackupSettings & backup_settings,
+        const String & backup_id,
         std::shared_ptr<IBackupCoordination> backup_coordination,
         const ContextPtr & context) const;
 

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -86,7 +86,6 @@ private:
     BackupMutablePtr openBackupForWriting(
         const BackupInfo & backup_info,
         const BackupSettings & backup_settings,
-        const String & backup_id,
         std::shared_ptr<IBackupCoordination> backup_coordination,
         const ContextPtr & context) const;
 

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -51,6 +51,10 @@ public:
     /// Returns UUID of the backup.
     virtual UUID getUUID() const = 0;
 
+    /// The backup's operation id (the `id` setting, else the UUID), as recorded in the manifest.
+    /// Empty for backups written before this field existed.
+    virtual const String & getBackupId() const = 0;
+
     /// Returns the base backup or null if there is no base backup.
     virtual std::shared_ptr<const IBackup> getBaseBackup() const = 0;
 

--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -89,6 +89,11 @@ def get_path_to_backup(backup_name):
     return os.path.join(instance.cluster.instances_dir, "backups", name)
 
 
+def read_backup_metadata(backup_name):
+    with open(os.path.join(get_path_to_backup(backup_name), ".backup")) as f:
+        return f.read()
+
+
 def find_files_in_backup_folder(backup_name):
     path = get_path_to_backup(backup_name)
     files = [f for f in glob.glob(path + "/**", recursive=True) if os.path.isfile(f)]
@@ -544,6 +549,25 @@ def test_incremental_backup_overflow():
     assert os.listdir(os.path.join(get_path_to_backup(incremental_backup_name))) == [
         ".backup"
     ]
+
+
+def test_backup_id_in_manifest():
+    create_and_fill_table(n=10)
+
+    # A custom `id` is recorded verbatim as <backup_id> in the manifest.
+    backup_name = new_backup_name()
+    known_id = "my_custom_backup_id"
+    instance.query(f"BACKUP TABLE test.table TO {backup_name} SETTINGS id='{known_id}'")
+    assert f"<backup_id>{known_id}</backup_id>" in read_backup_metadata(backup_name)
+
+    # With no `id`, the recorded backup_id defaults to the backup UUID.
+    backup_name2 = new_backup_name()
+    instance.query(f"BACKUP TABLE test.table TO {backup_name2}")
+    manifest = read_backup_metadata(backup_name2)
+    assert (
+        re.search("<backup_id>(.*?)</backup_id>", manifest).group(1)
+        == re.search("<uuid>(.*?)</uuid>", manifest).group(1)
+    )
 
 
 def test_incremental_backup_after_renaming_table():


### PR DESCRIPTION
Persists the backup's operation id (the `id` setting, or the auto-generated UUID when `id` is not set) into the `.backup` metadata as a `<backup_id>` element, and exposes it via `IBackup::getBackupId()`.

## Motivation

A backup's id is currently only associated with the operation in `system.backups` at creation time — it isn't stored in the backup itself. Recording it in the manifest lets the id be recovered when a backup is re-opened (for restore or inspection), so tooling can correlate an opened backup with the id it was created under without relying on the transient operation record.

## Compatibility

Additive, optional element — no backup format-version bump:
- Old binaries reading a new backup ignore the unknown `<backup_id>` element.
- New binaries reading an old backup (no element) leave it empty; `getBackupId()` returns an empty string.

The id is written XML-escaped alongside the existing `<uuid>`, threaded through `BackupFactory::CreateParams` and `BackupsWorker`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.976` (included in `26.7` and later)
<!-- ch-version-info:end -->