### PR TITLE
Fix flaky test 04491_outfile_compression_level_range

### DIFF
--- a/tests/queries/0_stateless/04491_outfile_compression_level_range.sh
+++ b/tests/queries/0_stateless/04491_outfile_compression_level_range.sh
@@ -40,7 +40,8 @@ echo "== deflate (zlib): max level accepted, output round-trips via ClickHouse =
 out="${CLICKHOUSE_TMP}/04491_out.deflate"
 rm -f "$out"
 ${CLICKHOUSE_LOCAL} -q "$query INTO OUTFILE '$out' COMPRESSION 'deflate' LEVEL ${max_level} FORMAT TSV" >/dev/null
-got=$(${CLICKHOUSE_LOCAL} -q "SELECT * FROM file('$out', 'TSV', 'a UInt64, b String', 'deflate') FORMAT TSV" | md5sum)
+# ORDER BY a: reading back through file() does not preserve row order under input_format_parallel_parsing.
+got=$(${CLICKHOUSE_LOCAL} -q "SELECT * FROM file('$out', 'TSV', 'a UInt64, b String', 'deflate') ORDER BY a FORMAT TSV" | md5sum)
 [ "$got" = "$reference" ] && echo "deflate max level: OK" || echo "deflate max level: MISMATCH"
 rm -f "$out"
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110210
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Fixes a flaky failure in `04491_outfile_compression_level_range` (seen on `Stateless tests (arm_binary, parallel)`).

The `deflate` section writes the query result to a file, reads it back via `file()`, and md5s the result against an order-sensitive reference. `SELECT * FROM file(...)` does not preserve row order when `input_format_parallel_parsing` is enabled (a CI-randomized setting), so the md5 differs even though the decoded data is correct.

Reproduced deterministically with `--input_format_parallel_parsing 1 --min_chunk_bytes_for_parallel_parsing 100`: 15/15 mismatch without the fix, 0/20 with it. The decoded data is intact (sorted md5 identical, 100000 rows) — only the row order varied. The same non-determinism reproduces with plain TSV and gzip files too, so this is unrelated to the `libdeflate` integration (#108074). The gzip section of the test avoids it by round-tripping through external `gunzip -c`, which preserves byte order.

Fix: add `ORDER BY a` to the readback so the comparison is order-independent.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110210&sha=d8ae08bce7706a1b1c0756032db9738a3d76abf8&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.946` (included in `26.7` and later)
<!-- ch-version-info:end -->