### PR TITLE
Fix create_release: import empty-patch guard at module load, not under checkout()

### DIFF
--- a/tests/ci/create_release.py
+++ b/tests/ci/create_release.py
@@ -129,6 +129,20 @@ from version_helper import (
     update_contributors,
 )
 
+# The empty-patch-release guard lives in `ci/jobs/scripts/release_checks.py` so
+# the `CI Tests` unit suite can exercise it without this module's release-only
+# dependencies. Import it here, at module load, while the working tree is still
+# the checked-out branch: `prepare()` later checks out the release ref (which may
+# predate this helper), and importing under that `checkout()` would read a tree
+# where the file does not exist. This script runs from `tests/ci` with the repo
+# root off `sys.path`, so add it before importing.
+_REPO_ROOT = str(Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.append(_REPO_ROOT)
+from ci.jobs.scripts.release_checks import (  # noqa: E402  pylint: disable=wrong-import-position
+    is_empty_patch_release,
+)
+
 CMAKE_PATH = get_abs_path(FILE_WITH_VERSION_PATH)
 CONTRIBUTORS_PATH = get_abs_path(GENERATED_CONTRIBUTORS)
 RELEASE_INFO_FILE = "/tmp/release_info.json"
@@ -291,17 +305,10 @@ class ReleaseInfo:
                 # (only-repo/only-docker) rebuild an already-tagged release and
                 # do not tag, so skip the check. This is checked before the
                 # out-of-order check below because "nothing to release" is the
-                # more fundamental condition.
-                #
-                # The guard lives in `ci/jobs/scripts/release_checks.py` so the
-                # `CI Tests` unit suite can exercise it without this module's
-                # release-only dependencies. This script runs from `tests/ci`
-                # with repo root off `sys.path`, so add it and import lazily.
-                repo_root = str(Path(__file__).resolve().parents[2])
-                if repo_root not in sys.path:
-                    sys.path.append(repo_root)
-                from ci.jobs.scripts.release_checks import is_empty_patch_release
-
+                # more fundamental condition. `is_empty_patch_release` is
+                # imported at module load (see top of file); it must not be
+                # imported here, under `checkout()`, where the working tree may
+                # predate the helper.
                 if not _skip_out_of_order_check and is_empty_patch_release(
                     version.patch, version.tweak
                 ):


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


## Problem

The scheduled **AutoReleases** workflow fails at the **Prepare Release Info** step:

```
ModuleNotFoundError: No module named 'ci.jobs.scripts.release_checks'
  File "tests/ci/create_release.py", line 303, in prepare
    from ci.jobs.scripts.release_checks import is_empty_patch_release
```

(e.g. [Release 26.3 / CreateRelease](https://github.com/ClickHouse/ClickHouse/actions/runs/29250533957)).

## Root cause

`ReleaseInfo.prepare()` imported `is_empty_patch_release` **inside** the
`with checkout(commit_ref):` block. Python resolves an import from the on-disk
working tree, and by that point the tree has been checked out to the release
ref — an older commit that predates `ci/jobs/scripts/release_checks.py` (added
2026-07-09 in "Move release_checks helper under ci/jobs/scripts"). The helper
is therefore absent on disk and the import raises.

## Fix

Move the `sys.path` append and the import to module load, while the working
tree is still the branch the runner checked out (master), which contains the
helper. The bound function is used unchanged inside the later `checkout()`.

The hermetic unit test (`ci/tests/test_create_release.py`) is unaffected — it
imports `ci.jobs.scripts.release_checks` directly, not `create_release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1019` (included in `26.7` and later)
<!-- ch-version-info:end -->