### PR TITLE
Text index: add adaptive roaringish storage width (W=16 / W=32) for text index positions

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -497,6 +497,7 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
     auto postings_serialization = PostingsSerialization(std::move(postings_codec), text_index_header->version);
     serialization_version = text_index_header->version;
     positions_codec = text_index_header->positions_codec;
+    positions_width = text_index_header->positions_width;
 
     analyzeDictionaryForTokens(text_index_header->sparse_index, postings_serialization, *dictionary_stream, state);
     analyzeDictionaryForPatterns(text_index_header->sparse_index, postings_serialization, *dictionary_stream, state);
@@ -1177,7 +1178,7 @@ void TextIndexSerialization::serializeTokenInfo(WriteBuffer & ostr, const TokenP
     }
 }
 
-void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, UInt8 positions_codec, WriteBuffer & ostr)
+void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, UInt8 positions_codec, UInt8 positions_width, WriteBuffer & ostr)
 {
     UInt64 codec_type = static_cast<UInt64>(posting_list_codec_type);
 
@@ -1188,7 +1189,10 @@ void TextIndexSerialization::serializeHeader(const DictionarySparseIndex & spars
         writeVarUInt(static_cast<UInt64>(has_positions), ostr);
 
     if (version >= static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithPositionsCodec))
+    {
         writeVarUInt(static_cast<UInt64>(positions_codec), ostr);
+        writeVarUInt(static_cast<UInt64>(positions_width), ostr);
+    }
 
     /// Sparse indexes are created with raw columns and bit-packed only by optimize.
     /// The write path never calls optimize, so expect the raw columns here.
@@ -1241,6 +1245,12 @@ TextIndexHeader TextIndexSerialization::deserializeHeaderPrefix(ReadBuffer & ist
         if (positions_codec > static_cast<UInt64>(TextIndexPositionCodec::Encoding::Pfor))
             throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown positions codec in text index header: {}", positions_codec);
         header.positions_codec = static_cast<UInt8>(positions_codec);
+
+        UInt64 positions_width = 0;
+        readVarUInt(positions_width, istr);
+        if (positions_width != TextIndexPositionCodec::WIDTH_32 && positions_width != TextIndexPositionCodec::WIDTH_16)
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Unknown positions width in text index header: {}", positions_width);
+        header.positions_width = static_cast<UInt8>(positions_width);
     }
 
     return header;
@@ -1446,10 +1456,32 @@ DictionarySparseIndex serializeTokensAndPostings(
     Stream & postings_stream,
     const MergeTreeIndexTextParams & params,
     PostingsSerialization & postings_serialization,
+    UInt8 & out_positions_width,
     MergeTreeIndexWriterStream * positions_stream = nullptr)
 {
     size_t num_tokens = sorted_tokens.size();
     size_t num_blocks = (num_tokens + params.dictionary_block_size - 1) / params.dictionary_block_size;
+
+    /// Pick this part's positions width once, from the largest group across all tokens: if every
+    /// position fits a 64-bit (W=16) entry, store at W=16 (~24% smaller); otherwise W=32. Only pfor
+    /// parts persist the width byte (WithPositionsCodec header), so raw parts stay W=32 -- a reader
+    /// defaults raw positions to W=32, and narrowing without recording the width would corrupt them.
+    out_positions_width = TextIndexPositionCodec::WIDTH_32;
+    const bool width_persisted = TextIndexPositionCodec::parseEncoding(params.positions_codec) == TextIndexPositionCodec::Encoding::Pfor;
+    if (positions_stream && width_persisted)
+    {
+        UInt32 max_group = 0;
+        for (const auto & entry : sorted_tokens)
+        {
+            if (!entry.positions)
+                continue;
+            entry.positions->finalizeOrdering();
+            for (const auto & e : entry.positions->getEntries())
+                max_group = std::max(max_group, e.group);
+        }
+        if (max_group <= TextIndexPositionCodec::MAX_GROUP32_FOR_WIDTH_16)
+            out_positions_width = TextIndexPositionCodec::WIDTH_16;
+    }
 
     auto sparse_index_tokens = ColumnString::create();
     auto & sparse_index_str = assert_cast<ColumnString &>(*sparse_index_tokens);
@@ -1499,12 +1531,21 @@ DictionarySparseIndex serializeTokensAndPostings(
                 entry.positions->finalizeOrdering();
                 const auto & position_entries = entry.positions->getEntries();
 
+                /// Narrow the W=32 build entries to the part's storage width when it's W=16.
+                std::vector<RoaringishEntry> narrowed;
+                std::span<const RoaringishEntry> to_encode{position_entries};
+                if (out_positions_width == TextIndexPositionCodec::WIDTH_16)
+                {
+                    narrowed = TextIndexPositionCodec::narrowTo16(position_entries);
+                    to_encode = narrowed;
+                }
+
                 token_info.header |= PostingsSerialization::Flags::HasPositions;
                 token_info.position_offset = positions_stream->plain_hashing.count();
-                token_info.position_cardinality = static_cast<UInt32>(position_entries.size());
+                token_info.position_cardinality = static_cast<UInt32>(to_encode.size());
 
                 TextIndexPositionCodec::encode(
-                    position_entries, positions_stream->plain_hashing,
+                    to_encode, positions_stream->plain_hashing,
                     TextIndexPositionCodec::parseEncoding(params.positions_codec));
             }
 
@@ -1552,17 +1593,19 @@ void MergeTreeIndexGranuleTextWritable::serializeBinaryWithMultipleStreams(Merge
     auto postings_codec = PostingListCodecFactory::createPostingListCodec(posting_list_codec_type);
     PostingsSerialization postings_serialization(std::move(postings_codec), serialization_version);
 
+    UInt8 positions_width = TextIndexPositionCodec::WIDTH_32;
     auto sparse_index_block = serializeTokensAndPostings(
         sorted_tokens,
         *dictionary_stream,
         *postings_stream,
         params,
         postings_serialization,
+        positions_width,
         positions_stream);
 
     TextIndexSerialization::serializeHeader(
         sparse_index_block, posting_list_codec_type, serialization_version, params.positions,
-        static_cast<UInt8>(positions_encoding), index_stream->compressed_hashing);
+        static_cast<UInt8>(positions_encoding), positions_width, index_stream->compressed_hashing);
 }
 
 void MergeTreeIndexGranuleTextWritable::deserializeBinary(ReadBuffer &, MergeTreeIndexVersion)

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -300,6 +300,9 @@ struct TextIndexHeader
     bool has_positions = false;
     /// Positions on-disk codec (TextIndexPositionCodec::Encoding as UInt8); persisted for version >= WithPositionsCodec, else defaults to Raw.
     UInt8 positions_codec = 0;
+    /// Roaringish storage bucket width for this part's positions (32 = 96-bit, 16 = 64-bit);
+    /// persisted for version >= WithPositionsCodec, else defaults to 32.
+    UInt8 positions_width = 32;
     DictionarySparseIndex sparse_index;
 };
 
@@ -319,7 +322,7 @@ struct TextIndexSerialization
 
     static void serializeTokens(const ColumnString & tokens, WriteBuffer & ostr, TokensFormat format);
     static void serializeTokenInfo(WriteBuffer & ostr, const TokenPostingsInfo & token_info);
-    static void serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, UInt8 positions_codec, WriteBuffer & ostr);
+    static void serializeHeader(const DictionarySparseIndex & sparse_index, IPostingListCodec::Type posting_list_codec_type, MergeTreeIndexVersion version, bool has_positions, UInt8 positions_codec, UInt8 positions_width, WriteBuffer & ostr);
 
     static TextIndexHeader deserializeHeader(ReadBuffer & istr);
     /// Reads only the version and posting list codec from the start of the header, without the
@@ -380,6 +383,9 @@ public:
     MergeTreeIndexVersion getSerializationVersion() const { return serialization_version; }
     /// Positions on-disk codec persisted in the header (TextIndexPositionCodec::Encoding as UInt8).
     UInt8 getPositionsCodec() const { return positions_codec; }
+    /// Roaringish storage width (32 or 16) persisted in the header; the phrase reader tags decoded
+    /// PositionLists with it so the matcher intersects at the width the part was written with.
+    UInt8 getPositionsWidth() const { return positions_width; }
 
     static PostingListPtr readPostingsBlock(
         MergeTreeIndexReaderStream & stream,
@@ -419,6 +425,8 @@ private:
     MergeTreeIndexVersion serialization_version = static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::Initial);
     /// Positions on-disk codec persisted in the header (TextIndexPositionCodec::Encoding as UInt8).
     UInt8 positions_codec = 0;
+    /// Roaringish storage width persisted in the header (32 or 16).
+    UInt8 positions_width = 32;
 };
 
 /// Text index granule created on writing of the index.

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -898,8 +898,9 @@ void MergeTreeReaderTextIndex::applyPostingsPhrase(
                 std::vector<PositionList> position_lists;
                 position_lists.reserve(position_offsets.size());
 
-                /// Decode with the codec persisted in this part's header, not current metadata.
+                /// Decode with the codec + width persisted in this part's header, not current metadata.
                 auto positions_codec = static_cast<TextIndexPositionCodec::Encoding>(granule->getPositionsCodec());
+                const UInt32 positions_width = granule->getPositionsWidth();
 
                 auto * data_buffer = positions_stream->getDataBuffer();
                 {
@@ -909,6 +910,7 @@ void MergeTreeReaderTextIndex::applyPostingsPhrase(
                         positions_stream->seekToMark({position_offsets[i], 0});
                         auto & positions = position_lists.emplace_back();
                         TextIndexPositionCodec::decode(*data_buffer, positions, positions_codec, position_cardinalities[i], position_payload_scratch);
+                        positions.bitmap_bits = positions_width; /// intersect at the width the part was stored with
                     }
                 }
 

--- a/src/Storages/MergeTree/TextIndexPhraseSearch.cpp
+++ b/src/Storages/MergeTree/TextIndexPhraseSearch.cpp
@@ -13,10 +13,14 @@ namespace DB
 PositionList TextIndexPhraseSearch::intersect(const PositionList & lhs, const PositionList & rhs, UInt32 shift)
 {
     PositionList result;
+    result.bitmap_bits = lhs.bitmap_bits;
     if (lhs.empty() || rhs.empty() || shift == 0)
         return result;
 
-    chassert(shift < RoaringishEntry::BITMAP_BITS);
+    /// Both lists come from the same part, so they share the storage width (positions per group).
+    chassert(lhs.bitmap_bits == rhs.bitmap_bits);
+    const UInt32 bitmap_bits = lhs.bitmap_bits;
+    chassert(shift < bitmap_bits);
 
     /// Collect matches as (key, bitmap); the intersection is small relative to the inputs.
     /// key = (doc_id << 32) | group, computed inline from the SoA lanes.
@@ -43,7 +47,7 @@ PositionList TextIndexPhraseSearch::intersect(const PositionList & lhs, const Po
 
             /// Phase 2: boundary crossing. High bits of LHS bitmap overflow into group+1.
             /// Skip when group is at max to avoid crossing into a different document.
-            UInt32 overflow_positions_bitmap = lhs.bitmap[lhs_idx] >> (RoaringishEntry::BITMAP_BITS - shift);
+            UInt32 overflow_positions_bitmap = lhs.bitmap[lhs_idx] >> (bitmap_bits - shift);
             if (overflow_positions_bitmap && lhs.group[lhs_idx] < std::numeric_limits<UInt32>::max())
             {
                 UInt64 boundary_key = lhs_key + 1; /// Same doc_id, group+1.
@@ -66,7 +70,7 @@ PositionList TextIndexPhraseSearch::intersect(const PositionList & lhs, const Po
         else if (lhs_key < rhs_key)
         {
             /// Phase 2 for non-matching LHS: check if LHS overflows into RHS's group.
-            UInt32 overflow_positions_bitmap = lhs.bitmap[lhs_idx] >> (RoaringishEntry::BITMAP_BITS - shift);
+            UInt32 overflow_positions_bitmap = lhs.bitmap[lhs_idx] >> (bitmap_bits - shift);
             if (overflow_positions_bitmap && lhs.group[lhs_idx] < std::numeric_limits<UInt32>::max())
             {
                 UInt64 boundary_key = lhs_key + 1;

--- a/src/Storages/MergeTree/TextIndexPositionCodec.cpp
+++ b/src/Storages/MergeTree/TextIndexPositionCodec.cpp
@@ -261,4 +261,36 @@ void TextIndexPositionCodec::decode(ReadBuffer & in, PositionList & pl, Encoding
         decodeRawSoA(in, pl, position_cardinality, payload_scratch);
 }
 
+std::vector<RoaringishEntry> TextIndexPositionCodec::narrowTo16(std::span<const RoaringishEntry> entries32)
+{
+    std::vector<RoaringishEntry> out;
+    out.reserve(entries32.size());
+    for (const auto & e : entries32)
+    {
+        const UInt32 lo = e.bitmap & 0xFFFFu;
+        const UInt32 hi = e.bitmap >> 16;
+        if (lo)
+            out.push_back(RoaringishEntry{e.doc_id, e.group * 2, lo});
+        if (hi)
+            out.push_back(RoaringishEntry{e.doc_id, e.group * 2 + 1, hi});
+    }
+    return out; // sorted: (doc, 2g) precedes (doc, 2g+1), and g was sorted
+}
+
+std::vector<RoaringishEntry> TextIndexPositionCodec::widenTo32(std::span<const RoaringishEntry> entries16)
+{
+    std::vector<RoaringishEntry> out;
+    out.reserve(entries16.size());
+    for (const auto & e : entries16)
+    {
+        const UInt32 g32 = e.group >> 1;
+        const UInt32 bm32 = (e.group & 1u) ? (e.bitmap << 16) : (e.bitmap & 0xFFFFu);
+        if (!out.empty() && out.back().doc_id == e.doc_id && out.back().group == g32)
+            out.back().bitmap |= bm32;
+        else
+            out.push_back(RoaringishEntry{e.doc_id, g32, bm32});
+    }
+    return out;
+}
+
 }

--- a/src/Storages/MergeTree/TextIndexPositionCodec.h
+++ b/src/Storages/MergeTree/TextIndexPositionCodec.h
@@ -62,6 +62,19 @@ public:
     /// `payload_scratch`, reused across calls). For Raw it de-interleaves the stored
     /// entries into the three arrays. See the other overload for `position_cardinality`.
     static void decode(ReadBuffer & in, PositionList & pl, Encoding encoding, UInt64 position_cardinality, PaddedPODArray<char> & payload_scratch);
+
+    /// Bucket widths (positions per group). 32 is the canonical build/merge form (96-bit entry);
+    /// 16 (64-bit entry) is used on disk for parts whose positions all fit under ~1M, halving the
+    /// bitmap lane. Entries convert losslessly between widths (a bitmap split/merge).
+    static constexpr UInt32 WIDTH_32 = 32;
+    static constexpr UInt32 WIDTH_16 = 16;
+    /// Largest group32 for which every position still fits a W=16 entry (group16 <= 65535).
+    static constexpr UInt32 MAX_GROUP32_FOR_WIDTH_16 = 32767;
+
+    /// W=32 -> W=16: split each 32-bit bitmap into the low/high 16-bit halves (groups 2g, 2g+1).
+    static std::vector<RoaringishEntry> narrowTo16(std::span<const RoaringishEntry> entries32);
+    /// W=16 -> W=32: merge groups (2k, 2k+1) back into group k with a 32-bit bitmap.
+    static std::vector<RoaringishEntry> widenTo32(std::span<const RoaringishEntry> entries16);
 };
 
 }

--- a/src/Storages/MergeTree/TextIndexPositionData.h
+++ b/src/Storages/MergeTree/TextIndexPositionData.h
@@ -135,6 +135,10 @@ struct PositionList
     PaddedPODArray<UInt32> doc;
     PaddedPODArray<UInt32> group;
     PaddedPODArray<UInt32> bitmap;
+    /// Bucket width (positions per group) the lanes are encoded at: 32 (96-bit entry) or 16 (64-bit
+    /// entry). group = pos / bitmap_bits, and bitmap holds bitmap_bits valid bits. The phrase matcher
+    /// uses this instead of a hardcoded 32 so a part stored at W=16 intersects correctly.
+    UInt32 bitmap_bits = RoaringishEntry::BITMAP_BITS;
 
     size_t size() const { return doc.size(); }
     bool empty() const { return doc.empty(); }

--- a/src/Storages/MergeTree/TextIndexUtils.cpp
+++ b/src/Storages/MergeTree/TextIndexUtils.cpp
@@ -273,6 +273,7 @@ MergeTextIndexesTask::MergeTextIndexesTask(
     /// Resolve each source part's codecs (postings + positions) from its own header.
     source_postings_serializations.reserve(segments.size());
     source_positions_codecs.reserve(segments.size());
+    source_positions_widths.reserve(segments.size());
 
     for (size_t i = 0; i < segments.size(); ++i)
     {
@@ -283,7 +284,16 @@ MergeTextIndexesTask::MergeTextIndexesTask(
         source_postings_serializations.emplace_back(
             PostingListCodecFactory::createPostingListCodec(header.codec_type), header.version);
         source_positions_codecs.emplace_back(static_cast<TextIndexPositionCodec::Encoding>(header.positions_codec));
+        source_positions_widths.emplace_back(header.positions_width);
     }
+
+    /// The merged part stores at W=16 only if it is pfor (only WithPositionsCodec parts persist the
+    /// width byte) and every source did (positions carry over unchanged); otherwise W=32.
+    if (TextIndexPositionCodec::parseEncoding(params.positions_codec) == TextIndexPositionCodec::Encoding::Pfor
+        && !source_positions_widths.empty()
+        && std::all_of(source_positions_widths.begin(), source_positions_widths.end(),
+                       [](UInt8 w) { return w == TextIndexPositionCodec::WIDTH_16; }))
+        output_positions_width = TextIndexPositionCodec::WIDTH_16;
 }
 
 MergeTextIndexesTask::~MergeTextIndexesTask() noexcept
@@ -392,12 +402,21 @@ void MergeTextIndexesTask::flushPostingList()
         }
         output_positions.resize(out + 1);
 
+        /// Narrow to the merged part's storage width (W=16 when all sources were W=16).
+        std::vector<RoaringishEntry> narrowed;
+        std::span<const RoaringishEntry> to_encode{output_positions.data(), output_positions.size()};
+        if (output_positions_width == TextIndexPositionCodec::WIDTH_16)
+        {
+            narrowed = TextIndexPositionCodec::narrowTo16(to_encode);
+            to_encode = narrowed;
+        }
+
         token_info.header |= PostingsSerialization::Flags::HasPositions;
         token_info.position_offset = positions_stream->plain_hashing.count();
-        token_info.position_cardinality = static_cast<UInt32>(output_positions.size());
+        token_info.position_cardinality = static_cast<UInt32>(to_encode.size());
 
         TextIndexPositionCodec::encode(
-            output_positions, positions_stream->plain_hashing,
+            to_encode, positions_stream->plain_hashing,
             TextIndexPositionCodec::parseEncoding(params.positions_codec));
     }
 
@@ -526,6 +545,14 @@ bool MergeTextIndexesTask::executeStep()
                     token_info.position_cardinality,
                     position_decode_scratch);
 
+                /// A source stored at W=16 must be widened to the canonical W=32 before merging.
+                if (source_positions_widths[current->order] == TextIndexPositionCodec::WIDTH_16)
+                {
+                    auto widened = TextIndexPositionCodec::widenTo32({position_entries.data(), position_entries.size()});
+                    position_entries.resize(widened.size());
+                    std::copy(widened.begin(), widened.end(), position_entries.begin());
+                }
+
                 /// Adjust doc_ids if merging parts with offset remapping.
                 if (merged_part_offsets)
                 {
@@ -578,7 +605,7 @@ void MergeTextIndexesTask::finalize()
                                                                        : TextIndexHeader::Version::WithPositions);
     TextIndexSerialization::serializeHeader(
         sparse_index, postings_serialization.getPostingListCodec()->getType(), serialization_version, params.positions,
-        static_cast<UInt8>(positions_encoding), index_stream->compressed_hashing);
+        static_cast<UInt8>(positions_encoding), output_positions_width, index_stream->compressed_hashing);
 
     for (auto & stream : output_streams_holders)
         stream->finalize();

--- a/src/Storages/MergeTree/TextIndexUtils.h
+++ b/src/Storages/MergeTree/TextIndexUtils.h
@@ -149,6 +149,12 @@ private:
     std::vector<PostingsSerialization> source_postings_serializations;
     /// Per-source positions codec, read from that source part's own header (decode with the format actually written).
     std::vector<TextIndexPositionCodec::Encoding> source_positions_codecs;
+    /// Per-source roaringish storage width (32 or 16), read from that source part's header; decoded
+    /// entries are widened to the canonical W=32 before merging.
+    std::vector<UInt8> source_positions_widths;
+    /// Storage width for the merged part: W=16 iff every source was W=16 (positions are preserved
+    /// across a merge, so their max position — hence the width — carries over), else W=32.
+    UInt8 output_positions_width = 32;
 
     bool is_initialized = false;
 };

--- a/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
+++ b/src/Storages/MergeTree/tests/gtest_posting_list_cursor.cpp
@@ -3622,7 +3622,7 @@ TEST(PostingListCursorTest, TextIndexHeaderPersistsCodecType)
     DictionarySparseIndex sparse_index(tokens->getPtr(), offsets->getPtr());
 
     WriteBufferFromOwnString out;
-    TextIndexSerialization::serializeHeader(sparse_index, IPostingListCodec::Type::Bitpacking, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec), /*has_positions=*/ false, /*positions_codec=*/ 0, out);
+    TextIndexSerialization::serializeHeader(sparse_index, IPostingListCodec::Type::Bitpacking, static_cast<MergeTreeIndexVersion>(TextIndexHeader::Version::WithCodec), /*has_positions=*/ false, /*positions_codec=*/ 0, /*positions_width=*/ 32, out);
 
     ReadBufferFromString in(out.str());
     auto sparse_index_data = TextIndexSerialization::deserializeHeader(in);


### PR DESCRIPTION
Store each part's roaringish position entries at 64-bit (W=16) instead of 96-bit (W=32) when the max token position fits. The in-memory representation stays canonical W=32; entries are narrowed at encode and widened at decode/merge, so the query path is width-agnostic apart from a per-list width tag.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reduce positions disk footprint by choosing a fitting bit size for Roarish entries adaptively.
