### PR TITLE
Native Arrow IPC reader: reject absent FlatBuffers union value

### DIFF
--- a/src/Processors/Formats/Impl/ArrowIPC/MessageReader.cpp
+++ b/src/Processors/Formats/Impl/ArrowIPC/MessageReader.cpp
@@ -87,6 +87,16 @@ bool MessageReader::readNextMessage(Message & out, Int64 expected_metadata_lengt
         throw Exception(ErrorCodes::INCORRECT_DATA, "Corrupted Arrow IPC message metadata");
 
     out.header = flatbuf::GetMessage(metadata_storage.data());
+
+    /// FlatBuffers verification only proves that a union value, *if present*, is a well-formed table; the
+    /// `Message.header` union is not `(required)`, so `VerifyMessageBuffer` accepts a message whose
+    /// `header_type` discriminant is set while the header value offset is absent (`Verifier::VerifyTable`
+    /// returns true for a null table). Every reader checks `header_type()` and then dereferences the typed
+    /// `header_as_X()` accessor, which returns null in exactly this case. Reject it here so a single guard
+    /// covers all those call sites instead of each one dereferencing null.
+    if (out.header->header_type() != flatbuf::MessageHeader_NONE && out.header->header() == nullptr)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Arrow IPC message header type is set but its value is missing");
+
     out.body_length = out.header->bodyLength();
     if (out.body_length < 0)
         throw Exception(ErrorCodes::INCORRECT_DATA, "Negative Arrow IPC message body length {}", out.body_length);

--- a/src/Processors/Formats/Impl/ArrowIPC/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/ArrowIPC/SchemaConverter.cpp
@@ -117,6 +117,14 @@ Enum validatedEnum(Enum value, Enum min_value, Enum max_value, const char * what
 
 ArrowType parseType(const flatbuf::Field & field)
 {
+    /// FlatBuffers verification only proves that a union value, *if present*, is a well-formed table; the
+    /// `Field.type` union is not `(required)`, so a schema whose `type_type` discriminant is set while the
+    /// type value offset is absent passes verification, and the typed `type_as_X()` accessors below return
+    /// null. Reject it here so a single guard covers all those call sites instead of each one dereferencing
+    /// null. A `Type_NONE` discriminant (no value) falls through to the `Unsupported` placeholder as before.
+    if (field.type_type() != flatbuf::Type_NONE && field.type() == nullptr)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Arrow IPC schema field type is set but its value is missing");
+
     ArrowType type;
     switch (field.type_type())
     {

--- a/tests/queries/0_stateless/04538_arrow_ipc_native_malformed_union.reference
+++ b/tests/queries/0_stateless/04538_arrow_ipc_native_malformed_union.reference
@@ -1,0 +1,2 @@
+header: rejected
+field: rejected

--- a/tests/queries/0_stateless/04538_arrow_ipc_native_malformed_union.sh
+++ b/tests/queries/0_stateless/04538_arrow_ipc_native_malformed_union.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: the native Arrow IPC reader is only built with the Arrow contrib.
+
+# The native Arrow IPC reader chooses a branch on a FlatBuffers union discriminant
+# (`Message.header_type`, `Field.type_type`) and then dereferences the matching typed
+# accessor. FlatBuffers verification accepts a buffer whose discriminant is set while the
+# union value offset is absent, so the accessor returns null. Dereferencing it used to
+# crash the server (a remotely triggerable SIGSEGV reachable at schema-inference time on
+# any `file()`/`url()`/`s3()` Arrow read). Both unions must now be rejected as INCORRECT_DATA.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Hand-build the malformed Arrow IPC streams with pure struct packing (no pyarrow dependency),
+# so the exact "discriminant set, value absent" wire shape is reproduced deterministically.
+python3 - "$WORK_DIR" <<'PY'
+import struct, sys, os
+work = sys.argv[1]
+
+def frame(meta):
+    # Modern encapsulated-message framing + end-of-stream marker.
+    return (struct.pack('<i', -1) + struct.pack('<i', len(meta)) + meta
+            + struct.pack('<i', -1) + struct.pack('<i', 0))
+
+# 1) Message whose header_type = Schema(1) but the header union value offset is omitted.
+b = bytearray(32)
+struct.pack_into('<I', b, 0, 20)                                  # root -> Message table @20
+for o, v in [(4, 14), (6, 8), (8, 0), (10, 4), (12, 0), (14, 0), (16, 0)]:  # Message vtable, header slot(12)=0
+    struct.pack_into('<H', b, o, v)
+struct.pack_into('<i', b, 20, 16); b[24] = 1                      # soffset; header_type=Schema, header ABSENT
+open(os.path.join(work, 'header.arrows'), 'wb').write(frame(bytes(b)))
+
+# 2) Valid Schema with one Field whose type_type = Int(2) but the type union value offset is omitted.
+b = bytearray(88)
+def p16(o, v): struct.pack_into('<H', b, o, v)
+def p32(o, v): struct.pack_into('<I', b, o, v)
+def pi32(o, v): struct.pack_into('<i', b, o, v)
+p32(0, 20)                                                        # root -> Message table @20
+p16(4, 14); p16(6, 12); p16(8, 0); p16(10, 4); p16(12, 8); p16(14, 0); p16(16, 0)  # Message vtable
+pi32(20, 16); b[24] = 1; p32(28, 16)                             # Message table: header_type=Schema, header ->Schema
+p16(32, 12); p16(34, 8); p16(36, 0); p16(38, 4); p16(40, 0); p16(42, 0)            # Schema vtable
+pi32(44, 12); p32(48, 4)                                          # Schema table: fields ->vector
+p32(52, 1); p32(56, 24)                                           # fields vector: 1 element ->Field @80
+p16(60, 18); p16(62, 8); p16(64, 0); p16(66, 0); p16(68, 4); p16(70, 0); p16(72, 0); p16(74, 0); p16(76, 0)  # Field vtable, type slot(70)=0
+pi32(80, 20); b[84] = 2                                           # Field table: type_type=Int, type ABSENT
+open(os.path.join(work, 'field.arrows'), 'wb').write(frame(bytes(b)))
+PY
+
+# Schema inference must reject both as corrupt data instead of crashing.
+for name in header field; do
+    ${CLICKHOUSE_LOCAL} -q "DESC file('$WORK_DIR/$name.arrows', 'ArrowStream')" 2>&1 \
+        | grep -qF "type is set but its value is missing" && echo "$name: rejected" || echo "$name: NOT REJECTED"
+done


### PR DESCRIPTION
The native Arrow IPC reader selects a branch on a FlatBuffers union discriminant (`Message.header_type`, `Field.type_type`) and then dereferences the matching typed accessor (`header_as_X`, `type_as_X`). FlatBuffers verification only proves that a union value, if present, is a well-formed table; these unions are not `(required)`, so `VerifyMessageBuffer` accepts a buffer whose discriminant is set while the value offset is absent (`Verifier::VerifyTable` returns `true` for a null table). The typed accessor then returns null and the reader dereferenced it: a remotely triggerable `SIGSEGV` reachable at schema-inference time on any `file()`/`url()`/`s3()` Arrow read, with default settings (the native reader is the default).

The fix guards both unions once at their choke points, `MessageReader::readNextMessage` and `parseType`, rejecting a missing value as `INCORRECT_DATA`. This covers all 18 typed-accessor dereferences, since every caller checks the discriminant first. Reproduced with two coredumps (null deref in `parseSchema` and in `parseType`) and verified fixed on an ASan/UBSan build; the added regression test feeds both malformed streams and asserts they are rejected. The full Arrow stateless suite passes.

The native reader is not in a released version, so this is not for changelog.

Related: https://github.com/ClickHouse/ClickHouse/pull/106522

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog: hardening for the unreleased native Arrow IPC reader.
