### PR TITLE
Add performance tests for wide integer `<=` and `>=`

### DIFF
--- a/tests/performance/wide_integer_comparison.xml
+++ b/tests/performance/wide_integer_comparison.xml
@@ -39,6 +39,7 @@
     <query>SELECT count() FROM cmp128 WHERE mixed_u1 &lt;= mixed_u2</query>
     <query>SELECT count() FROM cmp128 WHERE u1 &gt;= u2</query>
     <query>SELECT count() FROM cmp128 WHERE i1 &gt;= i2</query>
+    <query>SELECT count() FROM cmp128 WHERE mixed_u1 &gt;= mixed_u2</query>
     <query>SELECT count() FROM cmp128 WHERE u1 &lt; bitShiftLeft(toUInt128(1), 127)</query>
     <query>SELECT i1 FROM cmp128 ORDER BY i1 LIMIT 10</query>
     <query>SELECT u1 FROM cmp128 ORDER BY u1 DESC LIMIT 10</query>

--- a/tests/performance/wide_integer_comparison.xml
+++ b/tests/performance/wide_integer_comparison.xml
@@ -34,6 +34,10 @@
     <query>SELECT count() FROM cmp128 WHERE small_u1 &lt; small_u2</query>
     <query>SELECT count() FROM cmp128 WHERE mixed_u1 &lt; mixed_u2</query>
     <query>SELECT count() FROM cmp128 WHERE u1 &gt; u2</query>
+    <query>SELECT count() FROM cmp128 WHERE u1 &lt;= u2</query>
+    <query>SELECT count() FROM cmp128 WHERE i1 &lt;= i2</query>
+    <query>SELECT count() FROM cmp128 WHERE mixed_u1 &lt;= mixed_u2</query>
+    <query>SELECT count() FROM cmp128 WHERE u1 &gt;= u2</query>
     <query>SELECT count() FROM cmp128 WHERE i1 &gt;= i2</query>
     <query>SELECT count() FROM cmp128 WHERE u1 &lt; bitShiftLeft(toUInt128(1), 127)</query>
     <query>SELECT i1 FROM cmp128 ORDER BY i1 LIMIT 10</query>


### PR DESCRIPTION
Adds performance test coverage for the wide integer `<=` and `>=` operators, as asked in review on #109474: https://github.com/ClickHouse/ClickHouse/pull/109474#discussion_r3578338556

`<=` and `>=` do not share a kernel with `<` and `>`. `operator<=` is `operator_less` combined with `operator_eq`, and `operator>=` is `operator_greater` combined with `operator_eq`, so they exercise code the existing queries do not cover. The test previously covered `<` on four data shapes, `>` and `>=` on one shape each, and had no coverage of `<=` at all.

Added: `<=` on the fully random unsigned, random signed, and shared-high-limb shapes, and `>=` on the fully random unsigned shape. The shared-high-limb shape is the interesting one, since half of the rows share the high 64 bits and so reach the equality comparison.

All queries were validated locally against a release build.

**Incidental finding while benchmarking.** Measuring the columnar kernel shape (`c[i] = a[i] OP b[i]`) on the real `wide::integer` types with clang 21 at `x86-64-v3`, `<=` and `>=` are already consistently *faster* than `<` and `>` — so there is no headroom in `<=`/`>=` themselves:

| type | `<` | `<=` | `>` | `>=` |
|---|---|---|---|---|
| `UInt128` | 28.5 | 37.2 | 28.6 | 37.1 |
| `Int128` | 29.4 | 38.6 | 29.4 | 38.5 |
| `UInt256` | 24.6 | 40.8 | 24.5 | 43.6 |
| `Int256` | 24.7 | 42.0 | 24.6 | 42.0 |

(GB/s, best-of-40; the ranking is stable when the measurement order is reversed, so it is not order or thermal bias.)

The cause is codegen, not work done: the `less`/`equal` accumulator chain in `operator_less` vectorizes badly, narrowing masks (`vpackssdw`), round-tripping through GPRs (`vmovmskps` / `vpinsrd`) and spilling to the stack, while the `operator_less || operator_eq` form stays in clean 64-bit lanes with `vpand`/`vpor`. Rewriting `<` as `!(operator_greater || operator_eq)` reproduces the fast codegen and is 1.4-2x faster on all four types, with bit-identical results.

That is left for a separate PR rather than bundled here: it is a change to `wide_integer_impl.h` rather than to tests, and it needs a CI performance run to validate, since this machine is Zen 2 and cannot test the `x86-64-v4` kernel clones — which is exactly where an earlier revision of #109474 regressed.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Related: https://github.com/ClickHouse/ClickHouse/pull/109474


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.928` (included in `26.7` and later)
<!-- ch-version-info:end -->