### PR TITLE
Fix parser treating COMMENT as implicit alias in CREATE MATERIALIZED VIEW

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1731,6 +1731,7 @@ const char * ParserAlias::restricted_keywords[] =
     "ASOF",
     "BETWEEN",
     "CROSS",
+    "COMMENT",
     "PASTE",
     "FINAL",
     "FORMAT",

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1771,8 +1771,6 @@ const char * ParserAlias::restricted_keywords[] =
     nullptr
 };
 
-thread_local bool ParserAlias::comment_as_alias_restricted = false;
-
 bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ParserKeyword s_as(Keyword::AS);
@@ -1800,11 +1798,23 @@ bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (0 == strcasecmp(name.data(), *keyword))
                 return false;
 
-        /// COMMENT is only restricted as an implicit alias in the scoped context
-        /// of parsing a materialized view AS SELECT body (see ParserCreateQuery),
-        /// so that ordinary SELECT/alias parsing elsewhere is unaffected.
-        if (comment_as_alias_restricted && 0 == strcasecmp(name.data(), "COMMENT"))
-            return false;
+        /// Special case: an implicit alias literally named COMMENT is only ambiguous
+        /// when it is immediately followed by a string literal at the very end of the
+        /// query (e.g. "... FROM t COMMENT 'x'"), which is the trailing view/table
+        /// comment syntax. In that specific situation, reject it as an alias so the
+        /// caller backtracks and the caller-level comment parser can consume it
+        /// instead. Everywhere else (e.g. "SELECT 1 comment", "FROM t comment,"),
+        /// COMMENT remains a perfectly valid implicit alias.
+        if (0 == strcasecmp(name.data(), "COMMENT"))
+        {
+            Pos peek = pos;
+            if (peek->type == TokenType::StringLiteral)
+            {
+                ++peek;
+                if (peek->type == TokenType::EndOfStream || peek->type == TokenType::Semicolon)
+                    return false;
+            }
+        }
     }
 
     return true;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1808,9 +1808,10 @@ bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         if (0 == strcasecmp(name.data(), "COMMENT"))
         {
             Pos peek = pos;
-            if (peek->type == TokenType::StringLiteral)
+            Expected peek_expected;
+            ASTPtr comment_literal;
+            if (ParserStringLiteral().parse(peek, comment_literal, peek_expected))
             {
-                ++peek;
                 if (peek->type == TokenType::EndOfStream || peek->type == TokenType::Semicolon)
                     return false;
             }

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -1731,7 +1731,6 @@ const char * ParserAlias::restricted_keywords[] =
     "ASOF",
     "BETWEEN",
     "CROSS",
-    "COMMENT",
     "PASTE",
     "FINAL",
     "FORMAT",
@@ -1772,6 +1771,8 @@ const char * ParserAlias::restricted_keywords[] =
     nullptr
 };
 
+thread_local bool ParserAlias::comment_as_alias_restricted = false;
+
 bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 {
     ParserKeyword s_as(Keyword::AS);
@@ -1798,6 +1799,12 @@ bool ParserAlias::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         for (const char ** keyword = restricted_keywords; *keyword != nullptr; ++keyword)
             if (0 == strcasecmp(name.data(), *keyword))
                 return false;
+
+        /// COMMENT is only restricted as an implicit alias in the scoped context
+        /// of parsing a materialized view AS SELECT body (see ParserCreateQuery),
+        /// so that ordinary SELECT/alias parsing elsewhere is unaffected.
+        if (comment_as_alias_restricted && 0 == strcasecmp(name.data(), "COMMENT"))
+            return false;
     }
 
     return true;

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -410,6 +410,12 @@ public:
     {
     }
 
+    /// Scoped flag: when true, COMMENT is additionally treated as a restricted
+    /// (non-implicit-alias) keyword. Set/reset by ParserCreateQuery around
+    /// parsing of a materialized view's AS SELECT body, so that plain
+    /// SELECT/alias parsing elsewhere in the codebase is unaffected.
+    static thread_local bool comment_as_alias_restricted;
+
 private:
     static const char * restricted_keywords[];
 

--- a/src/Parsers/ExpressionElementParsers.h
+++ b/src/Parsers/ExpressionElementParsers.h
@@ -410,12 +410,6 @@ public:
     {
     }
 
-    /// Scoped flag: when true, COMMENT is additionally treated as a restricted
-    /// (non-implicit-alias) keyword. Set/reset by ParserCreateQuery around
-    /// parsing of a materialized view's AS SELECT body, so that plain
-    /// SELECT/alias parsing elsewhere in the codebase is unaffected.
-    static thread_local bool comment_as_alias_restricted;
-
 private:
     static const char * restricted_keywords[];
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1,4 +1,3 @@
-#include <base/scope_guard.h>
 #include <IO/ReadHelpers.h>
 #include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/ASTConstraintDeclaration.h>
@@ -1761,8 +1760,6 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (!s_as.ignore(pos, expected))
         return false;
 
-    ParserAlias::comment_as_alias_restricted = true;
-    SCOPE_EXIT({ ParserAlias::comment_as_alias_restricted = false; });
     if (!select_p.parse(pos, select, expected))
         return false;
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1,3 +1,4 @@
+#include <base/scope_guard.h>
 #include <IO/ReadHelpers.h>
 #include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/ASTConstraintDeclaration.h>
@@ -1760,6 +1761,8 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (!s_as.ignore(pos, expected))
         return false;
 
+    ParserAlias::comment_as_alias_restricted = true;
+    SCOPE_EXIT({ ParserAlias::comment_as_alias_restricted = false; });
     if (!select_p.parse(pos, select, expected))
         return false;
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1763,8 +1763,13 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     if (!select_p.parse(pos, select, expected))
         return false;
 
+    auto select_comment = parseComment(pos, expected);
+    if (comment && select_comment)
+        throw Exception(
+            ErrorCodes::SYNTAX_ERROR,
+            "Comment for a view cannot be specified both before and after AS SELECT; please use only one");
     if (!comment)
-        comment = parseComment(pos, expected);
+        comment = select_comment;
 
     auto query = make_intrusive<ASTCreateQuery>();
     node = query;

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1278,8 +1278,13 @@ bool ParserCreateWindowViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     if (!select_p.parse(pos, select, expected))
         return false;
 
+    auto select_comment = parseComment(pos, expected);
+    if (comment && select_comment)
+        throw Exception(
+            ErrorCodes::SYNTAX_ERROR,
+            "Comment for a view cannot be specified both before and after AS SELECT; please use only one");
     if (!comment)
-        comment = parseComment(pos, expected);
+        comment = select_comment;
 
     auto query = make_intrusive<ASTCreateQuery>();
     node = query;

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1008,13 +1008,13 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         }
     }
 
-    if (select)
+    if (select || as_table || as_table_function)
     {
         auto select_comment = parseComment(pos, expected);
         if (comment && select_comment)
             throw Exception(
                 ErrorCodes::SYNTAX_ERROR,
-                "Comment for a table cannot be specified both before and after AS SELECT; please use only one");
+                "Comment for a table cannot be specified both before and after AS; please use only one");
         if (!comment)
             comment = select_comment;
     }

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1008,7 +1008,17 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         }
     }
 
-    if (!comment)
+    if (select)
+    {
+        auto select_comment = parseComment(pos, expected);
+        if (comment && select_comment)
+            throw Exception(
+                ErrorCodes::SYNTAX_ERROR,
+                "Comment for a table cannot be specified both before and after AS SELECT; please use only one");
+        if (!comment)
+            comment = select_comment;
+    }
+    else if (!comment)
         comment = parseComment(pos, expected);
 
     /// `AS table` and `AS table_function` are formatted before the SQL SECURITY clause position,

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -5,3 +5,4 @@ view comment
 1
 1
 0
+single wv comment

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -7,3 +7,5 @@ view comment
 0
 single wv comment
 heredoc trailing comment
+single as-select comment
+plain table comment

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -6,3 +6,4 @@ view comment
 1
 0
 single wv comment
+heredoc trailing comment

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -1,5 +1,7 @@
 trailing comment test
 explicit alias comment
 1
+view comment
+1
 1
 0

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -1,0 +1,3 @@
+trailing comment test
+explicit alias comment
+1

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -9,3 +9,4 @@ single wv comment
 heredoc trailing comment
 single as-select comment
 plain table comment
+single as-table comment

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.reference
@@ -1,3 +1,5 @@
 trailing comment test
 explicit alias comment
 1
+1
+0

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -1,0 +1,28 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS src_04538;
+DROP TABLE IF EXISTS dst_04538;
+DROP TABLE IF EXISTS mv_04538;
+
+CREATE TABLE src_04538 (x UInt8) ENGINE = Memory;
+CREATE TABLE dst_04538 (x UInt8) ENGINE = Memory;
+
+-- Bug: previously failed to parse because COMMENT was consumed as an implicit alias for src_04538
+CREATE MATERIALIZED VIEW mv_04538 TO dst_04538 AS SELECT x FROM src_04538 COMMENT 'trailing comment test';
+
+SELECT comment FROM system.tables WHERE name = 'mv_04538' AND database = currentDatabase();
+
+DROP TABLE mv_04538;
+
+-- Explicit alias form should still work
+CREATE MATERIALIZED VIEW mv_04538 TO dst_04538 AS SELECT x FROM src_04538 AS s COMMENT 'explicit alias comment';
+
+SELECT comment FROM system.tables WHERE name = 'mv_04538' AND database = currentDatabase();
+
+DROP TABLE mv_04538;
+
+-- Explicit AS alias with the word "comment" should still work (not affected by restricted_keywords fix)
+SELECT 1 AS comment;
+
+DROP TABLE src_04538;
+DROP TABLE dst_04538;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -73,3 +73,16 @@ SELECT comment FROM system.tables WHERE name = 'wv_04538_single' AND database = 
 
 DROP TABLE wv_04538_single;
 DROP TABLE src_wv_04538;
+
+-- Regression test: a heredoc-style comment literal ($tag$...$tag$) must also be
+-- recognized by the trailing-comment lookahead, not just ordinary quoted string
+-- literals, since parseComment() accepts both forms (bot-flagged scenario).
+DROP TABLE IF EXISTS heredoc_src_04538;
+DROP TABLE IF EXISTS heredoc_mv_04538;
+CREATE TABLE heredoc_src_04538 (x UInt8) ENGINE = Memory;
+CREATE MATERIALIZED VIEW heredoc_mv_04538 ENGINE = MergeTree ORDER BY tuple() AS SELECT x FROM heredoc_src_04538 COMMENT $heredoc$heredoc trailing comment$heredoc$;
+
+SELECT comment FROM system.tables WHERE name = 'heredoc_mv_04538' AND database = currentDatabase();
+
+DROP TABLE heredoc_mv_04538;
+DROP TABLE heredoc_src_04538;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -3,6 +3,7 @@
 DROP TABLE IF EXISTS src_04538;
 DROP TABLE IF EXISTS dst_04538;
 DROP TABLE IF EXISTS mv_04538;
+DROP TABLE IF EXISTS mv_04538_dup;
 
 CREATE TABLE src_04538 (x UInt8) ENGINE = Memory;
 CREATE TABLE dst_04538 (x UInt8) ENGINE = Memory;
@@ -20,6 +21,9 @@ CREATE MATERIALIZED VIEW mv_04538 TO dst_04538 AS SELECT x FROM src_04538 AS s C
 SELECT comment FROM system.tables WHERE name = 'mv_04538' AND database = currentDatabase();
 
 DROP TABLE mv_04538;
+
+-- Specifying a comment in both the pre-AS and post-SELECT position should throw a clear error
+CREATE MATERIALIZED VIEW mv_04538_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_04538 COMMENT 'post-select comment'; -- { serverError SYNTAX_ERROR }
 
 -- Explicit AS alias with the word "comment" should still work (not affected by restricted_keywords fix)
 SELECT 1 AS comment;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -53,3 +53,23 @@ CREATE MATERIALIZED VIEW mv_04538_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as 
 -- for COMMENT is scoped only to that context.
 SELECT 1 comment;
 SELECT number FROM numbers(1) comment;
+
+-- Regression test: same duplicate-comment check must also apply to
+-- ParserCreateWindowViewQuery (window views use a separate parser from
+-- regular views), giving a clear SYNTAX_ERROR instead of a generic one
+-- (bot-flagged scenario).
+SET allow_experimental_window_view = 1;
+SET allow_experimental_analyzer = 0;
+
+DROP TABLE IF EXISTS src_wv_04538;
+CREATE TABLE src_wv_04538 (x UInt8, ts DateTime) ENGINE = Memory;
+
+CREATE WINDOW VIEW wv_04538_dup (x UInt8, w_start DateTime) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x, tumbleStart(w_id) AS w_start FROM src_wv_04538 GROUP BY x, tumble(ts, toIntervalSecond(5)) AS w_id COMMENT 'post-select comment'; -- { clientError SYNTAX_ERROR }
+
+-- Single comment (before AS SELECT) on a window view should still work.
+CREATE WINDOW VIEW wv_04538_single (x UInt8, w_start DateTime) ENGINE = Memory COMMENT 'single wv comment' AS SELECT x, tumbleStart(w_id) AS w_start FROM src_wv_04538 GROUP BY x, tumble(ts, toIntervalSecond(5)) AS w_id;
+
+SELECT comment FROM system.tables WHERE name = 'wv_04538_single' AND database = currentDatabase();
+
+DROP TABLE wv_04538_single;
+DROP TABLE src_wv_04538;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -29,3 +29,8 @@ DROP TABLE src_04538;
 DROP TABLE dst_04538;
 
 CREATE MATERIALIZED VIEW mv_04538_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_04538 COMMENT 'post-select comment'; -- { clientError SYNTAX_ERROR }
+-- Regression test: implicit alias "comment" (without AS) must still work outside
+-- of a materialized view's AS SELECT body, since the restricted-keyword check
+-- for COMMENT is scoped only to that context.
+SELECT 1 comment;
+SELECT number FROM numbers(1) comment;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -22,11 +22,10 @@ SELECT comment FROM system.tables WHERE name = 'mv_04538' AND database = current
 
 DROP TABLE mv_04538;
 
--- Specifying a comment in both the pre-AS and post-SELECT position should throw a clear error
-CREATE MATERIALIZED VIEW mv_04538_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_04538 COMMENT 'post-select comment'; -- { serverError SYNTAX_ERROR }
-
 -- Explicit AS alias with the word "comment" should still work (not affected by restricted_keywords fix)
 SELECT 1 AS comment;
 
 DROP TABLE src_04538;
 DROP TABLE dst_04538;
+
+CREATE MATERIALIZED VIEW mv_04538_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_04538 COMMENT 'post-select comment'; -- { clientError SYNTAX_ERROR }

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -86,3 +86,27 @@ SELECT comment FROM system.tables WHERE name = 'heredoc_mv_04538' AND database =
 
 DROP TABLE heredoc_mv_04538;
 DROP TABLE heredoc_src_04538;
+
+-- Regression test: same duplicate-comment check must also apply to the
+-- CREATE TABLE ... AS SELECT form (ParserCreateTableQuery), since the
+-- COMMENT-as-implicit-alias lookahead fix is global to ParserAlias and
+-- also affects table AS SELECT parsing (bot-flagged scenario).
+DROP TABLE IF EXISTS src_tbl_04538;
+CREATE TABLE src_tbl_04538 (x UInt8) ENGINE = Memory;
+
+CREATE TABLE t_dup_04538 ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_tbl_04538 COMMENT 'post-select comment'; -- { clientError SYNTAX_ERROR }
+
+-- Single comment (before AS SELECT) on a plain table should still work.
+CREATE TABLE t_single_04538 ENGINE = Memory COMMENT 'single as-select comment' AS SELECT x FROM src_tbl_04538;
+
+SELECT comment FROM system.tables WHERE name = 't_single_04538' AND database = currentDatabase();
+
+DROP TABLE t_single_04538;
+
+-- A plain CREATE TABLE (no AS SELECT at all) should be unaffected.
+CREATE TABLE t_plain_04538 (x UInt8) ENGINE = Memory COMMENT 'plain table comment';
+
+SELECT comment FROM system.tables WHERE name = 't_plain_04538' AND database = currentDatabase();
+
+DROP TABLE t_plain_04538;
+DROP TABLE src_tbl_04538;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -110,3 +110,21 @@ SELECT comment FROM system.tables WHERE name = 't_plain_04538' AND database = cu
 
 DROP TABLE t_plain_04538;
 DROP TABLE src_tbl_04538;
+
+-- Regression test: the same duplicate-comment check must also cover the
+-- AS table and AS table_function() forms of CREATE TABLE, not just AS SELECT,
+-- since CREATE TABLE t COMMENT 'pre' AS base COMMENT 'post' was already
+-- falling back to the old generic trailing-token error (bot-flagged scenario).
+DROP TABLE IF EXISTS base_04538;
+CREATE TABLE base_04538 (a Int32) ENGINE = TinyLog COMMENT 'original comment';
+
+CREATE TABLE t_astable_dup_04538 COMMENT 'pre comment' AS base_04538 COMMENT 'post comment'; -- { clientError SYNTAX_ERROR }
+CREATE TABLE t_astf_dup_04538 COMMENT 'pre comment' AS numbers(5) COMMENT 'post comment'; -- { clientError SYNTAX_ERROR }
+
+-- Single comment (after AS, no pre-AS comment) on the AS table form should still work.
+CREATE TABLE t_astable_single_04538 AS base_04538 COMMENT 'single as-table comment';
+
+SELECT comment FROM system.tables WHERE name = 't_astable_single_04538' AND database = currentDatabase();
+
+DROP TABLE t_astable_single_04538;
+DROP TABLE base_04538;

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias.sql
@@ -25,6 +25,25 @@ DROP TABLE mv_04538;
 -- Explicit AS alias with the word "comment" should still work (not affected by restricted_keywords fix)
 SELECT 1 AS comment;
 
+-- Regression test: comment specified before AS SELECT should not prevent
+-- an implicit alias named "comment" from being parsed correctly inside
+-- the SELECT body itself (bot-flagged scenario).
+CREATE VIEW v_04538 COMMENT 'view comment' AS SELECT 1 comment;
+
+SELECT comment FROM system.tables WHERE name = 'v_04538' AND database = currentDatabase();
+SELECT comment FROM v_04538;
+
+DROP TABLE v_04538;
+
+-- Regression test: implicit alias "comment" inside a materialized view AS SELECT
+-- body, when the view itself has no comment at all, should still work
+-- (bot-flagged scenario).
+CREATE MATERIALIZED VIEW mv_04538 TO dst_04538 AS SELECT x FROM src_04538 comment;
+
+SELECT x FROM dst_04538;
+
+DROP TABLE mv_04538;
+
 DROP TABLE src_04538;
 DROP TABLE dst_04538;
 

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
@@ -1,0 +1,2 @@
+Comment for a view cannot be specified both before and after AS SELECT; please use only one
+Comment for a view cannot be specified both before and after AS SELECT; please use only one

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
@@ -2,3 +2,4 @@ Comment for a view cannot be specified both before and after AS SELECT; please u
 Comment for a view cannot be specified both before and after AS SELECT; please use only one
 Comment for a table cannot be specified both before and after AS; please use only one
 Comment for a table cannot be specified both before and after AS; please use only one
+Comment for a table cannot be specified both before and after AS; please use only one

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
@@ -1,3 +1,4 @@
 Comment for a view cannot be specified both before and after AS SELECT; please use only one
 Comment for a view cannot be specified both before and after AS SELECT; please use only one
-Comment for a table cannot be specified both before and after AS SELECT; please use only one
+Comment for a table cannot be specified both before and after AS; please use only one
+Comment for a table cannot be specified both before and after AS; please use only one

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.reference
@@ -1,2 +1,3 @@
 Comment for a view cannot be specified both before and after AS SELECT; please use only one
 Comment for a view cannot be specified both before and after AS SELECT; please use only one
+Comment for a table cannot be specified both before and after AS SELECT; please use only one

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
@@ -35,3 +35,7 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS base_04538_sh;" 2>/dev/null
 $CLICKHOUSE_CLIENT --query="CREATE TABLE base_04538_sh (a Int32) ENGINE = TinyLog COMMENT 'original comment';"
 $CLICKHOUSE_CLIENT --query="CREATE TABLE t_astable_dup_04538_sh COMMENT 'pre comment' AS base_04538_sh COMMENT 'post comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS; please use only one'
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS base_04538_sh;"
+
+# Same check for the AS table_function() form (e.g. AS numbers(5)), since
+# CREATE TABLE already supported a trailing comment there before this PR.
+$CLICKHOUSE_CLIENT --query="CREATE TABLE t_astf_dup_04538_sh COMMENT 'pre comment' AS numbers(5) COMMENT 'post comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS; please use only one'

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
@@ -21,3 +21,10 @@ $CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analy
 $CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 --query="CREATE TABLE src_wv_04538_sh (x UInt8, ts DateTime) ENGINE = Memory;"
 $CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 --query="CREATE WINDOW VIEW wv_04538_sh_dup (x UInt8, w_start DateTime) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x, tumbleStart(w_id) AS w_start FROM src_wv_04538_sh GROUP BY x, tumble(ts, toIntervalSecond(5)) AS w_id COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a view cannot be specified both before and after AS SELECT; please use only one'
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_wv_04538_sh;"
+
+# Same check for the CREATE TABLE ... AS SELECT form (ParserCreateTableQuery),
+# since the COMMENT-as-implicit-alias lookahead fix is global to ParserAlias.
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_tbl_04538_sh;" 2>/dev/null
+$CLICKHOUSE_CLIENT --query="CREATE TABLE src_tbl_04538_sh (x UInt8) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE t_04538_sh_dup ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_tbl_04538_sh COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS SELECT; please use only one'
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_tbl_04538_sh;"

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
@@ -26,5 +26,12 @@ $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_wv_04538_sh;"
 # since the COMMENT-as-implicit-alias lookahead fix is global to ParserAlias.
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_tbl_04538_sh;" 2>/dev/null
 $CLICKHOUSE_CLIENT --query="CREATE TABLE src_tbl_04538_sh (x UInt8) ENGINE = Memory;"
-$CLICKHOUSE_CLIENT --query="CREATE TABLE t_04538_sh_dup ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_tbl_04538_sh COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS SELECT; please use only one'
+$CLICKHOUSE_CLIENT --query="CREATE TABLE t_04538_sh_dup ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_tbl_04538_sh COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS; please use only one'
 $CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_tbl_04538_sh;"
+
+# Same check for the AS table form (not AS SELECT), since CREATE TABLE
+# already supported a trailing comment there before this PR.
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS base_04538_sh;" 2>/dev/null
+$CLICKHOUSE_CLIENT --query="CREATE TABLE base_04538_sh (a Int32) ENGINE = TinyLog COMMENT 'original comment';"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE t_astable_dup_04538_sh COMMENT 'pre comment' AS base_04538_sh COMMENT 'post comment';" 2>&1 | grep -o 'Comment for a table cannot be specified both before and after AS; please use only one'
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS base_04538_sh;"

--- a/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
+++ b/tests/queries/0_stateless/04538_materialized_view_comment_implicit_alias_message.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Regression test: the duplicate-comment SYNTAX_ERROR for
+# CREATE MATERIALIZED VIEW ... COMMENT 'pre' AS SELECT ... COMMENT 'post'
+# must come from the dedicated duplicate-comment diagnostic, not merely from
+# the trailing COMMENT token being left unconsumed (both produce SYNTAX_ERROR,
+# so the error code alone does not distinguish them).
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_04538_sh; DROP TABLE IF EXISTS dst_04538_sh;" 2>/dev/null
+$CLICKHOUSE_CLIENT --query="CREATE TABLE src_04538_sh (x UInt8) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE dst_04538_sh (x UInt8) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query="CREATE MATERIALIZED VIEW mv_04538_sh_dup (x UInt8) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x FROM src_04538_sh COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a view cannot be specified both before and after AS SELECT; please use only one'
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_04538_sh; DROP TABLE IF EXISTS dst_04538_sh;"
+
+# Same check for ParserCreateWindowViewQuery.
+$CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 --query="DROP TABLE IF EXISTS src_wv_04538_sh;" 2>/dev/null
+$CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 --query="CREATE TABLE src_wv_04538_sh (x UInt8, ts DateTime) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --allow_experimental_window_view=1 --allow_experimental_analyzer=0 --query="CREATE WINDOW VIEW wv_04538_sh_dup (x UInt8, w_start DateTime) ENGINE = Memory COMMENT 'pre-as comment' AS SELECT x, tumbleStart(w_id) AS w_start FROM src_wv_04538_sh GROUP BY x, tumble(ts, toIntervalSecond(5)) AS w_id COMMENT 'post-select comment';" 2>&1 | grep -o 'Comment for a view cannot be specified both before and after AS SELECT; please use only one'
+$CLICKHOUSE_CLIENT --query="DROP TABLE IF EXISTS src_wv_04538_sh;"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110331

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fixed a parser bug where COMMENT was incorrectly consumed as an implicit alias when a SELECT query ended directly after a bare table identifier (e.g. `... FROM t COMMENT 'x'`), causing a misleading syntax error instead of the comment being applied to the view/table.