### PR TITLE
Strengthen QCC TopK test 04338: ProfileEvents usage check, ORDER BY ASC, negative LIMIT

### DIFF
--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
@@ -34,6 +34,8 @@
 495007
 --- QCC ProfileEvents after DROP PARTITION: no hits (key invalidated)
 1
+--- DESC rerun hits its warm entry (proves direction DESC populated QCC)
+1
 --- ASC after warming DESC: distinct direction key, must not hit
 7
 1007
@@ -57,3 +59,7 @@
 2007
 1007
 7
+--- Negative LIMIT does not reuse the TopK entry (0 hits)
+1
+--- Positive TopK query still hits after the negative run (not poisoned)
+1

--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
@@ -17,6 +17,9 @@
 997007
 996007
 995007
+--- QCC ProfileEvents (warm has 0 hits, cached has hits)
+1
+1
 --- After DROP PARTITION: ground truth (QCC off) comes from partition 1
 499007
 498007
@@ -29,3 +32,28 @@
 497007
 496007
 495007
+--- QCC ProfileEvents after DROP PARTITION: no hits (key invalidated)
+1
+--- ASC after warming DESC: distinct direction key, must not hit
+7
+1007
+2007
+3007
+4007
+7
+1007
+2007
+3007
+4007
+1
+--- Negative LIMIT: correct result, TopK-QCC path does not engage
+4007
+3007
+2007
+1007
+7
+4007
+3007
+2007
+1007
+7

--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.reference
@@ -59,6 +59,18 @@
 2007
 1007
 7
+--- Positive TopK ground truth (QCC off) after the negative run
+499007
+498007
+497007
+496007
+495007
+--- Positive TopK cached rerun: must match ground truth (not poisoned)
+499007
+498007
+497007
+496007
+495007
 --- Negative LIMIT does not reuse the TopK entry (0 hits)
 1
 --- Positive TopK query still hits after the negative run (not poisoned)

--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
@@ -53,13 +53,13 @@ SETTINGS index_granularity = 64,
 -- Partition 1 interleaves two kinds of rows in every granule (`id` is a per-row
 -- hash, so they are scattered uniformly):
 --   * "victims" (even `number`): `k` in [0, 500000), `w` matching every 1000th
---     row — each `k` is *below* the threshold, so `__topKFilter` drops them
+--     row -- each `k` is *below* the threshold, so `__topKFilter` drops them
 --     before the `WHERE` filter ever sees them;
---   * "decoys" (odd `number`): `k` >= 1500000 but `w = 1` — they survive
+--   * "decoys" (odd `number`): `k` >= 1500000 but `w = 1` -- they survive
 --     `__topKFilter` at any threshold, so every chunk of partition 1 reaches the
 --     `WHERE` filter non-empty, and `w = 7` then reduces it to zero rows.
 -- Net effect: the warm run records *all* granules of partition 1 as skippable
--- under the TopK-salted WHERE key, although they contain `w = 7` rows — those
+-- under the TopK-salted WHERE key, although they contain `w = 7` rows -- those
 -- were merely below a threshold that partition 0's rows established.
 INSERT INTO tab
 SELECT 0, intHash32(number), number, number % 1000
@@ -80,11 +80,25 @@ SELECT '--- DESC LIMIT 5 ground truth (QCC off): top rows all come from partitio
 SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS use_query_condition_cache = 0;
 
 SELECT '--- Warm run records partition 1 granules as skippable under the TopK salt';
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_warm';
 SELECT count() > 0 FROM system.query_condition_cache;
 
 SELECT '--- Cached run, same part set: must match ground truth';
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_cached';
+
+-- Correctness alone can stay green while the cache silently stops firing, so
+-- prove the cache is actually *used* via the ProfileEvents in system.query_log:
+-- the warm run finds nothing cached (0 hits), the cached run reuses entries (>0).
+SYSTEM FLUSH LOGS query_log;
+SELECT '--- QCC ProfileEvents (warm has 0 hits, cached has hits)';
+SELECT ProfileEvents['QueryConditionCacheHits'] = 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_warm' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+SELECT ProfileEvents['QueryConditionCacheHits'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_cached' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
 
 -- Dropping partition 0 removes the rows the threshold was computed from. The new
 -- top-5 lives entirely in partition 1, whose part is unchanged (same name) and
@@ -95,6 +109,36 @@ ALTER TABLE tab DROP PARTITION 0;
 SELECT '--- After DROP PARTITION: ground truth (QCC off) comes from partition 1';
 SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS use_query_condition_cache = 0;
 SELECT '--- QCC on must not reuse granule decisions recorded under the old part set';
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_afterdrop';
+
+-- Invalidation seen through ProfileEvents: because the part-set snapshot changed,
+-- the TopK-salted key changed too, so this run finds no matching entry (0 hits)
+-- even though the part `partition 1` and its plan parameters are unchanged.
+SYSTEM FLUSH LOGS query_log;
+SELECT '--- QCC ProfileEvents after DROP PARTITION: no hits (key invalidated)';
+SELECT ProfileEvents['QueryConditionCacheHits'] = 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_afterdrop' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+
+-- `condition_hash` folds the sort direction, so a warm `ORDER BY k DESC` entry
+-- must not be reused for `ORDER BY k ASC`: the direction change is a fresh key.
+SYSTEM CLEAR QUERY CONDITION CACHE;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 FORMAT Null;
+SELECT '--- ASC after warming DESC: distinct direction key, must not hit';
+SELECT k FROM tab WHERE w = 7 ORDER BY k ASC LIMIT 5 SETTINGS use_query_condition_cache = 0;
+SELECT k FROM tab WHERE w = 7 ORDER BY k ASC LIMIT 5 SETTINGS log_comment = '04338_asc';
+SYSTEM FLUSH LOGS query_log;
+SELECT ProfileEvents['QueryConditionCacheHits'] = 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_asc' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+
+-- A negative `LIMIT` is not a TopK plan (it becomes a `NegativeLimit` step with no
+-- `__topKFilter`), so it never engages the TopK-salted QCC path -- it must return
+-- the correct rows and cannot be poisoned by, or poison, the TopK entries above.
+SELECT '--- Negative LIMIT: correct result, TopK-QCC path does not engage';
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5 SETTINGS use_query_condition_cache = 0;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5;
 
 DROP TABLE tab;

--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
@@ -155,7 +155,15 @@ SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04
 SELECT '--- Negative LIMIT: correct result, TopK-QCC path does not engage';
 SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5 SETTINGS use_query_condition_cache = 0;
 SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5 SETTINGS log_comment = '04338_neg';
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_neg_pos2' FORMAT Null;
+-- The positive rerun after the negative query must return the SAME rows as the
+-- QCC-off ground truth, not merely report a cache hit. A FORMAT Null rerun would
+-- stay green even if 04338_neg (legitimately 0 hits) overwrote the positive TopK
+-- entry through a write-side key collision, so materialize the cached rerun and
+-- compare it row-for-row against the QCC-off ground truth.
+SELECT '--- Positive TopK ground truth (QCC off) after the negative run';
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS use_query_condition_cache = 0;
+SELECT '--- Positive TopK cached rerun: must match ground truth (not poisoned)';
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_neg_pos2';
 SYSTEM FLUSH LOGS query_log;
 SELECT '--- Negative LIMIT does not reuse the TopK entry (0 hits)';
 SELECT ProfileEvents['QueryConditionCacheHits'] = 0

--- a/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
+++ b/tests/queries/0_stateless/04338_query_condition_cache_topk_part_set_invalidation.sql
@@ -123,8 +123,19 @@ ORDER BY event_time_microseconds DESC LIMIT 1;
 
 -- `condition_hash` folds the sort direction, so a warm `ORDER BY k DESC` entry
 -- must not be reused for `ORDER BY k ASC`: the direction change is a fresh key.
+-- First prove the DESC warm-up really populated a TopK entry (a rerun hits it);
+-- otherwise the ASC 0-hits below would be a miss for the wrong reason (no entry
+-- at all on the one-part post-drop dataset), leaving the direction fold untested.
 SYSTEM CLEAR QUERY CONDITION CACHE;
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 FORMAT Null;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_descwarm' FORMAT Null;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_descrerun' FORMAT Null;
+SYSTEM FLUSH LOGS query_log;
+SELECT '--- DESC rerun hits its warm entry (proves direction DESC populated QCC)';
+SELECT ProfileEvents['QueryConditionCacheHits'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_descrerun' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+
 SELECT '--- ASC after warming DESC: distinct direction key, must not hit';
 SELECT k FROM tab WHERE w = 7 ORDER BY k ASC LIMIT 5 SETTINGS use_query_condition_cache = 0;
 SELECT k FROM tab WHERE w = 7 ORDER BY k ASC LIMIT 5 SETTINGS log_comment = '04338_asc';
@@ -136,9 +147,25 @@ ORDER BY event_time_microseconds DESC LIMIT 1;
 
 -- A negative `LIMIT` is not a TopK plan (it becomes a `NegativeLimit` step with no
 -- `__topKFilter`), so it never engages the TopK-salted QCC path -- it must return
--- the correct rows and cannot be poisoned by, or poison, the TopK entries above.
+-- the correct rows and neither reuse nor poison the TopK entries. Warm a positive
+-- TopK entry, run the negative-limit query (0 hits: it does not reuse the entry),
+-- then rerun the positive query (still hits: the negative run did not poison it).
+SYSTEM CLEAR QUERY CONDITION CACHE;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_neg_warm' FORMAT Null;
 SELECT '--- Negative LIMIT: correct result, TopK-QCC path does not engage';
 SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5 SETTINGS use_query_condition_cache = 0;
-SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5;
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT -5 SETTINGS log_comment = '04338_neg';
+SELECT k FROM tab WHERE w = 7 ORDER BY k DESC LIMIT 5 SETTINGS log_comment = '04338_neg_pos2' FORMAT Null;
+SYSTEM FLUSH LOGS query_log;
+SELECT '--- Negative LIMIT does not reuse the TopK entry (0 hits)';
+SELECT ProfileEvents['QueryConditionCacheHits'] = 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_neg' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
+SELECT '--- Positive TopK query still hits after the negative run (not poisoned)';
+SELECT ProfileEvents['QueryConditionCacheHits'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase() AND log_comment = '04338_neg_pos2' AND type = 'QueryFinish'
+ORDER BY event_time_microseconds DESC LIMIT 1;
 
 DROP TABLE tab;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/104478
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to the review on merged PR #104478 (@ PedroTadim asked to verify the query condition cache is actually used and to cover negative limits and `ORDER BY ... DESC`).

Strengthens `04338_query_condition_cache_topk_part_set_invalidation`:

- **ProfileEvents QCC-usage check.** The existing test only asserted result correctness, which can stay green while the cache silently stops firing. Added `system.query_log` `ProfileEvents['QueryConditionCacheHits']` assertions: the warm run has 0 hits, the cached run has hits, and the run after `DROP PARTITION` has 0 hits (proving the part-set-salt invalidation, not just a correct result).
- **`ORDER BY ... ASC` case.** After warming `ORDER BY k DESC`, an `ORDER BY k ASC` query must not reuse the DESC entry, since `condition_hash` folds the sort direction. Asserted via 0 hits.
- **Negative `LIMIT` case.** A negative `LIMIT` becomes a `NegativeLimit` plan step with no `__topKFilter`, so it never engages the TopK-salted QCC path. Added a correctness case (matches the `use_query_condition_cache = 0` ground truth) confirming it neither reuses nor poisons the TopK entries.

Verified: 20/20 passes with full randomization; base pass with `--no-random-settings`. The `ORDER BY ... DESC` path was already covered by the original test.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.950` (included in `26.7` and later)
<!-- ch-version-info:end -->