### PR TITLE
Revert "Revert "#110303: Fix Rust symbol localization locale""

### DIFF
--- a/cmake/localize_rust_c_symbols.sh
+++ b/cmake/localize_rust_c_symbols.sh
@@ -37,6 +37,9 @@
 
 set -eu
 
+# Keep sort and comm on the same portable bytewise ordering.
+export LC_ALL=C
+
 LIB_PATH="${1:-}"
 AR="${2:-}"
 OBJCOPY="${3:-}"


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#110373


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.966` (included in `26.7` and later)
<!-- ch-version-info:end -->