### PR TITLE
CI: Make the "Report messages" commit status a working link

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -9,6 +9,8 @@ the merge.  After the issue is reviewed and fixed, re-running CI will post
 a new OK status once the error/warning is no longer produced.
 """
 
+import sys
+
 from ci.praktika.gh import GH
 from ci.praktika.info import Info
 from ci.praktika.result import Result
@@ -40,7 +42,7 @@ def check():
             # Link the status to the workflow report page, where the error and
             # warning messages are listed in the notification panels at the top.
             try:
-                url = info.get_report_url()
+                url = info.get_job_report_url()
             except Exception as e:
                 print(f"WARNING: failed to build report url: {e}")
                 url = ""
@@ -50,9 +52,12 @@ def check():
                 description=description,
                 url=url,
             )
+            return False
     except Exception as e:
         print(f"WARNING: check_report_messages failed: {e}")
+    return True
 
 
 if __name__ == "__main__":
-    check()
+    if not check():
+        sys.exit(1)

--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -42,7 +42,7 @@ def check():
             # Link the status to the workflow report page, where the error and
             # warning messages are listed in the notification panels at the top.
             try:
-                url = info.get_job_report_url()
+                url = info.get_report_url()
             except Exception as e:
                 print(f"WARNING: failed to build report url: {e}")
                 url = ""

--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -37,8 +37,18 @@ def check():
             if warnings:
                 parts.append(f"{len(warnings)} warning(s)")
             description = ", ".join(parts)
+            # Link the status to the workflow report page, where the error and
+            # warning messages are listed in the notification panels at the top.
+            try:
+                url = info.get_report_url()
+            except Exception as e:
+                print(f"WARNING: failed to build report url: {e}")
+                url = ""
             GH.post_commit_status(
-                name=STATUS_NAME, status=Result.Status.FAIL, description=description, url=""
+                name=STATUS_NAME,
+                status=Result.Status.FAIL,
+                description=description,
+                url=url,
             )
     except Exception as e:
         print(f"WARNING: check_report_messages failed: {e}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Description

CI often fails with a `Report messages` commit status such as
`Report messages — 8 warning(s)` (e.g. https://github.com/ClickHouse/ClickHouse/pull/109847),
but the status link does not work, so there is no way to see what the
messages actually are.

The `check_report_messages` workflow hook posted the status with an empty
`target_url`, so clicking it in the GitHub checks UI led nowhere.

This PR points the status at the workflow report page via
`Info.get_report_url()` — the same helper the overall workflow status
already uses. That page renders the error/warning messages in the
notification panels at the top, so the `Report messages` status is now
clickable and shows exactly what was reported.

The URL build is guarded so that, if it ever fails, the blocking status is
still posted (with an empty URL, as before) rather than being skipped.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.940` (included in `26.7` and later)
<!-- ch-version-info:end -->