### PR TITLE
Make Field copy and destroy iterative to survive deeply nested literals

### DIFF
--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -31,6 +31,158 @@ extern const int LOGICAL_ERROR;
 extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
+void Field::initEmptyContainer(Types::Which w)
+{
+    switch (w)
+    {
+        case Types::Array:  new (&storage) Array();  break;
+        case Types::Tuple:  new (&storage) Tuple();  break;
+        case Types::Map:    new (&storage) Map();    break;
+        case Types::Object: new (&storage) Object(); break;
+        default: break;
+    }
+    which = w;
+}
+
+void Field::createContainerIteratively(const Field & src)
+{
+    /// Build *this as a deep copy of `src`. Each pending entry is a (source, destination)
+    /// pair of same-typed container Fields whose destination is empty and still needs its
+    /// elements copied in. Container children are created empty and enqueued instead of
+    /// being copied recursively, so the copy runs with a bounded native stack.
+    initEmptyContainer(src.which);
+
+    std::vector<std::pair<const Field *, Field *>> pending;
+
+    /// On a mid-copy allocation failure, tear down what was built so we neither leak the
+    /// partial container nor leave the storage in a half-constructed state (matches the
+    /// strong guarantee the recursive std::vector copy used to provide).
+    auto copy_level = [&pending](const Field & s, Field & d)
+    {
+        auto copy_vector = [&pending](const auto & sv, auto & dv)
+        {
+            dv.reserve(sv.size());  /// keep &dv.back() stable while we hand out pointers below
+            for (const Field & se : sv)
+            {
+                if (isContainer(se.which))
+                {
+                    dv.emplace_back();
+                    Field & de = dv.back();
+                    de.initEmptyContainer(se.which);
+                    pending.emplace_back(&se, &de);
+                }
+                else
+                    dv.push_back(se);  /// leaf: a shallow copy, no recursion
+            }
+        };
+
+        switch (d.which)
+        {
+            case Types::Array: copy_vector(s.get<Array>(), d.get<Array>()); break;
+            case Types::Tuple: copy_vector(s.get<Tuple>(), d.get<Tuple>()); break;
+            case Types::Map:   copy_vector(s.get<Map>(),   d.get<Map>());   break;
+            case Types::Object:
+            {
+                /// std::map insertion never invalidates references to existing elements,
+                /// so the &de pointers we enqueue stay valid.
+                for (const auto & [key, se] : s.get<Object>())
+                {
+                    if (isContainer(se.which))
+                    {
+                        Field & de = d.get<Object>().emplace(key, Field()).first->second;
+                        de.initEmptyContainer(se.which);
+                        pending.emplace_back(&se, &de);
+                    }
+                    else
+                        d.get<Object>().emplace(key, se);
+                }
+                break;
+            }
+            default: break;
+        }
+    };
+
+    try
+    {
+        copy_level(src, *this);
+        while (!pending.empty())
+        {
+            auto [s, d] = pending.back();
+            pending.pop_back();
+            copy_level(*s, *d);
+        }
+    }
+    catch (...)
+    {
+        destroy();
+        throw;
+    }
+}
+
+static bool containerIsEmpty(const Field & f)
+{
+    switch (f.getType())
+    {
+        case Field::Types::Array:  return f.safeGet<Array>().empty();
+        case Field::Types::Tuple:  return f.safeGet<Tuple>().empty();
+        case Field::Types::Map:    return f.safeGet<Map>().empty();
+        case Field::Types::Object: return f.safeGet<Object>().empty();
+        default: return true;
+    }
+}
+
+void Field::destroyContainerIteratively(Types::Which old_which) noexcept
+{
+    /// Tear down a (possibly deeply nested) container without native recursion: move every
+    /// non-empty nested-container child into an explicit worklist so each vector/map
+    /// destructor only ever destroys leaf elements (and already-emptied containers, which are
+    /// trivial), keeping the native stack depth bounded regardless of the nesting depth.
+    std::vector<Field> to_destroy;
+
+    auto steal_children = [&to_destroy](Field & container, Types::Which w)
+    {
+        auto steal_from_vector = [&to_destroy](auto & vec)
+        {
+            for (Field & elem : vec)
+                if (isContainer(elem.which) && !containerIsEmpty(elem))
+                    to_destroy.push_back(std::move(elem));
+        };
+
+        switch (w)
+        {
+            case Types::Array: steal_from_vector(container.get<Array>()); break;
+            case Types::Tuple: steal_from_vector(container.get<Tuple>()); break;
+            case Types::Map:   steal_from_vector(container.get<Map>());   break;
+            case Types::Object:
+                for (auto & [key, elem] : container.get<Object>())
+                    if (isContainer(elem.which) && !containerIsEmpty(elem))
+                        to_destroy.push_back(std::move(elem));
+                break;
+            default: break;
+        }
+    };
+
+    /// `which` is already Null here (set by destroy()), so drive off the saved `old_which`.
+    steal_children(*this, old_which);
+    switch (old_which)
+    {
+        case Types::Array:  destroy<Array>();  break;
+        case Types::Tuple:  destroy<Tuple>();  break;
+        case Types::Map:    destroy<Map>();    break;
+        case Types::Object: destroy<Object>(); break;
+        default: break;
+    }
+
+    while (!to_destroy.empty())
+    {
+        Field cur = std::move(to_destroy.back());
+        to_destroy.pop_back();
+        /// Empty `cur`'s nested containers into the worklist first, so destroying `cur` at the
+        /// end of this scope stays shallow (its remaining children are leaves or emptied).
+        steal_children(cur, cur.which);
+    }
+}
+
 bool AggregateFunctionStateData::operator < (const AggregateFunctionStateData &) const
 {
     throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Operator < is not implemented for AggregateFunctionStateData.");

--- a/src/Core/Field.cpp
+++ b/src/Core/Field.cpp
@@ -12,6 +12,9 @@
 #include <IO/WriteHelpers.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/readDecimalText.h>
+#include <Common/LockMemoryExceptionInThread.h>
+
+#include <absl/container/inlined_vector.h>
 
 
 using namespace std::literals;
@@ -52,7 +55,7 @@ void Field::createContainerIteratively(const Field & src)
     /// being copied recursively, so the copy runs with a bounded native stack.
     initEmptyContainer(src.which);
 
-    std::vector<std::pair<const Field *, Field *>> pending;
+    absl::InlinedVector<std::pair<const Field *, Field *>, 16> pending;
 
     /// On a mid-copy allocation failure, tear down what was built so we neither leak the
     /// partial container nor leave the storage in a half-constructed state (matches the
@@ -137,7 +140,15 @@ void Field::destroyContainerIteratively(Types::Which old_which) noexcept
     /// non-empty nested-container child into an explicit worklist so each vector/map
     /// destructor only ever destroys leaf elements (and already-emptied containers, which are
     /// trivial), keeping the native stack depth bounded regardless of the nesting depth.
-    std::vector<Field> to_destroy;
+    ///
+    /// This runs from ~Field, so it must not throw. The worklist can allocate, and allocation
+    /// goes through the throwing operator new, so suppress the memory-limit exception for its
+    /// lifetime (memory is still tracked, so freeing the value being destroyed is still credited).
+    /// The worklist only holds the current frontier of nested containers, which for a deeply
+    /// nested value is narrow (a deep literal is query-size bounded, so it cannot also be wide);
+    /// the inline buffer keeps that common case allocation-free.
+    LockMemoryExceptionInThread block_memory_limit_exception;
+    absl::InlinedVector<Field, 16> to_destroy;
 
     auto steal_children = [&to_destroy](Field & container, Types::Which w)
     {

--- a/src/Core/Field.h
+++ b/src/Core/Field.h
@@ -589,11 +589,24 @@ private:
         ptr->assign(std::move(str));
     }
 
-    void create(const Field & x)
+    /// Array/Tuple/Map/Object nest Fields inside Fields, so a straightforward
+    /// (recursive) copy/destroy overflows the native stack for a deeply nested value.
+    /// These containers are handled by explicit-worklist iterative helpers instead.
+    static bool isContainer(Types::Which w)
     {
-        dispatch([this] (auto & value) { createConcrete(value); }, x);
+        return w == Types::Array || w == Types::Tuple || w == Types::Map || w == Types::Object;
     }
 
+    void create(const Field & x)
+    {
+        if (isContainer(x.which))
+            createContainerIteratively(x);
+        else
+            dispatch([this] (auto & value) { createConcrete(value); }, x);
+    }
+
+    /// Moving a Field just steals the container buffer (no per-element recursion), so
+    /// the move paths only need the iterative teardown of the value being overwritten.
     void create(Field && x)
     {
         dispatch([this] (auto & value) { createConcrete(std::move(value)); }, x);
@@ -601,12 +614,26 @@ private:
 
     void assign(const Field & x)
     {
-        dispatch([this] (auto & value) { assignConcrete(value); }, x);
+        if (isContainer(x.which))
+        {
+            /// A vector/map copy-assignment would recurse per nesting level; rebuild instead.
+            destroy();
+            create(x);
+        }
+        else
+            dispatch([this] (auto & value) { assignConcrete(value); }, x);
     }
 
     void assign(Field && x)
     {
-        dispatch([this] (auto & value) { assignConcrete(std::move(value)); }, x);
+        if (isContainer(x.which))
+        {
+            /// A vector/map move-assignment first destroys the old (possibly deep) value recursively.
+            destroy();
+            create(std::move(x));
+        }
+        else
+            dispatch([this] (auto & value) { assignConcrete(std::move(value)); }, x);
     }
 
     template <typename CharT>
@@ -633,16 +660,10 @@ private:
                 destroy<String>();
                 break;
             case Types::Array:
-                destroy<Array>();
-                break;
             case Types::Tuple:
-                destroy<Tuple>();
-                break;
             case Types::Map:
-                destroy<Map>();
-                break;
             case Types::Object:
-                destroy<Object>();
+                destroyContainerIteratively(old_which);
                 break;
             case Types::AggregateFunctionState:
                 destroy<AggregateFunctionStateData>();
@@ -661,6 +682,14 @@ private:
         T * MAY_ALIAS ptr = reinterpret_cast<T*>(&storage);
         ptr->~T();
     }
+
+    /// Placement-construct an empty container of the given type into raw (or Null) storage.
+    void initEmptyContainer(Types::Which w);
+
+    /// Copy/destroy a (possibly deeply nested) Array/Tuple/Map/Object value using an explicit
+    /// worklist so the native stack depth stays bounded regardless of the nesting depth.
+    void createContainerIteratively(const Field & src);
+    void destroyContainerIteratively(Types::Which old_which) noexcept;
 };
 
 #undef DBMS_MIN_FIELD_SIZE

--- a/src/Core/tests/gtest_field.cpp
+++ b/src/Core/tests/gtest_field.cpp
@@ -54,3 +54,59 @@ GTEST_TEST(Field, Move)
     f = Array{String{"Hello, world (6)"}};
     ASSERT_EQ(f.safeGet<Array>()[0].safeGet<String>(), "Hello, world (6)");
 }
+
+
+/// Copying and destroying a deeply nested Field must not overflow the native stack, both when the
+/// source is a Field and when a container lvalue is wrapped/assigned through the templated
+/// constructor / assignment operator (which forward to createConcrete / assignConcrete, i.e. the
+/// underlying container copy, whose elements are copied via the iterative Field copy). The depth is
+/// far beyond what a recursive copy could survive.
+GTEST_TEST(Field, DeeplyNestedCopyAndDestroyDoesNotOverflowStack)
+{
+    static constexpr size_t depth = 100000;
+
+    /// Build the nested value iteratively (moving, never copying) so constructing the test input
+    /// is O(depth) and cannot overflow either.
+    auto make_deep_array = []
+    {
+        Array a;
+        a.push_back(Field{UInt64{1}});
+        for (size_t i = 0; i < depth; ++i)
+        {
+            Array next;
+            next.push_back(Field{std::move(a)});
+            a = std::move(next);
+        }
+        return a;
+    };
+
+    /// Field(const Field &): the ASTLiteral::clone path.
+    {
+        Field src{make_deep_array()};
+        Field copy = src;                 // NOLINT(performance-unnecessary-copy-initialization)
+        ASSERT_EQ(copy.getType(), Field::Types::Array);
+    }
+
+    /// Field(T &&) with a container lvalue: createConcrete -> container copy -> per-element Field copy.
+    {
+        Array a = make_deep_array();
+        Field from_lvalue{a};             // lvalue -> copy
+        ASSERT_EQ(from_lvalue.getType(), Field::Types::Array);
+    }
+
+    /// operator=(T &&) with a container lvalue: assignConcrete / destroy+createConcrete.
+    {
+        Array a = make_deep_array();
+        Field assigned;
+        assigned = a;                     // lvalue -> copy-assign
+        ASSERT_EQ(assigned.getType(), Field::Types::Array);
+    }
+
+    /// The same for a value nested inside an Object (the std::map-backed container).
+    {
+        Object obj;
+        obj.emplace("k", Field{make_deep_array()});
+        Field src{obj};                   // Object lvalue -> copy
+        ASSERT_EQ(src.getType(), Field::Types::Object);
+    }
+}

--- a/tests/queries/0_stateless/04538_deep_nested_literal_clone_no_crash.sh
+++ b/tests/queries/0_stateless/04538_deep_nested_literal_clone_no_crash.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# A deeply nested array literal parses into a single ASTLiteral whose Field nests one Array per
+# bracket. Analysing it clones the AST (deep-copying that Field) and eventually tears the Field
+# down; both the copy and the destructor used to recurse once per nesting level and overflow the
+# native stack. They are now iterative, so an arbitrarily deep literal must be rejected cleanly
+# with TOO_DEEP_RECURSION by a stack-guarded walk, never crash.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+python3 -c "print('SELECT ' + '['*100000 + '1' + ']'*100000 + '; -- { serverError TOO_DEEP_RECURSION }')" \
+    | $CLICKHOUSE_LOCAL --max_parser_depth=1000000000 --max_query_size=1000000000


### PR DESCRIPTION
A deeply nested collection literal such as `SELECT [[[ ... ]]]` is parsed into a single `ASTLiteral` whose `Field` nests one `Array`/`Tuple`/`Map` per level. Since the collection-of-literals parser is iterative, that `Field` can be built to an arbitrary depth (bounded only by the client-settable `max_parser_depth`) without tripping the parser's periodic `checkStackSize` guard, which relies on native recursion to fire.

The recursive `Field` copy constructor (reached via `ASTLiteral::clone` when the analyzer clones the AST) and the `Field` destructor then recurse once per nesting level with no stack guard and overflow the native stack, crashing the server. A `checkStackSize` guard cannot cover the destructor, because throwing from a destructor calls `std::terminate`.

This makes the copy and destroy of `Array`/`Tuple`/`Map`/`Object` fields (and the copy- and move-assignment paths that route through them) iterative, using an explicit worklist so the native stack depth stays bounded regardless of the nesting depth. The stack-guarded type-inference and formatting walks still reject genuinely too-deep structures cleanly with `TOO_DEEP_RECURSION`.

Related: https://github.com/ClickHouse/ClickHouse/pull/108892

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server crash (native stack overflow) when a deeply nested `Array`/`Tuple`/`Map`/`Object` literal is copied or destroyed, for example a query with a very deeply nested literal at a raised `max_parser_depth`.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.2.87`, `26.5.6.59`, `26.4.5.147`, `26.3.17.60`, `25.8.29.27`
<!-- ch-version-info:end -->