### PR TITLE
Send big list parts for distributed index analysis as scalars

### DIFF
--- a/docs/en/engines/table-engines/special/external-data.md
+++ b/docs/en/engines/table-engines/special/external-data.md
@@ -20,7 +20,7 @@ External data can be uploaded using the command-line client (in non-interactive 
 In the command-line client, you can specify a parameters section in the format
 
 ```bash
---external --file=... [--name=...] [--format=...] [--types=...|--structure=...]
+--external --file=... [--name=...] [--format=...] [--types=...|--structure=...] [--scalar]
 ```
 
 You may have multiple sections like this, for the number of tables being transmitted.
@@ -31,6 +31,7 @@ Only a single table can be retrieved from stdin.
 
 The following parameters are optional: **–name**– Name of the table. If omitted, _data is used.
 **–format** – Data format in the file. If omitted, TabSeparated is used.
+**–scalar** – Send the data as a scalar instead of a temporary table. The data must contain exactly one row; if it contains multiple columns, they are packed into a single tuple. The value is accessible in the query via `__getScalar('name')`.
 
 One of the following parameters is required:**–types** – A list of comma-separated column types. For example: `UInt64,String`. The columns will be named _1, _2, ...
 **–structure**– The table structure in the format`UserID UInt64`, `URL String`. Defines the column names and types.
@@ -48,6 +49,8 @@ $ cat /etc/passwd | sed 's/:/\t/g' | clickhouse-client --query="SELECT shell, co
 /bin/bash       4
 /usr/sbin/nologin       1
 /bin/sync       1
+$ echo 41 | clickhouse-client --query="SELECT __getScalar('threshold') + 1" --external --scalar --name=threshold --file=- --types=UInt64
+42
 ```
 
 When using the HTTP interface, external data is passed in the multipart/form-data format. Each table is transmitted as a separate file. The table name is taken from the file name. The `query_string` is passed the parameters `name_format`, `name_types`, and `name_structure`, where `name` is the name of the table that these parameters correspond to. The meaning of the parameters is the same as when using the command-line client.

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -854,6 +854,7 @@ void Client::addExtraOptions(OptionsDescription & options_description)
         ("name", po::value<std::string>()->default_value("_data"), "name of the table")
         ("format", po::value<std::string>()->default_value("TabSeparated"), "data format")
         ("structure", po::value<std::string>(), "structure")
+        ("scalar", "Send as Scalar packet (not Data)")
         ("types", po::value<std::string>(), "types");
 
     /// Commandline options related to hosts and ports.
@@ -1256,6 +1257,11 @@ void Client::readArguments(
             }
             else
                 break;
+        }
+        /// Options with no value
+        else if (in_external_group && (arg == "--scalar"))
+        {
+            external_tables_arguments.back().emplace_back(arg);
         }
         else
         {

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -888,8 +888,9 @@ void Client::processOptions(
 
         try
         {
-            external_tables.emplace_back(external_options);
-            if (external_tables.back().file == "-")
+            auto & external_data = external_options.contains("scalar") ? external_scalars : external_tables;
+            external_data.emplace_back(external_options);
+            if (external_data.back().file == "-")
                 ++number_of_external_tables_with_stdin_source;
             if (number_of_external_tables_with_stdin_source > 1)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Two or more external tables has stdin (-) set as --file field");

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -563,17 +563,23 @@ void ClientBase::adjustQueryEnd(
 void ClientBase::sendExternalTables(ASTPtr parsed_query)
 {
     const auto * select = parsed_query->as<ASTSelectWithUnionQuery>();
-    if (!select && !external_tables.empty())
+    bool has_external_data = !external_tables.empty() || !external_scalars.empty();
+    if (!select && has_external_data)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "External tables could be sent only with select query");
 
-    if (isEmbeeddedClient() && !external_tables.empty())
+    if (isEmbeeddedClient() && has_external_data)
         throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "External tables are not allowed in embedded more");
 
-    std::vector<ExternalTableDataPtr> data;
+    Scalars scalars;
+    std::vector<ExternalTableDataPtr> tables;
     for (auto & table : external_tables)
-        data.emplace_back(table.getData(client_context));
+        tables.emplace_back(table.getData(client_context));
+    for (auto & table : external_scalars)
+        scalars[table.name] = table.getScalar(client_context);
 
-    connection->sendExternalTablesData(data);
+    if (!scalars.empty())
+        connection->sendScalarsData(scalars);
+    connection->sendExternalTablesData(tables);
 }
 
 

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -470,6 +470,7 @@ protected:
     bool have_error = false;
 
     std::list<ExternalTable> external_tables; /// External tables info.
+    std::list<ExternalTable> external_scalars; /// External scalars info.
     bool send_external_tables = false;
     NameToNameMap query_parameters; /// Dictionary with query parameters for prepared statements.
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1253,7 +1253,7 @@ protected:
         num_rows += chunk.getNumRows();
 
         auto block = getPort().getHeader().cloneWithColumns(chunk.detachColumns());
-        connection.sendData(block, table_data.table_name, table_data.scalar);
+        connection.sendData(block, table_data.table_name, /*scalar=*/ false);
     }
 
 private:

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -1253,7 +1253,7 @@ protected:
         num_rows += chunk.getNumRows();
 
         auto block = getPort().getHeader().cloneWithColumns(chunk.detachColumns());
-        connection.sendData(block, table_data.table_name, false);
+        connection.sendData(block, table_data.table_name, table_data.scalar);
     }
 
 private:

--- a/src/Client/Connection.h
+++ b/src/Client/Connection.h
@@ -158,7 +158,7 @@ public:
 
     void sendClusterFunctionReadTaskResponse(const ClusterFunctionReadTaskResponse & response);
     /// Send all scalars.
-    void sendScalarsData(Scalars & data);
+    void sendScalarsData(Scalars & data) override;
 
     TablesStatusResponse getTablesStatus(const ConnectionTimeouts & timeouts,
                                          const TablesStatusRequest & request);

--- a/src/Client/IServerConnection.h
+++ b/src/Client/IServerConnection.h
@@ -53,6 +53,7 @@ struct ExternalTableData
     std::unique_ptr<QueryPipelineBuilder> pipe;
     std::string table_name;
     std::function<std::unique_ptr<QueryPipelineBuilder>()> creating_pipe_callback;
+    bool scalar = false;
     /// Flag if need to stop reading.
     std::atomic_bool is_cancelled = false;
 };

--- a/src/Client/IServerConnection.h
+++ b/src/Client/IServerConnection.h
@@ -53,7 +53,6 @@ struct ExternalTableData
     std::unique_ptr<QueryPipelineBuilder> pipe;
     std::string table_name;
     std::function<std::unique_ptr<QueryPipelineBuilder>()> creating_pipe_callback;
-    bool scalar = false;
     /// Flag if need to stop reading.
     std::atomic_bool is_cancelled = false;
 };
@@ -118,6 +117,9 @@ public:
 
     /// Send all contents of external (temporary) tables.
     virtual void sendExternalTablesData(ExternalTablesData & data) = 0;
+
+    /// Send all scalars.
+    virtual void sendScalarsData(Scalars & data) = 0;
 
     virtual void sendMergeTreeReadTaskResponse(const ParallelReadResponse & response) = 0;
 

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -822,6 +822,11 @@ void LocalConnection::sendExternalTablesData(ExternalTablesData &)
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented");
 }
 
+void LocalConnection::sendScalarsData(Scalars &)
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented");
+}
+
 void LocalConnection::sendMergeTreeReadTaskResponse(const ParallelReadResponse &)
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented");

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -145,6 +145,8 @@ public:
 
     void sendExternalTablesData(ExternalTablesData &) override;
 
+    void sendScalarsData(Scalars & data) override;
+
     void sendMergeTreeReadTaskResponse(const ParallelReadResponse & response) override;
 
     void sendMergeTreeAllRangesAnnouncementResponse(const InitialAllRangesAnnouncementResponse & response) override;

--- a/src/Core/ExternalTable.cpp
+++ b/src/Core/ExternalTable.cpp
@@ -42,7 +42,6 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int INCORRECT_RESULT_OF_SCALAR_SUBQUERY;
 }
 
 static Block materializeScalar(InputFormatPtr input)
@@ -54,12 +53,12 @@ static Block materializeScalar(InputFormatPtr input)
     Block block;
     while (block.rows() == 0 && executor.pull(block)) {}
     if (block.rows() != 1)
-        throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Scalar input returned {} rows", block.rows());
 
     Block tmp_block;
     while (tmp_block.rows() == 0 && executor.pull(tmp_block)) {}
     if (tmp_block.rows() > 0)
-        throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one block");
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Scalar input returned more than one block");
 
     if (block.columns() == 1)
         return block;
@@ -80,18 +79,17 @@ ExternalTableDataPtr BaseExternalTable::getData(ContextPtr context)
     auto data = std::make_unique<ExternalTableData>();
     data->pipe = std::make_unique<QueryPipelineBuilder>();
     data->table_name = name;
-    data->scalar = scalar;
-
-    if (scalar)
-    {
-        auto block = materializeScalar(std::move(input));
-        auto source = std::make_shared<SourceFromSingleChunk>(std::make_shared<const Block>(Block{block}));
-        data->pipe->init(Pipe(source));
-    }
-    else
-        data->pipe->init(Pipe(std::move(input)));
+    data->pipe->init(Pipe(std::move(input)));
 
     return data;
+}
+
+Block BaseExternalTable::getScalar(ContextPtr context)
+{
+    initReadBuffer();
+    initSampleBlock();
+    auto input = context->getInputFormat(format, *read_buffer, sample_block, context->getSettingsRef()[Setting::max_block_size]);
+    return materializeScalar(std::move(input));
 }
 
 void BaseExternalTable::clear()
@@ -198,8 +196,6 @@ ExternalTable::ExternalTable(const boost::program_options::variables_map & exter
         format = external_options["format"].as<std::string>();
     else
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "--format field have not been provided for external table");
-
-    scalar = external_options.contains("scalar");
 
     if (external_options.contains("structure"))
         parseStructureFromStructureField(external_options["structure"].as<std::string>());

--- a/src/Core/ExternalTable.cpp
+++ b/src/Core/ExternalTable.cpp
@@ -1,3 +1,9 @@
+#include <Columns/ColumnTuple.h>
+#include <Core/Block.h>
+#include <Core/ColumnsWithTypeAndName.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/Sources/SourceFromSingleChunk.h>
 #include <boost/program_options.hpp>
 #include <DataTypes/DataTypeFactory.h>
 #include <Storages/IStorage.h>
@@ -30,22 +36,60 @@ namespace DB
 namespace Setting
 {
     extern const SettingsUInt64 http_max_multipart_form_data_size;
+    extern const SettingsNonZeroUInt64 max_block_size;
 }
 
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int INCORRECT_RESULT_OF_SCALAR_SUBQUERY;
 }
+
+static Block materializeScalar(InputFormatPtr input)
+{
+    Pipe pipe(std::move(input));
+    QueryPipeline pipeline(std::move(pipe));
+    PullingPipelineExecutor executor(pipeline);
+
+    Block block;
+    while (block.rows() == 0 && executor.pull(block)) {}
+    if (block.rows() != 1)
+        throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one row");
+
+    Block tmp_block;
+    while (tmp_block.rows() == 0 && executor.pull(tmp_block)) {}
+    if (tmp_block.rows() > 0)
+        throw Exception(ErrorCodes::INCORRECT_RESULT_OF_SCALAR_SUBQUERY, "Scalar subquery returned more than one block");
+
+    if (block.columns() == 1)
+        return block;
+
+    return Block(ColumnsWithTypeAndName{{
+        ColumnTuple::create(block.getColumns()),
+        std::make_shared<DataTypeTuple>(block.getDataTypes(), block.getNames()),
+        "tuple"
+    }});
+}
+
 ExternalTableDataPtr BaseExternalTable::getData(ContextPtr context)
 {
     initReadBuffer();
     initSampleBlock();
-    auto input = context->getInputFormat(format, *read_buffer, sample_block, context->getSettingsRef().get("max_block_size").safeGet<UInt64>());
+    auto input = context->getInputFormat(format, *read_buffer, sample_block, context->getSettingsRef()[Setting::max_block_size]);
 
     auto data = std::make_unique<ExternalTableData>();
     data->pipe = std::make_unique<QueryPipelineBuilder>();
-    data->pipe->init(Pipe(std::move(input)));
     data->table_name = name;
+    data->scalar = scalar;
+
+    if (scalar)
+    {
+        auto block = materializeScalar(std::move(input));
+        auto source = std::make_shared<SourceFromSingleChunk>(std::make_shared<const Block>(Block{block}));
+        data->pipe->init(Pipe(source));
+    }
+    else
+        data->pipe->init(Pipe(std::move(input)));
 
     return data;
 }
@@ -154,6 +198,8 @@ ExternalTable::ExternalTable(const boost::program_options::variables_map & exter
         format = external_options["format"].as<std::string>();
     else
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "--format field have not been provided for external table");
+
+    scalar = external_options.contains("scalar");
 
     if (external_options.contains("structure"))
         parseStructureFromStructureField(external_options["structure"].as<std::string>());

--- a/src/Core/ExternalTable.h
+++ b/src/Core/ExternalTable.h
@@ -36,7 +36,6 @@ public:
     std::string file;       /// File with data or '-' if stdin
     std::string name;       /// The name of the table
     std::string format;     /// Name of the data storage format
-    bool scalar = false;    /// Send as Scalar
 
     /// Description of the table structure: (column name, data type name)
     VectorWithMemoryTracking<std::pair<std::string, std::string>> structure;
@@ -51,6 +50,7 @@ public:
 
     /// Get the table data - a pair (a stream with the contents of the table, the name of the table)
     ExternalTableDataPtr getData(ContextPtr context);
+    Block getScalar(ContextPtr context);
 
 protected:
     /// Clear all accumulated information

--- a/src/Core/ExternalTable.h
+++ b/src/Core/ExternalTable.h
@@ -36,6 +36,7 @@ public:
     std::string file;       /// File with data or '-' if stdin
     std::string name;       /// The name of the table
     std::string format;     /// Name of the data storage format
+    bool scalar = false;    /// Send as Scalar
 
     /// Description of the table structure: (column name, data type name)
     VectorWithMemoryTracking<std::pair<std::string, std::string>> structure;

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -126,15 +126,32 @@ GetPriorityForLoadBalancing::Func replicaIndexPriorityFunc()
     return [](size_t i) { return Priority{static_cast<Int64>(i)}; };
 }
 
-std::string buildAnalyzeIndexQuery(const StorageID & storage_id, const std::optional<std::string> & filter,
-                                   const OptionalVectorSearchParameters & vector_search_parameters,
-                                   const std::vector<std::string_view> & parts)
+Scalars buildPartsScalars(const std::vector<std::string_view> & parts)
 {
-    std::string query = fmt::format("SELECT * FROM mergeTreeAnalyzeIndexesUUID('{}', {}, ['{}']",
-        storage_id.uuid,
-        filter.value_or("true"),
-        fmt::join(parts, "','"));
+    auto column_string = ColumnString::create();
+    for (const auto & part : parts)
+        column_string->insertData(part.data(), part.length());
+    auto column_offsets = ColumnUInt64::create(1, parts.size());
+    auto column_array = ColumnArray::create(std::move(column_string), std::move(column_offsets));
 
+    Block block{
+        {std::move(column_array), std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>()), "parts"},
+    };
+    return Scalars{{"parts", std::move(block)}};
+}
+
+std::pair<Scalars, std::string> buildAnalyzeIndexQuery(const StorageID & storage_id, const std::optional<std::string> & filter,
+    const OptionalVectorSearchParameters & vector_search_parameters,
+    const std::vector<std::string_view> & parts)
+{
+    static constexpr size_t DISTRIBUTED_INDEX_ANALYSIS_INLINE_PARTS_LIMIT = 30;
+    bool inline_parts = parts.size() < DISTRIBUTED_INDEX_ANALYSIS_INLINE_PARTS_LIMIT;
+
+    std::string query = fmt::format("SELECT * FROM mergeTreeAnalyzeIndexesUUID('{}', {}", storage_id.uuid, filter.value_or("true"));
+    if (inline_parts)
+        query += fmt::format(", ['{}']", fmt::join(parts, "','"));
+    else
+        query += fmt::format(", __getScalar('parts')");
     if (vector_search_parameters)
     {
         query += fmt::format(", 'vector_search_index_analysis', array('{}', '{}', {}, {}, {}, {})",
@@ -142,9 +159,13 @@ std::string buildAnalyzeIndexQuery(const StorageID & storage_id, const std::opti
                         vector_search_parameters->limit, vector_search_parameters->reference_vector,
                         vector_search_parameters->additional_filters_present, vector_search_parameters->return_distances);
     }
-
     query += ")";
-    return query;
+
+    Scalars scalars;
+    if (!inline_parts)
+        scalars = buildPartsScalars(parts);
+
+    return std::make_pair(std::move(scalars), std::move(query));
 }
 
 SharedHeader indexAnalysisSampleBlock()
@@ -187,10 +208,10 @@ IndexAnalysisPartsRanges getIndexAnalysisFromReplicaSync(const LoggerPtr & logge
                                                      const OptionalVectorSearchParameters & vector_search_parameters, ContextPtr context, const Tables & external_tables,
                                                      const std::vector<std::string_view> & parts, Connection & connection)
 {
-    auto query = buildAnalyzeIndexQuery(storage_id, filter, vector_search_parameters, parts);
+    auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter, vector_search_parameters, parts);
     auto sample_block = indexAnalysisSampleBlock();
 
-    auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(connection, query, sample_block, context, ThrottlerPtr{}, Scalars{}, external_tables);
+    auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(connection, query, sample_block, context, ThrottlerPtr{}, scalars, external_tables);
     remote_query_executor->setLogger(logger);
     auto remote_source = std::make_shared<RemoteSource>(std::move(remote_query_executor), false, false, false);
     QueryPipeline pipeline(std::move(remote_source));
@@ -602,8 +623,8 @@ private:
                 continue;
 
             ProfileEvents::increment(ProfileEvents::DistributedIndexAnalysisScheduledReplicas);
-            auto query = buildAnalyzeIndexQuery(storage_id, filter_query, vector_search_parameters, remote_parts[i]);
-            auto executor = std::make_shared<RemoteQueryExecutor>(*connection, query, sample_block, execution_context, ThrottlerPtr{}, Scalars{}, external_tables);
+            auto [scalars, query] = buildAnalyzeIndexQuery(storage_id, filter_query, vector_search_parameters, remote_parts[i]);
+            auto executor = std::make_shared<RemoteQueryExecutor>(*connection, query, sample_block, execution_context, ThrottlerPtr{}, scalars, external_tables);
             executor->setLogger(logger);
 
             LOG_TRACE(logger, "Sending {} parts ({} marks, {} rows) to {}: {}",

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -289,7 +289,7 @@ void registerTableFunctionMergeTreeAnalyzeIndexes(TableFunctionFactory & factory
         []() { return std::make_shared<TableFunctionMergeTreeAnalyzeIndexes>(/* resolve_by_uuid_= */ true); },
         {
             .description = "Internal function for index analysis",
-            .examples = {{"mergeTreeAnalyzeIndexes", "SELECT * FROM mergeTreeAnalyzeIndexesUUID('table_uuid', predicate[, ['part1', 'part2']])", ""}},
+            .examples = {{"mergeTreeAnalyzeIndexesUUID", "SELECT * FROM mergeTreeAnalyzeIndexesUUID('table_uuid', predicate[, ['part1', 'part2']])", ""}},
             .category = FunctionDocumentation::Category::TableFunction
         },
         {.allow_readonly = true}

--- a/tests/queries/0_stateless/04600_clickhouse_client_scalars.reference
+++ b/tests/queries/0_stateless/04600_clickhouse_client_scalars.reference
@@ -1,0 +1,3 @@
+one-scalar
+('two-columns','scalar')
+scalar

--- a/tests/queries/0_stateless/04600_clickhouse_client_scalars.sh
+++ b/tests/queries/0_stateless/04600_clickhouse_client_scalars.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --external --scalar --name foo --format CSV --file <(echo one-scalar) --types 'String' -q "SELECT __getScalar('foo')"
+$CLICKHOUSE_CLIENT --external --scalar --name foo --format CSV --file <(echo two-columns,scalar) --types 'String, String' -q "SELECT __getScalar('foo')"
+$CLICKHOUSE_CLIENT --external --scalar --name foo --format CSV --file <(echo two-columns,scalar) --structure 'a String, b String' -q "SELECT __getScalar('foo').b"

--- a/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.reference
+++ b/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.reference
@@ -1,0 +1,9 @@
+-- { echo }
+select sum(key) from test_200_parts settings cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
+499999500000
+select sum(key) from test_20_parts settings cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
+499500
+SELECT * FROM mergeTreeAnalyzeIndexesUUID(?, true, __getScalar(?))	['_table_function.mergeTreeAnalyzeIndexesUUID']
+select sum(key) from `?` settings cluster_for_parallel_replicas=?;	['default.test_200_parts']
+SELECT * FROM mergeTreeAnalyzeIndexesUUID(?, true, [?..])	['_table_function.mergeTreeAnalyzeIndexesUUID']
+select sum(key) from test_20_parts settings cluster_for_parallel_replicas=?;	['default.test_20_parts']

--- a/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.sql
+++ b/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-merge-tree-settings, no-random-settings
+-- Tags: no-random-merge-tree-settings, no-random-settings, long
 -- - no-random-merge-tree-settings -- may change number of parts
 
 drop table if exists test_200_parts;

--- a/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.sql
+++ b/tests/queries/0_stateless/04600_distributed_index_analysis_scalars.sql
@@ -1,0 +1,37 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings
+-- - no-random-merge-tree-settings -- may change number of parts
+
+drop table if exists test_200_parts;
+create table test_200_parts (key Int, value Int) engine=MergeTree() order by key partition by key % 200 settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+system stop merges test_200_parts;
+insert into test_200_parts select number, number*100 from numbers(1e6) settings max_partitions_per_insert_block=200, max_block_size=1e6;
+
+drop table if exists test_20_parts;
+create table test_20_parts (key Int, value Int) engine=MergeTree() order by key partition by key % 20 settings distributed_index_analysis_min_parts_to_activate=0, distributed_index_analysis_min_indexes_bytes_to_activate=0;
+system stop merges test_20_parts;
+insert into test_20_parts select number, number*100 from numbers(1e3) settings max_partitions_per_insert_block=20, max_block_size=1e6;
+
+set allow_experimental_parallel_reading_from_replicas=0;
+set parallel_replicas_for_non_replicated_merge_tree=1;
+set parallel_replicas_index_analysis_only_on_coordinator=1;
+set parallel_replicas_local_plan=1;
+set distributed_index_analysis=1;
+set max_parallel_replicas=2;
+set allow_experimental_analyzer=1;
+--- Ignore warnings when replica does not respond, and analysis is done on initiator
+set send_logs_level='error';
+
+-- { echo }
+select sum(key) from test_200_parts settings cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
+select sum(key) from test_20_parts settings cluster_for_parallel_replicas='test_cluster_one_shard_two_replicas';
+
+-- { echoOff }
+system flush logs query_log;
+select normalizeQuery(query), tables
+from system.query_log
+where
+  event_date >= yesterday() AND event_time >= now() - 600
+  and type != 'QueryStart'
+  and query_kind = 'Select'
+  and endsWith(log_comment, '-' || currentDatabase()) -- "current_database = currentDatabase()" cannot be used, remote queries does not have it
+order by event_time_microseconds;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Send big list parts for distributed index analysis as scalars (avoids possible failures due to max_ast_elements/max_query_size and removes AST parsing overhead)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1085` (included in `26.7` and later)
<!-- ch-version-info:end -->