### PR TITLE
CI: Make "Report messages" status informational (green), never red

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -1,15 +1,14 @@
 """
-Workflow hook that posts a GH commit status summarising errors and warnings
-from the workflow-level report (``Result.ext["errors"]`` /
+Workflow hook that posts an informational GH commit status summarising the
+errors and warnings from the workflow-level report (``Result.ext["errors"]`` /
 ``Result.ext["warnings"]`` on the top-level workflow result).
 
-The hook itself never fails so that it does not block the post-hook step;
-the commit status it posts (FAIL when issues are present) is what blocks
-the merge.  After the issue is reviewed and fixed, re-running CI will post
-a new OK status once the error/warning is no longer produced.
+The status is always posted as success (green) and the hook always exits 0:
+it is purely informational and must never show up as red or block the merge.
+Its description carries the error/warning counts and it links to the report
+page, where the messages are listed in the notification panels at the top.
+When there are no messages, no status is posted.
 """
-
-import sys
 
 from ci.praktika.gh import GH
 from ci.praktika.info import Info
@@ -46,18 +45,17 @@ def check():
             except Exception as e:
                 print(f"WARNING: failed to build report url: {e}")
                 url = ""
+            # Always green: this status is informational and must not block the
+            # merge or show up as red, even when errors/warnings are present.
             GH.post_commit_status(
                 name=STATUS_NAME,
-                status=Result.Status.FAIL,
+                status=Result.Status.OK,
                 description=description,
                 url=url,
             )
-            return False
     except Exception as e:
         print(f"WARNING: check_report_messages failed: {e}")
-    return True
 
 
 if __name__ == "__main__":
-    if not check():
-        sys.exit(1)
+    check()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Description

Follow-up to #110389.

Currently, when the workflow report contains errors or warnings, the
`check_report_messages` post-hook makes the report messages appear red in two
ways:
1. it posts the `Report messages` commit status as `failure` (red), and
2. it exits non-zero, which fails the `Post Hooks` result and turns the
   `Mergeable Check` red — blocking the merge.

This makes the `Report messages` status purely **informational**: it is posted
as `success` (green) and the hook always exits `0`. The description still
carries the error/warning counts and the status still links to the report page
where the messages are listed in the notification panels, so the information is
preserved and visible — but `Report messages` no longer appears red or blocks
the merge.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.962` (included in `26.7` and later)
<!-- ch-version-info:end -->