### PR TITLE
Skip default-user password setup on install when default user is removed

### DIFF
--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -577,7 +577,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         fs::path pid_path = prefix / options["pid-path"].as<std::string>();
 
         bool has_password_for_default_user = false;
-        bool default_user_removed = false;
+        bool is_default_user_removed = false;
 
         if (!fs::exists(config_d))
         {
@@ -729,7 +729,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             {
                 /// The default user was explicitly removed, e.g. via `<default remove="1" />` in users.d.
                 /// There is no user to set up a password for.
-                default_user_removed = true;
+                is_default_user_removed = true;
             }
             else if (!configuration->getString("users.default.password", "").empty()
                 || !configuration->getString("users.default.password_sha256_hex", "").empty()
@@ -826,7 +826,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         bool can_ask_password = !noninteractive && stdout_is_a_tty;
 
         /// Set up password for default user.
-        if (default_user_removed)
+        if (is_default_user_removed)
         {
             fmt::print("{}The default user is removed from {} and {}. Not setting up a password for it.{}\n",
                 start_hilite, users_config_file.string(), users_d.string(), end_hilite);

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -577,6 +577,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         fs::path pid_path = prefix / options["pid-path"].as<std::string>();
 
         bool has_password_for_default_user = false;
+        bool default_user_removed = false;
 
         if (!fs::exists(config_d))
         {
@@ -724,7 +725,13 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             ConfigProcessor processor(users_config_file.string(), /* throw_on_bad_incl = */ false, /* log_to_console = */ false);
             ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(processor.processConfig()));
 
-            if (!configuration->getString("users.default.password", "").empty()
+            if (!configuration->has("users.default"))
+            {
+                /// The default user was explicitly removed, e.g. via `<default remove="1" />` in users.d.
+                /// There is no user to set up a password for.
+                default_user_removed = true;
+            }
+            else if (!configuration->getString("users.default.password", "").empty()
                 || !configuration->getString("users.default.password_sha256_hex", "").empty()
                 || !configuration->getString("users.default.password_double_sha1_hex", "").empty())
             {
@@ -819,7 +826,12 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
         bool can_ask_password = !noninteractive && stdout_is_a_tty;
 
         /// Set up password for default user.
-        if (has_password_for_default_user)
+        if (default_user_removed)
+        {
+            fmt::print("{}The default user is removed from {} and {}. Not setting up a password for it.{}\n",
+                start_hilite, users_config_file.string(), users_d.string(), end_hilite);
+        }
+        else if (has_password_for_default_user)
         {
             fmt::print("{}Password for the default user is already specified. To remind or reset, see {} and {}.{}\n",
                 start_hilite, users_config_file.string(), users_d.string(), end_hilite);


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/83887


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`clickhouse install` (and therefore `apt`/`dpkg` package upgrades) no longer prompts interactively to set up a password for the `default` user when that user has been explicitly removed from configuration via `<default remove="1" />` in `users.d`. Previously the installer only checked whether the `default` user already had a password configured, missing the case where the user itself does not exist in the merged configuration at all, so it kept asking for a password on every upgrade even though there was no user to set it for.