### PR TITLE
AI functions: send X-ClickHouse-AI-Function header from OpenAI provider

### DIFF
--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -79,7 +79,7 @@ SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
 
 ### Parameter map {#parameter-map}
 
-Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, which takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) and errors if it is instead set in the parameter map or named collection.
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, which takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) and errors if it is instead set in the parameter map or named collection. This is in order to enforce reproducible embeddings.
 
 The following parameters are common to all the AI functions:
 

--- a/src/Functions/AI/IAIProvider.h
+++ b/src/Functions/AI/IAIProvider.h
@@ -60,6 +60,10 @@ struct AIRequest
 
     /// Maximum number of tokens the model may generate in its response. This is a per-request limit, not a per-query limit.
     UInt64 max_tokens = 0;
+
+    /// SQL name of the AI function that produced this request (e.g. "aiGenerate").
+    /// Emitted by OpenAIProvider as the `X-ClickHouse-AI-Function` header; ignored by other providers.
+    String function_name;
 };
 
 /// Response from a single AI chat completion request. Returned by IAIProvider::call after parsing the provider's HTTP response.
@@ -95,6 +99,10 @@ struct AIEmbeddingRequest
     /// Optional target dimensionality for the output vectors. 0 means use the model's native size.
     /// Supported by OpenAI's `text-embedding-3-*` models; providers that ignore it return the native size.
     UInt64 dimensions = 0;
+
+    /// SQL name of the AI function that produced this request (e.g. "aiEmbed").
+    /// Emitted by OpenAIProvider as the `X-ClickHouse-AI-Function` header; ignored by other providers.
+    String function_name;
 };
 
 /// Response from a single embedding request. `embeddings` is aligned 1:1 with `AIEmbeddingRequest::inputs`.

--- a/src/Functions/AI/OpenAIProvider.cpp
+++ b/src/Functions/AI/OpenAIProvider.cpp
@@ -95,8 +95,8 @@ AIResponse OpenAIProvider::call(const AIRequest & ai_request, const ConnectionTi
     http_request.setContentType("application/json");
     if (!api_key.empty()) /// not all providers need API key
         http_request.set("Authorization", "Bearer " + api_key);
-    if (!ai_request.function_name.empty())
-        http_request.set("X-ClickHouse-AI-Function", ai_request.function_name);
+    chassert(!ai_request.function_name.empty());
+    http_request.set("X-ClickHouse-AI-Function", ai_request.function_name);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);
@@ -180,8 +180,8 @@ AIEmbeddingResponse OpenAIProvider::embed(const AIEmbeddingRequest & ai_embeddin
     http_request.setContentType("application/json");
     if (!api_key.empty()) /// not all providers need API key
         http_request.set("Authorization", "Bearer " + api_key);
-    if (!ai_embedding_request.function_name.empty())
-        http_request.set("X-ClickHouse-AI-Function", ai_embedding_request.function_name);
+    chassert(!ai_embedding_request.function_name.empty());
+    http_request.set("X-ClickHouse-AI-Function", ai_embedding_request.function_name);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);

--- a/src/Functions/AI/OpenAIProvider.cpp
+++ b/src/Functions/AI/OpenAIProvider.cpp
@@ -95,6 +95,8 @@ AIResponse OpenAIProvider::call(const AIRequest & ai_request, const ConnectionTi
     http_request.setContentType("application/json");
     if (!api_key.empty()) /// not all providers need API key
         http_request.set("Authorization", "Bearer " + api_key);
+    if (!ai_request.function_name.empty())
+        http_request.set("X-ClickHouse-AI-Function", ai_request.function_name);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);
@@ -178,6 +180,8 @@ AIEmbeddingResponse OpenAIProvider::embed(const AIEmbeddingRequest & ai_embeddin
     http_request.setContentType("application/json");
     if (!api_key.empty()) /// not all providers need API key
         http_request.set("Authorization", "Bearer " + api_key);
+    if (!ai_embedding_request.function_name.empty())
+        http_request.set("X-ClickHouse-AI-Function", ai_embedding_request.function_name);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -429,6 +429,7 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
                 ai_request.model = model;
                 ai_request.temperature = temperature;
                 ai_request.max_tokens = max_tokens;
+                ai_request.function_name = functionName();
 
                 /// update api_calls/quotas before call so failed calls are still added to total
                 ++total_api_calls;

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -429,7 +429,7 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
                 ai_request.model = model;
                 ai_request.temperature = temperature;
                 ai_request.max_tokens = max_tokens;
-                ai_request.function_name = functionName();
+                ai_request.function_name = getName();
 
                 /// update api_calls/quotas before call so failed calls are still added to total
                 ++total_api_calls;

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -141,8 +141,6 @@ protected:
     ContextPtr context;
     ContextPtr getContext() const { return context; }
 
-    virtual String functionName() const = 0;
-
     /// Function-specific parameters accepted in the trailing `Map(String, String)` argument, on top
     /// of `commonParams`. Each entry carries its own default (or is required). Default: none.
     virtual AIParamSpecs functionParams() const { return {}; }

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -62,8 +62,6 @@ private:
     static constexpr float default_temp = 0.0f;
     static constexpr size_t categories_arg_index = 1;
 
-    String functionName() const override { return name; }
-
     AIParamSpecs functionParams() const override
     {
         return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -211,6 +211,7 @@ public:
             AIEmbeddingRequest ai_embedding_request;
             ai_embedding_request.model = model;
             ai_embedding_request.dimensions = dimensions;
+            ai_embedding_request.function_name = getName();
             ai_embedding_request.inputs.reserve(batch_end - batch_start);
 
             for (size_t k = batch_start; k < batch_end; ++k)

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -99,7 +99,6 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args{
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
-            /// `model` must be a plain (non-nullable) `String`; constness is enforced by the column validator.
             {"model", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
         };
         FunctionArgumentDescriptors optional_args{
@@ -110,9 +109,7 @@ public:
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeFloat32>());
     }
 
-    /// Parameters accepted in the optional trailing `Map(String, String)` argument. `aiEmbed` does not
-    /// inherit `FunctionBaseAI`, so it declares its own spec (no `max_tokens`, which embeddings do not
-    /// use; no `model`, which is a required positional argument for `aiEmbed`).
+    /// Parameters accepted in the optional trailing `Map(String, String)` argument.
     static AIParamSpecs embeddingParams()
     {
         return {
@@ -318,7 +315,7 @@ from a chat one.
 
 The `model` is a required positional argument (a constant `String`). Unlike the text functions,
 `aiEmbed` does not read `model` from the named collection or the parameter map. A named collection
-that defines `model` is rejected rather than silently ignored.
+that defines `model` is rejected.
 
 The optional `dimensions` parameter, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -50,8 +50,6 @@ private:
     static constexpr float default_temp = 0.0f;
     static constexpr size_t instruction_arg_index = 1;
 
-    String functionName() const override { return name; }
-
     AIParamSpecs functionParams() const override
     {
         return {{"temperature", AIParamKind::Float, Field(static_cast<Float64>(default_temp))}};

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -44,8 +44,6 @@ public:
 private:
     static constexpr float default_temp = 0.7f;
 
-    String functionName() const override { return name; }
-
     AIParamSpecs functionParams() const override
     {
         return {

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -43,8 +43,6 @@ private:
     static constexpr float default_temp = 0.3f;
     static constexpr size_t target_language_arg_index = 1;
 
-    String functionName() const override { return name; }
-
     AIParamSpecs functionParams() const override
     {
         return {

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -932,6 +932,25 @@ def test_generate_retry_respects_api_call_quota(started_cluster):
     assert int(events["rows_skipped"]) == 1
 
 
+def test_function_name_header(started_cluster):
+    """The OpenAI provider tags every request with an `X-ClickHouse-AI-Function` header carrying the
+    SQL name of the calling function, so the upstream endpoint can tell which function made the call.
+    Covers the chat path (aiGenerate/aiClassify/aiExtract/aiTranslate) and the embedding path (aiEmbed)."""
+    cases = [
+        ("aiGenerate", "SELECT aiGenerate('hi', map('credentials', 'ai_mock'))"),
+        (
+            "aiClassify",
+            "SELECT aiClassify('hi', ['a', 'b'], map('credentials', 'ai_mock'))",
+        ),
+        ("aiExtract", "SELECT aiExtract('hi', 'the price', map('credentials', 'ai_mock'))"),
+        ("aiTranslate", "SELECT aiTranslate('hi', 'French', map('credentials', 'ai_mock'))"),
+        ("aiEmbed", "SELECT aiEmbed('hi', map('credentials', 'ai_embed'))"),
+    ]
+    for name, query in cases:
+        instance.query(query, settings=AI_SETTINGS)
+        assert last_request()["headers"].get("x-clickhouse-ai-function") == name
+
+
 def test_embed_retry_respects_api_call_quota(started_cluster):
     """The embedding path enforces the same per-attempt API-call quota: a retriable HTTP 500 is not
     retried past `ai_function_max_api_calls_per_query`."""

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -944,7 +944,10 @@ def test_function_name_header(started_cluster):
         ),
         ("aiExtract", "SELECT aiExtract('hi', 'the price', map('credentials', 'ai_mock'))"),
         ("aiTranslate", "SELECT aiTranslate('hi', 'French', map('credentials', 'ai_mock'))"),
-        ("aiEmbed", "SELECT aiEmbed('hi', map('credentials', 'ai_embed'))"),
+        (
+            "aiEmbed",
+            "SELECT aiEmbed('hi', 'test-embed-model', map('credentials', 'ai_embed'))",
+        ),
     ]
     for name, query in cases:
         instance.query(query, settings=AI_SETTINGS)


### PR DESCRIPTION
Tag every OpenAI-format request with the SQL name of the calling AI function so an upstream endpoint can identify it. Header only; other providers ignore the new AIRequest/AIEmbeddingRequest field.

With the change, the outbound POST gains one extra header line. For an aiGenerate call against a keyed collection, the request headers look like:

```HTML
  POST /v1/chat/completions HTTP/1.1
  Host: your-endpoint.example.com
  Content-Type: application/json
  Authorization: Bearer <api_key>
  X-ClickHouse-AI-Function: aiGenerate
  Content-Length: 142
```

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Tag OpenAI-format HTTP requests with the SQL name of the calling AI function for upstream endpoint identification.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.312` (included in `26.8` and later)
- Backported to: `26.7.2.38`, `26.6.2.139`, `26.5.6.101`
<!-- ch-version-info:end -->