### PR TITLE
Fix flaky 03101_analyzer_identifiers_4: qualify table names

### DIFF
--- a/tests/queries/0_stateless/03101_analyzer_identifiers_4.sql
+++ b/tests/queries/0_stateless/03101_analyzer_identifiers_4.sql
@@ -46,9 +46,11 @@ SELECT * EXCEPT('hello|world');
 
 SELECT * EXCEPT(hello) REPLACE(x + 1 AS x);
 
-SELECT COLUMNS('^c') FROM t;
-SELECT t.COLUMNS('^c') FROM t, u;
-SELECT t.COLUMNS('^c') EXCEPT (test_hello, test_world) FROM t, u;
+-- Qualify table names so resolution does not depend on session USE state
+-- (a client reconnect mid-test resets the current database, causing UNKNOWN_TABLE).
+SELECT COLUMNS('^c') FROM {CLICKHOUSE_DATABASE:Identifier}.t;
+SELECT t.COLUMNS('^c') FROM {CLICKHOUSE_DATABASE:Identifier}.t, {CLICKHOUSE_DATABASE:Identifier}.u;
+SELECT t.COLUMNS('^c') EXCEPT (test_hello, test_world) FROM {CLICKHOUSE_DATABASE:Identifier}.t, {CLICKHOUSE_DATABASE:Identifier}.u;
 
 SELECT '---';
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/23194
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flaky `03101_analyzer_identifiers_4`.

The test did `USE {db}` and then referenced tables `t` and `u` unqualified (`SELECT COLUMNS('^c') FROM t`). When the client reconnects mid-test, the session current-database is reset, so the unqualified names resolve against the wrong database and the query fails with `Code 60 UNKNOWN_TABLE: Unknown table expression identifier 't' ... Maybe you meant <db>.t?`. Because it depends on reconnect timing, it only surfaced sporadically in PR runs under sanitizer/coverage/DBReplicated randomization, never on master.

Fix: qualify the references with `{CLICKHOUSE_DATABASE:Identifier}` so resolution no longer depends on session `USE` state. Reference output is unchanged.

Flaky across 3 unrelated PRs (30d), 0 master failures:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107125&sha=&name_0=PR (amd_msan, WasmEdge)
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93462&sha=&name_0=PR (amd_tsan)
