### PR TITLE
Fix analyzer wording in 04402 test to unblock the style check

### DIFF
--- a/tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql
+++ b/tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql
@@ -8,7 +8,7 @@ SET enable_analyzer = 0;
 -- fill column, so a gap-fill row would be inserted twice into that column. This must be rejected.
 SELECT * FROM (SELECT 1 AS a0, a0 AS a4 ORDER BY a0 WITH FILL INTERPOLATE (a4)); -- { serverError INVALID_WITH_FILL_EXPRESSION }
 
--- The new analyzer materializes a separate interpolate column, so the same query is valid there.
+-- The analyzer materializes a separate interpolate column, so the same query is valid there.
 SELECT * FROM (SELECT 1 AS a0, a0 AS a4 ORDER BY a0 WITH FILL INTERPOLATE (a4)) SETTINGS enable_analyzer = 1;
 
 -- INTERPOLATE on a column that is not a fill column stays valid on the old analyzer.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110160
Related: https://github.com/ClickHouse/ClickHouse/pull/110103

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The repo-wide style rule rejecting the "new analyzer" wording (#110160, merged 2026-07-15 00:36 UTC) and the test `04402_with_fill_interpolate_fill_column_overlap.sql` containing a `-- The new analyzer materializes ...` comment (#110103, merged 2026-07-11) landed independently — each passed CI on a base that predated the other. Since #110160 merged, `master` contains both the rule and the violating file, so `Style check` fails on every branch based on it with:

```
tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql:11:-- The new analyzer materializes a separate interpolate column, so the same query is valid there.
The analyzer is enabled by default since ClickHouse 24.3 and is no longer new. Write "the analyzer" or "Analyzer" instead of "new analyzer"/"new query analyzer" in the lines above.
```

(`master` itself has not run `Style check` since the rule merged; the first run will fail the same way.)

Reword the comment to `The analyzer materializes ...` as the rule's message suggests. Comment-only change, no behavior or reference change. Verified locally that neither the single-line nor the wrapped-line pattern of the rule matches the file anymore, and that this was the only occurrence under `src`/`base`/`programs`/`utils`/`docs`/`tests` on current `master`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.973` (included in `26.7` and later)
<!-- ch-version-info:end -->