### PR TITLE
Fix Style check: reword analyzer comment in 04402 test

### DIFF
--- a/tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql
+++ b/tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql
@@ -8,7 +8,7 @@ SET enable_analyzer = 0;
 -- fill column, so a gap-fill row would be inserted twice into that column. This must be rejected.
 SELECT * FROM (SELECT 1 AS a0, a0 AS a4 ORDER BY a0 WITH FILL INTERPOLATE (a4)); -- { serverError INVALID_WITH_FILL_EXPRESSION }
 
--- The new analyzer materializes a separate interpolate column, so the same query is valid there.
+-- The analyzer materializes a separate interpolate column, so the same query is valid there.
 SELECT * FROM (SELECT 1 AS a0, a0 AS a4 ORDER BY a0 WITH FILL INTERPOLATE (a4)) SETTINGS enable_analyzer = 1;
 
 -- INTERPOLATE on a column that is not a fill column stays valid on the old analyzer.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

The check-style analyzer-wording pass (strengthened in #110160, merged 2026-07-14) now flags the comment on line 11 of `tests/queries/0_stateless/04402_with_fill_interpolate_fill_column_overlap.sql`:

```
-- The new analyzer materializes a separate interpolate column, so the same query is valid there.
```

This fails `Style check` on master, which blocks the entire downstream CI chain (Builds, Functional Tests, Integration, Stress, ...) for every PR based on current master. Confirmed on master (`pull_request_number = 0`) plus 10+ PRs starting 2026-07-15 00:38 UTC.

Fix: reword "The new analyzer" to "The analyzer" per the rule (`ci/jobs/scripts/check_style/various_checks.sh:266-302`). Verified both wording patterns are green locally on the edited file.
