### PR TITLE
Set the maximum 90-day cooldown for Dependabot version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,8 @@ updates:
     directory: "/ci/docker"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -14,6 +16,8 @@ updates:
     directory: "/ci/docker"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -22,6 +26,8 @@ updates:
     directory: "/ci/docker"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -30,6 +36,8 @@ updates:
     directory: "/ci/docker"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -39,6 +47,8 @@ updates:
     directory: "/tests/integration"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -47,6 +57,8 @@ updates:
     directory: "/tests/integration"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -55,6 +67,8 @@ updates:
     directory: "/tests/integration"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -63,6 +77,8 @@ updates:
     directory: "/tests/integration"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -72,6 +88,8 @@ updates:
     directory: "/docker/test"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -80,6 +98,8 @@ updates:
     directory: "/docker/test"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -88,6 +108,8 @@ updates:
     directory: "/docker/test"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -96,6 +118,8 @@ updates:
     directory: "/docker/test"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -107,6 +131,8 @@ updates:
     directory: "/rust/chcache"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -115,6 +141,8 @@ updates:
     directory: "/rust/workspace"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -27,7 +27,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -37,7 +37,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -48,7 +48,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -58,7 +58,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -68,7 +68,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -78,7 +78,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -89,7 +89,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -99,7 +99,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -109,7 +109,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -119,7 +119,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -132,7 +132,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
@@ -142,7 +142,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 90
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
Set `cooldown.default-days` to 90 (the maximum Dependabot allows, range 1–90) on every `updates` entry in `.github/dependabot.yaml`. All entries use a `monthly` schedule.

GitHub recently introduced a default 3-day package cooldown for Dependabot version updates (https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/). With a cooldown, a newly published release must have been available on its registry for the configured number of days before Dependabot opens a version-update pull request. This sets that window to the maximum of 90 days, matching the existing "the older the better" policy stated at the top of the config. Cooldown applies only to version updates; security updates are unaffected.

Note: all `updates` entries are currently fully inhibited (`open-pull-requests-limit: 0` and `ignore: "*"`), so this has no effect today — it is future-proofing in case any entry is re-enabled.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.999` (included in `26.7` and later)
<!-- ch-version-info:end -->