### PR TITLE
Reject non-transactional removal of parts created by uncommitted transactions

### DIFF
--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
@@ -177,6 +177,31 @@ void VersionMetadata::checkNonTransactionalRemovalIsPossible(const VersionInfo &
             info.creation_tid);
 }
 
+void VersionMetadata::checkCreationIsCommitted()
+{
+    auto info = getInfo();
+    /// A rollback sets the in-memory creation_csn to RolledBackCSN before removing the part from
+    /// the working set, so a rolled-back part can still be active here for a short while.
+    CSN creation_csn = info.creation_csn;
+    if (!creation_csn)
+        creation_csn = tryGetCSN(info.creation_tid);
+
+    if (creation_csn == Tx::UnknownCSN)
+        throw Exception(
+            ErrorCodes::SERIALIZATION_ERROR,
+            "Cannot use data object {}: it was created by transaction {} which is not committed yet. "
+            "Wait for the transaction to commit or roll back, and retry",
+            getObjectName(),
+            info.creation_tid);
+
+    if (creation_csn == Tx::RolledBackCSN)
+        throw Exception(
+            ErrorCodes::SERIALIZATION_ERROR,
+            "Cannot use data object {}: it was created by transaction {} which was rolled back",
+            getObjectName(),
+            info.creation_tid);
+}
+
 void VersionMetadata::lockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context)
 {
     LOG_TEST(

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
@@ -145,7 +145,10 @@ void VersionMetadata::setAndStoreRemovalTID(const TransactionID & tid)
 
         chassert(info.removal_tid.isEmpty() || tid == Tx::EmptyTID, fmt::format("removal_tid {}, tid {}", info.removal_tid, tid));
         info.removal_tid = tid;
-        if (tid.isNonTransactional())
+        /// A non-transactional removal can cover a part whose creating transaction has not
+        /// committed yet (it selects covered parts ignoring MVCC visibility). `creation_csn`
+        /// must be persisted before `removal_csn`, so defer the csn until creation resolves.
+        if (tid.isNonTransactional() && info.creation_csn)
             info.removal_csn = Tx::NonTransactionalCSN;
         return true;
     };
@@ -387,8 +390,12 @@ std::optional<bool> VersionMetadata::updateCSNIfNeeded(VersionInfo & current_inf
             }
             else if (csn_of_removal_tid)
             {
-                current_info.removal_csn = csn_of_removal_tid;
-                info_updated = true;
+                /// Never resolve removal_csn before creation_csn (see setAndStoreRemovalTID).
+                if (current_info.creation_csn)
+                {
+                    current_info.removal_csn = csn_of_removal_tid;
+                    info_updated = true;
+                }
             }
             else
             {
@@ -512,7 +519,9 @@ void VersionMetadata::validateInfo(const String & object_name, const VersionInfo
                 object_name,
                 info.removal_csn);
 
-        if (info.creation_tid != info.removal_tid && !info.removal_tid.isEmpty())
+        /// A non-transactional removal_tid over an unresolved creation is a valid deferred
+        /// state: the covering DROP could not see that the creating transaction is uncommitted.
+        if (info.creation_tid != info.removal_tid && !info.removal_tid.isEmpty() && !info.removal_tid.isNonTransactional())
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR, "Object {}, creation_csn is not set while removal_tid is not {}", object_name, info.removal_tid);
     }

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
@@ -138,21 +138,43 @@ void VersionMetadata::setAndStoreRemovalTID(const TransactionID & tid)
 {
     LOG_TEST(log, "Object {}, setAndStoreRemovalTID {}", getObjectName(), tid);
 
-    auto update_function = [tid](VersionInfo & info)
+    auto update_function = [this, tid](VersionInfo & info)
     {
         if (info.removal_tid == tid)
             return false;
 
         chassert(info.removal_tid.isEmpty() || tid == Tx::EmptyTID, fmt::format("removal_tid {}, tid {}", info.removal_tid, tid));
+
+        if (tid.isNonTransactional())
+            checkNonTransactionalRemovalIsPossible(info);
+
         info.removal_tid = tid;
-        /// A non-transactional removal can cover a part whose creating transaction has not
-        /// committed yet (it selects covered parts ignoring MVCC visibility). `creation_csn`
-        /// must be persisted before `removal_csn`, so defer the csn until creation resolves.
-        if (tid.isNonTransactional() && info.creation_csn)
+        if (tid.isNonTransactional())
             info.removal_csn = Tx::NonTransactionalCSN;
         return true;
     };
     updateInfoWithRefreshDataThenStoreAndSetMetadata(update_function);
+}
+
+void VersionMetadata::checkNonTransactionalRemovalIsPossible()
+{
+    checkNonTransactionalRemovalIsPossible(getInfo());
+}
+
+void VersionMetadata::checkNonTransactionalRemovalIsPossible(const VersionInfo & info)
+{
+    /// A non-transactional removal covers all active parts ignoring MVCC visibility, so it can
+    /// meet a part whose creating transaction is still running (e.g. a non-transactional
+    /// DROP PARTITION over a part inserted by a concurrent uncommitted transaction).
+    /// Removing such a part would persist removal_csn before creation_csn and silently discard
+    /// the uncommitted data on commit, so fail instead.
+    if (!info.creation_csn && tryGetCSN(info.creation_tid) == Tx::UnknownCSN)
+        throw Exception(
+            ErrorCodes::SERIALIZATION_ERROR,
+            "Cannot remove data object {}: it was created by transaction {} which is not committed yet. "
+            "Wait for the transaction to commit or roll back, and retry",
+            getObjectName(),
+            info.creation_tid);
 }
 
 void VersionMetadata::lockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context)
@@ -390,12 +412,8 @@ std::optional<bool> VersionMetadata::updateCSNIfNeeded(VersionInfo & current_inf
             }
             else if (csn_of_removal_tid)
             {
-                /// Never resolve removal_csn before creation_csn (see setAndStoreRemovalTID).
-                if (current_info.creation_csn)
-                {
-                    current_info.removal_csn = csn_of_removal_tid;
-                    info_updated = true;
-                }
+                current_info.removal_csn = csn_of_removal_tid;
+                info_updated = true;
             }
             else
             {
@@ -519,9 +537,7 @@ void VersionMetadata::validateInfo(const String & object_name, const VersionInfo
                 object_name,
                 info.removal_csn);
 
-        /// A non-transactional removal_tid over an unresolved creation is a valid deferred
-        /// state: the covering DROP could not see that the creating transaction is uncommitted.
-        if (info.creation_tid != info.removal_tid && !info.removal_tid.isEmpty() && !info.removal_tid.isNonTransactional())
+        if (info.creation_tid != info.removal_tid && !info.removal_tid.isEmpty())
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR, "Object {}, creation_csn is not set while removal_tid is not {}", object_name, info.removal_tid);
     }

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.h
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.h
@@ -106,6 +106,11 @@ public:
     /// Returns immediately if the part is already removed.
     virtual void setAndStoreNonTransactionalRemovalTID(const TransactionInfoContext & transaction_context) = 0;
 
+    /// Throws SERIALIZATION_ERROR if a non-transactional removal cannot proceed because the part's
+    /// creating transaction has not been committed yet. Callers removing several parts at once
+    /// check all of them first, so a failed removal does not leave some parts locked.
+    void checkNonTransactionalRemovalIsPossible();
+
     /// Checks if the data part can be safely removed from storage.
     /// Returns true if no running transaction can see this part anymore.
     /// Logic:
@@ -203,6 +208,9 @@ protected:
     /// The CSN is re-checked after the running-transaction lookup to close the race window between the two queries.
     /// Returns 0 if the transaction is still in progress with no committed CSN yet.
     CSN tryGetCSN(TransactionID tid);
+
+    /// Implementation of the public overload, applied to the given (possibly freshly reloaded) info.
+    void checkNonTransactionalRemovalIsPossible(const VersionInfo & info);
 
     /// Static validation of `VersionInfo` fields. Throws on invalid state.
     static void validateInfo(const String & object_name, const VersionInfo & info);

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.h
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.h
@@ -111,6 +111,12 @@ public:
     /// check all of them first, so a failed removal does not leave some parts locked.
     void checkNonTransactionalRemovalIsPossible();
 
+    /// Throws SERIALIZATION_ERROR unless the object's creating transaction is committed (rejects
+    /// both still-running and rolled-back creators). Used before publishing the object's data
+    /// elsewhere (e.g. MOVE PARTITION TO TABLE): a commit is irreversible, so once this check
+    /// passes under the parts lock, the data cannot retroactively become rolled-back.
+    void checkCreationIsCommitted();
+
     /// Checks if the data part can be safely removed from storage.
     /// Returns true if no running transaction can see this part anymore.
     /// Logic:

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9285,9 +9285,22 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
         std::vector<DataPartsVector> covered_parts_for_commit;
         covered_parts_for_commit.reserve(precommitted_parts.size());
 
-        /// Track covered parts locked by non-transactional operations for cleanup on failure.
-        /// For transactional operations, MergeTreeTransaction rollback handles unlocking.
-        DataPartsVector locked_parts_to_cleanup;
+        /// A non-transactional removal of a part created by a still-running transaction is rejected
+        /// (see checkNonTransactionalRemovalIsPossible). Unlike transactional locks (unlocked by
+        /// MergeTreeTransaction rollback), non-transactional removal marks cannot be undone once
+        /// persisted, so check all covered parts before locking any of them.
+        if (!txn)
+        {
+            for (const auto & part : precommitted_parts)
+            {
+                DataPartPtr covering_part;
+                DataPartsVector covered_parts = data.getActivePartsToReplace(part->info, part->name, covering_part, acquired_parts_lock);
+                if (covering_part)
+                    continue;
+                for (const auto & covered : covered_parts)
+                    covered->version->checkNonTransactionalRemovalIsPossible();
+            }
+        }
 
         for (const auto & part : precommitted_parts)
         {
@@ -9317,12 +9330,7 @@ MergeTreeData::DataPartsVector MergeTreeData::Transaction::commit(DataPartsLock 
             /// Call addNewPartAndRemoveCovered only if there's no covering part.
             /// If there's a covering part, the precommitted part will be marked as obsolete in NOEXCEPT_SCOPE below.
             if (!covering_part)
-            {
                 MergeTreeTransaction::addNewPartAndRemoveCovered(data.shared_from_this(), part, covered_parts, txn);
-                /// Track successfully locked parts for cleanup in case a later iteration fails.
-                if (!txn)
-                    locked_parts_to_cleanup.insert(locked_parts_to_cleanup.end(), covered_parts.begin(), covered_parts.end());
-            }
 
             covered_parts_for_commit.push_back(std::move(covered_parts));
         }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -5846,6 +5846,13 @@ void MergeTreeData::removePartsFromWorkingSet(MergeTreeTransaction * txn, const 
 {
     if (txn)
         transactions_enabled.store(true);
+    else
+    {
+        /// A non-transactional removal mark cannot be undone once persisted, so check all parts
+        /// before mutating anything (see checkNonTransactionalRemovalIsPossible).
+        for (const DataPartPtr & part : remove)
+            part->version->checkNonTransactionalRemovalIsPossible();
+    }
 
     auto remove_time = clear_without_timeout ? 0 : time(nullptr);
 

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -3113,6 +3113,17 @@ void StorageMergeTree::replacePartitionFrom(const StoragePtr & source_table, con
             auto data_parts_lock = lockParts();
             std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
 
+            /// Fail close before committing the cloned parts: the removal below is rejected if the
+            /// replaced range contains a part of a still-running transaction (see
+            /// checkNonTransactionalRemovalIsPossible), and at that point the cloned parts would
+            /// already be committed and could not be undone.
+            if (replace && !local_context->getCurrentTransaction())
+            {
+                for (const auto & part : getDataPartsVectorInPartitionForInternalUsage(DataPartState::Active, partition_id, data_parts_lock))
+                    if (drop_range.contains(part->info))
+                        part->version->checkNonTransactionalRemovalIsPossible();
+            }
+
             /** It is important that obtaining new block number and adding that block to parts set is done atomically.
               * Otherwise there is race condition - merge of blocks could happen in interval that doesn't yet contain new part.
               */
@@ -3282,6 +3293,16 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
         {
             auto dest_data_parts_lock = dest_table_storage->lockParts();
             auto src_data_parts_lock = lockParts();
+
+            /// Fail close before publishing anything in the destination table: the moved data must
+            /// come from committed transactions only (see checkCreationIsCommitted). A still-running
+            /// creator would also make the source-side removal below fail after the destination is
+            /// already committed, and a rolled-back part must never reappear in the destination.
+            if (!txn)
+            {
+                for (const auto & part : src_parts)
+                    part->version->checkCreationIsCommitted();
+            }
 
             std::vector<std::unique_ptr<PlainCommittingBlockHolder>> block_holders;
 

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
@@ -1,0 +1,4 @@
+case 1	0
+case 2	0
+case 3	0
+case 4	1

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
@@ -6,3 +6,9 @@ SERIALIZATION_ERROR
 case 2 after rollback	0
 case 2 after drop	0
 case 3	0
+SERIALIZATION_ERROR
+case 4 after reject	2	1
+case 4 after replace	1	100
+SERIALIZATION_ERROR
+case 5 after reject	0	2	107
+case 5 after move	100	0

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.reference
@@ -1,4 +1,8 @@
-case 1	0
-case 2	0
+SERIALIZATION_ERROR
+case 1 before commit	2
+case 1 after commit	2
+case 1 after drop	0
+SERIALIZATION_ERROR
+case 2 after rollback	0
+case 2 after drop	0
 case 3	0
-case 4	1

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tags: no-replicated-database, no-ordinary-database
+# Transactions are not supported in Replicated and Ordinary databases.
+# A non-transactional ALTER TABLE ... DROP PARTITION covers parts of not-yet-committed
+# transactions. It must not persist removal_csn before creation_csn is resolved,
+# otherwise version metadata validation fails with a logical error
+# "creation_csn is not set while removal_csn is set".
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+# shellcheck source=./transactions.lib
+. "$CUR_DIR"/transactions.lib
+
+$CLICKHOUSE_CLIENT -q "drop table if exists mt"
+$CLICKHOUSE_CLIENT -q "create table mt (n int) engine=MergeTree order by tuple()"
+
+# Case 1: the creating transaction commits after the non-transactional DROP PARTITION.
+tx 1 "begin transaction"
+tx 1 "insert into mt settings async_insert=0 values (1)"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+tx 1 "commit"
+$CLICKHOUSE_CLIENT -q "select 'case 1', count() from mt"
+
+# Case 2: the creating transaction rolls back after the non-transactional DROP PARTITION.
+tx 2 "begin transaction"
+tx 2 "insert into mt settings async_insert=0 values (2)"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+tx 2 "rollback"
+$CLICKHOUSE_CLIENT -q "select 'case 2', count() from mt"
+
+# Case 3 (control): DROP PARTITION over a committed part still works as before.
+$CLICKHOUSE_CLIENT -q "insert into mt values (3)"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+$CLICKHOUSE_CLIENT -q "select 'case 3', count() from mt"
+
+# The table must stay fully usable afterwards.
+$CLICKHOUSE_CLIENT -q "insert into mt values (4)"
+$CLICKHOUSE_CLIENT -q "select 'case 4', count() from mt"
+
+$CLICKHOUSE_CLIENT -q "drop table mt"

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
@@ -44,4 +44,31 @@ $CLICKHOUSE_CLIENT -q "insert into mt values (3)"
 $CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
 $CLICKHOUSE_CLIENT -q "select 'case 3', count() from mt"
 
+# Case 4: REPLACE PARTITION FROM is rejected before publishing the cloned parts: the destination
+# must keep exactly its old data (nothing removed, nothing added).
+$CLICKHOUSE_CLIENT -q "drop table if exists mt_src"
+$CLICKHOUSE_CLIENT -q "create table mt_src (n int) engine=MergeTree order by tuple()"
+$CLICKHOUSE_CLIENT -q "insert into mt_src values (100)"
+$CLICKHOUSE_CLIENT -q "insert into mt values (0)"
+tx 4 "begin transaction"
+tx 4 "insert into mt settings async_insert=0 values (1)"
+$CLICKHOUSE_CLIENT -q "alter table mt replace partition id 'all' from mt_src" 2>&1 | grep -oE "SERIALIZATION_ERROR" | head -1
+$CLICKHOUSE_CLIENT -q "select 'case 4 after reject', count(), sum(n) from mt"
+tx 4 "commit"
+$CLICKHOUSE_CLIENT -q "alter table mt replace partition id 'all' from mt_src"
+$CLICKHOUSE_CLIENT -q "select 'case 4 after replace', count(), sum(n) from mt"
+
+# Case 5: MOVE PARTITION TO TABLE is rejected before publishing anything in the destination.
+$CLICKHOUSE_CLIENT -q "drop table if exists mt_dst"
+$CLICKHOUSE_CLIENT -q "create table mt_dst (n int) engine=MergeTree order by tuple()"
+tx 5 "begin transaction"
+tx 5 "insert into mt settings async_insert=0 values (7)"
+$CLICKHOUSE_CLIENT -q "alter table mt move partition id 'all' to table mt_dst" 2>&1 | grep -oE "SERIALIZATION_ERROR" | head -1
+$CLICKHOUSE_CLIENT -q "select 'case 5 after reject', (select count() from mt_dst), count(), sum(n) from mt"
+tx 5 "rollback"
+$CLICKHOUSE_CLIENT -q "alter table mt move partition id 'all' to table mt_dst"
+$CLICKHOUSE_CLIENT -q "select 'case 5 after move', (select sum(n) from mt_dst), count() from mt"
+
 $CLICKHOUSE_CLIENT -q "drop table mt"
+$CLICKHOUSE_CLIENT -q "drop table mt_src"
+$CLICKHOUSE_CLIENT -q "drop table mt_dst"

--- a/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
+++ b/tests/queries/0_stateless/04546_nontx_drop_partition_over_uncommitted_part.sh
@@ -2,9 +2,10 @@
 # Tags: no-replicated-database, no-ordinary-database
 # Transactions are not supported in Replicated and Ordinary databases.
 # A non-transactional ALTER TABLE ... DROP PARTITION covers parts of not-yet-committed
-# transactions. It must not persist removal_csn before creation_csn is resolved,
-# otherwise version metadata validation fails with a logical error
-# "creation_csn is not set while removal_csn is set".
+# transactions. It used to persist removal_csn before creation_csn was resolved, failing
+# version metadata validation with a logical error "creation_csn is not set while removal_csn
+# is set". Now it fails close: the operation is rejected with SERIALIZATION_ERROR and the
+# uncommitted data stays intact.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -15,27 +16,32 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT -q "drop table if exists mt"
 $CLICKHOUSE_CLIENT -q "create table mt (n int) engine=MergeTree order by tuple()"
 
-# Case 1: the creating transaction commits after the non-transactional DROP PARTITION.
+# Case 1: DROP PARTITION is rejected while an uncommitted part exists; nothing is removed,
+# including the committed part in the same partition; the transaction then commits normally.
+$CLICKHOUSE_CLIENT -q "insert into mt values (0)"
 tx 1 "begin transaction"
 tx 1 "insert into mt settings async_insert=0 values (1)"
-$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'" 2>&1 | grep -oE "SERIALIZATION_ERROR" | head -1
+$CLICKHOUSE_CLIENT -q "select 'case 1 before commit', count() from mt"
 tx 1 "commit"
-$CLICKHOUSE_CLIENT -q "select 'case 1', count() from mt"
+$CLICKHOUSE_CLIENT -q "select 'case 1 after commit', count() from mt"
 
-# Case 2: the creating transaction rolls back after the non-transactional DROP PARTITION.
+# The committed parts must not be left locked for removal by the failed DROP.
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+$CLICKHOUSE_CLIENT -q "select 'case 1 after drop', count() from mt"
+
+# Case 2: same, but the creating transaction rolls back.
 tx 2 "begin transaction"
 tx 2 "insert into mt settings async_insert=0 values (2)"
-$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'" 2>&1 | grep -oE "SERIALIZATION_ERROR" | head -1
 tx 2 "rollback"
-$CLICKHOUSE_CLIENT -q "select 'case 2', count() from mt"
+$CLICKHOUSE_CLIENT -q "select 'case 2 after rollback', count() from mt"
+$CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
+$CLICKHOUSE_CLIENT -q "select 'case 2 after drop', count() from mt"
 
-# Case 3 (control): DROP PARTITION over a committed part still works as before.
+# Case 3 (control): DROP PARTITION over committed parts still works as before.
 $CLICKHOUSE_CLIENT -q "insert into mt values (3)"
 $CLICKHOUSE_CLIENT -q "alter table mt drop partition id 'all'"
 $CLICKHOUSE_CLIENT -q "select 'case 3', count() from mt"
-
-# The table must stay fully usable afterwards.
-$CLICKHOUSE_CLIENT -q "insert into mt values (4)"
-$CLICKHOUSE_CLIENT -q "select 'case 4', count() from mt"
 
 $CLICKHOUSE_CLIENT -q "drop table mt"


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/64528

## Problem

A non-transactional `ALTER TABLE ... DROP PARTITION` that covers a part inserted by a not-yet-committed transaction fails with a logical error `creation_csn is not set while removal_csn is set to 1`, which aborts the server in debug and sanitizer builds. Deterministic reproducer: session A runs `BEGIN TRANSACTION; INSERT INTO t VALUES (1);` and stays open; session B runs `ALTER TABLE t DROP PARTITION ID 'all'`. This also fires in stress runs of `01169_old_alter_partition_isolation_stress.sh` when the query fuzzer moves the `DROP PARTITION` out of its transaction.

## Root cause

The `VersionMetadata` refactor (d6350c12225) made `setAndStoreRemovalTID` write `removal_tid` **and** `removal_csn = Tx::NonTransactionalCSN` in a single update. A non-transactional removal selects covered parts ignoring MVCC visibility, so it can cover a part whose `creation_csn` is still unresolved (the creating transaction is running). Persisting `removal_csn` first violates the write-order invariant that `creation_csn` is persisted before `removal_csn` (the pre-refactor `isVisible` chasserted `!had_removal_csn || had_creation_csn`), and `validateInfo` raises the logical error. Only the non-transactional path can reach this state: a transactional remover picks covered parts from its MVCC snapshot and never sees uncommitted parts of other transactions.

## Solution

Fail close: reject the non-transactional removal instead of removing data whose fate is not decided yet (removing it would make the creator's `COMMIT` succeed while its rows are silently gone).

1. New `VersionMetadata::checkNonTransactionalRemovalIsPossible` throws `SERIALIZATION_ERROR` when the part's `creation_csn` is unresolved and `tryGetCSN(creation_tid)` shows the creating transaction is still running. Committed (CSN just not written back yet) and rolled-back creators proceed as before. `setAndStoreRemovalTID` calls it for non-transactional tids — the single choke point of every non-transactional removal.
2. `MergeTreeData::Transaction::commit` pre-checks **all** covered parts before locking any of them for non-transactional operations. A non-transactional removal mark cannot be undone once persisted, and the existing `locked_parts_to_cleanup` was dead code (populated, never consumed) — without the pre-pass, a multi-part `DROP PARTITION` failing on the Nth part left parts `1..N-1` permanently marked as removed while still Active, making them invisible to transactional readers (verified empirically). The dead code is removed.

The client sees `Code: 650. SERIALIZATION_ERROR: Cannot remove data object ...: it was created by transaction ... which is not committed yet. Wait for the transaction to commit or roll back, and retry` — the standard retryable conflict signal of the transactions MVCC model. After the creating transaction finishes, the same `DROP PARTITION` succeeds.

3. The same hazard existed in non-transactional `REPLACE PARTITION FROM` and `MOVE PARTITION TO TABLE`, which remove the old parts via `removePartsInRangeFromWorkingSet` **after** committing the cloned/moved parts (a rejected `REPLACE` used to leave a half-replaced destination). Now `removePartsFromWorkingSet` checks all parts before mutating any (every non-transactional multi-part removal is all-or-nothing), `replacePartitionFrom` checks the active parts inside the drop range before renaming and committing the clones, and `movePartitionToTable` checks the moved source parts before publishing anything in the destination.
4. Since `MOVE` publishes the moved data in another table, it uses the stricter `checkCreationIsCommitted`: the creating transaction must be committed — a rollback marks `creation_csn = RolledBackCSN` before removing the part from the working set, so rejecting only still-running creators would leave a window where rolled-back rows get committed into the destination. A commit is irreversible, so once this check passes under the parts lock the moved data cannot retroactively become rolled back.

Adjacent paths verified: background merges never meet uncommitted parts (once transactions are used, merges begin their own transaction and filter invisible parts); non-transactional `OPTIMIZE` on such tables is already rejected upstream with `ABORTED` before touching version metadata.

The new test covers: rejection with both a committed and an uncommitted part in the partition (and that the committed part is not left locked — a retried `DROP` after `COMMIT` removes everything), the `ROLLBACK` variant, the committed-parts control, and the `REPLACE PARTITION FROM` / `MOVE PARTITION TO TABLE` rejection with byte-identical destinations. The transactional isolation tests (`01168*`, `01169*`, `01170`, `01171`) pass locally with the fix.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error (`creation_csn is not set while removal_csn is set`) when a non-transactional `ALTER TABLE ... DROP PARTITION` removes a part inserted by a transaction that has not committed yet. Such an operation is now rejected with `SERIALIZATION_ERROR` and can be retried after the transaction commits or rolls back.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
