### PR TITLE
Retry functional tests on server (total) memory limit exceeded

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -120,6 +120,12 @@ MESSAGES_TO_RETRY = [
     # Transient Keeper errors that happen under heavy load (e.g. ARM ASan builds)
     "Coordination::Exception: Connection loss",
     "Coordination::Exception: Session expired",
+    # Server-global (total) memory tracker firing under heavy parallel co-scheduling
+    # on ASan shards: the OvercommitTracker kills queries across all co-scheduled
+    # tests once total RSS nears the shared server cap. Emitted only by the global
+    # tracker (programs/server/Server.cpp: setDescription("(total)")), never by a
+    # per-query/per-user limit, so retrying cannot mask a real per-query assertion.
+    "(total) memory limit exceeded",
 ]
 
 IGNORED_SANITIZER_ERRORS = [


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107441
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Retry a functional test that fails purely because the server-global `(total)` memory tracker fired under heavy parallel co-scheduling.

On the ASan functional shards, many tests run concurrently against one shared server. When co-scheduled queries push total RSS toward the shared server cap, the `OvercommitTracker` kills queries across all co-scheduled tests with `Code: 241 ... (total) memory limit exceeded ... OvercommitTracker decision`. This is a co-scheduling artifact, not a fault of the individual test, so it should be retried like the other transient heavy-load errors already in `MESSAGES_TO_RETRY`.

Observed on 2026-07-15 01:00-04:45 UTC: the `Stateless tests (amd_asan_ubsan, distributed plan, parallel)` job reddened on master and 15+ PRs with ~40 unrelated trivial tests per run failing with Code 241, all in a short window (7-day baseline for this lane is 2-10 Code-241 fails/day; the burst was ~1959, then self-resolved). Sample: `(total) memory limit exceeded: would use 5.03 GiB ..., current RSS: 39.37 GiB, maximum: 41.84 GiB. OvercommitTracker decision`.

The `(total)` prefix is set only by the server-global tracker (`programs/server/Server.cpp`, `total_memory_tracker.setDescription("(total)")`). Per-query and per-user memory-limit exceptions say `Query`/`User`, never `(total)`, so tests that legitimately assert a per-query/per-user limit are not affected and no test asserts the `(total)` string. This is the zero-throughput-cost complement to #107441 (which lowered concurrency on the azure ASan shard): it absorbs residual transient total-memory OOM on any ASan shard without reducing concurrency on healthy runs.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.993` (included in `26.7` and later)
<!-- ch-version-info:end -->