### PR TITLE
Fix locale-dependent symbol localization for Rust static libraries

### DIFF
--- a/cmake/localize_rust_c_symbols.sh
+++ b/cmake/localize_rust_c_symbols.sh
@@ -37,6 +37,14 @@
 
 set -eu
 
+# Force byte-order collation for the whole script.  sort and comm must agree on
+# ordering: under a UTF-8 locale many symbol names collate as equal (leading
+# underscores, digits, ...) and sort/comm break those ties differently, so comm
+# rejects sort's output ("file N is not in sorted order") and, even when it does
+# not, computes a wrong, under-sized intersection.  LC_ALL=C makes sort and comm
+# use plain byte comparison, which is deterministic and locale-independent.
+export LC_ALL=C
+
 LIB_PATH="${1:-}"
 AR="${2:-}"
 OBJCOPY="${3:-}"


### PR DESCRIPTION
`cmake/localize_rust_c_symbols.sh` localizes the C symbols a Rust static archive defines that ClickHouse also provides, so our own optimized definitions win the link. It computes the set with `sort` and `comm`, but ran both under the developer's locale.

Under a UTF-8 locale, GNU `sort` and `comm` disagree on collation: many symbol names collate as equal (leading underscores, digits, ...) and the two tools break those ties differently. So `comm` rejects `sort`'s output with `comm: file N is not in sorted order` and the build aborts at the `Localizing C-namespace symbols` step:

```
FAILED: contrib/delta-kernel-rs-cmake/CMakeFiles/localize_rust_c_delta_kernel_ffi
comm: file 1 is not in sorted order
comm: file 2 is not in sorted order
comm: input is not in sorted order
```

This is not only a build break. Even when `comm` does not error, UTF-8 collation computes a wrong, under-sized intersection: on `delta-kernel-rs` it found only 46 symbols to localize versus 200 under byte-order collation. On machines where it did not crash, the script silently under-localized, letting Rust's bundled `libm` and `compiler-rt` definitions win the link — exactly what this script exists to prevent.

Fix: force `LC_ALL=C` for the whole script so `sort` and `comm` use deterministic byte-order collation, agree with each other, and produce a correct, locale-independent result.

Verified locally: the previously-failing `ninja localize_rust_c_delta_kernel_ffi` target now succeeds, and a known `libm` symbol (`cbrt`) is correctly localized in the resulting archive.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)