### PR TITLE
Add `no-shared-merge-tree` tag to `04150_move_partition_inconsistent_granularity`

### DIFF
--- a/tests/queries/0_stateless/04150_move_partition_inconsistent_granularity.sql
+++ b/tests/queries/0_stateless/04150_move_partition_inconsistent_granularity.sql
@@ -1,4 +1,7 @@
--- Tags: zookeeper
+-- Tags: zookeeper, no-shared-merge-tree
+-- no-shared-merge-tree: the test requires non-adaptive granularity (index_granularity_bytes = 0),
+-- and SharedMergeTree rejects it at CREATE TABLE with "SharedMergeTree table cannot have index
+-- granularity (bytes) equals zero", so the tested scenario cannot exist there.
 -- Regression test for STID 4063-3b45.
 -- MOVE/REPLACE/ATTACH PARTITION between two tables with incompatible granularity
 -- settings (one adaptive, one non-adaptive) used to throw LOGICAL_ERROR in three of


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

The stateless test `04150_move_partition_inconsistent_granularity` creates tables with non-adaptive granularity (`index_granularity_bytes = 0`, `enable_mixed_granularity_parts = 0`) to exercise the MOVE/REPLACE PARTITION granularity-mismatch check. `SharedMergeTree` rejects such settings at `CREATE TABLE` with `SharedMergeTree table cannot have index granularity (bytes) equals zero` (`BAD_ARGUMENTS`), so the tested scenario cannot exist there and the test deterministically fails in configurations where `ReplicatedMergeTree` is replaced with `SharedMergeTree`. Add the `no-shared-merge-tree` tag with an explanatory comment.

Observed in the `CH Inc sync` run of https://github.com/ClickHouse/ClickHouse/pull/107567, job `Stateless tests (amd_asan_ubsan, distributed cache, meta in keeper, s3 storage, parallel, 2/2)`.

Related: https://github.com/ClickHouse/ClickHouse/pull/107567
