### PR TITLE
Use vector_similarity index built on a value-identity expression of the vector column

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -211,7 +211,9 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
         return no_layers_updated;
 
     /// Check if a vector similarity index exists on top of the search column.
-    /// Multi-column indexes cannot be used
+    /// Multi-column indexes cannot be used. An index built on an expression of the search column is only
+    /// usable if the expression preserves values (see getValuePreservingVectorSimilarityIndexColumn); otherwise the index is
+    /// built over transformed vectors and searching it with the raw reference vector returns the wrong top-K.
     const auto & indexes = read_from_mergetree_step->getStorageMetadata()->getSecondaryIndices();
     bool has_vector_similarity_index = false;
     for (const auto & index : indexes)
@@ -220,8 +222,7 @@ size_t tryUseVectorSearch(QueryPlan::Node * parent_node, QueryPlan::Nodes & /*no
             continue;
 
         chassert(index.expression);
-        auto required_columns = index.expression->getRequiredColumns();
-        if (required_columns.size() == 1 && required_columns[0] == search_column)
+        if (getValuePreservingVectorSimilarityIndexColumn(index) == search_column)
         {
             has_vector_similarity_index = true;
             break;

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -621,7 +621,13 @@ MergeTreeIndexConditionPtr MergeTreeIndexVectorSimilarity::createIndexCondition(
 
 MergeTreeIndexConditionPtr MergeTreeIndexVectorSimilarity::createIndexCondition(const ActionsDAG::Node * /*predicate*/, ContextPtr context, const std::optional<VectorSearchParameters> & parameters) const
 {
-    const String & index_column = index.column_names[0];
+    /// The index may be built on the vector column directly or on a value-preserving expression of it. Only in
+    /// that case is the index equivalent to the base column set in VectorSearchParameters::column. For any other
+    /// expression, keep the expression result name so alwaysUnknownOrTrue() rejects the index and the query
+    /// falls back to a correct brute-force scan instead of returning the wrong top-K (a table may carry both a
+    /// value-preserving and a non-value-preserving vector index on the same column).
+    const String value_preserving_column = getValuePreservingVectorSimilarityIndexColumn(index);
+    const String index_column = value_preserving_column.empty() ? index.column_names[0] : value_preserving_column;
     return std::make_shared<MergeTreeIndexConditionVectorSimilarity>(parameters, index_column, metric_kind, context);
 }
 

--- a/src/Storages/MergeTree/MergeTreeIndices.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndices.cpp
@@ -3,6 +3,7 @@
 #include <Storages/MergeTree/MergeTreeIndexLegacyHypothesis.h>
 
 #include <Columns/IColumn.h>
+#include <Functions/IFunction.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Common/escapeForFileName.h>
@@ -56,6 +57,16 @@ String getIndexFileName(const String & index_name, bool escape_filename)
 String IMergeTreeIndex::getFileName() const
 {
     return getIndexFileName(index.name, index.escape_filenames);
+}
+
+String getValuePreservingVectorSimilarityIndexColumn(const IndexDescription & index)
+{
+    const auto & outputs = index.expression->getActionsDAG().getOutputs();
+    const ActionsDAG::Node * node = outputs.size() == 1 ? outputs[0] : nullptr;
+    while (node && node->type == ActionsDAG::ActionType::FUNCTION && node->children.size() == 1
+        && (node->function_base->getName() == "identity" || node->function_base->getName() == "materialize"))
+        node = node->children[0];
+    return (node && node->type == ActionsDAG::ActionType::INPUT) ? node->result_name : String{};
 }
 
 Names IMergeTreeIndex::getColumnsRequiredForIndexCalc() const

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -389,6 +389,14 @@ void textIndexValidator(const IndexDescription & index, bool attach, const Merge
 
 String getIndexFileName(const String & index_name, bool escape_filename);
 
+/// A vector similarity index can be built on the vector column directly or on an expression of it
+/// (e.g. identity(vec)). The HNSW index is built over the expression result while the query searches with
+/// the raw reference vector, so the index is only equivalent to (and usable for) the base column when the
+/// expression preserves values. Return the base column name for a bare column optionally wrapped in
+/// value-identity functions (identity(), materialize()); return an empty string for any other expression
+/// (e.g. arrayMap(x -> 100 - x, vec)), which must not use the index or it would return the wrong top-K.
+String getValuePreservingVectorSimilarityIndexColumn(const IndexDescription & index);
+
 /// Check if an index substream file exists for the part. Returns true if the file is listed
 /// directly in checksums.txt (original or hashed name) OR if it's a virtual file inside
 /// skp_idx.packed (resolved through the storage overlay). Passing a null @storage skips

--- a/tests/queries/0_stateless/02354_vector_search_index_on_expression.reference
+++ b/tests/queries/0_stateless/02354_vector_search_index_on_expression.reference
@@ -1,0 +1,22 @@
+Index on a value-identity expression of vec is used
+Skip
+Name: idx
+Description: vector_similarity GRANULARITY 100000000
+Value-identity expression index returns the correct top-K
+0
+1
+2
+Non-value-preserving expression index is NOT used (would give wrong top-K)
+0
+Non-value-preserving expression index still returns the correct top-K (brute-force)
+0
+1
+2
+With both index kinds on the same column, only the value-preserving index is used
+Name: idx_good
+Mixed-index table returns the correct top-K
+0
+1
+2
+3
+4

--- a/tests/queries/0_stateless/02354_vector_search_index_on_expression.sql
+++ b/tests/queries/0_stateless/02354_vector_search_index_on_expression.sql
@@ -1,0 +1,60 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+-- Test for issue #110410: a vector_similarity index built on a value-identity expression of the vector
+-- column (e.g. identity(vec), materialize(vec)) must be usable, not silently fall back to brute-force.
+-- A non-value-preserving expression (e.g. arrayMap(x -> 100 - x, vec)) must NOT be treated as equivalent
+-- to the base column: the index is built over the transformed vectors while the query searches with the
+-- raw reference vector, so using it would return the wrong top-K. It falls back to a correct brute-force.
+
+SET explain_query_plan_default = 'legacy';
+
+SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas
+
+DROP TABLE IF EXISTS tab_id;
+DROP TABLE IF EXISTS tab_bad;
+
+CREATE TABLE tab_id(id Int32, vec Array(Float32), INDEX idx identity(vec) TYPE vector_similarity('hnsw', 'L2Distance', 2)) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 2;
+INSERT INTO tab_id VALUES (0, [0.0, 0.0]), (1, [1.0, 1.0]), (2, [2.0, 2.0]), (3, [3.0, 3.0]), (4, [10.0, 10.0]), (5, [20.0, 20.0]);
+
+SELECT 'Index on a value-identity expression of vec is used';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1 SELECT id FROM tab_id ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3
+)
+WHERE explain ILIKE '%Skip%' OR explain ILIKE '%Name: idx%' OR explain ILIKE '%vector_similarity%';
+
+SELECT 'Value-identity expression index returns the correct top-K';
+SELECT id FROM tab_id ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3 SETTINGS vector_search_with_rescoring = 0;
+
+-- Index built over 100 - vec, but the query searches with the raw reference vector [0, 0].
+CREATE TABLE tab_bad(id Int32, vec Array(Float32), INDEX idx arrayMap(x -> 100 - x, vec) TYPE vector_similarity('hnsw', 'L2Distance', 2)) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 2;
+INSERT INTO tab_bad VALUES (0, [0.0, 0.0]), (1, [1.0, 1.0]), (2, [2.0, 2.0]), (3, [3.0, 3.0]), (4, [10.0, 10.0]), (5, [20.0, 20.0]);
+
+SELECT 'Non-value-preserving expression index is NOT used (would give wrong top-K)';
+SELECT countIf(explain ILIKE '%Skip%') FROM (
+    EXPLAIN indexes=1 SELECT id FROM tab_bad ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3
+);
+
+SELECT 'Non-value-preserving expression index still returns the correct top-K (brute-force)';
+SELECT id FROM tab_bad ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3 SETTINGS vector_search_with_rescoring = 0;
+
+-- A table may carry both a value-preserving and a non-value-preserving vector index on the same column.
+-- Only the value-preserving one may be used; the non-value-preserving one must be rejected so it cannot
+-- return the wrong top-K.
+DROP TABLE IF EXISTS tab_mixed;
+CREATE TABLE tab_mixed(id Int32, vec Array(Float32),
+    INDEX idx_bad arrayMap(x -> 100 - x, vec) TYPE vector_similarity('hnsw', 'L2Distance', 2),
+    INDEX idx_good vec TYPE vector_similarity('hnsw', 'L2Distance', 2)) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8192;
+INSERT INTO tab_mixed SELECT number, [toFloat32(number), toFloat32(number)] FROM numbers(200);
+
+SELECT 'With both index kinds on the same column, only the value-preserving index is used';
+SELECT trimLeft(explain) AS explain FROM (
+    EXPLAIN indexes=1 SELECT id FROM tab_mixed ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 5
+)
+WHERE explain ILIKE '%Name: idx%';
+
+SELECT 'Mixed-index table returns the correct top-K';
+SELECT id FROM tab_mixed ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 5 SETTINGS vector_search_with_rescoring = 0;
+
+DROP TABLE tab_id;
+DROP TABLE tab_bad;
+DROP TABLE tab_mixed;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/110410
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `vector_similarity` index built on a value-preserving expression of the vector column (for example `identity(vec)` or `materialize(vec)`) being silently ignored and falling back to a full brute-force scan.


### Description

Closes: #110410

A `vector_similarity` index defined on an expression of the vector column was never used. Two code paths disagreed on the indexed column name: `tryUseVectorSearch` sets `VectorSearchParameters::column` from `index.expression->getRequiredColumns()` (the base column, e.g. `vec`), while `createIndexCondition` derived `index_column` from `index.column_names[0]`, the expression result name (e.g. `identity(vec)`). They never matched for an expression index, so `alwaysUnknownOrTrue()` always rejected it. Plain-column indexes worked because both names equal `vec`.

The index is only usable when the expression preserves values: the HNSW index is built over the expression result while the query searches with the raw reference vector. A non-value-preserving expression such as `arrayMap(x -> 100 - x, vec)` must NOT be treated as equivalent to base `vec`, or (with the default `vector_search_with_rescoring = 0`) `L2Distance` gets replaced by `_distance` from the transformed index and the query returns the wrong top-K.

Fix (in `useVectorSearch.cpp`, per review): introduce `getValuePreservingVectorSimilarityIndexColumn()`, which strips the value-identity wrappers `identity()` / `materialize()` down to a single INPUT node and returns its base column name, or an empty string for any other expression. The vector search optimizer enables the index only when this base column matches the query search column. `createIndexCondition` uses the same helper, so the per-index gate also rejects a non-value-preserving index. This is required because a table can carry both a value-preserving and a non-value-preserving `vector_similarity` index on the same column; gating only in the optimizer would still let the executor pick the non-value-preserving one.

Verified with `EXPLAIN indexes=1`: `vec`, `identity(vec)`, `materialize(vec)` are used with correct top-K; `arrayMap(x -> 100 - x, vec)`, an index on a different column, and a non-value-preserving index sitting next to a value-preserving one are not used and return correct results via brute-force. Regression test added: `02354_vector_search_index_on_expression` (includes the mixed-index case).
