### PR TITLE
Throw BAD_ARGUMENTS, not LOGICAL_ERROR, for incompatible granularity in MOVE/REPLACE PARTITION

### DIFF
--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -3236,7 +3236,7 @@ void StorageMergeTree::movePartitionToTable(const StoragePtr & dest_table, const
     for (const DataPartPtr & src_part : src_parts)
     {
         if (!dest_table_storage->canReplacePartition(src_part))
-            throw Exception(ErrorCodes::LOGICAL_ERROR,
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
                             "Cannot move partition '{}' because part '{}' has inconsistent granularity with table",
                             partition_id, src_part->name);
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -9225,7 +9225,7 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             /// Save deduplication block ids with special prefix replace_partition
 
             if (!canReplacePartition(src_part))
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
                                 "Cannot replace partition '{}' because part '{}"
                                 "' has inconsistent granularity with table", partition_id, src_part->name);
 
@@ -9520,7 +9520,7 @@ void StorageReplicatedMergeTree::movePartitionToTable(const StoragePtr & dest_ta
         for (const auto & src_part : src_all_parts)
         {
             if (!dest_table_storage->canReplacePartition(src_part))
-                throw Exception(ErrorCodes::LOGICAL_ERROR,
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
                                 "Cannot move partition '{}' because part '{}"
                                 "' has inconsistent granularity with table", partition_id, src_part->name);
 

--- a/tests/queries/0_stateless/04150_move_partition_inconsistent_granularity.sql
+++ b/tests/queries/0_stateless/04150_move_partition_inconsistent_granularity.sql
@@ -1,0 +1,69 @@
+-- Tags: zookeeper, no-shared-merge-tree
+-- no-shared-merge-tree: in Cloud/private CI ReplicatedMergeTree is substituted by
+--   SharedMergeTree, whose partition-move code does not go through this
+--   canReplacePartition granularity check, so the Replicated BAD_ARGUMENTS
+--   assertions below do not hold under SMT. The plain MergeTree cases still cover
+--   the fix on every configuration.
+-- Regression test for STID 4063-3b45.
+-- MOVE/REPLACE/ATTACH PARTITION between two tables with incompatible granularity
+-- settings (one adaptive, one non-adaptive) used to throw LOGICAL_ERROR in three of
+-- the four canReplacePartition call sites:
+--   * src/Storages/StorageMergeTree.cpp        - MOVE PARTITION TO TABLE
+--   * src/Storages/StorageReplicatedMergeTree.cpp - REPLACE PARTITION FROM
+--   * src/Storages/StorageReplicatedMergeTree.cpp - MOVE PARTITION TO TABLE
+-- This is a user-reachable condition (BuzzHouse hit it on 2026-05-01), so the
+-- correct error code is BAD_ARGUMENTS, not LOGICAL_ERROR. The wrong code caused
+-- a server-side abort in debug / sanitizer builds and a misleading internal-bug
+-- exception in release builds.
+--
+-- All four call sites now throw BAD_ARGUMENTS. The fourth site (REPLACE PARTITION
+-- on plain MergeTree, StorageMergeTree.cpp ~2601) was already BAD_ARGUMENTS before
+-- this fix and is exercised here as well to lock in the behaviour.
+
+DROP TABLE IF EXISTS src_nonadaptive SYNC;
+DROP TABLE IF EXISTS dst_adaptive SYNC;
+DROP TABLE IF EXISTS r_src_nonadaptive SYNC;
+DROP TABLE IF EXISTS r_dst_adaptive SYNC;
+
+-- ===== Plain MergeTree =====
+
+CREATE TABLE src_nonadaptive (a UInt64, b UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity_bytes = 0, enable_mixed_granularity_parts = 0;
+
+CREATE TABLE dst_adaptive (a UInt64, b UInt64)
+ENGINE = MergeTree ORDER BY a
+SETTINGS index_granularity_bytes = 10485760, enable_mixed_granularity_parts = 0;
+
+INSERT INTO src_nonadaptive SELECT number, number FROM numbers(1000);
+
+-- Plain MergeTree: MOVE PARTITION (StorageMergeTree.cpp ~2762, was LOGICAL_ERROR)
+ALTER TABLE src_nonadaptive MOVE PARTITION tuple() TO TABLE dst_adaptive; -- { serverError BAD_ARGUMENTS }
+
+-- Plain MergeTree: REPLACE PARTITION (StorageMergeTree.cpp ~2601, was already BAD_ARGUMENTS)
+ALTER TABLE dst_adaptive REPLACE PARTITION tuple() FROM src_nonadaptive; -- { serverError BAD_ARGUMENTS }
+
+-- ===== Replicated MergeTree =====
+
+CREATE TABLE r_src_nonadaptive (a UInt64, b UInt64)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04150/r_src', 'r1')
+ORDER BY a
+SETTINGS index_granularity_bytes = 0, enable_mixed_granularity_parts = 0;
+
+CREATE TABLE r_dst_adaptive (a UInt64, b UInt64)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/04150/r_dst', 'r1')
+ORDER BY a
+SETTINGS index_granularity_bytes = 10485760, enable_mixed_granularity_parts = 0;
+
+INSERT INTO r_src_nonadaptive SELECT number, number FROM numbers(1000);
+
+-- Replicated: REPLACE PARTITION FROM (StorageReplicatedMergeTree.cpp ~8992, was LOGICAL_ERROR)
+ALTER TABLE r_dst_adaptive REPLACE PARTITION tuple() FROM r_src_nonadaptive; -- { serverError BAD_ARGUMENTS }
+
+-- Replicated: MOVE PARTITION TO TABLE (StorageReplicatedMergeTree.cpp ~9287, was LOGICAL_ERROR)
+ALTER TABLE r_src_nonadaptive MOVE PARTITION tuple() TO TABLE r_dst_adaptive; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE src_nonadaptive SYNC;
+DROP TABLE dst_adaptive SYNC;
+DROP TABLE r_src_nonadaptive SYNC;
+DROP TABLE r_dst_adaptive SYNC;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/103881
Related: https://github.com/ClickHouse/ClickHouse/pull/110526
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`ALTER TABLE ... MOVE/REPLACE PARTITION` between two MergeTree tables with incompatible granularity (one adaptive, one non-adaptive) now throws `BAD_ARGUMENTS` instead of `LOGICAL_ERROR`. This is a user-reachable condition, so it should not surface as an internal error (which aborts the server in debug/sanitizer builds).


### Description

Reintroduces #103881, which was reverted in #110526 because it broke the private CI.

`MergeTreeData::canReplacePartition` rejects MOVE/REPLACE/ATTACH PARTITION when the source part's `mark_type.adaptive` does not match the destination's `canUseAdaptiveGranularity()`. Any user can create two tables with different `index_granularity_bytes`/`enable_mixed_granularity_parts` and trigger a partition transfer between them, so the correct error code is `BAD_ARGUMENTS`. Three of the four call sites threw `LOGICAL_ERROR`; the fourth (`StorageMergeTree::replacePartitionFrom`) already threw `BAD_ARGUMENTS`. This aligns all four.

Originally found by BuzzHouse (STID 4063-3b45) on `BuzzHouse (amd_tsan)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103862&sha=3bec163c6ba8dcb12ed1144c8ac75c261863cc81&name_0=PR&name_1=BuzzHouse%20%28amd_tsan%29

**Difference from #103881 (private CI fix):** the regression test `04150_move_partition_inconsistent_granularity` now carries the `no-shared-merge-tree` tag. Under the Cloud/private SharedMergeTree substitution, ReplicatedMergeTree partition moves go through a different code path that does not hit this `canReplacePartition` granularity check, so the Replicated `BAD_ARGUMENTS` assertions do not hold there. The plain MergeTree cases still exercise the fix on every configuration. This is the most likely cause of the private-CI break; @Algunenano / @hanfei1991, please run private CI before merging to confirm.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.61` (included in `26.8` and later)
<!-- ch-version-info:end -->