### PR TITLE
Fix wrong results and MergeTreeSetIndex assertion for reverse sorting key on wide parts

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2082,7 +2082,20 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                     {
                         const auto & col = (*index_columns)[i].column;
                         chassert(col);
-                        equal_boundaries_mask[i] = col->isNullAt(range.begin);
+                        /// The boundaries of column i in this last mark range are equal only when the
+                        /// value at range.begin coincides with the open far side of the range.
+                        ///
+                        /// Ascending key: the far side is +inf, and NULL maps to +inf (NULL_LAST), so the
+                        /// boundaries are equal exactly when the value at range.begin is NULL (then the whole
+                        /// tail is NULL, since NULLs sort last and are contiguous at the end of the part).
+                        ///
+                        /// Reverse (descending) key: NULLs sort first, so the value at range.begin is the
+                        /// part maximum (NULL/+inf) while the open far side reaches the part minimum. The
+                        /// range spans the whole column, not a single point, so the boundaries are never
+                        /// equal on a NULL first value. Treating them as equal (isNullAt) collapses the
+                        /// whole-part range to the point {+inf} and mis-prunes every non-NULL granule
+                        /// (false negatives for key IN (set) / key IS NOT NULL).
+                        equal_boundaries_mask[i] = !reverse_flags[i] && col->isNullAt(range.begin);
                     }
 
                     for (size_t sparse_pos = 0; sparse_pos < num_sparse_keys_loaded_in_memory; ++sparse_pos)
@@ -2099,12 +2112,14 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                         /// values. Using +inf unconditionally inverts the key range (left > right)
                         /// for a reverse key. index_bounds tightens this bound per call.
                         ///
-                        /// Exception: a nullable reverse key sorts NULLs at the +inf side
-                        /// (create_field_ref maps NULL to +inf for NULL_LAST). When the value at
-                        /// range.begin is NULL, `left` is that +inf sentinel and the open side still
-                        /// reaches the +inf side, so it must stay +inf; forcing -inf would drop the
-                        /// NULL rows and mis-prune the range (false negatives for has([NULL]) / IS NULL).
-                        right = (reverse_flags[key_col] && !left.isPositiveInfinity()) ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
+                        /// This holds even when the value at range.begin is NULL: on a reverse key
+                        /// NULLs sort first (NULL_LAST maps NULL to +inf, the part maximum), so `left`
+                        /// is +inf while the open far side still reaches the part minimum (-inf). The
+                        /// resulting range [-inf, +inf] spans the whole column and keeps both the NULL
+                        /// granules (has([NULL]) / IS NULL) and the non-NULL ones (key IN (set) /
+                        /// key IS NOT NULL); pinning the far side to +inf would collapse it to {+inf}
+                        /// (see also equal_boundaries_mask above) and drop every non-NULL granule.
+                        right = reverse_flags[key_col] ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
                     }
                 }
                 else
@@ -2162,13 +2177,14 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                     /// range (left > right) for a reverse key, which mis-prunes granules (wrong
                     /// results) and trips the MergeTreeSetIndex binary-search assertion.
                     ///
-                    /// Exception: a nullable reverse key sorts NULLs at the +inf side
-                    /// (create_field_ref maps NULL to +inf for NULL_LAST). When the value at
-                    /// range.begin is NULL, `left` is that +inf sentinel and the open side still
-                    /// reaches the +inf side, so it must stay the upper bound; forcing the lower
-                    /// bound would drop the NULL rows and mis-prune the range (false negatives for
-                    /// has([NULL]) / IS NULL).
-                    right = (reverse_flags[i] && !left.isPositiveInfinity()) ? index_bounds[i].left : index_bounds[i].right;
+                    /// This holds even when the value at range.begin is NULL: on a reverse key NULLs
+                    /// sort first (NULL_LAST maps NULL to +inf, the part maximum), so `left` is +inf
+                    /// while the open far side still reaches the part minimum. The resulting range
+                    /// [min, +inf] spans the whole column and correctly keeps both the NULL granules
+                    /// (has([NULL]) / IS NULL) and the non-NULL ones (key IN (set) / key IS NOT NULL);
+                    /// pinning the far side to +inf would collapse it to {+inf} and drop every
+                    /// non-NULL granule.
+                    right = reverse_flags[i] ? index_bounds[i].left : index_bounds[i].right;
                 }
             }
             else

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2094,7 +2094,11 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
 
                         create_field_ref(range.begin, key_col, left);
 
-                        right = POSITIVE_INFINITY;
+                        /// The last mark range opens towards +inf for an ascending key and towards
+                        /// -inf for a descending (reverse) key, whose last granule holds the smallest
+                        /// values. Using +inf unconditionally inverts the key range (left > right)
+                        /// for a reverse key. index_bounds tightens this bound per call.
+                        right = reverse_flags[key_col] ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
                     }
                 }
                 else
@@ -2145,7 +2149,13 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                     else
                         left = index_bounds[i].left;
 
-                    right = index_bounds[i].right;
+                    /// The last mark range is open on its far side. For an ascending key that far
+                    /// side is the upper bound of the part; for a descending (reverse) key the last
+                    /// granule holds the smallest values, so its open side is the lower bound.
+                    /// Using index_bounds[i].right unconditionally would produce an inverted key
+                    /// range (left > right) for a reverse key, which mis-prunes granules (wrong
+                    /// results) and trips the MergeTreeSetIndex binary-search assertion.
+                    right = reverse_flags[i] ? index_bounds[i].left : index_bounds[i].right;
                 }
             }
             else

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -2098,7 +2098,13 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                         /// -inf for a descending (reverse) key, whose last granule holds the smallest
                         /// values. Using +inf unconditionally inverts the key range (left > right)
                         /// for a reverse key. index_bounds tightens this bound per call.
-                        right = reverse_flags[key_col] ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
+                        ///
+                        /// Exception: a nullable reverse key sorts NULLs at the +inf side
+                        /// (create_field_ref maps NULL to +inf for NULL_LAST). When the value at
+                        /// range.begin is NULL, `left` is that +inf sentinel and the open side still
+                        /// reaches the +inf side, so it must stay +inf; forcing -inf would drop the
+                        /// NULL rows and mis-prune the range (false negatives for has([NULL]) / IS NULL).
+                        right = (reverse_flags[key_col] && !left.isPositiveInfinity()) ? NEGATIVE_INFINITY : POSITIVE_INFINITY;
                     }
                 }
                 else
@@ -2155,7 +2161,14 @@ MarkRanges MergeTreeDataSelectExecutor::markRangesFromPKRange(
                     /// Using index_bounds[i].right unconditionally would produce an inverted key
                     /// range (left > right) for a reverse key, which mis-prunes granules (wrong
                     /// results) and trips the MergeTreeSetIndex binary-search assertion.
-                    right = reverse_flags[i] ? index_bounds[i].left : index_bounds[i].right;
+                    ///
+                    /// Exception: a nullable reverse key sorts NULLs at the +inf side
+                    /// (create_field_ref maps NULL to +inf for NULL_LAST). When the value at
+                    /// range.begin is NULL, `left` is that +inf sentinel and the open side still
+                    /// reaches the +inf side, so it must stay the upper bound; forcing the lower
+                    /// bound would drop the NULL rows and mis-prune the range (false negatives for
+                    /// has([NULL]) / IS NULL).
+                    right = (reverse_flags[i] && !left.isPositiveInfinity()) ? index_bounds[i].left : index_bounds[i].right;
                 }
             }
             else

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
@@ -7,3 +7,8 @@ eq_max	1
 in_set	50
 multi_range	43
 multi_in	30
+null_part_type	Wide
+null_is_null	200
+null_has_null	200
+null_ge0	300
+null_lt_neg400	100

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
@@ -1,0 +1,9 @@
+part_type	Wide
+lt0	500
+ge0	500
+between	201
+eq_min	1
+eq_max	1
+in_set	50
+multi_range	43
+multi_in	30

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.reference
@@ -12,3 +12,7 @@ null_is_null	200
 null_has_null	200
 null_ge0	300
 null_lt_neg400	100
+null_is_not_null	800
+null_in_set	5
+null_is_not_null_full	800
+null_in_set_full	5

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
@@ -1,0 +1,39 @@
+-- Tags: no-random-merge-tree-settings
+-- Regression test for the reverse (DESC) sorting key primary-key range analysis on wide parts.
+-- The last mark range was opened towards +inf unconditionally, producing an inverted key range
+-- (left > right) for a descending key. That mis-pruned granules (wrong results / data loss) and,
+-- for `col IN (set)` predicates, tripped the "Invalid binary search result in MergeTreeSetIndex"
+-- assertion (STID 3252-3a4a). See PR #109000 discussion.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS t_rev;
+CREATE TABLE t_rev (id Int64)
+ENGINE = MergeTree ORDER BY id DESC
+SETTINGS min_rows_for_wide_part = 1, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
+INSERT INTO t_rev SELECT number - 500 FROM numbers(1000);
+
+SELECT 'part_type', part_type FROM system.parts WHERE table = 't_rev' AND database = currentDatabase() AND active;
+
+-- Ranges on a descending single key: index result must match a full scan.
+SELECT 'lt0', count() FROM t_rev WHERE id < 0;
+SELECT 'ge0', count() FROM t_rev WHERE id >= 0;
+SELECT 'between', count() FROM t_rev WHERE id BETWEEN -100 AND 100;
+SELECT 'eq_min', count() FROM t_rev WHERE id = -500;
+SELECT 'eq_max', count() FROM t_rev WHERE id = 499;
+
+-- The IN(set) path that produced the LOGICAL_ERROR in debug builds.
+SELECT 'in_set', count() FROM t_rev WHERE id IN (SELECT number - 500 FROM numbers(50));
+
+DROP TABLE IF EXISTS t_rev2;
+CREATE TABLE t_rev2 (id Int64, k UInt32)
+ENGINE = MergeTree ORDER BY (id DESC, k DESC)
+SETTINGS min_rows_for_wide_part = 1, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
+INSERT INTO t_rev2 SELECT number - 500, number % 7 FROM numbers(1000);
+
+-- Multi-column descending key: range on both key columns and set membership.
+SELECT 'multi_range', count() FROM t_rev2 WHERE id BETWEEN -50 AND 50 AND k < 3;
+SELECT 'multi_in', count() FROM t_rev2 WHERE id IN (SELECT number - 500 FROM numbers(30));
+
+DROP TABLE t_rev;
+DROP TABLE t_rev2;

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
@@ -10,7 +10,7 @@ SET allow_suspicious_low_cardinality_types = 1;
 DROP TABLE IF EXISTS t_rev;
 CREATE TABLE t_rev (id Int64)
 ENGINE = MergeTree ORDER BY id DESC
-SETTINGS min_rows_for_wide_part = 1, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
 INSERT INTO t_rev SELECT number - 500 FROM numbers(1000);
 
 SELECT 'part_type', part_type FROM system.parts WHERE table = 't_rev' AND database = currentDatabase() AND active;
@@ -28,7 +28,7 @@ SELECT 'in_set', count() FROM t_rev WHERE id IN (SELECT number - 500 FROM number
 DROP TABLE IF EXISTS t_rev2;
 CREATE TABLE t_rev2 (id Int64, k UInt32)
 ENGINE = MergeTree ORDER BY (id DESC, k DESC)
-SETTINGS min_rows_for_wide_part = 1, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1;
 INSERT INTO t_rev2 SELECT number - 500, number % 7 FROM numbers(1000);
 
 -- Multi-column descending key: range on both key columns and set membership.

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
@@ -35,5 +35,26 @@ INSERT INTO t_rev2 SELECT number - 500, number % 7 FROM numbers(1000);
 SELECT 'multi_range', count() FROM t_rev2 WHERE id BETWEEN -50 AND 50 AND k < 3;
 SELECT 'multi_in', count() FROM t_rev2 WHERE id IN (SELECT number - 500 FROM numbers(30));
 
+-- Nullable descending key: NULLs sort at the +inf side (NULL_LAST), i.e. first in a
+-- descending part, so the last mark range still reaches the +inf (NULL) side. Opening it
+-- unconditionally towards the lower bound for a reverse key dropped those NULL rows and
+-- mis-pruned the range (false negatives for has([NULL]) / IS NULL). See PR #109000, PR #110546.
+DROP TABLE IF EXISTS t_rev_null;
+CREATE TABLE t_rev_null (id Nullable(Int64))
+ENGINE = MergeTree ORDER BY id DESC
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0, index_granularity_bytes = 0, index_granularity = 8, allow_experimental_reverse_key = 1, allow_nullable_key = 1;
+INSERT INTO t_rev_null SELECT if(number < 800, number - 500, NULL) FROM numbers(1000);
+
+SELECT 'null_part_type', part_type FROM system.parts WHERE table = 't_rev_null' AND database = currentDatabase() AND active;
+
+-- All of these must match a full scan; the index must not drop the trailing NULL granules.
+-- optimize_use_implicit_projections is disabled so the counts reflect the rows actually read
+-- through the primary key range analysis rather than a precomputed count projection.
+SELECT 'null_is_null', count() FROM t_rev_null WHERE id IS NULL SETTINGS optimize_use_implicit_projections = 0;
+SELECT 'null_has_null', count() FROM t_rev_null WHERE has([NULL :: Nullable(Int64)], id) SETTINGS optimize_use_implicit_projections = 0;
+SELECT 'null_ge0', count() FROM t_rev_null WHERE id >= 0 SETTINGS optimize_use_implicit_projections = 0;
+SELECT 'null_lt_neg400', count() FROM t_rev_null WHERE id < -400 SETTINGS optimize_use_implicit_projections = 0;
+
 DROP TABLE t_rev;
 DROP TABLE t_rev2;
+DROP TABLE t_rev_null;

--- a/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
+++ b/tests/queries/0_stateless/04365_reverse_sorting_key_wide_part_pk_range.sql
@@ -55,6 +55,17 @@ SELECT 'null_has_null', count() FROM t_rev_null WHERE has([NULL :: Nullable(Int6
 SELECT 'null_ge0', count() FROM t_rev_null WHERE id >= 0 SETTINGS optimize_use_implicit_projections = 0;
 SELECT 'null_lt_neg400', count() FROM t_rev_null WHERE id < -400 SETTINGS optimize_use_implicit_projections = 0;
 
+-- Symmetric to the NULL granules above: on a nullable reverse key the whole-part range spans
+-- NULL (+inf side) down to the part minimum, so it must NOT be collapsed to the single point
+-- {+inf}. Setting the last mark's boundary-equality from isNullAt (correct only for ascending
+-- keys) or pinning the open far side to +inf dropped every non-NULL granule, giving 0 rows for
+-- `key IN (multi-element set)` and `key IS NOT NULL`. Both the sparse (default) and the full
+-- (use_lightweight_primary_key_index_analysis = 0) primary key analysis are exercised.
+SELECT 'null_is_not_null', count() FROM t_rev_null WHERE id IS NOT NULL SETTINGS optimize_use_implicit_projections = 0;
+SELECT 'null_in_set', count() FROM t_rev_null WHERE id IN (-400, -200, 0, 100, 299) SETTINGS optimize_use_implicit_projections = 0;
+SELECT 'null_is_not_null_full', count() FROM t_rev_null WHERE id IS NOT NULL SETTINGS optimize_use_implicit_projections = 0, use_lightweight_primary_key_index_analysis = 0;
+SELECT 'null_in_set_full', count() FROM t_rev_null WHERE id IN (-400, -200, 0, 100, 299) SETTINGS optimize_use_implicit_projections = 0, use_lightweight_primary_key_index_analysis = 0;
+
 DROP TABLE t_rev;
 DROP TABLE t_rev2;
 DROP TABLE t_rev_null;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/109000


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix wrong query results (missing rows) and a `Invalid binary search result in MergeTreeSetIndex` error on tables with a descending (reverse) sorting key when the affected part is stored in the `Wide` format. The primary key range analysis opened the last granule towards the wrong side for reverse keys.

### Description

`markRangesFromPKRange` built the last mark range with its far bound set to the upper bound (`+inf` / part max) unconditionally. For a descending (reverse) sorting key the last granule holds the smallest values, so its open side is the lower bound. Using the upper bound produced an inverted key range (`left > right`), which:

- mis-pruned granules and returned wrong (missing) rows for range and `IN (set)` predicates, and
- for a `col IN (subquery/set)` predicate, tripped the `Invalid binary search result in MergeTreeSetIndex` assertion (debug/sanitizer builds; release returned `{true, true}`).

The bug only surfaced on `Wide` parts: `Compact` parts store a trailing boundary mark, so the buggy last-granule branch was not reached with an open bound.

Fixed both the sparse-key and regular last-granule branches to open towards the lower bound (`index_bounds[i].left` / `NEGATIVE_INFINITY`) for reverse keys.

Found by the AST fuzzer on PR #109000 (STID 3252-3a4a):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109000&sha=2a6d768774cf9cac73cbce39257ab0bcac81becb&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29

Regression test `04365_reverse_sorting_key_wide_part_pk_range` checks index results against full scans on `Wide` reverse-key parts (single and multi-column keys, ranges, boundary values, and `IN (set)`); it fails before this change and passes after.
