### PR TITLE
Make previously unclickable `fail` links observable for vimium

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -339,6 +339,11 @@
             text-decoration: underline;
         }
 
+        .status-column a {
+            text-decoration: underline;
+            cursor: pointer;
+        }
+
         th, td {
             padding: 8px;
             border: 1px solid var(--table-border-color);
@@ -1612,16 +1617,20 @@
 
                 if (column === 'status') {
                     const value_ = value ? value.toLowerCase() : "";
-                    const span = document.createElement('span');
-                    span.className = getStatusClass(value_);
-                    span.textContent = value_;
+                    const clickable = (result.info && result.info.trim() !== "") || (Array.isArray(result.links) && result.links.length > 0) || (Array.isArray(result.results) && result.results.length > 0);
+                    const statusEl = clickable ? document.createElement('a') : document.createElement('span');
+                    statusEl.className = getStatusClass(value_);
+                    statusEl.textContent = value_;
                     td.classList.add('status-column');
                     row.dataset.status = value_;
-                    if ((result.info && result.info.trim() !== "") || (Array.isArray(result.links) && result.links.length > 0) || (Array.isArray(result.results) && result.results.length > 0)) {
-                        span.style.cursor = "pointer";
-                        span.addEventListener('click', () => toggleInfoRow(row, result.info, result.results, result.links));
+                    if (clickable) {
+                        statusEl.href = '#';
+                        statusEl.addEventListener('click', (e) => {
+                            e.preventDefault();
+                            toggleInfoRow(row, result.info, result.results, result.links);
+                        });
                     }
-                    td.appendChild(span);
+                    td.appendChild(statusEl);
                     row.style.display = shouldShowRow(filter, row.dataset.status) ? '' : 'none';
                 } else if (column === 'name') {
                     const statusValue = result["status"] ? result["status"].toLowerCase() : "";


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Currently, errors aren't able to interact with Vimium. It can open links, but not `span`. This changes clickable objects to `a`, so an extension can open them.

### Examples

Working version 
<img width="681" height="636" alt="image" src="https://github.com/user-attachments/assets/a05e8660-dae7-4e85-8429-0ad3196c5dd1" />
Broken version
<img width="681" height="636" alt="image" src="https://github.com/user-attachments/assets/008d92b7-f16f-4753-bc98-50db2ec11114" />


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.985` (included in `26.7` and later)
<!-- ch-version-info:end -->