### PR TITLE
Account for column read cost when reordering PREWHERE conditions

### DIFF
--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -62,6 +62,33 @@ static Int64 findMinPosition(const NameSet & condition_table_columns, const Name
     return min_position;
 }
 
+/// Greedy cost/benefit score used to order PREWHERE candidates: read cost (bytes) divided by the
+/// fraction of rows the condition eliminates. The lower the better. Without a reliable row estimate
+/// the benefit is 1 and the score is just `columns_size`. See #110462.
+static Float64 computeConditionCostScore(UInt64 columns_size, UInt64 estimated_row_count, UInt64 total_rows)
+{
+    /// Score = read cost / benefit, where benefit is the fraction of rows the condition eliminates.
+    /// A condition that reads a large column (e.g. the whole Map behind a map-key predicate) is only
+    /// worth hoisting to the front of PREWHERE if it eliminates proportionally many rows; a cheap,
+    /// selective filter on a small column wins. Lower is better.
+    ///
+    /// Without a usable estimate (no statistics / row count unknown) fall back to `columns_size`, which
+    /// matches the previous size-based ordering. Two conditions that read the same columns then keep
+    /// selectivity-first ordering (equal cost, `estimated_row_count` decides in the comparison tuple).
+    if (total_rows == 0)
+        return static_cast<Float64>(columns_size);
+
+    /// A condition that keeps all rows eliminates nothing: it is the worst possible prefilter and must
+    /// sort last, regardless of how cheap its columns are. Otherwise a small column that filters nothing
+    /// (e.g. a predicate matched by every row) would be ranked cheaper than a genuinely selective filter
+    /// on a wider column and hoisted ahead of it. See #110462.
+    if (estimated_row_count >= total_rows)
+        return std::numeric_limits<Float64>::max();
+
+    const Float64 eliminated_fraction = 1.0 - static_cast<Float64>(estimated_row_count) / static_cast<Float64>(total_rows);
+    return static_cast<Float64>(columns_size) / eliminated_fraction;
+}
+
 static NameSet getTableColumns(const StorageSnapshotPtr & storage_snapshot, const Names & queried_columns)
 {
     GetColumnsOptions options(GetColumnsOptions::All);
@@ -712,30 +739,6 @@ UInt64 MergeTreeWhereOptimizer::getColumnsSize(const NameSet & columns) const
     }
 
     return size;
-}
-
-Float64 MergeTreeWhereOptimizer::computeConditionCostScore(UInt64 columns_size, UInt64 estimated_row_count, UInt64 total_rows)
-{
-    /// Score = read cost / benefit, where benefit is the fraction of rows the condition eliminates.
-    /// A condition that reads a large column (e.g. the whole Map behind a map-key predicate) is only
-    /// worth hoisting to the front of PREWHERE if it eliminates proportionally many rows; a cheap,
-    /// selective filter on a small column wins. Lower is better.
-    ///
-    /// Without a usable estimate (no statistics / row count unknown) fall back to `columns_size`, which
-    /// matches the previous size-based ordering. Two conditions that read the same columns then keep
-    /// selectivity-first ordering (equal cost, `estimated_row_count` decides in the comparison tuple).
-    if (total_rows == 0)
-        return static_cast<Float64>(columns_size);
-
-    /// A condition that keeps all rows eliminates nothing: it is the worst possible prefilter and must
-    /// sort last, regardless of how cheap its columns are. Otherwise a small column that filters nothing
-    /// (e.g. a predicate matched by every row) would be ranked cheaper than a genuinely selective filter
-    /// on a wider column and hoisted ahead of it. See #110462.
-    if (estimated_row_count >= total_rows)
-        return std::numeric_limits<Float64>::max();
-
-    const Float64 eliminated_fraction = 1.0 - static_cast<Float64>(estimated_row_count) / static_cast<Float64>(total_rows);
-    return static_cast<Float64>(columns_size) / eliminated_fraction;
 }
 
 bool MergeTreeWhereOptimizer::columnsSupportPrewhere(const NameSet & columns) const

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <limits>
 #include <Core/Settings.h>
+#include <DataTypes/DataTypeMap.h>
 #include <DataTypes/IDataType.h>
 #include <DataTypes/NestedUtils.h>
 #include <Functions/IFunction.h>
@@ -707,14 +708,16 @@ UInt64 MergeTreeWhereOptimizer::getColumnsSize(const NameSet & columns) const
     /// `column_sizes` is keyed by base storage columns and holds only whole-column sizes;
     /// per-subcolumn stream sizes are not plumbed into this planning layer.
     ///
-    /// A `Map`-key subcolumn (e.g. `h.key_k` from `h['k']`) has no dedicated stream on disk:
+    /// A dynamic `Map`-key subcolumn (e.g. `h.key_k` from `h['k']`) has no dedicated stream on disk:
     /// evaluating it reads the entire `Map`. A naive lookup returns 0 and makes such a condition
     /// look free, so we charge it the base column's size instead. See #110462.
     ///
-    /// Other subcolumns (`Nullable.null`, `Array.size0`, tuple elements, LowCardinality dict) each
-    /// have their own small stream and do NOT force a full parent read, so charging them the whole
-    /// parent size would over-estimate their cost and could reorder cheap filters behind expensive
-    /// ones. We keep them at 0 (the historical behavior) rather than over-charging them.
+    /// All other subcolumns keep their own name and resolve to 0 (the historical behavior). This
+    /// includes the fixed physical `Map` subcolumns (`map.size0`, `map.keys`, `map.values`), which
+    /// have dedicated serializations and stream sizes and do NOT force a full-map read, as well as
+    /// `Nullable.null`, `Array.size0`, tuple elements and LowCardinality dict. Charging any of these
+    /// the whole parent size would over-estimate their cost and could reorder cheap filters behind
+    /// expensive ones.
     UInt64 size = 0;
     NameSet counted_storage_columns;
     const auto & storage_columns_description = storage_metadata->getColumns();
@@ -725,9 +728,12 @@ UInt64 MergeTreeWhereOptimizer::getColumnsSize(const NameSet & columns) const
         if (auto resolved = storage_columns_description.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column);
             resolved && resolved->isSubcolumn())
         {
-            /// Charge the base-column size only for subcolumns that force reading the whole parent
-            /// (Map subcolumns). Cheap physical substreams keep their own name and resolve to 0 below.
-            if (resolved->getTypeInStorage() && WhichDataType(*resolved->getTypeInStorage()).isMap())
+            /// Charge the base-column size only for the dynamic `Map` key-lookup subcolumn
+            /// (`key_<value>`), which has no dedicated stream and forces reading the whole `Map`.
+            /// The fixed physical `Map` subcolumns (`size0`, `keys`, `values`) and every other
+            /// subcolumn have their own small stream, so they keep their name and resolve to 0 below.
+            if (resolved->getTypeInStorage() && WhichDataType(*resolved->getTypeInStorage()).isMap()
+                && resolved->getSubcolumnName().starts_with(DataTypeMap::KEY_SUBCOLUMN_PREFIX))
                 size_column = resolved->getNameInStorage();
         }
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <limits>
 #include <Core/Settings.h>
+#include <DataTypes/IDataType.h>
 #include <DataTypes/NestedUtils.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/ActionsDAG.h>
@@ -676,26 +677,37 @@ std::optional<MergeTreeWhereOptimizer::OptimizeResult> MergeTreeWhereOptimizer::
 
 UInt64 MergeTreeWhereOptimizer::getColumnsSize(const NameSet & columns) const
 {
-    /// `column_sizes` is keyed by base storage columns. A subcolumn (e.g. the map-key subcolumn
-    /// `h.key_k`) is not a key, so a naive lookup returns 0 and makes the condition look free -
-    /// even though evaluating it reads the whole base column (the entire `Map`). Resolve each
-    /// column to its base storage name and charge the base column's size, deduplicating so that
-    /// several subcolumns of the same base column (e.g. `h.key_a`, `h.key_b`) are charged once.
-    /// See #110462.
+    /// `column_sizes` is keyed by base storage columns and holds only whole-column sizes;
+    /// per-subcolumn stream sizes are not plumbed into this planning layer.
+    ///
+    /// A `Map`-key subcolumn (e.g. `h.key_k` from `h['k']`) has no dedicated stream on disk:
+    /// evaluating it reads the entire `Map`. A naive lookup returns 0 and makes such a condition
+    /// look free, so we charge it the base column's size instead. See #110462.
+    ///
+    /// Other subcolumns (`Nullable.null`, `Array.size0`, tuple elements, LowCardinality dict) each
+    /// have their own small stream and do NOT force a full parent read, so charging them the whole
+    /// parent size would over-estimate their cost and could reorder cheap filters behind expensive
+    /// ones. We keep them at 0 (the historical behavior) rather than over-charging them.
     UInt64 size = 0;
     NameSet counted_storage_columns;
     const auto & storage_columns_description = storage_metadata->getColumns();
 
     for (const auto & column : columns)
     {
-        String storage_column = column;
-        if (auto resolved = storage_columns_description.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column))
-            storage_column = resolved->getNameInStorage();
+        String size_column = column;
+        if (auto resolved = storage_columns_description.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column);
+            resolved && resolved->isSubcolumn())
+        {
+            /// Charge the base-column size only for subcolumns that force reading the whole parent
+            /// (Map subcolumns). Cheap physical substreams keep their own name and resolve to 0 below.
+            if (resolved->getTypeInStorage() && WhichDataType(*resolved->getTypeInStorage()).isMap())
+                size_column = resolved->getNameInStorage();
+        }
 
-        if (!counted_storage_columns.insert(storage_column).second)
+        if (!counted_storage_columns.insert(size_column).second)
             continue;
 
-        if (auto it = column_sizes.find(storage_column); it != column_sizes.end())
+        if (auto it = column_sizes.find(size_column); it != column_sizes.end())
             size += it->second;
     }
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <limits>
 #include <Core/Settings.h>
 #include <DataTypes/NestedUtils.h>
 #include <Functions/IFunction.h>
@@ -708,11 +709,18 @@ Float64 MergeTreeWhereOptimizer::computeConditionCostScore(UInt64 columns_size, 
     /// worth hoisting to the front of PREWHERE if it eliminates proportionally many rows; a cheap,
     /// selective filter on a small column wins. Lower is better.
     ///
-    /// Without a usable estimate (no statistics, or estimate >= total) the benefit is 1, so the score
-    /// degrades to `columns_size` and matches the previous size-based ordering. Two conditions that
-    /// read the same columns keep selectivity-first ordering (equal cost, benefit decides).
-    if (total_rows == 0 || estimated_row_count >= total_rows)
+    /// Without a usable estimate (no statistics / row count unknown) fall back to `columns_size`, which
+    /// matches the previous size-based ordering. Two conditions that read the same columns then keep
+    /// selectivity-first ordering (equal cost, `estimated_row_count` decides in the comparison tuple).
+    if (total_rows == 0)
         return static_cast<Float64>(columns_size);
+
+    /// A condition that keeps all rows eliminates nothing: it is the worst possible prefilter and must
+    /// sort last, regardless of how cheap its columns are. Otherwise a small column that filters nothing
+    /// (e.g. a predicate matched by every row) would be ranked cheaper than a genuinely selective filter
+    /// on a wider column and hoisted ahead of it. See #110462.
+    if (estimated_row_count >= total_rows)
+        return std::numeric_limits<Float64>::max();
 
     const Float64 eliminated_fraction = 1.0 - static_cast<Float64>(estimated_row_count) / static_cast<Float64>(total_rows);
     return static_cast<Float64>(columns_size) / eliminated_fraction;

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -475,6 +475,7 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
             Condition cond(std::move(group_nodes));
             cond.table_columns = group_columns;
             cond.columns_size = getColumnsSize(group_columns);
+            cond.cost_score = static_cast<Float64>(cond.columns_size);
             cond.viable = true;
             cond.good = group_good;
 
@@ -482,6 +483,11 @@ void MergeTreeWhereOptimizer::analyzeImpl(Conditions & res, const RPNBuilderTree
             {
                 cond.good = true;
                 cond.estimated_row_count = estimator->estimateRelationProfile(storage_metadata, cond.nodes).rows;
+                /// Charge the read cost against how many rows the condition eliminates, so an
+                /// expensive whole-column read (e.g. a Map behind a map-key predicate) is not hoisted
+                /// ahead of a cheap, selective prefilter purely because it looks selective. See #110462.
+                const UInt64 total_rows = estimator->estimateRelationProfile().rows;
+                cond.cost_score = computeConditionCostScore(cond.columns_size, cond.estimated_row_count, total_rows);
                 LOG_DEBUG(log, "Condition group ({}) has estimated row count {}", cond.toString(), cond.estimated_row_count);
             }
 
@@ -669,13 +675,47 @@ std::optional<MergeTreeWhereOptimizer::OptimizeResult> MergeTreeWhereOptimizer::
 
 UInt64 MergeTreeWhereOptimizer::getColumnsSize(const NameSet & columns) const
 {
+    /// `column_sizes` is keyed by base storage columns. A subcolumn (e.g. the map-key subcolumn
+    /// `h.key_k`) is not a key, so a naive lookup returns 0 and makes the condition look free -
+    /// even though evaluating it reads the whole base column (the entire `Map`). Resolve each
+    /// column to its base storage name and charge the base column's size, deduplicating so that
+    /// several subcolumns of the same base column (e.g. `h.key_a`, `h.key_b`) are charged once.
+    /// See #110462.
     UInt64 size = 0;
+    NameSet counted_storage_columns;
+    const auto & storage_columns_description = storage_metadata->getColumns();
 
     for (const auto & column : columns)
-        if (column_sizes.contains(column))
-            size += column_sizes.at(column);
+    {
+        String storage_column = column;
+        if (auto resolved = storage_columns_description.tryGetColumnOrSubcolumn(GetColumnsOptions::AllPhysical, column))
+            storage_column = resolved->getNameInStorage();
+
+        if (!counted_storage_columns.insert(storage_column).second)
+            continue;
+
+        if (auto it = column_sizes.find(storage_column); it != column_sizes.end())
+            size += it->second;
+    }
 
     return size;
+}
+
+Float64 MergeTreeWhereOptimizer::computeConditionCostScore(UInt64 columns_size, UInt64 estimated_row_count, UInt64 total_rows)
+{
+    /// Score = read cost / benefit, where benefit is the fraction of rows the condition eliminates.
+    /// A condition that reads a large column (e.g. the whole Map behind a map-key predicate) is only
+    /// worth hoisting to the front of PREWHERE if it eliminates proportionally many rows; a cheap,
+    /// selective filter on a small column wins. Lower is better.
+    ///
+    /// Without a usable estimate (no statistics, or estimate >= total) the benefit is 1, so the score
+    /// degrades to `columns_size` and matches the previous size-based ordering. Two conditions that
+    /// read the same columns keep selectivity-first ordering (equal cost, benefit decides).
+    if (total_rows == 0 || estimated_row_count >= total_rows)
+        return static_cast<Float64>(columns_size);
+
+    const Float64 eliminated_fraction = 1.0 - static_cast<Float64>(estimated_row_count) / static_cast<Float64>(total_rows);
+    return static_cast<Float64>(columns_size) / eliminated_fraction;
 }
 
 bool MergeTreeWhereOptimizer::columnsSupportPrewhere(const NameSet & columns) const

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -81,6 +81,13 @@ private:
         /// the lower the better
         UInt64 estimated_row_count = 0;
 
+        /// Read cost per eliminated row: `columns_size / eliminated_fraction`. The lower the better.
+        /// Ranks conditions so a cheap, selective filter is preferred over a condition that must read a
+        /// large column (e.g. a whole Map to evaluate a map-key predicate) even when the latter looks more
+        /// selective. Without statistics it equals `columns_size`; for equal cost it matches selectivity-first
+        /// ordering. See getColumnsSize / computeConditionCostScore and #110462.
+        Float64 cost_score = 0;
+
         /// Does the condition contain primary key column?
         /// If so, it is better to move it further to the end of PREWHERE chain depending on minimal position in PK of any
         /// column in this condition because this condition have bigger chances to be already satisfied by PK analysis.
@@ -97,12 +104,13 @@ private:
                 names += n.getColumnName();
             }
             return fmt::format(
-                "Condition(exp:{} viable: {}, good: {}, min_position_in_primary_key: {}, estimated_row_count: {}, "
-                "columns_size: {}, table_columns.size: {})",
+                "Condition(exp:{} viable: {}, good: {}, min_position_in_primary_key: {}, cost_score: {}, "
+                "estimated_row_count: {}, columns_size: {}, table_columns.size: {})",
                 names,
                 viable,
                 good,
                 min_position_in_primary_key,
+                cost_score,
                 estimated_row_count,
                 columns_size,
                 table_columns.size());
@@ -110,7 +118,7 @@ private:
 
         auto tuple() const
         {
-            return std::make_tuple(!viable, !good, -min_position_in_primary_key, estimated_row_count, columns_size, table_columns.size());
+            return std::make_tuple(!viable, !good, -min_position_in_primary_key, cost_score, estimated_row_count, columns_size, table_columns.size());
         }
 
         /// Is condition a better candidate for moving to PREWHERE?
@@ -152,6 +160,11 @@ private:
     void optimizeArbitrary(ASTSelectQuery & select) const;
 
     UInt64 getColumnsSize(const NameSet & columns) const;
+
+    /// Greedy cost/benefit score used to order PREWHERE candidates: read cost (bytes) divided by the
+    /// fraction of rows the condition eliminates. The lower the better. Without a reliable row estimate
+    /// the benefit is 1 and the score is just `columns_size`. See #110462.
+    static Float64 computeConditionCostScore(UInt64 columns_size, UInt64 estimated_row_count, UInt64 total_rows);
 
     bool columnsSupportPrewhere(const NameSet & columns) const;
 

--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.h
@@ -161,11 +161,6 @@ private:
 
     UInt64 getColumnsSize(const NameSet & columns) const;
 
-    /// Greedy cost/benefit score used to order PREWHERE candidates: read cost (bytes) divided by the
-    /// fraction of rows the condition eliminates. The lower the better. Without a reliable row estimate
-    /// the benefit is 1 and the score is just `columns_size`. See #110462.
-    static Float64 computeConditionCostScore(UInt64 columns_size, UInt64 estimated_row_count, UInt64 total_rows);
-
     bool columnsSupportPrewhere(const NameSet & columns) const;
 
     bool isExpressionOverSortingKey(const RPNBuilderTreeNode & node) const;

--- a/tests/performance/prewhere_reorder_map_key_read_cost.xml
+++ b/tests/performance/prewhere_reorder_map_key_read_cost.xml
@@ -1,0 +1,63 @@
+<test>
+    <!-- Benchmarks PREWHERE reordering with a Map-key predicate combined with a cheap, selective
+         filter on a small column (regression #110462). Before the fix, the reorderer hoisted the
+         `h['k'] = const` map-key subcolumn predicate ahead of the cheap `modality != ''` filter
+         (it was charged zero read cost and looked more selective), forcing a full read of the fat
+         `Map` column for every granule. The fix charges the map-key predicate its base `Map` read
+         cost, so the cheap filter runs first and the whole Map is no longer read. -->
+
+    <settings>
+        <max_insert_threads>4</max_insert_threads>
+        <use_query_condition_cache>0</use_query_condition_cache>
+        <optimize_functions_to_subcolumns>1</optimize_functions_to_subcolumns>
+        <allow_reorder_prewhere_conditions>1</allow_reorder_prewhere_conditions>
+    </settings>
+
+    <!-- Wide part format: per-column sizes exist, so the cost model can charge the Map read. -->
+    <create_query>
+        CREATE TABLE prewhere_map_cost_wide (id UInt64, modality LowCardinality(String), h Map(String, String))
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0
+    </create_query>
+
+    <!-- Compact part format -->
+    <create_query>
+        CREATE TABLE prewhere_map_cost_compact (id UInt64, modality LowCardinality(String), h Map(String, String))
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS min_bytes_for_wide_part = '10G', min_rows_for_wide_part = 1000000000
+    </create_query>
+
+    <!-- `modality` is a tiny selective column; `h` holds two 300-byte values so a full Map read is
+         expensive. The few matching rows are clustered (id < 10000) so a correctly-ordered cheap
+         prefilter skips the Map in almost every granule; the unfixed order reads the whole Map. -->
+    <fill_query>
+        INSERT INTO prewhere_map_cost_wide
+        SELECT number AS id,
+               if(less(number, 10000), 'active', '') AS modality,
+               map('k', repeat('v', 300), 'k2', repeat('w', 300)) AS h
+        FROM numbers_mt(10000000)
+    </fill_query>
+    <fill_query>OPTIMIZE TABLE prewhere_map_cost_wide FINAL SETTINGS mutations_sync = 1</fill_query>
+
+    <fill_query>
+        INSERT INTO prewhere_map_cost_compact
+        SELECT number AS id,
+               if(less(number, 10000), 'active', '') AS modality,
+               map('k', repeat('v', 300), 'k2', repeat('w', 300)) AS h
+        FROM numbers_mt(10000000)
+    </fill_query>
+    <fill_query>OPTIMIZE TABLE prewhere_map_cost_compact FINAL SETTINGS mutations_sync = 1</fill_query>
+
+    <!-- Wide: cheap filter should be evaluated first; only matching rows read the Map. -->
+    <query>
+        SELECT count() FROM prewhere_map_cost_wide WHERE modality != '' AND h['k'] = 'nope'
+    </query>
+
+    <!-- Compact -->
+    <query>
+        SELECT count() FROM prewhere_map_cost_compact WHERE modality != '' AND h['k'] = 'nope'
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS prewhere_map_cost_wide</drop_query>
+    <drop_query>DROP TABLE IF EXISTS prewhere_map_cost_compact</drop_query>
+</test>

--- a/tests/queries/0_stateless/04053_prewhere_statistics_decimal_overflow.sql
+++ b/tests/queries/0_stateless/04053_prewhere_statistics_decimal_overflow.sql
@@ -3,7 +3,12 @@
 -- Workaround: `allow_reorder_prewhere_conditions = 0` keeps the original WHERE order
 -- so the NOT-IN guard stays at position 0.
 --
--- Tags: no-fasttest
+-- no-random-merge-tree-settings: the read-cost-aware PREWHERE ordering (#110462) ranks arraySum
+-- against the NOT-IN guard by physical column size, so randomized serialization/compression settings
+-- change which condition is hoisted and whether the overflow fires. Pin the layout so the repro is
+-- deterministic; the reorder still triggers the overflow on the default layout the test documents.
+--
+-- Tags: no-fasttest, no-random-merge-tree-settings
 
 DROP TABLE IF EXISTS test_prewhere_decimal_overflow;
 

--- a/tests/queries/0_stateless/04340_prewhere_reorder_map_key_read_cost.reference
+++ b/tests/queries/0_stateless/04340_prewhere_reorder_map_key_read_cost.reference
@@ -1,0 +1,5 @@
+-- cheap modality filter is placed before the Map-key predicate
+1
+-- correctness: result is the same regardless of ordering
+0
+0

--- a/tests/queries/0_stateless/04340_prewhere_reorder_map_key_read_cost.sql
+++ b/tests/queries/0_stateless/04340_prewhere_reorder_map_key_read_cost.sql
@@ -1,0 +1,33 @@
+-- Regression for #110462: the PREWHERE reorderer must not hoist a Map-key predicate ahead of a
+-- cheaper, more selective filter. Evaluating `h['k'] = const` reads the whole `Map` column, so it
+-- must be charged its read cost and stay after the cheap `modality != ''` filter. Runs against a
+-- real server (persisted per-column sizes); a single all-in-one clickhouse-local masks the bug.
+SET enable_analyzer = 1;
+SET optimize_functions_to_subcolumns = 1;
+SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
+SET allow_reorder_prewhere_conditions = 1; -- CI may inject 0, which would skip reordering
+SET explain_query_plan_default = 'legacy';
+
+DROP TABLE IF EXISTS t_prewhere_map_cost;
+CREATE TABLE t_prewhere_map_cost (id UInt64, modality LowCardinality(String), h Map(String, String))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+
+-- `modality` is a tiny, selective column; `h` is a fat Map (two 300-byte values) that is expensive
+-- to read in full. `OPTIMIZE FINAL` makes a single wide part so per-column sizes exist.
+INSERT INTO t_prewhere_map_cost
+SELECT number, if(number < 1000, 'active', ''), map('k', repeat('v', 300), 'k2', repeat('w', 300))
+FROM numbers(200000);
+OPTIMIZE TABLE t_prewhere_map_cost FINAL;
+
+SELECT '-- cheap modality filter is placed before the Map-key predicate';
+SELECT position(explain, 'modality') > 0 AND position(explain, 'modality') < position(explain, 'h.key_k') AS cheap_first
+FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_prewhere_map_cost WHERE modality != '' AND h['k'] = 'nope'
+) WHERE explain LIKE '%Prewhere filter column%';
+
+SELECT '-- correctness: result is the same regardless of ordering';
+SELECT count() FROM t_prewhere_map_cost WHERE modality != '' AND h['k'] = 'nope';
+SELECT count() FROM t_prewhere_map_cost WHERE modality != '' AND h['k'] = 'nope'
+SETTINGS allow_reorder_prewhere_conditions = 0;
+
+DROP TABLE t_prewhere_map_cost;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/110462
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Account for column read cost when reordering `PREWHERE` conditions. Previously a predicate on a `Map` key (e.g. `h['k'] = 'x'`) could be moved to the front of `PREWHERE` ahead of a cheaper, more selective filter, forcing the whole `Map` column to be read for every granule (a 3-5x slowdown on some workloads). The reorderer now charges a subcolumn predicate the read cost of its base column and prefers a cheap, selective filter over an expensive whole-column read.


### Description

Fixes the `PREWHERE` reordering regression reported in #110462.

**Root cause.** `MergeTreeWhereOptimizer` ordered candidate conditions by a tuple `(!viable, !good, -min_pos_in_pk, estimated_row_count, columns_size, ...)`. For `WHERE modality != '' AND h['k'] = 'nope'` (with `h Map(String,String)`, `optimize_functions_to_subcolumns` rewriting `h['k']` to the `h.key_k` subcolumn), the trace shows:

```
notEquals(modality,'')  estimated_row_count=100000  columns_size=1039
equals(h.key_k,'nope')  estimated_row_count=  2000  columns_size=   0
```

- `estimated_row_count` is compared before `columns_size`, and the equality selectivity heuristic (`default_cond_equal_factor = 0.01`) ranks the map-key predicate as more selective, so it is hoisted first.
- `columns_size` is `0` for the map-key subcolumn because `getColumnsSize` is keyed by base storage columns, so the subcolumn is not found and the condition also looks free.

Evaluating a map-key predicate reads the entire `Map` column, so putting it first defeats the cheap prefilter and reads the whole Map for every granule. This is a pure performance regression (result unchanged). It is distinct from #107988, whose storage-column grouping only merges multiple subcolumn conditions on the same base Map and never touches `estimated_row_count`.

**Fix.** Two changes in `MergeTreeWhereOptimizer`:

1. `getColumnsSize` resolves each column to its base storage column (via `tryGetColumnOrSubcolumn(...).getNameInStorage()`) and charges the base column's size, deduplicating so multiple subcolumns of one base column count once. A map-key predicate is now charged the full `Map` read cost.
2. Conditions are ordered by a read-cost-per-eliminated-row score `cost_score = columns_size / eliminated_fraction`, placed before `estimated_row_count` in the comparison tuple. A large read is preferred only if it eliminates proportionally many rows. Without statistics the score reduces to `columns_size` (previous behaviour); for conditions that read the same columns, ties fall through to `estimated_row_count`, keeping selectivity-first ordering.

**Verification** (running server, populated table, `#110462` repro):

| build | read (default) | read (`allow_reorder_prewhere_conditions=0`) |
|---|---|---|
| master (unfixed) | 128,750,576 B | 1,654,824 B |
| this PR | 1,654,824 B | 1,654,824 B |

~78x less read; the cheap `modality` filter is placed first. Result is identical in all cases. The broader `arrayElement` form (`optimize_functions_to_subcolumns = 0`) is fixed too (1,650,516 B). Existing PREWHERE / statistics tests pass unchanged; a new stateless regression test `04340_prewhere_reorder_map_key_read_cost` fails on unfixed master and passes with the fix.
