### PR TITLE
Add regression tests for reading PostgreSQL boolean arrays

### DIFF
--- a/tests/integration/test_postgresql_replica_database_engine/test_1.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_1.py
@@ -438,6 +438,65 @@ def test_user_managed_slots(started_cluster):
     replication_connection.close()
 
 
+def test_bool_and_bool_array(started_cluster):
+    """Test for https://github.com/ClickHouse/ClickHouse/issues/62544
+    A PostgreSQL `boolean[]` column failed to replicate through
+    MaterializedPostgreSQL because the array parser did not understand
+    PostgreSQL's 't'/'f' boolean text format. This checks both the initial
+    snapshot and the streaming replication path (INSERT and UPDATE), including
+    NULL scalars, NULL array elements and NULL arrays. Rows are written directly
+    in PostgreSQL so the values arrive over the wire exactly as '{t,f,...}'.
+    """
+    table_name = "test_bool_array"
+    cursor = pg_manager.get_db_cursor()
+    cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+    cursor.execute(
+        f'CREATE TABLE "{table_name}" '
+        "(key integer PRIMARY KEY, b boolean, arr boolean[])"
+    )
+    cursor.execute(
+        f'INSERT INTO "{table_name}" VALUES '
+        "(1, 't', '{t,t,t,f,f,f,t,t}'), "
+        "(2, 'f', '{f,f}'), "
+        "(3, NULL, '{t,NULL,f}'), "
+        "(4, 't', NULL)"
+    )
+
+    pg_manager.create_materialized_db(
+        ip=started_cluster.postgres_ip,
+        port=started_cluster.postgres_port,
+        settings=[f"materialized_postgresql_tables_list = '{table_name}'"],
+    )
+
+    # Initial snapshot.
+    check_tables_are_synchronized(instance, table_name)
+    assert (
+        instance.query(f"SELECT * FROM test_database.{table_name} ORDER BY key")
+        == "1\t1\t[1,1,1,0,0,0,1,1]\n"
+        "2\t0\t[0,0]\n"
+        "3\t\\N\t[1,NULL,0]\n"
+        "4\t1\t[]\n"
+    )
+
+    # Streaming replication: INSERT and UPDATE performed directly in PostgreSQL.
+    cursor.execute(f"""INSERT INTO "{table_name}" VALUES (5, 'f', '{{f,NULL,t,f}}')""")
+    cursor.execute(
+        f"""UPDATE "{table_name}" SET b = 'f', arr = '{{t,t,t}}' WHERE key = 1"""
+    )
+
+    check_tables_are_synchronized(instance, table_name)
+    assert (
+        instance.query(f"SELECT * FROM test_database.{table_name} ORDER BY key")
+        == "1\t0\t[1,1,1]\n"
+        "2\t0\t[0,0]\n"
+        "3\t\\N\t[1,NULL,0]\n"
+        "4\t1\t[]\n"
+        "5\t0\t[0,NULL,1,0]\n"
+    )
+
+    pg_manager.drop_materialized_db()
+
+
 def test_merge_table_over_materialized_postgresql(started_cluster):
     """
     Reading a MaterializedPostgreSQL table through Merge forces FINAL on the child read

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -951,6 +951,58 @@ def test_postgres_insert_boolean_array(started_cluster):
     cursor.execute("DROP TABLE test_bool_array")
 
 
+def test_postgres_read_boolean_array(started_cluster):
+    """Test for https://github.com/ClickHouse/ClickHouse/issues/62544
+    Reading a PostgreSQL BOOLEAN[] column through the `PostgreSQL` engine used to
+    fail with `pqxx::conversion_error: Could not convert string to t: 't'` because
+    the array parser did not understand PostgreSQL's 't'/'f' boolean text format.
+    The rows below are inserted directly in PostgreSQL (as in the issue), so the
+    values arrive over the wire exactly as '{t,t,t,f,f,f,t,t}'.
+    """
+    cursor = started_cluster.postgres_conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test_bool_read")
+    cursor.execute(
+        "CREATE TABLE test_bool_read (id integer, b boolean, booleans boolean[])"
+    )
+    cursor.execute(
+        "INSERT INTO test_bool_read VALUES "
+        "(1, 't', '{t,t,t,f,f,f,t,t}'), "
+        "(2, 'f', '{f,f}'), "
+        "(3, NULL, '{t,NULL,f}'), "
+        "(4, 't', NULL)"
+    )
+
+    table_func = f"postgresql('{started_cluster.postgres_ip}:{started_cluster.postgres_port}', 'postgres', 'test_bool_read', 'postgres', '{pg_pass}')"
+
+    # Reading through a `PostgreSQL` engine table with an explicit Array(Bool)
+    # schema (the exact form from the issue).
+    node1.query(
+        f"""CREATE TABLE test.test_bool_read (id Int32, b Bool, booleans Array(Bool))
+            ENGINE = PostgreSQL('{started_cluster.postgres_ip}:{started_cluster.postgres_port}', 'postgres', 'test_bool_read', 'postgres', '{pg_pass}')"""
+    )
+    result = node1.query("SELECT * FROM test.test_bool_read ORDER BY id")
+    expected = (
+        "1\ttrue\t[true,true,true,false,false,false,true,true]\n"
+        "2\tfalse\t[false,false]\n"
+        "3\tfalse\t[true,false,false]\n"
+        "4\ttrue\t[]\n"
+    )
+    assert result == expected
+
+    # Reading through the table function with automatic schema inference maps the
+    # boolean array to Array(Nullable(UInt8)) and keeps NULL array elements.
+    result = node1.query(f"SELECT * FROM {table_func} ORDER BY id")
+    expected = (
+        "1\t1\t[1,1,1,0,0,0,1,1]\n"
+        "2\t0\t[0,0]\n"
+        "3\t\\N\t[1,NULL,0]\n"
+        "4\t1\t[]\n"
+    )
+    assert result == expected
+
+    cursor.execute("DROP TABLE test_bool_read")
+
+
 def test_postgres_date32(started_cluster):
     """Test that PostgreSQL DATE values outside the Date (UInt16) range are correctly read.
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/62544
Related: https://github.com/ClickHouse/ClickHouse/pull/96006
Related: https://github.com/ClickHouse/ClickHouse/issues/72754

Reading a PostgreSQL `boolean[]` column through the `PostgreSQL` or `MaterializedPostgreSQL` engines used to fail with `pqxx::conversion_error: Could not convert string to t: 't'`, because the array parser in `insertPostgreSQLValue` did not understand PostgreSQL's `t`/`f` boolean text format.

The underlying bug was already fixed in #96006 (which closed the duplicate #72754), but that change only tested a boolean array inserted through ClickHouse and read back. It did not cover the exact scenario reported in #62544 — an array inserted directly in PostgreSQL — nor the `MaterializedPostgreSQL` engine, which the issue explicitly mentions and which had no boolean-array coverage at all.

This adds two regression tests:

- `test_storage_postgresql`: reads a `boolean[]` column inserted directly in PostgreSQL (so the values arrive over the wire exactly as `{t,t,t,f,f,f,t,t}`) through both an explicit `Array(Bool)` `PostgreSQL` engine table and the table function with automatic schema inference, including `NULL` array elements and `NULL` arrays.
- `test_postgresql_replica_database_engine`: replicates a table with a `boolean` scalar and a `boolean[]` column through `MaterializedPostgreSQL`, covering both the initial snapshot and streaming replication (`INSERT` and `UPDATE` performed directly in PostgreSQL).

Both tests were validated locally against PostgreSQL 16 and a server built from this branch; the local integration-test harness (Docker-in-Docker) is currently wedged on this machine, so the pytest harness itself will run in CI.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added regression tests for reading PostgreSQL `boolean[]` arrays through the `PostgreSQL` and `MaterializedPostgreSQL` engines.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.998` (included in `26.7` and later)
<!-- ch-version-info:end -->