### PR TITLE
Revert "Lower max_server_memory_usage_to_ram_ratio to 0.7 on sanitizer stateless runs"

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -694,33 +694,11 @@ def main():
             CH.set_random_timezone,
         ]
 
-        # Sanitizer builds run under heavy memory pressure: besides the server's
-        # own ASan overhead, the parallel runner keeps dozens of ASan-instrumented
-        # `clickhouse-client` processes alive at once (~0.4 GiB each, ~17 GiB in
-        # total on a 60 GiB host). With the default 0.9
-        # `max_server_memory_usage_to_ram_ratio` the server is allowed to grow to
-        # ~0.9 of RAM on its own, so it can drive the host into a global OOM and be
-        # killed at an RSS well below its own memory limit - before any query hits
-        # `MEMORY_LIMIT_EXCEEDED` - which surfaces as a "Server died" failure.
-        # Cap the server low enough that the clients' footprint still fits, so the
-        # server kills a runaway query gracefully instead of being OOM-killed by
-        # the host. This applies to every sanitizer run, not just the flaky check
-        # (which previously used 0.8, sufficient there only because it runs a small
-        # test subset at reduced concurrency). 0.7 stays comfortably above the
-        # largest legitimate single-query need (the ~25 GiB stateful-load INSERT).
-        sanitizers = ("asan", "tsan", "msan", "ubsan")
-        # In bugfix validation `args.options` is only `BugfixValidation`, so the
-        # sanitizer names never appear there. That mode instead downloads and swaps
-        # through several master-HEAD build-type binaries (`build_types`), most of
-        # them sanitizer builds, on the same memory-constrained runner. Key the
-        # ratio off those actual build types in that mode so the same runner-wide
-        # OOM cannot slip through the guard on the sanitizer bugfix-validation paths.
-        ratio_sources = build_types if is_bugfix_validation else [args.options]
-        if any(san in source for source in ratio_sources for san in sanitizers):
-            commands.append(lambda: CH.set_memory_ratio(0.7))
-
         if is_flaky_check:
             commands.append(CH.enable_thread_fuzzer_config)
+            sanitizers = ("asan", "tsan", "msan", "ubsan")
+            if any(san in args.options for san in sanitizers):
+                commands.append(lambda: CH.set_memory_ratio(0.8))
 
         os.environ["MALLOC_CONF"] = (
             f"prof_prefix:{temp_dir}/jemalloc_profiles/clickhouse.jemalloc"

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -264,32 +264,18 @@ class ClickHouseProc:
         os.environ["THREAD_FUZZER_pthread_mutex_unlock_BEFORE_SLEEP_TIME_US_MAX"] = "10000"
         os.environ["THREAD_FUZZER_pthread_mutex_unlock_AFTER_SLEEP_TIME_US_MAX"] = "10000"
 
-    def set_memory_ratio(self, ratio):
+    @staticmethod
+    def set_memory_ratio(ratio):
         config = f"""<clickhouse>
     <max_server_memory_usage_to_ram_ratio>{ratio}</max_server_memory_usage_to_ram_ratio>
 </clickhouse>
 """
-        # In DBReplicated mode `install.sh` has already cloned
-        # /etc/clickhouse-server into the two replica config dirs and `start`
-        # launches all three servers, so the override must be written into every
-        # replica config dir too - otherwise the extra replicas keep the default
-        # 0.9 ratio and can still drive the host into a global OOM under the
-        # heavier multi-server footprint (the very failure this cap prevents).
-        config_dirs = [self.ch_config_dir]
-        if self.is_db_replicated:
-            config_dirs += [
-                self.ch_config_dir_replica_1,
-                self.ch_config_dir_replica_2,
-            ]
-        for config_dir in config_dirs:
-            file_path = (
-                f"{config_dir}/config.d/max_server_memory_usage_to_ram_ratio.xml"
-            )
-            with open(file_path, "w") as f:
-                f.write(config)
-            print(
-                f"Set max_server_memory_usage_to_ram_ratio to {ratio} in {file_path}"
-            )
+        file_path = "/etc/clickhouse-server/config.d/max_server_memory_usage_to_ram_ratio.xml"
+        with open(file_path, "w") as f:
+            f.write(config)
+        print(
+            f"Set max_server_memory_usage_to_ram_ratio to {ratio} in {file_path}"
+        )
 
     def _install_light(self):
         """


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#110293


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.982` (included in `26.7` and later)
<!-- ch-version-info:end -->