### PR TITLE
Introduce PackedStringRef & PackedStringHashTable

### DIFF
--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <base/StringViewHash.h>
+
+/// PackedStringRef layout (16 bytes total):
+///
+///   +----------------------+----------------------+
+///   |    low (64 bits)     |    high (64 bits)    |
+///   +----------------------+----------------------+
+///
+/// This is a tagged union encoded in two 64-bit words. The interpretation of `high` depends on the string category.
+///
+/// ------------------------------------------------------------
+/// Small string (len > 0 and len <= MAX_INLINE_LEN = 11 bytes)
+///
+///   low:
+///     [ 0..31 ]   : hash32
+///     [32..63 ]   : inline string payload (first part, 4 bytes)
+///
+///   high:
+///     [ 0..55 ]   : inline string payload (second part, 7 bytes)
+///     [56..58 ]   : unused
+///     [59..62 ]   : inline string length (4 bits, max 15)
+///     [63 ]       : MUST be 0 (reserved for large-string tag)
+///
+/// ------------------------------------------------------------
+/// Medium string (len <= 2^32 - 1)
+///
+///   low:
+///     [ 0..31 ]   : hash32
+///     [32..63 ]   : length32
+///
+///   high:
+///     [ 0..55 ]   : pointer to string data
+///     [56..63 ]   : zero
+///
+/// Notes:
+///   - `high` stores an untagged pointer. Bit 63 of `high` MUST be zero for medium strings.
+///   - This is guaranteed by the platform pointer layout and is required for unambiguous mode detection.
+///
+/// ------------------------------------------------------------
+/// Large string (len > 2^32 - 1)
+///
+///   low:
+///     [ 0..63 ]   : full 64-bit length
+///
+///   high:
+///     [ 0..55 ]   : pointer to string data
+///     [56..62 ]   : zero
+///     [ 63 ]      : LARGE tag bit (borrowed from pointer high bit)
+///
+/// Notes:
+///   - Large string uses a tagged-pointer representation. Bit 63 of `high` is set to distinguish this mode.
+///   - This relies on the fact that valid user-space pointers do not occupy the highest 5 address bits on supported platforms.
+///
+/// ------------------------------------------------------------
+/// Empty string (len == 0)
+///
+///   low is unused
+///   high = 0
+///
+/// Notes:
+///   - Checking `high == 0` is sufficient to detect empty strings.
+///
+/// ------------------------------------------------------------
+/// Mode detection summary:
+///
+///   - isLarge()  : (high & LARGE_TAG) != 0
+///   - isSmall()  : !isLarge() && inline_length != 0
+///   - isMedium() : !isLarge() && inline_length == 0 && high != 0
+struct PackedStringRef
+{
+    uint64_t low;
+    uint64_t high;
+
+    // --- Layout Constants ---
+    static constexpr uint64_t HASH_SIZE_BYTES = 4;
+    static constexpr uint64_t HASH_SIZE_BITS = 32;
+
+    // Small String: High [59..62] bits store length, bit 63 must be 0
+    static constexpr uint64_t SMALL_LEN_SHIFT = 59;
+    static constexpr uint64_t MAX_SMALL_LEN   = 11;
+
+    // Large String: Use bit 63 as tag.
+    // Most 64-bit CPUs use 48-bit or 52-bit addressing.
+    // Masking the top 5 bits (63-59) ensures safety against tagging and TBI.
+    static constexpr uint64_t LARGE_TAG    = 1ULL << 63;
+    static constexpr uint64_t POINTER_MASK = 0x07FFFFFFFFFFFFFFULL;
+
+    /// ---------- Kind checks ----------
+
+    ALWAYS_INLINE bool isLarge() const
+    {
+        return (high & LARGE_TAG) != 0;
+    }
+
+    ALWAYS_INLINE bool isMedium() const
+    {
+        return !isLarge() && getSmallSize() == 0;
+    }
+
+    ALWAYS_INLINE bool isSmall() const
+    {
+        return !isLarge() && getSmallSize() != 0;
+    }
+
+    /// ---------- Small string ----------
+
+    ALWAYS_INLINE uint8_t getSmallSize() const
+    {
+        return static_cast<uint8_t>(high >> SMALL_LEN_SHIFT);
+    }
+
+    ALWAYS_INLINE const char * getSmallPtr() const
+    {
+        return reinterpret_cast<const char *>(&low) + HASH_SIZE_BYTES;
+    }
+
+    /// ---------- Medium string ----------
+
+    ALWAYS_INLINE uint32_t getMediumSize() const
+    {
+        return static_cast<uint32_t>(low >> HASH_SIZE_BITS);
+    }
+
+    ALWAYS_INLINE const char * getMediumPtr() const
+    {
+        return reinterpret_cast<const char *>(high);
+    }
+
+    /// ---------- Large string ----------
+
+    ALWAYS_INLINE uint64_t getLargeSize() const
+    {
+        return low;
+    }
+
+    ALWAYS_INLINE const char * getLargePtr() const
+    {
+        /// Clear top 5 bits to retrieve a clean canonical 64-bit pointer
+        return reinterpret_cast<const char*>(high & POINTER_MASK);
+    }
+
+    /// ---------- Common ----------
+
+    ALWAYS_INLINE uint32_t getHash() const
+    {
+        return static_cast<uint32_t>(low);
+    }
+
+    ALWAYS_INLINE size_t heapSize() const
+    {
+        if (isMedium())
+            return getMediumSize();
+        if (isLarge())
+            return getLargeSize();
+        return 0;
+    }
+
+    ALWAYS_INLINE explicit operator std::string_view() const
+    {
+        if (isSmall())
+            return {getSmallPtr(), getSmallSize()};
+        if (isMedium())
+            return {getMediumPtr(), getMediumSize()};
+        return {getLargePtr(), getLargeSize()};
+    }
+
+    /// ---------- Builder ----------
+
+    static ALWAYS_INLINE PackedStringRef build(const char * ptr, size_t len, uint32_t hash)
+    {
+        PackedStringRef r{};
+
+        if (len == 0)
+        {
+            r.low = 0;
+            r.high = 0;
+            return r;
+        }
+
+        /// 1. Small String Inline
+        if (len <= MAX_SMALL_LEN)
+        {
+            r.low = hash;
+            r.high = static_cast<uint64_t>(len) << SMALL_LEN_SHIFT;
+            memcpy(reinterpret_cast<char *>(&r.low) + sizeof(uint32_t), ptr, len);
+            return r;
+        }
+
+        /// 2. Medium String (32-bit length + 32-bit hash)
+        if (len <= std::numeric_limits<uint32_t>::max())
+        {
+            r.low = (static_cast<uint64_t>(len) << 32) | hash;
+            r.high = reinterpret_cast<uintptr_t>(ptr);
+            return r;
+        }
+
+        /// 3. Large String (64-bit length, tagged pointer)
+        r.low = len;
+        r.high = reinterpret_cast<uintptr_t>(ptr) | LARGE_TAG;
+        return r;
+    }
+};
+
+/// ---------- Equality ----------
+
+inline ALWAYS_INLINE bool operator==(PackedStringRef lhs, PackedStringRef rhs)
+{
+    if (lhs.low != rhs.low)
+        return false;
+
+    if (lhs.high == rhs.high)
+        return true;
+
+    if (lhs.isMedium() && rhs.isMedium()) [[likely]]
+    {
+#if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
+        return memequalWide(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize());
+#else
+        return memcmp(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize()) == 0;
+#endif
+    }
+
+    if (lhs.isLarge() && rhs.isLarge()) [[unlikely]]
+    {
+#if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
+        return memequalWide(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize());
+#else
+        return memcmp(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize()) == 0;
+#endif
+    }
+
+    return false;
+}
+
+namespace ZeroTraits
+{
+
+inline bool check(const PackedStringRef & x)
+{
+    return x.high == 0;
+}
+
+inline void set(PackedStringRef & x)
+{
+    x.high = 0;
+}
+
+}

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -1,83 +1,44 @@
 #pragma once
 
 #include <bit>
+#include <cstring>
 
 #include <base/StringViewHash.h>
 
-/// `PackedStringRef` encodes payload and tag bits inside two `uint64_t`
-/// words using `memcpy` into byte offsets that assume the LSB sits at the
-/// lowest address. On big-endian architectures, the inline payload, size
-/// bits, and large-string tag would alias to different bit positions, so
-/// build, isSmall and operator std::string_view would misdecode keys.
-static_assert(std::endian::native == std::endian::little,
-              "PackedStringRef encoding is little-endian specific");
-
-/// PackedStringRef layout (16 bytes total):
+/// PackedStringRef is a compact, 16-byte string representation that encodes
+/// payload and tag bits inside two 64-bit words.
 ///
-///   +----------------------+----------------------+
-///   |    low (64 bits)     |    high (64 bits)    |
-///   +----------------------+----------------------+
+/// The encoding uses a byte-stable layout: every field lives at a fixed byte
+/// offset inside the struct, independent of host endianness. Writes use
+/// `memcpy` at those byte offsets (and explicit little-endian shift helpers
+/// for the 56-bit packed pointer / 64-bit length), and reads mirror that.
 ///
-/// This is a tagged union encoded in two 64-bit words. The interpretation of `high` depends on the string category.
+/// Because `operator==` compares `low`/`high` as `uint64_t`, equality still
+/// holds across two values built by the same code: identical byte sequences
+/// yield identical `uint64_t` values regardless of endianness.
 ///
 /// ------------------------------------------------------------
-/// Small string (len > 0 and len <= MAX_INLINE_LEN = 11 bytes)
+/// Byte layout (16 bytes total, identical on little-endian and big-endian):
 ///
-///   low:
-///     [ 0..31 ]   : hash32
-///     [32..63 ]   : inline string payload (first part, 4 bytes)
+///   bytes  0..3  : hash32         (small / medium)
+///                  low 32 bits of length (large)
+///   bytes  4..7  : payload 0..3   (small)
+///                  length32       (medium)
+///                  high 32 bits of length (large)
+///   bytes  8..14 : payload 4..10  (small)
+///                  low 56 bits of pointer in little-endian byte order (medium / large)
+///   byte   15    : tag byte
+///                    bit 7    : LARGE flag
+///                    bits 3-6 : SMALL length (4 bits, 0 if not small)
+///                    bits 0-2 : reserved (0)
 ///
-///   high:
-///     [ 0..55 ]   : inline string payload (second part, 7 bytes)
-///     [56..58 ]   : unused
-///     [59..62 ]   : inline string length (4 bits, max 15)
-///     [63 ]       : MUST be 0 (reserved for large-string tag)
-///
-/// ------------------------------------------------------------
-/// Medium string (len <= 2^32 - 1)
-///
-///   low:
-///     [ 0..31 ]   : hash32
-///     [32..63 ]   : length32
-///
-///   high:
-///     [ 0..55 ]   : pointer to string data
-///     [56..63 ]   : zero
-///
-/// Notes:
-///   - `high` stores an untagged pointer. Bit 63 of `high` MUST be zero for medium strings.
-///   - This is guaranteed by the platform pointer layout and is required for unambiguous mode detection.
-///
-/// ------------------------------------------------------------
-/// Large string (len > 2^32 - 1)
-///
-///   low:
-///     [ 0..63 ]   : full 64-bit length
-///
-///   high:
-///     [ 0..55 ]   : pointer to string data
-///     [56..62 ]   : zero
-///     [ 63 ]      : LARGE tag bit (borrowed from pointer high bit)
-///
-/// Notes:
-///   - Large string uses a tagged-pointer representation. Bit 63 of `high` is set to distinguish this mode.
-///   - This relies on the fact that valid user-space pointers do not occupy the highest 5 address bits on supported platforms.
-///
-/// ------------------------------------------------------------
-/// Empty string (len == 0)
-///
-///   low is unused
-///   high = 0
-///
-/// Notes:
-///   - Checking `high == 0` is sufficient to detect empty strings.
+/// Empty: all 16 bytes are 0 (in particular, `high == 0`).
 ///
 /// ------------------------------------------------------------
 /// Mode detection summary:
-///
-///   - isLarge()  : (high & LARGE_TAG) != 0
-///   - isSmall()  : !isLarge() && inline_length != 0
-///   - isMedium() : !isLarge() && inline_length == 0 && high != 0
+///   - isLarge()  : tag byte has bit 7 set
+///   - isSmall()  : !isLarge() && SMALL length nibble != 0
+///   - isMedium() : !isLarge() && !isSmall() && high != 0
 ///   - isEmpty()  : high == 0
 struct PackedStringRef
 {
@@ -85,24 +46,60 @@ struct PackedStringRef
     uint64_t high;
 
     // --- Layout Constants ---
-    static constexpr uint64_t HASH_SIZE_BYTES = 4;
-    static constexpr uint64_t HASH_SIZE_BITS = 32;
+    static constexpr size_t HASH_SIZE_BYTES = 4;
+    static constexpr size_t TAG_BYTE_OFFSET = 15;
+    static constexpr size_t PACKED_POINTER_BYTES = 7;
+    static constexpr uint64_t MAX_SMALL_LEN = 11;
 
-    // Small String: High [59..62] bits store length, bit 63 must be 0
-    static constexpr uint64_t SMALL_LEN_SHIFT = 59;
-    static constexpr uint64_t MAX_SMALL_LEN   = 11;
+    /// Tag byte bit layout.
+    static constexpr uint8_t LARGE_TAG_BYTE = 0x80;
+    static constexpr uint8_t SMALL_LEN_SHIFT_IN_BYTE = 3;
+    static constexpr uint8_t SMALL_LEN_NIBBLE_MASK = 0x78;
 
-    // Large String: Use bit 63 as tag.
-    // Most 64-bit CPUs use 48-bit or 52-bit addressing.
-    // Masking the top 5 bits (63-59) ensures safety against tagging and TBI.
-    static constexpr uint64_t LARGE_TAG    = 1ULL << 63;
-    static constexpr uint64_t POINTER_MASK = 0x07FFFFFFFFFFFFFFULL;
+private:
+    ALWAYS_INLINE uint8_t * rawBytes() { return reinterpret_cast<uint8_t *>(this); }
+    ALWAYS_INLINE const uint8_t * rawBytes() const { return reinterpret_cast<const uint8_t *>(this); }
 
+    ALWAYS_INLINE uint8_t getTagByte() const { return rawBytes()[TAG_BYTE_OFFSET]; }
+
+    /// Store the low `n` bytes (n <= 8) of `value` at `dst` in little-endian
+    /// byte order, regardless of host endianness.
+    static ALWAYS_INLINE void storeLE(uint8_t * dst, uint64_t value, size_t n)
+    {
+        if constexpr (std::endian::native == std::endian::little)
+        {
+            std::memcpy(dst, &value, n);
+        }
+        else
+        {
+            for (size_t i = 0; i < n; ++i)
+                dst[i] = static_cast<uint8_t>(value >> (i * 8));
+        }
+    }
+
+    /// Load `n` bytes (n <= 8) from `src` interpreted as a little-endian
+    /// unsigned integer, regardless of host endianness.
+    static ALWAYS_INLINE uint64_t loadLE(const uint8_t * src, size_t n)
+    {
+        uint64_t value = 0;
+        if constexpr (std::endian::native == std::endian::little)
+        {
+            std::memcpy(&value, src, n);
+        }
+        else
+        {
+            for (size_t i = 0; i < n; ++i)
+                value |= static_cast<uint64_t>(src[i]) << (i * 8);
+        }
+        return value;
+    }
+
+public:
     /// ---------- Kind checks ----------
 
     ALWAYS_INLINE bool isLarge() const
     {
-        return (high & LARGE_TAG) != 0;
+        return (getTagByte() & LARGE_TAG_BYTE) != 0;
     }
 
     ALWAYS_INLINE bool isEmpty() const
@@ -124,44 +121,47 @@ struct PackedStringRef
 
     ALWAYS_INLINE uint8_t getSmallSize() const
     {
-        return static_cast<uint8_t>(high >> SMALL_LEN_SHIFT);
+        return static_cast<uint8_t>((getTagByte() & SMALL_LEN_NIBBLE_MASK) >> SMALL_LEN_SHIFT_IN_BYTE);
     }
 
     ALWAYS_INLINE const char * getSmallPtr() const
     {
-        return reinterpret_cast<const char *>(&low) + HASH_SIZE_BYTES;
+        return reinterpret_cast<const char *>(rawBytes() + HASH_SIZE_BYTES);
     }
 
     /// ---------- Medium string ----------
 
     ALWAYS_INLINE uint32_t getMediumSize() const
     {
-        return static_cast<uint32_t>(low >> HASH_SIZE_BITS);
+        uint32_t size = 0;
+        std::memcpy(&size, rawBytes() + HASH_SIZE_BYTES, sizeof(size));
+        return size;
     }
 
     ALWAYS_INLINE const char * getMediumPtr() const
     {
-        return reinterpret_cast<const char *>(high);
+        return reinterpret_cast<const char *>(loadLE(rawBytes() + sizeof(uint64_t), PACKED_POINTER_BYTES));
     }
 
     /// ---------- Large string ----------
 
     ALWAYS_INLINE uint64_t getLargeSize() const
     {
-        return low;
+        return loadLE(rawBytes(), sizeof(uint64_t));
     }
 
     ALWAYS_INLINE const char * getLargePtr() const
     {
-        /// Clear top 5 bits to retrieve a clean canonical 64-bit pointer
-        return reinterpret_cast<const char*>(high & POINTER_MASK);
+        return reinterpret_cast<const char *>(loadLE(rawBytes() + sizeof(uint64_t), PACKED_POINTER_BYTES));
     }
 
     /// ---------- Common ----------
 
     ALWAYS_INLINE uint32_t getHash() const
     {
-        return static_cast<uint32_t>(low);
+        uint32_t hash = 0;
+        std::memcpy(&hash, rawBytes(), sizeof(hash));
+        return hash;
     }
 
     ALWAYS_INLINE size_t heapSize() const
@@ -184,6 +184,21 @@ struct PackedStringRef
         return {getLargePtr(), getLargeSize()};
     }
 
+    /// Set the medium-string pointer (low 56 bits) and clear the tag byte.
+    /// Used by `keyHolderPersistKey` to rebind the key to arena-owned memory.
+    ALWAYS_INLINE void setMediumPointer(const char * ptr)
+    {
+        storeLE(rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+        rawBytes()[TAG_BYTE_OFFSET] = 0;
+    }
+
+    /// Set the large-string pointer (low 56 bits) and set the LARGE tag byte.
+    ALWAYS_INLINE void setLargePointer(const char * ptr)
+    {
+        storeLE(rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+        rawBytes()[TAG_BYTE_OFFSET] = LARGE_TAG_BYTE;
+    }
+
     /// ---------- Builder ----------
 
     static ALWAYS_INLINE PackedStringRef build(const char * ptr, size_t len, uint32_t hash)
@@ -191,32 +206,31 @@ struct PackedStringRef
         PackedStringRef r{};
 
         if (len == 0)
-        {
-            r.low = 0;
-            r.high = 0;
             return r;
-        }
 
         /// 1. Small String Inline
         if (len <= MAX_SMALL_LEN)
         {
-            r.low = hash;
-            r.high = static_cast<uint64_t>(len) << SMALL_LEN_SHIFT;
-            memcpy(reinterpret_cast<char *>(&r.low) + sizeof(uint32_t), ptr, len);
+            std::memcpy(r.rawBytes(), &hash, sizeof(hash));
+            std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, ptr, len);
+            r.rawBytes()[TAG_BYTE_OFFSET] = static_cast<uint8_t>(static_cast<uint8_t>(len) << SMALL_LEN_SHIFT_IN_BYTE);
             return r;
         }
 
         /// 2. Medium String (32-bit length + 32-bit hash)
         if (len <= std::numeric_limits<uint32_t>::max())
         {
-            r.low = (static_cast<uint64_t>(len) << 32) | hash;
-            r.high = reinterpret_cast<uintptr_t>(ptr);
+            uint32_t len32 = static_cast<uint32_t>(len);
+            std::memcpy(r.rawBytes(), &hash, sizeof(hash));
+            std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, &len32, sizeof(len32));
+            storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
             return r;
         }
 
-        /// 3. Large String (64-bit length, tagged pointer)
-        r.low = len;
-        r.high = reinterpret_cast<uintptr_t>(ptr) | LARGE_TAG;
+        /// 3. Large String (64-bit length, packed pointer + LARGE tag)
+        storeLE(r.rawBytes(), len, sizeof(uint64_t));
+        storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+        r.rawBytes()[TAG_BYTE_OFFSET] = LARGE_TAG_BYTE;
         return r;
     }
 };

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -276,6 +276,12 @@ inline bool check(const PackedStringRef & x)
 
 inline void set(PackedStringRef & x)
 {
+    /// Canonicalize the whole empty value to all-zero bytes, matching the documented
+    /// empty invariant above. `getHash` reads the low word, so leaving `low` with an
+    /// arbitrary byte pattern from uninitialized zero-cell storage would make the stored
+    /// empty key report a non-zero hash and land in a different bucket from subsequent
+    /// empty keys during `convertToTwoLevel`.
+    x.low = 0;
     x.high = 0;
 }
 

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -1,6 +1,16 @@
 #pragma once
 
+#include <bit>
+
 #include <base/StringViewHash.h>
+
+/// `PackedStringRef` encodes payload and tag bits inside two `uint64_t`
+/// words using `memcpy` into byte offsets that assume the LSB sits at the
+/// lowest address. On big-endian architectures, the inline payload, size
+/// bits, and large-string tag would alias to different bit positions, so
+/// build, isSmall and operator std::string_view would misdecode keys.
+static_assert(std::endian::native == std::endian::little,
+              "PackedStringRef encoding is little-endian specific");
 
 /// PackedStringRef layout (16 bytes total):
 ///

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -68,6 +68,7 @@
 ///   - isLarge()  : (high & LARGE_TAG) != 0
 ///   - isSmall()  : !isLarge() && inline_length != 0
 ///   - isMedium() : !isLarge() && inline_length == 0 && high != 0
+///   - isEmpty()  : high == 0
 struct PackedStringRef
 {
     uint64_t low;
@@ -94,9 +95,14 @@ struct PackedStringRef
         return (high & LARGE_TAG) != 0;
     }
 
+    ALWAYS_INLINE bool isEmpty() const
+    {
+        return high == 0;
+    }
+
     ALWAYS_INLINE bool isMedium() const
     {
-        return !isLarge() && getSmallSize() == 0;
+        return !isLarge() && getSmallSize() == 0 && !isEmpty();
     }
 
     ALWAYS_INLINE bool isSmall() const
@@ -159,6 +165,8 @@ struct PackedStringRef
 
     ALWAYS_INLINE explicit operator std::string_view() const
     {
+        if (isEmpty())
+            return {};
         if (isSmall())
             return {getSmallPtr(), getSmallSize()};
         if (isMedium())

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include <base/StringViewHash.h>
+#include <base/defines.h>
 
 /// PackedStringRef is a compact, 16-byte string representation that encodes
 /// payload and tag bits inside two 64-bit words.
@@ -45,7 +46,6 @@ struct PackedStringRef
     uint64_t low;
     uint64_t high;
 
-    // --- Layout Constants ---
     static constexpr size_t HASH_SIZE_BYTES = 4;
     static constexpr size_t SMALL_PAYLOAD_OFFSET = HASH_SIZE_BYTES;
     static constexpr size_t MEDIUM_LENGTH_OFFSET = HASH_SIZE_BYTES;
@@ -59,6 +59,10 @@ struct PackedStringRef
     static constexpr uint8_t SMALL_LEN_NIBBLE_MASK = 0x78;
 
     /// Low 56 bits of `high`: the packed pointer of the medium / large encodings.
+    /// 56 bits fit any user-space pointer on the supported targets: Linux x86-64 keeps user
+    /// addresses below 2^56 even with 5-level paging, and AArch64 virtual addresses take at
+    /// most 52 bits. Pointer tagging that sets the top bits (e.g. HWASan) would make the
+    /// truncation lossy; the setters assert the invariant in debug builds.
     static constexpr uint64_t POINTER_MASK = (uint64_t(1) << (PACKED_POINTER_BYTES * 8)) - 1;
 
 private:
@@ -100,8 +104,6 @@ private:
     }
 
 public:
-    /// ---------- Kind checks ----------
-
     ALWAYS_INLINE bool isLarge() const
     {
         return (getTagByte() & LARGE_TAG_BYTE) != 0;
@@ -122,8 +124,6 @@ public:
         return !isLarge() && getSmallSize() != 0;
     }
 
-    /// ---------- Small string ----------
-
     ALWAYS_INLINE uint8_t getSmallSize() const
     {
         return static_cast<uint8_t>((getTagByte() & SMALL_LEN_NIBBLE_MASK) >> SMALL_LEN_SHIFT_IN_BYTE);
@@ -133,8 +133,6 @@ public:
     {
         return reinterpret_cast<const char *>(rawBytes() + SMALL_PAYLOAD_OFFSET);
     }
-
-    /// ---------- Medium string ----------
 
     ALWAYS_INLINE uint32_t getMediumSize() const
     {
@@ -148,8 +146,6 @@ public:
         return reinterpret_cast<const char *>(loadLE(rawBytes() + sizeof(uint64_t), PACKED_POINTER_BYTES));
     }
 
-    /// ---------- Large string ----------
-
     ALWAYS_INLINE uint64_t getLargeSize() const
     {
         return loadLE(rawBytes(), sizeof(uint64_t));
@@ -159,8 +155,6 @@ public:
     {
         return reinterpret_cast<const char *>(loadLE(rawBytes() + sizeof(uint64_t), PACKED_POINTER_BYTES));
     }
-
-    /// ---------- Common ----------
 
     ALWAYS_INLINE uint32_t getHash() const
     {
@@ -196,6 +190,7 @@ public:
     /// Used by `keyHolderPersistKey` to rebind the key to arena-owned memory.
     ALWAYS_INLINE void setMediumPointer(const char * ptr)
     {
+        chassert((reinterpret_cast<uintptr_t>(ptr) >> (PACKED_POINTER_BYTES * 8)) == 0);
         storeLE(rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
         rawBytes()[TAG_BYTE_OFFSET] = 0;
     }
@@ -203,11 +198,10 @@ public:
     /// Set the large-string pointer (low 56 bits) and set the LARGE tag byte.
     ALWAYS_INLINE void setLargePointer(const char * ptr)
     {
+        chassert((reinterpret_cast<uintptr_t>(ptr) >> (PACKED_POINTER_BYTES * 8)) == 0);
         storeLE(rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
         rawBytes()[TAG_BYTE_OFFSET] = LARGE_TAG_BYTE;
     }
-
-    /// ---------- Builder ----------
 
     /// Build a packed value, computing the 32-bit content hash with `hash_fn(ptr, len)`.
     /// The functor is invoked only for the encodings that store a hash (small and medium,
@@ -225,7 +219,6 @@ public:
         if (len == 0)
             return r;
 
-        /// 1. Small String Inline
         if (len <= MAX_SMALL_LEN)
         {
             const uint32_t hash = hash_fn(ptr, len);
@@ -260,7 +253,6 @@ public:
             return r;
         }
 
-        /// 2. Medium String (32-bit hash + 32-bit length + packed pointer)
         if (len <= std::numeric_limits<uint32_t>::max())
         {
             const uint32_t hash = hash_fn(ptr, len);
@@ -279,7 +271,7 @@ public:
             return r;
         }
 
-        /// 3. Large String (64-bit length, packed pointer + LARGE tag)
+        /// Large string.
         if constexpr (std::endian::native == std::endian::little)
         {
             r.low = len;
@@ -294,8 +286,6 @@ public:
         return r;
     }
 };
-
-/// ---------- Equality ----------
 
 inline ALWAYS_INLINE bool operator==(PackedStringRef lhs, PackedStringRef rhs)
 {

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -8,17 +8,17 @@
 /// PackedStringRef is a compact, 16-byte string representation that encodes
 /// payload and tag bits inside two 64-bit words.
 ///
-/// The encoding uses a byte-stable layout: every field lives at a fixed byte
-/// offset inside the struct, independent of host endianness. Writes use
-/// `memcpy` at those byte offsets (and explicit little-endian shift helpers
-/// for the 56-bit packed pointer / 64-bit length), and reads mirror that.
-///
-/// Because `operator==` compares `low`/`high` as `uint64_t`, equality still
-/// holds across two values built by the same code: identical byte sequences
-/// yield identical `uint64_t` values regardless of endianness.
+/// Every field lives at a fixed byte offset inside the struct. The packed
+/// pointer and the 64-bit large length are stored in little-endian byte order
+/// via `storeLE`/`loadLE`; the multi-byte integer fields (hash32, length32)
+/// are stored in native byte order, so the byte image is stable within a host
+/// but not identical across hosts of different endianness. That is sufficient:
+/// the value never crosses processes, reads mirror writes, and `operator==`
+/// compares `low`/`high` as `uint64_t`, so equality holds between any two
+/// values built by the same code on the same host.
 ///
 /// ------------------------------------------------------------
-/// Byte layout (16 bytes total, identical on little-endian and big-endian):
+/// Byte layout (16 bytes total):
 ///
 ///   bytes  0..3  : hash32         (small / medium)
 ///                  low 32 bits of length (large)
@@ -47,6 +47,8 @@ struct PackedStringRef
 
     // --- Layout Constants ---
     static constexpr size_t HASH_SIZE_BYTES = 4;
+    static constexpr size_t SMALL_PAYLOAD_OFFSET = HASH_SIZE_BYTES;
+    static constexpr size_t MEDIUM_LENGTH_OFFSET = HASH_SIZE_BYTES;
     static constexpr size_t TAG_BYTE_OFFSET = 15;
     static constexpr size_t PACKED_POINTER_BYTES = 7;
     static constexpr uint64_t MAX_SMALL_LEN = 11;
@@ -129,7 +131,7 @@ public:
 
     ALWAYS_INLINE const char * getSmallPtr() const
     {
-        return reinterpret_cast<const char *>(rawBytes() + HASH_SIZE_BYTES);
+        return reinterpret_cast<const char *>(rawBytes() + SMALL_PAYLOAD_OFFSET);
     }
 
     /// ---------- Medium string ----------
@@ -137,7 +139,7 @@ public:
     ALWAYS_INLINE uint32_t getMediumSize() const
     {
         uint32_t size = 0;
-        std::memcpy(&size, rawBytes() + HASH_SIZE_BYTES, sizeof(size));
+        std::memcpy(&size, rawBytes() + MEDIUM_LENGTH_OFFSET, sizeof(size));
         return size;
     }
 
@@ -252,7 +254,7 @@ public:
             else
             {
                 std::memcpy(r.rawBytes(), &hash, sizeof(hash));
-                std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, ptr, len);
+                std::memcpy(r.rawBytes() + SMALL_PAYLOAD_OFFSET, ptr, len);
                 r.rawBytes()[TAG_BYTE_OFFSET] = static_cast<uint8_t>(static_cast<uint8_t>(len) << SMALL_LEN_SHIFT_IN_BYTE);
             }
             return r;
@@ -271,7 +273,7 @@ public:
             {
                 uint32_t len32 = static_cast<uint32_t>(len);
                 std::memcpy(r.rawBytes(), &hash, sizeof(hash));
-                std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, &len32, sizeof(len32));
+                std::memcpy(r.rawBytes() + MEDIUM_LENGTH_OFFSET, &len32, sizeof(len32));
                 storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
             }
             return r;

--- a/base/base/PackedStringRef.h
+++ b/base/base/PackedStringRef.h
@@ -56,6 +56,9 @@ struct PackedStringRef
     static constexpr uint8_t SMALL_LEN_SHIFT_IN_BYTE = 3;
     static constexpr uint8_t SMALL_LEN_NIBBLE_MASK = 0x78;
 
+    /// Low 56 bits of `high`: the packed pointer of the medium / large encodings.
+    static constexpr uint64_t POINTER_MASK = (uint64_t(1) << (PACKED_POINTER_BYTES * 8)) - 1;
+
 private:
     ALWAYS_INLINE uint8_t * rawBytes() { return reinterpret_cast<uint8_t *>(this); }
     ALWAYS_INLINE const uint8_t * rawBytes() const { return reinterpret_cast<const uint8_t *>(this); }
@@ -159,6 +162,9 @@ public:
 
     ALWAYS_INLINE uint32_t getHash() const
     {
+        if constexpr (std::endian::native == std::endian::little)
+            return static_cast<uint32_t>(low);
+
         uint32_t hash = 0;
         std::memcpy(&hash, rawBytes(), sizeof(hash));
         return hash;
@@ -201,7 +207,16 @@ public:
 
     /// ---------- Builder ----------
 
-    static ALWAYS_INLINE PackedStringRef build(const char * ptr, size_t len, uint32_t hash)
+    /// Build a packed value, computing the 32-bit content hash with `hash_fn(ptr, len)`.
+    /// The functor is invoked only for the encodings that store a hash (small and medium,
+    /// i.e. 1 <= len <= UINT32_MAX): large strings use the length as a hash surrogate and
+    /// the empty value is all zeros.
+    ///
+    /// On little-endian targets the small-string path reads whole words starting at `ptr`,
+    /// so the caller must guarantee at least 7 readable bytes past the end of the string
+    /// (`ColumnString::Chars` is a `PaddedPODArray` and provides more than that).
+    template <typename HashFn>
+    static ALWAYS_INLINE PackedStringRef build(const char * ptr, size_t len, HashFn && hash_fn)
     {
         PackedStringRef r{};
 
@@ -211,26 +226,69 @@ public:
         /// 1. Small String Inline
         if (len <= MAX_SMALL_LEN)
         {
-            std::memcpy(r.rawBytes(), &hash, sizeof(hash));
-            std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, ptr, len);
-            r.rawBytes()[TAG_BYTE_OFFSET] = static_cast<uint8_t>(static_cast<uint8_t>(len) << SMALL_LEN_SHIFT_IN_BYTE);
+            const uint32_t hash = hash_fn(ptr, len);
+            if constexpr (std::endian::native == std::endian::little)
+            {
+                /// Compose both words in registers. Byte-offset stores followed by a reload
+                /// of `low`/`high` defeat store-to-load forwarding, and the variable-length
+                /// payload copy compiles to a libc `memcpy` call; both dominate the per-row
+                /// cost of hash table probes with short keys.
+                uint64_t w0 = 0;
+                std::memcpy(&w0, ptr, sizeof(w0));
+                uint64_t w1 = 0;
+                /// Zero the bytes past the end of the string: they are part of the key identity.
+                if (len <= sizeof(w0))
+                {
+                    w0 &= ~uint64_t(0) >> ((sizeof(w0) - len) * 8);
+                }
+                else
+                {
+                    std::memcpy(&w1, ptr + sizeof(w0), sizeof(w1));
+                    w1 &= ~uint64_t(0) >> ((2 * sizeof(w0) - len) * 8);
+                }
+                r.low = hash | ((w0 & 0xFFFFFFFF) << 32);
+                r.high = (w0 >> 32) | (w1 << 32) | (len << (56 + SMALL_LEN_SHIFT_IN_BYTE));
+            }
+            else
+            {
+                std::memcpy(r.rawBytes(), &hash, sizeof(hash));
+                std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, ptr, len);
+                r.rawBytes()[TAG_BYTE_OFFSET] = static_cast<uint8_t>(static_cast<uint8_t>(len) << SMALL_LEN_SHIFT_IN_BYTE);
+            }
             return r;
         }
 
-        /// 2. Medium String (32-bit length + 32-bit hash)
+        /// 2. Medium String (32-bit hash + 32-bit length + packed pointer)
         if (len <= std::numeric_limits<uint32_t>::max())
         {
-            uint32_t len32 = static_cast<uint32_t>(len);
-            std::memcpy(r.rawBytes(), &hash, sizeof(hash));
-            std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, &len32, sizeof(len32));
-            storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+            const uint32_t hash = hash_fn(ptr, len);
+            if constexpr (std::endian::native == std::endian::little)
+            {
+                r.low = hash | (len << 32);
+                r.high = reinterpret_cast<uintptr_t>(ptr) & POINTER_MASK;
+            }
+            else
+            {
+                uint32_t len32 = static_cast<uint32_t>(len);
+                std::memcpy(r.rawBytes(), &hash, sizeof(hash));
+                std::memcpy(r.rawBytes() + HASH_SIZE_BYTES, &len32, sizeof(len32));
+                storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+            }
             return r;
         }
 
         /// 3. Large String (64-bit length, packed pointer + LARGE tag)
-        storeLE(r.rawBytes(), len, sizeof(uint64_t));
-        storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
-        r.rawBytes()[TAG_BYTE_OFFSET] = LARGE_TAG_BYTE;
+        if constexpr (std::endian::native == std::endian::little)
+        {
+            r.low = len;
+            r.high = (reinterpret_cast<uintptr_t>(ptr) & POINTER_MASK) | (uint64_t(LARGE_TAG_BYTE) << 56);
+        }
+        else
+        {
+            storeLE(r.rawBytes(), len, sizeof(uint64_t));
+            storeLE(r.rawBytes() + sizeof(uint64_t), reinterpret_cast<uintptr_t>(ptr), PACKED_POINTER_BYTES);
+            r.rawBytes()[TAG_BYTE_OFFSET] = LARGE_TAG_BYTE;
+        }
         return r;
     }
 };
@@ -245,25 +303,50 @@ inline ALWAYS_INLINE bool operator==(PackedStringRef lhs, PackedStringRef rhs)
     if (lhs.high == rhs.high)
         return true;
 
-    if (lhs.isMedium() && rhs.isMedium()) [[likely]]
+    if constexpr (std::endian::native == std::endian::little)
     {
+        /// Same `low`, different `high`: only medium/large values of the same kind can
+        /// still be equal. For small values the whole payload lives in the two words,
+        /// so the mismatch is final; empty cannot reach here because medium/large store
+        /// a non-zero length in `low`. Everything below is derived from the two words
+        /// already in registers - re-extracting fields through byte-offset loads adds
+        /// a chain of dependent instructions on the hot probe path.
+        const uint64_t lhs_tag = lhs.high >> 56;
+        const uint64_t rhs_tag = rhs.high >> 56;
+        if (lhs_tag != rhs_tag || (lhs_tag & PackedStringRef::SMALL_LEN_NIBBLE_MASK))
+            return false;
+
+        const char * lhs_ptr = reinterpret_cast<const char *>(lhs.high & PackedStringRef::POINTER_MASK);
+        const char * rhs_ptr = reinterpret_cast<const char *>(rhs.high & PackedStringRef::POINTER_MASK);
+        const size_t size = (lhs_tag & PackedStringRef::LARGE_TAG_BYTE) ? lhs.low : (lhs.low >> 32);
 #if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
-        return memequalWide(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize());
+        return memequalWide(lhs_ptr, rhs_ptr, size);
 #else
-        return memcmp(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize()) == 0;
+        return memcmp(lhs_ptr, rhs_ptr, size) == 0;
 #endif
     }
-
-    if (lhs.isLarge() && rhs.isLarge()) [[unlikely]]
+    else
     {
+        if (lhs.isMedium() && rhs.isMedium()) [[likely]]
+        {
 #if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
-        return memequalWide(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize());
+            return memequalWide(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize());
 #else
-        return memcmp(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize()) == 0;
+            return memcmp(lhs.getMediumPtr(), rhs.getMediumPtr(), lhs.getMediumSize()) == 0;
 #endif
-    }
+        }
 
-    return false;
+        if (lhs.isLarge() && rhs.isLarge()) [[unlikely]]
+        {
+#if defined(__SSE2__) || (defined(__aarch64__) && defined(__ARM_NEON))
+            return memequalWide(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize());
+#else
+            return memcmp(lhs.getLargePtr(), rhs.getLargePtr(), lhs.getLargeSize()) == 0;
+#endif
+        }
+
+        return false;
+    }
 }
 
 namespace ZeroTraits

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -282,14 +282,44 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
         for (size_t i = 0; i < rows; ++i)
         {
             auto str = column_string.getDataAt(i);
-            if (str.empty())
+            size_t size = str.size();
+            if (size == 0)
                 data[i] = 0;
-            else if (str.size() <= std::numeric_limits<UInt32>::max())
+#if defined(CRC_INT)
+            else if (size < 8)
+                /// Tiny keys (1..7 bytes) go through a single CRC instruction on the masked
+                /// word, exactly like `StringHashTableHash` for `StringKey8`. This avoids the
+                /// multiply-heavy `hashLessThan8` path inside `StringViewHash` for short strings,
+                /// which otherwise dominates low-cardinality short-string aggregation
+                /// (`group_by_sundy_li`, `if_transform_strings_to_enum`). Keys of 8 bytes or more
+                /// already use the cheap CRC loop in `StringViewHash` and are left unchanged, so
+                /// medium/large keys (e.g. URLs) keep the same hash and bucketing as before.
+                data[i] = hashTinyKey(str.data(), size);
+#endif
+            else if (size <= std::numeric_limits<UInt32>::max())
                 data[i] = static_cast<UInt32>(StringViewHash()(str));
             else
-                data[i] = static_cast<UInt32>(str.size());
+                data[i] = static_cast<UInt32>(size);
         }
     }
+
+#if defined(CRC_INT)
+    /// Hash a 1..7 byte key with a single CRC instruction.
+    /// Reading 8 bytes from the key start is safe: `ColumnString::Chars` is a `PaddedPODArray`
+    /// with at least 15 bytes of right padding, so the load never crosses the allocation end.
+    /// Trailing bytes beyond the key length are masked off, so the result depends only on the
+    /// key content and is independent of neighbouring data.
+    static ALWAYS_INLINE UInt32 hashTinyKey(const char * data, size_t size)
+    {
+        const UInt8 shift = static_cast<UInt8>((-size & 7) * 8);
+        UInt64 word;
+        memcpy(&word, data, sizeof(word));
+        word &= (~UInt64(0) >> shift);
+        size_t res = static_cast<size_t>(-1);
+        res = CRC_INT(static_cast<UInt32>(res), word);
+        return static_cast<UInt32>(res);
+    }
+#endif
 
     auto getKeyHolder(ssize_t row, [[maybe_unused]] Arena & pool) const
     {

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -2,6 +2,7 @@
 
 #include <Common/ColumnsHashingImpl.h>
 #include <Common/SipHash.h>
+#include <bit>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnString.h>
@@ -294,7 +295,7 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
                 /// (`group_by_sundy_li`, `if_transform_strings_to_enum`). Keys of 8 bytes or more
                 /// already use the cheap CRC loop in `StringViewHash` and are left unchanged, so
                 /// medium/large keys (e.g. URLs) keep the same hash and bucketing as before.
-                data[i] = hashTinyKey(str.data(), size);
+                data[i] = hashTinyKey(str.data(), size); /// NOLINT(bugprone-suspicious-stringview-data-usage)
 #endif
             else if (size <= std::numeric_limits<UInt32>::max())
                 data[i] = static_cast<UInt32>(StringViewHash()(str));
@@ -312,9 +313,17 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
     static ALWAYS_INLINE UInt32 hashTinyKey(const char * data, size_t size)
     {
         const UInt8 shift = static_cast<UInt8>((-size & 7) * 8);
-        UInt64 word;
+        UInt64 word = 0;
         memcpy(&word, data, sizeof(word));
-        word &= (~UInt64(0) >> shift);
+        /// `memcpy` places the key in the low bytes of `word` on little-endian and in the high
+        /// bytes on big-endian, so the trailing-byte mask has to follow the same direction.
+        /// `CRC_INT` is also defined on big-endian s390x, so masking the wrong end there would
+        /// fold neighbouring padding bytes into the hash and split a single tiny key into
+        /// several groups (the hash is stored in `PackedStringRef::low` and gates `operator==`).
+        if constexpr (std::endian::native == std::endian::little)
+            word &= (~UInt64(0) >> shift);
+        else
+            word &= (~UInt64(0) << shift);
         size_t res = static_cast<size_t>(-1);
         res = CRC_INT(static_cast<UInt32>(res), word);
         return static_cast<UInt32>(res);

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/ColumnsHashingImpl.h>
+#include <Common/PODArray.h>
 #include <Common/SipHash.h>
 #include <bit>
 #include <Columns/ColumnFixedString.h>
@@ -240,7 +241,7 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
 
     const IColumn::Offset * offsets;
     const UInt8 * chars;
-    WeakHash32 hashes{0};
+    PaddedPODArray<UInt32> hashes;
 
     /// Hashing strategy:
     /// - Empty string (len == 0):
@@ -277,7 +278,7 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
         const ColumnString & column_string = assert_cast<const ColumnString &>(*column);
         offsets = column_string.getOffsets().data();
         chars = column_string.getChars().data();
-        auto & data = hashes.getData();
+        auto & data = hashes;
         size_t rows = column_string.size();
         data.resize_exact(rows);
         for (size_t i = 0; i < rows; ++i)
@@ -336,13 +337,13 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
         {
             return ArenaPackedStringHolder{
                 PackedStringRef::build(
-                    reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes.getData()[row]),
+                    reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes[row]),
                 pool};
         }
         else
         {
             return PackedStringRef::build(
-                reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes.getData()[row]);
+                reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes[row]);
         }
     }
 

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Common/ColumnsHashingImpl.h>
-#include <Common/PODArray.h>
 #include <Common/SipHash.h>
 #include <bit>
 #include <Columns/ColumnFixedString.h>
@@ -217,25 +216,19 @@ protected:
 };
 
 /// For the case when there is one packed string key.
-template <
-    typename Value,
-    typename Mapped,
-    bool place_string_to_arena = true,
-    bool use_cache = true,
-    bool need_offset = false,
-    bool nullable = false>
+/// Unlike `HashMethodString`, this method does not support nullable keys or key offsets,
+/// and the key is always persisted into the arena by `keyHolderPersistKey`.
+template <typename Value, typename Mapped, bool use_cache>
 struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
-                              HashMethodPackedString<Value, Mapped, place_string_to_arena, use_cache, need_offset, nullable>,
+                              HashMethodPackedString<Value, Mapped, use_cache>,
                               Value,
                               Mapped,
                               use_cache,
-                              need_offset,
-                              nullable>
+                              /*need_offset=*/ false,
+                              /*nullable=*/ false>
 {
-    static_assert(!need_offset);
-    static_assert(!nullable);
-    using Self = HashMethodPackedString<Value, Mapped, place_string_to_arena, use_cache, need_offset, nullable>;
-    using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
+    using Self = HashMethodPackedString<Value, Mapped, use_cache>;
+    using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, false, false>;
 
     static constexpr bool has_cheap_key_calculation = false;
 
@@ -310,22 +303,15 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
     }
 #endif
 
-    auto getKeyHolder(ssize_t row, [[maybe_unused]] Arena & pool) const
+    ArenaPackedStringHolder getKeyHolder(ssize_t row, Arena & pool) const
     {
         const char * data = reinterpret_cast<const char *>(chars + offsets[row - 1]);
         const size_t size = offsets[row] - offsets[row - 1];
-        if constexpr (place_string_to_arena)
-        {
-            return ArenaPackedStringHolder{PackedStringRef::build(data, size, Hash{}), pool};
-        }
-        else
-        {
-            return PackedStringRef::build(data, size, Hash{});
-        }
+        return ArenaPackedStringHolder{PackedStringRef::build(data, size, Hash{}), pool};
     }
 
 protected:
-    friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
+    friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, false, false>;
 };
 
 /// For the case when there is one fixed-length string key.

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -282,7 +282,7 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
         for (size_t i = 0; i < rows; ++i)
         {
             auto str = column_string.getDataAt(i);
-            if (str.size() == 0)
+            if (str.empty())
                 data[i] = 0;
             else if (str.size() <= std::numeric_limits<UInt32>::max())
                 data[i] = StringViewHash()(str);

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -241,69 +241,48 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
 
     const IColumn::Offset * offsets;
     const UInt8 * chars;
-    PaddedPODArray<UInt32> hashes;
 
-    /// Hashing strategy:
-    /// - Empty string (len == 0):
-    ///   Use hash = 0. Empty keys are handled as a special case and do not participate
-    ///   in the unified encoding path to keep the main comparison logic simple.
-    ///
-    /// - String length <= UInt32 max:
-    ///   Use StringViewHash() to compute a 32-bit hash from string content.
-    ///   This hash is later combined with the string length (32-bit) to form a compact
-    ///   64-bit inline key metadata (hash | len), allowing:
-    ///     * Fast hash comparison
-    ///     * Length comparison without extra memory access
-    ///     * Reduced Cell size in the hash table
-    ///
-    /// - String length > UInt32 max:
-    ///   Such keys are extremely rare in practice. For these oversized strings,
-    ///   we fall back to using the low 32 bits of the string length as hash value.
-    ///   This intentionally sacrifices hash quality in exchange for:
-    ///     * Avoiding extra hashing cost
-    ///     * Preserving a uniform Cell layout
-    ///   Collisions are acceptable here due to the very low occurrence rate, and
-    ///   full string comparison is still used as the final equality check.
-    ///
-    /// Notes:
-    /// - 32-bit hash is sufficient for in-memory aggregation hash tables.
-    /// - A separate 64-bit hash is used only in external aggregation scenarios
-    ///   and is generated via a dedicated conversion path.
-    /// - This length-aware hashing scheme is a key building block for compact
-    ///   Cell design and cache-friendly probing in the optimized String Hash Table.
     HashMethodPackedString(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
         : Base(key_columns[0])
     {
-        const IColumn * column = key_columns[0];
-        const ColumnString & column_string = assert_cast<const ColumnString &>(*column);
+        const ColumnString & column_string = assert_cast<const ColumnString &>(*key_columns[0]);
         offsets = column_string.getOffsets().data();
         chars = column_string.getChars().data();
-        auto & data = hashes;
-        size_t rows = column_string.size();
-        data.resize_exact(rows);
-        for (size_t i = 0; i < rows; ++i)
-        {
-            auto str = column_string.getDataAt(i);
-            size_t size = str.size();
-            if (size == 0)
-                data[i] = 0;
-#if defined(CRC_INT)
-            else if (size < 8)
-                /// Tiny keys (1..7 bytes) go through a single CRC instruction on the masked
-                /// word, exactly like `StringHashTableHash` for `StringKey8`. This avoids the
-                /// multiply-heavy `hashLessThan8` path inside `StringViewHash` for short strings,
-                /// which otherwise dominates low-cardinality short-string aggregation
-                /// (`group_by_sundy_li`, `if_transform_strings_to_enum`). Keys of 8 bytes or more
-                /// already use the cheap CRC loop in `StringViewHash` and are left unchanged, so
-                /// medium/large keys (e.g. URLs) keep the same hash and bucketing as before.
-                data[i] = hashTinyKey(str.data(), size); /// NOLINT(bugprone-suspicious-stringview-data-usage)
-#endif
-            else if (size <= std::numeric_limits<UInt32>::max())
-                data[i] = static_cast<UInt32>(StringViewHash()(str));
-            else
-                data[i] = static_cast<UInt32>(size);
-        }
     }
+
+    /// Content hash stored inside the packed key. `PackedStringRef::build` invokes it
+    /// only for lengths that store a hash (1..UInt32 max): the empty value hashes to
+    /// zero by construction and oversized strings use the length as a hash surrogate,
+    /// trading hash quality for a uniform cell layout (full string comparison remains
+    /// the final equality check).
+    ///
+    /// Computing the hash inside `build` keeps a single pass over the string data:
+    /// a separate per-block hashing pass would read every key twice and allocate a
+    /// hash array per block. The flip side is that when the `Aggregator` prefetch
+    /// pipeline is active (hash table larger than L2), the look-ahead `getKeyHolder`
+    /// call rebuilds the key and hashes it a second time - the same behaviour as the
+    /// `StringHashTable` prefetch path this method replaces.
+    ///
+    /// A 32-bit hash is sufficient for in-memory aggregation hash tables; external
+    /// aggregation derives a 64-bit hash via a dedicated conversion path.
+    struct Hash
+    {
+        ALWAYS_INLINE UInt32 operator()(const char * data, size_t size) const
+        {
+#if defined(CRC_INT)
+            /// Tiny keys (1..7 bytes) go through a single CRC instruction on the masked
+            /// word, exactly like `StringHashTableHash` for `StringKey8`. This avoids the
+            /// multiply-heavy `hashLessThan8` path inside `StringViewHash` for short strings,
+            /// which otherwise dominates low-cardinality short-string aggregation
+            /// (`group_by_sundy_li`, `if_transform_strings_to_enum`). Keys of 8 bytes or more
+            /// already use the cheap CRC loop in `StringViewHash` and are left unchanged, so
+            /// medium/large keys (e.g. URLs) keep the same hash and bucketing as before.
+            if (size < 8)
+                return hashTinyKey(data, size);
+#endif
+            return static_cast<UInt32>(StringViewHash()(std::string_view(data, size)));
+        }
+    };
 
 #if defined(CRC_INT)
     /// Hash a 1..7 byte key with a single CRC instruction.
@@ -333,17 +312,15 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
 
     auto getKeyHolder(ssize_t row, [[maybe_unused]] Arena & pool) const
     {
+        const char * data = reinterpret_cast<const char *>(chars + offsets[row - 1]);
+        const size_t size = offsets[row] - offsets[row - 1];
         if constexpr (place_string_to_arena)
         {
-            return ArenaPackedStringHolder{
-                PackedStringRef::build(
-                    reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes[row]),
-                pool};
+            return ArenaPackedStringHolder{PackedStringRef::build(data, size, Hash{}), pool};
         }
         else
         {
-            return PackedStringRef::build(
-                reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes[row]);
+            return PackedStringRef::build(data, size, Hash{});
         }
     }
 

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -285,7 +285,7 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
             if (str.empty())
                 data[i] = 0;
             else if (str.size() <= std::numeric_limits<UInt32>::max())
-                data[i] = StringViewHash()(str);
+                data[i] = static_cast<UInt32>(StringViewHash()(str));
             else
                 data[i] = static_cast<UInt32>(str.size());
         }

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -214,6 +214,102 @@ protected:
     friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
 };
 
+/// For the case when there is one packed string key.
+template <
+    typename Value,
+    typename Mapped,
+    bool place_string_to_arena = true,
+    bool use_cache = true,
+    bool need_offset = false,
+    bool nullable = false>
+struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
+                              HashMethodPackedString<Value, Mapped, place_string_to_arena, use_cache, need_offset, nullable>,
+                              Value,
+                              Mapped,
+                              use_cache,
+                              need_offset,
+                              nullable>
+{
+    static_assert(!need_offset);
+    static_assert(!nullable);
+    using Self = HashMethodPackedString<Value, Mapped, place_string_to_arena, use_cache, need_offset, nullable>;
+    using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
+
+    static constexpr bool has_cheap_key_calculation = false;
+
+    const IColumn::Offset * offsets;
+    const UInt8 * chars;
+    WeakHash32 hashes{0};
+
+    /// Hashing strategy:
+    /// - Empty string (len == 0):
+    ///   Use hash = 0. Empty keys are handled as a special case and do not participate
+    ///   in the unified encoding path to keep the main comparison logic simple.
+    ///
+    /// - String length <= UInt32 max:
+    ///   Use StringViewHash() to compute a 32-bit hash from string content.
+    ///   This hash is later combined with the string length (32-bit) to form a compact
+    ///   64-bit inline key metadata (hash | len), allowing:
+    ///     * Fast hash comparison
+    ///     * Length comparison without extra memory access
+    ///     * Reduced Cell size in the hash table
+    ///
+    /// - String length > UInt32 max:
+    ///   Such keys are extremely rare in practice. For these oversized strings,
+    ///   we fall back to using the low 32 bits of the string length as hash value.
+    ///   This intentionally sacrifices hash quality in exchange for:
+    ///     * Avoiding extra hashing cost
+    ///     * Preserving a uniform Cell layout
+    ///   Collisions are acceptable here due to the very low occurrence rate, and
+    ///   full string comparison is still used as the final equality check.
+    ///
+    /// Notes:
+    /// - 32-bit hash is sufficient for in-memory aggregation hash tables.
+    /// - A separate 64-bit hash is used only in external aggregation scenarios
+    ///   and is generated via a dedicated conversion path.
+    /// - This length-aware hashing scheme is a key building block for compact
+    ///   Cell design and cache-friendly probing in the optimized String Hash Table.
+    HashMethodPackedString(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &)
+        : Base(key_columns[0])
+    {
+        const IColumn * column = key_columns[0];
+        const ColumnString & column_string = assert_cast<const ColumnString &>(*column);
+        offsets = column_string.getOffsets().data();
+        chars = column_string.getChars().data();
+        auto & data = hashes.getData();
+        size_t rows = column_string.size();
+        data.resize_exact(rows);
+        for (size_t i = 0; i < rows; ++i)
+        {
+            auto str = column_string.getDataAt(i);
+            if (str.size() == 0)
+                data[i] = 0;
+            else if (str.size() <= std::numeric_limits<UInt32>::max())
+                data[i] = StringViewHash()(str);
+            else
+                data[i] = static_cast<UInt32>(str.size());
+        }
+    }
+
+    ALWAYS_INLINE size_t getSize(size_t row) const { return offsets[row] - offsets[row - 1]; }
+
+    auto getKeyHolder(ssize_t row, [[maybe_unused]] Arena & pool) const
+    {
+        if constexpr (place_string_to_arena)
+        {
+            return ArenaPackedStringHolder{
+                PackedStringRef::build(reinterpret_cast<const char *>(chars + offsets[row - 1]), getSize(row), hashes.getData()[row]),
+                pool};
+        }
+        else
+        {
+            return PackedStringRef::build(reinterpret_cast<const char *>(chars + offsets[row - 1]), getSize(row), hashes.getData()[row]);
+        }
+    }
+
+protected:
+    friend class columns_hashing_impl::HashMethodBase<Self, Value, Mapped, use_cache, need_offset, nullable>;
+};
 
 /// For the case when there is one fixed-length string key.
 template <

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -291,19 +291,19 @@ struct HashMethodPackedString : public columns_hashing_impl::HashMethodBase<
         }
     }
 
-    ALWAYS_INLINE size_t getSize(size_t row) const { return offsets[row] - offsets[row - 1]; }
-
     auto getKeyHolder(ssize_t row, [[maybe_unused]] Arena & pool) const
     {
         if constexpr (place_string_to_arena)
         {
             return ArenaPackedStringHolder{
-                PackedStringRef::build(reinterpret_cast<const char *>(chars + offsets[row - 1]), getSize(row), hashes.getData()[row]),
+                PackedStringRef::build(
+                    reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes.getData()[row]),
                 pool};
         }
         else
         {
-            return PackedStringRef::build(reinterpret_cast<const char *>(chars + offsets[row - 1]), getSize(row), hashes.getData()[row]);
+            return PackedStringRef::build(
+                reinterpret_cast<const char *>(chars + offsets[row - 1]), offsets[row] - offsets[row - 1], hashes.getData()[row]);
         }
     }
 

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -449,13 +449,14 @@ protected:
 
             if constexpr (has_mapped)
             {
-                cache.value.first = it->getKey();
+                /// Using internal key getter for cache
+                cache.value.first = it->getKey(it->getValue());
                 cache.value.second = it->getMapped();
                 cached = &cache.value.second;
             }
             else
             {
-                cache.value = it->getKey();
+                cache.value = it->getValue();
             }
         }
 

--- a/src/Common/ColumnsHashingImpl.h
+++ b/src/Common/ColumnsHashingImpl.h
@@ -449,7 +449,8 @@ protected:
 
             if constexpr (has_mapped)
             {
-                /// Using internal key getter for cache
+                /// The cache stores the internal key type; the parameterless `getKey` may return
+                /// a converted external representation (e.g. `std::string_view` for `PackedStringRef`).
                 cache.value.first = it->getKey(it->getValue());
                 cache.value.second = it->getMapped();
                 cached = &cache.value.second;

--- a/src/Common/HashTable/Hash.h
+++ b/src/Common/HashTable/Hash.h
@@ -4,6 +4,7 @@
 #include <base/StringViewHash.h>
 #include <Core/Types.h>
 #include <Core/UUID.h>
+#include <base/PackedStringRef.h>
 #include <base/types.h>
 #include <base/unaligned.h>
 
@@ -557,3 +558,12 @@ struct IntHash32
 
 template <>
 struct DefaultHash<std::string_view> : public StringViewHash {};
+
+template <>
+struct DefaultHash<PackedStringRef>
+{
+    size_t operator() (PackedStringRef key) const
+    {
+        return key.getHash();
+    }
+};

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -66,6 +66,7 @@ struct HashMapCell
     using value_type = Pair;
     using mapped_type = Mapped;
     using key_type = Key;
+    using ExternalKey = std::conditional_t<std::is_same_v<std::decay_t<Key>, PackedStringRef>, std::string_view, Key>;
 
     value_type value;
 
@@ -74,7 +75,7 @@ struct HashMapCell
     HashMapCell(const value_type & value_, const State &) : value(value_) {}
 
     /// Get the key (externally).
-    const Key & getKey() const { return value.first; }
+    ExternalKey getKey() const { return static_cast<ExternalKey>(value.first); }
     Mapped & getMapped() { return value.second; }
     const Mapped & getMapped() const { return value.second; }
     const value_type & getValue() const { return value; }
@@ -82,9 +83,9 @@ struct HashMapCell
     /// Get the key (internally).
     static const Key & getKey(const value_type & value) { return value.first; }
 
-    bool keyEquals(const Key & key_) const { return bitEquals(value.first, key_); }
-    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(value.first, key_); }
-    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(value.first, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_) const { return bitEquals(value.first, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(value.first, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(value.first, key_); }
 
     void setHash(size_t /*hash_value*/) {}
     size_t getHash(const Hash & hash) const { return hash(value.first); }
@@ -170,9 +171,9 @@ struct HashMapCellWithSavedHash : public HashMapCell<Key, TMapped, Hash, TState>
 
     using Base::Base; // NOLINT(cppcoreguidelines-pro-type-member-init,hicpp-member-init) - see the note on the cell type above
 
-    bool keyEquals(const Key & key_) const { return bitEquals(this->value.first, key_); }
-    bool keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && bitEquals(this->value.first, key_); }
-    bool keyEquals(const Key & key_, size_t hash_, const typename Base::State &) const { return keyEquals(key_, hash_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_) const { return bitEquals(this->value.first, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t hash_) const { return saved_hash == hash_ && bitEquals(this->value.first, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t hash_, const typename Base::State &) const { return keyEquals(key_, hash_); }
 
     void setHash(size_t hash_value) { saved_hash = hash_value; }
     size_t getHash(const Hash & /*hash_function*/) const { return saved_hash; }

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -66,7 +66,7 @@ struct HashMapCell
     using value_type = Pair;
     using mapped_type = Mapped;
     using key_type = Key;
-    using ExternalKey = std::conditional_t<std::is_same_v<std::decay_t<Key>, PackedStringRef>, std::string_view, Key>;
+    using external_key_type = std::conditional_t<std::is_same_v<std::decay_t<Key>, PackedStringRef>, std::string_view, Key>;
 
     value_type value;
 
@@ -75,7 +75,7 @@ struct HashMapCell
     HashMapCell(const value_type & value_, const State &) : value(value_) {}
 
     /// Get the key (externally).
-    ExternalKey getKey() const { return static_cast<ExternalKey>(value.first); }
+    external_key_type getKey() const { return static_cast<external_key_type>(value.first); }
     Mapped & getMapped() { return value.second; }
     const Mapped & getMapped() const { return value.second; }
     const value_type & getValue() const { return value; }

--- a/src/Common/HashTable/HashMap.h
+++ b/src/Common/HashTable/HashMap.h
@@ -66,7 +66,7 @@ struct HashMapCell
     using value_type = Pair;
     using mapped_type = Mapped;
     using key_type = Key;
-    using external_key_type = std::conditional_t<std::is_same_v<std::decay_t<Key>, PackedStringRef>, std::string_view, Key>;
+    using external_key_type = std::conditional_t<std::is_same_v<Key, PackedStringRef>, std::string_view, const Key &>;
 
     value_type value;
 

--- a/src/Common/HashTable/HashTable.h
+++ b/src/Common/HashTable/HashTable.h
@@ -72,7 +72,7 @@ struct HashTableNoState
   * Otherwise the invariants in hash table probing do not met when NaNs are present.
   */
 template <typename T>
-inline bool bitEquals(T a, T b)
+inline ALWAYS_INLINE bool bitEquals(T a, T b)
 {
     if constexpr (is_floating_point<T>)
         /// Note that memcmp with constant size is a compiler builtin.
@@ -173,9 +173,9 @@ struct HashTableCell
     static const Key & getKey(const value_type & value) { return value; }  /// NOLINT(bugprone-return-const-ref-from-parameter)
 
     /// Are the keys at the cells equal?
-    bool keyEquals(const Key & key_) const { return bitEquals(key, key_); }
-    bool keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(key, key_); }
-    bool keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(key, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_) const { return bitEquals(key, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t /*hash_*/) const { return bitEquals(key, key_); }
+    bool ALWAYS_INLINE keyEquals(const Key & key_, size_t /*hash_*/, const State & /*state*/) const { return bitEquals(key, key_); }
 
     /// If the cell can remember the value of the hash function, then remember it.
     void setHash(size_t /*hash_value*/) {}

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include <Common/Arena.h>
 #include <base/PackedStringRef.h>
 
@@ -140,11 +142,17 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::SerializedKeyHolder & holder)
 
 namespace DB
 {
+
+/** ArenaPackedStringHolder is a key holder for a PackedStringRef key. Persisting copies
+  * the out-of-line payload (medium / large encodings) into the arena and rebases the
+  * packed pointer; small and empty keys are self-contained and need no persistence.
+  */
 struct ArenaPackedStringHolder
 {
     PackedStringRef key;
     Arena & pool;
 };
+
 }
 
 inline PackedStringRef & ALWAYS_INLINE keyHolderGetKey(DB::ArenaPackedStringHolder & holder)

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -161,12 +161,11 @@ inline void ALWAYS_INLINE keyHolderPersistKey(DB::ArenaPackedStringHolder & hold
 
     if (holder.key.isMedium())
     {
-        holder.key.high = reinterpret_cast<uintptr_t>(holder.pool.insert(holder.key.getMediumPtr(), holder.key.getMediumSize()));
+        holder.key.setMediumPointer(holder.pool.insert(holder.key.getMediumPtr(), holder.key.getMediumSize()));
     }
     else
     {
-        holder.key.high = reinterpret_cast<uintptr_t>(holder.pool.insert(holder.key.getLargePtr(), holder.key.getLargeSize()))
-            | PackedStringRef::LARGE_TAG;
+        holder.key.setLargePointer(holder.pool.insert(holder.key.getLargePtr(), holder.key.getLargeSize()));
     }
 }
 

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -154,9 +154,7 @@ inline PackedStringRef & ALWAYS_INLINE keyHolderGetKey(DB::ArenaPackedStringHold
 
 inline void ALWAYS_INLINE keyHolderPersistKey(DB::ArenaPackedStringHolder & holder)
 {
-    size_t len = holder.key.heapSize();
-
-    if (len == 0)
+    if (holder.key.heapSize() == 0)
         return;
 
     if (holder.key.isMedium())

--- a/src/Common/HashTable/HashTableKeyHolder.h
+++ b/src/Common/HashTable/HashTableKeyHolder.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <functional>
-
 #include <Common/Arena.h>
+#include <base/PackedStringRef.h>
 
 /**
   * In some aggregation scenarios, when adding a key to the hash table, we
@@ -137,6 +136,42 @@ inline void ALWAYS_INLINE keyHolderDiscardKey(DB::SerializedKeyHolder & holder)
     [[maybe_unused]] void * new_head = holder.pool.rollback(holder.key.size());
     chassert(new_head == holder.key.data());
     holder.key = std::string_view();
+}
+
+namespace DB
+{
+struct ArenaPackedStringHolder
+{
+    PackedStringRef key;
+    Arena & pool;
+};
+}
+
+inline PackedStringRef & ALWAYS_INLINE keyHolderGetKey(DB::ArenaPackedStringHolder & holder)
+{
+    return holder.key;
+}
+
+inline void ALWAYS_INLINE keyHolderPersistKey(DB::ArenaPackedStringHolder & holder)
+{
+    size_t len = holder.key.heapSize();
+
+    if (len == 0)
+        return;
+
+    if (holder.key.isMedium())
+    {
+        holder.key.high = reinterpret_cast<uintptr_t>(holder.pool.insert(holder.key.getMediumPtr(), holder.key.getMediumSize()));
+    }
+    else
+    {
+        holder.key.high = reinterpret_cast<uintptr_t>(holder.pool.insert(holder.key.getLargePtr(), holder.key.getLargeSize()))
+            | PackedStringRef::LARGE_TAG;
+    }
+}
+
+inline void ALWAYS_INLINE keyHolderDiscardKey(DB::ArenaPackedStringHolder &)
+{
 }
 
 inline void keyPrefetch(const std::string_view key)

--- a/src/Common/tests/gtest_packed_string_ref.cpp
+++ b/src/Common/tests/gtest_packed_string_ref.cpp
@@ -172,7 +172,8 @@ TEST(PackedStringRef, EqualityAcrossSmallBoundary)
 TEST(PackedStringRef, EqualityMedium)
 {
     const std::string content(25, 'y');
-    const std::string copy = content;
+    /// Deliberately a distinct buffer with the same content, not a reference to `content`.
+    const std::string copy(content.data(), content.size());
     const std::string other = std::string(24, 'y') + 'z';
 
     PackedStringRef ref = PackedStringRef::build(content.data(), content.size(), FixedHash{42});

--- a/src/Common/tests/gtest_packed_string_ref.cpp
+++ b/src/Common/tests/gtest_packed_string_ref.cpp
@@ -1,0 +1,205 @@
+#include <array>
+#include <bit>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include <base/PackedStringRef.h>
+#include <base/defines.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+/// `PackedStringRef::build` may read whole words starting at the string, so give it
+/// generous readable slack after the payload (`ColumnString::Chars` guarantees this
+/// in production via `PaddedPODArray` right padding).
+struct PaddedString
+{
+    explicit PaddedString(std::string_view s)
+    {
+        chassert(s.size() <= sizeof(buf) - 16);
+        std::memcpy(buf.data(), s.data(), s.size());
+        size = s.size();
+    }
+
+    const char * data() const { return buf.data(); }
+
+    std::array<char, 64> buf{};
+    size_t size = 0;
+};
+
+struct FixedHash
+{
+    uint32_t value;
+    uint32_t operator()(const char *, size_t) const { return value; }
+};
+
+std::array<uint8_t, 16> rawBytesOf(PackedStringRef ref)
+{
+    std::array<uint8_t, 16> bytes{};
+    std::memcpy(bytes.data(), &ref, sizeof(ref));
+    return bytes;
+}
+
+/// Reference byte image of the small encoding, built directly from the documented layout.
+std::array<uint8_t, 16> smallImage(uint32_t hash, std::string_view s)
+{
+    std::array<uint8_t, 16> bytes{};
+    std::memcpy(bytes.data(), &hash, sizeof(hash));
+    std::memcpy(bytes.data() + 4, s.data(), s.size());
+    bytes[15] = static_cast<uint8_t>(s.size() << 3);
+    return bytes;
+}
+
+}
+
+TEST(PackedStringRef, EmptyIsAllZeros)
+{
+    PackedStringRef ref = PackedStringRef::build(nullptr, 0, FixedHash{0xFFFFFFFF});
+    EXPECT_EQ(ref.low, 0u);
+    EXPECT_EQ(ref.high, 0u);
+    EXPECT_TRUE(ref.isEmpty());
+    EXPECT_EQ(static_cast<std::string_view>(ref), std::string_view{});
+}
+
+TEST(PackedStringRef, SmallLayout)
+{
+    if constexpr (std::endian::native != std::endian::little)
+        GTEST_SKIP() << "byte image checks assume the little-endian build path";
+
+    const uint32_t hash = 0xAABBCCDD;
+    for (size_t len = 1; len <= PackedStringRef::MAX_SMALL_LEN; ++len)
+    {
+        const std::string s = std::string("abcdefghijk").substr(0, len);
+        const PaddedString padded(s);
+        PackedStringRef ref = PackedStringRef::build(padded.data(), padded.size, FixedHash{hash});
+
+        EXPECT_TRUE(ref.isSmall()) << "len=" << len;
+        EXPECT_EQ(ref.getHash(), hash) << "len=" << len;
+        EXPECT_EQ(static_cast<std::string_view>(ref), std::string_view(s)) << "len=" << len;
+        EXPECT_EQ(rawBytesOf(ref), smallImage(hash, s)) << "len=" << len;
+    }
+}
+
+TEST(PackedStringRef, SmallWithEmbeddedAndTrailingZeroBytes)
+{
+    using namespace std::literals;
+    /// Unlike StringHashTable's fixed-size keys, the packed encoding stores an explicit
+    /// length, so content zero bytes (including trailing ones) are representable inline.
+    for (std::string_view s : {"a\0b"sv, "\0"sv, "ab\0\0"sv, "\0\0\0\0\0\0\0\0\0\0\0"sv})
+    {
+        const PaddedString padded(s);
+        PackedStringRef ref = PackedStringRef::build(padded.data(), padded.size, FixedHash{0x12345678});
+        EXPECT_TRUE(ref.isSmall());
+        EXPECT_EQ(static_cast<std::string_view>(ref), s);
+    }
+}
+
+TEST(PackedStringRef, MediumLayout)
+{
+    const uint32_t hash = 0x11223344;
+    for (size_t len : {12ul, 25ul, 48ul, 1000ul})
+    {
+        const std::string s(len, 'x');
+        PackedStringRef ref = PackedStringRef::build(s.data(), s.size(), FixedHash{hash});
+
+        EXPECT_TRUE(ref.isMedium()) << "len=" << len;
+        EXPECT_EQ(ref.getHash(), hash) << "len=" << len;
+        EXPECT_EQ(ref.getMediumSize(), len) << "len=" << len;
+        EXPECT_EQ(ref.getMediumPtr(), s.data()) << "len=" << len;
+        EXPECT_EQ(static_cast<std::string_view>(ref), std::string_view(s)) << "len=" << len;
+    }
+}
+
+TEST(PackedStringRef, LargeLayout)
+{
+    /// `build` does not read the content or invoke the hash functor for large strings,
+    /// so an oversized length with a small real buffer is safe here.
+    const char * ptr = reinterpret_cast<const char *>(0x0000123456789ABCull);
+    const size_t len = (1ull << 32) + 5;
+    PackedStringRef ref = PackedStringRef::build(ptr, len, FixedHash{0xDEAD});
+
+    EXPECT_TRUE(ref.isLarge());
+    EXPECT_EQ(ref.getLargeSize(), len);
+    EXPECT_EQ(ref.getLargePtr(), ptr);
+    /// The low 32 bits of the length act as the hash surrogate.
+    EXPECT_EQ(ref.getHash(), static_cast<uint32_t>(len));
+}
+
+TEST(PackedStringRef, EqualitySmall)
+{
+    const PaddedString a1("aa");
+    const PaddedString a2("aa");
+    const PaddedString b("bb");
+    const PaddedString a_longer("aaa");
+
+    PackedStringRef ref_a1 = PackedStringRef::build(a1.data(), a1.size, FixedHash{7});
+    PackedStringRef ref_a2 = PackedStringRef::build(a2.data(), a2.size, FixedHash{7});
+    PackedStringRef ref_b = PackedStringRef::build(b.data(), b.size, FixedHash{7});
+    PackedStringRef ref_a_longer = PackedStringRef::build(a_longer.data(), a_longer.size, FixedHash{7});
+
+    EXPECT_TRUE(ref_a1 == ref_a2);
+    /// Same (forced) hash, different payload or length: must compare unequal.
+    EXPECT_FALSE(ref_a1 == ref_b);
+    EXPECT_FALSE(ref_a1 == ref_a_longer);
+    EXPECT_FALSE(ref_a1 == PackedStringRef{});
+}
+
+TEST(PackedStringRef, EqualityAcrossSmallBoundary)
+{
+    const std::string seven(7, 'a');
+    const std::string eight(8, 'a');
+    const std::string eleven(11, 'a');
+    const std::string twelve(12, 'a');
+
+    const PaddedString p7(seven);
+    const PaddedString p8(eight);
+    const PaddedString p11(eleven);
+    const PaddedString p12(twelve);
+
+    PackedStringRef r7 = PackedStringRef::build(p7.data(), p7.size, FixedHash{7});
+    PackedStringRef r8 = PackedStringRef::build(p8.data(), p8.size, FixedHash{7});
+    PackedStringRef r11 = PackedStringRef::build(p11.data(), p11.size, FixedHash{7});
+    PackedStringRef r12 = PackedStringRef::build(p12.data(), p12.size, FixedHash{7});
+
+    EXPECT_FALSE(r7 == r8);
+    EXPECT_FALSE(r11 == r12);
+    EXPECT_TRUE(r11 == PackedStringRef::build(p11.data(), p11.size, FixedHash{7}));
+}
+
+TEST(PackedStringRef, EqualityMedium)
+{
+    const std::string content(25, 'y');
+    const std::string copy = content;
+    const std::string other = std::string(24, 'y') + 'z';
+
+    PackedStringRef ref = PackedStringRef::build(content.data(), content.size(), FixedHash{42});
+    PackedStringRef ref_same_buffer = PackedStringRef::build(content.data(), content.size(), FixedHash{42});
+    PackedStringRef ref_copy = PackedStringRef::build(copy.data(), copy.size(), FixedHash{42});
+    PackedStringRef ref_other = PackedStringRef::build(other.data(), other.size(), FixedHash{42});
+
+    /// Same pointer: decided by the word compare.
+    EXPECT_TRUE(ref == ref_same_buffer);
+    /// Different pointers, same content: decided by the content comparison.
+    EXPECT_TRUE(ref == ref_copy);
+    /// Forced hash collision with different content: content comparison must reject.
+    EXPECT_FALSE(ref == ref_other);
+}
+
+TEST(PackedStringRef, EqualityMediumVersusLargeLowCollision)
+{
+    /// Craft a medium value and a large value whose `low` words coincide:
+    /// medium: hash = 0xDEADBEEF, len = 12 -> low = 0xDEADBEEF | 12 << 32
+    /// large: len = (12 << 32) | 0xDEADBEEF -> same low word.
+    const std::string content(12, 'q');
+    PackedStringRef medium = PackedStringRef::build(content.data(), content.size(), FixedHash{0xDEADBEEF});
+
+    const size_t large_len = (12ull << 32) | 0xDEADBEEFull;
+    PackedStringRef large = PackedStringRef::build(content.data(), large_len, FixedHash{0});
+
+    ASSERT_EQ(medium.low, large.low);
+    EXPECT_FALSE(medium == large);
+    EXPECT_FALSE(large == medium);
+}

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -16,9 +16,9 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SERVER_LOGS = 54406;
 /// Minimum revision with exactly the same set of aggregation methods and rules to select them.
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
-static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54484;
+static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54485;
 static constexpr auto DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 26;
-static constexpr auto DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 1;
+static constexpr auto DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 5;
 static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA = 54410;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE = 54405;

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -17,8 +17,6 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SERVER_LOGS = 54406;
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
 static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54485;
-static constexpr auto DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 26;
-static constexpr auto DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 5;
 static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA = 54410;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE = 54405;

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -16,9 +16,9 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SERVER_LOGS = 54406;
 /// Minimum revision with exactly the same set of aggregation methods and rules to select them.
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
-static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54448;
-static constexpr auto DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 21;
-static constexpr auto DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 4;
+static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54484;
+static constexpr auto DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 26;
+static constexpr auto DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 1;
 static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA = 54410;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE = 54405;
@@ -165,6 +165,8 @@ static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_INTERNAL_QUERY_FLAG = 54486
 /// (sent right after the request, validated before the response).
 static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_TABLES_STATUS = 54487;
 
+static constexpr auto DBMS_MIN_REVISION_WITH_PACKED_STRING_HASH_TABLE = 54488;
+
 
 /// Version of ClickHouse TCP protocol.
 ///
@@ -173,5 +175,5 @@ static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_TABLES_STATUS = 
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54487;
+static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54488;
 }

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -16,7 +16,7 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SERVER_LOGS = 54406;
 /// Minimum revision with exactly the same set of aggregation methods and rules to select them.
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
-static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54485;
+static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54488;
 static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA = 54410;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE = 54405;
@@ -162,8 +162,6 @@ static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_INTERNAL_QUERY_FLAG = 54486
 /// Authenticate interserver `TablesStatusRequest` with a cluster-secret hash
 /// (sent right after the request, validated before the response).
 static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_TABLES_STATUS = 54487;
-
-static constexpr auto DBMS_MIN_REVISION_WITH_PACKED_STRING_HASH_TABLE = 54488;
 
 
 /// Version of ClickHouse TCP protocol.

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -16,6 +16,9 @@ static constexpr auto DBMS_MIN_REVISION_WITH_SERVER_LOGS = 54406;
 /// Minimum revision with exactly the same set of aggregation methods and rules to select them.
 /// Two-level (bucketed) aggregation is incompatible if servers are inconsistent in these rules
 /// (keys will be placed in different buckets and result will not be fully aggregated).
+/// Compare by protocol revision rather than major/minor version: the aggregation method can change
+/// within a single release (same major.minor) and only the revision distinguishes a pre-change
+/// server from a post-change one.
 static constexpr auto DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD = 54488;
 static constexpr auto DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA = 54410;
 

--- a/src/Interpreters/AggregatedData.h
+++ b/src/Interpreters/AggregatedData.h
@@ -38,8 +38,8 @@ using AggregatedDataWithUInt16Key = FixedImplicitZeroHashMap<UInt16, AggregateDa
 using AggregatedDataWithUInt32Key = HashMap<UInt32, AggregateDataPtr, HashCRC32<UInt32>>;
 using AggregatedDataWithUInt64Key = HashMap<UInt64, AggregateDataPtr, HashCRC32<UInt64>>;
 
+using AggregatedDataWithPackedStringKey = HashMap<PackedStringRef, AggregateDataPtr>;
 using AggregatedDataWithShortStringKey = StringHashMap<AggregateDataPtr>;
-
 using AggregatedDataWithStringKey = HashMapWithSavedHash<std::string_view, AggregateDataPtr>;
 
 using AggregatedDataWithKeys128 = HashMap<UInt128, AggregateDataPtr, UInt128HashCRC32>;
@@ -49,6 +49,7 @@ using AggregatedDataWithUInt32KeyTwoLevel = TwoLevelHashMap<UInt32, AggregateDat
 using AggregatedDataWithUInt64KeyTwoLevel = TwoLevelHashMap<UInt64, AggregateDataPtr, HashCRC32<UInt64>>;
 
 using AggregatedDataWithShortStringKeyTwoLevel = TwoLevelStringHashMap<AggregateDataPtr>;
+using AggregatedDataWithPackedStringKeyTwoLevel = TwoLevelHashMap<PackedStringRef, AggregateDataPtr>;
 
 using AggregatedDataWithStringKeyTwoLevel = TwoLevelHashMapWithSavedHash<std::string_view, AggregateDataPtr>;
 

--- a/src/Interpreters/AggregatedDataVariants.h
+++ b/src/Interpreters/AggregatedDataVariants.h
@@ -64,7 +64,7 @@ struct AggregatedDataVariants : private boost::noncopyable
 
     std::unique_ptr<AggregationMethodOneNumber<UInt32, AggregatedDataWithUInt64Key>>         key32;
     std::unique_ptr<AggregationMethodOneNumber<UInt64, AggregatedDataWithUInt64Key>>         key64;
-    std::unique_ptr<AggregationMethodStringNoCache<AggregatedDataWithShortStringKey>>               key_string;
+    std::unique_ptr<AggregationMethodPackedString<AggregatedDataWithPackedStringKey>>        key_string;
     std::unique_ptr<AggregationMethodFixedStringNoCache<AggregatedDataWithShortStringKey>>          key_fixed_string;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithUInt16Key, false, false, false>>  keys16;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithUInt32Key>>                   keys32;
@@ -78,7 +78,7 @@ struct AggregatedDataVariants : private boost::noncopyable
 
     std::unique_ptr<AggregationMethodOneNumber<UInt32, AggregatedDataWithUInt64KeyTwoLevel>> key32_two_level;
     std::unique_ptr<AggregationMethodOneNumber<UInt64, AggregatedDataWithUInt64KeyTwoLevel>> key64_two_level;
-    std::unique_ptr<AggregationMethodStringNoCache<AggregatedDataWithShortStringKeyTwoLevel>>       key_string_two_level;
+    std::unique_ptr<AggregationMethodPackedString<AggregatedDataWithPackedStringKeyTwoLevel>>       key_string_two_level;
     std::unique_ptr<AggregationMethodFixedStringNoCache<AggregatedDataWithShortStringKeyTwoLevel>>  key_fixed_string_two_level;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithUInt32KeyTwoLevel>>           keys32_two_level;
     std::unique_ptr<AggregationMethodKeysFixed<AggregatedDataWithUInt64KeyTwoLevel>>           keys64_two_level;

--- a/src/Interpreters/AggregationMethod.h
+++ b/src/Interpreters/AggregationMethod.h
@@ -120,7 +120,7 @@ struct AggregationMethodStringNoCache
     static void insertKeyIntoColumns(std::string_view key, std::vector<IColumn *> & key_columns, const Sizes &, const IColumn::SerializationSettings * settings);
 };
 
-/// For the case where there is one string key.
+/// For the case where there is one string key, stored as `PackedStringRef`.
 template <typename TData>
 struct AggregationMethodPackedString
 {
@@ -140,7 +140,7 @@ struct AggregationMethodPackedString
     explicit AggregationMethodPackedString(size_t size_hint) : data(size_hint) { }
 
     template <bool use_cache>
-    using StateImpl = ColumnsHashing::HashMethodPackedString<typename Data::value_type, Mapped, /*place_string_to_arena=*/true, use_cache>;
+    using StateImpl = ColumnsHashing::HashMethodPackedString<typename Data::value_type, Mapped, use_cache>;
 
     using State = StateImpl<true>;
     using StateNoCache = StateImpl<false>;
@@ -351,5 +351,6 @@ using AggregationMethodPreallocSerialized = AggregationMethodSerialized<TData, f
 
 template <typename TData>
 using AggregationMethodNullablePreallocSerialized = AggregationMethodSerialized<TData, true, true>;
+
 
 }

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3758,9 +3758,6 @@ void InterpreterSelectQuery::initSettings()
 
     const auto & client_info = context->getClientInfo();
 
-    /// Compare by protocol revision rather than major/minor version: the aggregation method can change
-    /// within a single release (same major.minor) and only the revision distinguishes a pre-change initiator
-    /// from a post-change one. This mirrors the initiator-side check in `MultiplexedConnections`/`HedgedConnections`.
     if (client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
         client_info.connection_tcp_protocol_version < DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD)
     {

--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -3757,11 +3757,12 @@ void InterpreterSelectQuery::initSettings()
         InterpreterSetQuery(query.settings(), context).executeForCurrentContext(options.ignore_setting_constraints);
 
     const auto & client_info = context->getClientInfo();
-    auto min_major = DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD;
-    auto min_minor = DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD;
 
+    /// Compare by protocol revision rather than major/minor version: the aggregation method can change
+    /// within a single release (same major.minor) and only the revision distinguishes a pre-change initiator
+    /// from a post-change one. This mirrors the initiator-side check in `MultiplexedConnections`/`HedgedConnections`.
     if (client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
-        std::forward_as_tuple(client_info.connection_client_version_major, client_info.connection_client_version_minor) < std::forward_as_tuple(min_major, min_minor))
+        client_info.connection_tcp_protocol_version < DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD)
     {
         /// Disable two-level aggregation due to version incompatibility.
         context->setSetting("group_by_two_level_threshold", Field(0));

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1898,12 +1898,12 @@ static PlannerContextPtr buildPlannerContext(const QueryTreeNodePtr & query_tree
         throw Exception(ErrorCodes::TOO_DEEP_SUBQUERIES, "Too deep subqueries. Maximum: {}", max_subquery_depth);
 
     const auto & client_info = mutable_context->getClientInfo();
-    auto min_major = static_cast<UInt64>(DBMS_MIN_MAJOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD);
-    auto min_minor = static_cast<UInt64>(DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD);
 
+    /// Compare by protocol revision rather than major/minor version: the aggregation method can change
+    /// within a single release (same major.minor) and only the revision distinguishes a pre-change initiator
+    /// from a post-change one. This mirrors the initiator-side check in `MultiplexedConnections`/`HedgedConnections`.
     bool need_to_disable_two_level_aggregation = client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
-        std::forward_as_tuple(client_info.connection_client_version_major, client_info.connection_client_version_minor)
-            < std::forward_as_tuple(min_major, min_minor);
+        client_info.connection_tcp_protocol_version < DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD;
 
     if (need_to_disable_two_level_aggregation)
     {

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1,7 +1,4 @@
 #include <Planner/Planner.h>
-
-#include <tuple>
-
 #include <DataTypes/DataTypesNumber.h>
 
 #include <Core/Names.h>
@@ -1899,9 +1896,6 @@ static PlannerContextPtr buildPlannerContext(const QueryTreeNodePtr & query_tree
 
     const auto & client_info = mutable_context->getClientInfo();
 
-    /// Compare by protocol revision rather than major/minor version: the aggregation method can change
-    /// within a single release (same major.minor) and only the revision distinguishes a pre-change initiator
-    /// from a post-change one. This mirrors the initiator-side check in `MultiplexedConnections`/`HedgedConnections`.
     bool need_to_disable_two_level_aggregation = client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
         client_info.connection_tcp_protocol_version < DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD;
 

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -1,4 +1,7 @@
 #include <Planner/Planner.h>
+
+#include <tuple>
+
 #include <DataTypes/DataTypesNumber.h>
 
 #include <Core/Names.h>
@@ -1899,8 +1902,8 @@ static PlannerContextPtr buildPlannerContext(const QueryTreeNodePtr & query_tree
     auto min_minor = static_cast<UInt64>(DBMS_MIN_MINOR_VERSION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD);
 
     bool need_to_disable_two_level_aggregation = client_info.query_kind == ClientInfo::QueryKind::SECONDARY_QUERY &&
-        client_info.connection_client_version_major < min_major &&
-        client_info.connection_client_version_minor < min_minor;
+        std::forward_as_tuple(client_info.connection_client_version_major, client_info.connection_client_version_minor)
+            < std::forward_as_tuple(min_major, min_minor);
 
     if (need_to_disable_two_level_aggregation)
     {

--- a/src/Storages/StorageJoin.cpp
+++ b/src/Storages/StorageJoin.cpp
@@ -692,13 +692,13 @@ namespace
 {
 
 template <typename T>
-const char * rawData(T & t)
+const char * rawData(const T & t)
 {
     return reinterpret_cast<const char *>(&t);
 }
 
 template <typename T>
-size_t rawSize(T &)
+size_t rawSize(const T &)
 {
     return sizeof(T);
 }

--- a/tests/integration/test_string_aggregation_compatibility/test.py
+++ b/tests/integration/test_string_aggregation_compatibility/test.py
@@ -63,7 +63,7 @@ def test_string_aggregation_compatibility(started_cluster):
     # With `serialize_string_in_memory_with_zero_byte=0` the new server uses the legacy
     # serialization format. Previously this used to surface a cross-version aggregation
     # bug (returning 20000 instead of 10000) when two-level aggregation was active.
-    # Starting from revision 54484, two-level aggregation is disabled when communicating
+    # Starting from revision 54485, two-level aggregation is disabled when communicating
     # with older servers (see DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD),
     # which prevents the bug from being triggered in this scenario.
     assert (

--- a/tests/integration/test_string_aggregation_compatibility/test.py
+++ b/tests/integration/test_string_aggregation_compatibility/test.py
@@ -60,9 +60,15 @@ def test_string_aggregation_compatibility(started_cluster):
 
     assert run_query(node1) == 10000
     assert run_query(node256) == 10000
+    # With `serialize_string_in_memory_with_zero_byte=0` the new server uses the legacy
+    # serialization format. Previously this used to surface a cross-version aggregation
+    # bug (returning 20000 instead of 10000) when two-level aggregation was active.
+    # Starting from revision 54484, two-level aggregation is disabled when communicating
+    # with older servers (see DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD),
+    # which prevents the bug from being triggered in this scenario.
     assert (
         run_query(node1, extra_settings={"serialize_string_in_memory_with_zero_byte": 0})
-        == 20000
+        == 10000
     )
 
 def test_string_aggregation_compatibility_setting(started_cluster):

--- a/tests/integration/test_string_aggregation_compatibility/test.py
+++ b/tests/integration/test_string_aggregation_compatibility/test.py
@@ -112,3 +112,59 @@ def test_string_aggregation_compatibility_setting(started_cluster):
         run_query(node1, extra_settings={"serialize_string_in_memory_with_zero_byte": 0})
         == 10000
     )
+
+
+def test_single_string_key_aggregation_compatibility(started_cluster):
+    # Unlike the two tests above, which group by `(id, s2)` and therefore go through the
+    # multi-key serialized aggregation path, this test groups by a single plain `String`
+    # key. That is exactly the path `PackedStringRef` replaces (the `key_string` /
+    # `key_string_two_level` variants), so it directly exercises the code this PR changes.
+    #
+    # The column mixes short keys that fit inline in a `PackedStringRef` (<= 11 bytes) with
+    # longer keys that spill to an out-of-line pointer (> 11 bytes), covering both
+    # representations. There are 1000 distinct keys, duplicated on both the new and the old
+    # (25.6) server; correct cross-version two-level aggregation must deduplicate them to
+    # 1000. A bucketing mismatch between versions would inflate the result (e.g. to 2000).
+    def create_tables(node, other_node_name):
+        node.query(
+            "DROP TABLE IF EXISTS repro3 SYNC; CREATE TABLE repro3 (s String) ENGINE = MergeTree ORDER BY s"
+        )
+        node.query(
+            "INSERT INTO repro3 SELECT concat('k', toString(number % 500)) FROM numbers(5000)"
+        )
+        node.query(
+            "INSERT INTO repro3 SELECT concat('long_string_key_', toString(number % 500)) FROM numbers(5000)"
+        )
+        node.query(
+            f"CREATE TABLE IF NOT EXISTS dist_repro3 (s String) AS remote('{other_node_name}', 'default.repro3', 'default', '')"
+        )
+        node.query(
+            "CREATE TABLE IF NOT EXISTS global_repro3 (s String) ENGINE = Merge('default', '.*repro3')"
+        )
+
+    create_tables(node1, other_node_name=node256.name)
+    create_tables(node256, other_node_name=node1.name)
+
+    def run_query(node, extra_settings={}):
+        return int(
+            node.query(
+                """
+        SELECT count()
+        FROM
+        (
+            SELECT s
+            FROM global_repro3
+            GROUP BY s
+        )""",
+                settings={"group_by_two_level_threshold": 1} | extra_settings,
+            )
+        )
+
+    assert run_query(node1) == 1000
+    assert run_query(node256) == 1000
+    # Same legacy in-memory serialization scenario as `test_string_aggregation_compatibility`,
+    # but on the single-`String` packed-key path.
+    assert (
+        run_query(node1, extra_settings={"serialize_string_in_memory_with_zero_byte": 0})
+        == 1000
+    )

--- a/tests/integration/test_string_aggregation_compatibility/test.py
+++ b/tests/integration/test_string_aggregation_compatibility/test.py
@@ -63,7 +63,7 @@ def test_string_aggregation_compatibility(started_cluster):
     # With `serialize_string_in_memory_with_zero_byte=0` the new server uses the legacy
     # serialization format. Previously this used to surface a cross-version aggregation
     # bug (returning 20000 instead of 10000) when two-level aggregation was active.
-    # Starting from revision 54485, two-level aggregation is disabled when communicating
+    # Starting from revision 54488, two-level aggregation is disabled when communicating
     # with older servers (see DBMS_MIN_REVISION_WITH_CURRENT_AGGREGATION_VARIANT_SELECTION_METHOD),
     # which prevents the bug from being triggered in this scenario.
     assert (

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -10,6 +10,10 @@ SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_
 -- Override randomized max_threads to avoid timeout on slow builds (ASan)
 SET max_threads=0;
 
+-- The runtime dataflow output-bytes estimate is sensitive to the block size, so pin
+-- `max_block_size` to its default to keep the estimate stable against randomization.
+SET max_block_size=65409;
+
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1';
 
 -- Unsupported at the moment, refer to comments in `RuntimeDataflowStatisticsCacheUpdater::recordAggregationStateSizes`

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -14,6 +14,12 @@ SET max_threads=0;
 -- `max_block_size` to its default to keep the estimate stable against randomization.
 SET max_block_size=65409;
 
+-- The aggregation-state size estimate is recorded per bucket after the conversion to
+-- a two-level hash table, so forcing the conversion from the very first block (the test
+-- randomization sets these thresholds as low as 1) shifts the estimate well away from the
+-- expected values calibrated under the default thresholds. Pin them to the defaults.
+SET group_by_two_level_threshold=100000, group_by_two_level_threshold_bytes=50000000;
+
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1';
 
 -- Unsupported at the moment, refer to comments in `RuntimeDataflowStatisticsCacheUpdater::recordAggregationStateSizes`

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -44,7 +44,7 @@ SYSTEM FLUSH LOGS query_log;
 
 -- Just checking that the estimation is not too far off
 WITH
-    [96, 500000, 11189312, 2359808, 64, 29920, 82456, 20000, 31064320, 275251200, 48271331/*, 641835*/] AS expected_bytes,
+    [3, 195461, 5962954, 1100491, 2, 16885, 42323, 9434, 23722663, 203701090, 82404720/*, 641835*/] AS expected_bytes,
     arrayJoin(arrayMap(x -> (untuple(x.1), x.2), arrayZip(res, expected_bytes))) AS res
 SELECT format('{} {} {}', res.1, res.2, res.3)
 FROM
@@ -58,4 +58,3 @@ FROM
     )
 )
 WHERE (greatest(res.2, res.3) / least(res.2, res.3)) > 2.5 AND NOT (res.2 < 100 AND res.3 < 100);
-

--- a/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_output_bytes_estimation.sql
@@ -68,3 +68,4 @@ FROM
     )
 )
 WHERE (greatest(res.2, res.3) / least(res.2, res.3)) > 2.5 AND NOT (res.2 < 100 AND res.3 < 100);
+


### PR DESCRIPTION
This PR introduces `PackedStringRef` and `PackedStringHashTable`, a compact string key representation and a corresponding hash table implementation, primarily targeting string-heavy aggregation workloads. This is part of #81944.

In the past we introduced `StringHashTable` https://github.com/ClickHouse/ClickHouse/pull/5417 to optimize small string keys. Since then, ClickHouse has continued to evolve and gained more hash table–level optimizations, such as better capacity prediction, prefetching, and more specialized fast paths. These optimizations are generally designed around a single, uniform hash table layout and access pattern. As a result, it has become increasingly difficult to integrate `StringHashTable` cleanly with them. Some optimizations, such as consecutive key handling, were already awkward with `StringHashTable`, and the situation has only become more complex as more logic has been added around hash tables.

Instead of pushing `StringHashTable` further, this change moves the optimization to the string representation itself. `PackedStringRef` encodes small, medium, and large strings into a fixed 16-byte object, storing short strings inline while using tagged pointers for longer strings. Small strings of up to 11 bytes are fully inlined, which already covers a large portion of real-world string keys (such as tags, short identifiers, and common dimension values), making this optimization effective even with a relatively conservative inline threshold.

<img width="600" height="400" alt="copied-2025-12-31-16_51_22_144" src="https://github.com/user-attachments/assets/4471e03a-561e-48a5-b672-6bb076b713a6" />

`PackedStringHashTable` is built around this representation and fits naturally into the existing optimization framework, including prefetching and capacity prediction.

At the moment this is only wired for aggregate string keys. Other usages of `StringHashTable` are left unchanged. If this approach proves effective, it can be gradually extended to more places and may eventually replace `StringHashTable`.

No dedicated perf test is added in this PR. Any noticeable regression or improvement should already be covered by existing aggregation-related performance tests in CI.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Introduces `PackedStringRef`, a compact 16-byte representation for single-`String` aggregation keys, to reduce hash-table cell size and improve string-heavy `GROUP BY` workloads. The change is limited to aggregate string keys; other `StringHashTable` users are unchanged.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.144` (included in `26.8` and later)
<!-- ch-version-info:end -->