### PR TITLE
Fix flaky 03394_distributed_shuffle_join_with_prewhere under join-order randomization

### DIFF
--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_with_prewhere.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_with_prewhere.sql
@@ -17,6 +17,7 @@ INSERT INTO test SELECT 'path' || number::String, 'ua', number FROM numbers(15);
 INSERT INTO test SELECT 'path' || number::String, 'jp', number FROM numbers(20);
 
 SET query_plan_join_swap_table = 0;
+SET query_plan_optimize_join_order_randomize = 0; -- Pinned because the test asserts on join plan/order
 
 SET
     make_distributed_plan = 1,


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03394_distributed_shuffle_join_with_prewhere` is flaky on master and across many PRs. It asserts on the distributed join plan via `EXPLAIN actions = 1`. CI randomizes `query_plan_optimize_join_order_randomize`; when it is nonzero the plan prints `Join: en[random~NNNNN] ⋈ de[random~MMMMM]` instead of `Join: en[N] ⋈ de[N]`. The reference normalizes `[\d+]` -> `[N]` but does not match the `[random~NNNNN]` form, so the plan diff fails.

CIDB's own randomized-settings diagnosis isolated this setting as the sole culprit: 186/186 runs FAIL with `query_plan_optimize_join_order_randomize` set, 211/211 PASS without it.

Fix: pin `SET query_plan_optimize_join_order_randomize = 0`, matching the other plan-asserting stateless tests. This does not touch `use_statistics` (the prewhere test deliberately exercises `use_statistics = 1`, unlike the sibling `_with_aggregation`/`_with_in` tests).

Verified locally with `clickhouse-local` EXPLAIN: with the culprit forced on, the pin restores `Join: en[N] ⋈ de[N]` (matches reference); without the pin the plan diverges to `[random~...]` (matches the CIDB failure).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107666&sha=462b0ef6fcb75b3fe5b83f12869ce0d2fbaa684b&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.995` (included in `26.7` and later)
<!-- ch-version-info:end -->