### PR TITLE
Disable lazy FINAL under read-in-order and for early-exit LIMIT queries

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -5,6 +5,7 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/PreparedSets.h>
 #include <Processors/QueryPlan/CreatingSetsStep.h>
+#include <Processors/QueryPlan/DistinctStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/InputSelectorStep.h>
@@ -404,8 +405,25 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
     for (size_t i = stack.size() - 1; i-- > 0;)
     {
         auto * step = stack[i].node->step.get();
-        if (typeid_cast<ExpressionStep *>(step) || typeid_cast<FilterStep *>(step))
+        if (const auto * expression_step = typeid_cast<ExpressionStep *>(step))
+        {
+            /// arrayJoin changes the number of rows, a limit above it is not comparable to selected_rows.
+            if (expression_step->getExpression().hasArrayJoin())
+                break;
             continue;
+        }
+        if (const auto * filter_step_above = typeid_cast<FilterStep *>(step))
+        {
+            if (filter_step_above->getExpression().hasArrayJoin())
+                break;
+            continue;
+        }
+        /// DISTINCT stops reading as soon as its pushed-down limit hint of distinct rows is produced.
+        if (const auto * distinct_step = typeid_cast<DistinctStep *>(step))
+        {
+            limit_above_reading = distinct_step->getLimitHint();
+            break;
+        }
         if (const auto * limit_step = typeid_cast<LimitStep *>(step))
         {
             size_t limit = limit_step->getLimit();

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -268,14 +268,16 @@ struct SplitResult
 
 /// Try to split parts into non-intersecting and intersecting by primary key.
 /// If all parts are non-intersecting, replaces the plan node directly and returns fully_replaced=true.
-/// Otherwise returns a plan for non-intersecting parts (or nullptr if none), and updates
-/// the reading step's analyzed result to contain only intersecting parts.
+/// Otherwise, if allow_partial_split is set, returns a plan for non-intersecting parts (or nullptr
+/// if none), and updates the reading step's analyzed result to contain only intersecting parts;
+/// if not set, leaves the reading step untouched and returns fully_replaced=true to stop.
 static SplitResult trySplitNonIntersectingParts(
     ReadFromMergeTree * reading_step,
     ReadFromMergeTree::AnalysisResultPtr analyzed_result,
     FilterStep * filter_step,
     QueryPlan::Node * read_node,
-    QueryPlan & query_plan)
+    QueryPlan & query_plan,
+    bool allow_partial_split)
 {
     const auto & metadata_snapshot = reading_step->getStorageMetadata();
     const auto & primary_key = metadata_snapshot->getPrimaryKey();
@@ -317,6 +319,11 @@ static SplitResult trySplitNonIntersectingParts(
     /// index. Leave the reading step untouched so the query falls back to a regular FINAL read.
     /// Must come before the `non_intersecting_parts_ranges.empty()` check to cover the all-intersecting case.
     if (!reading_step->getIndexReadTasks().empty())
+        return {.non_intersecting_plan = nullptr, .fully_replaced = true};
+
+    /// For queries that can stop reading early the set-building plan is a pessimization, and the
+    /// partial split alone does not preserve the reading order; keep the regular FINAL read.
+    if (!allow_partial_split)
         return {.non_intersecting_plan = nullptr, .fully_replaced = true};
 
     if (split.non_intersecting_parts_ranges.empty())
@@ -388,11 +395,12 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
         return;
 
     /// The steps above may rely on the reading step producing rows in the order of the
-    /// sorting key, but the replacement plan does not produce rows in any particular order.
-    /// Besides, read-in-order queries can often stop early, while the set-building phase
-    /// would read all filtered rows up front.
-    if (reading_step->readsInOrder())
-        return;
+    /// sorting key, but the set-building replacement plan does not produce rows in any
+    /// particular order. Besides, read-in-order queries can often stop early, while the
+    /// set-building phase would read all filtered rows up front. Such queries may still
+    /// use the full non-intersecting replacement, which preserves both the order and the
+    /// early exit — the flag is checked before the partial split below.
+    const bool reading_in_order = reading_step->readsInOrder();
 
     /// Skip if projection was applied.
     if (reading_step->getAnalyzedResult())
@@ -466,15 +474,16 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
         return;
 
     /// A limit below the number of selected rows means the query is expected to finish early.
-    if (limit_above_reading && analyzed_result && limit_above_reading < analyzed_result->selected_rows)
-        return;
+    const bool stops_reading_early = reading_in_order
+        || (limit_above_reading && analyzed_result && limit_above_reading < analyzed_result->selected_rows);
 
     /// Split parts into non-intersecting (unique key ranges, no FINAL needed) and
     /// intersecting (overlapping, need FINAL). This avoids running the expensive
     /// aggregation-based FINAL on parts that have no duplicates.
     /// When all parts are non-intersecting, replaceNodeWithPlan is called inside
     /// and fully_replaced is set — in that case we're done.
-    auto split_result = trySplitNonIntersectingParts(reading_step, analyzed_result, filter_step, read_node, query_plan);
+    auto split_result = trySplitNonIntersectingParts(
+        reading_step, analyzed_result, filter_step, read_node, query_plan, /*allow_partial_split=*/ !stops_reading_early);
 
     if (split_result.fully_replaced)
         return;

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -13,6 +13,7 @@
 #include <Processors/QueryPlan/LazilyUnorderedReadFromMergeTree.h>
 #include <Processors/QueryPlan/LazyFinalKeyAnalysisStep.h>
 #include <Processors/QueryPlan/LazyReadReplacingFinalStep.h>
+#include <Processors/QueryPlan/LimitStep.h>
 #include <Processors/QueryPlan/PartsSplitter.h>
 #include <Processors/QueryPlan/UnionStep.h>
 #include <Processors/Sources/LazyFinalSharedState.h>
@@ -385,9 +386,34 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
     if (data.merging_params.mode != MergeTreeData::MergingParams::Replacing)
         return;
 
+    /// The steps above may rely on the reading step producing rows in the order of the
+    /// sorting key, but the replacement plan does not produce rows in any particular order.
+    /// Besides, read-in-order queries can often stop early, while the set-building phase
+    /// would read all filtered rows up front.
+    if (reading_step->readsInOrder())
+        return;
+
     /// Skip if projection was applied.
     if (reading_step->getAnalyzedResult())
         return;
+
+    /// Find a LIMIT that applies directly to the reading step's output (only Expression/Filter
+    /// steps in between). Such a limit lets the query stop reading early, which the set-building
+    /// phase would defeat. Any other step consumes the whole stream and stops the search.
+    size_t limit_above_reading = 0;
+    for (size_t i = stack.size() - 1; i-- > 0;)
+    {
+        auto * step = stack[i].node->step.get();
+        if (typeid_cast<ExpressionStep *>(step) || typeid_cast<FilterStep *>(step))
+            continue;
+        if (const auto * limit_step = typeid_cast<LimitStep *>(step))
+        {
+            size_t limit = limit_step->getLimit();
+            size_t offset = limit_step->getOffset();
+            limit_above_reading = limit + offset < limit ? std::numeric_limits<size_t>::max() : limit + offset;
+        }
+        break;
+    }
 
     /// Check the immediate parent for a FilterStep or InputSelectorStep.
     FilterStep * filter_step = nullptr;
@@ -417,6 +443,10 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
     /// so selectRangesToRead uses the PK condition for index analysis.
     auto analyzed_result = reading_step->selectRangesToRead();
     if (reading_step->getParts().empty())
+        return;
+
+    /// A limit below the number of selected rows means the query is expected to finish early.
+    if (limit_above_reading && analyzed_result && limit_above_reading < analyzed_result->selected_rows)
         return;
 
     /// Split parts into non-intersecting (unique key ranges, no FINAL needed) and

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -424,7 +424,9 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
             limit_above_reading = distinct_step->getLimitHint();
             break;
         }
-        if (const auto * limit_step = typeid_cast<LimitStep *>(step))
+        /// With always_read_till_end (e.g. exact_rows_before_limit or WITH TOTALS) the query
+        /// reads the whole stream anyway, so the limit does not allow to stop reading early.
+        if (const auto * limit_step = typeid_cast<LimitStep *>(step); limit_step && !limit_step->alwaysReadTillEnd())
         {
             size_t limit = limit_step->getLimit();
             size_t offset = limit_step->getOffset();

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -427,9 +427,22 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
             continue;
         }
         /// DISTINCT stops reading as soon as its pushed-down limit hint of distinct rows is produced.
+        /// The hint is seeded from the query limit even when that limit reads till the end
+        /// (e.g. exact_rows_before_limit or WITH TOTALS), so confirm with the LimitStep above.
         if (const auto * distinct_step = typeid_cast<DistinctStep *>(step))
         {
-            limit_above_reading = distinct_step->getLimitHint();
+            if (size_t limit_hint = distinct_step->getLimitHint())
+            {
+                for (size_t j = i; j-- > 0;)
+                {
+                    auto * upper_step = stack[j].node->step.get();
+                    if (typeid_cast<ExpressionStep *>(upper_step) || typeid_cast<DistinctStep *>(upper_step))
+                        continue;
+                    if (const auto * limit_step = typeid_cast<LimitStep *>(upper_step); limit_step && !limit_step->alwaysReadTillEnd())
+                        limit_above_reading = limit_hint;
+                    break;
+                }
+            }
             break;
         }
         /// With always_read_till_end (e.g. exact_rows_before_limit or WITH TOTALS) the query

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyFinal.cpp
@@ -427,22 +427,13 @@ void optimizeLazyFinal(const Stack & stack, QueryPlan & query_plan, QueryPlan::N
             continue;
         }
         /// DISTINCT stops reading as soon as its pushed-down limit hint of distinct rows is produced.
-        /// The hint is seeded from the query limit even when that limit reads till the end
-        /// (e.g. exact_rows_before_limit or WITH TOTALS), so confirm with the LimitStep above.
+        /// The DISTINCT transform honors the hint even when the enclosing limit has
+        /// always_read_till_end (e.g. exact_rows_before_limit), so any non-zero hint means the
+        /// query terminates reading early; if the hint seeding ever starts to account for that,
+        /// this check follows automatically.
         if (const auto * distinct_step = typeid_cast<DistinctStep *>(step))
         {
-            if (size_t limit_hint = distinct_step->getLimitHint())
-            {
-                for (size_t j = i; j-- > 0;)
-                {
-                    auto * upper_step = stack[j].node->step.get();
-                    if (typeid_cast<ExpressionStep *>(upper_step) || typeid_cast<DistinctStep *>(upper_step))
-                        continue;
-                    if (const auto * limit_step = typeid_cast<LimitStep *>(upper_step); limit_step && !limit_step->alwaysReadTillEnd())
-                        limit_above_reading = limit_hint;
-                    break;
-                }
-            }
+            limit_above_reading = distinct_step->getLimitHint();
             break;
         }
         /// With always_read_till_end (e.g. exact_rows_before_limit or WITH TOTALS) the query

--- a/tests/performance/lazy_final_early_exit_limit.xml
+++ b/tests/performance/lazy_final_early_exit_limit.xml
@@ -1,0 +1,30 @@
+<test>
+    <!--
+        Lazy FINAL must not apply to queries that can stop reading early: its
+        set-building phase reads all rows selected for the filter columns before
+        either branch can return the first row, even when the runtime check picks
+        the fallback. The first two queries (a small LIMIT without ORDER BY and a
+        read-in-order LIMIT) must skip the optimization. The last query is a
+        control with a clustered filter and no limit: lazy FINAL still applies
+        there and must not regress.
+    -->
+    <settings>
+        <query_plan_optimize_lazy_final>1</query_plan_optimize_lazy_final>
+    </settings>
+
+    <create_query>
+        CREATE TABLE lazy_final_limit (k UInt64, v UInt64, c UInt8, payload String)
+        ENGINE = ReplacingMergeTree
+        ORDER BY k
+    </create_query>
+
+    <fill_query>SYSTEM STOP MERGES lazy_final_limit</fill_query>
+    <fill_query>INSERT INTO lazy_final_limit SELECT number, cityHash64(number, 1) % 100, number &lt; 50000, toString(cityHash64(number, 11)) FROM numbers_mt(8000000)</fill_query>
+    <fill_query>INSERT INTO lazy_final_limit SELECT number, cityHash64(number, 2) % 100, number &lt; 50000, toString(cityHash64(number, 12)) FROM numbers_mt(8000000)</fill_query>
+
+    <query>SELECT k, payload FROM lazy_final_limit FINAL WHERE v = 7 LIMIT 100 FORMAT Null</query>
+    <query>SELECT k, payload FROM lazy_final_limit FINAL WHERE v = 7 ORDER BY k LIMIT 100 FORMAT Null</query>
+    <query>SELECT count(), max(cityHash64(payload)) FROM lazy_final_limit FINAL WHERE c = 1 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS lazy_final_limit</drop_query>
+</test>

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -18,3 +18,11 @@ limit above arrayJoin:	1
 2	7	updated
 3	7	updated
 4	7	updated
+disjoint read-in-order limit, final read:	0
+disjoint small limit, final read:	0
+disjoint lazy off, final read:	1
+7	7
+107	7
+207	7
+307	7
+407	7

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -3,6 +3,7 @@ read-in-order:	0
 read-in-order, limit:	0
 small limit:	0
 large limit:	1
+limit reading till end:	1
 limit above full sort:	1
 distinct with limit:	0
 distinct without limit:	1

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -4,6 +4,9 @@ read-in-order, limit:	0
 small limit:	0
 large limit:	1
 limit above full sort:	1
+distinct with limit:	0
+distinct without limit:	1
+limit above arrayJoin:	1
 0	7	updated
 1	7	updated
 2	7	updated

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -1,0 +1,16 @@
+no order, no limit:	1
+read-in-order:	0
+read-in-order, limit:	0
+small limit:	0
+large limit:	1
+limit above full sort:	1
+0	7	updated
+1	7	updated
+2	7	updated
+3	7	updated
+4	7	updated
+0	7	updated
+1	7	updated
+2	7	updated
+3	7	updated
+4	7	updated

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -7,6 +7,7 @@ limit reading till end:	1
 limit above full sort:	1
 distinct with limit:	0
 distinct without limit:	1
+distinct with limit reading till end:	1
 limit above arrayJoin:	1
 0	7	updated
 1	7	updated

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.reference
@@ -7,7 +7,7 @@ limit reading till end:	1
 limit above full sort:	1
 distinct with limit:	0
 distinct without limit:	1
-distinct with limit reading till end:	1
+distinct with limit reading till end:	0
 limit above arrayJoin:	1
 0	7	updated
 1	7	updated

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -58,4 +58,29 @@ SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5;
 SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5
 SETTINGS query_plan_optimize_lazy_final = 0;
 
+-- When all selected parts do not intersect by the primary key, the whole FINAL read is
+-- replaced by a plain read. The replacement preserves the reading order and the early
+-- exit, so it must stay enabled for read-in-order and small-limit queries.
+-- Parts collapsed on insert get a non-zero level; unmerged level-0 parts are conservatively
+-- treated as intersecting (they may contain duplicate keys inside), so pin the setting.
+SET optimize_on_insert = 1;
+DROP TABLE IF EXISTS t_lazy_final_gates_disjoint;
+CREATE TABLE t_lazy_final_gates_disjoint (k UInt64, v UInt64, s String) ENGINE = ReplacingMergeTree ORDER BY k;
+SYSTEM STOP MERGES t_lazy_final_gates_disjoint;
+INSERT INTO t_lazy_final_gates_disjoint SELECT number, number % 100, toString(number) FROM numbers(100000);
+INSERT INTO t_lazy_final_gates_disjoint SELECT number + 100000, number % 100, toString(number + 100000) FROM numbers(100000);
+
+SELECT 'disjoint read-in-order limit, final read:', countIf(explain LIKE '%FINAL: 1%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates_disjoint FINAL WHERE v = 7 ORDER BY k LIMIT 10);
+
+SELECT 'disjoint small limit, final read:', countIf(explain LIKE '%FINAL: 1%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates_disjoint FINAL WHERE v = 7 LIMIT 10);
+
+-- Control for the assertion above: with the optimization disabled the FINAL read stays.
+SELECT 'disjoint lazy off, final read:', countIf(explain LIKE '%FINAL: 1%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates_disjoint FINAL WHERE v = 7 ORDER BY k LIMIT 10 SETTINGS query_plan_optimize_lazy_final = 0);
+
+SELECT k, v FROM t_lazy_final_gates_disjoint FINAL WHERE v = 7 ORDER BY k LIMIT 5;
+
 DROP TABLE t_lazy_final_gates;
+DROP TABLE t_lazy_final_gates_disjoint;

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -35,6 +35,19 @@ FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 1000000);
 SELECT 'limit above full sort:', countIf(explain LIKE '%InputSelector%') > 0
 FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY s LIMIT 10);
 
+-- DISTINCT with a pushed-down limit hint stops reading early: lazy FINAL must be disabled.
+SELECT 'distinct with limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 5);
+
+-- DISTINCT without a limit consumes the whole stream: lazy FINAL applies.
+SELECT 'distinct without limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7);
+
+-- arrayJoin changes the number of rows, so a limit above it is not comparable to the
+-- number of selected rows: lazy FINAL applies.
+SELECT 'limit above arrayJoin:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT arrayJoin([k, k]) FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 10);
+
 -- The results must be the same with and without the optimization.
 SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5;
 SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -11,6 +11,7 @@ INSERT INTO t_lazy_final_gates SELECT number, if(number < 20000, 7, 999), toStri
 INSERT INTO t_lazy_final_gates SELECT number, if(number < 20000, 7, 999), 'updated' FROM numbers(100000);
 
 SET enable_analyzer = 1, query_plan_optimize_lazy_final = 1, optimize_read_in_order = 1, max_threads = 4;
+SET exact_rows_before_limit = 0;
 
 -- Filter without ORDER BY and LIMIT: lazy FINAL applies.
 SELECT 'no order, no limit:', countIf(explain LIKE '%InputSelector%') > 0
@@ -30,6 +31,10 @@ FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 10);
 -- A LIMIT not smaller than the number of selected rows cannot stop reading early: lazy FINAL applies.
 SELECT 'large limit:', countIf(explain LIKE '%InputSelector%') > 0
 FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 1000000);
+
+-- With exact_rows_before_limit the limit reads the whole stream anyway: lazy FINAL applies.
+SELECT 'limit reading till end:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 10 SETTINGS exact_rows_before_limit = 1);
 
 -- A LIMIT above a full sort consumes the whole stream: lazy FINAL applies.
 SELECT 'limit above full sort:', countIf(explain LIKE '%InputSelector%') > 0

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -1,0 +1,43 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: the test checks the shape of the local query plan.
+
+DROP TABLE IF EXISTS t_lazy_final_gates;
+
+CREATE TABLE t_lazy_final_gates (k UInt64, v UInt64, s String) ENGINE = ReplacingMergeTree ORDER BY k;
+
+SYSTEM STOP MERGES t_lazy_final_gates;
+
+INSERT INTO t_lazy_final_gates SELECT number, if(number < 20000, 7, 999), toString(number) FROM numbers(100000);
+INSERT INTO t_lazy_final_gates SELECT number, if(number < 20000, 7, 999), 'updated' FROM numbers(100000);
+
+SET enable_analyzer = 1, query_plan_optimize_lazy_final = 1, optimize_read_in_order = 1, max_threads = 4;
+
+-- Filter without ORDER BY and LIMIT: lazy FINAL applies.
+SELECT 'no order, no limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7);
+
+-- Read-in-order: lazy FINAL must be disabled (the replacement plan does not produce rows in sorting key order).
+SELECT 'read-in-order:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k);
+
+SELECT 'read-in-order, limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 10);
+
+-- A small LIMIT without ORDER BY stops reading early: lazy FINAL must be disabled.
+SELECT 'small limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 10);
+
+-- A LIMIT not smaller than the number of selected rows cannot stop reading early: lazy FINAL applies.
+SELECT 'large limit:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 1000000);
+
+-- A LIMIT above a full sort consumes the whole stream: lazy FINAL applies.
+SELECT 'limit above full sort:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT k FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY s LIMIT 10);
+
+-- The results must be the same with and without the optimization.
+SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5;
+SELECT k, v, s FROM t_lazy_final_gates FINAL WHERE v = 7 ORDER BY k LIMIT 5
+SETTINGS query_plan_optimize_lazy_final = 0;
+
+DROP TABLE t_lazy_final_gates;

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -48,8 +48,9 @@ FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7 L
 SELECT 'distinct without limit:', countIf(explain LIKE '%InputSelector%') > 0
 FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7);
 
--- The DISTINCT limit hint is seeded from the query limit even when the limit reads till
--- the end, so it must not disable lazy FINAL in that case.
+-- The DISTINCT transform stops reading at its limit hint even when the enclosing limit
+-- has always_read_till_end (exact_rows_before_limit), so lazy FINAL must be disabled
+-- here the same way as without the setting.
 SELECT 'distinct with limit reading till end:', countIf(explain LIKE '%InputSelector%') > 0
 FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 5 SETTINGS exact_rows_before_limit = 1);
 

--- a/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
+++ b/tests/queries/0_stateless/04539_lazy_final_read_in_order_limit_disabled.sql
@@ -48,6 +48,11 @@ FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7 L
 SELECT 'distinct without limit:', countIf(explain LIKE '%InputSelector%') > 0
 FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7);
 
+-- The DISTINCT limit hint is seeded from the query limit even when the limit reads till
+-- the end, so it must not disable lazy FINAL in that case.
+SELECT 'distinct with limit reading till end:', countIf(explain LIKE '%InputSelector%') > 0
+FROM (EXPLAIN SELECT DISTINCT k % 10 FROM t_lazy_final_gates FINAL WHERE v = 7 LIMIT 5 SETTINGS exact_rows_before_limit = 1);
+
 -- arrayJoin changes the number of rows, so a limit above it is not comparable to the
 -- number of selected rows: lazy FINAL applies.
 SELECT 'limit above arrayJoin:', countIf(explain LIKE '%InputSelector%') > 0


### PR DESCRIPTION
<details>

<summary>Claude</summary>


The lazy FINAL replacement plan (hash aggregation over the sorting key plus a lazy column fetch) does not produce rows in any particular order, while the steps above may already rely on the reading step producing rows in sorting key order after optimizeReadInOrder converted them - in an experiment the result of such a query stayed ordered only by accident of execution, with no sorting transform left in the pipeline. Disable the optimization when the reading step reads in order, both for correctness and because the set-building phase reads all filtered rows before either branch can return the first row, defeating early exit.

For the same reason, disable it when a LIMIT smaller than the number of selected rows applies directly to the reading step's output (only Expression/Filter steps in between): such queries stop reading as soon as enough rows pass the filter. A limit above a stream-consuming step (full sort, aggregation) does not disable the optimization.


## Testing

- New test `04539_lazy_final_read_in_order_limit_disabled` checks the plan shape (`InputSelector` presence) for all six cases: filter-only (applies), read-in-order with and without limit (disabled), small bare limit (disabled), limit
not smaller than the selected rows (applies), limit above a full sort (applies), plus result equality with the optimization on and off.
- All existing `lazy_final` stateless tests pass unchanged.
- New performance test `lazy_final_early_exit_limit` (2 intersecting parts, 16M rows, `query_plan_optimize_lazy_final = 1`). Local comparison against the parent commit on a 48-core ARM machine: `FINAL WHERE v = 7 LIMIT 100` improves by
28% (0.103s → 0.075s), `FINAL WHERE v = 7 ORDER BY k LIMIT 100` by 24% (0.132s → 0.101s) — the saved time is the set-building barrier, so the relative win grows with table size. A control query with a clustered filter and no limit,
where lazy FINAL still applies, is unchanged (+3%, within threshold).
</details>

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The lazy `FINAL` optimization (`query_plan_optimize_lazy_final`, disabled by default) is no longer applied when the query reads in the order of the sorting key, because its replacement plan does not produce rows in sorting-key order, while the plan above may already rely on that after the read-in-order optimization, which could result in incorrectly ordered results. It is also no longer applied when a`LIMIT` smaller than the number of rows to read applies directly to the reading step, where the mandatory set-building pass would defeat early termination.


<img width="3220" height="211" alt="image" src="https://github.com/user-attachments/assets/c9c2c379-349c-44d9-bb6e-95282ab8eea1" />

