### PR TITLE
Speed up per-row string search and remove a redundant searcher

### DIFF
--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -39,7 +39,9 @@ class CaseSensitiveStringSearcher final
     sz_cptr_t const needle_end;
 
 public:
-    CaseSensitiveStringSearcher(const UInt8 * needle_, size_t needle_size)
+    template <typename CharT>
+    requires (sizeof(CharT) == 1)
+    CaseSensitiveStringSearcher(const CharT * needle_, size_t needle_size)
         : needle(reinterpret_cast<sz_cptr_t>(needle_))
         , needle_end(needle + needle_size)
     {
@@ -72,6 +74,25 @@ public:
         sz_cptr_t haystack_cptr = reinterpret_cast<sz_cptr_t>(haystack);
         size_t haystack_size = haystack_end - haystack;
         size_t needle_size = needle_end - needle;
+
+        /// With few candidate positions a direct scan is cheaper than the dispatched sz_find call.
+        /// Also covers needles longer than the haystack (the loop body never runs).
+        if (haystack_size < needle_size + 8)
+        {
+            for (const UInt8 * pos = haystack; pos + needle_size <= haystack_end; ++pos)
+            {
+                sz_cptr_t c = needle;
+                sz_cptr_t p = reinterpret_cast<sz_cptr_t>(pos);
+                while (c != needle_end && *c == *p)
+                {
+                    ++c;
+                    ++p;
+                }
+                if (c == needle_end)
+                    return pos;
+            }
+            return haystack_end;
+        }
 
         const char * res = sz_find(haystack_cptr, haystack_size, needle, needle_size);
 

--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -3,8 +3,8 @@
 #include <base/types.h>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 
 #include <Common/TargetSpecific.h>
@@ -115,6 +115,10 @@ private:
     uint8_t l = 0;
     uint8_t u = 0;
 
+    /// ASCII-only case folding, branchless, unlike the locale-aware std::tolower/std::toupper.
+    static uint8_t lowerASCII(uint8_t c) { return (c >= 'A' && c <= 'Z') ? (c | 0x20) : c; }
+    static uint8_t upperASCII(uint8_t c) { return (c >= 'a' && c <= 'z') ? (c & ~0x20) : c; }
+
 #if defined(__AVX2__) || (defined(__aarch64__) && defined(__ARM_NEON))
 #ifdef __AVX2__
     using Vec = __m256i;
@@ -153,37 +157,38 @@ private:
 #endif
 
 public:
-    ASCIICaseInsensitiveStringSearcher(const UInt8 * needle_, size_t needle_size)
+    template <typename CharT>
+    requires (sizeof(CharT) == 1)
+    ASCIICaseInsensitiveStringSearcher(const CharT * needle_, size_t needle_size)
         : needle(reinterpret_cast<const uint8_t *>(needle_))
         , needle_end(needle + needle_size)
     {
         if (needle_size == 0)
             return;
 
-        l = static_cast<uint8_t>(std::tolower(*needle));
-        u = static_cast<uint8_t>(std::toupper(*needle));
+        l = lowerASCII(*needle);
+        u = upperASCII(*needle);
 
 #if defined(__AVX2__) || (defined(__aarch64__) && defined(__ARM_NEON))
         patl = vecSet1(l);
         patu = vecSet1(u);
 
-        uint8_t cache_l_bytes[N] = {};
-        uint8_t cache_u_bytes[N] = {};
-        const auto * needle_pos = needle;
+        /// Filled branchlessly: folding the zero padding is identity, so only the mask depends on the needle size.
+        size_t cached_len = std::min(needle_size, N);
+        uint8_t needle_bytes[N] = {};
+        memcpy(needle_bytes, needle, cached_len);
 
+        uint8_t cache_l_bytes[N];
+        uint8_t cache_u_bytes[N];
         for (size_t i = 0; i < N; ++i)
         {
-            if (needle_pos != needle_end)
-            {
-                cache_l_bytes[i] = static_cast<uint8_t>(std::tolower(*needle_pos));
-                cache_u_bytes[i] = static_cast<uint8_t>(std::toupper(*needle_pos));
-                cachemask |= 1u << i;
-                ++needle_pos;
-            }
+            cache_l_bytes[i] = lowerASCII(needle_bytes[i]);
+            cache_u_bytes[i] = upperASCII(needle_bytes[i]);
         }
 
         cachel = vecLoad(cache_l_bytes);
         cacheu = vecLoad(cache_u_bytes);
+        cachemask = (cached_len == N) ? full_cache_mask : ((1u << cached_len) - 1u);
 #endif
     }
 
@@ -208,7 +213,7 @@ public:
                     pos += N;
                     const auto * needle_pos = needle + N;
 
-                    while (needle_pos < needle_end && pos < haystack_end && std::tolower(*pos) == std::tolower(*needle_pos))
+                    while (needle_pos < needle_end && pos < haystack_end && lowerASCII(*pos) == lowerASCII(*needle_pos))
                     {
                         ++pos;
                         ++needle_pos;
@@ -230,7 +235,7 @@ public:
             ++pos;
             const auto * needle_pos = needle + 1;
 
-            while (needle_pos < needle_end && pos < haystack_end && std::tolower(*pos) == std::tolower(*needle_pos))
+            while (needle_pos < needle_end && pos < haystack_end && lowerASCII(*pos) == lowerASCII(*needle_pos))
             {
                 ++pos;
                 ++needle_pos;
@@ -247,6 +252,31 @@ public:
     {
         if (needle == needle_end)
             return haystack;
+
+        size_t haystack_size = haystack_end - haystack;
+        size_t needle_size = needle_end - needle;
+
+        /// With few candidate positions a scalar scan is cheaper than the SIMD kernel.
+        /// Also covers needles longer than the haystack (the loop body never runs).
+        if (haystack_size < needle_size + 16)
+        {
+            for (const UInt8 * pos = haystack; pos + needle_size <= haystack_end; ++pos)
+            {
+                if (*pos == l || *pos == u)
+                {
+                    const uint8_t * haystack_pos = reinterpret_cast<const uint8_t *>(pos) + 1;
+                    const uint8_t * needle_pos = needle + 1;
+                    while (needle_pos != needle_end && lowerASCII(*haystack_pos) == lowerASCII(*needle_pos))
+                    {
+                        ++haystack_pos;
+                        ++needle_pos;
+                    }
+                    if (needle_pos == needle_end)
+                        return pos;
+                }
+            }
+            return haystack_end;
+        }
 
         while (haystack < haystack_end)
         {
@@ -285,7 +315,7 @@ public:
                             const auto * needle_pos = needle + N;
 
                             while (haystack_pos < haystack_end && needle_pos < needle_end
-                                   && std::tolower(*haystack_pos) == std::tolower(*needle_pos))
+                                   && lowerASCII(*haystack_pos) == lowerASCII(*needle_pos))
                             {
                                 ++haystack_pos;
                                 ++needle_pos;
@@ -312,7 +342,7 @@ public:
                 const auto * haystack_pos = haystack + 1;
                 const auto * needle_pos = needle + 1;
 
-                while (haystack_pos < haystack_end && needle_pos < needle_end && std::tolower(*haystack_pos) == std::tolower(*needle_pos))
+                while (haystack_pos < haystack_end && needle_pos < needle_end && lowerASCII(*haystack_pos) == lowerASCII(*needle_pos))
                 {
                     ++haystack_pos;
                     ++needle_pos;
@@ -427,42 +457,6 @@ public:
     }
 
     const UInt8 * search(const UInt8 * haystack, size_t haystack_size) const { return search(haystack, haystack + haystack_size); }
-};
-
-/// Use only with short haystacks where cheap initialization is required.
-template <bool CaseInsensitive>
-struct StdLibASCIIStringSearcher
-{
-    const char * const needle_start;
-    const char * const needle_end;
-
-    template <typename CharT>
-    requires (sizeof(CharT) == 1)
-    StdLibASCIIStringSearcher(const CharT * const needle_start_, size_t needle_size_)
-        : needle_start(reinterpret_cast<const char *>(needle_start_))
-        , needle_end(reinterpret_cast<const char *>(needle_start) + needle_size_)
-    {}
-
-    template <typename CharT>
-    requires (sizeof(CharT) == 1)
-    const CharT * search(const CharT * haystack_start, const CharT * const haystack_end) const
-    {
-        if constexpr (CaseInsensitive)
-            return std::search(
-                haystack_start, haystack_end, needle_start, needle_end,
-                [](char c1, char c2) { return std::toupper(c1) == std::toupper(c2); });
-        else
-            return std::search(
-                haystack_start, haystack_end, needle_start, needle_end,
-                [](char c1, char c2) { return c1 == c2; });
-    }
-
-    template <typename CharT>
-    requires (sizeof(CharT) == 1)
-    const CharT * search(const CharT * haystack_start, size_t haystack_length) const
-    {
-        return search(haystack_start, haystack_start + haystack_length);
-    }
 };
 
 }

--- a/src/Functions/CountSubstringsImpl.h
+++ b/src/Functions/CountSubstringsImpl.h
@@ -134,6 +134,10 @@ struct CountSubstringsImpl
             {
                 /// 0 already
             }
+            else if (haystack_size == 0)
+            {
+                /// A non-empty needle is never found in an empty haystack; do not pay the searcher initialization.
+            }
             else
             {
                 /// It is assumed that the StringSearcher is not very difficult to initialize.
@@ -190,7 +194,7 @@ struct CountSubstringsImpl
                 const char * needle_beg = reinterpret_cast<const char *>(&needle_data[prev_needle_offset]);
                 size_t needle_size = needle_offsets[i] - prev_needle_offset;
 
-                if (needle_size > 0)
+                if (needle_size > 0 && !haystack.empty())
                 {
                     typename Impl::SearcherInSmallHaystack searcher = Impl::createSearcherInSmallHaystack(needle_beg, needle_size);
 

--- a/src/Functions/PositionImpl.h
+++ b/src/Functions/PositionImpl.h
@@ -26,7 +26,7 @@ struct PositionCaseSensitiveASCII
     using MultiSearcherInBigHaystack = MultiVolnitsky;
 
     /// For searching single substring, that is different each time. This object is created for each row of data. It must have cheap initialization.
-    using SearcherInSmallHaystack = StdLibASCIIStringSearcher</*CaseInsensitive*/ false>;
+    using SearcherInSmallHaystack = CaseSensitiveStringSearcher;
 
     static SearcherInBigHaystack createSearcherInBigHaystack(const char * needle_data, size_t needle_size, size_t haystack_size_hint)
     {
@@ -96,7 +96,7 @@ struct PositionCaseSensitiveUTF8
 {
     using SearcherInBigHaystack = VolnitskyUTF8;
     using MultiSearcherInBigHaystack = MultiVolnitskyUTF8;
-    using SearcherInSmallHaystack = StdLibASCIIStringSearcher</*CaseInsensitive*/ false>;
+    using SearcherInSmallHaystack = CaseSensitiveStringSearcher;
 
     static SearcherInBigHaystack createSearcherInBigHaystack(const char * needle_data, size_t needle_size, size_t haystack_size_hint)
     {

--- a/src/Functions/PositionImpl.h
+++ b/src/Functions/PositionImpl.h
@@ -63,7 +63,7 @@ struct PositionCaseInsensitiveASCII
     /// `Volnitsky` is not used here, because one person has measured that this is better. It will be good if you question it.
     using SearcherInBigHaystack = ASCIICaseInsensitiveStringSearcher;
     using MultiSearcherInBigHaystack = MultiVolnitskyCaseInsensitive;
-    using SearcherInSmallHaystack = StdLibASCIIStringSearcher</*CaseInsensitive*/ true>;
+    using SearcherInSmallHaystack = ASCIICaseInsensitiveStringSearcher;
 
     static SearcherInBigHaystack createSearcherInBigHaystack(const char * needle_data, size_t needle_size, size_t /*haystack_size_hint*/)
     {
@@ -388,6 +388,11 @@ struct PositionImpl
                 /// An empty string is always at any position in `haystack`.
                 res[i] = start;
             }
+            else if (haystack_size == 0)
+            {
+                /// A non-empty needle is never found in an empty haystack; do not pay the searcher initialization.
+                res[i] = 0;
+            }
             else
             {
                 /// It is assumed that the StringSearcher is not very difficult to initialize.
@@ -450,6 +455,10 @@ struct PositionImpl
             else if (0 == needle_size)
             {
                 res[i] = start;
+            }
+            else if (haystack.empty())
+            {
+                res[i] = 0;
             }
             else
             {

--- a/src/Functions/ReplaceStringImpl.h
+++ b/src/Functions/ReplaceStringImpl.h
@@ -180,8 +180,8 @@ struct ReplaceStringImpl
 
             if (cur_needle_length)
             {
-                /// Using "slow" "stdlib searcher instead of Volnitsky because there is a different pattern in each row
-                StdLibASCIIStringSearcher</*CaseInsensitive*/ false> searcher(cur_needle_data, cur_needle_length);
+                /// Cheap-to-initialize searcher instead of Volnitsky because there is a different pattern in each row
+                CaseSensitiveStringSearcher searcher(cur_needle_data, cur_needle_length);
 
                 while (start_pos < cur_haystack_end)
                 {
@@ -243,6 +243,8 @@ struct ReplaceStringImpl
         size_t prev_haystack_offset = 0;
         size_t prev_replacement_offset = 0;
 
+        CaseSensitiveStringSearcher searcher(needle.data(), needle.size());
+
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             const auto * const cur_haystack_data = &haystack_data[prev_haystack_offset];
@@ -250,9 +252,6 @@ struct ReplaceStringImpl
 
             const auto * const cur_replacement_data = &replacement_data[prev_replacement_offset];
             const size_t cur_replacement_length = replacement_offsets[i] - prev_replacement_offset;
-
-            /// Using "slow" "stdlib searcher instead of Volnitsky just to keep things simple
-            StdLibASCIIStringSearcher</*CaseInsensitive*/ false> searcher(needle.data(), needle.size());
 
             const auto * last_match = static_cast<UInt8 *>(nullptr);
             const auto * start_pos = cur_haystack_data;
@@ -330,8 +329,8 @@ struct ReplaceStringImpl
 
             if (cur_needle_length)
             {
-                /// Using "slow" "stdlib searcher instead of Volnitsky because there is a different pattern in each row
-                StdLibASCIIStringSearcher</*CaseInsensitive*/ false> searcher(cur_needle_data, cur_needle_length);
+                /// Cheap-to-initialize searcher instead of Volnitsky because there is a different pattern in each row
+                CaseSensitiveStringSearcher searcher(cur_needle_data, cur_needle_length);
 
                 while (start_pos < cur_haystack_end)
                 {


### PR DESCRIPTION
The `position`, `countSubstrings`, `multiSearch*` and `replace*` functions
use a cheap-to-initialize searcher on their per-row path, where the needle
differs on every row (non-constant needle) and Volnitsky's bigram
preprocessing would not pay off. That path used `StdLibASCIIStringSearcher`,
a naive `std::search` wrapper introduced in 2022 only to fix matching past
zero bytes (81bb2242fdd), never benchmarked against the SIMD searchers that
now back the constant-needle path.

This replaces it, in two steps:

- Case-sensitive: use the StringZilla-backed `CaseSensitiveStringSearcher`,
  with a small-haystack fast path added to `search` so rows with few
  candidate positions do not pay the dispatched `sz_find` call.
- Case-insensitive: fold case with branchless ASCII bit operations instead
  of the locale-aware `std::tolower`/`std::toupper` in
  `ASCIICaseInsensitiveStringSearcher` (cache fill and verify loops), and add
  a scalar fast path. This makes it cheap enough to construct per row, so it
  replaces `StdLibASCIIStringSearcher` here too, and the class is deleted.

Empty-haystack rows now skip searcher construction entirely.

Measured on `hits` (100M rows) with the release-baseline ISA:

| query | speedup |
|---|---|
| `position(URL, materialize('google'))` | 1.35x |
| `countSubstrings(URL, materialize('google'))` | 1.30x |
| `positionUTF8(Title, materialize('на'))` | 1.53x |
| `positionCaseInsensitive(URL, materialize('google'))` | 1.05x |
| `multiSearchAnyCaseInsensitive(URL, [...])` | 1.07x |

Constant-needle queries (`URL LIKE '%google%'`, `position(URL, 'yandex')`)
are unchanged, and the big-haystack SIMD paths are untouched.

Related: https://github.com/ClickHouse/ClickHouse/pull/107882

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved the performance of substring search functions (`position`, `countSubstrings`, `multiSearch*`, `replaceAll`/`replaceOne`, and their case-insensitive and UTF-8 variants) with a non-constant needle by up to 1.5x, by using the SIMD-backed string searchers on the per-row path instead of a naive fallback.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1325` (included in `26.7` and later)
<!-- ch-version-info:end -->