### PR TITLE
Escape pytest node IDs so parametrized tests can be selected with --test

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import shlex
 import subprocess
 import time
 from pathlib import Path
@@ -98,6 +99,18 @@ def _mark_infrastructure_errors(results: list) -> int:
     if count:
         print(f"Marked {count} test result(s) as infrastructure errors")
     return count
+
+
+def quote_tests(tests: List[str]) -> str:
+    """Join test node IDs into a shell-safe, space-separated string.
+
+    A parametrized integration test node ID can contain spaces, parentheses and
+    quotes when the test is parametrized with SQL (e.g.
+    `test.py::test_simple_append[SELECT now() FROM numbers(2)]`). The pytest
+    command is executed through a shell, so each node ID must be quoted to
+    survive as a single argument instead of being split or mis-parsed.
+    """
+    return " ".join(shlex.quote(t) for t in tests)
 
 
 def start_docker_in_docker():
@@ -1072,7 +1085,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
     if parallel_test_modules:
         log_file = f"{temp_path}/pytest_parallel.log"
         test_result_parallel, parallel_timed_out = run_pytest_and_collect_results(
-            command=f"{' '.join(parallel_test_modules)} --report-log-exclude-logs-on-passed-tests -n {parallel_workers} {parallel_dist} --tb=short {repeat_option} --session-timeout={session_timeout_parallel}",
+            command=f"{quote_tests(parallel_test_modules)} --report-log-exclude-logs-on-passed-tests -n {parallel_workers} {parallel_dist} --tb=short {repeat_option} --session-timeout={session_timeout_parallel}",
             env=test_env,
             report_name="parallel",
             timeout=session_timeout_parallel + 600,
@@ -1114,7 +1127,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
                     session_timeout_sequential, flaky_check_remaining_s
                 )
             test_result_sequential, sequential_timed_out = run_pytest_and_collect_results(
-                command=f"{' '.join(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={iter_session_timeout_sequential}",
+                command=f"{quote_tests(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={iter_session_timeout_sequential}",
                 env=test_env,
                 report_name="sequential",
                 timeout=iter_session_timeout_sequential + 600,
@@ -1165,7 +1178,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
                 if parallel_test_modules:
                     bt_result_parallel, _ = run_pytest_and_collect_results(
-                        command=f"{' '.join(parallel_test_modules)} --report-log-exclude-logs-on-passed-tests -n {workers} --dist=loadfile --tb=short {repeat_option} --session-timeout={session_timeout_parallel}",
+                        command=f"{quote_tests(parallel_test_modules)} --report-log-exclude-logs-on-passed-tests -n {workers} --dist=loadfile --tb=short {repeat_option} --session-timeout={session_timeout_parallel}",
                         env=test_env,
                         report_name=f"parallel_{bugfix_bt}",
                         timeout=session_timeout_parallel + 600,
@@ -1181,7 +1194,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 bt_fail_num = len([r for r in bt_test_results if not r.is_ok()])
                 if sequential_test_modules and bt_fail_num < MAX_FAILS_BEFORE_DROP and not has_error:
                     bt_result_sequential, _ = run_pytest_and_collect_results(
-                        command=f"{' '.join(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={session_timeout_sequential}",
+                        command=f"{quote_tests(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={session_timeout_sequential}",
                         env=test_env,
                         report_name=f"sequential_{bugfix_bt}",
                         timeout=session_timeout_sequential + 600,
@@ -1238,7 +1251,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
         is_flaky_check or is_bugfix_validation or is_targeted_check or info.is_local_run
     ):
         test_result_retries, _ = run_pytest_and_collect_results(
-            command=f"{' '.join(failed_test_cases)} --report-log-exclude-logs-on-passed-tests --tb=short -n 1 --dist=loadfile --session-timeout=1200",
+            command=f"{quote_tests(failed_test_cases)} --report-log-exclude-logs-on-passed-tests --tb=short -n 1 --dist=loadfile --session-timeout=1200",
             env=test_env,
             report_name="retries",
             timeout=1200 + 600,

--- a/ci/praktika/__main__.py
+++ b/ci/praktika/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 import os
+import shlex
 import sys
 import textwrap
 
@@ -397,7 +398,13 @@ def main():
                     run_hooks=args.ci or args.run_hooks_locally,
                     no_docker=args.no_docker,
                     param=args.param,
-                    test=" ".join(args.test),
+                    # Quote each --test value individually: an integration test
+                    # node ID can contain spaces, parentheses and quotes when the
+                    # test is parametrized with SQL (e.g.
+                    # `test.py::t[SELECT now() FROM numbers(2)]`). The runner
+                    # interpolates this string into a shell command, so each value
+                    # must survive as a single, unmangled argument.
+                    test=" ".join(shlex.quote(t) for t in args.test),
                     pr=args.pr,
                     branch=args.branch,
                     sha=args.sha,

--- a/ci/tests/test_integration_test_name_quoting.py
+++ b/ci/tests/test_integration_test_name_quoting.py
@@ -1,0 +1,83 @@
+"""
+Tests for shell-safe passing of pytest test node IDs through the CI plumbing.
+
+A parametrized integration test node ID can contain spaces, parentheses and quotes
+when the test is parametrized with SQL, for example:
+
+    test_refreshable_mat_view/test.py::test_simple_append[False-True-SELECT now() as a, number as b FROM numbers(2)]
+
+Such a node ID travels through two shell (`shell=True`) boundaries before it reaches
+pytest:
+
+  1. `python -m ci.praktika run <job> --test <node id>` joins the `--test` values and the
+     runner interpolates them into a `docker run ...` command executed by the host shell
+     (`ci.praktika.__main__` / `ci.praktika.runner`).
+  2. Inside the job, `ci.jobs.integration_test_job` builds the pytest command as a single
+     string and runs it through the shell again.
+
+If the node ID is interpolated unquoted, the shell splits it on spaces and chokes on the
+parentheses (`syntax error near unexpected token '('`), so the test can never be selected.
+Both boundaries must quote each node ID so it survives as a single, unmangled argument.
+
+See ClickHouse/ClickHouse#91610.
+"""
+
+import os
+import shlex
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.integration_test_job import quote_tests
+
+# A representative parametrized node ID exercising spaces, parentheses, commas and the
+# `[...]` parametrization payload - i.e. the exact shape from the issue.
+PARAMETRIZED = (
+    "test_refreshable_mat_view/test.py::test_simple_append"
+    "[False-True-SELECT now() as a, number as b FROM numbers(2)]"
+)
+PLAIN = "test_storage_s3/test.py"
+PLAIN_CASE = "test_storage_s3/test.py::test_simple"
+
+
+# --- quote_tests (the job-side pytest command builder) -------------------------------
+
+
+def test_quote_tests_roundtrips_parametrized_node_id():
+    """A parametrized node ID must survive the shell as exactly one argument."""
+    assert shlex.split(quote_tests([PARAMETRIZED])) == [PARAMETRIZED]
+
+
+def test_quote_tests_keeps_multiple_node_ids_separate():
+    """Each node ID stays a distinct argument even when one contains spaces."""
+    tests = [PLAIN, PARAMETRIZED, PLAIN_CASE]
+    assert shlex.split(quote_tests(tests)) == tests
+
+
+def test_quote_tests_does_not_disturb_plain_module_paths():
+    """Plain module paths need no quoting - the common case must stay readable."""
+    assert quote_tests([PLAIN, PLAIN_CASE]) == f"{PLAIN} {PLAIN_CASE}"
+
+
+def test_quote_tests_empty():
+    assert quote_tests([]) == ""
+
+
+# --- praktika CLI --test quoting (the host-shell / docker-run boundary) --------------
+
+
+def _praktika_test_arg(test_values):
+    """Reproduce how `ci.praktika.__main__` turns `--test` values into the string the
+    runner interpolates into the `docker run ...` command run by the host shell."""
+    return " ".join(shlex.quote(t) for t in test_values)
+
+
+def test_praktika_test_arg_roundtrips_parametrized_node_id():
+    """The runner interpolates this into a shell command; splitting must recover the
+    original single argument (what docker then passes as one argv to the job)."""
+    assert shlex.split(_praktika_test_arg([PARAMETRIZED])) == [PARAMETRIZED]
+
+
+def test_praktika_test_arg_keeps_multiple_values_separate():
+    values = [PLAIN, PARAMETRIZED]
+    assert shlex.split(_praktika_test_arg(values)) == values


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/91610

A parametrized integration test node ID can contain spaces, parentheses and
quotes when the test is parametrized with SQL, e.g.:

    test_refreshable_mat_view/test.py::test_simple_append[False-True-SELECT now() as a, number as b FROM numbers(2)]

Such a node ID crosses two `shell=True` boundaries before it reaches `pytest`:
the host `docker run ...` command built by the praktika runner, and the
in-container `pytest ...` command built by the integration test job. Both
interpolated the value unquoted, so the shell split it on spaces and choked on
the parentheses (`/bin/sh: syntax error near unexpected token '('`), making the
test impossible to select.

This quotes each `--test` value at both boundaries with `shlex.quote`, so a node
ID survives as a single, unmangled argument:
- `ci/praktika/__main__.py` — quote each `--test` value before joining.
- `ci/jobs/integration_test_job.py` — a `quote_tests` helper applied to every
  `pytest` command builder.

Added `ci/tests/test_integration_test_name_quoting.py` covering the exact node
ID from the issue.

Verified locally end-to-end with a debug binary: the parametrized selector from
the issue runs and passes (`1 passed`), and a plain functional selector
(`00001_select_1`) still works unchanged.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1033` (included in `26.7` and later)
<!-- ch-version-info:end -->