### PR TITLE
Use partial sorting for `Dynamic` and `Object` statistics computation

### DIFF
--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -33,6 +33,27 @@ namespace ErrorCodes
 namespace
 {
 
+template <typename Container, typename Compare>
+void sortAndKeepTop(Container & container, size_t limit, Compare compare)
+{
+    if (container.size() <= limit)
+    {
+        std::sort(container.begin(), container.end(), compare);
+        return;
+    }
+
+    if (limit == 0)
+    {
+        container.clear();
+        return;
+    }
+
+    auto nth = container.begin() + limit;
+    std::nth_element(container.begin(), nth, container.end(), compare);
+    container.resize(limit);
+    std::sort(container.begin(), container.end(), compare);
+}
+
 /// Static default format settings to avoid creating it every time.
 const FormatSettings & getFormatSettings()
 {
@@ -1248,14 +1269,11 @@ void ColumnDynamic::prepareVariantsForSquashing(const VectorWithMemoryTracking<C
                 variants_with_sizes.emplace_back(total_variant_sizes[variant_name], variant);
         }
 
-        std::sort(variants_with_sizes.begin(), variants_with_sizes.end(), std::greater());
+        size_t variants_to_add = result_variants.size() <= max_dynamic_types ? max_dynamic_types + 1 - result_variants.size() : 0;
+        sortAndKeepTop(variants_with_sizes, variants_to_add, std::greater<>());
         /// Add the most frequent variants until we reach max_dynamic_types.
         for (const auto & [_, new_variant] : variants_with_sizes)
-        {
-            if (!canAddNewVariant(result_variants.size()))
-                break;
             result_variants.push_back(new_variant);
-        }
 
         result_variant_type = std::make_shared<DataTypeVariant>(result_variants);
     }
@@ -1378,19 +1396,15 @@ void ColumnDynamic::chooseDynamicStructureForMerge(const VectorWithMemoryTrackin
             if (variant_name != getSharedVariantTypeName())
                 variants_with_sizes.emplace_back(total_sizes[variant_name], variant_name, variant);
         }
-        std::sort(variants_with_sizes.begin(), variants_with_sizes.end(), std::greater());
+        sortAndKeepTop(variants_with_sizes, max_dynamic_types, std::greater<>());
 
         /// Take first max_dynamic_types variants from sorted list.
         DataTypes result_variants;
         result_variants.reserve(max_dynamic_types + 1); /// +1 for shared variant.
         /// Add shared variant.
         result_variants.push_back(getSharedVariantDataType());
-        for (const auto & [size, variant_name, variant_type] : variants_with_sizes)
-        {
-            /// Add variant to the resulting variants list until we reach max_dynamic_types.
-            if (canAddNewVariant(result_variants.size()))
-                result_variants.push_back(variant_type);
-        }
+        for (const auto & variant_with_size : variants_with_sizes)
+            result_variants.push_back(std::get<2>(variant_with_size));
 
         result_variant_type = std::make_shared<DataTypeVariant>(result_variants);
     }
@@ -1530,9 +1544,9 @@ void ColumnDynamic::takeOrCalculateStatisticsFrom(const VectorWithMemoryTracking
         candidates_with_sizes.reserve(shared_variant_candidates.size());
         for (const auto & [variant_name, size] : shared_variant_candidates)
             candidates_with_sizes.emplace_back(size, variant_name);
-        std::sort(candidates_with_sizes.begin(), candidates_with_sizes.end(), std::greater());
-        for (size_t i = 0; i < Statistics::MAX_SHARED_VARIANT_STATISTICS_SIZE; ++i)
-            new_statistics.shared_variants_statistics.emplace(candidates_with_sizes[i].second, candidates_with_sizes[i].first);
+        sortAndKeepTop(candidates_with_sizes, Statistics::MAX_SHARED_VARIANT_STATISTICS_SIZE, std::greater<>());
+        for (const auto & [size, variant_name] : candidates_with_sizes)
+            new_statistics.shared_variants_statistics.emplace(variant_name, size);
     }
 
     statistics = std::make_shared<const Statistics>(std::move(new_statistics));

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -31,6 +31,27 @@ const FormatSettings & getFormatSettings()
     return settings;
 }
 
+template <typename Container, typename Compare>
+void sortAndKeepTop(Container & container, size_t limit, Compare compare)
+{
+    if (container.size() <= limit)
+    {
+        std::sort(container.begin(), container.end(), compare);
+        return;
+    }
+
+    if (limit == 0)
+    {
+        container.clear();
+        return;
+    }
+
+    auto nth = container.begin() + limit;
+    std::nth_element(container.begin(), nth, container.end(), compare);
+    container.resize(limit);
+    std::sort(container.begin(), container.end(), compare);
+}
+
 const SerializationPtr & getDynamicSerialization()
 {
     static thread_local const SerializationPtr dynamic_serialization = DataTypeDynamic().getDefaultSerialization();
@@ -1750,12 +1771,16 @@ void ColumnObject::prepareForSquashing(const VectorWithMemoryTracking<ColumnPtr>
         }
 
         /// If sizes are equal, sort by path names in ascending order (for easier testing purposes).
-        std::sort(paths_with_sizes.begin(), paths_with_sizes.end(), [](const auto & left, const auto & right){ return std::tie(left.first, right.second) < std::tie(right.first, left.second); });
+        const auto compare_paths = [](const auto & left, const auto & right)
+        {
+            return std::tie(left.first, right.second) < std::tie(right.first, left.second);
+        };
 
         /// Fill dynamic_paths with first paths in sorted list until we reach the limit.
         size_t paths_to_add = max_dynamic_paths - dynamic_paths.size();
-        for (size_t i = 0; i != paths_to_add; ++i)
-            addNewDynamicPath(paths_with_sizes[i].second);
+        sortAndKeepTop(paths_with_sizes, paths_to_add, compare_paths);
+        for (const auto & [_, path] : paths_with_sizes)
+            addNewDynamicPath(path);
     }
     /// Otherwise keep all paths.
     else
@@ -1909,17 +1934,18 @@ void ColumnObject::chooseDynamicStructureForMerge(const VectorWithMemoryTracking
             paths_with_sizes.emplace_back(size, path);
 
         /// If sizes are equal, sort by path names in ascending order (for easier testing purposes).
-        std::sort(paths_with_sizes.begin(), paths_with_sizes.end(), [](const auto & left, const auto & right){ return std::tuple(right.first, left.second) < std::tuple(left.first, right.second); });
+        const auto compare_paths = [](const auto & left, const auto & right)
+        {
+            return std::tuple(right.first, left.second) < std::tuple(left.first, right.second);
+        };
+        sortAndKeepTop(paths_with_sizes, max_dynamic_paths, compare_paths);
 
         /// Fill dynamic_paths with first max_dynamic_paths paths in sorted list.
-        for (const auto & [size, path] : paths_with_sizes)
+        for (const auto & [_, path] : paths_with_sizes)
         {
-            if (dynamic_paths.size() < max_dynamic_paths)
-            {
-                auto it = dynamic_paths.emplace(path, ColumnDynamic::create(max_dynamic_types)).first;
-                dynamic_paths_ptrs.emplace(path, assert_cast<ColumnDynamic *>(it->second.get()));
-                sorted_dynamic_paths.insert(it->first);
-            }
+            auto it = dynamic_paths.emplace(path, ColumnDynamic::create(max_dynamic_types)).first;
+            dynamic_paths_ptrs.emplace(path, assert_cast<ColumnDynamic *>(it->second.get()));
+            sorted_dynamic_paths.insert(it->first);
         }
     }
     /// Use all dynamic paths from all source columns.
@@ -2063,9 +2089,9 @@ void ColumnObject::takeOrCalculateStatisticsFrom(const VectorWithMemoryTracking<
         candidates_with_sizes.reserve(shared_data_candidates.size());
         for (const auto & [path, size] : shared_data_candidates)
             candidates_with_sizes.emplace_back(size, path);
-        std::sort(candidates_with_sizes.begin(), candidates_with_sizes.end(), std::greater());
-        for (size_t i = 0; i < Statistics::MAX_SHARED_DATA_STATISTICS_SIZE; ++i)
-            new_statistics.shared_data_paths_statistics.emplace(candidates_with_sizes[i].second, candidates_with_sizes[i].first);
+        sortAndKeepTop(candidates_with_sizes, Statistics::MAX_SHARED_DATA_STATISTICS_SIZE, std::greater<>());
+        for (const auto & [size, path] : candidates_with_sizes)
+            new_statistics.shared_data_paths_statistics.emplace(path, size);
     }
 
     statistics = std::make_shared<const Statistics>(std::move(new_statistics));


### PR DESCRIPTION
Optimize top-candidate selection for internal statistics and dynamic structure handling in `ColumnDynamic` and `ColumnObject`.                                                 
                                                                                                                                                                                  
 Previously these paths fully sorted all candidates even though only the first `N` entries were needed. This replaces full sorting with partial selection via `std::nth_element`, followed by sorting only the retained prefix. The affected paths are used when squashing blocks, choosing dynamic structures for merges, and taking/calculating internal statistics for `Dynamic` and `Object` columns.

### Changelog category (leave one):                                                                                                                                            
- Performance Improvement                                                                                                                                                      

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes  into CHANGELOG.md):
Improved performance of squashing and merging `Dynamic` and `Object` columns with many dynamic variants or JSON paths.

### Documentation entry                                                                                                                                                        
- [x] Documentation is not required because this is an internal performance optimization.