### PR TITLE
Reduce 03251_insert_sparse_all_formats flaky-check timeout

### DIFF
--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-msan, no-azure-blob-storage
+# Tags: no-fasttest, long, no-msan, no-azure-blob-storage, no-random-settings
 # no-azure-blob-storage: too slow
 # no-msan: it is too slow
+# no-random-settings: serial loop over every I/O format on debug sits at the 600s per-test timeout; randomized query settings amplify wall-time ~3x and tip it over
 
 set -e
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104510
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/104510

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03251_insert_sparse_all_formats` is a `long`-tagged serial loop over every registered I/O format (`is_input AND is_output`), doing HTTP insert round-trips per format. On `amd_debug` it sits right at the 600s per-test hard timeout.

Flaky-check evidence on #104510 (sha cd8a62ef, `Stateless tests (amd_debug, flaky check)`, https://s3.amazonaws.com/clickhouse-test-reports/PRs/104510/cd8a62ef11453a15c87b30c946eb87f293372f04/stateless_tests_amd_debug_flaky_check/): the 5 repetitions ran 584s / 569s / 583s / 222s / 600s->FAIL. The FAIL is the clickhouse-test 600s per-test hard kill ("Timeout! Killing process group"), not the 180s flaky-check soft cap (correctly exempted by `long`). All queries in the failing run started and finished (no genuinely hung insert); the format executing when the process group was killed is incidental.

Root cause is environmental time-budget fragility, not a per-format regression: CI's randomized query settings are injected into every HTTP round-trip and amplify the full-loop wall-time ~3x, which is what drives the run-to-run variance that crosses the 600s ceiling.

Fix: add `no-random-settings`, which removes the amplifier while keeping full format coverage. The reference is deterministic (fixed `numbers(1000)` input, sipHash64 sums), so it is unchanged; verified locally that all formats still round-trip to the same reference sums under default settings.
