### PR TITLE
Fix flaky test 02543_alter_rename_modify_stuck

### DIFF
--- a/tests/queries/0_stateless/02543_alter_rename_modify_stuck.sh
+++ b/tests/queries/0_stateless/02543_alter_rename_modify_stuck.sh
@@ -20,10 +20,14 @@ $CLICKHOUSE_CLIENT --query="ALTER TABLE table_to_rename RENAME COLUMN v1 to v2" 
 
 counter=0 retries=60
 
+# Wait via system.columns (in-memory metadata), NOT `SHOW CREATE`. `SHOW CREATE` reads the
+# durable metadata, which `ALTER ... RENAME` commits before it updates the in-memory metadata.
+# The following `ALTER ... UPDATE` validates against in-memory metadata, so syncing on
+# `SHOW CREATE` can fire the UPDATE while in-memory metadata still lacks v2 -> NO_SUCH_COLUMN.
 I=0
 while [[ $counter -lt $retries ]]; do
     I=$((I + 1))
-    result=$($CLICKHOUSE_CLIENT --query "show create table table_to_rename")
+    result=$($CLICKHOUSE_CLIENT --query "SELECT name FROM system.columns WHERE database = currentDatabase() AND table = 'table_to_rename'")
     if [[ $result == *"v2"* ]]; then
         break;
     fi


### PR DESCRIPTION
<!--
No related open issue found.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `02543_alter_rename_modify_stuck` (fails with `Code: 16 ... There is no column \`v2\` in table (NO_SUCH_COLUMN_IN_TABLE)`).

The test backgrounds `ALTER TABLE ... RENAME COLUMN v1 to v2`, waits until `SHOW CREATE` shows `v2`, then runs `ALTER TABLE ... UPDATE v2 = 77`. `SHOW CREATE` reads the durable metadata, which `StorageMergeTree::alter` commits (`Database::alterTable`) BEFORE it updates the in-memory metadata (`setProperties` -> `setInMemoryMetadata`). The `ALTER ... UPDATE` builds its `MutationsInterpreter` against the in-memory metadata (`getInMemoryMetadataPtr`), so if the UPDATE lands between the durable commit and the in-memory update, it does not see `v2` yet and throws `NO_SUCH_COLUMN`. The engine ordering is intentional (deadlock avoidance), so this is a test synchronization bug.

Fix: poll `system.columns` (which reads the in-memory metadata, the same source the mutation validates against) instead of `SHOW CREATE`.

Failure spread: `NO_SUCH_COLUMN v2` seen on `Fast test`, `Stateless tests (amd_debug, s3)`, `Stateless tests (arm_binary)` across multiple unrelated PRs, 0 on master.

Reproduced deterministically with a temporary failpoint sleep inserted between the durable commit and the in-memory metadata update:
- polling `SHOW CREATE` -> UPDATE fails NO_SUCH_COLUMN (3/3);
- polling `system.columns` -> UPDATE OK (3/3).
After the fix: `--test-runs 40` with randomization = 40/40 pass.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.997` (included in `26.7` and later)
<!-- ch-version-info:end -->