### PR TITLE
Avoid per-row `Dynamic` type decoding for simple shared variants

### DIFF
--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -20,6 +20,8 @@
 #include <Common/SipHash.h>
 #include <Common/UnorderedSetWithMemoryTracking.h>
 
+#include <array>
+
 namespace DB
 {
 
@@ -32,6 +34,88 @@ namespace ErrorCodes
 
 namespace
 {
+
+template <typename Container, typename Compare>
+void sortAndKeepTop(Container & container, size_t limit, Compare compare)
+{
+    if (container.size() <= limit)
+    {
+        std::sort(container.begin(), container.end(), compare);
+        return;
+    }
+
+    if (limit == 0)
+    {
+        container.clear();
+        return;
+    }
+
+    auto nth = container.begin() + limit;
+    std::nth_element(container.begin(), nth, container.end(), compare);
+    container.resize(limit);
+    std::sort(container.begin(), container.end(), compare);
+}
+
+const String * tryGetOneByteEncodedTypeName(std::string_view value)
+{
+    if (value.empty())
+        return nullptr;
+
+    static const auto names = []
+    {
+        std::array<String, BINARY_TYPE_INDEX_SIZE> result;
+        result[static_cast<size_t>(BinaryTypeIndex::Nothing)] = "Nothing";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt8)] = "UInt8";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt16)] = "UInt16";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt32)] = "UInt32";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt64)] = "UInt64";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt128)] = "UInt128";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt256)] = "UInt256";
+        result[static_cast<size_t>(BinaryTypeIndex::Int8)] = "Int8";
+        result[static_cast<size_t>(BinaryTypeIndex::Int16)] = "Int16";
+        result[static_cast<size_t>(BinaryTypeIndex::Int32)] = "Int32";
+        result[static_cast<size_t>(BinaryTypeIndex::Int64)] = "Int64";
+        result[static_cast<size_t>(BinaryTypeIndex::Int128)] = "Int128";
+        result[static_cast<size_t>(BinaryTypeIndex::Int256)] = "Int256";
+        result[static_cast<size_t>(BinaryTypeIndex::Float32)] = "Float32";
+        result[static_cast<size_t>(BinaryTypeIndex::Float64)] = "Float64";
+        result[static_cast<size_t>(BinaryTypeIndex::Date)] = "Date";
+        result[static_cast<size_t>(BinaryTypeIndex::Date32)] = "Date32";
+        result[static_cast<size_t>(BinaryTypeIndex::DateTimeUTC)] = "DateTime";
+        result[static_cast<size_t>(BinaryTypeIndex::String)] = "String";
+        result[static_cast<size_t>(BinaryTypeIndex::UUID)] = "UUID";
+        result[static_cast<size_t>(BinaryTypeIndex::IPv4)] = "IPv4";
+        result[static_cast<size_t>(BinaryTypeIndex::IPv6)] = "IPv6";
+        result[static_cast<size_t>(BinaryTypeIndex::Bool)] = "Bool";
+        result[static_cast<size_t>(BinaryTypeIndex::BFloat16)] = "BFloat16";
+        result[static_cast<size_t>(BinaryTypeIndex::Time)] = "Time";
+        return result;
+    }();
+
+    size_t index = static_cast<size_t>(static_cast<UInt8>(value[0]));
+    if (index >= names.size() || names[index].empty())
+        return nullptr;
+
+    return &names[index];
+}
+
+const String & getTypeNameFromSharedVariantValue(
+    std::string_view value,
+    UnorderedMapWithMemoryTracking<std::string_view, String> & decoded_type_names)
+{
+    if (const auto * simple_type_name = tryGetOneByteEncodedTypeName(value))
+        return *simple_type_name;
+
+    auto cache_it = decoded_type_names.find(value);
+    if (cache_it == decoded_type_names.end())
+    {
+        ReadBufferFromMemory buf(value);
+        auto type = decodeDataType(buf);
+        cache_it = decoded_type_names.emplace(value, type->getName()).first;
+    }
+
+    return cache_it->second;
+}
 
 /// Static default format settings to avoid creating it every time.
 const FormatSettings & getFormatSettings()
@@ -1471,13 +1555,12 @@ ColumnDynamic::StatisticsPtr ColumnDynamic::getOrCalculateStatistics() const
     for (const auto & [variant_name, discr] : variant_info.variant_name_to_discriminator)
         calculated_statistics->variants_statistics[variant_name] = variant_column_ptr->getVariantByGlobalDiscriminator(discr).size();
 
+    UnorderedMapWithMemoryTracking<std::string_view, String> decoded_type_names;
     const auto & shared_variant = getSharedVariant();
     for (size_t i = 0; i != shared_variant.size(); ++i)
     {
         auto value = shared_variant.getDataAt(i);
-        ReadBufferFromMemory buf(value);
-        auto type = decodeDataType(buf);
-        auto type_name = type->getName();
+        const auto & type_name = getTypeNameFromSharedVariantValue(value, decoded_type_names);
         if (auto it = calculated_statistics->shared_variants_statistics.find(type_name); it != calculated_statistics->shared_variants_statistics.end())
             ++it->second;
         else if (calculated_statistics->shared_variants_statistics.size() < Statistics::MAX_SHARED_VARIANT_STATISTICS_SIZE)

--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -1,4 +1,5 @@
 #include <Common/SipHash.h>
+#include <Common/UnorderedMapWithMemoryTracking.h>
 #include <DataTypes/Serializations/SerializationDynamic.h>
 #include <DataTypes/Serializations/SerializationVariant.h>
 #include <DataTypes/Serializations/SerializationDynamicHelpers.h>
@@ -14,8 +15,11 @@
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/ReadHelpers.h>
+#include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadBufferFromString.h>
 #include <Formats/EscapingRuleUtils.h>
+
+#include <array>
 
 namespace DB
 {
@@ -24,6 +28,72 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+const String * tryGetOneByteEncodedTypeName(std::string_view value)
+{
+    if (value.empty())
+        return nullptr;
+
+    static const auto names = []
+    {
+        std::array<String, BINARY_TYPE_INDEX_SIZE> result;
+        result[static_cast<size_t>(BinaryTypeIndex::Nothing)] = "Nothing";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt8)] = "UInt8";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt16)] = "UInt16";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt32)] = "UInt32";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt64)] = "UInt64";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt128)] = "UInt128";
+        result[static_cast<size_t>(BinaryTypeIndex::UInt256)] = "UInt256";
+        result[static_cast<size_t>(BinaryTypeIndex::Int8)] = "Int8";
+        result[static_cast<size_t>(BinaryTypeIndex::Int16)] = "Int16";
+        result[static_cast<size_t>(BinaryTypeIndex::Int32)] = "Int32";
+        result[static_cast<size_t>(BinaryTypeIndex::Int64)] = "Int64";
+        result[static_cast<size_t>(BinaryTypeIndex::Int128)] = "Int128";
+        result[static_cast<size_t>(BinaryTypeIndex::Int256)] = "Int256";
+        result[static_cast<size_t>(BinaryTypeIndex::Float32)] = "Float32";
+        result[static_cast<size_t>(BinaryTypeIndex::Float64)] = "Float64";
+        result[static_cast<size_t>(BinaryTypeIndex::Date)] = "Date";
+        result[static_cast<size_t>(BinaryTypeIndex::Date32)] = "Date32";
+        result[static_cast<size_t>(BinaryTypeIndex::DateTimeUTC)] = "DateTime";
+        result[static_cast<size_t>(BinaryTypeIndex::String)] = "String";
+        result[static_cast<size_t>(BinaryTypeIndex::UUID)] = "UUID";
+        result[static_cast<size_t>(BinaryTypeIndex::IPv4)] = "IPv4";
+        result[static_cast<size_t>(BinaryTypeIndex::IPv6)] = "IPv6";
+        result[static_cast<size_t>(BinaryTypeIndex::Bool)] = "Bool";
+        result[static_cast<size_t>(BinaryTypeIndex::BFloat16)] = "BFloat16";
+        result[static_cast<size_t>(BinaryTypeIndex::Time)] = "Time";
+        return result;
+    }();
+
+    size_t index = static_cast<size_t>(static_cast<UInt8>(value[0]));
+    if (index >= names.size() || names[index].empty())
+        return nullptr;
+
+    return &names[index];
+}
+
+const String & getTypeNameFromSharedVariantValue(
+    std::string_view value,
+    UnorderedMapWithMemoryTracking<std::string_view, String> & decoded_type_names)
+{
+    if (const auto * simple_type_name = tryGetOneByteEncodedTypeName(value))
+        return *simple_type_name;
+
+    auto cache_it = decoded_type_names.find(value);
+    if (cache_it == decoded_type_names.end())
+    {
+        ReadBufferFromMemory buf(value);
+        auto type = decodeDataType(buf);
+        cache_it = decoded_type_names.emplace(value, type->getName()).first;
+    }
+
+    return cache_it->second;
+}
+
 }
 
 UInt128 SerializationDynamic::getHash(size_t max_dynamic_types_, const SerializationInfoSettings & serialization_info_settings_)
@@ -559,6 +629,7 @@ void SerializationDynamic::serializeBinaryBulkWithMultipleStreamsAndCountTotalSi
         const auto & shared_variant = column_dynamic.getSharedVariant();
         if (!shared_variant.empty())
         {
+            UnorderedMapWithMemoryTracking<std::string_view, String> decoded_type_names;
             const auto & local_discriminators = variant_column->getLocalDiscriminators();
             const auto & offsets = variant_column->getOffsets();
             const auto shared_variant_discr = variant_column->localDiscriminatorByGlobal(column_dynamic.getSharedVariantDiscriminator());
@@ -568,9 +639,7 @@ void SerializationDynamic::serializeBinaryBulkWithMultipleStreamsAndCountTotalSi
                 if (local_discriminators[i] == shared_variant_discr)
                 {
                     auto value = shared_variant.getDataAt(offsets[i]);
-                    ReadBufferFromMemory buf(value);
-                    auto type = decodeDataType(buf);
-                    auto type_name = type->getName();
+                    const auto & type_name = getTypeNameFromSharedVariantValue(value, decoded_type_names);
                     if (auto it = dynamic_state->statistics.shared_variants_statistics.find(type_name); it != dynamic_state->statistics.shared_variants_statistics.end())
                         ++it->second;
                     else if (dynamic_state->statistics.shared_variants_statistics.size() < ColumnDynamic::Statistics::MAX_SHARED_VARIANT_STATISTICS_SIZE)


### PR DESCRIPTION
Change created by codex as a by-product. Is shared variant in dynamic used reasonably often to warrant this improvement?

----

Optimize `Dynamic` shared-variant statistics calculation by avoiding repeated decoding of simple binary type encodings.

Shared-variant values include a binary-encoded type prefix, and statistics only need the type name. Previously, `ColumnDynamic` and `SerializationDynamic` decoded the type for every shared-variant row. This change adds a fast `BinaryTypeIndex` to type-name lookup for one-byte simple encodings and keeps the existing `decodeDataType` path for       
 complex encodings.

This reduces overhead when many `Dynamic` values are stored in the shared variant. The wire/storage format and user-visible behavior are unchanged.

### Changelog category (leave one):
  - Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes     
 into CHANGELOG.md):
Improve performance of `Dynamic` columns by avoiding repeated decoding of simple shared-variant type encodings while calculating statistics.