### PR TITLE
Fix deprecated syntax in Kafka/FileLog integration docs

### DIFF
--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -169,14 +169,20 @@ It is recommended that each Kafka topic have its own dedicated consumer group, e
 When the `MATERIALIZED VIEW` joins the engine, it starts collecting data in the background. This allows you to continually receive messages from Kafka and convert them to the required format using `SELECT`.
 One kafka table can have as many materialized views as you like, they do not read data from the kafka table directly, but receive new records (in blocks), this way you can write to several tables with different detail level (with grouping - aggregation and without).
 
-Example:
+Example, using [named collections](/operations/named-collections.md) to store the connection parameters:
 
 ```sql
+  CREATE NAMED COLLECTION kafka_creds AS
+    kafka_broker_list = 'localhost:9092',
+    kafka_topic_list = 'topic',
+    kafka_group_name = 'group1',
+    kafka_format = 'JSONEachRow';
+
   CREATE TABLE queue (
     timestamp UInt64,
     level String,
     message String
-  ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
+  ) ENGINE = Kafka(kafka_creds);
 
   CREATE TABLE daily (
     day Date,

--- a/docs/en/engines/table-engines/integrations/kafka.md
+++ b/docs/en/engines/table-engines/integrations/kafka.md
@@ -182,7 +182,9 @@ Example:
     day Date,
     level String,
     total UInt64
-  ) ENGINE = SummingMergeTree(day, (day, level), 8192);
+  ) ENGINE = SummingMergeTree
+  PARTITION BY toYYYYMM(day)
+  ORDER BY (day, level);
 
   CREATE MATERIALIZED VIEW consumer TO daily
     AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() AS total

--- a/docs/en/engines/table-engines/special/filelog.md
+++ b/docs/en/engines/table-engines/special/filelog.md
@@ -76,7 +76,9 @@ Example:
     day Date,
     level String,
     total UInt64
-  ) ENGINE = SummingMergeTree(day, (day, level), 8192);
+  ) ENGINE = SummingMergeTree
+  PARTITION BY toYYYYMM(day)
+  ORDER BY (day, level);
 
   CREATE MATERIALIZED VIEW consumer TO daily
     AS SELECT toDate(toDateTime(timestamp)) AS day, level, count() AS total


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/83825

The `Kafka` and `FileLog` integration docs used the deprecated positional-args `SummingMergeTree(day, (day, level), 8192)` syntax, which now raises `BAD_ARGUMENTS` (`This syntax for *MergeTree engine is deprecated`) instead of creating the table. Replaced with the extended `PARTITION BY` / `ORDER BY` syntax in both docs, and verified the new example creates and works correctly.

Also updated the `Kafka` example to use `CREATE NAMED COLLECTION` instead of positional connection arguments, per a follow-up comment on the issue. Verified end-to-end (`CREATE NAMED COLLECTION`, `CREATE TABLE ... ENGINE = Kafka(collection)`, materialized view into the fixed `SummingMergeTree` table) against a running server.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1149` (included in `26.7` and later)
<!-- ch-version-info:end -->