### PR TITLE
Retry apt index fetches in Docker image builds

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -20,7 +20,7 @@ ARG apt_archive="http://archive.ubuntu.com"
 
 # user/group precreated explicitly with fixed uid/gid on purpose.
 # The same uid/gid (101) is used both for alpine and ubuntu.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+RUN printf 'Acquire::Retries "5";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries \
     && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \

--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -20,7 +20,8 @@ ARG apt_archive="http://archive.ubuntu.com"
 
 # user/group precreated explicitly with fixed uid/gid on purpose.
 # The same uid/gid (101) is used both for alpine and ubuntu.
-RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
     && apt-get update \

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -26,7 +26,8 @@ ARG apt_archive="http://archive.ubuntu.com"
 # We do that in advance at the beginning of Dockerfile before any packages will be
 # installed to prevent picking those uid/gid by some unrelated software.
 # The same uid/gid (101) is used both for alpine and ubuntu.
-RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
     && apt-get update \

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -26,7 +26,7 @@ ARG apt_archive="http://archive.ubuntu.com"
 # We do that in advance at the beginning of Dockerfile before any packages will be
 # installed to prevent picking those uid/gid by some unrelated software.
 # The same uid/gid (101) is used both for alpine and ubuntu.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+RUN printf 'Acquire::Retries "5";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries \
     && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -15,7 +15,7 @@ ARG apt_archive="http://archive.ubuntu.com"
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
-RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+RUN printf 'Acquire::Retries "5";\nAPT::Update::Error-Mode "any";\n' > /etc/apt/apt.conf.d/80-retries \
     && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -15,7 +15,8 @@ ARG apt_archive="http://archive.ubuntu.com"
 # We do that in advance at the begining of Dockerfile before any packages will be
 # installed to prevent picking those uid / gid by some unrelated software.
 # The same uid / gid (101) is used both for alpine and ubuntu.
-RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+    && sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
     && groupadd -r clickhouse --gid=101 \
     && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
     && apt-get update \


### PR DESCRIPTION
<!--
Linked issues and pull requests.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Docker image-build checks (`Docker server image`, `Dockers Build (arm/amd)`, incl. on master) intermittently fail at the `apt-get update && apt-get install` base step in the Ubuntu Dockerfiles:

```
E: Package 'locales' has no installation candidate
E: Unable to locate package tzdata
E: Unable to locate package wget
```

A transient Ubuntu archive-mirror hiccup during `apt-get update` leaves a partial/empty package index, so the following `apt-get install` cannot resolve base packages and the build exits 100. The buildx retry allowlist in `ci/jobs/docker_server.py` matches `Failed to fetch` but not these two messages, and (per #108969) it is intentionally kept narrow so genuine Dockerfile errors are not retried 5x.

Fix at the root: set `Acquire::Retries "5"` in the first `RUN` layer of the three apt-based Ubuntu Dockerfiles so apt retries the HTTP index fetches internally before falling through to "no installation candidate". This retries only the transient fetch and never masks a genuinely missing package name. Same pattern already used in `ci/docker/integration/clickhouse_with_hms_catalog/Dockerfile`.

Files: `docker/server/Dockerfile.ubuntu`, `docker/server/Dockerfile.distroless`, `docker/keeper/Dockerfile.distroless`.

Validated locally: building the hardened base-install layer succeeds and `apt-config dump` confirms `Acquire::Retries "5"` is active for all subsequent `apt-get` calls in the image.
