### PR TITLE
Add note about S3-compatible storage providers

### DIFF
--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -34,7 +34,7 @@ family table engines can store data to `S3`, `AzureBlobStorage`, `HDFS` (unsuppo
 `azure_blob_storage`, `hdfs` (unsupported) respectively.
 
 :::note
-The `s3` disk type can also be used with S3-compatible object storage services, including Alibaba Cloud Object Storage Service (OSS). Configure `endpoint` with the provider's S3-compatible endpoint and account for any provider-specific compatibility requirements.
+The `s3` disk type can also be used with S3-compatible object storage services, such as Alibaba Cloud Object Storage Service (OSS). Configure `endpoint` with the provider's S3-compatible endpoint and account for any provider-specific compatibility requirements.
 :::
 
 Disk configuration requires:

--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -34,7 +34,7 @@ family table engines can store data to `S3`, `AzureBlobStorage`, `HDFS` (unsuppo
 `azure_blob_storage`, `hdfs` (unsupported) respectively.
 
 :::note
-The `s3` disk type can also be used with S3-compatible object storage services, such as Alibaba Cloud Object Storage Service (OSS). Configure `endpoint` with the provider's S3-compatible endpoint and account for any provider-specific compatibility requirements.
+The `s3` disk type can also be used with S3-compatible object storage providers, such as Alibaba Cloud Object Storage Service. Configure `endpoint` with the provider's S3-compatible endpoint and account for any provider-specific compatibility requirements.
 :::
 
 Disk configuration requires:

--- a/docs/en/operations/storing-data.md
+++ b/docs/en/operations/storing-data.md
@@ -33,6 +33,10 @@ storage configuration for the ClickHouse `MergeTree` family or `Log` family tabl
 family table engines can store data to `S3`, `AzureBlobStorage`, `HDFS` (unsupported) using a disk with types `s3`,
 `azure_blob_storage`, `hdfs` (unsupported) respectively.
 
+:::note
+The `s3` disk type can also be used with S3-compatible object storage services, including Alibaba Cloud Object Storage Service (OSS). Configure `endpoint` with the provider's S3-compatible endpoint and account for any provider-specific compatibility requirements.
+:::
+
 Disk configuration requires:
 
 1. A `type` section, equal to one of `s3`, `azure_blob_storage`, `hdfs` (unsupported), `local_blob_storage`, `web`.


### PR DESCRIPTION
Adds a note to the external storage documentation clarifying that the `s3` disk type can be used with S3-compatible object storage services, including Alibaba Cloud Object Storage Service (OSS).

This addresses the documentation gap described in Linear issue DOC-863.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry
- [x] Documentation is written for this change.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.992` (included in `26.7` and later)
<!-- ch-version-info:end -->