### PR TITLE
Make model a required positional argument for aiEmbed

### DIFF
--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -64,7 +64,7 @@ A function resolves the named collection to use from, in order:
    - [`ai_function_text_default_credentials`](/operations/settings/settings#ai_function_text_default_credentials) for the text functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`);
    - [`ai_function_embedding_default_credentials`](/operations/settings/settings#ai_function_embedding_default_credentials) for `aiEmbed`.
 
-If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint and model differ from an embeddings one.
+If neither is set, the call fails. The text and embedding functions use separate default settings because a chat-completions endpoint differs from an embeddings one.
 
 ```sql
 SET ai_function_text_default_credentials = 'ai_text_credentials';

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -47,7 +47,7 @@ CREATE NAMED COLLECTION ai_embedding_credentials AS
 |-----------|------|---------|-------------|
 | `provider` | String | — | Model provider. Supported: `'openai'`, `'anthropic'`. See note below. |
 | `endpoint` | String | — | API endpoint URL. |
-| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`). Used by the text functions; `aiEmbed` ignores it and takes `model` as a required positional argument. |
+| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`). Used by the text functions; `aiEmbed` requires `model` as a positional argument and errors if `model` is specified in the named collection. |
 | `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which allows targeting OpenAI-compatible servers that do not require authentication. |
 | `max_tokens` | UInt64 | `1024` | Maximum number of output tokens per API call. |
 | `api_version` | String | — | API version string. Used by Anthropic (`'2023-06-01'`). |
@@ -79,7 +79,7 @@ SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
 
 ### Parameter map {#parameter-map}
 
-Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, which takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) and never reads it from the parameter map or the named collection.
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, which takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) and errors if it is instead set in the parameter map or named collection.
 
 The following parameters are common to all the AI functions:
 

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -33,10 +33,10 @@ CREATE NAMED COLLECTION ai_text_credentials AS
     model = 'gpt-4o-mini',
     api_key = 'sk-...';
 
+-- `aiEmbed` does not read `model` from the named collection; pass it in the parameter map instead.
 CREATE NAMED COLLECTION ai_embedding_credentials AS
     provider = 'openai',
     endpoint = 'https://api.openai.com/v1/embeddings',
-    model = 'text-embedding-3-small',
     api_key = 'sk-...';
 ```
 
@@ -46,7 +46,7 @@ CREATE NAMED COLLECTION ai_embedding_credentials AS
 |-----------|------|---------|-------------|
 | `provider` | String | — | Model provider. Supported: `'openai'`, `'anthropic'`. See note below. |
 | `endpoint` | String | — | API endpoint URL. |
-| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`, `'text-embedding-3-small'`). |
+| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`). Used by the text functions; `aiEmbed` ignores it and requires `model` in the parameter map. |
 | `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which allows targeting OpenAI-compatible servers that do not require authentication. |
 | `max_tokens` | UInt64 | `1024` | Maximum number of output tokens per API call. |
 | `api_version` | String | — | API version string. Used by Anthropic (`'2023-06-01'`). |
@@ -78,14 +78,14 @@ SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
 
 ### Parameter map {#parameter-map}
 
-Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default.
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, whose `model` must be passed in the parameter map and is never read from the named collection.
 
 The following parameters are common to all the AI functions:
 
 | Key | Description |
 |-----|-------------|
 | `credentials` | Named collection to use (see above). |
-| `model` | Overrides the collection's `model`. |
+| `model` | Overrides the collection's `model` for the text functions. For `aiEmbed` it is required and read only from the parameter map. |
 
 Individual functions accept additional, function-specific parameters (such as `max_tokens`, `temperature`, `system_prompt`, `instructions`, and `dimensions`). See each function's reference below for the parameters it accepts and their defaults.
 

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -34,6 +34,7 @@ CREATE NAMED COLLECTION ai_text_credentials AS
     api_key = 'sk-...';
 
 -- `aiEmbed` does not read `model` from the named collection; pass it as a positional argument instead.
+-- Defining `model` in an `aiEmbed` collection is an error, not silently ignored.
 CREATE NAMED COLLECTION ai_embedding_credentials AS
     provider = 'openai',
     endpoint = 'https://api.openai.com/v1/embeddings',

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -33,7 +33,7 @@ CREATE NAMED COLLECTION ai_text_credentials AS
     model = 'gpt-4o-mini',
     api_key = 'sk-...';
 
--- `aiEmbed` does not read `model` from the named collection; pass it in the parameter map instead.
+-- `aiEmbed` does not read `model` from the named collection; pass it as a positional argument instead.
 CREATE NAMED COLLECTION ai_embedding_credentials AS
     provider = 'openai',
     endpoint = 'https://api.openai.com/v1/embeddings',
@@ -46,7 +46,7 @@ CREATE NAMED COLLECTION ai_embedding_credentials AS
 |-----------|------|---------|-------------|
 | `provider` | String | — | Model provider. Supported: `'openai'`, `'anthropic'`. See note below. |
 | `endpoint` | String | — | API endpoint URL. |
-| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`). Used by the text functions; `aiEmbed` ignores it and requires `model` in the parameter map. |
+| `model` | String | — | Model name (e.g. `'gpt-4o-mini'`). Used by the text functions; `aiEmbed` ignores it and takes `model` as a required positional argument. |
 | `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which allows targeting OpenAI-compatible servers that do not require authentication. |
 | `max_tokens` | UInt64 | `1024` | Maximum number of output tokens per API call. |
 | `api_version` | String | — | API version string. Used by Anthropic (`'2023-06-01'`). |
@@ -78,14 +78,14 @@ SELECT aiGenerate('Bonjour', map('credentials', 'other_credentials'));
 
 ### Parameter map {#parameter-map}
 
-Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, whose `model` must be passed in the parameter map and is never read from the named collection.
+Each function accepts an optional trailing `Map(String, String)` of parameters. All values are strings (quote numbers, e.g. `'0.2'`). Unknown keys are rejected. A key that is present overrides the corresponding named-collection value; a key that is absent falls back to the named collection (for `model`/`max_tokens`) or the built-in default. The exception is `aiEmbed`, which takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) and never reads it from the parameter map or the named collection.
 
 The following parameters are common to all the AI functions:
 
 | Key | Description |
 |-----|-------------|
 | `credentials` | Named collection to use (see above). |
-| `model` | Overrides the collection's `model` for the text functions. For `aiEmbed` it is required and read only from the parameter map. |
+| `model` | Overrides the collection's `model` (text functions only; `aiEmbed` takes `model` as a required positional argument, not a map key). |
 
 Individual functions accept additional, function-specific parameters (such as `max_tokens`, `temperature`, `system_prompt`, `instructions`, and `dimensions`). See each function's reference below for the parameters it accepts and their defaults.
 

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -4315,8 +4315,11 @@ static const std::vector<std::unordered_set<String>> & swapFuncs
         {"naiveBayesClassifier", "detectCharset", "detectLanguage", "detectLanguageUnknown", "detectLanguageMixed", "detectTonality"},
         /// Word-level NLP (language/extension + word)
         {"stem", "lemmatize", "synonyms"},
-        /// AI functions: text + optional params map
-        {"aiEmbed", "aiGenerate"},
+        /// AI text generation: text + optional params map
+        {"aiGenerate"},
+        /// aiEmbed takes (text, model[, params]); its arity matches no other AI function, so it is not
+        /// grouped for name-swapping (a swap would produce arity-mismatched calls).
+        {"aiEmbed"},
         /// AI functions: text + a per-function arg (categories / instruction / target_language) + optional params map
         {"aiClassify", "aiExtract", "aiTranslate"},
         /// Geo distance functions (lon1, lat1, lon2, lat2 → Float64)

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8574,10 +8574,10 @@ If true (default), exceeding an AI function quota limit (`ai_function_max_input_
 Maximum number of texts to include in a single HTTP request made by `aiEmbed`. Texts are grouped into batches of this size to reduce API call overhead. For example, 500 unique texts with a batch size of 100 result in 5 HTTP requests.
 )", EXPERIMENTAL) \
     DECLARE(String, ai_function_text_default_credentials, "", R"(
-Name of the named collection used by the text AI functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. A chat-completions endpoint and model differ from an embeddings one, so this is separate from `ai_function_embedding_default_credentials`.
+Name of the named collection used by the text AI functions (`aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`) when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. A chat-completions endpoint differs from an embeddings one, so this is separate from `ai_function_embedding_default_credentials`.
 )", EXPERIMENTAL) \
     DECLARE(String, ai_function_embedding_default_credentials, "", R"(
-Name of the named collection used by `aiEmbed` when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. Kept separate from `ai_function_text_default_credentials` because an embeddings endpoint and model differ from a chat one.
+Name of the named collection used by `aiEmbed` when the call does not pass `credentials` in its parameter map. Empty means no default: such calls must pass `credentials` explicitly. `aiEmbed` takes `model` as a required positional argument, not from the named collection. Kept separate from `ai_function_text_default_credentials` because an embeddings endpoint differs from a chat one.
 )", EXPERIMENTAL) \
     /* ############ END OF EXPERIMENTAL FEATURES ############# */ \
     /* ####################################################### */ \

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -228,7 +228,12 @@ FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
     {
         bool known = std::any_of(spec.begin(), spec.end(), [&](const AIParamSpec & p) { return p.name == key; });
         if (!known)
+        {
+            if (key == "model")
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "This function does not accept 'model' in the parameter map; pass 'model' to the function directly");
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown AI function parameter '{}'", key);
+        }
     }
 
     /// Resolve credentials first: they name the collection everything else is read from.

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -259,6 +259,14 @@ FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
 
     context->getRemoteHostFilter().checkURL(Poco::URI(params.collection.endpoint));
 
+    /// A function that does not declare `model` (i.e. `aiEmbed`, which takes it as an argument) must
+    /// not silently ignore a `model` defined in the named collection: reject it instead.
+    const bool declares_model = std::any_of(spec.begin(), spec.end(), [](const AIParamSpec & p) { return p.name == "model"; });
+    if (!declares_model && collection->has("model"))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "AI named collection '{}' defines 'model', which this function does not read from the named collection; "
+            "remove it from the collection and pass 'model' to the function directly", credentials);
+
     /// Resolve every declared parameter: map override -> named collection (if inherited) -> default.
     for (const auto & p : spec)
     {

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -271,12 +271,9 @@ FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
             params.values.emplace(String(p.name), readAIParamFromCollection(p.kind, collection, p.name));
         else if (p.default_value)
             params.values.emplace(String(p.name), *p.default_value);
-        else if (p.inherit_from_collection)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "AI named collection '{}' must have '{}', or it must be passed in the parameter map", credentials, p.name);
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "AI function parameter '{}' must be passed in the parameter map", p.name);
+                "AI named collection '{}' must have '{}', or it must be passed in the parameter map", credentials, p.name);
     }
 
     return params;

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -271,9 +271,12 @@ FunctionBaseAI::AIParams FunctionBaseAI::resolveAIParams(
             params.values.emplace(String(p.name), readAIParamFromCollection(p.kind, collection, p.name));
         else if (p.default_value)
             params.values.emplace(String(p.name), *p.default_value);
-        else
+        else if (p.inherit_from_collection)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "AI named collection '{}' must have '{}', or it must be passed in the parameter map", credentials, p.name);
+        else
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "AI function parameter '{}' must be passed in the parameter map", p.name);
     }
 
     return params;

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -62,13 +62,6 @@ namespace ErrorCodes
 namespace
 {
 
-/// Type validator for the `model` argument: a plain (non-nullable) `String`. Constness is enforced
-/// separately by the column validator.
-bool isPlainString(const IDataType & type)
-{
-    return isString(type);
-}
-
 class FunctionAiEmbed final : public IFunction
 {
 public:
@@ -106,7 +99,8 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args{
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
-            {"model", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isPlainString), &isColumnConst, "const String"},
+            /// `model` must be a plain (non-nullable) `String`; constness is enforced by the column validator.
+            {"model", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), &isColumnConst, "const String"},
         };
         FunctionArgumentDescriptors optional_args{
             {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
@@ -134,7 +128,6 @@ public:
             getContext(), arguments, embeddingParams(), settings[Setting::ai_function_embedding_default_credentials]);
 
         UInt64 dimensions = params.getUInt("dimensions");
-        /// `model` is a required positional argument (validated as a const String by getReturnTypeImpl).
         String model(arguments[model_arg_index].column->getDataAt(0));
 
         auto provider = createAIProvider(
@@ -323,7 +316,8 @@ separate default-credentials setting from the text functions, since an embedding
 from a chat one.
 
 The `model` is a required positional argument (a constant `String`). Unlike the text functions,
-`aiEmbed` does not read `model` from the named collection or the parameter map.
+`aiEmbed` does not read `model` from the named collection or the parameter map. A named collection
+that defines `model` is rejected rather than silently ignored.
 
 The optional `dimensions` parameter, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -62,6 +62,13 @@ namespace ErrorCodes
 namespace
 {
 
+/// Type validator for the `model` argument: a plain (non-nullable) `String`. Constness is enforced
+/// separately by the column validator.
+bool isPlainString(const IDataType & type)
+{
+    return isString(type);
+}
+
 class FunctionAiEmbed final : public IFunction
 {
 public:
@@ -99,10 +106,8 @@ public:
     {
         FunctionArgumentDescriptors mandatory_args{
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
+            {"model", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isPlainString), &isColumnConst, "const String"},
         };
-        /// The map is functionally required (it must carry `model`), but it stays optional at the arity
-        /// level so a missing map yields the specific "model must be passed" / missing-credentials error
-        /// from `resolveAIParams` rather than a generic arity mismatch.
         FunctionArgumentDescriptors optional_args{
             {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
@@ -111,14 +116,13 @@ public:
         return std::make_shared<DataTypeArray>(std::make_shared<DataTypeFloat32>());
     }
 
-    /// Parameters accepted in the trailing `Map(String, String)` argument. `aiEmbed` does not inherit
-    /// `FunctionBaseAI`, so it declares its own spec (no `max_tokens`, which embeddings do not use).
+    /// Parameters accepted in the optional trailing `Map(String, String)` argument. `aiEmbed` does not
+    /// inherit `FunctionBaseAI`, so it declares its own spec (no `max_tokens`, which embeddings do not
+    /// use; no `model`, which is a required positional argument for `aiEmbed`).
     static AIParamSpecs embeddingParams()
     {
         return {
             {"credentials", AIParamKind::String, std::nullopt},
-            /// `model` is required and must be passed in the parameter map; it is not read from the named collection.
-            {"model", AIParamKind::String, std::nullopt},
             {"dimensions", AIParamKind::UInt, Field(UInt64(0))},
         };
     }
@@ -130,7 +134,8 @@ public:
             getContext(), arguments, embeddingParams(), settings[Setting::ai_function_embedding_default_credentials]);
 
         UInt64 dimensions = params.getUInt("dimensions");
-        String model = params.getString("model");
+        /// `model` is a required positional argument (validated as a const String by getReturnTypeImpl).
+        String model(arguments[model_arg_index].column->getDataAt(0));
 
         auto provider = createAIProvider(
             params.collection.provider, params.collection.endpoint, params.collection.api_key, params.collection.api_version);
@@ -292,6 +297,7 @@ public:
 
 private:
     static constexpr size_t text_arg_index = 0;
+    static constexpr size_t model_arg_index = 1;
 
     ContextPtr context;
     ContextPtr getContext() const { return context; }
@@ -316,21 +322,22 @@ are taken from the `credentials` key of the parameter map, or from the
 separate default-credentials setting from the text functions, since an embeddings endpoint differs
 from a chat one.
 
-The `model` parameter is required and must be passed in the parameter map. Unlike the text functions,
-`aiEmbed` does not read `model` from the named collection.
+The `model` is a required positional argument (a constant `String`). Unlike the text functions,
+`aiEmbed` does not read `model` from the named collection or the parameter map.
 
 The optional `dimensions` parameter, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.
 )",
-        .syntax = "aiEmbed(text, params)",
+        .syntax = "aiEmbed(text, model[, params])",
         .arguments
         = {{"text", "Text to embed.", {"String"}},
-           {"params", "Constant `Map(String, String)` of parameters. Required key: `model` (embedding model name). Function-specific optional key: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameter `credentials` also applies (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
+           {"model", "Embedding model name.", {"const String"}},
+           {"params", "Optional constant `Map(String, String)` of parameters. Function-specific key: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameter `credentials` also applies (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
-        = {{"Embed a single string (`credentials` can be omitted if the `ai_function_embedding_default_credentials` setting is set)", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small'))", ""},
-           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small', 'dimensions', '256'))", ""},
-           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
+        = {{"Embed a single string (`credentials` can be omitted if the `ai_function_embedding_default_credentials` setting is set)", "SELECT aiEmbed('Hello world', 'text-embedding-3-small', map('credentials', 'ai_embedding_credentials'))", ""},
+           {"With explicit dimensions", "SELECT aiEmbed('Hello world', 'text-embedding-3-small', map('credentials', 'ai_embedding_credentials', 'dimensions', '256'))", ""},
+           {"Embed a column of texts", "SELECT aiEmbed(title, 'text-embedding-3-small', map('credentials', 'ai_embedding_credentials', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
         .introduced_in = {26, 6},
         .category = FunctionDocumentation::Category::AI});
 }

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -100,6 +100,9 @@ public:
         FunctionArgumentDescriptors mandatory_args{
             {"text", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringOrNullableString), nullptr, "String or Nullable(String)"},
         };
+        /// The map is functionally required (it must carry `model`), but it stays optional at the arity
+        /// level so a missing map yields the specific "model must be passed" / missing-credentials error
+        /// from `resolveAIParams` rather than a generic arity mismatch.
         FunctionArgumentDescriptors optional_args{
             {"params", static_cast<FunctionArgumentDescriptor::TypeValidator>(&FunctionBaseAI::isStringToStringMap), &isColumnConst, "const Map(String, String)"},
         };
@@ -114,7 +117,8 @@ public:
     {
         return {
             {"credentials", AIParamKind::String, std::nullopt},
-            {"model", AIParamKind::String, std::nullopt, /*inherit_from_collection=*/ true},
+            /// `model` is required and must be passed in the parameter map; it is not read from the named collection.
+            {"model", AIParamKind::String, std::nullopt},
             {"dimensions", AIParamKind::UInt, Field(UInt64(0))},
         };
     }
@@ -306,24 +310,27 @@ Within a single block of rows, inputs are grouped into batches of up to
 [`ai_function_embedding_max_batch_size`](/operations/settings/settings#ai_function_embedding_max_batch_size)
 entries per HTTP request to reduce per-call overhead.
 
-Credentials (a named collection specifying the provider, model, endpoint, and optionally an API key)
-are taken from the `credentials` key of the optional parameter map, or from the
+Credentials (a named collection specifying the provider, endpoint, and optionally an API key)
+are taken from the `credentials` key of the parameter map, or from the
 `ai_function_embedding_default_credentials` setting when the map omits it. Note that `aiEmbed` uses a
-separate default-credentials setting from the text functions, since an embeddings endpoint and model
-differ from a chat one.
+separate default-credentials setting from the text functions, since an embeddings endpoint differs
+from a chat one.
+
+The `model` parameter is required and must be passed in the parameter map. Unlike the text functions,
+`aiEmbed` does not read `model` from the named collection.
 
 The optional `dimensions` parameter, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.
 )",
-        .syntax = "aiEmbed(text[, params])",
+        .syntax = "aiEmbed(text, params)",
         .arguments
         = {{"text", "Text to embed.", {"String"}},
-           {"params", "Optional constant `Map(String, String)` of parameters. Function-specific keys: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameters `credentials` and `model` also apply (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
+           {"params", "Constant `Map(String, String)` of parameters. Required key: `model` (embedding model name). Function-specific optional key: `dimensions` (target dimensionality of the output vector; `0` or omitted means the model's native size). The common parameter `credentials` also applies (see [AI Functions](/sql-reference/functions/ai-functions)).", {"Map(String, String)"}}},
         .returned_value = {"The embedding vector, or an empty array if the input is NULL or empty, the request failed and `ai_function_throw_on_error` is disabled, or a quota was exceeded with `ai_function_throw_on_quota_exceeded` disabled.", {"Array(Float32)"}},
         .examples
-        = {{"Embed a single string (map parameter can be omitted if the `ai_function_embedding_default_credentials` setting is set)", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials'))", ""},
-           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'dimensions', '256'))", ""},
-           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embedding_credentials', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
+        = {{"Embed a single string (`credentials` can be omitted if the `ai_function_embedding_default_credentials` setting is set)", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small'))", ""},
+           {"With explicit dimensions", "SELECT aiEmbed('Hello world', map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small', 'dimensions', '256'))", ""},
+           {"Embed a column of texts", "SELECT aiEmbed(title, map('credentials', 'ai_embedding_credentials', 'model', 'text-embedding-3-small', 'dimensions', '256')) FROM articles LIMIT 10", ""}},
         .introduced_in = {26, 6},
         .category = FunctionDocumentation::Category::AI});
 }

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -121,28 +121,24 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
             f"CREATE NAMED COLLECTION ai_embed AS "
             f"provider = 'openai', "
             f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings', "
-            f"model = 'test-embed-model', "
             f"api_key = 'test-key'"
         )
         instance.query(
             f"CREATE NAMED COLLECTION ai_embed_error AS "
             f"provider = 'openai', "
             f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_error', "
-            f"model = 'test-embed-model', "
             f"api_key = 'test-key'"
         )
         instance.query(
             f"CREATE NAMED COLLECTION ai_embed_dup_index AS "
             f"provider = 'openai', "
             f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_dup_index', "
-            f"model = 'test-embed-model', "
             f"api_key = 'test-key'"
         )
         instance.query(
             f"CREATE NAMED COLLECTION ai_embed_wrong_count AS "
             f"provider = 'openai', "
             f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_wrong_count', "
-            f"model = 'test-embed-model', "
             f"api_key = 'test-key'"
         )
         # Endpoints that drop the connection for the first N requests (armed via /set-flaky),
@@ -158,7 +154,6 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
             f"CREATE NAMED COLLECTION ai_embed_flaky AS "
             f"provider = 'openai', "
             f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_flaky', "
-            f"model = 'test-embed-model', "
             f"api_key = 'test-key'"
         )
 
@@ -568,6 +563,18 @@ def test_embed_basic(started_cluster):
     vec = parse_embedding(result)
     assert len(vec) == 4  # DEFAULT_EMBED_DIM in mock server
     assert any(v != 0.0 for v in vec)
+
+
+def test_embed_rejects_model_in_named_collection(started_cluster):
+    """aiEmbed takes `model` as a positional argument and never reads it from the named collection.
+    A collection that defines `model` (e.g. the text collection `ai_mock`) is rejected rather than
+    silently ignored."""
+    error = instance.query_and_get_error(
+        "SELECT aiEmbed('hello', 'test-embed-model', map('credentials', 'ai_mock'))",
+        settings=AI_SETTINGS,
+    )
+    assert "BAD_ARGUMENTS" in error
+    assert "defines 'model'" in error
 
 
 def test_embed_uses_embedding_default_credentials(started_cluster):

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -295,10 +295,10 @@ def test_generate_model_override_with_default_credentials(started_cluster):
 
 
 def test_embed_model_override_with_default_credentials(started_cluster):
-    """Same for aiEmbed: the required `map('model', ...)` sets the embedding model on the request, with
-    the collection selected via `ai_function_embedding_default_credentials`."""
+    """Same for aiEmbed: the required positional `model` argument sets the embedding model on the
+    request, with the collection selected via `ai_function_embedding_default_credentials`."""
     instance.query(
-        "SELECT aiEmbed('hi', map('model', 'override-embed-model'))",
+        "SELECT aiEmbed('hi', 'override-embed-model')",
         settings={**AI_SETTINGS, "ai_function_embedding_default_credentials": "ai_embed"},
     )
     assert json.loads(last_request()["body"])["model"] == "override-embed-model"
@@ -562,7 +562,7 @@ def parse_embedding(s):
 def test_embed_basic(started_cluster):
     """Single-row aiEmbed returns an `Array(Float32)` of the model's native size."""
     result = instance.query(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed', 'model', 'test-embed-model'))",
+        "SELECT aiEmbed('hello', 'test-embed-model', map('credentials', 'ai_embed'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -575,7 +575,7 @@ def test_embed_uses_embedding_default_credentials(started_cluster):
     (non-empty) request must actually use `ai_function_embedding_default_credentials`. Confirms the
     embedding default is applied on the request path, not only for the zero-row fast path."""
     result = instance.query(
-        "SELECT aiEmbed('hello', map('model', 'test-embed-model'))",
+        "SELECT aiEmbed('hello', 'test-embed-model')",
         settings={**AI_SETTINGS, "ai_function_embedding_default_credentials": "ai_embed"},
     )
     vec = parse_embedding(result)
@@ -588,7 +588,7 @@ def test_embed_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('alpha'), ('beta'), ('gamma')")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input ORDER BY x",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     rows = [parse_embedding(line) for line in result.strip().split("\n")]
@@ -601,7 +601,7 @@ def test_embed_multiple_rows(started_cluster):
 def test_embed_with_dimensions(started_cluster):
     """The `dimensions` argument is forwarded to the provider and honored in the response."""
     result = instance.query(
-        "SELECT aiEmbed('hello world', map('credentials', 'ai_embed', 'model', 'test-embed-model', 'dimensions', '16'))",
+        "SELECT aiEmbed('hello world', 'test-embed-model', map('credentials', 'ai_embed', 'dimensions', '16'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -616,7 +616,7 @@ def test_embed_null_and_empty_input(started_cluster):
     )
     qid = unique_query_id("embed_null_empty")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input_nullable ORDER BY x NULLS FIRST",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input_nullable ORDER BY x NULLS FIRST",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -642,7 +642,7 @@ def test_embed_profile_events_token_accounting(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('abc'), ('de'), ('fghi')")
     qid = unique_query_id("embed_tokens")
     instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -662,7 +662,7 @@ def test_embed_batching(started_cluster):
     )
     qid = unique_query_id("embed_batch")
     instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input",
         settings={**AI_SETTINGS, "ai_function_embedding_max_batch_size": 2},
         query_id=qid,
     )
@@ -676,7 +676,7 @@ def test_embed_batching(started_cluster):
 def test_embed_error_throw(started_cluster):
     """By default, provider errors propagate as `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER`."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_error', 'model', 'test-embed-model'))",
+        "SELECT aiEmbed('hello', 'test-embed-model', map('credentials', 'ai_embed_error'))",
         settings=AI_SETTINGS,
     )
     assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
@@ -687,7 +687,7 @@ def test_embed_error_graceful(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_error', 'model', 'test-embed-model')) FROM test_input",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed_error')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_throw_on_error": 0,
@@ -701,7 +701,7 @@ def test_embed_error_graceful(started_cluster):
 def test_embed_duplicate_index_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses with duplicate `index` values."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_dup_index', 'model', 'test-embed-model')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed_dup_index')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -711,7 +711,7 @@ def test_embed_duplicate_index_rejected(started_cluster):
 def test_embed_wrong_count_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses whose `data` size != number of inputs."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_wrong_count', 'model', 'test-embed-model')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed_wrong_count')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -722,7 +722,7 @@ def test_embed_empty_input_table(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     qid = unique_query_id("embed_zero_rows")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -742,7 +742,7 @@ def test_embed_quota_input_tokens_exceeded(started_cluster):
     # Each batch costs `sum(len(text))` input tokens. With batch_size=1 and rows
     # of length 5 ("row_0".."row_3"), the second batch pushes us over a 5-token cap.
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
+        "SELECT aiEmbed(x, 'test-embed-model', map('credentials', 'ai_embed')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_embedding_max_batch_size": 1,
@@ -817,7 +817,7 @@ def test_embed_retries_on_network_error(started_cluster):
     set_flaky(2)
     qid = unique_query_id("embed_retry_net")
     result = instance.query(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_flaky', 'model', 'test-embed-model'))",
+        "SELECT aiEmbed('hello', 'test-embed-model', map('credentials', 'ai_embed_flaky'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -930,7 +930,7 @@ def test_embed_retry_respects_api_call_quota(started_cluster):
     retried past `ai_function_max_api_calls_per_query`."""
     qid = unique_query_id("embed_quota_caps_retries")
     result = instance.query(
-        "SELECT aiEmbed('server error', map('credentials', 'ai_embed_error', 'model', 'test-embed-model'))",
+        "SELECT aiEmbed('server error', 'test-embed-model', map('credentials', 'ai_embed_error'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -295,8 +295,8 @@ def test_generate_model_override_with_default_credentials(started_cluster):
 
 
 def test_embed_model_override_with_default_credentials(started_cluster):
-    """Same for aiEmbed: `map('model', ...)` overrides the embedding model on the request, with the
-    collection selected via `ai_function_embedding_default_credentials`."""
+    """Same for aiEmbed: the required `map('model', ...)` sets the embedding model on the request, with
+    the collection selected via `ai_function_embedding_default_credentials`."""
     instance.query(
         "SELECT aiEmbed('hi', map('model', 'override-embed-model'))",
         settings={**AI_SETTINGS, "ai_function_embedding_default_credentials": "ai_embed"},
@@ -562,7 +562,7 @@ def parse_embedding(s):
 def test_embed_basic(started_cluster):
     """Single-row aiEmbed returns an `Array(Float32)` of the model's native size."""
     result = instance.query(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed'))",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed', 'model', 'test-embed-model'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -575,7 +575,7 @@ def test_embed_uses_embedding_default_credentials(started_cluster):
     (non-empty) request must actually use `ai_function_embedding_default_credentials`. Confirms the
     embedding default is applied on the request path, not only for the zero-row fast path."""
     result = instance.query(
-        "SELECT aiEmbed('hello')",
+        "SELECT aiEmbed('hello', map('model', 'test-embed-model'))",
         settings={**AI_SETTINGS, "ai_function_embedding_default_credentials": "ai_embed"},
     )
     vec = parse_embedding(result)
@@ -588,7 +588,7 @@ def test_embed_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('alpha'), ('beta'), ('gamma')")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input ORDER BY x",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     rows = [parse_embedding(line) for line in result.strip().split("\n")]
@@ -601,7 +601,7 @@ def test_embed_multiple_rows(started_cluster):
 def test_embed_with_dimensions(started_cluster):
     """The `dimensions` argument is forwarded to the provider and honored in the response."""
     result = instance.query(
-        "SELECT aiEmbed('hello world', map('credentials', 'ai_embed', 'dimensions', '16'))",
+        "SELECT aiEmbed('hello world', map('credentials', 'ai_embed', 'model', 'test-embed-model', 'dimensions', '16'))",
         settings=AI_SETTINGS,
     )
     vec = parse_embedding(result)
@@ -616,7 +616,7 @@ def test_embed_null_and_empty_input(started_cluster):
     )
     qid = unique_query_id("embed_null_empty")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input_nullable ORDER BY x NULLS FIRST",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input_nullable ORDER BY x NULLS FIRST",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -642,7 +642,7 @@ def test_embed_profile_events_token_accounting(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('abc'), ('de'), ('fghi')")
     qid = unique_query_id("embed_tokens")
     instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -662,7 +662,7 @@ def test_embed_batching(started_cluster):
     )
     qid = unique_query_id("embed_batch")
     instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
         settings={**AI_SETTINGS, "ai_function_embedding_max_batch_size": 2},
         query_id=qid,
     )
@@ -676,7 +676,7 @@ def test_embed_batching(started_cluster):
 def test_embed_error_throw(started_cluster):
     """By default, provider errors propagate as `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER`."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_error'))",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_error', 'model', 'test-embed-model'))",
         settings=AI_SETTINGS,
     )
     assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
@@ -687,7 +687,7 @@ def test_embed_error_graceful(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_error')) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_error', 'model', 'test-embed-model')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_throw_on_error": 0,
@@ -701,7 +701,7 @@ def test_embed_error_graceful(started_cluster):
 def test_embed_duplicate_index_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses with duplicate `index` values."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_dup_index')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_dup_index', 'model', 'test-embed-model')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -711,7 +711,7 @@ def test_embed_duplicate_index_rejected(started_cluster):
 def test_embed_wrong_count_rejected(started_cluster):
     """`OpenAIProvider::embed` rejects responses whose `data` size != number of inputs."""
     error = instance.query_and_get_error(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed_wrong_count')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed_wrong_count', 'model', 'test-embed-model')) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
     assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
@@ -722,7 +722,7 @@ def test_embed_empty_input_table(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     qid = unique_query_id("embed_zero_rows")
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -742,7 +742,7 @@ def test_embed_quota_input_tokens_exceeded(started_cluster):
     # Each batch costs `sum(len(text))` input tokens. With batch_size=1 and rows
     # of length 5 ("row_0".."row_3"), the second batch pushes us over a 5-token cap.
     result = instance.query(
-        "SELECT aiEmbed(x, map('credentials', 'ai_embed')) FROM test_input",
+        "SELECT aiEmbed(x, map('credentials', 'ai_embed', 'model', 'test-embed-model')) FROM test_input",
         settings={
             **AI_SETTINGS,
             "ai_function_embedding_max_batch_size": 1,
@@ -817,7 +817,7 @@ def test_embed_retries_on_network_error(started_cluster):
     set_flaky(2)
     qid = unique_query_id("embed_retry_net")
     result = instance.query(
-        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_flaky'))",
+        "SELECT aiEmbed('hello', map('credentials', 'ai_embed_flaky', 'model', 'test-embed-model'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,
@@ -930,7 +930,7 @@ def test_embed_retry_respects_api_call_quota(started_cluster):
     retried past `ai_function_max_api_calls_per_query`."""
     qid = unique_query_id("embed_quota_caps_retries")
     result = instance.query(
-        "SELECT aiEmbed('server error', map('credentials', 'ai_embed_error'))",
+        "SELECT aiEmbed('server error', map('credentials', 'ai_embed_error', 'model', 'test-embed-model'))",
         settings={
             **AI_SETTINGS,
             "ai_function_max_retries": 5,

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -100,6 +100,9 @@ aiEmbed
 -- aiEmbed: too many arguments
 -- aiEmbed: non-constant parameter map
 -- aiEmbed: wrong type for parameter argument (not a map)
+-- aiEmbed: model is required in the parameter map
+-- aiEmbed: model supplied via the parameter map resolves
+0
 -- aiEmbed: return type
 result	Array(Float32)
 -- aiEmbed: return type with dimensions

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -104,6 +104,7 @@ aiEmbed
 -- aiEmbed: non-constant model argument
 -- aiEmbed: model is a required positional argument
 -- aiEmbed: model in the parameter map is rejected
+-- aiEmbed: model in the named collection is rejected
 -- aiEmbed: model supplied as a positional argument resolves
 0
 -- aiEmbed: return type

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -100,8 +100,11 @@ aiEmbed
 -- aiEmbed: too many arguments
 -- aiEmbed: non-constant parameter map
 -- aiEmbed: wrong type for parameter argument (not a map)
--- aiEmbed: model is required in the parameter map
--- aiEmbed: model supplied via the parameter map resolves
+-- aiEmbed: wrong type for model argument (not a string)
+-- aiEmbed: non-constant model argument
+-- aiEmbed: model is a required positional argument
+-- aiEmbed: model in the parameter map is rejected
+-- aiEmbed: model supplied as a positional argument resolves
 0
 -- aiEmbed: return type
 result	Array(Float32)

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -137,8 +137,15 @@ CREATE NAMED COLLECTION ai_credentials AS
     model = 'test-model',
     api_key = 'fake-key';
 
+-- aiEmbed takes `model` as a positional argument, so its named collection must not define `model`.
+DROP NAMED COLLECTION IF EXISTS ai_embed_credentials;
+CREATE NAMED COLLECTION ai_embed_credentials AS
+    provider = 'openai',
+    endpoint = 'http://localhost:1/v1/embeddings',
+    api_key = 'fake-key';
+
 SET ai_function_text_default_credentials = 'ai_credentials';
-SET ai_function_embedding_default_credentials = 'ai_credentials';
+SET ai_function_embedding_default_credentials = 'ai_embed_credentials';
 
 -- =============================================================================
 -- 7. Return type verification
@@ -191,9 +198,18 @@ SELECT aiGenerate('hi', map('credentials', 'ai_bad_provider')); -- { serverError
 
 SELECT '-- Unknown provider name on empty input';
 SELECT aiGenerate(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
-SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+
+-- aiEmbed needs a `model`-free collection so the unknown-provider error (not the collection-model
+-- check) is what rejects the call.
+DROP NAMED COLLECTION IF EXISTS ai_bad_provider_embed;
+CREATE NAMED COLLECTION ai_bad_provider_embed AS
+    provider = 'unknown_provider',
+    endpoint = 'http://localhost:1/v1/embeddings',
+    api_key = 'fake-key';
+SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_bad_provider_embed')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_bad_provider;
+DROP NAMED COLLECTION ai_bad_provider_embed;
 
 -- =============================================================================
 -- 11. Provider name: anthropic
@@ -209,11 +225,19 @@ CREATE NAMED COLLECTION ai_anthropic AS
 SELECT '-- Anthropic provider resolves';
 SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_anthropic')) AS result FROM tab);
 
+-- aiEmbed needs a `model`-free collection (it takes `model` as a positional argument).
+DROP NAMED COLLECTION IF EXISTS ai_anthropic_embed;
+CREATE NAMED COLLECTION ai_anthropic_embed AS
+    provider = 'anthropic',
+    endpoint = 'http://localhost:1/v1/messages',
+    api_key = 'fake-key';
+
 SELECT '-- aiEmbed rejects anthropic provider';
-SELECT aiEmbed('hi', 'claude-test', map('credentials', 'ai_anthropic')); -- { serverError NOT_IMPLEMENTED }
-SELECT aiEmbed(x, 'claude-test', map('credentials', 'ai_anthropic')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed('hi', 'claude-test', map('credentials', 'ai_anthropic_embed')); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed(x, 'claude-test', map('credentials', 'ai_anthropic_embed')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
 
 DROP NAMED COLLECTION ai_anthropic;
+DROP NAMED COLLECTION ai_anthropic_embed;
 
 -- =============================================================================
 -- 12. Parameter map: keys and validation
@@ -438,10 +462,15 @@ SELECT aiEmbed('hi'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 -- `model` in the parameter map is rejected: it is not a known map key for aiEmbed.
 SELECT '-- aiEmbed: model in the parameter map is rejected';
-SELECT aiEmbed('hi', 'test-model', map('credentials', 'ai_credentials', 'model', 'other-model')); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed('hi', 'test-model', map('credentials', 'ai_embed_credentials', 'model', 'other-model')); -- { serverError BAD_ARGUMENTS }
+
+-- `model` defined in the named collection is rejected rather than silently ignored: aiEmbed never
+-- reads `model` from the collection (ai_credentials defines `model`).
+SELECT '-- aiEmbed: model in the named collection is rejected';
+SELECT aiEmbed('hi', 'test-model', map('credentials', 'ai_credentials')); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiEmbed: model supplied as a positional argument resolves';
-SELECT count() FROM (SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_credentials')) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_embed_credentials')) AS result FROM tab);
 
 SELECT '-- aiEmbed: return type';
 DROP TABLE IF EXISTS _03300_ret_embed;
@@ -585,3 +614,4 @@ SET ai_function_text_default_credentials = '';
 SET ai_function_embedding_default_credentials = '';
 DROP TABLE IF EXISTS tab;
 DROP NAMED COLLECTION ai_credentials;
+DROP NAMED COLLECTION ai_embed_credentials;

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -191,7 +191,7 @@ SELECT aiGenerate('hi', map('credentials', 'ai_bad_provider')); -- { serverError
 
 SELECT '-- Unknown provider name on empty input';
 SELECT aiGenerate(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
-SELECT aiEmbed(x, map('credentials', 'ai_bad_provider', 'model', 'test-model')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_bad_provider;
 
@@ -210,8 +210,8 @@ SELECT '-- Anthropic provider resolves';
 SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_anthropic')) AS result FROM tab);
 
 SELECT '-- aiEmbed rejects anthropic provider';
-SELECT aiEmbed('hi', map('credentials', 'ai_anthropic', 'model', 'claude-test')); -- { serverError NOT_IMPLEMENTED }
-SELECT aiEmbed(x, map('credentials', 'ai_anthropic', 'model', 'claude-test')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed('hi', 'claude-test', map('credentials', 'ai_anthropic')); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed(x, 'claude-test', map('credentials', 'ai_anthropic')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
 
 DROP NAMED COLLECTION ai_anthropic;
 
@@ -417,26 +417,36 @@ SELECT '-- aiEmbed: too few arguments';
 SELECT aiEmbed(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiEmbed: too many arguments';
-SELECT aiEmbed('x', map('dimensions', '256'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT aiEmbed('x', 'test-model', map('dimensions', '256'), 'extra'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 SELECT '-- aiEmbed: non-constant parameter map';
-SELECT aiEmbed(x, map('dimensions', toString(number))) FROM (SELECT x, 0 AS number FROM tab); -- { serverError ILLEGAL_COLUMN }
+SELECT aiEmbed(x, 'test-model', map('dimensions', toString(number))) FROM (SELECT x, 0 AS number FROM tab); -- { serverError ILLEGAL_COLUMN }
 
 SELECT '-- aiEmbed: wrong type for parameter argument (not a map)';
+SELECT aiEmbed(x, 'test-model', 256) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+SELECT '-- aiEmbed: wrong type for model argument (not a string)';
 SELECT aiEmbed(x, 256) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
--- Unlike the text functions, aiEmbed requires `model` in the parameter map and never reads it
--- from the named collection (ai_credentials has a `model`, but it is ignored here).
-SELECT '-- aiEmbed: model is required in the parameter map';
-SELECT aiEmbed('hi', map('credentials', 'ai_credentials')); -- { serverError BAD_ARGUMENTS }
+SELECT '-- aiEmbed: non-constant model argument';
+SELECT aiEmbed(x, x) FROM tab; -- { serverError ILLEGAL_COLUMN }
 
-SELECT '-- aiEmbed: model supplied via the parameter map resolves';
-SELECT count() FROM (SELECT aiEmbed(x, map('credentials', 'ai_credentials', 'model', 'test-model')) AS result FROM tab);
+-- `model` is a required positional argument for aiEmbed (unlike the text functions, which read it
+-- from the parameter map or the named collection).
+SELECT '-- aiEmbed: model is a required positional argument';
+SELECT aiEmbed('hi'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+-- `model` in the parameter map is rejected: it is not a known map key for aiEmbed.
+SELECT '-- aiEmbed: model in the parameter map is rejected';
+SELECT aiEmbed('hi', 'test-model', map('credentials', 'ai_credentials', 'model', 'other-model')); -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- aiEmbed: model supplied as a positional argument resolves';
+SELECT count() FROM (SELECT aiEmbed(x, 'test-model', map('credentials', 'ai_credentials')) AS result FROM tab);
 
 SELECT '-- aiEmbed: return type';
 DROP TABLE IF EXISTS _03300_ret_embed;
 CREATE TABLE _03300_ret_embed ENGINE = Memory AS
-    SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM tab;
+    SELECT aiEmbed(x, 'test-model') AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed';
 DROP TABLE IF EXISTS _03300_ret_embed;
@@ -444,24 +454,24 @@ DROP TABLE IF EXISTS _03300_ret_embed;
 SELECT '-- aiEmbed: return type with dimensions';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 CREATE TABLE _03300_ret_embed_dim ENGINE = Memory AS
-    SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '256')) AS result FROM tab;
+    SELECT aiEmbed(x, 'test-model', map('dimensions', '256')) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed_dim';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 
 SELECT '-- aiEmbed: empty input executes';
-SELECT count() FROM (SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, 'test-model') AS result FROM tab);
 
 SELECT '-- aiEmbed: empty input with dimensions';
-SELECT count() FROM (SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '128')) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, 'test-model', map('dimensions', '128')) AS result FROM tab);
 
 -- `dimensions` is a row-independent constant, so an out-of-range value must fail
 -- the query even when the source has zero rows.
 SELECT '-- aiEmbed: out-of-range dimensions on empty input';
-SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '18446744073709551615')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, 'test-model', map('dimensions', '18446744073709551615')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiEmbed: nonexistent named collection';
-SELECT aiEmbed('hello', map('credentials', 'nonexistent_collection_xyz')); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
+SELECT aiEmbed('hello', 'test-model', map('credentials', 'nonexistent_collection_xyz')); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
 
 SELECT '-- aiEmbed: batch size setting default';
 SELECT default FROM system.settings WHERE name = 'ai_function_embedding_max_batch_size';
@@ -475,7 +485,7 @@ DROP TABLE IF EXISTS _03300_embed_null_out;
 CREATE TABLE _03300_embed_null_in (x Nullable(String)) ENGINE = Memory;
 INSERT INTO _03300_embed_null_in VALUES (NULL);
 CREATE TABLE _03300_embed_null_out ENGINE = Memory AS
-    SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM _03300_embed_null_in;
+    SELECT aiEmbed(x, 'test-model') AS result FROM _03300_embed_null_in;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_embed_null_out';
 
@@ -500,7 +510,7 @@ CREATE TABLE _03300_embed_default
 (
     id UInt32,
     doc String,
-    vector Array(Float32) DEFAULT aiEmbed(doc, map('model', 'test-model'))
+    vector Array(Float32) DEFAULT aiEmbed(doc, 'test-model')
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_embed_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(vector) FROM _03300_embed_default;

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -191,7 +191,7 @@ SELECT aiGenerate('hi', map('credentials', 'ai_bad_provider')); -- { serverError
 
 SELECT '-- Unknown provider name on empty input';
 SELECT aiGenerate(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
-SELECT aiEmbed(x, map('credentials', 'ai_bad_provider')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, map('credentials', 'ai_bad_provider', 'model', 'test-model')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_bad_provider;
 
@@ -210,8 +210,8 @@ SELECT '-- Anthropic provider resolves';
 SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_anthropic')) AS result FROM tab);
 
 SELECT '-- aiEmbed rejects anthropic provider';
-SELECT aiEmbed('hi', map('credentials', 'ai_anthropic')); -- { serverError NOT_IMPLEMENTED }
-SELECT aiEmbed(x, map('credentials', 'ai_anthropic')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed('hi', map('credentials', 'ai_anthropic', 'model', 'claude-test')); -- { serverError NOT_IMPLEMENTED }
+SELECT aiEmbed(x, map('credentials', 'ai_anthropic', 'model', 'claude-test')) FROM (SELECT '' AS x WHERE 0); -- { serverError NOT_IMPLEMENTED }
 
 DROP NAMED COLLECTION ai_anthropic;
 
@@ -425,10 +425,18 @@ SELECT aiEmbed(x, map('dimensions', toString(number))) FROM (SELECT x, 0 AS numb
 SELECT '-- aiEmbed: wrong type for parameter argument (not a map)';
 SELECT aiEmbed(x, 256) FROM tab; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
+-- Unlike the text functions, aiEmbed requires `model` in the parameter map and never reads it
+-- from the named collection (ai_credentials has a `model`, but it is ignored here).
+SELECT '-- aiEmbed: model is required in the parameter map';
+SELECT aiEmbed('hi', map('credentials', 'ai_credentials')); -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- aiEmbed: model supplied via the parameter map resolves';
+SELECT count() FROM (SELECT aiEmbed(x, map('credentials', 'ai_credentials', 'model', 'test-model')) AS result FROM tab);
+
 SELECT '-- aiEmbed: return type';
 DROP TABLE IF EXISTS _03300_ret_embed;
 CREATE TABLE _03300_ret_embed ENGINE = Memory AS
-    SELECT aiEmbed(x) AS result FROM tab;
+    SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed';
 DROP TABLE IF EXISTS _03300_ret_embed;
@@ -436,21 +444,21 @@ DROP TABLE IF EXISTS _03300_ret_embed;
 SELECT '-- aiEmbed: return type with dimensions';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 CREATE TABLE _03300_ret_embed_dim ENGINE = Memory AS
-    SELECT aiEmbed(x, map('dimensions', '256')) AS result FROM tab;
+    SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '256')) AS result FROM tab;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_ret_embed_dim';
 DROP TABLE IF EXISTS _03300_ret_embed_dim;
 
 SELECT '-- aiEmbed: empty input executes';
-SELECT count() FROM (SELECT aiEmbed(x) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM tab);
 
 SELECT '-- aiEmbed: empty input with dimensions';
-SELECT count() FROM (SELECT aiEmbed(x, map('dimensions', '128')) AS result FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '128')) AS result FROM tab);
 
 -- `dimensions` is a row-independent constant, so an out-of-range value must fail
 -- the query even when the source has zero rows.
 SELECT '-- aiEmbed: out-of-range dimensions on empty input';
-SELECT aiEmbed(x, map('dimensions', '18446744073709551615')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed(x, map('model', 'test-model', 'dimensions', '18446744073709551615')) FROM (SELECT '' AS x WHERE 0); -- { serverError BAD_ARGUMENTS }
 
 SELECT '-- aiEmbed: nonexistent named collection';
 SELECT aiEmbed('hello', map('credentials', 'nonexistent_collection_xyz')); -- { serverError NAMED_COLLECTION_DOESNT_EXIST }
@@ -467,7 +475,7 @@ DROP TABLE IF EXISTS _03300_embed_null_out;
 CREATE TABLE _03300_embed_null_in (x Nullable(String)) ENGINE = Memory;
 INSERT INTO _03300_embed_null_in VALUES (NULL);
 CREATE TABLE _03300_embed_null_out ENGINE = Memory AS
-    SELECT aiEmbed(x) AS result FROM _03300_embed_null_in;
+    SELECT aiEmbed(x, map('model', 'test-model')) AS result FROM _03300_embed_null_in;
 SELECT name, type FROM system.columns
     WHERE database = currentDatabase() AND table = '_03300_embed_null_out';
 
@@ -492,7 +500,7 @@ CREATE TABLE _03300_embed_default
 (
     id UInt32,
     doc String,
-    vector Array(Float32) DEFAULT aiEmbed(doc)
+    vector Array(Float32) DEFAULT aiEmbed(doc, map('model', 'test-model'))
 ) ENGINE = MergeTree ORDER BY id;
 INSERT INTO _03300_embed_default (id, doc) VALUES (1, 'hello world');
 SELECT id, length(vector) FROM _03300_embed_default;

--- a/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
+++ b/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
@@ -34,11 +34,11 @@ function check_access_both()
         SET allow_experimental_ai_functions = 1;
         SELECT aiGenerate('hi', map('credentials', '$collection_name')) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('hi', map('credentials', '$collection_name')) FORMAT Null;
+        SELECT aiEmbed('hi', map('credentials', '$collection_name', 'model', 'test-model')) FORMAT Null;
         SELECT 'SEP';
         SELECT aiGenerate(x, map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed(x, map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiEmbed(x, map('credentials', '$collection_name', 'model', 'test-model')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
     " 2>&1 | awk '
         /ACCESS_DENIED/ { denied = 1; next }
         /^SEP$/ { print (denied ? "ACCESS_DENIED" : "OK"); denied = 0; next }
@@ -58,11 +58,11 @@ function check_access_both_default()
         SET ai_function_embedding_default_credentials = '$collection_name';
         SELECT aiGenerate('hi') FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('hi') FORMAT Null;
+        SELECT aiEmbed('hi', map('model', 'test-model')) FORMAT Null;
         SELECT 'SEP';
         SELECT aiGenerate(x) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed(x) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiEmbed(x, map('model', 'test-model')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
     " 2>&1 | awk '
         /ACCESS_DENIED/ { denied = 1; next }
         /^SEP$/ { print (denied ? "ACCESS_DENIED" : "OK"); denied = 0; next }

--- a/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
+++ b/tests/queries/0_stateless/04142_ai_functions_named_collection_access.sh
@@ -34,11 +34,11 @@ function check_access_both()
         SET allow_experimental_ai_functions = 1;
         SELECT aiGenerate('hi', map('credentials', '$collection_name')) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('hi', map('credentials', '$collection_name', 'model', 'test-model')) FORMAT Null;
+        SELECT aiEmbed('hi', 'test-model', map('credentials', '$collection_name')) FORMAT Null;
         SELECT 'SEP';
         SELECT aiGenerate(x, map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed(x, map('credentials', '$collection_name', 'model', 'test-model')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiEmbed(x, 'test-model', map('credentials', '$collection_name')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
     " 2>&1 | awk '
         /ACCESS_DENIED/ { denied = 1; next }
         /^SEP$/ { print (denied ? "ACCESS_DENIED" : "OK"); denied = 0; next }
@@ -58,11 +58,11 @@ function check_access_both_default()
         SET ai_function_embedding_default_credentials = '$collection_name';
         SELECT aiGenerate('hi') FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed('hi', map('model', 'test-model')) FORMAT Null;
+        SELECT aiEmbed('hi', 'test-model') FORMAT Null;
         SELECT 'SEP';
         SELECT aiGenerate(x) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
         SELECT 'SEP';
-        SELECT aiEmbed(x, map('model', 'test-model')) FROM (SELECT '' AS x WHERE 0) FORMAT Null;
+        SELECT aiEmbed(x, 'test-model') FROM (SELECT '' AS x WHERE 0) FORMAT Null;
     " 2>&1 | awk '
         /ACCESS_DENIED/ { denied = 1; next }
         /^SEP$/ { print (denied ? "ACCESS_DENIED" : "OK"); denied = 0; next }

--- a/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
+++ b/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
@@ -35,7 +35,7 @@ SET ai_function_embedding_default_credentials = '';
 SELECT '-- No defaults: text function fails';
 SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }
 SELECT '-- No defaults: aiEmbed fails';
-SELECT aiEmbed('hi'); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed('hi', 'embed-model'); -- { serverError BAD_ARGUMENTS }
 
 -- Set only the text default. aiGenerate resolves; aiEmbed still has no default.
 SET ai_function_text_default_credentials = 'ai_text_nc';
@@ -44,15 +44,15 @@ SELECT '-- Text default set: aiGenerate resolves via default';
 SELECT count() FROM (SELECT aiGenerate(x) AS r FROM tab);
 
 SELECT '-- Text default does not leak into aiEmbed';
-SELECT aiEmbed('hi'); -- { serverError BAD_ARGUMENTS }
+SELECT aiEmbed('hi', 'embed-model'); -- { serverError BAD_ARGUMENTS }
 
 -- Set only the embedding default (clear the text one). aiEmbed resolves; text fails.
 SET ai_function_text_default_credentials = '';
 SET ai_function_embedding_default_credentials = 'ai_embed_nc';
 
--- aiEmbed requires `model` in the parameter map; credentials still come from the default setting.
+-- aiEmbed requires `model` as a positional argument; credentials still come from the default setting.
 SELECT '-- Embedding default set: aiEmbed resolves via default';
-SELECT count() FROM (SELECT aiEmbed(x, map('model', 'embed-model')) AS r FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, 'embed-model') AS r FROM tab);
 
 SELECT '-- Embedding default does not leak into text functions';
 SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
+++ b/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
@@ -50,8 +50,9 @@ SELECT aiEmbed('hi'); -- { serverError BAD_ARGUMENTS }
 SET ai_function_text_default_credentials = '';
 SET ai_function_embedding_default_credentials = 'ai_embed_nc';
 
+-- aiEmbed requires `model` in the parameter map; credentials still come from the default setting.
 SELECT '-- Embedding default set: aiEmbed resolves via default';
-SELECT count() FROM (SELECT aiEmbed(x) AS r FROM tab);
+SELECT count() FROM (SELECT aiEmbed(x, map('model', 'embed-model')) AS r FROM tab);
 
 SELECT '-- Embedding default does not leak into text functions';
 SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
+++ b/tests/queries/0_stateless/04492_ai_functions_default_credentials.sql
@@ -6,7 +6,7 @@
 -- Default-credentials resolution for AI functions.
 -- The text functions (aiGenerate/aiClassify/aiExtract/aiTranslate) and aiEmbed
 -- use separate default-credentials settings, because a chat-completions endpoint
--- and model differ from an embeddings one. A per-call `credentials` map key
+-- differs from an embeddings one. A per-call `credentials` map key
 -- overrides the default. All tests run without a real AI provider.
 -- =============================================================================
 
@@ -22,10 +22,10 @@ CREATE NAMED COLLECTION ai_text_nc AS
     endpoint = 'http://localhost:1/v1/chat/completions',
     model = 'chat-model',
     api_key = 'fake-key';
+-- aiEmbed takes `model` as a positional argument, so its collection must not define `model`.
 CREATE NAMED COLLECTION ai_embed_nc AS
     provider = 'openai',
     endpoint = 'http://localhost:1/v1/embeddings',
-    model = 'embed-model',
     api_key = 'fake-key';
 
 -- Start with no defaults set: bare calls must fail with a clear error.
@@ -61,10 +61,11 @@ SELECT aiGenerate('hi'); -- { serverError BAD_ARGUMENTS }
 SELECT '-- Map credentials override with no text default';
 SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_text_nc')) AS r FROM tab);
 
--- Map credentials override wins over a set default.
+-- Map credentials override wins over a set default. `ai_embed_nc` has no `model`, so aiGenerate
+-- passes it in the map.
 SET ai_function_text_default_credentials = 'ai_text_nc';
 SELECT '-- Map credentials override wins over default';
-SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_embed_nc')) AS r FROM tab);
+SELECT count() FROM (SELECT aiGenerate(x, map('credentials', 'ai_embed_nc', 'model', 'embed-model')) AS r FROM tab);
 
 -- =============================================================================
 -- Cleanup


### PR DESCRIPTION
`aiEmbed` now takes `model` as a required positional argument: `aiEmbed(text, model[, params])`. The model is read only from that argument — not from the parameter map, and not from the named collection (unlike the text functions, which still read `model` from the map or the collection).

Example:
```sql
-- Fails — model argument omitted:
SELECT aiEmbed('Hello world');
-- Received exception:
-- Code: 42. DB::Exception: An incorrect number of arguments was specified
-- for function 'aiEmbed'. (NUMBER_OF_ARGUMENTS_DOESNT_MATCH)

-- Works — model as the second positional argument:
SELECT aiEmbed('Hello world', 'text-embedding-3-small', map('credentials', 'ai_embedding_credentials'));

-- credentials can be omitted when the ai_function_embedding_default_credentials setting is set:
SELECT aiEmbed('Hello world', 'text-embedding-3-small');
```

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Experimental Feature



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `aiEmbed` function now takes `model` as a required positional argument (`aiEmbed(text, model[, params])`) instead of reading it from the named collection. This ensures reproducibility for embeddings.
