### PR TITLE
Account for Map subcolumn on-disk size in prewhere optimization

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -865,7 +865,8 @@ InterpreterSelectQuery::InterpreterSelectQuery(
             && !query.hasJoin()) /// Join may produce rows with nulls or default values, it's difficult to analyze if they affected or not.
         {
             /// PREWHERE optimization: transfer some condition from WHERE to PREWHERE if enabled and viable
-            if (const auto & column_sizes = storage->getColumnSizes(); !column_sizes.empty())
+            Names queried_columns = syntax_analyzer_result->requiredSourceColumns();
+            if (const auto & column_sizes = storage->getColumnSizes(queried_columns); !column_sizes.empty())
             {
                 /// Extract column compressed sizes.
                 std::unordered_map<std::string, UInt64> column_compressed_sizes;
@@ -875,8 +876,6 @@ InterpreterSelectQuery::InterpreterSelectQuery(
                 SelectQueryInfo current_info;
                 current_info.query = query_ptr;
                 current_info.syntax_analyzer_result = syntax_analyzer_result;
-
-                Names queried_columns = syntax_analyzer_result->requiredSourceColumns();
                 const auto & supported_prewhere_columns = storage->supportedPrewhereColumns();
 
                 RangesInDataParts parts_for_estimator;

--- a/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizePrewhere.cpp
@@ -175,7 +175,9 @@ void optimizePrewhere(QueryPlan::Node & parent_node, const bool remove_unused_co
     if (!optimize)
         return;
 
-    auto column_sizes = storage.getColumnSizes();
+    const auto & queried_columns = source_step_with_filter->requiredSourceColumns();
+
+    auto column_sizes = storage.getColumnSizes(queried_columns);
     if (column_sizes.empty())
         return;
 
@@ -191,8 +193,6 @@ void optimizePrewhere(QueryPlan::Node & parent_node, const bool remove_unused_co
     std::unordered_map<std::string, UInt64> column_compressed_sizes;
     for (const auto & [name, sizes] : column_sizes)
         column_compressed_sizes[name] = sizes.data_compressed;
-
-    const auto & queried_columns = source_step_with_filter->requiredSourceColumns();
 
     /// Statistics are only used to reorder conditions, so skip if there is just one.
     const auto & filter_root_node = filter_step->getExpression().findInOutputs(filter_step->getFilterColumnName());

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -196,6 +196,10 @@ public:
     using ColumnSizeByName = std::unordered_map<std::string, ColumnSize>;
     virtual ColumnSizeByName getColumnSizes() const { return {}; }
 
+    /// Same as parameterless overload but also includes sizes for requested subcolumns
+    /// The default implementation falls back to the parameterless version.
+    virtual ColumnSizeByName getColumnSizes(const Names & /*columns*/) const { return getColumnSizes(); }
+
     /// Same as getColumnSizes() but may return nullopt in some specific engines like Merge/Alias
     virtual std::optional<ColumnSizeByName> tryGetColumnSizes() const { return getColumnSizes(); }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -6954,6 +6954,41 @@ void MergeTreeData::addPartContributionToColumnAndSecondaryIndexSizesUnlocked(co
     primary_index_size.add(part->getIndexSizeFromFile());
 }
 
+IStorage::ColumnSizeByName MergeTreeData::getColumnSizes(const Names & columns) const
+{
+    auto result = getColumnSizes();
+
+    /// Collect subcolumn names that are not already in the result.
+    Names subcolumn_names;
+    for (const auto & col_name : columns)
+    {
+        if (result.contains(col_name))
+            continue;
+
+        subcolumn_names.push_back(col_name);
+    }
+
+    if (subcolumn_names.empty())
+        return result;
+
+    /// For each requested column that is a subcolumn and not already in the result,
+    /// aggregate its size across all active parts using getSubcolumnSize.
+    /// This gives the correct on-disk size for subcolumns based on required substreams.
+    auto parts_lock = readLockParts();
+    auto committed_parts_range = getDataPartsStateRange(DataPartState::Active);
+    for (const auto & part : committed_parts_range)
+    {
+        for (const auto & col_name : subcolumn_names)
+        {
+            auto column = part->tryGetColumn(col_name);
+            if (column && column->isSubcolumn())
+                result[col_name].add(part->getSubcolumnSize(col_name));
+        }
+    }
+
+    return result;
+}
+
 void MergeTreeData::removePartContributionToColumnAndSecondaryIndexSizes(const DataPartPtr & part) const
 {
     /// If sizes are calculated lazily, don't remove part contribution. All sizes from all active parts will be calculated later.

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1139,6 +1139,8 @@ public:
         return column_sizes;
     }
 
+    ColumnSizeByName getColumnSizes(const Names & columns) const override;
+
     IndexSizeByName getSecondaryIndexSizes() const override
     {
         /// Always keep locks order parts_lock -> sizes_lock

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -267,6 +267,7 @@ public:
     }
 
     ColumnSizeByName getColumnSizes() const override { auto target = tryGetTargetTable(); return target ? target->getColumnSizes() : ColumnSizeByName{}; }
+    ColumnSizeByName getColumnSizes(const Names & columns) const override { auto target = tryGetTargetTable(); return target ? target->getColumnSizes(columns) : ColumnSizeByName{}; }
     std::optional<ColumnSizeByName> tryGetColumnSizes() const override
     {
         auto target = tryGetTargetTable();

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1802,6 +1802,19 @@ IStorage::ColumnSizeByName StorageMerge::getColumnSizes() const
     return column_sizes;
 }
 
+IStorage::ColumnSizeByName StorageMerge::getColumnSizes(const Names & columns) const
+{
+    ColumnSizeByName column_sizes;
+
+    forEachTable([&](const auto & table)
+    {
+        for (const auto & [name, size] : table->getColumnSizes(columns))
+            column_sizes[name].add(size);
+    });
+
+    return column_sizes;
+}
+
 std::optional<IStorage::ColumnSizeByName> StorageMerge::tryGetColumnSizes() const
 {
     try

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -150,6 +150,7 @@ private:
         const IStorage * ignore_self);
 
     ColumnSizeByName getColumnSizes() const override;
+    ColumnSizeByName getColumnSizes(const Names & columns) const override;
 
     std::optional<ColumnSizeByName> tryGetColumnSizes() const override;
 

--- a/src/Storages/StorageProxy.h
+++ b/src/Storages/StorageProxy.h
@@ -36,6 +36,7 @@ public:
     bool supportsColumnsWithDynamicStructure() const override { return getNested()->supportsColumnsWithDynamicStructure(); }
 
     ColumnSizeByName getColumnSizes() const override { return getNested()->getColumnSizes(); }
+    ColumnSizeByName getColumnSizes(const Names & columns) const override { return getNested()->getColumnSizes(columns); }
 
     StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & base_metadata, ContextPtr query_context) const override
     {

--- a/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.reference
+++ b/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.reference
@@ -1,0 +1,5 @@
+-- cheap modality filter is placed before the Map-key predicate
+1
+-- correctness: result is the same regardless of ordering
+0
+0

--- a/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.reference
+++ b/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.reference
@@ -3,3 +3,5 @@
 -- correctness: result is the same regardless of ordering
 0
 0
+-- legacy InterpreterSelectQuery path: cheap filter first
+1

--- a/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.sql
+++ b/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.sql
@@ -35,4 +35,15 @@ SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope';
 SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope'
 SETTINGS allow_reorder_prewhere_conditions = 0;
 
+-- Same check through the legacy InterpreterSelectQuery PREWHERE path
+-- (disable both the analyzer and the plan-based PREWHERE optimizer).
+SET enable_analyzer = 0;
+SET query_plan_optimize_prewhere = 0;
+
+SELECT '-- legacy InterpreterSelectQuery path: cheap filter first';
+SELECT position(explain, 'modality') > 0 AND position(explain, 'modality') < position(explain, 'arrayElement') AS cheap_first
+FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope'
+) WHERE explain LIKE '%Prewhere filter column%';
+
 DROP TABLE t_prewhere_map_cost;

--- a/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.sql
+++ b/tests/queries/0_stateless/04513_prewhere_map_subcolumn_read_cost.sql
@@ -1,0 +1,38 @@
+-- Regression test: the PREWHERE optimizer must account for Map-key subcolumn read cost.
+-- When `optimize_functions_to_subcolumns` rewrites `h['k']` to the `h.key_k` subcolumn,
+-- the optimizer must see its actual on-disk size (the whole Map) via getSubcolumnSize
+-- and place the cheap `modality` filter before the expensive Map-key predicate.
+--
+-- We disable statistics so that only columns_size drives the ordering,
+-- and use equality conditions on both sides so that both are "good" conditions
+-- (isConditionGood only returns true for equals).
+
+SET enable_analyzer = 1;
+SET optimize_functions_to_subcolumns = 1;
+SET optimize_move_to_prewhere = 1;
+SET query_plan_optimize_prewhere = 1;
+SET allow_reorder_prewhere_conditions = 1;
+SET use_statistics = 0;
+SET explain_query_plan_default = 'legacy';
+
+DROP TABLE IF EXISTS t_prewhere_map_cost;
+CREATE TABLE t_prewhere_map_cost (id UInt64, modality LowCardinality(String), h Map(String, String))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+
+INSERT INTO t_prewhere_map_cost
+SELECT number, if(number < 1000, 'active', ''), map('k', repeat('v', 300), 'k2', repeat('w', 300))
+FROM numbers(200000);
+OPTIMIZE TABLE t_prewhere_map_cost FINAL;
+
+SELECT '-- cheap modality filter is placed before the Map-key predicate';
+SELECT position(explain, 'modality') > 0 AND position(explain, 'modality') < position(explain, 'h.key_k') AS cheap_first
+FROM (
+    EXPLAIN actions = 1 SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope'
+) WHERE explain LIKE '%Prewhere filter column%';
+
+SELECT '-- correctness: result is the same regardless of ordering';
+SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope';
+SELECT count() FROM t_prewhere_map_cost WHERE modality = '' AND h['k'] = 'nope'
+SETTINGS allow_reorder_prewhere_conditions = 0;
+
+DROP TABLE t_prewhere_map_cost;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Account for Map subcolumn on-disk size in prewhere optimization. This fixes the regression in PREWHERE introduced in https://github.com/ClickHouse/ClickHouse/pull/99200. Part of https://github.com/ClickHouse/ClickHouse/issues/110462.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1072` (included in `26.7` and later)
- Backported to: `26.6.2.82`, `26.5.6.55`
<!-- ch-version-info:end -->