### PR TITLE
Parse UUID hex in a single validate-and-convert pass

### DIFF
--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -72,10 +72,15 @@ static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
     const auto * src_ptr = src.data();
     const auto size = src.size();
 
+    /// Decode into a local UUID and copy into `uuid` only after validation passes. parseHexChecked
+    /// writes the destination as it converts, so decoding straight into `uuid` would clobber the
+    /// caller's value on an invalid input; tryParseUUID / tryReadUUIDText must leave it unchanged.
+    UUID tmp;
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    const std::reverse_iterator<UInt8 *> dst(reinterpret_cast<UInt8 *>(&uuid) + sizeof(UUID));
+    const std::reverse_iterator<UInt8 *> dst(reinterpret_cast<UInt8 *>(&tmp) + sizeof(UUID));
 #else
-    auto * dst = reinterpret_cast<UInt8 *>(&uuid);
+    auto * dst = reinterpret_cast<UInt8 *>(&tmp);
 #endif
     if (size == 36)
     {
@@ -121,6 +126,7 @@ static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
             return ReturnType(false);
     }
 
+    uuid = tmp;
     return ReturnType(true);
 }
 

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -46,22 +46,22 @@ namespace ErrorCodes
     extern const int SYNTAX_ERROR;
 }
 
+/// Converts num_bytes hex-encoded bytes from src to dst in a single pass, folding validity into
+/// `error`: every hex digit is looked up once, and any invalid digit (which unhex maps to 0xff)
+/// raises the high nibble of `error`. Valid nibbles are 0..15, so `error & 0xF0` is nonzero iff
+/// some digit was invalid. This fuses validation and conversion, avoiding a separate scan.
 template <size_t num_bytes, typename IteratorSrc, typename IteratorDst>
-inline void parseHex(IteratorSrc src, IteratorDst dst)
+inline void parseHexChecked(IteratorSrc src, IteratorDst dst, UInt8 & error)
 {
     size_t src_pos = 0;
     size_t dst_pos = 0;
     for (; dst_pos < num_bytes; ++dst_pos, src_pos += 2)
-        dst[dst_pos] = unhex2(reinterpret_cast<const char *>(&src[src_pos]));
-}
-
-/// Returns true if all bytes in [begin, end) are valid hexadecimal digits (0-9, a-f, A-F).
-static inline bool areHexChars(const UInt8 * begin, const UInt8 * end)
-{
-    for (const UInt8 * p = begin; p != end; ++p)
-        if (unhex(static_cast<char>(*p)) == 0xff)
-            return false;
-    return true;
+    {
+        const UInt8 hi = unhex(static_cast<char>(src[src_pos]));
+        const UInt8 lo = unhex(static_cast<char>(src[src_pos + 1]));
+        error |= hi | lo;
+        dst[dst_pos] = static_cast<UInt8>(hi * 16 + lo);
+    }
 }
 
 template <typename ReturnType>
@@ -79,13 +79,16 @@ static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
 #endif
     if (size == 36)
     {
-        /// Validate 8-4-4-4-12 layout: dashes at positions 8, 13, 18, 23 and hex digits in the rest.
-        if (src_ptr[8] != '-' || src_ptr[13] != '-' || src_ptr[18] != '-' || src_ptr[23] != '-'
-            || !areHexChars(src_ptr, src_ptr + 8)
-            || !areHexChars(src_ptr + 9, src_ptr + 13)
-            || !areHexChars(src_ptr + 14, src_ptr + 18)
-            || !areHexChars(src_ptr + 19, src_ptr + 23)
-            || !areHexChars(src_ptr + 24, src_ptr + 36))
+        /// Validate the 8-4-4-4-12 layout while converting: dashes at positions 8, 13, 18, 23 and hex
+        /// digits everywhere else. Conversion and hex validation happen in one pass (see parseHexChecked).
+        UInt8 error = 0;
+        parseHexChecked<4>(src_ptr, dst + 8, error);
+        parseHexChecked<2>(src_ptr + 9, dst + 12, error);
+        parseHexChecked<2>(src_ptr + 14, dst + 14, error);
+        parseHexChecked<2>(src_ptr + 19, dst, error);
+        parseHexChecked<6>(src_ptr + 24, dst + 2, error);
+        const bool bad_dashes = src_ptr[8] != '-' || src_ptr[13] != '-' || src_ptr[18] != '-' || src_ptr[23] != '-';
+        if (bad_dashes || (error & 0xF0))
         {
             if constexpr (throw_exception)
                 throw Exception(
@@ -94,15 +97,13 @@ static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
             else
                 return ReturnType(false);
         }
-        parseHex<4>(src_ptr, dst + 8);
-        parseHex<2>(src_ptr + 9, dst + 12);
-        parseHex<2>(src_ptr + 14, dst + 14);
-        parseHex<2>(src_ptr + 19, dst);
-        parseHex<6>(src_ptr + 24, dst + 2);
     }
     else if (size == 32)
     {
-        if (!areHexChars(src_ptr, src_ptr + 32))
+        UInt8 error = 0;
+        parseHexChecked<8>(src_ptr, dst + 8, error);
+        parseHexChecked<8>(src_ptr + 16, dst, error);
+        if (error & 0xF0)
         {
             if constexpr (throw_exception)
                 throw Exception(
@@ -111,8 +112,6 @@ static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
             else
                 return ReturnType(false);
         }
-        parseHex<8>(src_ptr, dst + 8);
-        parseHex<8>(src_ptr + 16, dst);
     }
     else
     {

--- a/src/IO/tests/gtest_parse_uuid.cpp
+++ b/src/IO/tests/gtest_parse_uuid.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+
+#include <IO/ReadHelpers.h>
+#include <base/UUID.h>
+
+#include <span>
+#include <string_view>
+
+using namespace DB;
+
+namespace
+{
+
+std::span<const UInt8> asSpan(std::string_view s)
+{
+    return {reinterpret_cast<const UInt8 *>(s.data()), s.size()};
+}
+
+}
+
+TEST(ParseUUID, Valid36)
+{
+    UUID uuid;
+    ASSERT_TRUE(tryParseUUID(asSpan("550e8400-e29b-41d4-a716-446655440000"), uuid));
+    EXPECT_EQ(uuid, parseUUID(asSpan("550e8400-e29b-41d4-a716-446655440000")));
+}
+
+TEST(ParseUUID, Valid32)
+{
+    UUID uuid;
+    ASSERT_TRUE(tryParseUUID(asSpan("550e8400e29b41d4a716446655440000"), uuid));
+    EXPECT_EQ(uuid, parseUUID(asSpan("550e8400-e29b-41d4-a716-446655440000")));
+}
+
+/// tryParseUUID / tryReadUUIDText must leave the output object untouched when parsing fails, so
+/// callers that keep a sentinel/default in the output slot are not corrupted by a rejected input.
+TEST(ParseUUID, OutputUnchangedOnFailure)
+{
+    const UUID sentinel = parseUUID(asSpan("11111111-1111-1111-1111-111111111111"));
+
+    /// Invalid hex digit in a 36-char string (correct dashes, bad content).
+    {
+        UUID uuid = sentinel;
+        ASSERT_FALSE(tryParseUUID(asSpan("zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"), uuid));
+        EXPECT_EQ(uuid, sentinel);
+    }
+
+    /// Invalid hex digit only in the trailing group of a 36-char string (prefix groups are valid).
+    {
+        UUID uuid = sentinel;
+        ASSERT_FALSE(tryParseUUID(asSpan("550e8400-e29b-41d4-a716-4466554400zz"), uuid));
+        EXPECT_EQ(uuid, sentinel);
+    }
+
+    /// Correct hex but wrong dash positions in a 36-char string.
+    {
+        UUID uuid = sentinel;
+        ASSERT_FALSE(tryParseUUID(asSpan("550e8400e-29b-41d4-a716-44665544000"), uuid));
+        EXPECT_EQ(uuid, sentinel);
+    }
+
+    /// Invalid hex digit in a 32-char string.
+    {
+        UUID uuid = sentinel;
+        ASSERT_FALSE(tryParseUUID(asSpan("550e8400e29b41d4a71644665544zzzz"), uuid));
+        EXPECT_EQ(uuid, sentinel);
+    }
+
+    /// Unexpected length.
+    {
+        UUID uuid = sentinel;
+        ASSERT_FALSE(tryParseUUID(asSpan("550e8400"), uuid));
+        EXPECT_EQ(uuid, sentinel);
+    }
+}


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/107609
-->

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up parsing of `UUID` values from text (e.g. `JSONExtract` into `LowCardinality(UUID)`, `toUUID`, `CAST AS UUID`) by validating and converting hex digits in a single pass instead of two.

### Description

Related: #107609 (ARM `low_cardinality_from_json` query 6 regression).

`parseUUID` (added in #104370 to reject non-hex input) validated every hex digit in a separate `areHexChars` scan and then re-scanned the same bytes to convert them via `unhex2`. That is two `unhex`/table lookups per byte on the hot JSON UUID parsing path, which showed up as a ~12% ARM regression on `low_cardinality_from_json` query 6 (Neoverse-V2).

This fuses the two passes: `parseHexChecked` converts each nibble once and OR-accumulates the lookups into an `error` byte. An invalid hex digit maps to `0xff` via the existing `unhex` table, so `error & 0xF0` is nonzero iff any digit was invalid. The 36-char dash-position check is unchanged. Rejection behavior is byte-for-byte identical to before (invalid hex still throws / returns the documented fallback), so #104370's intent is preserved; the regression test `04211_uuid_parser_strict_validation_86714` still passes unchanged.

The reporter's independent controlled ARM benchmark for exactly this one-pass approach measured about -9% recovery on the affected query with the string-tuple control staying neutral.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1027` (included in `26.7` and later)
<!-- ch-version-info:end -->