### PR TITLE
Fix flaky 03203_system_query_metric_log amount-of-events check

### DIFF
--- a/tests/queries/0_stateless/03203_system_query_metric_log.sh
+++ b/tests/queries/0_stateless/03203_system_query_metric_log.sh
@@ -24,11 +24,21 @@ function check_log()
 {
     interval=$1
 
-    # Check that the amount of events collected is correct, leaving a 80% of margin.
+    # Check that the amount of events collected is correct.
+    # The upper bound catches runaway over-collection with a generous 80% margin.
+    # The lower bound is only 1: on a heavily oversubscribed runner the
+    # `BackgroundSchedulePool` task that samples the metrics can be starved, and
+    # `QueryMetricLogStatus::scheduleNext` deliberately skips the lost runs instead
+    # of catching up, so few events are collected. The smaller the interval, the
+    # more likely this is, so any lower bound that scales up as the interval shrinks
+    # is exactly backwards for robustness. Requiring at least one row still verifies
+    # that collection happened for a positive interval (the disabled and short-query
+    # cases below assert 0), and the always-emitted final row guarantees it is
+    # attainable regardless of scheduling.
     $CLICKHOUSE_CLIENT -m -q """
         SELECT '--Interval $interval: check that amount of events is correct';
         SELECT
-            count() BETWEEN ((ceil(2500 / $interval) - 1) * 0.2) AND ((ceil(2500 / $interval) + 1) * 1.8)
+            count() BETWEEN 1 AND ((ceil(2500 / $interval) + 1) * 1.8)
         FROM system.query_metric_log
         WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_id = '${query_prefix}_${interval}'
     """


### PR DESCRIPTION
Fixes flakiness of the stateless test `03203_system_query_metric_log`, seen on master in `Stateless tests (amd_tsan, s3 storage, parallel)` (CI's own rerun diagnosis confirmed it transient: "Runs: 3, Failed: 0, Passed: 3 ... not reproducible").

The "check that amount of events is correct" assertion failed for the smallest interval (123 ms), whose lower bound was `(ceil(2500 / 123) - 1) * 0.2 = 4`.

The metric samples are produced by a `BackgroundSchedulePool` task, and `QueryMetricLogStatus::scheduleNext` deliberately skips lost runs when the pool is starved (it resets `next_collect_time` to now and schedules immediately instead of firing catch-up runs). So under heavy load fewer events are collected — this is the correct server behavior, not a regression. The old lower bound scaled *up* as the interval shrank, so the smallest interval demanded the highest minimum count while being the most likely to be starved — exactly backwards for robustness.

This relaxes the lower bound to a constant `1`. The generous upper bound is kept so runaway over-collection is still caught. Requiring at least one row still proves collection happened for a positive interval (the disabled `query_metric_log_interval=0` and short-query cases still assert `0`), and the always-emitted final row from `QueryMetricLog::finishQuery` guarantees the lower bound is attainable regardless of scheduling.

Verified locally end-to-end (interval 1000/400/123 → 3/7/21 events, all pass; disabled/short-query → 0) and that starved counts 1–3 now pass while a runaway count of 40 still fails.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=81f8ef5172094f3a8abe5b01e3fe9fdc68307951&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F3%29

Related: https://github.com/ClickHouse/ClickHouse/issues/71244

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)
