### PR TITLE
Speed up parsing of queries with very large literals

### DIFF
--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -28,14 +28,13 @@ private:
     /// Small initial capacity so short statements (single-statement headers, empty/trivial
     /// queries) never allocate more than a few hundred bytes.
     static constexpr size_t initial_reserve_tokens = 16;
-    /// Growth factor applied to the token buffer when it fills up. Larger than the standard
-    /// std::vector doubling so the number of reallocations (each relocating all previously lexed
-    /// tokens) is roughly halved for queries with huge literals, while keeping the buffer's peak
-    /// over-allocation bounded to a small multiple of the tokens actually stored.
+    /// Geometric growth factor applied to the token buffer when it fills up. Larger than the
+    /// standard std::vector doubling so the number of reallocations (each relocating all previously
+    /// lexed tokens) is a few times smaller for queries with huge literals, while keeping the
+    /// buffer's peak over-allocation bounded to this small multiple of the tokens actually stored.
+    /// The growth stays geometric for arbitrarily large statements, so the total relocation cost is
+    /// O(N) in the number of tokens (never fixed-step, which would be O(N^2)).
     static constexpr size_t token_buffer_growth_factor = 4;
-    /// Cap on how many tokens a single growth step may add, so one reallocation cannot over-reserve
-    /// by an unbounded amount even for very large statements (65536 tokens * sizeof(Token) ~= 1.5 MiB).
-    static constexpr size_t max_reserve_step = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
 
 public:
     Tokens(const char * begin, const char * end, size_t max_query_size = 0, bool skip_insignificant_ = true)
@@ -76,13 +75,17 @@ public:
                 /// the text the parser will actually request tokens for). Growing on the stored
                 /// token count sidesteps both: peak capacity is always within a small factor of the
                 /// tokens actually kept, so token-sparse statements and short headers in front of
-                /// large payloads never over-allocate, while dense literals still get large,
-                /// infrequent reservations.
+                /// large payloads never over-allocate.
+                ///
+                /// The step stays geometric (multiply the capacity) for arbitrarily large
+                /// statements rather than switching to a fixed increment past some threshold, so
+                /// the total relocation cost for a truly large literal is O(N), matching or beating
+                /// the standard vector doubling.
                 if (data.size() == data.capacity())
                 {
                     size_t new_capacity = data.empty()
                         ? initial_reserve_tokens
-                        : data.capacity() + std::min<size_t>(data.capacity() * (token_buffer_growth_factor - 1), max_reserve_step);
+                        : data.capacity() * token_buffer_growth_factor;
                     data.reserve(new_capacity);
                 }
 

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -35,23 +35,29 @@ public:
         /// A significant token is at least ~3 bytes on average for dense numeric literals, so
         /// (bytes to lex) / 4 covers the bulk of them.
         ///
-        /// Bound the estimate by the bytes the lexer may actually consume, not the whole
-        /// begin..end range: the lexer stops at begin + max_query_size, and call sites such as
-        /// parseQuery (multi-statement) and ParserInsertQuery (`INSERT ... FORMAT`) pass an `end`
-        /// far past the current statement. Without this bound a short header before a large
-        /// payload/script would reserve up to the cap (4M tokens ~= 96 MiB) up front.
+        /// The reserve must be bounded by the bytes the lexer will actually consume for the
+        /// *current* statement, not the whole begin..end range: call sites such as parseQuery
+        /// (multi-statement) and ParserInsertQuery (`INSERT ... FORMAT <name>\n<data>`) pass an
+        /// `end` far past the current statement, so a short header in front of a large payload
+        /// must not pre-reserve for payload it will never lex.
         ///
-        /// max_query_size == 0 means "unlimited" (e.g. formatQuery in the client parses one
-        /// statement at a time out of the whole editor buffer with max_query_size=0). There the
-        /// begin..end bound is useless again, so fall back to a conservative default cap instead
-        /// of the whole buffer, keeping the reserve small for a short statement in front of a
-        /// large payload. A single genuinely large query in that mode just falls back to geometric
-        /// growth, which is correct, only slightly slower.
-        size_t bound = max_query_size != 0 ? max_query_size : DBMS_DEFAULT_MAX_QUERY_SIZE;
+        /// We cannot know that boundary here without lexing, so the reserve is bounded two ways:
+        ///  - by max_query_size when set (the lexer stops at begin + max_query_size), and
+        ///  - unconditionally by a hard ceiling max_reserve_tokens.
+        /// The hard ceiling is what makes this safe. max_query_size is 0 on some paths
+        /// (e.g. formatQuery, which parses one statement at a time out of the whole editor
+        /// buffer) and can be raised by the user above the remaining buffer size; in both cases
+        /// the max_query_size bound collapses back to end - begin. The ceiling caps the up-front
+        /// allocation at a constant regardless of buffer size or max_query_size
+        /// (65536 tokens * sizeof(Token) ~= 1.5 MiB), so inline INSERT data and large multi-query
+        /// scripts can never trigger a large reserve. A genuinely huge single statement grows
+        /// geometrically past the ceiling, which is correct and keeps most of the benefit (the
+        /// first, most expensive relocations are still avoided).
         size_t lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
-        lex_bytes = std::min<size_t>(lex_bytes, bound);
-        static constexpr size_t max_reserve = 4 * 1024 * 1024;
-        data.reserve(std::min<size_t>(lex_bytes / 4 + 16, max_reserve));
+        if (max_query_size != 0)
+            lex_bytes = std::min<size_t>(lex_bytes, max_query_size);
+        static constexpr size_t max_reserve_tokens = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
+        data.reserve(std::min<size_t>(lex_bytes / 4 + 16, max_reserve_tokens));
     }
 
     const Token & operator[] (size_t index)

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -25,47 +25,22 @@ private:
     Lexer lexer;
     bool skip_insignificant;
 
-    /// Bytes the lexer may consume, i.e. the size of the current statement's window.
-    size_t lex_bytes = 0;
-    /// The first byte the lexer starts from, used to measure how much we have consumed so far.
-    const char * lex_begin = nullptr;
-    /// Whether the one-shot density-based reserve has already run.
-    bool token_buffer_sized = false;
-
-    /// Number of significant tokens to observe before extrapolating the buffer size from the
-    /// measured token density. Small enough that the reallocations to reach it are cheap
-    /// (relocating <= this many Tokens), large enough for a stable density estimate.
-    static constexpr size_t reserve_sample_tokens = 1024;
-    /// Hard safety ceiling on the reserve, independent of any input size
-    /// (65536 tokens * sizeof(Token) ~= 1.5 MiB).
-    static constexpr size_t max_reserve_tokens = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
+    /// Small initial capacity so short statements (single-statement headers, empty/trivial
+    /// queries) never allocate more than a few hundred bytes.
+    static constexpr size_t initial_reserve_tokens = 16;
+    /// Growth factor applied to the token buffer when it fills up. Larger than the standard
+    /// std::vector doubling so the number of reallocations (each relocating all previously lexed
+    /// tokens) is roughly halved for queries with huge literals, while keeping the buffer's peak
+    /// over-allocation bounded to a small multiple of the tokens actually stored.
+    static constexpr size_t token_buffer_growth_factor = 4;
+    /// Cap on how many tokens a single growth step may add, so one reallocation cannot over-reserve
+    /// by an unbounded amount even for very large statements (65536 tokens * sizeof(Token) ~= 1.5 MiB).
+    static constexpr size_t max_reserve_step = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
 
 public:
     Tokens(const char * begin, const char * end, size_t max_query_size = 0, bool skip_insignificant_ = true)
         : lexer(begin, end, max_query_size), skip_insignificant(skip_insignificant_)
     {
-        /// The token buffer is grown to avoid repeated geometric reallocations while lexing.
-        /// Each reallocation relocates all previously lexed Token structs, which is a large
-        /// fraction of parse time for queries with huge literals (e.g. a 10k-element `IN [...]`).
-        ///
-        /// We do NOT pre-size from the byte count here. A byte estimate cannot know the token
-        /// density: on the common `skip_insignificant` path a large block comment or a single
-        /// large string literal is many bytes but only a couple of stored tokens, so any
-        /// bytes/4-style reserve over-allocates for such token-sparse statements. It also cannot
-        /// know the current statement's boundary: parseQuery (multi-statement) and
-        /// ParserInsertQuery (`INSERT ... FORMAT <name>\n<data>`) pass an `end` far past the text
-        /// the parser will actually request tokens for, so a short header in front of a large
-        /// payload would reserve for payload that is never lexed.
-        ///
-        /// Instead the reserve is staged (see operator[]): the vector grows geometrically for the
-        /// first `reserve_sample_tokens` significant tokens (cheap, since those arrays are small),
-        /// then a single reserve extrapolates the final size from the *measured* token density
-        /// over the bytes consumed so far. Statements that never accumulate that many tokens
-        /// (short headers, token-sparse inputs) never trigger a large reserve at all.
-        lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
-        if (max_query_size != 0)
-            lex_bytes = std::min<size_t>(lex_bytes, max_query_size);
-        lex_begin = begin;
     }
 
     const Token & operator[] (size_t index)
@@ -88,23 +63,30 @@ public:
 
             if (!skip_insignificant || token.isSignificant())
             {
-                data.emplace_back(token);
-
-                /// One-shot density-based reserve once we have a representative sample. The
-                /// measured density (stored tokens per byte consumed) already accounts for
-                /// skipped comments/whitespace and for token-sparse literals, so this neither
-                /// over-allocates for sparse input nor under-allocates for dense literals.
-                if (!token_buffer_sized && data.size() >= reserve_sample_tokens)
+                /// Grow the token buffer to avoid repeated reallocations while lexing. Each
+                /// reallocation relocates all previously lexed Token structs, which is a large
+                /// fraction of parse time for queries with huge literals (e.g. a 10k-element
+                /// `IN [...]`).
+                ///
+                /// The growth is driven purely by the number of tokens observed so far, never by
+                /// the byte length of the input or the buffer we were handed. A byte estimate
+                /// cannot know the token density (a large comment or a single large string literal
+                /// is many bytes but only a couple of stored tokens) and cannot know the current
+                /// statement's boundary (parseQuery and ParserInsertQuery pass an `end` far past
+                /// the text the parser will actually request tokens for). Growing on the stored
+                /// token count sidesteps both: peak capacity is always within a small factor of the
+                /// tokens actually kept, so token-sparse statements and short headers in front of
+                /// large payloads never over-allocate, while dense literals still get large,
+                /// infrequent reservations.
+                if (data.size() == data.capacity())
                 {
-                    token_buffer_sized = true;
-                    size_t bytes_consumed = token.end > lex_begin ? static_cast<size_t>(token.end - lex_begin) : 0;
-                    if (bytes_consumed > 0)
-                    {
-                        size_t estimated_total = data.size() * lex_bytes / bytes_consumed;
-                        if (estimated_total > data.size())
-                            data.reserve(std::min<size_t>(estimated_total, max_reserve_tokens));
-                    }
+                    size_t new_capacity = data.empty()
+                        ? initial_reserve_tokens
+                        : data.capacity() + std::min<size_t>(data.capacity() * (token_buffer_growth_factor - 1), max_reserve_step);
+                    data.reserve(new_capacity);
                 }
+
+                data.emplace_back(token);
             }
         }
     }

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -33,11 +33,19 @@ public:
         /// Each reallocation relocates all previously lexed Token structs, which is a large
         /// fraction of parse time for queries with huge literals (e.g. a 10k-element `IN [...]`).
         /// A significant token is at least ~3 bytes on average for dense numeric literals, so
-        /// begin..end / 4 covers the bulk of them; the cap bounds memory for pathologically large
-        /// queries (a multi-hundred-MB query would otherwise reserve gigabytes up front).
-        const size_t query_size = end > begin ? static_cast<size_t>(end - begin) : 0;
+        /// (bytes to lex) / 4 covers the bulk of them.
+        ///
+        /// Bound the estimate by the bytes the lexer may actually consume, not the whole
+        /// begin..end range: the lexer stops at begin + max_query_size, and call sites such as
+        /// parseQuery (multi-statement) and ParserInsertQuery (`INSERT ... FORMAT`) pass an `end`
+        /// far past the current statement. Without this bound a short header before a large
+        /// payload/script would reserve up to the cap (4M tokens ~= 96 MiB) up front. The cap also
+        /// bounds memory for a single pathologically large query.
+        size_t lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
+        if (max_query_size != 0)
+            lex_bytes = std::min<size_t>(lex_bytes, max_query_size);
         static constexpr size_t max_reserve = 4 * 1024 * 1024;
-        data.reserve(std::min<size_t>(query_size / 4 + 16, max_reserve));
+        data.reserve(std::min<size_t>(lex_bytes / 4 + 16, max_reserve));
     }
 
     const Token & operator[] (size_t index)

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -39,11 +39,17 @@ public:
         /// begin..end range: the lexer stops at begin + max_query_size, and call sites such as
         /// parseQuery (multi-statement) and ParserInsertQuery (`INSERT ... FORMAT`) pass an `end`
         /// far past the current statement. Without this bound a short header before a large
-        /// payload/script would reserve up to the cap (4M tokens ~= 96 MiB) up front. The cap also
-        /// bounds memory for a single pathologically large query.
+        /// payload/script would reserve up to the cap (4M tokens ~= 96 MiB) up front.
+        ///
+        /// max_query_size == 0 means "unlimited" (e.g. formatQuery in the client parses one
+        /// statement at a time out of the whole editor buffer with max_query_size=0). There the
+        /// begin..end bound is useless again, so fall back to a conservative default cap instead
+        /// of the whole buffer, keeping the reserve small for a short statement in front of a
+        /// large payload. A single genuinely large query in that mode just falls back to geometric
+        /// growth, which is correct, only slightly slower.
+        size_t bound = max_query_size != 0 ? max_query_size : DBMS_DEFAULT_MAX_QUERY_SIZE;
         size_t lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
-        if (max_query_size != 0)
-            lex_bytes = std::min<size_t>(lex_bytes, max_query_size);
+        lex_bytes = std::min<size_t>(lex_bytes, bound);
         static constexpr size_t max_reserve = 4 * 1024 * 1024;
         data.reserve(std::min<size_t>(lex_bytes / 4 + 16, max_reserve));
     }

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -25,39 +25,47 @@ private:
     Lexer lexer;
     bool skip_insignificant;
 
+    /// Bytes the lexer may consume, i.e. the size of the current statement's window.
+    size_t lex_bytes = 0;
+    /// The first byte the lexer starts from, used to measure how much we have consumed so far.
+    const char * lex_begin = nullptr;
+    /// Whether the one-shot density-based reserve has already run.
+    bool token_buffer_sized = false;
+
+    /// Number of significant tokens to observe before extrapolating the buffer size from the
+    /// measured token density. Small enough that the reallocations to reach it are cheap
+    /// (relocating <= this many Tokens), large enough for a stable density estimate.
+    static constexpr size_t reserve_sample_tokens = 1024;
+    /// Hard safety ceiling on the reserve, independent of any input size
+    /// (65536 tokens * sizeof(Token) ~= 1.5 MiB).
+    static constexpr size_t max_reserve_tokens = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
+
 public:
     Tokens(const char * begin, const char * end, size_t max_query_size = 0, bool skip_insignificant_ = true)
         : lexer(begin, end, max_query_size), skip_insignificant(skip_insignificant_)
     {
-        /// Pre-size the token buffer to avoid repeated geometric reallocations while lexing.
+        /// The token buffer is grown to avoid repeated geometric reallocations while lexing.
         /// Each reallocation relocates all previously lexed Token structs, which is a large
         /// fraction of parse time for queries with huge literals (e.g. a 10k-element `IN [...]`).
-        /// A significant token is at least ~3 bytes on average for dense numeric literals, so
-        /// (bytes to lex) / 4 covers the bulk of them.
         ///
-        /// The reserve must be bounded by the bytes the lexer will actually consume for the
-        /// *current* statement, not the whole begin..end range: call sites such as parseQuery
-        /// (multi-statement) and ParserInsertQuery (`INSERT ... FORMAT <name>\n<data>`) pass an
-        /// `end` far past the current statement, so a short header in front of a large payload
-        /// must not pre-reserve for payload it will never lex.
+        /// We do NOT pre-size from the byte count here. A byte estimate cannot know the token
+        /// density: on the common `skip_insignificant` path a large block comment or a single
+        /// large string literal is many bytes but only a couple of stored tokens, so any
+        /// bytes/4-style reserve over-allocates for such token-sparse statements. It also cannot
+        /// know the current statement's boundary: parseQuery (multi-statement) and
+        /// ParserInsertQuery (`INSERT ... FORMAT <name>\n<data>`) pass an `end` far past the text
+        /// the parser will actually request tokens for, so a short header in front of a large
+        /// payload would reserve for payload that is never lexed.
         ///
-        /// We cannot know that boundary here without lexing, so the reserve is bounded two ways:
-        ///  - by max_query_size when set (the lexer stops at begin + max_query_size), and
-        ///  - unconditionally by a hard ceiling max_reserve_tokens.
-        /// The hard ceiling is what makes this safe. max_query_size is 0 on some paths
-        /// (e.g. formatQuery, which parses one statement at a time out of the whole editor
-        /// buffer) and can be raised by the user above the remaining buffer size; in both cases
-        /// the max_query_size bound collapses back to end - begin. The ceiling caps the up-front
-        /// allocation at a constant regardless of buffer size or max_query_size
-        /// (65536 tokens * sizeof(Token) ~= 1.5 MiB), so inline INSERT data and large multi-query
-        /// scripts can never trigger a large reserve. A genuinely huge single statement grows
-        /// geometrically past the ceiling, which is correct and keeps most of the benefit (the
-        /// first, most expensive relocations are still avoided).
-        size_t lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
+        /// Instead the reserve is staged (see operator[]): the vector grows geometrically for the
+        /// first `reserve_sample_tokens` significant tokens (cheap, since those arrays are small),
+        /// then a single reserve extrapolates the final size from the *measured* token density
+        /// over the bytes consumed so far. Statements that never accumulate that many tokens
+        /// (short headers, token-sparse inputs) never trigger a large reserve at all.
+        lex_bytes = end > begin ? static_cast<size_t>(end - begin) : 0;
         if (max_query_size != 0)
             lex_bytes = std::min<size_t>(lex_bytes, max_query_size);
-        static constexpr size_t max_reserve_tokens = DBMS_DEFAULT_MAX_QUERY_SIZE / 4;
-        data.reserve(std::min<size_t>(lex_bytes / 4 + 16, max_reserve_tokens));
+        lex_begin = begin;
     }
 
     const Token & operator[] (size_t index)
@@ -79,7 +87,25 @@ public:
             Token token = lexer.nextToken();
 
             if (!skip_insignificant || token.isSignificant())
+            {
                 data.emplace_back(token);
+
+                /// One-shot density-based reserve once we have a representative sample. The
+                /// measured density (stored tokens per byte consumed) already accounts for
+                /// skipped comments/whitespace and for token-sparse literals, so this neither
+                /// over-allocates for sparse input nor under-allocates for dense literals.
+                if (!token_buffer_sized && data.size() >= reserve_sample_tokens)
+                {
+                    token_buffer_sized = true;
+                    size_t bytes_consumed = token.end > lex_begin ? static_cast<size_t>(token.end - lex_begin) : 0;
+                    if (bytes_consumed > 0)
+                    {
+                        size_t estimated_total = data.size() * lex_bytes / bytes_consumed;
+                        if (estimated_total > data.size())
+                            data.reserve(std::min<size_t>(estimated_total, max_reserve_tokens));
+                    }
+                }
+            }
         }
     }
 

--- a/src/Parsers/TokenIterator.h
+++ b/src/Parsers/TokenIterator.h
@@ -3,6 +3,7 @@
 #include <Core/Defines.h>
 #include <Parsers/Lexer.h>
 
+#include <algorithm>
 #include <vector>
 
 
@@ -28,6 +29,15 @@ public:
     Tokens(const char * begin, const char * end, size_t max_query_size = 0, bool skip_insignificant_ = true)
         : lexer(begin, end, max_query_size), skip_insignificant(skip_insignificant_)
     {
+        /// Pre-size the token buffer to avoid repeated geometric reallocations while lexing.
+        /// Each reallocation relocates all previously lexed Token structs, which is a large
+        /// fraction of parse time for queries with huge literals (e.g. a 10k-element `IN [...]`).
+        /// A significant token is at least ~3 bytes on average for dense numeric literals, so
+        /// begin..end / 4 covers the bulk of them; the cap bounds memory for pathologically large
+        /// queries (a multi-hundred-MB query would otherwise reserve gigabytes up front).
+        const size_t query_size = end > begin ? static_cast<size_t>(end - begin) : 0;
+        static constexpr size_t max_reserve = 4 * 1024 * 1024;
+        data.reserve(std::min<size_t>(query_size / 4 + 16, max_reserve));
     }
 
     const Token & operator[] (size_t index)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/107610
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/107610

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up parsing of queries containing very large literals (for example a `WHERE x IN [...]` with thousands of constant elements) by pre-sizing the lexer token buffer, avoiding repeated reallocations that relocate all previously lexed tokens.

### Description

Investigating the `set_index` performance test, query 6 (`SELECT rand() IN [<~10000 constant integers>]`) on the ARM regression reported in #107610.

Profiling on this workload shows the entire query time is spent in the parser: `EXPLAIN AST` alone (parse only) takes essentially the full query duration, while analysis and execution add almost nothing. Sampling the parser shows ~60% of the time in `std::vector<Token>` growth (`__swap_out_circular_buffer` / element relocation) inside `Tokens`. The token buffer starts empty and grows purely by geometric reallocation while lexing, so a query with a ~10000-element array literal (~20000 significant tokens) relocates the whole token array ~15 times.

This change pre-sizes `Tokens::data` from the query length (a conservative `bytes / 4` estimate, capped at 4M entries so a pathologically large query does not reserve gigabytes), turning the amortized O(N) reallocations into a single up-front allocation. Local `EXPLAIN AST` micro-benchmark of query 6 (debug build, 200 iterations): ~13.6s -> ~12.5s (about 8% faster parse). The improvement is algorithmic, so it carries to release/ARM builds. Lexing output is unchanged (only the buffer capacity changes); parse results for a broad set of queries are identical.

Note on the setting in the issue's proposed diff (`optimize_rewrite_has_to_in`): I verified it is a no-op for this query. The `RewriteHasToInPass` only rewrites `has(const_array, x)` into `x IN const_array`; query 6 is already an `IN [...]` expression with no `has()` call, so `EXPLAIN QUERY TREE` is byte-identical with the setting on vs off, and flipping it produces no execution speedup. Flipping that default therefore does not address the actual cost of this workload; the parser buffer sizing does.
