### PR TITLE
Retry CI logs cluster probe on transient MEMORY_LIMIT_EXCEEDED

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
+++ b/ci/jobs/scripts/functional_tests/setup_log_cluster.sh
@@ -49,29 +49,31 @@ function check_logs_credentials()
     __set_connection_args
     __shadow_credentials
     local code
-    # The remote CI logs cluster occasionally resets the connection, which is
-    # transient and unrelated to the credentials. Retry only that specific
-    # case. We match it on the stderr message "Connection reset by peer" rather
-    # than the exit status: the shell keeps only the low 8 bits of the client's
-    # exit code, so unrelated errors (e.g. 466/722) alias to 210, and the
-    # client also raises NETWORK_ERROR for permanent cases (protocol mismatch,
-    # generic NetException). A short --connect_timeout (instead of the 10s
-    # default) is applied to the probe only, so a real outage or a
-    # non-recoverable error (auth, config, DNS) fails fast: this probe is
-    # best-effort and must not slow every CI job. Export queries keep the
-    # default timeouts.
+    # The remote CI logs cluster occasionally fails a probe for reasons that are
+    # transient and unrelated to our credentials: it resets the connection, or
+    # it is momentarily over its memory limit and rejects the query with
+    # MEMORY_LIMIT_EXCEEDED (its RSS crosses the cap for a few seconds under
+    # load from other CI jobs). Retry only those transient cases. We match on
+    # the stderr message rather than the exit status: the shell keeps only the
+    # low 8 bits of the client's exit code, so unrelated errors (e.g. 466/722)
+    # alias to 210, and the client also raises NETWORK_ERROR for permanent
+    # cases (protocol mismatch, generic NetException). A short --connect_timeout
+    # (instead of the 10s default) is applied to the probe only, so a real
+    # outage or a non-recoverable error (auth, config, DNS) fails fast: this
+    # probe is best-effort and must not slow every CI job. Export queries keep
+    # the default timeouts.
     local attempt err
     # BEGIN: logs-cluster connectivity probe loop
     for attempt in 1 2 3; do
         # Catch both success and error to not fail on `set -e`. Capture stderr
-        # so we can distinguish the transient reset from other failures.
+        # so we can distinguish transient failures from permanent ones.
         err=$(clickhouse-client "${CONNECTION_ARGS[@]:?}" --connect_timeout 3 -q 'SELECT 1 FORMAT Null' 2>&1) && return 0 || code=$?
-        # Only a "Connection reset by peer" is worth retrying; anything else
-        # will not recover on retry, so stop immediately.
-        if [[ "$err" != *"Connection reset by peer"* ]]; then
+        # Only transient failures are worth retrying; anything else will not
+        # recover on retry, so stop immediately.
+        if [[ "$err" != *"Connection reset by peer"* && "$err" != *"MEMORY_LIMIT_EXCEEDED"* ]]; then
             break
         fi
-        echo "Attempt ${attempt}/3 to connect to CI Logs cluster failed (connection reset by peer)"
+        echo "Attempt ${attempt}/3 to connect to CI Logs cluster failed (transient error), retrying"
         [ "$attempt" -lt 3 ] && sleep "$((attempt + 1))"
     done
     # END: logs-cluster connectivity probe loop


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110173
Related: https://github.com/ClickHouse/ClickHouse/pull/110200
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110173
Related: https://github.com/ClickHouse/ClickHouse/pull/110200

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

Follow-up to #110173. The CI logs cluster connectivity probe in `setup_log_cluster.sh` retried only on `Connection reset by peer` and broke out immediately on any other error. In practice the remote cluster also transiently rejects the probe with `Code: 241 MEMORY_LIMIT_EXCEEDED` when its RSS momentarily crosses the cap under load from other CI jobs (e.g. `would use 425.94 GiB ... maximum: 424.80 GiB`). That produced a non-fatal `Failed to start log export` "Report messages" warning even though the test job passed.

Extend the retryable-transient match to also cover `MEMORY_LIMIT_EXCEEDED` (3 attempts, short `--connect_timeout`). Permanent failures (auth, DNS, config) still fail fast on the first attempt.

Example (report from #110200 at `6487481b79b`, 4 jobs, all passing):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110200&sha=6487481b79b6f6e56ab8340e102229ea9f372ed7&name_0=PR
