### PR TITLE
Fix sporadic Values-template failure with synthesized literals

### DIFF
--- a/src/Parsers/ASTLiteral.cpp
+++ b/src/Parsers/ASTLiteral.cpp
@@ -54,6 +54,7 @@ String ASTLiteral::getID(char delim) const
 
 ASTPtr ASTLiteral::clone() const
 {
+    /// The copy constructor clears the token-info bit - see `ASTLiteral(const ASTLiteral &)`.
     auto res = make_intrusive<ASTLiteral>(*this);
     res->unique_column_name = {};
     return res;

--- a/src/Parsers/ASTLiteral.h
+++ b/src/Parsers/ASTLiteral.h
@@ -13,17 +13,43 @@ protected:
     struct ASTLiteralFlags
     {
         using ParentFlags = ASTWithAliasFlags;
-        static constexpr UInt32 RESERVED_BITS = ASTWithAliasFlags::RESERVED_BITS + 1;
+        static constexpr UInt32 RESERVED_BITS = ASTWithAliasFlags::RESERVED_BITS + 2;
 
         UInt32 _parent_reserved : ParentFlags::RESERVED_BITS;
         UInt32 use_legacy_column_name_of_tuple : 1;
-        UInt32 unused : 30;
+        /// Set only by `recordLiteralTokens`: this literal's own span is in the literal token map.
+        /// A synthesized literal leaves it unset, so it cannot be taken for a recorded literal
+        /// whose freed address it reused.
+        UInt32 has_token_info : 1;
+        UInt32 unused : 29;
     };
 
 public:
     explicit ASTLiteral(Field value_)
         : value(std::move(value_))
     {
+    }
+
+    /// A copy lives at its own address, which the literal token map knows nothing about, so it
+    /// starts out with no token info however the original was built. `clone` goes through here too.
+    ASTLiteral(const ASTLiteral & other)
+        : ASTWithAlias(other)
+        , value(other.value)
+        , unique_column_name(other.unique_column_name)
+    {
+        setHasTokenInfo(false);
+    }
+
+    ASTLiteral & operator=(const ASTLiteral & other)
+    {
+        if (this != &other)
+        {
+            ASTWithAlias::operator=(other);
+            value = other.value;
+            unique_column_name = other.unique_column_name;
+            setHasTokenInfo(false);
+        }
+        return *this;
     }
 
     Field value;
@@ -45,6 +71,16 @@ public:
     bool getUseLegacyColumnNameOfTuple() const
     {
         return flags<ASTLiteralFlags>().use_legacy_column_name_of_tuple;
+    }
+
+    void setHasTokenInfo(bool _value)
+    {
+        flags<ASTLiteralFlags>().has_token_info = _value;
+    }
+
+    bool hasTokenInfo() const
+    {
+        return flags<ASTLiteralFlags>().has_token_info;
     }
 
     /** Get the text that identifies this element. */

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -67,16 +67,20 @@ namespace
 /// Helper to record literal token positions in the map stored in Expected.
 /// The char* pointers reference the original query string buffer.
 ///
+/// The only place `has_token_info` is set, which is what lets a consumer tell a recorded
+/// literal from a synthesized one sitting at a recorded literal's freed address.
+///
 /// Why insert_or_assign: When parsing nested literals like tuples `(1, 2)`,
 /// the parser may reuse memory addresses due to make_shared's small object optimization.
 /// The final composite literal may get the same address as an earlier element.
 /// We want the token info for the final literal, so insert_or_assign overwrites earlier entries.
-inline void recordLiteralTokens(const ASTLiteral * literal, IParser::Pos begin, IParser::Pos end, Expected & expected)
+inline void recordLiteralTokens(ASTLiteral * literal, IParser::Pos begin, IParser::Pos end, Expected & expected)
 {
     if (expected.literal_token_map)
     {
         --end;
         expected.literal_token_map->insert_or_assign(literal, LiteralTokenInfo{begin->begin, end->end});
+        literal->setHasTokenInfo(true);
     }
 }
 

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -955,6 +955,11 @@ static void highlightRegexps(const ASTPtr & node, Expected & expected, size_t de
     if (!literal || literal->value.getType() != Field::Types::String)
         return;
 
+    /// Only literals actually tokenized from the query carry valid token info; a synthesized
+    /// literal may have inherited a stale map entry from a freed literal that reused its address.
+    if (!literal->hasTokenInfo())
+        return;
+
     /// Look up token position from the map stored in Expected
     if (!expected.literal_token_map)
         return;

--- a/src/Parsers/tests/gtest_literal_token_map.cpp
+++ b/src/Parsers/tests/gtest_literal_token_map.cpp
@@ -1,6 +1,11 @@
-#include <gtest/gtest.h>
-
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/IParser.h>
 #include <Parsers/LiteralTokenInfo.h>
+#include <Parsers/TokenIterator.h>
+
+#include <gtest/gtest.h>
 
 #include <random>
 #include <unordered_map>
@@ -140,4 +145,262 @@ TEST(LiteralTokenMap, AgreesWithUnorderedMap)
                 EXPECT_EQ(map.find(absent), nullptr);
         }
     }
+}
+
+
+/// The tests below cover the `has_token_info` bit rather than the map mechanics above.
+/// The invariant: a literal reporting `hasTokenInfo` has a valid span in the map, and a
+/// parser-synthesized literal reports false. `forget` covers subtrees the parser discards;
+/// the bit covers synthesized literals it keeps, which have no subtree to forget.
+
+namespace
+{
+
+/// Reads the token-info marker where it exists, and falls back to the map lookup that stands in for
+/// it without the fix, so this file also compiles against the merge base. The template keeps the
+/// discarded branch uninstantiated.
+template <typename Literal>
+bool literalHasTokenInfo(const Literal & literal, const LiteralTokenMap & token_map)
+{
+    if constexpr (requires { literal.hasTokenInfo(); })
+        return literal.hasTokenInfo();
+    else
+        return token_map.find(&literal) != nullptr;
+}
+
+/// Leave a dead span in the map at `literal`'s own address, the state an allocator produces when it
+/// hands that address to a new literal. Staged rather than awaited, so the check is deterministic.
+void recordStaleSpanAt(LiteralTokenMap & token_map, const ASTLiteral * literal)
+{
+    token_map.insert_or_assign(literal, someTokenInfo(999));
+}
+
+void collectLiterals(const ASTPtr & ast, std::vector<const ASTLiteral *> & out)
+{
+    if (const auto * literal = ast->as<ASTLiteral>())
+        out.push_back(literal);
+    for (const auto & child : ast->children)
+        collectLiterals(child, out);
+}
+
+ASTPtr parseWithTokenMap(const std::string & expr, LiteralTokenMap & token_map)
+{
+    Tokens tokens(expr.data(), expr.data() + expr.size());
+    IParser::Pos pos(tokens, 1000, 1000);
+    Expected expected;
+    expected.literal_token_map = &token_map;
+    ParserExpression parser;
+    ASTPtr ast;
+    EXPECT_TRUE(parser.parse(pos, ast, expected)) << "failed to parse: " << expr;
+    return ast;
+}
+
+/// A tokenized literal must be in the map; an untokenized literal must not report token info.
+void checkInvariant(const ASTPtr & ast, const LiteralTokenMap & token_map)
+{
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    for (const auto * literal : literals)
+    {
+        if (literalHasTokenInfo(*literal, token_map))
+        {
+            EXPECT_NE(token_map.find(literal), nullptr)
+                << "literal flagged `hasTokenInfo` must have a token map entry: " << literal->getID(' ');
+        }
+    }
+}
+
+/// Return literals that were NOT tokenized from the query (synthesized by a parser).
+std::vector<const ASTLiteral *> synthesizedLiterals(const ASTPtr & ast, const LiteralTokenMap & token_map)
+{
+    std::vector<const ASTLiteral *> all;
+    collectLiterals(ast, all);
+    std::vector<const ASTLiteral *> out;
+    for (const auto * literal : all)
+        if (!literalHasTokenInfo(*literal, token_map))
+            out.push_back(literal);
+    return out;
+}
+
+}
+
+/// `ParserCastOperator` synthesizes the cast value, so it can inherit the span of the
+/// discarded `'sumState'` string-literal probe.
+TEST(LiteralTokenMap, NumericCastOperatorLiteralHasNoTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("initializeAggregation('sumState', 0::UInt64)", token_map);
+    checkInvariant(ast, token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    bool saw_cast_value = false;
+    for (const auto * literal : literals)
+    {
+        /// The cast value `'0'` survives as `ASTLiteral(String "0")`; it must not report token info.
+        if (literal->value.getType() == Field::Types::String && literal->value.safeGet<String>() == "0")
+        {
+            saw_cast_value = true;
+            recordStaleSpanAt(token_map, literal);
+            EXPECT_FALSE(literalHasTokenInfo(*literal, token_map))
+                << "synthesized numeric-cast literal '0' must not report token info";
+        }
+    }
+    EXPECT_TRUE(saw_cast_value) << "expected the synthesized numeric-cast literal '0' in the AST";
+}
+
+/// The literal synthesized by `ParserMySQLGlobalVariable` (`@@name` -> `globalVariable('name')`) survives
+/// in a templatable position but is never tokenized, so it must not report token info.
+TEST(LiteralTokenMap, GlobalVariableLiteralHasNoTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("@@max_allowed_packet", token_map);
+    checkInvariant(ast, token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    ASSERT_FALSE(literals.empty()) << "expected the globalVariable name literal in the AST";
+    for (const auto * literal : literals)
+        recordStaleSpanAt(token_map, literal);
+
+    EXPECT_EQ(synthesizedLiterals(ast, token_map).size(), literals.size())
+        << "globalVariable name literal must be synthesized (no token info)";
+}
+
+/// Slow-path Tuple literal: `((1, 2))` produces an `ASTLiteral(Tuple)` synthesized in `getResultImpl`,
+/// without recording token info. It must not report token info.
+TEST(LiteralTokenMap, SlowPathTupleLiteralHasNoTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("materialize(1) IN ((1, 2))", token_map);
+    checkInvariant(ast, token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    bool saw_tuple = false;
+    for (const auto * literal : literals)
+    {
+        if (literal->value.getType() == Field::Types::Tuple)
+        {
+            saw_tuple = true;
+            recordStaleSpanAt(token_map, literal);
+            EXPECT_FALSE(literalHasTokenInfo(*literal, token_map))
+                << "synthesized slow-path Tuple literal must not report token info";
+        }
+    }
+    EXPECT_TRUE(saw_tuple) << "expected a synthesized Tuple literal in the AST";
+}
+
+/// An array of literals is consumed by the fast path as ONE composite literal, which the parser
+/// tokenizes, so it must report token info and be findable. This is the positive counterpart of the
+/// Tuple case above: the same `Field::Types` check there sees a synthesized literal, here a recorded
+/// one, so the bit tracks how the literal was built rather than what type it holds.
+TEST(LiteralTokenMap, ArrayLiteralTokenInfoInvariant)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("x = [1, 2, 3]", token_map);
+    checkInvariant(ast, token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    bool saw_array = false;
+    for (const auto * literal : literals)
+    {
+        if (literal->value.getType() == Field::Types::Array)
+        {
+            saw_array = true;
+            EXPECT_TRUE(literalHasTokenInfo(*literal, token_map)) << "fast-path Array literal is tokenized";
+            EXPECT_NE(token_map.find(literal), nullptr);
+        }
+    }
+    EXPECT_TRUE(saw_array) << "expected an Array literal in the AST";
+}
+
+/// `EXTRACT` injects `UInt64` literals into `plus`/`minus`/`intDiv` chains (`buildExtractTimePartAST`) that are
+/// never tokenized; those must not report token info.
+TEST(LiteralTokenMap, ExtractInjectedLiteralsHaveNoTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("EXTRACT(CENTURY FROM materialize(now()))", token_map);
+    checkInvariant(ast, token_map);
+
+    /// The 1, 100, 1 injected constants are all synthesized.
+    std::vector<const ASTLiteral *> injected = synthesizedLiterals(ast, token_map);
+    ASSERT_FALSE(injected.empty()) << "EXTRACT(CENTURY ...) must inject synthesized numeric literals";
+    for (const auto * literal : injected)
+    {
+        recordStaleSpanAt(token_map, literal);
+        EXPECT_FALSE(literalHasTokenInfo(*literal, token_map))
+            << "EXTRACT-injected literal must not report token info";
+    }
+}
+
+/// Covers all three copy paths: `clone`, copy construction and assignment, plus self-assignment.
+TEST(LiteralTokenMap, CloneDoesNotInheritTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("x = 12345", token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    bool saw = false;
+    for (const auto * literal : literals)
+    {
+        if (!literalHasTokenInfo(*literal, token_map))
+            continue;
+        saw = true;
+
+        /// Each copy below gets the hazard staged at its own address, so the map holds a dead span
+        /// for it exactly as an allocator handing out a freed literal's address would.
+        ASTPtr copy = literal->clone();
+        const auto * cloned = copy->as<ASTLiteral>();
+        ASSERT_NE(cloned, nullptr);
+        recordStaleSpanAt(token_map, cloned);
+        EXPECT_FALSE(literalHasTokenInfo(*cloned, token_map)) << "a clone owns no map entry, so it must not claim one";
+
+        /// Not only through `clone`: callers copy-construct literals directly (for instance
+        /// `ConstantNode::toAST` and `RewriteSumFunctionWithSumAndCountVisitor`), so the copy
+        /// constructor itself has to clear it.
+        ASTLiteral direct_copy(*literal);
+        recordStaleSpanAt(token_map, &direct_copy);
+        EXPECT_FALSE(literalHasTokenInfo(direct_copy, token_map)) << "a copy-constructed literal owns no map entry";
+
+        /// Assignment lands in an object that already exists at its own address, so it has the
+        /// same problem as copy construction.
+        ASTLiteral assigned(Field{UInt64{0}});
+        assigned = *literal;
+        recordStaleSpanAt(token_map, &assigned);
+        EXPECT_FALSE(literalHasTokenInfo(assigned, token_map)) << "an assigned-to literal owns no map entry";
+
+        /// Self-assignment must not throw away token info the literal legitimately owns. Routed
+        /// through a reference so the compiler does not see a literal `x = x` and reject it.
+        ASTLiteral & self = const_cast<ASTLiteral &>(*literal);
+        ASTLiteral & alias_of_self = self;
+        self = alias_of_self;
+        EXPECT_TRUE(literalHasTokenInfo(*literal, token_map)) << "self-assignment must keep its own token info";
+        EXPECT_NE(token_map.find(literal), nullptr);
+    }
+    EXPECT_TRUE(saw) << "expected at least one recorded literal to clone";
+}
+
+/// Sanity: a real tokenized literal DOES report token info and is present in the map.
+TEST(LiteralTokenMap, TokenizedLiteralReportsTokenInfo)
+{
+    LiteralTokenMap token_map;
+    ASTPtr ast = parseWithTokenMap("x = 12345", token_map);
+    checkInvariant(ast, token_map);
+
+    std::vector<const ASTLiteral *> literals;
+    collectLiterals(ast, literals);
+    bool saw = false;
+    for (const auto * literal : literals)
+    {
+        if (literal->value.getType() == Field::Types::UInt64 && literal->value.safeGet<UInt64>() == 12345)
+        {
+            saw = true;
+            EXPECT_TRUE(literalHasTokenInfo(*literal, token_map)) << "tokenized numeric literal must report token info";
+            EXPECT_NE(token_map.find(literal), nullptr);
+        }
+    }
+    EXPECT_TRUE(saw);
 }

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -58,9 +58,18 @@ static void extractLiteralTokensImpl(
     if (auto * literal = ast->as<ASTLiteral>())
     {
         /// Null and Bool literals are never recorded by the parser, so always push nullopt.
-        /// This also protects against stale token_map entries from address reuse.
         Field::Types::Which field_type = literal->value.getType();
         if (field_type == Field::Types::Null || field_type == Field::Types::Bool)
+        {
+            result.push_back(std::nullopt);
+            return;
+        }
+
+        /// Only literals actually tokenized from the query carry valid token info. A literal
+        /// synthesized by the parser (e.g. the Tuple/Array slow path, the EXTRACT arithmetic
+        /// operands, casts) has the bit unset, so we must ignore any token_map entry it may have
+        /// inherited from a freed, previously recorded literal that reused its address.
+        if (!literal->hasTokenInfo())
         {
             result.push_back(std::nullopt);
             return;

--- a/src/Processors/Formats/Impl/tests/gtest_constant_expression_template_token_guard.cpp
+++ b/src/Processors/Formats/Impl/tests/gtest_constant_expression_template_token_guard.cpp
@@ -1,0 +1,108 @@
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <Parsers/ASTLiteral.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/IParser.h>
+#include <Parsers/LiteralTokenInfo.h>
+#include <Parsers/TokenIterator.h>
+#include <Processors/Formats/Impl/ConstantExpressionTemplate.h>
+
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <stdexcept>
+#include <vector>
+
+using namespace DB;
+
+namespace
+{
+
+void collectLiterals(const ASTPtr & ast, std::vector<const ASTLiteral *> & out)
+{
+    if (const auto * literal = ast->as<ASTLiteral>())
+        out.push_back(literal);
+    for (const auto & child : ast->children)
+        collectLiterals(child, out);
+}
+
+/// Deduce a template the way `ValuesBlockInputFormat` does and render it. `stage_stale` runs between
+/// parsing and deduction, so a test can put the map into the state address reuse produces.
+String deduceTemplate(
+    const std::string & expr,
+    const String & result_type_name,
+    const std::function<void(const ASTPtr &, LiteralTokenMap &)> & stage_stale = {})
+{
+    tryRegisterFunctions();
+    tryRegisterAggregateFunctions();
+
+    Tokens tokens(expr.data(), expr.data() + expr.size());
+    IParser::Pos pos(tokens, 1000, 1000);
+    TokenIterator begin(tokens);
+
+    LiteralTokenMap token_map;
+    Expected expected;
+    expected.literal_token_map = &token_map;
+
+    ASTPtr ast;
+    ParserExpression parser;
+    if (!parser.parse(pos, ast, expected))
+        throw std::runtime_error("failed to parse: " + expr);
+
+    if (stage_stale)
+        stage_stale(ast, token_map);
+
+    ConstantExpressionTemplate::Cache cache;
+    auto structure = cache.getFromCacheOrConstruct(
+        DataTypeFactory::instance().get(result_type_name),
+        /*null_as_default=*/false,
+        begin,
+        /*expression_end=*/pos,
+        ast,
+        token_map,
+        getContext().context,
+        /*found_in_cache=*/nullptr,
+        /*salt=*/")");
+
+    return structure->dumpTemplate();
+}
+
+}
+
+/// A literal the parser synthesized must not be turned into a template placeholder, however the
+/// token map is keyed. `ParserCastOperator` keeps the type as text and builds `'1.5'` for the value
+/// after discarding the AST of `Decimal32(3)`, so the allocator can hand `'1.5'` the address the
+/// type argument `3` used - and with it that argument's recorded span.
+TEST(ConstantExpressionTemplateTokenGuard, SynthesizedCastLiteralIsNotTemplated)
+{
+    const std::string expr = "1.5::Decimal32(3)";
+    const size_t type_argument_offset = expr.find("(3)") + 1;
+
+    auto stage_type_argument_span = [&](const ASTPtr & ast, LiteralTokenMap & token_map)
+    {
+        std::vector<const ASTLiteral *> literals;
+        collectLiterals(ast, literals);
+
+        const ASTLiteral * cast_value = nullptr;
+        for (const auto * literal : literals)
+            if (literal->value.getType() == Field::Types::String && literal->value.safeGet<String>() == "1.5")
+                cast_value = literal;
+        ASSERT_NE(cast_value, nullptr) << "expected the synthesized cast value literal '1.5'";
+
+        const char * stale_begin = expr.data() + type_argument_offset;
+        token_map.insert_or_assign(cast_value, LiteralTokenInfo{stale_begin, stale_begin + 1});
+    };
+
+    /// Every token stays a token: the type argument keeps its own `'3'` and no placeholder appears.
+    EXPECT_EQ(
+        deduceTemplate(expr, "Decimal64(3)", stage_type_argument_span),
+        "'1.5', '::', 'Decimal32', '(', '3', ')', eof");
+}
+
+/// Control for the test above: a literal that really was tokenized still becomes a placeholder, so
+/// an absent placeholder there is a fact about the guard and not about this file's rendering.
+TEST(ConstantExpressionTemplateTokenGuard, TokenizedLiteralIsTemplated)
+{
+    EXPECT_EQ(deduceTemplate("1 + 2", "UInt64"), "UInt64, '+', UInt64, eof");
+}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111970
Related: https://github.com/ClickHouse/ClickHouse/pull/109368
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a sporadic `Cannot parse string ... as UInt64 ... While executing ValuesBlockInputFormat` error that could occur when inserting values whose expressions contain a numeric cast such as `initializeAggregation('sumState', 0::UInt64)`.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/111970
Related: https://github.com/ClickHouse/ClickHouse/pull/109368

Found while investigating the sporadic failure of `03443_projection_sparse` reported on #109368 (CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109368&sha=ea8c0f26f97b5a838442598c846acce74e9b3993&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29). The same signature also hit several unrelated PRs, most recently #111589 on 2026-07-26, which is where the tracking issue #111970 comes from.

Failing query: `INSERT INTO t_projection_sparse VALUES ('bb', initializeAggregation('sumState', 0::UInt64))`, error `Cannot parse string 'sumState' as UInt64`.

Root cause: the literal token map used by `ConstantExpressionTemplate` (added in #93974 when `begin`/`end` were removed from `ASTLiteral`) is keyed by raw `ASTLiteral *` pointers, and entries of literals discarded during parser backtracking are never removed. Some parsers synthesize a literal that survives into the AST but is never tokenized, so it has no entry of its own, yet the allocator can hand it a freed address whose stale entry is still in the map. In the failing case the discarded `'sumState'` string-literal probe, tried by `ParserCastOperator` before it sees there is no `::`, left the entry that the synthesized `0` cast value then reused. `ConstantExpressionTemplate` read the stale span, positioned the placeholder over the `'sumState'` text, and a later row fed `'sumState'` into a `UInt64` placeholder.

Fix: enforce the invariant on the object instead of at each synthesis site. `ASTLiteral` gets a `has_token_info` bit that is set only in `recordLiteralTokens`, the single place a literal is tokenized from the query text, and both consumers of the map (`ConstantExpressionTemplate` and the LIKE/REGEXP highlighting) ignore a literal whose bit is unset. Address reuse is then harmless for every synthesized literal, including the `Tuple`/`Array` slow-path nodes and the numeric operands `EXTRACT` injects into `plus`/`minus`/`intDiv` chains, several of which are built with no access to `Expected`.

The failure is an allocator address-reuse race, so a deterministic SQL reproducer is not possible; a unit test asserts the invariant for the tokenized and the synthesized shapes.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1048` (included in `26.8` and later)
<!-- ch-version-info:end -->