### PR TITLE
Add tests for compareTrackAt in partial_merge join

### DIFF
--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
@@ -1,0 +1,12 @@
+3	L3	R3
+nan	Lnan	Rnan
+-inf	L-inf	
+1	L1	
+2	L2	
+3	L3	R3
+7	L7	
+8	L8	
+9	L9	
+inf	Linf	
+nan	Lnan	Rnan
+1

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
@@ -1,12 +1,13 @@
-3	L3	R3
-inf	Linf	Rinf
--inf	L-inf	
-1	L1	
-2	L2	
-3	L3	R3
-7	L7	
-8	L8	
-9	L9	
-inf	Linf	Rinf
-nan	Lnan	
+3	0	L3	R3
+inf	0	Linf	Rinf
+-inf	0	L-inf	
+1	0	L1	
+2	0	L2	
+3	0	L3	R3
+7	0	L7	
+8	0	L8	
+9	0	L9	
+inf	0	Linf	Rinf
+nan	10	Lnan10	
+nan	20	Lnan20	
 0

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.reference
@@ -1,5 +1,5 @@
 3	L3	R3
-nan	Lnan	Rnan
+inf	Linf	Rinf
 -inf	L-inf	
 1	L1	
 2	L2	
@@ -7,6 +7,6 @@ nan	Lnan	Rnan
 7	L7	
 8	L8	
 9	L9	
-inf	Linf	
-nan	Lnan	Rnan
-1
+inf	Linf	Rinf
+nan	Lnan	
+0

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
@@ -10,6 +10,10 @@
 -- which explicitly leaves partial_merge's bitwise behavior unchanged.
 
 SET join_algorithm = 'partial_merge';
+-- Pin max_block_size so the whole sorted left input is one block. CI randomizes
+-- max_block_size; a small value would split the 7,8,9 < 10 run across blocks and
+-- compareTrackAt would never return |track| > 1, silently voiding the coverage.
+SET max_block_size = 65505;
 
 DROP TABLE IF EXISTS t_04546_left;
 DROP TABLE IF EXISTS t_04546_right;

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
@@ -1,0 +1,35 @@
+-- Test compareTrackAt with Float64/NaN/Inf keys in partial_merge join.
+-- ColumnVector<Float64>::compareTrackAt (ColumnVector.h:157) uses
+-- CompareHelper<Float64>::compare with NaN handling (nan_direction_hint).
+-- Exercises multi-row skipping on Float keys and NaN=NaN matching.
+
+SET join_algorithm = 'partial_merge';
+
+DROP TABLE IF EXISTS t_04546_left;
+DROP TABLE IF EXISTS t_04546_right;
+
+CREATE TABLE t_04546_left (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
+CREATE TABLE t_04546_right (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
+
+-- Left: -inf, 1, 2, 3, 7, 8, 9, inf, nan (sorted)
+-- Right: 0, 3, 5, 10, nan (sorted)
+INSERT INTO t_04546_left VALUES (-inf, 'L-inf'), (1, 'L1'), (2, 'L2'), (3, 'L3'), (7, 'L7'), (8, 'L8'), (9, 'L9'), (inf, 'Linf'), (nan, 'Lnan');
+INSERT INTO t_04546_right VALUES (0, 'R0'), (3, 'R3'), (5, 'R5'), (10, 'R10'), (nan, 'Rnan');
+
+-- INNER JOIN: matching keys 3 and NaN.
+-- isNaN() prefix pins NaN rows last so the ORDER BY is deterministic regardless
+-- of the sort's nan_direction_hint (which CI randomizes).
+SELECT l.key, l.val, r.val
+FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key
+ORDER BY isNaN(l.key), l.key, l.val;
+
+-- LEFT JOIN: all left rows, right values for matches
+SELECT l.key, l.val, r.val
+FROM t_04546_left l LEFT JOIN t_04546_right r ON l.key = r.key
+ORDER BY isNaN(l.key), l.key, l.val;
+
+-- NaN matches NaN in merge join (compareAt returns 0 for NaN=NaN)
+SELECT count() FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key WHERE isNaN(l.key);
+
+DROP TABLE t_04546_left;
+DROP TABLE t_04546_right;

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
@@ -1,7 +1,8 @@
--- Test compareTrackAt with Float64/NaN/Inf keys in partial_merge join.
+-- Test compareTrackAt with Float64 / +-Inf keys in partial_merge join.
 -- ColumnVector<Float64>::compareTrackAt (ColumnVector.h:157) uses
--- CompareHelper<Float64>::compare with NaN handling (nan_direction_hint).
--- Exercises multi-row skipping on Float keys and NaN=NaN matching.
+-- CompareHelper<Float64>::compare, which drives multi-row skipping over the
+-- sorted Float keys. NaN keys must follow equi-join semantics (NaN != NaN),
+-- so a NaN key never produces a match; only finite keys and +-Inf match.
 
 SET join_algorithm = 'partial_merge';
 
@@ -11,24 +12,25 @@ DROP TABLE IF EXISTS t_04546_right;
 CREATE TABLE t_04546_left (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
 CREATE TABLE t_04546_right (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
 
--- Left: -inf, 1, 2, 3, 7, 8, 9, inf, nan (sorted)
--- Right: 0, 3, 5, 10, nan (sorted)
+-- Left:  -inf, 1, 2, 3, 7, 8, 9, inf, nan
+-- Right:  0, 3, 5, 10, inf
+-- Finite match: 3. +-Inf: +inf matches, -inf does not. NaN must never match.
 INSERT INTO t_04546_left VALUES (-inf, 'L-inf'), (1, 'L1'), (2, 'L2'), (3, 'L3'), (7, 'L7'), (8, 'L8'), (9, 'L9'), (inf, 'Linf'), (nan, 'Lnan');
-INSERT INTO t_04546_right VALUES (0, 'R0'), (3, 'R3'), (5, 'R5'), (10, 'R10'), (nan, 'Rnan');
+INSERT INTO t_04546_right VALUES (0, 'R0'), (3, 'R3'), (5, 'R5'), (10, 'R10'), (inf, 'Rinf');
 
--- INNER JOIN: matching keys 3 and NaN.
--- isNaN() prefix pins NaN rows last so the ORDER BY is deterministic regardless
--- of the sort's nan_direction_hint (which CI randomizes).
+-- INNER JOIN: matching keys are 3 and +inf; NaN does not match.
+-- isNaN() prefix pins any NaN row last so the ORDER BY is deterministic
+-- regardless of the sort's nan_direction_hint (which CI randomizes).
 SELECT l.key, l.val, r.val
 FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key
 ORDER BY isNaN(l.key), l.key, l.val;
 
--- LEFT JOIN: all left rows, right values for matches
+-- LEFT JOIN: all left rows, right values for matches (3 and +inf); NaN unmatched.
 SELECT l.key, l.val, r.val
 FROM t_04546_left l LEFT JOIN t_04546_right r ON l.key = r.key
 ORDER BY isNaN(l.key), l.key, l.val;
 
--- NaN matches NaN in merge join (compareAt returns 0 for NaN=NaN)
+-- NaN follows equi-join semantics: NaN != NaN, so a NaN key never matches (expect 0).
 SELECT count() FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key WHERE isNaN(l.key);
 
 DROP TABLE t_04546_left;

--- a/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
+++ b/tests/queries/0_stateless/04546_partial_merge_join_float_nan.sql
@@ -1,37 +1,44 @@
--- Test compareTrackAt with Float64 / +-Inf keys in partial_merge join.
+-- Test compareTrackAt with Float64 / +-Inf / NaN keys in partial_merge join.
 -- ColumnVector<Float64>::compareTrackAt (ColumnVector.h:157) uses
 -- CompareHelper<Float64>::compare, which drives multi-row skipping over the
--- sorted Float keys. NaN keys must follow equi-join semantics (NaN != NaN),
--- so a NaN key never produces a match; only finite keys and +-Inf match.
+-- sorted Float keys. To actually exercise the NaN branch of compareTrackAt the
+-- NaN key is present on BOTH sides as the first key; a mismatching second key
+-- then keeps the overall join from matching. partial_merge compares float keys
+-- bitwise (nullableCompareAt), so NaN==NaN on the first key; the second key is
+-- what excludes the pair. This is independent of the equi-join NaN semantics
+-- change in the hash / full_sorting_merge / direct algorithms (PR #106540),
+-- which explicitly leaves partial_merge's bitwise behavior unchanged.
 
 SET join_algorithm = 'partial_merge';
 
 DROP TABLE IF EXISTS t_04546_left;
 DROP TABLE IF EXISTS t_04546_right;
 
-CREATE TABLE t_04546_left (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
-CREATE TABLE t_04546_right (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
+CREATE TABLE t_04546_left  (k1 Float64, k2 UInt32, val String) ENGINE = MergeTree() ORDER BY (k1, k2);
+CREATE TABLE t_04546_right (k1 Float64, k2 UInt32, val String) ENGINE = MergeTree() ORDER BY (k1, k2);
 
--- Left:  -inf, 1, 2, 3, 7, 8, 9, inf, nan
--- Right:  0, 3, 5, 10, inf
--- Finite match: 3. +-Inf: +inf matches, -inf does not. NaN must never match.
-INSERT INTO t_04546_left VALUES (-inf, 'L-inf'), (1, 'L1'), (2, 'L2'), (3, 'L3'), (7, 'L7'), (8, 'L8'), (9, 'L9'), (inf, 'Linf'), (nan, 'Lnan');
-INSERT INTO t_04546_right VALUES (0, 'R0'), (3, 'R3'), (5, 'R5'), (10, 'R10'), (inf, 'Rinf');
+-- Left  k1:  -inf, 1, 2, 3, 7, 8, 9, inf, nan, nan
+-- Right k1:   0, 3, 5, 10, inf, nan
+-- Finite match: 3. +-Inf: +inf matches, -inf does not. Runs 7,8,9 < 10 force a
+-- first-key track skip. NaN is on both sides so compareTrackAt compares NaN vs
+-- NaN, but the second key differs (10/20 left vs 30 right) so no NaN pair joins.
+INSERT INTO t_04546_left  VALUES (-inf, 0, 'L-inf'), (1, 0, 'L1'), (2, 0, 'L2'), (3, 0, 'L3'), (7, 0, 'L7'), (8, 0, 'L8'), (9, 0, 'L9'), (inf, 0, 'Linf'), (nan, 10, 'Lnan10'), (nan, 20, 'Lnan20');
+INSERT INTO t_04546_right VALUES (0, 0, 'R0'), (3, 0, 'R3'), (5, 0, 'R5'), (10, 0, 'R10'), (inf, 0, 'Rinf'), (nan, 30, 'Rnan30');
 
--- INNER JOIN: matching keys are 3 and +inf; NaN does not match.
+-- INNER JOIN on (k1, k2): matches are (3,0) and (inf,0); no NaN pair matches.
 -- isNaN() prefix pins any NaN row last so the ORDER BY is deterministic
 -- regardless of the sort's nan_direction_hint (which CI randomizes).
-SELECT l.key, l.val, r.val
-FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key
-ORDER BY isNaN(l.key), l.key, l.val;
+SELECT l.k1, l.k2, l.val, r.val
+FROM t_04546_left l INNER JOIN t_04546_right r ON l.k1 = r.k1 AND l.k2 = r.k2
+ORDER BY isNaN(l.k1), l.k1, l.k2, l.val;
 
--- LEFT JOIN: all left rows, right values for matches (3 and +inf); NaN unmatched.
-SELECT l.key, l.val, r.val
-FROM t_04546_left l LEFT JOIN t_04546_right r ON l.key = r.key
-ORDER BY isNaN(l.key), l.key, l.val;
+-- LEFT JOIN: all left rows, right values for matches (3,0) and (inf,0); NaN rows unmatched.
+SELECT l.k1, l.k2, l.val, r.val
+FROM t_04546_left l LEFT JOIN t_04546_right r ON l.k1 = r.k1 AND l.k2 = r.k2
+ORDER BY isNaN(l.k1), l.k1, l.k2, l.val;
 
--- NaN follows equi-join semantics: NaN != NaN, so a NaN key never matches (expect 0).
-SELECT count() FROM t_04546_left l INNER JOIN t_04546_right r ON l.key = r.key WHERE isNaN(l.key);
+-- compareTrackAt sees NaN vs NaN on k1, but the second key differs, so no NaN row joins (expect 0).
+SELECT count() FROM t_04546_left l INNER JOIN t_04546_right r ON l.k1 = r.k1 AND l.k2 = r.k2 WHERE isNaN(l.k1);
 
 DROP TABLE t_04546_left;
 DROP TABLE t_04546_right;

--- a/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.reference
+++ b/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.reference
@@ -1,0 +1,15 @@
+3	10	L3a	R3a
+5	20	L5b	R5b
+5	30	L5c	R5c
+10	10	L10a	R10a
+1	10	L1a	
+1	20	L1b	
+2	10	L2a	
+2	20	L2b	
+3	10	L3a	R3a
+5	10	L5a	
+5	20	L5b	R5b
+5	30	L5c	R5c
+10	10	L10a	R10a
+10	20	L10b	
+4

--- a/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.sql
+++ b/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.sql
@@ -1,0 +1,36 @@
+-- Test compareTrackAt multi-row skipping in partial_merge join with multi-key sort.
+-- MergeJoin.cpp:327 uses compareTrackAt on the first sort key to skip N rows at once
+-- (via nextN(-cmp) at MergeJoin.cpp:340), then falls back to regular compareAt for
+-- secondary keys when the first key is equal. Exercises the interaction between
+-- first-key track skipping and secondary-key matching.
+
+SET join_algorithm = 'partial_merge';
+
+DROP TABLE IF EXISTS t_04547_left;
+DROP TABLE IF EXISTS t_04547_right;
+
+-- Multi-key tables: (key1, key2)
+CREATE TABLE t_04547_left  (key1 UInt32, key2 UInt32, val String) ENGINE = MergeTree() ORDER BY (key1, key2);
+CREATE TABLE t_04547_right (key1 UInt32, key2 UInt32, val String) ENGINE = MergeTree() ORDER BY (key1, key2);
+
+-- Left key1:  1,1,2,2,3,5,5,5,10,10 — runs of key1 values less than right's key1
+-- force compareTrackAt to return track > 1 on the first key, then test secondary key
+INSERT INTO t_04547_left  VALUES (1,10,'L1a'), (1,20,'L1b'), (2,10,'L2a'), (2,20,'L2b'), (3,10,'L3a'), (5,10,'L5a'), (5,20,'L5b'), (5,30,'L5c'), (10,10,'L10a'), (10,20,'L10b');
+INSERT INTO t_04547_right VALUES (3,10,'R3a'), (5,20,'R5b'), (5,30,'R5c'), (10,10,'R10a');
+
+-- INNER JOIN on (key1, key2): verify multi-row skip on key1 does not miss key2 matches
+SELECT l.key1, l.key2, l.val, r.val
+FROM t_04547_left l INNER JOIN t_04547_right r ON l.key1 = r.key1 AND l.key2 = r.key2
+ORDER BY l.key1, l.key2;
+
+-- LEFT JOIN: all left rows present, right values only for exact (key1,key2) matches
+SELECT l.key1, l.key2, l.val, r.val
+FROM t_04547_left l LEFT JOIN t_04547_right r ON l.key1 = r.key1 AND l.key2 = r.key2
+ORDER BY l.key1, l.key2;
+
+-- Exact count of inner join matches
+SELECT count()
+FROM t_04547_left l INNER JOIN t_04547_right r ON l.key1 = r.key1 AND l.key2 = r.key2;
+
+DROP TABLE t_04547_left;
+DROP TABLE t_04547_right;

--- a/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.sql
+++ b/tests/queries/0_stateless/04547_partial_merge_join_multikey_track.sql
@@ -5,6 +5,10 @@
 -- first-key track skipping and secondary-key matching.
 
 SET join_algorithm = 'partial_merge';
+-- Pin max_block_size so the whole sorted left input is one block. CI randomizes
+-- max_block_size; a small value would split the key1 runs across blocks and
+-- compareTrackAt would never return track > 1, silently voiding the coverage.
+SET max_block_size = 65505;
 
 DROP TABLE IF EXISTS t_04547_left;
 DROP TABLE IF EXISTS t_04547_right;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/99706
Related: https://github.com/ClickHouse/ClickHouse/pull/99013
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Test-only. Adds `compareTrackAt` coverage for the `partial_merge` join algorithm (the devirtualized `IColumn::compareAt` used for merge-sorted joins, PR #99013). Reopens #99706, renumbered to 04546/04547.

- `04546`: `Float64` / `+-Inf` / `NaN` keys. Exercises float `compareTrackAt` multi-row skipping around `+-inf`. The `NaN` case is composite (`NaN` first key on both sides, mismatching second key) so `compareTrackAt` compares `NaN` vs `NaN` while the `(k1, k2)` join yields no `NaN` match. `partial_merge` compares float keys bitwise; this is independent of the hash / `full_sorting_merge` / `direct` `NaN != NaN` equi-join change in #106540, which explicitly leaves `partial_merge` unchanged.
- `04547`: multi-key sort. `compareTrackAt` skips multiple rows on the first key, then falls back to `compareAt` for the secondary key on first-key ties.
