### PR TITLE
Add test for compact MergeTree deduplication with multiple codecs

### DIFF
--- a/tests/queries/0_stateless/04548_compact_multi_codec_dedup.reference
+++ b/tests/queries/0_stateless/04548_compact_multi_codec_dedup.reference
@@ -1,0 +1,4 @@
+1
+1	hello	1.5
+2	world	2.5
+3	foo	3.5

--- a/tests/queries/0_stateless/04548_compact_multi_codec_dedup.reference
+++ b/tests/queries/0_stateless/04548_compact_multi_codec_dedup.reference
@@ -1,4 +1,9 @@
+2
+2
 1
 1	hello	1.5
+1	hello	1.5
 2	world	2.5
+2	world	2.5
+3	foo	3.5
 3	foo	3.5

--- a/tests/queries/0_stateless/04548_compact_multi_codec_dedup.sql
+++ b/tests/queries/0_stateless/04548_compact_multi_codec_dedup.sql
@@ -1,15 +1,15 @@
--- Regression test for PR #97522: non-deterministic `uncompressed_hash` in
--- compact `MergeTree` parts with multiple distinct compression codecs.
+-- Regression test for PR #97522: non-deterministic uncompressed_hash in compact
+-- MergeTree parts with multiple distinct compression codecs.
 --
--- `MergeTreeWriterCompact` groups substreams by codec in a `streams_by_codec`
--- map. Before the fix, this was `std::unordered_map`, whose iteration order is
--- non-deterministic, so the same data could produce different `uncompressed_hash`
--- values across inserts, breaking deduplication. The fix uses `std::map`.
+-- MergeTreeDataPartWriterCompact::addToChecksums iterates a streams_by_codec map
+-- when computing each part's uncompressed_hash. Before the fix this was a
+-- std::unordered_map with non-deterministic iteration order, so two identical
+-- parts could get different uncompressed_hash values. The fix uses std::map.
 --
--- This test uses columns with three distinct codecs (LZ4, ZSTD, DoubleDelta+LZ4)
--- to ensure multiple entries in `streams_by_codec`. Forcing compact parts via
--- `min_bytes_for_wide_part = 10485760`. Two identical inserts must be deduplicated
--- to exactly one active part.
+-- Deduplication is disabled here so the two identical inserts stay as two separate
+-- compact parts, and we assert their uncompressed_hash values are identical. This
+-- targets system.parts.uncompressed_hash_of_compressed_files, which still consumes
+-- the checksum path today (unlike insert deduplication, which now hashes the block).
 
 DROP TABLE IF EXISTS t_04548_mc_dedup;
 
@@ -22,20 +22,26 @@ CREATE TABLE t_04548_mc_dedup
 ENGINE = MergeTree
 ORDER BY id
 SETTINGS
-    non_replicated_deduplication_window = 1000,
+    non_replicated_deduplication_window = 0,
     min_bytes_for_wide_part = 10485760,
     min_rows_for_wide_part  = 10485760;
 
 SYSTEM STOP MERGES t_04548_mc_dedup;
 
 INSERT INTO t_04548_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
--- Identical insert: must be deduplicated (uncompressed_hash must be deterministic)
+-- Identical data, second part: its uncompressed_hash must equal the first's.
 INSERT INTO t_04548_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
 
--- Exactly one active part after two identical inserts
+-- Two active parts (deduplication is off).
 SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_04548_mc_dedup' AND active;
 
--- Data is intact
+-- Both are compact parts.
+SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_04548_mc_dedup' AND active AND part_type = 'Compact';
+
+-- The two identical compact parts must have the same uncompressed_hash (1 distinct value).
+SELECT uniqExact(uncompressed_hash_of_compressed_files) FROM system.parts WHERE database = currentDatabase() AND table = 't_04548_mc_dedup' AND active;
+
+-- Data is intact.
 SELECT id, val1, val2 FROM t_04548_mc_dedup ORDER BY id;
 
 DROP TABLE t_04548_mc_dedup;

--- a/tests/queries/0_stateless/04548_compact_multi_codec_dedup.sql
+++ b/tests/queries/0_stateless/04548_compact_multi_codec_dedup.sql
@@ -1,0 +1,41 @@
+-- Regression test for PR #97522: non-deterministic `uncompressed_hash` in
+-- compact `MergeTree` parts with multiple distinct compression codecs.
+--
+-- `MergeTreeWriterCompact` groups substreams by codec in a `streams_by_codec`
+-- map. Before the fix, this was `std::unordered_map`, whose iteration order is
+-- non-deterministic, so the same data could produce different `uncompressed_hash`
+-- values across inserts, breaking deduplication. The fix uses `std::map`.
+--
+-- This test uses columns with three distinct codecs (LZ4, ZSTD, DoubleDelta+LZ4)
+-- to ensure multiple entries in `streams_by_codec`. Forcing compact parts via
+-- `min_bytes_for_wide_part = 10485760`. Two identical inserts must be deduplicated
+-- to exactly one active part.
+
+DROP TABLE IF EXISTS t_04548_mc_dedup;
+
+CREATE TABLE t_04548_mc_dedup
+(
+    id    UInt64   CODEC(LZ4),
+    val1  String   CODEC(ZSTD(1)),
+    val2  Float64  CODEC(DoubleDelta, LZ4)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    non_replicated_deduplication_window = 1000,
+    min_bytes_for_wide_part = 10485760,
+    min_rows_for_wide_part  = 10485760;
+
+SYSTEM STOP MERGES t_04548_mc_dedup;
+
+INSERT INTO t_04548_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
+-- Identical insert: must be deduplicated (uncompressed_hash must be deterministic)
+INSERT INTO t_04548_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
+
+-- Exactly one active part after two identical inserts
+SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_04548_mc_dedup' AND active;
+
+-- Data is intact
+SELECT id, val1, val2 FROM t_04548_mc_dedup ORDER BY id;
+
+DROP TABLE t_04548_mc_dedup;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/97522
Related: https://github.com/ClickHouse/ClickHouse/pull/99719
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Reopens #99719 (closed as stale) as a fresh PR, renumbered to 04548
(04042 is now taken on master).

Regression coverage for PR #97522 (non-deterministic `uncompressed_hash`
in compact MergeTree parts with multiple distinct compression codecs, fixed
by switching `streams_by_codec` from `unordered_map` to `map`). Uses three
distinct codecs (LZ4 / ZSTD(1) / DoubleDelta+LZ4) in a compact part; two
identical inserts must deduplicate to exactly one active part.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1022` (included in `26.7` and later)
<!-- ch-version-info:end -->