### PR TITLE
Make asynchronous insert flush respond to KILL QUERY

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -143,6 +143,7 @@ static struct InitFiu
     REGULAR(lazy_pipe_fds_fail_close) \
     ONCE(create_empty_part_inject_stale_dir) \
     PAUSEABLE(infinite_sleep) \
+    PAUSEABLE(async_insert_flush_pause_in_executor) \
     PAUSEABLE(stop_moving_part_before_swap_with_active) \
     REGULAR(replicated_merge_tree_all_replicas_stale) \
     REGULAR(zero_copy_lock_zk_fail_before_op) \

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1328,7 +1328,8 @@ Chunk AsynchronousInsertQueue::processEntriesWithParsing(
         std::move(on_error),
         data->size_in_bytes,
         data->entries.size(),
-        std::move(adding_defaults_transform));
+        std::move(adding_defaults_transform),
+        [query_status = insert_context->getProcessListElement()] { return query_status && query_status->isKilled(); });
 
     auto deduplication_info = DeduplicationInfo::create(/*async_insert=*/true);
 

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -3,6 +3,7 @@
 #include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
 
 #include <base/scope_guard.h>
+#include <Common/FailPoint.h>
 
 namespace DB
 {
@@ -11,6 +12,12 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_EXCEPTION;
+    extern const int QUERY_WAS_CANCELLED;
+}
+
+namespace FailPoints
+{
+    extern const char async_insert_flush_pause_in_executor[];
 }
 
 StreamingFormatExecutor::StreamingFormatExecutor(
@@ -19,11 +26,13 @@ StreamingFormatExecutor::StreamingFormatExecutor(
     ErrorCallback on_error_,
     size_t total_bytes_,
     size_t total_chunks_,
-    SimpleTransformPtr adding_defaults_transform_)
+    SimpleTransformPtr adding_defaults_transform_,
+    CancelCallback is_cancelled_)
     : header(header_)
     , format(std::move(format_))
     , on_error(std::move(on_error_))
     , adding_defaults_transform(std::move(adding_defaults_transform_))
+    , is_cancelled(std::move(is_cancelled_))
     , port(format->getPort().getHeader(), format.get())
     , result_columns(header.cloneEmptyColumns())
     , checkpoints(result_columns.size())
@@ -97,6 +106,11 @@ size_t StreamingFormatExecutor::execute(size_t num_bytes)
         port.setNeeded();
         while (true)
         {
+            FailPointInjection::pauseFailPoint(FailPoints::async_insert_flush_pause_in_executor);
+
+            if (is_cancelled && is_cancelled())
+                throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Format streaming was cancelled");
+
             auto status = format->prepare();
 
             switch (status)
@@ -123,6 +137,9 @@ size_t StreamingFormatExecutor::execute(size_t num_bytes)
     catch (Exception & e)
     {
         format->resetParser();
+        /// Cancellation aborts the whole execution; it is not a recoverable per-input parse error.
+        if (e.code() == ErrorCodes::QUERY_WAS_CANCELLED)
+            throw;
         return on_error(result_columns, checkpoints, e);
     }
     catch (std::exception & e)

--- a/src/Processors/Executors/StreamingFormatExecutor.h
+++ b/src/Processors/Executors/StreamingFormatExecutor.h
@@ -21,13 +21,20 @@ public:
     /// to result columns in comparison to previous call of `execute`.
     using ErrorCallback = std::function<size_t(const MutableColumns &, const ColumnCheckpoints &, Exception &)>;
 
+    /// Optional predicate polled once per chunk inside `execute`. When it returns true the
+    /// execution is aborted with QUERY_WAS_CANCELLED (rethrown past `on_error`, not treated as a
+    /// per-input parse error). Lets manually-driven callers honor query cancellation, which the
+    /// pipeline executor would otherwise provide.
+    using CancelCallback = std::function<bool()>;
+
     StreamingFormatExecutor(
         const Block & header_,
         InputFormatPtr format_,
         ErrorCallback on_error_ = [](const MutableColumns &, const ColumnCheckpoints, Exception & e) -> size_t { throw std::move(e); },
         size_t total_bytes_ = 0,
         size_t total_chunks_ = 0,
-        SimpleTransformPtr adding_defaults_transform_ = nullptr);
+        SimpleTransformPtr adding_defaults_transform_ = nullptr,
+        CancelCallback is_cancelled_ = {});
 
     /// Returns numbers of new read rows.
     size_t execute(size_t num_bytes = 0);
@@ -51,6 +58,7 @@ private:
     const InputFormatPtr format;
     const ErrorCallback on_error;
     const SimpleTransformPtr adding_defaults_transform;
+    const CancelCallback is_cancelled;
 
     InputPort port;
     MutableColumns result_columns;

--- a/tests/queries/0_stateless/04547_async_insert_flush_cancellation.reference
+++ b/tests/queries/0_stateless/04547_async_insert_flush_cancellation.reference
@@ -1,0 +1,1 @@
+Format streaming was cancelled

--- a/tests/queries/0_stateless/04547_async_insert_flush_cancellation.sh
+++ b/tests/queries/0_stateless/04547_async_insert_flush_cancellation.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: uses a PAUSEABLE failpoint whose channel is global to the server, so concurrent
+# test instances would interfere with each other's ENABLE/DISABLE/WAIT sequence.
+
+# Regression test: a background async-insert flush must honor KILL QUERY. Before the fix, the
+# parsing loop in StreamingFormatExecutor::execute never polled the cancellation flag, so a flush
+# of a buffered payload kept running after KILL and could trip the stress hung check.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+TABLE="t_async_flush_cancel_${CLICKHOUSE_DATABASE}"
+CLIENT_QUERY_ID="async_flush_client_${CLICKHOUSE_DATABASE}_$$"
+FP=async_insert_flush_pause_in_executor
+CLIENT_OUT="${CLICKHOUSE_TMP}/async_flush_client_$$.out"
+
+function cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT $FP" 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query LIKE '%$TABLE%' AND query NOT LIKE '%KILL QUERY%' SYNC FORMAT Null" 2>/dev/null ||:
+    wait 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $TABLE" 2>/dev/null ||:
+    rm -f "$CLIENT_OUT"
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $TABLE"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE $TABLE (x UInt64) ENGINE = MergeTree ORDER BY x"
+
+# Park the flush inside the executor loop as soon as it starts.
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT $FP"
+
+# Synchronous async insert over HTTP: the server parses the body (the "Parsed" data kind that goes
+# through StreamingFormatExecutor). The request blocks waiting for the background flush, which parks
+# at the failpoint. Its own query_id lets us exclude it from the KILL below.
+printf '1\n2\n3\n' | ${CLICKHOUSE_CURL} \
+    "${CLICKHOUSE_URL}&query_id=${CLIENT_QUERY_ID}&async_insert=1&wait_for_async_insert=1&async_insert_busy_timeout_min_ms=10&async_insert_busy_timeout_max_ms=10&query=INSERT+INTO+${TABLE}+FORMAT+TSV" \
+    --data-binary @- > "$CLIENT_OUT" 2>&1 &
+
+# Deterministically wait until the flush has parked at the failpoint (no polling / sleeping).
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT $FP PAUSE"
+
+# Kill ONLY the background flush (query_kind AsyncInsertFlush), not the client's own insert, without
+# waiting for it to exit. This sets is_killed on the flush's process-list element.
+$CLICKHOUSE_CLIENT -q "
+    KILL QUERY WHERE query_kind = 'AsyncInsertFlush' AND query LIKE '%$TABLE%'
+    FORMAT Null"
+
+# Release the loop and disable so a resumed iteration skips the failpoint.
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT $FP"
+
+# The synchronous client waits on the same entry the flush was processing; when the flush aborts,
+# the entry is finished with the cancellation exception and the client observes it.
+wait 2>/dev/null ||:
+
+# Fixed: the parsing loop honored the kill and aborted the flush, so the client sees the executor's
+#        own cancellation message ("Format streaming was cancelled").
+# Unfixed: the parsing loop ignored the kill; the flush finished parsing and only the downstream
+#        pushing pipeline caught the kill, so the client sees the generic "Query was cancelled"
+#        instead (empty grep => the reference diff FAILs). For a large payload this is the 20-minute
+#        unkillable parse that tripped the stress hung check.
+grep -oE "Format streaming was cancelled" "$CLIENT_OUT" | head -1


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/issues/107941

## Problem

A background asynchronous insert flush does not respond to `KILL QUERY`. Killing the flush sets `is_cancelled = 1` on its `system.processes` row, but the flush keeps parsing the entire buffered payload before stopping. For a large payload this is a long unkillable window — a flush of ~2M JSON rows was observed running ~1395 s after being killed, which trips the stress-test hung check (`Hung check failed, possible deadlock found`; it is neither hung nor a deadlock, just slow and unkillable). In production a runaway flush (large `async_insert_max_data_size`, slow parse/storage) cannot be aborted.

## Root cause

The parsing half of the flush, `AsynchronousInsertQueue::processData` → `processEntriesWithParsing`, drives the input format manually via `StreamingFormatExecutor::execute`. That method's `while (true)` loop calls `format->prepare` / `format->work` per chunk and never polls any cancellation flag — it bypasses the `PipelineExecutor`, which is the only place that normally observes `QueryStatus::isKilled`. So the kill has no effect during parsing. The downstream *pushing* pipeline (`CompletedPipelineExecutor`, fed the parsed chunk) is cancellation-aware, but it only runs after the whole payload has been parsed, so it honors the kill only once the expensive part is already done.

## Fix

`StreamingFormatExecutor` gains an optional cancellation predicate (`std::function<bool()>`, trailing constructor argument, default empty) polled once per chunk in the loop; when it fires, the loop throws `QUERY_WAS_CANCELLED`. That exception is rethrown past the loop's `catch (Exception &)` — which otherwise routes to the per-input `on_error` parse-error handler — so cancellation aborts the whole flush instead of being recorded as a parse error and unwinds through `processData` to `finishWithException`, which finishes every buffered entry with the cancellation (so `wait_for_async_insert=1` clients observe it). `AsynchronousInsertQueue::processEntriesWithParsing` passes the flush query's kill flag as the predicate. The default-empty predicate leaves the other `StreamingFormatExecutor` callers (Kafka, NATS, RabbitMQ, FileLog) unchanged.

A new PAUSEABLE failpoint `async_insert_flush_pause_in_executor` parks the loop so the regression test `04547_async_insert_flush_cancellation` can kill the flush mid-parse and assert it aborts from the parse loop (client sees `Format streaming was cancelled`) rather than only later from the pushing pipeline (`Query was cancelled`) — the latter is what an unfixed build produces, and the test FAILs on it.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A background asynchronous insert flush now stops promptly when killed with `KILL QUERY`; previously a flush of a large buffered payload kept parsing to the end and ignored the cancellation.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1068` (included in `26.7` and later)
<!-- ch-version-info:end -->