### PR TITLE
Pin PR build tweak and restore new/cloud version types in extracted CHVersion

### DIFF
--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -236,6 +236,10 @@ class CHVersion:
         self.version_type = version_type
         return self._refresh()
 
+    def with_tweak(self, tweak: int) -> "CHVersion":
+        self.tweak = int(tweak)
+        return self._refresh()
+
     def get_stable_release_type(self) -> str:
         return VersionType.LTS if self.minor % 5 == 3 else VersionType.STABLE
 

--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -23,10 +23,12 @@ SET(VERSION_STRING {string})
 
 
 class VersionType:
+    NEW = "new"
     TESTING = "testing"
     STABLE = "stable"
     LTS = "lts"
-    VALID = {TESTING, STABLE, LTS}
+    CLOUD = "cloud"
+    VALID = {NEW, TESTING, STABLE, LTS, CLOUD}
 
 
 def _read_versions() -> dict:

--- a/ci/jobs/scripts/workflow_hooks/version_log.py
+++ b/ci/jobs/scripts/workflow_hooks/version_log.py
@@ -14,6 +14,14 @@ def _add_build_to_version_history():
     )
     commit_parents = Shell.get_output("git log --format=%P -n 1").split(" ")
     version = CHVersion.get_current_version(no_strict=True)
+    if info.pr_number != 0:
+        # Pin the tweak in PRs. `HEAD` is the ephemeral merge commit, whose
+        # first-parent commit count diverges across close/reopen and re-runs of
+        # the same PR as `master` advances. Artifacts are keyed by the head SHA,
+        # so an unpinned tweak would store diverging version strings -- here and
+        # in the packages built from the pipeline kv data -- under one artifact
+        # prefix. The tweak is meaningless in a PR anyway.
+        version = version.with_tweak(1)
     data = {
         "check_start_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "pull_request_number": info.pr_number,

--- a/ci/jobs/scripts/workflow_hooks/version_log.py
+++ b/ci/jobs/scripts/workflow_hooks/version_log.py
@@ -7,21 +7,28 @@ from ci.jobs.scripts.cidb_cluster import CIDBCluster
 from ci.jobs.scripts.clickhouse_version import CHVersion
 
 
+def _build_version(info):
+    """The build version recorded for this run.
+
+    In a PR the tweak is pinned to 1. `HEAD` is the ephemeral merge commit,
+    whose first-parent commit count diverges across close/reopen and re-runs of
+    the same PR as `master` advances. Artifacts are keyed by the head SHA, so an
+    unpinned tweak would store diverging version strings -- both in the
+    `version_history` log and in the packages built from the pipeline kv data --
+    under one artifact prefix. The tweak is meaningless in a PR anyway."""
+    version = CHVersion.get_current_version(no_strict=True)
+    if info.pr_number != 0:
+        version = version.with_tweak(1)
+    return version
+
+
 def _add_build_to_version_history():
     info = Info()
     Shell.check(
         f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:"
     )
     commit_parents = Shell.get_output("git log --format=%P -n 1").split(" ")
-    version = CHVersion.get_current_version(no_strict=True)
-    if info.pr_number != 0:
-        # Pin the tweak in PRs. `HEAD` is the ephemeral merge commit, whose
-        # first-parent commit count diverges across close/reopen and re-runs of
-        # the same PR as `master` advances. Artifacts are keyed by the head SHA,
-        # so an unpinned tweak would store diverging version strings -- here and
-        # in the packages built from the pipeline kv data -- under one artifact
-        # prefix. The tweak is meaningless in a PR anyway.
-        version = version.with_tweak(1)
+    version = _build_version(info)
     data = {
         "check_start_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "pull_request_number": info.pr_number,

--- a/ci/tests/test_version_log.py
+++ b/ci/tests/test_version_log.py
@@ -1,0 +1,100 @@
+"""
+Tests for the PR tweak-pinning contract in
+`ci.jobs.scripts.workflow_hooks.version_log`.
+
+In a PR, `HEAD` is the ephemeral merge commit whose first-parent commit count
+(the tweak) changes across close/reopen and re-runs as `master` advances, while
+artifacts stay keyed by the head SHA. So the recorded version must pin the tweak
+to `1` regardless of what `git rev-list` returns, otherwise one artifact prefix
+would accumulate diverging version strings. These tests lock that behaviour in
+both sinks: the `version_history` row and the pipeline kv data.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+# `version_log` imports `praktika` by bare name, so put `ci/` on the path too.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import ci.jobs.scripts.clickhouse_version as chv
+import ci.jobs.scripts.workflow_hooks.version_log as version_log
+from ci.jobs.scripts.clickhouse_version import CHVersion
+
+# The tweak the git history would yield on the merge ref: anything but 1, so a
+# test that expects 1 is really exercising the pin, not the default.
+_GIT_TWEAK = 57
+
+
+class _FakeInfo:
+    """Stand-in for `praktika.info.Info`, shared by `version_log` and
+    `clickhouse_version` (the latter calls `Info().store_kv_data` from
+    `store_version_data_in_ci_pipeline`)."""
+
+    kv = {}
+
+    def __init__(self, pr_number):
+        self.pr_number = pr_number
+        self.git_branch = "feature-branch"
+        self.pr_url = "http://example/pr"
+        self.sha = "headsha"
+        self.commit_url = "http://example/commit/headsha"
+
+    def store_kv_data(self, key, value):
+        _FakeInfo.kv[key] = value
+
+
+def _patch_get_current_version(monkeypatch):
+    # `get_current_version` reads the file + git history; here it always yields
+    # the git tweak, so the pin (or its absence) is the only thing under test.
+    def fake(cls, with_tweak=True, no_strict=False):
+        return CHVersion(
+            26, 6, 1, "54511", tweak=_GIT_TWEAK, githash="deadbeef", version_type="testing"
+        )
+
+    monkeypatch.setattr(CHVersion, "get_current_version", classmethod(fake))
+
+
+def test_build_version_pins_tweak_in_pr(monkeypatch):
+    _patch_get_current_version(monkeypatch)
+    version = version_log._build_version(_FakeInfo(pr_number=12345))
+    assert version.tweak == 1
+    assert version.string == "26.6.1.1"
+    assert version.describe == "v26.6.1.1-testing"
+
+
+def test_build_version_keeps_git_tweak_outside_pr(monkeypatch):
+    _patch_get_current_version(monkeypatch)
+    version = version_log._build_version(_FakeInfo(pr_number=0))
+    assert version.tweak == _GIT_TWEAK
+    assert version.string == f"26.6.1.{_GIT_TWEAK}"
+
+
+def test_pr_run_records_pinned_tweak_in_both_sinks(monkeypatch):
+    _patch_get_current_version(monkeypatch)
+    _FakeInfo.kv = {}
+    monkeypatch.setattr(version_log, "Info", lambda: _FakeInfo(pr_number=12345))
+    monkeypatch.setattr(chv, "Info", lambda: _FakeInfo(pr_number=12345))
+    monkeypatch.setattr(version_log.Shell, "check", staticmethod(lambda *a, **k: True))
+    monkeypatch.setattr(
+        version_log.Shell, "get_output", staticmethod(lambda *a, **k: "p1 p2")
+    )
+
+    inserts = []
+
+    class _FakeCIDB:
+        def insert_json(self, table, json_str):
+            inserts.append((table, json_str))
+
+    monkeypatch.setattr(version_log, "CIDBCluster", lambda: _FakeCIDB())
+
+    version_log._add_build_to_version_history()
+
+    # version_history row
+    assert len(inserts) == 1
+    table, payload = inserts[0]
+    assert table == "version_history"
+    assert payload["version"] == "26.6.1.1"
+    # pipeline kv data
+    assert _FakeInfo.kv["version"]["string"] == "26.6.1.1"
+    assert _FakeInfo.kv["version"]["tweak"] == 1


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109867
Related: https://github.com/ClickHouse/clickhouse-private/pull/63826
-->

Follow-up to #109867, which extracted the tag-free `CHVersion` model. Two behaviors that the previous `get_current_version_as_dict` provided were dropped by the extraction; this restores both.

## Pin the version tweak in PRs

The extracted `get_current_version` computes the tweak from git history unconditionally. In PR CI, `HEAD` is the ephemeral merge commit, whose first-parent commit count diverges across close/reopen and re-runs of the same PR as `master` advances. Artifacts are keyed by the head SHA, so an unpinned tweak stores diverging version strings — in the `version_history` log and in the packages built from the pipeline kv data — under one artifact prefix. That is the invariant the deleted PR-specific version tests protected.

`version_log` now pins the tweak to 1 in PRs (it is meaningless there anyway) through a small `with_tweak` helper on `CHVersion`, so `get_current_version` itself stays free of the CI `Info` context.

## Restore the `new` and `cloud` version types

`VersionType.VALID` was narrowed to `{testing, stable, lts}`, but the private release flow still uses `VersionType.NEW` for new releases and `cloud` for private cloud patch releases (`tests/ci/create_release.py`), and `tests/ci/version_helper.py` keeps both in its valid set. Once the follow-up `CreateRelease` sync routes those callers through this extracted `CHVersion`, `with_description` would raise `ValueError`. Both types are added back; `prestable` stays dropped since nothing under `tests/ci` references it.

This change was originally part of #109867 but did not make it into the merge — the merge captured the pre-fix branch head — so it is re-submitted here.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1082` (included in `26.7` and later)
<!-- ch-version-info:end -->