### PR TITLE
Docs: responsive docs image sizing

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -47,6 +47,35 @@ html:not(.dark) .ch-usecase-arrow {
 .ch-overlay-shadow {
     box-shadow: 0 8px 32px rgba(0,0,0,0.28), 0 2px 8px rgba(0,0,0,0.18);
 }
+
+/* Preserve the sm/md/lg image hierarchy from the previous docs site.
+   Mintlify's content column is narrower, so 480px keeps md visibly distinct
+   from a full-width lg image. */
+.ch-image-sm,
+.ch-image-md,
+.ch-image-lg {
+    width: 100%;
+    margin-inline: auto;
+}
+
+.ch-image-sm {
+    max-width: 300px;
+}
+
+.ch-image-md {
+    max-width: 480px;
+}
+
+.ch-image-lg {
+    max-width: 100%;
+}
+
+.ch-image-sm img,
+.ch-image-md img,
+.ch-image-lg img {
+    width: 100%;
+    height: auto;
+}
 /* MCP icon — mask-size/repeat extracted from inline style; URL stays inline */
 .ch-mcp-icon {
     -webkit-mask-size: contain;

--- a/docs/snippets/_GCS_authentication_and_bucket.mdx
+++ b/docs/snippets/_GCS_authentication_and_bucket.mdx
@@ -2,15 +2,19 @@
 <Accordion title="Create GCS buckets and an HMAC key">
 ### ch_bucket_us_east1 {#ch_bucket_us_east1}
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-bucket-1.webp" alt="Creating a GCS bucket in US East 1" />
 </Frame>
+</div>
 
 ### ch_bucket_us_east4 {#ch_bucket_us_east4}
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-bucket-2.webp" alt="Creating a GCS bucket in US East 4" />
 </Frame>
+</div>
 
 ### Generate an access key {#generate-an-access-key}
 
@@ -18,40 +22,52 @@
 
 Open **Cloud Storage > Settings > Interoperability** and either choose an existing **Access key**, or **CREATE A KEY FOR A SERVICE ACCOUNT**.  This guide covers the path for creating a new key for a new service account.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-create-a-service-account-key.webp" alt="Generating a service account HMAC key in GCS" />
 </Frame>
+</div>
 
 ### Add a new service account {#add-a-new-service-account}
 
 If this is a project with no existing service account, **CREATE NEW ACCOUNT**.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-create-service-account-0.webp" alt="Adding a new service account in GCS" />
 </Frame>
+</div>
 
 There are three steps to creating the service account, in the first step give the account a meaningful name, ID, and description.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-create-service-account-a.webp" alt="Defining a new service account name and ID in GCS" />
 </Frame>
+</div>
 
 In the Interoperability settings dialog the IAM role **Storage Object Admin** role is recommended; select that role in step two.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-create-service-account-2.webp" alt="Selecting IAM role Storage Object Admin in GCS" />
 </Frame>
+</div>
 
 Step three is optional and not used in this guide.  You may allow users to have these privileges based on your policies.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-create-service-account-3.webp" alt="Configuring additional settings for the new service account in GCS" />
 </Frame>
+</div>
 
 The service account HMAC key will be displayed.  Save this information, as it will be used in the ClickHouse configuration.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/s3/GCS-guide-key.webp" alt="Retrieving the generated HMAC key for GCS" />
 </Frame>
+</div>
 
 </Accordion>

--- a/docs/snippets/_S3_authentication_and_bucket.mdx
+++ b/docs/snippets/_S3_authentication_and_bucket.mdx
@@ -11,27 +11,35 @@ In the following steps you'll be creating a service account user (not a login us
 
 2. In the `Users` menu, select `Create user`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-1.webp" alt="AWS IAM Management Console - Adding a new user" />
 </Frame>
+</div>
 
 3. Enter the username and set the credential type to `Access key - Programmatic access` and select `Next: Permissions`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-2.webp" alt="Setting user name and access type for IAM user" />
 </Frame>
+</div>
 
 4. Don't add the user to any group; select `Next: Tags`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-3.webp" alt="Skipping group assignment for IAM user" />
 </Frame>
+</div>
 
 5. Unless you need to add any tags, select `Next: Review`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-4.webp" alt="Skipping tag assignment for IAM user" />
 </Frame>
+</div>
 
 6. Select `Create User`
 
@@ -39,9 +47,11 @@ In the following steps you'll be creating a service account user (not a login us
 The warning message stating that the user has no permissions can be ignored; permissions will be granted on the bucket for the user in the next section
 </Note>
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-5.webp" alt="Creating the IAM user with no permissions warning" />
 </Frame>
+</div>
 
 7. The user is now created; click on `show` and copy the access and secret keys.
 
@@ -49,29 +59,37 @@ The warning message stating that the user has no permissions can be ignored; per
 Save the keys somewhere else; this is the only time that the secret access key will be available.
 </Note>
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-6.webp" alt="Viewing and copying the IAM user access keys" />
 </Frame>
+</div>
 
 8. Click close, then find the user in the users screen.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-7.webp" alt="Finding the newly created IAM user in the users list" />
 </Frame>
+</div>
 
 9. Copy the ARN (Amazon Resource Name) and save it for use when configuring the access policy for the bucket.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-8.webp" alt="Copying the ARN of the IAM user" />
 </Frame>
+</div>
 
 ### Create an S3 bucket {#create-an-s3-bucket}
 
 1. In the S3 bucket section, select `Create bucket`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-9.webp" alt="Starting the S3 bucket creation process" />
 </Frame>
+</div>
 
 2. Enter a bucket name, leave other options default
 
@@ -81,53 +99,69 @@ The bucket name must be unique across AWS, not just the organization, or it will
 
 3. Leave `Block all Public Access` enabled; public access isn't needed.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-a.webp" alt="Configuring the S3 bucket settings with public access blocked" />
 </Frame>
+</div>
 
 4. Select `Create Bucket` at the bottom of the page
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-b.webp" alt="Finalizing S3 bucket creation" />
 </Frame>
+</div>
 
 5. Select the link, copy the ARN, and save it for use when configuring the access policy for the bucket.
 
 6. Once the bucket has been created, find the new S3 bucket in the S3 bucket list and select the link
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-c.webp" alt="Finding the newly created S3 bucket in the buckets list" />
 </Frame>
+</div>
 
 7. Select `Create folder`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-d.webp" alt="Creating a new folder in the S3 bucket" />
 </Frame>
+</div>
 
 8. Enter a folder name that will be the target for the ClickHouse S3 disk and select `Create folder`
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-e.webp" alt="Setting the folder name for ClickHouse S3 disk usage" />
 </Frame>
+</div>
 
 9. The folder should now be visible on the bucket list
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-f.webp" alt="Viewing the newly created folder in the S3 bucket" />
 </Frame>
+</div>
 
 10. Select the checkbox for the new folder and click on `Copy URL` Save the URL copied to be used in the ClickHouse storage configuration in the next section.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-g.webp" alt="Copying the S3 folder URL for ClickHouse configuration" />
 </Frame>
+</div>
 
 11. Select the `Permissions` tab and click on the `Edit` button in the `Bucket Policy` section
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/s3/s3-h.webp" alt="Accessing the S3 bucket policy configuration" />
 </Frame>
+</div>
 
 12. Add a bucket policy, example below:
 

--- a/docs/snippets/_add_remote_ip_access_list_detail.mdx
+++ b/docs/snippets/_add_remote_ip_access_list_detail.mdx
@@ -2,14 +2,18 @@
 <Accordion title="Manage your IP Access List">
 From your ClickHouse Cloud services list choose the service that you will work with and switch to **Settings**.  If the IP Access List doesn't contain the IP Address or range of the remote system that needs to connect to your ClickHouse Cloud service, then you can resolve the problem with **Add IPs**:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/ip-allow-list-check-list.webp" alt="Check to see if the service allows traffic from your IP address in the IP Access List" />
 </Frame>
+</div>
 
 Add the individual IP Address, or the range of addresses that need to connect to your ClickHouse Cloud service. Modify the form as you see fit and then **Save**.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/ip-allow-list-add-current-ip.webp" alt="Add your current IP address to the IP Access List in ClickHouse Cloud" />
 </Frame>
+</div>
 
 </Accordion>

--- a/docs/snippets/_avoid_optimize_final.mdx
+++ b/docs/snippets/_avoid_optimize_final.mdx
@@ -5,9 +5,11 @@ Each insert creates a new part containing sorted, compressed column files, along
 
 Over time, background processes merge smaller parts into larger ones to reduce fragmentation and improve query performance.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/bestpractices/simple_merges.webp" alt="Simple merges" />
 </Frame>
+</div>
 
 While it's tempting to manually trigger this merge using:
 

--- a/docs/snippets/_clickhouse_mysql_cloud_setup.mdx
+++ b/docs/snippets/_clickhouse_mysql_cloud_setup.mdx
@@ -30,9 +30,11 @@ Select "Connect" from the left menu:
 <Step title={<>Choose <code>MySQL</code></>} id="choose-mysql">
 Select `MySQL` from the `Connect With` drop down.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/mysql4.webp" alt="ClickHouse Cloud connection screen showing MySQL option selection" />
 </Frame>
+</div>
 
 </Step>
 <Step title="Enable the MySQL interface" id="enable-mysql-interface-existing-service">
@@ -41,9 +43,11 @@ This will expose port `3306` for this service and prompt you with your MySQL con
 </Step>
 </Steps>
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/mysql5.webp" alt="ClickHouse Cloud connection screen with MySQL interface enabled showing connection details" />
 </Frame>
+</div>
 
 ## Creating a readonly MySQL user in ClickHouse Cloud {#creating-multiple-mysql-users-in-clickhouse-cloud}
 ClickHouse Cloud automatically creates a `mysql4<subdomain>` user that shares the same password as the default user.

--- a/docs/snippets/_clickstack_tagging.mdx
+++ b/docs/snippets/_clickstack_tagging.mdx
@@ -10,12 +10,16 @@ Tags provide a flexible way to categorize and filter based on your needs.
 
 This makes it easy to find related items and maintain an organized workspace as your collection grows.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/use-cases/observability/clickstack-tags-search.webp" alt="Tags in saved search" />
 </Frame>
+</div>
 
 You can also select multiple tags to filter and view items across different categories:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/use-cases/observability/clickstack-tags-dashboard.webp" alt="Multiple tags selected in dashboard" />
 </Frame>
+</div>

--- a/docs/snippets/_create_clickpipe.mdx
+++ b/docs/snippets/_create_clickpipe.mdx
@@ -53,9 +53,11 @@ Finally, you can configure permissions for the internal ClickPipes user.
 
 By clicking on "Complete Setup", the system will register your ClickPipe, and you'll be able to see it listed in the summary table.
 
+<div className="ch-image-sm">
 <Frame>
   <img src="/images/integrations/data-ingestion/clickpipes/cp_success.webp" alt="Success notice" />
 </Frame>
+</div>
 
 <Frame>
   <img src="/images/integrations/data-ingestion/clickpipes/cp_remove.webp" alt="Remove notice" />

--- a/docs/snippets/_gather_your_details_http.mdx
+++ b/docs/snippets/_gather_your_details_http.mdx
@@ -10,14 +10,18 @@ To connect to ClickHouse with HTTP(S) you need this information:
 The details for your ClickHouse Cloud service are available in the ClickHouse Cloud console.
 Select a service and click **Connect**:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/cloud-connect-button.webp" alt="ClickHouse Cloud service connect button" />
 </Frame>
+</div>
 
 Choose **HTTPS**. Connection details are displayed in an example `curl` command.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/connection-details-https.webp" alt="ClickHouse Cloud HTTPS connection details" />
 </Frame>
+</div>
 
 If you're using self-managed ClickHouse, the connection details are set by your ClickHouse administrator.

--- a/docs/snippets/_gather_your_details_native.mdx
+++ b/docs/snippets/_gather_your_details_native.mdx
@@ -10,14 +10,18 @@ To connect to ClickHouse with native TCP you need this information:
 The details for your ClickHouse Cloud service are available in the ClickHouse Cloud console.
 Select the service that you will connect to and click **Connect**:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/cloud-connect-button.webp" alt="ClickHouse Cloud service connect button" />
 </Frame>
+</div>
 
 Choose **Native**, and the details are available in an example `clickhouse-client` command.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/connection-details-native.webp" alt="ClickHouse Cloud Native TCP connection details" />
 </Frame>
+</div>
 
 If you're using self-managed ClickHouse, the connection details are set by your ClickHouse administrator.

--- a/docs/snippets/_macos.mdx
+++ b/docs/snippets/_macos.mdx
@@ -25,9 +25,11 @@ By default, MacOS won't run applications or tools created by a developer who can
 
 When attempting to run any `clickhouse` command, you may see this error:
 
+<div className="ch-image-sm">
 <Frame>
   <img src="/images/knowledgebase/fix-the-developer-verification-error-in-macos/dev-verification-error.webp" alt="MacOS developer verification error dialog" />
 </Frame>
+</div>
 
 To get around this verification error, you need to remove the app from MacOS' quarantine bin either by finding the appropriate setting in your System Settings window, using the terminal, or by re-installing ClickHouse.
 
@@ -37,16 +39,20 @@ The easiest way to remove the `clickhouse` executable from the quarantine bin is
 1. Open **System settings**.
 1. Navigate to **Privacy & Security**:
 
+    <div className="ch-image-md">
     <Frame>
       <img src="/images/knowledgebase/fix-the-developer-verification-error-in-macos/privacy-and-security-default-view.webp" alt="MacOS Privacy & Security settings default view" />
     </Frame>
+    </div>
 
 1. Scroll to the bottom of the window to find a message saying _"clickhouse-macos-aarch64" was blocked from use because it isn't from an identified developer".
 1. Click **Allow Anyway**.
 
+    <div className="ch-image-md">
     <Frame>
       <img src="/images/knowledgebase/fix-the-developer-verification-error-in-macos/privacy-and-security-screen-allow-anyway.webp" alt="MacOS Privacy & Security settings showing Allow Anyway button" />
     </Frame>
+    </div>
 
 1. Enter your MacOS user password.
 

--- a/docs/snippets/_migration_guide.mdx
+++ b/docs/snippets/_migration_guide.mdx
@@ -3,9 +3,11 @@
 
 [Amazon Redshift](https://aws.amazon.com/redshift/) is a popular cloud data warehousing solution that is part of the Amazon Web Services offerings. This guide presents different approaches to migrating data from a Redshift instance to ClickHouse. We will cover three options:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/redshift-to-clickhouse.webp" alt="Redshift to ClickHouse Migration Options" />
 </Frame>
+</div>
 
 From the ClickHouse instance standpoint, you can either:
 
@@ -23,9 +25,11 @@ We used Redshift as a data source in this tutorial. However, the migration appro
 
 In the push scenario, the idea is to leverage a third-party tool or service (either custom code or an [ETL/ELT](https://en.wikipedia.org/wiki/Extract,_transform,_load#ETL_vs._ELT)) to send your data to your ClickHouse instance. For example, you can use a software like [Airbyte](https://www.airbyte.com/) to move data between your Redshift instance (as a source) and ClickHouse as a destination ([see our integration guide for Airbyte](/integrations/connectors/data-ingestion/etl-tools/airbyte-and-clickhouse))
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/push.webp" alt="PUSH Redshift to ClickHouse" />
 </Frame>
+</div>
 
 ### Pros {#pros}
 
@@ -42,9 +46,11 @@ In the push scenario, the idea is to leverage a third-party tool or service (eit
 
 In the pull scenario, the idea is to leverage the ClickHouse JDBC Bridge to connect to a Redshift cluster directly from a ClickHouse instance and perform `INSERT INTO ... SELECT` queries:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/pull.webp" alt="PULL from Redshift to ClickHouse" />
 </Frame>
+</div>
 
 ### Pros {#pros-1}
 
@@ -175,9 +181,11 @@ Ok.
 
 In this scenario, we export data to S3 in an intermediary pivot format and, in a second step, load the data from S3 into ClickHouse.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/pivot.webp" alt="PIVOT from Redshift using S3" />
 </Frame>
+</div>
 
 ### Pros {#pros-2}
 
@@ -197,15 +205,19 @@ In this scenario, we export data to S3 in an intermediary pivot format and, in a
 
 Using Redshift's [UNLOAD](https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html) feature, export the data into an existing private S3 bucket:
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/s3-1.webp" alt="UNLOAD from Redshift to S3" style={{ backgroundColor: "white" }} />
 </Frame>
+</div>
 
 It will generate part files containing the raw data in S3
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/integrations/data-ingestion/redshift/s3-2.webp" alt="Data in S3" style={{ backgroundColor: "white" }} />
 </Frame>
+</div>
 
 </Step>
 <Step title="Create the table in ClickHouse" id="create-the-table-in-clickhouse">

--- a/docs/snippets/_service_actions_menu.mdx
+++ b/docs/snippets/_service_actions_menu.mdx
@@ -1,6 +1,8 @@
 
 Select your service, followed by `Data sources` -> `Predefined sample data`.
 
+<div className="ch-image-md">
 <Frame>
   <img src="/images/_snippets/cloud-service-actions-menu.webp" alt="ClickHouse Cloud service Actions menu showing Data sources and Predefined sample data options" />
 </Frame>
+</div>

--- a/docs/snippets/ar/components/Image.jsx
+++ b/docs/snippets/ar/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/components/Image.jsx
+++ b/docs/snippets/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/es/components/Image.jsx
+++ b/docs/snippets/es/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/fr/components/Image.jsx
+++ b/docs/snippets/fr/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/ja/components/Image.jsx
+++ b/docs/snippets/ja/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/ko/components/Image.jsx
+++ b/docs/snippets/ko/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/pt-BR/components/Image.jsx
+++ b/docs/snippets/pt-BR/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/ru/components/Image.jsx
+++ b/docs/snippets/ru/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };

--- a/docs/snippets/zh/components/Image.jsx
+++ b/docs/snippets/zh/components/Image.jsx
@@ -1,7 +1,11 @@
-export const Image = ({ img, alt, size }) => {
+export const Image = ({ img, alt, size = "lg" }) => {
+  const normalizedSize = ["sm", "md", "lg"].includes(size) ? size : "lg";
+
   return (
-    <Frame>
-      <img src={img} alt={alt} />
-    </Frame>
+    <div className={`ch-image-${normalizedSize}`}>
+      <Frame>
+        <img src={img} alt={alt} />
+      </Frame>
+    </div>
   );
 };


### PR DESCRIPTION
Restores the visual size hierarchy for documentation images after the Mintlify migration. Images now use responsive `sm` (300px), `md` (480px), and `lg` (full-width) wrappers across the shared component and localized copies.

The root cause was that the previous `md` cap exceeded Mintlify's narrower content column, while 47 default-language snippet images had also lost their original `sm` or `md` metadata when they were converted to raw `<Frame><img>` blocks to avoid import collisions.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry for user-facing changes
- [x] This change updates documentation presentation only.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1095` (included in `26.7` and later)
<!-- ch-version-info:end -->