### PR TITLE
CI: run ClickBench log-replication teardown inside the with block, flushing first

### DIFF
--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -128,17 +128,22 @@ def main():
                     name="Queries", results=query_results, stopwatch=stop_watch_
                 )
             )
+
+            # Tear down log replication while the local server is still up.
+            # `setup_log_cluster.sh --stop-log-replication` operates on the
+            # local server (it drops the `_sender`/`_watcher` replication
+            # tables there), and `ClickHouseService.__exit__` SIGTERMs that
+            # server on block exit, so this must run inside the `with`,
+            # symmetric with `start_log_exports` above.
+            Shell.check(
+                "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh --stop-log-replication",
+                verbose=True,
+            )
     except Exception as e:
         print(traceback.format_exc(), file=sys.stdout)
         results.append(
             Result(name="Job error", status=Result.Status.FAIL, info=str(e))
         )
-
-    # stop log replication
-    Shell.check(
-        "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh --stop-log-replication",
-        verbose=True,
-    )
 
     Result.create_from(
         results=results,

--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -80,65 +80,66 @@ def main():
             results=results,
             config_hooks=config_hooks,
         ):
-            if not info.is_local_run:
-                if not ch.start_log_exports(check_start_time=stop_watch.start_time):
-                    print("WARNING: Failed to start log export")
+            try:
+                if not info.is_local_run:
+                    if not ch.start_log_exports(
+                        check_start_time=stop_watch.start_time
+                    ):
+                        print("WARNING: Failed to start log export")
 
-            results.append(
-                r := Result.from_commands_run(
-                    name="Load the data",
-                    command="clickhouse-client --time < ./ci/jobs/scripts/clickbench/create.sql",
+                results.append(
+                    r := Result.from_commands_run(
+                        name="Load the data",
+                        command="clickhouse-client --time < ./ci/jobs/scripts/clickbench/create.sql",
+                    )
                 )
-            )
-            if not r.is_ok():
-                raise RuntimeError(f"[{r.name}] failed: {r.info}")
+                if not r.is_ok():
+                    raise RuntimeError(f"[{r.name}] failed: {r.info}")
 
-            print("Queries")
-            stop_watch_ = Utils.Stopwatch()
-            TRIES = 3
-            QUERY_NUM = 1
+                print("Queries")
+                stop_watch_ = Utils.Stopwatch()
+                TRIES = 3
+                QUERY_NUM = 1
 
-            with open(
-                "./ci/jobs/scripts/clickbench/queries.sql", "r"
-            ) as queries_file:
-                query_results = []
-                for query in queries_file:
-                    query = query.strip()
-                    timing = []
+                with open(
+                    "./ci/jobs/scripts/clickbench/queries.sql", "r"
+                ) as queries_file:
+                    query_results = []
+                    for query in queries_file:
+                        query = query.strip()
+                        timing = []
 
-                    for i in range(1, TRIES + 1):
-                        query_id = f"q{QUERY_NUM}-{i}"
-                        res, out, time_err = Shell.get_res_stdout_stderr(
-                            f'clickhouse-client --query_id {query_id} --time --format Null --query "{query}" --progress 0',
-                            verbose=True,
-                        )
-                        timing.append(time_err)
-                        query_results.append(
-                            Result(
-                                name=f"{QUERY_NUM}_{i}",
-                                status=Result.Status.OK,
-                                duration=float(time_err),
+                        for i in range(1, TRIES + 1):
+                            query_id = f"q{QUERY_NUM}-{i}"
+                            res, out, time_err = Shell.get_res_stdout_stderr(
+                                f'clickhouse-client --query_id {query_id} --time --format Null --query "{query}" --progress 0',
+                                verbose=True,
                             )
-                        )
-                    print(timing)
-                    QUERY_NUM += 1
+                            timing.append(time_err)
+                            query_results.append(
+                                Result(
+                                    name=f"{QUERY_NUM}_{i}",
+                                    status=Result.Status.OK,
+                                    duration=float(time_err),
+                                )
+                            )
+                        print(timing)
+                        QUERY_NUM += 1
 
-            results.append(
-                Result.create_from(
-                    name="Queries", results=query_results, stopwatch=stop_watch_
+                results.append(
+                    Result.create_from(
+                        name="Queries", results=query_results, stopwatch=stop_watch_
+                    )
                 )
-            )
-
-            # Tear down log replication while the local server is still up.
-            # `setup_log_cluster.sh --stop-log-replication` operates on the
-            # local server (it drops the `_sender`/`_watcher` replication
-            # tables there), and `ClickHouseService.__exit__` SIGTERMs that
-            # server on block exit, so this must run inside the `with`,
-            # symmetric with `start_log_exports` above.
-            Shell.check(
-                "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh --stop-log-replication",
-                verbose=True,
-            )
+            finally:
+                # Tear down log replication while the local server is still up,
+                # on both the success and the failure path. `stop_log_exports`
+                # runs `SYSTEM FLUSH LOGS` and `--stop-log-replication` against
+                # the local server (dropping the `_sender`/`_watcher` tables),
+                # and `ClickHouseService.__exit__` SIGTERMs that server on block
+                # exit. Symmetric with `start_log_exports` above.
+                if not info.is_local_run:
+                    ch.stop_log_exports()
     except Exception as e:
         print(traceback.format_exc(), file=sys.stdout)
         results.append(

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -335,6 +335,12 @@ class ClickHouseProc:
 
     @staticmethod
     def stop_log_exports():
+        # Flush buffered system-log records into the `system.*_log` tables so
+        # the `_watcher` materialized views feed the final rows into the
+        # `_sender` tables before `--stop-log-replication` drops them. Without
+        # this the tail of `query_log` and the other logs stays buffered and is
+        # lost from the export. Matches `SQLStorm`.
+        Shell.check('clickhouse-client --query "SYSTEM FLUSH LOGS"', verbose=True)
         return Shell.check(
             "./ci/jobs/scripts/functional_tests/setup_log_cluster.sh --stop-log-replication",
             verbose=True,


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110485
Related: https://github.com/ClickHouse/ClickHouse/pull/103810
-->

`ClickBench` was tearing down its log replication *after* leaving the `with ClickHouseService(...)` block (the context manager added in #103810), whose `__exit__` sends `SIGTERM` to the local server. So the teardown ran against a server that was already stopped, and the final benchmark queries' `system.*_log` rows never reached the central CI logs cluster.

Despite its name, `setup_log_cluster.sh` does not manage the remote log cluster — that cluster is a separate, pre-existing destination. What the script sets up and tears down is log *replication* on the **local** server: `--setup-logs-replication` creates the per-table `_sender` (`Distributed`) and `_watcher` (materialized view) objects that stream `system.*_log` rows to the remote cluster, and `--stop-log-replication` drops them. Both run against the local server, so the teardown needs it running — exactly like `start_log_exports`, which is already called inside the `with` block.

Changes:
- Move the teardown inside the `with` block, in a `try`/`finally` around the benchmark body, so it runs on both the success and the failure path while the local server is still up. It is now symmetric with `start_log_exports`.
- Call the `ch.stop_log_exports` helper instead of invoking `setup_log_cluster.sh --stop-log-replication` directly.
- Make `ClickHouseProc.stop_log_exports` run `SYSTEM FLUSH LOGS` before `--stop-log-replication`, so the buffered tail of `query_log` and the other logs is materialized (and fed through the `_watcher` views into `_sender`) before those tables are dropped. Matches `SQLStorm`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):