### PR TITLE
Fix iceberg() table function reading stale snapshot after table recreate

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.h
@@ -54,8 +54,8 @@ Explicit path to desired Iceberg metadata file, should be relative to path in ob
     DECLARE(String, iceberg_metadata_table_uuid, "", R"(
 Explicit table UUID to read metadata for. Ignored if iceberg_metadata_file_path is set.
 )", 0) \
-    DECLARE(Bool, iceberg_recent_metadata_file_by_last_updated_ms_field, false, R"(
-If enabled, the engine would use the metadata file with the most recent last_updated_ms json field. Does not make sense to use with iceberg_metadata_file_path.
+    DECLARE(Bool, iceberg_recent_metadata_file_by_last_updated_ms_field, true, R"(
+If enabled, the engine selects the current metadata file by the most recent `last-updated-ms` json field instead of the highest version number in the file name. This is robust to catalog-less (table function / bare path) reads of a table that was dropped and recreated at the same location: file version numbers reset on recreate, so the leftover metadata of the dropped table has a higher version and would otherwise shadow the recreated table, while `last-updated-ms` is monotonic wall-clock and correctly identifies the latest write. Set to 0 to restore the previous highest-version selection. Does not make sense to use with iceberg_metadata_file_path.
 )", 0) \
     DECLARE(UInt32, iceberg_metadata_async_prefetch_period_ms, 0, R"(
 The period in milliseconds to asynchronously prefetch the latest metadata snapshot from a remote iceberg catalog. Default is 0 - disabled.

--- a/tests/integration/test_storage_iceberg_no_spark/test_recreate_stale_snapshot.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_recreate_stale_snapshot.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/87574
+#
+# After an Iceberg table is dropped and recreated at the same location, the
+# catalog-less `iceberg()` table function used to return the OLD rows: it
+# resolved the current metadata file by the highest version number in the file
+# name, but version numbers reset on recreate, so the dropped table's leftover
+# metadata (higher version) shadowed the freshly recreated one. Selecting the
+# metadata file by the monotonic `last-updated-ms` field (now the default) fixes
+# it. The DataLakeCatalog engine always resolved this correctly via the catalog
+# metadata pointer; both must now agree.
+
+import uuid
+
+import pyarrow as pa
+from pyiceberg.schema import Schema, NestedField
+from pyiceberg.partitioning import PartitionSpec
+from pyiceberg.table.sorting import SortOrder
+from pyiceberg.types import LongType, StringType
+
+from test_read_in_order_with_pyiceberg import (
+    CATALOG_NAME,
+    create_clickhouse_iceberg_database,
+    load_catalog_impl,
+)
+
+_SCHEMA = Schema(
+    NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+    NestedField(field_id=2, name="name", field_type=StringType(), required=False),
+)
+
+
+def test_recreate_stale_snapshot(started_cluster_iceberg_no_spark):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    catalog = load_catalog_impl(started_cluster_iceberg_no_spark)
+    namespace = f"clickhouse_{uuid.uuid4().hex}"
+    table_short = "recreate_test"
+    identifier = f"{namespace}.{table_short}"
+
+    # Distinct s3 location per run so the leftover metadata of previous runs
+    # cannot interfere with this one.
+    table_dir = f"recreate_{uuid.uuid4().hex}"
+    location = f"s3://warehouse-rest/{table_dir}"
+
+    def make_table():
+        return catalog.create_table(
+            identifier=identifier,
+            schema=_SCHEMA,
+            location=location,
+            partition_spec=PartitionSpec(),
+            sort_order=SortOrder(),
+        )
+
+    # 1. Create + insert 3 rows.
+    table = make_table()
+    table.append(
+        pa.table(
+            {
+                "id": pa.array([1, 2, 3], type=pa.int64()),
+                "name": pa.array(["a", "b", "c"], type=pa.string()),
+            }
+        )
+    )
+
+    create_clickhouse_iceberg_database(
+        started_cluster_iceberg_no_spark, instance, CATALOG_NAME
+    )
+
+    # The s3 path the catalog-less table function reads (matches `location`).
+    table_function = (
+        f"icebergS3(s3, filename = '{table_dir}/', "
+        "url = 'http://minio1:9001/warehouse-rest/')"
+    )
+
+    def tf_count():
+        return int(instance.query(f"SELECT count() FROM {table_function}").strip())
+
+    def catalog_count():
+        return int(
+            instance.query(
+                f"SELECT count() FROM {CATALOG_NAME}.`{identifier}`"
+            ).strip()
+        )
+
+    assert tf_count() == 3
+    assert catalog_count() == 3
+
+    # 2. Drop (pyiceberg does not purge files) and recreate empty at the same
+    #    location. The old metadata (3 rows, higher version number) is left
+    #    behind on s3.
+    catalog.drop_table(identifier)
+    make_table()
+
+    # Reload the catalog database so it picks up the recreated table.
+    create_clickhouse_iceberg_database(
+        started_cluster_iceberg_no_spark, instance, CATALOG_NAME
+    )
+
+    # Both readers must now see the recreated (empty) table, not the stale 3
+    # rows of the dropped one.
+    assert catalog_count() == 0
+    assert tf_count() == 0
+
+    # Old highest-version selection is still available on demand.
+    stale = int(
+        instance.query(
+            f"SELECT count() FROM {table_function} "
+            "SETTINGS iceberg_recent_metadata_file_by_last_updated_ms_field = 0"
+        ).strip()
+    )
+    assert stale == 3


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/87574
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/87574

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `iceberg()`/`icebergS3()`/`IcebergLocal` reader returning rows of a previous table after an Iceberg table is dropped and recreated at the same location. The current metadata file is now selected by the `last-updated-ms` field instead of the highest version number in the file name (version numbers reset on recreate). Set `iceberg_recent_metadata_file_by_last_updated_ms_field = 0` to restore the previous behavior.

### Description

Fixes #87574.

When an Iceberg table is dropped and recreated at the same object-storage location, a catalog-less read (the `iceberg()` table function or `ENGINE = Iceberg(...)`, without a `DataLakeCatalog` in front) returned the **old** rows. The `DataLakeCatalog` database engine returned the correct (recreated) result. Both should agree.

**Root cause.** With no catalog pointer, no `version-hint.text`, and default settings, the current metadata file was resolved by listing `metadata/*.metadata.json` and picking the highest version number in the file name (`BY_METADATA_FILE_VERSION`). Iceberg version numbers **reset** when a table is recreated (a fresh table starts at `00000`), and drop does not purge files, so the dropped table's leftover metadata (e.g. `00001-...`, the old data) has a higher version than the recreated table's `00000-...` and shadows it. The catalog engine is unaffected because it reads the catalog's authoritative `metadata_location`.

**Fix.** Default `iceberg_recent_metadata_file_by_last_updated_ms_field` to `true`, so the current metadata file is chosen by the spec's monotonic wall-clock `last-updated-ms` field. This value keeps increasing across drop/recreate, so it correctly identifies the latest write. For a table that is only appended to (no recreate), the highest version and the highest `last-updated-ms` point at the same file, so there is no behavior change; this is confirmed by the existing e2e test that already asserts both strategies agree for a fresh table. The previous selection remains available via `iceberg_recent_metadata_file_by_last_updated_ms_field = 0` (backward compatible).

**Reproduced** deterministically with PyIceberg (`SqlCatalog`) + `icebergLocal`: after create+insert(3)/drop/recreate, `SELECT count()` returned 3 (stale) before and 0 (correct) after; the added integration test covers the same drop/recreate cycle over MinIO comparing the `iceberg()` table function against the `DataLakeCatalog` engine.

**Tradeoff note (for review):** selecting by `last-updated-ms` requires parsing every `metadata/*.metadata.json` on resolution instead of only reading the max-version file name, which is more object-storage reads for tables that accumulate many metadata files. The old cheaper behavior stays available via the setting. cc @scanhex12 — please weigh in on whether this default is acceptable or whether the selection should be narrowed to the recreate case only.
