### PR TITLE
Docs: correct default value for cloud default of `use_concurrency_control`

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -353,7 +353,7 @@ Set to `0` to disable this limit.
     DECLARE(Bool, use_concurrency_control, true, R"(
 Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).
 
-Cloud default value: `0`.
+Cloud default value: `1`.
 )", 0) \
     DECLARE(MaxThreads, max_download_threads, 4, R"(
 The maximum number of threads to download data (e.g. for URL engine).


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
The default value for `use_concurrency_control` is 1 in Cloud:

```
select now(),* from system.settings 
where name = 'use_concurrency_control'
format PrettyCompactMonoBlock;

Row 1:
──────
now():             2026-07-16 11:43:45
name:              use_concurrency_control
value:             1
changed:           1
description:       Respect the server's concurrency control (see the `concurrent_threads_soft_limit_num` and `concurrent_threads_soft_limit_ratio_to_cores` global server settings). If disabled, it allows using a larger number of threads even if the server is overloaded (not recommended for normal usage, and needed mostly for tests).
min:               ᴺᵁᴸᴸ
max:               ᴺᵁᴸᴸ
disallowed_values: []
readonly:          0
type:              Bool
default:           1
alias_for:
is_obsolete:       0
tier:              Production
```

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
