### PR TITLE
Add non-owning ValueRef to reduce Field materialization on hot paths

### DIFF
--- a/src/Columns/ValueRef.h
+++ b/src/Columns/ValueRef.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <Columns/IColumn.h>
+#include <Core/Field.h>
+
+#include <cstddef>
+#include <type_traits>
+
+
+namespace DB
+{
+
+/** A non-owning reference to a single value stored at row `row` of `column`.
+  *
+  * The point of `ValueRef` is to let hot code inspect, compare, copy, or hash one value that
+  * already lives inside an `IColumn` without materializing a `Field`. A `Field` allocates and
+  * branches on its type tag; a `ValueRef` is just a pointer plus an index, so it is trivially
+  * copyable and never touches the heap. It also preserves the exact type of the value, because the
+  * referenced column knows its own `IDataType` — there is no lossy `NearestFieldType` collapse
+  * (e.g. `UInt8` -> `UInt64`, `Float32` -> `Float64`) that a round trip through `Field` performs.
+  *
+  * Lifetime / validity: a `ValueRef` is valid only while `column` is alive and row `row` is not
+  * invalidated (by `insert`, `popBack`, mutation, etc.). Never store a `ValueRef` past the lifetime
+  * of the column it points into. This non-ownership is the whole benefit and the main hazard versus
+  * an owning `Field`.
+  *
+  * `toField` is an escape hatch, meant for the boundaries where an owned value is genuinely
+  * required (AST literals, serialization, settings). The goal is to defer or avoid that call, not
+  * to make it convenient.
+  */
+struct ValueRef
+{
+    const IColumn * column = nullptr;
+    size_t row = 0;
+
+    ValueRef() = default;
+
+    ValueRef(const IColumn & column_, size_t row_)
+        : column(&column_), row(row_)
+    {
+    }
+
+    /// A default-constructed `ValueRef` references nothing.
+    bool isValid() const { return column != nullptr; }
+
+    /// Materialize into an owned `Field`. Use only at a boundary that truly needs ownership.
+    Field toField() const { return (*column)[row]; }
+
+    /// Same as `toField`, reusing the caller's `Field` storage.
+    void toField(Field & out) const { column->get(row, out); }
+
+    /// Whether the referenced value is SQL `NULL`.
+    bool isNull() const { return column->isNullAt(row); }
+
+    /// Whether the referenced value equals the column's default (zero / empty).
+    bool isDefault() const { return column->isDefaultAt(row); }
+
+    /// Mix the referenced value into `hash`.
+    void updateHashWithValue(SipHash & hash) const { column->updateHashWithValue(row, hash); }
+
+    /// Append the referenced value to `dst`. Requires `dst` to be structurally compatible with the
+    /// referenced column (the same precondition as `IColumn::insertFrom`).
+    void insertInto(IColumn & dst) const { dst.insertFrom(*column, row); }
+
+    /** Three-way comparison against another `ValueRef`, routed through `IColumn::compareAt` so no
+      * `Field` is constructed. Returns a negative / zero / positive value when `*this` is less than
+      * / equal to / greater than `rhs`.
+      *
+      * Precondition: both columns are structurally comparable (see `IColumn::structureEquals`),
+      * mirroring what `IColumn::compareAt` itself requires. `nan_direction_hint` follows the exact
+      * `IColumn::compareAt` semantics for `NULL` and `NaN` ordering.
+      */
+    int compareAt(const ValueRef & rhs, int nan_direction_hint) const
+    {
+        chassert(rhs.column != nullptr);
+        chassert(column->structureEquals(*rhs.column));
+        return column->compareAt(row, rhs.row, *rhs.column, nan_direction_hint);
+    }
+};
+
+/// The whole point is that a `ValueRef` is as cheap to pass around as a raw pointer: no ownership,
+/// no heap, memcpy-able. If this ever stops holding, the type has grown a responsibility it should
+/// not have.
+static_assert(std::is_trivially_copyable_v<ValueRef>);
+
+}

--- a/src/Columns/tests/gtest_value_ref.cpp
+++ b/src/Columns/tests/gtest_value_ref.cpp
@@ -1,0 +1,184 @@
+#include <gtest/gtest.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnLowCardinality.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <Columns/ValueRef.h>
+
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypesNumber.h>
+
+#include <Common/SipHash.h>
+
+#include <vector>
+
+using namespace DB;
+
+namespace
+{
+
+/// Build a column of `type` and append every value in `values` (given as `Field`s).
+ColumnPtr makeColumn(const DataTypePtr & type, const std::vector<Field> & values)
+{
+    auto column = type->createColumn();
+    for (const auto & value : values)
+        column->insert(value);
+    return column;
+}
+
+/// For every row: a `ValueRef` must reproduce exactly what `operator[]` / `get` return, and match
+/// the column's own null/default/hash answers. This is the core "the wrapper adds nothing but
+/// convenience" guarantee.
+void checkRoundTrip(const IColumn & column)
+{
+    for (size_t row = 0; row < column.size(); ++row)
+    {
+        ValueRef ref(column, row);
+        ASSERT_TRUE(ref.isValid());
+
+        /// toField() parity with operator[].
+        EXPECT_EQ(ref.toField(), column[row]) << "row " << row;
+
+        /// toField(Field &) parity with get(row, Field &).
+        Field via_out;
+        ref.toField(via_out);
+        Field via_get;
+        column.get(row, via_get);
+        EXPECT_EQ(via_out, via_get) << "row " << row;
+
+        /// null / default parity.
+        EXPECT_EQ(ref.isNull(), column.isNullAt(row)) << "row " << row;
+        EXPECT_EQ(ref.isDefault(), column.isDefaultAt(row)) << "row " << row;
+
+        /// hash parity.
+        SipHash ref_hash;
+        ref.updateHashWithValue(ref_hash);
+        SipHash col_hash;
+        column.updateHashWithValue(row, col_hash);
+        EXPECT_EQ(ref_hash.get64(), col_hash.get64()) << "row " << row;
+    }
+}
+
+/// Within one column, ValueRef::compareAt must agree with IColumn::compareAt for every pair.
+void checkComparisonParity(const IColumn & column, int nan_direction_hint)
+{
+    for (size_t i = 0; i < column.size(); ++i)
+    {
+        for (size_t j = 0; j < column.size(); ++j)
+        {
+            ValueRef a(column, i);
+            ValueRef b(column, j);
+            EXPECT_EQ(
+                a.compareAt(b, nan_direction_hint),
+                column.compareAt(i, j, column, nan_direction_hint))
+                << "pair (" << i << ", " << j << ")";
+        }
+    }
+}
+
+}
+
+TEST(ValueRef, DefaultConstructedIsInvalid)
+{
+    ValueRef ref;
+    EXPECT_FALSE(ref.isValid());
+    EXPECT_EQ(ref.column, nullptr);
+}
+
+TEST(ValueRef, Numbers)
+{
+    /// UInt8 exercises the type-fidelity point: operator[] on ValueRef reflects what the column
+    /// stores; unlike a manual NearestFieldType round trip there is no surprise here beyond what
+    /// IColumn itself does.
+    auto column = makeColumn(std::make_shared<DataTypeUInt8>(), {UInt64(0), UInt64(1), UInt64(255), UInt64(7)});
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+    checkComparisonParity(*column, -1);
+}
+
+TEST(ValueRef, Floats)
+{
+    auto column = makeColumn(
+        std::make_shared<DataTypeFloat64>(),
+        {Float64(-1.5), Float64(0.0), Float64(3.25), std::numeric_limits<Float64>::quiet_NaN()});
+    checkRoundTrip(*column);
+    /// NaN ordering depends on nan_direction_hint; both must stay consistent with the column.
+    checkComparisonParity(*column, 1);
+    checkComparisonParity(*column, -1);
+}
+
+TEST(ValueRef, Strings)
+{
+    auto column = makeColumn(std::make_shared<DataTypeString>(), {"", "a", "abc", "abd", "zzz"});
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+}
+
+TEST(ValueRef, Nullable)
+{
+    auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>());
+    auto column = makeColumn(type, {Int64(-5), Null(), Int64(0), Int64(42), Null()});
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+    checkComparisonParity(*column, -1);
+}
+
+TEST(ValueRef, Array)
+{
+    auto type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeUInt64>());
+    auto column = makeColumn(
+        type,
+        {Array{}, Array{UInt64(1)}, Array{UInt64(1), UInt64(2)}, Array{UInt64(1), UInt64(3)}});
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+}
+
+TEST(ValueRef, LowCardinality)
+{
+    auto type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
+    auto column = makeColumn(type, {"red", "green", "red", "blue", "green"});
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+}
+
+TEST(ValueRef, Const)
+{
+    auto inner = makeColumn(std::make_shared<DataTypeString>(), {"same"});
+    auto column = ColumnConst::create(std::move(inner), 4);
+    checkRoundTrip(*column);
+    checkComparisonParity(*column, 1);
+}
+
+TEST(ValueRef, CompareAcrossColumnsSameType)
+{
+    auto lhs = makeColumn(std::make_shared<DataTypeInt64>(), {Int64(10), Int64(20)});
+    auto rhs = makeColumn(std::make_shared<DataTypeInt64>(), {Int64(15), Int64(20)});
+
+    ValueRef a(*lhs, 0);   // 10
+    ValueRef b(*rhs, 0);   // 15
+    ValueRef c(*rhs, 1);   // 20
+    ValueRef d(*lhs, 1);   // 20
+
+    EXPECT_LT(a.compareAt(b, 1), 0);   // 10 < 15
+    EXPECT_GT(b.compareAt(a, 1), 0);   // 15 > 10
+    EXPECT_EQ(c.compareAt(d, 1), 0);   // 20 == 20 across columns
+}
+
+TEST(ValueRef, InsertIntoRoundTrips)
+{
+    auto source = makeColumn(std::make_shared<DataTypeString>(), {"x", "yy", "zzz"});
+    auto dest = std::make_shared<DataTypeString>()->createColumn();
+
+    for (size_t row = 0; row < source->size(); ++row)
+        ValueRef(*source, row).insertInto(*dest);
+
+    ASSERT_EQ(dest->size(), source->size());
+    for (size_t row = 0; row < source->size(); ++row)
+        EXPECT_EQ((*dest)[row], (*source)[row]) << "row " << row;
+}


### PR DESCRIPTION
Introduce `ValueRef`, a lightweight non-owning reference to a single value stored at a given row of an `IColumn` (a `const IColumn *` plus a row index). It lets hot code inspect, compare, copy, and hash one value without materializing a `Field`, and it preserves the exact column type — there is no lossy `NearestFieldType` collapse (e.g. `UInt8` -> `UInt64`, `Float32` -> `Float64`) that a round trip through `Field` performs.

Motivation: a `Field` allocates and branches on its type tag; on hot paths that read one scalar out of a column, constructing a `Field` just to look at it is wasteful. Every `ValueRef` primitive delegates to an existing `IColumn` method (`operator[]`/`get`, `compareAt`, `isNullAt`, `isDefaultAt`, `updateHashWithValue`, `insertFrom`), so the type is a thin, trivially-copyable wrapper (enforced by `static_assert`) rather than new column logic. `toField`/`toField(Field &)` remain as escape hatches for boundaries that genuinely need an owned value.

This is the first (infrastructure) step of a pilot to reduce `Field` materialization on hot paths; no existing call site is changed yet, so there is no behavior change. `compareAt` routes through `IColumn::compareAt` with a debug `structureEquals` precondition and `nan_direction_hint` passthrough.

Testing: adds `gtest_value_ref.cpp` covering round-trip vs `operator[]`/`get`, null/default/hash parity, and `compareAt` parity across `UInt8`, `Float64` (incl. `NaN`), `String`, `Nullable`, `Array`, `LowCardinality`, and `Const` columns, plus a cross-column same-type compare and an `insertInto` round-trip. All 10 tests pass locally.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Internal refactor: add a non-owning `ValueRef` helper. No user-facing change.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
