### PR TITLE
Fix reading subcolumns of a missing DEFAULT column on the fly (Opus)

### DIFF
--- a/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
+++ b/src/Storages/MergeTree/MergeTreeBlockReadUtils.cpp
@@ -134,7 +134,15 @@ bool injectRequiredColumnsRecursively(
 
     /// Column doesn't have default value and don't exist in part
     /// don't need to add to required set.
-    const auto column_default = storage_snapshot->getDefault(column_name);
+    /// A DEFAULT expression is attached to the whole column in the metadata, not to its
+    /// subcolumns, and `getDefault` does not understand subcolumn names (e.g. "qb.1").
+    /// So for a subcolumn of a missing DEFAULT column, look up the default by the name in
+    /// storage ("qb"); otherwise the source columns of the default expression would not be
+    /// injected into the read set and the default would be evaluated on empty inputs.
+    String default_column_name = column_name;
+    if (column_in_storage && column_in_storage->isSubcolumn())
+        default_column_name = column_in_storage->getNameInStorage();
+    const auto column_default = storage_snapshot->getDefault(default_column_name);
     ASTPtr default_expression = column_default.has_value() ? column_default->expression : nullptr;
     if (!default_expression)
         return false;

--- a/tests/queries/0_stateless/04516_qbit_distance_transposed_unmaterialized_default.reference
+++ b/tests/queries/0_stateless/04516_qbit_distance_transposed_unmaterialized_default.reference
@@ -1,0 +1,8 @@
+BFloat16 transposed on unmaterialized DEFAULT matches full-column read
+1
+Int8 quantized transposed on unmaterialized DEFAULT matches full-column read
+1
+BFloat16 transposed after MATERIALIZE COLUMN matches full-column read
+1
+Int8 quantized transposed after MATERIALIZE COLUMN matches full-column read
+1

--- a/tests/queries/0_stateless/04516_qbit_distance_transposed_unmaterialized_default.sql
+++ b/tests/queries/0_stateless/04516_qbit_distance_transposed_unmaterialized_default.sql
@@ -1,0 +1,56 @@
+-- The transposed QBit distance functions are rewritten by DistanceTransposedPartialReadsPass to read
+-- individual bit-plane subcolumns (qb.1, qb.2, ...) of the QBit column instead of the whole column.
+-- When the QBit column has a DEFAULT and is not yet materialized on a part, reading its subcolumns must
+-- recompute the default from its source columns, exactly like a normal full-column read does. Previously
+-- the source column of the default was not injected into the read set, so it was fed an empty array and
+-- the implicit QBit CAST failed with "Array arguments must have size N for QBit conversion, got 0".
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/110634
+
+SET allow_experimental_qbit_type = 1;
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_qbit_default;
+
+-- Wide parts, so bit-plane subcolumns are separate streams that can be requested individually.
+CREATE TABLE t_qbit_default (id UInt32, v Array(BFloat16))
+    ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+
+INSERT INTO t_qbit_default
+    SELECT number, arrayMap(i -> toFloat32(i + number), range(8)) FROM numbers(8);
+
+-- Add QBit columns with a DEFAULT but do NOT materialize them: the existing parts stay without qb/qi.
+ALTER TABLE t_qbit_default
+    ADD COLUMN qb QBit(BFloat16, 8, 8) DEFAULT CAST(v, 'Array(BFloat16)'),
+    ADD COLUMN qi QBit(Int8, 8, 8) DEFAULT arrayMap(quantizeBFloat16ToInt8, CAST(v, 'Array(BFloat16)'));
+
+-- The optimized subcolumn read (default) of the unmaterialized DEFAULT must agree with the unoptimized
+-- full-column read. With the bug the optimized query threw SIZES_OF_ARRAYS_DONT_MATCH instead.
+SELECT 'BFloat16 transposed on unmaterialized DEFAULT matches full-column read';
+WITH arrayMap(i -> toFloat32(i), range(8)) AS ref
+SELECT
+    (SELECT arraySort(groupArray(round(cosineDistanceTransposed(qb, ref, 8), 4))) FROM t_qbit_default)
+  = (SELECT arraySort(groupArray(round(cosineDistanceTransposed(qb, ref, 8), 4))) FROM t_qbit_default SETTINGS optimize_qbit_distance_function_reads = 0);
+
+SELECT 'Int8 quantized transposed on unmaterialized DEFAULT matches full-column read';
+WITH arrayMap(i -> toFloat32(i), range(8)) AS ref
+SELECT
+    (SELECT arraySort(groupArray(round(cosineDistanceTransposedQuantized(qi, ref, 8), 4))) FROM t_qbit_default)
+  = (SELECT arraySort(groupArray(round(cosineDistanceTransposedQuantized(qi, ref, 8), 4))) FROM t_qbit_default SETTINGS optimize_qbit_distance_function_reads = 0);
+
+-- After materializing the columns the transposed read must still give the same result.
+ALTER TABLE t_qbit_default MATERIALIZE COLUMN qb SETTINGS mutations_sync = 2;
+ALTER TABLE t_qbit_default MATERIALIZE COLUMN qi SETTINGS mutations_sync = 2;
+
+SELECT 'BFloat16 transposed after MATERIALIZE COLUMN matches full-column read';
+WITH arrayMap(i -> toFloat32(i), range(8)) AS ref
+SELECT
+    (SELECT arraySort(groupArray(round(cosineDistanceTransposed(qb, ref, 8), 4))) FROM t_qbit_default)
+  = (SELECT arraySort(groupArray(round(cosineDistanceTransposed(qb, ref, 8), 4))) FROM t_qbit_default SETTINGS optimize_qbit_distance_function_reads = 0);
+
+SELECT 'Int8 quantized transposed after MATERIALIZE COLUMN matches full-column read';
+WITH arrayMap(i -> toFloat32(i), range(8)) AS ref
+SELECT
+    (SELECT arraySort(groupArray(round(cosineDistanceTransposedQuantized(qi, ref, 8), 4))) FROM t_qbit_default)
+  = (SELECT arraySort(groupArray(round(cosineDistanceTransposedQuantized(qi, ref, 8), 4))) FROM t_qbit_default SETTINGS optimize_qbit_distance_function_reads = 0);
+
+DROP TABLE t_qbit_default;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110634

Reading a subcolumn of a column that has a `DEFAULT` expression and is not physically present in a part (e.g. after `ALTER TABLE ... ADD COLUMN ... DEFAULT` on existing data, whether or not an `ALTER TABLE ... MATERIALIZE COLUMN` mutation is running) did not inject the source columns of the `DEFAULT` expression into the read set. `injectRequiredColumnsRecursively` looked up the default by the full requested name, but a `DEFAULT` is attached to the whole column in the metadata, never to its subcolumns (e.g. `qb.1`), so the lookup found nothing.

As a result the source column of the default was not read, and `IMergeTreeReader::evaluateMissingDefaults` substituted the type's default value (an empty array) for it. The default was then evaluated on empty inputs. For an ordinary column this silently returned wrong values for the subcolumn; for a `QBit` column the implicit `CAST` of the empty array threw `Array arguments must have size N for QBit conversion, got 0` (`SIZES_OF_ARRAYS_DONT_MATCH`).

This broke the transposed vector-distance functions `cosineDistanceTransposed`, `cosineDistanceTransposedQuantized` (and the `L2`/`dotProduct` variants), because `DistanceTransposedPartialReadsPass` rewrites them to read individual bit-plane subcolumns of the `QBit` column. A full-column read of the same column (e.g. with `optimize_qbit_distance_function_reads = 0`) recomputed the default correctly the whole time.

The fix makes `injectRequiredColumnsRecursively` look up the default by the name in storage (stripping the subcolumn) for subcolumn requests, so the expression's source columns are read and the real values are computed — exactly like a full-column read. This is a general fix for any subcolumn read of an unmaterialized `DEFAULT` column, not only `QBit`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reading a subcolumn of a column that has a `DEFAULT` expression and is not materialized in a part (e.g. after `ALTER TABLE ... ADD COLUMN` or during `ALTER TABLE ... MATERIALIZE COLUMN`): the subcolumn was filled with type default values instead of the evaluated `DEFAULT` expression, and the transposed vector-distance functions (`cosineDistanceTransposed` and others) on such `QBit` columns failed with `SIZES_OF_ARRAYS_DONT_MATCH`.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
--->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
