### PR TITLE
Clarify input_format_parquet_page_filter_push_down docs

### DIFF
--- a/docs/reference/settings/formats.mdx
+++ b/docs/reference/settings/formats.mdx
@@ -1317,7 +1317,7 @@ Schedule prefetches more aggressively if memory usage is below than threshold. P
 
 <VersionHistory rows={[{"id": "row-1","items": [{"label": "25.8"},{"label": "1"},{"label": "New setting (no effect when input_format_parquet_use_native_reader_v3 is disabled)"}]}]}/>
 
-Skip pages using min/max values from column index.
+Skip pages using min/max values from column index. This page-level pruning is separate from whole-row-group pruning (input_format_parquet_filter_push_down), bloom-filter pruning (input_format_parquet_bloom_filter_push_down) and Iceberg pruning, each of which can already drop data before this setting applies. So disabling this setting alone does not guarantee a full physical scan: a row group may still be pruned by the settings above, leaving read_rows = 0. To force a full physical scan even when a WHERE condition filters out everything, disable this setting together with the other pruning settings listed above.
 
 ## input_format_parquet_prefer_block_bytes {#input_format_parquet_prefer_block_bytes}   
 

--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -210,7 +210,7 @@ Schedule prefetches more aggressively if memory usage is below than threshold. P
 Approximate memory limit for Parquet reader v3. Limits how many row groups or columns can be read in parallel. When reading multiple files in one query, the limit is on total memory usage across those files.
 )", 0) \
     DECLARE(Bool, input_format_parquet_page_filter_push_down, true, R"(
-Skip pages using min/max values from column index.
+Skip pages using min/max values from column index. This page-level pruning is separate from whole-row-group pruning (input_format_parquet_filter_push_down), bloom-filter pruning (input_format_parquet_bloom_filter_push_down) and Iceberg pruning, each of which can already drop data before this setting applies. So disabling this setting alone does not guarantee a full physical scan: a row group may still be pruned by the settings above, leaving read_rows = 0. To force a full physical scan even when a WHERE condition filters out everything, disable this setting together with the other pruning settings listed above.
 )", 0) \
     DECLARE(Bool, input_format_parquet_use_offset_index, true, R"(
 Minor tweak to how pages are read from parquet file when no page filtering is used.


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/97172
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Clarifies the `input_format_parquet_page_filter_push_down` setting description.

In #97172 a user observed `read_rows = 0` in `system.query_log` for an Iceberg/Parquet read whose `WHERE` filtered out all rows, after disabling `input_format_parquet_filter_push_down`, `input_format_parquet_bloom_filter_push_down` and the Iceberg pruning/cache settings. This is expected behavior (confirmed by @PedroTadim on the issue): page-level column-index min/max pruning is controlled by the separate, default-on `input_format_parquet_page_filter_push_down`. When a `WHERE` condition prunes all data pages, no rows are decoded, so `read_rows` is 0.

The old description ("Skip pages using min/max values from column index.") did not mention that this setting is independent of `input_format_parquet_filter_push_down` or that it must also be disabled to force a full physical scan. This adds that note. Docs only, no behavior change.
