### PR TITLE
Revert some changes from #109105, add performance test that shows the degradation.

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -273,10 +273,13 @@ void ISerialization::deserializeBinaryBulkWithMultipleStreams(
     else if (ReadBuffer * stream = settings.getter(settings.path))
     {
         size_t prev_size = column->size();
-        /// `column` may be shared — e.g. it was placed into the substreams cache by an earlier substream
-        /// read — and appending to it in place would then mutate data still referenced by another owner.
-        /// Clone it when shared; `IColumn::mutate` is a no-op for the common uniquely-owned case.
-        MutableColumnPtr mutable_column = IColumn::mutate(std::move(column));
+        /// Use assumeMutable instead of IColumn::mutate: columns may be shared via the substreams
+        /// cache between multiple readers (e.g. reading both a subcolumn and the full column).
+        /// This sharing is intentional by design; IColumn::mutate would clone the column on
+        /// use_count > 1, defeating the cache and causing unnecessary copies.
+        /// MergeTree readers return a set of constant columns that are not mutated after reading,
+        /// so sharing subcolumns via the same ColumnPtr is safe.
+        auto mutable_column = column->assumeMutable();
         double avg_value_size_hint = 0.0;
         if (settings.get_avg_value_size_hint_callback)
             avg_value_size_hint = settings.get_avg_value_size_hint_callback(settings.path);

--- a/src/DataTypes/Serializations/SerializationArrayOffsets.cpp
+++ b/src/DataTypes/Serializations/SerializationArrayOffsets.cpp
@@ -39,10 +39,8 @@ void SerializationArrayOffsets::deserializeBinaryBulkWithMultipleStreams(
         /// Instead we need to insert data from the current range from it.
         if (rows_offset)
         {
-            /// `column` may alias `cached_column` (the substream can be read first with rows_offset == 0,
-            /// placing `column` itself into the cache, and then re-read in the same range with rows_offset > 0),
-            /// so clone it when shared — `IColumn::mutate` is a no-op when uniquely owned — before the append
-            /// and the in-place rows_offset compaction below.
+            /// IColumn::mutate is safe here: when rows_offset > 0, the cache always stores a cut() copy
+            /// (see the fresh-read path below), so `column` itself is never shared via the cache.
             MutableColumnPtr mutable_column = IColumn::mutate(std::move(column));
             mutable_column->insertRangeFrom(*cached_column, cached_column->size() - num_read_rows, num_read_rows);
             column = std::move(mutable_column);
@@ -74,9 +72,7 @@ void SerializationArrayOffsets::deserializeBinaryBulkWithMultipleStreams(
         }
     }
 
-    /// Apply rows_offset if needed. `column` is uniquely owned here (it was cloned above on the cache path
-    /// when shared, and the fresh-read path caches a separate cut() copy), so this in-place compaction does
-    /// not touch storage referenced elsewhere.
+    /// Apply rows_offset if needed.
     if (rows_offset)
     {
         auto mutable_column = column->assumeMutable();

--- a/src/DataTypes/Serializations/SerializationStringSize.cpp
+++ b/src/DataTypes/Serializations/SerializationStringSize.cpp
@@ -219,10 +219,8 @@ void SerializationStringSize::deserializeBinaryBulkWithSizeStream(
         /// Instead we need to insert data from the current range from it.
         if (rows_offset)
         {
-            /// `column` may alias `cached_column` (the substream can be read first with rows_offset == 0,
-            /// placing `column` itself into the cache, and then re-read in the same range with rows_offset > 0),
-            /// so clone it when shared — `IColumn::mutate` is a no-op when uniquely owned — before the append
-            /// and the in-place rows_offset compaction below.
+            /// IColumn::mutate is safe here: when rows_offset > 0, the cache always stores a cut() copy
+            /// (see the fresh-read path below), so `column` itself is never shared via the cache.
             MutableColumnPtr mutable_column = IColumn::mutate(std::move(column));
             mutable_column->insertRangeFrom(*cached_column, cached_column->size() - num_read_rows, num_read_rows);
             column = std::move(mutable_column);
@@ -254,9 +252,7 @@ void SerializationStringSize::deserializeBinaryBulkWithSizeStream(
         }
     }
 
-    /// Apply rows_offset if needed. `column` is uniquely owned here (it was cloned above on the cache path
-    /// when shared, and the fresh-read path caches a separate cut() copy), so this in-place compaction does
-    /// not touch storage referenced elsewhere.
+    /// Apply rows_offset if needed.
     if (rows_offset)
     {
         auto mutable_column = column->assumeMutable();

--- a/src/DataTypes/Serializations/SerializationVariant.cpp
+++ b/src/DataTypes/Serializations/SerializationVariant.cpp
@@ -562,14 +562,9 @@ void SerializationVariant::deserializeBinaryBulkWithMultipleStreams(
         /// Instead we need to insert data from the current range from it.
         if (rows_offset)
         {
-            /// `col`'s discriminators may alias `cached_column`: a prior rows_offset == 0 read of this
-            /// substream caches the discriminators column itself (see the deserialize path below, where
-            /// `discriminators_for_cache` is `col.getLocalDiscriminatorsPtr()` and not a `cut()` copy).
-            /// On a later rows_offset > 0 cache hit, appending in place — and the in-place rows_offset
-            /// compaction that follows — would then mutate storage still referenced by the cache, the same
-            /// COW hole the size readers close. Clone when shared; `IColumn::mutate` is a no-op when
-            /// uniquely owned.
             ColumnPtr & discriminators = col.getLocalDiscriminatorsPtr();
+            /// IColumn::mutate is safe here: when rows_offset > 0, the cache always stores a cut() copy
+            /// (see the fresh-read path below), so discriminators are never shared via the cache.
             MutableColumnPtr mutable_discriminators = IColumn::mutate(std::move(discriminators));
             mutable_discriminators->insertRangeFrom(*cached_column, cached_column->size() - num_read_rows, num_read_rows);
             discriminators = std::move(mutable_discriminators);

--- a/src/DataTypes/Serializations/tests/gtest_string_serialization.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_string_serialization.cpp
@@ -77,12 +77,6 @@ TEST(StringSerialization, IncorrectStateAfterMemoryLimitExceeded)
 
         run_with_memory_failures([&]() { serialization->deserializeBinaryBulkWithMultipleStreams(result_column, 0, src_column->size(), settings, state, nullptr); });
 
-        /// A `MEMORY_LIMIT_EXCEEDED` thrown while deserializing may leave `result_column` null: the COW-safe
-        /// deserialize path moves the column into a mutable clone and only assigns it back to `result_column`
-        /// on success. That is acceptable — we only require that any column that does survive stays consistent.
-        if (!result_column)
-            continue;
-
         auto & result = assert_cast<ColumnString &>(*result_column->assumeMutable());
         if (!result.empty())
         {

--- a/tests/performance/tuple_subcolumn_deserialization.xml
+++ b/tests/performance/tuple_subcolumn_deserialization.xml
@@ -1,0 +1,70 @@
+<test>
+    <!-- Wide parts: full Tuple + named subcolumns, alternating granule skipping via minmax index -->
+    <create_query>
+        CREATE TABLE tuple_deser_wide
+        (
+            id UInt64,
+            skip UInt8,
+            t Tuple(a String, b String, c String, d String, e String),
+            INDEX idx_skip skip TYPE minmax GRANULARITY 1
+        )
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS
+            min_bytes_for_wide_part = 0,
+            index_granularity = 2048,
+            index_granularity_bytes = 0,
+            string_serialization_version = 'single_stream'
+    </create_query>
+
+    <fill_query>
+        INSERT INTO tuple_deser_wide
+        SELECT
+            number,
+            intDiv(number, 2048) % 2,
+            tuple(randomString(1000), randomString(1000), randomString(1000), randomString(1000), randomString(1000))
+        FROM numbers(400000)
+    </fill_query>
+
+    <fill_query>OPTIMIZE TABLE tuple_deser_wide FINAL</fill_query>
+
+    <query>
+        SELECT t, t.a, t.b, t.c, t.d, t.e
+        FROM tuple_deser_wide
+        WHERE skip = 0
+        FORMAT Null
+        SETTINGS max_threads = 1, preferred_block_size_bytes = 1000000000000
+    </query>
+
+    <!-- Compact parts: nested Tuple so that subcolumns share substreams via cache -->
+    <create_query>
+        CREATE TABLE tuple_deser_compact
+        (
+            id UInt64,
+            t Tuple(inner Tuple(a String, b String, c String, d String, e String))
+        )
+        ENGINE = MergeTree ORDER BY id
+        SETTINGS
+            min_bytes_for_wide_part = 1000000000000,
+            string_serialization_version = 'single_stream'
+    </create_query>
+
+    <fill_query>
+        INSERT INTO tuple_deser_compact
+        SELECT
+            number,
+            tuple(tuple(randomString(1000), randomString(1000), randomString(1000), randomString(1000), randomString(1000)))
+        FROM numbers(400000)
+    </fill_query>
+
+    <fill_query>OPTIMIZE TABLE tuple_deser_compact FINAL</fill_query>
+
+    <query>
+        SELECT t.inner, t.inner.a, t.inner.b, t.inner.c, t.inner.d, t.inner.e
+        FROM tuple_deser_compact
+        FORMAT Null
+        SETTINGS max_threads = 1, preferred_block_size_bytes = 1000000000000
+    </query>
+
+    <drop_query>DROP TABLE IF EXISTS tuple_deser_wide</drop_query>
+    <drop_query>DROP TABLE IF EXISTS tuple_deser_compact</drop_query>
+</test>


### PR DESCRIPTION
Revert part of the changes in serializations from https://github.com/ClickHouse/ClickHouse/pull/109105, add performance test that clearly shows the performance degradation after these changes.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
