### PR TITLE
Stop fuzzing `FORGET PARTITION`

### DIFF
--- a/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
+++ b/src/Client/BuzzHouse/AST/SQLProtoStr.cpp
@@ -4778,10 +4778,6 @@ CONV_FN(AlterItem, alter)
             ret += "DROP DETACHED ";
             SinglePartitionExprToString(ret, alter.drop_detached_partition());
             break;
-        case AlterType::kForgetPartition:
-            ret += "FORGET ";
-            SinglePartitionExprToString(ret, alter.forget_partition());
-            break;
         case AlterType::kAttachPartition:
             ret += "ATTACH ";
             SinglePartitionExprToString(ret, alter.attach_partition());

--- a/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
+++ b/src/Client/BuzzHouse/Generator/StatementGenerator.cpp
@@ -2135,8 +2135,6 @@ std::optional<String> StatementGenerator::alterSingleTable(
                      rg, 1, rg.nextSmallNumber() < 9, true, t, ati->mutable_drop_detached_partition()->mutable_partition());
              }},
             {5 * static_cast<uint32_t>(no_oracle && is_mt),
-             [&] { generateNextTablePartition(rg, 0, rg.nextBool(), false, t, ati->mutable_forget_partition()->mutable_partition()); }},
-            {5 * static_cast<uint32_t>(no_oracle && is_mt),
              [&]
              {
                  generateNextTablePartition(rg, 1, rg.nextSmallNumber() < 9, true, t, ati->mutable_attach_partition()->mutable_partition());

--- a/src/Client/BuzzHouse/Proto/SQLGrammar.proto
+++ b/src/Client/BuzzHouse/Proto/SQLGrammar.proto
@@ -2288,7 +2288,6 @@ message AlterItem {
         SinglePartitionExpr detach_partition = 34;
         SinglePartitionExpr drop_partition = 35;
         SinglePartitionExpr drop_detached_partition = 36;
-        SinglePartitionExpr forget_partition = 37;
         SinglePartitionExpr attach_partition = 38;
         AttachPartitionFrom attach_partition_from = 39;
         AttachPartitionFrom replace_partition_from = 40;

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -6294,27 +6294,26 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             case ASTAlterCommand::DROP_PARTITION:
             case ASTAlterCommand::ATTACH_PARTITION:
             case ASTAlterCommand::DROP_DETACHED_PARTITION:
-            case ASTAlterCommand::FORGET_PARTITION:
-                /// DROP PARTITION <-> FORGET PARTITION carry the same PARTITION <expr> payload.
-                /// Gated on !part: DROP/DETACH PART hold a string part name, which FORGET PARTITION
-                /// (no PART form) cannot reparse.
-                if (!alter_cmd->part
-                    && (alter_cmd->type == ASTAlterCommand::DROP_PARTITION || alter_cmd->type == ASTAlterCommand::FORGET_PARTITION)
-                    && fuzz_rand() % 20 == 0)
-                    alter_cmd->type = alter_cmd->type == ASTAlterCommand::DROP_PARTITION ? ASTAlterCommand::FORGET_PARTITION
-                                                                                         : ASTAlterCommand::DROP_PARTITION;
                 if (fuzz_rand() % 20 == 0)
                     alter_cmd->detach = !alter_cmd->detach;
-                /// Do not flip `part`: PARTITION holds an ASTPartition while PART holds a string
-                /// part name (parsed differently), so a plain toggle produces unreparseable text.
+                if (fuzz_rand() % 20 == 0)
+                    alter_cmd->part = !alter_cmd->part;
                 break;
             case ASTAlterCommand::MOVE_PARTITION:
                 if (fuzz_rand() % 20 == 0)
                     alter_cmd->detach = !alter_cmd->detach;
-                /// Swap DISK<->VOLUME only: both carry move_destination_name so it round-trips. Never
-                /// switch a TABLE move or switch to TABLE — that needs a to_table we do not synthesize.
-                if (!alter_cmd->move_destination_name.empty() && fuzz_rand() % 10 == 0)
-                    alter_cmd->move_destination_type = (fuzz_rand() % 2 == 0) ? DataDestinationType::DISK : DataDestinationType::VOLUME;
+                if (fuzz_rand() % 20 == 0)
+                    alter_cmd->part = !alter_cmd->part;
+                /// Cycle move destination type between DISK, VOLUME, TABLE
+                if (fuzz_rand() % 10 == 0)
+                {
+                    static const DataDestinationType dest_types[] = {
+                        DataDestinationType::DISK,
+                        DataDestinationType::VOLUME,
+                        DataDestinationType::TABLE,
+                    };
+                    alter_cmd->move_destination_type = dest_types[fuzz_rand() % 3];
+                }
                 break;
             case ASTAlterCommand::DROP_CONSTRAINT:
             case ASTAlterCommand::MODIFY_CONSTRAINT:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`FORGET PARTITION` is not a query that can be fuzzed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1077` (included in `26.7` and later)
<!-- ch-version-info:end -->