### PR TITLE
Apply lazy materialization to FINAL with a filter and LIMIT without ORDER BY

### DIFF
--- a/src/Processors/QueryPlan/JoinLazyColumnsStep.cpp
+++ b/src/Processors/QueryPlan/JoinLazyColumnsStep.cpp
@@ -24,6 +24,13 @@ QueryPipelineBuilderPtr JoinLazyColumnsStep::updatePipeline(QueryPipelineBuilder
     if (pipelines.size() != 2)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "JoinLazyColumnsStep must have two pipelines");
 
+    /// The transform joins exactly one main and one lazy stream. The main branch is not
+    /// necessarily single-stream (e.g. a limit without a sorting step above the reading).
+    if (pipelines[0]->getNumStreams() > 1)
+        pipelines[0]->resize(1);
+    if (pipelines[1]->getNumStreams() > 1)
+        pipelines[1]->resize(1);
+
     auto transform = std::make_shared<LazyMaterializingTransform>(input_headers.front(), input_headers.back(), lazy_materializing_rows, dataflow_cache_updater);
     transform->setPassThrough(pass_through);
     return QueryPipelineBuilder::mergePipelines(std::move(pipelines[0]), std::move(pipelines[1]), transform, &processors);

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -348,6 +348,22 @@ static SplitFilterResult splitFilterStep(const FilterStep & filter_step, const s
                 break;
             }
         }
+
+        /// The filter column is computed and consumed by the main half; in the lazy half it can
+        /// only be a dangling input pass-through, and the column does not exist downstream of the
+        /// main filter. Remove it here: `removeDanglingNodes` is not applied to the last lazy DAG
+        /// (its pass-through outputs form the final header), so a filter at the bottom of the
+        /// chain would otherwise keep an input that no block provides.
+        auto & lazy_outputs = split_result.second.getOutputs();
+        for (size_t i = 0; i < lazy_outputs.size(); ++i)
+        {
+            if (lazy_outputs[i]->result_name == name)
+            {
+                lazy_outputs.erase(lazy_outputs.begin() + i);
+                split_result.second.removeUnusedActions();
+                break;
+            }
+        }
     }
 
     FilterDAGInfo filter_dag_info;
@@ -439,13 +455,24 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
         return false;
 
     auto * sorting_step = typeid_cast<SortingStep *>(root.children.front()->step.get());
-    if (!sorting_step)
-        return false;
+    bool reading_in_order = false;
 
-    if (sorting_step->getType() != SortingStep::Type::Full && sorting_step->getType() != SortingStep::Type::FinishSorting)
-        return false;
+    /// The chain of Expression/Filter steps down to the reading step starts right below
+    /// the sorting step, or right below the limit when there is no sorting. The latter is
+    /// allowed only for FINAL with a filter (checked below): the filter cannot run before
+    /// the FINAL merge, so all columns are read for every scanned row until the limit is
+    /// reached, and deferring the unneeded ones pays off the same way as with a sort.
+    QueryPlan::Node * chain_top_node = root.children.front();
 
-    bool reading_in_order = sorting_step->getType() == SortingStep::Type::FinishSorting;
+    if (sorting_step)
+    {
+        if (sorting_step->getType() != SortingStep::Type::Full && sorting_step->getType() != SortingStep::Type::FinishSorting)
+            return false;
+
+        reading_in_order = sorting_step->getType() == SortingStep::Type::FinishSorting;
+
+        chain_top_node = root.children.front()->children.front();
+    }
 
     const auto limit = limit_step->getLimit();
     if (limit == 0 || (max_limit_for_lazy_materialization != 0 && limit > max_limit_for_lazy_materialization))
@@ -453,29 +480,29 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
 
     StepStack steps_to_update;
 
-    auto * sorting_node = root.children.front();
-    auto * reading_step = findReadingStep(*sorting_node->children.front(), steps_to_update);
+    auto * reading_step = findReadingStep(*chain_top_node, steps_to_update);
     if (!reading_step)
         return false;
 
     if (!canUseLazyMaterializationForReadingStep(reading_step))
         return false;
 
-    if (!allExpressionsSuitableForLazyMaterialization(sorting_node->children.front()))
+    if (!allExpressionsSuitableForLazyMaterialization(chain_top_node))
         return false;
 
-    const auto & sorting_header = *sorting_step->getOutputHeader();
+    const auto & chain_top_header = *chain_top_node->step->getOutputHeader();
     /// At this moment, required_columns are corresponding to output header columns of every step.
-    std::vector<bool> required_columns(sorting_header.columns(), false);
+    std::vector<bool> required_columns(chain_top_header.columns(), false);
 
-    for (const auto & descr : sorting_step->getSortDescription())
-        required_columns[sorting_header.getPositionByName(descr.column_name)] = true;
+    if (sorting_step)
+        for (const auto & descr : sorting_step->getSortDescription())
+            required_columns[chain_top_header.getPositionByName(descr.column_name)] = true;
 
     bool has_filter = false;
 
     std::vector<PlanStepWithRequiredDAGPositions> steps_to_split;
 
-    auto * node = sorting_node->children.front();
+    auto * node = chain_top_node;
     while (!node->children.empty())
     {
         IQueryPlanStep * step = node->step.get();
@@ -535,6 +562,13 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
     /// Disable the case with read-in-order and no filter.
     /// It's not likely we can optimize it more.
     if (reading_in_order && !has_filter)
+        return false;
+
+    /// Without a sorting step, defer columns only for FINAL with a filter: the filter cannot
+    /// be moved to PREWHERE (it would run before the FINAL merge and change its result), so
+    /// this is the only way to avoid reading all columns for every scanned row. For non-FINAL
+    /// reads, PREWHERE already covers this shape.
+    if (!sorting_step && (!read_from_merge_tree->isQueryWithFinal() || !has_filter))
         return false;
 
     std::unique_ptr<LazilyReadFromMergeTree> lazy_reading;
@@ -636,9 +670,12 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
         }
     }
 
-    auto new_sorting_step = std::move(root.children.front()->step); // = std::make_unique<SortingStep>(main_plan.getCurrentHeader(), sorting_step->getSortDescription(), sorting_step->getLimit(), sorting_step->getSettings());
-    new_sorting_step->updateInputHeader(main_plan.getCurrentHeader());
-    main_plan.addStep(std::move(new_sorting_step));
+    if (sorting_step)
+    {
+        auto new_sorting_step = std::move(root.children.front()->step);
+        new_sorting_step->updateInputHeader(main_plan.getCurrentHeader());
+        main_plan.addStep(std::move(new_sorting_step));
+    }
 
     limit_step->updateInputHeader(main_plan.getCurrentHeader());
     main_plan.addStep(std::move(root.step));

--- a/tests/performance/lazy_materialization_final_limit.xml
+++ b/tests/performance/lazy_materialization_final_limit.xml
@@ -1,0 +1,24 @@
+<test>
+    <!--
+        Lazy materialization for FINAL with a filter and a LIMIT without ORDER BY.
+        The filter cannot be moved to PREWHERE for FINAL, so without the optimization
+        every scanned row drags the wide payload column through the FINAL merge until
+        the limit is satisfied. The last query is a control: the ORDER BY + LIMIT
+        shape was optimized before and must not change.
+    -->
+    <create_query>
+        CREATE TABLE lazy_mat_final_limit (k UInt64, v UInt64, payload String)
+        ENGINE = ReplacingMergeTree
+        ORDER BY k
+    </create_query>
+
+    <fill_query>SYSTEM STOP MERGES lazy_mat_final_limit</fill_query>
+    <fill_query>INSERT INTO lazy_mat_final_limit SELECT number, cityHash64(number, 1) % 10000, randomPrintableASCII(2000) FROM numbers_mt(500000)</fill_query>
+    <fill_query>INSERT INTO lazy_mat_final_limit SELECT number, cityHash64(number, 2) % 10000, randomPrintableASCII(2000) FROM numbers_mt(500000)</fill_query>
+
+    <query>SELECT k, payload FROM lazy_mat_final_limit FINAL WHERE v = 7 LIMIT 10 FORMAT Null</query>
+    <query>SELECT k, payload FROM lazy_mat_final_limit FINAL WHERE v = 7 LIMIT 100 FORMAT Null</query>
+    <query>SELECT k, payload FROM lazy_mat_final_limit FINAL WHERE v = 7 ORDER BY k LIMIT 10 FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS lazy_mat_final_limit</drop_query>
+</test>

--- a/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.reference
+++ b/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.reference
@@ -3,7 +3,12 @@ no FINAL:	0
 FINAL no filter:	0
 FINAL no limit:	0
 FINAL big limit:	0
+FINAL prewhere limit:	1
 winners:	10	10	10
+prewhere winners:	10	10	10
 full set equal:	1
+prewhere full set equal:	1
 is_deleted plan:	1
 is_deleted rows:	875	0
+row policy plan:	1
+row policy rows:	10	10	1

--- a/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.reference
+++ b/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.reference
@@ -1,0 +1,9 @@
+FINAL filter limit:	1
+no FINAL:	0
+FINAL no filter:	0
+FINAL no limit:	0
+FINAL big limit:	0
+winners:	10	10	10
+full set equal:	1
+is_deleted plan:	1
+is_deleted rows:	875	0

--- a/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.sql
+++ b/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.sql
@@ -38,15 +38,28 @@ FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL WHERE v = 7);
 SELECT 'FINAL big limit:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
 FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 100000);
 
+-- An explicit PREWHERE is carried by the reading step itself, with no FilterStep above it:
+-- lazy materialization applies.
+SELECT 'FINAL prewhere limit:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL PREWHERE v = 7 LIMIT 10);
+
 -- Every returned row must be the FINAL winner (the second insert), keys distinct.
 SELECT 'winners:', count(), countIf(payload LIKE 'v2\_%'), uniqExact(k)
 FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10);
+
+SELECT 'prewhere winners:', count(), countIf(payload LIKE 'v2\_%'), uniqExact(k)
+FROM (SELECT k, payload FROM t_lazy_final_limit FINAL PREWHERE v = 7 LIMIT 10);
 
 -- The full matching set must be the same with and without the optimization.
 SELECT 'full set equal:',
     (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10000))
     =
     (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10000 SETTINGS query_plan_optimize_lazy_materialization = 0));
+
+SELECT 'prewhere full set equal:',
+    (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL PREWHERE v = 7 LIMIT 10000))
+    =
+    (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL PREWHERE v = 7 LIMIT 10000 SETTINGS query_plan_optimize_lazy_materialization = 0));
 
 -- Version and is_deleted columns are handled by the FINAL merge on the main branch.
 CREATE TABLE t_lazy_final_limit_ver (k UInt64, ver UInt64, is_del UInt8, v UInt64, payload String)
@@ -63,6 +76,18 @@ FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit_ver FINAL WHERE v = 7 LIMIT
 -- 1000 matching keys minus 125 deleted by the second insert.
 SELECT 'is_deleted rows:', count(), countIf(k < 500 AND payload NOT LIKE 'v2\_%')
 FROM (SELECT k, payload FROM t_lazy_final_limit_ver FINAL WHERE v = 7 LIMIT 2000);
+
+-- A row policy is a reader-embedded filter as well: lazy materialization applies even
+-- without WHERE, and the returned rows respect the policy.
+CREATE ROW POLICY policy_04540 ON t_lazy_final_limit FOR SELECT USING k < 50000 TO ALL;
+
+SELECT 'row policy plan:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL LIMIT 10);
+
+SELECT 'row policy rows:', count(), countIf(payload LIKE 'v2\_%'), max(k) < 50000
+FROM (SELECT k, payload FROM t_lazy_final_limit FINAL LIMIT 10);
+
+DROP ROW POLICY policy_04540 ON t_lazy_final_limit;
 
 DROP TABLE t_lazy_final_limit;
 DROP TABLE t_lazy_final_limit_ver;

--- a/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.sql
+++ b/tests/queries/0_stateless/04540_lazy_materialization_final_limit_no_order.sql
@@ -1,0 +1,68 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: the test checks the shape of the local query plan.
+
+DROP TABLE IF EXISTS t_lazy_final_limit;
+DROP TABLE IF EXISTS t_lazy_final_limit_ver;
+
+CREATE TABLE t_lazy_final_limit (k UInt64, v UInt64, payload String) ENGINE = ReplacingMergeTree ORDER BY k;
+
+SYSTEM STOP MERGES t_lazy_final_limit;
+
+INSERT INTO t_lazy_final_limit SELECT number, if(number < 1000, 7, 999), 'v1_' || toString(number) FROM numbers(100000);
+INSERT INTO t_lazy_final_limit SELECT number, if(number < 1000, 7, 999), 'v2_' || toString(number) FROM numbers(100000);
+
+-- The test relies on settings that are randomized by the test runner: pin them.
+SET enable_analyzer = 1, max_threads = 4;
+SET query_plan_optimize_lazy_materialization = 1, query_plan_max_limit_for_lazy_materialization = 10000;
+SET optimize_move_to_prewhere = 1;
+
+-- FINAL with a filter and a small LIMIT without ORDER BY: lazy materialization applies
+-- (the filter cannot be moved to PREWHERE, so this is the only way to avoid reading
+-- all columns for every scanned row).
+SELECT 'FINAL filter limit:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10);
+
+-- Without FINAL the filter is served by PREWHERE: not applied.
+SELECT 'no FINAL:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit WHERE v = 7 LIMIT 10);
+
+-- Without a filter: not applied.
+SELECT 'FINAL no filter:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL LIMIT 10);
+
+-- Without a limit: not applied.
+SELECT 'FINAL no limit:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL WHERE v = 7);
+
+-- A limit above query_plan_max_limit_for_lazy_materialization: not applied.
+SELECT 'FINAL big limit:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 100000);
+
+-- Every returned row must be the FINAL winner (the second insert), keys distinct.
+SELECT 'winners:', count(), countIf(payload LIKE 'v2\_%'), uniqExact(k)
+FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10);
+
+-- The full matching set must be the same with and without the optimization.
+SELECT 'full set equal:',
+    (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10000))
+    =
+    (SELECT (count(), sum(cityHash64(payload)), sum(k)) FROM (SELECT k, payload FROM t_lazy_final_limit FINAL WHERE v = 7 LIMIT 10000 SETTINGS query_plan_optimize_lazy_materialization = 0));
+
+-- Version and is_deleted columns are handled by the FINAL merge on the main branch.
+CREATE TABLE t_lazy_final_limit_ver (k UInt64, ver UInt64, is_del UInt8, v UInt64, payload String)
+ENGINE = ReplacingMergeTree(ver, is_del) ORDER BY k;
+
+SYSTEM STOP MERGES t_lazy_final_limit_ver;
+
+INSERT INTO t_lazy_final_limit_ver SELECT number, 1, 0, if(number < 1000, 7, 999), 'v1_' || toString(number) FROM numbers(100000);
+INSERT INTO t_lazy_final_limit_ver SELECT number, 2, number % 4 = 0, if(number < 1000, 7, 999), 'v2_' || toString(number) FROM numbers(500);
+
+SELECT 'is_deleted plan:', countIf(explain LIKE '%LazilyReadFromMergeTree%') > 0
+FROM (EXPLAIN SELECT payload FROM t_lazy_final_limit_ver FINAL WHERE v = 7 LIMIT 2000);
+
+-- 1000 matching keys minus 125 deleted by the second insert.
+SELECT 'is_deleted rows:', count(), countIf(k < 500 AND payload NOT LIKE 'v2\_%')
+FROM (SELECT k, payload FROM t_lazy_final_limit_ver FINAL WHERE v = 7 LIMIT 2000);
+
+DROP TABLE t_lazy_final_limit;
+DROP TABLE t_lazy_final_limit_ver;


### PR DESCRIPTION
<!--
  Related: https://github.com/ClickHouse/ClickHouse/pull/110431
  -->
  
<details>

<summary>Claude</summary>

  ## Motivation
  
  For a query like `SELECT heavy_columns FROM t FINAL WHERE pred LIMIT n` the predicate cannot be moved to PREWHERE: it would run before the FINAL merge and change its result (a row version matching the predicate may lose to a newer
  version that does not match, and vice versa). So every scanned row drags all requested columns through the FINAL merge until `n` rows pass the filter — with a wide payload column and a selective predicate, almost all of that I/O is
  wasted. For non-FINAL reads this shape is already served well by PREWHERE, which is why it never needed lazy materialization.
  
  Lazy materialization already supports FINAL for `ReplacingMergeTree` in the `ORDER BY` + `LIMIT` shape (the merge columns — sorting key, version, `is_deleted` — stay in the main read). The only thing missing was the plan pattern:
  `optimizeLazyMaterialization2` required a `SortingStep` under the `LimitStep`.
  
  ## Changes
  
  Allow the pattern `Limit → [Expression/Filter]* → ReadFromMergeTree` without a sorting step, gated on FINAL plus a filter (or prewhere/row policy). The main branch reads only the filter inputs, the columns needed by the FINAL merge and
  the row references; the remaining columns are fetched after the limit, i.e. for at most `limit + offset` rows. The same `query_plan_max_limit_for_lazy_materialization` threshold applies (default 10000).
  
  The sorting-less shape surfaced two latent problems in the shared machinery, fixed here:
  
  - `splitFilterStep` now removes the filter column from the lazy half of the split DAG. It is computed and consumed by the main half and does not exist downstream, but `removeDanglingNodes` is intentionally not applied to the last lazy
  DAG (its pass-through outputs form the final header), so a filter at the bottom of the chain kept an input that no block provides and failed with `NOT_FOUND_COLUMN_IN_BLOCK`. This never triggered before because with a sort there is
  always an expression step between the sort and the filter, and for non-FINAL reads the filter becomes PREWHERE. 
  - `JoinLazyColumnsStep` now resizes both input pipelines to a single stream. `LazyMaterializingTransform` joins exactly one main and one lazy stream; with a sorting step the main branch is always single-stream by the time it reaches the
  join, but without one it keeps `max_threads` streams, and the extra streams bypassed the transform. The resize sits above the limit, so at most `limit + offset` rows pass through it.
  
  ## Results
  
  Local perf.py comparison against the parent commit (48-core ARM, release build), added as `tests/performance/lazy_materialization_final_limit.xml`: `ReplacingMergeTree` with 2 fully intersecting parts of 500K rows, 2KB payload, 0.01%
  filter selectivity, medians of 7 runs:
  
  - `FINAL WHERE v = 7 LIMIT 10`: 0.127s → 0.048s (**-62%**)
  - `FINAL WHERE v = 7 LIMIT 100`: 0.158s → 0.057s (**-64%**)
  - control `FINAL WHERE v = 7 ORDER BY k LIMIT 10` (the previously optimized shape): -1%, within threshold
  
  The known trade-off is the same one the existing `ORDER BY` + `LIMIT` shape accepts by default: with narrow payloads the fixed cost of the lazy fetch and join can exceed the win (about +30% on a 20 ms query in a synthetic check with a
  ~130-byte payload). `query_plan_max_limit_for_lazy_materialization` and `query_plan_optimize_lazy_materialization` remain the control knobs.
  
  ## Testing
  
  - New test `04540_lazy_materialization_final_limit_no_order`: plan shape (`LazilyReadFromMergeTree` presence) for FINAL+filter+limit (applies), non-FINAL (PREWHERE, not applied), no filter / no limit / limit above the threshold (not
  applied); result correctness — returned rows are the FINAL winners, the full matching set is identical with the optimization on and off, and a `ReplacingMergeTree(version, is_deleted)` table with partial updates and deletions returns
  exactly the non-deleted winners.
  - All 33 existing `lazy_materialization`/`lazy_final` stateless tests pass repeatedly under the test runner's settings randomization.
  
</details>

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Lazy materialization is now applied to queries with `FINAL`, a filter, and a small `LIMIT`, even without `ORDER BY` (for `ReplacingMergeTree`). 

The filter of a `FINAL` query cannot be moved to `PREWHERE`, so previously all requested columns were read for every scanned row until the limit was satisfied; now the columns not needed by the filter and the `FINAL` merge are fetched only for the rows that remain after the limit, which makes such queries several times faster when they select wide columns with a selective filter. Controlled by the existing settings `query_plan_optimize_lazy_materialization` and `query_plan_max_limit_for_lazy_materialization`.


<img width="2981" height="404" alt="image" src="https://github.com/user-attachments/assets/5ffd4086-dc37-4566-ac92-abb0bcc99803" />


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1334` (included in `26.7` and later)
- Backported to: `26.7.2.11`, `26.6.2.108`, `26.5.6.70`
<!-- ch-version-info:end -->