### PR TITLE
Bump runner-init version to 74

### DIFF
--- a/ci/praktika/infrastructure/runner/runner-init.py
+++ b/ci/praktika/infrastructure/runner/runner-init.py
@@ -40,7 +40,7 @@ class RunnerConfig:
     """Configuration and runtime state for the GitHub Actions runner."""
 
     # Constants
-    version: int = 73
+    version: int = 74
     init_environment: str = Environment.TEST
     verbose = False
     script_path = os.path.abspath(__file__)


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/110577, which bumped the macOS CI runner provisioning `version` to 73 so `Jinja2` get installed on the runners. A single reboot turned out not to be enough.

Related: https://github.com/ClickHouse/ClickHouse/pull/110577

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1087` (included in `26.7` and later)
<!-- ch-version-info:end -->