### PR TITLE
Adjust query cache randomization in stress tests

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -178,7 +178,11 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")
 
-    if i > 0 and random.random() < 1 / 3:
+    # Enable the query cache only rarely: it is set as a client option for the
+    # whole run, so with a high probability it collides with the many tests that
+    # use a non-throw `*_overflow_mode`, which `use_query_cache` forbids
+    # (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE), turning into stress noise.
+    if i > 0 and random.random() < 1 / 50:
         client_options.append("use_query_cache=1")
         client_options.append("query_cache_nondeterministic_function_handling='ignore'")
         client_options.append("query_cache_system_table_handling='ignore'")

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -178,14 +178,25 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")
 
-    # Enable the query cache only rarely: it is set as a client option for the
-    # whole run, so with a high probability it collides with the many tests that
-    # use a non-throw `*_overflow_mode`, which `use_query_cache` forbids
-    # (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE), turning into stress noise.
+    # Enable the query cache only rarely, and when we do, force every overflow
+    # mode to 'throw'. use_query_cache is set as a client option for the whole
+    # run and is incompatible with a non-throw `*_overflow_mode`
+    # (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE), so the many tests that
+    # touch overflow modes would otherwise turn it into stress noise.
     if i > 0 and random.random() < 1 / 50:
         client_options.append("use_query_cache=1")
         client_options.append("query_cache_nondeterministic_function_handling='ignore'")
         client_options.append("query_cache_system_table_handling='ignore'")
+        client_options.append("read_overflow_mode='throw'")
+        client_options.append("read_overflow_mode_leaf='throw'")
+        client_options.append("group_by_overflow_mode='throw'")
+        client_options.append("sort_overflow_mode='throw'")
+        client_options.append("result_overflow_mode='throw'")
+        client_options.append("timeout_overflow_mode='throw'")
+        client_options.append("set_overflow_mode='throw'")
+        client_options.append("join_overflow_mode='throw'")
+        client_options.append("transfer_overflow_mode='throw'")
+        client_options.append("distinct_overflow_mode='throw'")
 
     if i % 5 == 1:
         client_options.append("memory_tracker_fault_probability=0.001")

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -178,25 +178,23 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")
 
-    # Enable the query cache only rarely, and when we do, force every overflow
-    # mode to 'throw'. use_query_cache is set as a client option for the whole
-    # run and is incompatible with a non-throw `*_overflow_mode`
-    # (QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE), so the many tests that
-    # touch overflow modes would otherwise turn it into stress noise.
-    if i > 0 and random.random() < 1 / 50:
+    # Rarely enable the query cache; independently, half the time also exercise
+    # non-throw `*_overflow_mode` settings.
+    if i > 0 and random.random() < 1 / 15:
         client_options.append("use_query_cache=1")
         client_options.append("query_cache_nondeterministic_function_handling='ignore'")
         client_options.append("query_cache_system_table_handling='ignore'")
-        client_options.append("read_overflow_mode='throw'")
-        client_options.append("read_overflow_mode_leaf='throw'")
-        client_options.append("group_by_overflow_mode='throw'")
-        client_options.append("sort_overflow_mode='throw'")
-        client_options.append("result_overflow_mode='throw'")
-        client_options.append("timeout_overflow_mode='throw'")
-        client_options.append("set_overflow_mode='throw'")
-        client_options.append("join_overflow_mode='throw'")
-        client_options.append("transfer_overflow_mode='throw'")
-        client_options.append("distinct_overflow_mode='throw'")
+        if random.random() < 1 / 2:
+            client_options.append("read_overflow_mode='break'")
+            client_options.append("read_overflow_mode_leaf='break'")
+            client_options.append("group_by_overflow_mode='break'")
+            client_options.append("sort_overflow_mode='break'")
+            client_options.append("result_overflow_mode='break'")
+            client_options.append("timeout_overflow_mode='break'")
+            client_options.append("set_overflow_mode='break'")
+            client_options.append("join_overflow_mode='break'")
+            client_options.append("transfer_overflow_mode='break'")
+            client_options.append("distinct_overflow_mode='break'")
 
     if i % 5 == 1:
         client_options.append("memory_tracker_fault_probability=0.001")

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -178,23 +178,23 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
             client_options.append("join_algorithm='auto'")
             client_options.append("max_rows_in_join=1000")
 
-    # Rarely enable the query cache; independently, half the time also exercise
-    # non-throw `*_overflow_mode` settings.
+    # Rarely enable the query cache; independently, half the time also pin the
+    # `*_overflow_mode` settings to 'throw'.
     if i > 0 and random.random() < 1 / 15:
         client_options.append("use_query_cache=1")
         client_options.append("query_cache_nondeterministic_function_handling='ignore'")
         client_options.append("query_cache_system_table_handling='ignore'")
         if random.random() < 1 / 2:
-            client_options.append("read_overflow_mode='break'")
-            client_options.append("read_overflow_mode_leaf='break'")
-            client_options.append("group_by_overflow_mode='break'")
-            client_options.append("sort_overflow_mode='break'")
-            client_options.append("result_overflow_mode='break'")
-            client_options.append("timeout_overflow_mode='break'")
-            client_options.append("set_overflow_mode='break'")
-            client_options.append("join_overflow_mode='break'")
-            client_options.append("transfer_overflow_mode='break'")
-            client_options.append("distinct_overflow_mode='break'")
+            client_options.append("read_overflow_mode='throw'")
+            client_options.append("read_overflow_mode_leaf='throw'")
+            client_options.append("group_by_overflow_mode='throw'")
+            client_options.append("sort_overflow_mode='throw'")
+            client_options.append("result_overflow_mode='throw'")
+            client_options.append("timeout_overflow_mode='throw'")
+            client_options.append("set_overflow_mode='throw'")
+            client_options.append("join_overflow_mode='throw'")
+            client_options.append("transfer_overflow_mode='throw'")
+            client_options.append("distinct_overflow_mode='throw'")
 
     if i % 5 == 1:
         client_options.append("memory_tracker_fault_probability=0.001")


### PR DESCRIPTION
In the stress harness (`ci/jobs/scripts/stress/stress.py`), `use_query_cache=1` was enabled as a client option for the whole run with probability `1/3`. `use_query_cache` is incompatible with a non-throw `*_overflow_mode` (`QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE`), so it collided too often with tests and the default randomization.

Lower the query-cache probability to `1/15`, and within that block set the `*_overflow_mode` settings to `'break'` half the time — so both the query cache and non-throw overflow modes keep getting exercised under stress.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1073` (included in `26.7` and later)
<!-- ch-version-info:end -->