### PR TITLE
Fix AST fuzzer client crash rewriting a query-parameter identifier into a subcolumn accessor

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -3500,10 +3500,12 @@ void QueryFuzzer::fuzzExpressionList(ASTExpressionList & expr_list)
                 /// optionally with APPLY/EXCEPT/REPLACE transformers attached.
                 new_child = makeFuzzedAsteriskLikeMatcher();
             }
-            else if (auto * ident = typeid_cast<ASTIdentifier *>(child.get()); ident && fuzz_rand() % 250 == 0)
+            else if (auto * ident = typeid_cast<ASTIdentifier *>(child.get()); ident && !ident->isParam() && fuzz_rand() % 250 == 0)
             {
                 /// Rewrite a column reference into one of its potential subcolumn accessors
                 /// (typeid_cast is exact, so ASTTableIdentifier / ASTQueryParameter are left alone).
+                /// isParam() identifiers carry a {x:Identifier} placeholder as an empty name_part,
+                /// which the rebuilt ASTIdentifier below would assert on, so skip them.
                 static const Strings subcolumn_names = {"keys", "null", "size0", "values"};
                 const String subcolumn = pickRandomly(fuzz_rand, subcolumn_names);
                 switch (fuzz_rand() % 5)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110506
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`QueryFuzzer::fuzzExpressionList` has a branch (added in #110228) that rewrites a column reference `c` into one of its subcolumn accessors: `c.null`, `c.1`, `c[0]`, `getSubcolumn(c, ...)`. For a query-parameter identifier like `{p:Identifier}.col`, the `ASTIdentifier` stores the placeholder as an empty `name_part` plus a `name_params` child. Cases 0 and 3 copied `name_parts` (including that empty part) and rebuilt the identifier via `make_intrusive<ASTIdentifier>(std::move(parts))` without the `name_params`, so the constructor took the non-parametrized branch and tripped `chassert(!part.empty())`, aborting `clickhouse-client` (SIGABRT) mid-fuzzing.

The fix skips parameter identifiers in this branch (`!ident->isParam()`): the branch is for column references, and query-parameter identifiers are not fuzzed here.

Found by the AST fuzzer (client-side abort). CIDB shows this hitting several unrelated PRs and master starting 2026-07-16, e.g. `AST fuzzer (amd_tsan)`:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110641&sha=9be63c5843bb3d9cdb7267ea5e81ce6a025b5155&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29

Client-side backtrace: `QueryFuzzer::fuzzExpressionList` (QueryFuzzer.cpp:3515) -> `make_intrusive<ASTIdentifier>` -> `ASTIdentifier::ASTIdentifier` (ASTIdentifier.cpp:48) -> `chassert(!part.empty())`.

Note: the same `!part.empty()` assertion can also be reached server-side (`IdentifierNode::toASTImpl`) via an unresolved `{p:Identifier}` inside a named `WINDOW` clause; that is a separate parser issue fixed by #110506. This PR fixes only the client-side fuzzer path, which #110506 does not touch.

Verified locally (debug build): the AST fuzzer crashes client-side without this change and no longer does with it.
