### PR TITLE
Fix flaky timeout in 03209_json_type_horizontal_merges

### DIFF
--- a/tests/queries/0_stateless/03209_json_type_horizontal_merges.sql.j2
+++ b/tests/queries/0_stateless/03209_json_type_horizontal_merges.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
+-- Tags: no-fasttest, long, no-flaky-check, no-debug, no-tsan, no-asan, no-msan, no-ubsan
 -- Random settings limits: index_granularity=(100, None); index_granularity_bytes=(100000, None)
 
 SET enable_json_type = 1;

--- a/tests/queries/0_stateless/03209_json_type_horizontal_merges.sql.j2
+++ b/tests/queries/0_stateless/03209_json_type_horizontal_merges.sql.j2
@@ -1,4 +1,5 @@
 -- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
+-- Random settings limits: index_granularity=(100, None); index_granularity_bytes=(100000, None)
 
 SET enable_json_type = 1;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110084

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`03209_json_type_horizontal_merges` hit the 600s kill threshold in `Stateless tests (arm_binary, parallel)` (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110084&sha=95567e078f1ffaefeff30bf735eaec75be77b684&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29).

Root cause: the test declares its own MergeTree part-storage settings in every `CREATE TABLE`, but CI randomization can still inject `index_granularity=1` (one mark per row) on top. On the ~900K rows of JSON dynamic paths this test builds, that inflates each `OPTIMIZE FINAL` merge ~137x. Measured locally: default `index_granularity` OPTIMIZE FINAL = 0.88s, `index_granularity=1` = 120s. The test runs 5 merges over 2 table configs, so unlucky draws push the run past 600s. History over 7 days: p50 17s, but the tail already reaches 553s (2695 OK runs), and one run timed out at 600s.

Fix: add `no-random-merge-tree-settings` so the test keeps its declared storage settings. This matches the established pattern for sibling JSON tests `03208_array_of_json_read_subcolumns_2_memory` and `03222_json_squashing`.

Unrelated to #110084 (no UUID2 involvement); found on that PR's CI.
