### PR TITLE
Fix undefined float-to-int cast on NaN in the `SZ3` codec quantizer

### DIFF
--- a/src/Compression/tests/gtest_compressionCodec.cpp
+++ b/src/Compression/tests/gtest_compressionCodec.cpp
@@ -1822,6 +1822,75 @@ TEST(SZ3Test, DecompressFreesScratchBufferOnTruncatedPayload)
     }
     ASSERT_TRUE(saw_rejection) << "A truncated SZ3 payload must be rejected, not silently accepted";
 }
+
+TEST(SZ3Test, LorenzoRegSerializesAndDecodesRegressionCoefficients)
+{
+    /// Companion to the SQL test 04604_sz3_codec_lorenzo_reg: a positive signal that this data shape really
+    /// exercises the `ALGO_LORENZO_REG` loaders whose `remaining_length` accounting was fixed
+    /// (`RegressionPredictor::load` and `ComposedPredictor::load` decrement it by the bytes the Huffman
+    /// `decode` consumed, not by the uncompressed index count). A plain round trip could silently pass
+    /// through the bit-exact `ALGO_LOSSLESS` fallback, or through a lossy block in which no block selected
+    /// the regression predictor, and then a regression in the fixed loaders would go unnoticed.
+    auto codec = makeCodec("SZ3('ALGO_LORENZO_REG', 'ABS', 0.01)", std::make_shared<DataTypeFloat64>());
+
+    /// The same data shape as the SQL test: a smooth signal with a linear trend, so the per-block predictor
+    /// selection picks the regression predictor for the blocks.
+    constexpr size_t num_values = 8192;
+    std::vector<Float64> values(num_values);
+    for (size_t i = 0; i < num_values; ++i)
+        values[i] = static_cast<double>(i) * 0.5 + std::sin(static_cast<double>(i) * 0.1);
+
+    const char * source = reinterpret_cast<const char *>(values.data());
+    const UInt32 source_size = static_cast<UInt32>(values.size() * sizeof(Float64));
+
+    PODArray<char> encoded(codec->getCompressedReserveSize(source_size));
+    const UInt32 encoded_size = codec->compress(source, source_size, encoded.data());
+    encoded.resize(encoded_size);
+
+    /// The stored config must keep ALGO_LORENZO_REG: SZ3 rewrites `cmprAlgo` to ALGO_LOSSLESS when the
+    /// lossy result does not win over plain zstd, and that path would never reach the fixed loaders.
+    {
+        SZ3::Config config;
+        SZ_load_config(config, encoded.data() + sz3StreamOffset(), encoded_size - sz3StreamOffset());
+        ASSERT_EQ(config.cmprAlgo, SZ3::ALGO_LORENZO_REG) << "Test setup expects an ALGO_LORENZO_REG block";
+        ASSERT_EQ(config.num, num_values);
+    }
+
+    /// The regression-coefficient stream must be non-empty. Its element count is the first field of the
+    /// inner buffer: `BlockwiseDecomposition::save` writes the Lorenzo fallback predictor (nothing), then
+    /// `ComposedPredictor::save` writes each sub-predictor - the Lorenzo predictor (nothing), then the
+    /// regression predictor, which starts with the count of its quantized coefficients. A zero count would
+    /// mean no block selected the regression predictor, and `RegressionPredictor::load` would never run
+    /// the fixed decode.
+    {
+        const std::vector<unsigned char> inner = sz3ExtractInnerBuffer(encoded.data());
+        ASSERT_GE(inner.size(), sizeof(size_t));
+        size_t coeff_count = 0;
+        memcpy(&coeff_count, inner.data(), sizeof(coeff_count));
+        ASSERT_GT(coeff_count, 0u) << "Expected at least one regression-predicted block";
+        /// Every regression-predicted 1-D block stores two quantized coefficients (slope and intercept).
+        ASSERT_EQ(coeff_count % 2, 0u);
+    }
+
+    /// Decompression must decode those coefficients. Before the fix, `RegressionPredictor::load`
+    /// understated `remaining_length` (the uncompressed coefficient count overshoots the Huffman-compressed
+    /// stream size), so the following `encoder.load` rejected the block with "SZ3 Huffman: encoded length
+    /// exceeds compressed buffer" (CORRUPTED_DATA) and the data was unreadable. The round trip must also be
+    /// lossy - within the ABS bound but not bit-exact - proving the quantizer path produced the block.
+    PODArray<char> decoded(source_size);
+    const UInt32 decoded_size = codec->decompress(encoded.data(), encoded_size, decoded.data());
+    ASSERT_EQ(decoded_size, source_size);
+    const auto * decoded_values = reinterpret_cast<const Float64 *>(decoded.data());
+    Float64 max_error = 0.0;
+    size_t changed = 0;
+    for (size_t i = 0; i < num_values; ++i)
+    {
+        max_error = std::max(max_error, std::fabs(values[i] - decoded_values[i]));
+        changed += (values[i] != decoded_values[i]) ? 1 : 0;
+    }
+    ASSERT_LE(max_error, 0.011);
+    ASSERT_GT(changed, 0u) << "Expected a lossy round trip; a bit-exact result means the lossless fallback was used";
+}
 #endif
 
 /// Expects getCompressionCodecForFile to reject the block with the given error code.

--- a/tests/queries/0_stateless/04603_sz3_codec_non_finite.reference
+++ b/tests/queries/0_stateless/04603_sz3_codec_non_finite.reference
@@ -1,0 +1,4 @@
+NaN and infinities survive the round trip, finite values stay within the error bound
+1	1	1	1	1	1	1	1	1	1	1
+The same holds after the data is recompressed by a merge
+1	1	1	1	1	1	1	1	1	1	1

--- a/tests/queries/0_stateless/04603_sz3_codec_non_finite.reference
+++ b/tests/queries/0_stateless/04603_sz3_codec_non_finite.reference
@@ -1,4 +1,4 @@
 NaN and infinities survive the round trip, finite values stay within the error bound
-1	1	1	1	1	1	1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1	1	1	1
 The same holds after the data is recompressed by a merge
-1	1	1	1	1	1	1	1	1	1	1
+1	1	1	1	1	1	1	1	1	1	1	1	1

--- a/tests/queries/0_stateless/04603_sz3_codec_non_finite.sql
+++ b/tests/queries/0_stateless/04603_sz3_codec_non_finite.sql
@@ -36,6 +36,10 @@ FROM
 );
 
 SELECT 'NaN and infinities survive the round trip, finite values stay within the error bound';
+-- The last two columns are a positive signal that the ABS columns really stayed on the lossy SZ3 path:
+-- a lossless fallback would reproduce every finite value bit-exactly. (The default-configured columns are
+-- expected to be stored losslessly here: the default REL error bound is relative to the value range, which
+-- is infinite for this data, so SZ3 keeps them bit-exact by design.)
 SELECT
     countIf(isNaN(f64_default)) = 1,
     countIf(f64_default = inf) = 1,
@@ -47,7 +51,9 @@ SELECT
     countIf(f64_abs = inf) = 1,
     countIf(f64_abs = -inf) = 1,
     maxIf(abs(orig64 - f64_abs), isFinite(orig64)) <= 0.011,
-    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011
+    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011,
+    countIf(f64_abs != orig64 AND isFinite(orig64)) > 0,
+    countIf(f32_abs != orig32 AND isFinite(orig32)) > 0
 FROM tab_sz3_non_finite;
 
 SELECT 'The same holds after the data is recompressed by a merge';
@@ -63,7 +69,9 @@ SELECT
     countIf(f64_abs = inf) = 1,
     countIf(f64_abs = -inf) = 1,
     maxIf(abs(orig64 - f64_abs), isFinite(orig64)) <= 0.011,
-    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011
+    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011,
+    countIf(f64_abs != orig64 AND isFinite(orig64)) > 0,
+    countIf(f32_abs != orig32 AND isFinite(orig32)) > 0
 FROM tab_sz3_non_finite;
 
 DROP TABLE tab_sz3_non_finite;

--- a/tests/queries/0_stateless/04603_sz3_codec_non_finite.sql
+++ b/tests/queries/0_stateless/04603_sz3_codec_non_finite.sql
@@ -1,0 +1,69 @@
+-- Tags: no-fasttest, no-random-settings
+-- no-fasttest: needs sz3 library
+-- no-random-settings: a randomized `max_compress_block_size` that is not a multiple of the float width
+-- is rejected by the SZ3 codec at write time
+
+-- Non-finite values (NaN, +-inf) cannot be quantized: the quantizer used to cast
+-- `fabs(data - pred) / error_bound` to an integer without checking that the value is representable,
+-- which is undefined behavior for NaN and infinities (caught by UBSan in stress tests).
+-- Such values must instead be stored losslessly on the unpredictable path, so they round-trip exactly
+-- while finite values stay within the error bound.
+
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS tab_sz3_non_finite;
+
+CREATE TABLE tab_sz3_non_finite (
+    key    UInt64,
+    orig64 Float64,
+    orig32 Float32,
+    f64_default Float64 CODEC(SZ3),
+    f32_default Float32 CODEC(SZ3),
+    f64_abs Float64 CODEC(SZ3('ALGO_INTERP', 'ABS', 0.01)),
+    f32_abs Float32 CODEC(SZ3('ALGO_INTERP', 'ABS', 0.01))
+) ENGINE = MergeTree ORDER BY key;
+
+INSERT INTO tab_sz3_non_finite
+SELECT
+    number,
+    v, v, v, v, v, v
+FROM
+(
+    SELECT
+        number,
+        multiIf(number = 3, nan, number = 500, inf, number = 501, -inf, sin(number * 0.01) * 100) AS v
+    FROM numbers(1000)
+);
+
+SELECT 'NaN and infinities survive the round trip, finite values stay within the error bound';
+SELECT
+    countIf(isNaN(f64_default)) = 1,
+    countIf(f64_default = inf) = 1,
+    countIf(f64_default = -inf) = 1,
+    countIf(isNaN(f32_default)) = 1,
+    countIf(f32_default = inf) = 1,
+    countIf(f32_default = -inf) = 1,
+    countIf(isNaN(f64_abs)) = 1,
+    countIf(f64_abs = inf) = 1,
+    countIf(f64_abs = -inf) = 1,
+    maxIf(abs(orig64 - f64_abs), isFinite(orig64)) <= 0.011,
+    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011
+FROM tab_sz3_non_finite;
+
+SELECT 'The same holds after the data is recompressed by a merge';
+OPTIMIZE TABLE tab_sz3_non_finite FINAL;
+SELECT
+    countIf(isNaN(f64_default)) = 1,
+    countIf(f64_default = inf) = 1,
+    countIf(f64_default = -inf) = 1,
+    countIf(isNaN(f32_default)) = 1,
+    countIf(f32_default = inf) = 1,
+    countIf(f32_default = -inf) = 1,
+    countIf(isNaN(f64_abs)) = 1,
+    countIf(f64_abs = inf) = 1,
+    countIf(f64_abs = -inf) = 1,
+    maxIf(abs(orig64 - f64_abs), isFinite(orig64)) <= 0.011,
+    maxIf(abs(orig32 - f32_abs), isFinite(orig32)) <= 0.011
+FROM tab_sz3_non_finite;
+
+DROP TABLE tab_sz3_non_finite;

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.reference
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.reference
@@ -1,0 +1,4 @@
+ALGO_LORENZO_REG data round-trips within the error bound (the read failed with CORRUPTED_DATA before the fix)
+1	1
+The same holds after a merge recompresses the data
+1	1

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.reference
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.reference
@@ -1,4 +1,4 @@
 ALGO_LORENZO_REG data round-trips within the error bound (the read failed with CORRUPTED_DATA before the fix)
-1	1
+1	1	1
 The same holds after a merge recompresses the data
 1	1

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
@@ -20,6 +20,11 @@ CREATE TABLE tab_sz3_lorenzo_reg (
     val  Float64 CODEC(SZ3('ALGO_LORENZO_REG', 'ABS', 0.01))
 ) ENGINE = MergeTree ORDER BY key;
 
+-- Stop background merges so the pre-merge assertion below sees the data after exactly one lossy pass.
+-- Otherwise a background merge could fire between the second INSERT and that SELECT, recompress the
+-- column through the lossy codec, and inflate the error past the one-pass bound, making the test flaky.
+SYSTEM STOP MERGES tab_sz3_lorenzo_reg;
+
 -- A smooth signal with a linear trend, so the regression predictor is actually selected for the blocks
 -- (as opposed to the lossless fallback that SZ3 uses for tiny or incompressible inputs).
 -- Two parts, so the OPTIMIZE FINAL below actually merges and re-reads the SZ3 column during the merge.
@@ -38,10 +43,11 @@ SELECT 'ALGO_LORENZO_REG data round-trips within the error bound (the read faile
 SELECT count() = 100000, max(abs(orig - val)) <= 0.011, countIf(val != orig) > 0 FROM tab_sz3_lorenzo_reg;
 
 SELECT 'The same holds after a merge recompresses the data';
+SYSTEM START MERGES tab_sz3_lorenzo_reg;
 OPTIMIZE TABLE tab_sz3_lorenzo_reg FINAL;
--- A merge decompresses and recompresses the column through the lossy codec, so every pass adds up to
--- the ABS bound (0.01) on top of the previous one. The initial write, a possible concurrent background
--- merge of the two parts, and the OPTIMIZE FINAL rewrite give at most three lossy passes.
+-- The OPTIMIZE FINAL merge decompresses and recompresses the column through the lossy codec, so the data
+-- has now gone through two lossy passes: the initial write and this merge. Each pass can add up to the
+-- ABS bound (0.01), and we keep a small extra margin on top for codec rounding.
 SELECT count() = 100000, max(abs(orig - val)) <= 0.031 FROM tab_sz3_lorenzo_reg;
 
 DROP TABLE tab_sz3_lorenzo_reg;

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
@@ -1,0 +1,40 @@
+-- Tags: no-fasttest, no-random-settings
+-- no-fasttest: needs sz3 library
+-- no-random-settings: a randomized `max_compress_block_size` that is not a multiple of the float width
+-- is rejected by the SZ3 codec at write time
+
+-- Regression test for the SZ3 `ALGO_LORENZO_REG` decompression path.
+-- `RegressionPredictor::load` (used only by `ALGO_LORENZO_REG`) decremented `remaining_length` by the
+-- uncompressed regression-coefficient count after the Huffman `decode`, instead of the bytes `decode`
+-- actually consumed. The understated bound then made the following `encoder.load` reject valid data with
+-- "SZ3 Huffman: encoded length exceeds compressed buffer", so a column written with
+-- `CODEC(SZ3('ALGO_LORENZO_REG', ...))` could be inserted but failed every later read with CORRUPTED_DATA.
+
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS tab_sz3_lorenzo_reg;
+
+CREATE TABLE tab_sz3_lorenzo_reg (
+    key  UInt64,
+    orig Float64,
+    val  Float64 CODEC(SZ3('ALGO_LORENZO_REG', 'ABS', 0.01))
+) ENGINE = MergeTree ORDER BY key;
+
+-- A smooth signal with a linear trend, so the regression predictor is actually selected for the blocks
+-- (as opposed to the lossless fallback that SZ3 uses for tiny or incompressible inputs).
+-- Two parts, so the OPTIMIZE FINAL below actually merges and re-reads the SZ3 column during the merge.
+INSERT INTO tab_sz3_lorenzo_reg
+SELECT number, number * 0.5 + sin(number * 0.1), number * 0.5 + sin(number * 0.1)
+FROM numbers(50000);
+INSERT INTO tab_sz3_lorenzo_reg
+SELECT number, number * 0.5 + sin(number * 0.1), number * 0.5 + sin(number * 0.1)
+FROM numbers(50000, 50000);
+
+SELECT 'ALGO_LORENZO_REG data round-trips within the error bound (the read failed with CORRUPTED_DATA before the fix)';
+SELECT count() = 100000, max(abs(orig - val)) <= 0.011 FROM tab_sz3_lorenzo_reg;
+
+SELECT 'The same holds after a merge recompresses the data';
+OPTIMIZE TABLE tab_sz3_lorenzo_reg FINAL;
+SELECT count() = 100000, max(abs(orig - val)) <= 0.011 FROM tab_sz3_lorenzo_reg;
+
+DROP TABLE tab_sz3_lorenzo_reg;

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
@@ -31,7 +31,11 @@ SELECT number, number * 0.5 + sin(number * 0.1), number * 0.5 + sin(number * 0.1
 FROM numbers(50000, 50000);
 
 SELECT 'ALGO_LORENZO_REG data round-trips within the error bound (the read failed with CORRUPTED_DATA before the fix)';
-SELECT count() = 100000, max(abs(orig - val)) <= 0.011 FROM tab_sz3_lorenzo_reg;
+-- The last column is a positive signal that the data really stayed on the lossy SZ3 path: the bit-exact
+-- ALGO_LOSSLESS fallback (used when the lossy result does not win) would reproduce the input exactly and
+-- would not exercise the fixed decompression path. The gtest SZ3Test.LorenzoRegSerializesAndDecodesRegressionCoefficients
+-- additionally verifies that this data shape serializes a non-empty regression-coefficient stream.
+SELECT count() = 100000, max(abs(orig - val)) <= 0.011, countIf(val != orig) > 0 FROM tab_sz3_lorenzo_reg;
 
 SELECT 'The same holds after a merge recompresses the data';
 OPTIMIZE TABLE tab_sz3_lorenzo_reg FINAL;

--- a/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
+++ b/tests/queries/0_stateless/04604_sz3_codec_lorenzo_reg.sql
@@ -35,6 +35,9 @@ SELECT count() = 100000, max(abs(orig - val)) <= 0.011 FROM tab_sz3_lorenzo_reg;
 
 SELECT 'The same holds after a merge recompresses the data';
 OPTIMIZE TABLE tab_sz3_lorenzo_reg FINAL;
-SELECT count() = 100000, max(abs(orig - val)) <= 0.011 FROM tab_sz3_lorenzo_reg;
+-- A merge decompresses and recompresses the column through the lossy codec, so every pass adds up to
+-- the ABS bound (0.01) on top of the previous one. The initial write, a possible concurrent background
+-- merge of the two parts, and the OPTIMIZE FINAL rewrite give at most three lossy passes.
+SELECT count() = 100000, max(abs(orig - val)) <= 0.031 FROM tab_sz3_lorenzo_reg;
 
 DROP TABLE tab_sz3_lorenzo_reg;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110430
Caused by: https://github.com/ClickHouse/ClickHouse/pull/108788

Stress tests with UBSan sporadically fail with:

```
contrib/sz3/include/SZ3/quantizer/LinearQuantizer.hpp:45:49: runtime error: nan is outside the range of representable values of type 'long'
```

for example on https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110430&sha=2f139250fec65930580e67de7ebd07b87392fd16&name_0=PR&name_1=Stress%20test%20%28amd_asan_ubsan%29 (also seen on master and several unrelated PRs since #108788 revived the `SZ3` codec).

`SZ3::LinearQuantizer::quantize_and_overwrite` casts `fabs(data - pred) * error_bound_reciprocal` straight to `int64_t`; for NaN or infinite input the cast is undefined behavior. Such values can never be quantized — the error-bound recheck below the cast sends them to the unpredictable (lossless) storage anyway — so the fix in the `ClickHouse/SZ3` fork (commit `dda0caee243719d1dad10a9f05bc18eeedc2ab6b` on the `ClickHouse/v3.3.2` branch) routes them there before the cast. Behavior for finite in-range values is unchanged: `scaled_diff >= radius * 2` implies the old `quant_index` check would have sent them to the unpredictable path as well.

Verified with a standalone reproducer compiled with `-fsanitize=undefined,float-cast-overflow -fno-sanitize-recover=all`: before the fix it fails exactly like the stress report; after the fix, NaN and infinities round-trip losslessly through all three supported algorithms (`ALGO_INTERP`, `ALGO_INTERP_LORENZO`, `ALGO_LORENZO_REG`) for both `Float32` and `Float64`, including the codec's default `REL` error-bound mode. The new test `04603_sz3_codec_non_finite` covers the same scenario end-to-end and would trigger the UBSan report without the fix.

The submodule bump (to `ff760cc` on the same branch, ClickHouse/SZ3#2) additionally fixes the `remaining_length` accounting after a Huffman `decode` in `RegressionPredictor::load` and `ComposedPredictor::load`: the code subtracted the uncompressed index count instead of the bytes the decode consumed, which understated the bound and made a later `encoder.load` reject valid data. As a result, a column written with `CODEC(SZ3('ALGO_LORENZO_REG', ...))` could be inserted but failed every later read with `CORRUPTED_DATA` ("SZ3 Huffman: encoded length exceeds compressed buffer"). The new test `04604_sz3_codec_lorenzo_reg` covers the round trip end-to-end (including after a merge recompresses the data, where the lossy error of each pass compounds), and the new gtest `SZ3Test.LorenzoRegSerializesAndDecodesRegressionCoefficients` asserts that this data shape really stays on the `ALGO_LORENZO_REG` path and serializes a non-empty regression-coefficient stream, so the fixed loaders are positively exercised.

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed reading data compressed with the experimental `SZ3('ALGO_LORENZO_REG', ...)` codec, which previously failed with `CORRUPTED_DATA`, and avoided undefined behavior when compressing non-finite floating-point values (`NaN` and infinities) with the experimental `SZ3` codec.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1154` (included in `26.7` and later)
<!-- ch-version-info:end -->