### PR TITLE
Make `04498_query_condition_cache_local_files` non-parallel

### DIFF
--- a/tests/queries/0_stateless/04498_query_condition_cache_local_files.sh
+++ b/tests/queries/0_stateless/04498_query_condition_cache_local_files.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
 # Tag no-fasttest: needs Parquet
+# Tag no-parallel: asserts `QueryConditionCacheHits` on the instance-wide query condition cache.
+# A parallel sibling test can wipe that cache at any moment: dropping or renaming any UUID-less
+# (path-keyed) `MergeTree` table calls `Context::clearCaches`, which clears the query condition
+# cache along with the other path-keyed caches, turning an expected cache hit into a miss.
 
 # Tests that the Query Condition Cache works for local Parquet files backed by the
 # `File` table engine (previously the cache was populated only for object storage).
@@ -26,7 +30,9 @@
 #     stale "nothing matches" decision for the old file version must not be reused.
 #
 # The table gets a unique UUID per test run and a per-database file path, so the
-# cache keys are isolated and the test is parallel-safe without a global cache reset.
+# cache keys are isolated and the test needs no global cache reset. The keys being
+# isolated does not make the hit assertions parallel-safe, though - see the
+# no-parallel tag above.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

The new test `04498_query_condition_cache_local_files` (added in https://github.com/ClickHouse/ClickHouse/pull/109247) is flaky in parallel test runs: an expected `QueryConditionCacheHits` occasionally comes back as 0 (`result differs with reference`), while reruns of the test alone always pass. It failed three times on 2026-07-16 across two unrelated PRs (#110433, #110630), e.g. [this report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110433&sha=62da4c8be297d0ee37833fc6d0af32868f4bbc9f&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29).

Root cause, confirmed from the server log and `metric_log` of that failed run: dropping or renaming any UUID-less (path-keyed, e.g. Ordinary-database) `MergeTree` table calls `Context::clearCaches`, which clears the instance-wide query condition cache along with the other path-keyed caches. `CurrentMetric_QueryConditionCacheEntries` dropped from 331 to 1 exactly between the test's cache-populating query and the query expected to hit the cache, with no `SYSTEM DROP QUERY CONDITION CACHE` anywhere in the log. A parallel sibling test can therefore turn any expected cache hit into a miss.

This is the same reason all other tests asserting query condition cache hits (`03229_query_condition_cache_*`, `04275_104781_qcc_prewhere_skip_index_attribution`, `02346_text_index_bug108519_qcc_skip_index`) are tagged `no-parallel`. Tag this test the same way and update its header comment accordingly. Miss assertions are unaffected (a sibling clear cannot cause a spurious hit), so the tag is the only change needed.

Related: https://github.com/ClickHouse/ClickHouse/pull/109247


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1130` (included in `26.7` and later)
<!-- ch-version-info:end -->