### PR TITLE
docs: fix broken cluster() link on Distributed engine page

### DIFF
--- a/docs/ar/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ar/reference/engines/table-engines/special/distributed.mdx
@@ -276,11 +276,7 @@ SETTINGS
 `_shard_num` — يحتوي على قيمة `shard_num` من جدول `system.clusters`. النوع: [UInt32](/ar/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster`](/ar/reference/functions/table-functions/cluster) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `&#95;shard&#95;num&#96; متاح فيهما أيضًا.
-=======
-  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster](../../../sql-reference/table-functions/cluster.md) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `_shard_num` متاح فيهما أيضًا.
->>>>>>> Stashed changes
+  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster`](/ar/reference/functions/table-functions/cluster) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `_shard_num` متاح فيهما أيضًا.
 </Note>
 
 **انظر أيضًا**

--- a/docs/ar/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ar/reference/engines/table-engines/special/distributed.mdx
@@ -276,7 +276,11 @@ SETTINGS
 `_shard_num` — يحتوي على قيمة `shard_num` من جدول `system.clusters`. النوع: [UInt32](/ar/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster`](/ar/reference/functions/table-functions/cluster) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `&#95;shard&#95;num&#96; متاح فيهما أيضًا.
+=======
+  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster](../../../sql-reference/table-functions/cluster.md) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `_shard_num` متاح فيهما أيضًا.
+>>>>>>> Stashed changes
 </Note>
 
 **انظر أيضًا**

--- a/docs/ar/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ar/reference/engines/table-engines/special/distributed.mdx
@@ -276,7 +276,7 @@ SETTINGS
 `_shard_num` — يحتوي على قيمة `shard_num` من جدول `system.clusters`. النوع: [UInt32](/ar/reference/data-types/int-uint).
 
 <Note>
-  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster](../../../sql-reference/table-functions/cluster.md) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `&#95;shard&#95;num&#96; متاح فيهما أيضًا.
+  نظرًا لأن دالتي دوال الجداول [`remote`](/ar/reference/functions/table-functions/remote) و[`cluster`](/ar/reference/functions/table-functions/cluster) تنشئان داخليًا جدولًا مؤقتًا من نوع Distributed، فإن `&#95;shard&#95;num&#96; متاح فيهما أيضًا.
 </Note>
 
 **انظر أيضًا**

--- a/docs/es/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/es/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,11 @@ Para obtener más información sobre cómo se procesan las consultas distribuida
 `_shard_num` — Contiene el valor `shard_num` de la tabla `system.clusters`. Tipo: [UInt32](/es/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster`](/es/reference/functions/table-functions/cluster) crean internamente una tabla Distributed temporal, `&#95;shard&#95;num&#96; también está disponible allí.
+=======
+  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster](../../../sql-reference/table-functions/cluster.md) crean internamente una tabla Distributed temporal, `_shard_num` también está disponible allí.
+>>>>>>> Stashed changes
 </Note>
 
 **Véase también**

--- a/docs/es/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/es/reference/engines/table-engines/special/distributed.mdx
@@ -277,11 +277,7 @@ Para obtener más información sobre cómo se procesan las consultas distribuida
 `_shard_num` — Contiene el valor `shard_num` de la tabla `system.clusters`. Tipo: [UInt32](/es/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster`](/es/reference/functions/table-functions/cluster) crean internamente una tabla Distributed temporal, `&#95;shard&#95;num&#96; también está disponible allí.
-=======
-  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster](../../../sql-reference/table-functions/cluster.md) crean internamente una tabla Distributed temporal, `_shard_num` también está disponible allí.
->>>>>>> Stashed changes
+  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster`](/es/reference/functions/table-functions/cluster) crean internamente una tabla Distributed temporal, `_shard_num` también está disponible allí.
 </Note>
 
 **Véase también**

--- a/docs/es/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/es/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,7 @@ Para obtener más información sobre cómo se procesan las consultas distribuida
 `_shard_num` — Contiene el valor `shard_num` de la tabla `system.clusters`. Tipo: [UInt32](/es/reference/data-types/int-uint).
 
 <Note>
-  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster](../../../sql-reference/table-functions/cluster.md) crean internamente una tabla Distributed temporal, `&#95;shard&#95;num&#96; también está disponible allí.
+  Como las funciones de tabla [`remote`](/es/reference/functions/table-functions/remote) y [`cluster`](/es/reference/functions/table-functions/cluster) crean internamente una tabla Distributed temporal, `&#95;shard&#95;num&#96; también está disponible allí.
 </Note>
 
 **Véase también**

--- a/docs/fr/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/fr/reference/engines/table-engines/special/distributed.mdx
@@ -277,11 +277,7 @@ Pour en savoir plus sur le traitement des requêtes distribuées `in` et `global
 `_shard_num` — Contient la valeur `shard_num` issue de la table `system.clusters`. Type : [UInt32](/fr/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster`](/fr/reference/functions/table-functions/cluster) créent en interne une table Distributed temporaire, `&#95;shard&#95;num&#96; y est aussi disponible.
-=======
-  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster](../../../sql-reference/table-functions/cluster.md) créent en interne une table Distributed temporaire, `_shard_num` y est aussi disponible.
->>>>>>> Stashed changes
+  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster`](/fr/reference/functions/table-functions/cluster) créent en interne une table Distributed temporaire, `_shard_num` y est aussi disponible.
 </Note>
 
 **Voir aussi**

--- a/docs/fr/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/fr/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,11 @@ Pour en savoir plus sur le traitement des requêtes distribuées `in` et `global
 `_shard_num` — Contient la valeur `shard_num` issue de la table `system.clusters`. Type : [UInt32](/fr/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster`](/fr/reference/functions/table-functions/cluster) créent en interne une table Distributed temporaire, `&#95;shard&#95;num&#96; y est aussi disponible.
+=======
+  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster](../../../sql-reference/table-functions/cluster.md) créent en interne une table Distributed temporaire, `_shard_num` y est aussi disponible.
+>>>>>>> Stashed changes
 </Note>
 
 **Voir aussi**

--- a/docs/fr/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/fr/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,7 @@ Pour en savoir plus sur le traitement des requêtes distribuées `in` et `global
 `_shard_num` — Contient la valeur `shard_num` issue de la table `system.clusters`. Type : [UInt32](/fr/reference/data-types/int-uint).
 
 <Note>
-  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster](../../../sql-reference/table-functions/cluster.md) créent en interne une table Distributed temporaire, `&#95;shard&#95;num&#96; y est aussi disponible.
+  Comme les fonctions de table [`remote`](/fr/reference/functions/table-functions/remote) et [`cluster`](/fr/reference/functions/table-functions/cluster) créent en interne une table Distributed temporaire, `&#95;shard&#95;num&#96; y est aussi disponible.
 </Note>
 
 **Voir aussi**

--- a/docs/ja/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ja/reference/engines/table-engines/special/distributed.mdx
@@ -277,11 +277,7 @@ SETTINGS
 `_shard_num` — テーブル `system.clusters` の `shard_num` の値が格納されています。型: [UInt32](/ja/reference/data-types/int-uint)。
 
 <Note>
-<<<<<<< Updated upstream
-  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster`](/ja/reference/functions/table-functions/cluster) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`&#95;shard&#95;num&#96; はそれらでも利用できます。
-=======
-  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster](../../../sql-reference/table-functions/cluster.md) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`_shard_num` はそれらでも利用できます。
->>>>>>> Stashed changes
+  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster`](/ja/reference/functions/table-functions/cluster) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`_shard_num` はそれらでも利用できます。
 </Note>
 
 **関連項目**

--- a/docs/ja/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ja/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,11 @@ SETTINGS
 `_shard_num` — テーブル `system.clusters` の `shard_num` の値が格納されています。型: [UInt32](/ja/reference/data-types/int-uint)。
 
 <Note>
+<<<<<<< Updated upstream
   [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster`](/ja/reference/functions/table-functions/cluster) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`&#95;shard&#95;num&#96; はそれらでも利用できます。
+=======
+  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster](../../../sql-reference/table-functions/cluster.md) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`_shard_num` はそれらでも利用できます。
+>>>>>>> Stashed changes
 </Note>
 
 **関連項目**

--- a/docs/ja/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ja/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,7 @@ SETTINGS
 `_shard_num` — テーブル `system.clusters` の `shard_num` の値が格納されています。型: [UInt32](/ja/reference/data-types/int-uint)。
 
 <Note>
-  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster](../../../sql-reference/table-functions/cluster.md) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`&#95;shard&#95;num&#96; はそれらでも利用できます。
+  [`remote`](/ja/reference/functions/table-functions/remote) および [`cluster`](/ja/reference/functions/table-functions/cluster) テーブル関数は内部で一時的な Distributed テーブルを作成するため、`&#95;shard&#95;num&#96; はそれらでも利用できます。
 </Note>
 
 **関連項目**

--- a/docs/ko/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ko/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,11 @@ SETTINGS
 `_shard_num` — 테이블 `system.clusters`의 `shard_num` 값을 포함합니다. 유형: [UInt32](/ko/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster`](/ko/reference/functions/table-functions/cluster) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `&#95;shard&#95;num&#96;도 여기에서 사용할 수 있습니다.
+=======
+  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster](../../../sql-reference/table-functions/cluster.md) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `_shard_num`도 여기에서 사용할 수 있습니다.
+>>>>>>> Stashed changes
 </Note>
 
 **관련 항목**

--- a/docs/ko/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ko/reference/engines/table-engines/special/distributed.mdx
@@ -277,11 +277,7 @@ SETTINGS
 `_shard_num` — 테이블 `system.clusters`의 `shard_num` 값을 포함합니다. 유형: [UInt32](/ko/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster`](/ko/reference/functions/table-functions/cluster) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `&#95;shard&#95;num&#96;도 여기에서 사용할 수 있습니다.
-=======
-  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster](../../../sql-reference/table-functions/cluster.md) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `_shard_num`도 여기에서 사용할 수 있습니다.
->>>>>>> Stashed changes
+  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster`](/ko/reference/functions/table-functions/cluster) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `_shard_num`도 여기에서 사용할 수 있습니다.
 </Note>
 
 **관련 항목**

--- a/docs/ko/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ko/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,7 @@ SETTINGS
 `_shard_num` — 테이블 `system.clusters`의 `shard_num` 값을 포함합니다. 유형: [UInt32](/ko/reference/data-types/int-uint).
 
 <Note>
-  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster](../../../sql-reference/table-functions/cluster.md) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `&#95;shard&#95;num&#96;도 여기에서 사용할 수 있습니다.
+  [`remote`](/ko/reference/functions/table-functions/remote) 및 [`cluster`](/ko/reference/functions/table-functions/cluster) 테이블 함수는 내부적으로 임시 분산 테이블을 생성하므로 `&#95;shard&#95;num&#96;도 여기에서 사용할 수 있습니다.
 </Note>
 
 **관련 항목**

--- a/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
@@ -276,11 +276,7 @@ Para saber mais sobre como as consultas distribuídas `in` e `global in` são pr
 `_shard_num` — Contém o valor de `shard_num` da tabela `system.clusters`. Tipo: [UInt32](/pt-BR/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster`](/pt-BR/reference/functions/table-functions/cluster) criam internamente uma tabela Distributed temporária, `&#95;shard&#95;num&#96; também fica disponível nelas.
-=======
-  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster](../../../sql-reference/table-functions/cluster.md) criam internamente uma tabela Distributed temporária, `_shard_num` também fica disponível nelas.
->>>>>>> Stashed changes
+  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster`](/pt-BR/reference/functions/table-functions/cluster) criam internamente uma tabela Distributed temporária, `_shard_num` também fica disponível nelas.
 </Note>
 
 **Veja também**

--- a/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
@@ -276,7 +276,11 @@ Para saber mais sobre como as consultas distribuídas `in` e `global in` são pr
 `_shard_num` — Contém o valor de `shard_num` da tabela `system.clusters`. Tipo: [UInt32](/pt-BR/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster`](/pt-BR/reference/functions/table-functions/cluster) criam internamente uma tabela Distributed temporária, `&#95;shard&#95;num&#96; também fica disponível nelas.
+=======
+  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster](../../../sql-reference/table-functions/cluster.md) criam internamente uma tabela Distributed temporária, `_shard_num` também fica disponível nelas.
+>>>>>>> Stashed changes
 </Note>
 
 **Veja também**

--- a/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/pt-BR/reference/engines/table-engines/special/distributed.mdx
@@ -276,7 +276,7 @@ Para saber mais sobre como as consultas distribuídas `in` e `global in` são pr
 `_shard_num` — Contém o valor de `shard_num` da tabela `system.clusters`. Tipo: [UInt32](/pt-BR/reference/data-types/int-uint).
 
 <Note>
-  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster](../../../sql-reference/table-functions/cluster.md) criam internamente uma tabela Distributed temporária, `&#95;shard&#95;num&#96; também fica disponível nelas.
+  Como as funções de tabela [`remote`](/pt-BR/reference/functions/table-functions/remote) e [`cluster`](/pt-BR/reference/functions/table-functions/cluster) criam internamente uma tabela Distributed temporária, `&#95;shard&#95;num&#96; também fica disponível nelas.
 </Note>
 
 **Veja também**

--- a/docs/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/reference/engines/table-engines/special/distributed.mdx
@@ -255,7 +255,7 @@ To learn more about how distributed `in` and `global in` queries are processed, 
 `_shard_num` — Contains the `shard_num` value from the table `system.clusters`. Type: [UInt32](/reference/data-types/int-uint).
 
 <Note>
-Since [`remote`](/reference/functions/table-functions/remote) and [`cluster`](/reference/functions/table-functions/cluster) table functions internally create temporary Distributed table, `_shard_num` is available there too.
+Since [`remote`](/reference/functions/table-functions/remote) and [`cluster](../../../sql-reference/table-functions/cluster.md) table functions internally create temporary Distributed table, `_shard_num` is available there too.
 </Note>
 
 **See Also**

--- a/docs/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/reference/engines/table-engines/special/distributed.mdx
@@ -255,7 +255,7 @@ To learn more about how distributed `in` and `global in` queries are processed, 
 `_shard_num` — Contains the `shard_num` value from the table `system.clusters`. Type: [UInt32](/reference/data-types/int-uint).
 
 <Note>
-Since [`remote`](/reference/functions/table-functions/remote) and [`cluster](../../../sql-reference/table-functions/cluster.md) table functions internally create temporary Distributed table, `_shard_num` is available there too.
+Since [`remote`](/reference/functions/table-functions/remote) and [`cluster`](/reference/functions/table-functions/cluster) table functions internally create temporary Distributed table, `_shard_num` is available there too.
 </Note>
 
 **See Also**

--- a/docs/ru/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ru/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,11 @@ SETTINGS
 `_shard_num` — содержит значение `shard_num` из таблицы `system.clusters`. Тип: [UInt32](/ru/reference/data-types/int-uint).
 
 <Note>
+<<<<<<< Updated upstream
   Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster`](/ru/reference/functions/table-functions/cluster) внутренне создают временную Distributed таблицу, `&#95;shard&#95;num&#96; также доступен и в них.
+=======
+  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster](../../../sql-reference/table-functions/cluster.md) внутренне создают временную Distributed таблицу, `_shard_num` также доступен и в них.
+>>>>>>> Stashed changes
 </Note>
 
 **См. также**

--- a/docs/ru/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ru/reference/engines/table-engines/special/distributed.mdx
@@ -277,11 +277,7 @@ SETTINGS
 `_shard_num` — содержит значение `shard_num` из таблицы `system.clusters`. Тип: [UInt32](/ru/reference/data-types/int-uint).
 
 <Note>
-<<<<<<< Updated upstream
-  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster`](/ru/reference/functions/table-functions/cluster) внутренне создают временную Distributed таблицу, `&#95;shard&#95;num&#96; также доступен и в них.
-=======
-  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster](../../../sql-reference/table-functions/cluster.md) внутренне создают временную Distributed таблицу, `_shard_num` также доступен и в них.
->>>>>>> Stashed changes
+  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster`](/ru/reference/functions/table-functions/cluster) внутренне создают временную Distributed таблицу, `_shard_num` также доступен и в них.
 </Note>
 
 **См. также**

--- a/docs/ru/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/ru/reference/engines/table-engines/special/distributed.mdx
@@ -277,7 +277,7 @@ SETTINGS
 `_shard_num` — содержит значение `shard_num` из таблицы `system.clusters`. Тип: [UInt32](/ru/reference/data-types/int-uint).
 
 <Note>
-  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster](../../../sql-reference/table-functions/cluster.md) внутренне создают временную Distributed таблицу, `&#95;shard&#95;num&#96; также доступен и в них.
+  Поскольку табличные функции [`remote`](/ru/reference/functions/table-functions/remote) и [`cluster`](/ru/reference/functions/table-functions/cluster) внутренне создают временную Distributed таблицу, `&#95;shard&#95;num&#96; также доступен и в них.
 </Note>
 
 **См. также**

--- a/docs/zh/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/zh/reference/engines/table-engines/special/distributed.mdx
@@ -274,11 +274,7 @@ SETTINGS
 `_shard_num` — 包含表 `system.clusters` 中的 `shard_num` 值。类型：[UInt32](/zh/reference/data-types/int-uint)。
 
 <Note>
-<<<<<<< Updated upstream
-  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster`](/zh/reference/functions/table-functions/cluster) 表函数在内部会创建临时 Distributed 表，因此 `&#95;shard&#95;num&#96; 在这些函数中也可用。
-=======
-  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster](../../../sql-reference/table-functions/cluster.md) 表函数在内部会创建临时 Distributed 表，因此 `_shard_num` 在这些函数中也可用。
->>>>>>> Stashed changes
+  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster`](/zh/reference/functions/table-functions/cluster) 表函数在内部会创建临时 Distributed 表，因此 `_shard_num` 在这些函数中也可用。
 </Note>
 
 **另请参见**

--- a/docs/zh/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/zh/reference/engines/table-engines/special/distributed.mdx
@@ -274,7 +274,11 @@ SETTINGS
 `_shard_num` — 包含表 `system.clusters` 中的 `shard_num` 值。类型：[UInt32](/zh/reference/data-types/int-uint)。
 
 <Note>
+<<<<<<< Updated upstream
   由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster`](/zh/reference/functions/table-functions/cluster) 表函数在内部会创建临时 Distributed 表，因此 `&#95;shard&#95;num&#96; 在这些函数中也可用。
+=======
+  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster](../../../sql-reference/table-functions/cluster.md) 表函数在内部会创建临时 Distributed 表，因此 `_shard_num` 在这些函数中也可用。
+>>>>>>> Stashed changes
 </Note>
 
 **另请参见**

--- a/docs/zh/reference/engines/table-engines/special/distributed.mdx
+++ b/docs/zh/reference/engines/table-engines/special/distributed.mdx
@@ -274,7 +274,7 @@ SETTINGS
 `_shard_num` — 包含表 `system.clusters` 中的 `shard_num` 值。类型：[UInt32](/zh/reference/data-types/int-uint)。
 
 <Note>
-  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster](../../../sql-reference/table-functions/cluster.md) 表函数在内部会创建临时 Distributed 表，因此 `&#95;shard&#95;num&#96; 在这些函数中也可用。
+  由于 [`remote`](/zh/reference/functions/table-functions/remote) 和 [`cluster`](/zh/reference/functions/table-functions/cluster) 表函数在内部会创建临时 Distributed 表，因此 `&#95;shard&#95;num&#96; 在这些函数中也可用。
 </Note>
 
 **另请参见**


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry
n/a

### Description
On the Distributed table engine page (virtual columns note), the link for the `cluster` table function:

1. Never closed the markdown code span (`[`cluster]` missing the trailing backtick before `]`)
2. Used a stale relative path into `sql-reference/table-functions/clusters.md`-style tree that no longer matches the Mintlify docs layout

This leaves a broken inline link next to the correctly linked `remote` table function.

### Changes
- English `docs/reference/.../distributed.mdx` and locale mirrors (ar/es/fr/ja/ko/pt-BR/ru/zh): point `cluster` at the absolute Mintlify path used for `remote`, with a closed code span.

### Documentation
- [x] Documentation is written / corrected

AI-assisted; human-reviewed.
