### PR TITLE
Retry gh auth token validation on transient GitHub API errors

### DIFF
--- a/ci/praktika/gh_auth.py
+++ b/ci/praktika/gh_auth.py
@@ -17,6 +17,27 @@ except (ImportError, AssertionError):
 
 from praktika.utils import Shell
 
+# `gh auth login --with-token` validates the token against api.github.com. A single
+# transient GitHub API 5xx/timeout there would otherwise hard-fail the whole job.
+# Retry only on transport-class errors; auth errors (e.g. HTTP 401 bad token) stay fatal.
+_GH_AUTH_RETRY_ERRORS = [
+    "HTTP 500",
+    "HTTP 502",
+    "HTTP 503",
+    "HTTP 504",
+    "HTTP 429",
+    "Service Unavailable",
+    "Bad Gateway",
+    "Gateway Timeout",
+    "Too Many Requests",
+    "Internal Server Error",
+    "i/o timeout",
+    "TLS handshake timeout",
+    "connection reset by peer",
+    "connection refused",
+    "EOF",
+]
+
 
 class GHAuth:
 
@@ -100,6 +121,8 @@ class GHAuth:
             "gh auth login --with-token",
             stdin_str=f"{access_token}\n",
             strict=True,
+            retries=4,
+            retry_errors=_GH_AUTH_RETRY_ERRORS,
         )
 
     @classmethod
@@ -115,6 +138,8 @@ class GHAuth:
                 "gh auth login --with-token",
                 stdin_str=f"{access_token}\n",
                 strict=True,
+                retries=4,
+                retry_errors=_GH_AUTH_RETRY_ERRORS,
             )
             return
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110674
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

praktika's GH-auth pre-step runs `gh auth login --with-token`, which validates the token against `api.github.com`. A single transient GitHub API 5xx there (e.g. `HTTP 503 Service Unavailable`) hard-failed the entire job with `GH auth failed - required by job`.

Observed on a 40+ min `LLVM Coverage` job (PR #110674, commit fd47e5f):
```
WARNING: GH auth failed: command failed, exit code 1,
error validating token: HTTP 503: 503 Service Unavailable (https://api.github.com/)
ERROR: GH auth failed - required by job
```

This retries the token-validation call up to 4 times with exponential backoff, but **only** on transport-class errors (5xx / 429 / timeouts / connection resets). Non-transient auth errors (e.g. `HTTP 401 Bad credentials`) stay fatal and fail fast. It reuses the existing `Shell.check` `retries`/`retry_errors` mechanism, mirroring the docker buildx (`BUILDX_RETRY_ERRORS`) and wget retry patterns already in the repo.

Verified with a fake `gh` emitting the exact 503 line: without retry a single 503 hard-fails; with the fix it survives 2 transient 503s and succeeds on the 3rd attempt; a non-transient 401 still fails fast after 1 attempt (no wasted retries).

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110674&sha=fd47e5fd4a17fd5d2e8718015c62a288d297fb33&name_0=PR&name_1=LLVM%20Coverage


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1110` (included in `26.7` and later)
<!-- ch-version-info:end -->