### PR TITLE
Fix AST fuzzer abort on parametrized identifiers in fuzzExpressionList

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -3513,10 +3513,14 @@ void QueryFuzzer::fuzzExpressionList(ASTExpressionList & expr_list)
                 /// optionally with APPLY/EXCEPT/REPLACE transformers attached.
                 new_child = makeFuzzedAsteriskLikeMatcher();
             }
-            else if (auto * ident = typeid_cast<ASTIdentifier *>(child.get()); ident && fuzz_rand() % 250 == 0)
+            else if (auto * ident = typeid_cast<ASTIdentifier *>(child.get());
+                     ident && !ident->isParam() && fuzz_rand() % 250 == 0)
             {
-                /// Rewrite a column reference into one of its potential subcolumn accessors
-                /// (typeid_cast is exact, so ASTTableIdentifier / ASTQueryParameter are left alone).
+                /// Rewrite a column reference into one of its potential subcolumn accessors.
+                /// typeid_cast is exact, so ASTTableIdentifier is left alone; isParam() excludes
+                /// parametrized identifiers ({x:Type}) whose name_parts hold empty placeholders,
+                /// which would otherwise reach the ASTIdentifier(name_parts) ctor without name_params
+                /// and trip its chassert(!part.empty()).
                 static const Strings subcolumn_names = {"keys", "null", "size0", "values"};
                 const String subcolumn = pickRandomly(fuzz_rand, subcolumn_names);
                 switch (fuzz_rand() % 5)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/110228


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes an AST fuzzer abort (`Logical error: '!part.empty()'`) introduced by #110228.

The subcolumn-accessor rewrite in `QueryFuzzer::fuzzExpressionList` matches a
`SELECT`-list child via `typeid_cast<ASTIdentifier *>`. A parametrized identifier
`{name:type}` also parses into an `ASTIdentifier` (`ExpressionElementParsers.cpp`:
`make_intrusive<ASTIdentifier>("", make_intrusive<ASTQueryParameter>(...))`), whose
single `name_parts` entry is empty and whose parameter lives in a child. The rewrite
copied `name_parts` (`[""]`), appended a subcolumn, and rebuilt
`ASTIdentifier(name_parts)` without the parameter child, so the constructor's
`chassert(!part.empty())` aborted.

Guard the branch with `!ident->isParam()`, mirroring the existing check used
elsewhere in this file (the identifier collector already excludes parametrized
identifiers for the same reason).

Aborts all AST fuzzer variants (amd_debug, arm_asan_ubsan, amd_tsan, amd_msan,
targeted, old_compatibility). 20 PRs + 1 master hit on 2026-07-16, first appearing
with commit 4cf16c718a3289 (#110228). Example CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110671&sha=45e9ace92a66f93bd0b272645863e29cfdef93b2&name_0=PR&name_1=AST%20fuzzer%20%28amd_msan%29
