### PR TITLE
Add regression test for implicit-boolean WHERE filter on projection and parallel-replicas read paths

### DIFF
--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
@@ -1,24 +1,27 @@
 -- normal path
-0	19
-1	20
-2	20
-3	20
-4	20
--- projection path
-0	19
-1	20
-2	20
-3	20
-4	20
+1	1
+2	1
+3	1
+4	1
+5	1
+-- projection path (projection actually used)
+1	1
+2	1
+3	1
+4	1
+5	1
 -- parallel replicas, local plan
-0	19
-1	20
-2	20
-3	20
-4	20
+1	1
+2	1
+3	1
+4	1
+5	1
 -- parallel replicas, remote plan
-0	19
-1	20
-2	20
-3	20
-4	20
+1	1
+2	1
+3	1
+4	1
+5	1
+-- parallel replicas engaged (both plans)
+04371_pr_local	1
+04371_pr_remote	1

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
@@ -1,0 +1,24 @@
+-- normal path
+0	19
+1	20
+2	20
+3	20
+4	20
+-- projection path
+0	19
+1	20
+2	20
+3	20
+4	20
+-- parallel replicas, local plan
+0	19
+1	20
+2	20
+3	20
+4	20
+-- parallel replicas, remote plan
+0	19
+1	20
+2	20
+3	20
+4	20

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
@@ -26,6 +26,3 @@
 1
 -- remote plan reads all replicas remotely
 1
--- parallel replicas engaged (both plans)
-04371_pr_local	1
-04371_pr_remote	1

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
@@ -1,15 +1,20 @@
 -- normal path
-1	1
-2	1
-3	1
-4	1
-5	1
+0	19
+1	20
+2	20
+3	20
+4	20
+-- issue #110795 reproducer
+0	19
+1	20
+2	20
+3	20
+4	20
 -- projection path (projection actually used)
-1	1
-2	1
-3	1
-4	1
-5	1
+1	20
+2	20
+3	20
+4	20
 -- parallel replicas, local plan
 1	1
 2	1

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.reference
@@ -22,6 +22,10 @@
 3	1
 4	1
 5	1
+-- local plan reads initiator locally
+1
+-- remote plan reads all replicas remotely
+1
 -- parallel replicas engaged (both plans)
 04371_pr_local	1
 04371_pr_remote	1

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -1,0 +1,40 @@
+-- Tags: no-parallel-replicas
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/110795
+--
+-- A bare non-UInt8 column in WHERE is an implicit-boolean filter (`a != 0`).
+-- The normal read path coerces it, but the projection read path
+-- (optimize_use_projections = 1) and the parallel-replicas read path used to
+-- reject it with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER (Code 59). All three paths
+-- must now agree.
+
+DROP TABLE IF EXISTS t_04371;
+
+CREATE TABLE t_04371 (a UInt32, b UInt32, PROJECTION p (SELECT b, count() GROUP BY b))
+ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_04371 SELECT number, number % 5 FROM numbers(100);
+
+SELECT '-- normal path';
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
+
+SELECT '-- projection path';
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS optimize_use_projections = 1, enable_parallel_replicas = 0;
+
+SELECT '-- parallel replicas, local plan';
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+         parallel_replicas_for_non_replicated_merge_tree = 1,
+         parallel_replicas_min_number_of_rows_per_replica = 0,
+         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+         parallel_replicas_local_plan = 1;
+
+SELECT '-- parallel replicas, remote plan';
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
+         parallel_replicas_for_non_replicated_merge_tree = 1,
+         parallel_replicas_min_number_of_rows_per_replica = 0,
+         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+         parallel_replicas_local_plan = 0;
+
+DROP TABLE t_04371;

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -2,39 +2,53 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/110795
 --
 -- A bare non-UInt8 column in WHERE is an implicit-boolean filter (`a != 0`).
--- The normal read path coerces it, but the projection read path
--- (optimize_use_projections = 1) and the parallel-replicas read path used to
--- reject it with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER (Code 59). All three paths
--- must now agree.
+-- The projection read path (optimize_use_projections = 1) and the parallel-replicas
+-- read path used to reject it with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER (Code 59).
+-- All three paths must now agree AND each path must actually be taken: the assertions
+-- below fail if the projection is silently not used or parallel replicas is not engaged,
+-- so a fallback to a plain local read cannot leave the regression uncovered.
 
 DROP TABLE IF EXISTS t_04371;
 
-CREATE TABLE t_04371 (a UInt32, b UInt32, PROJECTION p (SELECT b, count() GROUP BY b))
-ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_04371 (a UInt32, b UInt32, PROJECTION p (SELECT a, count() GROUP BY a))
+ENGINE = MergeTree ORDER BY b;
 INSERT INTO t_04371 SELECT number, number % 5 FROM numbers(100);
 
 SELECT '-- normal path';
-SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
 SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
 
-SELECT '-- projection path';
-SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
-SETTINGS optimize_use_projections = 1, enable_parallel_replicas = 0;
+-- projection path: force_optimize_projection = 1 throws PROJECTION_NOT_USED if the
+-- projection is not chosen, so this deterministically asserts the projection path is taken.
+SELECT '-- projection path (projection actually used)';
+SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
+
+SET automatic_parallel_replicas_mode = 0;
+SET parallel_replicas_only_with_analyzer = 0;  -- necessary for CI run with disabled analyzer
+SET enable_parallel_replicas = 1, max_parallel_replicas = 3,
+    parallel_replicas_for_non_replicated_merge_tree = 1,
+    parallel_replicas_min_number_of_rows_per_replica = 0,
+    cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
+    optimize_use_projections = 0;
 
 SELECT '-- parallel replicas, local plan';
-SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
-SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
-         parallel_replicas_for_non_replicated_merge_tree = 1,
-         parallel_replicas_min_number_of_rows_per_replica = 0,
-         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
-         parallel_replicas_local_plan = 1;
+SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
+SETTINGS parallel_replicas_local_plan = 1, log_comment = '04371_pr_local';
 
 SELECT '-- parallel replicas, remote plan';
-SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
-SETTINGS enable_parallel_replicas = 1, max_parallel_replicas = 3,
-         parallel_replicas_for_non_replicated_merge_tree = 1,
-         parallel_replicas_min_number_of_rows_per_replica = 0,
-         cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
-         parallel_replicas_local_plan = 0;
+SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
+SETTINGS parallel_replicas_local_plan = 0, log_comment = '04371_pr_remote';
+
+SYSTEM FLUSH LOGS query_log;
+
+SELECT '-- parallel replicas engaged (both plans)';
+SELECT log_comment, ProfileEvents['ParallelReplicasUsedCount'] > 0
+FROM system.query_log
+WHERE current_database = currentDatabase()
+  AND log_comment IN ('04371_pr_local', '04371_pr_remote')
+  AND type = 'QueryFinish' AND initial_query_id = query_id
+ORDER BY log_comment
+SETTINGS enable_parallel_replicas = 0;
 
 DROP TABLE t_04371;

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -24,8 +24,12 @@ SELECT '-- projection path (projection actually used)';
 SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
 SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
 
+-- enable_analyzer = 1 is required: parallel_replicas_local_plan = 1 only engages the local
+-- plan with the analyzer on (canUseLocalPlanForParallelReplicas returns false otherwise), so
+-- without pinning it a randomized old-analyzer run would silently send the local-plan query
+-- through the same remote path and leave that half of the regression uncovered.
+SET enable_analyzer = 1;
 SET automatic_parallel_replicas_mode = 0;
-SET parallel_replicas_only_with_analyzer = 0;  -- necessary for CI run with disabled analyzer
 SET enable_parallel_replicas = 1, max_parallel_replicas = 3,
     parallel_replicas_for_non_replicated_merge_tree = 1,
     parallel_replicas_min_number_of_rows_per_replica = 0,
@@ -39,6 +43,17 @@ SETTINGS parallel_replicas_local_plan = 1, log_comment = '04371_pr_local';
 SELECT '-- parallel replicas, remote plan';
 SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
 SETTINGS parallel_replicas_local_plan = 0, log_comment = '04371_pr_remote';
+
+-- Plan-shape assertions lock in the local/remote split independently of the row results:
+-- the local plan reads the initiator's share via ReadFromMergeTree and the rest remotely,
+-- the remote plan reads every replica remotely with no local ReadFromMergeTree.
+SELECT '-- local plan reads initiator locally';
+SELECT countIf(explain ILIKE '%ReadFromMergeTree%') > 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 1);
+
+SELECT '-- remote plan reads all replicas remotely';
+SELECT countIf(explain ILIKE '%ReadFromMergeTree%') = 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 0);
 
 SYSTEM FLUSH LOGS query_log;
 

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -4,25 +4,32 @@
 -- A bare non-UInt8 column in WHERE is an implicit-boolean filter (`a != 0`).
 -- The projection read path (optimize_use_projections = 1) and the parallel-replicas
 -- read path used to reject it with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER (Code 59).
--- The result checks below verify all paths agree; the plan-shape checks verify the
--- projection and parallel-replicas paths are actually taken, so a silent fallback to
--- a plain local read cannot leave the regression uncovered.
 
 DROP TABLE IF EXISTS t_04371;
 
-CREATE TABLE t_04371 (a UInt32, b UInt32, PROJECTION p (SELECT a, count() GROUP BY a))
-ENGINE = MergeTree ORDER BY b;
+-- Table and projection match the issue: the projection groups by b, and the reproducer
+-- filters on a, so the implicit-boolean filter column is not the projection key/output.
+CREATE TABLE t_04371 (a UInt32, b UInt32, PROJECTION p (SELECT b, count() GROUP BY b))
+ENGINE = MergeTree ORDER BY a;
 INSERT INTO t_04371 SELECT number, number % 5 FROM numbers(100);
 
 SELECT '-- normal path';
-SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
-SETTINGS optimize_use_projections = 0, enable_parallel_replicas = 0;
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS optimize_use_projections = 0;
 
--- projection path: force_optimize_projection = 1 throws PROJECTION_NOT_USED if the
--- projection is not chosen, so this deterministically asserts the projection path is taken.
+-- Issue #110795 reproducer. WHERE a filters on a column not stored in the projection,
+-- so the projection is not chosen (force_optimize_projection would throw PROJECTION_NOT_USED
+-- here); enabling projections still triggered the Code 59 rejection during planning, so
+-- result-parity with the normal path is the regression lock for this exact shape.
+SELECT '-- issue #110795 reproducer';
+SELECT b, count() FROM t_04371 WHERE a GROUP BY b ORDER BY b
+SETTINGS optimize_use_projections = 1;
+
+-- When the implicit-boolean filter is on the projection key the projection is chosen,
+-- so force_optimize_projection = 1 deterministically asserts the projection path is taken.
 SELECT '-- projection path (projection actually used)';
-SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
-SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
+SELECT b, count() FROM t_04371 WHERE b GROUP BY b ORDER BY b
+SETTINGS optimize_use_projections = 1, force_optimize_projection = 1;
 
 SET automatic_parallel_replicas_mode = 0;
 SET enable_parallel_replicas = 1, max_parallel_replicas = 3,

--- a/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
+++ b/tests/queries/0_stateless/04371_implicit_bool_filter_projection_parallel_replicas.sql
@@ -4,9 +4,9 @@
 -- A bare non-UInt8 column in WHERE is an implicit-boolean filter (`a != 0`).
 -- The projection read path (optimize_use_projections = 1) and the parallel-replicas
 -- read path used to reject it with ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER (Code 59).
--- All three paths must now agree AND each path must actually be taken: the assertions
--- below fail if the projection is silently not used or parallel replicas is not engaged,
--- so a fallback to a plain local read cannot leave the regression uncovered.
+-- The result checks below verify all paths agree; the plan-shape checks verify the
+-- projection and parallel-replicas paths are actually taken, so a silent fallback to
+-- a plain local read cannot leave the regression uncovered.
 
 DROP TABLE IF EXISTS t_04371;
 
@@ -24,11 +24,6 @@ SELECT '-- projection path (projection actually used)';
 SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
 SETTINGS optimize_use_projections = 1, force_optimize_projection = 1, enable_parallel_replicas = 0;
 
--- enable_analyzer = 1 is required: parallel_replicas_local_plan = 1 only engages the local
--- plan with the analyzer on (canUseLocalPlanForParallelReplicas returns false otherwise), so
--- without pinning it a randomized old-analyzer run would silently send the local-plan query
--- through the same remote path and leave that half of the regression uncovered.
-SET enable_analyzer = 1;
 SET automatic_parallel_replicas_mode = 0;
 SET enable_parallel_replicas = 1, max_parallel_replicas = 3,
     parallel_replicas_for_non_replicated_merge_tree = 1,
@@ -36,34 +31,29 @@ SET enable_parallel_replicas = 1, max_parallel_replicas = 3,
     cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost',
     optimize_use_projections = 0;
 
+-- The two result checks stay analyzer-agnostic so a randomized run verifies the same
+-- rows with and without the analyzer.
 SELECT '-- parallel replicas, local plan';
 SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
-SETTINGS parallel_replicas_local_plan = 1, log_comment = '04371_pr_local';
+SETTINGS parallel_replicas_local_plan = 1;
 
 SELECT '-- parallel replicas, remote plan';
 SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5
-SETTINGS parallel_replicas_local_plan = 0, log_comment = '04371_pr_remote';
+SETTINGS parallel_replicas_local_plan = 0;
 
--- Plan-shape assertions lock in the local/remote split independently of the row results:
--- the local plan reads the initiator's share via ReadFromMergeTree and the rest remotely,
--- the remote plan reads every replica remotely with no local ReadFromMergeTree.
+-- enable_analyzer = 1 is pinned only here, where the plan shape is asserted: the local
+-- plan for parallel replicas engages only with the analyzer on
+-- (canUseLocalPlanForParallelReplicas returns false otherwise), so without the pin a
+-- randomized old-analyzer run would silently route the local-plan query through the
+-- remote path and leave that half of the regression uncovered.
 SELECT '-- local plan reads initiator locally';
 SELECT countIf(explain ILIKE '%ReadFromMergeTree%') > 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
-FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 1);
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 1)
+SETTINGS enable_analyzer = 1;
 
 SELECT '-- remote plan reads all replicas remotely';
 SELECT countIf(explain ILIKE '%ReadFromMergeTree%') = 0 AND countIf(explain ILIKE '%ReadFromRemoteParallelReplicas%') > 0
-FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 0);
-
-SYSTEM FLUSH LOGS query_log;
-
-SELECT '-- parallel replicas engaged (both plans)';
-SELECT log_comment, ProfileEvents['ParallelReplicasUsedCount'] > 0
-FROM system.query_log
-WHERE current_database = currentDatabase()
-  AND log_comment IN ('04371_pr_local', '04371_pr_remote')
-  AND type = 'QueryFinish' AND initial_query_id = query_id
-ORDER BY log_comment
-SETTINGS enable_parallel_replicas = 0;
+FROM (EXPLAIN SELECT a, count() FROM t_04371 WHERE a GROUP BY a ORDER BY a LIMIT 5 SETTINGS parallel_replicas_local_plan = 0)
+SETTINGS enable_analyzer = 1;
 
 DROP TABLE t_04371;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/110795
-->

Related: https://github.com/ClickHouse/ClickHouse/issues/110795

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Regression test for #110795. A bare non-`UInt8` column in `WHERE` is an implicit-boolean filter (`col != 0`). The normal read path coerces it, but the issue reported that the projection read path (`optimize_use_projections = 1`) and the parallel-replicas read path rejected it with `Code 59 ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER` on 26.7.1.408 / 26.7.1.653.

The defect no longer reproduces on current master. The projection path was fixed by #106590 and the WHERE-field-as-condition work in #89603; the parallel-replicas remote path (verified via `EXPLAIN` showing `ReadFromRemoteParallelReplicas`) also returns correct results. There was no test covering the non-`UInt8` case across both alternative read paths, so this adds one:

- normal path
- projection path (`optimize_use_projections = 1`)
- parallel replicas, `parallel_replicas_local_plan = 1`
- parallel replicas, `parallel_replicas_local_plan = 0` (remote plan)

All four must return the same result.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1303` (included in `26.7` and later)
<!-- ch-version-info:end -->