### PR TITLE
Fix flaky 00965_send_logs_level_concurrent_queries

### DIFF
--- a/tests/queries/0_stateless/00965_send_logs_level_concurrent_queries.sh
+++ b/tests/queries/0_stateless/00965_send_logs_level_concurrent_queries.sh
@@ -5,9 +5,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 for _ in {1..10}; do
-    # Match the <Trace> marker anywhere: the log prefix omits host_name/query_id when
-    # empty, so its column is not fixed and a positional awk '{print $8}' is fragile.
-    ${CLICKHOUSE_CLIENT_BINARY} --send_logs_level="trace" --query="SELECT * from numbers(1000000);" 2>&1 | grep -q '<Trace>' && echo "OK" || echo "Fail" &
+    # A query at trace level must deliver verbose (<Debug>/<Trace>) logs to the client, while the same
+    # query at information level must not -- that threshold is what this test checks. Match the marker
+    # anywhere on the line: the log prefix omits host_name/query_id when empty, so their columns are not
+    # fixed and a positional awk '{print $8}' is fragile. Accept <Debug> as well as <Trace>: a trivial
+    # SELECT is not guaranteed to emit a <Trace>-priority line (the LOG_TRACE calls on the query path are
+    # all conditional), but `executeQuery` always logs the incoming query at <Debug>, so requiring
+    # <Debug>|<Trace> is deterministic and stays symmetric with the information-level negative check.
+    ${CLICKHOUSE_CLIENT_BINARY} --send_logs_level="trace" --query="SELECT * from numbers(1000000);" 2>&1 | grep -q '<Debug>\|<Trace>' && echo "OK" || echo "Fail" &
     ${CLICKHOUSE_CLIENT_BINARY} --send_logs_level="information" --query="SELECT * from numbers(1000000);" 2>&1 | grep '<Debug>\|<Trace>' &
 done
 


### PR DESCRIPTION
## Problem

`00965_send_logs_level_concurrent_queries` is flaky on both `master` and pull requests (surfacing as a `-OK/+Fail` diff). It runs a query at `send_logs_level=trace` and asserts a verbose log line reached the client by matching `<Trace>`.

## Root cause

A trivial `SELECT * from numbers(...)` is not guaranteed to emit a `<Trace>`-priority line — every `LOG_TRACE` on the query path is conditional. Under concurrency and randomized settings a run occasionally delivers no `<Trace>` line, so the check prints `Fail`.

## Solution

`executeQuery` always logs the incoming query at `<Debug>` (`logQuery`), which is delivered at trace verbosity but filtered out at information verbosity. Match `<Debug>` as well as `<Trace>`, making the positive check deterministic and symmetric with the information-level negative check just below (which already asserts `<Debug>`/`<Trace>` are absent). The test still verifies the `send_logs_level` threshold: verbose logs are delivered at `trace` and filtered at `information`.

Verified against a running server: the patched test yields 10 `OK`, and an `information`-level query delivers no `<Debug>`/`<Trace>` lines.

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.356` (included in `26.9` and later)
- Backported to: `26.8.1.2040`
<!-- ch-version-info:end -->