### PR TITLE
Fix flaky 01137_order_by_func: pin optimize_read_in_order

### DIFF
--- a/tests/queries/0_stateless/01137_order_by_func.sql
+++ b/tests/queries/0_stateless/01137_order_by_func.sql
@@ -1,3 +1,6 @@
+-- Tags: long
+-- ^ 10M-row fixture exceeds the flaky-check 180s per-run soft cap on sanitizer builds.
+
 DROP TABLE IF EXISTS pk_func;
 CREATE TABLE pk_func(d DateTime, ui UInt32) ENGINE = MergeTree ORDER BY toDate(d) SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
@@ -5,7 +8,7 @@ INSERT INTO pk_func SELECT '2020-05-05 01:00:00', number FROM numbers(1000000);
 INSERT INTO pk_func SELECT '2020-05-06 01:00:00', number FROM numbers(1000000);
 INSERT INTO pk_func SELECT '2020-05-07 01:00:00', number FROM numbers(1000000);
 
-SELECT * FROM pk_func ORDER BY toDate(d), ui LIMIT 5;
+SELECT * FROM pk_func ORDER BY toDate(d), ui LIMIT 5 SETTINGS optimize_read_in_order = 1, query_plan_read_in_order = 1;
 
 DROP TABLE pk_func;
 
@@ -20,6 +23,6 @@ ORDER BY
     A ASC,
     -B ASC
 LIMIT 3
-SETTINGS max_threads = 1;
+SETTINGS max_threads = 1, optimize_read_in_order = 1, query_plan_read_in_order = 1;
 
 DROP TABLE nORX;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/issues/110815
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

### Description

Fixes flaky `01137_order_by_func` (issue #110815).

The test verifies read-in-order works with functional / monotonic sort keys (`ORDER BY toDate(d)`, `ORDER BY (A, negate(B))`). CI randomizes `optimize_read_in_order` (tests/clickhouse-test:1362). When it is randomized to `0`, the final `LIMIT 3` query over the 10M-row `nORX` table can no longer stop early and turns into a full scan + sort.

Measured locally (clickhouse-local, same query):
- `optimize_read_in_order=0` -> SelectedRows = 10008192 (full scan)
- `optimize_read_in_order=1` -> SelectedRows = 81920 (~122x fewer)

On slow `amd_tsan, s3 storage` runs the full-scan variant exceeds `max_execution_time`: the failing report shows `Estimated query execution time (759.039 seconds) is too long. Maximum: 600 ... (TOO_SLOW)` (code 160), reading 3988868 rows in 302s before aborting.

Fix: pin `optimize_read_in_order=1` and `query_plan_read_in_order=1` on the two ORDER BY queries. Disabling read-in-order defeats the test's purpose, so pinning it preserves intent while removing the flakiness. Output is unchanged (verified byte-identical to the reference).

CI report of the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108936&sha=cd0376c77eb7deab41a0e0ff40cc074cf8244335&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%203%2F3%29
