### PR TITLE
Add Keeper create with sequential counter

### DIFF
--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -429,6 +429,7 @@ struct CreateRequest : virtual Request
     bool include_stats = false;
     bool include_ttl = false;
     int64_t ttl = 0;
+    std::optional<int64_t> initial_sequential_counter;
 
     /// should it succeed if node already exists
     bool not_exists = false;
@@ -442,6 +443,8 @@ struct CreateRequest : virtual Request
             + sizeof(is_ephemeral) + sizeof(is_sequential) + acls.size() * sizeof(ACL);
         if (include_ttl)
             base_size += sizeof(ttl);
+        if (initial_sequential_counter)
+            base_size += sizeof(*initial_sequential_counter);
         return base_size;
     }
 };
@@ -826,6 +829,7 @@ public:
         const String & data,
         bool is_ephemeral,
         bool is_sequential,
+        std::optional<int64_t> initial_sequential_counter,
         const ACLs & acls,
         CreateCallback callback) = 0;
 

--- a/src/Common/ZooKeeper/KeeperFeatureFlags.h
+++ b/src/Common/ZooKeeper/KeeperFeatureFlags.h
@@ -31,6 +31,7 @@ enum class KeeperFeatureFlag : size_t
     LIST_WITH_STAT_AND_DATA,
     GET_CHILDREN_RECURSIVE,
     CREATE_TTL,
+    CREATE_WITH_SEQUENTIAL_COUNTER,
 };
 
 class KeeperFeatureFlags

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
@@ -100,6 +100,7 @@ void KeeperOverDispatcher::create(
     const String & data,
     bool is_ephemeral,
     bool is_sequential,
+    std::optional<int64_t> initial_sequential_counter,
     const ACLs & acls,
     CreateCallback callback)
 {
@@ -108,6 +109,7 @@ void KeeperOverDispatcher::create(
     request->data = data;
     request->is_ephemeral = is_ephemeral;
     request->is_sequential = is_sequential;
+    request->initial_sequential_counter = initial_sequential_counter;
     request->acls = acls;
 
     pushRequest(request, [callback](const ZooKeeperResponsePtr & response)

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.h
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.h
@@ -44,6 +44,7 @@ public:
         const String & data,
         bool is_ephemeral,
         bool is_sequential,
+        std::optional<int64_t> initial_sequential_counter,
         const ACLs & acls,
         CreateCallback callback) override;
 

--- a/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
+++ b/src/Common/ZooKeeper/SystemTablesDataTypes.cpp
@@ -67,6 +67,7 @@ DB::DataTypePtr SystemTablesDataTypes::operationEnum()
             {"Multi",               static_cast<Int16>(OpNum::Multi)},
             {"Create2",             static_cast<Int16>(OpNum::Create2)},
             {"CreateTTL",           static_cast<Int16>(OpNum::CreateTTL)},
+            {"CreateWithSequentialCounter", static_cast<Int16>(OpNum::CreateWithSequentialCounter)},
             {"CheckWatch",          static_cast<Int16>(OpNum::CheckWatch)},
             {"RemoveWatch",         static_cast<Int16>(OpNum::RemoveWatch)},
             {"MultiRead",           static_cast<Int16>(OpNum::MultiRead)},

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -8,6 +8,7 @@
 #include <base/types.h>
 
 #include <functional>
+#include <limits>
 
 #ifdef ZOOKEEPER_IMPL
 #  error "TestKeeper must not use ZooKeeper implementation"
@@ -305,6 +306,15 @@ std::pair<ResponsePtr, Undo> TestKeeperCreateRequest::process(TestKeeper::Contai
     response.zxid = zxid;
     Undo undo;
 
+    if (initial_sequential_counter
+        && (is_ephemeral || is_sequential || include_stats || include_ttl || not_exists
+            || *initial_sequential_counter < 0
+            || *initial_sequential_counter == std::numeric_limits<int64_t>::max()))
+    {
+        response.error = Error::ZBADARGUMENTS;
+        return { std::make_shared<CreateResponse>(response), undo };
+    }
+
     if (container.contains(path))
     {
         if (not_exists)
@@ -327,7 +337,7 @@ std::pair<ResponsePtr, Undo> TestKeeperCreateRequest::process(TestKeeper::Contai
         else
         {
             TestKeeper::Node created_node;
-            created_node.seq_num = 0;
+            created_node.seq_num = initial_sequential_counter.value_or(0);
             created_node.stat.czxid = zxid;
             created_node.stat.mzxid = zxid;
             created_node.stat.ctime = std::chrono::system_clock::now().time_since_epoch() / std::chrono::milliseconds(1);
@@ -824,6 +834,7 @@ TestKeeper::TestKeeper(const zkutil::ZooKeeperArgs & args_)
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::CHECK_STAT);
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::TRY_REMOVE);
     keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::LIST_WITH_STAT_AND_DATA);
+    keeper_feature_flags.enableFeatureFlag(KeeperFeatureFlag::CREATE_WITH_SEQUENTIAL_COUNTER);
 
     processing_thread = ThreadFromGlobalPool([this] { processingThread(); });
 }
@@ -1059,6 +1070,7 @@ void TestKeeper::create(
     const String & data,
     bool is_ephemeral,
     bool is_sequential,
+    std::optional<int64_t> initial_sequential_counter,
     const ACLs &,
     CreateCallback callback)
 {
@@ -1067,6 +1079,7 @@ void TestKeeper::create(
     request.data = data;
     request.is_ephemeral = is_ephemeral;
     request.is_sequential = is_sequential;
+    request.initial_sequential_counter = initial_sequential_counter;
 
     RequestInfo request_info;
     request_info.request = std::make_shared<TestKeeperCreateRequest>(std::move(request));

--- a/src/Common/ZooKeeper/TestKeeper.h
+++ b/src/Common/ZooKeeper/TestKeeper.h
@@ -51,6 +51,7 @@ public:
             const String & data,
             bool is_ephemeral,
             bool is_sequential,
+            std::optional<int64_t> initial_sequential_counter,
             const ACLs & acls,
             CreateCallback callback) override;
 
@@ -130,7 +131,7 @@ public:
         bool is_ttl = false;
         int64_t ttl = 0;
         Stat stat{};
-        int32_t seq_num = 0;
+        int64_t seq_num = 0;
     };
 
     using Container = std::map<std::string, Node>;

--- a/src/Common/ZooKeeper/Types.h
+++ b/src/Common/ZooKeeper/Types.h
@@ -26,6 +26,8 @@ template <typename R>
 using AsyncResponses = std::vector<std::pair<std::string, std::future<R>>>;
 
 Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::string & data, int create_mode, bool ignore_if_exists = false);
+Coordination::RequestPtr makeCreateRequestWithSequentialCounter(
+    const std::string & path, const std::string & data, int64_t initial_sequential_counter);
 Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version, bool try_remove = false);
 Coordination::RequestPtr makeSetRequest(const std::string & path, const std::string & data, int version);
 Coordination::RequestPtr makeCheckRequest(const std::string & path, int version, bool not_exists = false, std::optional<Coordination::Stat> stat_to_check = std::nullopt);

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -492,7 +492,8 @@ Coordination::Error ZooKeeper::tryGetChildrenWatch(
     return code;
 }
 
-Coordination::Error ZooKeeper::createImpl(const std::string & path, const std::string & data, int32_t mode, std::string & path_created)
+Coordination::Error ZooKeeper::createImpl(const std::string & path, const std::string & data, int32_t mode, std::string & path_created,
+    std::optional<int64_t> initial_sequential_counter)
 {
     std::optional<DB::OpenTelemetry::SpanHolder> maybe_span;
     if (sampleForOpenTelemetryTracing())
@@ -509,7 +510,9 @@ Coordination::Error ZooKeeper::createImpl(const std::string & path, const std::s
         DB::OpenTelemetry::SetTraceFlagInCurrentContext(DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS, true);
     }
 
-    auto future_result = asyncTryCreateNoThrow(path, data, mode);
+    auto future_result = initial_sequential_counter
+        ? asyncTryCreateWithSequentialCounterNoThrow(path, data, *initial_sequential_counter)
+        : asyncTryCreateNoThrow(path, data, mode);
 
     if (!waitForFutureWithProgress(future_result))
     {
@@ -550,6 +553,33 @@ Coordination::Error ZooKeeper::tryCreate(const std::string & path, const std::st
 
     return code;
 }
+
+std::string ZooKeeper::createWithSequentialCounter(
+    const std::string & path, const std::string & data, int64_t initial_sequential_counter)
+{
+    std::string path_created;
+    check(tryCreateWithSequentialCounter(path, data, initial_sequential_counter, path_created), path);
+    return path_created;
+}
+
+Coordination::Error ZooKeeper::tryCreateWithSequentialCounter(
+    const std::string & path, const std::string & data, int64_t initial_sequential_counter, std::string & path_created)
+{
+    Coordination::Error code = createImpl(
+        path, data, CreateMode::Persistent, path_created, initial_sequential_counter);
+
+    if (code == Coordination::Error::ZNOTREADONLY && exists(path))
+        return Coordination::Error::ZNODEEXISTS;
+
+    if (!(code == Coordination::Error::ZOK
+        || code == Coordination::Error::ZNONODE
+        || code == Coordination::Error::ZNODEEXISTS
+        || code == Coordination::Error::ZNOCHILDRENFOREPHEMERALS))
+        throw KeeperException::fromPath(code, path);
+
+    return code;
+}
+
 
 Coordination::Error ZooKeeper::tryCreate(const std::string & path, const std::string & data, int32_t mode)
 {
@@ -1606,7 +1636,7 @@ std::future<Coordination::CreateResponse> ZooKeeper::asyncCreate(const std::stri
             promise->set_value(response);
     };
 
-    impl->create(path, data, mode & 1, mode & 2, {}, std::move(callback));
+    impl->create(path, data, mode & 1, mode & 2, std::nullopt, {}, std::move(callback));
     return future;
 }
 
@@ -1620,7 +1650,26 @@ std::future<Coordination::CreateResponse> ZooKeeper::asyncTryCreateNoThrow(const
         promise->set_value(response);
     };
 
-    impl->create(path, data, mode & 1, mode & 2, {}, std::move(callback));
+    impl->create(path, data, mode & 1, mode & 2, std::nullopt, {}, std::move(callback));
+    return future;
+}
+
+std::future<Coordination::CreateResponse> ZooKeeper::asyncTryCreateWithSequentialCounterNoThrow(
+    const std::string & path, const std::string & data, int64_t initial_sequential_counter)
+{
+    if (!isFeatureEnabled(DB::KeeperFeatureFlag::CREATE_WITH_SEQUENTIAL_COUNTER))
+        throw KeeperException(
+            Coordination::Error::ZUNIMPLEMENTED, "Keeper does not support `CreateWithSequentialCounter`");
+
+    auto promise = std::make_shared<std::promise<Coordination::CreateResponse>>();
+    auto future = promise->get_future();
+
+    auto callback = [promise](const Coordination::CreateResponse & response) mutable
+    {
+        promise->set_value(response);
+    };
+
+    impl->create(path, data, false, false, initial_sequential_counter, {}, std::move(callback));
     return future;
 }
 
@@ -2064,6 +2113,17 @@ Coordination::RequestPtr makeCreateRequest(const std::string & path, const std::
     request->not_exists = ignore_if_exists;
     return request;
 }
+
+Coordination::RequestPtr makeCreateRequestWithSequentialCounter(
+    const std::string & path, const std::string & data, int64_t initial_sequential_counter)
+{
+    auto request = std::make_shared<Coordination::ZooKeeperCreateRequest>();
+    request->path = path;
+    request->data = data;
+    request->initial_sequential_counter = initial_sequential_counter;
+    return request;
+}
+
 
 Coordination::RequestPtr makeRemoveRequest(const std::string & path, int version, bool try_remove)
 {

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -250,6 +250,9 @@ public:
     /// Create a znode.
     /// Throw an exception if something went wrong.
     std::string create(const std::string & path, const std::string & data, int32_t mode);
+    /// Create a persistent znode with the counter used for its first child creation.
+    std::string createWithSequentialCounter(
+        const std::string & path, const std::string & data, int64_t initial_sequential_counter);
 
     /// Does not throw in the following cases:
     /// * The parent for the created node does not exist
@@ -258,6 +261,8 @@ public:
     /// In case of other errors throws an exception.
     Coordination::Error tryCreate(const std::string & path, const std::string & data, int32_t mode, std::string & path_created);
     Coordination::Error tryCreate(const std::string & path, const std::string & data, int32_t mode);
+    Coordination::Error tryCreateWithSequentialCounter(
+        const std::string & path, const std::string & data, int64_t initial_sequential_counter, std::string & path_created);
 
     /// Create a Persistent node.
     /// Does nothing if the node already exists.
@@ -525,6 +530,8 @@ public:
     FutureCreate asyncCreate(const std::string & path, const std::string & data, int32_t mode);
     /// Like the previous one but don't throw any exceptions on future.get()
     FutureCreate asyncTryCreateNoThrow(const std::string & path, const std::string & data, int32_t mode);
+    FutureCreate asyncTryCreateWithSequentialCounterNoThrow(
+        const std::string & path, const std::string & data, int64_t initial_sequential_counter);
 
     using FutureGet = std::future<Coordination::GetResponse>;
     FutureGet asyncGet(const std::string & path);
@@ -642,7 +649,8 @@ private:
     void updateAvailabilityZones();
 
     /// The following methods don't any throw exceptions but return error codes.
-    Coordination::Error createImpl(const std::string & path, const std::string & data, int32_t mode, std::string & path_created);
+    Coordination::Error createImpl(const std::string & path, const std::string & data, int32_t mode, std::string & path_created,
+        std::optional<int64_t> initial_sequential_counter = std::nullopt);
     Coordination::Error removeImpl(const std::string & path, int32_t version);
     Coordination::Error getImpl(
         const std::string & path, std::string & res, Coordination::Stat * stat, Coordination::WatchCallbackPtrOrEventPtr watch_callback);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -239,6 +239,9 @@ void ZooKeeperCreateRequest::writeImpl(WriteBuffer & out) const
     Coordination::write(data, out);
     Coordination::write(acls, out);
 
+    chassert(
+        !initial_sequential_counter
+        || (!is_ephemeral && !is_sequential && !include_stats && !include_ttl && !not_exists));
     CreateMode flags = CreateMode::PERSISTENT;
     if (include_ttl)
     {
@@ -258,6 +261,8 @@ void ZooKeeperCreateRequest::writeImpl(WriteBuffer & out) const
 
     if (include_ttl)
         Coordination::write(ttl, out);
+    if (initial_sequential_counter)
+        Coordination::write(*initial_sequential_counter, out);
 }
 
 size_t ZooKeeperCreateRequest::sizeImpl() const
@@ -266,6 +271,8 @@ size_t ZooKeeperCreateRequest::sizeImpl() const
     auto size = Coordination::size(path) + Coordination::size(data) + Coordination::size(acls) + Coordination::size(flags);
     if (include_ttl)
         size += Coordination::size(ttl);
+    if (initial_sequential_counter)
+        size += Coordination::size(*initial_sequential_counter);
     return size;
 }
 
@@ -283,9 +290,11 @@ void ZooKeeperCreateRequest::readImpl(ReadBuffer & in)
     /// that disagree with the wire create-mode (e.g. Create2 carrying a TTL flag would
     /// otherwise pass feature-gating as Create2 yet create a TTL node here).
     const bool from_create_ttl_opnum = include_ttl;
+    const bool from_create_with_sequential_counter_opnum = initial_sequential_counter.has_value();
     is_ephemeral = false;
     is_sequential = false;
     include_ttl = false;
+    initial_sequential_counter.reset();
 
     /// org.apache.zookeeper.CreateMode.fromFlag — reject unknown flags rather than
     /// silently treating them as PERSISTENT.
@@ -330,6 +339,18 @@ void ZooKeeperCreateRequest::readImpl(ReadBuffer & in)
     if (include_stats && include_ttl)
         throw Coordination::Exception(Coordination::Error::ZBADARGUMENTS,
             "Create2 must not carry a TTL create-mode flag");
+
+    if (from_create_with_sequential_counter_opnum)
+    {
+        if (flags != CreateMode::PERSISTENT || include_stats || include_ttl || not_exists)
+            throw Coordination::Exception(
+                Coordination::Error::ZBADARGUMENTS,
+                "`CreateWithSequentialCounter` only supports persistent nodes");
+
+        int64_t counter = 0;
+        Coordination::read(counter, in);
+        initial_sequential_counter = counter;
+    }
 
     if (include_ttl)
         Coordination::read(ttl, in);
@@ -1440,6 +1461,9 @@ ZooKeeperResponsePtr ZooKeeperCreateRequest::makeResponse() const
     if (op_num == OpNum::Create2)
         return std::make_shared<ZooKeeperCreate2Response>();
 
+    if (op_num == OpNum::CreateWithSequentialCounter)
+        return std::make_shared<ZooKeeperCreateWithSequentialCounterResponse>();
+
     if (op_num == OpNum::CreateIfNotExists)
         return std::make_shared<ZooKeeperCreateIfNotExistsResponse>();
 
@@ -1765,6 +1789,8 @@ void registerZooKeeperRequest(ZooKeeperRequestFactory & factory)
             res->include_stats = true;
         else if constexpr (num == OpNum::CreateTTL)
             res->include_ttl = true;
+        else if constexpr (num == OpNum::CreateWithSequentialCounter)
+            res->initial_sequential_counter.emplace();
         else if constexpr (num == OpNum::CheckStat)
             res->stat_to_check.emplace();
         else if constexpr (num == OpNum::TryRemove)
@@ -1791,6 +1817,7 @@ ZooKeeperRequestFactory::ZooKeeperRequestFactory()
     registerZooKeeperRequest<OpNum::Create, ZooKeeperCreateRequest>(*this);
     registerZooKeeperRequest<OpNum::Create2, ZooKeeperCreateRequest>(*this);
     registerZooKeeperRequest<OpNum::CreateTTL, ZooKeeperCreateRequest>(*this);
+    registerZooKeeperRequest<OpNum::CreateWithSequentialCounter, ZooKeeperCreateRequest>(*this);
     registerZooKeeperRequest<OpNum::Remove, ZooKeeperRemoveRequest>(*this);
     registerZooKeeperRequest<OpNum::TryRemove, ZooKeeperRemoveRequest>(*this);
     registerZooKeeperRequest<OpNum::Exists, ZooKeeperExistsRequest>(*this);

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -249,6 +249,8 @@ struct ZooKeeperCreateRequest final : public CreateRequest, ZooKeeperRequest
 
     OpNum getOpNum() const override
     {
+        if (initial_sequential_counter)
+            return OpNum::CreateWithSequentialCounter;
         if (include_ttl)
             return OpNum::CreateTTL;
         if (include_stats)
@@ -301,6 +303,12 @@ struct ZooKeeperCreate2Response : ZooKeeperCreateResponse
 struct ZooKeeperCreateIfNotExistsResponse : ZooKeeperCreateResponse
 {
     OpNum getOpNum() const override { return OpNum::CreateIfNotExists; }
+    using ZooKeeperCreateResponse::ZooKeeperCreateResponse;
+};
+
+struct ZooKeeperCreateWithSequentialCounterResponse : ZooKeeperCreateResponse
+{
+    OpNum getOpNum() const override { return OpNum::CreateWithSequentialCounter; }
     using ZooKeeperCreateResponse::ZooKeeperCreateResponse;
 };
 

--- a/src/Common/ZooKeeper/ZooKeeperConstants.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.cpp
@@ -24,6 +24,7 @@ static const std::unordered_set<int32_t> VALID_OPERATIONS =
     static_cast<int32_t>(OpNum::Reconfig),
     static_cast<int32_t>(OpNum::Multi),
     static_cast<int32_t>(OpNum::CreateTTL),
+    static_cast<int32_t>(OpNum::CreateWithSequentialCounter),
     static_cast<int32_t>(OpNum::MultiRead),
     static_cast<int32_t>(OpNum::CreateIfNotExists),
     static_cast<int32_t>(OpNum::Auth),
@@ -59,6 +60,7 @@ std::string_view opNumToString(OpNum op_num)
         case OpNum::Create: return "Create";
         case OpNum::Create2: return "Create2";
         case OpNum::CreateTTL: return "CreateTTL";
+        case OpNum::CreateWithSequentialCounter: return "CreateWithSequentialCounter";
         case OpNum::Remove: return "Remove";
         case OpNum::Exists: return "Exists";
         case OpNum::Get: return "Get";
@@ -118,6 +120,7 @@ const char * toOperationTypeMetricLabel(OpNum op_num)
         case OpNum::Create:
         case OpNum::Create2:
         case OpNum::CreateTTL:
+        case OpNum::CreateWithSequentialCounter:
         case OpNum::Remove:
         case OpNum::TryRemove:
         case OpNum::RemoveWatch:

--- a/src/Common/ZooKeeper/ZooKeeperConstants.h
+++ b/src/Common/ZooKeeper/ZooKeeperConstants.h
@@ -54,6 +54,7 @@ enum class OpNum : int32_t
     TryRemove = 505,
     FilteredListWithStatsAndData = 506,
     ListRecursive = 507,
+    CreateWithSequentialCounter = 508,
 
     SessionID = 997, /// Special internal request
 };

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1741,6 +1741,7 @@ void ZooKeeper::create(
     const String & data,
     bool is_ephemeral,
     bool is_sequential,
+    std::optional<int64_t> initial_sequential_counter,
     const ACLs & acls,
     CreateCallback callback)
 {
@@ -1749,6 +1750,7 @@ void ZooKeeper::create(
     request.data = data;
     request.is_ephemeral = is_ephemeral;
     request.is_sequential = is_sequential;
+    request.initial_sequential_counter = initial_sequential_counter;
 
     ACLs final_acls = acls.empty() ? default_acls : acls;
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -146,6 +146,7 @@ public:
         const String & data,
         bool is_ephemeral,
         bool is_sequential,
+        std::optional<int64_t> initial_sequential_counter,
         const ACLs & acls,
         CreateCallback callback) override;
 

--- a/src/Common/ZooKeeper/examples/zkutil_test_commands_new_lib.cpp
+++ b/src/Common/ZooKeeper/examples/zkutil_test_commands_new_lib.cpp
@@ -51,7 +51,7 @@ try
 
     std::cout << "create\n";
 
-    zk.create("/test", "old", false, false, {},
+    zk.create("/test", "old", false, false, std::nullopt, {},
         [&](const CreateResponse & response)
         {
             if (response.error != Coordination::Error::ZOK)

--- a/src/Common/ZooKeeper/tests/gtest_testkeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_testkeeper.cpp
@@ -27,7 +27,7 @@ void create(TestKeeper & keeper, const String & path, const String & data, bool 
 {
     std::promise<CreateResponse> sink;
     std::future<CreateResponse> future = sink.get_future();
-    keeper.create(path, data, is_ephemeral, /* is_sequential */ false, {},
+    keeper.create(path, data, is_ephemeral, /* is_sequential */ false, std::nullopt, {},
         [&](const auto & response) { sink.set_value(std::move(response)); });
 
     CreateResponse response = future.get();

--- a/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
+++ b/src/Common/ZooKeeper/tests/gtest_zookeeper.cpp
@@ -75,3 +75,28 @@ TEST(ZooKeeperTest, ListRequestWireRoundTrip)
     roundtrip(OpNum::FilteredListWithStatsAndData, ListRequestType::EPHEMERAL_ONLY, true, false);
     roundtrip(OpNum::FilteredListWithStatsAndData, ListRequestType::ALL, false, true);
 }
+
+TEST(ZooKeeperTest, CreateWithSequentialCounterWireRoundTrip)
+{
+    constexpr int64_t initial_sequential_counter = 123456789;
+    auto request_ptr = zkutil::makeCreateRequestWithSequentialCounter(
+        "/round/trip", "data", initial_sequential_counter);
+    auto & request = dynamic_cast<ZooKeeperCreateRequest &>(*request_ptr);
+    ASSERT_EQ(request.getOpNum(), OpNum::CreateWithSequentialCounter);
+
+    WriteBufferFromOwnString out;
+    request.writeImpl(out);
+
+    auto decoded = ZooKeeperRequestFactory::instance().get(OpNum::CreateWithSequentialCounter);
+    auto & decoded_create = dynamic_cast<ZooKeeperCreateRequest &>(*decoded);
+    ReadBufferFromString in(out.str());
+    decoded_create.readImpl(in);
+
+    EXPECT_TRUE(in.eof());
+    EXPECT_EQ(decoded_create.getOpNum(), OpNum::CreateWithSequentialCounter);
+    EXPECT_EQ(decoded_create.path, request.path);
+    EXPECT_EQ(decoded_create.data, request.data);
+    EXPECT_FALSE(decoded_create.is_ephemeral);
+    EXPECT_FALSE(decoded_create.is_sequential);
+    EXPECT_EQ(decoded_create.initial_sequential_counter, initial_sequential_counter);
+}

--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -76,6 +76,7 @@ KeeperContext::KeeperContext(bool standalone_keeper_, CoordinationSettingsPtr co
         KeeperFeatureFlag::CHECK_STAT,
         KeeperFeatureFlag::PERSISTENT_WATCHES,
         KeeperFeatureFlag::TRY_REMOVE,
+        KeeperFeatureFlag::CREATE_WITH_SEQUENTIAL_COUNTER,
         KeeperFeatureFlag::LIST_WITH_STAT_AND_DATA,
     };
 
@@ -621,6 +622,8 @@ bool KeeperContext::isOperationSupported(Coordination::OpNum operation) const
             return feature_flags.isEnabled(KeeperFeatureFlag::CREATE_WITH_STATS);
         case Coordination::OpNum::CreateTTL:
             return feature_flags.isEnabled(KeeperFeatureFlag::CREATE_TTL);
+        case Coordination::OpNum::CreateWithSequentialCounter:
+            return feature_flags.isEnabled(KeeperFeatureFlag::CREATE_WITH_SEQUENTIAL_COUNTER);
         case Coordination::OpNum::TryRemove:
             return feature_flags.isEnabled(KeeperFeatureFlag::TRY_REMOVE);
         case Coordination::OpNum::SetWatch:

--- a/src/Coordination/KeeperRequestDispatcher.cpp
+++ b/src/Coordination/KeeperRequestDispatcher.cpp
@@ -93,6 +93,7 @@ static bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & 
     if (request->getOpNum() == Coordination::OpNum::Create
         || request->getOpNum() == Coordination::OpNum::Create2
         || request->getOpNum() == Coordination::OpNum::CreateTTL
+        || request->getOpNum() == Coordination::OpNum::CreateWithSequentialCounter
         || request->getOpNum() == Coordination::OpNum::CreateIfNotExists
         || request->getOpNum() == Coordination::OpNum::Set)
     {
@@ -115,6 +116,7 @@ static bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & 
                 case Coordination::OpNum::Create:
                 case Coordination::OpNum::Create2:
                 case Coordination::OpNum::CreateTTL:
+                case Coordination::OpNum::CreateWithSequentialCounter:
                 case Coordination::OpNum::CreateIfNotExists: {
                     Coordination::ZooKeeperCreateRequest & create_req
                         = dynamic_cast<Coordination::ZooKeeperCreateRequest &>(*sub_zk_request);

--- a/src/Coordination/KeeperRequestDispatcherOld.cpp
+++ b/src/Coordination/KeeperRequestDispatcherOld.cpp
@@ -108,6 +108,7 @@ bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & request
     if (request->getOpNum() == Coordination::OpNum::Create
         || request->getOpNum() == Coordination::OpNum::Create2
         || request->getOpNum() == Coordination::OpNum::CreateTTL
+        || request->getOpNum() == Coordination::OpNum::CreateWithSequentialCounter
         || request->getOpNum() == Coordination::OpNum::CreateIfNotExists
         || request->getOpNum() == Coordination::OpNum::Set)
     {
@@ -125,6 +126,7 @@ bool checkIfRequestIncreaseMem(const Coordination::ZooKeeperRequestPtr & request
                 case Coordination::OpNum::Create:
                 case Coordination::OpNum::Create2:
                 case Coordination::OpNum::CreateTTL:
+                case Coordination::OpNum::CreateWithSequentialCounter:
                 case Coordination::OpNum::CreateIfNotExists: {
                     Coordination::ZooKeeperCreateRequest & create_req
                         = dynamic_cast<Coordination::ZooKeeperCreateRequest &>(*sub_zk_request);

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -522,6 +522,7 @@ struct CreateNodeDelta
     ACLId acl_id;
     String data;
     std::optional<int64_t> ttl;
+    std::optional<int64_t> initial_sequential_counter;
 };
 
 struct RemoveNodeDelta
@@ -1145,7 +1146,9 @@ Coordination::Error KeeperStorage::commit(KeeperStorage::DeltaRange deltas)
             {
                 if constexpr (std::same_as<DeltaType, CreateNodeDelta>)
                 {
-                    if (!createNode(path, operation.data, operation.stat, operation.acl_id, digest_on_commit, operation.ttl))
+                    if (!createNode(
+                            path, operation.data, operation.stat, operation.acl_id, digest_on_commit,
+                            operation.ttl, operation.initial_sequential_counter))
                         onStorageInconsistency("Failed to create a node");
 
                     return Coordination::Error::ZOK;
@@ -1251,7 +1254,8 @@ bool KeeperStorage::createNode(
     const Coordination::Stat & stat,
     ACLId acl_id,
     bool update_digest,
-    std::optional<int64_t> ttl) TSA_NO_THREAD_SAFETY_ANALYSIS
+    std::optional<int64_t> ttl,
+    std::optional<int64_t> initial_sequential_counter) TSA_NO_THREAD_SAFETY_ANALYSIS
 {
     auto parent_path = Coordination::parentNodePath(path);
     auto node_it = container.find(parent_path);
@@ -1276,6 +1280,8 @@ bool KeeperStorage::createNode(
         ttl_paths.insert(path);
         committed_ttl_nodes.fetch_add(1);
     }
+    if (initial_sequential_counter)
+        created_node.stats.setSeqNum(*initial_sequential_counter);
 
     auto [map_key, _] = container.insert(path, std::move(created_node));
     /// Take child path from key owned by map.
@@ -1359,6 +1365,7 @@ auto callOnConcreteRequestType(Coordination::ZooKeeperRequest & zk_request, F fu
         case Coordination::OpNum::Create2:
         case Coordination::OpNum::CreateIfNotExists:
         case Coordination::OpNum::CreateTTL:
+        case Coordination::OpNum::CreateWithSequentialCounter:
             return function(static_cast<Coordination::ZooKeeperCreateRequest &>(zk_request));
         case Coordination::OpNum::Remove:
             return function(static_cast<Coordination::ZooKeeperRemoveRequest &>(zk_request));
@@ -1605,6 +1612,16 @@ static Coordination::Error preprocess(
         if (zk_request.ttl <= 0 || zk_request.ttl > MAX_KEEPER_TTL_MS)
             return Coordination::Error::ZBADARGUMENTS;
     }
+    if (zk_request.initial_sequential_counter)
+    {
+        if (zk_request.is_ephemeral || zk_request.is_sequential || zk_request.include_stats || zk_request.include_ttl
+            || zk_request.not_exists || *zk_request.initial_sequential_counter < 0
+            || *zk_request.initial_sequential_counter == std::numeric_limits<int64_t>::max())
+            return Coordination::Error::ZBADARGUMENTS;
+    }
+
+    if (parent_node->stats.seqNum() == std::numeric_limits<int64_t>::max())
+        return Coordination::Error::ZBADARGUMENTS;
 
     if (zk_request.is_ephemeral)
         storage.uncommitted_state.ephemerals[session_id].emplace(path_created);
@@ -1640,7 +1657,8 @@ static Coordination::Error preprocess(
     storage.prepareCreateNode(
         parent_path, parent_node_ref, new_parent_stats, new_parent_num_children,
         path_created, child_node_ref, stat, acl_id, zk_request.data,
-        zk_request.include_ttl ? std::optional(zk_request.ttl) : std::nullopt);
+        zk_request.include_ttl ? std::optional(zk_request.ttl) : std::nullopt,
+        zk_request.initial_sequential_counter);
 
     return Coordination::Error::ZOK;
 }
@@ -4238,7 +4256,8 @@ void KeeperStorage::prepareCreateNode(
     std::string_view parent_path, UncommittedNodeRef parent,
     const NodeStats & new_parent_stats, int32_t new_parent_num_children,
     std::string_view path, UncommittedNodeRef node, const Coordination::Stat & stat,
-    ACLId acl_id, std::string_view data, std::optional<int64_t> ttl)
+    ACLId acl_id, std::string_view data, std::optional<int64_t> ttl,
+    std::optional<int64_t> initial_sequential_counter)
 {
     /// (prepareCreateNode combines parent node update and new node creation. Currently these
     ///  operations are independent here, and we could equally well remove the parent update from
@@ -4257,7 +4276,7 @@ void KeeperStorage::prepareCreateNode(
     staging_deltas.emplace_back(
         std::string{path},
         staging_zxid,
-        CreateNodeDelta{stat, acl_id, std::string{data}, ttl});
+        CreateNodeDelta{stat, acl_id, std::string{data}, ttl, initial_sequential_counter});
 
     auto node_it = *node.it;
     chassert(!node_it->second.node);
@@ -4268,6 +4287,8 @@ void KeeperStorage::prepareCreateNode(
     node_ptr->acl_id = acl_id;
     if (ttl)
         node_ptr->stats.setTTL(*ttl);
+    if (initial_sequential_counter)
+        node_ptr->stats.setSeqNum(*initial_sequential_counter);
 }
 
 void KeeperStorage::prepareRemoveNodeWithoutUpdatingParent(

--- a/src/Coordination/KeeperStorage.h
+++ b/src/Coordination/KeeperStorage.h
@@ -596,7 +596,8 @@ public:
         const Coordination::Stat & stat,
         ACLId acl_id,
         bool update_digest,
-        std::optional<int64_t> ttl) TSA_NO_THREAD_SAFETY_ANALYSIS;
+        std::optional<int64_t> ttl,
+        std::optional<int64_t> initial_sequential_counter) TSA_NO_THREAD_SAFETY_ANALYSIS;
 
     // Remove node in the storage
     // Returns false if it failed to remove the node, true otherwise
@@ -695,7 +696,8 @@ public:
         std::string_view parent_path, UncommittedNodeRef parent,
         const NodeStats & new_parent_stats, int32_t new_parent_num_children,
         std::string_view path, UncommittedNodeRef node, const Coordination::Stat & stat,
-        ACLId acl_id, std::string_view data, std::optional<int64_t> ttl = std::nullopt);
+        ACLId acl_id, std::string_view data, std::optional<int64_t> ttl = std::nullopt,
+        std::optional<int64_t> initial_sequential_counter = std::nullopt);
     void prepareRemoveNode(
         std::string_view parent_path, UncommittedNodeRef parent,
         const NodeStats & new_parent_stats, int32_t new_parent_num_children,

--- a/src/Coordination/tests/gtest_coordination.cpp
+++ b/src/Coordination/tests/gtest_coordination.cpp
@@ -928,6 +928,7 @@ TYPED_TEST(CoordinationTest, TestFeatureFlags)
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CHECK_STAT));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::TRY_REMOVE));
     ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::LIST_WITH_STAT_AND_DATA));
+    ASSERT_TRUE(feature_flags.isEnabled(KeeperFeatureFlag::CREATE_WITH_SEQUENTIAL_COUNTER));
 }
 
 #endif

--- a/src/Coordination/tests/gtest_coordination_storage.cpp
+++ b/src/Coordination/tests/gtest_coordination_storage.cpp
@@ -2277,4 +2277,64 @@ TYPED_TEST(CoordinationTest, TestFailedMultiRollsBackTTLDestroyTime)
     EXPECT_EQ(uncommitted->stats.destroyTime(), original_destroy_time);
 }
 
+TYPED_TEST(CoordinationTest, TestCreateWithSequentialCounter)
+{
+    using namespace DB;
+    using namespace Coordination;
+    using Storage [[maybe_unused]] = DB::KeeperStorage;
+
+    Storage storage{500, "", this->keeper_context};
+    int64_t zxid = 0;
+    const int64_t session_id = 1;
+
+    const auto create = [&](const String & path, bool sequential, std::optional<int64_t> initial_counter = std::nullopt)
+    {
+        auto request = std::make_shared<ZooKeeperCreateRequest>();
+        request->path = path;
+        request->is_sequential = sequential;
+        request->initial_sequential_counter = initial_counter;
+
+        storage.preprocessRequest(request, session_id, /*time=*/0, ++zxid);
+        auto responses = storage.processRequest(request, session_id, zxid);
+        const auto & response = dynamic_cast<const ZooKeeperCreateResponse &>(*responses[0].response);
+        return std::pair{response.error, response.path_created};
+    };
+
+    const auto remove = [&](const String & path)
+    {
+        auto request = std::make_shared<ZooKeeperRemoveRequest>();
+        request->path = path;
+
+        storage.preprocessRequest(request, session_id, /*time=*/0, ++zxid);
+        auto responses = storage.processRequest(request, session_id, zxid);
+        ASSERT_EQ(responses[0].response->error, Error::ZOK);
+    };
+
+    EXPECT_EQ(create("/parent", false, 100).first, Error::ZOK);
+    EXPECT_EQ(create("/parent/config", false).second, "/parent/config");
+    EXPECT_EQ(create("/parent/foo-", true).second, "/parent/foo-0000000101");
+    EXPECT_EQ(create("/parent/bar-", true).second, "/parent/bar-0000000102");
+
+    remove("/parent/config");
+    remove("/parent/foo-0000000101");
+    remove("/parent/bar-0000000102");
+    remove("/parent");
+
+    EXPECT_EQ(create("/parent", false, 500).first, Error::ZOK);
+    EXPECT_EQ(create("/parent/foo-", true).second, "/parent/foo-0000000500");
+
+    EXPECT_EQ(create("/negative", false, -1).first, Error::ZBADARGUMENTS);
+    EXPECT_EQ(
+        create("/overflow", false, std::numeric_limits<int64_t>::max()).first,
+        Error::ZBADARGUMENTS);
+
+    auto ephemeral_request = std::make_shared<ZooKeeperCreateRequest>();
+    ephemeral_request->path = "/ephemeral";
+    ephemeral_request->is_ephemeral = true;
+    ephemeral_request->initial_sequential_counter = 1;
+    storage.preprocessRequest(ephemeral_request, session_id, /*time=*/0, ++zxid);
+    auto responses = storage.processRequest(ephemeral_request, session_id, zxid);
+    EXPECT_EQ(responses[0].response->error, Error::ZBADARGUMENTS);
+}
+
 #endif


### PR DESCRIPTION
Keeper uses a counter stored on each parent node to generate sequential child names. Deleting and recreating the parent normally starts that counter from zero. This change adds a Keeper-specific create operation that accepts an explicit starting counter. Ordinary ZooKeeper create requests are unchanged.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a Keeper create operation that accepts an initial sequential counter.

### Documentation entry:
- [x] Documentation is not required for this Keeper protocol API extension.