### PR TITLE
Upgrade check: tolerate removed experimental text-index setting on attach

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -357,6 +357,13 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 # `Unknown tokenizer: 'unicode_word'` appears because the `unicode_word` tokenizer was renamed to `asciiCJK`
 #       (with `unicodeWord` as a transitional alias). Tables from old versions using `unicode_word` trigger this
 #       on attach. Narrowed to the exact legacy name so genuinely unsupported tokenizer names are not masked.
+# `Unknown setting 'allow_experimental_text_index_positions'` appears because #109900 renamed the experimental
+#       text-index MergeTree setting `allow_experimental_text_index_positions` to
+#       `allow_experimental_text_index_phrase_search` (and the text-index argument `positions` to
+#       `support_phrase_search`) without a compatibility alias. Both were experimental (subject to change at any
+#       time, no production usage expected), so the feature owner declined an engine-side alias. Tables written by
+#       an older server that reference the removed setting fail on attach after the upgrade. Narrowed to the exact
+#       legacy setting name so genuinely unknown settings are not masked.
 # `Azure::Storage::StorageException.*Not found address of host` is a transient Azure blob DNS resolution failure
 #       for `openbucketforpublicci.blob.core.windows.net`. Filtered via regex in the secondary pipe below to match
 #       both the Azure SDK exception type AND the DNS error together, so non-Azure DNS errors are not masked.
@@ -515,6 +522,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Key expressions cannot contain subqueries" \
            -e "Expression must be deterministic but it contains non-deterministic part" \
            -e "Unknown tokenizer: 'unicode_word'" \
+           -e "Unknown setting 'allow_experimental_text_index_positions'" \
            -e "This engine is deprecated and is not supported in transactions" \
            -e "Prevent converting Nullable type to non-Nullable type inside mutation" \
            -e "e.what() = failed to parse response body" \

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -364,6 +364,11 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       time, no production usage expected), so the feature owner declined an engine-side alias. Tables written by
 #       an older server that reference the removed setting fail on attach after the upgrade. Narrowed to the exact
 #       legacy setting name so genuinely unknown settings are not masked.
+# `Unexpected text index arguments: positions` is the sibling failure from the same #109900 rename: the text-index
+#       argument `positions` was renamed to `support_phrase_search`, so a table written by an older server with
+#       `positions = 0/1` in its text index definition leaves `positions` unrecognized and fails on attach in
+#       textIndexCreator/textIndexValidator. Narrowed to the exact legacy argument name so genuinely unexpected
+#       text index arguments are not masked.
 # `Azure::Storage::StorageException.*Not found address of host` is a transient Azure blob DNS resolution failure
 #       for `openbucketforpublicci.blob.core.windows.net`. Filtered via regex in the secondary pipe below to match
 #       both the Azure SDK exception type AND the DNS error together, so non-Azure DNS errors are not masked.
@@ -523,6 +528,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Expression must be deterministic but it contains non-deterministic part" \
            -e "Unknown tokenizer: 'unicode_word'" \
            -e "Unknown setting 'allow_experimental_text_index_positions'" \
+           -e "Unexpected text index arguments: positions" \
            -e "This engine is deprecated and is not supported in transactions" \
            -e "Prevent converting Nullable type to non-Nullable type inside mutation" \
            -e "e.what() = failed to parse response body" \


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110615
Related: https://github.com/ClickHouse/ClickHouse/pull/110787
Related: https://github.com/ClickHouse/ClickHouse/pull/109900
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

#109900 renamed the experimental MergeTree setting `allow_experimental_text_index_positions` to `allow_experimental_text_index_phrase_search` (and the text-index argument `positions` to `support_phrase_search`) without a compatibility alias. A table written by an older server references the removed setting, so the newer server rejects it on `ATTACH` and the `Upgrade check (amd_release)` reports an error-level message:

```
Code: 115. DB::Exception: Unknown setting 'allow_experimental_text_index_positions': for storage MergeTree: Cannot attach table `test_5`.`tab` ... INDEX idx (message) TYPE text(tokenizer = splitByNonAlpha, positions = 1) ... SETTINGS allow_experimental_text_index_positions = 1 ... (UNKNOWN_SETTING)
```

This is a master-wide flaky upgrade-compatibility failure that hit several unrelated PRs, e.g. #110615, #108950, #100394 (none touching text indexes).

An engine-side compatibility alias was proposed in #110787 and declined by the text-index feature owner: both the setting and the `positions` argument were experimental (subject to change at any time, no production usage expected), so no compat is warranted in the engine.

Given that, the fix belongs in the upgrade check: allow-list the exact legacy setting name in the upgrade error grep, mirroring the existing `Unknown tokenizer: 'unicode_word'` entry that already handles the sibling text-index tokenizer rename from the same feature. Narrowed to the exact name so genuinely unknown settings are not masked.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110615&sha=cd3230f13038705339c3080112f4877341d1a7ad&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
