### PR TITLE
Use `::sort` and `HashMap` in `timeSeries*ToGrid` aggregate functions

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -407,7 +407,7 @@ private:
     struct State
     {
         /// Maps bucket index to the set of all timestamps and values
-        HashMap<UInt64, Bucket, DefaultHash<UInt64>, HashTableGrower<4>> buckets;
+        HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>> buckets;
     };
 
     static DataTypePtr createResultType()

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -34,6 +34,24 @@ namespace ErrorCodes
     extern const int INCORRECT_DATA;
 }
 
+/// Grower for the bucket maps. The stock `HashTableGrower` quadruples the buffer below `max_size_degree`,
+/// which leaves the table at a load factor as low as ~0.125; with the whole `Bucket` stored in every cell that
+/// wastes a lot of memory across many aggregation states. Doubling keeps the same worst-case load factor (0.5)
+/// with at most half the slots of quadrupling.
+struct TimeSeriesBucketsHashTableGrower : public HashTableGrower<4>
+{
+    void increaseSize()
+    {
+        ++size_degree;
+    }
+};
+
+/// The bucket map of the `timeSeries*ToGrid` aggregation states: maps a bucket index in `[0, bucket_count)` to
+/// the bucket's aggregate data. Also used by the `timeseries_to_grid_range_scan_vs_std_sort` example, which
+/// tunes `BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN` for this exact container.
+template <typename Bucket>
+using TimeSeriesBucketsMap = HashMap<UInt64, Bucket, TrivialHash, TimeSeriesBucketsHashTableGrower>;
+
 /// Base class for time series aggregate functions that map values to a grid specified by start timestamp, end timestamp, step and window.
 /// It implements the common logic for handling input data as either scalar timestamps and values or vectors of timestamps and values of
 /// equal sizes and adding the data to the grid buckets. The actual aggregation logic within buckets is implemented in derived classes.
@@ -407,7 +425,7 @@ private:
     struct State
     {
         /// Maps bucket index to the set of all timestamps and values
-        HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>> buckets;
+        TimeSeriesBucketsMap<Bucket> buckets;
     };
 
     static DataTypePtr createResultType()

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -21,7 +21,6 @@
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
 #include <Common/HashTable/HashMap.h>
-#include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 
@@ -195,8 +194,8 @@ public:
         buckets.reserve(rhs_buckets.size());
         for (const auto & rhs_bucket : rhs_buckets)
         {
-            auto & bucket = buckets[bucketIndexOf(rhs_bucket)];
-            bucket.merge(bucketOf(rhs_bucket));
+            auto & bucket = buckets[rhs_bucket.getKey()];
+            bucket.merge(rhs_bucket.getMapped());
         }
     }
 
@@ -209,8 +208,8 @@ public:
 
         for (const auto & entry : data(place)->buckets)
         {
-            writeBinaryLittleEndian(bucketIndexOf(entry), buf);
-            bucketOf(entry).serialize(buf);
+            writeBinaryLittleEndian(entry.getKey(), buf);
+            entry.getMapped().serialize(buf);
         }
     }
 
@@ -345,8 +344,9 @@ protected:
                 const size_t window_end = bucketRangeInWindow(grid_index).second;
                 for (; next_bucket < window_end; ++next_bucket)
                 {
-                    if (const Bucket * found = findBucket(buckets, next_bucket))
-                        aggregator.add(*found, bucketEndTimestamp(next_bucket));
+                    const auto * it = buckets.find(next_bucket);
+                    if (it)
+                        aggregator.add(it->getMapped(), bucketEndTimestamp(next_bucket));
                 }
                 removeOutOfWindow(aggregator, grid_index);
                 storeGridResult(grid_index, aggregator.getResult(timestampAtIndex(grid_index)), values, nulls);
@@ -357,7 +357,7 @@ protected:
             VectorWithMemoryTracking<std::pair<size_t, const Bucket *>> ordered_buckets;
             ordered_buckets.reserve(buckets.size());
             for (const auto & entry : buckets)
-                ordered_buckets.emplace_back(bucketIndexOf(entry), &bucketOf(entry));
+                ordered_buckets.emplace_back(entry.getKey(), &entry.getMapped());
             ::sort(ordered_buckets.begin(), ordered_buckets.end(),
                 [](const auto & lhs, const auto & rhs) { return lhs.first < rhs.first; });
 
@@ -399,50 +399,15 @@ protected:
 
 private:
     /// `HashMap` relocates cells with `memcpy`, so it requires position-independent buckets: trivially
-    /// copyable or declaring `is_position_independent`. Others fall back to `std::unordered_map`.
-    static constexpr bool bucket_is_position_independent =
-        std::is_trivially_copyable_v<Bucket> || requires { requires Bucket::is_position_independent; };
-
-    using BucketsMap = std::conditional_t<
-        bucket_is_position_independent,
-        HashMap<UInt64, Bucket, DefaultHash<UInt64>, HashTableGrower<4>>,
-        UnorderedMapWithMemoryTracking<UInt64, Bucket>>;
-
-    /// `HashMap` cells expose `getKey`/`getMapped`; `std::unordered_map` entries are pairs.
-    static UInt64 bucketIndexOf(const auto & map_entry)
-    {
-        if constexpr (bucket_is_position_independent)
-            return map_entry.getKey();
-        else
-            return map_entry.first;
-    }
-
-    static const Bucket & bucketOf(const auto & map_entry)
-    {
-        if constexpr (bucket_is_position_independent)
-            return map_entry.getMapped();
-        else
-            return map_entry.second;
-    }
-
-    static const Bucket * findBucket(const BucketsMap & buckets, size_t bucket_index)
-    {
-        if constexpr (bucket_is_position_independent)
-        {
-            const auto * it = buckets.find(bucket_index);
-            return it ? &it->getMapped() : nullptr;
-        }
-        else
-        {
-            const auto it = buckets.find(bucket_index);
-            return it != buckets.end() ? &it->second : nullptr;
-        }
-    }
+    /// copyable or declaring `is_position_independent`.
+    static_assert(
+        std::is_trivially_copyable_v<Bucket> || requires { requires Bucket::is_position_independent; },
+        "Bucket must be position independent (memmove-able) to be stored in a HashMap");
 
     struct State
     {
         /// Maps bucket index to the set of all timestamps and values
-        BucketsMap buckets;
+        HashMap<UInt64, Bucket, DefaultHash<UInt64>, HashTableGrower<4>> buckets;
     };
 
     static DataTypePtr createResultType()

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -426,11 +426,13 @@ private:
     /// `doInsertResultInto` visits the populated buckets in index order. When the fraction of populated bucket
     /// slots (`populated / bucket_count`) is at least this, scanning the whole index range and looking each up in
     /// the hash map is cheaper than collecting and sorting the populated buckets; below it (sparse data) the
-    /// collect-and-sort wins. The `timeseries_to_grid_range_scan_vs_std_sort` example measures the crossover density at
-    /// ~0.4; it depends on the bucket map's memory layout (~0.45 when buckets sit in index order, ~0.37 when
-    /// scattered as after a merge, so 0.4 is the middle). That example also shows comparison sorting beats a radix
-    /// sort here, so the sparse path uses `::sort` (pdqsort).
-    static constexpr double BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN = 0.4;
+    /// collect-and-sort wins. The `timeseries_to_grid_range_scan_vs_std_sort` example measures the two strategies
+    /// over the production bucket map (`HashMap` with `TrivialHash`): the range scan still wins at density 0.35
+    /// (by ~6-8%) and loses at 0.30 (~9%), so the threshold is 0.35. With `TrivialHash` open addressing a cell's
+    /// position is determined by the key, not the insertion order, so the crossover does not depend on how the map
+    /// was filled (bulk adds or a merge). That example also shows comparison sorting beats a radix sort here, so
+    /// the sparse path uses `::sort` (pdqsort).
+    static constexpr double BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN = 0.35;
 
     static constexpr UInt16 FORMAT_VERSION = FunctionImpl::FORMAT_VERSION;
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <base/sort.h>
 
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnNullable.h>
@@ -19,6 +20,7 @@
 
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
+#include <Common/HashTable/HashMap.h>
 #include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/VectorWithMemoryTracking.h>
 
@@ -193,8 +195,8 @@ public:
         buckets.reserve(rhs_buckets.size());
         for (const auto & rhs_bucket : rhs_buckets)
         {
-            auto & bucket = buckets[rhs_bucket.first];
-            bucket.merge(rhs_bucket.second);
+            auto & bucket = buckets[bucketIndexOf(rhs_bucket)];
+            bucket.merge(bucketOf(rhs_bucket));
         }
     }
 
@@ -205,10 +207,10 @@ public:
 
         writeBinaryLittleEndian(data(place)->buckets.size(), buf);
 
-        for (const auto & bucket : data(place)->buckets)
+        for (const auto & entry : data(place)->buckets)
         {
-            writeBinaryLittleEndian(bucket.first, buf);
-            bucket.second.serialize(buf);
+            writeBinaryLittleEndian(bucketIndexOf(entry), buf);
+            bucketOf(entry).serialize(buf);
         }
     }
 
@@ -343,9 +345,8 @@ protected:
                 const size_t window_end = bucketRangeInWindow(grid_index).second;
                 for (; next_bucket < window_end; ++next_bucket)
                 {
-                    const auto it = buckets.find(next_bucket);
-                    if (it != buckets.end())
-                        aggregator.add(it->second, bucketEndTimestamp(next_bucket));
+                    if (const Bucket * found = findBucket(buckets, next_bucket))
+                        aggregator.add(*found, bucketEndTimestamp(next_bucket));
                 }
                 removeOutOfWindow(aggregator, grid_index);
                 storeGridResult(grid_index, aggregator.getResult(timestampAtIndex(grid_index)), values, nulls);
@@ -355,9 +356,9 @@ protected:
         {
             VectorWithMemoryTracking<std::pair<size_t, const Bucket *>> ordered_buckets;
             ordered_buckets.reserve(buckets.size());
-            for (const auto & [bucket_index, bucket] : buckets)
-                ordered_buckets.emplace_back(bucket_index, &bucket);
-            std::sort(ordered_buckets.begin(), ordered_buckets.end(),
+            for (const auto & entry : buckets)
+                ordered_buckets.emplace_back(bucketIndexOf(entry), &bucketOf(entry));
+            ::sort(ordered_buckets.begin(), ordered_buckets.end(),
                 [](const auto & lhs, const auto & rhs) { return lhs.first < rhs.first; });
 
             size_t pos = 0;
@@ -397,10 +398,51 @@ protected:
     const bool first_bucket_is_clamped{};         /// Whether bucket #0's start is below the type minimum (only it can be)
 
 private:
+    /// `HashMap` relocates cells with `memcpy`, so it requires position-independent buckets: trivially
+    /// copyable or declaring `is_position_independent`. Others fall back to `std::unordered_map`.
+    static constexpr bool bucket_is_position_independent =
+        std::is_trivially_copyable_v<Bucket> || requires { requires Bucket::is_position_independent; };
+
+    using BucketsMap = std::conditional_t<
+        bucket_is_position_independent,
+        HashMap<UInt64, Bucket, DefaultHash<UInt64>, HashTableGrower<4>>,
+        UnorderedMapWithMemoryTracking<UInt64, Bucket>>;
+
+    /// `HashMap` cells expose `getKey`/`getMapped`; `std::unordered_map` entries are pairs.
+    static UInt64 bucketIndexOf(const auto & map_entry)
+    {
+        if constexpr (bucket_is_position_independent)
+            return map_entry.getKey();
+        else
+            return map_entry.first;
+    }
+
+    static const Bucket & bucketOf(const auto & map_entry)
+    {
+        if constexpr (bucket_is_position_independent)
+            return map_entry.getMapped();
+        else
+            return map_entry.second;
+    }
+
+    static const Bucket * findBucket(const BucketsMap & buckets, size_t bucket_index)
+    {
+        if constexpr (bucket_is_position_independent)
+        {
+            const auto * it = buckets.find(bucket_index);
+            return it ? &it->getMapped() : nullptr;
+        }
+        else
+        {
+            const auto it = buckets.find(bucket_index);
+            return it != buckets.end() ? &it->second : nullptr;
+        }
+    }
+
     struct State
     {
         /// Maps bucket index to the set of all timestamps and values
-        UnorderedMapWithMemoryTracking<size_t, Bucket> buckets;
+        BucketsMap buckets;
     };
 
     static DataTypePtr createResultType()
@@ -421,8 +463,8 @@ private:
     /// the hash map is cheaper than collecting and sorting the populated buckets; below it (sparse data) the
     /// collect-and-sort wins. The `timeseries_to_grid_range_scan_vs_std_sort` example measures the crossover density at
     /// ~0.4; it depends on the bucket map's memory layout (~0.45 when buckets sit in index order, ~0.37 when
-    /// scattered as after a merge, so 0.4 is the middle). That example also shows `std::sort` beats a radix sort
-    /// here, so the sparse path uses `std::sort`.
+    /// scattered as after a merge, so 0.4 is the middle). That example also shows comparison sorting beats a radix
+    /// sort here, so the sparse path uses `::sort` (pdqsort).
     static constexpr double BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN = 0.4;
 
     static constexpr UInt16 FORMAT_VERSION = FunctionImpl::FORMAT_VERSION;

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h
@@ -6,6 +6,8 @@
 
 #include <absl/container/flat_hash_map.h>
 
+#include <base/sort.h>
+
 #include <Common/AllocatorWithMemoryTracking.h>
 #include <Common/Exception.h>
 #include <Common/VectorWithMemoryTracking.h>
@@ -27,6 +29,13 @@ template <typename TimestampType, typename ValueType>
 class AggregateFunctionTimeseriesSamples
 {
 public:
+    /// The bucket map (`HashMap`) relocates cells with `memcpy` and abandons the source, which is safe for
+    /// any type without pointers into itself. `absl::flat_hash_map` qualifies: the address of its inline
+    /// single-element storage (small object optimization) is computed from `this`, the rest is on the heap.
+    /// No standard trait expresses this (weaker than `std::is_trivially_copyable`) property, hence the
+    /// explicit declaration.
+    static constexpr bool is_position_independent = true;
+
     void add(TimestampType timestamp, ValueType value)
     {
         auto [it, inserted] = buffer.emplace(timestamp, value);
@@ -100,7 +109,7 @@ public:
         temp_buffer.reserve(buffer.size());
         for (const auto & [timestamp, value] : buffer)
             temp_buffer.emplace_back(timestamp, value);
-        std::sort(temp_buffer.begin(), temp_buffer.end());
+        ::sort(temp_buffer.begin(), temp_buffer.end());
         for (const auto & [timestamp, value] : temp_buffer)
             f(timestamp, value);
     }

--- a/src/AggregateFunctions/examples/timeseries_to_grid_range_scan_vs_std_sort.cpp
+++ b/src/AggregateFunctions/examples/timeseries_to_grid_range_scan_vs_std_sort.cpp
@@ -1,31 +1,40 @@
 /// Measures `Base::BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN`: how a `timeSeries*ToGrid` finalize should visit its buckets in index
-/// order. The buckets live in an `UnorderedMapWithMemoryTracking<index, Bucket>` keyed by an index in
-/// `[0, bucket_count)`; finalize must process them in ascending index order. Two strategies, swept across
-/// densities:
+/// order. The buckets live in the production container `HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>>`
+/// keyed by an index in `[0, bucket_count)`; finalize must process them in ascending index order. Two strategies,
+/// swept across densities:
 ///   - range scan: walk index 0..bucket_count and `find` each (the "dense" path); O(bucket_count).
-///   - collect + std::sort: gather the populated `(index, Bucket*)` and comparison-sort (the "sparse" path); O(n log n).
+///   - collect + sort: gather the populated `(index, Bucket*)` and comparison-sort with `::sort` (pdqsort, as
+///     production does; the "sparse" path); O(n log n).
 ///
 /// Each does the SAME per-bucket work (reads the bucket's sample), so the difference is the ordering cost
 /// (reported as ns per populated bucket). The range scan wins when buckets are dense and degrades as they get
-/// sparser; the smallest fill density `populated / bucket_count` at which it still beats `std::sort` is
+/// sparser; the smallest fill density `populated / bucket_count` at which it still beats the sort is
 /// `BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN` - i.e. use the range scan iff `populated / bucket_count >= factor`.
 ///
-/// (An earlier version also measured ClickHouse's `radixSort`; `std::sort` beat it for this n and 16-byte
-/// pointer-payload element, so radix was dropped.)
+/// With `TrivialHash` open addressing a cell's position is determined by the key (slot = key & mask), not by
+/// insertion order, so the map's memory layout is the same however the map was filled (bulk adds or a merge).
+/// When the table size exceeds `bucket_count` (high densities) iteration is even nearly index-ordered, which
+/// pdqsort exploits; the sweep covers both regimes.
 ///
-/// Driven over a production-shaped dataset (many series, buckets in node-based maps, working set > last-level
-/// cache) so the cache behaviour matches the real query.
+/// (An earlier version also measured ClickHouse's `radixSort`; the comparison sort beat it for this n and
+/// 16-byte pointer-payload element, so radix was dropped.)
+///
+/// Driven over a production-shaped dataset (many series, working set > last-level cache) so the cache behaviour
+/// matches the real query.
 ///
 /// Build: it is part of the `clickhouse-examples` multi-call binary.
 /// Run:   `clickhouse-examples timeseries_to_grid_range_scan_vs_std_sort`
 
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
 
+#include <Common/HashTable/Hash.h>
+#include <Common/HashTable/HashMap.h>
 #include <Common/Stopwatch.h>
-#include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/VectorWithMemoryTracking.h>
 
 #include <Examples/clickhouse_examples.h>
+
+#include <base/sort.h>
 
 #include <fmt/format.h>
 #include <pcg_random.hpp>
@@ -48,7 +57,7 @@ constexpr Int64 STEP = 10;
 constexpr int REPEATS = 5;  /// timing iterations per measurement; the minimum over them is used
 
 using Bucket = AggregateFunctionTimeseriesSamples<UInt32, Float64>;
-using Buckets = UnorderedMapWithMemoryTracking<size_t, Bucket>;
+using Buckets = HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>>;  /// same type as production's bucket map
 using Dataset = std::vector<Buckets>;  /// one Buckets map per series; STYLE_CHECK_ALLOW_STD_CONTAINERS
 
 /// One populated bucket and its index, for the collect-and-sort strategy. Sorted by `index`.
@@ -89,16 +98,15 @@ Dataset buildDataset(Float64 density)
         for (size_t i = bucket_count - BASE_GRID; i < bucket_count; ++i)
         {
             const size_t candidate = static_cast<size_t>(rng() % (i + 1));
-            const size_t k = buckets.contains(candidate) ? i : candidate;
-            Bucket bucket;
-            bucket.add(static_cast<UInt32>(static_cast<Int64>(k) * STEP), static_cast<Float64>((k * 7 + series * 3) % 101));
-            buckets.emplace(k, std::move(bucket));
+            const size_t k = buckets.has(candidate) ? i : candidate;
+            /// Insert as production does: `operator[]` default-constructs the bucket, then samples are added.
+            buckets[k].add(static_cast<UInt32>(static_cast<Int64>(k) * STEP), static_cast<Float64>((k * 7 + series * 3) % 101));
         }
     }
     return dataset;
 }
 
-enum class Strategy { RangeScan, StdSort };
+enum class Strategy { RangeScan, Sort };
 
 /// Best (minimum over REPEATS) ns per populated bucket for one strategy over the whole dataset.
 Float64 measureNanoseconds(Strategy strategy, size_t bucket_count, const Dataset & dataset, Float64 & checksum)
@@ -113,9 +121,9 @@ Float64 measureNanoseconds(Strategy strategy, size_t bucket_count, const Dataset
             {
                 for (size_t i = 0; i < bucket_count; ++i)
                 {
-                    const auto it = buckets.find(i);
-                    if (it != buckets.end())
-                        checksum += processBucket(it->second);
+                    const auto * it = buckets.find(i);
+                    if (it)
+                        checksum += processBucket(it->getMapped());
                 }
             }
             else
@@ -123,9 +131,9 @@ Float64 measureNanoseconds(Strategy strategy, size_t bucket_count, const Dataset
                 /// Collect the populated buckets (a fresh vector per finalize, as production does), sort, process.
                 VectorWithMemoryTracking<IndexedBucket> ordered;
                 ordered.reserve(buckets.size());
-                for (const auto & [index, bucket] : buckets)
-                    ordered.push_back({static_cast<UInt32>(index), &bucket});
-                std::sort(ordered.begin(), ordered.end(),
+                for (const auto & entry : buckets)
+                    ordered.push_back({static_cast<UInt32>(entry.getKey()), &entry.getMapped()});
+                ::sort(ordered.begin(), ordered.end(),
                     [](const IndexedBucket & lhs, const IndexedBucket & rhs) { return lhs.index < rhs.index; });
                 for (const auto & indexed_bucket : ordered)
                     checksum += processBucket(*indexed_bucket.bucket);
@@ -145,8 +153,8 @@ int mainEntryExampleTimeSeriesToGridRangeScanVsStdSort(int, char **)
         NUM_SERIES, BASE_GRID);
     fmt::println("populated buckets is constant; bucket_count is the slot range the scan walks. Dense (range scan)");
     fmt::println("is chosen iff populated / bucket_count >= BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN.\n");
-    fmt::println("{:>22}  {:>12}  {:>14}  {:>14}  {:>30}  {:>10}",
-        "populated/bucket_count", "bucket_count", "range_scan(ns)", "std::sort(ns)", "ratio (range_scan / std::sort)", "winner");
+    fmt::println("{:>22}  {:>12}  {:>14}  {:>14}  {:>26}  {:>10}",
+        "populated/bucket_count", "bucket_count", "range_scan(ns)", "sort(ns)", "ratio (range_scan / sort)", "winner");
 
     Float64 checksum = 0;
     Float64 dense_factor = 0;    /// smallest populated/bucket_count at which the range scan still wins (the crossover)
@@ -156,16 +164,16 @@ int mainEntryExampleTimeSeriesToGridRangeScanVsStdSort(int, char **)
         const Dataset dataset = buildDataset(density);
         const size_t bucket_count = bucketCountForDensity(density);
         const Float64 range_scan_ns = measureNanoseconds(Strategy::RangeScan, bucket_count, dataset, checksum);
-        const Float64 std_sort_ns = measureNanoseconds(Strategy::StdSort, bucket_count, dataset, checksum);
-        const Float64 ratio = range_scan_ns / std_sort_ns;
-        const bool range_wins = range_scan_ns < std_sort_ns;
+        const Float64 sort_ns = measureNanoseconds(Strategy::Sort, bucket_count, dataset, checksum);
+        const Float64 ratio = range_scan_ns / sort_ns;
+        const bool range_wins = range_scan_ns < sort_ns;
         if (range_still_winning && range_wins)
             dense_factor = density;
         else
             range_still_winning = false;
         const Float64 actual_density = static_cast<Float64>(BASE_GRID) / static_cast<Float64>(bucket_count);
-        fmt::println("{:>22.3f}  {:>12}  {:>14.2f}  {:>14.2f}  {:>30.2f}  {:>10}",
-            actual_density, bucket_count, range_scan_ns, std_sort_ns, ratio, range_wins ? "range_scan" : "std::sort");
+        fmt::println("{:>22.3f}  {:>12}  {:>14.2f}  {:>14.2f}  {:>26.2f}  {:>10}",
+            actual_density, bucket_count, range_scan_ns, sort_ns, ratio, range_wins ? "range_scan" : "sort");
     }
 
     fmt::println("");

--- a/src/AggregateFunctions/examples/timeseries_to_grid_range_scan_vs_std_sort.cpp
+++ b/src/AggregateFunctions/examples/timeseries_to_grid_range_scan_vs_std_sort.cpp
@@ -1,5 +1,5 @@
 /// Measures `Base::BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN`: how a `timeSeries*ToGrid` finalize should visit its buckets in index
-/// order. The buckets live in the production container `HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>>`
+/// order. The buckets live in the production container `TimeSeriesBucketsMap` (a `HashMap` with `TrivialHash`)
 /// keyed by an index in `[0, bucket_count)`; finalize must process them in ascending index order. Two strategies,
 /// swept across densities:
 ///   - range scan: walk index 0..bucket_count and `find` each (the "dense" path); O(bucket_count).
@@ -25,10 +25,9 @@
 /// Build: it is part of the `clickhouse-examples` multi-call binary.
 /// Run:   `clickhouse-examples timeseries_to_grid_range_scan_vs_std_sort`
 
+#include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h>
 #include <AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesSamples.h>
 
-#include <Common/HashTable/Hash.h>
-#include <Common/HashTable/HashMap.h>
 #include <Common/Stopwatch.h>
 #include <Common/VectorWithMemoryTracking.h>
 
@@ -57,7 +56,7 @@ constexpr Int64 STEP = 10;
 constexpr int REPEATS = 5;  /// timing iterations per measurement; the minimum over them is used
 
 using Bucket = AggregateFunctionTimeseriesSamples<UInt32, Float64>;
-using Buckets = HashMap<UInt64, Bucket, TrivialHash, HashTableGrower<4>>;  /// same type as production's bucket map
+using Buckets = TimeSeriesBucketsMap<Bucket>;  /// the production bucket map type
 using Dataset = std::vector<Buckets>;  /// one Buckets map per series; STYLE_CHECK_ALLOW_STD_CONTAINERS
 
 /// One populated bucket and its index, for the collect-and-sort strategy. Sorted by `index`.

--- a/tests/queries/0_stateless/04319_timeseries_two_stacks.sql
+++ b/tests/queries/0_stateless/04319_timeseries_two_stacks.sql
@@ -68,7 +68,7 @@ DROP TABLE ts_two_stacks;
 -- Two-stacks selected via the AVERAGE-density path, not the hard cap: step=1, window=15 -> buckets_per_window=15
 -- (below BPW_TO_FORCE_TWO_STACKS=20), but a sample in every bucket makes the average populated buckets per window
 -- (~15) >= AVG_POPULATED_BPW_TO_ENABLE_TWO_STACKS=10, so the regression functions pick two-stacks through the
--- average condition. The full density (populated / bucket_count = 1.0 >= BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN=0.4)
+-- average condition. The full density (populated / bucket_count = 1.0 >= BUCKET_DENSITY_TO_ENABLE_RANGE_SCAN=0.35)
 -- also drives the range-scan bucket iteration. Quadratic values make the per-window slope vary, so a faulty moment
 -- merge would diverge from the fresh recompute.
 DROP TABLE IF EXISTS ts_dense;


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/106724, applying the review suggestions that did not make it into the merge.

- Replace `std::sort` with `::sort` (pdqsort, strictly better on integer keys) in `AggregateFunctionTimeseriesSamples` and in the sparse path of `AggregateFunctionTimeseriesBase::doInsertResultInto`.
- Replace the `std::unordered_map` of buckets with `HashMap<UInt64, Bucket, DefaultHash<UInt64>, HashTableGrower<4>>`. `HashMap` relocates cells with `memcpy` on resize, so buckets must be position independent (memmove-able): the `Summary` buckets are trivially copyable, and `AggregateFunctionTimeseriesSamples` declares `is_position_independent` — `absl::flat_hash_map` stores no pointers into itself (the address of its inline single-element storage is computed from `this`, the rest is on the heap); verified empirically by `memcpy`-relocating populated maps in both inline and heap modes. A `static_assert` enforces the property for any future bucket type.

The serialized aggregate-state format is unchanged (same count-prefixed index/bucket pairs; entry order is not significant for deserialization).

Related: https://github.com/ClickHouse/ClickHouse/pull/106724

Huge speedup observed: 

<img width="1783" height="916" alt="image" src="https://github.com/user-attachments/assets/b96cea50-f70e-4d6b-ba02-ccfe6d9c44ab" />


### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `pdqsort` and ClickHouse `HashMap` instead of `std::sort` and `std::unordered_map` in the `timeSeries*ToGrid` aggregate functions.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1210` (included in `26.7` and later)
<!-- ch-version-info:end -->