### PR TITLE
Fix query result cache for PromQL queries

### DIFF
--- a/src/Parsers/Prometheus/ParserPrometheusQuery.cpp
+++ b/src/Parsers/Prometheus/ParserPrometheusQuery.cpp
@@ -76,6 +76,8 @@ bool ParserPrometheusQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     table_exp->table_function = table_function;
     table_exp->children.emplace_back(table_exp->table_function);
     table->table_expression = table_exp;
+    /// AST visitors traverse children, not members, so the table expression must be linked as a child too.
+    table->children.push_back(table->table_expression);
     tables->children.push_back(table);
     select_query->setExpression(ASTSelectQuery::Expression::TABLES, tables);
 

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -96,6 +96,10 @@ void PrometheusHTTPProtocolAPI::executePromQLQuery(
 
         /// Mind using the getResultType() method from PrometheusQueryToSQL::Converter, not from the PrometheusQueryTree.
         writeQueryResponse(response, executor, converter.getResultType());
+
+        /// Store the buffered result in the query result cache now (no-op if no cache writers exist in the pipeline):
+        /// the executor's destructor cancels the pipeline processors, after which the pending write would be discarded.
+        io.pipeline.finalizeWriteInQueryResultCache();
     }
     catch (...)
     {

--- a/tests/integration/test_prometheus_protocols/test_query_cache.py
+++ b/tests/integration/test_prometheus_protocols/test_query_cache.py
@@ -1,0 +1,107 @@
+import json
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from .prometheus_test_utils import execute_query_via_http_api
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+)
+
+EVALUATION_TIME = 1700000000
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        node.query(
+            "CREATE TABLE prometheus_data (id UUID, timestamp DateTime64(3, 'UTC'), value Float64)"
+            " ENGINE = MergeTree ORDER BY (id, timestamp)"
+        )
+        node.query(
+            "CREATE TABLE prometheus_tags (id UUID, metric_name LowCardinality(String),"
+            " tags Map(LowCardinality(String), String),"
+            " min_time SimpleAggregateFunction(min, Nullable(DateTime64(3, 'UTC'))),"
+            " max_time SimpleAggregateFunction(max, Nullable(DateTime64(3, 'UTC'))))"
+            " ENGINE = AggregatingMergeTree ORDER BY (metric_name, id)"
+            " SETTINGS allow_dimensions_outside_sorting_key = 1"
+        )
+        node.query(
+            "CREATE TABLE prometheus_metrics (metric_family_name String, type String, unit String, help String)"
+            " ENGINE = ReplacingMergeTree ORDER BY metric_family_name"
+        )
+        node.query(
+            "CREATE TABLE prometheus ENGINE = TimeSeries"
+            " DATA prometheus_data TAGS prometheus_tags METRICS prometheus_metrics"
+        )
+        node.query(
+            "INSERT INTO prometheus_tags VALUES ('00000000-0000-0000-0000-000000000001', 'up',"
+            " {'instance':'host1'}, toDateTime64(1699999000, 3, 'UTC'), toDateTime64(1700001000, 3, 'UTC'))"
+        )
+        node.query(
+            "INSERT INTO prometheus_data VALUES"
+            " ('00000000-0000-0000-0000-000000000001', toDateTime64(1700000000, 3, 'UTC'), 1)"
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def clear_query_cache():
+    node.query("SYSTEM DROP QUERY CACHE")
+    yield
+
+
+def run_instant_query(params, expect_error=False):
+    result = execute_query_via_http_api(
+        node.ip_address,
+        9093,
+        "/api/v1/query",
+        "up",
+        timestamp=EVALUATION_TIME,
+        params=params,
+        expect_error=expect_error,
+    )
+    return result if expect_error else json.loads(result)
+
+
+def get_query_cache_hits():
+    return int(node.query("SELECT sum(value) FROM system.events WHERE event = 'QueryCacheHits'"))
+
+
+def test_query_cache_rejected_by_default():
+    # The transpiled SQL contains non-deterministic timeSeries* functions, so the default
+    # query_cache_nondeterministic_function_handling = 'throw' must reject the query.
+    error = run_instant_query({"use_query_cache": 1}, expect_error=True)
+    assert "non-deterministic" in error
+    assert int(node.query("SELECT count() FROM system.query_cache")) == 0
+
+
+def test_query_cache_stores_and_hits():
+    params = {
+        "use_query_cache": 1,
+        "query_cache_nondeterministic_function_handling": "save",
+    }
+    expected = {
+        "resultType": "vector",
+        "result": [
+            {
+                "metric": {"__name__": "up", "instance": "host1"},
+                "value": [EVALUATION_TIME, "1"],
+            }
+        ],
+    }
+
+    assert run_instant_query(params) == expected
+    assert int(node.query("SELECT count() FROM system.query_cache")) == 1
+
+    hits_before = get_query_cache_hits()
+    assert run_instant_query(params) == expected
+    assert get_query_cache_hits() == hits_before + 1

--- a/tests/queries/0_stateless/04549_promql_dialect_query_cache.reference
+++ b/tests/queries/0_stateless/04549_promql_dialect_query_cache.reference
@@ -1,0 +1,9 @@
+-- 'auto' evaluation time transpiles to now(), the query cache must reject it by default
+QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS
+-- explicit evaluation time is deterministic, the second run is served from the cache
+[('__name__','up'),('instance','host1')]	2023-11-14 22:13:20.000	1
+[('__name__','up'),('instance','host1')]	2023-11-14 22:13:20.000	1
+-- a different PromQL query must not collide with the cached one
+[('instance','host1')]	2023-11-14 22:13:20.000	2
+0	1
+1	0

--- a/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
+++ b/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
@@ -43,5 +43,5 @@ $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
 $CLICKHOUSE_CLIENT -q "
 SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses']
 FROM system.query_log
-WHERE event_date >= yesterday() AND type = 'QueryFinish' AND query_id IN ('$QUERY_ID_1', '$QUERY_ID_2')
+WHERE event_date >= yesterday() AND type = 'QueryFinish' AND current_database = currentDatabase() AND query_id IN ('$QUERY_ID_1', '$QUERY_ID_2')
 ORDER BY query_id"

--- a/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
+++ b/tests/queries/0_stateless/04549_promql_dialect_query_cache.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-replicated-database
+# no-fasttest: the PromQL grammar requires ANTLR4 which is disabled in the fast-test build.
+# no-replicated-database: the experimental TimeSeries table engine does not round-trip through DatabaseReplicated.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --allow_experimental_time_series_table 1 -m -q "
+CREATE TABLE ts_data (id UUID, timestamp DateTime64(3, 'UTC'), value Float64) ENGINE = MergeTree ORDER BY (id, timestamp);
+CREATE TABLE ts_tags (
+    id UUID,
+    metric_name LowCardinality(String),
+    tags Map(LowCardinality(String), String),
+    min_time SimpleAggregateFunction(min, Nullable(DateTime64(3, 'UTC'))),
+    max_time SimpleAggregateFunction(max, Nullable(DateTime64(3, 'UTC'))))
+ENGINE = AggregatingMergeTree ORDER BY (metric_name, id) SETTINGS allow_dimensions_outside_sorting_key = 1;
+CREATE TABLE ts_metrics (metric_family_name String, type String, unit String, help String) ENGINE = ReplacingMergeTree ORDER BY metric_family_name;
+CREATE TABLE ts ENGINE = TimeSeries DATA ts_data TAGS ts_tags METRICS ts_metrics;
+INSERT INTO ts_tags VALUES ('00000000-0000-0000-0000-000000000001', 'up', {'instance':'host1'}, toDateTime64(1699999000, 3, 'UTC'), toDateTime64(1700001000, 3, 'UTC'));
+INSERT INTO ts_data VALUES ('00000000-0000-0000-0000-000000000001', toDateTime64(1700000000, 3, 'UTC'), 1);
+"
+
+promql_client()
+{
+    $CLICKHOUSE_CLIENT --allow_experimental_time_series_table 1 --dialect promql --promql_table ts --use_query_cache 1 "$@"
+}
+
+echo "-- 'auto' evaluation time transpiles to now(), the query cache must reject it by default"
+promql_client -q "up" 2>&1 | grep -o "QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS" | head -1
+
+echo "-- explicit evaluation time is deterministic, the second run is served from the cache"
+QUERY_ID_1="${CLICKHOUSE_DATABASE}_promql_query_cache_1"
+QUERY_ID_2="${CLICKHOUSE_DATABASE}_promql_query_cache_2"
+promql_client --promql_evaluation_time 1700000000 --query_id "$QUERY_ID_1" -q "up"
+promql_client --promql_evaluation_time 1700000000 --query_id "$QUERY_ID_2" -q "up"
+
+echo "-- a different PromQL query must not collide with the cached one"
+promql_client --promql_evaluation_time 1700000000 -q "up * 2"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+$CLICKHOUSE_CLIENT -q "
+SELECT ProfileEvents['QueryCacheHits'], ProfileEvents['QueryCacheMisses']
+FROM system.query_log
+WHERE event_date >= yesterday() AND type = 'QueryFinish' AND query_id IN ('$QUERY_ID_1', '$QUERY_ID_2')
+ORDER BY query_id"


### PR DESCRIPTION
The query result cache did not work correctly for PromQL queries, in both directions.

The `promql` dialect transpiles a query into `SELECT * FROM prometheusQuery('table', '<promql>', now())`, but `ParserPrometheusQuery` did not link the table expression into the `children` of `ASTTablesInSelectQueryElement`. In-place AST visitors traverse `children`, so `astContainsNonDeterministicFunctions` never saw `now()` and the default `query_cache_nondeterministic_function_handling = 'throw'` protection was silently bypassed.

The Prometheus HTTP API (`/api/v1/query`, `/api/v1/query_range`) could never populate the cache.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the query result cache for PromQL queries. The `promql` dialect bypassed the non-deterministic-function check and could serve stale results anchored at `now()`; the Prometheus HTTP API (`/api/v1/query`, `/api/v1/query_range`) never stored cache entries at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)