### PR TITLE
Make the universal installer output friendlier

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -1,5 +1,32 @@
 #!/bin/sh -e
 
+# Decorated output is enabled only where it will render correctly:
+# colors need stdout to be a TTY and a capable TERM (the script itself arrives
+# on stdin when run as `curl https://clickhouse.com/ | sh`, but stdout is still
+# the terminal there), and the logo needs a UTF-8 locale.
+# NO_COLOR (https://no-color.org) disables colors.
+ESC=$(printf '\033')
+RESET=''; BOLD=''; DIM=''; YELLOW=''; CYAN=''; BLUE=''
+if [ -t 1 ] && [ -n "${TERM}" ] && [ "${TERM}" != "dumb" ] && [ -z "${NO_COLOR}" ]
+then
+    RESET="${ESC}[0m"; BOLD="${ESC}[1m"; DIM="${ESC}[2m"
+    YELLOW="${ESC}[93m"; CYAN="${ESC}[36m"; BLUE="${ESC}[34m"
+fi
+
+echo
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *[Uu][Tt][Ff]-8*|*[Uu][Tt][Ff]8*)
+        printf '%s\n' "   ${BOLD}█ █ █ █${RESET}"
+        printf '%s\n' "   ${BOLD}█ █ █ █ ▄${RESET}     ${BOLD}ClickHouse${RESET}"
+        printf '%s\n' "   ${BOLD}█ █ █ █ ▀${RESET}     ${DIM}the fastest open source database${RESET}"
+        printf '%s\n' "   ${BOLD}█ █ █ █${RESET}       ${DIM}for real-time analytics${RESET}"
+        ;;
+    *)
+        printf '%s\n' "   ${BOLD}ClickHouse${RESET} ${DIM}- the fastest open source database for real-time analytics${RESET}"
+        ;;
+esac
+echo
+
 OS=$(uname -s)
 ARCH=$(uname -m)
 
@@ -62,11 +89,15 @@ then
     fi
 fi
 
+printf '%s\n' "${BLUE}==>${RESET} ${BOLD}Detecting platform${RESET}"
+
 if [ -z "${DIR}" ]
 then
-    echo "Operating system '${OS}' / architecture '${ARCH}' is unsupported."
+    echo "    Operating system '${OS}' / architecture '${ARCH}' is unsupported." >&2
     exit 1
 fi
+
+printf '%s\n' "    ${OS} ${ARCH} -> ${DIR} (latest master build)"
 
 clickhouse_download_filename_prefix="clickhouse"
 clickhouse="$clickhouse_download_filename_prefix"
@@ -85,20 +116,13 @@ do
 done
 
 URL="https://builds.clickhouse.com/master/${DIR}/clickhouse"
-echo
-echo "Will download ${URL} into ${clickhouse}"
-echo
+printf '%s\n' "${BLUE}==>${RESET} ${BOLD}Downloading clickhouse${RESET}"
+printf '%s\n' "    ${DIM}${URL} -> ./${clickhouse}${RESET}"
 curl "${URL}" -o "${clickhouse}" && chmod a+x "${clickhouse}" || exit 1
-echo
-echo "Successfully downloaded the ClickHouse binary, you can run it as:
-    ./${clickhouse}"
-
-echo
-echo "You can also install it:
-sudo ./${clickhouse} install"
 
 # Also install clickhousectl, the CLI for ClickHouse local and Cloud.
 # Set CLICKHOUSE_ONLY=1 to skip.
+chctl_installed=
 if [ -z "${CLICKHOUSE_ONLY}" ]
 then
     chctl_target=
@@ -124,8 +148,6 @@ then
 
     if [ -n "${chctl_target}" ]
     then
-        echo
-        echo "Fetching the latest clickhousectl release..."
         chctl_tag=$(curl -fsSL "https://api.github.com/repos/ClickHouse/clickhousectl/releases/latest" \
             | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
 
@@ -134,7 +156,8 @@ then
             chctl_install_dir="${HOME}/.local/bin"
             chctl_archive="clickhousectl-${chctl_target}-${chctl_tag}.tar.gz"
             chctl_url="https://builds.clickhouse.com/clickhousectl/${chctl_archive}"
-            echo "Will download ${chctl_url} into ${chctl_install_dir}/clickhousectl"
+            printf '%s\n' "${BLUE}==>${RESET} ${BOLD}Downloading clickhousectl ${chctl_tag}${RESET}"
+            printf '%s\n' "    ${DIM}${chctl_url} -> ${chctl_install_dir}/clickhousectl${RESET}"
             chctl_tmp=$(mktemp -d)
             if mkdir -p "${chctl_install_dir}" \
                 && curl -fsSL "${chctl_url}" -o "${chctl_tmp}/${chctl_archive}" \
@@ -143,27 +166,52 @@ then
             then
                 chmod a+x "${chctl_install_dir}/clickhousectl"
                 ln -sf "${chctl_install_dir}/clickhousectl" "${chctl_install_dir}/chctl"
-                echo
-                echo "Successfully installed clickhousectl to ${chctl_install_dir}/clickhousectl"
-                echo "Created alias: chctl -> clickhousectl"
+                chctl_installed=1
+                printf '%s\n' "    installed to ${chctl_install_dir}/clickhousectl ${DIM}(alias: chctl)${RESET}"
                 case ":$PATH:" in
                     *":${chctl_install_dir}:"*) ;;
                     *)
-                        echo
-                        echo "NOTE: ${chctl_install_dir} is not in your PATH."
-                        echo "Add it by running:"
-                        echo
-                        echo "  export PATH=\"${chctl_install_dir}:\$PATH\""
-                        echo
-                        echo "You may want to add that line to your shell profile (~/.bashrc, ~/.zshrc, etc.)"
+                        printf '%s\n' "    ${DIM}NOTE: ${chctl_install_dir} is not in your PATH. Add it with:${RESET}"
+                        printf '%s\n' "      export PATH=\"${chctl_install_dir}:\$PATH\""
+                        printf '%s\n' "    ${DIM}(you may want to add that line to your shell profile, e.g. ~/.bashrc or ~/.zshrc)${RESET}"
                         ;;
                 esac
             else
-                echo "Warning: failed to download clickhousectl. Continuing."
+                echo "Warning: failed to download clickhousectl. Continuing." >&2
             fi
             rm -rf "${chctl_tmp}"
         else
-            echo "Warning: could not determine the latest clickhousectl release. Continuing."
+            echo "Warning: could not determine the latest clickhousectl release. Continuing." >&2
         fi
     fi
 fi
+
+# Pad commands so the descriptions line up, even when the binary got a
+# non-clashing name like clickhouse.0. 27 = len("sudo ./clickhouse install") + 2.
+PAD=$((17 + ${#clickhouse}))
+[ "${PAD}" -lt 27 ] && PAD=27
+
+echo
+printf '%s\n' "${BOLD}Get started:${RESET}"
+printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "./${clickhouse}" "Open an interactive ClickHouse shell using clickhouse-local"
+printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "./${clickhouse} server" "Start a server in the current directory"
+printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "sudo ./${clickhouse} install" "Install system-wide with config and a service"
+
+if [ -n "${chctl_installed}" ]
+then
+    echo
+    printf '%s\n' "${BOLD}For AI agents:${RESET}"
+    printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "chctl skills" "Install the official ClickHouse Agent Skills"
+    printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "chctl local" "Work with local ClickHouse"
+    printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "chctl local postgres" "Work with local Postgres"
+    printf "  ${YELLOW}%-${PAD}s${RESET}%s\n" "chctl cloud" "Work with ClickHouse Cloud, the managed service for ClickHouse and Postgres"
+fi
+
+echo
+printf '%s\n' "${BOLD}Learn more:${RESET}"
+printf '%s\n' "  Quick start       ${CYAN}https://clickhouse.com/docs/getting-started/quick-start${RESET}"
+printf '%s\n' "  clickhousectl     ${CYAN}https://clickhouse.com/docs/interfaces/cli${RESET}"
+printf '%s\n' "  ClickHouse Cloud  ${CYAN}https://clickhouse.com/cloud${RESET}"
+printf '%s\n' "  Docs              ${CYAN}https://clickhouse.com/docs${RESET}"
+printf '%s\n' "  Community         ${CYAN}https://clickhouse.com/slack${RESET}"
+echo


### PR DESCRIPTION
The universal installation script (`curl https://clickhouse.com/ | sh`) currently prints a few plain lines. This PR gives it a friendlier, more helpful output, similar to what other modern installers do: the ClickHouse logo and tagline, Homebrew-style sections for platform detection and downloads, and a footer with quick-start commands, `chctl` commands for AI agents, and documentation links.

Example output:

<img width="1256" height="795" alt="image" src="https://github.com/user-attachments/assets/b34b1ba3-65f4-49fc-9b22-f6e08c24e5b2" />

In a terminal, the sections are colored (bold headers, yellow commands, cyan links, blue `==>` arrows) and the logo uses the terminal's default foreground, so it renders white on dark themes and dark on light themes. Colors are enabled only when stdout is a TTY with a capable `TERM` and `NO_COLOR` is unset (the script arrives on stdin under `curl | sh`, but stdout is still the terminal there). The logo falls back to a plain-text header on non-UTF-8 locales.

All existing behavior is preserved: build-variant dispatch, the non-clashing `clickhouse.N` filename (the footer commands reference the actual filename), the `CLICKHOUSE_ONLY=1` opt-out (which also hides the "For AI agents" section), the `PATH` hint for `clickhousectl`, and the warnings on the `clickhousectl` failure paths. The script remains POSIX `sh`.

Tested end-to-end on macOS arm64: plain run, run under a pty (colors), `CLICKHOUSE_ONLY=1`, and the filename-clash path; the downloaded binary passes `./clickhouse local -q "SELECT version()"`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The universal installation script (`curl https://clickhouse.com/ | sh`) now produces friendlier output: the ClickHouse logo, colors (when the terminal supports them; disabled with `NO_COLOR`), the detected platform, and quick-start commands with documentation links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)