### PR TITLE
Fix flaky test 01017_uniqCombined_memory_usage

### DIFF
--- a/tests/queries/0_stateless/01017_uniqCombined_memory_usage.sql
+++ b/tests/queries/0_stateless/01017_uniqCombined_memory_usage.sql
@@ -32,14 +32,14 @@ SELECT 'K=16';
 SELECT 'UInt32';
 SET max_memory_usage = 2000000;
 SELECT sum(u) FROM (SELECT intDiv(number, 4096) AS k, uniqCombined(16)(number % 4096) u FROM numbers(4096 * 100) GROUP BY k); -- { serverError MEMORY_LIMIT_EXCEEDED }
-SET max_memory_usage = 5230000;
+SET max_memory_usage = 6300000;
 SELECT sum(u) FROM (SELECT intDiv(number, 4096) AS k, uniqCombined(16)(number % 4096) u FROM numbers(4096 * 100) GROUP BY k);
 
 -- HashTable for UInt64 (used until (1<<11) elements), hence 2048 elements
 SELECT 'UInt64';
 SET max_memory_usage = 2000000;
 SELECT sum(u) FROM (SELECT intDiv(number, 2048) AS k, uniqCombined(16)(reinterpretAsString(number % 2048)) u FROM numbers(2048 * 100) GROUP BY k); -- { serverError MEMORY_LIMIT_EXCEEDED }
-SET max_memory_usage = 5900000;
+SET max_memory_usage = 7100000;
 SELECT sum(u) FROM (SELECT intDiv(number, 2048) AS k, uniqCombined(16)(reinterpretAsString(number % 2048)) u FROM numbers(2048 * 100) GROUP BY k);
 
 SELECT 'K=18';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

No related open issue found (searched by test name, error phrase, and CIDB history).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The two `K=16` positive-case budgets left effectively zero headroom. CI failures (arm builds) show the tracked peak landing exactly at the configured limit: `would use 4.99 MiB ... maximum: 4.99 MiB` (UInt32, budget 5230000) and `would use 5.63 MiB ... maximum: 5.63 MiB` (UInt64, budget 5900000). Since the test sets `memory_profiler_step = 1`, every allocation is flushed to the query tracker, so allocator/arena rounding variance on arm/release intermittently tips these two positive cases over `MEMORY_LIMIT_EXCEEDED` in `AggregatingTransform`.

Fix: give the two flaky `K=16` positive budgets ~20% headroom over the observed peak (6300000 and 7100000). The negative-case budgets (2000000) are unchanged, so the `serverError MEMORY_LIMIT_EXCEEDED` assertions still catch any regression that inflates the uniqCombined HLL state. The `K=12` and `K=18` budgets already have sufficient margin and are untouched.

Same class of tight-threshold flakiness previously fixed by #9667 and #68508.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1128` (included in `26.7` and later)
<!-- ch-version-info:end -->