### PR TITLE
Fix flaky 03008_deduplication_insert_into_partitioned_table

### DIFF
--- a/tests/queries/0_stateless/03008_deduplication_insert_into_partitioned_table.sql
+++ b/tests/queries/0_stateless/03008_deduplication_insert_into_partitioned_table.sql
@@ -1,5 +1,9 @@
-DROP TABLE IF EXISTS partitioned_table;
-DROP TABLE IF EXISTS mv_table;
+DROP TABLE IF EXISTS partitioned_table_1;
+DROP TABLE IF EXISTS mv_table_1;
+DROP TABLE IF EXISTS partitioned_table_2;
+DROP TABLE IF EXISTS mv_table_2;
+DROP TABLE IF EXISTS partitioned_table_3;
+DROP TABLE IF EXISTS mv_table_3;
 
 
 SET deduplicate_blocks_in_dependent_materialized_views = 1;
@@ -7,77 +11,77 @@ SET deduplicate_blocks_in_dependent_materialized_views = 1;
 
 SELECT 'no user deduplication token';
 
-CREATE TABLE partitioned_table
+CREATE TABLE partitioned_table_1
     (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table', '{replica}')
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_1', '{replica}')
     partition by key % 10
     order by tuple();
 
-CREATE MATERIALIZED VIEW mv_table (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_mv', '{replica}')
+CREATE MATERIALIZED VIEW mv_table_1 (key Int64, value String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_1_mv', '{replica}')
     ORDER BY tuple()
-    AS SELECT key, value FROM partitioned_table;
+    AS SELECT key, value FROM partitioned_table_1;
 
-INSERT INTO partitioned_table VALUES (1, 'A'), (2, 'B');
-INSERT INTO partitioned_table VALUES (1, 'A'), (2, 'C');
-INSERT INTO partitioned_table VALUES (1, 'D'), (2, 'B');
+INSERT INTO partitioned_table_1 VALUES (1, 'A'), (2, 'B');
+INSERT INTO partitioned_table_1 VALUES (1, 'A'), (2, 'C');
+INSERT INTO partitioned_table_1 VALUES (1, 'D'), (2, 'B');
 
 SELECT 'partitioned_table is not deduplicated because the inserts are different (deduplication works per insert):';
-SELECT * FROM partitioned_table ORDER BY ALL;
+SELECT * FROM partitioned_table_1 ORDER BY ALL;
 SELECT 'mv_table is not deduplicated because the inserted blocks was different:';
-SELECT * FROM mv_table ORDER BY ALL;
+SELECT * FROM mv_table_1 ORDER BY ALL;
 
-DROP TABLE partitioned_table;
-DROP TABLE mv_table;
+DROP TABLE partitioned_table_1;
+DROP TABLE mv_table_1;
 
 
 SELECT 'with user deduplication token';
 
-CREATE TABLE partitioned_table
+CREATE TABLE partitioned_table_2
     (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table', '{replica}')
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_2', '{replica}')
     partition by key % 10
     order by tuple();
 
-CREATE MATERIALIZED VIEW mv_table (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_mv', '{replica}')
+CREATE MATERIALIZED VIEW mv_table_2 (key Int64, value String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_2_mv', '{replica}')
     ORDER BY tuple()
-    AS SELECT key, value FROM partitioned_table;
+    AS SELECT key, value FROM partitioned_table_2;
 
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_1' VALUES (1, 'A'), (2, 'B');
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_2' VALUES (1, 'A'), (2, 'C');
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_3' VALUES (1, 'D'), (2, 'B');
+INSERT INTO partitioned_table_2 SETTINGS insert_deduplication_token='token_1' VALUES (1, 'A'), (2, 'B');
+INSERT INTO partitioned_table_2 SETTINGS insert_deduplication_token='token_2' VALUES (1, 'A'), (2, 'C');
+INSERT INTO partitioned_table_2 SETTINGS insert_deduplication_token='token_3' VALUES (1, 'D'), (2, 'B');
 
 SELECT 'partitioned_table is not deduplicated because different tokens:';
-SELECT * FROM partitioned_table ORDER BY ALL;
+SELECT * FROM partitioned_table_2 ORDER BY ALL;
 SELECT 'mv_table is not deduplicated because different tokens:';
-SELECT * FROM mv_table ORDER BY ALL;
+SELECT * FROM mv_table_2 ORDER BY ALL;
 
-DROP TABLE partitioned_table;
-DROP TABLE mv_table;
+DROP TABLE partitioned_table_2;
+DROP TABLE mv_table_2;
 
 
 SELECT 'with incorrect usage of user deduplication token';
 
-CREATE TABLE partitioned_table
+CREATE TABLE partitioned_table_3
     (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table', '{replica}')
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_3', '{replica}')
     partition by key % 10
     order by tuple();
 
-CREATE MATERIALIZED VIEW mv_table (key Int64, value String)
-    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_mv', '{replica}')
+CREATE MATERIALIZED VIEW mv_table_3 (key Int64, value String)
+    ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03008_deduplication_insert_into_partitioned_table_3_mv', '{replica}')
     ORDER BY tuple()
-    AS SELECT key, value FROM partitioned_table;
+    AS SELECT key, value FROM partitioned_table_3;
 
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_0' VALUES (1, 'A'), (2, 'B');
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_0' VALUES (1, 'A'), (2, 'C');
-INSERT INTO partitioned_table SETTINGS insert_deduplication_token='token_0' VALUES (1, 'D'), (2, 'B');
+INSERT INTO partitioned_table_3 SETTINGS insert_deduplication_token='token_0' VALUES (1, 'A'), (2, 'B');
+INSERT INTO partitioned_table_3 SETTINGS insert_deduplication_token='token_0' VALUES (1, 'A'), (2, 'C');
+INSERT INTO partitioned_table_3 SETTINGS insert_deduplication_token='token_0' VALUES (1, 'D'), (2, 'B');
 
 SELECT 'partitioned_table is deduplicated because equal tokens:';
-SELECT * FROM partitioned_table ORDER BY ALL;
+SELECT * FROM partitioned_table_3 ORDER BY ALL;
 SELECT 'mv_table is deduplicated because equal tokens:';
-SELECT * FROM mv_table ORDER BY ALL;
+SELECT * FROM mv_table_3 ORDER BY ALL;
 
-DROP TABLE partitioned_table;
-DROP TABLE mv_table;
+DROP TABLE partitioned_table_3;
+DROP TABLE mv_table_3;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flakiness in `03008_deduplication_insert_into_partitioned_table`.

The test runs 3 cases sequentially, each `CREATE TABLE` -> `INSERT` -> `SELECT` -> `DROP TABLE`, and every case reused the SAME table names AND the SAME explicit `ReplicatedMergeTree` ZooKeeper path.

Table identity on RMT is the ZK path. With an async `DROP TABLE`, a case's table may not yet be gone on a second replica when the next case's `CREATE TABLE` at the same ZK path runs. The second replica then finds the path still populated (`This table /clickhouse/tables/... is already created, will add new replica`) and re-attaches to the previous case's not-yet-dropped table instead of creating a fresh one. The old rows resurface on read, producing the intermittent x2 row doubling.

Fix: give each of the 3 cases its own distinct table names and its own distinct explicit ZK paths (suffix `_1`/`_2`/`_3`). Once every case owns a unique path, a `CREATE` can never land on a previous case's not-yet-dropped path, so the resurrection cannot happen. This is a generic test-hygiene improvement (async `DROP` + reused path is racy on ReplicatedMergeTree in general).

Deduplication intent is preserved exactly (all 3 cases, both partitions, different-tokens / equal-tokens). Assertions are not weakened and the `.reference` file is unchanged.

cc @CheSema
