### PR TITLE
Docs: fix sticky docs sidebar controls

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -852,38 +852,74 @@ html:not(.dark) .pagination-prev:hover {
    Sticky sidebar header (search + Ask AI)
    ============================================
 
-   `#sidebar-content` is the sidebar's scroll container (Mintlify gives it
-   `overflow-y-auto`). Its three direct children are, in order:
+   Mintlify's scroll viewport lives directly inside `#sidebar-content`. The
+   viewport's inner wrapper has three children, in order:
      [0] the logo + dark-mode-toggle row  (div.flex.justify-between.items-center)
      [1] the search + Ask AI row          (div.flex.flex-col.gap-4.mt-6)
      [2] the page navigation              (#navigation-items)
-   Because all three live inside the one scrolling box, the logo and search
-   rows scroll away with the nav. To pin them, move the scroll boundary off
-   `#sidebar-content` and onto `#navigation-items` only: lay `#sidebar-content`
-   out as a flex column that clips instead of scrolls, and let the nav list
-   flex-grow into the remaining height and scroll on its own. The two header
-   rows then stay put at the top while the nav scrolls beneath them.
+   Keep Mintlify's viewport as the scroll container so its visible Base UI
+   scrollbar continues to work. Pin the logo and search rows within that
+   viewport while the navigation scrolls beneath them.
    `#sidebar` is `hidden lg:flex`, so this only affects the desktop sidebar. */
-#sidebar-content {
-    display: flex !important;
-    flex-direction: column;
-    overflow-y: hidden !important;
-    min-height: 0;
+#sidebar-content > div[role="presentation"] > div[role="presentation"] > div:first-child,
+#sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2) {
+    position: sticky;
+    z-index: 20;
+    background: #ffffff;
 }
-#sidebar-content > #navigation-items {
-    flex: 1 1 auto;
-    min-height: 0;
-    overflow-y: auto;
+
+#sidebar-content > div[role="presentation"] > div[role="presentation"] > div:first-child {
+    top: 0;
+    z-index: 21;
+}
+
+#sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2) {
+    top: 3.5rem;
+}
+
+/* Cover the complete sticky header, including the space above, between, and
+   below its two rows, so menu items cannot show through while scrolling. */
+#sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2)::before {
+    position: absolute;
+    z-index: -1;
+    top: -5rem;
+    right: -1rem;
+    bottom: -2rem;
+    left: -1.75rem;
+    background: #ffffff;
+    content: "";
+    pointer-events: none;
+}
+
+.dark #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:first-child,
+.dark #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2),
+:is(.dark) #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:first-child,
+:is(.dark) #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2) {
+    background: #151515;
+}
+
+.dark #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2)::before,
+:is(.dark) #sidebar-content > div[role="presentation"] > div[role="presentation"] > div:nth-child(2)::before {
+    background: #151515;
+}
+
+#sidebar-content #navigation-items {
     /* Mintlify inserts an empty `mt-8` list before the first real menu item.
-       Move that spacing outside the scrolling box so the scrollbar track starts
-       level with the first item instead of directly below search and Ask AI. */
-    margin-top: 2.5rem;
+       Preserve an explicit gap between the sticky controls and the first menu
+       item rather than relying on that empty element's collapsed margin. */
+    margin-top: 2rem;
     scrollbar-width: thin;
     scrollbar-color: #d1d5db transparent;
 }
 
 #navigation-items > ul.list-none.mt-8:first-child:empty {
     margin-top: 0 !important;
+}
+
+/* Start Mintlify's scrollbar track at the first navigation item rather than at
+   the top of the sticky logo/search header. */
+#sidebar-content > [data-component-part="scroll-area-scrollbar"][data-orientation="vertical"] {
+    margin-top: 9.25rem;
 }
 
 #navigation-items::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- adapt the docs sidebar sticky header to Mintlify's new Base UI scroll viewport markup
- keep the logo, search, and Ask AI controls fixed while the navigation scrolls
- preserve Mintlify's default 32px gap before the first navigation item
- align the visible scrollbar track with the first navigation item

## Why

Mintlify added scroll viewport wrappers around the sidebar content. The existing selectors no longer matched the navigation structure, causing the header controls to scroll away and later attempts to move scrolling onto the navigation list bypassed Mintlify's visible scrollbar.

This keeps Mintlify's viewport as the scroll owner and makes only the header rows sticky, preserving the platform scrollbar behavior.

## Validation

- checked the updated sidebar in the local Mintlify preview at desktop width
- verified the logo and search/Ask AI rows remain fixed while scrolling
- verified the scrollbar remains visible and begins at the first navigation item
- verified the default navigation gap computes to 32px
- ran `git diff --check`
- verified balanced CSS braces

### Changelog category (leave one):

- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Keep the ClickHouse documentation sidebar controls sticky while preserving the platform's default navigation spacing and scrollbar alignment.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1119` (included in `26.7` and later)
<!-- ch-version-info:end -->