### PR TITLE
Docs: fix scoped language client docs validation

### DIFF
--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -21,8 +21,8 @@ The check definitions are declared once here and shared with the Praktika job
 (``ci/jobs/docs_job_mintlify.py``), which imports them. The aggregator job runs
 the full set (``DEFAULT_CHECKS`` plus, when a locale tree changed,
 ``LOCALE_CHECKS``); this client driver runs only ``CLIENT_CHECKS`` -- the checks
-a consuming repo can act on for the slice it owns (default-locale snippet
-imports, validate, and internal links).
+a consuming repo can act on for the slice it owns (validation, including the
+snippet-import policy in scoped mode, and internal links).
 Redirects, external links, and the locale checks are aggregator-global and are
 left to the aggregator job. With ``--scoped``, ``mint validate`` is replaced by
 ``scoped_validate.mjs`` over the replaced folders plus every out-of-scope file
@@ -74,24 +74,34 @@ DEFAULT_CHECKS = [
 ]
 
 # The subset a consuming client repo (e.g. clickhouse-connect) runs: only the
-# checks that validate the slice it owns. The snippet check rejects missing
-# file-local imports in default-locale snippets, `mint validate` proves its docs.json
-# fragment and frontmatter are well-formed, and the internal-links check proves
-# its own links and anchors resolve. Redirects, external links, and the locale
-# checks are aggregator-global concerns a client neither owns nor can fix (they
-# depend on the site-wide redirects map, third-party sites, and the translated
-# trees), so the client driver does not run them.
-CLIENT_CHECKS = [SNIPPET_IMPORTS_CHECK, VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
+# checks that validate the slice it owns. The snippet-import policy is not a
+# separate client check: scoped_validate_check bundles it with the scoped
+# validator, so language-client workflows get both as one validation step.
+# `mint validate` proves the docs.json fragment and frontmatter are well-formed,
+# and the internal-links check proves the client's own links and anchors resolve.
+# Redirects, external links, and locale checks are aggregator-global concerns a
+# client cannot fix.
+CLIENT_CHECKS = [VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
 
 
 # Swaps the full `mint validate` (which MDX-parses the whole site, ~13 minutes)
-# for scoped_validate.mjs over just the replaced folders -- see that script's
-# header for what it covers.
+# for the snippet-import policy check plus scoped_validate.mjs over just the
+# replaced folders -- see that script's header for what it covers. Keep these
+# in one logical validation check so adding client checks cannot accidentally
+# leave the full validator enabled alongside the scoped one.
 def scoped_validate_check(scopes):
-    command = "node ../ci/jobs/scripts/docs/scoped_validate.mjs " + " ".join(
+    scoped_command = "node ../ci/jobs/scripts/docs/scoped_validate.mjs " + " ".join(
         f"--scope {shlex.quote(scope)}" for scope in scopes
     )
-    return ("Validate docs.json and the replaced folders (scoped)", command + " .")
+    command = f"{SNIPPET_IMPORTS_CHECK[1]} && {scoped_command} ."
+    return ("Validate docs.json and the replaced folders (scoped)", command)
+
+
+def client_checks(scoped, scopes):
+    """Select the full or scoped validator plus client-owned link checks."""
+    if scoped:
+        return [scoped_validate_check(scopes), INTERNAL_LINKS_CHECK]
+    return list(CLIENT_CHECKS)
 
 # Locale-only checks, kept out of DEFAULT_CHECKS: the Praktika job runs them only
 # when a PR touches the locale folders (top-level or snippets/<locale>/) -- they
@@ -234,9 +244,7 @@ def main(argv=None):
     # checks it can act on (see CLIENT_CHECKS): validate + internal links. The
     # aggregator-global checks -- redirects, external links, and the locale
     # checks -- are run by the aggregator's own Praktika job, not here.
-    checks = list(CLIENT_CHECKS)
-    if args.scoped:
-        checks[0] = scoped_validate_check(replace_dests)
+    checks = client_checks(args.scoped, replace_dests)
     results = [(name, run_check(docs_root, name, command))
                for name, command in checks]
 

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -74,14 +74,14 @@ DEFAULT_CHECKS = [
 ]
 
 # The subset a consuming client repo (e.g. clickhouse-connect) runs: only the
-# checks that validate the slice it owns. The snippet-import policy is not a
-# separate client check: scoped_validate_check bundles it with the scoped
-# validator, so language-client workflows get both as one validation step.
-# `mint validate` proves the docs.json fragment and frontmatter are well-formed,
-# and the internal-links check proves the client's own links and anchors resolve.
-# Redirects, external links, and locale checks are aggregator-global concerns a
-# client cannot fix.
-CLIENT_CHECKS = [VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
+# checks that validate the slice it owns. Unscoped callers retain the standalone
+# snippet-import policy check alongside `mint validate`. In scoped mode,
+# scoped_validate_check bundles the snippet policy with the scoped validator, so
+# language-client workflows get both as one validation step without running the
+# full validator. The internal-links check proves the client's own links and
+# anchors resolve. Redirects, external links, and locale checks are
+# aggregator-global concerns a client cannot fix.
+CLIENT_CHECKS = [SNIPPET_IMPORTS_CHECK, VALIDATE_CHECK, INTERNAL_LINKS_CHECK]
 
 
 # Swaps the full `mint validate` (which MDX-parses the whole site, ~13 minutes)


### PR DESCRIPTION
### Summary

Fix language-client documentation checks using `--scoped` so they run the snippet-import policy and `scoped_validate.mjs` as one validation check, without also invoking the slow full-site `mint validate`.

The regression was caused by replacing `CLIENT_CHECKS[0]`: after the snippet-import check was prepended, the scoped validator replaced that check instead of `VALIDATE_CHECK`. Check selection is now explicit and independent of list ordering.

### Validation

- Parsed `mintlify_docs_check.py` with Python's AST parser.
- Verified full and scoped client check selection.
- Verified the scoped command includes the snippet-import check and `scoped_validate.mjs`, and excludes `mint validate`.
- Ran `git diff --check`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable (CI-only change).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1183` (included in `26.7` and later)
<!-- ch-version-info:end -->