### PR TITLE
docs: fix dead install/Keeper/float links in development + ops pages

### DIFF
--- a/docs/en/development/continuous-integration.md
+++ b/docs/en/development/continuous-integration.md
@@ -39,7 +39,7 @@ Go to the check report and look for `ERROR` and `WARNING` messages.
 ## Description check {#description-check}
 
 Check that the description of your pull request conforms to the template [PULL_REQUEST_TEMPLATE.md](https://github.com/ClickHouse/ClickHouse/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
-You have to specify a changelog category for your change (e.g., Bug Fix), and write a user-readable message describing the change for [CHANGELOG.md](../whats-new/changelog/index.md)
+You have to specify a changelog category for your change (e.g., Bug Fix), and write a user-readable message describing the change for [CHANGELOG.md](https://github.com/ClickHouse/ClickHouse/blob/master/CHANGELOG.md)
 
 ## Docker image {#docker-image}
 

--- a/docs/en/development/developer-instruction.md
+++ b/docs/en/development/developer-instruction.md
@@ -151,9 +151,9 @@ newFunctionName(arg1, arg2[, arg3])
 
 **Arguments**
 
-- `arg1` — Description of the argument. [DataType](../data-types/float.md)
-- `arg2` — Description of the argument. [DataType](../data-types/float.md)
-- `arg3` — Description of optional argument (optional). [DataType](../data-types/float.md)
+- `arg1` — Description of the argument. [DataType](../sql-reference/data-types/float.md)
+- `arg2` — Description of the argument. [DataType](../sql-reference/data-types/float.md)
+- `arg3` — Description of optional argument (optional). [DataType](../sql-reference/data-types/float.md)
 
 **Implementation Details**
 
@@ -161,7 +161,7 @@ A description of implementation details if relevant.
 
 **Returned value**
 
-- Returns {insert what the function returns here}. [DataType](../data-types/float.md)
+- Returns {insert what the function returns here}. [DataType](../sql-reference/data-types/float.md)
 
 **Example**
 

--- a/docs/en/interfaces/client.md
+++ b/docs/en/interfaces/client.md
@@ -34,7 +34,7 @@ To also install it, run:
 sudo ./clickhouse install
 ```
 
-See [Install ClickHouse](../getting-started/install/install.mdx) for more installation options.
+See [Install ClickHouse](../../get-started/setup/install.mdx) for more installation options.
 
 Different client and server versions are compatible with one another, but some features may not be available in older clients. We recommend using the same version for client and server.
 

--- a/docs/en/operations/_troubleshooting.md
+++ b/docs/en/operations/_troubleshooting.md
@@ -11,13 +11,13 @@
 ### You cannot get deb packages from ClickHouse repository with apt-get {#you-cannot-get-deb-packages-from-clickhouse-repository-with-apt-get}
 
 - Check firewall settings.
-- If you cannot access the repository for any reason, download packages as described in the [install guide](../getting-started/install.md) article and install them manually using the `sudo dpkg -i <packages>` command. You will also need the `tzdata` package.
+- If you cannot access the repository for any reason, download packages as described in the [install guide](/get-started/setup/install) article and install them manually using the `sudo dpkg -i <packages>` command. You will also need the `tzdata` package.
 
 ### You cannot update deb packages from ClickHouse repository with apt-get {#you-cannot-update-deb-packages-from-clickhouse-repository-with-apt-get}
 
 - The issue may be happened when the GPG key is changed.
 
-Please use the manual from the [setup](../getting-started/install.md#setup-the-debian-repository) page to update the repository configuration.
+Please use the manual from the [setup](/get-started/setup/self-managed/debian-ubuntu) page to update the repository configuration.
 
 ### You get different warnings with `apt-get update` {#you-get-different-warnings-with-apt-get-update}
 
@@ -62,7 +62,7 @@ sudo find /var/lib/yum/repos/ /var/cache/yum/ -name 'clickhouse-*' -type d -exec
 sudo rm -f /etc/yum.repos.d/clickhouse.repo
 ```
 
-After that follow the [install guide](../getting-started/install.md#from-rpm-packages)
+After that follow the [install guide](/get-started/setup/self-managed/rpm)
 
 ### You can't run the Docker container {#you-cant-run-docker-container}
 

--- a/docs/en/operations/opentelemetry.md
+++ b/docs/en/operations/opentelemetry.md
@@ -26,7 +26,7 @@ The trace context is propagated to downstream services in the following cases:
 
 ## Tracing ClickHouse Keeper Requests {#tracing-clickhouse-keeper-requests}
 
-ClickHouse supports OpenTelemetry tracing for [ClickHouse Keeper](../guides/sre/keeper/index.md) requests (ZooKeeper-compatible coordination service). This feature provides detailed visibility into the lifecycle of Keeper operations, from client request submission through server-side processing.
+ClickHouse supports OpenTelemetry tracing for [ClickHouse Keeper](../../guides/oss/deployment-and-scaling/keeper/index.mdx) requests (ZooKeeper-compatible coordination service). This feature provides detailed visibility into the lifecycle of Keeper operations, from client request submission through server-side processing.
 
 ### Enabling Keeper Tracing {#enabling-keeper-tracing}
 

--- a/docs/en/operations/tips.md
+++ b/docs/en/operations/tips.md
@@ -156,7 +156,7 @@ Otherwise you may get `Illegal instruction` crashes when hypervisor is run on ol
 
 ## ClickHouse Keeper and ZooKeeper {#zookeeper}
 
-ClickHouse Keeper is recommended to replace ZooKeeper for ClickHouse clusters.  See the documentation for [ClickHouse Keeper](../guides/sre/keeper/index.md)
+ClickHouse Keeper is recommended to replace ZooKeeper for ClickHouse clusters.  See the documentation for [ClickHouse Keeper](../../guides/oss/deployment-and-scaling/keeper/index.mdx)
 
 If you would like to continue using ZooKeeper then it is best to use a fresh version of ZooKeeper – 3.4.9 or later. The version in stable Linux distributions may be outdated.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry
n/a

### Description
Several contributor and operations pages still pointed at pre-reorg paths that 404:

| Page | Was | Now |
|------|-----|-----|
| `docs/en/development/developer-instruction.md` | `../data-types/float.md` | `../sql-reference/data-types/float.md` |
| `docs/en/development/continuous-integration.md` | `../whats-new/changelog/index.md` | GitHub `CHANGELOG.md` on master |
| `docs/en/operations/_troubleshooting.md` | `../getting-started/install.md` (+ section anchors) | `/get-started/setup/install` and self-managed debian/rpm |
| `docs/en/operations/tips.md`, `opentelemetry.md` | `../guides/sre/keeper/index.md` | `docs/guides/oss/.../keeper` |
| `docs/en/interfaces/client.md` | `../getting-started/install/install.mdx` | `get-started/setup/install.mdx` |

Link-only; no behavior change.

### Documentation
- [x] Documentation is written / corrected

AI-assisted; human-reviewed.