### PR TITLE
Restore Parquet column pruning for Iceberg schema-evolved reads

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -1068,6 +1068,85 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
                 add_filter_inputs(stripped_prewhere_info->prewhere_actions);
         }
 
+        /// Prune the Parquet read to only the columns the query needs on the Iceberg
+        /// schema-evolution path. `getInitialSchemaByPath` above set `initial_header` to the
+        /// FULL underlying file schema, so without this the format reader decodes every
+        /// physical column of the old schema even when the query needs only one. The Iceberg
+        /// schema-transform DAG (built below) maps OLD-schema input names to NEW-schema output
+        /// names, so removing its unused actions yields exactly the old-schema columns to read.
+        ///
+        /// Only done when there are no equality-delete files: those are applied (by name, on
+        /// the old-schema block) before the schema transform runs, so their key columns must
+        /// stay in the read header even if the query does not select them. Pruning stays
+        /// robust: if any needed name is not a transform output, we keep the full schema
+        /// rather than fail, so unusual column shapes just fall back to current behavior.
+        std::optional<ActionsDAG> iceberg_pruned_transform;
+#if USE_AVRO
+        if (schema_changed)
+        {
+            const auto * iceberg_object_info = dynamic_cast<const IcebergDataObjectInfo *>(object_info.get());
+            if (iceberg_object_info && iceberg_object_info->info.equality_deletes_objects.empty())
+            {
+                if (auto transform = configuration->getSchemaTransformer(context_, object_info))
+                {
+                    /// New-schema names the pipeline needs after the transform: the query
+                    /// columns plus any column referenced only by a stripped filter/PREWHERE.
+                    /// Subcolumns (e.g. `t.x`) collapse to their storage column, since the
+                    /// transform's outputs are top-level field names.
+                    NameSet seen;
+                    Names needed_names;
+                    auto add_needed = [&](const String & needed_name)
+                    {
+                        if (seen.insert(needed_name).second)
+                            needed_names.push_back(needed_name);
+                    };
+                    for (const auto & column : read_from_format_info.requested_columns)
+                        add_needed(column.getNameInStorage());
+                    if (stripped_row_level_filter)
+                        for (const auto & required : stripped_row_level_filter->actions.getRequiredColumns())
+                            add_needed(required.name);
+                    if (stripped_prewhere_info)
+                        for (const auto & required : stripped_prewhere_info->prewhere_actions.getRequiredColumns())
+                            add_needed(required.name);
+
+                    ActionsDAG pruned = transform->clone();
+                    NameSet output_names;
+                    for (const auto * output : pruned.getOutputs())
+                        output_names.insert(output->result_name);
+
+                    bool all_present = true;
+                    for (const auto & needed_name : needed_names)
+                    {
+                        if (!output_names.contains(needed_name))
+                        {
+                            all_present = false;
+                            break;
+                        }
+                    }
+
+                    if (all_present)
+                    {
+                        pruned.removeUnusedActions(needed_names);
+
+                        /// Keep exactly the old-schema columns the pruned transform still reads,
+                        /// preserving the original header's column types/order.
+                        NameSet required_names;
+                        for (const auto & required : pruned.getRequiredColumns())
+                            required_names.insert(required.name);
+
+                        Block pruned_header;
+                        for (const auto & column : initial_header)
+                            if (required_names.contains(column.name))
+                                pruned_header.insert(column);
+
+                        initial_header = std::move(pruned_header);
+                        iceberg_pruned_transform = std::move(pruned);
+                    }
+                }
+            }
+        }
+#endif
+
         chassert(object_info->getObjectMetadata().has_value());
 
         LOG_DEBUG(
@@ -1152,9 +1231,9 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             /// inputs). For non-stripped (Parquet) reads the filter columns aren't
             /// referenced after the format reader so this is a no-op.
             ///
-            /// FIXME: This is currently not done for the below case (configuration->getSchemaTransformer())
-            /// because it is an iceberg case where transformer contains columns ids (just increasing numbers)
-            /// which do not match requested_columns (while here requested_columns were adjusted to match physical columns).
+            /// The Iceberg `getSchemaTransformer()` case below is pruned separately (see the
+            /// `iceberg_pruned_transform` branch): its transform's inputs/outputs are field
+            /// names too, so it is pruned above where `initial_header` is narrowed to match.
             Names needed_names = read_from_format_info.requested_columns.getNames();
             auto add_filter_required_names = [&needed_names](const ActionsDAG & dag)
             {
@@ -1167,11 +1246,15 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
                 add_filter_required_names(stripped_prewhere_info->prewhere_actions);
             schema_transform->removeUnusedActions(needed_names);
         }
-        if (!schema_transform)
+        else if (iceberg_pruned_transform)
         {
-            auto transform = configuration->getSchemaTransformer(context_, object_info);
-            if (transform)
-                schema_transform = transform->clone();
+            /// Iceberg schema-evolution path: reuse the transform already pruned above (where
+            /// `initial_header` was narrowed to match its required old-schema columns).
+            schema_transform = std::move(iceberg_pruned_transform);
+        }
+        else if (auto transform = configuration->getSchemaTransformer(context_, object_info))
+        {
+            schema_transform = transform->clone();
         }
 
         if (schema_transform.has_value())

--- a/tests/queries/0_stateless/04545_iceberg_schema_evolution_column_pruning_110897.reference
+++ b/tests/queries/0_stateless/04545_iceberg_schema_evolution_column_pruning_110897.reference
@@ -1,0 +1,10 @@
+sum_id	19999900000
+added_col_null	200000	200000
+wide_col	200	40000000
+filter_nonsel	199914000
+prewhere	200000
+id_read_is_pruned	1
+evolved_sum_id	19999900000
+renamed_col	200	40000000
+retyped_k	9900000	Int64
+evolved_read_is_pruned	1

--- a/tests/queries/0_stateless/04545_iceberg_schema_evolution_column_pruning_110897.sh
+++ b/tests/queries/0_stateless/04545_iceberg_schema_evolution_column_pruning_110897.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option).
+# - no-parallel: asserts on per-query ProfileEvents read from system.query_log,
+#   so it must not race other queries flushing into the shared query_log; it
+#   also compares decoded byte counts, which parallel cache/IO pressure could
+#   perturb. Unique table/database names isolate data but not those globals.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/110897 :
+# after an Iceberg table's schema evolves (e.g. ADD COLUMN), reads of data files
+# written under the old schema stopped pruning Parquet columns, so a query that
+# needs only `id` decoded every physical column of the old file (including wide
+# string columns it never referenced). This asserts pruning is restored while
+# results stay correct.
+
+TABLE="t_${CLICKHOUSE_DATABASE}_${RANDOM}"
+TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+rm -rf "${TABLE_PATH}" 2>/dev/null
+
+# id + one wide string column. min_bytes_for_wide_part is irrelevant (Iceberg
+# stores Parquet); the wide `s1` is what makes full-schema reads expensive.
+# max_insert_threads=1: a parallel insert writes one data file per thread and
+# commits each as a SEPARATE Iceberg snapshot, so a read can resolve an
+# intermediate snapshot and see a partial row set. One thread = one atomic commit.
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${TABLE} (id Int64, s1 String, k Int32) ENGINE = IcebergLocal('${TABLE_PATH}', 'Parquet')"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --max_insert_threads=1 --query \
+    "INSERT INTO ${TABLE} SELECT number, repeat('x', 200), number % 100 FROM numbers(200000)"
+
+# Schema evolution: add an unrelated nullable column. The already-written data
+# file now has a schema id different from the table's current schema id, which
+# is the trigger for the pruning-disabled path.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "ALTER TABLE ${TABLE} ADD COLUMN s2 Nullable(String)"
+
+# --- Correctness: results must be identical to a non-evolved read ------------
+# sum over id only (the reported query).
+${CLICKHOUSE_CLIENT} --query "SELECT 'sum_id', sum(id) FROM ${TABLE}"
+# The added column reads as all-NULL for the old file.
+${CLICKHOUSE_CLIENT} --query "SELECT 'added_col_null', count(), countIf(s2 IS NULL) FROM ${TABLE}"
+# The wide column is still fully readable when actually requested.
+${CLICKHOUSE_CLIENT} --query "SELECT 'wide_col', any(length(s1)), sum(length(s1)) FROM ${TABLE}"
+# Filter on a column the projection does not output (k) must still work.
+${CLICKHOUSE_CLIENT} --query "SELECT 'filter_nonsel', sum(id) FROM ${TABLE} WHERE k = 7"
+# PREWHERE on the wide column.
+${CLICKHOUSE_CLIENT} --query "SELECT 'prewhere', count() FROM ${TABLE} PREWHERE s1 = repeat('x', 200)"
+
+# --- Pruning: the fix must not read the wide column for an id-only query ------
+# Robust, randomization-proof assertion: an id-only read must decode far fewer
+# bytes than a read that genuinely needs the wide `s1` column. Before the fix
+# both decoded the full old schema, so the ratio was ~1; after the fix the
+# id-only read is an order of magnitude smaller. We require a >=3x gap, well
+# below the observed ~23x but safely above any per-run noise.
+Q_ID="qid_${CLICKHOUSE_DATABASE}_${RANDOM}"
+Q_S1="qs1_${CLICKHOUSE_DATABASE}_${RANDOM}"
+${CLICKHOUSE_CLIENT} --query "SELECT sum(id) FROM ${TABLE} SETTINGS log_comment='${Q_ID}'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SELECT sum(length(s1)) FROM ${TABLE} SETTINGS log_comment='${Q_S1}'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+
+${CLICKHOUSE_CLIENT} --query "
+SELECT 'id_read_is_pruned',
+       (SELECT ProfileEvents['SelectedBytes'] FROM system.query_log
+          WHERE log_comment = '${Q_ID}' AND type = 'QueryFinish'
+            AND current_database = currentDatabase()
+          ORDER BY event_time_microseconds DESC LIMIT 1) * 3
+       <
+       (SELECT ProfileEvents['SelectedBytes'] FROM system.query_log
+          WHERE log_comment = '${Q_S1}' AND type = 'QueryFinish'
+            AND current_database = currentDatabase()
+          ORDER BY event_time_microseconds DESC LIMIT 1)
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+rm -rf "${TABLE_PATH}" 2>/dev/null
+
+# --- Other schema-evolution shapes: rename, removal, type change -------------
+# The reported issue used ADD COLUMN; these apply the other evolutions the
+# transform DAG can produce (rename -> alias, drop -> pruned input, type change
+# -> cast) to the same old-schema data file, chained so it also covers multiple
+# evolutions. Each must keep results correct AND still prune the wide column.
+T2="t2_${CLICKHOUSE_DATABASE}_${RANDOM}"
+T2_PATH="${USER_FILES_PATH}/${T2}/"
+rm -rf "${T2_PATH}" 2>/dev/null
+
+# id + wide s1 + a to-be-dropped wide column d + an int k to be retyped.
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${T2} (id Int64, s1 String, d String, k Int32) ENGINE = IcebergLocal('${T2_PATH}', 'Parquet')"
+# max_insert_threads=1 for a single atomic snapshot (see note on the first insert).
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --async_insert=0 --max_insert_threads=1 --query \
+    "INSERT INTO ${T2} SELECT number, repeat('x', 200), repeat('y', 150), toInt32(number % 100) FROM numbers(200000)"
+
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "ALTER TABLE ${T2} RENAME COLUMN s1 TO s1_wide"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "ALTER TABLE ${T2} DROP COLUMN d"
+# int -> long is one of Iceberg's allowed primitive promotions.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query "ALTER TABLE ${T2} MODIFY COLUMN k Int64"
+
+# Correctness after all three evolutions on the old data file.
+${CLICKHOUSE_CLIENT} --query "SELECT 'evolved_sum_id', sum(id) FROM ${T2}"
+${CLICKHOUSE_CLIENT} --query "SELECT 'renamed_col', any(length(s1_wide)), sum(length(s1_wide)) FROM ${T2}"
+${CLICKHOUSE_CLIENT} --query "SELECT 'retyped_k', sum(k), any(toTypeName(k)) FROM ${T2}"
+
+# Pruning still holds on the fully-evolved schema: id-only decodes far fewer
+# bytes than reading the renamed wide column (same >=3x check as above).
+Q2_ID="q2id_${CLICKHOUSE_DATABASE}_${RANDOM}"
+Q2_W="q2w_${CLICKHOUSE_DATABASE}_${RANDOM}"
+${CLICKHOUSE_CLIENT} --query "SELECT sum(id) FROM ${T2} SETTINGS log_comment='${Q2_ID}'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SELECT sum(length(s1_wide)) FROM ${T2} SETTINGS log_comment='${Q2_W}'" > /dev/null
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+
+${CLICKHOUSE_CLIENT} --query "
+SELECT 'evolved_read_is_pruned',
+       (SELECT ProfileEvents['SelectedBytes'] FROM system.query_log
+          WHERE log_comment = '${Q2_ID}' AND type = 'QueryFinish'
+            AND current_database = currentDatabase()
+          ORDER BY event_time_microseconds DESC LIMIT 1) * 3
+       <
+       (SELECT ProfileEvents['SelectedBytes'] FROM system.query_log
+          WHERE log_comment = '${Q2_W}' AND type = 'QueryFinish'
+            AND current_database = currentDatabase()
+          ORDER BY event_time_microseconds DESC LIMIT 1)
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${T2}"
+rm -rf "${T2_PATH}" 2>/dev/null


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/110897
-->


### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Restore Parquet column pruning for Iceberg data files written under an older schema. After schema evolution (e.g. `ALTER TABLE ... ADD COLUMN`), reading an old data file decoded every physical column even when the query needed only one; now only the columns the query requires are read.


### Description

Fixes #110897. When an Iceberg table's schema evolves, `IcebergMetadata::getInitialSchemaByPath` returns the full underlying (old) file schema for data files whose schema id differs from the current one. In `StorageObjectStorageSource::createReader` this full schema became the Parquet reader's `initial_header`, so the reader decoded every physical column of the old file; the schema-transform DAG only ran afterwards. Adding one unrelated nullable column turned `SELECT sum(id)` from decoding just `id` into also decoding the table's wide string columns (reporter measured ~23x more selected bytes, ~5x peak memory).

The Iceberg schema-transform DAG maps old-schema input names to new-schema output names (by field name), so pruning its unused actions against the query's required columns yields exactly the old-schema physical columns to read. This is the same pruning the Delta path already does; here it is applied to the Iceberg `getSchemaTransformer()` path and the pruned transform is reused so the read header and the transform stay consistent.

Pruning is applied only when there are no equality-delete files: equality deletes are applied by name on the old-schema block before the schema transform runs, so their key columns must remain in the read header even if the query does not select them. When any needed column is not a transform output the full schema is kept, so unusual column shapes fall back to current behavior rather than failing.

Regression test `04545_iceberg_schema_evolution_column_pruning_110897` asserts an id-only read decodes far fewer bytes than a read that needs the wide column, and that results (including reads of the added and renamed columns, and filters on non-selected columns) stay correct.
