### PR TITLE
[CI Proof] convertMySQLDataType wraps Array/Variant-based geo types in Nullable, throwing ILLEGAL_TYPE_OF_ARGUMENT on nullable MySQL spatial columns

### DIFF
--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -1190,6 +1190,60 @@ def test_mysql_geometry(started_cluster):
     conn.close()
 
 
+def test_mysql_nullable_geometry(started_cluster):
+    # A MySQL spatial column is nullable unless declared `NOT NULL`. With the `geometry` mapping on by
+    # default, `convertMySQLDataType` wraps the `Array`/`Variant`-based geometric type in `Nullable`,
+    # which those types cannot be inside, so schema inference throws `ILLEGAL_TYPE_OF_ARGUMENT`. A
+    # correct conversion must succeed and preserve a real MySQL `NULL`.
+    table_name = "test_mysql_nullable_geometry"
+    node1.query(f"DROP TABLE IF EXISTS {table_name}")
+
+    conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
+    drop_mysql_table(conn, table_name)
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"""
+            CREATE TABLE `clickhouse`.`{table_name}` (
+            `id` int NOT NULL,
+            `ls` linestring,
+            `pg` polygon,
+            `mls` multilinestring,
+            `mpg` multipolygon,
+            `geo` geometry,
+            PRIMARY KEY (`id`)) ENGINE=InnoDB;
+        """
+        )
+        # A row whose spatial columns are all NULL (the MySQL default when a value is omitted).
+        cursor.execute(f"INSERT INTO `clickhouse`.`{table_name}` (id) VALUES (1)")
+        cursor.execute(f"SELECT count(*) FROM `clickhouse`.`{table_name}`")
+        assert cursor.fetchone()[0] == 1
+
+    conn.commit()
+
+    table_function = (
+        f"mysql('mysql80:3306', 'clickhouse', '{table_name}', 'root', '{mysql_pass}')"
+    )
+
+    # `node1.query` raises if the server throws, so a successful `DESCRIBE` is the primary assertion:
+    # on buggy master it throws `ILLEGAL_TYPE_OF_ARGUMENT`.
+    described = node1.query(f"DESCRIBE {table_function}")
+    inferred_columns = [line.split("\t")[0] for line in described.strip().split("\n")]
+    assert inferred_columns == ["id", "ls", "pg", "mls", "mpg", "geo"], described
+
+    # The stored spatial values are all NULL; a correct conversion must preserve `NULL` rather than
+    # coerce it to the default (empty) geometry. This holds for any null-preserving representation
+    # without pinning a specific type.
+    nulls = node1.query(
+        "SELECT ls IS NULL, pg IS NULL, mls IS NULL, mpg IS NULL, geo IS NULL "
+        f"FROM {table_function} WHERE id = 1"
+    ).strip()
+    assert nulls == "1\t1\t1\t1\t1", nulls
+
+    node1.query(f"DROP TABLE IF EXISTS {table_name}")
+    drop_mysql_table(conn, table_name)
+    conn.close()
+
+
 def test_joins(started_cluster):
     conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
     drop_mysql_table(conn, "test_joins_mysql_users")


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (requires CI cluster topology or too many iterations to reproduce locally). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** convertMySQLDataType wraps Array/Variant-based geo types in Nullable, throwing ILLEGAL_TYPE_OF_ARGUMENT on nullable MySQL spatial columns

**Root cause:** src/DataTypes/convertMySQLDataType.cpp:171-172 applies `std::make_shared<DataTypeNullable>(res)` to `res` regardless of whether `res` can be inside Nullable. Before this PR the non-Point spatial types produced `String` (canBeInsideNullable=true), so `Nullable(String)` was valid; the new geo types (`Array`/`Variant` based) cannot be inside `Nullable`.

**Affected locations:**
- `src/DataTypes/convertMySQLDataType.cpp:172` — unconditional Nullable wrap of a geo-typed res
- `src/DataTypes/convertMySQLDataType.cpp:143` — linestring -> LineString (Array(Point)) branch; same for polygon/multilinestring/multipolygon/geometry at 147/151/155/163
- `src/Databases/MySQL/FetchTablesColumnsList.cpp:119` — passes is_nullable=true for nullable MySQL columns when external_table_functions_use_nulls (default true)

**Why CI is needed:** By default (geometry mapping on), any MySQL integration over a table with a nullable spatial column becomes unusable - schema inference throws and the table cannot be created/described/read. This is a regression: those columns previously mapped to `Nullable(String)` and worked. Affects the `mysql()` table function, `MySQL` table engine, and `MySQL` database engine.

**Suggested fix:** When the mapped type cannot be inside Nullable (e.g. `!res->canBeInsideNullable()`), either skip the Nullable wrap for geo types (geo columns are inherently non-Nullable in ClickHouse) or fall back to `Nullable(String)` for nullable spatial columns.

## Assumptions
The bot recorded these claims it could not verify directly from source. A maintainer ✅ confirms; ❌ flags a wrong premise (the bot should rework or close the finding).

- [ ] **A plain MySQL spatial column (declared without NOT NULL) is reported as IS_NULLABLE='YES' in information_schema.columns**
  - *Why unverifiable:* the test harness could not connect to the MySQL container in this sandbox
  - *Falsifiable test:* CREATE TABLE t (g LINESTRING) in MySQL, then read information_schema.columns.IS_NULLABLE for column g (expected 'YES'); then DESCRIBE mysql(...) from ClickHouse (expected exception).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
