### PR TITLE
Fix RENAME TABLE of a Distributed table with a non-empty async-insert queue

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -2028,9 +2028,44 @@ void StorageDistributed::flushClusterNodesAllDataImpl(ContextPtr local_context, 
     }
 }
 
+void StorageDistributed::checkTableCanBeRenamed(const StorageID & new_name) const
+{
+    /// Nothing on disk to move (a `remote()`/`cluster()` table function).
+    if (relative_data_path.empty())
+        return;
+
+    /// `ATTACH ... FROM` calls rename() with an unchanged StorageID only to move the data into
+    /// place, before the table is reachable. That is not a rename of a live table.
+    if (getStorageID() == new_name)
+        return;
+
+    /// An Atomic database keys the data directory by UUID and never moves it, so only a UUID-less
+    /// (Ordinary) endpoint reaches renameOnDisk below.
+    if (getStorageID().hasUUID() && new_name.hasUUID())
+        return;
+
+    /// The Ordinary-to-Atomic conversion assigns a UUID to each table and runs during startup.
+    /// Requiring the acquired UUID keeps a startup script renaming within Ordinary out of the
+    /// exemption, since startup scripts also run before the server is completely started.
+    const bool converting_ordinary_to_atomic = !getStorageID().hasUUID() && new_name.hasUUID();
+    if (converting_ordinary_to_atomic
+        && getContext()->getApplicationType() == Context::ApplicationType::SERVER
+        && !getContext()->isServerCompletelyStarted())
+        return;
+
+    throw Exception(
+        ErrorCodes::NOT_IMPLEMENTED,
+        "Cannot rename Distributed table {} because its asynchronous insert queue directory would have to be moved, "
+        "which cannot be done while inserts and sends are running. Use an Atomic database, where the data directory "
+        "is keyed by UUID and is not moved. An existing Ordinary database can be converted by creating the "
+        "'convert_ordinary_to_atomic' file in the flags directory and restarting the server",
+        getStorageID().getNameForLogs());
+}
+
 void StorageDistributed::rename(const String & new_path_to_table_data, const StorageID & new_table_id)
 {
     chassert(relative_data_path != new_path_to_table_data);
+    checkTableCanBeRenamed(new_table_id);
     if (!relative_data_path.empty())
         renameOnDisk(new_path_to_table_data);
     renameInMemory(new_table_id);

--- a/src/Storages/StorageDistributed.h
+++ b/src/Storages/StorageDistributed.h
@@ -114,6 +114,8 @@ public:
 
     void rename(const String & new_path_to_table_data, const StorageID & new_table_id) override;
 
+    void checkTableCanBeRenamed(const StorageID & new_name) const override;
+
     void checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const override;
 
     /// in the sub-tables, you need to manually add and delete columns

--- a/tests/integration/test_distributed_storage_configuration/test.py
+++ b/tests/integration/test_distributed_storage_configuration/test.py
@@ -20,24 +20,38 @@ def start_cluster():
     try:
         cluster.start()
         node.query("DROP DATABASE IF EXISTS test")
-        node.query(
-            "CREATE DATABASE test ENGINE=Ordinary",
-            settings={"allow_deprecated_database_ordinary": 1},
-        )  # Different paths with Atomic
+        node.query("CREATE DATABASE test")
         yield cluster
     finally:
         cluster.shutdown()
 
 
+def _dist_mon_dir(node, root, table):
+    """Per-shard queue directory of `table` on `root`, taken from the server's own path.
+
+    An Atomic database keys the data directory by UUID, so it cannot be spelled out here.
+    """
+    for path in node.query(
+        "SELECT arrayJoin(data_paths) FROM system.tables "
+        "WHERE database = 'test' AND name = '{table}'".format(table=table)
+    ).splitlines():
+        if path.startswith("/{root}/".format(root=root)):
+            return path.rstrip("/") + "/default@127%2E0%2E0%2E2:9000"
+    return None
+
+
 def _files_in_dist_mon(node, root, table):
+    directory = _dist_mon_dir(node, root, table)
+    if directory is None:
+        return 0
     return int(
         node.exec_in_container(
             [
                 "bash",
                 "-c",
                 # `-maxdepth 1` to avoid /tmp/ subdirectory
-                "find /{root}/data/test/{table}/default@127%2E0%2E0%2E2:9000 -maxdepth 1 -type f 2>/dev/null | wc -l".format(
-                    root=root, table=table
+                "find '{directory}' -maxdepth 1 -type f 2>/dev/null | wc -l".format(
+                    directory=directory
                 ),
             ]
         ).split("\n")[0]
@@ -96,8 +110,15 @@ def test_insert(start_cluster):
     #
     # DROP
     #
-    node.query("DROP TABLE test.dist2_foo")
-    for disk in ["test_dist_conf_disk1", "test_dist_conf_disk2"]:
-        node.exec_in_container(
-            ["bash", "-c", "test ! -e /{}/data/test/dist2_foo".format(disk)]
-        )
+    # Resolve the directories while the table still exists, otherwise the check below asserts
+    # nothing.
+    data_paths = node.query(
+        "SELECT arrayJoin(data_paths) FROM system.tables "
+        "WHERE database = 'test' AND name = 'dist2_foo'"
+    ).splitlines()
+    assert len(data_paths) == 2, data_paths
+
+    # SYNC: an Atomic database removes the data directory in the background otherwise.
+    node.query("DROP TABLE test.dist2_foo SYNC")
+    for path in data_paths:
+        node.exec_in_container(["bash", "-c", "test ! -e '{}'".format(path)])

--- a/tests/queries/0_stateless/01155_rename_move_materialized_view.sql
+++ b/tests/queries/0_stateless/01155_rename_move_materialized_view.sql
@@ -43,7 +43,11 @@ RENAME TABLE test_01155_ordinary.mv2 TO test_01155_atomic.mv2;
 RENAME TABLE test_01155_ordinary.dst TO test_01155_atomic.dst;
 RENAME TABLE test_01155_ordinary.src TO test_01155_atomic.src;
 SET check_table_dependencies=0; -- Otherwise we'll get error "test_01155_ordinary.dict depends on test_01155_ordinary.dist" in the next line.
-RENAME TABLE test_01155_ordinary.dist TO test_01155_atomic.dist;
+-- A Distributed table cannot be moved out of an Ordinary database by hand, because its
+-- async-insert queue directory would have to move under concurrent inserts and sends. It holds no
+-- data of its own once flushed, so recreate it in the destination instead.
+DROP TABLE test_01155_ordinary.dist;
+CREATE TABLE test_01155_atomic.dist (s String, x String DEFAULT 'asdf') ENGINE=Distributed(test_shard_localhost, test_01155_ordinary, src);
 SET check_table_dependencies=1;
 RENAME DICTIONARY test_01155_ordinary.dict TO test_01155_atomic.dict;
 SELECT 'ordinary after rename:';
@@ -83,7 +87,9 @@ RENAME TABLE test_01155_atomic.mv1 TO test_01155_ordinary.mv1;
 RENAME TABLE test_01155_atomic.mv2 TO test_01155_ordinary.mv2;
 RENAME TABLE test_01155_atomic.dst TO test_01155_ordinary.dst;
 RENAME TABLE test_01155_atomic.src TO test_01155_ordinary.src;
-RENAME TABLE test_01155_atomic.dist TO test_01155_ordinary.dist;
+-- Recreated rather than renamed, for the same reason as above.
+DROP TABLE test_01155_atomic.dist;
+CREATE TABLE test_01155_ordinary.dist (s String, x String DEFAULT 'asdf') ENGINE=Distributed(test_shard_localhost, test_01155_ordinary, src);
 RENAME DICTIONARY test_01155_atomic.dict TO test_01155_ordinary.dict;
 
 INSERT INTO dist(s) VALUES ('after renaming tables');

--- a/tests/queries/0_stateless/04801_distributed_rename_ordinary_refused.reference
+++ b/tests/queries/0_stateless/04801_distributed_rename_ordinary_refused.reference
@@ -1,0 +1,10 @@
+ordinary rename refused
+ordinary to atomic refused
+atomic to ordinary refused
+atomic rename allowed
+dist2
+local
+no data path is not refused
+dist
+local
+no_path2

--- a/tests/queries/0_stateless/04801_distributed_rename_ordinary_refused.sql
+++ b/tests/queries/0_stateless/04801_distributed_rename_ordinary_refused.sql
@@ -1,0 +1,42 @@
+SET send_logs_level = 'fatal';
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier};
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier};
+
+SET allow_deprecated_database_ordinary = 1;
+-- Creation of a database with Ordinary engine emits a warning.
+CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier} ENGINE = Ordinary;
+SET allow_deprecated_database_ordinary = 0;
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier} ENGINE = Atomic;
+
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.local (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.dist (x UInt32)
+    ENGINE = Distributed(test_shard_localhost, {CLICKHOUSE_DATABASE:String}, local);
+
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.local (x UInt32) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE {CLICKHOUSE_DATABASE_1:Identifier}.dist (x UInt32)
+    ENGINE = Distributed(test_shard_localhost, {CLICKHOUSE_DATABASE_1:String}, local);
+
+SELECT 'ordinary rename refused';
+RENAME TABLE {CLICKHOUSE_DATABASE:Identifier}.dist TO {CLICKHOUSE_DATABASE:Identifier}.dist2; -- { serverError NOT_IMPLEMENTED }
+
+SELECT 'ordinary to atomic refused';
+RENAME TABLE {CLICKHOUSE_DATABASE:Identifier}.dist TO {CLICKHOUSE_DATABASE_1:Identifier}.dist_moved; -- { serverError NOT_IMPLEMENTED }
+
+SELECT 'atomic to ordinary refused';
+RENAME TABLE {CLICKHOUSE_DATABASE_1:Identifier}.dist TO {CLICKHOUSE_DATABASE:Identifier}.dist_moved; -- { serverError NOT_IMPLEMENTED }
+
+-- An Atomic database keys the data directory by UUID, so nothing moves and the rename is allowed.
+SELECT 'atomic rename allowed';
+RENAME TABLE {CLICKHOUSE_DATABASE_1:Identifier}.dist TO {CLICKHOUSE_DATABASE_1:Identifier}.dist2;
+SELECT name FROM system.tables WHERE database = concat(currentDatabase(), '_1') ORDER BY name;
+
+-- The refusal is about the queue directory, not about Distributed tables in general: a table
+-- function target has no data path.
+SELECT 'no data path is not refused';
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.no_path AS remote('127.0.0.1', system.one);
+RENAME TABLE {CLICKHOUSE_DATABASE:Identifier}.no_path TO {CLICKHOUSE_DATABASE:Identifier}.no_path2;
+SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
+
+DROP DATABASE {CLICKHOUSE_DATABASE:Identifier};
+DROP DATABASE {CLICKHOUSE_DATABASE_1:Identifier};


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/92124

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`RENAME TABLE` of a `Distributed` table is now refused when it would have to move the table's asynchronous insert queue directory, which only happens in the deprecated `Ordinary` database engine. Previously the rename appeared to succeed while a file that was still queued kept being addressed by its pre-rename path, so its rows were never delivered: with `background_insert_batch = 0` `SYSTEM FLUSH DISTRIBUTED` failed with `Cannot open file ... errno: 2`, and with `background_insert_batch = 1` it reported success while delivering nothing. An `Atomic` database keys the data directory by UUID and never moves it, so renames there are unaffected.

### Description

A `Distributed` table keeps one async-insert queue directory per shard under its data path. In an `Ordinary` database `RENAME TABLE` moves that path, and nothing serialises the move against concurrent work: `DistributedSink` resolves a queue directory, links the block into it and enqueues it without holding the mutex the move takes, and `SYSTEM FLUSH DISTRIBUTED` copies the queue pointers under that mutex but runs the sends after releasing it. `pause()` does not help either, since it only deactivates the scheduled task while the flush runs on a foreground pool.

Rather than synchronise the move, this removes the case: `DatabaseAtomic::renameTable` never calls `IStorage::rename` at all (it moves the metadata file and calls `renameInMemory`, and the data directory is `store/<uuid>`), and `DatabaseOnDisk` is the only caller of it. So the defect is confined to `Ordinary`, which is deprecated behind `allow_deprecated_database_ordinary`, and refusing the rename there means no queue repointing, no task pause, and no filesystem work under a mutex.

The refusal is skipped in three cases: no data path (a `remote()` target), `ATTACH ... FROM` (which calls `rename()` with an unchanged `StorageID` only to move data into place before the table is reachable), and the `Ordinary`-to-`Atomic` conversion, which assigns a UUID to every table during startup. That last one requires the acquired UUID, matching `StorageReplicatedMergeTree::checkTableCanBeRenamed`, since startup scripts also run before the server is completely started. Verified live: converting a database holding a `Distributed` table with a queued file succeeds and delivers that row.

`01155_rename_move_materialized_view` moved such a table between the two engines by hand and now recreates it, which is what a user has to do. `test_distributed_storage_configuration` used `Ordinary` for a predictable data path and now reads the path from `system.tables`, keeping its `RENAME` coverage on `Atomic`.
