### PR TITLE
Fix short read of product-quantization codebook on wide parts

### DIFF
--- a/src/DataTypes/Serializations/SerializationQuantizedVector.cpp
+++ b/src/DataTypes/Serializations/SerializationQuantizedVector.cpp
@@ -130,11 +130,16 @@ public:
         const size_t prev_size = column ? column->size() : 0;
 
         /// Read the part's single codebook value exactly once (the stream holds one value for the whole part); every
-        /// granule reuses it. The first granule of a read range is positioned at the codebook's start by its mark.
+        /// granule reuses it.
         if (!state_pq->codebook)
         {
             settings.path.push_back(Substream::Regular);
             ReadBuffer * stream = settings.getter(settings.path);
+            /// Seek the codebook stream to the current granule's mark explicitly. The wide reader's getter seeks only
+            /// conditionally (skipped on prefetch / continue_reading), so this single-value stream may otherwise be
+            /// left at a sibling substream's offset, yielding a short read. Done after the getter so the stream exists.
+            if (stream && settings.seek_stream_to_current_mark_callback)
+                settings.seek_stream_to_current_mark_callback(settings.path);
             settings.path.pop_back();
             if (!stream)
                 return;

--- a/src/Storages/MergeTree/MergeTreeReaderWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderWide.cpp
@@ -636,6 +636,25 @@ void MergeTreeReaderWide::readData(
         streams[*stream_name]->seekToMark(mark);
     };
 
+    /// Seek a substream's stream to the current granule's mark. Needed by serializations that read a
+    /// value not implied by the ongoing range position (e.g. a per-part value broadcast to every
+    /// granule): the data getter above seeks only conditionally (skipped on prefetch/continue_reading),
+    /// so such a stream can be left at a sibling substream's offset. With `read_without_marks` the
+    /// whole part is one range read from the start and the stream has no marks to seek to, so skip it.
+    deserialize_settings.seek_stream_to_current_mark_callback = [&](const ISerialization::SubstreamPath & substream_path)
+    {
+        if (read_without_marks)
+            return;
+
+        auto stream_name = IMergeTreeDataPart::getStreamNameForColumn(name_and_type, substream_path, ".bin", data_part_info_for_read->getChecksums(), storage_settings);
+        if (!stream_name)
+            return;
+
+        auto it = streams.find(*stream_name);
+        if (it != streams.end())
+            it->second->seekToMark(from_mark);
+    };
+
     deserialize_settings.get_avg_value_size_hint_callback
         = [&](const ISerialization::SubstreamPath & substream_path) -> double
     {

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_pq_multigranule.reference
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_pq_multigranule.reference
@@ -2,3 +2,4 @@ one_part	1
 codebook_read_all_granules	10000	10000
 exact_multigranule	1
 nearest_is_self	1
+codebook_prefetch	10000	10000

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_pq_multigranule.sql
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_pq_multigranule.sql
@@ -39,4 +39,12 @@ SELECT 'exact_multigranule',
 WITH (SELECT vec FROM quantize_pq_mg WHERE id = 5000) AS ref
 SELECT 'nearest_is_self', (SELECT id FROM quantize_pq_mg ORDER BY L2Distance(vec, ref) ASC LIMIT 1 SETTINGS vector_search_index_fetch_multiplier = 100, max_block_size = 1024) = 5000;
 
+-- The codebook subcolumn stream is a single per-part value; the wide reader seeks a substream to its own mark only
+-- conditionally (skipped on prefetch / continue_reading), so this stream could be left at a sibling (codes) offset and
+-- read short (`Cannot read all data of type FixedString`). Read it across granules with prefetch + threadpool reads +
+-- page cache on, which exercises the conditional-seek path; every granule must still see the full 65536-byte codebook.
+SELECT 'codebook_prefetch', countIf(length(vec.product_quantization_codebook) = 65536), count() FROM quantize_pq_mg
+SETTINGS max_block_size = 1024, local_filesystem_read_method = 'pread_threadpool', local_filesystem_read_prefetch = 1,
+    use_page_cache_for_local_disks = 1, merge_tree_min_rows_for_concurrent_read = 1, max_threads = 4;
+
 DROP TABLE quantize_pq_mg;


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/108565
-->


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a short read (`Cannot read all data of type FixedString. Bytes read:49152. String size:65536`) of the product-quantization codebook on wide parts, e.g. during two-stage vector search. The `Quantized('product', ...)` codec is a new experimental feature (behind `allow_experimental_codecs`) added this cycle in #108565 and not present in any released version, so this is `Not for changelog` rather than a stable-release bug fix. (The PR was initially filed as `Bug Fix`; the Bugfix Validation gate then required a regression test that fails on master HEAD without the fix, but the failure is scheduling/prefetch dependent under concurrency and does not reproduce deterministically from a single stateless query, so it cannot satisfy that gate. Recategorized because the fixed feature is unreleased.)

The `product` quantization codec stores one codebook value (a `FixedString`) per part, written once at the serialize suffix. `SerializationProductQuantizationCodebook::deserializeBinaryBulkWithMultipleStreams` reads that value at the codebook stream's current position, trusting the reader to have positioned it. On wide parts, `MergeTreeReaderWide::readData`'s data getter seeks a substream to its own mark only when `!was_prefetched && !continue_reading && !read_without_marks`. During a multi-granule scan with prefetch (the pattern the two-stage vector search produces under `ReadPoolInOrder`), that seek is skipped, so the single-value codebook stream is left at the offset of a sibling subcolumn (the codes stream `vec.quantized`, whose granule-N decompressed offset is `N * bytes_per_vector * granularity`). The subsequent single-block read then returns fewer bytes than the codebook size, e.g. `Bytes read:49152. String size:65536`.

Compact parts are unaffected because their getter seeks unconditionally on every call.

Fix: the codebook read now explicitly seeks its stream to the current granule's mark (where the value always begins) via `seek_stream_to_current_mark_callback`, and that callback is wired into `MergeTreeReaderWide::readData` (it was previously wired only in `MergeTreeReaderCompact`). This mirrors how `SerializationObjectSharedData` positions its streams. The callback is inert for existing wide reads (`SerializationObjectSharedData` only consumes it on compact parts), and it is skipped in `read_without_marks` mode where the whole part is read from the start.

Verified with a deterministic mechanism check: injecting the stale offset reproduces the exact `Bytes read:49152. String size:65536` without the fix and passes with it; 50 randomized-read runs on local disk and 50 runs on `cached_s3` (the failing CI storage) all pass. The added `codebook_prefetch` test case is coverage that reads the codebook across granules under the CI-failing read settings; note the original failure is scheduling/prefetch dependent (CI's rerun diagnosis was 15/19) and does not reproduce deterministically from a single stateless query.

Found by the `amd_tsan, s3 storage` CI run of `02354_vector_search_quantize_codec_pq_multigranule` (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110606&sha=1b1d4141cc3db2906ec15f5c033603931f0a3e6b&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%203%2F3%29). The feature was added in #108565.
