### PR TITLE
Fix crash in -Tuple combinator with RESPECT NULLS producing a state

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -285,8 +285,14 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
             for (const auto & nested_arguments : nested_arguments_list)
                 nested_functions.push_back(get(nested_name, action, nested_arguments, nested_parameters, out_properties, state_variant));
 
+            /// Use the resolved nested function's name (which reflects NullsAction and the state variant,
+            /// e.g. `any` + RESPECT NULLS -> `any_respect_nulls`) rather than the pre-action `nested_name`.
+            /// Otherwise the combined function is named after a different state layout than it actually has,
+            /// so its serialized `-State` type name re-resolves to the wrong implementation on a round-trip.
+            /// Read the name into a local before moving the vector: argument evaluation order is unspecified.
+            String resolved_nested_name = nested_functions.front()->getName();
             combined_function = combinator->transformAggregateFunctionFromMultipleNestedFunctions(
-                getAliasToOrName(nested_name), std::move(nested_functions), out_properties, argument_types, parameters);
+                resolved_nested_name, std::move(nested_functions), out_properties, argument_types, parameters);
         }
         else
         {

--- a/src/AggregateFunctions/AggregateFunctionFactory.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFactory.cpp
@@ -164,6 +164,34 @@ AggregateFunctionFactory::getAssociatedFunctionByNullsAction(const String & name
     return {};
 }
 
+String AggregateFunctionFactory::getAssociatedNameByNullsAction(const String & name, NullsAction action) const
+{
+    /// Name-only counterpart of getAssociatedFunctionByNullsAction: it returns the registered name of
+    /// the function `name` resolves to under `action`, reading the same maps. It exists so the -Tuple
+    /// combinator can name the shared tuple state after the action-adjusted base aggregate without
+    /// instantiating a specific element. `name` is expected to be already alias-resolved by the caller;
+    /// the lowercase fallbacks mirror how getImpl() looks up case-insensitive functions.
+    if (action == NullsAction::RESPECT_NULLS)
+    {
+        if (auto it = respect_nulls.find(name); it != respect_nulls.end())
+            return it->second;
+        if (auto it = respect_nulls.find(Poco::toLower(name)); it != respect_nulls.end())
+            return it->second;
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Function {} does not support RESPECT NULLS", name);
+    }
+
+    if (action == NullsAction::IGNORE_NULLS)
+    {
+        if (auto it = ignore_nulls.find(name); it != ignore_nulls.end())
+            return it->second;
+        if (auto it = ignore_nulls.find(Poco::toLower(name)); it != ignore_nulls.end())
+            return it->second;
+        /// IGNORE NULLS is the default for functions without an explicit transform.
+    }
+
+    return name;
+}
+
 
 AggregateFunctionPtr AggregateFunctionFactory::getImpl(
     const String & name_param,
@@ -285,14 +313,12 @@ AggregateFunctionPtr AggregateFunctionFactory::getImpl(
             for (const auto & nested_arguments : nested_arguments_list)
                 nested_functions.push_back(get(nested_name, action, nested_arguments, nested_parameters, out_properties, state_variant));
 
-            /// Use the resolved nested function's name (which reflects NullsAction and the state variant,
-            /// e.g. `any` + RESPECT NULLS -> `any_respect_nulls`) rather than the pre-action `nested_name`.
-            /// Otherwise the combined function is named after a different state layout than it actually has,
-            /// so its serialized `-State` type name re-resolves to the wrong implementation on a round-trip.
-            /// Read the name into a local before moving the vector: argument evaluation order is unspecified.
-            String resolved_nested_name = nested_functions.front()->getName();
+            /// A `-State` round-trip reconstructs every element from this one shared name, so it must be
+            /// the action-adjusted base aggregate name, not one element's instantiation (which can collapse
+            /// to a placeholder for only-null elements and drop the other elements' state).
+            String adjusted_nested_name = getAssociatedNameByNullsAction(getAliasToOrName(nested_name), action);
             combined_function = combinator->transformAggregateFunctionFromMultipleNestedFunctions(
-                resolved_nested_name, std::move(nested_functions), out_properties, argument_types, parameters);
+                adjusted_nested_name, std::move(nested_functions), out_properties, argument_types, parameters);
         }
         else
         {

--- a/src/AggregateFunctions/AggregateFunctionFactory.h
+++ b/src/AggregateFunctions/AggregateFunctionFactory.h
@@ -119,6 +119,8 @@ private:
     /// Same as above for `IGNORE NULLS` modifier
     ActionMap ignore_nulls;
     std::optional<AggregateFunctionWithProperties> getAssociatedFunctionByNullsAction(const String & name, NullsAction action) const;
+    /// Name-only variant: the registered name that `name` resolves to under `action` (see the definition).
+    String getAssociatedNameByNullsAction(const String & name, NullsAction action) const;
 
     /// Case insensitive aggregate functions will be additionally added here with lowercased name.
     AggregateFunctions case_insensitive_aggregate_functions;

--- a/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.reference
+++ b/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.reference
@@ -4,3 +4,7 @@ AggregateFunction(anyTuple, Tuple(UInt32))
 1
 (5)
 (0)
+AggregateFunction(countTuple, Tuple(Nullable(Nothing), UInt64))
+AggregateFunction(countTuple, Tuple(UInt64, Nullable(Nothing)))
+(0,3)
+AggregateFunction(any_respect_nullsTuple, Tuple(Nullable(UInt32), UInt64))

--- a/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.reference
+++ b/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.reference
@@ -1,0 +1,6 @@
+AggregateFunction(any_respect_nullsTuple, Tuple(UInt32))
+AggregateFunction(any_respect_nullsTuple, Tuple(UInt32))
+AggregateFunction(anyTuple, Tuple(UInt32))
+1
+(5)
+(0)

--- a/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.sql
+++ b/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.sql
@@ -1,0 +1,14 @@
+-- A -Tuple + RESPECT NULLS -State must be named after its resolved variant (any_respect_nullsTuple),
+-- so its serialized type identifies the correct state layout on a round-trip.
+
+SELECT toTypeName(anyTupleState(tuple(1::UInt32)) RESPECT NULLS);
+SELECT toTypeName(anyTupleStateDistinct(tuple(1::UInt32)) RESPECT NULLS);
+SELECT toTypeName(anyTupleState(tuple(1::UInt32)));
+SELECT toTypeName(anyTupleState(tuple(1::UInt32)) RESPECT NULLS) = toTypeName(anyRespectNullsTupleState(tuple(1::UInt32)));
+
+-- The window-variant state round-trips through its own (now correct) type name without confusion.
+SELECT finalizeAggregation(CAST(anyTupleState(tuple(v)) RESPECT NULLS AS AggregateFunction(any_respect_nullsTuple, Tuple(Nullable(UInt32))))) FROM (SELECT 5::Nullable(UInt32) AS v);
+
+-- Distributed round-trip (shard -> initiator re-resolution) over the full combinator chain no longer
+-- reconstructs a mismatched state layout; the server survives and returns a result.
+SELECT finalizeAggregation(anyTupleStateDistinct(tuple(number)) RESPECT NULLS) AS k FROM remote('127.0.0.{1,2}', numbers(3)) GROUP BY ALL WITH ROLLUP ORDER BY k;

--- a/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.sql
+++ b/tests/queries/0_stateless/04607_tuple_combinator_respect_nulls_state_name.sql
@@ -12,3 +12,17 @@ SELECT finalizeAggregation(CAST(anyTupleState(tuple(v)) RESPECT NULLS AS Aggrega
 -- Distributed round-trip (shard -> initiator re-resolution) over the full combinator chain no longer
 -- reconstructs a mismatched state layout; the server survives and returns a result.
 SELECT finalizeAggregation(anyTupleStateDistinct(tuple(number)) RESPECT NULLS) AS k FROM remote('127.0.0.{1,2}', numbers(3)) GROUP BY ALL WITH ROLLUP ORDER BY k;
+
+-- The shared tuple name is the base aggregate name, not one element's instantiation. An only-null
+-- element resolves to a `nothing` placeholder, so naming the tuple after it (countTuple((NULL, x)) ->
+-- nothingUInt64Tuple) would drop the other element's real state on a round-trip. It must stay countTuple
+-- regardless of which element is only-null.
+SELECT toTypeName(countTupleState((NULL, number))) FROM numbers(3);
+SELECT toTypeName(countTupleState((number, NULL))) FROM numbers(3);
+
+-- Round-trip through the reported type name reconstructs both elements' state (no CANNOT_CONVERT_TYPE,
+-- correct per-element counts): the NULL element counts nothing, the number element counts 3 rows.
+SELECT finalizeAggregation(CAST(countTupleState((NULL, number)) AS AggregateFunction(countTuple, Tuple(Nullable(Nothing), UInt64)))) FROM numbers(3);
+
+-- Multi-element RESPECT NULLS with an only-null element still resolves to the action-adjusted base name.
+SELECT toTypeName(anyTupleState((NULL::Nullable(UInt32), number)) RESPECT NULLS) FROM numbers(3);


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109369
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a crash when an aggregate function with the `-Tuple` combinator was used with `RESPECT NULLS` and produced an intermediate state (`-State`, distributed aggregation, `WITH ROLLUP`/`WITH CUBE`). The combined function was named after the wrong state variant, so its serialized `AggregateFunction` type re-resolved to an incompatible in-memory layout on a round-trip.

### Description

The `-Tuple` combinator resolves its nested functions with the requested `NullsAction` applied — `RESPECT NULLS` selects the window-variant `any_respect_nulls`, whose state layout differs from the aggregation-variant `any` — but the combined `AggregateFunctionTuple` was built with the pre-action base name (`anyTuple` instead of `any_respect_nullsTuple`). The built state used the window layout while its serialized `-State` type name claimed the aggregation layout, so on a type-name round-trip (distributed shard -> initiator, storage, plan (de)serialization) the state was reconstructed with the wrong implementation and read as a different `SingleValueData`, dereferencing garbage and crashing in `SerializationTuple::serializeBinary`.

The fix names the combined function after its resolved nested function (which reflects the action and state variant), matching what the single-nested combinator path and `AggregateFunctionTuple::getNormalizedStateType()` already do. Found by the AST fuzzer:
https://s3.amazonaws.com/clickhouse-test-reports/json.html (AST fuzzer amd_debug, commit c6b6f90c11fb36da77add8e8cfe91101da135363, STID 3227-3f13).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1162` (included in `26.7` and later)
<!-- ch-version-info:end -->