### PR TITLE
Add evaluateConstantExpressionAsColumn to avoid Field materialization

### DIFF
--- a/src/Interpreters/evaluateConstantExpression.cpp
+++ b/src/Interpreters/evaluateConstantExpression.cpp
@@ -64,7 +64,7 @@ namespace ErrorCodes
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
-static EvaluateConstantExpressionResult getFieldAndDataTypeFromLiteral(ASTLiteral * literal)
+static EvaluateConstantExpressionColumnResult getColumnAndDataTypeFromLiteral(ASTLiteral * literal)
 {
     auto type = applyVisitor(FieldToDataType(), literal->value);
     /// In case of Array field nested fields can have different types.
@@ -72,13 +72,13 @@ static EvaluateConstantExpressionResult getFieldAndDataTypeFromLiteral(ASTLitera
     /// when result type is Array(Float64).
     /// So, we need to convert this field to the result type.
     Field res = convertFieldToType(literal->value, *type);
-    return {res, type};
+    return {type->createColumnConst(1, res), type};
 }
 
-static std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressionImpl(const ASTPtr & node, const ContextPtr & context, bool no_throw)
+static std::optional<EvaluateConstantExpressionColumnResult> evaluateConstantExpressionAsColumnImpl(const ASTPtr & node, const ContextPtr & context, bool no_throw)
 {
     if (ASTLiteral * literal = node->as<ASTLiteral>())
-        return getFieldAndDataTypeFromLiteral(literal);
+        return getColumnAndDataTypeFromLiteral(literal);
 
     NamesAndTypesList source_columns = {{ "_dummy", std::make_shared<DataTypeUInt8>() }};
 
@@ -165,7 +165,7 @@ static std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressio
         /// AST potentially could be transformed to literal during TreeRewriter analyze.
         /// For example if we have SQL user defined function that return literal AS subquery.
         if (ASTLiteral * literal = ast->as<ASTLiteral>())
-            return getFieldAndDataTypeFromLiteral(literal);
+            return getColumnAndDataTypeFromLiteral(literal);
 
         auto actions = ExpressionAnalyzer(ast, syntax_result, context).getConstActionsDAG();
 
@@ -202,17 +202,41 @@ static std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressio
                         "Element of set in IN, VALUES, or LIMIT, or aggregate function parameter, or a table function argument "
                         "is not a constant expression (result column is not const): {}", result_name);
 
-    return std::make_pair((*result_column)[0], result_type);
+    /// Keep the value as a size-1 const column: this preserves the exact SQL type (no `Field`
+    /// `NearestFieldType` collapse) and lets callers read it without materializing a `Field`.
+    return std::make_pair(result_column, result_type);
+}
+
+/// Materialize the column result into the legacy `Field` result. Used by the `Field`-returning
+/// entry points below, which remain for callers not yet migrated to the column API.
+static std::optional<EvaluateConstantExpressionResult> materializeToField(std::optional<EvaluateConstantExpressionColumnResult> column_result)
+{
+    if (!column_result)
+        return {};
+    return std::make_pair((*column_result->first)[0], std::move(column_result->second));
+}
+
+std::optional<EvaluateConstantExpressionColumnResult> tryEvaluateConstantExpressionAsColumn(const ASTPtr & node, const ContextPtr & context)
+{
+    return evaluateConstantExpressionAsColumnImpl(node, context, true);
+}
+
+EvaluateConstantExpressionColumnResult evaluateConstantExpressionAsColumn(const ASTPtr & node, const ContextPtr & context)
+{
+    auto res = evaluateConstantExpressionAsColumnImpl(node, context, false);
+    if (!res)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "evaluateConstantExpression expected to return a result or throw an exception");
+    return *res;
 }
 
 std::optional<EvaluateConstantExpressionResult> tryEvaluateConstantExpression(const ASTPtr & node, const ContextPtr & context)
 {
-    return evaluateConstantExpressionImpl(node, context, true);
+    return materializeToField(evaluateConstantExpressionAsColumnImpl(node, context, true));
 }
 
 EvaluateConstantExpressionResult evaluateConstantExpression(const ASTPtr & node, const ContextPtr & context)
 {
-    auto res = evaluateConstantExpressionImpl(node, context, false);
+    auto res = materializeToField(evaluateConstantExpressionAsColumnImpl(node, context, false));
     if (!res)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "evaluateConstantExpression expected to return a result or throw an exception");
     return *res;

--- a/src/Interpreters/evaluateConstantExpression.h
+++ b/src/Interpreters/evaluateConstantExpression.h
@@ -2,6 +2,7 @@
 
 #include <Core/Block_fwd.h>
 #include <Core/Field.h>
+#include <Columns/IColumn_fwd.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/Context_fwd.h>
 #include <Parsers/IAST_fwd.h>
@@ -20,6 +21,14 @@ using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 
 using EvaluateConstantExpressionResult = std::pair<Field, std::shared_ptr<const IDataType>>;
 
+/** The value of a constant expression as a single-row column plus its exact type.
+  * Unlike `EvaluateConstantExpressionResult`, this keeps the precise SQL type (`UInt8`, `Float32`,
+  * `DateTime64`, ...) instead of collapsing it through `Field`'s `NearestFieldType` mapping, and it
+  * avoids materializing a `Field` at all. `column` is a size-1 (const) column; read it with the typed
+  * `IColumn` accessors (`getUInt`, `getDataAt`, ...) or a `ValueRef`.
+  */
+using EvaluateConstantExpressionColumnResult = std::pair<ColumnPtr, std::shared_ptr<const IDataType>>;
+
 /** Evaluate constant expression and its type.
   * Used in rare cases - for elements of set for IN, for data to INSERT.
   * Throws exception if it's not a constant expression.
@@ -28,6 +37,14 @@ using EvaluateConstantExpressionResult = std::pair<Field, std::shared_ptr<const 
 EvaluateConstantExpressionResult evaluateConstantExpression(const ASTPtr & node, const ContextPtr & context);
 
 std::optional<EvaluateConstantExpressionResult> tryEvaluateConstantExpression(const ASTPtr & node, const ContextPtr & context);
+
+/** Same as `evaluateConstantExpression`, but returns the value as a single-row column + exact type,
+  * without collapsing the type through `Field`. Prefer this on paths that only need to read a scalar
+  * (via `IColumn` typed getters) — it avoids a `Field` materialization and preserves the SQL type.
+  */
+EvaluateConstantExpressionColumnResult evaluateConstantExpressionAsColumn(const ASTPtr & node, const ContextPtr & context);
+
+std::optional<EvaluateConstantExpressionColumnResult> tryEvaluateConstantExpressionAsColumn(const ASTPtr & node, const ContextPtr & context);
 
 /** Evaluate constant expression and returns ASTLiteral with its value.
   */

--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -1,6 +1,7 @@
 #include <Storages/StoragePrometheusQuery.h>
 
 #include <Common/logger_useful.h>
+#include <Columns/IColumn.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -25,6 +26,20 @@ namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+
+/// Read a required String literal argument as a value, without materializing a `Field`.
+String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, std::string_view arg_name)
+{
+    auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
+    if (!WhichDataType(*type).isStringOrFixedString())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got {}", arg_name, type->getName());
+    return String(column->getDataAt(0));
+}
+
 }
 
 StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(ASTs & args, const ContextPtr & context, bool over_range)
@@ -64,27 +79,13 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
         if (args.size() == min_num_args)
         {
             /// prometheusQuery( 'my_time_series_table', ... )
-            auto table_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-
-            if (table_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'table_name' must be a literal with type String, got {}", table_name_field.getType());
-
-            time_series_storage_id.table_name = table_name_field.safeGet<String>();
+            time_series_storage_id.table_name = getStringConstArgument(args[argument_index++], context, "table_name");
         }
         else
         {
             /// prometheusQuery( 'mydb', 'my_time_series_table', ... )
-            auto database_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-            auto table_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-
-            if (database_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'database_name' must be a literal with type String, got {}", database_name_field.getType());
-
-            if (table_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'table_name' must be a literal with type String, got {}", table_name_field.getType());
-
-            time_series_storage_id.database_name = database_name_field.safeGet<String>();
-            time_series_storage_id.table_name = table_name_field.safeGet<String>();
+            time_series_storage_id.database_name = getStringConstArgument(args[argument_index++], context, "database_name");
+            time_series_storage_id.table_name = getStringConstArgument(args[argument_index++], context, "table_name");
         }
     }
 
@@ -97,11 +98,7 @@ StoragePrometheusQuery::Configuration StoragePrometheusQuery::getConfiguration(A
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    auto promql_query_field = evaluateConstantExpression(args[argument_index++], context).first;
-    if (promql_query_field.getType() != Field::Types::String)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'promql_query' must be a literal with type String, got {}", promql_query_field.getType());
-
-    PrometheusQueryTree promql_query{promql_query_field.safeGet<String>(), timestamp_scale};
+    PrometheusQueryTree promql_query{getStringConstArgument(args[argument_index++], context, "promql_query"), timestamp_scale};
 
     PrometheusQueryEvaluationMode mode = {};
     DateTime64 start_time;

--- a/src/Storages/StoragePrometheusQuery.cpp
+++ b/src/Storages/StoragePrometheusQuery.cpp
@@ -35,8 +35,14 @@ namespace
 String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, std::string_view arg_name)
 {
     auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
-    if (!WhichDataType(*type).isStringOrFixedString())
+    /// Accept `Nullable`/`LowCardinality` wrappers: the previous `Field`-based code read the value
+    /// via `operator[]`, which flattens wrappers, so a non-NULL `Nullable(String)`/
+    /// `LowCardinality(String)` constant passed the String check. Preserve that, and still reject a
+    /// NULL value as before.
+    if (!isStringOrFixedString(removeLowCardinalityAndNullable(type)))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got {}", arg_name, type->getName());
+    if (column->isNullAt(0))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got NULL", arg_name);
     return String(column->getDataAt(0));
 }
 

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
+#include <Columns/IColumn.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesDecimal.h>
@@ -36,6 +37,20 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
     extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace
+{
+
+/// Read a required String literal argument as a value, without materializing a `Field`.
+String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, std::string_view arg_name)
+{
+    auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
+    if (!WhichDataType(*type).isStringOrFixedString())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got {}", arg_name, type->getName());
+    return String(column->getDataAt(0));
+}
+
 }
 
 namespace TimeSeriesSetting
@@ -82,27 +97,13 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
         if (args.size() == min_num_args)
         {
             /// timeSeriesSelector( 'my_time_series_table', ... )
-            auto table_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-
-            if (table_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'table_name' must be a literal with type String, got {}", table_name_field.getType());
-
-            time_series_storage_id.table_name = table_name_field.safeGet<String>();
+            time_series_storage_id.table_name = getStringConstArgument(args[argument_index++], context, "table_name");
         }
         else
         {
             /// timeSeriesSelector( 'mydb', 'my_time_series_table', ... )
-            auto database_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-            auto table_name_field = evaluateConstantExpression(args[argument_index++], context).first;
-
-            if (database_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'database_name' must be a literal with type String, got {}", database_name_field.getType());
-
-            if (table_name_field.getType() != Field::Types::String)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'table_name' must be a literal with type String, got {}", table_name_field.getType());
-
-            time_series_storage_id.database_name = database_name_field.safeGet<String>();
-            time_series_storage_id.table_name = table_name_field.safeGet<String>();
+            time_series_storage_id.database_name = getStringConstArgument(args[argument_index++], context, "database_name");
+            time_series_storage_id.table_name = getStringConstArgument(args[argument_index++], context, "table_name");
         }
     }
 
@@ -118,11 +119,7 @@ StorageTimeSeriesSelector::Configuration StorageTimeSeriesSelector::getConfigura
 
     UInt32 timestamp_scale = tryGetDecimalScale(*timestamp_data_type).value_or(0);
 
-    auto selector_field = evaluateConstantExpression(args[argument_index++], context).first;
-    if (selector_field.getType() != Field::Types::String)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument 'selector' must be a literal with type String, got {}", selector_field.getType());
-
-    PrometheusQueryTree selector{selector_field.safeGet<String>()};
+    PrometheusQueryTree selector{getStringConstArgument(args[argument_index++], context, "selector")};
 
     auto [min_time_field, min_time_type] = evaluateConstantExpression(args[argument_index++], context);
     auto [max_time_field, max_time_type] = evaluateConstantExpression(args[argument_index++], context);

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -46,8 +46,14 @@ namespace
 String getStringConstArgument(const ASTPtr & arg, const ContextPtr & context, std::string_view arg_name)
 {
     auto [column, type] = evaluateConstantExpressionAsColumn(arg, context);
-    if (!WhichDataType(*type).isStringOrFixedString())
+    /// Accept `Nullable`/`LowCardinality` wrappers: the previous `Field`-based code read the value
+    /// via `operator[]`, which flattens wrappers, so a non-NULL `Nullable(String)`/
+    /// `LowCardinality(String)` constant passed the String check. Preserve that, and still reject a
+    /// NULL value as before.
+    if (!isStringOrFixedString(removeLowCardinalityAndNullable(type)))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got {}", arg_name, type->getName());
+    if (column->isNullAt(0))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Argument '{}' must be a literal with type String, got NULL", arg_name);
     return String(column->getDataAt(0));
 }
 


### PR DESCRIPTION
## Part of a larger effort to eliminate `DB::Field`

This PR is one step in an ongoing, multi-phase effort to **remove `DB::Field`** from the ClickHouse server, replacing it with type-consistent, copy-free representations (a size-1 `IColumn` + `DataTypePtr` for owned values, and a non-owning column-reference for transient reads). The motivation: `Field`'s type tags do not map to ClickHouse SQL types (its `NearestFieldType` mapping collapses `UInt8` -> `UInt64`, `Float32` -> `Float64`, `DateTime64` -> `Decimal`, ...), which is a recurring source of type bugs, and `Field` forces copies of data that already lives in memory as columns. Each PR in the effort is small, self-contained, behavior-preserving, and independently mergeable; this is one of the first.

## This change

`evaluateConstantExpression` already builds a size-1 `ColumnConst` internally, then discards it by returning `(*result_column)[0]` as a `Field`. That both allocates a `Field` and collapses the exact SQL type through `Field`'s `NearestFieldType` mapping.

This adds `evaluateConstantExpressionAsColumn` and `tryEvaluateConstantExpressionAsColumn`, which return the value as `{ColumnPtr /* size 1 */, DataTypePtr}` — preserving the exact type and avoiding the `Field` materialization. The existing `Field`-returning `evaluateConstantExpression`/`tryEvaluateConstantExpression` become thin shims over the new functions, so behavior is unchanged for callers that have not been migrated.

As a first use, the plain-`String` literal arguments of `prometheusQuery`/`prometheusQueryRange` (`StoragePrometheusQuery`) and `timeSeriesSelector` (`StorageTimeSeriesSelector`) now read their value with `IColumn::getDataAt` instead of materializing a `Field` and calling `safeGet<String>`.

There is no user-facing behavior change.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Internal refactor: add a column-returning `evaluateConstantExpressionAsColumn` to avoid materializing a `Field` for constant expressions. No user-facing change.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
