### PR TITLE
Fix `04603_quota_zero_interval` breaking parallel and stress runs

### DIFF
--- a/tests/queries/0_stateless/04603_quota_zero_interval.sh
+++ b/tests/queries/0_stateless/04603_quota_zero_interval.sh
@@ -7,18 +7,22 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-# Quota is a server-global entity, so scope the name to this test's database to
-# stay safe when run in parallel with itself.
+# A quota is a server-global entity, so scope the name to this test's database to
+# stay safe when run in parallel with itself. Do NOT assign the quota to the
+# shared `default` user: the interval check happens at CREATE time regardless of
+# assignment, and a query quota on `default` would be consumed by every
+# concurrent test's queries, exhaust the limit, and make the server reject them
+# with QUOTA_EXCEEDED under stress/parallel runs.
 Q="quota_zero_${CLICKHOUSE_DATABASE}"
 
 ${CLICKHOUSE_CLIENT} -q "DROP QUOTA IF EXISTS ${Q}"
 
-${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 0 SECOND MAX queries = 1000 TO default" 2>&1 | grep -o -m1 "BAD_ARGUMENTS"
+${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 0 SECOND MAX queries = 1000" 2>&1 | grep -o -m1 "BAD_ARGUMENTS"
 # Fractional interval that rounds down to zero seconds hits the same path.
-${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 0.4 SECOND MAX queries = 1000 TO default" 2>&1 | grep -o -m1 "BAD_ARGUMENTS"
+${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 0.4 SECOND MAX queries = 1000" 2>&1 | grep -o -m1 "BAD_ARGUMENTS"
 
 # A positive interval still works and the server keeps running.
-${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 1 HOUR MAX queries = 1000 TO default"
+${CLICKHOUSE_CLIENT} -q "CREATE QUOTA ${Q} FOR INTERVAL 1 HOUR MAX queries = 1000"
 ${CLICKHOUSE_CLIENT} -q "SELECT 'ok'"
 
 ${CLICKHOUSE_CLIENT} -q "DROP QUOTA IF EXISTS ${Q}"


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110846
Related: https://github.com/ClickHouse/ClickHouse/pull/106215

The stateless test `04603_quota_zero_interval` created a query quota with `TO default`. A quota is a server-global entity, and in stress and parallel runs all stateless tests execute concurrently against the same server as the `default` user. The quota on `default` was therefore consumed by every concurrent query, exhausted its limit (`MAX queries = 1000` per hour), and made the server reject subsequent queries with `QUOTA_EXCEEDED` — eventually taking the whole server down (`Server is not responding`).

This surfaced as a `Stress test (amd_msan)` failure on PR #106215 after that PR merged the test in from `master`:

```
Quota for user `default` for 3600s has been exceeded: queries = 3116/1 ...
Name of quota template: `quota_zero_test_...`. (QUOTA_EXCEEDED)
...
Server is not responding. Cannot execute 'SELECT 1' query.
```

The interval is validated at CREATE time in `InterpreterCreateQuotaQuery`, independent of the `TO` assignment, so the quota does not need to be assigned to anyone for the test to exercise the `BAD_ARGUMENTS` rejection. Dropping the `TO default` clause makes the test stop touching the shared `default` user, so it is safe under stress and parallel execution. The reference output (`BAD_ARGUMENTS` / `BAD_ARGUMENTS` / `ok`) is unchanged.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106215&sha=0b2a2b671abe9df2dae40253fb8fafacaf699575&name_0=PR&name_1=Stress%20test%20%28amd_msan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1178` (included in `26.7` and later)
<!-- ch-version-info:end -->