### PR TITLE
Support identifier query parameters in CREATE ROLE and ALTER ROLE

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -7323,7 +7323,7 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
                 create_role->settings.reset();
             else
             {
-                create_role->new_name.clear();
+                create_role->new_name.reset();
                 create_role->alter_settings.reset();
             }
         }

--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -7,6 +7,7 @@
 #include <Interpreters/executeDDLQueryOnCluster.h>
 #include <Interpreters/removeOnClusterClauseIfNeeded.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 
 
 namespace DB
@@ -29,8 +30,8 @@ namespace
             role.setName(override_name);
         else if (!query.new_name.empty())
             role.setName(query.new_name);
-        else if (query.names.size() == 1)
-            role.setName(query.names.front());
+        else if (query.names->size() == 1)
+            role.setName(query.names->toStrings().at(0));
 
         if (override_settings)
             role.settings.applyChanges(*override_settings);
@@ -49,8 +50,9 @@ BlockIO InterpreterCreateRoleQuery::execute()
 
     auto & access_control = getContext()->getAccessControl();
 
+    Strings names = query.names->toStrings();
     const auto access_type = query.alter ? AccessType::ALTER_ROLE : AccessType::CREATE_ROLE;
-    for (const auto & name : query.names)
+    for (const auto & name : names)
         getContext()->checkAccess(access_type, name);
 
     if (!query.new_name.empty() && !query.alter)
@@ -87,16 +89,16 @@ BlockIO InterpreterCreateRoleQuery::execute()
         };
         if (query.if_exists)
         {
-            auto ids = storage->find<Role>(query.names);
+            auto ids = storage->find<Role>(names);
             storage->tryUpdate(ids, update_func);
         }
         else
-            storage->update(storage->getIDs<Role>(query.names), update_func);
+            storage->update(storage->getIDs<Role>(names), update_func);
     }
     else
     {
         std::vector<AccessEntityPtr> new_roles;
-        for (const auto & name : query.names)
+        for (const auto & name : names)
         {
             auto new_role = std::make_shared<Role>();
             updateRoleFromQueryImpl(*new_role, query, name, settings_from_query);
@@ -105,7 +107,7 @@ BlockIO InterpreterCreateRoleQuery::execute()
 
         if (!query.storage_name.empty())
         {
-            for (const auto & name : query.names)
+            for (const auto & name : names)
             {
                 if (auto another_storage_ptr = access_control.findExcludingStorage(AccessEntityType::ROLE, name, storage_ptr))
                     throw Exception(ErrorCodes::ACCESS_ENTITY_ALREADY_EXISTS, "Role {} already exists in storage {}", name, another_storage_ptr->getStorageName());

--- a/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateRoleQuery.cpp
@@ -28,8 +28,8 @@ namespace
     {
         if (!override_name.empty())
             role.setName(override_name);
-        else if (!query.new_name.empty())
-            role.setName(query.new_name);
+        else if (query.new_name)
+            role.setName(query.new_name->toString());
         else if (query.names->size() == 1)
             role.setName(query.names->toStrings().at(0));
 
@@ -55,8 +55,8 @@ BlockIO InterpreterCreateRoleQuery::execute()
     for (const auto & name : names)
         getContext()->checkAccess(access_type, name);
 
-    if (!query.new_name.empty() && !query.alter)
-        getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name);
+    if (query.new_name && !query.alter)
+        getContext()->checkAccess(AccessType::CREATE_ROLE, query.new_name->toString());
 
     std::optional<AlterSettingsProfileElements> settings_from_query;
     if (query.alter_settings)

--- a/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowCreateAccessEntityQuery.cpp
@@ -104,7 +104,7 @@ namespace
     ASTPtr getCreateQueryImpl(const Role & role, const AccessControl * access_control, bool attach_mode)
     {
         auto query = make_intrusive<ASTCreateRoleQuery>();
-        query->names.emplace_back(role.getName());
+        query->names = make_intrusive<ASTUserNamesWithHost>(role.getName());
         query->attach = attach_mode;
 
         if (!role.settings.empty())

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -15,6 +15,7 @@
 #include <Parsers/ASTSetQuery.h>
 #include <Parsers/ASTViewTargets.h>
 #include <Parsers/FieldFromAST.h>
+#include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTCreateUserQuery.h>
 #include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/TablePropertiesQueriesASTs.h>
@@ -59,6 +60,15 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
             if (create_user_query->names)
             {
                 ASTPtr names = create_user_query->names;
+                visitChildren(names);
+            }
+            visitChildren(ast);
+        }
+        else if (auto * create_role_query = dynamic_cast<ASTCreateRoleQuery *>(ast.get()))
+        {
+            if (create_role_query->names)
+            {
+                ASTPtr names = create_role_query->names;
                 visitChildren(names);
             }
             visitChildren(ast);

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -71,6 +71,11 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
                 ASTPtr names = create_role_query->names;
                 visitChildren(names);
             }
+            if (create_role_query->new_name)
+            {
+                ASTPtr new_name = create_role_query->new_name;
+                visitChildren(new_name);
+            }
             visitChildren(ast);
         }
         else if (auto * create_query = dynamic_cast<ASTCreateQuery *>(ast.get()))

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -9,9 +9,10 @@ namespace DB
 {
 namespace
 {
-    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
+    void formatRenameTo(const IAST & new_name, WriteBuffer & ostr, const IAST::FormatSettings & format)
     {
-        ostr << " RENAME TO " << quoteString(new_name);
+        ostr << " RENAME TO ";
+        new_name.format(ostr, format);
     }
 
     void formatSettings(const ASTSettingsProfileElements & settings, WriteBuffer & ostr, const IAST::FormatSettings & format)
@@ -40,6 +41,9 @@ ASTPtr ASTCreateRoleQuery::clone() const
 
     if (names)
         res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+
+    if (new_name)
+        res->new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name->clone());
 
     if (settings)
         res->settings = boost::static_pointer_cast<ASTSettingsProfileElements>(settings->clone());
@@ -80,8 +84,8 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
 
     formatOnCluster(ostr, format);
 
-    if (!new_name.empty())
-        formatRenameTo(new_name, ostr, format);
+    if (new_name)
+        formatRenameTo(*new_name, ostr, format);
 
     if (alter_settings)
         formatAlterSettings(*alter_settings, ostr, format);

--- a/src/Parsers/Access/ASTCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRoleQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 
@@ -8,18 +9,6 @@ namespace DB
 {
 namespace
 {
-    void formatNames(const Strings & names, WriteBuffer & ostr)
-    {
-        ostr << " ";
-        bool need_comma = false;
-        for (const String & name : names)
-        {
-            if (std::exchange(need_comma, true))
-                ostr << ", ";
-            ostr << backQuoteIfNeed(name);
-        }
-    }
-
     void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
     {
         ostr << " RENAME TO " << quoteString(new_name);
@@ -48,6 +37,9 @@ String ASTCreateRoleQuery::getID(char) const
 ASTPtr ASTCreateRoleQuery::clone() const
 {
     auto res = make_intrusive<ASTCreateRoleQuery>(*this);
+
+    if (names)
+        res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
 
     if (settings)
         res->settings = boost::static_pointer_cast<ASTSettingsProfileElements>(settings->clone());
@@ -78,7 +70,8 @@ void ASTCreateRoleQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & f
     else if (or_replace)
         ostr << " OR REPLACE";
 
-    formatNames(names, ostr);
+    ostr << " ";
+    names->format(ostr, format);
 
     if (!storage_name.empty())
         ostr

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -9,6 +9,7 @@ namespace DB
 {
 class ASTSettingsProfileElements;
 class ASTAlterSettingsProfileElements;
+class ASTUserNameWithHost;
 class ASTUserNamesWithHost;
 
 
@@ -35,7 +36,7 @@ public:
     bool or_replace = false;
 
     boost::intrusive_ptr<ASTUserNamesWithHost> names;
-    String new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     String storage_name;
 
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;

--- a/src/Parsers/Access/ASTCreateRoleQuery.h
+++ b/src/Parsers/Access/ASTCreateRoleQuery.h
@@ -9,6 +9,7 @@ namespace DB
 {
 class ASTSettingsProfileElements;
 class ASTAlterSettingsProfileElements;
+class ASTUserNamesWithHost;
 
 
 /** CREATE ROLE [IF NOT EXISTS | OR REPLACE] name
@@ -33,7 +34,7 @@ public:
     bool if_not_exists = false;
     bool or_replace = false;
 
-    Strings names;
+    boost::intrusive_ptr<ASTUserNamesWithHost> names;
     String new_name;
     String storage_name;
 

--- a/src/Parsers/Access/ParserCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRoleQuery.cpp
@@ -2,7 +2,9 @@
 #include <Parsers/Access/ParserCreateRoleQuery.h>
 #include <Parsers/Access/ASTCreateRoleQuery.h>
 #include <Parsers/Access/ASTSettingsProfileElement.h>
+#include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/ParserSettingsProfileElement.h>
+#include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
@@ -96,9 +98,10 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
             or_replace = true;
     }
 
-    Strings names;
-    if (!parseRoleNames(pos, expected, names))
+    ASTPtr names_ast;
+    if (!ParserUserNamesWithHost(/*allow_query_parameter=*/true).parse(pos, names_ast, expected))
         return false;
+    auto names = boost::static_pointer_cast<ASTUserNamesWithHost>(names_ast);
 
     String new_name;
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;
@@ -108,7 +111,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     while (true)
     {
-        if (alter && new_name.empty() && (names.size() == 1) && parseRenameTo(pos, expected, new_name))
+        if (alter && new_name.empty() && (names->size() == 1) && parseRenameTo(pos, expected, new_name))
             continue;
 
         if (alter)

--- a/src/Parsers/Access/ParserCreateRoleQuery.cpp
+++ b/src/Parsers/Access/ParserCreateRoleQuery.cpp
@@ -5,7 +5,6 @@
 #include <Parsers/Access/ASTUserNameWithHost.h>
 #include <Parsers/Access/ParserSettingsProfileElement.h>
 #include <Parsers/Access/ParserUserNameWithHost.h>
-#include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
@@ -16,14 +15,19 @@ namespace DB
 {
 namespace
 {
-    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, String & new_name)
+    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & new_name)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!ParserKeyword{Keyword::RENAME_TO}.ignore(pos, expected))
                 return false;
 
-            return parseRoleName(pos, expected, new_name);
+            ASTPtr new_name_ast;
+            if (!ParserUserNameWithHost(/*allow_query_parameter=*/true).parse(pos, new_name_ast, expected))
+                return false;
+
+            new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name_ast);
+            return true;
         });
     }
 
@@ -103,7 +107,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
         return false;
     auto names = boost::static_pointer_cast<ASTUserNamesWithHost>(names_ast);
 
-    String new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     boost::intrusive_ptr<ASTSettingsProfileElements> settings;
     boost::intrusive_ptr<ASTAlterSettingsProfileElements> alter_settings;
     String cluster;
@@ -111,7 +115,7 @@ bool ParserCreateRoleQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     while (true)
     {
-        if (alter && new_name.empty() && (names->size() == 1) && parseRenameTo(pos, expected, new_name))
+        if (alter && !new_name && (names->size() == 1) && parseRenameTo(pos, expected, new_name))
             continue;
 
         if (alter)

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.reference
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.reference
@@ -1,0 +1,5 @@
+CREATE ROLE role_param_04612
+CREATE ROLE role_param_04612_a
+CREATE ROLE role_param_04612_b
+CREATE ROLE role_param_04612 SETTINGS max_memory_usage = 5000001
+CREATE ROLE role_param_04612_renamed SETTINGS max_memory_usage = 5000001

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.reference
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.reference
@@ -3,3 +3,4 @@ CREATE ROLE role_param_04612_a
 CREATE ROLE role_param_04612_b
 CREATE ROLE role_param_04612 SETTINGS max_memory_usage = 5000001
 CREATE ROLE role_param_04612_renamed SETTINGS max_memory_usage = 5000001
+CREATE ROLE role_param_04612_renamed_twice SETTINGS max_memory_usage = 5000001

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.reference
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.reference
@@ -4,3 +4,4 @@ CREATE ROLE role_param_04612_b
 CREATE ROLE role_param_04612 SETTINGS max_memory_usage = 5000001
 CREATE ROLE role_param_04612_renamed SETTINGS max_memory_usage = 5000001
 CREATE ROLE role_param_04612_renamed_twice SETTINGS max_memory_usage = 5000001
+CREATE ROLE role_param_04612_renamed_twice SETTINGS max_memory_usage = 5000001

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.sql
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.sql
@@ -1,7 +1,7 @@
 -- Test for issue #109298: identifier query parameters worked in `CREATE USER`
 -- but were rejected with a syntax error in `CREATE ROLE` and `ALTER ROLE`.
 
-DROP ROLE IF EXISTS role_param_04612, role_param_04612_a, role_param_04612_b, role_param_04612_renamed;
+DROP ROLE IF EXISTS role_param_04612, role_param_04612_a, role_param_04612_b, role_param_04612_renamed, role_param_04612_renamed_twice;
 
 SET param_role_name = 'role_param_04612';
 CREATE ROLE {role_name:Identifier};
@@ -18,4 +18,8 @@ SHOW CREATE ROLE role_param_04612;
 ALTER ROLE {role_name:Identifier} RENAME TO role_param_04612_renamed;
 SHOW CREATE ROLE role_param_04612_renamed;
 
-DROP ROLE role_param_04612_renamed, role_param_04612_a, role_param_04612_b;
+SET param_role_target = 'role_param_04612_renamed_twice';
+ALTER ROLE role_param_04612_renamed RENAME TO {role_target:Identifier};
+SHOW CREATE ROLE role_param_04612_renamed_twice;
+
+DROP ROLE role_param_04612_renamed_twice, role_param_04612_a, role_param_04612_b;

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.sql
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.sql
@@ -1,0 +1,21 @@
+-- Test for issue #109298: identifier query parameters worked in `CREATE USER`
+-- but were rejected with a syntax error in `CREATE ROLE` and `ALTER ROLE`.
+
+DROP ROLE IF EXISTS role_param_04612, role_param_04612_a, role_param_04612_b, role_param_04612_renamed;
+
+SET param_role_name = 'role_param_04612';
+CREATE ROLE {role_name:Identifier};
+SHOW CREATE ROLE role_param_04612;
+
+SET param_role_a = 'role_param_04612_a';
+CREATE ROLE {role_a:Identifier}, role_param_04612_b;
+SHOW CREATE ROLE role_param_04612_a;
+SHOW CREATE ROLE role_param_04612_b;
+
+ALTER ROLE {role_name:Identifier} SETTINGS max_memory_usage = 5000001;
+SHOW CREATE ROLE role_param_04612;
+
+ALTER ROLE {role_name:Identifier} RENAME TO role_param_04612_renamed;
+SHOW CREATE ROLE role_param_04612_renamed;
+
+DROP ROLE role_param_04612_renamed, role_param_04612_a, role_param_04612_b;

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.sql
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel
+-- Tag no-parallel: creates fixed-name global roles
+
 -- Test for issue #109298: identifier query parameters worked in `CREATE USER`
 -- but were rejected with a syntax error in `CREATE ROLE` and `ALTER ROLE`.
 

--- a/tests/queries/0_stateless/04612_create_role_query_parameters.sql
+++ b/tests/queries/0_stateless/04612_create_role_query_parameters.sql
@@ -25,4 +25,9 @@ SET param_role_target = 'role_param_04612_renamed_twice';
 ALTER ROLE role_param_04612_renamed RENAME TO {role_target:Identifier};
 SHOW CREATE ROLE role_param_04612_renamed_twice;
 
+-- An unset parameter must be an error and must not create or rename anything
+CREATE ROLE {role_unset:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+ALTER ROLE role_param_04612_renamed_twice RENAME TO {role_unset:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SHOW CREATE ROLE role_param_04612_renamed_twice;
+
 DROP ROLE role_param_04612_renamed_twice, role_param_04612_a, role_param_04612_b;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/109298
Related: https://github.com/ClickHouse/ClickHouse/pull/109696

`CREATE ROLE {name:Identifier}` failed with a syntax error while the equivalent `CREATE USER {name:Identifier}` worked:

```sql
SET param_role = 'test_role';
CREATE ROLE {role:Identifier};  -- Syntax error: failed at position 13
CREATE USER {role:Identifier};  -- works
```

### Root cause

`ParserCreateRoleQuery` parses role names through `parseRoleNames`, which hardcodes `allow_query_parameter=false` and flattens the names to `Strings` at parse time, so `ReplaceQueryParameterVisitor` never gets an AST node to substitute into. `CREATE USER` doesn't have this problem because it stores the live `ASTUserNamesWithHost` AST on the query (#81387) and substitutes parameters before flattening.

### Fix

Mirror the `CREATE USER` design for roles: store role names as `ASTUserNamesWithHost` in `ASTCreateRoleQuery`, parse with `allow_query_parameter=true`, add the corresponding substitution branch in `ReplaceQueryParameterVisitor`, and flatten to strings in the interpreters after substitution. `ALTER ROLE {name:Identifier}` (settings changes and as the `RENAME TO` source) works as well.

`DROP ROLE`/`GRANT`/`SET ROLE` are intentionally left out of scope to keep the change minimal; PR #109696 proposes broader coverage of those contexts.

Verified by code-path analysis plus the included stateless test `04612_create_role_query_parameters`; no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Identifier query parameters are now supported for names in `CREATE ROLE` and `ALTER ROLE`, consistent with `CREATE USER`.
