### PR TITLE
Fix JSON schema inference failing for integer literals above UInt64 range

### DIFF
--- a/docs/en/interfaces/schema-inference.md
+++ b/docs/en/interfaces/schema-inference.md
@@ -1502,6 +1502,7 @@ This setting does not apply to the `JSON` data type.
 If enabled, ClickHouse will try to infer integers instead of floats in schema inference for text formats.
 If all numbers in the column from sample data are integers, the result type will be `Int64`, if at least one number is float, the result type will be `Float64`.
 If the sample data contains only integers and at least one integer is positive and overflows `Int64`, ClickHouse will infer `UInt64`.
+In JSON formats, an integer that doesn't fit into `Int64`/`UInt64` is inferred as `Float64` (in other text formats such values fall back to `String`).
 
 Enabled by default.
 

--- a/docs/en/interfaces/schema-inference.md
+++ b/docs/en/interfaces/schema-inference.md
@@ -1502,7 +1502,7 @@ This setting does not apply to the `JSON` data type.
 If enabled, ClickHouse will try to infer integers instead of floats in schema inference for text formats.
 If all numbers in the column from sample data are integers, the result type will be `Int64`, if at least one number is float, the result type will be `Float64`.
 If the sample data contains only integers and at least one integer is positive and overflows `Int64`, ClickHouse will infer `UInt64`.
-In JSON formats, an integer that doesn't fit into `Int64`/`UInt64` is inferred as `Float64` (in other text formats such values fall back to `String`).
+In JSON and CSV formats, an integer that doesn't fit into `Int64`/`UInt64` is inferred as `Float64`; formats inferring from escaped text (such as `TSV` and `TSKV`) fall back to `String` for such values, preserving the digits exactly.
 
 Enabled by default.
 

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -1064,9 +1064,10 @@ namespace
                 /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
                 /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way as
                 /// `tryInferNumberFromStringImpl` does for numbers inside strings.
-                /// Only for JSON: without this fallback JSON inference fails with a parse error, while
-                /// other text formats fall back to String and preserve the digits exactly.
-                /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
+                /// Only for JSON: without this fallback JSON inference fails with a parse error.
+                /// Formats inferring from escaped text (e.g. TSV) intentionally keep their String
+                /// fallback for such values, and CSV already infers Float64 via `tryInferNumberFromString`.
+                /// The check for a leading digit filters out signed 'inf'/'nan', which also parse as floats.
                 if constexpr (is_json)
                 {
                     if (parsed_as_float)
@@ -1113,9 +1114,10 @@ namespace
             /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
             /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way as
             /// `tryInferNumberFromStringImpl` does for numbers inside strings.
-            /// Only for JSON: without this fallback JSON inference fails with a parse error, while
-            /// other text formats fall back to String and preserve the digits exactly.
-            /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
+            /// Only for JSON: without this fallback JSON inference fails with a parse error.
+            /// Formats inferring from escaped text (e.g. TSV) intentionally keep their String
+            /// fallback for such values, and CSV already infers Float64 via `tryInferNumberFromString`.
+            /// The check for a leading digit filters out signed 'inf'/'nan', which also parse as floats.
             if constexpr (is_json)
             {
                 if (parsed_as_float)

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -1036,8 +1036,13 @@ namespace
 
                 /// NOTE: it may break parsing of tryReadFloat() != tryReadIntText() + parsing of '.'/'e'
                 /// But, for now it is true
-                if (tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional) && has_fractional)
+                bool parsed_as_float = tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional);
+                if (parsed_as_float && has_fractional)
                     return std::make_shared<DataTypeFloat64>();
+
+                /// Remember the position after the parsed float to be able to infer
+                /// Float64 for integers that don't fit into Int64/UInt64.
+                char * float_end = buf.position();
 
                 Int64 tmp_int = 0;
                 buf.position() = number_start;
@@ -1055,6 +1060,21 @@ namespace
                 if (tryReadIntText(tmp_uint, buf))
                     return std::make_shared<DataTypeUInt64>();
 
+                /// The number was parsed as a float without a fractional part and starts with a digit,
+                /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
+                /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way
+                /// as tryInferNumberFromStringImpl does for numbers inside strings.
+                /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
+                if (parsed_as_float)
+                {
+                    char * digits_start = (*number_start == '-' || *number_start == '+') ? number_start + 1 : number_start;
+                    if (digits_start != float_end && isNumericASCII(*digits_start))
+                    {
+                        buf.position() = float_end;
+                        return std::make_shared<DataTypeFloat64>();
+                    }
+                }
+
                 return nullptr;
             }
 
@@ -1064,7 +1084,8 @@ namespace
             PeekableReadBuffer peekable_buf(buf);
             PeekableReadBufferCheckpoint checkpoint(peekable_buf);
 
-            if (tryReadFloat<is_json>(tmp_float, peekable_buf, settings, has_fractional) && has_fractional)
+            bool parsed_as_float = tryReadFloat<is_json>(tmp_float, peekable_buf, settings, has_fractional);
+            if (parsed_as_float && has_fractional)
                 return std::make_shared<DataTypeFloat64>();
             peekable_buf.rollbackToCheckpoint(/* drop= */ false);
 
@@ -1076,12 +1097,31 @@ namespace
                     json_info->negative_integers.insert(type.get());
                 return type;
             }
-            peekable_buf.rollbackToCheckpoint(/* drop= */ true);
+            peekable_buf.rollbackToCheckpoint(/* drop= */ false);
 
             /// In case of Int64 overflow we can try to infer UInt64.
             UInt64 tmp_uint = 0;
             if (tryReadIntText(tmp_uint, peekable_buf))
                 return std::make_shared<DataTypeUInt64>();
+
+            /// The number was parsed as a float without a fractional part and starts with a digit,
+            /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
+            /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way
+            /// as tryInferNumberFromStringImpl does for numbers inside strings.
+            /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
+            if (parsed_as_float)
+            {
+                peekable_buf.rollbackToCheckpoint(/* drop= */ true);
+                if (*peekable_buf.position() == '-' || *peekable_buf.position() == '+')
+                    ++peekable_buf.position();
+                if (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                {
+                    /// Consume the rest of the digits to move the position to the end of the number.
+                    while (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                        ++peekable_buf.position();
+                    return std::make_shared<DataTypeFloat64>();
+                }
+            }
         }
         else if (tryReadFloat<is_json>(tmp_float, buf, settings, has_fractional))
         {

--- a/src/Formats/SchemaInferenceUtils.cpp
+++ b/src/Formats/SchemaInferenceUtils.cpp
@@ -1041,8 +1041,8 @@ namespace
                     return std::make_shared<DataTypeFloat64>();
 
                 /// Remember the position after the parsed float to be able to infer
-                /// Float64 for integers that don't fit into Int64/UInt64.
-                char * float_end = buf.position();
+                /// Float64 for integers that don't fit into Int64/UInt64 (JSON only).
+                [[maybe_unused]] char * float_end = buf.position();
 
                 Int64 tmp_int = 0;
                 buf.position() = number_start;
@@ -1062,16 +1062,21 @@ namespace
 
                 /// The number was parsed as a float without a fractional part and starts with a digit,
                 /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
-                /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way
-                /// as tryInferNumberFromStringImpl does for numbers inside strings.
+                /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way as
+                /// `tryInferNumberFromStringImpl` does for numbers inside strings.
+                /// Only for JSON: without this fallback JSON inference fails with a parse error, while
+                /// other text formats fall back to String and preserve the digits exactly.
                 /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
-                if (parsed_as_float)
+                if constexpr (is_json)
                 {
-                    char * digits_start = (*number_start == '-' || *number_start == '+') ? number_start + 1 : number_start;
-                    if (digits_start != float_end && isNumericASCII(*digits_start))
+                    if (parsed_as_float)
                     {
-                        buf.position() = float_end;
-                        return std::make_shared<DataTypeFloat64>();
+                        char * digits_start = (*number_start == '-' || *number_start == '+') ? number_start + 1 : number_start;
+                        if (digits_start != float_end && isNumericASCII(*digits_start))
+                        {
+                            buf.position() = float_end;
+                            return std::make_shared<DataTypeFloat64>();
+                        }
                     }
                 }
 
@@ -1106,20 +1111,25 @@ namespace
 
             /// The number was parsed as a float without a fractional part and starts with a digit,
             /// so it consists only of digits (with an optional sign), but doesn't fit into Int64/UInt64.
-            /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way
-            /// as tryInferNumberFromStringImpl does for numbers inside strings.
+            /// It is an integer that overflows 64-bit types: infer Float64 for it, the same way as
+            /// `tryInferNumberFromStringImpl` does for numbers inside strings.
+            /// Only for JSON: without this fallback JSON inference fails with a parse error, while
+            /// other text formats fall back to String and preserve the digits exactly.
             /// The check for a leading digit filters out 'inf'/'nan', which also parse as floats.
-            if (parsed_as_float)
+            if constexpr (is_json)
             {
-                peekable_buf.rollbackToCheckpoint(/* drop= */ true);
-                if (*peekable_buf.position() == '-' || *peekable_buf.position() == '+')
-                    ++peekable_buf.position();
-                if (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                if (parsed_as_float)
                 {
-                    /// Consume the rest of the digits to move the position to the end of the number.
-                    while (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                    peekable_buf.rollbackToCheckpoint(/* drop= */ true);
+                    if (*peekable_buf.position() == '-' || *peekable_buf.position() == '+')
                         ++peekable_buf.position();
-                    return std::make_shared<DataTypeFloat64>();
+                    if (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                    {
+                        /// Consume the rest of the digits to move the position to the end of the number.
+                        while (!peekable_buf.eof() && isNumericASCII(*peekable_buf.position()))
+                            ++peekable_buf.position();
+                        return std::make_shared<DataTypeFloat64>();
+                    }
                 }
             }
         }

--- a/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.reference
+++ b/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.reference
@@ -15,6 +15,9 @@ num	Nullable(Float64)
 num	Nullable(Float64)					
 huge integer inside an array
 arr	Array(Nullable(Float64))					
-huge integer in Values format
-c1	Nullable(Float64)					
-c1	Nullable(Float64)					
+TSV still infers String for huge integers
+c1	Nullable(String)					
+huge integer in a file (non-string read buffer)
+num	Nullable(Float64)					
+Dynamic stores huge JSON integers as Float64, consistent with CSV
+Float64

--- a/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.reference
+++ b/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.reference
@@ -1,0 +1,20 @@
+huge positive integer
+num	Nullable(Float64)					
+name	Nullable(String)					
+huge negative integer
+num	Nullable(Float64)					
+boundary values that fit into 64-bit types keep integer types
+num	Nullable(Int64)					
+num	Nullable(Int64)					
+num	Nullable(UInt64)					
+boundary values just outside 64-bit ranges
+num	Nullable(Float64)					
+num	Nullable(Float64)					
+merging with regular integers
+num	Nullable(Float64)					
+num	Nullable(Float64)					
+huge integer inside an array
+arr	Array(Nullable(Float64))					
+huge integer in Values format
+c1	Nullable(Float64)					
+c1	Nullable(Float64)					

--- a/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
+++ b/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
@@ -1,0 +1,24 @@
+-- Test for issue #110563: JSONEachRow schema inference failed with a parsing error
+-- for valid JSON integer literals that don't fit into Int64/UInt64.
+-- Such integers are now inferred as Float64, the same way as oversized integers
+-- inside strings (see tryInferNumberFromStringImpl).
+
+select 'huge positive integer';
+desc format('JSONEachRow', '{"num":2942420318599003496251392,"name":"Matt"}');
+select 'huge negative integer';
+desc format('JSONEachRow', '{"num":-2942420318599003496251392}');
+select 'boundary values that fit into 64-bit types keep integer types';
+desc format('JSONEachRow', '{"num":9223372036854775807}');
+desc format('JSONEachRow', '{"num":-9223372036854775808}');
+desc format('JSONEachRow', '{"num":18446744073709551615}');
+select 'boundary values just outside 64-bit ranges';
+desc format('JSONEachRow', '{"num":18446744073709551616}');
+desc format('JSONEachRow', '{"num":-9223372036854775809}');
+select 'merging with regular integers';
+desc format('JSONEachRow', '{"num":1}, {"num":2942420318599003496251392}');
+desc format('JSONEachRow', '{"num":2942420318599003496251392}, {"num":1}');
+select 'huge integer inside an array';
+desc format('JSONEachRow', '{"arr":[1, 2942420318599003496251392]}');
+select 'huge integer in Values format';
+desc format('Values', '(2942420318599003496251392)');
+desc format('Values', '(1), (2942420318599003496251392)');

--- a/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
+++ b/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
@@ -1,7 +1,9 @@
 -- Test for issue #110563: JSONEachRow schema inference failed with a parsing error
 -- for valid JSON integer literals that don't fit into Int64/UInt64.
--- Such integers are now inferred as Float64, the same way as oversized integers
--- inside strings (see tryInferNumberFromStringImpl).
+-- Such integers are now inferred as Float64 in JSON formats, the same way as
+-- oversized integers inside strings (see `tryInferNumberFromStringImpl`).
+-- Non-JSON text formats are unchanged: they keep falling back to String,
+-- preserving the digits exactly.
 
 select 'huge positive integer';
 desc format('JSONEachRow', '{"num":2942420318599003496251392,"name":"Matt"}');
@@ -19,6 +21,15 @@ desc format('JSONEachRow', '{"num":1}, {"num":2942420318599003496251392}');
 desc format('JSONEachRow', '{"num":2942420318599003496251392}, {"num":1}');
 select 'huge integer inside an array';
 desc format('JSONEachRow', '{"arr":[1, 2942420318599003496251392]}');
-select 'huge integer in Values format';
-desc format('Values', '(2942420318599003496251392)');
-desc format('Values', '(1), (2942420318599003496251392)');
+select 'TSV still infers String for huge integers';
+desc format('TSV', '2942420318599003496251392');
+select 'huge integer in a file (non-string read buffer)';
+set engine_file_truncate_on_insert = 1;
+insert into function file(currentDatabase() || '_04611.jsonl', 'LineAsString', 'line String') values ('{"num":2942420318599003496251392}');
+desc file(currentDatabase() || '_04611.jsonl', 'JSONEachRow');
+select 'Dynamic stores huge JSON integers as Float64, consistent with CSV';
+drop table if exists t_04611_dynamic;
+create table t_04611_dynamic (d Dynamic) engine = Memory;
+insert into t_04611_dynamic format JSONEachRow {"d":2942420318599003496251392};
+select dynamicType(d) from t_04611_dynamic;
+drop table t_04611_dynamic;

--- a/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
+++ b/tests/queries/0_stateless/04611_json_schema_inference_integers_above_uint64.sql
@@ -1,9 +1,9 @@
 -- Test for issue #110563: JSONEachRow schema inference failed with a parsing error
 -- for valid JSON integer literals that don't fit into Int64/UInt64.
 -- Such integers are now inferred as Float64 in JSON formats, the same way as
--- oversized integers inside strings (see `tryInferNumberFromStringImpl`).
--- Non-JSON text formats are unchanged: they keep falling back to String,
--- preserving the digits exactly.
+-- oversized integers inside strings (see `tryInferNumberFromStringImpl`) and as
+-- CSV already does. Formats inferring from escaped text (e.g. TSV) are unchanged:
+-- they keep falling back to String, preserving the digits exactly.
 
 select 'huge positive integer';
 desc format('JSONEachRow', '{"num":2942420318599003496251392,"name":"Matt"}');


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110563

Schema inference in JSON formats failed for valid integer literals that don't fit into `Int64`/`UInt64`:

```sql
DESCRIBE TABLE format('JSONEachRow', '{"num":2942420318599003496251392,"name":"Matt"}');
-- Code: 636 ... Code: 27. DB::Exception: Cannot parse input: expected ',' before: '251392,"name":"Matt"}'
```

### Root cause

In `tryInferNumber` (`src/Formats/SchemaInferenceUtils.cpp`), when a value overflows both the `Int64` and the `UInt64` parse, the function returns `nullptr` with the buffer left in the middle of the number, and the JSON row reader then fails on the leftover digits with the misleading `expected ','` error. The string-based sibling `tryInferNumberFromStringImpl` has a `Float64` fallback after integer overflow — which is why `CSV` already degrades gracefully to `Float64` — but the buffer-based path used by JSON inference does not.

### Fix

For JSON formats only, infer `Float64` for integers that don't fit into 64-bit types, in both branches of `tryInferNumber` (the `ReadBufferFromString` fast path and the `PeekableReadBuffer` path). A leading-digit check keeps signed `inf`/`nan` tokens out of the fallback. Formats inferring from escaped text (`TSV`, `TSKV`, `Form`, Hive partitioning) are deliberately unchanged and keep their exact-`String` fallback — the included test pins that.

One intentional, related behavior change: the `Dynamic` type reading a huge integer from JSON input previously stored it as `String` (via the incomplete-type fallback) and now stores `Float64` — making it consistent with `Dynamic` reading the same value from CSV, which already stores `Float64`. The test pins this too.

Docs: added a sentence about out-of-64-bit-range integers to `docs/en/interfaces/schema-inference.md`.

Verified by code-path analysis plus the included stateless test `04611_json_schema_inference_integers_above_uint64` (boundary values at the `Int64`/`UInt64` edges, negative values, row merging, arrays, a `file()`-based case to exercise the non-string read-buffer path, and the `TSV`/`Dynamic` pins); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed schema inference in JSON formats failing with a parsing error for valid integer literals that do not fit into `Int64`/`UInt64`; such integers are now inferred as `Float64`, consistent with `CSV`.
