### PR TITLE
Add test: `stack.size() < 2` early-return in `processAndOptimizeTextIndexFunctions` untested when text-index `ReadFromMergeTree` is the query-plan root

### DIFF
--- a/tests/queries/0_stateless/04612_text_index_prewhere_direct_read_plan_root.reference
+++ b/tests/queries/0_stateless/04612_text_index_prewhere_direct_read_plan_root.reference
@@ -1,0 +1,3 @@
+alpha beta
+alpha zzz
+1

--- a/tests/queries/0_stateless/04612_text_index_prewhere_direct_read_plan_root.sql
+++ b/tests/queries/0_stateless/04612_text_index_prewhere_direct_read_plan_root.sql
@@ -1,0 +1,35 @@
+-- Test text-index PREWHERE direct read when ReadFromMergeTree is the query-plan root (no WHERE/aggregation above it)
+
+DROP TABLE IF EXISTS t_text_root;
+SET allow_experimental_full_text_index = 1;
+-- Direct read is disabled under parallel replicas; pin it off so the optimization is deterministic.
+SET enable_parallel_replicas = 0;
+
+DROP TABLE IF EXISTS t_text_root;
+
+CREATE TABLE t_text_root
+(
+    msg String,
+    INDEX msg_idx msg TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_text_root VALUES ('alpha beta'), ('gamma delta'), ('alpha zzz');
+
+-- Root-level MergeTree read with a text-index PREWHERE and nothing above the reading step.
+SELECT msg FROM t_text_root
+PREWHERE hasAnyTokens(msg, ['alpha'])
+ORDER BY msg
+SETTINGS query_plan_direct_read_from_text_index = 1;
+
+-- Direct read from the text index is engaged (synthetic column present in the plan).
+SELECT count() > 0 FROM
+(
+    EXPLAIN actions = 1
+    SELECT msg FROM t_text_root
+    PREWHERE hasAnyTokens(msg, ['alpha'])
+    SETTINGS query_plan_direct_read_from_text_index = 1
+)
+WHERE explain ILIKE '%__text_index_msg_idx%';
+
+DROP TABLE IF EXISTS t_text_root;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #110710](https://github.com/ClickHouse/ClickHouse/pull/110710).
PR fixes a double-registration in `optimizeDirectReadFromTextIndex` where the same `ReadFromMergeTree` step is visited by the query-plan pass more than once (identical text-index predicate in `PREWHERE` and `WHERE` over `Merge -> Distributed -> MergeTree`). The pass previously re-registered the synt

**1. `stack.size() < 2` early-return in `processAndOptimizeTextIndexFunctions` untested when text-index `ReadFromMergeTree` is the query-plan root**
  `src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp:909`
  **Risk:** `optimizeTreeSecondPass` calls `processAndOptimizeTextIndexFunctions(stack, ...)` for every node; when the text-indexed `ReadFromMergeTree` is the plan root, `stack.size()` is 1, so line 908 must return before line 911 dereferences `(stack.rbegin() + 1)->node`. Risk: if this guard is removed or its condition inverted during a refactor, this common query pattern dereferences an out-of-range stack iterator, causing a server crash (SIGSEGV).
  **What's unique vs PR tests:** The PR's regression test always uses `SELECT count() FROM logs_merge PREWHERE ... WHERE ...` over `Merge -> Distributed`, so aggregation/Merge steps sit above the `ReadFromMergeTree` and the pass never reaches the `stack.size() < 2` branch. This test uses a plain `SELECT col ... PREWHERE` with no WHERE/aggregation so the `ReadFromMergeTree` is the plan root, the only shape that exercises line 909.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/678b034d-7a50-45ae-a91b-c3957d5f2d28)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)