### PR TITLE
[WIP] Rewrite same-database view targets on RENAME DATABASE

### DIFF
--- a/src/Databases/DatabaseAtomic.cpp
+++ b/src/Databases/DatabaseAtomic.cpp
@@ -12,6 +12,8 @@
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
 #include <Interpreters/Context.h>
+#include <Parsers/ASTCreateQuery.h>
+#include <Parsers/ASTViewTargets.h>
 #include <Storages/StorageMaterializedView.h>
 #include <Storages/StorageTimeSeries.h>
 #include <base/isSharedPtrUnique.h>
@@ -32,6 +34,7 @@ namespace Setting
 {
     extern const SettingsBool check_referential_table_dependencies;
     extern const SettingsBool check_table_dependencies;
+    extern const SettingsBool fsync_metadata;
 }
 
 namespace ErrorCodes
@@ -64,6 +67,31 @@ public:
     }
     UUID uuid() const override { return table()->getStorageID().uuid; }
 };
+
+namespace
+{
+    /// Rewrites the database name of external view targets (a materialized view's "TO" target or a
+    /// TimeSeries table's "SAMPLES"/"TAGS"/"METRICS" targets) from `old_database_name` to
+    /// `new_database_name`. Inner targets are referenced by a UUID or a constructed name (an empty
+    /// `table_id`) and are left untouched. Returns true if the query was changed.
+    bool renameDatabaseInViewTargets(ASTCreateQuery & create, const String & old_database_name, const String & new_database_name)
+    {
+        if (!create.targets)
+            return false;
+
+        bool changed = false;
+        for (auto & target : create.targets->targets)
+        {
+            auto & table_id = target.table_id;
+            if (!table_id.table_name.empty() && table_id.database_name == old_database_name)
+            {
+                table_id.database_name = new_database_name;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+}
 
 DatabaseAtomic::DatabaseAtomic(
     String name_,
@@ -727,7 +755,19 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     /// CREATE, ATTACH, DROP, DETACH and RENAME DATABASE must hold DDLGuard
     createDirectories();
     waitDatabaseStarted();
+
+    /// The rename itself runs under `mutex` (released when the helper returns); persisting the rewritten
+    /// metadata must not hold it, because DatabaseReplicated takes `metadata_mutex` for persistence while
+    /// the digest checks lock `metadata_mutex` before `mutex` - taking them in the other order would deadlock.
+    auto rewritten = renameDatabaseLocked(query_context, new_name);
+    persistRewrittenViewTargetsMetadata(rewritten, query_context);
+}
+
+std::vector<RewrittenViewTargetsMetadata> DatabaseAtomic::renameDatabaseLocked(ContextPtr query_context, const String & new_name)
+{
     std::lock_guard lock(mutex);
+
+    const String old_database_name = database_name;
 
     bool check_ref_deps = query_context->getSettingsRef()[Setting::check_referential_table_dependencies];
     bool check_loading_deps = !check_ref_deps && query_context->getSettingsRef()[Setting::check_table_dependencies];
@@ -792,6 +832,59 @@ void DatabaseAtomic::renameDatabase(ContextPtr query_context, const String & new
     {
         db_disk->moveDirectory(old_path_to_table_symlinks, path_to_table_symlinks);
         tryCreateMetadataSymlink();
+    }
+
+    /// All tables moved together with the database, so rewrite same-database external view targets
+    /// (a TimeSeries table's SAMPLES/TAGS/METRICS or a materialized view's external TO target) from the
+    /// old database name to the new one - both in memory and in the table metadata. The on-disk
+    /// persistence runs in the caller, after `mutex` is released.
+    return updateViewTargetsAndCollectMetadata(old_database_name, new_name, query_context);
+}
+
+std::vector<RewrittenViewTargetsMetadata> DatabaseAtomic::updateViewTargetsAndCollectMetadata(
+    const String & old_database_name, const String & new_database_name, const ContextPtr & query_context)
+{
+    auto db_disk = getDisk();
+    std::vector<RewrittenViewTargetsMetadata> rewritten;
+
+    for (const auto & [table_name, storage] : tables)
+    {
+        /// Update the references kept in memory by the storage so the table stays usable without a restart.
+        /// Only tables that actually had a same-database external target need their metadata rewritten.
+        if (!storage->updateExternalTargetsAfterDatabaseRename(old_database_name, new_database_name))
+            continue;
+
+        /// Rewrite the same references in the on-disk metadata so they survive a restart.
+        String table_metadata_path = getObjectMetadataPath(table_name);
+        String old_statement = readMetadataFile(db_disk, table_metadata_path);
+        ASTPtr ast = parseQueryFromMetadata(log, query_context, table_metadata_path, old_statement);
+        auto & create = ast->as<ASTCreateQuery &>();
+        bool changed_on_disk = renameDatabaseInViewTargets(create, old_database_name, new_database_name);
+
+        /// The in-memory storage and the on-disk create query are built from the same definition, so a
+        /// storage that reported an in-memory change must have a matching external target on disk too.
+        /// Keep them from silently diverging (which would re-introduce the bug after a restart).
+        chassert(changed_on_disk);
+        if (!changed_on_disk)
+            continue;
+
+        rewritten.push_back({table_name, std::move(old_statement), getObjectDefinitionFromCreateQuery(ast)});
+    }
+
+    return rewritten;
+}
+
+void DatabaseAtomic::persistRewrittenViewTargetsMetadata(
+    const std::vector<RewrittenViewTargetsMetadata> & rewritten, const ContextPtr & query_context)
+{
+    auto db_disk = getDisk();
+    bool fsync = query_context->getSettingsRef()[Setting::fsync_metadata];
+    for (const auto & item : rewritten)
+    {
+        String table_metadata_path = getObjectMetadataPath(item.table_name);
+        String table_metadata_tmp_path = table_metadata_path + create_suffix;
+        writeMetadataFile(db_disk, table_metadata_tmp_path, item.new_statement, fsync);
+        db_disk->replaceFile(table_metadata_tmp_path, table_metadata_path);
     }
 }
 

--- a/src/Databases/DatabaseAtomic.h
+++ b/src/Databases/DatabaseAtomic.h
@@ -9,6 +9,15 @@
 namespace DB
 {
 
+/// Describes a table whose on-disk metadata must be rewritten because RENAME DATABASE changed the
+/// database name of its external view targets (see DatabaseAtomic::renameDatabase).
+struct RewrittenViewTargetsMetadata
+{
+    String table_name;
+    String old_statement;
+    String new_statement;
+};
+
 /// All tables in DatabaseAtomic have persistent UUID and store data in
 /// /clickhouse_path/store/xxx/xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy/
 /// where xxxyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy is UUID of the table.
@@ -80,6 +89,21 @@ public:
     void setDetachedTableNotInUseForce(const UUID & uuid) override;
 
 protected:
+    /// Performs the under-`mutex` part of renameDatabase (renames the database and its tables in memory)
+    /// and returns the metadata of the tables whose on-disk definition has to be rewritten. The lock is
+    /// released when this returns, so the caller can persist the metadata without holding `mutex`.
+    std::vector<RewrittenViewTargetsMetadata> renameDatabaseLocked(ContextPtr query_context, const String & new_name);
+
+    /// Updates the in-memory external view targets of every table of this (just renamed) database and
+    /// returns the metadata of the tables whose on-disk definition has to be rewritten because of the rename.
+    std::vector<RewrittenViewTargetsMetadata> updateViewTargetsAndCollectMetadata(
+        const String & old_database_name, const String & new_database_name, const ContextPtr & query_context) TSA_REQUIRES(mutex);
+
+    /// Persists the rewritten table metadata. The base implementation writes the local `.sql` files;
+    /// DatabaseReplicated also updates the metadata nodes and the digest in ZooKeeper.
+    virtual void persistRewrittenViewTargetsMetadata(
+        const std::vector<RewrittenViewTargetsMetadata> & rewritten, const ContextPtr & query_context);
+
     void commitAlterTable(const StorageID & table_id, const String & table_metadata_tmp_path, const String & table_metadata_path, const String & statement, ContextPtr query_context) override;
     void commitCreateTable(const ASTCreateQuery & query, const StoragePtr & table,
                            const String & table_metadata_tmp_path, const String & table_metadata_path, ContextPtr query_context) override;

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -2168,6 +2168,35 @@ void DatabaseReplicated::renameDatabase(ContextPtr query_context, const String &
     getZooKeeper()->set(db_name_path, getDatabaseName());
 }
 
+void DatabaseReplicated::persistRewrittenViewTargetsMetadata(
+    const std::vector<RewrittenViewTargetsMetadata> & rewritten, const ContextPtr & query_context)
+{
+    if (rewritten.empty())
+        return;
+
+    std::lock_guard lock{metadata_mutex};
+
+    /// Apply the changes in ZooKeeper before the local metadata files (ZooKeeper is the source of truth
+    /// for recovery) and adjust the digest to account for the rewritten statements.
+    Coordination::Requests ops;
+    UInt64 new_digest = tables_metadata_digest;
+    for (const auto & item : rewritten)
+    {
+        String metadata_zk_path = zookeeper_path + "/metadata/" + escapeForFileName(item.table_name);
+        ops.emplace_back(zkutil::makeSetRequest(metadata_zk_path, item.new_statement, -1));
+        new_digest -= DB::getMetadataHash(item.table_name, item.old_statement);
+        new_digest += DB::getMetadataHash(item.table_name, item.new_statement);
+    }
+    ops.emplace_back(zkutil::makeSetRequest(replica_path + "/digest", toString(new_digest), -1));
+    getZooKeeper()->multi(ops);
+
+    /// Now write the local metadata files and update the in-memory digest to match.
+    DatabaseAtomic::persistRewrittenViewTargetsMetadata(rewritten, query_context);
+    tables_metadata_digest = new_digest;
+
+    assertDigest(query_context);
+}
+
 void DatabaseReplicated::stopReplication()
 {
     try

--- a/src/Databases/DatabaseReplicated.h
+++ b/src/Databases/DatabaseReplicated.h
@@ -172,6 +172,9 @@ protected:
                           const String & table_metadata_tmp_path, const String & table_metadata_path,
                           const String & statement, ContextPtr query_context) override;
 
+    void persistRewrittenViewTargetsMetadata(
+        const std::vector<RewrittenViewTargetsMetadata> & rewritten, const ContextPtr & query_context) override;
+
 private:
     void tryConnectToZooKeeperAndInitDatabase(LoadingStrictnessLevel mode);
     void initDatabaseReplica(const ZooKeeperPtr & current_zookeeper, LoadingStrictnessLevel mode);

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -486,6 +486,15 @@ public:
      */
     virtual void renameInMemory(const StorageID & new_table_id);
 
+    /** Called for each table of a database renamed by RENAME DATABASE old_database_name TO new_database_name.
+      * All tables of the database move together, so a storage that references other tables of the same
+      * database by an explicit database-qualified name (a materialized view's external "TO" target or a
+      * TimeSeries table's "SAMPLES"/"TAGS"/"METRICS" targets) should rewrite those references in memory
+      * from old_database_name to new_database_name. The on-disk metadata is rewritten separately by the database.
+      * Returns true if any reference was changed.
+      */
+    virtual bool updateExternalTargetsAfterDatabaseRename(const String & /*old_database_name*/, const String & /*new_database_name*/) { return false; }
+
     /** ALTER tables in the form of column changes that do not affect the change
       * to Storage or its parameters. Executes under alter lock (lockForAlter).
       */

--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -853,6 +853,21 @@ void StorageMaterializedView::renameInMemory(const StorageID & new_table_id)
         refresher->rename(new_table_id, getTargetTableId());
 }
 
+bool StorageMaterializedView::updateExternalTargetsAfterDatabaseRename(const String & old_database_name, const String & new_database_name)
+{
+    /// An inner target table moves together with the view and is referenced by UUID, so it needs no rewriting here.
+    /// Only an external "TO" target located in the renamed database has to be updated.
+    if (has_inner_table)
+        return false;
+
+    std::lock_guard guard(target_table_id_mutex);
+    if (target_table_id.database_name != old_database_name)
+        return false;
+
+    target_table_id.database_name = new_database_name;
+    return true;
+}
+
 void StorageMaterializedView::startup()
 {
     if (const auto configured_delay_ms = getContext()->getServerSettings()[ServerSetting::startup_mv_delay_ms]; configured_delay_ms)

--- a/src/Storages/StorageMaterializedView.h
+++ b/src/Storages/StorageMaterializedView.h
@@ -70,6 +70,8 @@ public:
 
     void renameInMemory(const StorageID & new_table_id) override;
 
+    bool updateExternalTargetsAfterDatabaseRename(const String & old_database_name, const String & new_database_name) override;
+
     void startup() override;
     void flushAndPrepareForShutdown() override;
     void shutdown(bool is_drop) override;

--- a/src/Storages/StorageTimeSeries.cpp
+++ b/src/Storages/StorageTimeSeries.cpp
@@ -177,7 +177,13 @@ StoragePtr StorageTimeSeries::getTargetTableImpl(ViewTarget::Kind target_kind, c
     auto index = static_cast<size_t>(target_kind - ViewTarget::Samples);
     if (index >= targets.size() || targets[index].kind != target_kind)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected target kind {} (index={})", target_kind, index);
-    const auto & target = targets[index];
+
+    /// The database name of an external target can change concurrently (RENAME DATABASE), so take a snapshot.
+    StorageID target_table_id = StorageID::createEmpty();
+    {
+        std::lock_guard lock(targets_mutex);
+        target_table_id = targets[index].table_id;
+    }
 
     auto lookup = [&](const StorageID & id) -> StoragePtr
     {
@@ -186,31 +192,31 @@ StoragePtr StorageTimeSeries::getTargetTableImpl(ViewTarget::Kind target_kind, c
             .second;
     };
 
-    /// For external targets `target.table_id` contains a table name.
-    if (!target.table_id.table_name.empty())
+    /// For external targets `target_table_id` contains a table name.
+    if (!target_table_id.table_name.empty())
     {
-        auto res = lookup(target.table_id);
+        auto res = lookup(target_table_id);
         if (!res && throw_if_not_found)
         {
             throw Exception(ErrorCodes::UNKNOWN_TABLE, "The {} target table {} for TimeSeries table {} doesn't exist",
-                            target_kind, target.table_id.getNameForLogs(), getStorageID().getNameForLogs());
+                            target_kind, target_table_id.getNameForLogs(), getStorageID().getNameForLogs());
         }
         return res;
     }
 
-    /// For inner targets in Atomic databases `target.table_id` has a UUID but no name — look up directly by UUID.
-    if (target.table_id.hasUUID())
+    /// For inner targets in Atomic databases `target_table_id` has a UUID but no name — look up directly by UUID.
+    if (target_table_id.hasUUID())
     {
-        auto res = DatabaseCatalog::instance().tryGetByUUID(target.table_id.uuid).second;
+        auto res = DatabaseCatalog::instance().tryGetByUUID(target_table_id.uuid).second;
         if (!res && throw_if_not_found)
             throw Exception(ErrorCodes::UNKNOWN_TABLE, "The {} inner table {} for TimeSeries table {} doesn't exist",
-                            target_kind, target.table_id.getNameForLogs(), getStorageID().getNameForLogs());
+                            target_kind, target_table_id.getNameForLogs(), getStorageID().getNameForLogs());
         return res;
     }
 
-    chassert(target.table_id.empty());
+    chassert(target_table_id.empty());
 
-    /// For inner targets in non-Atomic databases, `target.table_id` is empty and we look up the inner table by its constructed name.
+    /// For inner targets in non-Atomic databases, `target_table_id` is empty and we look up the inner table by its constructed name.
     StorageID time_series_table_id = getStorageID();
     StorageID inner_table_id{time_series_table_id.getDatabaseName(), getTimeSeriesInnerTableName(target_kind, time_series_table_id)};
 
@@ -533,6 +539,26 @@ void StorageTimeSeries::renameInMemory(const StorageID & new_table_id)
     }
 
     IStorage::renameInMemory(new_table_id);
+}
+
+
+bool StorageTimeSeries::updateExternalTargetsAfterDatabaseRename(const String & old_database_name, const String & new_database_name)
+{
+    std::lock_guard lock(targets_mutex);
+    bool changed = false;
+    for (auto & target : targets)
+    {
+        /// Inner targets are referenced by a UUID (Atomic databases) or by a constructed name (an empty
+        /// `table_id`), so they move with the table and need no rewriting. Only external targets that point
+        /// to a table in the renamed database have to be updated.
+        if (!target.is_inner_table && !target.table_id.table_name.empty()
+            && target.table_id.database_name == old_database_name)
+        {
+            target.table_id.database_name = new_database_name;
+            changed = true;
+        }
+    }
+    return changed;
 }
 
 

--- a/src/Storages/StorageTimeSeries.h
+++ b/src/Storages/StorageTimeSeries.h
@@ -5,6 +5,7 @@
 #include <Storages/IStorage_fwd.h>
 #include <Storages/StorageWithCommonVirtualColumns.h>
 #include <array>
+#include <mutex>
 
 
 namespace DB
@@ -89,6 +90,8 @@ public:
 
     void renameInMemory(const StorageID & new_table_id) override;
 
+    bool updateExternalTargetsAfterDatabaseRename(const String & old_database_name, const String & new_database_name) override;
+
     void checkAlterIsPossible(const AlterCommands & commands, ContextPtr local_context) const override;
     void alter(const AlterCommands & params, ContextPtr local_context, AlterLockHolder & table_lock_holder) override;
 
@@ -128,7 +131,10 @@ private:
 
     MultiVersion<TimeSeriesSettings> storage_settings;
 
-    const std::vector<Target> targets;
+    /// `targets` is initialized in the constructor and afterwards only the `table_id.database_name` of
+    /// external targets can change (when the database is renamed by RENAME DATABASE), guarded by `targets_mutex`.
+    mutable std::mutex targets_mutex;
+    std::vector<Target> targets;
     const bool has_inner_tables;
 };
 

--- a/tests/queries/0_stateless/04409_rename_database_view_targets.reference
+++ b/tests/queries/0_stateless/04409_rename_database_view_targets.reference
@@ -1,0 +1,14 @@
+-- Replicated: materialized view external TO target --
+mv reads target after rename:
+2
+mv reads target after reload:
+2
+digest consistent (probe table exists):
+1
+-- Atomic: TimeSeries external targets --
+samples target got the row routed through TimeSeries:
+3
+targets rewritten on disk (occurrences of old db name, want 0):
+0
+samples target still reachable after reload:
+4

--- a/tests/queries/0_stateless/04409_rename_database_view_targets.sh
+++ b/tests/queries/0_stateless/04409_rename_database_view_targets.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-parallel, no-replicated-database
+# Tag no-parallel: enables a REGULAR failpoint that affects the whole server process.
+# Tag no-replicated-database: the test creates its own Replicated database, and the experimental
+#                             TimeSeries engine does not round-trip through a Replicated default database.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# RENAME DATABASE moves every table of the database together. A materialized view's external "TO"
+# target and a TimeSeries table's external SAMPLES/TAGS/METRICS targets are stored with the database
+# name; they must be rewritten to the new database name (in memory and on disk) so the tables stay
+# usable after the rename and survive a reload.
+
+###########################################################################################
+# Replicated database: materialized view with an external TO target. This also exercises the
+# DatabaseReplicated path that rewrites the metadata node and the digest in ZooKeeper.
+###########################################################################################
+RDB_OLD="${CLICKHOUSE_DATABASE}_rold"
+RDB_NEW="${CLICKHOUSE_DATABASE}_rnew"
+ZK_PATH="/test/rename_database_view_targets/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${RDB_OLD} ENGINE = Replicated('${ZK_PATH}', 's1', 'r1')"
+
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "
+    CREATE TABLE ${RDB_OLD}.src (x UInt64) ENGINE = MergeTree ORDER BY x;
+    CREATE TABLE ${RDB_OLD}.dest (x UInt64) ENGINE = MergeTree ORDER BY x;
+    CREATE MATERIALIZED VIEW ${RDB_OLD}.mv TO ${RDB_OLD}.dest AS SELECT x FROM ${RDB_OLD}.src;
+    INSERT INTO ${RDB_OLD}.dest VALUES (10), (20);
+"
+
+# Force the metadata digest assertion to always run (skip the 1/16 probability gate), so any
+# divergence between the local metadata, ZooKeeper and the digest is caught immediately. In release
+# builds assertDigestWithProbability is compiled out, so this is a no-op there.
+${CLICKHOUSE_CLIENT} -q "SYSTEM ENABLE FAILPOINT database_replicated_force_metadata_digest_check"
+
+# --send_logs_level=fatal hides the benign "Replacing outdated dependencies" notice: the view's TO
+# target dependency moves to the new database while its SELECT source stays in the old name.
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none --send_logs_level=fatal -q "RENAME DATABASE ${RDB_OLD} TO ${RDB_NEW}"
+
+echo "-- Replicated: materialized view external TO target --"
+# Selecting from a "TO" materialized view reads from its target table, so this resolves the in-memory
+# target id. Before the fix it pointed at the dropped old database and threw UNKNOWN_TABLE.
+echo "mv reads target after rename:"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${RDB_NEW}.mv"
+
+# Reload the database from local metadata. If the TO target had not been rewritten, the reloaded view
+# would point at the dropped old database and the read below would fail. (Only the external TO target
+# is rewritten; the view's SELECT source is intentionally left untouched, as for any RENAME DATABASE.)
+${CLICKHOUSE_CLIENT} --send_logs_level=fatal -q "DETACH DATABASE ${RDB_NEW}; ATTACH DATABASE ${RDB_NEW}"
+echo "mv reads target after reload:"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${RDB_NEW}.mv"
+
+# With the forced digest check still on, an unrelated DDL must SUCCEED, proving the digest stayed
+# consistent through the rewrite. Run it without grep so a crash or lost connection fails the test.
+${CLICKHOUSE_CLIENT} --distributed_ddl_output_mode=none -q "CREATE TABLE ${RDB_NEW}.probe (id UInt64) ENGINE = ReplicatedMergeTree ORDER BY id"
+echo "digest consistent (probe table exists):"
+${CLICKHOUSE_CLIENT} -q "EXISTS TABLE ${RDB_NEW}.probe"
+
+${CLICKHOUSE_CLIENT} -q "SYSTEM DISABLE FAILPOINT database_replicated_force_metadata_digest_check"
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${RDB_NEW} SYNC" 2>/dev/null || true
+
+###########################################################################################
+# Atomic database: TimeSeries table with external SAMPLES/TAGS/METRICS targets (the reported case).
+###########################################################################################
+ADB_OLD="${CLICKHOUSE_DATABASE}_aold"
+ADB_NEW="${CLICKHOUSE_DATABASE}_anew"
+
+${CLICKHOUSE_CLIENT} -q "CREATE DATABASE ${ADB_OLD} ENGINE = Atomic"
+
+${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table=1 -q "
+    CREATE TABLE ${ADB_OLD}.smpl (id UInt64, timestamp DateTime64(3), value Float64)
+        ENGINE = MergeTree ORDER BY (id, timestamp);
+    CREATE TABLE ${ADB_OLD}.tgs (id UInt64, metric_name LowCardinality(String),
+        tags Map(LowCardinality(String), String), min_time DateTime64(3), max_time DateTime64(3))
+        ENGINE = MergeTree ORDER BY id;
+    CREATE TABLE ${ADB_OLD}.mtr (metric_family_name String, type String, unit String, help String)
+        ENGINE = ReplacingMergeTree ORDER BY metric_family_name;
+    CREATE TABLE ${ADB_OLD}.ts ENGINE = TimeSeries
+        SAMPLES ${ADB_OLD}.smpl TAGS ${ADB_OLD}.tgs METRICS ${ADB_OLD}.mtr;
+    INSERT INTO ${ADB_OLD}.smpl VALUES (1, toDateTime64(100, 3), 10.0), (2, toDateTime64(100, 3), 20.0);
+"
+
+${CLICKHOUSE_CLIENT} --send_logs_level=fatal -q "RENAME DATABASE ${ADB_OLD} TO ${ADB_NEW}"
+
+echo "-- Atomic: TimeSeries external targets --"
+# Inserting through the TimeSeries table routes to its SAMPLES target, resolving the in-memory target
+# id. Before the fix it pointed at the dropped old database and threw UNKNOWN_TABLE.
+${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table=1 -q "
+    INSERT INTO ${ADB_NEW}.ts (metric_name, tags, time_series)
+    VALUES ('foo', map(), [(toDateTime64(200, 3), 5.0)])"
+echo "samples target got the row routed through TimeSeries:"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${ADB_NEW}.smpl"
+echo "targets rewritten on disk (occurrences of old db name, want 0):"
+${CLICKHOUSE_CLIENT} -q "SHOW CREATE TABLE ${ADB_NEW}.ts" | grep -o -F "${ADB_OLD}" | wc -l
+
+# Reload from on-disk metadata: the TimeSeries table is rebuilt from its rewritten .sql definition.
+${CLICKHOUSE_CLIENT} --send_logs_level=fatal -q "DETACH DATABASE ${ADB_NEW}; ATTACH DATABASE ${ADB_NEW}"
+${CLICKHOUSE_CLIENT} --allow_experimental_time_series_table=1 -q "
+    INSERT INTO ${ADB_NEW}.ts (metric_name, tags, time_series)
+    VALUES ('bar', map(), [(toDateTime64(300, 3), 7.0)])"
+echo "samples target still reachable after reload:"
+${CLICKHOUSE_CLIENT} -q "SELECT count() FROM ${ADB_NEW}.smpl"
+
+${CLICKHOUSE_CLIENT} -q "DROP DATABASE ${ADB_NEW} SYNC" 2>/dev/null || true


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Rewrite same-database view targets on RENAME DATABASE