### PR TITLE
Fix extremes over aggregate function states throwing on multi-chunk results

### DIFF
--- a/src/Processors/Transforms/ExtremesTransform.cpp
+++ b/src/Processors/Transforms/ExtremesTransform.cpp
@@ -117,9 +117,9 @@ void ExtremesTransform::transform(DB::Chunk & chunk)
                 continue;
 
             /// Extremes of columns of non-comparable types (e.g. aggregate function states)
-            /// cannot be merged across chunks: comparing such values throws. Keep the
-            /// default values obtained from the first chunk, the same as a single-chunk
-            /// result produces for such columns.
+            /// cannot be merged across chunks: comparing such values throws. Keep the values
+            /// obtained from the first chunk; for aggregate function states `getExtremes`
+            /// fills in default states, so the result is consistent with the single-chunk case.
             if (!is_comparable_column[i])
                 continue;
 

--- a/src/Processors/Transforms/ExtremesTransform.cpp
+++ b/src/Processors/Transforms/ExtremesTransform.cpp
@@ -1,6 +1,7 @@
 #include <Processors/Transforms/ExtremesTransform.h>
 #include <Columns/IColumn.h>
 #include <Core/Field.h>
+#include <DataTypes/IDataType.h>
 #include <Common/NaNUtils.h>
 
 namespace DB
@@ -11,6 +12,10 @@ ExtremesTransform::ExtremesTransform(SharedHeader header)
 {
     /// Port for Extremes.
     outputs.emplace_back(outputs.front().getHeader(), this);
+
+    is_comparable_column.reserve(header->columns());
+    for (const auto & column : *header)
+        is_comparable_column.push_back(column.type->isComparable());
 }
 
 IProcessor::Status ExtremesTransform::prepare()
@@ -109,6 +114,13 @@ void ExtremesTransform::transform(DB::Chunk & chunk)
         for (size_t i = 0; i < num_columns; ++i)
         {
             if (isColumnConst(*extremes_columns[i]))
+                continue;
+
+            /// Extremes of columns of non-comparable types (e.g. aggregate function states)
+            /// cannot be merged across chunks: comparing such values throws. Keep the
+            /// default values obtained from the first chunk, the same as a single-chunk
+            /// result produces for such columns.
+            if (!is_comparable_column[i])
                 continue;
 
             Field min_value = (*extremes_columns[i])[0];

--- a/src/Processors/Transforms/ExtremesTransform.h
+++ b/src/Processors/Transforms/ExtremesTransform.h
@@ -25,6 +25,10 @@ protected:
 
 private:
     MutableColumns extremes_columns;
+
+    /// Whether the column type is comparable: extremes of multiple chunks
+    /// can be merged only for comparable types.
+    std::vector<UInt8> is_comparable_column;
 };
 
 }

--- a/tests/queries/0_stateless/04613_extremes_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04613_extremes_aggregate_function_state.reference
@@ -1,3 +1,17 @@
 multi-chunk result with aggregate function states
+multi-chunk extremes of comparable columns are still merged
+0	90
+1	91
+2	92
+3	93
+4	94
+5	95
+6	96
+7	97
+8	98
+9	99
+
+0	90
+9	99
 single-chunk result still works
 ok

--- a/tests/queries/0_stateless/04613_extremes_aggregate_function_state.reference
+++ b/tests/queries/0_stateless/04613_extremes_aggregate_function_state.reference
@@ -1,0 +1,3 @@
+multi-chunk result with aggregate function states
+single-chunk result still works
+ok

--- a/tests/queries/0_stateless/04613_extremes_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04613_extremes_aggregate_function_state.sql
@@ -11,6 +11,14 @@ group by k
 settings extremes = 1, max_block_size = 10, max_threads = 1
 format Null;
 
+-- Extremes of comparable columns must still be merged across chunks
+select 'multi-chunk extremes of comparable columns are still merged';
+select number % 10 as k, max(number) as m
+from numbers(100)
+group by k
+order by k
+settings extremes = 1, max_block_size = 3, max_threads = 1;
+
 select 'single-chunk result still works';
 select number % 2 as k, argMaxState(number, number) as st
 from numbers(10)

--- a/tests/queries/0_stateless/04613_extremes_aggregate_function_state.sql
+++ b/tests/queries/0_stateless/04613_extremes_aggregate_function_state.sql
@@ -1,0 +1,21 @@
+-- Test for issue #100698: SELECT with `extremes = 1` over aggregate function states
+-- (e.g. `argMaxState`) threw `ILLEGAL_TYPE_OF_ARGUMENT` when the result spanned
+-- multiple chunks, because `ExtremesTransform` compared serialized aggregate function
+-- states while merging extremes of the chunks. Extremes of columns of non-comparable
+-- types now keep the default values, the same as a single-chunk result produces.
+
+select 'multi-chunk result with aggregate function states';
+select number % 100 as k, argMaxState(number, number) as st
+from numbers(1000)
+group by k
+settings extremes = 1, max_block_size = 10, max_threads = 1
+format Null;
+
+select 'single-chunk result still works';
+select number % 2 as k, argMaxState(number, number) as st
+from numbers(10)
+group by k
+settings extremes = 1
+format Null;
+
+select 'ok';


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/100698

`SELECT` with `extremes = 1` over a column holding aggregate function states (e.g. `argMaxState`) threw an exception when the result spanned more than one chunk:

```sql
SELECT k, argMaxState(v, t) FROM t GROUP BY k SETTINGS extremes = 1;
-- Code: 43. DB::Exception: Bad type of Field: it is AggregateFunctionState, expected: ... (ILLEGAL_TYPE_OF_ARGUMENT)
```

Single-chunk results worked (the extremes rows contain default states), which explains why the failure depended on cardinality and `max_block_size`.

### Root cause

`ExtremesTransform` merges the extremes of consecutive chunks by comparing `Field` values (`src/Processors/Transforms/ExtremesTransform.cpp`). `AggregateFunctionStateData::operator<` unconditionally throws `ILLEGAL_TYPE_OF_ARGUMENT`, so the first chunk after the initial one killed the query.

### Fix

Precompute per-column flags from the header (`IDataType::isComparable()`) and skip the cross-chunk merge for columns of non-comparable types, keeping the values obtained from the first chunk. For aggregate function states, `ColumnAggregateFunction::getExtremes` fills in default states regardless of the data, so the result is exactly what a single-chunk result already produces — and matches the documented behavior that extremes output default values for non-numeric columns. This also covers `Tuple`/`Array`/`Map` wrapping aggregate function states, which previously threw the same way.

Note: for the experimental `QBit` type (also non-comparable, but with data-dependent `getExtremes`), the extremes are now taken from the first chunk instead of being lexicographically merged across chunks — extremes for that type are semantically arbitrary either way.

Verified by code-path analysis plus the included stateless test `04613_extremes_aggregate_function_state` (multi-chunk repro with `max_block_size = 10` over 100 groups, and a single-chunk sanity case); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SELECT` with `extremes = 1` throwing an exception when the result contains aggregate function states (e.g. `argMaxState`) and spans multiple chunks; extremes of non-comparable columns now keep default values, consistent with single-chunk results.
