### PR TITLE
Respect format settings when parsing query parameter values

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -1298,7 +1298,7 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
         && connection->getServerRevision(connection_parameters.timeouts) < DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS)
     {
         /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
-        ReplaceQueryParameterVisitor visitor(query_parameters);
+        ReplaceQueryParameterVisitor visitor(query_parameters, getFormatSettings(client_context));
         visitor.visit(parsed_query);
 
         /// Get new query after substitutions.
@@ -1315,7 +1315,7 @@ void ClientBase::processOrdinaryQuery(String query, ASTPtr parsed_query)
             /// Replace query parameters because AST cannot be serialized otherwise.
             if (!query_parameters.empty())
             {
-                ReplaceQueryParameterVisitor visitor(query_parameters);
+                ReplaceQueryParameterVisitor visitor(query_parameters, getFormatSettings(client_context));
                 visitor.visit(parsed_query);
             }
 
@@ -1986,7 +1986,7 @@ void ClientBase::processInsertQuery(String query, ASTPtr parsed_query)
         && connection->getServerRevision(connection_parameters.timeouts) < DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS)
     {
         /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
-        ReplaceQueryParameterVisitor visitor(query_parameters);
+        ReplaceQueryParameterVisitor visitor(query_parameters, getFormatSettings(client_context));
         visitor.visit(parsed_query);
 
         /// Get new query after substitutions.
@@ -2604,7 +2604,7 @@ void ClientBase::processParsedSingleQuery(
         {
             /// Resolve query parameters used as setting values, e.g. `SET max_threads = {threads:UInt64}`.
             SettingsChanges changes = set_query->changes;
-            replaceQueryParametersInSettingsChanges(changes, client_context->getQueryParameters());
+            replaceQueryParametersInSettingsChanges(changes, client_context->getQueryParameters(), getFormatSettings(client_context));
 
             /// Save all changes in settings to avoid losing them if the connection is lost.
             for (const auto & change : changes)

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2981,7 +2981,7 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
             auto view_metadata = table->getInMemoryMetadataPtr(getQueryContext(), false);
             auto query = view_metadata->getSelectQuery().inner_query->clone();
             NameToNameMap parameterized_view_values = analyzeFunctionParamValues(table_expression, getQueryContext());
-            StorageView::replaceQueryParametersIfParameterizedView(query, parameterized_view_values);
+            StorageView::replaceQueryParametersIfParameterizedView(query, parameterized_view_values, getFormatSettings(getQueryContext()));
 
             ASTCreateQuery create;
             create.set(create.select, query);
@@ -3236,7 +3236,7 @@ StoragePtr Context::buildParameterizedViewStorage(const String & database_name, 
 
     auto original_view_metadata = original_view->getInMemoryMetadataPtr(getQueryContext(), false);
     auto query = original_view_metadata->getSelectQuery().inner_query->clone();
-    StorageView::replaceQueryParametersIfParameterizedView(query, param_values);
+    StorageView::replaceQueryParametersIfParameterizedView(query, param_values, getFormatSettings(getQueryContext()));
 
     ASTCreateQuery create;
     create.set(create.select, query);

--- a/src/Interpreters/InterpreterExplainQuery.cpp
+++ b/src/Interpreters/InterpreterExplainQuery.cpp
@@ -199,7 +199,7 @@ namespace
 
             auto view_query = metadata->getSelectQuery().inner_query->clone();
             NameToNameMap parameter_values = analyzeFunctionParamValues(table_expr.table_function, query_context);
-            StorageView::replaceQueryParametersIfParameterizedView(view_query, parameter_values);
+            StorageView::replaceQueryParametersIfParameterizedView(view_query, parameter_values, getFormatSettings(query_context));
 
             /// Replace the table function with a subquery in-place on this table expression,
             /// rather than using `StorageView::replaceWithSubquery` which only handles the

--- a/src/Interpreters/InterpreterSetQuery.cpp
+++ b/src/Interpreters/InterpreterSetQuery.cpp
@@ -2,6 +2,7 @@
 #include <Backups/RestoreSettings.h>
 #include <Core/Settings.h>
 #include <Databases/IDatabase.h>
+#include <Formats/FormatFactory.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterFactory.h>
@@ -39,7 +40,7 @@ BlockIO InterpreterSetQuery::execute()
     /// Work on a copy so the original AST keeps the placeholders: they are still needed by the
     /// old-server compatibility rewrite in ClientBase::processOrdinaryQuery.
     SettingsChanges changes = ast.changes;
-    replaceQueryParametersInSettingsChanges(changes, getContext()->getQueryParameters());
+    replaceQueryParametersInSettingsChanges(changes, getContext()->getQueryParameters(), getFormatSettings(getContext()));
     /// Pass as const on purpose: the non-const checkSettingsConstraints overload rewrites the
     /// changes (dropping no-op changes), which would lose the "changed" flag for a setting
     /// explicitly set to its current value. The original code applies const `ast.changes`.
@@ -58,7 +59,7 @@ void InterpreterSetQuery::executeForCurrentContext(bool ignore_setting_constrain
     /// Resolve query parameters used as setting values, e.g. `SELECT ... SETTINGS max_threads = {threads:UInt64}`.
     /// Work on a copy so the original AST keeps the placeholders (see the note in execute()).
     SettingsChanges changes = ast.changes;
-    replaceQueryParametersInSettingsChanges(changes, getContext()->getQueryParameters());
+    replaceQueryParametersInSettingsChanges(changes, getContext()->getQueryParameters(), getFormatSettings(getContext()));
     /// const on purpose - see the note in execute().
     if (!ignore_setting_constraints)
         getContext()->checkSettingsConstraints(std::as_const(changes), SettingSource::QUERY);

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -179,7 +179,6 @@ Field ReplaceQueryParameterVisitor::resolveParameterValueAsField(const String & 
     auto temp_column_ptr = data_type->createColumn();
     IColumn & temp_column = *temp_column_ptr;
     ReadBufferFromString read_buffer{value};
-    FormatSettings format_settings;
 
     const SerializationPtr & serialization = data_type->getDefaultSerialization();
     try
@@ -261,9 +260,9 @@ void ReplaceQueryParameterVisitor::visitSetQuery(ASTSetQuery & set_query)
     visitSettingsChanges(set_query.changes);
 }
 
-void replaceQueryParametersInSettingsChanges(SettingsChanges & changes, const NameToNameMap & parameters)
+void replaceQueryParametersInSettingsChanges(SettingsChanges & changes, const NameToNameMap & parameters, const FormatSettings & format_settings)
 {
-    ReplaceQueryParameterVisitor(parameters).visitSettingsChanges(changes);
+    ReplaceQueryParameterVisitor(parameters, format_settings).visitSettingsChanges(changes);
 }
 
 void ReplaceQueryParameterVisitor::visitIdentifier(ASTPtr & ast)

--- a/src/Interpreters/ReplaceQueryParameterVisitor.h
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.h
@@ -2,6 +2,7 @@
 
 #include <Core/Names.h>
 #include <Core/Types.h>
+#include <Formats/FormatSettings.h>
 #include <Parsers/IAST_fwd.h>
 
 namespace DB
@@ -17,8 +18,12 @@ class SettingsChanges;
 class ReplaceQueryParameterVisitor
 {
 public:
-    explicit ReplaceQueryParameterVisitor(const NameToNameMap & parameters)
+    /// Format settings affect how parameter values are parsed, e.g. `date_time_input_format`
+    /// for a `{param:DateTime}` parameter. Pass the settings obtained from the query context
+    /// (see `getFormatSettings`) so that the corresponding settings of the user are respected.
+    ReplaceQueryParameterVisitor(const NameToNameMap & parameters, const FormatSettings & format_settings_)
         : query_parameters(parameters)
+        , format_settings(format_settings_)
     {}
 
     void visit(ASTPtr & ast);
@@ -32,6 +37,7 @@ public:
 
 private:
     const NameToNameMap & query_parameters;
+    FormatSettings format_settings;
     size_t num_replaced_parameters = 0;
 
     const String & getParamValue(const String & name);
@@ -49,6 +55,6 @@ private:
 
 /// Resolve query parameters used as setting values in a SettingsChanges list, in place.
 /// Convenience wrapper around ReplaceQueryParameterVisitor::visitSettingsChanges.
-void replaceQueryParametersInSettingsChanges(SettingsChanges & changes, const NameToNameMap & parameters);
+void replaceQueryParametersInSettingsChanges(SettingsChanges & changes, const NameToNameMap & parameters, const FormatSettings & format_settings);
 
 }

--- a/src/Interpreters/evaluateConstantExpression.cpp
+++ b/src/Interpreters/evaluateConstantExpression.cpp
@@ -15,6 +15,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeLowCardinality.h>
+#include <Formats/FormatFactory.h>
 #include <Functions/IFunction.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/castColumn.h>
@@ -94,7 +95,7 @@ static std::optional<EvaluateConstantExpressionResult> evaluateConstantExpressio
         ast->setAlias("constant_expression");
     }
 
-    ReplaceQueryParameterVisitor param_visitor(context->getQueryParameters());
+    ReplaceQueryParameterVisitor param_visitor(context->getQueryParameters(), getFormatSettings(context));
     param_visitor.visit(ast);
 
     String result_name;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1421,7 +1421,7 @@ static BlockIO executeQueryImpl(
         bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
         if (out_ast && probably_has_params)
         {
-            ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
+            ReplaceQueryParameterVisitor visitor(context->getQueryParameters(), getFormatSettings(context));
             visitor.visit(out_ast);
             if (visitor.getNumberOfReplacedParameters())
                 query = out_ast->formatWithSecretsOneLine();

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -14,6 +14,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/FieldToDataType.h>
+#include <Formats/FormatFactory.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/ExpressionActions.h>
@@ -516,7 +517,7 @@ ConstantExpressionTemplate::Cache::getFromCacheOrConstruct(const DataTypePtr & r
     ASTPtr expression = expression_->clone();
     ReplaceLiteralsVisitor visitor(context, token_info_vec);
     visitor.visit(expression, result_column_type->isNullable() || null_as_default);
-    ReplaceQueryParameterVisitor param_visitor(context->getQueryParameters());
+    ReplaceQueryParameterVisitor param_visitor(context->getQueryParameters(), getFormatSettings(context));
     param_visitor.visit(expression);
 
     UInt64 template_hash = TemplateStructure::getTemplateHash(expression, visitor.replaced_literals, result_column_type, null_as_default, salt);

--- a/src/Storages/StorageView.cpp
+++ b/src/Storages/StorageView.cpp
@@ -434,9 +434,9 @@ static ASTTableExpression * getFirstTableExpression(ASTSelectQuery & select_quer
     return select_element->table_expression->as<ASTTableExpression>();
 }
 
-void StorageView::replaceQueryParametersIfParameterizedView(ASTPtr & outer_query, const NameToNameMap & parameter_values)
+void StorageView::replaceQueryParametersIfParameterizedView(ASTPtr & outer_query, const NameToNameMap & parameter_values, const FormatSettings & format_settings)
 {
-    ReplaceQueryParameterVisitor visitor(parameter_values);
+    ReplaceQueryParameterVisitor visitor(parameter_values, format_settings);
     visitor.visit(outer_query);
 }
 

--- a/src/Storages/StorageView.h
+++ b/src/Storages/StorageView.h
@@ -9,6 +9,8 @@
 namespace DB
 {
 
+struct FormatSettings;
+
 class StorageView final : public StorageWithCommonVirtualColumns
 {
     static VirtualColumnsDescription createVirtuals();
@@ -49,7 +51,7 @@ public:
     void drop() override;
     void alter(const AlterCommands & params, ContextPtr context, AlterLockHolder & table_lock_holder) override;
 
-    static void replaceQueryParametersIfParameterizedView(ASTPtr & outer_query, const NameToNameMap & parameter_values);
+    static void replaceQueryParametersIfParameterizedView(ASTPtr & outer_query, const NameToNameMap & parameter_values, const FormatSettings & format_settings);
 
     static void replaceWithSubquery(ASTSelectQuery & select_query, ASTPtr & view_name, const StorageMetadataPtr & metadata_snapshot, const bool parameterized_view)
     {

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
@@ -1,5 +1,7 @@
 best_effort parses an ISO 8601 value with a timezone suffix
 2026-02-03 21:03:24
 basic rejects the timezone suffix
+parameters in a SETTINGS clause still work
+54321
 parameters in INSERT VALUES respect the setting
 2026-02-03 21:03:24

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
@@ -1,0 +1,3 @@
+best_effort parses an ISO 8601 value with a timezone suffix
+2026-02-03 21:03:24
+basic rejects the timezone suffix

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.reference
@@ -1,3 +1,5 @@
 best_effort parses an ISO 8601 value with a timezone suffix
 2026-02-03 21:03:24
 basic rejects the timezone suffix
+parameters in INSERT VALUES respect the setting
+2026-02-03 21:03:24

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
@@ -10,3 +10,11 @@ select {dt:DateTime('UTC')};
 select 'basic rejects the timezone suffix';
 set date_time_input_format = 'basic';
 select {dt:DateTime('UTC')}; -- { serverError BAD_QUERY_PARAMETER }
+
+select 'parameters in INSERT VALUES respect the setting';
+set date_time_input_format = 'best_effort';
+drop table if exists t_04614;
+create table t_04614 (d DateTime('UTC')) engine = Memory;
+insert into t_04614 values ({dt:DateTime('UTC')});
+select * from t_04614;
+drop table t_04614;

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
@@ -11,6 +11,10 @@ select 'basic rejects the timezone suffix';
 set date_time_input_format = 'basic';
 select {dt:DateTime('UTC')}; -- { serverError BAD_QUERY_PARAMETER }
 
+select 'parameters in a SETTINGS clause still work';
+set param_limit = '54321';
+select getSetting('max_rows_to_read') settings max_rows_to_read = {limit:UInt64};
+
 select 'parameters in INSERT VALUES respect the setting';
 set date_time_input_format = 'best_effort';
 drop table if exists t_04614;

--- a/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
+++ b/tests/queries/0_stateless/04614_query_parameter_format_settings.sql
@@ -1,0 +1,12 @@
+-- Test for issue #95913: query parameter values were parsed with default format
+-- settings, ignoring the settings of the session such as `date_time_input_format`.
+
+set param_dt = '2026-02-03T21:03:24Z';
+
+select 'best_effort parses an ISO 8601 value with a timezone suffix';
+set date_time_input_format = 'best_effort';
+select {dt:DateTime('UTC')};
+
+select 'basic rejects the timezone suffix';
+set date_time_input_format = 'basic';
+select {dt:DateTime('UTC')}; -- { serverError BAD_QUERY_PARAMETER }


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/95913

Query parameter values were parsed with default-constructed `FormatSettings`, ignoring the settings of the session:

```sql
SET param_dt = '2026-02-03T21:03:24Z';
SET date_time_input_format = 'best_effort';
SELECT {dt:DateTime};
-- Code: 457. DB::Exception: Value 2026-02-03T21:03:24Z cannot be parsed as DateTime ... (BAD_QUERY_PARAMETER)
```

### Root cause

`ReplaceQueryParameterVisitor::resolveParameterValueAsField` deserialized parameter values with a local `FormatSettings format_settings;`, so settings such as `date_time_input_format` had no effect on `{param:Type}` parsing.

### Fix

`ReplaceQueryParameterVisitor` now takes `FormatSettings` in its constructor (stored by value), and every substitution site passes `getFormatSettings(<context>)`: `executeQuery`, `evaluateConstantExpression`, `ConstantExpressionTemplate` (the `INSERT ... VALUES` path), `StorageView::replaceQueryParametersIfParameterizedView` (with its callers in `Context` and `InterpreterExplainQuery`), `InterpreterSetQuery` and the client-side substitution in `ClientBase`. The constructor parameter is required (no default), so the compiler enforces that no substitution site is missed.

Note on scope: this makes the whole class of text-input format settings apply to parameter parsing (e.g. `date_time_input_format`, `bool_true_representation`, `input_format_tsv_enum_as_number`), which is the requested behavior and consistent with how `CAST` from `String` already honors these settings — the serialize-then-CAST path used for `JSON`/`Dynamic`/`Variant` parameters previously used mismatched settings between the two steps and is now symmetric.

Verified by code-path analysis plus the included stateless test `04614_query_parameter_format_settings` (`best_effort` positive case, `basic` negative case, and a parameter inside `INSERT ... VALUES`); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Query parameter values (e.g. `{param:DateTime}`) are now parsed using the format settings of the session, such as `date_time_input_format`, instead of the default settings.
