### PR TITLE
Fix flaky 03921_kafka_formats (tolerate Kafka at-least-once re-delivery)

### DIFF
--- a/tests/queries/0_stateless/03921_kafka_formats.sh
+++ b/tests/queries/0_stateless/03921_kafka_formats.sh
@@ -112,22 +112,28 @@ $CLICKHOUSE_CLIENT -q "
     SELECT * FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_kafka;
 "
 
-# Wait for all messages to be consumed (120s to allow for slow consumer group assignment)
+# Wait for all messages to be consumed (120s to allow for slow consumer group assignment).
+# Guard each count query: under transient load a failed/empty result must fall back to 0,
+# otherwise the shell arithmetic below throws "integer expression expected".
 for i in $(seq 1 120); do
-    json_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_json_dst")
-    csv_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_csv_dst")
-    tsv_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_dst")
+    json_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_json_dst SETTINGS max_execution_time=5" 2>/dev/null || echo 0)
+    csv_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_csv_dst SETTINGS max_execution_time=5" 2>/dev/null || echo 0)
+    tsv_count=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_dst SETTINGS max_execution_time=5" 2>/dev/null || echo 0)
     if [ "$json_count" -ge 3 ] && [ "$csv_count" -ge 3 ] && [ "$tsv_count" -ge 3 ]; then
         break
     fi
     sleep 1
 done
 
+# SELECT DISTINCT: Kafka is at-least-once, so a batch whose offset commit does not land
+# before the next poll gets re-delivered and the MV re-inserts the same rows. DISTINCT
+# collapses such exact duplicates while still catching dropped rows (fewer) or mis-parsed
+# formats (an extra distinct row) - i.e. it preserves what this test verifies.
 echo "--- JSONEachRow ---"
-$CLICKHOUSE_CLIENT -q "SELECT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_json_dst ORDER BY a"
+$CLICKHOUSE_CLIENT -q "SELECT DISTINCT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_json_dst ORDER BY a"
 
 echo "--- CSV ---"
-$CLICKHOUSE_CLIENT -q "SELECT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_csv_dst ORDER BY a"
+$CLICKHOUSE_CLIENT -q "SELECT DISTINCT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_csv_dst ORDER BY a"
 
 echo "--- TSV ---"
-$CLICKHOUSE_CLIENT -q "SELECT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_dst ORDER BY a"
+$CLICKHOUSE_CLIENT -q "SELECT DISTINCT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_dst ORDER BY a"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/96487
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Stabilize the flaky `03921_kafka_formats` stateless test (master-wide, not caused by any single PR: 0 failures on `master` in 30 days, but it failed across 8+ unrelated PR runs on 2026-07-15/16, e.g. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110179&sha=fa683b6d73ed9e58fb74a753b13cd24e8020f173&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29 and the amd_tsan run pointed out by @ alexey-milovidov on #96487).

Two independent flake modes, both test-side:

1. `result differs with reference` (duplicate rows). Kafka is at-least-once: when a batch's offset commit does not land before the next poll (under load/rebalance) the batch is re-delivered and the MV re-inserts the same rows into the plain-MergeTree destination. The final `SELECT a, b ORDER BY a` then shows duplicates. Fixed with `SELECT DISTINCT a, b`, which collapses exact-duplicate re-delivery while still catching dropped rows (fewer rows) and mis-parsed formats (a differing distinct row) - the format-parsing behavior this test verifies is preserved.

2. `[: : integer expression expected` on stderr. In the `parallel` check the server's *global* budget (`max_server_memory_usage`, 41.84 GiB) is shared across all concurrently-running tests. When it is momentarily saturated by the other tests, even the trivial poll-loop `SELECT count() FROM <MergeTree>` (asking for a ~1 MiB chunk) is rejected by the total memory tracker: `Code: 241 ... (total) memory limit exceeded ... current RSS: 41.85 GiB, maximum: 41.84 GiB (MEMORY_LIMIT_EXCEEDED)`. On that exception the client writes to stderr and exits 241 with empty stdout, so `count=$(clickhouse-client -q "SELECT count() ...")` captured an empty string and the next line `[ "$count" -ge 3 ]` became `[ "" -ge 3 ]`, which makes bash print `integer expression expected`. clickhouse-test fails any run that writes to stderr, even though the stdout rows were all correct. The `count()` is a victim of host-wide saturation, not itself expensive. Guarded each count query with `SETTINGS max_execution_time=5` and `2>/dev/null || echo 0`, so a transient failure falls back to `0` and the poll loop retries, matching the pattern already used in the sibling `03923_kafka2_keeper_offsets.sh`.

No reference change (three distinct rows stay three rows). No source code touched; single test file.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1242` (included in `26.7` and later)
<!-- ch-version-info:end -->