### PR TITLE
Flaky check: match a fixture's extensionless stem when mapping it to its owning test

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -119,15 +119,20 @@ class Targeting:
         Fixtures carry their owning test's five-digit prefix by convention, so
         the prefix narrows the candidates to the `NNNNN_*` tests at the suite
         root (a handful of files, never the whole suite). Among those, prefer the
-        ones whose body actually references the fixture by name — either the full
-        filename or its extensionless stem, since format schemas are conventionally
-        referenced without the extension (`format_schema = 'NNNNN_foo:Message'`
-        for `format_schemas/NNNNN_foo.proto`); fall back to all
-        prefix siblings when the reference is constructed dynamically and cannot
-        be found textually. Return an empty list when the file has no numeric
-        prefix or no test with that prefix exists — there is then genuinely
-        nothing to rerun, and emitting a pattern that matches no test would make
-        `clickhouse-test` exit 1 (the failure mode `PR #104097` fixed).
+        ones whose body references the fixture's literal filename. When none
+        does, retry with the extensionless stem, since format schemas are
+        conventionally referenced without the extension
+        (`format_schema = 'NNNNN_foo:Message'` for `format_schemas/NNNNN_foo.proto`).
+        The stem is strictly a fallback: a short or cross-extension stem
+        (`03250.proto` → `03250`, or `03036_archive1.tar` next to a test that
+        reads `03036_archive1.zip`) would otherwise pull unrelated prefix
+        siblings into mappings the literal filename already resolves precisely.
+        Fall back to all prefix siblings when neither matches — the reference is
+        then constructed dynamically and cannot be found textually. Return an
+        empty list when the file has no numeric prefix or no test with that
+        prefix exists — there is then genuinely nothing to rerun, and emitting a
+        pattern that matches no test would make `clickhouse-test` exit 1 (the
+        failure mode `PR #104097` fixed).
         """
         match = re.match(r"(\d{5})", os.path.basename(fpath))
         if match is None:
@@ -142,15 +147,19 @@ class Targeting:
             return []
         fname = os.path.basename(fpath)
         stem = os.path.splitext(fname)[0]
-        referencing = []
+        by_fname = []
+        by_stem = []
         for base_name, test_file in candidates.items():
             try:
                 with test_file.open("r", encoding="utf-8", errors="ignore") as f:
                     body = f.read()
-                    if fname in body or stem in body:
-                        referencing.append(base_name)
             except OSError:
                 continue
+            if fname in body:
+                by_fname.append(base_name)
+            elif stem in body:
+                by_stem.append(base_name)
+        referencing = by_fname or by_stem
         return sorted(referencing) if referencing else sorted(candidates)
 
     @staticmethod

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -119,7 +119,10 @@ class Targeting:
         Fixtures carry their owning test's five-digit prefix by convention, so
         the prefix narrows the candidates to the `NNNNN_*` tests at the suite
         root (a handful of files, never the whole suite). Among those, prefer the
-        ones whose body actually references the fixture by name; fall back to all
+        ones whose body actually references the fixture by name — either the full
+        filename or its extensionless stem, since format schemas are conventionally
+        referenced without the extension (`format_schema = 'NNNNN_foo:Message'`
+        for `format_schemas/NNNNN_foo.proto`); fall back to all
         prefix siblings when the reference is constructed dynamically and cannot
         be found textually. Return an empty list when the file has no numeric
         prefix or no test with that prefix exists — there is then genuinely
@@ -138,11 +141,13 @@ class Targeting:
         if not candidates:
             return []
         fname = os.path.basename(fpath)
+        stem = os.path.splitext(fname)[0]
         referencing = []
         for base_name, test_file in candidates.items():
             try:
                 with test_file.open("r", encoding="utf-8", errors="ignore") as f:
-                    if fname in f.read():
+                    body = f.read()
+                    if fname in body or stem in body:
                         referencing.append(base_name)
             except OSError:
                 continue

--- a/ci/tests/test_find_tests.py
+++ b/ci/tests/test_find_tests.py
@@ -90,6 +90,39 @@ def test_subdirectory_data_fixture_maps_to_owning_test():
     assert owning == ["02716_parquet_invalid_date32"]
 
 
+def test_format_schema_maps_to_owning_test_by_extensionless_stem():
+    # Format schemas are conventionally referenced without the extension
+    # (`format_schema = '00825_protobuf_format_persons:Person'`), so the literal
+    # filename never appears in any test body. The stem fallback still maps the
+    # fixture to exactly its owning test instead of every `00825_*` sibling.
+    owning = Targeting._tests_owning_data_file(
+        "tests/queries/0_stateless/format_schemas/00825_protobuf_format_persons.proto"
+    )
+    assert owning == ["00825_protobuf_format_persons"]
+
+
+def test_literal_filename_match_beats_short_stem():
+    # `03250.proto` is referenced by filename in exactly one test, but its bare
+    # stem `03250` also appears in an unrelated sibling's body (tests routinely
+    # embed their own numeric prefix in table names). The literal match must
+    # take precedence, or the short stem would broaden a mapping that was
+    # already precise.
+    owning = Targeting._tests_owning_data_file(
+        "tests/queries/0_stateless/format_schemas/03250.proto"
+    )
+    assert owning == ["03250_SYSTEM_DROP_FORMAT_SCHEMA_CACHE_FOR_Protobuf"]
+
+
+def test_literal_filename_match_beats_cross_extension_stem():
+    # `03036_archive1.tar` is read by one test, while a sibling reads only
+    # `03036_archive1.zip`. The shared stem `03036_archive1` must not pull the
+    # `.zip`-only sibling into the `.tar` fixture's mapping.
+    owning = Targeting._tests_owning_data_file(
+        "tests/queries/0_stateless/data_minio/03036_archive1.tar"
+    )
+    assert owning == ["03036_reading_s3_archives"]
+
+
 def test_orphan_data_file_maps_to_owning_test_by_prefix():
     # PR #104097 reproducer: `_derive_test_name` returns None for this `.tsv`,
     # so it used to be skipped. It carries the `02995` prefix of the test that


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The CI flaky check maps a changed auxiliary file back to the tests that own it (`_tests_owning_data_file` in `ci/jobs/scripts/find_tests.py`): candidates are narrowed to tests sharing the fixture's five-digit prefix, and among those it prefers the ones whose body references the fixture's literal filename, falling back to *all* prefix siblings otherwise.

Format schemas are conventionally referenced without the extension — `format_schema = 'NNNNN_foo:Message'` for `format_schemas/NNNNN_foo.proto` — so a PR adding a schema fixture never matches the literal-filename check and hits the fallback. On https://github.com/ClickHouse/ClickHouse/pull/107739 this made the flaky check (both public and in the `CH Inc sync` run) repeatedly execute the heavy, unrelated `04409_filesystem_cache_reserve_granularity` (a number-prefix sibling of the PR's own test), which deterministically fails with "Test runs too long" under ASan: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=107739&sha=b37d1cc3dbb68cb2c2e3f82de590b84d0e79e2bd&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20flaky%20check%29

Fix: match in two tiers. Candidates whose body references the fixture's literal filename win outright; only when no candidate matches the full filename is the extensionless stem consulted, and only when neither matches does the mapping fall back to all prefix siblings. Keeping the stem strictly as a fallback prevents a short or cross-extension stem from broadening mappings the literal filename already resolves precisely (`format_schemas/03250.proto` stays mapped to exactly `03250_SYSTEM_DROP_FORMAT_SCHEMA_CACHE_FOR_Protobuf` even though its bare stem `03250` appears in an unrelated sibling's table names, and `data_minio/03036_archive1.tar` stays mapped to exactly `03036_reading_s3_archives` even though a sibling reads `03036_archive1.zip`).

Verified that `00825_protobuf_format_persons.proto` now maps to exactly `00825_protobuf_format_persons` (previously: fallback to every `00825_*` test), and that filename-referenced fixtures (`data_parquet/02716_data.parquet`) keep their precise mapping. Regression tests for the motivating case and both would-be-broadened cases are added to `ci/tests/test_find_tests.py`.

Related: https://github.com/ClickHouse/ClickHouse/pull/107739


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1196` (included in `26.7` and later)
<!-- ch-version-info:end -->