### PR TITLE
Fix CHECK TABLE reporting healthy parts as broken for JSON columns with long paths

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2933,6 +2933,21 @@ std::optional<String> IMergeTreeDataPart::getStreamNameOrHash(
     const String & extension,
     const IDataPartStorage & storage_)
 {
+    /// NAME_MAX on most local filesystems.
+    static constexpr size_t max_local_file_name_length = 255;
+
+    if (stream_name.size() + extension.size() > max_local_file_name_length)
+    {
+        /// A file with such a long raw name is normally stored under the hashed name
+        /// (see the `replace_long_file_name_to_hash` setting). Probe the hash first:
+        /// probing the raw name on a local disk throws `File name too long` instead of
+        /// returning false, which made `CHECK TABLE` report healthy parts as broken
+        /// for `JSON` columns with long paths.
+        auto hash = sipHash128String(stream_name);
+        if (storage_.existsFile(hash + extension))
+            return hash;
+    }
+
     if (storage_.existsFile(stream_name + extension))
         return stream_name;
 

--- a/tests/queries/0_stateless/04619_check_table_json_long_paths.reference
+++ b/tests/queries/0_stateless/04619_check_table_json_long_paths.reference
@@ -1,0 +1,2 @@
+check result
+1

--- a/tests/queries/0_stateless/04619_check_table_json_long_paths.sql
+++ b/tests/queries/0_stateless/04619_check_table_json_long_paths.sql
@@ -1,0 +1,16 @@
+-- Test for issue #100153: `CHECK TABLE` reported healthy parts as broken for `JSON`
+-- columns with paths longer than the filesystem name limit, because probing the raw
+-- substream file name threw `File name too long` before the hashed name was tried.
+
+set enable_json_type = 1;
+
+drop table if exists t_04619;
+create table t_04619 (j JSON) engine = MergeTree order by tuple()
+    settings min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0, replace_long_file_name_to_hash = 1;
+
+insert into t_04619 select toJSONString(map(repeat('a', 300), 42));
+
+select 'check result';
+check table t_04619 settings check_query_single_value_result = 1;
+
+drop table t_04619;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/100153

`CHECK TABLE` reported healthy parts as broken when a `JSON` column contained a path long enough that the escaped substream file name exceeds the filesystem name limit:

```sql
CREATE TABLE t (j JSON) ENGINE = MergeTree ORDER BY tuple() SETTINGS min_bytes_for_wide_part = 0;
INSERT INTO t SELECT toJSONString(map(repeat('a', 300), 42));
CHECK TABLE t;  -- 0, "File name too long"
```

### Root cause

For wide parts, `CHECK TABLE` resolves the streams listed in `columns_substreams.txt` (raw, unhashed names) through the storage-based `IMergeTreeDataPart::getStreamNameOrHash`, which probes `existsFile(raw_name)` first. For a name longer than `NAME_MAX` (255 bytes), `DiskLocal::existsFile` uses the throwing overload of `fs::is_regular_file`, which raises `File name too long` instead of returning `false` — so the hashed name (the file actually on disk, thanks to `replace_long_file_name_to_hash`) is never tried, and the part is reported broken.

### Fix

When the probed name is longer than 255 bytes, probe the hashed name first. The raw probe is kept afterwards, so parts on object storages that legitimately store longer raw names (written with `replace_long_file_name_to_hash = 0`) still resolve.

Verified by code-path analysis plus the included stateless test `04619_check_table_json_long_paths`; no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `CHECK TABLE` reporting healthy parts as broken with a `File name too long` error for `JSON` columns with long paths.
