### PR TITLE
Enforce per-query and per-user temporary data limits on external sort

### DIFF
--- a/src/Processors/QueryPlan/SortingStep.cpp
+++ b/src/Processors/QueryPlan/SortingStep.cpp
@@ -17,6 +17,7 @@
 #include <Processors/Transforms/PartialSortingTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <QueryPipeline/scatterByPartition.h>
+#include <Common/CurrentThread.h>
 #include <Common/JSONBuilder.h>
 #include <Common/MemoryTrackerUtils.h>
 
@@ -424,9 +425,19 @@ void SortingStep::mergeSorting(
 {
     bool increase_sort_description_compile_attempts = true;
 
+    /// Prefer the temporary data scope of the query context: it accounts for the per-query and
+    /// per-user limits (`max_temporary_data_on_disk_size_for_query` and `_for_user`), which the
+    /// server-global scope does not. Fall back to the global scope when there is no query
+    /// context (e.g. when the pipeline is built outside of a query).
+    TemporaryDataOnDiskScopePtr parent_scope;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        parent_scope = query_context->getTempDataOnDisk();
+    if (!parent_scope)
+        parent_scope = Context::getGlobalContextInstance()->getSharedTempDataOnDisk();
+
     TemporaryDataOnDiskScopePtr tmp_data_on_disk = nullptr;
-    if (auto data = Context::getGlobalContextInstance()->getSharedTempDataOnDisk())
-        tmp_data_on_disk = data->childScope({
+    if (parent_scope)
+        tmp_data_on_disk = parent_scope->childScope({
             .current_metric = CurrentMetrics::TemporaryFilesForSort,
             .bytes_compressed = ProfileEvents::ExternalSortCompressedBytes,
             .bytes_uncompressed = ProfileEvents::ExternalSortUncompressedBytes,

--- a/tests/queries/0_stateless/04620_external_sort_temp_data_limit.reference
+++ b/tests/queries/0_stateless/04620_external_sort_temp_data_limit.reference
@@ -1,0 +1,1 @@
+spill without per-query limit works

--- a/tests/queries/0_stateless/04620_external_sort_temp_data_limit.sql
+++ b/tests/queries/0_stateless/04620_external_sort_temp_data_limit.sql
@@ -1,0 +1,12 @@
+-- Test for issue #105638: `max_temporary_data_on_disk_size_for_query` was not enforced
+-- on external sort spill, because the spill scope was created from the server-global
+-- temporary data scope instead of the scope of the query context that carries the
+-- per-query and per-user limits.
+
+select 'spill without per-query limit works';
+select toString(cityHash64(number)) as s from numbers(2000000) order by s format Null
+settings max_bytes_before_external_sort = 10000000, max_bytes_ratio_before_external_sort = 0, max_threads = 1;
+
+select toString(cityHash64(number)) as s from numbers(2000000) order by s format Null
+settings max_bytes_before_external_sort = 10000000, max_bytes_ratio_before_external_sort = 0, max_threads = 1,
+         max_temporary_data_on_disk_size_for_query = 1000000; -- { serverError TOO_MANY_ROWS_OR_BYTES }


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/105638

`max_temporary_data_on_disk_size_for_query` and `max_temporary_data_on_disk_size_for_user` were not enforced on external sort spill: a query with `ORDER BY` could spill arbitrarily more temporary data than the configured limits, while `GROUP BY` (aggregation) spill respected them.

### Root cause

`SortingStep::mergeSorting` created the spill scope from the server-global temporary data scope (`Context::getGlobalContextInstance()->getSharedTempDataOnDisk()`). The per-query and per-user limit scopes are installed by `ProcessList` on the *query context* (`Context::getTempDataOnDisk`), so the global scope bypassed them — only the server-level limit applied. Aggregation already uses the query context's scope (`Planner.cpp`), hence the asymmetry.

### Fix

Prefer the temporary data scope of the current query context (via `CurrentThread::tryGetQueryContext`), falling back to the global scope when there is no query context (e.g. pipelines built outside of a query). The query scope's parent chain is query → user → server root, so all three limits are enforced; threads without a query context keep the old behavior exactly.

Note on user-visible behavior: queries that previously spilled past the configured per-query/per-user limits in `ORDER BY` now correctly fail with `TOO_MANY_ROWS_OR_BYTES` — that is the documented contract of these settings, and matches the existing enforcement for `GROUP BY`/`JOIN` spill. The defaults are unlimited, so only users who set the limits are affected.

Known follow-up (not in this PR, to keep it one logical change): the plan-deserialization path of `AggregatingStep` and `JoinStepLogical` still create their spill scopes from the global context and bypass the per-query limits the same way.

Verified by code-path analysis plus the included stateless test `04620_external_sort_temp_data_limit`; no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `max_temporary_data_on_disk_size_for_query` and `max_temporary_data_on_disk_size_for_user` not being enforced on external sort spill.
