### PR TITLE
Pin part_loading_tree_rollback tests to the local default storage policy

### DIFF
--- a/tests/queries/0_stateless/04063_part_loading_tree_rollback_reparent.sh
+++ b/tests/queries/0_stateless/04063_part_loading_tree_rollback_reparent.sh
@@ -39,24 +39,17 @@ cleanup()
 trap cleanup EXIT
 cleanup
 
+# Pin to the local `default` policy: the raw txn_version.txt fabricated below only parses on a
+# local disk, and `no-object-storage` does not fire when the server default policy is object storage.
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE ${TABLE} (x UInt32)
     ENGINE = MergeTree ORDER BY x
+    SETTINGS storage_policy = 'default'
 "
 
 # One insert creates a committed part (`all_1_1_0`) with valid data files that we
 # will copy to build the fake parts needed for the test scenario.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
-
-# The fabrication below writes part files (a raw txn_version.txt) straight into the part
-# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
-# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
-# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
-# object-storage metadata and part loading throws. Skip on any non-local disk.
-if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
-    echo OK
-    exit 0
-fi
 
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]

--- a/tests/queries/0_stateless/04063_part_loading_tree_rollback_reparent.sh
+++ b/tests/queries/0_stateless/04063_part_loading_tree_rollback_reparent.sh
@@ -48,6 +48,16 @@ $CLICKHOUSE_CLIENT -q "
 # will copy to build the fake parts needed for the test scenario.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
 
+# The fabrication below writes part files (a raw txn_version.txt) straight into the part
+# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
+# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
+# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
+# object-storage metadata and part loading throws. Skip on any non-local disk.
+if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
+    echo OK
+    exit 0
+fi
+
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]
     FROM system.tables

--- a/tests/queries/0_stateless/04241_part_loading_tree_rollback_contains.sh
+++ b/tests/queries/0_stateless/04241_part_loading_tree_rollback_contains.sh
@@ -46,6 +46,16 @@ $CLICKHOUSE_CLIENT -q "
 # Create a committed source part on disk that we will clone to fabricate the test parts.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
 
+# The fabrication below writes part files (a raw txn_version.txt) straight into the part
+# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
+# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
+# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
+# object-storage metadata and part loading throws. Skip on any non-local disk.
+if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
+    echo OK
+    exit 0
+fi
+
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]
     FROM system.tables

--- a/tests/queries/0_stateless/04241_part_loading_tree_rollback_contains.sh
+++ b/tests/queries/0_stateless/04241_part_loading_tree_rollback_contains.sh
@@ -38,23 +38,16 @@ cleanup()
 trap cleanup EXIT
 cleanup
 
+# Pin to the local `default` policy: the raw txn_version.txt fabricated below only parses on a
+# local disk, and `no-object-storage` does not fire when the server default policy is object storage.
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE ${TABLE} (x UInt32)
     ENGINE = MergeTree ORDER BY x
+    SETTINGS storage_policy = 'default'
 "
 
 # Create a committed source part on disk that we will clone to fabricate the test parts.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
-
-# The fabrication below writes part files (a raw txn_version.txt) straight into the part
-# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
-# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
-# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
-# object-storage metadata and part loading throws. Skip on any non-local disk.
-if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
-    echo OK
-    exit 0
-fi
 
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]

--- a/tests/queries/0_stateless/04417_part_loading_tree_rollback_evict_reinsert_contains.sh
+++ b/tests/queries/0_stateless/04417_part_loading_tree_rollback_evict_reinsert_contains.sh
@@ -61,6 +61,16 @@ $CLICKHOUSE_CLIENT -q "
 # Create a committed source part on disk that we clone to fabricate the test parts.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
 
+# The fabrication below writes part files (a raw txn_version.txt) straight into the part
+# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
+# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
+# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
+# object-storage metadata and part loading throws. Skip on any non-local disk.
+if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
+    echo OK
+    exit 0
+fi
+
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]
     FROM system.tables

--- a/tests/queries/0_stateless/04417_part_loading_tree_rollback_evict_reinsert_contains.sh
+++ b/tests/queries/0_stateless/04417_part_loading_tree_rollback_evict_reinsert_contains.sh
@@ -53,23 +53,16 @@ cleanup()
 trap cleanup EXIT
 cleanup
 
+# Pin to the local `default` policy: the raw txn_version.txt fabricated below only parses on a
+# local disk, and `no-object-storage` does not fire when the server default policy is object storage.
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE ${TABLE} (x UInt32)
     ENGINE = MergeTree ORDER BY x
+    SETTINGS storage_policy = 'default'
 "
 
 # Create a committed source part on disk that we clone to fabricate the test parts.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
-
-# The fabrication below writes part files (a raw txn_version.txt) straight into the part
-# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
-# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
-# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
-# object-storage metadata and part loading throws. Skip on any non-local disk.
-if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
-    echo OK
-    exit 0
-fi
 
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]

--- a/tests/queries/0_stateless/04500_part_loading_tree_rollback_tmp_metadata.sh
+++ b/tests/queries/0_stateless/04500_part_loading_tree_rollback_tmp_metadata.sh
@@ -34,24 +34,17 @@ cleanup()
 trap cleanup EXIT
 cleanup
 
+# Pin to the local `default` policy: the raw txn_version.txt fabricated below only parses on a
+# local disk, and `no-object-storage` does not fire when the server default policy is object storage.
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE ${TABLE} (x UInt32)
     ENGINE = MergeTree ORDER BY x
+    SETTINGS storage_policy = 'default'
 "
 
 # One insert creates a committed part (`all_1_1_0`) with valid data files that we
 # will copy to build the fake parts needed for the test scenario.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
-
-# The fabrication below writes part files (a raw txn_version.txt) straight into the part
-# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
-# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
-# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
-# object-storage metadata and part loading throws. Skip on any non-local disk.
-if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
-    echo OK
-    exit 0
-fi
 
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]

--- a/tests/queries/0_stateless/04500_part_loading_tree_rollback_tmp_metadata.sh
+++ b/tests/queries/0_stateless/04500_part_loading_tree_rollback_tmp_metadata.sh
@@ -43,6 +43,16 @@ $CLICKHOUSE_CLIENT -q "
 # will copy to build the fake parts needed for the test scenario.
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
 
+# The fabrication below writes part files (a raw txn_version.txt) straight into the part
+# directory, which is only valid on a local disk. The `no-object-storage` tag only skips the
+# object-storage *runner* modes (--s3-storage/--azure-blob-storage); it does not fire when the
+# server's *default* disk is object-storage (e.g. under stress), where the raw file is not valid
+# object-storage metadata and part loading throws. Skip on any non-local disk.
+if [ "$($CLICKHOUSE_CLIENT -q "SELECT type FROM system.disks WHERE name = (SELECT disk_name FROM system.parts WHERE database = currentDatabase() AND table = '${TABLE}' AND active LIMIT 1)")" != "Local" ]; then
+    echo OK
+    exit 0
+fi
+
 DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1]
     FROM system.tables


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/100992
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes stress-test `Cannot start clickhouse-server` boot failures with `Code: 246 CORRUPTED_DATA: Part all_5_6_1_0 intersects previous part all_1_5_4_1 and the transaction metadata of at least one of them could not be read` for tables `t_plt_reparent` / `t_plt_evict_reinsert`.

**Cause.** The four `part_loading_tree_rollback` tests (`04063`, `04241`, `04417`, `04500`, added in #100992) fabricate a rolled-back part by writing a raw `txn_version.txt` straight into the part directory with `cp`+`printf`. That is only valid on a local disk. On an object-storage / `local_blob_storage` disk a part-dir file must be `DiskObjectStorageMetadata` format, so the raw file fails to parse (`CANNOT_PARSE_INPUT_ASSERTION_FAILED` in `DiskObjectStorageMetadata::deserialize`), which #100992's new `PartLoadingTree::add` txn-metadata read classifies as `Unreadable` and turns into a fatal `Code 246` at part load. The failed `ATTACH` leaves a detached, poisoned table whose `.sql` survives to the stress restart, so the next boot aborts.

The tests carry `no-object-storage`, but that tag only skips the object-storage *runner* modes (`--s3-storage` / `--azure-blob-storage`); it does not fire when the server's *default* disk is object-storage (as under stress), so the tests run there anyway.

**Fix.** Pin the four `CREATE TABLE`s to `SETTINGS storage_policy = 'default'`, so the seeding part always lands on the built-in local `default` disk even when the MergeTree default policy is object-storage under stress. The raw `txn_version.txt` fabrication then parses and the `PartLoadingTree::add` regression keeps running (it is not turned into a skipped no-op). The stress config override (`config.d/s3_storage_policy_for_merge_tree_by_default.xml`) only sets `<merge_tree><storage_policy>`, so the built-in `default` policy is never remapped and the pin is reliable. Same pattern as the already-merged raw-filesystem test `04063_drop_detached_part_with_try_n_suffix.sh`.

Deterministic; reproduced both directions locally (object-storage default disk: without the pin `Code 246`, with the pin the ATTACH succeeds and the assertions run; local disk unchanged).

**Follow-ups for the author (@ tuanpach), not addressed here:**
1. Should `no-object-storage` also skip when the server *default* disk is object-storage? The runner-flag-only gate misses this whole class of raw part-fabrication tests.
2. Should the load-time `Unreadable` txn-metadata case abort the entire server boot, or skip/quarantine the single affected part/table? A single unparseable `txn_version.txt` currently prevents startup.
