### PR TITLE
Support comparing Date with a String containing a date and time

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -1014,7 +1014,42 @@ private:
             return DataTypeUInt8().createColumnConst(input_rows_count, IsOperation<Op>::not_equals);
         }
 
-        Field converted = convertFieldToType(string_value, *type_to_compare, type_string, params.format_settings);
+        /// The type to which the string constant is converted. Usually it is the type of the other argument.
+        /// But a Date/Date32 argument can also be compared with a string containing a date and time:
+        /// then the string is converted to DateTime64, and the arguments are compared through their common type.
+        DataTypePtr string_conversion_type = type_to_compare;
+        Field converted;
+
+        if (WhichDataType(type_to_compare).isDateOrDate32())
+        {
+            converted = tryConvertFieldToType(string_value, *type_to_compare, type_string, params.format_settings);
+
+            if (converted.isNull())
+            {
+                /// The string cannot be parsed as Date/Date32, e.g. it contains a date with a time: '2026-01-01 00:00:00'.
+                /// Try to parse it as DateTime64 with the scale 6 - it is enough for fractional seconds up to microseconds,
+                /// and extra digits are ignored by parsing. DateTime64 is used instead of DateTime because parsing
+                /// of the latter clamps values outside the [1970, 2106] years range, while DateTime64 covers
+                /// the whole range of Date32. The default time zone is used, as for a DateTime64 literal.
+                DataTypePtr datetime_type = std::make_shared<DataTypeDateTime64>(6);
+                Field converted_to_datetime = tryConvertFieldToType(string_value, *datetime_type, type_string, params.format_settings);
+
+                if (converted_to_datetime.isNull())
+                {
+                    /// The string is not a date with a time either. Repeat the conversion to Date/Date32 to report the original error.
+                    converted = convertFieldToType(string_value, *type_to_compare, type_string, params.format_settings);
+                }
+                else
+                {
+                    converted = converted_to_datetime;
+                    string_conversion_type = datetime_type;
+                }
+            }
+        }
+        else
+        {
+            converted = convertFieldToType(string_value, *type_to_compare, type_string, params.format_settings);
+        }
 
         /// If not possible to convert, comparison with =, <, >, <=, >= yields to false and comparison with != yields to true.
         if (converted.isNull())
@@ -1022,11 +1057,11 @@ private:
             return DataTypeUInt8().createColumnConst(input_rows_count, IsOperation<Op>::not_equals);
         }
 
-        ColumnPtr column_converted = type_to_compare->createColumnConst(input_rows_count, converted);
+        ColumnPtr column_converted = string_conversion_type->createColumnConst(input_rows_count, converted);
 
         ColumnsWithTypeAndName tmp_columns{
-            {left_const ? column_converted : col_left_untyped->getPtr(), type_to_compare, ""},
-            {!left_const ? column_converted : col_right_untyped->getPtr(), type_to_compare, ""},
+            {left_const ? column_converted : col_left_untyped->getPtr(), left_const ? string_conversion_type : type_to_compare, ""},
+            {!left_const ? column_converted : col_right_untyped->getPtr(), !left_const ? string_conversion_type : type_to_compare, ""},
         };
 
         return executeImpl(tmp_columns, result_type, input_rows_count);

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -3750,7 +3750,15 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
 
                     if (!should_keep_original_string_constant)
                     {
-                        const_value = convertFieldToType(const_value, *key_expr_type_not_null);
+                        /// A Date/Date32 key column can also be compared with a string containing a date and time
+                        /// (the string is then parsed as DateTime64, see `executeWithConstString`), so a failure
+                        /// to convert such a string to the key type is not an error. Skip building the atom,
+                        /// and the condition will be checked during execution.
+                        if (isDateOrDate32(key_expr_type_not_null))
+                            const_value = tryConvertFieldToType(const_value, *key_expr_type_not_null);
+                        else
+                            const_value = convertFieldToType(const_value, *key_expr_type_not_null);
+
                         if (const_value.isNull())
                             return false;
                         /// No need to set condition_is_relaxed because we're doing exact conversion

--- a/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexBloomFilter.cpp
@@ -130,6 +130,17 @@ void MergeTreeIndexGranuleBloomFilter::fillingBloomFilter(BloomFilterPtr & bf, c
 namespace
 {
 
+/// A String value that cannot be parsed as the target type (e.g. a `Date` column compared
+/// with a date-and-time string, see the similar handling in `KeyCondition`) must not fail
+/// the whole query during index analysis. Return a Null field instead, so that the caller
+/// excludes the atom from the index condition.
+Field convertFieldSkippingUnparsableDateStrings(const Field & field, const IDataType & type, const IDataType * hint = nullptr)
+{
+    if (field.getType() == Field::Types::String && WhichDataType(type).isDateOrDate32())
+        return tryConvertFieldToType(field, type, hint);
+    return convertFieldToType(field, type, hint);
+}
+
 ColumnWithTypeAndName getPreparedSetInfo(const ConstSetPtr & prepared_set)
 {
     if (prepared_set->getDataTypes().size() == 1)
@@ -702,7 +713,7 @@ static ColumnPtr createColumnFromConstantArray(const Field & value_field, const 
         if ((f.isNull() && !is_nullable) || f.isDecimal(f.getType())) /// NOLINT(readability-static-accessed-through-instance)
             return nullptr;
 
-        auto converted = convertFieldToType(f, *actual_type);
+        auto converted = convertFieldSkippingUnparsableDateStrings(f, *actual_type);
         if (converted.isNull())
             return nullptr;
 
@@ -818,7 +829,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
                 {
                     out.function = RPNElement::FUNCTION_HAS;
                     const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-                    auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+                    auto converted_field = convertFieldSkippingUnparsableDateStrings(value_field, *actual_type, value_type.get());
                     if (converted_field.isNull())
                         return false;
 
@@ -860,7 +871,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
 
             out.function = function_name == "equals" ? RPNElement::FUNCTION_EQUALS : RPNElement::FUNCTION_NOT_EQUALS;
             const DataTypePtr actual_type = BloomFilter::getPrimitiveType(index_type);
-            auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+            auto converted_field = convertFieldSkippingUnparsableDateStrings(value_field, *actual_type, value_type.get());
             if (converted_field.isNull())
                 return false;
 
@@ -907,7 +918,7 @@ bool MergeTreeIndexConditionBloomFilter::traverseTreeEquals(
 
         out.function = RPNElement::FUNCTION_HAS;
         const DataTypePtr actual_type = BloomFilter::getPrimitiveType(array_type->getNestedType());
-        auto converted_field = convertFieldToType(value_field, *actual_type, value_type.get());
+        auto converted_field = convertFieldSkippingUnparsableDateStrings(value_field, *actual_type, value_type.get());
         if (converted_field.isNull())
             return false;
 

--- a/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
+++ b/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
@@ -39,3 +39,4 @@ Filtering by a Date key column
 1
 1
 Invalid strings still throw
+1

--- a/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
+++ b/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
@@ -38,5 +38,5 @@ Filtering by a Date key column
 2
 1
 1
-Invalid strings still throw
 1
+Invalid strings still throw

--- a/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
+++ b/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.reference
@@ -1,0 +1,41 @@
+Date vs a string with a date and time
+1
+0
+1
+1
+1
+0
+0
+1
+1
+String on the left side
+1
+0
+1
+1
+Date32
+1
+1
+0
+1
+1
+1
+Fractional seconds
+1
+1
+0
+1
+Non-constant date column
+1
+1
+1
+1
+Strings without a time still work
+1
+1
+1
+Filtering by a Date key column
+2
+1
+1
+Invalid strings still throw

--- a/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.sql
+++ b/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.sql
@@ -56,6 +56,13 @@ SELECT count() FROM t_date_vs_datetime_string WHERE d = '2026-01-01 00:00:00';
 SELECT count() FROM t_date_vs_datetime_string WHERE d > '2026-01-01 12:00:00';
 DROP TABLE t_date_vs_datetime_string;
 
+-- A bloom filter skip index on a `Date` column must not fail the query either.
+DROP TABLE IF EXISTS t_date_bloom_filter;
+CREATE TABLE t_date_bloom_filter (d Date, INDEX bf d TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_date_bloom_filter VALUES ('2026-01-01'), ('2026-01-02'), ('2026-01-03');
+SELECT count() FROM t_date_bloom_filter WHERE d = '2026-01-02 00:00:00';
+DROP TABLE t_date_bloom_filter;
+
 SELECT 'Invalid strings still throw';
 SELECT toDate('2026-01-01') = 'garbage'; -- { serverError CANNOT_PARSE_DATE }
 SELECT toDate32('2026-01-01') = 'garbage'; -- { serverError CANNOT_PARSE_DATE }

--- a/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.sql
+++ b/tests/queries/0_stateless/04624_date_vs_datetime_string_comparison.sql
@@ -1,0 +1,62 @@
+-- Comparing Date/Date32 with a String containing a date and time.
+-- https://github.com/ClickHouse/ClickHouse/issues/99372
+
+-- The time zone is pinned because the test framework randomizes `session_timezone`,
+-- and some time zones have DST transitions at midnight.
+SET session_timezone = 'UTC';
+
+SELECT 'Date vs a string with a date and time';
+SELECT toDate('2026-01-01') < '2026-01-01 12:00:00';
+SELECT toDate('2026-01-01') > '2026-01-01 12:00:00';
+SELECT toDate('2026-01-01') <= '2026-01-01 00:00:00';
+SELECT toDate('2026-01-01') >= '2026-01-01 00:00:00';
+SELECT toDate('2026-01-01') = '2026-01-01 00:00:00';
+SELECT toDate('2026-01-01') != '2026-01-01 00:00:00';
+SELECT toDate('2026-01-01') = '2026-01-01 12:00:00';
+SELECT toDate('2026-01-01') != '2026-01-01 12:00:00';
+SELECT toDate('2026-01-02') > '2026-01-01 23:59:59';
+
+SELECT 'String on the left side';
+SELECT '2026-01-01 12:00:00' > toDate('2026-01-01');
+SELECT '2026-01-01 12:00:00' < toDate('2026-01-01');
+SELECT '2026-01-01 00:00:00' = toDate('2026-01-01');
+SELECT '2026-01-01 12:00:00' != toDate('2026-01-01');
+
+SELECT 'Date32';
+SELECT toDate32('2026-01-01') < '2026-01-01 12:00:00';
+SELECT toDate32('2026-01-01') = '2026-01-01 00:00:00';
+SELECT toDate32('2026-01-01') = '2026-01-01 12:00:00';
+SELECT '2026-01-01 12:00:00' > toDate32('2026-01-01');
+SELECT toDate32('1950-06-15') = '1950-06-15 00:00:00';
+SELECT toDate32('1950-06-15') < '1950-06-15 12:00:00';
+
+SELECT 'Fractional seconds';
+SELECT toDate('2026-01-01') < '2026-01-01 00:00:00.500';
+SELECT toDate('2026-01-01') = '2026-01-01 00:00:00.000';
+SELECT toDate('2026-01-01') = '2026-01-01 00:00:00.500';
+SELECT '2026-01-01 00:00:00.500' > toDate('2026-01-01');
+
+SELECT 'Non-constant date column';
+SELECT materialize(toDate('2026-01-01')) < '2026-01-01 12:00:00';
+SELECT materialize(toDate('2026-01-01')) = '2026-01-01 00:00:00';
+SELECT materialize(toDate32('2026-01-01')) < '2026-01-01 12:00:00';
+SELECT '2026-01-01 12:00:00' > materialize(toDate('2026-01-01'));
+
+SELECT 'Strings without a time still work';
+SELECT toDate('2026-01-01') = '2026-01-01';
+SELECT toDate('2026-01-01') < '2026-01-02';
+SELECT toDateTime('2026-01-01 00:00:00') = '2026-01-01';
+
+SELECT 'Filtering by a Date key column';
+DROP TABLE IF EXISTS t_date_vs_datetime_string;
+CREATE TABLE t_date_vs_datetime_string (d Date) ENGINE = MergeTree ORDER BY d;
+INSERT INTO t_date_vs_datetime_string VALUES ('2025-12-31'), ('2026-01-01'), ('2026-01-02');
+SELECT count() FROM t_date_vs_datetime_string WHERE d < '2026-01-01 12:00:00';
+SELECT count() FROM t_date_vs_datetime_string WHERE d = '2026-01-01 00:00:00';
+SELECT count() FROM t_date_vs_datetime_string WHERE d > '2026-01-01 12:00:00';
+DROP TABLE t_date_vs_datetime_string;
+
+SELECT 'Invalid strings still throw';
+SELECT toDate('2026-01-01') = 'garbage'; -- { serverError CANNOT_PARSE_DATE }
+SELECT toDate32('2026-01-01') = 'garbage'; -- { serverError CANNOT_PARSE_DATE }
+SELECT toDate('2026-01-01') < '2026-01-01 12:00:00 garbage'; -- { serverError TYPE_MISMATCH }


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/99372

Comparing a `Date` or `Date32` value with a `String` containing a date **with a time** threw an exception, while the same comparison against a `DateTime` column worked:

```sql
SELECT toDate('2026-01-01') < '2026-01-01 12:00:00';
-- Code: 53. DB::Exception: Cannot convert string '2026-01-01 12:00:00' to type Date. (TYPE_MISMATCH)
SELECT toDateTime('2026-01-01 00:00:00') < '2026-01-02';  -- works
```

### Root cause

`executeWithConstString` in `FunctionsComparison.h` converts the string constant to the other side's type; parsing `2026-01-01 12:00:00` as `Date` fails on the trailing time. The same throwing conversion sits in `KeyCondition` (filtering a `MergeTree` table by its `Date` key) and in the `bloom_filter` skip index analysis, so the error also fired there.

### Fix

When the string does not parse as `Date`/`Date32`, retry it as `DateTime64(6)` and compare through the existing mixed date/datetime supertype path — the same semantics as a native `Date` vs `DateTime` comparison (the `Date` side is midnight in the session timezone). `DateTime64` is used instead of `DateTime` because its parsing does not clamp pre-1970 values (correctness for `Date32`) and supports fractional seconds; scale 6 covers the whole `Date32` range without `Int64` overflow. Strings that parse as neither still throw exactly the previous errors.

`KeyCondition` and the `bloom_filter` index analysis now use the non-throwing conversion for `Date`/`Date32` columns and simply exclude the atom from index analysis when the string doesn't parse as the column type (no pruning; correctness comes from the execution-time filter, which handles the comparison per the above).

Disclosed behavior notes:
- Only previously-throwing comparisons change results; date-only strings take the original path first and are bit-identical.
- `IN` with such strings still throws (set building converts independently) — can be addressed in a follow-up.
- For a `Date` key column, an unparseable string in `WHERE` now errors at execution rather than during index analysis, so a fully-pruned/empty table returns an empty result instead of an error — matching the existing behavior for non-key columns.

Verified by code-path analysis plus the stateless test `04624_date_vs_datetime_string_comparison` (both operand orders, all comparison operators, `Date32` pre-epoch values, fractional seconds, `MergeTree` key filtering, a `bloom_filter`-indexed column, unchanged error cases; session timezone pinned); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Comparing `Date` and `Date32` values with a string containing a date and time (e.g. `toDate('2026-01-01') < '2026-01-01 12:00:00'`) now works instead of throwing, consistent with `DateTime` comparisons.
