### PR TITLE
Do not flatten an unsubstituted query parameter into the RENAME TO target of ALTER USER

### DIFF
--- a/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
+++ b/src/Interpreters/Access/InterpreterCreateUserQuery.cpp
@@ -57,7 +57,7 @@ namespace
         if (override_name)
             user.setName(override_name->toString());
         else if (query.new_name)
-            user.setName(*query.new_name);
+            user.setName(query.new_name->toString());
         else if (query.names->size() == 1)
             user.setName(query.names->toStrings().at(0));
 
@@ -212,7 +212,7 @@ BlockIO InterpreterCreateUserQuery::execute()
         access->checkAccess(query.alter ? AccessType::ALTER_USER : AccessType::CREATE_USER, name);
 
     if (query.new_name && !query.alter)
-        access->checkAccess(AccessType::CREATE_USER, *query.new_name);
+        access->checkAccess(AccessType::CREATE_USER, query.new_name->toString());
 
     bool implicit_no_password_allowed = access_control.isImplicitNoPasswordAllowed();
     bool no_password_allowed = access_control.isNoPasswordAllowed();

--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -61,6 +61,11 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
                 ASTPtr names = create_user_query->names;
                 visitChildren(names);
             }
+            if (create_user_query->new_name)
+            {
+                ASTPtr new_name = create_user_query->new_name;
+                visitChildren(new_name);
+            }
             visitChildren(ast);
         }
         else if (auto * create_query = dynamic_cast<ASTCreateQuery *>(ast.get()))

--- a/src/Parsers/Access/ASTCreateUserQuery.cpp
+++ b/src/Parsers/Access/ASTCreateUserQuery.cpp
@@ -12,9 +12,10 @@ namespace DB
 
 namespace
 {
-    void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
+    void formatRenameTo(const IAST & new_name, WriteBuffer & ostr, const IAST::FormatSettings & format)
     {
-        ostr << " RENAME TO " << quoteString(new_name);
+        ostr << " RENAME TO ";
+        new_name.format(ostr, format);
     }
 
     void formatAuthenticationData(const std::vector<boost::intrusive_ptr<ASTAuthenticationData>> & authentication_methods, WriteBuffer & ostr, const IAST::FormatSettings & settings)
@@ -190,6 +191,9 @@ ASTPtr ASTCreateUserQuery::clone() const
 
     if (names)
         res->names = boost::static_pointer_cast<ASTUserNamesWithHost>(names->clone());
+
+    if (new_name)
+        res->new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name->clone());
 
     if (roles)
         res->roles = boost::static_pointer_cast<ASTRolesOrUsersSet>(roles->clone());

--- a/src/Parsers/Access/ASTCreateUserQuery.h
+++ b/src/Parsers/Access/ASTCreateUserQuery.h
@@ -8,6 +8,7 @@
 
 namespace DB
 {
+class ASTUserNameWithHost;
 class ASTUserNamesWithHost;
 class ASTRolesOrUsersSet;
 class ASTDatabaseOrNone;
@@ -52,7 +53,7 @@ public:
     bool replace_authentication_methods = false;
 
     boost::intrusive_ptr<ASTUserNamesWithHost> names;
-    std::optional<String> new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     String storage_name;
 
     std::vector<boost::intrusive_ptr<ASTAuthenticationData>> authentication_methods;

--- a/src/Parsers/Access/ParserCreateUserQuery.cpp
+++ b/src/Parsers/Access/ParserCreateUserQuery.cpp
@@ -9,7 +9,6 @@
 #include <Parsers/Access/ParserSettingsProfileElement.h>
 #include <Parsers/Access/ParserUserNameWithHost.h>
 #include <Parsers/Access/ParserPublicSSHKey.h>
-#include <Parsers/Access/parseUserName.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
@@ -35,18 +34,18 @@ namespace ErrorCodes
 
 namespace
 {
-    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, std::optional<String> & new_name)
+    bool parseRenameTo(IParserBase::Pos & pos, Expected & expected, boost::intrusive_ptr<ASTUserNameWithHost> & new_name)
     {
         return IParserBase::wrapParseImpl(pos, [&]
         {
             if (!ParserKeyword{Keyword::RENAME_TO}.ignore(pos, expected))
                 return false;
 
-            String maybe_new_name;
-            if (!parseUserName(pos, expected, maybe_new_name, /*allow_query_parameter=*/true))
+            ASTPtr new_name_ast;
+            if (!ParserUserNameWithHost(/*allow_query_parameter=*/true).parse(pos, new_name_ast, expected))
                 return false;
 
-            new_name.emplace(std::move(maybe_new_name));
+            new_name = boost::static_pointer_cast<ASTUserNameWithHost>(new_name_ast);
             return true;
         });
     }
@@ -582,7 +581,7 @@ bool ParserCreateUserQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
 
     auto pos_after_parsing_names = pos;
 
-    std::optional<String> new_name;
+    boost::intrusive_ptr<ASTUserNameWithHost> new_name;
     std::optional<AllowedClientHosts> hosts;
     std::optional<AllowedClientHosts> add_hosts;
     std::optional<AllowedClientHosts> remove_hosts;

--- a/tests/queries/0_stateless/04626_create_user_rename_query_parameter.reference
+++ b/tests/queries/0_stateless/04626_create_user_rename_query_parameter.reference
@@ -1,0 +1,4 @@
+CREATE USER user_param_04626 IDENTIFIED WITH no_password
+CREATE USER user_param_04626_renamed IDENTIFIED WITH no_password
+CREATE USER user_param_04626_renamed_twice IDENTIFIED WITH no_password
+CREATE USER user_param_04626_renamed_twice IDENTIFIED WITH no_password

--- a/tests/queries/0_stateless/04626_create_user_rename_query_parameter.sql
+++ b/tests/queries/0_stateless/04626_create_user_rename_query_parameter.sql
@@ -1,0 +1,25 @@
+-- Test for a bug found in the review of PR #110973: `ALTER USER x RENAME TO {new:Identifier}`
+-- flattened the rename target to a string at parse time, so the query parameter was never
+-- substituted and the user was silently renamed to the literal `{new:Identifier}`.
+
+DROP USER IF EXISTS user_param_04626, user_param_04626_renamed, user_param_04626_renamed_twice;
+
+CREATE USER user_param_04626 IDENTIFIED WITH no_password;
+SHOW CREATE USER user_param_04626;
+
+SET param_user_target = 'user_param_04626_renamed';
+ALTER USER user_param_04626 RENAME TO {user_target:Identifier};
+SHOW CREATE USER user_param_04626_renamed;
+SHOW CREATE USER user_param_04626; -- { serverError UNKNOWN_USER }
+
+-- The rename source can be a query parameter as well
+SET param_user_source = 'user_param_04626_renamed';
+SET param_user_target_twice = 'user_param_04626_renamed_twice';
+ALTER USER {user_source:Identifier} RENAME TO {user_target_twice:Identifier};
+SHOW CREATE USER user_param_04626_renamed_twice;
+
+-- An unset parameter is an error instead of renaming the user to the literal parameter text
+ALTER USER user_param_04626_renamed_twice RENAME TO {user_param_04626_unset:Identifier}; -- { serverError UNKNOWN_QUERY_PARAMETER }
+SHOW CREATE USER user_param_04626_renamed_twice;
+
+DROP USER user_param_04626_renamed_twice;

--- a/tests/queries/0_stateless/04626_create_user_rename_query_parameter.sql
+++ b/tests/queries/0_stateless/04626_create_user_rename_query_parameter.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel
+-- Tag no-parallel: creates fixed-name global users
+
 -- Test for a bug found in the review of PR #110973: `ALTER USER x RENAME TO {new:Identifier}`
 -- flattened the rename target to a string at parse time, so the query parameter was never
 -- substituted and the user was silently renamed to the literal `{new:Identifier}`.


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110973

`ALTER USER x RENAME TO {new_name:Identifier}` silently renamed the user to the literal string `{new_name:Identifier}` instead of the parameter's value — with the parameter set or not:

```sql
SET param_target = 'bob';
ALTER USER alice RENAME TO {target:Identifier};
-- alice is now literally named `{target:Identifier}`
```

### Root cause

`ParserCreateUserQuery`'s `parseRenameTo` flattened the parsed name (including an unsubstituted query parameter) to a `String` at parse time via `parseUserName`, so `ReplaceQueryParameterVisitor` — which runs after parsing — never saw an AST node to substitute.

### Fix

Store the rename target as an AST node (`ASTUserNameWithHost`) until parameters are substituted, mirroring the design used for user *names*: the parser keeps the AST, `ReplaceQueryParameterVisitor` visits it, and the interpreter flattens it to a string afterwards. An unset parameter now fails cleanly with `UNKNOWN_QUERY_PARAMETER` before any rename happens. This is the same design as the `CREATE ROLE`/`ALTER ROLE` parameter support proposed in #110973 (both PRs touch `ReplaceQueryParameterVisitor` near each other; they merge cleanly in either order).

Formatting note: the formatted query now renders `RENAME TO name` (identifier form, backquoted when needed) instead of `RENAME TO 'name'`; both forms parse on old and new servers, and no test reference depends on the old form. `RENAME TO` targets are never persisted to access storage, so there is no on-disk compatibility concern.

Verified by code-path analysis plus the stateless test `04626_create_user_rename_query_parameter` (rename via parameter, source-and-target parameters, the unset-parameter bug case asserting no rename side effect, `SHOW CREATE` checks); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ALTER USER ... RENAME TO {parameter:Identifier}` renaming the user to the literal parameter placeholder instead of substituting the parameter's value.
