### PR TITLE
Include the source table identity in the ATTACH PARTITION FROM deduplication id

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -12,6 +12,7 @@
 #include <Common/Macros.h>
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEventsScope.h>
+#include <Common/SipHash.h>
 #include <Common/StringUtils.h>
 #include <Common/ThreadFuzzer.h>
 #include <Common/ZooKeeper/KeeperException.h>
@@ -9217,6 +9218,18 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
 
         String drop_range_fake_part_name = getPartNamePossiblyFake(format_version, drop_range);
 
+        /// The deduplication block id must depend not only on the content of the attached parts, but also on the
+        /// identity of the source table. Otherwise `ATTACH PARTITION FROM` of identical data from two different
+        /// source tables would be considered the same operation, and the second attach would be a silent no-op
+        /// (see issue #105632). Prefer the source table UUID because it is stable across renames (so a retry of
+        /// the same query produces the same block id even if the table was renamed in between); tables without
+        /// a UUID (e.g. in an `Ordinary` database) fall back to the fully qualified name.
+        const auto src_storage_id = src_data.getStorageID();
+        const String src_table_identity = src_storage_id.hasUUID()
+            ? toString(src_storage_id.uuid)
+            : src_storage_id.getFullNameNotQuoted();
+        const String src_identity_hash = getHexUIntUppercase(sipHash64(src_table_identity));
+
         std::set<String> replaced_parts;
         for (const auto & src_part : src_all_parts)
         {
@@ -9238,7 +9251,9 @@ std::unique_ptr<ReplicatedMergeTreeLogEntryData> StorageReplicatedMergeTree::rep
             else
                 LOG_INFO(log, "Trying to attach {} with hash_hex {}", src_part->name, hash_hex);
 
-            std::vector<std::string> block_id_path = (replace || is_duplicated_part) ? std::vector<std::string>() : std::vector<std::string>{(fs::path(zookeeper_path) / "blocks" / (partition_id + "_replace_from_" + hash_hex))};
+            std::vector<std::string> block_id_path = (replace || is_duplicated_part)
+                ? std::vector<std::string>()
+                : std::vector<std::string>{(fs::path(zookeeper_path) / "blocks" / (partition_id + "_replace_from_" + src_identity_hash + "_" + hash_hex))};
 
             auto lock = allocateBlockNumber(
                 partition_id,

--- a/tests/queries/0_stateless/04629_attach_partition_from_different_sources.reference
+++ b/tests/queries/0_stateless/04629_attach_partition_from_different_sources.reference
@@ -1,0 +1,3 @@
+after attach from src1	3
+after attach from src2	6
+after repeated attach from src1	6

--- a/tests/queries/0_stateless/04629_attach_partition_from_different_sources.sql
+++ b/tests/queries/0_stateless/04629_attach_partition_from_different_sources.sql
@@ -1,0 +1,35 @@
+-- Tags: zookeeper
+
+-- Attaching identical data from two different source tables must not be deduplicated
+-- against each other (issue #105632), while a retry of the attach from the same source
+-- table must still be deduplicated.
+
+DROP TABLE IF EXISTS dst_105632 SYNC;
+DROP TABLE IF EXISTS src1_105632;
+DROP TABLE IF EXISTS src2_105632;
+
+CREATE TABLE dst_105632 (k Int32, v Int32)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/dst_105632', 'r1')
+PARTITION BY k ORDER BY v;
+
+CREATE TABLE src1_105632 (k Int32, v Int32) ENGINE = MergeTree PARTITION BY k ORDER BY v;
+CREATE TABLE src2_105632 (k Int32, v Int32) ENGINE = MergeTree PARTITION BY k ORDER BY v;
+
+-- Identical data in both source tables, so the parts have identical checksums.
+INSERT INTO src1_105632 VALUES (0, 1), (0, 2), (0, 3);
+INSERT INTO src2_105632 VALUES (0, 1), (0, 2), (0, 3);
+
+ALTER TABLE dst_105632 ATTACH PARTITION 0 FROM src1_105632;
+SELECT 'after attach from src1', count() FROM dst_105632;
+
+-- Identical data from a different source table: must be attached, not deduplicated.
+ALTER TABLE dst_105632 ATTACH PARTITION 0 FROM src2_105632;
+SELECT 'after attach from src2', count() FROM dst_105632;
+
+-- The same operation repeated from the same source table must still be deduplicated.
+ALTER TABLE dst_105632 ATTACH PARTITION 0 FROM src1_105632;
+SELECT 'after repeated attach from src1', count() FROM dst_105632;
+
+DROP TABLE dst_105632 SYNC;
+DROP TABLE src1_105632;
+DROP TABLE src2_105632;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/105632
Related: https://github.com/ClickHouse/ClickHouse/issues/31005

`ALTER TABLE dst ATTACH PARTITION ... FROM src` on a `ReplicatedMergeTree` destination silently did nothing when a partition with identical content had already been attached **from a different source table**: the deduplication block id was content-only (`<partition_id>_replace_from_<checksum>`), so the second attach was treated as a retry of the first.

```sql
ALTER TABLE dst ATTACH PARTITION 0 FROM src1;  -- 3 rows attached
ALTER TABLE dst ATTACH PARTITION 0 FROM src2;  -- src2 has identical 3 rows: silently ignored
```

### Fix

Mix the source table's identity into the block id: `<partition_id>_replace_from_<sipHash64(source identity)>_<checksum>`, where the identity is the source table UUID (stable across renames), falling back to the fully qualified name for UUID-less tables (`Ordinary` databases). Retrying the same `ALTER` from the same source still deduplicates; attaching from a different source now attaches. True `REPLACE PARTITION` is unaffected (it uses an empty block id path); `MOVE PARTITION TO TABLE` likewise.

### Disclosed trade-offs

- **Upgrade window:** pre-upgrade `blocks/` znodes use the old format, so a replay of an attach performed before the upgrade will not deduplicate. Old znodes are cleaned beyond `replicated_deduplication_window` (10000) or `replicated_deduplication_window_seconds` (1 hour) — but the time threshold is measured against the newest block, so on an idle table old entries can persist indefinitely. The same applies to mixed-version clusters (a retry landing on a not-yet-upgraded host writes the old-format id).
- **Cross-host retry scope:** the identity is the initiator-side source UUID. For `Replicated` databases and modern `ON CLUSTER` DDL the UUID is identical on all hosts, so cross-host retries (e.g. DDL worker takeover) still deduplicate. For source tables created per-host independently (differing UUIDs) or mixed `Atomic`/`Ordinary` topologies, a cross-host retry of the same logical operation would no longer deduplicate — the previous content-only id covered those; using the qualified name instead of the UUID would trade rename-stability for host-stability. Happy to switch if maintainers prefer.

Verified by code-path analysis plus the stateless test `04629_attach_partition_from_different_sources` (attach identical data from two sources → both attach; re-attach from the same source → still deduplicated); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `ATTACH PARTITION ... FROM` on a `ReplicatedMergeTree` table silently doing nothing when identical data had already been attached from a different source table.
