### PR TITLE
Support date-and-time string literals in IN for Date columns

### DIFF
--- a/src/Analyzer/SetUtils.cpp
+++ b/src/Analyzer/SetUtils.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnTuple.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeDateTime64.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -12,6 +13,7 @@
 #include <Interpreters/Set.h>
 #include <Interpreters/convertFieldToType.h>
 
+#include <Common/DateLUTImpl.h>
 #include <Common/assert_cast.h>
 
 namespace DB
@@ -80,6 +82,65 @@ size_t getCompoundTypeDepth(const IDataType & type)
     return depth;
 }
 
+/// A `Date`/`Date32` element of a set can also be specified as a string containing a date and time,
+/// consistently with comparison operators (see `executeWithConstString` in `FunctionsComparison.h`):
+/// `d IN ('2026-01-01 00:00:00')` behaves the same as `d = '2026-01-01 00:00:00'`.
+/// The string is parsed as `DateTime64` with the scale 6 - it is enough for fractional seconds up to microseconds,
+/// and extra digits are ignored by parsing. `DateTime64` is used instead of `DateTime` because parsing
+/// of the latter clamps values outside the [1970, 2106] years range, while `DateTime64` covers
+/// the whole range of `Date32`. The default time zone is used, as for a `DateTime64` literal.
+///
+/// The parsed value can be equal to a value of the column type only if it is exactly the midnight of a date
+/// representable in that type; then the element is converted to that date. Any other value
+/// (e.g. `'2026-01-01 12:00:00'`) is excluded from the set, like other values that do not represent
+/// any possible value of the type of the filtered column (see `convertFieldToTypeCheckEnum`).
+std::optional<Field> convertDateAndTimeStringToDate(const Field & from_value, const IDataType & from_type, const IDataType & to_type)
+{
+    const auto datetime_type = std::make_shared<DataTypeDateTime64>(6);
+    Field converted_to_datetime = tryConvertFieldToType(from_value, *datetime_type, &from_type);
+
+    if (converted_to_datetime.isNull())
+    {
+        /// The string is not a date with a time either. Repeat the conversion to `Date`/`Date32` to report the original error.
+        Field result = convertFieldToType(from_value, to_type, &from_type, {}, /*strict=*/ true);
+        if (result.isNull())
+            return std::nullopt;
+        return result;
+    }
+
+    const Int64 ticks = converted_to_datetime.safeGet<DecimalField<DateTime64>>().getValue().value;
+    const Int64 ticks_per_second = datetime_type->getScaleMultiplier().value;
+
+    /// A value with a fractional second is not the midnight of any date.
+    if (ticks % ticks_per_second != 0)
+        return std::nullopt;
+
+    const Int64 seconds = ticks / ticks_per_second;
+    const DateLUTImpl & time_zone = datetime_type->getTimeZone();
+    const ExtendedDayNum day_num = time_zone.toDayNum(seconds);
+
+    /// A value inside a day (not its first time point) is not equal to any date.
+    if (time_zone.fromDayNum(day_num) != seconds)
+        return std::nullopt;
+
+    const Int32 day = day_num.toUnderType();
+
+    if (WhichDataType(to_type).isDate32())
+    {
+        /// A date outside the range of `Date32` is not equal to any value of the column.
+        if (day < -DAYNUM_OFFSET_EPOCH || day >= DATE_LUT_MAX_EXTEND_DAY_NUM)
+            return std::nullopt;
+
+        return Field(static_cast<Int64>(day));
+    }
+
+    /// A date outside the range of `Date` is not equal to any value of the column.
+    if (day < 0 || day > DATE_LUT_MAX_DAY_NUM)
+        return std::nullopt;
+
+    return Field(static_cast<UInt64>(day));
+}
+
 /// Uses `convertFieldToType` with `strict=true` to prevent unexpected results in case of conversion with loss of precision.
 /// Example: `SELECT 33.3 :: Decimal(9, 1) AS a WHERE a IN (33.33 :: Decimal(9, 2))`
 /// 33.33 in the set is converted to 33.3, but it is not equal to 33.3 in the column, so the result should still be empty.
@@ -87,6 +148,23 @@ size_t getCompoundTypeDepth(const IDataType & type)
 std::optional<Field> convertFieldToTypeCheckEnum(
     const Field & from_value, const IDataType & from_type, const IDataType & to_type, bool forbid_unknown_enum_values)
 {
+    if (from_value.getType() == Field::Types::String)
+    {
+        const IDataType * to_type_not_null = &to_type;
+        if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(to_type_not_null))
+            to_type_not_null = nullable_type->getNestedType().get();
+
+        if (WhichDataType(*to_type_not_null).isDateOrDate32())
+        {
+            Field result = tryConvertFieldToType(from_value, to_type, &from_type, {}, /*strict=*/ true);
+            if (!result.isNull())
+                return result;
+
+            /// The string cannot be parsed as `Date`/`Date32`, e.g. it contains a date with a time: '2026-01-01 00:00:00'.
+            return convertDateAndTimeStringToDate(from_value, from_type, *to_type_not_null);
+        }
+    }
+
     try
     {
         Field result = convertFieldToType(from_value, to_type, &from_type, {}, /*strict=*/ true);

--- a/tests/queries/0_stateless/04627_date_in_datetime_strings.reference
+++ b/tests/queries/0_stateless/04627_date_in_datetime_strings.reference
@@ -1,0 +1,39 @@
+Date IN strings with a date and time
+1
+0
+0
+1
+0
+1
+Fractional seconds
+1
+0
+Date32
+1
+0
+1
+0
+0
+Dates out of the range of the column type never match
+0
+Mixed lists
+1
+1
+0
+1
+Non-constant date column
+1
+0
+1
+Nullable
+1
+0
+Strings without a time still work
+1
+0
+Filtering by a Date key column
+1
+0
+2
+2
+Invalid strings still throw

--- a/tests/queries/0_stateless/04627_date_in_datetime_strings.sql
+++ b/tests/queries/0_stateless/04627_date_in_datetime_strings.sql
@@ -1,0 +1,63 @@
+-- Using strings containing a date and time as elements of an `IN` set for a `Date`/`Date32` column.
+-- A follow-up to https://github.com/ClickHouse/ClickHouse/pull/111000 which fixed comparison operators.
+
+-- The time zone is pinned because the test framework randomizes `session_timezone`,
+-- and some time zones have DST transitions at midnight.
+SET session_timezone = 'UTC';
+
+SELECT 'Date IN strings with a date and time';
+SELECT toDate('2026-01-01') IN ('2026-01-01 00:00:00');
+SELECT toDate('2026-01-01') IN ('2026-01-01 12:00:00');
+SELECT toDate('2026-01-01') IN ('2026-01-02 00:00:00');
+SELECT toDate('2026-01-01') IN '2026-01-01 00:00:00';
+SELECT toDate('2026-01-01') NOT IN ('2026-01-01 00:00:00');
+SELECT toDate('2026-01-01') NOT IN ('2026-01-01 12:00:00');
+
+SELECT 'Fractional seconds';
+SELECT toDate('2026-01-01') IN ('2026-01-01 00:00:00.000');
+SELECT toDate('2026-01-01') IN ('2026-01-01 00:00:00.500');
+
+SELECT 'Date32';
+SELECT toDate32('2026-01-01') IN ('2026-01-01 00:00:00');
+SELECT toDate32('2026-01-01') IN ('2026-01-01 12:00:00');
+SELECT toDate32('1950-06-15') IN ('1950-06-15 00:00:00');
+SELECT toDate32('1950-06-15') IN ('1950-06-15 12:00:00');
+SELECT toDate32('1950-06-15') NOT IN ('1950-06-15 00:00:00');
+
+SELECT 'Dates out of the range of the column type never match';
+SELECT toDate('2026-01-01') IN ('1950-06-15 00:00:00');
+
+SELECT 'Mixed lists';
+SELECT toDate('2026-01-01') IN ('2026-01-01 00:00:00', '2025-05-05');
+SELECT toDate('2026-01-01') IN ('2026-01-01 12:00:00', '2026-01-01');
+SELECT toDate('2026-01-01') IN ('2026-01-01 12:00:00', '2025-05-05');
+SELECT toDate('2026-01-01') IN ('2026-01-02 00:00:00', toDate('2026-01-01'));
+
+SELECT 'Non-constant date column';
+SELECT materialize(toDate('2026-01-01')) IN ('2026-01-01 00:00:00');
+SELECT materialize(toDate('2026-01-01')) IN ('2026-01-01 12:00:00');
+SELECT materialize(toDate32('2026-01-01')) IN ('2026-01-01 00:00:00');
+
+SELECT 'Nullable';
+SELECT toNullable(toDate('2026-01-01')) IN ('2026-01-01 00:00:00');
+SELECT toNullable(toDate('2026-01-01')) IN ('2026-01-01 12:00:00');
+
+SELECT 'Strings without a time still work';
+SELECT toDate('2026-01-01') IN ('2026-01-01');
+SELECT toDate('2026-01-01') IN ('2026-01-02');
+
+SELECT 'Filtering by a Date key column';
+DROP TABLE IF EXISTS t_date_in_datetime_strings;
+CREATE TABLE t_date_in_datetime_strings (d Date) ENGINE = MergeTree ORDER BY d;
+INSERT INTO t_date_in_datetime_strings VALUES ('2025-12-31'), ('2026-01-01'), ('2026-01-02');
+SELECT count() FROM t_date_in_datetime_strings WHERE d IN ('2026-01-01 00:00:00');
+SELECT count() FROM t_date_in_datetime_strings WHERE d IN ('2026-01-01 12:00:00');
+SELECT count() FROM t_date_in_datetime_strings WHERE d IN ('2026-01-01 00:00:00', '2026-01-02 00:00:00');
+SELECT count() FROM t_date_in_datetime_strings WHERE d NOT IN ('2026-01-01 00:00:00');
+DROP TABLE t_date_in_datetime_strings;
+
+SELECT 'Invalid strings still throw';
+SELECT toDate('2026-01-01') IN ('garbage'); -- { serverError CANNOT_PARSE_DATE }
+SELECT toDate32('2026-01-01') IN ('garbage'); -- { serverError CANNOT_PARSE_DATE }
+SELECT toDate('2026-01-01') IN ('2026-01-01 12:00:00 garbage'); -- { serverError TYPE_MISMATCH }
+SELECT toDate('2026-01-01') IN ('2026-01-01 00:00:00', 'garbage'); -- { serverError CANNOT_PARSE_DATE }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111000

`d IN ('2026-01-01 00:00:00')` on a `Date` column threw `TYPE_MISMATCH`, while the equivalent comparison `d = '2026-01-01 00:00:00'` works with #111000. This PR extends the same semantics to `IN`/`NOT IN` set building. Best merged after #111000 (independent code, but the two together make string handling consistent across `=` and `IN`).

### Mechanism

All literal `IN` sets funnel through one conversion point (`convertFieldToTypeCheckEnum` in `src/Analyzer/SetUtils.cpp`, used by the analyzer, the planner and the legacy path). Since `IN` is pure equality, "compare through the `DateTime64` supertype" is exactly equivalent to: keep a string element iff it parses as `DateTime64(6)` and is the exact midnight of a day representable in the column type; otherwise the element can never equal any `Date` value and is excluded from the set (the same principle the strict-`IN` machinery already applies to non-representable numeric literals). The set stays `Date`-typed, so index analysis and set indexes work unchanged. Unparsable strings throw the same errors as before.

`toDate('2026-01-01') IN ('2026-01-01 00:00:00')` → 1, `IN ('2026-01-01 12:00:00')` → 0, `NOT IN` accordingly.

### Disclosed asymmetries (pre-existing, deliberately out of scope)

- **Typed `DateTime` elements truncate-match on master**: `d IN (toDateTime('... 12:00:00'))` returns 1 (DateTime→Date truncation in `convertFieldToType`), contradicting both `d = toDateTime('... 12:00:00')` (0) and — after this PR — the string spelling (0). Changing that would alter long-standing behavior of typed elements and deserves its own discussion.
- String elements here parse with default format settings (like all `IN` literals), while `=` honors the session's `date_time_input_format` after #110985/#111000 — a value parsable only with `best_effort` still throws in `IN`.
- Single-element tuple form `tuple(d) IN (('...',))` takes the generic tuple conversion and still throws — same structural gap that already exists for enum literals in tuples.
- A datetime string on the *left* of `IN` against a `Date` set is likewise untouched.

Verified by code-path analysis plus the stateless test `04627_date_in_datetime_strings` (midnight/noon, fractional seconds, `NOT IN`, `Date32` incl. pre-epoch, out-of-range dates, mixed lists, `Nullable`, MergeTree key filtering, unchanged error cases; session timezone pinned); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`IN` with string literals containing a date and time now works for `Date` and `Date32` columns, consistent with the comparison operators.
