### PR TITLE
Enforce per-query temporary data limits on join spill and deserialized aggregation plans

### DIFF
--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -1113,11 +1113,11 @@ QueryPlanStepPtr AggregatingStep::deserialize(Deserialization & ctx)
 
     /// Prefer the temporary data scope of the query context: it accounts for the per-query and
     /// per-user limits (`max_temporary_data_on_disk_size_for_query` and `_for_user`), which the
-    /// server-global scope does not. Fall back to the global scope when there is no query
-    /// context (e.g. when the plan is deserialized outside of a query).
+    /// server-global scope does not. Fall back to the global scope when the deserialization
+    /// context is not a query context (e.g. when a skipped plan packet is deserialized).
     TemporaryDataOnDiskScopePtr tmp_data_scope;
-    if (auto query_context = CurrentThread::tryGetQueryContext())
-        tmp_data_scope = query_context->getTempDataOnDisk();
+    if (ctx.context)
+        tmp_data_scope = ctx.context->getTempDataOnDisk();
     if (!tmp_data_scope)
         tmp_data_scope = Context::getGlobalContextInstance()->getTempDataOnDisk();
 

--- a/src/Processors/QueryPlan/AggregatingStep.cpp
+++ b/src/Processors/QueryPlan/AggregatingStep.cpp
@@ -31,6 +31,7 @@
 #include <Processors/Transforms/MemoryBoundMerging.h>
 #include <Processors/Transforms/MergingAggregatedMemoryEfficientTransform.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
+#include <Common/CurrentThread.h>
 #include <Common/JSONBuilder.h>
 #include <Core/SettingsEnums.h>
 
@@ -1110,6 +1111,16 @@ QueryPlanStepPtr AggregatingStep::deserialize(Deserialization & ctx)
         ctx.settings[QueryPlanSerializationSetting::max_entries_for_hash_table_stats],
         ctx.settings[QueryPlanSerializationSetting::max_size_to_preallocate_for_aggregation]);
 
+    /// Prefer the temporary data scope of the query context: it accounts for the per-query and
+    /// per-user limits (`max_temporary_data_on_disk_size_for_query` and `_for_user`), which the
+    /// server-global scope does not. Fall back to the global scope when there is no query
+    /// context (e.g. when the plan is deserialized outside of a query).
+    TemporaryDataOnDiskScopePtr tmp_data_scope;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        tmp_data_scope = query_context->getTempDataOnDisk();
+    if (!tmp_data_scope)
+        tmp_data_scope = Context::getGlobalContextInstance()->getTempDataOnDisk();
+
     Aggregator::Params params{
         keys,
         aggregates,
@@ -1120,7 +1131,7 @@ QueryPlanStepPtr AggregatingStep::deserialize(Deserialization & ctx)
         ctx.settings[QueryPlanSerializationSetting::group_by_two_level_threshold_bytes],
         ctx.settings[QueryPlanSerializationSetting::max_bytes_before_external_group_by],
         ctx.settings[QueryPlanSerializationSetting::empty_result_for_aggregation_by_empty_set],
-        Context::getGlobalContextInstance()->getTempDataOnDisk(),
+        std::move(tmp_data_scope),
         0, //settings[QueryPlanSerializationSetting::max_threads],
         ctx.settings[QueryPlanSerializationSetting::min_free_disk_space_for_temporary_data],
         ctx.settings[QueryPlanSerializationSetting::compile_aggregate_expressions],

--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -5,6 +5,7 @@
 
 #include <base/scope_guard.h>
 
+#include <Common/CurrentThread.h>
 #include <Common/JSONBuilder.h>
 #include <Common/safe_cast.h>
 #include <Common/typeid_cast.h>
@@ -1103,9 +1104,19 @@ static QueryPlanNode buildPhysicalJoinImpl(
 {
     auto * logical_lookup = typeid_cast<JoinStepLogicalLookup *>(children.back()->step.get());
 
+    /// Prefer the temporary data scope of the query context: it accounts for the per-query and
+    /// per-user limits (`max_temporary_data_on_disk_size_for_query` and `_for_user`), which the
+    /// server-global scope does not. Fall back to the global scope when there is no query
+    /// context (e.g. when the plan is optimized outside of a query).
+    TemporaryDataOnDiskScopePtr tmp_data_scope;
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+        tmp_data_scope = query_context->getTempDataOnDisk();
+    if (!tmp_data_scope)
+        tmp_data_scope = Context::getGlobalContextInstance()->getTempDataOnDisk();
+
     auto table_join = std::make_shared<TableJoin>(join_settings, logical_lookup && logical_lookup->useNulls(),
         Context::getGlobalContextInstance()->getGlobalTemporaryVolume(),
-        Context::getGlobalContextInstance()->getTempDataOnDisk());
+        std::move(tmp_data_scope));
 
     PreparedJoinStorage prepared_join_storage;
     if (logical_lookup)

--- a/tests/queries/0_stateless/04625_agg_join_temp_data_limits.reference
+++ b/tests/queries/0_stateless/04625_agg_join_temp_data_limits.reference
@@ -1,0 +1,2 @@
+join spill without per-query limit works
+aggregation spill on remote plan without per-query limit works

--- a/tests/queries/0_stateless/04625_agg_join_temp_data_limits.sql
+++ b/tests/queries/0_stateless/04625_agg_join_temp_data_limits.sql
@@ -1,3 +1,5 @@
+-- Tags: shard
+
 -- Follow-up to https://github.com/ClickHouse/ClickHouse/pull/110993: `max_temporary_data_on_disk_size_for_query`
 -- was not enforced on join spill and on aggregation spill of deserialized query plans, because in both places the
 -- spill scope was created from the server-global temporary data scope instead of the scope of the query context
@@ -6,16 +8,16 @@
 -- Grace hash join always writes the non-current buckets to disk, so the spill is deterministic.
 select 'join spill without per-query limit works';
 select count()
-from (select number as k, toString(cityHash64(number)) as v from numbers(1000000)) as t1
-inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(1000000)) as t2
+from (select number as k, toString(cityHash64(number)) as v from numbers(300000)) as t1
+inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(300000)) as t2
 on t1.k = t2.k
 format Null
 settings enable_analyzer = 1, join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 4,
          max_bytes_ratio_before_external_join = 0, query_plan_optimize_join_order_randomize = 0, max_threads = 1;
 
 select count()
-from (select number as k, toString(cityHash64(number)) as v from numbers(1000000)) as t1
-inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(1000000)) as t2
+from (select number as k, toString(cityHash64(number)) as v from numbers(300000)) as t1
+inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(300000)) as t2
 on t1.k = t2.k
 format Null
 settings enable_analyzer = 1, join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 4,
@@ -26,7 +28,7 @@ settings enable_analyzer = 1, join_algorithm = 'grace_hash', grace_hash_join_ini
 -- aggregation step on it, taking the spill scope on the plan-deserialization path.
 drop table if exists t_04625;
 create table t_04625 (n UInt64) engine = MergeTree order by n;
-insert into t_04625 select number from numbers(2000000);
+insert into t_04625 select number from numbers(500000);
 
 select 'aggregation spill on remote plan without per-query limit works';
 select toString(cityHash64(n)) as s from remote('127.0.0.{1,2}', currentDatabase(), t_04625) group by s

--- a/tests/queries/0_stateless/04625_agg_join_temp_data_limits.sql
+++ b/tests/queries/0_stateless/04625_agg_join_temp_data_limits.sql
@@ -1,0 +1,43 @@
+-- Follow-up to https://github.com/ClickHouse/ClickHouse/pull/110993: `max_temporary_data_on_disk_size_for_query`
+-- was not enforced on join spill and on aggregation spill of deserialized query plans, because in both places the
+-- spill scope was created from the server-global temporary data scope instead of the scope of the query context
+-- that carries the per-query and per-user limits.
+
+-- Grace hash join always writes the non-current buckets to disk, so the spill is deterministic.
+select 'join spill without per-query limit works';
+select count()
+from (select number as k, toString(cityHash64(number)) as v from numbers(1000000)) as t1
+inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(1000000)) as t2
+on t1.k = t2.k
+format Null
+settings enable_analyzer = 1, join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 4,
+         max_bytes_ratio_before_external_join = 0, query_plan_optimize_join_order_randomize = 0, max_threads = 1;
+
+select count()
+from (select number as k, toString(cityHash64(number)) as v from numbers(1000000)) as t1
+inner join (select number as k, toString(cityHash64(number + 1)) as v from numbers(1000000)) as t2
+on t1.k = t2.k
+format Null
+settings enable_analyzer = 1, join_algorithm = 'grace_hash', grace_hash_join_initial_buckets = 4,
+         max_bytes_ratio_before_external_join = 0, query_plan_optimize_join_order_randomize = 0, max_threads = 1,
+         max_temporary_data_on_disk_size_for_query = 100000; -- { serverError TOO_MANY_ROWS_OR_BYTES }
+
+-- The remote workers receive a serialized query plan (`serialize_query_plan`) and deserialize the partial
+-- aggregation step on it, taking the spill scope on the plan-deserialization path.
+drop table if exists t_04625;
+create table t_04625 (n UInt64) engine = MergeTree order by n;
+insert into t_04625 select number from numbers(2000000);
+
+select 'aggregation spill on remote plan without per-query limit works';
+select toString(cityHash64(n)) as s from remote('127.0.0.{1,2}', currentDatabase(), t_04625) group by s
+format Null
+settings enable_analyzer = 1, serialize_query_plan = 1, prefer_localhost_replica = 0, enable_parallel_replicas = 0,
+         max_bytes_before_external_group_by = 10000000, max_bytes_ratio_before_external_group_by = 0, max_threads = 1;
+
+select toString(cityHash64(n)) as s from remote('127.0.0.{1,2}', currentDatabase(), t_04625) group by s
+format Null
+settings enable_analyzer = 1, serialize_query_plan = 1, prefer_localhost_replica = 0, enable_parallel_replicas = 0,
+         max_bytes_before_external_group_by = 10000000, max_bytes_ratio_before_external_group_by = 0, max_threads = 1,
+         max_temporary_data_on_disk_size_for_query = 1000000; -- { serverError TOO_MANY_ROWS_OR_BYTES }
+
+drop table t_04625;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/110993

Follow-up to #110993 (which fixed the same class of bug for external sort): `max_temporary_data_on_disk_size_for_query` and `max_temporary_data_on_disk_size_for_user` were still bypassed in two places that created their spill scope from the server-global temporary data scope instead of the query context's scope (which carries the per-query and per-user limits):

- `JoinStepLogical::buildPhysicalJoinImpl` — join spill (`grace_hash` bucket files, hash-join spilling) under the analyzer was not limited. This was the only `TableJoin` construction site still using the global scope; the legacy paths already use the query context.
- `AggregatingStep::deserialize` — aggregation spill of deserialized query plans (remote workers executing a serialized distributed plan) was not limited. The deserialization context (`ctx.context`, the executing query's context on all live paths) is used, falling back to the global scope for non-query deserialization.

As with #110993, queries that previously spilled past the configured limits in these paths now correctly fail with `TOO_MANY_ROWS_OR_BYTES`; the defaults are unlimited, so only users who set the limits are affected.

Verified by code-path analysis plus the stateless test `04625_agg_join_temp_data_limits` (deterministic `grace_hash` spill with pinned bucket count, and a `remote()` query with `serialize_query_plan = 1` exercising the deserialized-plan path; controls without the limit included); no local build was run, so correctness relies on CI.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `max_temporary_data_on_disk_size_for_query` and `max_temporary_data_on_disk_size_for_user` not being enforced on join spill and on aggregation spill of distributed queries with serialized query plans.
