### PR TITLE
Reject incomplete MergeTree statistics scopes

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -204,6 +204,7 @@ static struct InitFiu
     ONCE(mt_alter_throw_in_durable_rollback) \
     REGULAR(rmt_merge_selecting_task_no_free_threads) \
     REGULAR(rmt_merge_selecting_task_max_part_size) \
+    ONCE(merge_tree_load_statistics_file_throw_once) \
     REGULAR(merge_tree_load_statistics_throw) \
     PAUSEABLE(smt_mutate_task_pause_in_prepare) \
     PAUSEABLE(smt_merge_selecting_task_pause_when_scheduled) \

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -842,6 +842,25 @@ std::optional<NameAndTypePair> ColumnsDescription::tryGetColumn(const GetColumns
     return {};
 }
 
+std::optional<String> tryGetNullableParentColumnName(const ColumnsDescription & columns, const String & column_name)
+{
+    /// A literal top-level column named e.g. `m.null` is a normal column, not
+    /// the synthetic null map of `m`, and must never borrow `m` statistics.
+    if (columns.tryGet(column_name))
+        return std::nullopt;
+
+    static constexpr char null_suffix[] = ".null";
+    if (!column_name.ends_with(null_suffix))
+        return std::nullopt;
+
+    String parent_name = column_name.substr(0, column_name.size() - (sizeof(null_suffix) - 1));
+    const auto * parent_column = columns.tryGet(parent_name);
+    if (!parent_column || !isNullableOrLowCardinalityNullable(parent_column->type))
+        return std::nullopt;
+
+    return parent_name;
+}
+
 NameAndTypePair ColumnsDescription::getColumn(const GetColumnsOptions & options, const String & column_name) const
 {
     auto column = tryGetColumn(options, column_name);

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -317,6 +317,11 @@ private:
     mutable std::vector<std::pair<GetCacheKey, std::shared_ptr<const NamesAndTypesList>>> get_cache;
 };
 
+/// Resolve a synthetic Nullable `.null` subcolumn to its parent column name.
+/// A real top-level column with the exact subcolumn name always takes precedence;
+/// other dotted names are not mapped.
+std::optional<String> tryGetNullableParentColumnName(const ColumnsDescription & columns, const String & column_name);
+
 class ASTColumnDeclaration;
 
 struct DefaultExpressionsInfo

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -142,6 +142,7 @@ namespace ErrorCodes
 namespace FailPoints
 {
     extern const char remove_merge_tree_part_delay[];
+    extern const char merge_tree_load_statistics_file_throw_once[];
     extern const char merge_tree_load_statistics_throw[];
 }
 
@@ -1186,12 +1187,19 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(
         if (!column_desc)
             continue;
 
-        size_t file_size = reader.getFileSize(filename);
-        auto file_buf = reader.readFile(disk, packed_file, filename, read_settings, file_size);
-
-        CompressedReadBuffer compressed_buf(*file_buf);
         try
         {
+            if (!required_columns.empty())
+            {
+                fiu_do_on(FailPoints::merge_tree_load_statistics_file_throw_once, {
+                    throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in statistics member load");
+                });
+            }
+
+            size_t file_size = reader.getFileSize(filename);
+            auto file_buf = reader.readFile(disk, packed_file, filename, read_settings, file_size);
+
+            CompressedReadBuffer compressed_buf(*file_buf);
             auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
             if (column_stat)
                 result.emplace(column_desc->name, std::move(column_stat));
@@ -1220,10 +1228,17 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & require
         if (!column_desc)
             continue;
 
-        auto file_buf = getDataPartStorage().readFile(filename, read_settings, checksum.file_size);
-        CompressedReadBuffer compressed_buf(*file_buf);
         try
         {
+            if (!required_columns.empty())
+            {
+                fiu_do_on(FailPoints::merge_tree_load_statistics_file_throw_once, {
+                    throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Injected failure in statistics member load");
+                });
+            }
+
+            auto file_buf = getDataPartStorage().readFile(filename, read_settings, checksum.file_size);
+            CompressedReadBuffer compressed_buf(*file_buf);
             auto column_stat = ColumnStatistics::deserialize(compressed_buf, column_desc->type);
             if (column_stat)
                 result.emplace(column_desc->name, std::move(column_stat));

--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1136,7 +1136,11 @@ PackedFilesReader * IMergeTreeDataPart::getStatisticsPackedReader() const
     return statistics_reader.get();
 }
 
-static const ColumnDescription * getColumnForStatisticsFile(const String & filename, const ColumnsDescription & all_columns, const NameSet & required_columns)
+static const ColumnDescription * getColumnForStatisticsFile(
+    const String & filename,
+    const ColumnsDescription & part_columns,
+    const NameSet & required_columns,
+    const ColumnsDescription & current_columns)
 {
     chassert(filename.starts_with(STATS_FILE_PREFIX));
     chassert(filename.ends_with(STATS_FILE_SUFFIX));
@@ -1144,19 +1148,23 @@ static const ColumnDescription * getColumnForStatisticsFile(const String & filen
     size_t num_chars_to_truncate = STATS_FILE_PREFIX.size() + STATS_FILE_SUFFIX.size();
     String column_name = unescapeForFileName(filename.substr(STATS_FILE_PREFIX.size(), filename.size() - num_chars_to_truncate));
 
-    /// `<col>.null` subcolumn may appear in required_columns when
-    /// `optimize_functions_to_subcolumns=1`, keep stats for the parent column in that case.
-    if (!required_columns.empty()
-        && !required_columns.contains(column_name)
-        && !required_columns.contains(column_name + ".null"))
+    /// A synthetic `<col>.null` subcolumn may appear in required_columns when
+    /// `optimize_functions_to_subcolumns=1`; keep stats for the Nullable parent
+    /// in that case. A real top-level column named `<col>.null` must not make us
+    /// load the unrelated parent statistics file.
+    if (!required_columns.empty() && !required_columns.contains(column_name))
     {
-        return nullptr;
+        const String null_subcolumn = column_name + ".null";
+        const auto nullable_parent = tryGetNullableParentColumnName(current_columns, null_subcolumn);
+        if (!required_columns.contains(null_subcolumn) || !nullable_parent || *nullable_parent != column_name)
+            return nullptr;
     }
 
-    return all_columns.tryGet(column_name);
+    return part_columns.tryGet(column_name);
 }
 
-ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesReader & reader, const NameSet & required_columns) const
+ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(
+    const PackedFilesReader & reader, const NameSet & required_columns, const ColumnsDescription & current_columns) const
 {
     ColumnsStatistics result;
     auto read_settings = storage.getContext()->getReadSettings();
@@ -1174,7 +1182,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
         if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
             throw Exception(ErrorCodes::CORRUPTED_DATA, "File {} is not a statistics file", filename);
 
-        const auto * column_desc = getColumnForStatisticsFile(filename, *columns_description, required_columns);
+        const auto * column_desc = getColumnForStatisticsFile(filename, *columns_description, required_columns, current_columns);
         if (!column_desc)
             continue;
 
@@ -1198,7 +1206,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsPacked(const PackedFilesRead
     return result;
 }
 
-ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & required_columns) const
+ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & required_columns, const ColumnsDescription & current_columns) const
 {
     ColumnsStatistics result;
     auto read_settings = storage.getContext()->getReadSettings();
@@ -1208,7 +1216,7 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & require
         if (!filename.ends_with(STATS_FILE_SUFFIX) || !filename.starts_with(STATS_FILE_PREFIX))
             continue;
 
-        const auto * column_desc = getColumnForStatisticsFile(filename, *columns_description, required_columns);
+        const auto * column_desc = getColumnForStatisticsFile(filename, *columns_description, required_columns, current_columns);
         if (!column_desc)
             continue;
 
@@ -1241,20 +1249,25 @@ ColumnsStatistics IMergeTreeDataPart::loadStatistics() const
     auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::loadStatistics");
 
     if (auto * reader = getStatisticsPackedReader())
-        return loadStatisticsPacked(*reader, {});
+        return loadStatisticsPacked(*reader, {}, *columns_description);
 
-    return loadStatisticsWide({});
+    return loadStatisticsWide({}, *columns_description);
 }
 
-ColumnsStatistics IMergeTreeDataPart::loadStatistics(const Names & required_columns) const
+ColumnsStatistics IMergeTreeDataPart::loadStatistics(const Names & required_columns, const ColumnsDescription & current_columns) const
 {
     auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::loadStatistics");
     NameSet required_columns_set(required_columns.begin(), required_columns.end());
 
     if (auto * reader = getStatisticsPackedReader())
-        return loadStatisticsPacked(*reader, required_columns_set);
+        return loadStatisticsPacked(*reader, required_columns_set, current_columns);
 
-    return loadStatisticsWide(required_columns_set);
+    return loadStatisticsWide(required_columns_set, current_columns);
+}
+
+ColumnsStatistics IMergeTreeDataPart::loadStatistics(const Names & required_columns) const
+{
+    return loadStatistics(required_columns, *columns_description);
 }
 
 Estimates IMergeTreeDataPart::getEstimates() const

--- a/src/Storages/MergeTree/IMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.h
@@ -189,6 +189,7 @@ public:
 
     ColumnsStatistics loadStatistics() const;
     ColumnsStatistics loadStatistics(const Names & required_columns) const;
+    ColumnsStatistics loadStatistics(const Names & required_columns, const ColumnsDescription & current_columns) const;
     Estimates getEstimates() const;
     void setEstimates(const Estimates & new_estimates);
 
@@ -837,8 +838,9 @@ private:
     void loadDefaultCompressionCodec();
     void loadSourcePartsSet();
 
-    ColumnsStatistics loadStatisticsPacked(const PackedFilesReader & reader, const NameSet & required_columns) const;
-    ColumnsStatistics loadStatisticsWide(const NameSet & required_columns) const;
+    ColumnsStatistics loadStatisticsPacked(
+        const PackedFilesReader & reader, const NameSet & required_columns, const ColumnsDescription & current_columns) const;
+    ColumnsStatistics loadStatisticsWide(const NameSet & required_columns, const ColumnsDescription & current_columns) const;
     PackedFilesReader * getStatisticsPackedReader() const;
 
     void writeColumns(const NamesAndTypesList & columns_, const WriteSettings & settings);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -904,21 +904,28 @@ ConditionSelectivityEstimatorPtr MergeTreeData::getConditionSelectivityEstimator
     LOG_DEBUG(log, "Loading statistics");
     ConditionSelectivityEstimatorBuilder estimator_builder(local_context);
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::LoadedStatisticsMicroseconds);
+    bool all_parts_loaded = true;
     for (const auto & part : parts)
     {
+        if (!part.data_part)
+            return nullptr;
+
         try
         {
             auto parts_lock = readLockParts();
             auto stats = part.data_part->loadStatistics(required_columns);
-            estimator_builder.markDataPart(part.data_part);
-            for (const auto & [column_name, stat] : stats)
-                estimator_builder.addStatistics(column_name, stat);
+            estimator_builder.addDataPartStatistics(part.data_part, stats);
         }
         catch (...)
         {
+            all_parts_loaded = false;
             tryLogCurrentException(log, fmt::format("while loading statistics on part {}", part.data_part->info.getPartNameV1()));
+            break;
         }
     }
+
+    if (!all_parts_loaded)
+        return nullptr;
 
     return estimator_builder.getEstimator();
 }
@@ -3161,35 +3168,52 @@ try
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeData::refreshStatistics");
     DataPartsVector data_parts = getDataPartsVectorForInternalUsage();
-    if (cached_estimator)
+    bool cache_is_current = false;
     {
-        if (!cached_estimator->isStale(data_parts))
+        std::lock_guard<std::mutex> lock(stats_mutex);
+        cache_is_current = cached_estimator && !cached_estimator->isStale(data_parts);
+        if (!cache_is_current)
         {
-            LOG_DEBUG(log, "The parts in this storage does not change, will not refresh statistics");
-            if (interval_seconds)
-                refresh_stats_task->scheduleAfter(interval_seconds * 1000);
-            return;
+            /// The query path reuses cached_estimator without checking the
+            /// current part scope. Do not leave a stale snapshot available while
+            /// this refresh is in progress; exact-scope cache validation can make
+            /// retention safe in the future.
+            cached_estimator = nullptr;
         }
     }
+
+    if (cache_is_current)
+    {
+        LOG_DEBUG(log, "The parts in this storage does not change, will not refresh statistics");
+        if (interval_seconds)
+            refresh_stats_task->scheduleAfter(interval_seconds * 1000);
+        return;
+    }
+
     LOG_DEBUG(log, "Refreshing statistics");
     ConditionSelectivityEstimatorBuilder estimator_builder(getContext());
+    bool all_parts_loaded = true;
     for (const DataPartPtr & data_part : data_parts)
     {
         try
         {
             auto parts_lock = readLockParts();
             auto stats = data_part->loadStatistics();
-            estimator_builder.markDataPart(data_part);
-            for (const auto & [column_name, stat] : stats)
-                estimator_builder.addStatistics(column_name, stat);
+            estimator_builder.addDataPartStatistics(data_part, stats);
         }
         catch (...)
         {
+            all_parts_loaded = false;
             tryLogCurrentException(log, fmt::format("while loading statistics on part {}", data_part->info.getPartNameV1()));
+            break;
         }
     }
-    std::lock_guard<std::mutex> lock(stats_mutex);
-    cached_estimator = estimator_builder.getEstimator();
+    if (all_parts_loaded)
+    {
+        auto new_estimator = estimator_builder.getEstimator();
+        std::lock_guard<std::mutex> lock(stats_mutex);
+        cached_estimator = std::move(new_estimator);
+    }
     if (interval_seconds)
         refresh_stats_task->scheduleAfter(interval_seconds * 1000);
 }

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
@@ -1,5 +1,6 @@
 #include <Storages/MergeTree/WhatIfStatisticalEstimator.h>
 
+#include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/WhatIfFilterAnalysis.h>
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 #include <Common/Exception.h>
@@ -34,8 +35,14 @@ bool tryEstimateWithStatistics(
     collectFilterInputColumns(filter_node, filter_input_columns);
 
     for (const auto & col : filter_input_columns)
-        if (!index_columns_set.contains(col))
+    {
+        if (index_columns_set.contains(col))
+            continue;
+
+        const auto matching_column = tryGetNullableParentColumnName(metadata->getColumns(), col);
+        if (!matching_column || !index_columns_set.contains(*matching_column))
             return false;
+    }
 
     Names required_stats_columns(filter_input_columns.begin(), filter_input_columns.end());
 
@@ -49,7 +56,7 @@ bool tryEstimateWithStatistics(
 
         try
         {
-            auto stats = part.data_part->loadStatistics(required_stats_columns);
+            auto stats = part.data_part->loadStatistics(required_stats_columns, metadata->getColumns());
             builder.addDataPartStatistics(part.data_part, stats);
         }
         catch (const Exception &) /// Ok — statistical estimation is best-effort

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
@@ -37,6 +37,8 @@ bool tryEstimateWithStatistics(
         if (!index_columns_set.contains(col))
             return false;
 
+    Names required_stats_columns(filter_input_columns.begin(), filter_input_columns.end());
+
     ConditionSelectivityEstimatorBuilder builder(context);
     bool all_parts_loaded = true;
 
@@ -47,7 +49,7 @@ bool tryEstimateWithStatistics(
 
         try
         {
-            auto stats = part.data_part->loadStatistics();
+            auto stats = part.data_part->loadStatistics(required_stats_columns);
             builder.addDataPartStatistics(part.data_part, stats);
         }
         catch (const Exception &) /// Ok — statistical estimation is best-effort
@@ -65,7 +67,6 @@ bool tryEstimateWithStatistics(
     if (!estimator)
         return false;
 
-    Names required_stats_columns(filter_input_columns.begin(), filter_input_columns.end());
     if (!estimator->hasStatisticsFor(metadata, required_stats_columns))
         return false;
 

--- a/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
+++ b/src/Storages/MergeTree/WhatIfStatisticalEstimator.cpp
@@ -38,32 +38,35 @@ bool tryEstimateWithStatistics(
             return false;
 
     ConditionSelectivityEstimatorBuilder builder(context);
-    bool has_any_stats = false;
+    bool all_parts_loaded = true;
 
     for (const auto & part : parts)
     {
+        if (!part.data_part)
+            return false;
+
         try
         {
             auto stats = part.data_part->loadStatistics();
-            if (!stats.empty())
-            {
-                builder.markDataPart(part.data_part);
-                for (const auto & [column_name, stat] : stats)
-                    builder.addStatistics(column_name, stat);
-                has_any_stats = true;
-            }
+            builder.addDataPartStatistics(part.data_part, stats);
         }
         catch (const Exception &) /// Ok — statistical estimation is best-effort
         {
+            all_parts_loaded = false;
             tryLogCurrentException(__PRETTY_FUNCTION__);
+            break;
         }
     }
 
-    if (!has_any_stats)
+    if (!all_parts_loaded)
         return false;
 
     auto estimator = builder.getEstimator();
     if (!estimator)
+        return false;
+
+    Names required_stats_columns(filter_input_columns.begin(), filter_input_columns.end());
+    if (!estimator->hasStatisticsFor(metadata, required_stats_columns))
         return false;
 
     auto profile = estimator->estimateRelationProfile(metadata, filter_node);

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -1,7 +1,9 @@
 #include <Storages/Statistics/ConditionSelectivityEstimator.h>
 
-#include <stack>
+#include <algorithm>
 #include <cmath>
+#include <stack>
+#include <string_view>
 
 #include <Common/logger_useful.h>
 #include <DataTypes/DataTypeNothing.h>
@@ -207,6 +209,32 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfile() const
         result.column_stats.emplace(column_name, estimator.estimateCardinality());
     }
     return result;
+}
+
+bool ConditionSelectivityEstimator::hasStatisticsFor(const StorageMetadataPtr & metadata, const Names & columns) const
+{
+    return std::all_of(columns.begin(), columns.end(), [&](const auto & column)
+    {
+        /// The analyzer may expose a nullable column's `.null` subcolumn as the
+        /// filter input, while persisted statistics are keyed by the parent column.
+        constexpr std::string_view null_suffix = ".null";
+        String statistics_column = column;
+        if (!column_estimators.contains(statistics_column)
+            && column.size() > null_suffix.size()
+            && column.ends_with(null_suffix)
+            && metadata)
+        {
+            String parent_name = column.substr(0, column.size() - null_suffix.size());
+            const auto * parent_column = metadata->getColumns().tryGet(parent_name);
+            if (parent_column && isNullableOrLowCardinalityNullable(parent_column->type))
+                statistics_column = parent_name;
+        }
+
+        auto it = column_estimators.find(statistics_column);
+        return it != column_estimators.end()
+            && it->second.stats != nullptr
+            && isCompatibleStatistics(metadata, it->second.stats, statistics_column);
+    });
 }
 
 RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const StorageMetadataPtr & metadata, const ActionsDAG::Node * node) const
@@ -494,30 +522,78 @@ void ConditionSelectivityEstimatorBuilder::incrementRowCount(UInt64 rows)
 
 void ConditionSelectivityEstimatorBuilder::markDataPart(const DataPartPtr & data_part)
 {
+    if (!data_part || !marked_part_set.insert(data_part.get()).second)
+    {
+        invalid_scope = true;
+        current_part_columns.clear();
+        return;
+    }
+
     estimator->parts_names.push_back(data_part->name);
     estimator->total_rows += data_part->rows_count;
+    ++marked_parts;
+    current_part_columns.clear();
+}
+
+void ConditionSelectivityEstimatorBuilder::addDataPartStatistics(const DataPartPtr & data_part, const ColumnsStatistics & statistics)
+{
+    markDataPart(data_part);
+    if (invalid_scope)
+        return;
+
+    for (const auto & [column_name, column_stats] : statistics)
+        addStatistics(column_name, column_stats);
 }
 
 void ConditionSelectivityEstimatorBuilder::addStatistics(const String & column_name, const ColumnStatisticsPtr & column_stats)
 {
-    if (column_stats != nullptr)
-    {
-        has_data = true;
-        auto & column_estimator = estimator->column_estimators[column_name];
+    if (column_stats == nullptr || incomplete_columns.contains(column_name))
+        return;
 
-        if (column_estimator.stats == nullptr)
-            column_estimator.stats = column_stats;
-        else if (column_estimator.stats->structureEquals(*column_stats))
-            column_estimator.stats->merge(column_stats);
-        /// else: incompatible statistics (e.g. a concurrent ALTER changed the column type,
-        /// shifting the aggregate-function state layout). Skip this part's statistics so the
-        /// estimator still works with the compatible parts instead of crashing.
+    if (marked_parts && !current_part_columns.insert(column_name).second)
+    {
+        incomplete_columns.insert(column_name);
+        return;
     }
+
+    has_data = true;
+    auto & column_estimator = estimator->column_estimators[column_name];
+
+    if (column_estimator.stats == nullptr)
+        column_estimator.stats = column_stats;
+    else if (column_estimator.stats->structureEquals(*column_stats))
+        column_estimator.stats->merge(column_stats);
+    else
+    {
+        /// Incompatible statistics (e.g. a concurrent ALTER changed the column type)
+        /// are incomplete for the whole scope. Drop this column at getEstimator()
+        /// rather than merging a compatible subset into a seemingly complete estimator.
+        incomplete_columns.insert(column_name);
+        return;
+    }
+
+    if (marked_parts)
+        ++column_part_counts[column_name];
 }
 
-ConditionSelectivityEstimatorPtr ConditionSelectivityEstimatorBuilder::getEstimator() const
+ConditionSelectivityEstimatorPtr ConditionSelectivityEstimatorBuilder::getEstimator()
 {
-    return has_data ? estimator : nullptr;
+    if (invalid_scope)
+        return nullptr;
+
+    if (marked_parts)
+    {
+        for (auto it = estimator->column_estimators.begin(); it != estimator->column_estimators.end();)
+        {
+            auto count_it = column_part_counts.find(it->first);
+            if (incomplete_columns.contains(it->first) || count_it == column_part_counts.end() || count_it->second != marked_parts)
+                it = estimator->column_estimators.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    return has_data && !estimator->column_estimators.empty() ? estimator : nullptr;
 }
 
 ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::Selectivity::applyNot() const

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -213,28 +213,22 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfile() const
 
 bool ConditionSelectivityEstimator::hasStatisticsFor(const StorageMetadataPtr & metadata, const Names & columns) const
 {
-    return std::all_of(columns.begin(), columns.end(), [&](const auto & column)
-    {
-        /// The analyzer may expose a nullable column's `.null` subcolumn as the
-        /// filter input, while persisted statistics are keyed by the parent column.
-        constexpr std::string_view null_suffix = ".null";
-        String statistics_column = column;
-        if (!column_estimators.contains(statistics_column)
-            && column.size() > null_suffix.size()
-            && column.ends_with(null_suffix)
-            && metadata)
+    return std::all_of(
+        columns.begin(),
+        columns.end(),
+        [&](const auto & column)
         {
-            String parent_name = column.substr(0, column.size() - null_suffix.size());
-            const auto * parent_column = metadata->getColumns().tryGet(parent_name);
-            if (parent_column && isNullableOrLowCardinalityNullable(parent_column->type))
-                statistics_column = parent_name;
-        }
+            String statistics_column = column;
+            if (!column_estimators.contains(statistics_column) && metadata)
+            {
+                if (auto parent_name = tryGetNullableParentColumnName(metadata->getColumns(), column))
+                    statistics_column = *parent_name;
+            }
 
-        auto it = column_estimators.find(statistics_column);
-        return it != column_estimators.end()
-            && it->second.stats != nullptr
-            && isCompatibleStatistics(metadata, it->second.stats, statistics_column);
-    });
+            auto it = column_estimators.find(statistics_column);
+            return it != column_estimators.end() && it->second.stats != nullptr
+                && isCompatibleStatistics(metadata, it->second.stats, statistics_column);
+        });
 }
 
 RelationProfile ConditionSelectivityEstimator::estimateRelationProfile(const StorageMetadataPtr & metadata, const ActionsDAG::Node * node) const
@@ -493,17 +487,11 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
     {
         String bare_column_name = node.getColumnName();
 
-        auto dot_pos = bare_column_name.rfind('.');
-        if (dot_pos != std::string::npos && bare_column_name.compare(dot_pos + 1, std::string::npos, "null") == 0)
+        if (auto parent_name = tryGetNullableParentColumnName(metadata->getColumns(), bare_column_name))
         {
-            String parent_name = bare_column_name.substr(0, dot_pos);
-            const ColumnDescription * parent_col = metadata->getColumns().tryGet(parent_name);
-            if (parent_col && isNullableOrLowCardinalityNullable(parent_col->type))
-            {
-                out.function = RPNElement::FUNCTION_IS_NULL;
-                out.null_check_columns.insert(parent_name);
-                return true;
-            }
+            out.function = RPNElement::FUNCTION_IS_NULL;
+            out.null_check_columns.insert(*parent_name);
+            return true;
         }
     }
 

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -3,8 +3,14 @@
 #include <Storages/Statistics/Statistics.h>
 
 #include <Core/Field.h>
+#include <Core/Names.h>
 #include <Core/PlainRanges.h>
 #include <Interpreters/ActionsDAG.h>
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace DB
 {
@@ -61,6 +67,7 @@ public:
     RelationProfile estimateRelationProfile(const StorageMetadataPtr & metadata, const RPNBuilderTreeNode & node) const;
     RelationProfile estimateRelationProfile(const StorageMetadataPtr & metadata, const std::vector<RPNBuilderTreeNode> & nodes) const;
     RelationProfile estimateRelationProfile() const;
+    bool hasStatisticsFor(const StorageMetadataPtr & metadata, const Names & columns) const;
 
     bool isStale(const std::vector<DataPartPtr> & data_parts) const;
 
@@ -135,13 +142,21 @@ class ConditionSelectivityEstimatorBuilder
 public:
     explicit ConditionSelectivityEstimatorBuilder(ContextPtr context_);
     void addStatistics(const String & column_name, const ColumnStatisticsPtr & column_stats);
+    void addDataPartStatistics(const DataPartPtr & data_part, const ColumnsStatistics & statistics);
     void incrementRowCount(UInt64 rows);
-    void markDataPart(const DataPartPtr & data_part);
-    ConditionSelectivityEstimatorPtr getEstimator() const;
+    ConditionSelectivityEstimatorPtr getEstimator();
 
 private:
+    void markDataPart(const DataPartPtr & data_part);
+
     bool has_data = false;
     ConditionSelectivityEstimatorPtr estimator;
+    size_t marked_parts = 0;
+    std::unordered_set<const IMergeTreeDataPart *> marked_part_set;
+    std::unordered_map<String, size_t> column_part_counts;
+    std::unordered_set<String> incomplete_columns;
+    std::unordered_set<String> current_part_columns;
+    bool invalid_scope = false;
 };
 
 }

--- a/tests/integration/test_statistics_cache/test.py
+++ b/tests/integration/test_statistics_cache/test.py
@@ -1,5 +1,6 @@
-import uuid
+import shlex
 import threading
+import uuid
 import pytest
 from helpers.cluster import ClickHouseCluster
 
@@ -280,6 +281,173 @@ def test_join_load_then_hit_and_parallel_readers():
     for t in threads:
         t.join()
     assert not errs, f"errors: {errs}"
+
+def test_join_statistics_corruption_falls_back_without_partial_estimates():
+    """A failed part/column load must not change join estimates for the full scope."""
+    partial = "partial_stats_111014"
+    dim = "partial_dim_111014"
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {partial} SYNC")
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {dim} SYNC")
+    _query_retry(ch1, f"""
+        CREATE TABLE {partial} (k UInt32, v UInt32)
+        ENGINE = MergeTree PARTITION BY intDiv(k, 1000) ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0,
+                 min_bytes_for_full_part_storage = 0,
+                 refresh_statistics_interval = 0,
+                 auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {partial} SELECT number, number FROM numbers(1000)")
+    _query(ch1, f"INSERT INTO {partial} SELECT number + 1000, number + 1000 FROM numbers(1000)")
+    _query_retry(ch1, f"ALTER TABLE {partial} ADD STATISTICS v TYPE Basic")
+    _query_retry(ch1, f"ALTER TABLE {partial} MATERIALIZE STATISTICS v")
+
+    _query_retry(ch1, f"""
+        CREATE TABLE {dim} (k UInt32)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS min_bytes_for_full_part_storage = 0,
+                 auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {dim} SELECT number FROM numbers(2000)")
+
+    part_names = _query(ch1, f"""
+        SELECT name
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = '{partial}' AND active
+        ORDER BY name
+        FORMAT TabSeparated
+    """).strip().splitlines()
+    assert len(part_names) == 2, part_names
+    affected_part = part_names[-1]
+    part_path = _query(ch1, f"""
+        SELECT path
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = '{partial}'
+          AND name = '{affected_part}' AND active
+        FORMAT TabSeparated
+    """).strip()
+    stats_files = ch1.exec_in_container(
+        ["bash", "-c", f"find {shlex.quote(part_path.rstrip('/'))} -maxdepth 1 -type f -name 'statistics*' -printf '%f\\n' | sort"],
+        user="root",
+    ).strip().splitlines()
+    assert len(stats_files) == 1 and stats_files[0] in {"statistics.packed", "statistics_v.stats"}, {
+        "part_path": part_path,
+        "stats_files": stats_files,
+        "files": ch1.exec_in_container(
+            ["bash", "-c", f"find {shlex.quote(part_path.rstrip('/'))} -maxdepth 1 -type f -printf '%f\\n' | sort"],
+            user="root",
+        ),
+    }
+    stats_path = f"{part_path.rstrip('/')}/{stats_files[0]}"
+    quoted_stats_path = shlex.quote(stats_path)
+    backup_path = f"{stats_path}.partial_stats_backup"
+    quoted_backup_path = shlex.quote(backup_path)
+    ch1.exec_in_container(["bash", "-c", f"test -s {quoted_stats_path}"], user="root")
+
+    join_sql = f"""
+        SELECT count()
+        FROM {partial} AS s INNER JOIN {dim} AS d ON s.k = d.k
+        WHERE s.v >= 1500
+    """
+
+    def _plan(use_statistics):
+        return _query(ch1, f"""
+            EXPLAIN PLAN keep_logical_steps=1, actions=1
+            {join_sql}
+            SETTINGS use_statistics={use_statistics}, use_statistics_cache=0,
+                     use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0,
+                     query_plan_optimize_join_order_limit=10
+        """)
+
+    def _result_rows(plan):
+        return tuple(line.strip() for line in plan.splitlines() if "ResultRows:" in line)
+
+    no_stats_rows = _result_rows(_plan(0))
+    clean_rows = _result_rows(_plan(1))
+    assert clean_rows != no_stats_rows, {
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "reason": "clean statistics did not affect the visible join estimate",
+    }
+
+    def _mutate_stats(remove):
+        nonlocal backup_created
+        backup_created = False
+        ch1.exec_in_container(
+            ["bash", "-c", f"rm -f {quoted_backup_path}; cp -a {quoted_stats_path} {quoted_backup_path}"],
+            user="root",
+        )
+        backup_created = True
+        if remove:
+            ch1.exec_in_container(["rm", "-f", stats_path], user="root")
+        else:
+            ch1.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    f"size=$(stat -c %s {quoted_stats_path}); "
+                    f"dd if=/dev/zero of={quoted_stats_path} bs=1 count=$size conv=notrunc status=none",
+                ],
+                user="root",
+            )
+
+    def _restore_stats():
+        if not backup_created:
+            return
+        ch1.exec_in_container(
+            ["bash", "-c", f"rm -f {quoted_stats_path}; mv -f {quoted_backup_path} {quoted_stats_path}"],
+            user="root",
+        )
+
+    observed_rows = {}
+    for remove in (False, True):
+        backup_created = False
+        original_hash = ch1.exec_in_container(
+            ["bash", "-c", f"sha256sum {quoted_stats_path}"],
+            user="root",
+        ).split()[0]
+        try:
+            _mutate_stats(remove)
+            if remove:
+                ch1.exec_in_container(["test", "!", "-e", stats_path], user="root")
+            else:
+                mutated_hash = ch1.exec_in_container(
+                    ["bash", "-c", f"sha256sum {quoted_stats_path}"],
+                    user="root",
+                ).split()[0]
+                assert mutated_hash != original_hash
+            observed_rows["missing" if remove else "zeroed"] = _result_rows(_plan(1))
+            assert _query(ch1, f"""
+                {join_sql}
+                SETTINGS use_statistics_for_part_pruning=0,
+                         optimize_use_projections=0, optimize_use_implicit_projections=0
+                FORMAT TabSeparated
+            """).strip() == "500"
+        finally:
+            _restore_stats()
+
+    assert observed_rows["zeroed"] == no_stats_rows, {
+        "mode": "zeroed",
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "observed_rows": observed_rows,
+    }
+    assert observed_rows["missing"] == no_stats_rows, {
+        "mode": "missing",
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "observed_rows": observed_rows,
+    }
+    assert observed_rows["zeroed"] != clean_rows, {
+        "mode": "zeroed",
+        "clean_rows": clean_rows,
+        "observed_rows": observed_rows,
+    }
+    assert observed_rows["missing"] != clean_rows, {
+        "mode": "missing",
+        "clean_rows": clean_rows,
+        "observed_rows": observed_rows,
+    }
 
 def test_alter_interval_requires_detach_attach():
     _create_tbl(ch1, "alt_tbl", 0)

--- a/tests/integration/test_statistics_cache/test.py
+++ b/tests/integration/test_statistics_cache/test.py
@@ -283,7 +283,7 @@ def test_join_load_then_hit_and_parallel_readers():
     assert not errs, f"errors: {errs}"
 
 def test_join_statistics_corruption_falls_back_without_partial_estimates():
-    """A failed part/column load must not change join estimates for the full scope."""
+    """A failed part/column load or mixed scope must not change join estimates."""
     partial = "partial_stats_111014"
     dim = "partial_dim_111014"
     _query_retry(ch1, f"DROP TABLE IF EXISTS {partial} SYNC")
@@ -370,7 +370,7 @@ def test_join_statistics_corruption_falls_back_without_partial_estimates():
         "reason": "clean statistics did not affect the visible join estimate",
     }
 
-    def _mutate_stats(remove):
+    def _mutate_stats():
         nonlocal backup_created
         backup_created = False
         ch1.exec_in_container(
@@ -378,13 +378,35 @@ def test_join_statistics_corruption_falls_back_without_partial_estimates():
             user="root",
         )
         backup_created = True
-        if remove:
-            ch1.exec_in_container(["rm", "-f", stats_path], user="root")
+        if stats_files[0] == "statistics.packed":
+            member_name = "statistics_v.stats"
+            # A v0 packed-index entry stores the member name followed by its
+            # UInt64 payload offset and size. Keep the index intact and damage
+            # only this column's compressed payload.
+            ch1.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail; export LC_ALL=C; "
+                    f"version=$(od -An -tu1 -N 1 {quoted_stats_path} | tr -d ' '); "
+                    f"test \"$version\" -eq 0; "
+                    f"member=$(grep -abo -F {shlex.quote(member_name)} {quoted_stats_path} | cut -d: -f1); "
+                    f"test -n \"$member\"; "
+                    f"test $(grep -abo -F {shlex.quote(member_name)} {quoted_stats_path} | wc -l) -eq 1; "
+                    f"offset_pos=$((member + {len(member_name)})); "
+                    f"offset=$(od -An -tu8 -j $offset_pos -N 8 {quoted_stats_path} | tr -d ' '); "
+                    f"size=$(od -An -tu8 -j $((offset_pos + 8)) -N 8 {quoted_stats_path} | tr -d ' '); "
+                    f"test \"$offset\" -gt 0; test \"$size\" -gt 0; "
+                    f"dd if=/dev/zero of={quoted_stats_path} bs=1 seek=$offset count=$size conv=notrunc status=none",
+                ],
+                user="root",
+            )
         else:
             ch1.exec_in_container(
                 [
                     "bash",
                     "-c",
+                    "set -euo pipefail; "
                     f"size=$(stat -c %s {quoted_stats_path}); "
                     f"dd if=/dev/zero of={quoted_stats_path} bs=1 count=$size conv=notrunc status=none",
                 ],
@@ -399,55 +421,112 @@ def test_join_statistics_corruption_falls_back_without_partial_estimates():
             user="root",
         )
 
-    observed_rows = {}
-    for remove in (False, True):
-        backup_created = False
-        original_hash = ch1.exec_in_container(
+    backup_created = False
+    original_hash = ch1.exec_in_container(
+        ["bash", "-c", f"sha256sum {quoted_stats_path}"],
+        user="root",
+    ).split()[0]
+    try:
+        _mutate_stats()
+        mutated_hash = ch1.exec_in_container(
             ["bash", "-c", f"sha256sum {quoted_stats_path}"],
             user="root",
         ).split()[0]
-        try:
-            _mutate_stats(remove)
-            if remove:
-                ch1.exec_in_container(["test", "!", "-e", stats_path], user="root")
-            else:
-                mutated_hash = ch1.exec_in_container(
-                    ["bash", "-c", f"sha256sum {quoted_stats_path}"],
-                    user="root",
-                ).split()[0]
-                assert mutated_hash != original_hash
-            observed_rows["missing" if remove else "zeroed"] = _result_rows(_plan(1))
-            assert _query(ch1, f"""
-                {join_sql}
-                SETTINGS use_statistics_for_part_pruning=0,
-                         optimize_use_projections=0, optimize_use_implicit_projections=0
-                FORMAT TabSeparated
-            """).strip() == "500"
-        finally:
-            _restore_stats()
+        assert mutated_hash != original_hash
+        observed_zeroed = _result_rows(_plan(1))
+        assert _query(ch1, f"""
+            {join_sql}
+            SETTINGS use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0
+            FORMAT TabSeparated
+        """).strip() == "500"
+    finally:
+        _restore_stats()
 
-    assert observed_rows["zeroed"] == no_stats_rows, {
+    assert observed_zeroed == no_stats_rows, {
         "mode": "zeroed",
         "clean_rows": clean_rows,
         "no_stats_rows": no_stats_rows,
-        "observed_rows": observed_rows,
+        "observed_rows": observed_zeroed,
     }
-    assert observed_rows["missing"] == no_stats_rows, {
-        "mode": "missing",
-        "clean_rows": clean_rows,
-        "no_stats_rows": no_stats_rows,
-        "observed_rows": observed_rows,
-    }
-    assert observed_rows["zeroed"] != clean_rows, {
+    assert observed_zeroed != clean_rows, {
         "mode": "zeroed",
         "clean_rows": clean_rows,
-        "observed_rows": observed_rows,
+        "observed_rows": observed_zeroed,
     }
-    assert observed_rows["missing"] != clean_rows, {
-        "mode": "missing",
-        "clean_rows": clean_rows,
-        "observed_rows": observed_rows,
+
+    mixed = "partial_stats_mixed_111014"
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {mixed} SYNC")
+    _query_retry(ch1, f"""
+        CREATE TABLE {mixed} (k UInt32, v UInt32)
+        ENGINE = MergeTree PARTITION BY intDiv(k, 1000) ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0,
+                 min_bytes_for_full_part_storage = 0,
+                 refresh_statistics_interval = 0,
+                 auto_statistics_types = ''
+    """)
+    _query(ch1, f"SET materialize_statistics_on_insert = 0; INSERT INTO {mixed} SELECT number, number FROM numbers(1000)")
+    _query_retry(ch1, f"ALTER TABLE {mixed} ADD STATISTICS v TYPE Basic")
+    _query(ch1, f"SET materialize_statistics_on_insert = 1; INSERT INTO {mixed} SELECT number + 1000, number + 1000 FROM numbers(1000)")
+
+    mixed_part_names = _query(ch1, f"""
+        SELECT name
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = '{mixed}' AND active
+        ORDER BY name
+        FORMAT TabSeparated
+    """).strip().splitlines()
+    assert len(mixed_part_names) == 2, mixed_part_names
+    mixed_stats_files = {}
+    for part_name in mixed_part_names:
+        mixed_part_path = _query(ch1, f"""
+            SELECT path
+            FROM system.parts
+            WHERE database = currentDatabase() AND table = '{mixed}'
+              AND name = '{part_name}' AND active
+            FORMAT TabSeparated
+        """).strip()
+        mixed_stats_files[part_name] = ch1.exec_in_container(
+            ["bash", "-c", f"find {shlex.quote(mixed_part_path.rstrip('/'))} -maxdepth 1 -type f -name 'statistics*' -printf '%f\\n' | sort"],
+            user="root",
+        ).strip().splitlines()
+
+    assert sorted(bool(files) for files in mixed_stats_files.values()) == [False, True], mixed_stats_files
+
+    mixed_join_sql = f"""
+        SELECT count()
+        FROM {mixed} AS s INNER JOIN {dim} AS d ON s.k = d.k
+        WHERE s.v >= 1500
+    """
+
+    def _mixed_plan(use_statistics):
+        return _query(ch1, f"""
+            EXPLAIN PLAN keep_logical_steps=1, actions=1
+            {mixed_join_sql}
+            SETTINGS use_statistics={use_statistics}, use_statistics_cache=0,
+                     use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0,
+                     query_plan_optimize_join_order_limit=10
+        """)
+
+    mixed_no_stats_rows = _result_rows(_mixed_plan(0))
+    mixed_rows = _result_rows(_mixed_plan(1))
+    assert mixed_no_stats_rows and mixed_rows, {
+        "mixed_rows": mixed_rows,
+        "mixed_no_stats_rows": mixed_no_stats_rows,
+        "reason": "EXPLAIN PLAN did not expose a ResultRows estimate",
     }
+    assert mixed_rows == mixed_no_stats_rows, {
+        "mixed_rows": mixed_rows,
+        "mixed_no_stats_rows": mixed_no_stats_rows,
+        "reason": "a part without v statistics must reject the mixed statistics scope",
+    }
+    assert _query(ch1, f"""
+        {mixed_join_sql}
+        SETTINGS use_statistics_for_part_pruning=0,
+                 optimize_use_projections=0, optimize_use_implicit_projections=0
+        FORMAT TabSeparated
+    """).strip() == "500"
 
 def test_alter_interval_requires_detach_attach():
     _create_tbl(ch1, "alt_tbl", 0)

--- a/tests/integration/test_statistics_cache/test.py
+++ b/tests/integration/test_statistics_cache/test.py
@@ -528,6 +528,103 @@ def test_join_statistics_corruption_falls_back_without_partial_estimates():
         FORMAT TabSeparated
     """).strip() == "500"
 
+def test_join_statistics_unreadable_unrelated_column_preserves_complete_stats():
+    """An unreadable non-filter statistic must not discard complete filter statistics."""
+    partial = "unrelated_stats_111016"
+    dim = "unrelated_dim_111016"
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {partial} SYNC")
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {dim} SYNC")
+    _query_retry(ch1, f"""
+        CREATE TABLE {partial} (k UInt32, a UInt32, z UInt32)
+        ENGINE = MergeTree PARTITION BY intDiv(k, 1000) ORDER BY k
+        SETTINGS refresh_statistics_interval = 0,
+                 auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {partial} SELECT number, number, number FROM numbers(1000)")
+    _query(ch1, f"INSERT INTO {partial} SELECT number + 1000, number + 1000, number + 1000 FROM numbers(1000)")
+    _query_retry(ch1, f"ALTER TABLE {partial} ADD STATISTICS a TYPE Basic")
+    _query_retry(ch1, f"ALTER TABLE {partial} ADD STATISTICS z TYPE Basic")
+    _query_retry(ch1, f"ALTER TABLE {partial} MATERIALIZE STATISTICS a")
+    _query_retry(ch1, f"ALTER TABLE {partial} MATERIALIZE STATISTICS z")
+
+    _query_retry(ch1, f"""
+        CREATE TABLE {dim} (k UInt32)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {dim} SELECT number FROM numbers(2000)")
+
+    join_sql = f"""
+        SELECT sum(s.a)
+        FROM {partial} AS s INNER JOIN {dim} AS d ON s.k = d.k
+        WHERE s.z >= 1500
+    """
+
+    def _plan(use_statistics):
+        return _query(ch1, f"""
+            EXPLAIN PLAN keep_logical_steps=1, actions=1
+            {join_sql}
+            SETTINGS use_statistics={use_statistics}, use_statistics_cache=0,
+                     use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0,
+                     query_plan_optimize_join_order_limit=10
+        """)
+
+    def _result_rows(plan):
+        return tuple(line.strip() for line in plan.splitlines() if "ResultRows:" in line)
+
+    no_stats_rows = _result_rows(_plan(0))
+    clean_rows = _result_rows(_plan(1))
+    assert clean_rows and no_stats_rows, {
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "reason": "EXPLAIN PLAN did not expose a ResultRows estimate",
+    }
+    assert clean_rows != no_stats_rows, {
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "reason": "clean filter statistics did not affect the visible join estimate",
+    }
+    clean_result = _query(ch1, f"""
+        {join_sql}
+        SETTINGS use_statistics_for_part_pruning=0,
+                 optimize_use_projections=0, optimize_use_implicit_projections=0
+        FORMAT TabSeparated
+    """).strip()
+
+    # Column statistics are serialized in std::map order, so the ONCE failpoint omits a before loading z.
+    failpoint = "merge_tree_load_statistics_file_throw_once"
+    _query(ch1, f"SYSTEM ENABLE FAILPOINT {failpoint}")
+    try:
+        unreadable_rows = _result_rows(_plan(1))
+        failpoint_enabled = _query(ch1, f"""
+            SELECT enabled
+            FROM system.fail_points
+            WHERE name = '{failpoint}'
+            FORMAT TabSeparated
+        """).strip()
+        unreadable_result = _query(ch1, f"""
+            {join_sql}
+            SETTINGS use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0
+            FORMAT TabSeparated
+        """).strip()
+    finally:
+        _query(ch1, f"SYSTEM DISABLE FAILPOINT {failpoint}")
+
+    assert unreadable_rows == clean_rows, {
+        "clean_rows": clean_rows,
+        "no_stats_rows": no_stats_rows,
+        "unreadable_rows": unreadable_rows,
+        "reason": "an unrelated unreadable statistic discarded complete filter statistics",
+    }
+    assert failpoint_enabled == "0", f"{failpoint} did not fire during the statistics load"
+    assert unreadable_result == clean_result, {
+        "clean_result": clean_result,
+        "unreadable_result": unreadable_result,
+        "reason": "statistics corruption changed the query result",
+    }
+
 def test_alter_interval_requires_detach_attach():
     _create_tbl(ch1, "alt_tbl", 0)
     _query(ch1, "SELECT count() FROM alt_tbl WHERE v>0.99 AND k>=0 SETTINGS use_statistics_cache=1, log_comment='alt-pre' FORMAT Null")

--- a/tests/integration/test_statistics_cache/test.py
+++ b/tests/integration/test_statistics_cache/test.py
@@ -528,6 +528,176 @@ def test_join_statistics_corruption_falls_back_without_partial_estimates():
         FORMAT TabSeparated
     """).strip() == "500"
 
+def test_failed_refresh_clears_stale_cache_without_partial_publication():
+    """A failed background refresh must expose neither the old nor a partial estimator."""
+    fact = "refresh_fail_closed_111016"
+    dim = "refresh_fail_closed_dim_111016"
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {fact} SYNC")
+    _query_retry(ch1, f"DROP TABLE IF EXISTS {dim} SYNC")
+    _query_retry(ch1, f"""
+        CREATE TABLE {fact} (k UInt32, v UInt32)
+        ENGINE = MergeTree PARTITION BY intDiv(k, 1000) ORDER BY k
+        SETTINGS min_bytes_for_wide_part = 0,
+                 min_bytes_for_full_part_storage = 0,
+                 refresh_statistics_interval = 1,
+                 auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {fact} SELECT number, number FROM numbers(1000)")
+    _query_retry(ch1, f"ALTER TABLE {fact} ADD STATISTICS v TYPE Basic")
+    _query_retry(ch1, f"ALTER TABLE {fact} MATERIALIZE STATISTICS v")
+
+    _query_retry(ch1, f"""
+        CREATE TABLE {dim} (k UInt32)
+        ENGINE = MergeTree ORDER BY k
+        SETTINGS auto_statistics_types = ''
+    """)
+    _query(ch1, f"INSERT INTO {dim} SELECT number FROM numbers(2000)")
+
+    join_sql = f"""
+        SELECT count()
+        FROM {fact} AS s INNER JOIN {dim} AS d ON s.k = d.k
+        WHERE s.v >= 1500
+    """
+
+    def _plan_sql(use_statistics, tag):
+        return f"""
+            EXPLAIN PLAN keep_logical_steps=1, actions=1
+            {join_sql}
+            SETTINGS use_statistics={use_statistics}, use_statistics_cache=1,
+                     use_statistics_for_part_pruning=0,
+                     optimize_use_projections=0, optimize_use_implicit_projections=0,
+                     query_plan_optimize_join_order_limit=10,
+                     log_comment='{tag}'
+        """
+
+    def _result_rows(plan):
+        return tuple(line.strip() for line in plan.splitlines() if "ResultRows:" in line)
+
+    initial_no_stats_rows = _result_rows(_query(ch1, _plan_sql(0, "refresh-fail-initial-no-stats")))
+    warm_tag = "refresh-fail-warm"
+    warm_plan = _wait_hit(ch1, warm_tag, _plan_sql(1, warm_tag))
+    warm_rows = _result_rows(warm_plan)
+    assert warm_rows and initial_no_stats_rows and warm_rows != initial_no_stats_rows, {
+        "warm_rows": warm_rows,
+        "initial_no_stats_rows": initial_no_stats_rows,
+        "reason": "the warmed estimator did not affect the visible join estimate",
+    }
+
+    # Deactivate the task while retaining the warmed estimator, so the new part
+    # can be corrupted before any refresh sees the stale cache scope.
+    _query_retry(ch1, f"ALTER TABLE {fact} MODIFY SETTING refresh_statistics_interval = 0")
+    retained_tag = "refresh-fail-retained"
+    retained_rows = _result_rows(_query(ch1, _plan_sql(1, retained_tag)))
+    _assert_hit(ch1, retained_tag)
+    assert retained_rows == warm_rows
+
+    _query(ch1, f"INSERT INTO {fact} SELECT number + 1000, number + 1000 FROM numbers(1000)")
+    part_names = _query(ch1, f"""
+        SELECT name
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = '{fact}' AND active
+        ORDER BY name DESC
+        FORMAT TabSeparated
+    """).strip().splitlines()
+    assert len(part_names) == 2, part_names
+    affected_part = part_names[0]
+    part_path = _query(ch1, f"""
+        SELECT path
+        FROM system.parts
+        WHERE database = currentDatabase() AND table = '{fact}'
+          AND name = '{affected_part}' AND active
+        FORMAT TabSeparated
+    """).strip()
+    stats_files = ch1.exec_in_container(
+        ["bash", "-c", f"find {shlex.quote(part_path.rstrip('/'))} -maxdepth 1 -type f -name 'statistics*' -printf '%f\\n' | sort"],
+        user="root",
+    ).strip().splitlines()
+    assert len(stats_files) == 1 and stats_files[0] in {"statistics.packed", "statistics_v.stats"}, {
+        "part_path": part_path,
+        "stats_files": stats_files,
+    }
+    stats_path = f"{part_path.rstrip('/')}/{stats_files[0]}"
+    quoted_stats_path = shlex.quote(stats_path)
+    backup_path = f"{stats_path}.refresh_fail_closed_backup"
+    quoted_backup_path = shlex.quote(backup_path)
+    ch1.exec_in_container(
+        ["bash", "-c", f"rm -f {quoted_backup_path}; cp -a {quoted_stats_path} {quoted_backup_path}"],
+        user="root",
+    )
+    original_hash = ch1.exec_in_container(
+        ["bash", "-c", f"sha256sum {quoted_stats_path}"],
+        user="root",
+    ).split()[0]
+
+    try:
+        if stats_files[0] == "statistics.packed":
+            member_name = "statistics_v.stats"
+            ch1.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail; export LC_ALL=C; "
+                    f"member=$(grep -abo -F {shlex.quote(member_name)} {quoted_stats_path} | cut -d: -f1); "
+                    f"test -n \"$member\"; "
+                    f"test $(grep -abo -F {shlex.quote(member_name)} {quoted_stats_path} | wc -l) -eq 1; "
+                    f"offset_pos=$((member + {len(member_name)})); "
+                    f"offset=$(od -An -tu8 -j $offset_pos -N 8 {quoted_stats_path} | tr -d ' '); "
+                    f"size=$(od -An -tu8 -j $((offset_pos + 8)) -N 8 {quoted_stats_path} | tr -d ' '); "
+                    f"test \"$offset\" -gt 0; test \"$size\" -gt 0; "
+                    f"dd if=/dev/zero of={quoted_stats_path} bs=1 seek=$offset count=$size conv=notrunc status=none",
+                ],
+                user="root",
+            )
+        else:
+            ch1.exec_in_container(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail; "
+                    f"size=$(stat -c %s {quoted_stats_path}); "
+                    f"test \"$size\" -gt 0; "
+                    f"dd if=/dev/zero of={quoted_stats_path} bs=1 count=$size conv=notrunc status=none",
+                ],
+                user="root",
+            )
+
+        corrupted_hash = ch1.exec_in_container(
+            ["bash", "-c", f"sha256sum {quoted_stats_path}"],
+            user="root",
+        ).split()[0]
+        assert corrupted_hash != original_hash
+
+        no_stats_rows = _result_rows(_query(ch1, _plan_sql(0, "refresh-fail-no-stats")))
+        assert no_stats_rows
+
+        # Changing 0 -> 60 starts a refresh immediately. A failed refresh schedules
+        # its next attempt 60 seconds later, leaving a deterministic observation window.
+        _query_retry(ch1, f"ALTER TABLE {fact} MODIFY SETTING refresh_statistics_interval = 60")
+        miss_tag = "refresh-fail-cache-miss"
+        refreshed_plan = ch1.query_with_retry(
+            SET_PREFIX + "\n" + _plan_sql(1, miss_tag),
+            retry_count=100,
+            sleep_time=0.1,
+            check_callback=lambda plan: (
+                _result_rows(plan) == no_stats_rows
+                and _loaded_stats_us(ch1, miss_tag) > 0
+            ),
+        )
+        refreshed_rows = _result_rows(refreshed_plan)
+        assert refreshed_rows == no_stats_rows, {
+            "warm_rows": warm_rows,
+            "no_stats_rows": no_stats_rows,
+            "refreshed_rows": refreshed_rows,
+            "reason": "failed refresh retained the stale estimator or published a partial one",
+        }
+        _assert_load(ch1, miss_tag)
+    finally:
+        _query_retry(ch1, f"ALTER TABLE {fact} MODIFY SETTING refresh_statistics_interval = 0")
+        ch1.exec_in_container(
+            ["bash", "-c", f"rm -f {quoted_stats_path}; mv -f {quoted_backup_path} {quoted_stats_path}"],
+            user="root",
+        )
+
 def test_join_statistics_unreadable_unrelated_column_preserves_complete_stats():
     """An unreadable non-filter statistic must not discard complete filter statistics."""
     partial = "unrelated_stats_111016"

--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
@@ -2,6 +2,10 @@
   status:       applicable
   source:           statistical
   empirical_status: disabled
+--- statistical: required-column load bypasses unrestricted statistics failpoint ---
+  status:       applicable
+  source:           statistical
+  empirical_status: disabled
 --- statistical: filter touches non-index column, bails to applicability_only ---
   status:       applicable
   source:           applicability_only

--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.reference
@@ -10,3 +10,15 @@
   status:       applicable
   source:           applicability_only
   empirical_status: disabled
+--- statistical: synthetic nullable .null input maps to parent ---
+  status:       applicable
+  source:           statistical
+  empirical_status: disabled
+--- statistical: exact synthetic .null index remains applicable ---
+  status:       applicable
+  source:           statistical
+  empirical_status: disabled
+--- applicability_only: physical .null shadow has no statistics ---
+  status:       applicable
+  source:           applicability_only
+  empirical_status: disabled

--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-replicated-database, no-random-merge-tree-settings
+# Tags: no-fasttest, no-parallel, no-replicated-database, no-random-merge-tree-settings
 # no-fasttest: column statistics (tdigest/uniq) require the full build
 # no-replicated-database: hypothetical indexes are session-scoped and not replicated
 # no-random-merge-tree-settings: test requires deterministic index_granularity
@@ -7,6 +7,13 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
+
+FAILPOINT=merge_tree_load_statistics_throw
+cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT ${FAILPOINT}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 
 $CLICKHOUSE_CLIENT -n -q "
     SET allow_experimental_statistics = 1;
@@ -27,6 +34,19 @@ $CLICKHOUSE_CLIENT -n -q "
     SET allow_statistics_optimize = 1;
     CREATE HYPOTHETICAL INDEX idx_b ON t_hypo_stat_mc (b) TYPE minmax GRANULARITY 1;
     EXPLAIN WHATIF empirical = 0 SELECT * FROM t_hypo_stat_mc WHERE b < 50;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+# The failpoint is installed only in the no-argument loadStatistics() overload.
+# WhatIf must request the filter columns explicitly, so an unrelated failure in
+# an unrestricted all-columns load cannot disable the statistical estimate.
+echo "--- statistical: required-column load bypasses unrestricted statistics failpoint ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_b_failpoint ON t_hypo_stat_mc (b) TYPE minmax GRANULARITY 1;
+    SYSTEM ENABLE FAILPOINT ${FAILPOINT};
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM t_hypo_stat_mc WHERE b < 50;
+    SYSTEM DISABLE FAILPOINT ${FAILPOINT};
 " | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
 
 # Filter references a non-index column (c), so statistical estimation bails to applicability_only.

--- a/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
+++ b/tests/queries/0_stateless/04507_hypothetical_index_statistical_multicolumn.sh
@@ -59,3 +59,59 @@ $CLICKHOUSE_CLIENT -n -q "
 " | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
 
 $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_hypo_stat_mc"
+
+DROP_TABLE=t_hypo_stat_nullable
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    SET materialize_statistics_on_insert = 1;
+
+    DROP TABLE IF EXISTS ${DROP_TABLE};
+    CREATE TABLE ${DROP_TABLE}
+    (
+        id UInt64,
+        v Nullable(UInt64) STATISTICS(basic, tdigest),
+        m Nullable(UInt64) STATISTICS(basic, tdigest)
+    )
+    ENGINE = MergeTree ORDER BY id
+    SETTINGS index_granularity = 100, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, auto_statistics_types = '';
+    INSERT INTO ${DROP_TABLE}
+    SELECT number,
+           if(number % 4 = 0, NULL, toUInt64(number % 100)),
+           if(number % 2 = 0, NULL, toUInt64(number % 100))
+    FROM numbers(10000);
+    ALTER TABLE ${DROP_TABLE} ADD COLUMN \`m.null\` UInt8 DEFAULT 1;
+"
+
+# The analyzer exposes the synthetic `v.null` input while statistics are keyed
+# by `v`. Matching may resolve only this Nullable null subcolumn to its parent.
+echo "--- statistical: synthetic nullable .null input maps to parent ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_v_null_synthetic ON ${DROP_TABLE} (v) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM ${DROP_TABLE} WHERE v < 50 AND NOT v.null;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+# An index explicitly defined on the synthetic subcolumn was already accepted
+# by exact-name matching. Keep that behavior before falling back to the parent.
+echo "--- statistical: exact synthetic .null index remains applicable ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_v_null_exact ON ${DROP_TABLE} (v.null) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM ${DROP_TABLE} WHERE NOT v.null;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+# A physical top-level `m.null` added after the part was written shadows the
+# synthetic subcolumn. Even though the old part schema does not contain it, the
+# current schema must prevent borrowing the unrelated parent `m` statistics.
+echo "--- applicability_only: physical .null shadow has no statistics ---"
+$CLICKHOUSE_CLIENT -n -q "
+    SET allow_experimental_statistics = 1;
+    SET allow_statistics_optimize = 1;
+    CREATE HYPOTHETICAL INDEX idx_m_null_physical ON ${DROP_TABLE} (\`m.null\`) TYPE minmax GRANULARITY 1;
+    EXPLAIN WHATIF empirical = 0 SELECT * FROM ${DROP_TABLE} WHERE \`m.null\`;
+" | grep -E '^\s+status:|^\s+source:|^\s+empirical_status:'
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${DROP_TABLE}"


### PR DESCRIPTION
Superseded by:

- #112201 — propagate corrupt MergeTree statistics errors.
- #112204 — reject statistics that cover only a subset of selected parts.

Please review them separately as requested. #112204 is temporarily stacked on
#112201 and will be retargeted to `master` after #112201 merges.
