### PR TITLE
Fix heap-use-after-free in getProcessorsProfileLogInfo for a dangling output peer

### DIFF
--- a/src/Interpreters/ProcessorsProfileLog.cpp
+++ b/src/Interpreters/ProcessorsProfileLog.cpp
@@ -16,6 +16,7 @@
 #include <base/getFQDNOrHostName.h>
 #include <Common/ClickHouseRevision.h>
 #include <Common/DateLUTImpl.h>
+#include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/logger_useful.h>
 
 namespace DB
@@ -98,9 +99,36 @@ VectorWithMemoryTracking<IProcessor::ProcessorsProfileLogInfo> getProcessorsProf
     VectorWithMemoryTracking<IProcessor::ProcessorsProfileLogInfo> infos;
     infos.reserve(processors.size());
 
+    auto get_proc_id = [](const IProcessor & proc) -> UInt64 { return reinterpret_cast<std::uintptr_t>(&proc); };
+
+    /// Map each input port's shared connection id to its owning processor id. Connected ports share one
+    /// state, so an output port finds its peer through this map without dereferencing the peer processor,
+    /// whose lifetime is not guaranteed here (it may already be destroyed during pipeline teardown).
+    UnorderedMapWithMemoryTracking<const void *, UInt64> input_connection_to_id;
     for (const auto & processor : processors)
     {
-        infos.push_back(processor->getProcessorsProfileLogInfo());
+        auto proc_id = get_proc_id(*processor);
+        for (const auto & port : processor->getInputs())
+            if (port.isConnected())
+                input_connection_to_id.try_emplace(port.getConnectionId(), proc_id);
+    }
+
+    for (const auto & processor : processors)
+    {
+        auto info = processor->getProcessorsProfileLogInfo();
+
+        for (const auto & port : processor->getOutputs())
+        {
+            if (!port.isConnected())
+                continue;
+            /// Only record the parent if the peer input port belongs to a processor in this set.
+            auto it = input_connection_to_id.find(port.getConnectionId());
+            if (it == input_connection_to_id.end())
+                continue;
+            info.parent_ids.push_back(it->second);
+        }
+
+        infos.push_back(std::move(info));
     }
 
     return infos;

--- a/src/Interpreters/tests/gtest_processors_profile_log_dangling_peer.cpp
+++ b/src/Interpreters/tests/gtest_processors_profile_log_dangling_peer.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <Interpreters/ProcessorsProfileLog.h>
+#include <Processors/IProcessor.h>
+#include <Processors/Port.h>
+
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypesNumber.h>
+
+#include <memory>
+
+using namespace DB;
+
+namespace
+{
+
+SharedHeader makeHeader()
+{
+    return std::make_shared<Block>(Block{ColumnWithTypeAndName(ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "x")});
+}
+
+/// Minimal processor with a single output port. Used as the surviving upstream.
+class OneOutputProcessor final : public IProcessor
+{
+public:
+    explicit OneOutputProcessor(SharedHeader header) : IProcessor({}, {Block(*header)}) { }
+    String getName() const override { return "OneOutputProcessor"; }
+    Status prepare() override { return Status::Finished; }
+};
+
+/// Minimal processor with a single input port. Used as the downstream peer.
+class OneInputProcessor final : public IProcessor
+{
+public:
+    explicit OneInputProcessor(SharedHeader header) : IProcessor({Block(*header)}, {}) { }
+    String getName() const override { return "OneInputProcessor"; }
+    Status prepare() override { return Status::Finished; }
+};
+
+}
+
+/// Regression test for the release-reachable heap-use-after-free in getProcessorsProfileLogInfo
+/// (follow-up to #110955 / issue #110834, which fixed the same shape in the debug-only printPipeline).
+///
+/// A surviving processor keeps an output port that is still isConnected() after its downstream peer
+/// processor has been destroyed: the shared Port::State is ref-counted, so the survivor's side stays
+/// connected, and the raw peer pointer is not cleared on destruction. Building parent_ids by following
+/// that output port to its peer processor dereferenced a freed processor (heap-use-after-free under
+/// ASAN), on a release-reachable path (executeQuery.cpp logQueryFinish, scalar-subquery logging).
+TEST(ProcessorsProfileLog, DoesNotDereferenceDanglingOutputPeer)
+{
+    auto header = makeHeader();
+
+    auto upstream = std::make_shared<OneOutputProcessor>(header);
+    auto downstream = std::make_shared<OneInputProcessor>(header);
+
+    connect(upstream->getOutputs().front(), downstream->getInputs().front());
+    ASSERT_TRUE(upstream->getOutputs().front().isConnected());
+
+    /// Destroy the downstream peer while the survivor's output port stays connected.
+    downstream.reset();
+    ASSERT_TRUE(upstream->getOutputs().front().isConnected());
+
+    /// Only the survivor is passed in -- exactly what remains when a downstream processor was
+    /// removed/destroyed during pipeline teardown.
+    Processors processors{upstream};
+
+    auto infos = getProcessorsProfileLogInfo(processors);
+
+    ASSERT_EQ(infos.size(), 1u);
+    /// The dangling peer is not in the set, so it contributes no parent id (and is never dereferenced).
+    EXPECT_TRUE(infos[0].parent_ids.empty());
+}
+
+/// A well-formed pipeline (both processors present) still records the parent link, so the fix does not
+/// regress the parent_ids stored in system.processors_profile_log for normal queries.
+TEST(ProcessorsProfileLog, RecordsParentIdForProcessorsInSet)
+{
+    auto header = makeHeader();
+
+    auto upstream = std::make_shared<OneOutputProcessor>(header);
+    auto downstream = std::make_shared<OneInputProcessor>(header);
+    connect(upstream->getOutputs().front(), downstream->getInputs().front());
+
+    Processors processors{upstream, downstream};
+
+    auto infos = getProcessorsProfileLogInfo(processors);
+
+    ASSERT_EQ(infos.size(), 2u);
+
+    const auto upstream_id = reinterpret_cast<std::uintptr_t>(upstream.get());
+    const auto downstream_id = reinterpret_cast<std::uintptr_t>(downstream.get());
+
+    /// upstream's only output feeds downstream's input, so upstream lists downstream as its parent.
+    ASSERT_EQ(infos[0].id, upstream_id);
+    ASSERT_EQ(infos[0].parent_ids.size(), 1u);
+    EXPECT_EQ(infos[0].parent_ids[0], downstream_id);
+
+    /// downstream has no outputs, so it has no parents.
+    ASSERT_EQ(infos[1].id, downstream_id);
+    EXPECT_TRUE(infos[1].parent_ids.empty());
+}

--- a/src/Processors/IProcessor.cpp
+++ b/src/Processors/IProcessor.cpp
@@ -163,13 +163,8 @@ IProcessor::ProcessorsProfileLogInfo IProcessor::getProcessorsProfileLogInfo() c
 
     info.id = get_proc_id(*this);
 
-    for (const auto & port : outputs)
-    {
-        if (!port.isConnected())
-            continue;
-        const IProcessor & next = port.getInputPort().getProcessor();
-        info.parent_ids.push_back(get_proc_id(next));
-    }
+    /// parent_ids are populated by the free getProcessorsProfileLogInfo(const Processors &) overload: a
+    /// peer processor reached through a port may already be destroyed, so it must not be dereferenced here.
 
     info.plan_step = reinterpret_cast<std::uintptr_t>(query_plan_step);
     info.plan_step_name = plan_step_name;

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -230,6 +230,12 @@ public:
     const SharedHeader & getSharedHeader() const { return header; }
     bool ALWAYS_INLINE isConnected() const { return state != nullptr; }
 
+    /// Identity of the shared state of two connected ports (both sides return the same value).
+    /// Lets diagnostics match an output port to its peer input port without dereferencing the
+    /// peer processor, whose lifetime is not guaranteed during pipeline teardown. Opaque on
+    /// purpose: only pointer identity is meaningful.
+    const void * getConnectionId() const { return state.get(); }
+
     void ALWAYS_INLINE assumeConnected() const
     {
         if (unlikely(!isConnected()))


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110955
Related: https://github.com/ClickHouse/ClickHouse/issues/110834
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a heap-use-after-free when collecting `system.processors_profile_log` parent ids on query finish: a processor could be read through a still-connected output port after its peer processor was already destroyed during pipeline teardown.

### Description

`IProcessor::getProcessorsProfileLogInfo()` built `parent_ids` by following each connected output port to its peer via `port.getInputPort().getProcessor()`. A `Port` keeps its `shared_ptr<State>` (so it stays `isConnected()`) and its raw `processor` pointer even after the peer processor is destroyed, so during streaming pipeline teardown (`ExecutingGraph::removeNode` erases finished processors while survivors still reference them through ports) this dereferenced a freed processor.

Unlike the debug-only `printPipeline` variant fixed in #110955, this path is reachable in release builds: `finalizeQueryPipelineBeforeLogging` gathers the profile info unconditionally on successful query finish, and `logProcessorProfile(context, processors)` is also called for scalar-subquery / prepared-set logging.

The parent-id computation is moved into the free `getProcessorsProfileLogInfo(const Processors &)`, which has the whole processor set: it maps each input port's shared connection id to the owning processor id, then matches each connected output port through that map. It never dereferences a peer processor, and produces identical `parent_ids` for well-formed pipelines. This mirrors the connection-identity approach approved in #110955 (`Port::getConnectionId()`); if #110955 merges first the duplicated accessor drops out cleanly.
