### PR TITLE
Skip 04062_text_index_json_all_values_ghdata on MSan (WasmEdge timeout)

### DIFF
--- a/tests/queries/0_stateless/04062_text_index_json_all_values_ghdata.sh
+++ b/tests/queries/0_stateless/04062_text_index_json_all_values_ghdata.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-parallel-replicas, no-fasttest, no-object-storage, long, no-flaky-check
+# Tags: no-parallel-replicas, no-fasttest, no-object-storage, long, no-flaky-check, no-msan
 
 # Tests that text indexes built on JSONAllValues work correctly on a real-world
 # GitHub Events dataset (ghdata_sample.json) with various query patterns.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108715
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/108715
(No open tracking issue found for this test.)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`04062_text_index_json_all_values_ghdata` overruns the 600s per-test cap on the
`amd_msan, WasmEdge` build. It loads a 14.7 MB real-world ghdata JSON, builds a
`text` index over `JSONAllValues`, `OPTIMIZE FINAL`, then runs ~35 queries. It is
inherently heavy, and MSan (origin tracking) + WasmEdge is the slowest build.

CIDB (45d, this test): amd_msan p50 169s / p99 372s / max 600.2s (cap -> FAIL);
every other build has 2x+ headroom (tsan 273s, asan 226s, debug 60s, arm 74s).
The failure is MSan-exclusive tail variance, not a randomized setting (CIDB rerun
diagnosis: same settings passed on rerun). Reported on PR #108715
([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=108715&sha=0a08285a8f911131cc9633269e153b75f98870cc&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29)),
which did not modify this test.

Add `no-msan` to skip only the MSan build variant (for this test, amd_msan runs
are 100% WasmEdge). Coverage is preserved: JSON parsing under MSan is still
covered by sibling ghdata tests (`01825_json_type_ghdata`,
`03247_ghdata_string_to_json_alter`, `03273_ghdata_json_to_json_alter`), and the
text-index code by the `02346_text_index_*` suite. Same precedent as sibling
`01825_json_type_ghdata_insert_select` (same dataset), already tagged
`no-asan, no-tsan, no-msan`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.51` (included in `26.8` and later)
<!-- ch-version-info:end -->