### PR TITLE
CI: size stateless per-test memory limit by sanitizer build, not `asan_ubsan` substring

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -103,16 +103,12 @@ def run_tests(
     if "--no-zookeeper" not in extra_args:
         extra_args += " --zookeeper"
     # Remove --report-logs-stats, it hides sanitizer errors in def reportLogStats(args): clickhouse_execute(args, "SYSTEM FLUSH LOGS")
-    # Sanitizer client binaries carry ~500 MiB RSS each (ASan redzones +
-    # quarantine, TSan/MSan shadow); a per-test cgroup holding ~10 concurrent
-    # clients needs 10 GiB, not the 5 GiB non-sanitizer default, or it OOM-kills
-    # them mid-test. Match ALL sanitizer builds via `SANITIZERS`, not the literal
-    # `asan_ubsan` substring: the `tsan` / `msan` lanes (and the private
-    # `amd_ubsan` lane, which runs the ASan+UBSan binary) are sanitizer builds
-    # too but their names don't contain `asan_ubsan`, so the old check under-sized
-    # them. During bugfix validation the same job runs several build types, so the
-    # limit must follow the binary under test (`build_type`) rather than the job
-    # name, or a master-side memory-limit failure would be inverted as a bug.
+    # Sanitizer clients are memory-heavy (~500 MiB RSS each), so a per-test cgroup
+    # running ~10 concurrent clients needs 10 GiB or it OOM-kills them mid-test.
+    # Detect every sanitizer via `SANITIZERS`, not the literal `asan_ubsan`: the
+    # `tsan`/`msan` lanes (and private `amd_ubsan`, an ASan+UBSan binary) lack that
+    # substring. Bugfix validation runs several builds per job, so key off the
+    # tested `build_type` over the job name (else a master limit failure reads as a bug).
     limit_source = build_type if build_type is not None else Info().job_name
     memory_limit = (
         10 * 2**30 if any(san in limit_source for san in SANITIZERS) else 5 * 2**30

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -26,6 +26,19 @@ temp_dir = f"{Utils.cwd()}/ci/tmp"
 SANITIZERS = ("asan", "tsan", "msan", "ubsan")
 
 
+def stateless_memory_limit(source):
+    """Per-test cgroup memory limit (`clickhouse-test --memory-limit`) for a run
+    identified by `source` (a build type, job-parameter string, or job name).
+
+    Sanitizer clients are memory-heavy (~500 MiB RSS each), so a test running
+    ~10 concurrent clients needs 10 GiB or the per-test cgroup OOM-kills them
+    mid-test. Every sanitizer build gets 10 GiB, others 5 GiB. Match via
+    `SANITIZERS`, not the literal `asan_ubsan` substring: the `tsan`/`msan` lanes
+    (and the private `amd_ubsan` lane, an ASan+UBSan binary) lack that substring.
+    """
+    return 10 * 2**30 if any(san in source for san in SANITIZERS) else 5 * 2**30
+
+
 class JobStages(metaclass=MetaClasses.WithIter):
     INSTALL_CLICKHOUSE = "install"
     START = "start"
@@ -103,16 +116,11 @@ def run_tests(
     if "--no-zookeeper" not in extra_args:
         extra_args += " --zookeeper"
     # Remove --report-logs-stats, it hides sanitizer errors in def reportLogStats(args): clickhouse_execute(args, "SYSTEM FLUSH LOGS")
-    # Sanitizer clients are memory-heavy (~500 MiB RSS each), so a per-test cgroup
-    # running ~10 concurrent clients needs 10 GiB or it OOM-kills them mid-test.
-    # Detect every sanitizer via `SANITIZERS`, not the literal `asan_ubsan`: the
-    # `tsan`/`msan` lanes (and private `amd_ubsan`, an ASan+UBSan binary) lack that
-    # substring. Bugfix validation runs several builds per job, so key off the
-    # tested `build_type` over the job name (else a master limit failure reads as a bug).
+    # Bugfix validation runs several builds per job, so size the limit from the
+    # tested `build_type` over the job name (else a master-side memory-limit
+    # failure would be inverted as a reproduced bug).
     limit_source = build_type if build_type is not None else Info().job_name
-    memory_limit = (
-        10 * 2**30 if any(san in limit_source for san in SANITIZERS) else 5 * 2**30
-    )
+    memory_limit = stateless_memory_limit(limit_source)
     # Hand the time budget to `clickhouse-test` itself via `--global_time_limit`
     # so it stops *gracefully* between tests and exits with
     # `GLOBAL_TIME_LIMIT_EXIT_CODE` - reported as a benign "time limit reached"
@@ -1212,11 +1220,7 @@ def main():
                 ).set_timing(stopwatch=diag_stopwatch)
             )
         elif failed_tests:
-            memory_limit = (
-                10 * 2**30
-                if any(san in Info().job_name for san in SANITIZERS)
-                else 5 * 2**30
-            )
+            memory_limit = stateless_memory_limit(Info().job_name)
             diag_command = (
                 f"clickhouse-test --testname --check-zookeeper-session --hung-check"
                 f" --memory-limit {memory_limit} --trace --capture-client-stacktrace"

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -103,12 +103,20 @@ def run_tests(
     if "--no-zookeeper" not in extra_args:
         extra_args += " --zookeeper"
     # Remove --report-logs-stats, it hides sanitizer errors in def reportLogStats(args): clickhouse_execute(args, "SYSTEM FLUSH LOGS")
-    # During bugfix validation the same job runs several build types, so the
-    # memory limit must follow the binary under test (`build_type`) rather than
-    # the job name. Otherwise an `amd_asan_ubsan` run gets the 5 GiB default and
-    # a master-side memory-limit failure would be inverted as a reproduced bug.
+    # Sanitizer client binaries carry ~500 MiB RSS each (ASan redzones +
+    # quarantine, TSan/MSan shadow); a per-test cgroup holding ~10 concurrent
+    # clients needs 10 GiB, not the 5 GiB non-sanitizer default, or it OOM-kills
+    # them mid-test. Match ALL sanitizer builds via `SANITIZERS`, not the literal
+    # `asan_ubsan` substring: the `tsan` / `msan` lanes (and the private
+    # `amd_ubsan` lane, which runs the ASan+UBSan binary) are sanitizer builds
+    # too but their names don't contain `asan_ubsan`, so the old check under-sized
+    # them. During bugfix validation the same job runs several build types, so the
+    # limit must follow the binary under test (`build_type`) rather than the job
+    # name, or a master-side memory-limit failure would be inverted as a bug.
     limit_source = build_type if build_type is not None else Info().job_name
-    memory_limit = 10 * 2**30 if "asan_ubsan" in limit_source else 5 * 2**30
+    memory_limit = (
+        10 * 2**30 if any(san in limit_source for san in SANITIZERS) else 5 * 2**30
+    )
     # Hand the time budget to `clickhouse-test` itself via `--global_time_limit`
     # so it stops *gracefully* between tests and exits with
     # `GLOBAL_TIME_LIMIT_EXIT_CODE` - reported as a benign "time limit reached"
@@ -1209,7 +1217,9 @@ def main():
             )
         elif failed_tests:
             memory_limit = (
-                10 * 2**30 if "asan_ubsan" in Info().job_name else 5 * 2**30
+                10 * 2**30
+                if any(san in Info().job_name for san in SANITIZERS)
+                else 5 * 2**30
             )
             diag_command = (
                 f"clickhouse-test --testname --check-zookeeper-session --hung-check"

--- a/ci/tests/test_stateless_memory_limit.py
+++ b/ci/tests/test_stateless_memory_limit.py
@@ -1,0 +1,77 @@
+"""
+Tests for `ci.jobs.functional_tests.stateless_memory_limit`.
+
+The per-test cgroup memory limit passed to `clickhouse-test --memory-limit` must
+be 10 GiB for sanitizer builds (their clients hold ~500 MiB RSS each, so a test
+running ~10 concurrent clients reaches the 5 GiB non-sanitizer cap and the cgroup
+OOM-kills them) and 5 GiB otherwise. The classification must match ANY sanitizer
+via `SANITIZERS`, not the literal `asan_ubsan` substring: the `tsan` / `msan`
+lanes, and the private `amd_ubsan` lane (which runs the ASan+UBSan binary), do
+not contain `asan_ubsan` and were previously under-sized to 5 GiB.
+See ClickHouse/ClickHouse#111028.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.functional_tests import SANITIZERS, stateless_memory_limit
+
+GiB = 2**30
+
+# Job-name parameter strings as they appear in `Info().job_name`, plus the
+# build-type tokens used during bugfix validation. Every sanitizer flavor must
+# resolve to 10 GiB regardless of the surrounding option string or arch prefix.
+SANITIZER_SOURCES = [
+    "Stateless tests (amd_ubsan, SharedCatalog, meta in keeper, s3 storage, sequential)",
+    "Stateless tests (amd_tsan, meta in keeper, s3 storage, sequential, 1/2)",
+    "Stateless tests (amd_msan, SharedCatalog, meta in keeper, s3 storage, sequential)",
+    "Stateless tests (amd_asan_ubsan, distributed plan, parallel)",
+    "Stateless tests (arm_tsan, s3 storage, parallel)",
+    "Stateless tests (arm_msan, s3 storage, parallel)",
+    "Stateless tests (arm_asan_ubsan, s3 storage, parallel)",
+    # bugfix-validation build types (passed as `build_type`):
+    "amd_asan_ubsan",
+    "amd_tsan",
+    "amd_msan",
+    "arm_asan_ubsan",
+]
+
+NON_SANITIZER_SOURCES = [
+    "Stateless tests (amd_debug, distributed cache, meta in keeper, s3 storage, sequential)",
+    "Stateless tests (amd_release, s3 storage, parallel)",
+    "Stateless tests (amd_binary, parallel)",
+    "amd_debug",
+    "arm_debug",
+]
+
+
+@pytest.mark.parametrize("source", SANITIZER_SOURCES)
+def test_sanitizer_lanes_get_10gib(source):
+    assert stateless_memory_limit(source) == 10 * GiB
+
+
+@pytest.mark.parametrize("source", NON_SANITIZER_SOURCES)
+def test_non_sanitizer_lanes_get_5gib(source):
+    assert stateless_memory_limit(source) == 5 * GiB
+
+
+def test_private_amd_ubsan_is_treated_as_sanitizer():
+    """The private `amd_ubsan` lane runs the ASan+UBSan binary; its name lacks
+    the `asan_ubsan` substring but must still get 10 GiB (the original bug)."""
+    assert "asan_ubsan" not in "amd_ubsan"
+    assert stateless_memory_limit("amd_ubsan") == 10 * GiB
+
+
+def test_every_sanitizer_token_lifts_the_limit():
+    """Each token in `SANITIZERS` on its own must select the 10 GiB tier, so a
+    future refactor back to a single literal substring is caught here."""
+    for san in SANITIZERS:
+        assert stateless_memory_limit(f"amd_{san}") == 10 * GiB
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

Stateless tests on sanitizer CI lanes (`tsan`, `msan`, and the private `amd_ubsan`) intermittently fail with `Reason: having stderror: ...: Killed` on tests that spawn many concurrent `clickhouse client` processes — most visibly `03029_shared_merge_tree_slow_merge` (`REPLICAS=10`). The run is otherwise correct; it self-heals on rerun, so it reads as endemic flakiness. The most-affected test is in the private test suite, and the failures are endemic on `master` itself (`PR=0`), not attributable to any single PR.

## Root cause

`clickhouse-test` runs each test inside a per-test memory cgroup whose `memory.max` is the `--memory-limit` value. `ci/jobs/functional_tests.py` sized that value with `10 GiB if "asan_ubsan" in <source> else 5 GiB`. The intent is "sanitizer builds get 10 GiB, non-sanitizer 5 GiB", but the check matched only the literal substring `asan_ubsan`, so sanitizer lanes whose name doesn't contain that exact token (`tsan`, `msan`, and the private `amd_ubsan` lane, which actually runs the ASan+UBSan binary) got the 5 GiB non-sanitizer limit.

A sanitizer `clickhouse client` doing this workload holds ~500 MiB RSS (instrumented statics + ASan redzones/quarantine + shadow; jemalloc disabled under sanitizers), so ~10 concurrent clients reach ~5 GiB and the cgroup OOM-kills one. `clickhouse-test` fails any test whose stderr is non-empty, so the shell's "Killed" job-control notice fails the test.

Evidence (private dmesg): `oom-kill:constraint=CONSTRAINT_MEMCG, oom_memcg=.../clickhouse-test-<pid>`, `memory: usage 5242880kB, limit 5242880kB` — the per-test 5 GiB cgroup at its cap, no global host OOM.

## Solution

Use the existing module constant `SANITIZERS = ("asan", "tsan", "msan", "ubsan")` (already used for `set_memory_ratio` and `nproc`) at both `--memory-limit` sites, so every sanitizer lane gets 10 GiB. Peak per-client `RssAnon` measured on the master sanitizer binaries confirms 10 GiB comfortably holds 10 concurrent clients for every sanitizer, so no per-sanitizer tier is introduced. The `build_type`-vs-`job_name` selection for bugfix validation is preserved.

| sanitizer | peak RssAnon / client | ×10 clients | fits 10 GiB? |
|---|---|---|---|
| tsan | ~146 MiB (flat under all workloads) | ~1.4 GiB | yes (~7× headroom) |
| msan | ~157 MiB (flat) | ~1.5 GiB | yes (~6.5×) |
| asan_ubsan (control) | 264 MiB fixed → ~500+ under alloc/free churn | ~2.6–5.0 GiB | yes |

Only ASan keeps a free-quarantine that accumulates under churn (267 fixed + ~240 quarantine ≈ 500 MiB — the ~500×10 ≈ 5 GiB behind the historical 5 GiB OOM). TSan (shadow on touched addresses) and MSan (shadow+origins) have no quarantine, so for a thin client they stay pinned at the fixed footprint and are actually *lighter* than ASan. Consistent with the `amd_asan_ubsan` lane already running at 10 GiB with zero `03029` OOM.

This file is byte-identical (in the touched region) with `clickhouse-private` and syncs into it, so this single public change also fixes the private `amd_ubsan`/`amd_tsan`/`amd_msan` lanes.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.5.72`
<!-- ch-version-info:end -->