### PR TITLE
Return HTTP_FORBIDDEN (403) for ACCESS_DENIED over HTTP

### DIFF
--- a/src/Server/HTTP/exceptionCodeToHTTPStatus.cpp
+++ b/src/Server/HTTP/exceptionCodeToHTTPStatus.cpp
@@ -6,6 +6,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int BAD_ARGUMENTS;
     extern const int CANNOT_PARSE_TEXT;
     extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
@@ -78,7 +79,8 @@ Poco::Net::HTTPResponse::HTTPStatus exceptionCodeToHTTPStatus(int exception_code
         return HTTPResponse::HTTP_UNAUTHORIZED;
     }
     if (exception_code == ErrorCodes::UNKNOWN_USER || exception_code == ErrorCodes::WRONG_PASSWORD
-        || exception_code == ErrorCodes::AUTHENTICATION_FAILED || exception_code == ErrorCodes::SET_NON_GRANTED_ROLE)
+        || exception_code == ErrorCodes::AUTHENTICATION_FAILED || exception_code == ErrorCodes::SET_NON_GRANTED_ROLE
+        || exception_code == ErrorCodes::ACCESS_DENIED)
     {
         return HTTPResponse::HTTP_FORBIDDEN;
     }

--- a/tests/queries/0_stateless/04612_access_denied_http_forbidden.reference
+++ b/tests/queries/0_stateless/04612_access_denied_http_forbidden.reference
@@ -1,0 +1,2 @@
+HTTP/1.1 403 Forbidden
+X-ClickHouse-Exception-Code: 497

--- a/tests/queries/0_stateless/04612_access_denied_http_forbidden.sh
+++ b/tests/queries/0_stateless/04612_access_denied_http_forbidden.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TMP_DIR=$(mktemp -d "$CUR_DIR"/04612_XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# A user without any grants gets ACCESS_DENIED (error code 497) when reading a table.
+# Over HTTP this must be reported as 403 Forbidden, not 500 Internal Server Error.
+
+user="user_04612_${CLICKHOUSE_DATABASE}"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user}"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user} IDENTIFIED WITH no_password"
+
+URL="${CLICKHOUSE_PORT_HTTP_PROTO}://${user}:@${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT_HTTP}/"
+
+${CLICKHOUSE_CURL} -s -D "$TMP_DIR/headers" -o /dev/null "${URL}" --data-binary "SELECT * FROM system.numbers LIMIT 1"
+
+head -n 1 "$TMP_DIR/headers" | sed 's/\r$//'
+grep -o "X-ClickHouse-Exception-Code: 497" "$TMP_DIR/headers" | head -n 1
+
+${CLICKHOUSE_CLIENT} --query "DROP USER ${user}"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/84540
Related: https://github.com/ClickHouse/ClickHouse/pull/84698
-->

An `ACCESS_DENIED` exception (error code 497) was reported over the HTTP interface as `500 Internal Server Error`, even though it is an authorization failure and should be `403 Forbidden`. This made it impossible for clients to distinguish permission errors from genuine server errors, and caused permission failures to trigger server-error alerts in monitoring.

This maps `ACCESS_DENIED` to `HTTP_FORBIDDEN` in `exceptionCodeToHTTPStatus`, alongside the other authentication/authorization error codes (`UNKNOWN_USER`, `WRONG_PASSWORD`, `AUTHENTICATION_FAILED`, `SET_NON_GRANTED_ROLE`).

Continuation of #84698, which was blocked on a missing test — this PR adds a stateless test verifying that a query rejected with `ACCESS_DENIED` returns `403 Forbidden` over HTTP.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Return HTTP code `403 Forbidden` (instead of `500 Internal Server Error`) for `ACCESS_DENIED` exceptions over the HTTP interface.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.539` (included in `26.8` and later)
<!-- ch-version-info:end -->