### PR TITLE
Fix async-insert deduplication token bleed across partitions

### DIFF
--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -139,6 +139,38 @@ DeduplicationInfo::FilterResult DeduplicationInfo::deduplicateSelf(bool deduplic
 }
 
 
+DeduplicationInfo::Ptr DeduplicationInfo::filterToPartition(const PaddedPODArray<UInt64> & row_to_partition, size_t partition_index) const
+{
+    /// An empty selector means the block was not split (single partition); with dedup off or a
+    /// single token there is nothing to attribute. Every token then belongs to this partition.
+    if (disabled || row_to_partition.empty() || getCount() <= 1)
+        return cloneSelf();
+
+    /// Keep only tokens that have at least one row in this partition.
+    std::set<size_t> absent_offsets;
+    for (size_t i = 0; i < offsets.size(); ++i)
+    {
+        bool present = false;
+        for (size_t row = getTokenBegin(i); row < getTokenEnd(i); ++row)
+        {
+            if (row_to_partition[row] == partition_index)
+            {
+                present = true;
+                break;
+            }
+        }
+        if (!present)
+            absent_offsets.insert(i);
+    }
+
+    if (absent_offsets.empty())
+        return cloneSelf();
+
+    /// filterImpl drops the absent tokens and keeps the block/offsets consistent.
+    return filterImpl(absent_offsets).deduplication_info;
+}
+
+
 DeduplicationInfo::FilterResult DeduplicationInfo::recalculateBlock(DeduplicationInfo::FilterResult && filtered, const std::string & partition_id, ContextPtr context) const
 {
     if (filtered.removed_rows == 0)

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -92,13 +92,6 @@ public:
     FilterResult deduplicateSelf(bool deduplication_enabled, const std::string & partition_id, ContextPtr context) const;
     FilterResult deduplicateBlock(const std::vector<std::string> & existing_block_ids, const std::string & partition_id, ContextPtr context) const;
 
-    /// Restrict this info to a single partition of a coalesced (async) insert.
-    /// row_to_partition maps each source row to its partition index (as produced by
-    /// MergeTreeDataWriter::splitBlockIntoParts, i.e. IColumn::Selector); partition_index
-    /// selects the partition. Tokens that contributed no row to partition_index are dropped,
-    /// so a token only registers in the partition its own rows landed in. An empty
-    /// row_to_partition means the block was not split (a single partition) and every token
-    /// is kept as-is.
     Ptr filterToPartition(const PaddedPODArray<UInt64> & row_to_partition, size_t partition_index) const;
 
     std::vector<DeduplicationHash> getDeduplicationHashes(const std::string & partition_id, bool deduplication_enabled) const;

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -7,6 +7,7 @@
 #include <Interpreters/Context_fwd.h>
 #include <Interpreters/StorageIDMaybeEmpty.h>
 #include <Core/Block_fwd.h>
+#include <Common/PODArray_fwd.h>
 
 #include <Common/Logger.h>
 #include <base/defines.h>
@@ -90,6 +91,15 @@ public:
     };
     FilterResult deduplicateSelf(bool deduplication_enabled, const std::string & partition_id, ContextPtr context) const;
     FilterResult deduplicateBlock(const std::vector<std::string> & existing_block_ids, const std::string & partition_id, ContextPtr context) const;
+
+    /// Restrict this info to a single partition of a coalesced (async) insert.
+    /// row_to_partition maps each source row to its partition index (as produced by
+    /// MergeTreeDataWriter::splitBlockIntoParts, i.e. IColumn::Selector); partition_index
+    /// selects the partition. Tokens that contributed no row to partition_index are dropped,
+    /// so a token only registers in the partition its own rows landed in. An empty
+    /// row_to_partition means the block was not split (a single partition) and every token
+    /// is kept as-is.
+    Ptr filterToPartition(const PaddedPODArray<UInt64> & row_to_partition, size_t partition_index) const;
 
     std::vector<DeduplicationHash> getDeduplicationHashes(const std::string & partition_id, bool deduplication_enabled) const;
 

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -483,8 +483,13 @@ void MergeTreeTemporaryPart::prewarmCaches()
 }
 
 BlocksWithPartition MergeTreeDataWriter::splitBlockIntoParts(
-    Block && block, size_t max_parts, const StorageMetadataPtr & metadata_snapshot, ContextPtr context)
+    Block && block, size_t max_parts, const StorageMetadataPtr & metadata_snapshot, ContextPtr context, IColumn::Selector * out_selector)
 {
+    /// out_selector is left empty when the block is not split (a single resulting partition);
+    /// the caller then knows every row belongs to the only partition.
+    if (out_selector)
+        out_selector->clear();
+
     BlocksWithPartition result;
     if (block.empty() || !block.rows())
     {
@@ -553,6 +558,10 @@ BlocksWithPartition MergeTreeDataWriter::splitBlockIntoParts(
 
     for (auto & item : result)
         item.partition_id = item.partition.getID(metadata_snapshot->getPartitionKey().sample_block);
+
+    /// Hand the row -> partition-index mapping to the caller (deduplication uses it).
+    if (out_selector)
+        *out_selector = std::move(selector);
 
     return result;
 }

--- a/src/Storages/MergeTree/MergeTreeDataWriter.h
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.h
@@ -70,8 +70,16 @@ public:
     /** Split the block to blocks, each of them must be written as separate part.
       *  (split rows by partition)
       * Works deterministically: if same block was passed, function will return same result in same order.
+      * When out_selector is set, it receives the row -> partition-index mapping (empty when the block
+      * is not split, i.e. a single resulting partition). Deduplication needs it to attribute each
+      * source row to the partition it landed in.
       */
-    static BlocksWithPartition splitBlockIntoParts(Block && block, size_t max_parts, const StorageMetadataPtr & metadata_snapshot, ContextPtr context);
+    static BlocksWithPartition splitBlockIntoParts(
+        Block && block,
+        size_t max_parts,
+        const StorageMetadataPtr & metadata_snapshot,
+        ContextPtr context,
+        IColumn::Selector * out_selector = nullptr);
 
     /// This structure contains not completely written temporary part.
     /// Some writes may happen asynchronously, e.g. for blob storages.

--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -104,7 +104,8 @@ void MergeTreeSink::consume(Chunk & chunk)
     auto block = getHeader().cloneWithColumns(chunk.getColumns());
 
     auto deduplication_info = chunk.getChunkInfos().getSafe<DeduplicationInfo>();
-    auto part_blocks = MergeTreeDataWriter::splitBlockIntoParts(std::move(block), max_parts_per_block, metadata_snapshot, context);
+    IColumn::Selector partition_selector;
+    auto part_blocks = MergeTreeDataWriter::splitBlockIntoParts(std::move(block), max_parts_per_block, metadata_snapshot, context, &partition_selector);
 
     using DelayedPartitions = std::vector<MergeTreeDelayedChunk::Partition>;
     DelayedPartitions partitions;
@@ -115,8 +116,10 @@ void MergeTreeSink::consume(Chunk & chunk)
 
     auto process_list_element = context->getProcessListElement();
 
-    for (auto & current_block : part_blocks)
+    for (size_t part_index = 0; part_index < part_blocks.size(); ++part_index)
     {
+        auto & current_block = part_blocks[part_index];
+
         /// A single INSERT can split into very many parts (e.g. high-cardinality partition key with
         /// max_partitions_per_insert_block); honor cancellation/timeout between them.
         if (process_list_element)
@@ -125,7 +128,9 @@ void MergeTreeSink::consume(Chunk & chunk)
         ProfileEvents::Counters part_counters;
         auto partition_scope = std::make_unique<ProfileEventsScope>(&part_counters);
 
-        auto current_deduplication_info = deduplication_info->cloneSelf();
+        /// Keep only the tokens whose own rows landed in this partition, so a coalesced async
+        /// insert does not register a token in partitions it never wrote to.
+        auto current_deduplication_info = deduplication_info->filterToPartition(partition_selector, part_index);
 
         {
             ProfileEventTimeIncrement<Microseconds> duplication_elapsed(ProfileEvents::DuplicationElapsedMicroseconds);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -292,21 +292,26 @@ void ReplicatedMergeTreeSink::consume(Chunk & chunk)
 
     auto deduplication_info = chunk.getChunkInfos().getSafe<DeduplicationInfo>();
 
-    BlocksWithPartition part_blocks = MergeTreeDataWriter::splitBlockIntoParts(std::move(block), max_parts_per_block, metadata_snapshot, context);
+    IColumn::Selector partition_selector;
+    BlocksWithPartition part_blocks = MergeTreeDataWriter::splitBlockIntoParts(std::move(block), max_parts_per_block, metadata_snapshot, context, &partition_selector);
 
     decltype(delayed_parts) current_parts;
 
     size_t total_streams = 0;
     bool support_parallel_write = false;
 
-    for (auto & current_block : part_blocks)
+    for (size_t part_index = 0; part_index < part_blocks.size(); ++part_index)
     {
+        auto & current_block = part_blocks[part_index];
+
         Stopwatch watch;
 
         ProfileEvents::Counters part_counters;
         auto profile_events_scope = std::make_unique<ProfileEventsScope>(&part_counters);
 
-        auto current_deduplication_info = deduplication_info->cloneSelf();
+        /// Keep only the tokens whose own rows landed in this partition, so a coalesced async
+        /// insert does not register a token in partitions it never wrote to.
+        auto current_deduplication_info = deduplication_info->filterToPartition(partition_selector, part_index);
 
         {
             ProfileEventTimeIncrement<Microseconds> duplication_elapsed(ProfileEvents::DuplicationElapsedMicroseconds);

--- a/tests/queries/0_stateless/03662_async_insert_dedup_token_partition_bleed.reference
+++ b/tests/queries/0_stateless/03662_async_insert_dedup_token_partition_bleed.reference
@@ -1,0 +1,3 @@
+MergeTree	[(0,10),(1,20),(1,30)]	3
+ReplicatedMergeTree	[(0,10),(1,20),(1,30)]	3
+single-entry-multi-partition	[(0,1),(1,2)]	2

--- a/tests/queries/0_stateless/03662_async_insert_dedup_token_partition_bleed.sh
+++ b/tests/queries/0_stateless/03662_async_insert_dedup_token_partition_bleed.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs the async insert queue to coalesce several tokens into one flush.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/111031
+# When several async-insert entries with distinct insert_deduplication_token values are
+# coalesced into one flush, each token used to be registered in the dedup log of EVERY
+# partition the flush touched, not only the partition its own rows landed in. A later
+# legitimately-distinct insert reusing one of those tokens in a partition it never wrote
+# to was then silently deduplicated away (silent data loss). Affects MergeTree and
+# ReplicatedMergeTree (shared sink split logic).
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Common async settings: long busy timeout so nothing auto-fires; one explicit flush
+# coalesces the queued entries into a single batch. insert_deduplication_token is excluded
+# from the async queue key, so entries with distinct tokens land in ONE flush.
+async_insert=(--async_insert=1 --wait_for_async_insert=0
+    --async_insert_busy_timeout_min_ms=600000 --async_insert_busy_timeout_max_ms=600000
+    --async_insert_use_adaptive_busy_timeout=0 --insert_deduplicate=1)
+
+run_engine() {
+    local label=$1 engine=$2 table=$3
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS $table"
+    $CLICKHOUSE_CLIENT -q "
+    CREATE TABLE $table (p UInt8, x UInt64)
+    ENGINE = $engine PARTITION BY p ORDER BY x
+    SETTINGS non_replicated_deduplication_window = 1000, deduplicate_merge_projection_mode = 'drop'"
+
+    # Coalesce two entries: token A lands only in p=0, token B lands only in p=1.
+    $CLICKHOUSE_CLIENT "${async_insert[@]}" --insert_deduplication_token='A' -q "INSERT INTO $table VALUES (0, 10)"
+    $CLICKHOUSE_CLIENT "${async_insert[@]}" --insert_deduplication_token='B' -q "INSERT INTO $table VALUES (1, 20)"
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE $table"
+
+    # Token A was never used in p=1, so this row must be accepted (was dropped before the fix).
+    $CLICKHOUSE_CLIENT "${async_insert[@]}" --insert_deduplication_token='A' -q "INSERT INTO $table VALUES (1, 30)"
+    $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE $table"
+
+    # Expected: [(0,10),(1,20),(1,30)]. Before the fix (1,30) was silently dropped -> count 2.
+    # enable_parallel_replicas=0: this check verifies inserted data, not the read path; parallel
+    # replicas need a matching cluster topology that this test does not set up.
+    $CLICKHOUSE_CLIENT -q "SELECT '$label', groupArray((p, x)), count() FROM (SELECT p, x FROM $table ORDER BY p, x) SETTINGS enable_parallel_replicas = 0"
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE $table"
+}
+
+run_engine 'MergeTree' 'MergeTree' 'bleed_mt'
+run_engine 'ReplicatedMergeTree' "ReplicatedMergeTree('/clickhouse/tables/{database}/bleed_rmt', 'r1')" 'bleed_rmt'
+
+# A single async entry whose one token legitimately spans two partitions must still
+# deduplicate on a full re-insert (the token belongs in both partitions it wrote to).
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS single_multi"
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE single_multi (p UInt8, x UInt64)
+ENGINE = MergeTree PARTITION BY p ORDER BY x
+SETTINGS non_replicated_deduplication_window = 1000"
+$CLICKHOUSE_CLIENT "${async_insert[@]}" --insert_deduplication_token='T' -q "INSERT INTO single_multi VALUES (0, 1), (1, 2)"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE single_multi"
+$CLICKHOUSE_CLIENT "${async_insert[@]}" --insert_deduplication_token='T' -q "INSERT INTO single_multi VALUES (0, 1), (1, 2)"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE single_multi"
+# Expected: [(0,1),(1,2)] count 2 (fully deduplicated, not doubled).
+$CLICKHOUSE_CLIENT -q "SELECT 'single-entry-multi-partition', groupArray((p, x)), count() FROM (SELECT p, x FROM single_multi ORDER BY p, x) SETTINGS enable_parallel_replicas = 0"
+$CLICKHOUSE_CLIENT -q "DROP TABLE single_multi"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111031
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111031

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed silent data loss with async inserts and deduplication (`async_insert=1`, `async_insert_deduplicate=1`). When several async-insert entries with distinct `insert_deduplication_token` values were coalesced into one flush that wrote to disjoint partitions, each token was registered in the deduplication log of every partition the flush touched, not only the partition its own rows landed in. A later insert reusing one of those tokens in a partition it never wrote to was then silently deduplicated away. Tokens are now registered only against the partition their rows actually landed in.


### Description

When several async-insert entries with distinct `insert_deduplication_token`s are coalesced into one flush, a single `DeduplicationInfo` carries one token per entry over the combined block. Both sinks split that block by partition, but the deduplication info was cloned in full for every partition, so `getDeduplicationHashes(partition_id)` produced a block id for every token tagged with that partition. Because a user token's block id (`<partition>_<hash-of-token>`) is data-independent, a token that contributed no rows to a partition still committed a block id there, so it bled into partitions it never wrote to. This diverges from synchronous inserts, where a token only registers in the partition its rows land in.

The fix threads the partition scatter selector (already computed inside `splitBlockIntoParts`) out to the sink and filters each partition's `DeduplicationInfo` down to the tokens whose rows actually landed in that partition, before computing the block ids. A single entry whose one token legitimately spans several partitions is unaffected (its token has rows in each of them). Covers both `MergeTree` and `ReplicatedMergeTree` (shared split logic).


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.6.2.98`, `26.5.6.63`, `26.4.5.151`, `26.3.17.65`
<!-- ch-version-info:end -->