### PR TITLE
Report the crashed server log on multi-server stateless runs

### DIFF
--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1208,6 +1208,17 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 return None
             return max(candidates, key=lambda p: p.stat().st_mtime)
 
+        def pick_file_with(pattern: str, needle: str) -> Path | None:
+            # Select the specific log that contains the hit, not merely the most
+            # recently modified one. On multi-server runs (e.g. DatabaseReplicated)
+            # the crashed server stops logging first and so has the OLDEST mtime,
+            # while surviving replicas keep writing - picking by mtime would hand
+            # the parser a log without the crash and yield a bogus "Unknown error".
+            out = Shell.get_output(
+                f"cd {self.log_dir} && grep -la '{needle}' {pattern} 2>/dev/null | head -n 1 || true"
+            ).strip()
+            return Path(self.log_dir) / out if out else None
+
         sanitizer_hits = Shell.get_output(
             f"sed -n '/.*anitizer/,${{p}}' {self.log_dir}/stderr*.log 2>/dev/null | "
             f'grep -a -v "ASan doesn\'t fully support makecontext/swapcontext functions" | '
@@ -1220,9 +1231,12 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             f"cd {self.log_dir} && grep -a '<Fatal>' clickhouse-server*.log 2>/dev/null | head -n 1 || true"
         )
         if sanitizer_hits or fatal_hits:
-            server_log = pick_latest_file(
-                "clickhouse-server*.err.log"
-            ) or pick_latest_file("clickhouse-server*.log")
+            server_log = (
+                pick_file_with("clickhouse-server*.err.log", "<Fatal>")
+                or pick_file_with("clickhouse-server*.log", "<Fatal>")
+                or pick_latest_file("clickhouse-server*.err.log")
+                or pick_latest_file("clickhouse-server*.log")
+            )
             stderr_log = pick_latest_file("stderr*.log")
             if not (server_log or stderr_log):
                 results.append(


### PR DESCRIPTION
`check_fatal_messages_in_logs` detected a crash by globbing all `clickhouse-server*.log` for `<Fatal>`, but then parsed a single log chosen by mtime (`pick_latest_file`). On multi-server runs (e.g. `DatabaseReplicated`) the crashed server stops logging first and so has the oldest mtime, while the surviving replicas keep writing. Picking by mtime handed the parser a replica log with no `<Fatal>`, which matched no error pattern and produced a useless "Unknown error" / "Lost connection to server" failure instead of naming the crash.

Now the log that actually contains the `<Fatal>` is selected (`grep -l` on content), falling back to mtime only if no file matches.

Example: on a DBReplicated coverage run, a real `Logical error: Arguments of 'multiply' have incorrect data types` abort in `clickhouse-server.log` was reported only as "Server died" + "Unknown error"; with this change it is named as the logical error with its stack trace.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1271` (included in `26.7` and later)
<!-- ch-version-info:end -->