### PR TITLE
Preserve const result for `replicate`

### DIFF
--- a/src/Functions/replicate.h
+++ b/src/Functions/replicate.h
@@ -28,6 +28,8 @@ public:
         return 0;
     }
 
+    bool useDefaultImplementationForConstants() const override { return true; }
+
     bool isVariadic() const override { return true; }
 
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return true; }

--- a/tests/queries/0_stateless/04612_function_replicate_preserves_const.reference
+++ b/tests/queries/0_stateless/04612_function_replicate_preserves_const.reference
@@ -1,0 +1,1 @@
+Const(Array(String))

--- a/tests/queries/0_stateless/04612_function_replicate_preserves_const.sql
+++ b/tests/queries/0_stateless/04612_function_replicate_preserves_const.sql
@@ -1,0 +1,1 @@
+SELECT toColumnTypeName(replicate('ClickHouse', [1, 2, 3]));


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/103015

When all arguments passed to `replicate` are constant, the function returns a materialized `Array` column instead of preserving the `Const` column type. This differs from equivalent functions such as `arrayWithConstant` and causes unnecessary materialization of a value that is constant for every row.

This change enables the standard constant-argument implementation of the function framework (`useDefaultImplementationForConstants`). When every argument is constant, `replicate` is evaluated once and its result is wrapped in a `ColumnConst`, which also makes the expression eligible for constant folding. Calls with non-constant arguments keep the existing execution path.

A stateless test checks that `toColumnTypeName(replicate('ClickHouse', [1, 2, 3]))` returns `Const(Array(String))`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Function `replicate` now returns a constant column when all its arguments are constant, like `arrayWithConstant`.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=111069&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/111069](https://github.com/search?q=head%3Async-upstream%2Fpr%2F111069+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.9.1.1519` (included in `26.9` and later)
<!-- ch-version-info:end -->