### PR TITLE
Fix type inconsistency during rhs-columns materialization in hash JOINs

### DIFF
--- a/src/Interpreters/HashJoin/HashJoinResult.cpp
+++ b/src/Interpreters/HashJoin/HashJoinResult.cpp
@@ -66,10 +66,11 @@ static ColumnWithTypeAndName copyLeftKeyColumnToRight(
         right_column.column = JoinCommon::filterWithBlanks(right_column.column, *null_map_filter);
 
     if (!right_column.type->equals(*right_key_type))
-    {
         right_column.column = castColumnAccurate(right_column, right_key_type);
-        right_column.type = right_key_type;
-    }
+
+    /// Types may be equal but not identical, e.g. `DateTime` with different timezones,
+    /// which shares the physical representation but affects expressions over the key (issue #111033).
+    right_column.type = right_key_type;
 
     right_column.column = right_column.column->convertToFullColumnIfConst();
     return right_column;

--- a/src/Interpreters/HashJoin/HashJoinResult.cpp
+++ b/src/Interpreters/HashJoin/HashJoinResult.cpp
@@ -68,8 +68,8 @@ static ColumnWithTypeAndName copyLeftKeyColumnToRight(
     if (!right_column.type->equals(*right_key_type))
         right_column.column = castColumnAccurate(right_column, right_key_type);
 
-    /// Types may be equal but not identical, e.g. `DateTime` with different timezones,
-    /// which shares the physical representation but affects expressions over the key (issue #111033).
+    /// Types may be equal but not identical, DateTime with different timezones
+    /// share physical representation but affect expressions over the key (issue #111033)
     right_column.type = right_key_type;
 
     right_column.column = right_column.column->convertToFullColumnIfConst();

--- a/tests/queries/0_stateless/04612_hash_join_right_key_timezone.reference
+++ b/tests/queries/0_stateless/04612_hash_join_right_key_timezone.reference
@@ -1,0 +1,22 @@
+hash
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:01	1970-01-01 09:00:01	DateTime(\'Asia/Tokyo\')
+parallel_hash
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:01	1970-01-01 09:00:01	DateTime(\'Asia/Tokyo\')
+grace_hash
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:01	1970-01-01 09:00:01	DateTime(\'Asia/Tokyo\')
+full_sorting_merge
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:01	1970-01-01 09:00:01	DateTime(\'Asia/Tokyo\')
+swapped timezones
+1970-01-01 00:00:00	1970-01-01 00:00:00	DateTime(\'UTC\')
+1970-01-01 00:00:01	1970-01-01 00:00:01	DateTime(\'UTC\')
+DateTime64
+1970-01-01 09:00:00.000	1970-01-01 09:00:00.000	DateTime64(3, \'Asia/Tokyo\')
+1970-01-01 09:00:01.000	1970-01-01 09:00:01.000	DateTime64(3, \'Asia/Tokyo\')
+left join with unmatched rows
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:01	1970-01-01 09:00:01	DateTime(\'Asia/Tokyo\')
+1970-01-01 09:00:00	1970-01-01 09:00:00	DateTime(\'Asia/Tokyo\')

--- a/tests/queries/0_stateless/04612_hash_join_right_key_timezone.sql
+++ b/tests/queries/0_stateless/04612_hash_join_right_key_timezone.sql
@@ -1,0 +1,50 @@
+-- Expressions over the right join key must keep its timezone (issue #111033).
+
+SELECT 'hash';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'UTC') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'hash';
+
+SELECT 'parallel_hash';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'UTC') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'parallel_hash';
+
+SELECT 'grace_hash';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'UTC') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'grace_hash';
+
+SELECT 'full_sorting_merge';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'UTC') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'full_sorting_merge';
+
+SELECT 'swapped timezones';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime(number, 'UTC') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'hash';
+
+SELECT 'DateTime64';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime64(number, 3, 'UTC') AS k FROM numbers(2)) AS l
+INNER JOIN (SELECT toDateTime64(number, 3, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY r.k
+SETTINGS join_algorithm = 'hash';
+
+SELECT 'left join with unmatched rows';
+SELECT toString(r.k), r.k, toTypeName(r.k)
+FROM (SELECT toDateTime(number, 'UTC') AS k FROM numbers(3)) AS l
+LEFT JOIN (SELECT toDateTime(number, 'Asia/Tokyo') AS k FROM numbers(2)) AS r ON l.k = r.k
+ORDER BY l.k
+SETTINGS join_algorithm = 'hash';


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a bug where materializing the right-side columns during *_hash JOINs was involving the wrong timezone. Closes #111033.
