### PR TITLE
CI: rename report messages status

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -13,7 +13,7 @@ from ci.praktika.gh import GH
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 
-STATUS_NAME = "Report messages"
+STATUS_NAME = "CI Infrastructure Messages"
 
 
 def check():


### PR DESCRIPTION
This updates the CI workflow status name to `CI Infrastructure Messages` and clarifies the warning emitted when log export cannot be enabled for the CI Logs cluster.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1282` (included in `26.7` and later)
<!-- ch-version-info:end -->