### PR TITLE
Add negative-case tests for the Quantized vector codec

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_negative.reference
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_negative.reference
@@ -1,0 +1,1 @@
+rows_after_failed_inserts	1

--- a/tests/queries/0_stateless/02354_vector_search_quantize_codec_negative.sql
+++ b/tests/queries/0_stateless/02354_vector_search_quantize_codec_negative.sql
@@ -1,0 +1,35 @@
+-- The `Quantized(method, dimensions[, ...])` column codec is only valid on an Array(Float32|Float64|BFloat16) column,
+-- and every stored vector must have exactly `dimensions` elements. This test pins down the error surface: the type is
+-- rejected at DDL time, the per-vector length is rejected at write time, and the codec cannot be chained with a
+-- compression codec.
+
+SET allow_experimental_codecs = 1;
+
+DROP TABLE IF EXISTS quantize_neg;
+
+-- DDL-time: the Quantized codec is only supported on Array(Float32|Float64|BFloat16). A non-Array column, an Array of a
+-- non-float element type, or a nested Nullable/LowCardinality element is rejected at CREATE TABLE with ILLEGAL_COLUMN.
+CREATE TABLE quantize_neg (id UInt32, vec UInt32 CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id; -- { serverError ILLEGAL_COLUMN }
+CREATE TABLE quantize_neg (id UInt32, vec Array(Int32) CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id; -- { serverError ILLEGAL_COLUMN }
+CREATE TABLE quantize_neg (id UInt32, vec Array(String) CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id; -- { serverError ILLEGAL_COLUMN }
+CREATE TABLE quantize_neg (id UInt32, vec Array(Nullable(Float32)) CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id; -- { serverError ILLEGAL_COLUMN }
+CREATE TABLE quantize_neg (id UInt32, vec Array(LowCardinality(Float32)) CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id; -- { serverError ILLEGAL_COLUMN }
+
+-- DDL-time: the Quantized codec is a NONE-category codec, so it cannot be chained with a compression codec.
+CREATE TABLE quantize_neg (id UInt32, vec Array(Float32) CODEC(Quantized('int8', 64), ZSTD)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+-- Write-time: every stored vector must have exactly `dimensions` elements, checked while encoding the codes on INSERT.
+CREATE TABLE quantize_neg (id UInt32, vec Array(Float32) CODEC(Quantized('int8', 64))) ENGINE = MergeTree ORDER BY id;
+
+-- A vector shorter than the declared dimensions is rejected.
+INSERT INTO quantize_neg SELECT 1, arrayMap(j -> toFloat32(j), range(32)); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+-- An empty vector is rejected (0 != 64).
+INSERT INTO quantize_neg SELECT 1, []::Array(Float32); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+-- A block that mixes a correct-length row with a wrong-length row is rejected as a whole (the write is atomic).
+INSERT INTO quantize_neg VALUES (1, arrayMap(j -> toFloat32(j), range(64))), (2, arrayMap(j -> toFloat32(j), range(63))); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+
+-- A correct-length vector still inserts, and the failed inserts above left no rows behind.
+INSERT INTO quantize_neg SELECT 1, arrayMap(j -> toFloat32(j), range(64));
+SELECT 'rows_after_failed_inserts', count() FROM quantize_neg;
+
+DROP TABLE quantize_neg;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108565
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Adds negative-case coverage for the `Quantized(...)` vector column codec (#108565), requested by @egor-click on that PR. Test-only, no source change.

Two new stateless tests:

- `02354_vector_search_quantize_codec_negative.sql`: the codec's error surface, all SQL-observable.
  - DDL-time `ILLEGAL_COLUMN`: the codec is only valid on `Array(Float32|Float64|BFloat16)`, so a non-Array column, `Array(Int32)`, `Array(String)`, `Array(Nullable(Float32))` and `Array(LowCardinality(Float32))` are rejected at `CREATE TABLE`.
  - DDL-time `BAD_ARGUMENTS`: `Quantized(...)` is a NONE-category codec and cannot be chained with a compression codec.
  - Write-time `SIZES_OF_ARRAYS_DONT_MATCH`: a vector whose length differs from the declared `dimensions` (short, empty, or a mixed-length block) is rejected on `INSERT`.
- `02354_vector_search_quantize_codec_bf16_precision.sql`: stores `Array(BFloat16)` and runs the two-stage `vector_search_use_quantized_codes` path. This covers the coarse-storage case (the existing two-stage tests all store `Array(Float32)`): the shortlist is rescored against the stored BFloat16 vectors, so the final top-k still matches an exact BFloat16 brute-force scan.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.136` (included in `26.8` and later)
<!-- ch-version-info:end -->