### PR TITLE
ReaderExecutor: coordinate cleanup, run-anchored reach, serve-to-bound long connections

### DIFF
--- a/src/IO/OffsetMap.cpp
+++ b/src/IO/OffsetMap.cpp
@@ -29,32 +29,26 @@ void OffsetMap::build(const StoredObjects & objects)
             total_size = StoredObject::UnknownSize;
             segments.push_back(Segment{
                 .object = obj,
-                .logical_offset = 0,
+                .file_offset = 0,
                 .size = StoredObject::UnknownSize,
             });
             return;
         }
         segments.push_back(Segment{
             .object = obj,
-            .logical_offset = total_size,
+            .file_offset = total_size,
             .size = obj.bytes_size,
         });
         total_size += obj.bytes_size;
     }
 }
 
-const StoredObject * OffsetMap::findObjectAt(size_t logical_offset, size_t * object_logical_start_offset) const
+const OffsetMap::Segment * OffsetMap::findObjectAt(size_t file_offset) const
 {
     /// Linear scan: the segment count equals the file's object count, a handful at most.
     for (const auto & seg : segments)
-    {
-        if (seg.logical_offset <= logical_offset && logical_offset < seg.logical_offset + seg.size)
-        {
-            if (object_logical_start_offset)
-                *object_logical_start_offset = seg.logical_offset;
-            return &seg.object;
-        }
-    }
+        if (seg.file_offset <= file_offset && file_offset < seg.file_offset + seg.size)
+            return &seg;
     return nullptr;
 }
 

--- a/src/IO/OffsetMap.h
+++ b/src/IO/OffsetMap.h
@@ -8,13 +8,11 @@ namespace DB
 {
 
 /// Maps file offsets to (object, offset-within-object), abstracting many storage objects behind
-/// a single file. Offsets are in the concatenated-file space: object sizes are byte lengths as
-/// stored, so any payload/header (logical vs physical) split is the caller's concern, not this map's.
+/// a single file. Offsets are in the concatenated-file space (payload/header split is the caller's).
 class OffsetMap
 {
 public:
-    /// One object's placement in the concatenated file: `file_offset` is the object's start
-    /// offset in the file, `size` its byte length.
+    /// One object's placement in the file: `file_offset` is its start, `size` its length.
     struct Segment
     {
         StoredObject object;
@@ -22,10 +20,9 @@ public:
         size_t size = 0;
     };
 
-    /// Objects are concatenated in their input order to form the file.
     void build(const StoredObjects & objects);
 
-    /// The segment containing `file_offset`, or nullptr if it is at or past `totalSize`.
+    /// The segment containing `file_offset`, or nullptr if at or past `totalSize`.
     const Segment * findObjectAt(size_t file_offset) const;
 
     size_t totalSize() const { return total_size; }

--- a/src/IO/OffsetMap.h
+++ b/src/IO/OffsetMap.h
@@ -7,31 +7,32 @@
 namespace DB
 {
 
-/// Maps logical file offsets to (object, offset-within-object).
-/// Used to abstract many storage objects behind a single logical file.
+/// Maps file offsets to (object, offset-within-object), abstracting many storage objects behind
+/// a single file. Offsets are in the concatenated-file space: object sizes are byte lengths as
+/// stored, so any payload/header (logical vs physical) split is the caller's concern, not this map's.
 class OffsetMap
 {
 public:
-    /// Objects are concatenated in their input order to form the logical file.
+    /// One object's placement in the concatenated file: `file_offset` is the object's start
+    /// offset in the file, `size` its byte length.
+    struct Segment
+    {
+        StoredObject object;
+        size_t file_offset = 0;
+        size_t size = 0;
+    };
+
+    /// Objects are concatenated in their input order to form the file.
     void build(const StoredObjects & objects);
 
-    /// Find the object containing `logical_offset`, or nullptr if it is at or past
-    /// `totalSize`. When given, `object_logical_start_offset` returns that object's start
-    /// offset in the logical file.
-    const StoredObject * findObjectAt(size_t logical_offset, size_t * object_logical_start_offset = nullptr) const;
+    /// The segment containing `file_offset`, or nullptr if it is at or past `totalSize`.
+    const Segment * findObjectAt(size_t file_offset) const;
 
     size_t totalSize() const { return total_size; }
 
     bool hasUnknownSize() const { return total_size == StoredObject::UnknownSize; }
 
 private:
-    struct Segment
-    {
-        StoredObject object;
-        size_t logical_offset = 0;
-        size_t size = 0;
-    };
-
     VectorWithMemoryTracking<Segment> segments;
     size_t total_size = 0;
 };

--- a/src/IO/ReadContinuityTracker.cpp
+++ b/src/IO/ReadContinuityTracker.cpp
@@ -7,16 +7,45 @@ namespace DB
 
 void ReadContinuityTracker::recordReadRange(size_t start_pos, size_t len)
 {
-    /// A backward or far-forward jump (gap > bridgeable_gap) is a discontinuity: close the run first.
-    if (last_pos && (start_pos < *last_pos || start_pos - *last_pos > options.bridgeable_gap))
+    /// A range from the past is a re-declaration (overlapping feeds re-declare the
+    /// same span), not a pattern signal: skip the covered part, feed only the new
+    /// tail. Genuine backward jumps arrive as `recordSeek`.
+    if (last_pos && start_pos < *last_pos)
+    {
+        if (start_pos + len <= *last_pos)
+            return;
+        len = start_pos + len - *last_pos;
+        start_pos = *last_pos;
+    }
+    /// A far-forward jump (gap > bridgeable_gap) is a discontinuity: close the run first.
+    if (last_pos && start_pos - *last_pos > options.bridgeable_gap)
         closeRun();
+    /// Only a continuation of a NON-EMPTY run confirms anything: the first read
+    /// after a seek also lands exactly at the frontier but carries no evidence.
+    const bool exact_continuation = last_pos && start_pos == *last_pos && *last_pos != run_start;
     if (!last_pos)
         run_start = start_pos;
     last_pos = start_pos + len;
+    /// An EXACT continuation is a positive continuity signal: checkpoint the grown run
+    /// into the estimate (the same fold `closeRun` does, without ending the run).
+    /// Trackers start empty on every reader, so without this a first-ever UNBROKEN
+    /// scan would stay in the warming state forever - its run never closes, the
+    /// estimate never rises, and the prediction stays at the damped floor. With it,
+    /// each confirmed continuation warms the estimate toward the observed run.
+    if (exact_continuation)
+        checkpointRun();
 }
 
 void ReadContinuityTracker::recordSeek(size_t new_pos)
 {
+    /// A gapless seek (to the exact frontier) is the same positive continuity
+    /// signal as an exact-continuation serve: checkpoint, keep the run.
+    if (last_pos && new_pos == *last_pos)
+    {
+        if (*last_pos != run_start)
+            checkpointRun();
+        return;
+    }
     /// A forward gap within bridgeable_gap keeps the run; any other jump closes it.
     if (last_pos && new_pos >= *last_pos && new_pos - *last_pos <= options.bridgeable_gap)
         return;
@@ -25,20 +54,36 @@ void ReadContinuityTracker::recordSeek(size_t new_pos)
     last_pos = new_pos;
 }
 
+double ReadContinuityTracker::foldedEstimate() const
+{
+    return options.ewma_alpha * static_cast<double>(currentRun())
+        + (1.0 - options.ewma_alpha) * expected_run;
+}
+
+void ReadContinuityTracker::checkpointRun()
+{
+    expected_run = foldedEstimate();
+}
+
 size_t ReadContinuityTracker::currentRun() const
 {
     return last_pos ? *last_pos - run_start : 0;
 }
 
-size_t ReadContinuityTracker::predictedForwardLength() const
+size_t ReadContinuityTracker::predictedEnd() const
 {
-    return std::max<size_t>(currentRun(), static_cast<size_t>(expected_run));
+    if (!last_pos)
+        return 0;
+    /// The prediction is "the estimate as if the live run checkpointed right now"
+    /// (`foldedEstimate`), floored at the estimate (via the max) so live evidence
+    /// never talks history down before the run outgrows it.
+    return *last_pos + std::max<size_t>(
+        static_cast<size_t>(foldedEstimate()), static_cast<size_t>(expected_run));
 }
 
 void ReadContinuityTracker::closeRun()
 {
-    expected_run = options.ewma_alpha * static_cast<double>(currentRun())
-        + (1.0 - options.ewma_alpha) * expected_run;
+    checkpointRun();
     run_start = 0;
     last_pos.reset();
 }

--- a/src/IO/ReadContinuityTracker.cpp
+++ b/src/IO/ReadContinuityTracker.cpp
@@ -7,9 +7,8 @@ namespace DB
 
 void ReadContinuityTracker::recordReadRange(size_t start_pos, size_t len)
 {
-    /// A range from the past is a re-declaration (overlapping feeds re-declare the
-    /// same span), not a pattern signal: skip the covered part, feed only the new
-    /// tail. Genuine backward jumps arrive as `recordSeek`.
+    /// A past range re-declares an already-fed span; feed only its new tail (backward jumps
+    /// come via `recordSeek`).
     if (last_pos && start_pos < *last_pos)
     {
         if (start_pos + len <= *last_pos)
@@ -17,21 +16,15 @@ void ReadContinuityTracker::recordReadRange(size_t start_pos, size_t len)
         len = start_pos + len - *last_pos;
         start_pos = *last_pos;
     }
-    /// A far-forward jump (gap > bridgeable_gap) is a discontinuity: close the run first.
+    /// A far-forward jump (gap > bridgeable_gap) is a discontinuity.
     if (last_pos && start_pos - *last_pos > options.bridgeable_gap)
         closeRun();
-    /// Only a continuation of a NON-EMPTY run confirms anything: the first read
-    /// after a seek also lands exactly at the frontier but carries no evidence.
     const bool exact_continuation = last_pos && start_pos == *last_pos && *last_pos != run_start;
     if (!last_pos)
         run_start = start_pos;
     last_pos = start_pos + len;
-    /// An EXACT continuation is a positive continuity signal: checkpoint the grown run
-    /// into the estimate (the same fold `closeRun` does, without ending the run).
-    /// Trackers start empty on every reader, so without this a first-ever UNBROKEN
-    /// scan would stay in the warming state forever - its run never closes, the
-    /// estimate never rises, and the prediction stays at the damped floor. With it,
-    /// each confirmed continuation warms the estimate toward the observed run.
+    /// Warm the estimate on each confirmed continuation, else a first unbroken scan (whose run
+    /// never closes) would stay at the floor forever.
     if (exact_continuation)
         checkpointRun();
 }
@@ -74,9 +67,8 @@ size_t ReadContinuityTracker::predictedEnd() const
 {
     if (!last_pos)
         return 0;
-    /// The prediction is "the estimate as if the live run checkpointed right now"
-    /// (`foldedEstimate`), floored at the estimate (via the max) so live evidence
-    /// never talks history down before the run outgrows it.
+    /// The estimate as if the live run checkpointed now, floored at history so live evidence
+    /// cannot talk it down before the run outgrows it.
     return *last_pos + std::max<size_t>(
         static_cast<size_t>(foldedEstimate()), static_cast<size_t>(expected_run));
 }

--- a/src/IO/ReadContinuityTracker.h
+++ b/src/IO/ReadContinuityTracker.h
@@ -25,8 +25,9 @@ public:
         /// from `min_bytes_for_seek`.
         size_t bridgeable_gap = 2 * MiB;
         /// EWMA weight for the just-finished run (0..1): higher trusts the most
-        /// recent run more, lower is smoother / decays slower.
-        double ewma_alpha = 0.5;
+        /// recent run more, lower is smoother / decays slower. Also the damping
+        /// of the live run inside `predictedEnd`.
+        double ewma_alpha = 0.7;
     };
 
     /// All-defaults overload kept separate from the `Options` one: a default
@@ -39,17 +40,26 @@ public:
     }
 
     /// Record a `len`-byte window served forward from `start_pos`: extends the run when
-    /// it continues the frontier (within `bridgeable_gap`), else closes the run first.
+    /// it continues the frontier (within `bridgeable_gap`); a far-forward range closes
+    /// the run first. A range from the past is a re-declaration, not a pattern signal:
+    /// the covered part is skipped and only the tail past the frontier feeds the run.
     void recordReadRange(size_t start_pos, size_t len);
 
     /// Record a seek to `new_pos`: a forward gap within `bridgeable_gap` keeps the run; any
     /// other jump closes it, folding its span into the estimate.
     void recordSeek(size_t new_pos);
 
-    /// The predicted contiguous length (bytes) the read will cover going forward:
-    /// `max(currentRun, estimate)` - "we have read this far contiguously (or did last
-    /// time), so expect about as far again".
-    size_t predictedForwardLength() const;
+    /// The predicted ABSOLUTE end of the current run, anchored at the run (the
+    /// last seek position), not at the caller's offset:
+    /// `frontier + max(ewma_alpha * currentRun + (1 - ewma_alpha) * estimate, estimate)`.
+    /// The first read of a
+    /// run predicts only the historical estimate; as the run accumulates
+    /// evidence the end grows as `run_start + (1 + alpha) * run` - proportional,
+    /// and identical for every caller wherever they ask from (anchoring the full
+    /// length at the caller's offset would re-anchor it forward as the cursor
+    /// advances, inflating the prediction at twice the consumption rate).
+    /// 0 before the first serve / right after a reset.
+    size_t predictedEnd() const;
 
     /// The current contiguous run span (frontier - run start).
     size_t currentRun() const;
@@ -58,6 +68,14 @@ public:
     size_t estimate() const { return static_cast<size_t>(expected_run); }
 
 private:
+    /// The estimator's single defining formula: the EWMA fold of the live run into
+    /// the carried estimate, `alpha * currentRun + (1 - alpha) * expected_run`.
+    double foldedEstimate() const;
+
+    /// Fold the current run span into the EWMA estimate WITHOUT ending the run -
+    /// the positive-signal checkpoint for exact continuations and gapless seeks.
+    void checkpointRun();
+
     /// Fold the current run span into the EWMA estimate and clear the run.
     void closeRun();
 

--- a/src/IO/ReadContinuityTracker.h
+++ b/src/IO/ReadContinuityTracker.h
@@ -8,14 +8,10 @@
 namespace DB
 {
 
-/// Estimates how far a read will continue contiguously - a predicted forward length in
-/// bytes - from the sequence of served byte ranges and seeks arriving at a reader.
-///
-/// The run span is the bytes covered forward without a far seek (a forward gap up to
-/// `bridgeable_gap` is bridged and stays in the run). A far seek folds the finished run into an
-/// EWMA of past run lengths and resets the run while keeping the estimate, so the read right
-/// after a far seek is still predicted long (trusting the previous run); repeated random
-/// seeks decay the EWMA toward zero.
+/// Estimates how far a read continues contiguously, from the served byte ranges and seeks. A run
+/// is the bytes covered forward without a far seek (a forward gap up to `bridgeable_gap` stays in
+/// the run); a far seek folds the run into an EWMA of past run lengths and resets, so the read
+/// after a far seek is still predicted long, while repeated random seeks decay the EWMA toward zero.
 class ReadContinuityTracker
 {
 public:
@@ -24,9 +20,7 @@ public:
         /// Forward gap up to which a serve still continues the run; the caller sets it
         /// from `min_bytes_for_seek`.
         size_t bridgeable_gap = 2 * MiB;
-        /// EWMA weight for the just-finished run (0..1): higher trusts the most
-        /// recent run more, lower is smoother / decays slower. Also the damping
-        /// of the live run inside `predictedEnd`.
+        /// EWMA weight for the just-finished run (0..1): higher trusts the recent run more.
         double ewma_alpha = 0.7;
     };
 
@@ -39,26 +33,17 @@ public:
     {
     }
 
-    /// Record a `len`-byte window served forward from `start_pos`: extends the run when
-    /// it continues the frontier (within `bridgeable_gap`); a far-forward range closes
-    /// the run first. A range from the past is a re-declaration, not a pattern signal:
-    /// the covered part is skipped and only the tail past the frontier feeds the run.
+    /// Record a `len`-byte window served forward from `start_pos`: extends the run within
+    /// `bridgeable_gap`, else closes it first. A past range re-declares an already-fed span (tail only).
     void recordReadRange(size_t start_pos, size_t len);
 
     /// Record a seek to `new_pos`: a forward gap within `bridgeable_gap` keeps the run; any
     /// other jump closes it, folding its span into the estimate.
     void recordSeek(size_t new_pos);
 
-    /// The predicted ABSOLUTE end of the current run, anchored at the run (the
-    /// last seek position), not at the caller's offset:
-    /// `frontier + max(ewma_alpha * currentRun + (1 - ewma_alpha) * estimate, estimate)`.
-    /// The first read of a
-    /// run predicts only the historical estimate; as the run accumulates
-    /// evidence the end grows as `run_start + (1 + alpha) * run` - proportional,
-    /// and identical for every caller wherever they ask from (anchoring the full
-    /// length at the caller's offset would re-anchor it forward as the cursor
-    /// advances, inflating the prediction at twice the consumption rate).
-    /// 0 before the first serve / right after a reset.
+    /// The predicted ABSOLUTE end of the current run: `frontier + max(foldedEstimate, estimate)`.
+    /// Anchored at the run start, not the caller's offset -- anchoring at the offset would re-anchor
+    /// forward as the cursor advances, inflating the prediction. 0 before the first serve / after a reset.
     size_t predictedEnd() const;
 
     /// The current contiguous run span (frontier - run start).
@@ -68,15 +53,13 @@ public:
     size_t estimate() const { return static_cast<size_t>(expected_run); }
 
 private:
-    /// The estimator's single defining formula: the EWMA fold of the live run into
-    /// the carried estimate, `alpha * currentRun + (1 - alpha) * expected_run`.
+    /// The EWMA fold of the live run into the estimate: `alpha * currentRun + (1 - alpha) * expected_run`.
     double foldedEstimate() const;
 
-    /// Fold the current run span into the EWMA estimate WITHOUT ending the run -
-    /// the positive-signal checkpoint for exact continuations and gapless seeks.
+    /// Fold the run into the estimate without ending it (the positive-signal checkpoint).
     void checkpointRun();
 
-    /// Fold the current run span into the EWMA estimate and clear the run.
+    /// Fold the run into the estimate and clear it.
     void closeRun();
 
     Options options;

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -337,8 +337,7 @@ size_t ReaderExecutor::totalSize() const
     /// (initDecryption throws on a partial file), so physical is either 0 or >= data_start_offset.
     if (physical == 0)
         return 0;
-    chassert(physical >= data_start_offset);
-    return physical - data_start_offset;
+    return toLogical(physical);
 }
 
 void ReaderExecutor::addDecryptionLayer(
@@ -377,16 +376,16 @@ void ReaderExecutor::initDecryption()
 
     /// The headers sit at the front of the first object; identify it (its `remote_path` is the
     /// stable cache key for disk files).
-    size_t object_start_offset = 0;
-    const StoredObject * object = offset_map.findObjectAt(0, &object_start_offset);
-    if (!object)
+    const auto * segment = offset_map.findObjectAt(0);
+    if (!segment)
         return;
+    const StoredObject & object = segment->object;
 
     /// Cache hit: parse the cached header bytes and skip the source read. The size check guards
     /// against a stale entry from a differently-layered file at the same path.
     if (encryption_header_cache)
     {
-        if (auto cached = encryption_header_cache->read(object->remote_path);
+        if (auto cached = encryption_header_cache->read(object.remote_path);
             cached && cached->size() == data_start_offset)
         {
             auto cached_block = std::make_shared<OwnedChainedBuffer>(data_start_offset);
@@ -402,7 +401,7 @@ void ReaderExecutor::initDecryption()
 
     /// Miss: read the headers from the source (one-shot; no long connection).
     auto block = std::make_shared<OwnedChainedBuffer>(data_start_offset);
-    const size_t got = readOneShot(*object, /*object_offset=*/0, data_start_offset, block->data());
+    const size_t got = readOneShot(object, /*object_offset=*/0, data_start_offset, block->data());
 
     /// Under size-unknown sources a short read means EOF rather than an error, so 0 bytes is an
     /// empty object (same as the size-known empty branch above) and a partial read is corruption.
@@ -421,7 +420,7 @@ void ReaderExecutor::initDecryption()
     decryptor.parseHeaders(header_chain);
 
     if (encryption_header_cache)
-        encryption_header_cache->write(object->remote_path, String(block->data(), got));
+        encryption_header_cache->write(object.remote_path, String(block->data(), got));
 #endif
 }
 
@@ -443,19 +442,17 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     if (atEnd())
         return {};
 
-    /// The offset map and object sizes are physical; logical `position` maps to physical
-    /// `position + data_start_offset` (the encryption headers sit at the file front, and
-    /// `data_start_offset` is 0 without encryption).
-    const size_t position_physical = position + data_start_offset;
-    size_t object_physical_start_offset = 0;
-    const StoredObject * object = offset_map.findObjectAt(position_physical, &object_physical_start_offset);
-    if (!object)
+    /// The offset map and object sizes are physical; `toPhys` crosses logical `position` into it.
+    const size_t position_physical = toPhys(position);
+    const auto * segment = offset_map.findObjectAt(position_physical);
+    if (!segment)
     {
         reached_eof = true;
         return {};
     }
 
-    const size_t object_offset = position_physical - object_physical_start_offset;
+    const StoredObject & object = segment->object;
+    const size_t object_offset = position_physical - segment->file_offset;
 
     /// Clamp the block to the object boundary so a window never straddles two
     /// objects; the next call continues in the next object. Unknown total size
@@ -463,7 +460,7 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     size_t want = block_size;
     if (!offset_map.hasUnknownSize())
     {
-        const size_t remaining_in_object = object->bytes_size - object_offset;
+        const size_t remaining_in_object = object.bytes_size - object_offset;
         want = std::min(block_size, remaining_in_object);
         if (want == 0)
         {
@@ -480,7 +477,7 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     auto block = std::make_shared<OwnedChainedBuffer>(want);
 
     size_t got = 0;
-    if (long_conn && long_conn->servesObject(object->remote_path)
+    if (long_conn && long_conn->servesObject(object.remote_path)
         && long_conn->canContinue(object_offset, want, min_bytes_for_seek))
     {
         /// Reuse the held connection for this contiguous (or small-gap) window.
@@ -494,10 +491,10 @@ ChainedBuffers ReaderExecutor::readNextWindow()
         /// to continue, else fall back to a one-shot read.
         if (long_conn)
             dropLongConnection();
-        if (shouldOpenLongConnection() && tryOpenLongConnection(*object, object_offset))
+        if (shouldOpenLongConnection() && tryOpenLongConnection(object, object_offset))
             got = serveFromLongConnection(object_offset, want, block->data());
         else
-            got = readOneShot(*object, object_offset, want, block->data());
+            got = readOneShot(object, object_offset, want, block->data());
     }
 
     /// Requested bytes equal source bytes until caches / over-read coalescing land; any bridged
@@ -520,7 +517,7 @@ ChainedBuffers ReaderExecutor::readNextWindow()
         /// The object is shorter than its declared size — truncated or corrupt.
         throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
             "ReaderExecutor: read {} of {} bytes at offset {} from {} (declared size {})",
-            got, want, position, object->remote_path, object->bytes_size);
+            got, want, position, object.remote_path, object.bytes_size);
     }
 
     continuity_tracker.recordReadRange(position, got);

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -480,11 +480,13 @@ ChainedBuffers ReaderExecutor::readNextWindow()
 
     size_t got = 0;
     if (long_conn && long_conn->servesObject(object.remote_path)
-        && long_conn->canContinue(object_offset, want, min_bytes_for_seek))
+        && long_conn->canServeAt(object_offset, min_bytes_for_seek))
     {
-        /// Reuse the held connection for this contiguous (or small-gap) window.
+        /// Reuse the held connection, serving only up to its bound (a short window is fine); the
+        /// next call reopens at the bound rather than draining and re-reading the residual.
         stats.add(Stats::LongConnectionHits);
-        got = serveFromLongConnection(object_offset, want, block->data());
+        const size_t serve = std::min(want, long_conn->read_until - object_offset);
+        got = serveFromLongConnection(object_offset, serve, block->data());
     }
     else
     {
@@ -504,22 +506,18 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     stats.add(Stats::BytesFromSource, got);
     stats.add(Stats::RequestedBytes, got);
 
-    if (offset_map.hasUnknownSize())
+    /// A short window (`got < want`) is normal -- the held connection served up to its bound, or the
+    /// object ended; advance by `got` and let the next call continue. EOF is the only `got == 0`, and
+    /// nothing read below a known-size source's declared end is truncation.
+    if (got == 0)
     {
-        /// At unknown total size a short read is the only EOF signal.
-        if (got == 0)
-        {
-            reached_eof = true;
-            long_conn.reset();   /// at EOF the connection is done, not an incomplete drop
-            return {};
-        }
-    }
-    else if (got < want)
-    {
-        /// The object is shorter than its declared size — truncated or corrupt.
-        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
-            "ReaderExecutor: read {} of {} bytes at offset {} from {} (declared size {})",
-            got, want, position, object.remote_path, object.bytes_size);
+        reached_eof = true;
+        long_conn.reset();
+        if (!offset_map.hasUnknownSize() && position < totalSize())
+            throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA,
+                "ReaderExecutor: source ended at {} of {} bytes for {} (declared size {})",
+                position, totalSize(), object.remote_path, object.bytes_size);
+        return {};
     }
 
     continuity_tracker.recordReadRange(position, got);
@@ -538,7 +536,7 @@ void ReaderExecutor::seek(size_t new_position)
 {
     LOG_TRACE(log, "seek: {} -> {}", position, new_position);
     /// Feed the estimator; a held connection that can't continue to `new_position` is dropped
-    /// lazily by the next `readNextWindow` (its `canContinue` check).
+    /// lazily by the next `readNextWindow` (its `canServeAt` check).
     continuity_tracker.recordSeek(new_position);
     position = new_position;
     reached_eof = false;

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -444,8 +444,8 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     if (atEnd())
         return {};
 
-    /// The offset map and object sizes are physical; `toPhys` crosses logical `position` into it.
-    const size_t position_physical = toPhys(position);
+    /// The offset map and object sizes are physical; `toPhysical` crosses logical `position` into it.
+    const size_t position_physical = toPhysical(position);
     const auto * segment = offset_map.findObjectAt(position_physical);
     if (!segment)
     {

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -123,7 +123,7 @@ ReaderExecutor::ReaderExecutor(
     Options options)
     : source(std::move(source_))
     , block_size(options.block_size ? options.block_size : DEFAULT_BLOCK_SIZE)
-    , continuity_tracker(ReadContinuityTracker::Options{.bridgeable_gap = options.min_bytes_for_seek})
+    , fetch_tracker(ReadContinuityTracker::Options{.bridgeable_gap = options.min_bytes_for_seek})
     , long_connection_limit(std::move(options.long_connection_limit))
     , encryption_header_cache(std::move(options.encryption_header_cache))
     , min_bytes_for_seek(options.min_bytes_for_seek)
@@ -234,7 +234,7 @@ bool ReaderExecutor::shouldOpenLongConnection() const
     if (long_conn || !long_connection_limit)
         return false;
     /// Open a long connection when the predicted run end runs past this window.
-    return clampReach(continuity_tracker.predictedEnd(), position) > position + block_size;
+    return clampReach(fetch_tracker.predictedEnd(), position) > position + block_size;
 }
 
 bool ReaderExecutor::tryOpenLongConnection(const StoredObject & object, size_t object_offset)
@@ -252,7 +252,7 @@ bool ReaderExecutor::tryOpenLongConnection(const StoredObject & object, size_t o
     /// reads ahead only as far as the pattern predicts (no full-object over-read when just a
     /// slice is used). Reuse spans this bound; once the read runs past it the connection completes
     /// (pool-reusable) and the next window opens a fresh, longer one as the run keeps growing.
-    const size_t forward = clampReach(continuity_tracker.predictedEnd(), position) - position;
+    const size_t forward = clampReach(fetch_tracker.predictedEnd(), position) - position;
     size_t read_until_obj = object_offset + forward;
     if (!offset_map.hasUnknownSize())
         read_until_obj = std::min<size_t>(read_until_obj, object.bytes_size);
@@ -482,8 +482,7 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     if (long_conn && long_conn->servesObject(object.remote_path)
         && long_conn->canServeAt(object_offset, min_bytes_for_seek))
     {
-        /// Reuse the held connection, serving only up to its bound (a short window is fine); the
-        /// next call reopens at the bound rather than draining and re-reading the residual.
+        /// Serve only up to the bound (a short window is fine); avoids draining and re-reading it.
         stats.add(Stats::LongConnectionHits);
         const size_t serve = std::min(want, long_conn->read_until - object_offset);
         got = serveFromLongConnection(object_offset, serve, block->data());
@@ -506,9 +505,8 @@ ChainedBuffers ReaderExecutor::readNextWindow()
     stats.add(Stats::BytesFromSource, got);
     stats.add(Stats::RequestedBytes, got);
 
-    /// A short window (`got < want`) is normal -- the held connection served up to its bound, or the
-    /// object ended; advance by `got` and let the next call continue. EOF is the only `got == 0`, and
-    /// nothing read below a known-size source's declared end is truncation.
+    /// A short window is normal (advance by `got`, re-call); only `got == 0` is EOF, where a
+    /// known-size source ending early is truncation.
     if (got == 0)
     {
         reached_eof = true;
@@ -520,7 +518,7 @@ ChainedBuffers ReaderExecutor::readNextWindow()
         return {};
     }
 
-    continuity_tracker.recordReadRange(position, got);
+    fetch_tracker.recordReadRange(position, got);
 
     /// Decrypt the freshly-read, uniquely-owned block in place at its logical offset. CTR is
     /// position-addressable, so decrypting just this window is exact.
@@ -537,7 +535,7 @@ void ReaderExecutor::seek(size_t new_position)
     LOG_TRACE(log, "seek: {} -> {}", position, new_position);
     /// Feed the estimator; a held connection that can't continue to `new_position` is dropped
     /// lazily by the next `readNextWindow` (its `canServeAt` check).
-    continuity_tracker.recordSeek(new_position);
+    fetch_tracker.recordSeek(new_position);
     position = new_position;
     reached_eof = false;
 }

--- a/src/IO/ReaderExecutor.cpp
+++ b/src/IO/ReaderExecutor.cpp
@@ -218,10 +218,12 @@ ReaderExecutor::LongConnection::drainTail(size_t max_tail, size_t block_bytes, L
     }
 }
 
-size_t ReaderExecutor::clampReach(size_t reach, size_t logical_pos) const
+size_t ReaderExecutor::clampReach(size_t predicted_end, size_t logical_pos) const
 {
-    /// The estimator's reach is unclamped; bound it to the file end when the size is known.
-    size_t end = logical_pos + reach;
+    /// The estimator's predicted run end is run-anchored and unclamped: bound it to the file end
+    /// when the size is known, and never below `logical_pos` (a prediction behind the current
+    /// position means no reach there, not a negative one).
+    size_t end = std::max(predicted_end, logical_pos);
     if (!offset_map.hasUnknownSize())
         end = std::min(end, totalSize());
     return end;
@@ -231,8 +233,8 @@ bool ReaderExecutor::shouldOpenLongConnection() const
 {
     if (long_conn || !long_connection_limit)
         return false;
-    /// Open a long connection when the predicted contiguous reach runs past this window.
-    return clampReach(continuity_tracker.predictedForwardLength(), position) > position + block_size;
+    /// Open a long connection when the predicted run end runs past this window.
+    return clampReach(continuity_tracker.predictedEnd(), position) > position + block_size;
 }
 
 bool ReaderExecutor::tryOpenLongConnection(const StoredObject & object, size_t object_offset)
@@ -244,13 +246,13 @@ bool ReaderExecutor::tryOpenLongConnection(const StoredObject & object, size_t o
         return false;
     }
 
-    /// Bound the held GET to the predicted forward reach (`clampReach` of the estimator), kept
+    /// Bound the held GET to the predicted run end (`clampReach` of the estimator), kept
     /// object-local and clamped to the object end. The estimate adapts: a long contiguous run
     /// grows it toward the whole object, while sparse access keeps it small -- so the connection
     /// reads ahead only as far as the pattern predicts (no full-object over-read when just a
     /// slice is used). Reuse spans this bound; once the read runs past it the connection completes
     /// (pool-reusable) and the next window opens a fresh, longer one as the run keeps growing.
-    const size_t forward = clampReach(continuity_tracker.predictedForwardLength(), position) - position;
+    const size_t forward = clampReach(continuity_tracker.predictedEnd(), position) - position;
     size_t read_until_obj = object_offset + forward;
     if (!offset_map.hasUnknownSize())
         read_until_obj = std::min<size_t>(read_until_obj, object.bytes_size);

--- a/src/IO/ReaderExecutor.h
+++ b/src/IO/ReaderExecutor.h
@@ -209,6 +209,12 @@ private:
     /// Drop the held connection: drain a small tail to complete it, else account it incomplete.
     void dropLongConnection();
 
+    /// The only logical<->physical converters: physical = header-inclusive file coords (the offset
+    /// map, object offsets); logical = payload coords (`position`, `totalSize`). A raw
+    /// `+/- data_start_offset` anywhere else is a bug.
+    size_t toPhys(size_t logical) const { return logical + data_start_offset; }
+    size_t toLogical(size_t physical) const { chassert(physical >= data_start_offset); return physical - data_start_offset; }
+
     /// Whether served payload is encrypted (`data_start_offset` is the header size,
     /// 0 when there is no encryption / no SSL).
     bool needsDecryption() const { return data_start_offset > 0; }

--- a/src/IO/ReaderExecutor.h
+++ b/src/IO/ReaderExecutor.h
@@ -193,8 +193,8 @@ private:
         return !offset_map.hasUnknownSize() && position >= totalSize();
     }
 
-    /// Predicted forward reach as a logical end position, clamped to the file end.
-    size_t clampReach(size_t reach, size_t logical_pos) const;
+    /// Clamp the estimator's run-anchored predicted end to `[logical_pos, file end]`.
+    size_t clampReach(size_t predicted_end, size_t logical_pos) const;
     /// Open a long connection now? True when a slot budget is configured, none is held,
     /// and the estimator predicts the read continues past this window.
     bool shouldOpenLongConnection() const;

--- a/src/IO/ReaderExecutor.h
+++ b/src/IO/ReaderExecutor.h
@@ -160,9 +160,8 @@ private:
         bool isComplete(bool at_eof) const { return at_eof || atBound(); }
         /// Whether any bytes have been consumed from the stream (read or skipped) since it opened.
         bool consumedAnyBytes() const { return current_position > opened_at; }
-        /// Forward, within `bridgeable_gap`, and still below the bound. A window crossing the bound
-        /// is served short (up to `read_until`), not rejected -- rejecting would drain the residual
-        /// and re-read it on the next connection.
+        /// Forward, within `bridgeable_gap`, and still below the bound (a crossing window is served
+        /// short, not rejected).
         bool canServeAt(size_t off, size_t bridgeable_gap) const
         {
             return off >= current_position && off - current_position <= bridgeable_gap && off < read_until;
@@ -211,9 +210,8 @@ private:
     /// Drop the held connection: drain a small tail to complete it, else account it incomplete.
     void dropLongConnection();
 
-    /// The only logical<->physical converters: physical = header-inclusive file coords (the offset
-    /// map, object offsets); logical = payload coords (`position`, `totalSize`). A raw
-    /// `+/- data_start_offset` anywhere else is a bug.
+    /// The only logical<->physical converters (physical = header-inclusive file coords, logical =
+    /// payload coords); a raw `+/- data_start_offset` elsewhere is a bug.
     size_t toPhys(size_t logical) const { return logical + data_start_offset; }
     size_t toLogical(size_t physical) const { chassert(physical >= data_start_offset); return physical - data_start_offset; }
 
@@ -236,7 +234,7 @@ private:
     /// Held source connection reused across sequential windows; empty when none is open.
     std::optional<LongConnection> long_conn;
     /// Forward-reach estimator, fed `recordReadRange`/`recordSeek`; drives the open-long decision.
-    ReadContinuityTracker continuity_tracker;
+    ReadContinuityTracker fetch_tracker;
     /// Connection-reuse budget; null disables long connections (the stateless path).
     std::shared_ptr<LongConnectionLimit> long_connection_limit;
     /// Global encryption-header cache; null disables caching (url / non-disk reads).

--- a/src/IO/ReaderExecutor.h
+++ b/src/IO/ReaderExecutor.h
@@ -212,7 +212,7 @@ private:
 
     /// The only logical<->physical converters (physical = header-inclusive file coords, logical =
     /// payload coords); a raw `+/- data_start_offset` elsewhere is a bug.
-    size_t toPhys(size_t logical) const { return logical + data_start_offset; }
+    size_t toPhysical(size_t logical) const { return logical + data_start_offset; }
     size_t toLogical(size_t physical) const { chassert(physical >= data_start_offset); return physical - data_start_offset; }
 
     /// Whether served payload is encrypted (`data_start_offset` is the header size,

--- a/src/IO/ReaderExecutor.h
+++ b/src/IO/ReaderExecutor.h
@@ -160,10 +160,12 @@ private:
         bool isComplete(bool at_eof) const { return at_eof || atBound(); }
         /// Whether any bytes have been consumed from the stream (read or skipped) since it opened.
         bool consumedAnyBytes() const { return current_position > opened_at; }
-        /// Forward, within `bridgeable_gap`, and `[off, off+want)` stays inside the bound.
-        bool canContinue(size_t off, size_t want, size_t bridgeable_gap) const
+        /// Forward, within `bridgeable_gap`, and still below the bound. A window crossing the bound
+        /// is served short (up to `read_until`), not rejected -- rejecting would drain the residual
+        /// and re-read it on the next connection.
+        bool canServeAt(size_t off, size_t bridgeable_gap) const
         {
-            return off >= current_position && off - current_position <= bridgeable_gap && off + want <= read_until;
+            return off >= current_position && off - current_position <= bridgeable_gap && off < read_until;
         }
 
         /// Read up to `want` bytes from the open stream into `dst`; advances the frontier.
@@ -202,7 +204,7 @@ private:
     /// no slot was available (caller falls back to a one-shot read).
     bool tryOpenLongConnection(const StoredObject & object, size_t object_offset);
     /// Serve one window (<= `want`) from the held connection, bridging a small leading gap;
-    /// releases the connection if it reaches its bound. Precondition: `canContinue`.
+    /// releases the connection if it reaches its bound. Precondition: `canServeAt`.
     size_t serveFromLongConnection(size_t object_offset, size_t want, char * dst);
     /// One-shot bounded read (the stateless path): open, seek, read `want` into `dst`.
     size_t readOneShot(const StoredObject & object, size_t object_offset, size_t want, char * dst);

--- a/src/IO/tests/gtest_offset_map.cpp
+++ b/src/IO/tests/gtest_offset_map.cpp
@@ -14,11 +14,10 @@ TEST(OffsetMap, SingleObject)
     EXPECT_EQ(map.totalSize(), 1000u);
     EXPECT_FALSE(map.hasUnknownSize());
 
-    size_t file_offset = 12345;
-    const auto * o = map.findObjectAt(100, &file_offset);
+    const auto * o = map.findObjectAt(100);
     ASSERT_NE(o, nullptr);
-    EXPECT_EQ(o->remote_path, "obj_a");
-    EXPECT_EQ(file_offset, 0u);
+    EXPECT_EQ(o->object.remote_path, "obj_a");
+    EXPECT_EQ(o->file_offset, 0u);
 
     EXPECT_NE(map.findObjectAt(999), nullptr);
     EXPECT_EQ(map.findObjectAt(1000), nullptr);  // at end
@@ -36,21 +35,20 @@ TEST(OffsetMap, MultipleObjects)
     map.build(objects);
     EXPECT_EQ(map.totalSize(), 1000u);
 
-    size_t file_offset = 0;
-    const auto * a = map.findObjectAt(0, &file_offset);
+    const auto * a = map.findObjectAt(0);
     ASSERT_NE(a, nullptr);
-    EXPECT_EQ(a->remote_path, "blob_0");
-    EXPECT_EQ(file_offset, 0u);
+    EXPECT_EQ(a->object.remote_path, "blob_0");
+    EXPECT_EQ(a->file_offset, 0u);
 
-    const auto * b = map.findObjectAt(300, &file_offset);
+    const auto * b = map.findObjectAt(300);
     ASSERT_NE(b, nullptr);
-    EXPECT_EQ(b->remote_path, "blob_1");
-    EXPECT_EQ(file_offset, 300u);
+    EXPECT_EQ(b->object.remote_path, "blob_1");
+    EXPECT_EQ(b->file_offset, 300u);
 
-    const auto * c = map.findObjectAt(800, &file_offset);
+    const auto * c = map.findObjectAt(800);
     ASSERT_NE(c, nullptr);
-    EXPECT_EQ(c->remote_path, "blob_2");
-    EXPECT_EQ(file_offset, 800u);
+    EXPECT_EQ(c->object.remote_path, "blob_2");
+    EXPECT_EQ(c->file_offset, 800u);
 
     EXPECT_NE(map.findObjectAt(999), nullptr);
     EXPECT_EQ(map.findObjectAt(1000), nullptr);
@@ -65,11 +63,10 @@ TEST(OffsetMap, ObjectBoundary)
     OffsetMap map;
     map.build(objects);
 
-    size_t file_offset = 0;
-    const auto * o = map.findObjectAt(100, &file_offset);  // first byte of the second object
+    const auto * o = map.findObjectAt(100);  // first byte of the second object
     ASSERT_NE(o, nullptr);
-    EXPECT_EQ(o->remote_path, "b");
-    EXPECT_EQ(file_offset, 100u);
+    EXPECT_EQ(o->object.remote_path, "b");
+    EXPECT_EQ(o->file_offset, 100u);
 
     EXPECT_EQ(map.findObjectAt(200), nullptr);
 }
@@ -87,5 +84,5 @@ TEST(OffsetMap, UnknownSize)
     /// Any offset below the sentinel resolves to the single object.
     const auto * o = map.findObjectAt(1'000'000);
     ASSERT_NE(o, nullptr);
-    EXPECT_EQ(o->remote_path, "obj");
+    EXPECT_EQ(o->object.remote_path, "obj");
 }

--- a/src/IO/tests/gtest_read_continuity_tracker.cpp
+++ b/src/IO/tests/gtest_read_continuity_tracker.cpp
@@ -16,9 +16,12 @@ TEST(ReadContinuityTracker, ContiguousServesExtendRun)
     auto t = makeTracker();
     t.recordReadRange(0, 50);
     EXPECT_EQ(t.currentRun(), 50u);
-    t.recordReadRange(50, 50);   /// exactly continues the frontier
+    t.recordReadRange(50, 50);   /// exactly continues the frontier -> checkpoint
     EXPECT_EQ(t.currentRun(), 100u);
-    EXPECT_EQ(t.predictedForwardLength(), 100u);
+    /// The exact continuation checkpointed the run: estimate = 0.5 * 100 = 50;
+    /// frontier(100) + max(0.5 * run(100) + 0.5 * est(50), est(50)) = 175.
+    EXPECT_EQ(t.estimate(), 50u);
+    EXPECT_EQ(t.predictedEnd(), 175u);
 }
 
 TEST(ReadContinuityTracker, SmallGapBridgesRun)
@@ -36,7 +39,8 @@ TEST(ReadContinuityTracker, LargeGapBreaksRunAndFoldsEstimate)
     t.recordReadRange(300, 50);   /// gap 200 > bridgeable_gap -> closes the 100-run, starts a new one
     EXPECT_EQ(t.currentRun(), 50u);
     EXPECT_EQ(t.estimate(), 50u);   /// 0.5*100 + 0.5*0
-    EXPECT_EQ(t.predictedForwardLength(), 50u);
+    /// frontier(350) + max(0.5 * run(50), estimate(50)) = 400.
+    EXPECT_EQ(t.predictedEnd(), 400u);
 }
 
 TEST(ReadContinuityTracker, ForwardNearSeekKeepsRun)
@@ -56,7 +60,9 @@ TEST(ReadContinuityTracker, FarSeekFoldsButStillPredictsLong)
     t.recordSeek(1000);   /// far -> fold the 100-run into the estimate, restart
     EXPECT_EQ(t.currentRun(), 0u);
     EXPECT_EQ(t.estimate(), 50u);
-    EXPECT_EQ(t.predictedForwardLength(), 50u);   /// still long: trusts the previous run
+    /// Anchored at the seek target: 1000 + max(0, 50) = 1050 - still predicts a
+    /// historical-length run from the NEW position, nothing from the old one.
+    EXPECT_EQ(t.predictedEnd(), 1050u);
 }
 
 TEST(ReadContinuityTracker, BackwardSeekFolds)
@@ -80,15 +86,73 @@ TEST(ReadContinuityTracker, RepeatedSeeksDecayEstimate)
     EXPECT_EQ(t.estimate(), 12u);   /// 12.5 truncated
 }
 
-TEST(ReadContinuityTracker, PredictedForwardLengthIsMaxOfRunAndEstimate)
+TEST(ReadContinuityTracker, PredictedEndIsRunAnchored)
 {
     auto t = makeTracker(/*bridgeable_gap=*/100, /*alpha=*/0.5);
     t.recordReadRange(0, 100);
     t.recordSeek(1000);   /// estimate 50, run reset
     t.recordReadRange(1000, 20);   /// a small new run of 20
     EXPECT_EQ(t.currentRun(), 20u);
-    EXPECT_EQ(t.predictedForwardLength(), 50u);   /// max(20, 50)
-    t.recordReadRange(1020, 60);   /// run grows to 80
+    /// frontier(1020) + max(0.5*20 + 0.5*50 = 35, 50) = 1070: the estimate dominates early.
+    EXPECT_EQ(t.predictedEnd(), 1070u);
+    t.recordReadRange(1020, 60);   /// exact continuation -> checkpoint: est = 0.5*80 + 0.5*50 = 65
     EXPECT_EQ(t.currentRun(), 80u);
-    EXPECT_EQ(t.predictedForwardLength(), 80u);   /// max(80, 50)
+    /// frontier(1080) + max(0.5*80 + 0.5*65 = 72, 65) = 1152: the blend overtakes the
+    /// estimate smoothly; growth stays run-proportional, never caller-re-anchored.
+    EXPECT_EQ(t.predictedEnd(), 1152u);
 }
+
+TEST(ReadContinuityTracker, PredictedEndIsZeroBeforeFirstServe)
+{
+    auto t = makeTracker();
+    EXPECT_EQ(t.predictedEnd(), 0u);
+}
+
+TEST(ReadContinuityTracker, UnbrokenScanWarmsTheEstimate)
+{
+    /// Trackers start empty on every reader; without continuation checkpoints an
+    /// unbroken scan would never raise the estimate (the run never closes). Each
+    /// exact continuation folds the grown run in, so confidence rises with the scan.
+    auto t = makeTracker(/*bridgeable_gap=*/100, /*alpha=*/0.5);
+    t.recordReadRange(0, 100);       /// starts the run: no evidence yet
+    EXPECT_EQ(t.estimate(), 0u);
+    t.recordReadRange(100, 100);     /// checkpoint: est = 0.5 * 200 = 100
+    EXPECT_EQ(t.estimate(), 100u);
+    t.recordReadRange(200, 100);     /// checkpoint: est = 0.5 * 300 + 0.5 * 100 = 200
+    EXPECT_EQ(t.estimate(), 200u);
+    EXPECT_EQ(t.predictedEnd(), 300u + 250u);   /// frontier + max(0.5 * 300 + 0.5 * 200, 200)
+
+    /// A gapless seek is the same positive signal.
+    auto s = makeTracker(/*bridgeable_gap=*/100, /*alpha=*/0.5);
+    s.recordReadRange(0, 100);
+    s.recordSeek(100);               /// gapless: checkpoint, run kept
+    EXPECT_EQ(s.estimate(), 50u);
+    EXPECT_EQ(s.currentRun(), 100u);
+
+    /// The first read AFTER A JUMP lands at the frontier but confirms nothing.
+    auto j = makeTracker(/*bridgeable_gap=*/100, /*alpha=*/0.5);
+    j.recordReadRange(0, 100);
+    j.recordSeek(1000);              /// far: fold(est=50), restart
+    j.recordReadRange(1000, 20);     /// empty-run continuation: NO checkpoint
+    EXPECT_EQ(j.estimate(), 50u);
+}
+
+TEST(ReadContinuityTracker, RangesFromThePastAreSkipped)
+{
+    /// Overlapping feeds re-declare spans an earlier feed already covered (the plan
+    /// window slides over the same region); the covered part is a re-declaration,
+    /// not a pattern signal - it must neither fold the run nor extend it. Only the
+    /// tail past the frontier feeds, and it counts as an exact continuation.
+    auto t = makeTracker(/*bridgeable_gap=*/100, /*alpha=*/0.5);
+    t.recordReadRange(0, 100);
+    t.recordReadRange(0, 100);       /// fully covered -> no-op
+    EXPECT_EQ(t.currentRun(), 100u);
+    EXPECT_EQ(t.estimate(), 0u);
+    t.recordReadRange(50, 100);      /// overlaps the frontier: feeds only [100, 150)
+    EXPECT_EQ(t.currentRun(), 150u);
+    EXPECT_EQ(t.estimate(), 75u);    /// the clipped tail continued the run -> checkpoint: 0.5 * 150
+    t.recordReadRange(500, 50);      /// a far-forward range still breaks the run
+    EXPECT_EQ(t.currentRun(), 50u);
+    EXPECT_EQ(t.estimate(), 112u);   /// close folded the 150-run: 0.5 * 150 + 0.5 * 75
+}
+

--- a/src/IO/tests/gtest_reader_executor.cpp
+++ b/src/IO/tests/gtest_reader_executor.cpp
@@ -402,13 +402,14 @@ TEST_F(ReaderExecutorTest, MissingFileWithUnknownSizeThrows)
 
 TEST_F(ReaderExecutorTest, TruncatedKnownSizeFileThrows)
 {
-    /// A known-size object whose file is shorter than its declared size is
-    /// truncated/corrupt; the executor must throw rather than return a short read.
+    /// A known-size object whose file is shorter than its declared size is truncated/corrupt: the
+    /// executor serves the bytes that exist, then throws when the source ends before the declared
+    /// total (rather than silently reporting a short file).
     StoredObject obj = makeFile("short.bin", 100);
     obj.bytes_size = 1000;  // pretend the object is larger than the file on disk
     ReaderExecutor ex(std::make_shared<LocalSourceReader>(), {obj}, ReaderExecutor::Options{.block_size = 256});
 
-    EXPECT_ANY_THROW(ex.readNextWindow());
+    EXPECT_ANY_THROW(drain(ex));
 }
 
 /// The metrics tests read the executor's ProfileEvents from a fresh per-test ThreadGroup


### PR DESCRIPTION
Cache-independent refactors split out of the `ReaderExecutor` cache-chain PR (#110029) so they can
be reviewed and merged on their own. All are behind the experimental `use_reader_executor` path
(off by default); no user-facing behavior change.

- OffsetMap: `findObjectAt` returns a `Segment` (object + file offset) instead of a `StoredObject*`
  plus a `size_t*` out-param; `Segment::logical_offset` renamed to `file_offset` (it was always a
  physical file offset).
- Centralize the executor's physical<->logical coordinate conversions behind `toPhys`/`toLogical`
  instead of scattered inline `+/- data_start_offset`.
- Track a run-anchored reach prediction (`predictedEnd`) for the held source connection.
- Serve a window that crosses the connection's bound as a short window (`canServeAt`) instead of
  dropping the connection and draining+re-reading the residual, which over-read on a cold scan.

Verified: the `ReaderExecutor` / `OffsetMap` / `ReadContinuityTracker` / `PipelineReadBuffer` gtests
and the `0431x`/`0434x`/`0450x` executor functional tests.

Related: https://github.com/ClickHouse/ClickHouse/pull/110029

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
