### PR TITLE
Fix bug with `data_kind = Preprocessed` failing the whole async batch

### DIFF
--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1095,7 +1095,8 @@ try
         const InsertData::EntryPtr & entry,
         const String & parsing_exception,
         size_t num_rows,
-        size_t num_bytes) mutable
+        size_t num_bytes,
+        bool is_flush_error = false) mutable
     {
         /// Track per-entry stats for reporting back to clients on success.
         if (parsing_exception.empty())
@@ -1138,7 +1139,12 @@ try
         /// If there was a parsing error,
         /// the entry won't be flushed anyway,
         /// so add the log element immediately.
-        if (!elem.exception.empty())
+        if (is_flush_error)
+        {
+            /// Per-entry conversion failure at flush: log immediately as `FlushError` with a real `flush_time`.
+            appendElementsToLogSafe(*async_insert_log, {std::move(elem)}, std::chrono::system_clock::now(), parsing_exception);
+        }
+        else if (!elem.exception.empty())
         {
             elem.status = AsynchronousInsertLogElement::ParsingError;
             async_insert_log->add(std::move(elem));
@@ -1400,10 +1406,11 @@ Chunk AsynchronousInsertQueue::processPreprocessedEntries(
         }
         catch (...)
         {
-            /// Isolate the failure to this entry, mirroring the parsing path (processEntriesWithParsing)
-            auto exception = getCurrentExceptionMessage(/*with_stacktrace=*/ false);
-            LOG_ERROR(logger, "Failed conversion for insert query id {}. {}", entry->query_id, exception);
-            add_to_async_insert_log(entry, exception, /*num_rows=*/ 0, block->bytes());
+            /// Per-entry isolation: log as `FlushError` (not `ParsingError`) with a real
+            /// `flush_time`, via the `is_flush_error` path in `add_to_async_insert_log`.
+            const auto exception_msg = getCurrentExceptionMessage(/*with_stacktrace=*/ false);
+            LOG_ERROR(logger, "Failed conversion for insert query id {}. {}", entry->query_id, exception_msg);
+            add_to_async_insert_log(entry, exception_msg, /*num_rows=*/ 0, block->bytes(), /*is_flush_error=*/ true);
             entry->finish(std::current_exception());
             entry->resetChunk();
             continue;

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1093,13 +1093,13 @@ try
 
     auto add_entry_to_asynchronous_insert_log = [&, query_by_format = NameToNameMap{}](
         const InsertData::EntryPtr & entry,
-        const String & parsing_exception,
+        const String & exception,
         size_t num_rows,
         size_t num_bytes,
         bool is_flush_error = false) mutable
     {
         /// Track per-entry stats for reporting back to clients on success.
-        if (parsing_exception.empty())
+        if (exception.empty())
             per_entry_progress_results[entry.get()] = ResultProgress{num_rows, num_bytes};
 
         if (!async_insert_log)
@@ -1114,7 +1114,7 @@ try
         elem.query_id = entry->query_id;
         elem.bytes = num_bytes;
         elem.rows = num_rows;
-        elem.exception = parsing_exception;
+        elem.exception = exception;
         elem.data_kind = entry->chunk.getDataKind();
         elem.timeout_milliseconds = data->timeout_ms.count();
         elem.flush_query_id = insert_query_id;
@@ -1136,13 +1136,10 @@ try
         else
             elem.query_for_logging = get_query_by_format(entry->format);
 
-        /// If there was a parsing error,
-        /// the entry won't be flushed anyway,
-        /// so add the log element immediately.
         if (is_flush_error)
         {
             /// Per-entry conversion failure at flush: log immediately as `FlushError` with a real `flush_time`.
-            appendElementsToLogSafe(*async_insert_log, {std::move(elem)}, std::chrono::system_clock::now(), parsing_exception);
+            appendElementsToLogSafe(*async_insert_log, {std::move(elem)}, std::chrono::system_clock::now(), exception);
         }
         else if (!elem.exception.empty())
         {
@@ -1196,7 +1193,7 @@ try
         if (async_insert_log)
         {
             for (const auto & entry : data->entries)
-                add_entry_to_asynchronous_insert_log(entry, /*parsing_exception=*/ "", /*num_rows=*/ 0, entry->chunk.byteSize());
+                add_entry_to_asynchronous_insert_log(entry, /*exception=*/ "", /*num_rows=*/ 0, entry->chunk.byteSize());
 
             auto exception = getCurrentExceptionMessage(false);
             auto flush_time = std::chrono::system_clock::now();
@@ -1394,7 +1391,7 @@ Chunk AsynchronousInsertQueue::processPreprocessedEntries(
         Block block_to_insert = *block;
         if (block_to_insert.rows() == 0)
         {
-            add_to_async_insert_log(entry, /*parsing_exception=*/ "", block_to_insert.rows(), block_to_insert.bytes());
+            add_to_async_insert_log(entry, /*exception=*/ "", block_to_insert.rows(), block_to_insert.bytes());
             entry->resetChunk();
             continue;
         }
@@ -1424,7 +1421,7 @@ Chunk AsynchronousInsertQueue::processPreprocessedEntries(
 
         deduplication_info->setUserToken(entry->async_dedup_token, block_to_insert.rows());
 
-        add_to_async_insert_log(entry, /*parsing_exception=*/ "", block_to_insert.rows(), block_to_insert.bytes());
+        add_to_async_insert_log(entry, /*exception=*/ "", block_to_insert.rows(), block_to_insert.bytes());
         entry->resetChunk();
     }
 

--- a/src/Interpreters/AsynchronousInsertQueue.cpp
+++ b/src/Interpreters/AsynchronousInsertQueue.cpp
@@ -1393,8 +1393,21 @@ Chunk AsynchronousInsertQueue::processPreprocessedEntries(
             continue;
         }
 
-        if (!isCompatibleHeader(block_to_insert, header))
-            convertBlockToHeader(block_to_insert, header, context_);
+        try
+        {
+            if (!isCompatibleHeader(block_to_insert, header))
+                convertBlockToHeader(block_to_insert, header, context_);
+        }
+        catch (...)
+        {
+            /// Isolate the failure to this entry, mirroring the parsing path (processEntriesWithParsing)
+            auto exception = getCurrentExceptionMessage(/*with_stacktrace=*/ false);
+            LOG_ERROR(logger, "Failed conversion for insert query id {}. {}", entry->query_id, exception);
+            add_to_async_insert_log(entry, exception, /*num_rows=*/ 0, block->bytes());
+            entry->finish(std::current_exception());
+            entry->resetChunk();
+            continue;
+        }
 
         auto columns = block_to_insert.getColumns();
         for (size_t i = 0, s = columns.size(); i < s; ++i)

--- a/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.reference
+++ b/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.reference
@@ -2,3 +2,5 @@
 1	100
 === native block (Preprocessed): bad entry is isolated, good entry survives ===
 1	100
+Preprocessed	Ok	1
+Preprocessed	FlushError	1

--- a/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.reference
+++ b/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.reference
@@ -1,0 +1,4 @@
+=== VALUES (Parsed): bad entry is isolated, good entry survives ===
+1	100
+=== native block (Preprocessed): bad entry is isolated, good entry survives ===
+1	100

--- a/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.sh
+++ b/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Per-entry error isolation on the async insert queue flush.
+# Two async entries with the same query share one bucket; a concurrent `MODIFY COLUMN` makes
+# only one of them unconvertible at flush. In both the parsing path (`INSERT ... VALUES`,
+# `data_kind = Parsed`, isolated via `on_error` in `processEntriesWithParsing`) and the block
+# path (native block, `data_kind = Preprocessed`, isolated in `processPreprocessedEntries`),
+# the bad entry fails on its own and the valid sibling (id=1, '100' -> 100) still lands.
+# Before the block-path fix the unconvertible block failed the whole batch and dropped the
+# good sibling too.
+
+async=(--async_insert=1 --wait_for_async_insert=0 --async_insert_busy_timeout_max_ms=300000 --async_insert_busy_timeout_min_ms=300000 --async_insert_use_adaptive_busy_timeout=0)
+
+echo "=== VALUES (Parsed): bad entry is isolated, good entry survives ==="
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_async_iso_values"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE t_async_iso_values (id Int64, amount String) ENGINE = MergeTree ORDER BY id"
+$CLICKHOUSE_CLIENT "${async[@]}" -q "INSERT INTO t_async_iso_values VALUES (1, '100')"
+$CLICKHOUSE_CLIENT "${async[@]}" -q "INSERT INTO t_async_iso_values VALUES (2, 'hello')"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE t_async_iso_values MODIFY COLUMN amount Int64"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE t_async_iso_values"
+$CLICKHOUSE_CLIENT -q "SELECT id, amount FROM t_async_iso_values ORDER BY id"
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_async_iso_values"
+
+echo "=== native block (Preprocessed): bad entry is isolated, good entry survives ==="
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t_async_iso_block"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE t_async_iso_block (id Int64, amount String) ENGINE = MergeTree ORDER BY id"
+$CLICKHOUSE_CLIENT -q "SELECT toInt64(1) AS id, '100'::String AS amount FORMAT Native"   | $CLICKHOUSE_CLIENT "${async[@]}" -q "INSERT INTO t_async_iso_block FORMAT Native"
+$CLICKHOUSE_CLIENT -q "SELECT toInt64(2) AS id, 'hello'::String AS amount FORMAT Native" | $CLICKHOUSE_CLIENT "${async[@]}" -q "INSERT INTO t_async_iso_block FORMAT Native"
+$CLICKHOUSE_CLIENT -q "ALTER TABLE t_async_iso_block MODIFY COLUMN amount Int64"
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE t_async_iso_block"
+$CLICKHOUSE_CLIENT -q "SELECT id, amount FROM t_async_iso_block ORDER BY id"
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_async_iso_block"

--- a/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.sh
+++ b/tests/queries/0_stateless/04612_async_insert_block_batch_error_isolation.sh
@@ -6,12 +6,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # Per-entry error isolation on the async insert queue flush.
 # Two async entries with the same query share one bucket; a concurrent `MODIFY COLUMN` makes
-# only one of them unconvertible at flush. In both the parsing path (`INSERT ... VALUES`,
-# `data_kind = Parsed`, isolated via `on_error` in `processEntriesWithParsing`) and the block
-# path (native block, `data_kind = Preprocessed`, isolated in `processPreprocessedEntries`),
-# the bad entry fails on its own and the valid sibling (id=1, '100' -> 100) still lands.
-# Before the block-path fix the unconvertible block failed the whole batch and dropped the
-# good sibling too.
+# only one unconvertible at flush. Both the parsing path (`INSERT ... VALUES`, `data_kind =
+# Parsed`, isolated via `on_error` in `processEntriesWithParsing`) and the block path (native
+# block, `data_kind = Preprocessed`, isolated in `processPreprocessedEntries`) must isolate
+# the bad entry so the valid sibling (id=1, '100' -> 100) still lands.
+# Before the block-path fix the unconvertible block failed the whole batch.
 
 async=(--async_insert=1 --wait_for_async_insert=0 --async_insert_busy_timeout_max_ms=300000 --async_insert_busy_timeout_min_ms=300000 --async_insert_use_adaptive_busy_timeout=0)
 
@@ -33,4 +32,7 @@ $CLICKHOUSE_CLIENT -q "SELECT toInt64(2) AS id, 'hello'::String AS amount FORMAT
 $CLICKHOUSE_CLIENT -q "ALTER TABLE t_async_iso_block MODIFY COLUMN amount Int64"
 $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH ASYNC INSERT QUEUE t_async_iso_block"
 $CLICKHOUSE_CLIENT -q "SELECT id, amount FROM t_async_iso_block ORDER BY id"
+# Verify the bad entry is recorded as a failure in the log, not silently dropped.
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS asynchronous_insert_log"
+$CLICKHOUSE_CLIENT -q "SELECT data_kind, status, flush_time_microseconds > 0 AS has_flush_time FROM system.asynchronous_insert_log WHERE database = currentDatabase() AND table = 't_async_iso_block' AND event_date >= yesterday() AND event_time >= now() - 600 ORDER BY status"
 $CLICKHOUSE_CLIENT -q "DROP TABLE t_async_iso_block"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
closes https://github.com/ClickHouse/ClickHouse/issues/111064


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed asynchronous Native-format inserts so one buffered entry that becomes incompatible after `ALTER ... MODIFY COLUMN` no longer causes the whole batch to fail.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1312` (included in `26.7` and later)
- Backported to: `26.6.2.96`, `26.5.6.77`, `26.4.5.165`, `26.3.17.63`
<!-- ch-version-info:end -->