### PR TITLE
Fix flaky test_rename_distributed_parallel_insert_and_select

### DIFF
--- a/tests/integration/test_rename_column/test.py
+++ b/tests/integration/test_rename_column/test.py
@@ -269,6 +269,37 @@ def rename_column_on_cluster(
             break
 
 
+def _num2_converged(nodes, table_name):
+    return all(
+        node.query(
+            "SELECT count() FROM system.columns "
+            "WHERE database = 'default' AND table IN ('{t}', '{t}_replicated') "
+            "AND name = 'num2'".format(t=table_name)
+        ).strip()
+        == "2"
+        for node in nodes
+    )
+
+
+def wait_for_rename_to_num2(nodes, table_name, attempts=12, poll_seconds=5):
+    # Best-effort cleanup renames + async ON CLUSTER replication can leave the
+    # column as foo2/foo3 on some replicas. Re-drive the idempotent rename-back
+    # until num2 is present on every node's Distributed and _replicated tables,
+    # so the strict queries below do not race schema convergence (UNKNOWN_IDENTIFIER).
+    tables = [table_name, "%s_replicated" % table_name]
+    for _ in range(attempts):
+        if _num2_converged(nodes, table_name):
+            return
+        for old_name in ("foo2", "foo3"):
+            for table in tables:
+                rename_column_on_cluster(nodes[0], table, old_name, "num2", 1, True)
+        time.sleep(poll_seconds)
+    if not _num2_converged(nodes, table_name):
+        raise Exception(
+            "columns did not converge to num2 for {} on all nodes".format(table_name)
+        )
+
+
 def alter_move(node, table_name, iterations=1, ignore_exception=False):
     i = 0
     while True:
@@ -809,14 +840,7 @@ def test_rename_distributed_parallel_insert_and_select(started_cluster):
         for task in tasks:
             task.get(timeout=240)
 
-        rename_column_on_cluster(node1, table_name, "foo2", "num2", 1, True)
-        rename_column_on_cluster(
-            node1, "%s_replicated" % table_name, "foo2", "num2", 1, True
-        )
-        rename_column_on_cluster(node1, table_name, "foo3", "num2", 1, True)
-        rename_column_on_cluster(
-            node1, "%s_replicated" % table_name, "foo3", "num2", 1, True
-        )
+        wait_for_rename_to_num2(nodes, table_name)
 
         insert(node1, table_name, 1000, col_names=["num", "num2"])
         select(node1, table_name, "num2")


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110970
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/110970

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the chronic flaky `test_rename_column/test.py::test_rename_distributed_parallel_insert_and_select` (`Code: 47 UNKNOWN_IDENTIFIER` on `amd_msan`/`amd_tsan`).

The cleanup renames back to `num2` run via `ON CLUSTER` (async distributed DDL + async ReplicatedMergeTree metadata replication) with `ignore_exception=True`, so a failed or late rename is swallowed. The strict final selects then run immediately with no wait for schema convergence. When a distributed `SELECT ... WHERE num2 ...` is forwarded to a shard replica whose local `_replicated` metadata has not yet converged to `num2` (still `foo2`/`foo3`), that shard's analyzer throws `UNKNOWN_IDENTIFIER`. This is correct engine behaviour (per-shard schema during async metadata replication); the test asserted before its precondition held.

Replaces the fixed cleanup renames with `wait_for_rename_to_num2`, which re-drives the idempotent `ON CLUSTER` rename-back and polls `system.columns` until `num2` is present on every node's Distributed and `_replicated` table before the strict selects. This repairs both a swallowed cleanup rename and async replication lag. Test-only change; strict assertions unchanged.

Reproduced deterministically: a local-only `RENAME num2 -> foo2` on node1 makes the Distributed schema outrun a shard replica, and a strict `SELECT ... WHERE foo2` then fails with the exact `Code: 47` from CI (`Received from node4:9000 ... Identifier '__table1.foo2' cannot be resolved`); with the wait it passes. Fixed test: 10/10 runs pass.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110970&sha=b16c36ef0ff5c635f3cd4ffb7175c840a7198cc3&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%208%2F8%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1254` (included in `26.7` and later)
- Backported to: `26.6.8.8`, `26.3.33.92`
<!-- ch-version-info:end -->