### PR TITLE
Add `CompressionCodecAdaptive` with per-block codec selection

### DIFF
--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -1,5 +1,9 @@
 #include <Compression/CompressionCodecAdaptive.h>
 
+#include <algorithm>
+#include <array>
+#include <span>
+#include <string_view>
 #include <Compression/CompressedSizeCalculator.h>
 #include <Compression/CompressionFactory.h>
 #include <Core/Defines.h>
@@ -12,11 +16,6 @@
 #include <Common/Exception.h>
 #include <Common/PODArray.h>
 #include <Common/SipHash.h>
-
-#include <algorithm>
-#include <array>
-#include <span>
-#include <string_view>
 
 
 namespace DB

--- a/src/Compression/CompressionCodecAdaptive.cpp
+++ b/src/Compression/CompressionCodecAdaptive.cpp
@@ -1,0 +1,165 @@
+#include <Compression/CompressionCodecAdaptive.h>
+
+#include <Compression/CompressedSizeCalculator.h>
+#include <Compression/CompressionFactory.h>
+#include <Core/Defines.h>
+#include <Core/TypeId.h>
+#include <DataTypes/IDataType.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/IAST.h>
+#include <Parsers/parseQuery.h>
+#include <base/defines.h>
+#include <Common/Exception.h>
+#include <Common/PODArray.h>
+#include <Common/SipHash.h>
+
+#include <algorithm>
+#include <array>
+#include <span>
+#include <string_view>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+struct CandidateGroup
+{
+    std::string_view codec_expr;
+    std::span<const TypeIndex> types;
+};
+
+constexpr std::array T64_TYPES = {
+    TypeIndex::Int8,   TypeIndex::Int16,     TypeIndex::Int32,     TypeIndex::Int64,      TypeIndex::UInt8,
+    TypeIndex::UInt16, TypeIndex::UInt32,    TypeIndex::UInt64,    TypeIndex::Enum8,      TypeIndex::Enum16,
+    TypeIndex::Date,   TypeIndex::Date32,    TypeIndex::DateTime,  TypeIndex::DateTime64, TypeIndex::Time,
+    TypeIndex::Time64, TypeIndex::Decimal32, TypeIndex::Decimal64, TypeIndex::IPv4,
+};
+
+/// Candidate codecs for the adaptive pool, grouped by codec expression.
+/// TODO: extend candidates as codecs as we see some proof they are faster than the default and can compress better.
+/// TODO: play around with chains to see if they are worth it (could be too slow). Until then, they are banned.
+constexpr std::array<CandidateGroup, 1> CANDIDATES = {{
+    {"T64", T64_TYPES}, /// T64 defaults to the byte flavour (over bit). Good: same size + faster [de]compression.
+}};
+
+/// Build the codec described by `expr` for `type` so type-aware codecs get the type they need.
+/// E.g. T64 derives its type_idx from it, to compress and to calculate its size.
+CompressionCodecPtr buildCodecForType(std::string_view expr, const IDataType & type)
+{
+    ParserCodec parser;
+    const String query = "(" + String(expr) + ")";
+    ASTPtr ast = parseQuery(parser, query, /*max_query_size=*/0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+    return CompressionCodecFactory::instance().get(ast, &type);
+}
+
+[[noreturn]] void throwMustNotBeInvokedDirectly()
+{
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "CompressionCodecAdaptive must not be invoked directly: it never appears on disk");
+}
+
+}
+
+Codecs AdaptiveCodec::poolForType(const IDataType & type, const CompressionCodecPtr & deployment_default)
+{
+    /// An encrypting default must not reach here as substituting a codec would drop the encryption. Must handle this in the caller.
+    if (deployment_default->isEncryption())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Adaptive codec pool must not be built from an encrypting default");
+
+    Codecs pool{CompressionCodecFactory::instance().get("NONE", {}), deployment_default};
+    const TypeIndex type_id = type.getTypeId();
+    for (const auto & [codec_expr, types] : CANDIDATES)
+        if (std::ranges::find(types, type_id) != types.end())
+            pool.push_back(buildCodecForType(codec_expr, type));
+    return pool;
+}
+
+VectorWithMemoryTracking<TypeIndex> AdaptiveCodec::candidateTypeIndexes()
+{
+    VectorWithMemoryTracking<TypeIndex> result;
+    for (const auto & group : CANDIDATES)
+        for (const TypeIndex type_id : group.types)
+            if (std::ranges::find(result, type_id) == result.end()) /// distinct: a type may appear in more than one group
+                result.push_back(type_id);
+    return result;
+}
+
+bool AdaptiveCodec::isCandidateType(const IDataType & type)
+{
+    const TypeIndex type_id = type.getTypeId();
+    for (const auto & group : CANDIDATES)
+        if (std::ranges::find(group.types, type_id) != group.types.end())
+            return true;
+    return false;
+}
+
+CompressionCodecPtr AdaptiveCodec::select(const Codecs & pool, const char * source, UInt32 source_size)
+{
+    chassert(!pool.empty());
+
+    PODArray<char> scratch;
+    size_t best_idx = 0;
+    UInt32 best_size = CompressedSizeCalculator::getCompressedBlockSize(*pool[0], source, source_size, scratch);
+
+    for (size_t i = 1; i < pool.size(); ++i)
+    {
+        const UInt32 size = CompressedSizeCalculator::getCompressedBlockSize(*pool[i], source, source_size, scratch);
+        const bool is_smaller = size < best_size;
+        best_idx = is_smaller ? i : best_idx;
+        best_size = is_smaller ? size : best_size;
+    }
+
+    return pool[best_idx];
+}
+
+CompressionCodecAdaptive::CompressionCodecAdaptive(const IDataType & type, const CompressionCodecPtr & deployment_default)
+    : pool(AdaptiveCodec::poolForType(type, deployment_default))
+{
+    chassert(!pool.empty());
+    setCodecDescription("Adaptive");
+}
+
+UInt32 CompressionCodecAdaptive::compress(const char * source, UInt32 source_size, char * dest) const
+{
+    CompressionCodecPtr winner = AdaptiveCodec::select(pool, source, source_size);
+    return winner->compress(source, source_size, dest);
+}
+
+UInt32 CompressionCodecAdaptive::getMaxCompressedDataSize(UInt32 uncompressed_size) const
+{
+    UInt32 max_reserve = 0;
+    for (const auto & codec : pool)
+        max_reserve = std::max(max_reserve, codec->getCompressedReserveSize(uncompressed_size));
+    return max_reserve;
+}
+
+void CompressionCodecAdaptive::updateHash(SipHash & hash) const
+{
+    getCodecDesc()->updateTreeHash(hash, /*ignore_aliases=*/true);
+    for (const auto & codec : pool)
+        codec->updateHash(hash);
+}
+
+uint8_t CompressionCodecAdaptive::getMethodByte() const
+{
+    throwMustNotBeInvokedDirectly();
+}
+
+UInt32 CompressionCodecAdaptive::doCompressData(const char *, UInt32, char *) const
+{
+    throwMustNotBeInvokedDirectly();
+}
+
+UInt32 CompressionCodecAdaptive::doDecompressData(const char *, UInt32, char *, UInt32) const
+{
+    throwMustNotBeInvokedDirectly();
+}
+
+}

--- a/src/Compression/CompressionCodecAdaptive.h
+++ b/src/Compression/CompressionCodecAdaptive.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <Compression/ICompressionCodec.h>
+#include <Core/TypeId.h>
+#include <Common/VectorWithMemoryTracking.h>
+
+namespace DB
+{
+
+class IDataType;
+
+
+/// Decision logic for adaptive CODEC(Default) resolution
+namespace AdaptiveCodec
+{
+
+/// Candidate codecs for `type`, in priority order. [0] is `NONE`: a block that no codec can shrink is stored uncompressed.
+/// [1] is the default codec, thus we get "no worse than the default" compression. Extra candidates come from a per-type table.
+Codecs poolForType(const IDataType & type, const CompressionCodecPtr & deployment_default);
+
+/// Pick the codec from `pool` whose compressed block is smallest.
+/// TODO: return the winner's compressed bytes alongside the codec so compress() can skip re-compressing when a codec that can't report its size cheaply wins.
+CompressionCodecPtr select(const Codecs & pool, const char * source, UInt32 source_size);
+
+/// The distinct types that can get a non-default codec.
+VectorWithMemoryTracking<TypeIndex> candidateTypeIndexes();
+
+/// Whether `type` has a candidate beyond `NONE` and the default. Only such types are wrapped: for the rest, selection would compress
+/// the default twice (once to measure, once to write) and could at best store a block raw, not worth the cost.
+/// TODO: once we save the compression result and reuse it, wrapping is free, wrap every type.
+bool isCandidateType(const IDataType & type);
+
+}
+
+/// Adaptive codec picks the smallest-output codec per block from a default codec + type-appropriate pool and delegates to it.
+/// On disk, each block carries the winner's method byte and reader decodes it with no knowledge of "adaptive".
+/// The wrapper itself never appears on disk.
+class CompressionCodecAdaptive final : public ICompressionCodec
+{
+public:
+    CompressionCodecAdaptive(const IDataType & type, const CompressionCodecPtr & deployment_default);
+
+    uint8_t getMethodByte() const override;
+    void updateHash(SipHash & hash) const override;
+
+    /// Selects the best codec for this block and delegates to it. The result carries the winner's method byte.
+    /// Runs on every block regardless of size. Selection cost scales with the block, so there is no small-block skip.
+    UInt32 compress(const char * source, UInt32 source_size, char * dest) const override;
+
+    bool isCompression() const override { return true; }
+    bool isGenericCompression() const override { return false; }
+    String getDescription() const override { return "Resolve CODEC(Default) to the best per-block codec from a type-appropriate pool."; }
+
+protected:
+    /// Max across all codecs in the pool. Exceeds `uncompressed_size` as this reserves the memory codecs need while compressing.
+    UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const override;
+
+    /// Adaptive never appears on disk: it self-describes each block via the winner's method byte, so these must never be invoked directly.
+    UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
+    UInt32 doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;
+
+private:
+    /// pool[0] is NONE, pool[1] is the deployment default
+    Codecs pool;
+};
+
+}

--- a/src/Compression/CompressionCodecMultiple.cpp
+++ b/src/Compression/CompressionCodecMultiple.cpp
@@ -151,6 +151,14 @@ bool CompressionCodecMultiple::isCompression() const
     return false;
 }
 
+bool CompressionCodecMultiple::isEncryption() const
+{
+    for (const auto & codec : codecs)
+        if (codec->isEncryption())
+            return true;
+    return false;
+}
+
 
 void registerCodecMultiple(CompressionCodecFactory & factory)
 {

--- a/src/Compression/CompressionCodecMultiple.h
+++ b/src/Compression/CompressionCodecMultiple.h
@@ -27,6 +27,7 @@ protected:
 
     bool isCompression() const override;
     bool isGenericCompression() const override { return false; }
+    bool isEncryption() const override;
 
     String getDescription() const override { return "Apply multiple codecs consecutively defined by user."; }
 

--- a/src/Compression/CompressionCodecNone.h
+++ b/src/Compression/CompressionCodecNone.h
@@ -17,8 +17,6 @@ public:
 
     void updateHash(SipHash & hash) const override;
 
-    std::optional<UInt32> tryGetCompressedSize(const char * /*source*/, UInt32 source_size) const override { return source_size; }
-
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
     UInt32 doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;

--- a/src/Compression/CompressionCodecNone.h
+++ b/src/Compression/CompressionCodecNone.h
@@ -17,6 +17,8 @@ public:
 
     void updateHash(SipHash & hash) const override;
 
+    std::optional<UInt32> tryGetCompressedSize(const char * /*source*/, UInt32 source_size) const override { return source_size; }
+
 protected:
     UInt32 doCompressData(const char * source, UInt32 source_size, char * dest) const override;
     UInt32 doDecompressData(const char * source, UInt32 source_size, char * dest, UInt32 uncompressed_size) const override;

--- a/src/Compression/CompressionFactory.cpp
+++ b/src/Compression/CompressionFactory.cpp
@@ -36,6 +36,19 @@ CompressionCodecPtr CompressionCodecFactory::getDefaultCodec() const
     return default_codec;
 }
 
+bool CompressionCodecFactory::isDefaultCodec(const ASTPtr & codec)
+{
+    /// No CODEC(...) clause: the default codec.
+    if (codec == nullptr)
+        return true;
+    /// CODEC(Default)
+    const auto * func = codec->as<ASTFunction>();
+    if (!func || func->name != "CODEC" || !func->arguments || func->arguments->children.size() != 1)
+        return false;
+    const auto * ident = func->arguments->children[0]->as<ASTIdentifier>();
+    return ident && ident->name() == DEFAULT_CODEC_NAME;
+}
+
 
 CompressionCodecPtr CompressionCodecFactory::get(const String & family_name, std::optional<int> level) const
 {

--- a/src/Compression/CompressionFactory.h
+++ b/src/Compression/CompressionFactory.h
@@ -46,6 +46,10 @@ public:
     /// Return default codec (currently LZ4)
     CompressionCodecPtr getDefaultCodec() const;
 
+    /// True if `codec` is the default codec: no CODEC clause (null), or a lone CODEC(Default).
+    /// A compound such as CODEC(Delta, Default) would return false.
+    static bool isDefaultCodec(const ASTPtr & codec);
+
     /// Validate codecs AST specified by user and parses codecs description (substitute default parameters)
     ASTPtr validateCodecAndGetPreprocessedAST(const ASTPtr & ast, const DataTypePtr & column_type, bool sanity_check, bool allow_experimental_codecs) const;
 

--- a/src/Compression/ICompressionCodec.h
+++ b/src/Compression/ICompressionCodec.h
@@ -45,7 +45,7 @@ public:
     UInt64 getHash() const;
 
     /// Compressed bytes from uncompressed source to dest. Dest should preallocate memory
-    UInt32 compress(const char * source, UInt32 source_size, char * dest) const;
+    virtual UInt32 compress(const char * source, UInt32 source_size, char * dest) const;
 
     /// Decompress bytes from compressed source to dest. Dest should preallocate memory;
     UInt32 decompress(const char * source, UInt32 source_size, char * dest) const;
@@ -115,7 +115,8 @@ protected:
     /// This is used for fuzz testing
     friend int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size);
 
-    /// Return size of compressed data without header
+    /// Upper bound on the compressed data size without the header. While compressing, a codec may temporarily write more bytes
+    /// into `dest` than its final result, so the bound covers those writes too and may exceed the actual compressed size.
     virtual UInt32 getMaxCompressedDataSize(UInt32 uncompressed_size) const { return uncompressed_size; }
 
     /// Actually compress data without header

--- a/src/Compression/tests/gtest_compression_codec_adaptive.cpp
+++ b/src/Compression/tests/gtest_compression_codec_adaptive.cpp
@@ -1,22 +1,24 @@
-#include <gtest/gtest.h>
-
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <vector>
 #include <Compression/CompressedSizeCalculator.h>
 #include <Compression/CompressionCodecAdaptive.h>
 #include <Compression/CompressionCodecMultiple.h>
 #include <Compression/CompressionFactory.h>
 #include <Compression/CompressionInfo.h>
 #include <Compression/ICompressionCodec.h>
+#include <Core/Defines.h>
 #include <Core/TypeId.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/IDataType.h>
+#include <Parsers/ExpressionElementParsers.h>
+#include <Parsers/IAST_fwd.h>
+#include <Parsers/parseQuery.h>
 #include <base/defines.h>
 #include <base/unaligned.h>
+#include <gtest/gtest.h>
 #include <Common/PODArray.h>
-
-#include <atomic>
-#include <cstring>
-#include <thread>
-#include <vector>
 
 using namespace DB;
 
@@ -141,6 +143,27 @@ TEST(AdaptiveCodecPool, MultipleCodecAggregatesEncryption)
     EXPECT_TRUE(factory.get("LZ4, AES_128_GCM_SIV")->isEncryption());
     EXPECT_FALSE(factory.get("LZ4")->isEncryption());
     EXPECT_FALSE(factory.get("LZ4, ZSTD")->isEncryption());
+}
+
+TEST(CompressionCodecFactory, IsDefaultCodec)
+{
+    const auto codec = [](const String & expr)
+    {
+        ParserCodec parser;
+        const String query = "(" + expr + ")";
+        ASTPtr parsed = parseQuery(parser, query, /*max_query_size=*/0, DBMS_DEFAULT_MAX_PARSER_DEPTH, DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+        return CompressionCodecFactory::instance().validateCodecAndGetPreprocessedAST(
+            parsed, /*column_type=*/nullptr, /*sanity_check=*/true, /*allow_experimental_codecs=*/false);
+    };
+
+    /// No CODEC clause resolves to the default codec.
+    EXPECT_TRUE(CompressionCodecFactory::isDefaultCodec(nullptr));
+    EXPECT_TRUE(CompressionCodecFactory::isDefaultCodec(codec("Default")));
+
+    /// Anything else is an explicit user choice, even a chain containing Default.
+    EXPECT_FALSE(CompressionCodecFactory::isDefaultCodec(codec("LZ4")));
+    EXPECT_FALSE(CompressionCodecFactory::isDefaultCodec(codec("ZSTD(3)")));
+    EXPECT_FALSE(CompressionCodecFactory::isDefaultCodec(codec("Delta, Default")));
 }
 
 TEST(AdaptiveCodecSelector, MonotonicNarrowIntegersPickT64)

--- a/src/Compression/tests/gtest_compression_codec_adaptive.cpp
+++ b/src/Compression/tests/gtest_compression_codec_adaptive.cpp
@@ -1,0 +1,321 @@
+#include <gtest/gtest.h>
+
+#include <Compression/CompressedSizeCalculator.h>
+#include <Compression/CompressionCodecAdaptive.h>
+#include <Compression/CompressionCodecMultiple.h>
+#include <Compression/CompressionFactory.h>
+#include <Compression/CompressionInfo.h>
+#include <Compression/ICompressionCodec.h>
+#include <Core/TypeId.h>
+#include <DataTypes/DataTypeFactory.h>
+#include <DataTypes/IDataType.h>
+#include <base/defines.h>
+#include <base/unaligned.h>
+#include <Common/PODArray.h>
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+using namespace DB;
+
+namespace
+{
+
+constexpr auto LZ4 = static_cast<uint8_t>(CompressionMethodByte::LZ4);
+constexpr auto T64 = static_cast<uint8_t>(CompressionMethodByte::T64);
+constexpr auto NONE = static_cast<uint8_t>(CompressionMethodByte::NONE);
+
+DataTypePtr type(const String & name)
+{
+    return DataTypeFactory::instance().get(name);
+}
+
+CompressionCodecPtr defaultCodec()
+{
+    return CompressionCodecFactory::instance().getDefaultCodec();
+}
+
+/// A constructible representative IDataType per scalar (codec-leaf) TypeIndex. Deliberately covers more than today's candidates.
+/// If someone makes one of these a candidate for a codec that rejects it, the drift guard builds it and the rejection is caught at once.
+/// Composite and wrapper types (Array, Tuple, Map, Nullable, ...) are never codec leaves, so they return nullptr.
+DataTypePtr representativeType(TypeIndex idx)
+{
+    switch (idx)
+    {
+        case TypeIndex::Int8: return type("Int8");
+        case TypeIndex::Int16: return type("Int16");
+        case TypeIndex::Int32: return type("Int32");
+        case TypeIndex::Int64: return type("Int64");
+        case TypeIndex::Int128: return type("Int128");
+        case TypeIndex::Int256: return type("Int256");
+        case TypeIndex::UInt8: return type("UInt8");
+        case TypeIndex::UInt16: return type("UInt16");
+        case TypeIndex::UInt32: return type("UInt32");
+        case TypeIndex::UInt64: return type("UInt64");
+        case TypeIndex::UInt128: return type("UInt128");
+        case TypeIndex::UInt256: return type("UInt256");
+        case TypeIndex::BFloat16: return type("BFloat16");
+        case TypeIndex::Float32: return type("Float32");
+        case TypeIndex::Float64: return type("Float64");
+        case TypeIndex::Decimal32: return type("Decimal(9, 2)");
+        case TypeIndex::Decimal64: return type("Decimal(18, 2)");
+        case TypeIndex::Decimal128: return type("Decimal(38, 2)");
+        case TypeIndex::Decimal256: return type("Decimal(76, 2)");
+        case TypeIndex::Date: return type("Date");
+        case TypeIndex::Date32: return type("Date32");
+        case TypeIndex::DateTime: return type("DateTime");
+        case TypeIndex::DateTime64: return type("DateTime64(3)");
+        case TypeIndex::Time: return type("Time");
+        case TypeIndex::Time64: return type("Time64(3)");
+        case TypeIndex::Enum8: return type("Enum8('a' = 1)");
+        case TypeIndex::Enum16: return type("Enum16('a' = 1)");
+        case TypeIndex::String: return type("String");
+        case TypeIndex::FixedString: return type("FixedString(16)");
+        case TypeIndex::UUID: return type("UUID");
+        case TypeIndex::IPv4: return type("IPv4");
+        case TypeIndex::IPv6: return type("IPv6");
+        default: return nullptr;
+    }
+}
+
+/// Serialize values to a little-endian byte buffer, the way the codecs read them back.
+template <typename T>
+std::vector<char> bytesOf(const std::vector<T> & values)
+{
+    std::vector<char> bytes(values.size() * sizeof(T));
+    char * pos = bytes.data();
+    for (const T value : values)
+    {
+        unalignedStoreLittleEndian<T>(pos, value);
+        pos += sizeof(T);
+    }
+    return bytes;
+}
+
+}
+
+TEST(AdaptiveCodecPool, EachCandidateTypeBuildsWithDefaultAnchor)
+{
+    /// Drift guard. Every candidate must build for its type (naming a codec the type cannot take would otherwise throw at write time).
+    for (const TypeIndex idx : AdaptiveCodec::candidateTypeIndexes())
+    {
+        const DataTypePtr t = representativeType(idx);
+        ASSERT_NE(t, nullptr) << "no representative type for candidate TypeIndex " << static_cast<int>(idx)
+                              << " -- add a case to representativeType()";
+
+        Codecs pool;
+        ASSERT_NO_THROW(pool = AdaptiveCodec::poolForType(*t, defaultCodec())) << "TypeIndex " << static_cast<int>(idx);
+        EXPECT_EQ(pool[0]->getMethodByte(), NONE) << "TypeIndex " << static_cast<int>(idx); /// NONE is always [0]
+        EXPECT_EQ(pool[1].get(), defaultCodec().get()) << "TypeIndex " << static_cast<int>(idx); /// default is always [1]
+        EXPECT_GE(pool.size(), 3u) << "TypeIndex " << static_cast<int>(idx);
+    }
+}
+
+TEST(AdaptiveCodecPool, RepresentativeTypesMatchTheirIndex)
+{
+    for (int i = 0; i < 256; ++i)
+    {
+        const auto idx = static_cast<TypeIndex>(i);
+        if (const DataTypePtr t = representativeType(idx))
+            EXPECT_EQ(t->getTypeId(), idx) << "representativeType built the wrong type for TypeIndex " << i;
+    }
+}
+
+TEST(AdaptiveCodecPool, NonCandidateTypesGetNoneAndDefaultOnly)
+{
+    for (const auto * name : {"Int128", "UInt256", "Decimal(38, 2)", "String", "Float32", "Float64", "UUID"})
+    {
+        auto pool = AdaptiveCodec::poolForType(*type(name), defaultCodec());
+        EXPECT_EQ(pool.size(), 2u) << "type " << name;
+        EXPECT_EQ(pool[0]->getMethodByte(), NONE) << "type " << name;
+        EXPECT_EQ(pool[1].get(), defaultCodec().get()) << "type " << name;
+    }
+}
+
+TEST(AdaptiveCodecPool, MultipleCodecAggregatesEncryption)
+{
+    auto & factory = CompressionCodecFactory::instance();
+    EXPECT_TRUE(factory.get("AES_128_GCM_SIV")->isEncryption());
+    EXPECT_TRUE(factory.get("LZ4, AES_128_GCM_SIV")->isEncryption());
+    EXPECT_FALSE(factory.get("LZ4")->isEncryption());
+    EXPECT_FALSE(factory.get("LZ4, ZSTD")->isEncryption());
+}
+
+TEST(AdaptiveCodecSelector, MonotonicNarrowIntegersPickT64)
+{
+    std::vector<UInt32> values(100000);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<UInt32>(i);
+    auto bytes = bytesOf(values);
+
+    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
+    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
+    EXPECT_EQ(winner->getMethodByte(), T64);
+}
+
+TEST(AdaptiveCodecSelector, RepeatingWideValuesPickDefault)
+{
+    /// A short pattern of full-range values, repeated: LZ4 crushes the repetition, but T64 sees a wide min/max cannot shrink it.
+    const std::vector<UInt32> pattern = {0u, 0xFFFFFFFFu, 0x0F0F0F0Fu, 0xF0F0F0F0u, 0x12345678u, 0x9ABCDEF0u, 0xDEADBEEFu, 0xCAFEBABEu};
+    std::vector<UInt32> values(100000);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = pattern[i % pattern.size()];
+    auto bytes = bytesOf(values);
+
+    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
+    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
+    EXPECT_EQ(winner->getMethodByte(), LZ4);
+}
+
+TEST(AdaptiveCodecSelector, ConstantColumnPicksT64)
+{
+    std::vector<UInt32> values(100000, 42u);
+    auto bytes = bytesOf(values);
+
+    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
+    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
+    EXPECT_EQ(winner->getMethodByte(), T64);
+}
+
+TEST(AdaptiveCodecSelector, TieGoesToEarliestCandidate)
+{
+    /// Two distinct but identical codecs produce the same size, the earliest must win (strict <).
+    auto lz4a = CompressionCodecFactory::instance().get("LZ4", {});
+    auto lz4b = CompressionCodecFactory::instance().get("LZ4", {});
+    ASSERT_NE(lz4a.get(), lz4b.get());
+    Codecs pool = {lz4a, lz4b};
+
+    std::vector<UInt32> values(1000);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<UInt32>(i * 7);
+    auto bytes = bytesOf(values);
+
+    auto winner = AdaptiveCodec::select(pool, bytes.data(), static_cast<UInt32>(bytes.size()));
+    EXPECT_EQ(winner.get(), lz4a.get());
+    EXPECT_NE(winner.get(), lz4b.get());
+}
+
+TEST(CompressionCodecAdaptive, CompressRoundTripsViaWinnerByte)
+{
+    std::vector<UInt32> values(100000);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<UInt32>(i);
+    auto bytes = bytesOf(values);
+    const UInt32 size = static_cast<UInt32>(bytes.size());
+
+    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
+
+    PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
+    const UInt32 encoded_size = adaptive.compress(bytes.data(), size, encoded.data());
+
+    const uint8_t method = ICompressionCodec::readMethod(encoded.data());
+    EXPECT_EQ(method, T64); /// monotonic integers -> T64 wins
+
+    /// Decode exactly as a normal reader would: look the codec up by the on-disk method byte.
+    auto decoder = CompressionCodecFactory::instance().get(method);
+    PODArray<char> decoded(size);
+    const UInt32 decoded_size = decoder->decompress(encoded.data(), encoded_size, decoded.data());
+    ASSERT_EQ(decoded_size, size);
+    EXPECT_EQ(0, memcmp(decoded.data(), bytes.data(), size));
+}
+
+TEST(CompressionCodecAdaptive, TinyBlockStoredRaw)
+{
+    /// 16 bytes: every compressing candidate's framing alone exceeds the raw bytes, so NONE wins.
+    std::vector<UInt32> values(4);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<UInt32>(i);
+    auto bytes = bytesOf(values);
+    const UInt32 size = static_cast<UInt32>(bytes.size());
+
+    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
+
+    PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
+    adaptive.compress(bytes.data(), size, encoded.data());
+    EXPECT_EQ(ICompressionCodec::readMethod(encoded.data()), NONE);
+}
+
+TEST(CompressionCodecAdaptive, HashHasOwnNamespace)
+{
+    /// getHash() identifies the codec when the Compact writer groups column streams. CompressionCodecAdaptive and CompressionCodecMultiple
+    /// fold their children's hashes the same way, so the leading "Adaptive" descriptor is what keeps the two distinct.
+    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
+    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
+    ASSERT_EQ(pool.size(), 3u);
+    CompressionCodecMultiple multiple(pool);
+    EXPECT_NE(adaptive.getHash(), multiple.getHash());
+
+    CompressionCodecAdaptive adaptive_string(*type("String"), defaultCodec());
+    EXPECT_NE(adaptive_string.getHash(), defaultCodec()->getHash());
+
+    CompressionCodecAdaptive adaptive_int64(*type("Int64"), defaultCodec());
+    EXPECT_NE(adaptive.getHash(), adaptive_int64.getHash());
+}
+
+TEST(CompressionCodecAdaptive, DirectInvocationThrows)
+{
+#ifdef DEBUG_OR_SANITIZER_BUILD
+    GTEST_SKIP() << "this test triggers LOGICAL_ERROR, runs only if DEBUG_OR_SANITIZER_BUILD is not defined";
+#else
+    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
+    /// Adaptive never appears on disk, so the public method byte accessor must reject direct use.
+    EXPECT_ANY_THROW(adaptive.getMethodByte());
+#endif
+}
+
+TEST(CompressionCodecAdaptive, ConcurrentCompressIsThreadSafe)
+{
+    CompressionCodecAdaptive adaptive(*type("UInt32"), defaultCodec());
+
+    constexpr size_t num_threads = 8;
+    std::vector<std::thread> threads;
+    std::atomic<bool> ok{true};
+    for (size_t t = 0; t < num_threads; ++t)
+    {
+        threads.emplace_back(
+            [&adaptive, t, &ok]()
+            {
+                std::vector<UInt32> values(10000);
+                for (size_t i = 0; i < values.size(); ++i)
+                    values[i] = static_cast<UInt32>(i + t); /// per-thread distinct buffer
+                auto bytes = bytesOf(values);
+                const UInt32 size = static_cast<UInt32>(bytes.size());
+
+                PODArray<char> encoded(adaptive.getCompressedReserveSize(size));
+                const UInt32 encoded_size = adaptive.compress(bytes.data(), size, encoded.data());
+
+                auto decoder = CompressionCodecFactory::instance().get(ICompressionCodec::readMethod(encoded.data()));
+                PODArray<char> decoded(size);
+                if (decoder->decompress(encoded.data(), encoded_size, decoded.data()) != size
+                    || memcmp(decoded.data(), bytes.data(), size) != 0)
+                    ok = false;
+            });
+    }
+    for (auto & th : threads)
+        th.join();
+    EXPECT_TRUE(ok);
+}
+
+TEST(GetCompressedBlockSize, CalculateMatchesCompressForT64)
+{
+    std::vector<UInt32> values(50000);
+    for (size_t i = 0; i < values.size(); ++i)
+        values[i] = static_cast<UInt32>(i);
+    auto bytes = bytesOf(values);
+    const UInt32 size = static_cast<UInt32>(bytes.size());
+
+    auto pool = AdaptiveCodec::poolForType(*type("UInt32"), defaultCodec());
+    ASSERT_EQ(pool.size(), 3u);
+    const auto & t64 = pool[2];
+    ASSERT_EQ(t64->getMethodByte(), T64);
+
+    PODArray<char> scratch;
+    const UInt32 calculated = CompressedSizeCalculator::getCompressedBlockSize(*t64, bytes.data(), size, scratch);
+
+    /// Re-derive size from a real compress: calculation must match exactly
+    PODArray<char> encoded(t64->getCompressedReserveSize(size));
+    const UInt32 actual = t64->compress(bytes.data(), size, encoded.data());
+    EXPECT_EQ(calculated, actual);
+}


### PR DESCRIPTION
`CompressionCodecAdaptive` picks the smallest-output codec for each block from a pool (`NONE`, the deployment default, and type-appropriate candidates) and compresses the block with it. Candidates are priced by `CompressedSizeCalculator` (#109054). A codec that can compute its compressed size is priced without compressing, the rest compress into scratch and are measured. The winner's method byte lands on disk, so readers decode each block with no knowledge of the wrapper.

This is the selection core of the RFC (#105404): how `CODEC(Default)` resolves per block. Nothing constructs the codec yet, a follow-up wires it into merges and mutations behind an experimental setting.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.98` (included in `26.8` and later)
<!-- ch-version-info:end -->