### PR TITLE
Fix flaky 02346_text_index_parallel_replicas

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
+++ b/tests/queries/0_stateless/02346_text_index_parallel_replicas.sql
@@ -11,6 +11,10 @@ SET enable_analyzer = 1;
 -- With small index granularity, the amount of rows left to read after the index analysis might be too small to utilize parallel replicas. So, we set it to 0.
 SET parallel_replicas_min_number_of_rows_per_replica = 0;
 
+-- TextIndexUsedEmbeddedPostings only increments on a tokens-cache miss (the token infos are read from
+-- disk). With the global cache warm the probe below reads 0 and the test flaps, so read tokens from disk.
+SET use_text_index_tokens_cache = 0;
+
 DROP TABLE IF EXISTS tab;
 
 CREATE TABLE tab


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110057
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `02346_text_index_parallel_replicas` (2 head=master failures in the last 5 days: `Stateless tests (arm_binary, parallel)` @ 2ef6d104, and one host-OOM run that is unrelated).

The final probe asserts `sum(ProfileEvents['TextIndexUsedEmbeddedPostings']) > 0`. That counter is incremented only in `TextIndexSerialization::deserializeTokenInfo` (`MergeTreeIndexText.cpp`), which runs on a tokens-cache miss. `fillTokensFromCache` serves search tokens from the global `TextIndexTokensCache` on a hit and skips deserialization, so once the cache is warm the counter stays 0 and the probe reads `1 0` instead of `1 1`. On a shared CI server the cache is warmed by a prior query (a retry, a previous run of this test, or another text index test), which is why CI re-ran the failing case 112/112 PASS ("not reproducible").

Reading tokens from disk (`use_text_index_tokens_cache = 0`) makes the counter deterministic without weakening the check: the test still verifies embedded postings are used under parallel replicas. Reproduced locally deterministically (50/50 fail on a warm cache; 0/50 with the fix). The setting is already used the same way by sibling text index tests.

Requested in https://github.com/ClickHouse/ClickHouse/pull/110057.
