### PR TITLE
Add test that Remote/RemoteSecure storage engines respect remote_url_allow_hosts

### DIFF
--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -318,3 +318,36 @@ def test_table_function_remote(start_cluster):
             "SELECT * FROM remote('localhost:800', system, metrics)"
         )
     )
+
+
+def test_storage_engine_remote(start_cluster):
+    # The persistent Remote/RemoteSecure engines must enforce remote_url_allow_hosts, like the
+    # remote/remoteSecure table functions: the check runs at CREATE time, before any connection.
+    for engine in ["Remote", "RemoteSecure"]:
+        # Disallowed host: rejected with UNACCEPTABLE_URL.
+        assert "not allowed in configuration file" in node6.query_and_get_error(
+            f"CREATE TABLE test_remote_engine (dummy UInt8) ENGINE = {engine}('example01-01-3', system, one)"
+        )
+        # A glob that expands to an allowed and a disallowed host is rejected: every expanded host
+        # is checked, not only the first one.
+        assert "not allowed in configuration file" in node6.query_and_get_error(
+            f"CREATE TABLE test_remote_engine (dummy UInt8) ENGINE = {engine}('example01-01-{{1,3}}', system, one)"
+        )
+        # Allowed host, but a disallowed explicit port is still rejected.
+        assert (
+            'URL "localhost:800" is not allowed in configuration file'
+            in node6.query_and_get_error(
+                f"CREATE TABLE test_remote_engine (dummy UInt8) ENGINE = {engine}('localhost:800', system, one)"
+            )
+        )
+        # Allowed host: the table is created (system.tables reports it as Distributed).
+        node6.query(
+            f"CREATE TABLE test_remote_engine (dummy UInt8) ENGINE = {engine}('example01-01-1', system, one)"
+        )
+        assert (
+            node6.query(
+                "SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = 'test_remote_engine'"
+            ).strip()
+            == "Distributed"
+        )
+        node6.query("DROP TABLE test_remote_engine")


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106189
Related: https://github.com/ClickHouse/ClickHouse/pull/108507
-->

Related: #106189

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #106189 (Remote/RemoteSecure storage engines): add a regression test proving the engines honor `remote_url_allow_hosts`, requested in that PR.

The engines already enforce it: `registerStorageRemote` and the `remote`/`remoteSecure` table functions share `parseRemoteFunctionArguments`, whose ad-hoc-cluster branch calls `getRemoteHostFilter().checkHostAndPort(...)` for every parsed host. For the engines this runs during `CREATE`, so a disallowed host is rejected with `UNACCEPTABLE_URL` before the table is created. There was no test covering this, so this PR adds one.

`test_allowed_url_from_config/test.py::test_storage_engine_remote` reuses the existing `node6` (restrictive `remote_url_allow_hosts`) and, for both `Remote` and `RemoteSecure`, asserts that a disallowed host, a glob expanding to a disallowed host, and a disallowed port are all rejected, while an allowed host creates the table. It is an integration test because `remote_url_allow_hosts` is a server-config setting and cannot be set per query.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1268` (included in `26.7` and later)
<!-- ch-version-info:end -->