### PR TITLE
Compute async-insert deduplication data hash once instead of per partition

### DIFF
--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -345,6 +345,20 @@ UInt128 DeduplicationInfo::calculateDataHashColumnWise(size_t offset, const Bloc
 }
 
 
+void DeduplicationInfo::prewarmDataHashes() const
+{
+    if (disabled || !original_block || original_block->empty())
+        return;
+
+    for (size_t offset = 0; offset < offsets.size(); ++offset)
+    {
+        /// User-token tokens never hash the data (getBlockUnifiedHash), so skip them.
+        if (tokens[offset].by_user.empty())
+            calculateDataHashColumnWise(offset, *original_block);
+    }
+}
+
+
 DeduplicationHash DeduplicationInfo::getBlockUnifiedHash(size_t offset, const std::string & partition_id) const
 {
     // when there is no user token, compute the full column-wise hash of the data

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -64,6 +64,7 @@ protected:
     /// src/Storages/MergeTree/tests/gtest_async_inserts.cpp
     friend std::vector<Int64> testSelfDeduplicate(std::vector<Int64> data, std::vector<size_t> offsets, std::vector<String> hashes);
     friend std::vector<String> testSelfDeduplicateStrings(std::vector<String> data, std::vector<size_t> offsets, std::vector<String> hashes);
+    friend std::vector<bool> testPrewarmDataHashes(std::vector<Int64> data, std::vector<size_t> offsets, std::vector<String> hashes);
 
 public:
     using Ptr = std::shared_ptr<DeduplicationInfo>;
@@ -92,6 +93,10 @@ public:
     FilterResult deduplicateBlock(const std::vector<std::string> & existing_block_ids, const std::string & partition_id, ContextPtr context) const;
 
     std::vector<DeduplicationHash> getDeduplicationHashes(const std::string & partition_id, bool deduplication_enabled) const;
+
+    /// Cache the partition-independent per-token data hashes once, so per-partition
+    /// clones reuse them (via the copy ctor) instead of recomputing per partition.
+    void prewarmDataHashes() const;
 
     size_t getCount() const;
     size_t getRows() const;

--- a/src/Storages/MergeTree/MergeTreeSink.cpp
+++ b/src/Storages/MergeTree/MergeTreeSink.cpp
@@ -115,6 +115,11 @@ void MergeTreeSink::consume(Chunk & chunk)
 
     auto process_list_element = context->getProcessListElement();
 
+    /// Warm the data hashes once here: the per-partition clones below share this object's
+    /// tokens via the copy ctor, so they reuse the cache instead of rehashing per partition.
+    if (deduplicate)
+        deduplication_info->prewarmDataHashes();
+
     for (auto & current_block : part_blocks)
     {
         /// A single INSERT can split into very many parts (e.g. high-cardinality partition key with

--- a/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeSink.cpp
@@ -299,6 +299,11 @@ void ReplicatedMergeTreeSink::consume(Chunk & chunk)
     size_t total_streams = 0;
     bool support_parallel_write = false;
 
+    /// Warm the data hashes once here: the per-partition clones below share this object's
+    /// tokens via the copy ctor, so they reuse the cache instead of rehashing per partition.
+    if (deduplicate)
+        deduplication_info->prewarmDataHashes();
+
     for (auto & current_block : part_blocks)
     {
         Stopwatch watch;

--- a/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
+++ b/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
@@ -136,4 +136,84 @@ TEST(AsyncInsertsTest, testSelfDeduplicateStrings)
     test_impl({"ab","c","a","bc"},{2,4},{"",""},{"ab","c","a","bc"});
 }
 
+
+/// Build a DeduplicationInfo with the given tokens and return, per token,
+/// {cold before prewarm, warm after prewarm on the original, warm on a fresh cloneSelf()}.
+/// An empty hash string means "no user token" (data hash is used). This exercises the
+/// per-partition reuse: the sinks clone the original once per partition, so a warm original
+/// must make every clone inherit the cache instead of rehashing.
+std::vector<bool> testPrewarmDataHashes(std::vector<Int64> data, std::vector<size_t> offsets, std::vector<String> hashes)
+{
+    MutableColumnPtr column = DataTypeInt64().createColumn();
+    for (auto datum : data)
+        column->insert(datum);
+    Block block({ColumnWithTypeAndName(std::move(column), DataTypePtr(new DataTypeInt64()), "a")});
+
+    auto deduplication_info = DeduplicationInfo::create(true);
+    deduplication_info->setRootViewID({});
+    deduplication_info->disabled = false; // there is no insert dependencies instance in this test
+    deduplication_info->updateOriginalBlock(Chunk(block.getColumns(), block.rows()), std::make_shared<const Block>(block.cloneEmpty()));
+
+    chassert(offsets.size() == hashes.size());
+    chassert(!offsets.empty());
+
+    deduplication_info->setUserToken(hashes[0], offsets[0]);
+    for (size_t i = 1; i < offsets.size(); ++i)
+        deduplication_info->setUserToken(hashes[i], offsets[i] - offsets[i - 1]);
+
+    chassert(offsets.size() == deduplication_info->getCount());
+
+    std::vector<bool> result;
+    result.reserve(hashes.size() * 3);
+
+    /// (a) cold before prewarm
+    for (size_t i = 0; i < hashes.size(); ++i)
+        result.push_back(deduplication_info->tokens[i].data_hash_batch.has_value());
+
+    deduplication_info->prewarmDataHashes();
+
+    /// (b) warm on the original after prewarm
+    for (size_t i = 0; i < hashes.size(); ++i)
+        result.push_back(deduplication_info->tokens[i].data_hash_batch.has_value());
+
+    /// (c) warm on a fresh clone (per-partition clones must inherit the cache)
+    auto clone = deduplication_info->cloneSelf();
+    for (size_t i = 0; i < hashes.size(); ++i)
+        result.push_back(clone->tokens[i].data_hash_batch.has_value());
+
+    return result;
+}
+
+TEST(AsyncInsertsTest, testPrewarmDataHashes)
+{
+    /// Three no-user-token tokens (getCount() > 1): all cold before, all warm after, clone inherits.
+    {
+        auto r = testPrewarmDataHashes({1, 2, 3, 4, 5, 6}, {2, 4, 6}, {"", "", ""});
+        ASSERT_EQ(r, (std::vector<bool>{
+            false, false, false, // cold before
+            true,  true,  true,  // warm after prewarm
+            true,  true,  true})); // clone inherits the warm cache
+    }
+    /// Mixed: user-token tokens must NOT be warmed (they never hash the data); only the
+    /// data tokens get cached, and the clone inherits exactly that set.
+    {
+        auto r = testPrewarmDataHashes({1, 2, 3, 4, 5, 6}, {2, 4, 6}, {"u", "", "u"});
+        ASSERT_EQ(r, (std::vector<bool>{
+            false, false, false,
+            false, true,  false,
+            false, true,  false}));
+    }
+    /// A single no-user-token token that spans several partitions is rehashed once per
+    /// partition on the commit path, so it must be warmed too (getCount()==1 is in scope).
+    {
+        auto r = testPrewarmDataHashes({1, 2, 3}, {3}, {""});
+        ASSERT_EQ(r, (std::vector<bool>{false, true, true}));
+    }
+    /// A single user-token token has nothing to warm (data hash is never used).
+    {
+        auto r = testPrewarmDataHashes({1, 2, 3}, {3}, {"u"});
+        ASSERT_EQ(r, (std::vector<bool>{false, false, false}));
+    }
+}
+
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111147
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111147

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Speed up deduplication of async inserts that span multiple partitions. The per-token data hash is now computed once instead of once per partition, so a single async insert covering `P` partitions no longer recomputes the column-wise hash `P` times.


### Description

Reported in #111147. Self-deduplication of an async insert that spans several partitions recomputed the full column-wise data hash for every partition, making the deduplication step scale as `O(P * N)` (P = partitions, N = tokens). The reporter observed 39s in `DuplicationElapsedMicroseconds` for one wide multi-partition async insert.

Root cause: both `MergeTreeSink::consume` and `ReplicatedMergeTreeSink::consume` clone the shared `DeduplicationInfo` per partition and self-deduplicate each clone. The data hash is cached in `data_hash_batch`, but it was filled on the per-partition clone, which is discarded after the partition; the original object that is re-cloned for the next partition stayed cold, so the expensive `SipHash` ran again for every partition.

The data hash is partition-independent (`partition_id` is only stamped onto the returned hash, never folded into `data_hash_batch`), and the copy constructor already propagates the cache and shares `original_block`. So this warms the hashes once, before the partition loop, via a new `DeduplicationInfo::prewarmDataHashes()`; each per-partition clone then inherits the warm cache and the data hashing becomes `O(N)`. This covers the single-token case too: a lone data token that spans P partitions was otherwise rehashed once per partition on the commit path. The warm-up is gated by the sink's `deduplicate` flag and skips user-token tokens (which never hash the data).

Block ids and deduplication decisions are unchanged: the cached hash is identical whether computed early or lazily. Added a unit test (`AsyncInsertsTest.testPrewarmDataHashes`) asserting the original is warmed once, a per-partition clone inherits the cache, user-token tokens are not hashed, and a single data token is warmed while a single user token is not.

Complementary to #111049 (async-insert partition token bleed); this change is independent and based on current master.
