### PR TITLE
Don't copy the file-info manifest in BackupsWorker::writeBackupEntries

### DIFF
--- a/src/Backups/BackupCoordinationFileInfos.cpp
+++ b/src/Backups/BackupCoordinationFileInfos.cpp
@@ -24,12 +24,17 @@ void BackupCoordinationFileInfos::addFileInfos(BackupFileInfos && file_infos_, c
     file_infos.emplace(host_id_, std::move(file_infos_));
 }
 
-BackupFileInfos BackupCoordinationFileInfos::getFileInfos(const String & host_id_) const
+const BackupFileInfos & BackupCoordinationFileInfos::getFileInfos(const String & host_id_) const
 {
     prepare();
     auto it = file_infos.find(host_id_);
     if (it == file_infos.end())
-        return {};
+    {
+        static const BackupFileInfos empty;
+        return empty;
+    }
+    /// Safe to return by reference: after prepare() the per-host vectors are never mutated (addFileInfos() throws
+    /// once prepared), and file_infos_for_all_hosts already holds raw pointers into them.
     return it->second;
 }
 

--- a/src/Backups/BackupCoordinationFileInfos.h
+++ b/src/Backups/BackupCoordinationFileInfos.h
@@ -38,7 +38,8 @@ public:
     void addFileInfos(BackupFileInfos && file_infos, const String & host_id);
 
     /// Returns file infos for the specified host after preparation.
-    BackupFileInfos getFileInfos(const String & host_id) const;
+    /// Returned by reference; the referenced storage is immutable after prepare() (see addFileInfos()).
+    const BackupFileInfos & getFileInfos(const String & host_id) const;
 
     /// Iterates the file infos of all hosts in place, without copying them into a vector.
     void forEachFileInfoForAllHosts(const std::function<void(const BackupFileInfo &)> & callback) const;

--- a/src/Backups/BackupCoordinationLocal.cpp
+++ b/src/Backups/BackupCoordinationLocal.cpp
@@ -110,7 +110,7 @@ void BackupCoordinationLocal::addFileInfos(BackupFileInfos && file_infos_)
     file_infos.addFileInfos(std::move(file_infos_), "");
 }
 
-BackupFileInfos BackupCoordinationLocal::getFileInfos() const
+const BackupFileInfos & BackupCoordinationLocal::getFileInfos() const
 {
     std::lock_guard lock{file_infos_mutex};
     return file_infos.getFileInfos("");

--- a/src/Backups/BackupCoordinationLocal.h
+++ b/src/Backups/BackupCoordinationLocal.h
@@ -62,7 +62,7 @@ public:
     String getKeeperMapDataPath(const String & table_zookeeper_root_path) const override;
 
     void addFileInfos(BackupFileInfos && file_infos) override;
-    BackupFileInfos getFileInfos() const override;
+    const BackupFileInfos & getFileInfos() const override;
     void forEachFileInfoForAllHosts(const std::function<void(const BackupFileInfo &)> & callback) const override;
     bool startWritingFile(size_t data_file_index) override;
 

--- a/src/Backups/BackupCoordinationOnCluster.cpp
+++ b/src/Backups/BackupCoordinationOnCluster.cpp
@@ -768,7 +768,7 @@ void BackupCoordinationOnCluster::addFileInfos(BackupFileInfos && file_infos_)
     serializeToMultipleZooKeeperNodes(zookeeper_path + "/file_infos/" + current_host, file_infos_str, "addFileInfos");
 }
 
-BackupFileInfos BackupCoordinationOnCluster::getFileInfos() const
+const BackupFileInfos & BackupCoordinationOnCluster::getFileInfos() const
 {
     auto component_guard = Coordination::setCurrentComponent("BackupCoordinationOnCluster::getFileInfos");
     std::lock_guard lock{file_infos_mutex};

--- a/src/Backups/BackupCoordinationOnCluster.h
+++ b/src/Backups/BackupCoordinationOnCluster.h
@@ -78,7 +78,7 @@ public:
     String getKeeperMapDataPath(const String & table_zookeeper_root_path) const override;
 
     void addFileInfos(BackupFileInfos && file_infos) override;
-    BackupFileInfos getFileInfos() const override;
+    const BackupFileInfos & getFileInfos() const override;
     void forEachFileInfoForAllHosts(const std::function<void(const BackupFileInfo &)> & callback) const override;
     bool startWritingFile(size_t data_file_index) override;
 

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -772,7 +772,7 @@ void BackupsWorker::writeBackupEntries(
     LOG_TRACE(log, "{}, num backup entries={}", Stage::WRITING_BACKUP, backup_entries.size());
     backup_coordination->setStage(Stage::WRITING_BACKUP, "", /* sync = */ true);
 
-    auto file_infos = backup_coordination->getFileInfos();
+    const auto & file_infos = backup_coordination->getFileInfos();
     if (file_infos.size() != backup_entries.size())
     {
         throw Exception(

--- a/src/Backups/IBackupCoordination.h
+++ b/src/Backups/IBackupCoordination.h
@@ -109,7 +109,10 @@ public:
     /// Adds file information.
     /// If specified checksum+size are new for this IBackupContentsInfo the function sets `is_data_file_required`.
     virtual void addFileInfos(BackupFileInfos && file_infos) = 0;
-    virtual BackupFileInfos getFileInfos() const = 0;
+    /// Returns the file infos of the current host by reference to avoid copying them (a backup can contain millions).
+    /// The reference is valid until the coordination is destroyed. It must only be called after file collection has
+    /// finished (i.e. no more addFileInfos()), because the referenced storage is immutable only after preparation.
+    virtual const BackupFileInfos & getFileInfos() const = 0;
 
     /// Iterates the file infos of all hosts in place, without copying them into a vector
     /// (a backup can contain millions).


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/109861
https://github.com/ClickHouse/clickhouse-private/issues/62693

`BackupsWorker::writeBackupEntries` got the current host's file-info list from `IBackupCoordination::getFileInfos()` **by value** — a deep copy of the whole manifest, large for backups with millions of files, though only read-only indexed access is needed. Return it by `const` reference instead: the storage is owned by the coordination and immutable after preparation, so the reference stays valid for the write phase.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced peak memory usage of `BACKUP` by no longer copying the internal list of file infos when writing backup entries (significant for backups containing millions of files).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1306` (included in `26.7` and later)
- Backported to: `26.6.3.22`
<!-- ch-version-info:end -->