### PR TITLE
Fix flaky 03630_benchmark_accept_invalid_certificate (SOCKET_TIMEOUT)

### DIFF
--- a/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.sh
+++ b/tests/queries/0_stateless/03630_benchmark_accept_invalid_certificate.sh
@@ -9,11 +9,16 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 config_path=$(mktemp "$CUR_DIR/$(basename "${BASH_SOURCE[0]}" ".sh")-XXXXXX.yaml")
 touch $config_path
 
-$CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure |& grep -m1 -F -o -e "certificate verify failed" || {
+# Give the TLS handshake a generous budget: the default 10 s connect_timeout /
+# handshake_timeout_ms can fire on slow lanes (amd_tsan, s3, parallel) before
+# certificate verification runs, leaking a SOCKET_TIMEOUT into the output.
+BENCHMARK_TIMEOUTS="--connect_timeout 60 --handshake_timeout_ms 60000"
+
+$CLICKHOUSE_BENCHMARK $BENCHMARK_TIMEOUTS --config $config_path -q "select 1" -i 1 --secure |& grep -m1 -F -o -e "certificate verify failed" || {
   echo "--secure should require --accept-invalid-certificate" >&2
-  $CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure >&2
+  $CLICKHOUSE_BENCHMARK $BENCHMARK_TIMEOUTS --config $config_path -q "select 1" -i 1 --secure >&2
 }
-$CLICKHOUSE_BENCHMARK --config $config_path -q "select 1" -i 1 --secure --accept-invalid-certificate |& grep -F -e Exception
+$CLICKHOUSE_BENCHMARK $BENCHMARK_TIMEOUTS --config $config_path -q "select 1" -i 1 --secure --accept-invalid-certificate |& grep -F -e Exception
 
 rm -f "${config_path:?}"
 exit 0


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/100332
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Stabilize flaky `03630_benchmark_accept_invalid_certificate`.

`clickhouse-benchmark` uses the default `handshake_timeout_ms = 10000` (10 s). On slow lanes (amd_tsan, s3, parallel) the TLS handshake to the secure port can exceed 10 s, so the client aborts with `Code: 209 ... (SOCKET_TIMEOUT)` before certificate verification runs: the first invocation loses its expected `certificate verify failed` line, and the SOCKET_TIMEOUT text trips `grep Exception` in the second. `Server died` is the harness verdict from the same slow window, not a crash.

Fix: add `--connect_timeout 60 --handshake_timeout_ms 60000` to the benchmark invocations, as done for `01600_benchmark_query` (#108570) and `03636_benchmark_error_messages` (#103298, #103668). Same assertions preserved (`--secure` still requires `--accept-invalid-certificate`); verified 50/50 against a local TLS server.

Reported on #100332 by @alexey-milovidov. CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100332&sha=2e8002b9b58bff2f4a23619780dc107d68d70aa9&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F3%29


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1310` (included in `26.7` and later)
<!-- ch-version-info:end -->