### PR TITLE
Docs: optimize docs CSS class selectors

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2554,8 +2554,8 @@ html:not(.dark) mark b {
    ============================================ */
 
 /* Light mode - remove gray-800 text color from nav tabs (let it inherit naturally) */
-html:not(.dark) .nav-tabs button[class*="text-gray-800"]>div,
-html:not(.dark) button.nav-tabs-item[class*="text-gray-800"]>div {
+html:not(.dark) .nav-tabs button.text-gray-800>div,
+html:not(.dark) button.nav-tabs-item.text-gray-800>div {
     color: inherit;
 }
 
@@ -3137,7 +3137,7 @@ a.nav-dropdown-item[href^="https://langfuse.com/docs"]:focus-visible > svg:last-
 }
 
 /* Preserve active-page styling (border + text color) when Home is selected */
-#navigation-items > ul.sidebar-group > li:only-child > a[class*="text-primary"] {
+#navigation-items > ul.sidebar-group > li:only-child > a.text-primary {
     border-left-color: currentColor !important;
 }
 
@@ -3331,7 +3331,7 @@ a.mobile-nav-tabs-item[href$="/products/clickhouse-private/index"] {
    hook is Mintlify's hard-coded pill background utility (light `bg-[#FDEAD8]`,
    always present in the class list even in dark mode). The title is the
    .break-words span; the METHOD pill spans carry no .break-words. */
-#sidebar a:has(div[class*="bg-[#FDEAD8]"]) span.break-words {
+#sidebar a:has(div.bg-\[\#FDEAD8\]) span.break-words {
     text-decoration: line-through;
 }
 


### PR DESCRIPTION
## Summary

- Replace the deprecated-sidebar `[class*=...]` matcher inside `:has()` with the exact escaped Tailwind class.
- Replace the two remaining class-substring selectors in the custom stylesheet with exact class selectors.
- Preserve the existing styling while giving browsers precise invalidation keys.

## Root cause and impact

The substring class matcher inside `:has()` prevents Chrome and Safari from using class-change invalidation filtering. A class mutation anywhere on the page can therefore trigger a full-document style recalculation.

On the session-settings page, the recalculation took roughly 270 ms per hit. Profiling the exact-class selector reduced average scroll-frame time from approximately 110 ms to 9.5 ms on heavy pages.

The other two selectors are outside `:has()` and are lower-impact cleanups. Their current Mintlify elements carry the exact `text-gray-800` and `text-primary` class tokens, so the replacements preserve matching behavior.

## Validation

- `git diff --check`
- Confirmed all replacement selectors parse successfully in the live page.
- Confirmed the old and new nav-tab selectors match the same two live DOM nodes.
- Verified no executable `[class*=...]` selectors remain in `docs/_site/styles.css`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improves documentation scrolling performance by replacing broad class-substring CSS selectors with exact class selectors.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1262` (included in `26.7` and later)
<!-- ch-version-info:end -->