### PR TITLE
Re-do the ChangeLog PR tail during release recovery runs

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -129,7 +129,10 @@ jobs:
         run: |
           python3 ./tests/ci/create_release.py --create-bump-version-pr ${{ inputs.dry-run == true && '--dry-run' || '' }}
       - name: Bump Docker versions, Changelog, Security
-        if: ${{ inputs.type == 'patch' && ! inputs.only-repo && ! inputs.only-docker }}
+        # Runs in recovery (only-repo/only-docker) too, so a tail skipped by an
+        # earlier interrupted run is re-done. The step is idempotent: it exits
+        # early when the auto/<tag> ChangeLog PR is already open or merged.
+        if: ${{ inputs.type == 'patch' }}
         shell: bash
         run: |
           python3 ./tests/ci/create_release.py --set-progress-started --progress "update changelog, docker version, security"
@@ -165,7 +168,9 @@ jobs:
           python3 ./utils/security-generator/generate_security.py > SECURITY.md
           git diff HEAD
       - name: Create ChangeLog PR
-        if: ${{ inputs.type == 'patch' && ! inputs.dry-run && ! inputs.only-repo && ! inputs.only-docker }}
+        # Runs in recovery too (see above). When the previous step exited early
+        # there is no diff, so create-pull-request detects no changes and is a no-op.
+        if: ${{ inputs.type == 'patch' && ! inputs.dry-run }}
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           author: "robot-clickhouse <robot-clickhouse@users.noreply.github.com>"
@@ -183,7 +188,9 @@ jobs:
             ### Changelog category (leave one):
             - Not for changelog (changelog entry is not required)
       - name: Complete previous steps and Restore git state
-        if: ${{ inputs.type == 'patch' && ! inputs.only-repo && ! inputs.only-docker }}
+        # Pairs with the changelog steps above: it completes the progress phase
+        # they start and restores git state, so it must run whenever they do.
+        if: ${{ inputs.type == 'patch' }}
         shell: bash
         run: |
           git reset --hard HEAD


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/111176
Related: https://github.com/ClickHouse/ClickHouse/pull/111175

## Motivation

Release recovery runs (`only-repo` / `only-docker`) rebuild repos and docker images for an already-tagged release. They skipped the whole post-release tail — "Bump Docker versions, Changelog, Security", "Create ChangeLog PR", and "Complete previous steps and Restore git state" — via `! inputs.only-repo && ! inputs.only-docker` guards.

When an earlier interrupted run had already published the tag, GitHub release, repo and docker, but died before opening the `auto/<tag>` PR, finishing the release through recovery left that tail permanently undone. The release then never landed in `utils/list-versions/version_date.tsv`, which is the release registry that docs, support-status and tooling read from.

This is exactly what happened to `v26.3.17.56-lts` and `v26.6.2.81-stable`; their registry PRs had to be created by hand (see the related PRs above).

## Change

Drop the recovery exclusion from the three tail steps so a missed tail is re-done on the next recovery run. The tail is already idempotent, so this is safe to run every time:

- "Bump Docker versions, Changelog, Security" exits early when the `auto/<tag>` PR is already open or merged.
- When it exits early there is no working-tree diff, so `create-pull-request` detects no changes and is a no-op.
- HEAD is the dispatch branch (`master`) in recovery just as in the normal flow — recovery skips the version-bump step that would otherwise move HEAD — so the PR is still based on `master`.

The version-bump step (`--create-bump-version-pr`) stays gated to non-recovery runs; only the changelog/`version_date.tsv` tail is affected.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...