### PR TITLE
Fix retry classification for Azure request timeouts

### DIFF
--- a/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
+++ b/src/IO/AzureBlobStorage/isRetryableAzureException.cpp
@@ -12,6 +12,11 @@ bool isRetryableAzureException(const Azure::Core::RequestFailedException & e, bo
     if (dynamic_cast<const Azure::Core::Http::TransportException *>(&e))
         return true;
 
+    /// Retry 408 consistently with the Azure SDK retry policy.
+    /// `PocoAzureHTTPClient` also uses it to represent transport timeouts.
+    if (e.StatusCode == Azure::Core::Http::HttpStatusCode::RequestTimeout)
+        return true;
+
     /// Azure may be provisioning access for quite a long time, so 403 is retriable in some cases
     /// It makes sense for IDisk::checkAccess() which is called early on startup and terminates the server/keeper if the check fails
     if (may_be_provisioning_access && e.StatusCode == Azure::Core::Http::HttpStatusCode::Forbidden)

--- a/src/IO/AzureBlobStorage/tests/gtest_is_retryable_azure_exception.cpp
+++ b/src/IO/AzureBlobStorage/tests/gtest_is_retryable_azure_exception.cpp
@@ -1,0 +1,17 @@
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+
+#include <gtest/gtest.h>
+
+#include <IO/AzureBlobStorage/isRetryableAzureException.h>
+
+TEST(IsRetryableAzureException, RequestTimeoutIsRetryable)
+{
+    Azure::Core::RequestFailedException exception("request timeout");
+    exception.StatusCode = Azure::Core::Http::HttpStatusCode::RequestTimeout;
+
+    EXPECT_TRUE(DB::isRetryableAzureException(exception));
+}
+
+#endif


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/110724

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Transient Azure Blob Storage request timeouts are now retried instead of being treated as non-retryable errors that can mark healthy `MergeTree` data parts as potentially broken.
