### PR TITLE
Ignorelist third-party Thrift protocol for UBSan

### DIFF
--- a/tests/ubsan_ignorelist.txt
+++ b/tests/ubsan_ignorelist.txt
@@ -20,3 +20,6 @@ src:*/contrib/boost/boost/geometry/*
 # We don't want to receive sanitizer alerts from third-party libraries during fuzzing
 src:*/contrib/contrib/protobuf/*
 src:*/contrib/libprotobuf-mutator/*
+
+# Signed integer overflow in Thrift protocol checkReadBytesAvailable (map/list/set size times element size) on corrupt Parquet/ORC metadata - third-party code, the bounded read is rechecked by the transport.
+src:*/contrib/thrift/lib/cpp/src/thrift/protocol/*


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110171
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Description

Ignorelist third-party Thrift for UBSan.

`Stress test (arm_asan_ubsan, s3)` reported (STID 3543-4a91):

```
contrib/thrift/lib/cpp/src/thrift/protocol/TCompactProtocol.h:160:49:
runtime error: signed integer overflow: 2133724293 * 2 cannot be represented in type 'int'
```

Line 160 is `trans_->checkReadBytesAvailable(map.size_ * elmSize)` in `TCompactProtocol::checkReadBytesAvailable(TMap&)`. `map.size_` (int32) and `elmSize` are read from the compact-protocol wire (corrupt/fuzzed Parquet/ORC metadata), so a large declared map cardinality overflows signed `int`. This is vendored third-party Thrift arithmetic; the read it guards is still bounded and rechecked by the transport, so there is no unbounded read or allocation in a release build. Only the UBSan sanitizer build aborts on the overflow.

The same `size * element-size` idiom is present in the `TSet`/`TList` overloads and in `TBinaryProtocol`/`TProtocol`. Add `src:*/contrib/thrift/lib/cpp/src/thrift/protocol/*` to `tests/ubsan_ignorelist.txt`, scoped to the protocol sources (like the existing `contrib/boost/boost/geometry` subtree entry), consistent with the existing third-party UBSan entries.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110171&sha=b3699207b14e085180bef427dac73696403b023c&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29
