### PR TITLE
Fix full_sorting_merge join filling non-joined Enum columns with invalid 0

### DIFF
--- a/src/Processors/Transforms/MergeJoinTransform.cpp
+++ b/src/Processors/Transforms/MergeJoinTransform.cpp
@@ -119,29 +119,30 @@ int ALWAYS_INLINE totallyCompare(FullMergeJoinCursor & lhs, FullMergeJoinCursor 
     return 0;
 }
 
-ColumnPtr indexColumn(const ColumnPtr & column, const PaddedPODArray<UInt64> & indices)
+ColumnPtr indexColumn(const ColumnPtr & column, const DataTypePtr & type, const PaddedPODArray<UInt64> & indices)
 {
     auto new_col = column->cloneEmpty();
     new_col->reserve(indices.size());
     for (size_t idx : indices)
     {
-        /// rows where default value should be inserted have index == size
+        /// Rows where a default should be inserted have index == size. Fill them through the
+        /// data type: types whose default is not all-zero (e.g. Enum, whose default is the
+        /// first member) must not get a raw zero. Every non-joined-row fill in this file goes
+        /// through the data type for the same reason.
         if (idx < column->size())
             new_col->insertFrom(*column, idx);
         else
-            new_col->insertDefault();
+            type->insertDefaultInto(*new_col);
     }
     return new_col;
 }
 
-Columns indexColumns(const Columns & columns, const PaddedPODArray<UInt64> & indices)
+Columns indexColumns(const Columns & columns, const DataTypes & types, const PaddedPODArray<UInt64> & indices)
 {
     Columns new_columns;
     new_columns.reserve(columns.size());
-    for (const auto & column : columns)
-    {
-        new_columns.emplace_back(indexColumn(column, indices));
-    }
+    for (size_t i = 0; i < columns.size(); ++i)
+        new_columns.emplace_back(indexColumn(columns[i], types[i], indices));
     return new_columns;
 }
 
@@ -622,6 +623,20 @@ MutableColumns MergeJoinAlgorithm::getEmptyResultColumns() const
     return result_cols;
 }
 
+DataTypes MergeJoinAlgorithm::getOutputTypes() const
+{
+    /// Types of the columns produced by getEmptyResultColumns(): left header columns
+    /// followed by right header columns. Used to fill non-joined rows with the proper
+    /// type default (e.g. the first Enum member) instead of a raw zero.
+    DataTypes types;
+    for (size_t i = 0; i < 2; ++i)
+    {
+        const auto & header_types = input_headers[i]->getDataTypes();
+        types.insert(types.end(), header_types.begin(), header_types.end());
+    }
+    return types;
+}
+
 Columns MergeJoinAlgorithm::getEmptyResultColumns(size_t pos) const
 {
     MutableColumns mutable_cols;
@@ -706,6 +721,7 @@ std::optional<MergeJoinAlgorithm::Status> MergeJoinAlgorithm::handleAsofJoinStat
     const auto & left_columns = left_cursor.getCurrent().getColumns();
 
     MutableColumns result_cols = getEmptyResultColumns();
+    const auto output_types = getOutputTypes();
 
     while (left_cursor.isValid() && asof_join_state.hasMatch(left_cursor, asof_inequality))
     {
@@ -725,7 +741,8 @@ std::optional<MergeJoinAlgorithm::Status> MergeJoinAlgorithm::handleAsofJoinStat
         for (const auto & col : left_columns)
             result_cols[i++]->insertFrom(*col, left_cursor.getRow());
         for (; i < result_cols.size(); ++i)
-            result_cols[i]->insertDefault();
+            /// Type-aware default (Enum -> first member) rather than a raw zero.
+            output_types[i]->insertDefaultInto(*result_cols[i]);
         chassert(i == result_cols.size());
 
         left_cursor.next();
@@ -748,7 +765,10 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::allJoin()
 
     Chunk result;
 
-    Columns rcols = indexColumns(cursors[1].getCurrent().getColumns(), idx_map[1]);
+    const auto & left_types = input_headers[0]->getDataTypes();
+    const auto & right_types = input_headers[1]->getDataTypes();
+
+    Columns rcols = indexColumns(cursors[1].getCurrent().getColumns(), right_types, idx_map[1]);
     Columns lcols;
     if (!left_to_right_key_remap.empty())
     {
@@ -772,7 +792,7 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::allJoin()
                     if (auto it = left_to_right_key_remap.find(col_idx); it != left_to_right_key_remap.end())
                         new_col->insertFrom(*rcols[it->second], i);
                     else
-                        new_col->insertDefault();
+                        left_types[col_idx]->insertDefaultInto(*new_col);
                 }
             }
             lcols.push_back(std::move(new_col));
@@ -780,7 +800,7 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::allJoin()
     }
     else
     {
-        lcols = indexColumns(cursors[0].getCurrent().getColumns(), idx_map[0]);
+        lcols = indexColumns(cursors[0].getCurrent().getColumns(), left_types, idx_map[0]);
     }
 
     for (auto & col : lcols)
@@ -956,9 +976,11 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::anyJoin()
         /// empty map means identity mapping
         if (!idx_map[source_num].empty())
         {
-            for (const auto & col : cursors[source_num].getCurrent().getColumns())
+            const auto & source_types = input_headers[source_num]->getDataTypes();
+            const auto & source_columns = cursors[source_num].getCurrent().getColumns();
+            for (size_t i = 0; i < source_columns.size(); ++i)
             {
-                result.addColumn(indexColumn(col, idx_map[source_num]));
+                result.addColumn(indexColumn(source_columns[i], source_types[i], idx_map[source_num]));
             }
         }
         else
@@ -987,6 +1009,7 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::asofJoin()
     const auto & right_columns = right_cursor.getCurrent().getColumns();
 
     MutableColumns result_cols = getEmptyResultColumns();
+    const auto output_types = getOutputTypes();
 
     while (left_cursor.isValid() && right_cursor.isValid())
     {
@@ -1061,7 +1084,7 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::asofJoin()
                         for (const auto & col : left_columns)
                             result_cols[i++]->insertFrom(*col, lpos);
                         for (; i < result_cols.size(); ++i)
-                            result_cols[i]->insertDefault();
+                            output_types[i]->insertDefaultInto(*result_cols[i]);
                         chassert(i == result_cols.size());
                     }
                 }
@@ -1098,7 +1121,7 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::asofJoin()
                 for (const auto & col : left_columns)
                     result_cols[i++]->insertRangeFrom(*col, lpos, num);
                 for (; i < result_cols.size(); ++i)
-                    result_cols[i]->insertManyDefaults(num);
+                    output_types[i]->insertManyDefaultsInto(*result_cols[i], num);
                 chassert(i == result_cols.size());
             }
         }
@@ -1118,27 +1141,56 @@ MergeJoinAlgorithm::Status MergeJoinAlgorithm::asofJoin()
 Chunk MergeJoinAlgorithm::createBlockWithDefaults(size_t source_num, size_t start, size_t num_rows) const
 {
     ColumnRawPtrs cols;
+    /// Parallel to `cols`: used to fill non-joined rows through the data type (see indexColumn).
+    DataTypes types;
     const auto & columns_left = source_num == 0 ? cursors[0].getCurrent().getColumns() : getEmptyResultColumns(0);
     const auto & columns_right = source_num == 1 ? cursors[1].getCurrent().getColumns() : getEmptyResultColumns(1);
+    const auto & types_left = input_headers[0]->getDataTypes();
+    const auto & types_right = input_headers[1]->getDataTypes();
 
     for (size_t i = 0; i < columns_left.size(); ++i)
     {
         if (auto it = left_to_right_key_remap.find(i); source_num == 0 || it == left_to_right_key_remap.end())
         {
             cols.push_back(columns_left[i].get());
+            types.push_back(types_left[i]);
         }
         else
         {
             cols.push_back(columns_right[it->second].get());
+            types.push_back(types_right[it->second]);
         }
     }
 
-    for (const auto & col : columns_right)
+    for (size_t i = 0; i < columns_right.size(); ++i)
     {
-        cols.push_back(col.get());
+        cols.push_back(columns_right[i].get());
+        types.push_back(types_right[i]);
     }
+
     Chunk result_chunk;
-    copyColumnsResized(cols, start, num_rows, result_chunk);
+    for (size_t i = 0; i < cols.size(); ++i)
+    {
+        const auto & col = cols[i];
+        if (col->empty())
+        {
+            /// add defaults (through the data type, not cloneResized which would zero-fill)
+            auto default_col = col->cloneEmpty();
+            types[i]->insertManyDefaultsInto(*default_col, num_rows);
+            result_chunk.addColumn(std::move(default_col));
+        }
+        else if (col->size() == 1)
+        {
+            /// copy same row n times
+            result_chunk.addColumn(replicateRow(*col, num_rows));
+        }
+        else
+        {
+            /// cut column
+            chassert(start + num_rows <= col->size());
+            result_chunk.addColumn(col->cut(start, num_rows));
+        }
+    }
     return result_chunk;
 }
 

--- a/src/Processors/Transforms/MergeJoinTransform.h
+++ b/src/Processors/Transforms/MergeJoinTransform.h
@@ -258,6 +258,9 @@ private:
     void getEmptyResultColumns(MutableColumns & result_cols, size_t pos) const;
     MutableColumns getEmptyResultColumns() const;
     Columns getEmptyResultColumns(size_t pos) const;
+    /// Types of the columns produced by getEmptyResultColumns() (left header ++ right header),
+    /// used to fill non-joined rows with the proper type default instead of a raw zero.
+    DataTypes getOutputTypes() const;
 
     Chunk createBlockWithDefaults(size_t source_num);
     Chunk createBlockWithDefaults(size_t source_num, size_t start, size_t num_rows) const;

--- a/tests/queries/0_stateless/04545_full_sorting_merge_join_enum_default.reference
+++ b/tests/queries/0_stateless/04545_full_sorting_merge_join_enum_default.reference
@@ -1,0 +1,44 @@
+1
+1
+x	b
+y	a
+LEFT use_nulls=0
+a	q	a	x	\N
+b	q	b	y	b
+c	q	a	x	\N
+a	q	a	x	\N
+b	q	b	y	b
+c	q	a	x	\N
+RIGHT use_nulls=0
+b	q	b	y	b
+	p	a	x	\N
+b	q	b	y	b
+	p	a	x	\N
+FULL use_nulls=0
+	p	a	x	\N
+a	q	a	x	\N
+b	q	b	y	b
+c	q	a	x	\N
+	p	a	x	\N
+a	q	a	x	\N
+b	q	b	y	b
+c	q	a	x	\N
+FULL use_nulls=1
+a	q	\N	\N	\N
+b	q	b	y	b
+c	q	\N	\N	\N
+\N	\N	a	x	\N
+a	q	\N	\N	\N
+b	q	b	y	b
+c	q	\N	\N	\N
+\N	\N	a	x	\N
+USING FULL
+x	b
+y	a
+x	b
+y	a
+ASOF LEFT
+1	b
+2	a
+1	b
+2	a

--- a/tests/queries/0_stateless/04545_full_sorting_merge_join_enum_default.sql
+++ b/tests/queries/0_stateless/04545_full_sorting_merge_join_enum_default.sql
@@ -1,0 +1,74 @@
+-- Tests that full_sorting_merge fills non-joined outer-join rows of Enum columns with the
+-- type default (the first enum member), matching the other join algorithms, instead of a
+-- raw 0 which is not a valid enum element (issue #111184: wrong results + UNKNOWN_ELEMENT_OF_ENUM).
+
+DROP TABLE IF EXISTS tl;
+DROP TABLE IF EXISTS tr;
+
+CREATE TABLE tl (s String) ENGINE = MergeTree ORDER BY s;
+CREATE TABLE tr (s String, e Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO tl VALUES ('x'), ('y');
+INSERT INTO tr VALUES ('x', 'b');
+
+-- Reporter's exact repro: both must return 1 (the non-joined row's e is the type default 'a').
+SELECT count() FROM tl AS l LEFT JOIN tr AS r ON l.s = r.s WHERE r.e = 'a' SETTINGS join_algorithm = 'hash';
+SELECT count() FROM tl AS l LEFT JOIN tr AS r ON l.s = r.s WHERE r.e = 'a' SETTINGS join_algorithm = 'full_sorting_merge';
+
+-- Selecting the padded column must not raise UNKNOWN_ELEMENT_OF_ENUM.
+SELECT l.s, r.e FROM tl AS l LEFT JOIN tr AS r ON l.s = r.s ORDER BY l.s SETTINGS join_algorithm = 'full_sorting_merge';
+
+DROP TABLE tl;
+DROP TABLE tr;
+
+-- Cross-algorithm agreement for LEFT/RIGHT/FULL over Enum8/Enum16/Nullable(Enum), both
+-- join_use_nulls modes. full_sorting_merge output must match hash exactly.
+
+CREATE TABLE tl (s String, le Enum8('p' = 1, 'q' = 2)) ENGINE = MergeTree ORDER BY s;
+CREATE TABLE tr (s String, e8 Enum8('a' = 1, 'b' = 2), e16 Enum16('x' = 100, 'y' = 200), ne Nullable(Enum8('a' = 1, 'b' = 2))) ENGINE = MergeTree ORDER BY s;
+INSERT INTO tl VALUES ('a', 'q'), ('b', 'q'), ('c', 'q');
+INSERT INTO tr VALUES ('b', 'b', 'y', 'b'), ('d', 'a', 'x', NULL);
+
+SELECT 'LEFT use_nulls=0';
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l LEFT JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.e8 SETTINGS join_algorithm = 'hash', join_use_nulls = 0;
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l LEFT JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.e8 SETTINGS join_algorithm = 'full_sorting_merge', join_use_nulls = 0;
+
+SELECT 'RIGHT use_nulls=0';
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l RIGHT JOIN tr AS r ON l.s = r.s ORDER BY r.s, l.s SETTINGS join_algorithm = 'hash', join_use_nulls = 0;
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l RIGHT JOIN tr AS r ON l.s = r.s ORDER BY r.s, l.s SETTINGS join_algorithm = 'full_sorting_merge', join_use_nulls = 0;
+
+SELECT 'FULL use_nulls=0';
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l FULL JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.s, r.e8 SETTINGS join_algorithm = 'hash', join_use_nulls = 0;
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l FULL JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.s, r.e8 SETTINGS join_algorithm = 'full_sorting_merge', join_use_nulls = 0;
+
+SELECT 'FULL use_nulls=1';
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l FULL JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.s, r.e8 SETTINGS join_algorithm = 'hash', join_use_nulls = 1;
+SELECT l.s, l.le, r.e8, r.e16, r.ne FROM tl AS l FULL JOIN tr AS r ON l.s = r.s ORDER BY l.s, r.s, r.e8 SETTINGS join_algorithm = 'full_sorting_merge', join_use_nulls = 1;
+
+DROP TABLE tl;
+DROP TABLE tr;
+
+-- USING join (key remap branch) with an Enum payload.
+CREATE TABLE tl (s String) ENGINE = MergeTree ORDER BY s;
+CREATE TABLE tr (s String, e Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO tl VALUES ('x'), ('y');
+INSERT INTO tr VALUES ('x', 'b');
+
+SELECT 'USING FULL';
+SELECT s, e FROM tl AS l FULL JOIN tr AS r USING (s) ORDER BY s SETTINGS join_algorithm = 'hash';
+SELECT s, e FROM tl AS l FULL JOIN tr AS r USING (s) ORDER BY s SETTINGS join_algorithm = 'full_sorting_merge';
+
+DROP TABLE tl;
+DROP TABLE tr;
+
+-- ASOF LEFT JOIN with an Enum payload on the right (unmatched left row must default to 'a').
+CREATE TABLE tl (k UInt32, t UInt32) ENGINE = MergeTree ORDER BY (k, t);
+CREATE TABLE tr (k UInt32, t UInt32, e Enum8('a' = 1, 'b' = 2)) ENGINE = MergeTree ORDER BY (k, t);
+INSERT INTO tl VALUES (1, 100), (2, 100);
+INSERT INTO tr VALUES (1, 50, 'b');
+
+SELECT 'ASOF LEFT';
+SELECT l.k, r.e FROM tl AS l ASOF LEFT JOIN tr AS r ON l.k = r.k AND l.t >= r.t ORDER BY l.k SETTINGS join_algorithm = 'hash';
+SELECT l.k, r.e FROM tl AS l ASOF LEFT JOIN tr AS r ON l.k = r.k AND l.t >= r.t ORDER BY l.k SETTINGS join_algorithm = 'full_sorting_merge';
+
+DROP TABLE tl;
+DROP TABLE tr;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111184
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111184

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `join_algorithm = 'full_sorting_merge'` filling the non-joined rows of a `LEFT`/`RIGHT`/`FULL`/`ASOF` `JOIN` with a raw zero instead of the column type default. For an `Enum` column (whose default is its first element, not `0`) this produced wrong results (a filter on the padded value dropped the unmatched rows, so an outer join silently behaved like an inner one) and a `UNKNOWN_ELEMENT_OF_ENUM` error when the column was selected.

### Description

Under `join_algorithm = 'full_sorting_merge'`, non-joined outer-join rows were padded with raw zeros rather than the column type's default value. The other join algorithms (`hash`, `parallel_hash`, `grace_hash`, `partial_merge`) fill via the data type and were unaffected; `join_algorithm` is a performance setting and must not change results.

The zero-fill happened at several type-blind padding sites in `MergeJoinAlgorithm` (`cloneResized` on an empty column, and `IColumn::insertDefault` for sentinel indices in `indexColumn`, plus the `ASOF` result fills). For a numeric column the default is `0`, so the bug was invisible; for an `Enum8`/`Enum16` the default is the first member, so `0` is an invalid element. This is fixed by filling non-joined rows through the data type (`IDataType::insertManyDefaultsInto` / `insertDefaultInto`), using the input header types the algorithm already holds.

Verified that `full_sorting_merge` now matches `hash` for `LEFT`/`RIGHT`/`FULL`/`ASOF` joins over `Enum8`/`Enum16`/`Nullable(Enum)`/wrapped payloads, with both `join_use_nulls` values.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.140` (included in `26.8` and later)
<!-- ch-version-info:end -->