### PR TITLE
Docs: update broken monitoring dashboard image

### DIFF
--- a/docs/ar/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/ar/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ import { Image } from "/snippets/ar/components/Image.jsx";
   ## لوحة معلومات observability المتقدمة المضمّنة
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="لقطة شاشة 2023-11-12 الساعة 6 08 58 مساءً" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="لوحة observability المتقدمة الأصلية" size="md" />
 
 يأتي ClickHouse مزودًا بميزة لوحة معلومات observability متقدمة مضمّنة يمكن الوصول إليها عبر `$HOST:$PORT/dashboard` (يتطلب اسم مستخدم وكلمة مرور)، وتعرض المقاييس التالية:
 

--- a/docs/en/operations/monitoring.md
+++ b/docs/en/operations/monitoring.md
@@ -25,7 +25,7 @@ You can monitor:
 
 ## Built-in advanced observability dashboard {#built-in-advanced-observability-dashboard}
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Screenshot 2023-11-12 at 6 08 58 PM" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Native advanced observability dashboard" size="md" />
 
 ClickHouse comes with a built-in advanced observability dashboard feature which can be accessed by `$HOST:$PORT/dashboard` (requires user and password) that shows the following metrics:
 - Queries/second

--- a/docs/es/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/es/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ Puede supervisar:
   ## Panel integrado de observabilidad avanzada
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Captura de pantalla 2023-11-12 a las 6 08 58 p. m." size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Panel avanzado de observabilidad nativo" size="md" />
 
 ClickHouse incluye un panel integrado avanzado de observabilidad al que se puede acceder mediante `$HOST:$PORT/dashboard` (requiere usuario y contraseña) y que muestra las siguientes métricas:
 

--- a/docs/fr/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/fr/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ Vous pouvez surveiller :
   ## Tableau de bord avancé d&#39;observability intégré
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Capture d’écran 2023-11-12 à 6 08 58 PM" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Tableau de bord avancé natif d’observabilité" size="md" />
 
 ClickHouse inclut une fonctionnalité intégrée de tableau de bord avancé d&#39;observability, accessible via `$HOST:$PORT/dashboard` (nécessite un utilisateur et un mot de passe), qui affiche les métriques suivantes :
 

--- a/docs/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ You can monitor:
 
 ## Built-in advanced observability dashboard {#built-in-advanced-observability-dashboard}
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Screenshot 2023-11-12 at 6 08 58 PM" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Native advanced observability dashboard" size="md" />
 
 ClickHouse comes with a built-in advanced observability dashboard feature which can be accessed by `$HOST:$PORT/dashboard` (requires user and password) that shows the following metrics:
 - Queries/second

--- a/docs/ja/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/ja/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ import { Image } from "/snippets/ja/components/Image.jsx";
   ## 組み込みの高度なオブザーバビリティダッシュボード
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="2023-11-12 午後6時08分58秒のスクリーンショット" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="ネイティブの高度なオブザーバビリティダッシュボード" size="md" />
 
 ClickHouse には組み込みの高度なオブザーバビリティダッシュボード機能があり、`$HOST:$PORT/dashboard` でアクセスできます (ユーザー名とパスワードが必要です) 。このダッシュボードでは、次のメトリクスを確認できます。
 

--- a/docs/ko/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/ko/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ import { Image } from "/snippets/ko/components/Image.jsx";
   ## 내장 고급 관측성 대시보드
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="2023-11-12 오후 6시 08분 58초 스크린샷" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="네이티브 고급 관측성 대시보드" size="md" />
 
 ClickHouse에는 `$HOST:$PORT/dashboard`에서 접속할 수 있는 내장 고급 관측성 대시보드 기능이 포함되어 있으며(사용자 및 비밀번호 필요), 다음 메트릭을 표시합니다:
 

--- a/docs/pt-BR/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/pt-BR/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -24,7 +24,7 @@ Você pode monitorar:
   ## Painel avançado de observabilidade integrado
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Captura de tela de 2023-11-12 às 6 08 58 PM" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Dashboard avançado nativo de observabilidade" size="md" />
 
 O ClickHouse inclui um painel avançado de observabilidade integrado, que pode ser acessado em `$HOST:$PORT/dashboard` (requer usuário e senha) e exibe as seguintes métricas:
 

--- a/docs/ru/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/ru/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -22,7 +22,7 @@ import { Image } from "/snippets/ru/components/Image.jsx";
   ## Встроенная расширенная панель мониторинга обсервабилити
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="Снимок экрана 2023-11-12 в 6 08 58 PM" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="Встроенная расширенная панель обсервабилити" size="md" />
 
 В ClickHouse есть встроенная расширенная панель мониторинга обсервабилити, доступная по адресу `$HOST:$PORT/dashboard` (требуются имя пользователя и пароль), где отображаются следующие метрики:
 

--- a/docs/zh/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
+++ b/docs/zh/guides/oss/deployment-and-scaling/monitoring/monitoring.mdx
@@ -24,7 +24,7 @@ import { Image } from "/snippets/zh/components/Image.jsx";
   ## 内置高级可观测性仪表板
 </div>
 
-<Image img="https://github.com/ClickHouse/ClickHouse/assets/3936029/2bd10011-4a47-4b94-b836-d44557c7fdc1" alt="截图 2023-11-12 下午 6 08 58" size="md" />
+<Image img="/images/cloud/manage/monitoring/native_advanced_dashboard.webp" alt="原生高级可观测性仪表板" size="md" />
 
 ClickHouse 内置了高级可观测性仪表板，可通过 `$HOST:$PORT/dashboard` 访问 (需要用户名和密码) ，显示以下指标：
 


### PR DESCRIPTION
Replace the external GitHub attachment used by the monitoring guide with the existing tracked `native_advanced_dashboard.webp` asset. Apply the same fix to the legacy English source and all translated copies so the dashboard renders consistently across locales.

The external attachment does not render in the Mintlify preview, leaving a broken image in the built-in advanced observability dashboard section. Using the repository asset removes that external rendering dependency.

Validated with scoped Mintlify validation, snippet import checks, locale component checks, read-only copy checks, autogenerated-region checks, `git diff --check`, and a local Mintlify preview that loaded the image at 1600×870.

Reported at: https://clickhouse.com/docs/guides/oss/deployment-and-scaling/monitoring/monitoring?mintlify_preview=1

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.
