### PR TITLE
Fix flaky 03309_json_with_progress_exception: timeout in pending state

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1941,9 +1941,17 @@ static BlockIO executeQueryImpl(
         if (process_list_entry)
         {
             /// Query was killed before execution
-            if (process_list_entry->getQueryStatus()->isKilled())
+            auto query_status = process_list_entry->getQueryStatus();
+            if (query_status->isKilled())
+            {
+                /// The deadline (max_execution_time) can fire while the query is still pending (e.g. slow to
+                /// analyze/plan). Report it as a timeout, not a generic cancellation, so callers see the same
+                /// TIMEOUT_EXCEEDED they would get had the deadline fired during execution.
+                if (query_status->getCancelReason() == CancelReason::TIMEOUT)
+                    query_status->throwIfKilled();
                 throw Exception(ErrorCodes::QUERY_WAS_CANCELLED,
-                    "Query '{}' is killed in pending state", process_list_entry->getQueryStatus()->getInfo().client_info.current_query_id);
+                    "Query '{}' is killed in pending state", query_status->getInfo().client_info.current_query_id);
+            }
         }
 
         /// Hold element of process list till end of query execution.


### PR DESCRIPTION
When `max_execution_time` fires while a query is still pending (being analyzed/planned, before any executor starts), the client now gets `TIMEOUT_EXCEEDED` instead of a generic `QUERY_WAS_CANCELLED` "killed in pending state", matching the error it would get had the deadline fired during execution. Under load this was making `03309_json_with_progress_exception` flaky, because the query occasionally spends more than a second in planning and the deadline fires before execution begins.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111198

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.75` (included in `26.8` and later)
<!-- ch-version-info:end -->