### PR TITLE
Testing: verify server stacktrace log attachment with an artificial hung test (on top of brew lldb fix)

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1011,31 +1011,41 @@ def _ensure_lldb_installed():
     if _LLDB_INSTALL_ATTEMPTED:
         return
     _LLDB_INSTALL_ATTEMPTED = True
-    # Install via Homebrew on every platform, not `apt-get`. `brew install llvm`
-    # ships `lldb` and needs no root, whereas the fast-test container runs
-    # unprivileged: there `apt-get update` fails with
-    # "List directory /var/lib/apt/lists/partial is missing. - Acquire (13:
-    # Permission denied)", lldb never lands, and `print_c_stacktraces` only logs
-    # `lldb: command not found`. On macOS the runner already brew-installs llvm
-    # at provisioning (see runner-init.py), so this is just a safety net there.
-    try:
-        subprocess.run(["brew", "install", "llvm"], check=True, timeout=600)
-    except Exception as e:
-        print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
-        return
-    # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
-    # system PATH — so prepend the formula's bin dir, matching how the macOS
-    # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
-    # `get_stacktraces_from_lldb` stays empty and the install is wasted.
-    try:
-        prefix = subprocess.run(
-            ["brew", "--prefix", "llvm"],
-            check=True, capture_output=True, text=True, timeout=30,
-        ).stdout.strip()
-        if prefix:
-            os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
-    except Exception as e:
-        print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
+    # Use the native package manager of each platform: Homebrew on macOS,
+    # `apt-get` on Linux. `brew` is not present in the Linux `clickhouse-test`
+    # containers, and the macOS runner has no `apt-get`, so a single manager
+    # cannot serve both.
+    if platform.system() == "Darwin":
+        # The macOS runner already brew-installs llvm at provisioning (see
+        # runner-init.py), so this is just a safety net there.
+        try:
+            subprocess.run(["brew", "install", "llvm"], check=True, timeout=600)
+        except Exception as e:
+            print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
+            return
+        # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
+        # system PATH — so prepend the formula's bin dir, matching how the macOS
+        # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
+        # `get_stacktraces_from_lldb` stays empty and the install is wasted.
+        try:
+            prefix = subprocess.run(
+                ["brew", "--prefix", "llvm"],
+                check=True, capture_output=True, text=True, timeout=30,
+            ).stdout.strip()
+            if prefix:
+                os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
+        except Exception as e:
+            print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
+    else:
+        try:
+            env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
+            subprocess.run(["apt-get", "update"], check=True, env=env, timeout=60)
+            subprocess.run(
+                ["apt-get", "install", "-y", "lldb"],
+                check=True, env=env, timeout=120,
+            )
+        except Exception as e:
+            print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1025,18 +1025,13 @@ def _ensure_lldb_installed():
         print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
         return
     # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
-    # system PATH — so prepend the formula's bin dir, matching how the macOS
-    # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
-    # `get_stacktraces_from_lldb` stays empty and the install is wasted.
-    try:
-        prefix = subprocess.run(
-            ["brew", "--prefix", "llvm"],
-            check=True, capture_output=True, text=True, timeout=30,
-        ).stdout.strip()
-        if prefix:
-            os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
-    except Exception as e:
-        print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
+    # system PATH — so prepend the formula's bin dir, or `shutil.which("lldb")`
+    # in `get_stacktraces_from_lldb` stays empty and the install is wasted. The
+    # keg-only `opt/llvm` path is stable across versions, so derive it directly
+    # (the same way `runner-init.py`'s `macos_job_path` assembles the job PATH)
+    # rather than spending a second `brew --prefix llvm` subprocess on it.
+    brew_prefix = "/opt/homebrew" if platform.machine() == "arm64" else "/usr/local"
+    os.environ["PATH"] = f"{brew_prefix}/opt/llvm/bin:{os.environ.get('PATH', '')}"
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -984,19 +984,22 @@ _LLDB_INSTALL_ATTEMPTED = False
 
 
 def _ensure_lldb_installed():
-    """Make sure `lldb` is on PATH, installing it on the fly if not.
+    """Make sure `lldb` is on PATH on macOS, installing it on the fly if not.
 
-    TEMPORARY scaffolding: the CI base images currently ship `gdb` (from the
-    `clickhouse/cctools` layer), not `lldb`. While the switch to `lldb` is in
-    flight, install it at runtime so `print_c_stacktraces` keeps working.
-    Once `ci/docker/cctools/Dockerfile` (and the images that copy from it)
-    install `lldb` permanently, this helper and its single call site below
-    should be removed.
+    macOS only. TEMPORARY scaffolding for the Darwin fast test, whose runner is
+    a bare macOS host (not a container) where `lldb` is not guaranteed to be on
+    PATH. Install it at runtime via Homebrew so `print_c_stacktraces` keeps
+    working. On Linux this is a no-op: the fast test runs in the unprivileged
+    `clickhouse/fasttest` container (`docker run --user $(id -u):$(id -g)`, see
+    `ci/praktika/runner.py`), so an on-the-fly `apt-get install` cannot work
+    there — Linux `lldb` must be baked into the image instead (see PR #104815,
+    `Install lldb in CI Docker images alongside gdb`). Remove this helper and
+    its single call site once macOS ships `lldb` on the default PATH too.
 
     Never raise: `print_c_stacktraces` is a best-effort diagnostic. If the
-    install fails (no sudo, no network, no `brew`, ...), let
-    `shell_get_output` return "" so the surrounding diagnostic flow keeps
-    going instead of crashing during an already-broken run.
+    install fails (no network, no `brew`, ...), let `shell_get_output` return ""
+    so the surrounding diagnostic flow keeps going instead of crashing during an
+    already-broken run.
 
     Bounded and idempotent: each subprocess call has a hard timeout so a
     stalled package mirror cannot wedge stacktrace collection for minutes,
@@ -1006,46 +1009,34 @@ def _ensure_lldb_installed():
     attempt already failed.
     """
     global _LLDB_INSTALL_ATTEMPTED
+    if platform.system() != "Darwin":
+        # Linux gets `lldb` from the image, not on demand (see docstring).
+        return
     if shutil.which("lldb"):
         return
     if _LLDB_INSTALL_ATTEMPTED:
         return
     _LLDB_INSTALL_ATTEMPTED = True
-    # Use the native package manager of each platform: Homebrew on macOS,
-    # `apt-get` on Linux. `brew` is not present in the Linux `clickhouse-test`
-    # containers, and the macOS runner has no `apt-get`, so a single manager
-    # cannot serve both.
-    if platform.system() == "Darwin":
-        # The macOS runner already brew-installs llvm at provisioning (see
-        # runner-init.py), so this is just a safety net there.
-        try:
-            subprocess.run(["brew", "install", "llvm"], check=True, timeout=600)
-        except Exception as e:
-            print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
-            return
-        # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
-        # system PATH — so prepend the formula's bin dir, matching how the macOS
-        # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
-        # `get_stacktraces_from_lldb` stays empty and the install is wasted.
-        try:
-            prefix = subprocess.run(
-                ["brew", "--prefix", "llvm"],
-                check=True, capture_output=True, text=True, timeout=30,
-            ).stdout.strip()
-            if prefix:
-                os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
-        except Exception as e:
-            print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
-    else:
-        try:
-            env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
-            subprocess.run(["apt-get", "update"], check=True, env=env, timeout=60)
-            subprocess.run(
-                ["apt-get", "install", "-y", "lldb"],
-                check=True, env=env, timeout=120,
-            )
-        except Exception as e:
-            print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
+    # The macOS runner already brew-installs llvm at provisioning (see
+    # runner-init.py), so this is just a safety net there.
+    try:
+        subprocess.run(["brew", "install", "llvm"], check=True, timeout=600)
+    except Exception as e:
+        print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
+        return
+    # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
+    # system PATH — so prepend the formula's bin dir, matching how the macOS
+    # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
+    # `get_stacktraces_from_lldb` stays empty and the install is wasted.
+    try:
+        prefix = subprocess.run(
+            ["brew", "--prefix", "llvm"],
+            check=True, capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        if prefix:
+            os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
+    except Exception as e:
+        print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1011,18 +1011,31 @@ def _ensure_lldb_installed():
     if _LLDB_INSTALL_ATTEMPTED:
         return
     _LLDB_INSTALL_ATTEMPTED = True
+    # Install via Homebrew on every platform, not `apt-get`. `brew install llvm`
+    # ships `lldb` and needs no root, whereas the fast-test container runs
+    # unprivileged: there `apt-get update` fails with
+    # "List directory /var/lib/apt/lists/partial is missing. - Acquire (13:
+    # Permission denied)", lldb never lands, and `print_c_stacktraces` only logs
+    # `lldb: command not found`. On macOS the runner already brew-installs llvm
+    # at provisioning (see runner-init.py), so this is just a safety net there.
     try:
-        if platform.system() == "Darwin":
-            subprocess.run(["brew", "install", "llvm"], check=True, timeout=180)
-        else:
-            env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
-            subprocess.run(["apt-get", "update"], check=True, env=env, timeout=60)
-            subprocess.run(
-                ["apt-get", "install", "-y", "lldb"],
-                check=True, env=env, timeout=120,
-            )
+        subprocess.run(["brew", "install", "llvm"], check=True, timeout=600)
     except Exception as e:
         print(f"Could not install lldb on the fly: {e}", file=sys.stderr)
+        return
+    # `brew install llvm` is keg-only — it does not symlink `lldb` onto the
+    # system PATH — so prepend the formula's bin dir, matching how the macOS
+    # job PATH is assembled in runner-init.py, or `shutil.which("lldb")` in
+    # `get_stacktraces_from_lldb` stays empty and the install is wasted.
+    try:
+        prefix = subprocess.run(
+            ["brew", "--prefix", "llvm"],
+            check=True, capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        if prefix:
+            os.environ["PATH"] = f"{prefix}/bin:{os.environ.get('PATH', '')}"
+    except Exception as e:
+        print(f"Could not resolve brew llvm prefix: {e}", file=sys.stderr)
 
 
 # collect server stacktraces using lldb (used uniformly on Linux and macOS)

--- a/tests/queries/0_stateless/04612_artificial_timeout_stacktrace_dump.sh
+++ b/tests/queries/0_stateless/04612_artificial_timeout_stacktrace_dump.sh
@@ -12,6 +12,19 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# Hang ONLY on macOS. This test exists to exercise the stacktrace dump on the
+# `Fast test (arm_darwin)` run; there is no point hanging it on Linux, where the
+# on-demand `lldb` install cannot work in the unprivileged fast-test container
+# anyway (see `_ensure_lldb_installed` in `tests/clickhouse-test`). Worse, this
+# is a plain stateless test, so on Linux it would also run in the Linux
+# `Fast test` and every `Stateless tests` job and time them all out. Those jobs
+# are transitive `needs` of `Fast test (arm_darwin)` (via the `arm_darwin` build
+# and `CORE_BLOCKING_JOB_NAMES`), so their failure trips the per-job `if:` guard
+# (`!contains(needs.*.outputs.pipeline_status, 'failure')`) and the macOS job we
+# actually care about is skipped before it can run. Exiting cleanly on Linux
+# (the reference is empty) keeps that chain green so the macOS job runs.
+[ "$(uname)" != "Darwin" ] && exit 0
+
 # Start a long-running server-side query in its own session so that
 # `clickhouse-test`'s per-test process-group kill cannot reach it. The query
 # keeps running in `system.processes` well past the end of the run, so the

--- a/tests/queries/0_stateless/04612_artificial_timeout_stacktrace_dump.sh
+++ b/tests/queries/0_stateless/04612_artificial_timeout_stacktrace_dump.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# NOTE: This test is intentionally broken — it never finishes. It exists only to
+# exercise the stacktrace-dump reporting fixed in
+# https://github.com/ClickHouse/ClickHouse/pull/107173 on the macOS
+# `Fast test (arm_darwin)` run: when a test times out and the end-of-run hung
+# check fires, the runner must write the full server stacktraces to
+# `sql_stacktraces.log` / `c_stacktraces.log` and attach them to the report
+# instead of flooding `job.log`. Do NOT merge this test.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Start a long-running server-side query in its own session so that
+# `clickhouse-test`'s per-test process-group kill cannot reach it. The query
+# keeps running in `system.processes` well past the end of the run, so the
+# end-of-run hung check fires and dumps/attaches the server stacktraces.
+# `os.setsid` is used instead of `setsid(1)`, which is absent on macOS; running
+# it in the backgrounded child (not a process-group leader) lets `setsid`
+# succeed. The client command is passed as argv words, so no nested quoting.
+#
+# `max_execution_time = 0` and `max_estimated_execution_time = 0` disable the
+# server-side execution-time guard: with the fast-test profile default of 600s,
+# the speed estimator otherwise aborts the query (`Code: 160 ... Estimated query
+# execution time is too long`) after a few minutes — before the end-of-run hung
+# check runs — so `system.processes` would be empty and nothing would be dumped.
+python3 -c 'import os, sys, subprocess; os.setsid(); subprocess.Popen(sys.argv[1:])' \
+    $CLICKHOUSE_CLIENT --query "SELECT sleepEachRow(1) FROM numbers(100000) SETTINGS max_block_size = 1, max_execution_time = 0, max_estimated_execution_time = 0" &
+
+# Hang the test itself far past `clickhouse-test --timeout` so it is reported as
+# a timeout too.
+sleep 100000


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/112058
Related: https://github.com/ClickHouse/ClickHouse/pull/107173
-->

**Testing PR — do not merge.** Rebased onto the brew-based lldb install fix (#112058) to verify, on a real `Fast test` run, that a hung query's server stacktraces are written to files and attached to the report.

It carries two things:

- The `_ensure_lldb_installed` change from #112058: install `lldb` on demand via Homebrew instead of `apt-get` (which fails unprivileged in the fast-test container), plus the keg-only PATH fix so `shutil.which("lldb")` resolves.
- A throwaway stateless test, `04612_artificial_timeout_stacktrace_dump.sh`, that never finishes. It detaches a long-running server-side query (`SELECT sleepEachRow(1) FROM numbers(100000)` with `max_execution_time = 0` so the server does not self-kill it) into its own session via `os.setsid`, so it lingers in `system.processes` past the end of the run. The end-of-run hung check then fires and calls `print_sql_stacktraces` / `print_c_stacktraces`, which write `sql_stacktraces.log` / `c_stacktraces.log` for `fast_test.py` to attach. Its foreground also hangs past `--timeout` so the test is reported as a timeout too.

Expected result: the CI report carries `sql_stacktraces.log` (and, where `lldb` is available, `c_stacktraces.log`) as attached artifacts, and `job.log` keeps only a trimmed preview.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
