### PR TITLE
Fail during cmake generate instead of corrupting StorageSystemLicenses.generated.cpp

### DIFF
--- a/src/Storages/System/CMakeLists.txt
+++ b/src/Storages/System/CMakeLists.txt
@@ -40,12 +40,14 @@ set(GENERATED_LICENSES_SRC "${CMAKE_CURRENT_BINARY_DIR}/StorageSystemLicenses.ge
 # CMake order-only dependency chain.
 execute_process(
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/StorageSystemLicenses.sh "${CMAKE_SOURCE_DIR}"
-    OUTPUT_FILE ${GENERATED_LICENSES_SRC}
+    OUTPUT_FILE ${GENERATED_LICENSES_SRC}.tmp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE LICENSES_RESULT)
 if (NOT LICENSES_RESULT EQUAL 0)
-    message(WARNING "Failed to generate StorageSystemLicenses.generated.cpp")
+    file(REMOVE ${GENERATED_LICENSES_SRC}.tmp)
+    message(FATAL_ERROR "Failed to generate StorageSystemLicenses.generated.cpp")
 endif()
+file(RENAME ${GENERATED_LICENSES_SRC}.tmp ${GENERATED_LICENSES_SRC})
 
 list (APPEND storages_system_sources ${GENERATED_LICENSES_SRC})
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Now, failed licenses will not corrupt .cpp files.