### PR TITLE
Upload stripped binaries for OK fast tests

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -170,6 +170,7 @@ def main():
 
     clickhouse_bin_path = Path(f"{build_dir}/programs/clickhouse")
     clickhouse_se_path = Path(f"{build_dir}/programs/self-extracting/clickhouse")
+    clickhouse_se_stripped_path = Path(f"{build_dir}/programs/self-extracting/clickhouse-stripped")
 
     for path in [
         Path(temp_dir) / "clickhouse",
@@ -293,15 +294,19 @@ def main():
 
     if res and JobStages.BUILD in stages:
         se_check_path = Path(build_dir) / "clickhouse_se_check"
+        se_stripped_check_path = Path(build_dir) / "clickhouse_se_stripped_check"
         commands = [
             "sccache --show-stats",
             "clickhouse-client --version",
-            # Verify the self-extracting bundle works: copy it so the first-run
-            # in-place decompression does not corrupt the artifact we will upload,
-            # then run --version to trigger extraction and confirm it produces output.
+            # Verify both self-extracting bundles: copy each so the first-run
+            # in-place decompression does not corrupt the artifacts we will upload,
+            # then run --version to trigger extraction and confirm output.
             f"cp {clickhouse_se_path} {se_check_path}",
             f"chmod +x {se_check_path}",
             f"{se_check_path} --version",
+            f"cp {clickhouse_se_stripped_path} {se_stripped_check_path}",
+            f"chmod +x {se_stripped_check_path}",
+            f"{se_stripped_check_path} --version",
         ]
         results.append(
             Result.from_commands_run(
@@ -381,7 +386,9 @@ def main():
 
     if clickhouse_se_path.is_file():
         # do not reupload clickhouse binary for non-building jobs (e.g. darwin tests)
-        attach_files.append(clickhouse_se_path)
+        attach_files.append(
+            clickhouse_se_path if attach_debug else clickhouse_se_stripped_path
+        )
     if attach_debug:
         attach_files.extend(CH.prepare_logs(info=info, all=True))
 

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -384,11 +384,12 @@ def main():
             attach_debug = True
         job_info = results[-1].info
 
-    if clickhouse_se_path.is_file():
+    clickhouse_upload_path = (
+        clickhouse_se_path if (attach_debug or not res) else clickhouse_se_stripped_path
+    )
+    if clickhouse_upload_path.is_file():
         # do not reupload clickhouse binary for non-building jobs (e.g. darwin tests)
-        attach_files.append(
-            clickhouse_se_path if attach_debug else clickhouse_se_stripped_path
-        )
+        attach_files.append(clickhouse_upload_path)
     if attach_debug:
         attach_files.extend(CH.prepare_logs(info=info, all=True))
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The difference between stripped and unstripped binaries is 87MB vs 691MB. On OK fast tests we will upload stripped binaries.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1288` (included in `26.7` and later)
<!-- ch-version-info:end -->