### PR TITLE
Docs: widen content on large screens

### DIFF
--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2513,6 +2513,10 @@ html:not(.dark) .ch-logo-invert {
         padding-left: max(calc(19rem + 2rem), calc((100vw - 1504px) / 2 + 2rem)) !important;
         padding-right: min(calc(100vw - 19rem - 1504px + 2rem), calc((100vw - 1504px) / 2 + 2rem)) !important;
     }
+
+    html:not([data-page-mode="custom"]) #ch-custom-footer [data-inner] {
+        max-width: 1440px !important;
+    }
 }
 
 /* Reduce inner flex gap and left padding */

--- a/docs/_site/styles.css
+++ b/docs/_site/styles.css
@@ -2491,22 +2491,27 @@ html:not(.dark) .ch-logo-invert {
     }
 }
 
-/* On wide viewports, doc pages spread their content out: content-area centers
-   via mx-auto while content-side-layout (TOC / API request+response panels) sticks
-   to the right edge, leaving a big gap between them. Cap #content-container at
-   the exact width of content (768) + gap (32) + side-layout (448) + 32px x 2
-   padding = 1312px, and center it. The footer mirrors the same horizontal range
-   so its left and right edges line up with the content block. */
-@media (min-width: 1616px) {
+/* On wide viewports, give the article more room while keeping it aligned with
+   content-side-layout (TOC / API request+response panels). Cap #content-container
+   at the exact width of content (960) + gap (32) + side-layout (448) + 32px x 2
+   padding = 1504px, and center it. The 1824px breakpoint accommodates the
+   sidebar (304), the capped container (1504), and a desktop scrollbar, so the
+   layout cannot overflow when it takes effect. The footer mirrors the same
+   horizontal range so its edges line up with the content block. */
+@media (min-width: 1824px) {
+    html:not([data-page-mode="custom"]) #content-area {
+        max-width: 60rem !important;
+    }
+
     html:not([data-page-mode="custom"]) #content-container {
-        max-width: 1312px !important;
-        margin-left: max(19rem, calc((100vw - 1312px) / 2)) !important;
+        max-width: 1504px !important;
+        margin-left: max(19rem, calc((100vw - 1504px) / 2)) !important;
         margin-right: auto !important;
     }
 
     html:not([data-page-mode="custom"]) #ch-custom-footer {
-        padding-left: max(calc(19rem + 2rem), calc((100vw - 1312px) / 2 + 2rem)) !important;
-        padding-right: min(calc(100vw - 19rem - 1312px + 2rem), calc((100vw - 1312px) / 2 + 2rem)) !important;
+        padding-left: max(calc(19rem + 2rem), calc((100vw - 1504px) / 2 + 2rem)) !important;
+        padding-right: min(calc(100vw - 19rem - 1504px + 2rem), calc((100vw - 1504px) / 2 + 2rem)) !important;
     }
 }
 


### PR DESCRIPTION
Widen the primary documentation content area from 768px to 960px on viewports at least 1824px wide. The surrounding container and footer calculations expand in step so the sidebar, article, side layout, and footer remain aligned without horizontal overflow, while narrower and custom pages remain unchanged.

Validated in the local Mintlify preview at 1920px with the navbar visible and no horizontal overflow. The stylesheet also passes CSS parsing and `git diff --check`.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Widen the documentation content area on large screens.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1281` (included in `26.7` and later)
<!-- ch-version-info:end -->