### PR TITLE
Fix flaky test_replicated_users grant/rename under async replication

### DIFF
--- a/tests/integration/test_replicated_users/test.py
+++ b/tests/integration/test_replicated_users/test.py
@@ -160,28 +160,36 @@ def test_grant_revoke_replicated(started_cluster, use_on_cluster: bool):
     node1.query("SYSTEM RELOAD CONFIG")
     on_cluster = "ON CLUSTER default" if use_on_cluster else ""
 
-    node1.query(f"CREATE USER theuser2 {on_cluster}")
+    try:
+        node1.query(f"CREATE USER theuser2 {on_cluster}")
 
-    assert node1.query(f"GRANT {on_cluster} SELECT ON *.* to theuser2") == ""
+        assert node1.query(f"GRANT {on_cluster} SELECT ON *.* to theuser2") == ""
 
-    assert node2.query("SHOW GRANTS FOR theuser2") == "GRANT SELECT ON *.* TO theuser2\n"
+        # The grant is replicated to node2 asynchronously, so read it back with a
+        # retry: a bare read here races the replication and can observe empty grants.
+        assert_eq_with_retry(
+            node2, "SHOW GRANTS FOR theuser2", "GRANT SELECT ON *.* TO theuser2"
+        )
 
-    assert node1.query(f"REVOKE {on_cluster} SELECT ON *.* from theuser2") == ""
-    node1.query(f"DROP USER theuser2 {on_cluster}")
+        assert node1.query(f"REVOKE {on_cluster} SELECT ON *.* from theuser2") == ""
+    finally:
+        # Always drop theuser2 and restore the default profile, even if an assert
+        # above fails, so the leftover user/config cannot leak into later tests.
+        node1.query(f"DROP USER IF EXISTS theuser2 {on_cluster}")
 
-    node1.replace_config(
-        "/etc/clickhouse-server/users.d/users.xml",
-        inspect.cleandoc(
-            """
-            <clickhouse>
-                <profiles>
-                    <default/>
-                </profiles>
-            </clickhouse>
-            """
-        ),
-    )
-    node1.query("SYSTEM RELOAD CONFIG")
+        node1.replace_config(
+            "/etc/clickhouse-server/users.d/users.xml",
+            inspect.cleandoc(
+                """
+                <clickhouse>
+                    <profiles>
+                        <default/>
+                    </profiles>
+                </clickhouse>
+                """
+            ),
+        )
+        node1.query("SYSTEM RELOAD CONFIG")
 
 
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111007
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes two flaky failures in `test_replicated_users` seen under `amd_tsan`, reported by @ alexey-milovidov on #111007:
- `test_grant_revoke_replicated[With_ignored_on_cluster]` — empty `SHOW GRANTS` right after a replicated `GRANT`.
- `test_rename_replicated[USER]` — `ACCESS_ENTITY_ALREADY_EXISTS` on `ALTER USER ... RENAME`.

Both trace to a single test bug, not a server bug.

Root cause. `test_grant_revoke_replicated` reads the grant back from `node2` at line 167 with a bare, un-retried `node2.query("SHOW GRANTS FOR theuser2")`. It is the only cross-replica read in the file without a retry; every other one already uses `query_with_retry` / `assert_eq_with_retry`. `ReplicatedAccessStorage` propagates the write to `node2` asynchronously, so a fast read can observe stale state. In the failing run `node2` was read 265 ms after the `node1` grant and returned empty.

The second failure is a cascade of the first: when line 167 fails, the test aborts before its `DROP USER theuser2`, leaking `theuser2`; the next test then does `ALTER USER theuser RENAME TO theuser2` and correctly hits the leftover entity (all 20 retries fail identically; the server-side collision check is behaving as intended). CI history confirms the two tests fail together in the same commit, never independently.

Fix (test only):
- Read the grant back with `assert_eq_with_retry` so it tolerates the replication window.
- Wrap the `theuser2` create/drop in `try/finally` so the user and the profile config are always restored, even on an earlier assertion failure, so nothing can leak into later tests.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111007&sha=472b806e1820703eafeb6fb2dcd4e928bb482baf&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29

Verification: the two failing tests plus their siblings pass in the integration harness (7 passed, no retries). Reverting to the bare read reproduces the stale-`node2` read against a local 2-node replicated-access cluster.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1003` (included in `26.8` and later)
<!-- ch-version-info:end -->