### PR TITLE
Move noisy log from 'trace' to 'test' level

### DIFF
--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -835,7 +835,7 @@ void QueryPlan::convertToDistributed(const QueryPlanOptimizationSettings & optim
     {
         auto it = distributed_plan.stage_depends_on.find(stage.first);
         const auto & dependencies = it != distributed_plan.stage_depends_on.end() ? it->second : std::unordered_map<String, String>{};
-        LOG_TRACE(getLogger("optimize"), "Distributed stage: '{}' depends on: [{}] plan:\n{}",
+        LOG_TEST(getLogger("optimize"), "Distributed stage: '{}' depends on: [{}] plan:\n{}",
             stage.first, fmt::join(dependencies, ", "), dumpQueryPlan(stage.second.query_plan_fragment));
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1316` (included in `26.7` and later)
<!-- ch-version-info:end -->