### PR TITLE
Fix LOGICAL_ERROR on lambda whose body folds a Bool/UInt8 conditional

### DIFF
--- a/src/DataTypes/DataTypeFunction.cpp
+++ b/src/DataTypes/DataTypeFunction.cpp
@@ -31,7 +31,30 @@ std::string DataTypeFunction::doGetName() const
 
 bool DataTypeFunction::equals(const IDataType & rhs) const
 {
-    return typeid(rhs) == typeid(*this) && getName() == rhs.getName();
+    if (typeid(rhs) != typeid(*this))
+        return false;
+
+    const auto & rhs_function = static_cast<const DataTypeFunction &>(rhs);
+
+    /// Compare element-wise via IDataType::equals rather than by getName(), so that types sharing the
+    /// same underlying type but differing only by display name (e.g. Bool and UInt8) compare equal,
+    /// consistent with every other composite type (Array/Tuple/Nullable/Map/LowCardinality). Argument
+    /// and return types may be nullptr for not-yet-resolved lambdas; a nullptr equals only nullptr.
+    auto element_equals = [](const DataTypePtr & lhs_type, const DataTypePtr & rhs_type)
+    {
+        if (!lhs_type || !rhs_type)
+            return lhs_type == rhs_type;
+        return lhs_type->equals(*rhs_type);
+    };
+
+    if (argument_types.size() != rhs_function.argument_types.size())
+        return false;
+
+    for (size_t i = 0; i < argument_types.size(); ++i)
+        if (!element_equals(argument_types[i], rhs_function.argument_types[i]))
+            return false;
+
+    return element_equals(return_type, rhs_function.return_type);
 }
 
 void DataTypeFunction::updateHashImpl(SipHash & hash) const

--- a/tests/queries/0_stateless/03718_lambda_multiif_bool_uint8_type.reference
+++ b/tests/queries/0_stateless/03718_lambda_multiif_bool_uint8_type.reference
@@ -1,0 +1,6 @@
+['ALL','ALL']
+['ALL']
+[true,false]
+['ALL','Z']
+['ALL']
+[]

--- a/tests/queries/0_stateless/03718_lambda_multiif_bool_uint8_type.sql
+++ b/tests/queries/0_stateless/03718_lambda_multiif_bool_uint8_type.sql
@@ -1,0 +1,13 @@
+-- A lambda body that folds a constant-condition if/multiIf mixing a Bool literal branch with a
+-- UInt8 comparison branch used to abort with LOGICAL_ERROR "Lambda resolved type Function(... -> Bool)
+-- is not equal to type from actions DAG Function(... -> UInt8)" under the analyzer. See issue #111237.
+SET enable_analyzer = 1;
+
+SELECT arrayFilter(p -> multiIf(false, true, p = 'ALL'), array('ALL', 'X', 'ALL'));
+SELECT arrayFilter(p -> if(false, true, p = 'ALL'), array('ALL', 'X'));
+SELECT arrayMap(p -> multiIf(false, true, p = 'ALL'), array('ALL', 'X'));
+SELECT arrayFilter(p -> multiIf(p = 'Z', true, false, true, p = 'ALL'), array('ALL', 'X', 'Z'));
+
+-- Previously-working shapes must keep working.
+SELECT arrayFilter(p -> multiIf(false, 1, p = 'ALL'), array('ALL', 'X'));
+SELECT arrayFilter(p -> multiIf(false, true, 0), array('ALL', 'X'));


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111237
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` ("Lambda resolved type ... is not equal to type from actions DAG ...") when a higher-order function's lambda body is a constant-condition `if`/`multiIf` that mixes a `Bool` literal branch with a `UInt8` comparison branch, e.g. `arrayFilter(p -> multiIf(false, true, p = 'ALL'), ['ALL'])`.


### Description

`arrayFilter(p -> multiIf(false, true, p = 'ALL'), ['ALL'])` aborted under the analyzer with `Lambda resolved type Function(String -> Bool) is not equal to type from actions DAG Function(String -> UInt8). (LOGICAL_ERROR)`.

`IfConstantConditionPass` folds the constant-condition conditional to its non-constant branch (the `UInt8` comparison), changing the lambda body type `Bool -> UInt8`, while the lambda node keeps its resolved `Function(... -> Bool)` type. `PlannerActionsVisitor` then rebuilds the lambda's DAG type from the folded body and compares it to the stored type via `DataTypeFunction::equals`.

`DataTypeFunction::equals` compared by `getName()` string, so `Function(... -> Bool)` and `Function(... -> UInt8)` were treated as different even though `Bool` is `DataTypeUInt8` with a custom display name (same `typeid`). Every other composite type (`Array`/`Tuple`/`Nullable`/`Map`/`LowCardinality`) compares element-wise via `IDataType::equals`, under which `Bool` and `UInt8` are equal. This makes `DataTypeFunction::equals` compare its argument and return types the same way (nullptr-safe for not-yet-resolved lambdas).

Repro (aborts on master under the analyzer, works on this branch):
```sql
SELECT arrayFilter(p -> multiIf(false, true, p = 'ALL'), array('ALL'));
```

Closes https://github.com/ClickHouse/ClickHouse/issues/111237
