### PR TITLE
Fix map[key] returning a later duplicate key instead of the first

### DIFF
--- a/src/DataTypes/DataTypeMapHelpers.cpp
+++ b/src/DataTypes/DataTypeMapHelpers.cpp
@@ -23,10 +23,7 @@ constexpr size_t KEY_NOT_FOUND = std::numeric_limits<size_t>::max();
 /// Phase 1: Find the position of the requested key in each row.
 ///
 /// Builds `matched_positions[i]` = flat index into the keys/values column
-/// where the key was found for row (start + i), or KEY_NOT_FOUND.
-/// Uses position prediction: if the key was at relative offset K in the
-/// previous row, we try offset K first in the current row before falling
-/// back to a linear scan.
+/// of the first key matching `key` in row (start + i), or KEY_NOT_FOUND.
 /// ---------------------------------------------------------------------------
 
 /// Generic key matcher that uses virtual compareAt. Used as a fallback
@@ -91,6 +88,15 @@ struct KeyMatcherFixedString
 
 /// The core position-finding loop, parametrized by Matcher type.
 /// For each row in [start, end), finds the flat index of the matching key.
+///
+/// `m[key]` returns the value of the FIRST occurrence of the key in the row, so
+/// each row is scanned left to right and the first match is taken. Duplicate keys
+/// in a Map are a legal (if degenerate) state, so a position-prediction shortcut
+/// across rows is not used: it could accept a later duplicate at the predicted
+/// offset while an earlier occurrence exists, yielding a value that depends on the
+/// preceding rows in the block (see issue #111203). Ruling out an earlier duplicate
+/// still requires scanning from the start, so there is no correct constant-time
+/// shortcut to prefer over the scan.
 template <typename Matcher>
 void findKeyPositions(
     const ColumnArray::Offsets & offsets,
@@ -102,48 +108,20 @@ void findKeyPositions(
     size_t num_rows = end - start;
     matched_positions.resize(num_rows);
 
-    /// Relative offset of the key within the map from the previous row.
-    /// Used for position prediction.
-    size_t predicted_relative_pos = 0;
-    bool have_prediction = false;
-
     for (size_t i = start; i < end; ++i)
     {
         size_t positions_row_idx = i - start;
         size_t offset_start = offsets[ssize_t(i) - 1];
         size_t offset_end = offsets[i];
 
-        /// Try the predicted position first.
-        if (have_prediction)
-        {
-            size_t predicted_pos = offset_start + predicted_relative_pos;
-            if (predicted_pos < offset_end && matcher.match(predicted_pos))
-            {
-                matched_positions[positions_row_idx] = predicted_pos;
-                continue;
-            }
-        }
-
-        /// Prediction missed or not available. Fall back to linear scan.
-        bool found = false;
+        matched_positions[positions_row_idx] = KEY_NOT_FOUND;
         for (size_t j = offset_start; j < offset_end; ++j)
         {
             if (matcher.match(j))
             {
                 matched_positions[positions_row_idx] = j;
-                predicted_relative_pos = j - offset_start;
-                have_prediction = true;
-                found = true;
                 break;
             }
-        }
-
-        if (!found)
-        {
-            /// Keep the prediction unchanged: if only this row is missing the key,
-            /// subsequent rows likely have the same key order, so the prediction
-            /// may still be valid. A wrong prediction costs only one extra match call.
-            matched_positions[positions_row_idx] = KEY_NOT_FOUND;
         }
     }
 }

--- a/src/Functions/array/arrayElement.cpp
+++ b/src/Functions/array/arrayElement.cpp
@@ -1835,49 +1835,20 @@ void FunctionArrayElement<mode>::executeMatchKeyToIndex(
     const Offsets & offsets, PaddedPODArray<UInt64> & matched_idxs, const Matcher & matcher)
 {
     size_t rows = offsets.size();
-    size_t expected_match_pos = 0;
-    bool matched = false;
-    if (!rows)
-        return;
 
-    /// In practice, map keys are usually in the same order, it is worth a try to
-    /// predict the next key position. So it can avoid a lot of unnecessary comparisons.
-    for (size_t j = offsets[-1], end = offsets[0]; j < end; ++j)
+    /// `m[key]` returns the value of the FIRST occurrence of the key in the row, so each
+    /// row is scanned left to right and the first match is taken (index encoded as
+    /// position + 1, with 0 meaning "not found"). Duplicate keys in a Map are a legal
+    /// (if degenerate) state, so a cross-row position-prediction shortcut is not used: it
+    /// could accept a later duplicate at the predicted offset while an earlier occurrence
+    /// exists, yielding a value that depends on the preceding rows in the block (see issue
+    /// #111203). Ruling out an earlier duplicate still requires scanning from the start,
+    /// so there is no correct constant-time shortcut to prefer over the scan.
+    for (size_t i = 0; i < rows; ++i)
     {
-        if (matcher.match(j, 0))
-        {
-            matched_idxs.push_back(j - offsets[-1] + 1);
-            matched = true;
-            expected_match_pos = end + j - offsets[-1];
-            break;
-        }
-    }
-    if (!matched)
-    {
-        expected_match_pos = offsets[0];
-        matched_idxs.push_back(0);
-    }
-    size_t i = 1;
-    for (; i < rows; ++i)
-    {
-        const auto & begin = offsets[i - 1];
+        const auto & begin = offsets[ssize_t(i) - 1];
         const auto & end = offsets[i];
-        if (expected_match_pos < end && matcher.match(expected_match_pos, i))
-        {
-            auto map_key_index = expected_match_pos - begin;
-            matched_idxs.push_back(map_key_index + 1);
-            expected_match_pos = end + map_key_index;
-        }
-        else
-            break;
-    }
-
-    // fallback to linear search
-    for (; i < rows; ++i)
-    {
-        matched = false;
-        const auto & begin = offsets[i - 1];
-        const auto & end = offsets[i];
+        bool matched = false;
         for (size_t j = begin; j < end; ++j)
         {
             if (matcher.match(j, i))

--- a/tests/queries/0_stateless/04546_map_element_duplicate_keys_first_match.reference
+++ b/tests/queries/0_stateless/04546_map_element_duplicate_keys_first_match.reference
@@ -1,0 +1,28 @@
+wide, filter id=2, subcolumns=0	FIRST
+wide, filter id=2, subcolumns=1	FIRST
+wide, no filter, subcolumns=0	1	prime
+wide, no filter, subcolumns=0	2	FIRST
+wide, no filter, subcolumns=1	1	prime
+wide, no filter, subcolumns=1	2	FIRST
+wide, count first value, subcolumns=0	1
+wide, count first value, subcolumns=1	1
+compact, filter id=2, subcolumns=0	FIRST
+compact, filter id=2, subcolumns=1	FIRST
+compact, no filter, subcolumns=0	1	prime
+compact, no filter, subcolumns=0	2	FIRST
+compact, no filter, subcolumns=1	1	prime
+compact, no filter, subcolumns=1	2	FIRST
+Nullable(String) subcolumns=0	FIRST
+Nullable(String) subcolumns=1	FIRST
+LowCardinality(String) subcolumns=0	FIRST
+LowCardinality(String) subcolumns=1	FIRST
+LowCardinality(Nullable(String)) subcolumns=0	FIRST
+LowCardinality(Nullable(String)) subcolumns=1	FIRST
+UInt64 subcolumns=0	111
+UInt64 subcolumns=1	111
+Array(String) subcolumns=0	['FIRST']
+Array(String) subcolumns=1	['FIRST']
+LowCardinality(String) key subcolumns=0	FIRST
+LowCardinality(String) key subcolumns=1	FIRST
+UInt64 key subcolumns=0	FIRST
+UInt64 key subcolumns=1	FIRST

--- a/tests/queries/0_stateless/04546_map_element_duplicate_keys_first_match.sql
+++ b/tests/queries/0_stateless/04546_map_element_duplicate_keys_first_match.sql
@@ -1,0 +1,96 @@
+-- Tags: no-random-merge-tree-settings
+-- map[key] must return the value of the FIRST occurrence of the key in the row, and the
+-- result must not depend on optimize_functions_to_subcolumns, on preceding rows in the
+-- block, or on whether a filter isolates the row (issue #111203).
+
+DROP TABLE IF EXISTS t_map_dup;
+
+-- Wide part (min_bytes_for_wide_part = 0). Row 1 primes the cross-row key-position state:
+-- its match for '' sits at relative position 1. Row 2 has '' at positions 0 and 1, so a
+-- prediction of position 1 would wrongly return the second occurrence.
+CREATE TABLE t_map_dup (id UInt64, m Map(String, String))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_dup VALUES (1, map('x', 'k', '', 'prime')), (2, map('', 'FIRST', '', 'SECOND'));
+
+SELECT 'wide, filter id=2, subcolumns=0', m[''] FROM t_map_dup WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'wide, filter id=2, subcolumns=1', m[''] FROM t_map_dup WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT 'wide, no filter, subcolumns=0', id, m[''] FROM t_map_dup ORDER BY id SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'wide, no filter, subcolumns=1', id, m[''] FROM t_map_dup ORDER BY id SETTINGS optimize_functions_to_subcolumns = 1;
+-- The issue's count() example: filtering on the first duplicate's value must match exactly one row.
+SELECT 'wide, count first value, subcolumns=0', count() FROM t_map_dup WHERE id = 2 AND m[''] = 'FIRST' SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'wide, count first value, subcolumns=1', count() FROM t_map_dup WHERE id = 2 AND m[''] = 'FIRST' SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE t_map_dup;
+
+-- Compact part (default min_bytes_for_wide_part) exercises the other reader path.
+CREATE TABLE t_map_dup (id UInt64, m Map(String, String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_map_dup VALUES (1, map('x', 'k', '', 'prime')), (2, map('', 'FIRST', '', 'SECOND'));
+
+SELECT 'compact, filter id=2, subcolumns=0', m[''] FROM t_map_dup WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'compact, filter id=2, subcolumns=1', m[''] FROM t_map_dup WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT 'compact, no filter, subcolumns=0', id, m[''] FROM t_map_dup ORDER BY id SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'compact, no filter, subcolumns=1', id, m[''] FROM t_map_dup ORDER BY id SETTINGS optimize_functions_to_subcolumns = 1;
+
+DROP TABLE t_map_dup;
+
+-- Value-type matrix: the first-match value must be returned for every wrapper. Each table
+-- primes the key position at 1 in row 1, then has a duplicate key in row 2.
+DROP TABLE IF EXISTS t_map_types;
+
+-- Nullable(String) value
+CREATE TABLE t_map_types (id UInt64, m Map(String, Nullable(String)))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', 'k', 'd', 'prime')), (2, map('d', 'FIRST', 'd', 'SECOND'));
+SELECT 'Nullable(String) subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'Nullable(String) subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- LowCardinality(String) value
+CREATE TABLE t_map_types (id UInt64, m Map(String, LowCardinality(String)))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', 'k', 'd', 'prime')), (2, map('d', 'FIRST', 'd', 'SECOND'));
+SELECT 'LowCardinality(String) subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'LowCardinality(String) subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- LowCardinality(Nullable(String)) value
+CREATE TABLE t_map_types (id UInt64, m Map(String, LowCardinality(Nullable(String))))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', 'k', 'd', 'prime')), (2, map('d', 'FIRST', 'd', 'SECOND'));
+SELECT 'LowCardinality(Nullable(String)) subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'LowCardinality(Nullable(String)) subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- UInt64 value
+CREATE TABLE t_map_types (id UInt64, m Map(String, UInt64))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', 10, 'd', 20)), (2, map('d', 111, 'd', 222));
+SELECT 'UInt64 subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'UInt64 subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- Array(String) value
+CREATE TABLE t_map_types (id UInt64, m Map(String, Array(String)))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', ['k'], 'd', ['prime'])), (2, map('d', ['FIRST'], 'd', ['SECOND']));
+SELECT 'Array(String) subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'Array(String) subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- Key-type matrix.
+
+-- LowCardinality(String) key
+CREATE TABLE t_map_types (id UInt64, m Map(LowCardinality(String), String))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map('x', 'k', 'd', 'prime')), (2, map('d', 'FIRST', 'd', 'SECOND'));
+SELECT 'LowCardinality(String) key subcolumns=0', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'LowCardinality(String) key subcolumns=1', m['d'] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;
+
+-- UInt64 key
+CREATE TABLE t_map_types (id UInt64, m Map(UInt64, String))
+ENGINE = MergeTree ORDER BY id SETTINGS min_bytes_for_wide_part = 0;
+INSERT INTO t_map_types VALUES (1, map(9, 'k', 7, 'prime')), (2, map(7, 'FIRST', 7, 'SECOND'));
+SELECT 'UInt64 key subcolumns=0', m[7] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 0;
+SELECT 'UInt64 key subcolumns=1', m[7] FROM t_map_types WHERE id = 2 SETTINGS optimize_functions_to_subcolumns = 1;
+DROP TABLE t_map_types;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111203
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `map[key]` returning the value of a later duplicate key instead of the first one. When a `Map` column contained duplicate keys, the result of `map[key]` could depend on preceding rows in the same block and on the `optimize_functions_to_subcolumns` setting, so a `SELECT` and a `WHERE` over the same row could disagree.

### Description

`m[key]` must return the value of the FIRST occurrence of the key in a row. Two key-lookup loops used a cross-row position-prediction shortcut: if the previous row's first match was at relative offset K, offset K was tried first in the current row and accepted if it matched, without checking for an earlier occurrence. With duplicate keys the prediction could land on a later duplicate, and because the predicted offset depended on preceding rows, the result was block- and setting-dependent (see the `count()` mismatch in the issue).

Fix: drop the prediction and scan each row left to right, taking the first match. The prediction only saved work when the match was at a non-first position, which is exactly the unsafe case; when the match is at position 0 the scan finds it in one comparison, so no correctness-preserving shortcut is faster than the scan.

Both affected paths are fixed so the setting stays semantics-preserving:
- `findKeyPositions` in `DataTypeMapHelpers.cpp` (the `optimize_functions_to_subcolumns` subcolumn path).
- `executeMatchKeyToIndex` in `arrayElement.cpp` (the `arrayElement`/`m[key]` path).

New stateless test `04546_map_element_duplicate_keys_first_match` asserts the first-match value is returned with the setting on and off, with and without a filter, and across value types (String, Nullable, LowCardinality, LowCardinality(Nullable), UInt64, Array) and key types (String, LowCardinality(String), UInt64), on both wide and compact parts.

Closes https://github.com/ClickHouse/ClickHouse/issues/111203
