### PR TITLE
Refuse to install test configs when destination aliases the source

### DIFF
--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -8,6 +8,17 @@ set -x -e
 DEST_SERVER_PATH="${1:-/etc/clickhouse-server}"
 DEST_CLIENT_PATH="${2:-/etc/clickhouse-client}"
 SRC_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+# This script does `rm -rf "$DEST_SERVER_PATH"/config.d` and then repopulates
+# it with symlinks and generated files derived from "$SRC_PATH"/config.d. If
+# the two ever resolve to the same directory (e.g. DEST_SERVER_PATH pointing
+# at a bind mount of the repo's own tests/config), that first step destroys
+# the tracked source configs themselves. Refuse instead of running.
+if [ "$(readlink -f "$DEST_SERVER_PATH/config.d" 2>/dev/null || echo "$DEST_SERVER_PATH/config.d")" = "$(readlink -f "$SRC_PATH/config.d")" ]; then
+    echo "Refusing to install: DEST_SERVER_PATH/config.d ($DEST_SERVER_PATH/config.d) resolves to the same directory as SRC_PATH/config.d ($SRC_PATH/config.d). This script deletes and repopulates that directory, which would destroy the tracked test configs." >&2
+    exit 1
+fi
+
 if [ $# -ge 2 ]; then
     shift 2
 fi

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -9,11 +9,7 @@ DEST_SERVER_PATH="${1:-/etc/clickhouse-server}"
 DEST_CLIENT_PATH="${2:-/etc/clickhouse-client}"
 SRC_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-# This script does `rm -rf "$DEST_SERVER_PATH"/config.d` and then repopulates
-# it with symlinks and generated files derived from "$SRC_PATH"/config.d. If
-# the two ever resolve to the same directory (e.g. DEST_SERVER_PATH pointing
-# at a bind mount of the repo's own tests/config), that first step destroys
-# the tracked source configs themselves. Refuse instead of running.
+# Below we rm -rf config.d before repopulating it; refuse if that would wipe the source configs.
 if [ "$(readlink -f "$DEST_SERVER_PATH/config.d" 2>/dev/null || echo "$DEST_SERVER_PATH/config.d")" = "$(readlink -f "$SRC_PATH/config.d")" ]; then
     echo "Refusing to install: DEST_SERVER_PATH/config.d ($DEST_SERVER_PATH/config.d) resolves to the same directory as SRC_PATH/config.d ($SRC_PATH/config.d). This script deletes and repopulates that directory, which would destroy the tracked test configs." >&2
     exit 1


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/90883

### Problem

`tests/config/install.sh` deletes `DEST_SERVER_PATH/config.d` with `rm -rf`, then repopulates it with symlinks derived from `SRC_PATH/config.d`.

If `DEST_SERVER_PATH` is set up so its `config.d` resolves to the same directory as the repo's own `tests/config/config.d` (for example a bind mount pointing `/etc/clickhouse-server` back at the source tree), that `rm -rf` deletes the tracked source configs instead of just clearing generated symlinks.

This also explains the `<async>0</async>` / `<async>1</async>` flip reported in the issue: after the `config.d` wipe, the four `sed`-generated files (`logger_trace.xml`, `keeper_port.xml`, `storage_conf.xml`, `storage_conf_02944.xml`) get rewritten in place with randomized values, leaving `git status` dirty on the tracked source tree.

### Fix

Resolve both paths with `readlink -f` and compare them before the destructive step.
If they alias, the script exits with an error instead of running.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry: