### PR TITLE
Perf tests: precision-targeted run policy, confirmation reruns, CPU pinning

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -426,7 +426,12 @@ def run_performance_tests(server_dir, port, runs, max_queries, time_budget_s):
             f"{repo_path}/tests/performance/scripts/perf.py "
             f"--host localhost localhost "
             f"--port {port} {port} "
-            f"--runs {runs} --max-queries {max_queries} "
+            # Exactly `runs` runs: profile collection wants quick coverage,
+            # not measurement precision, so pin the minimum and both caps
+            # instead of the legacy --runs ("at least N"), which would widen
+            # the adaptive policy to its default minimum of 5.
+            f"--min-runs {runs} --cap {runs} --cap-fast {runs} "
+            f"--max-queries {max_queries} "
             f"--max-query-seconds 15 --prewarm-max-query-seconds 15 "
             f"--profile-seconds 0 "
             f"{repo_path}/tests/performance/{test_file}",

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -533,7 +533,8 @@ def get_physical_core_cpu_list():
 # The static default (max_threads=12, tests/performance/scripts/config/users.d/
 # perf-comparison-tweaks-users.xml) is kept for arm (m8g.4xlarge: 16 real
 # cores). The zzz- prefix makes this file sort after (and thus override) the
-# static users.d files.
+# static users.d files. Standalone compare.sh entrypoints write the same
+# override in write_max_threads_override (keep the two in sync).
 MAX_THREADS_OVERRIDE_FILE = "zzz-cpu-pinning-max-threads.xml"
 MAX_THREADS_OVERRIDE_XML = """\
 <!--
@@ -927,16 +928,19 @@ class CHServer:
 
     @classmethod
     def run_test(
-        cls, test_file, runs=7, max_queries=0, results_path=f"{temp_dir}/perf_wd/"
+        cls, test_file, runs=None, max_queries=0, results_path=f"{temp_dir}/perf_wd/"
     ):
         test_name = test_file.split("/")[-1].removesuffix(".xml")
         sw = Utils.Stopwatch()
+        # --runs ("at least N runs per query") is passed only when explicitly
+        # requested; by default the adaptive run policy decides the counts.
+        runs_arg = f"--runs {runs}" if runs is not None else ""
         res, out, err = Shell.get_res_stdout_stderr(
             f"./tests/performance/scripts/perf.py --host localhost localhost \
                 --port {cls.LEFT_SERVER_PORT} {cls.RIGHT_SERVER_PORT} \
                 --binary {perf_left}/clickhouse {perf_right}/clickhouse \
                 --http-port {cls.LEFT_SERVER_HTTP_PORT} {cls.RIGHT_SERVER_HTTP_PORT} \
-                --runs {runs} --max-queries {max_queries} \
+                {runs_arg} --max-queries {max_queries} \
                 --profile-seconds 10 \
                 {test_file}",
             verbose=True,
@@ -1459,7 +1463,6 @@ def main():
                 max_queries = 0 if test in benchmarks else 10
                 CHServer.run_test(
                     "./tests/performance/" + test,
-                    runs=7,
                     max_queries=max_queries,
                     results_path=perf_wd,
                 )

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -594,6 +594,13 @@ def write_max_threads_override():
     """
     if not Utils.is_amd():
         print("Not x86_64 - keeping the static max_threads")
+        # Reused workspaces (mkdir -p / cp -r) may carry an override from an
+        # earlier x86_64 run; remove it so the static value actually applies.
+        for config_dir in (perf_left_config, perf_right_config):
+            stale = Path(config_dir) / "users.d" / MAX_THREADS_OVERRIDE_FILE
+            if stale.exists():
+                print(f"Removing stale max_threads override [{stale}]")
+                stale.unlink()
         return True
     max_threads = len(get_physical_core_cpu_list().split(","))
     for config_dir in (perf_left_config, perf_right_config):

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -541,16 +541,16 @@ MAX_THREADS_OVERRIDE_XML = """\
     Written by ci/jobs/performance_tests.py at job setup, x86_64 only (arm
     keeps max_threads=12 from perf-comparison-tweaks-users.xml).
 
-    The x86_64 runner (m7i.4xlarge) has 8 physical cores x 2 hyperthreads and
-    both servers are pinned with taskset to one hyperthread per physical core.
-    max_threads=8 matches that CPU set: one query thread per physical core, so
-    whether two threads share a hyperthread sibling no longer depends on the
-    scheduler (measured A/A noise: amd 0.51% vs arm 0.42%).
+    Both servers are pinned with taskset to one hyperthread per physical core
+    and max_threads is set to the size of that CPU set (e.g. 8 on
+    m7i.4xlarge: 8 physical cores x 2 hyperthreads), one query thread per
+    pinned CPU, so whether two threads share a hyperthread sibling no longer
+    depends on the scheduler (measured A/A noise: amd 0.51% vs arm 0.42%).
 -->
 <clickhouse>
     <profiles>
         <default>
-            <max_threads>8</max_threads>
+            <max_threads>{max_threads}</max_threads>
         </default>
     </profiles>
 </clickhouse>
@@ -558,15 +558,21 @@ MAX_THREADS_OVERRIDE_XML = """\
 
 
 def write_max_threads_override():
-    """Write the x86_64 max_threads override into both servers' users.d."""
+    """Write the x86_64 max_threads override into both servers' users.d.
+
+    max_threads is derived from the pinned CPU list, so the one-thread-per-
+    pinned-CPU invariant holds on any runner shape (smaller/larger/non-SMT
+    x86 hosts), not just the current m7i.4xlarge.
+    """
     if not Utils.is_amd():
         print("Not x86_64 - keeping the static max_threads")
         return True
+    max_threads = len(get_physical_core_cpu_list().split(","))
     for config_dir in (perf_left_config, perf_right_config):
         target = Path(config_dir) / "users.d" / MAX_THREADS_OVERRIDE_FILE
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(MAX_THREADS_OVERRIDE_XML)
-        print(f"Wrote max_threads override to [{target}]")
+        target.write_text(MAX_THREADS_OVERRIDE_XML.format(max_threads=max_threads))
+        print(f"Wrote max_threads={max_threads} override to [{target}]")
     return True
 
 

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -514,21 +514,28 @@ def get_physical_core_cpu_list():
     # to start the servers. Pick, per physical core, the first sibling the
     # process is actually allowed to run on.
     getaffinity = getattr(os, "sched_getaffinity", None)
-    allowed = getaffinity(0) if getaffinity else None
-    cores = {}
     try:
-        for path in Path("/sys/devices/system/cpu").glob(
-            "cpu[0-9]*/topology/thread_siblings_list"
-        ):
-            # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
+        allowed = getaffinity(0) if getaffinity else None
+    except OSError:
+        allowed = None
+    cores = {}
+    # Per-file tolerance, matching the compare.sh copy: one unreadable or
+    # malformed sibling file must not discard the rest of the topology, or
+    # the two pinners could pin the main run and the confirm rerun to
+    # different CPU sets.
+    for path in Path("/sys/devices/system/cpu").glob(
+        "cpu[0-9]*/topology/thread_siblings_list"
+    ):
+        # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
+        try:
             siblings = [
                 int(s) for s in re.split(r"[,-]", path.read_text().strip()) if s
             ]
-            usable = [c for c in siblings if allowed is None or c in allowed]
-            if usable:
-                cores[min(siblings)] = min(usable)
-    except (OSError, ValueError):
-        cores = {}
+        except (OSError, ValueError):
+            continue
+        usable = [c for c in siblings if allowed is None or c in allowed]
+        if usable:
+            cores[min(siblings)] = min(usable)
     cpus = set(cores.values())
     if not cpus:
         print(
@@ -897,6 +904,12 @@ class CHServer:
 
     def start(self):
         print(f"Starting [{self.name}] ClickHouse server")
+        # Rewrite the max_threads override right before starting: praktika
+        # stages can be re-entered by a fresh process whose affinity mask may
+        # differ from the one CONFIGURE saw, and taskset (start_cmd) is
+        # computed at construction time - the override must match it.
+        # Idempotent; compare.sh::restart does the same for its flows.
+        write_max_threads_override()
         print("Command: ", self.start_cmd)
         self.log_fd = open(self.log_file, "w")
         self.proc = subprocess.Popen(

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -493,6 +493,13 @@ def get_perf_arch():
     Utils.raise_with_error("Unknown processor architecture")
 
 
+def cpu_pinning_enabled():
+    """Pinning requires Linux (taskset, sysfs topology, sched_getaffinity),
+    not just the CPU family: a local x86_64 macOS run must not get a taskset
+    prefix it cannot execute."""
+    return Utils.is_amd() and os.uname().sysname == "Linux"
+
+
 def get_physical_core_cpu_list():
     """Return a taskset -c CPU list with one hyperthread per physical core.
 
@@ -592,8 +599,8 @@ def write_max_threads_override():
     pinned-CPU invariant holds on any runner shape (smaller/larger/non-SMT
     x86 hosts), not just the current m7i.4xlarge.
     """
-    if not Utils.is_amd():
-        print("Not x86_64 - keeping the static max_threads")
+    if not cpu_pinning_enabled():
+        print("CPU pinning disabled (needs Linux x86_64) - keeping the static max_threads")
         # Reused workspaces (mkdir -p / cp -r) may carry an override from an
         # earlier x86_64 run; remove it so the static value actually applies.
         for config_dir in (perf_left_config, perf_right_config):
@@ -899,7 +906,9 @@ class CHServer:
         # thread per physical core and removes scheduler-dependent hyperthread
         # sibling sharing. arm (real cores only) is unchanged.
         taskset_prefix = (
-            f"taskset -c {get_physical_core_cpu_list()} " if Utils.is_amd() else ""
+            f"taskset -c {get_physical_core_cpu_list()} "
+            if cpu_pinning_enabled()
+            else ""
         )
 
         # The perf-comparison config removes <http_port>; re-enable it on the

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -493,6 +493,82 @@ def get_perf_arch():
     Utils.raise_with_error("Unknown processor architecture")
 
 
+def get_physical_core_cpu_list():
+    """Return a taskset -c CPU list with one hyperthread per physical core.
+
+    On the x86_64 perf runner (m7i.4xlarge: 8 physical cores x 2 hyperthreads)
+    both measured servers are pinned to this list so that query threads never
+    end up sharing a hyperthread sibling with each other depending on scheduler
+    mood - a top suspect for the amd-vs-arm A/A noise gap (0.51% vs 0.42%).
+
+    Parses /sys/devices/system/cpu/cpu*/topology/thread_siblings_list and keeps
+    the first sibling of each unique pair; falls back to cpus 0..(nproc/2 - 1)
+    if the sysfs topology is unavailable. Only call at runtime on the Linux CI
+    host (there is no /sys on macOS) - never at import time.
+
+    Must stay in sync with cpu_pinning_prefix in ci/jobs/scripts/perf/compare.sh
+    (the server restart path used by the confirm-changes stage).
+    """
+    cpus = set()
+    try:
+        for path in Path("/sys/devices/system/cpu").glob(
+            "cpu[0-9]*/topology/thread_siblings_list"
+        ):
+            # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
+            first = re.split(r"[,-]", path.read_text().strip())[0]
+            cpus.add(int(first))
+    except (OSError, ValueError, IndexError):
+        cpus = set()
+    if not cpus:
+        print(
+            "WARNING: could not parse cpu topology from sysfs, "
+            "falling back to the first half of the cpus"
+        )
+        cpus = set(range(max((os.cpu_count() or 2) // 2, 1)))
+    return ",".join(str(cpu) for cpu in sorted(cpus))
+
+
+# users.d override applied only on x86_64, where both servers are pinned with
+# taskset to one hyperthread per physical core (see get_physical_core_cpu_list).
+# The static default (max_threads=12, tests/performance/scripts/config/users.d/
+# perf-comparison-tweaks-users.xml) is kept for arm (m8g.4xlarge: 16 real
+# cores). The zzz- prefix makes this file sort after (and thus override) the
+# static users.d files.
+MAX_THREADS_OVERRIDE_FILE = "zzz-cpu-pinning-max-threads.xml"
+MAX_THREADS_OVERRIDE_XML = """\
+<!--
+    Written by ci/jobs/performance_tests.py at job setup, x86_64 only (arm
+    keeps max_threads=12 from perf-comparison-tweaks-users.xml).
+
+    The x86_64 runner (m7i.4xlarge) has 8 physical cores x 2 hyperthreads and
+    both servers are pinned with taskset to one hyperthread per physical core.
+    max_threads=8 matches that CPU set: one query thread per physical core, so
+    whether two threads share a hyperthread sibling no longer depends on the
+    scheduler (measured A/A noise: amd 0.51% vs arm 0.42%).
+-->
+<clickhouse>
+    <profiles>
+        <default>
+            <max_threads>8</max_threads>
+        </default>
+    </profiles>
+</clickhouse>
+"""
+
+
+def write_max_threads_override():
+    """Write the x86_64 max_threads override into both servers' users.d."""
+    if not Utils.is_amd():
+        print("Not x86_64 - keeping the static max_threads")
+        return True
+    for config_dir in (perf_left_config, perf_right_config):
+        target = Path(config_dir) / "users.d" / MAX_THREADS_OVERRIDE_FILE
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(MAX_THREADS_OVERRIDE_XML)
+        print(f"Wrote max_threads override to [{target}]")
+    return True
+
+
 def build_perf_query_history_link(test_name, check_name):
     """Build a ClickHouse Play link showing performance history for a query on master."""
     table = Settings.CI_DB_TABLE_NAME or "checks"
@@ -775,11 +851,20 @@ class CHServer:
         self.server_path = serever_path
         self.name = "Reference" if is_left else "Patched"
 
+        # On x86_64 pin both servers to one hyperthread per physical core (the
+        # same list for both: they are measured alternately, not concurrently).
+        # Together with the max_threads=8 users.d override this keeps one query
+        # thread per physical core and removes scheduler-dependent hyperthread
+        # sibling sharing. arm (real cores only) is unchanged.
+        taskset_prefix = (
+            f"taskset -c {get_physical_core_cpu_list()} " if Utils.is_amd() else ""
+        )
+
         # The perf-comparison config removes <http_port>; re-enable it on the
         # command line (a documented config override, see Server.cpp) with a
         # distinct port per server, so that shell-script tests can talk to the
         # server over HTTP.
-        self.start_cmd = f"{serever_path}/clickhouse-server --config-file={serever_path}/config/config.xml \
+        self.start_cmd = f"{taskset_prefix}{serever_path}/clickhouse-server --config-file={serever_path}/config/config.xml \
             -- --path {serever_path}/db --user_files_path {serever_path}/db/user_files \
             --top_level_domains_path {serever_path}/top_level_domains --tcp_port {server_port} \
             --http_port {http_port} \
@@ -1291,6 +1376,9 @@ def main():
             f"mkdir -p {perf_left}/coordination {perf_right}/coordination",
             # Symlink user_files from the repository into both servers' user_files directories
             f'for f in ./tests/performance/user_files/*; do [ -e "$f" ] || continue; ln -sf "$(readlink -f "$f")" {perf_left}/db/user_files/; ln -sf "$(readlink -f "$f")" {perf_right}/db/user_files/; done',
+            # On x86_64, cap max_threads at the number of pinned physical
+            # cores (must run after the right->left config copy above).
+            write_max_threads_override,
         ]
         results.append(Result.from_commands_run(name="Configure", command=commands))
         res = results[-1].is_ok()

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -501,13 +501,15 @@ def get_physical_core_cpu_list():
     end up sharing a hyperthread sibling with each other depending on scheduler
     mood - a top suspect for the amd-vs-arm A/A noise gap (0.51% vs 0.42%).
 
-    Parses /sys/devices/system/cpu/cpu*/topology/thread_siblings_list and keeps
-    the first sibling of each unique pair; falls back to cpus 0..(nproc/2 - 1)
-    if the sysfs topology is unavailable. Only call at runtime on the Linux CI
-    host (there is no /sys on macOS) - never at import time.
+    Parses /sys/devices/system/cpu/cpu*/topology/thread_siblings_list, keeps
+    the first ALLOWED sibling of each unique pair (intersected with the
+    process affinity mask), and falls back to all allowed cpus if the sysfs
+    topology is unavailable. Only call at runtime on the Linux CI host (there
+    is no /sys on macOS) - never at import time.
 
-    Must stay in sync with cpu_pinning_prefix in ci/jobs/scripts/perf/compare.sh
-    (the server restart path used by the confirm-changes stage).
+    Must stay in sync with pinned_cpu_list in ci/jobs/scripts/perf/compare.sh
+    (the server restart path used by the standalone flows and the
+    confirm-changes rerun).
     """
     # Sysfs exposes the HOST topology: on a cpuset-limited run the process may
     # only be allowed a subset of it, and taskset with a disallowed CPU fails
@@ -538,15 +540,19 @@ def get_physical_core_cpu_list():
             cores[min(siblings)] = min(usable)
     cpus = set(cores.values())
     if not cpus:
+        # Without topology, halving would be a guess that drops real cores on
+        # non-SMT hosts and on masks that already expose one sibling per core
+        # (e.g. Cpus_allowed_list: 1,3). Keep every allowed CPU instead: the
+        # degraded mode allows hyperthread sharing (the pre-pinning behavior)
+        # but never skews measurements by idling half the cores.
         print(
-            "WARNING: could not parse cpu topology from sysfs, "
-            "falling back to the first half of the allowed cpus"
+            "WARNING: could not parse cpu topology from sysfs; using all "
+            "allowed cpus (sibling pairs unknown, hyperthread sharing possible)"
         )
         if allowed:
-            allowed_sorted = sorted(allowed)
-            cpus = set(allowed_sorted[: max(len(allowed_sorted) // 2, 1)])
+            cpus = set(allowed)
         else:
-            cpus = set(range(max((os.cpu_count() or 2) // 2, 1)))
+            cpus = set(range(os.cpu_count() or 2))
     return ",".join(str(cpu) for cpu in sorted(cpus))
 
 

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -509,22 +509,37 @@ def get_physical_core_cpu_list():
     Must stay in sync with cpu_pinning_prefix in ci/jobs/scripts/perf/compare.sh
     (the server restart path used by the confirm-changes stage).
     """
-    cpus = set()
+    # Sysfs exposes the HOST topology: on a cpuset-limited run the process may
+    # only be allowed a subset of it, and taskset with a disallowed CPU fails
+    # to start the servers. Pick, per physical core, the first sibling the
+    # process is actually allowed to run on.
+    getaffinity = getattr(os, "sched_getaffinity", None)
+    allowed = getaffinity(0) if getaffinity else None
+    cores = {}
     try:
         for path in Path("/sys/devices/system/cpu").glob(
             "cpu[0-9]*/topology/thread_siblings_list"
         ):
             # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
-            first = re.split(r"[,-]", path.read_text().strip())[0]
-            cpus.add(int(first))
-    except (OSError, ValueError, IndexError):
-        cpus = set()
+            siblings = [
+                int(s) for s in re.split(r"[,-]", path.read_text().strip()) if s
+            ]
+            usable = [c for c in siblings if allowed is None or c in allowed]
+            if usable:
+                cores[min(siblings)] = min(usable)
+    except (OSError, ValueError):
+        cores = {}
+    cpus = set(cores.values())
     if not cpus:
         print(
             "WARNING: could not parse cpu topology from sysfs, "
-            "falling back to the first half of the cpus"
+            "falling back to the first half of the allowed cpus"
         )
-        cpus = set(range(max((os.cpu_count() or 2) // 2, 1)))
+        if allowed:
+            allowed_sorted = sorted(allowed)
+            cpus = set(allowed_sorted[: max(len(allowed_sorted) // 2, 1)])
+        else:
+            cpus = set(range(max((os.cpu_count() or 2) // 2, 1)))
     return ",".join(str(cpu) for cpu in sorted(cpus))
 
 

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -272,6 +272,11 @@ function write_max_threads_override
     cpus=$(pinned_cpu_list)
     if [ -z "$cpus" ]
     then
+        # Pinning is disabled (non-x86_64). Reused workspaces may carry an
+        # override from an earlier x86_64 run; remove it so the static
+        # max_threads actually applies.
+        rm -f left/config/users.d/zzz-cpu-pinning-max-threads.xml \
+            right/config/users.d/zzz-cpu-pinning-max-threads.xml ||:
         return 0
     fi
     max_threads=$(( $(echo "$cpus" | tr -cd , | wc -c) + 1 ))
@@ -1404,7 +1409,9 @@ create view test_runs as
         -- The worst per-single-run wall time across the queries of the test:
         -- each query is judged against its own run count, so a mixed test
         -- cannot hide a genuinely slow query behind a high average count.
-        max(t.client / ((t.runs + 1) * 2)) max_single_run_time
+        -- client-time excludes prewarm (perf.py measures from after it), so
+        -- the divisor is the measured runs only: runs per server x 2 servers.
+        max(t.client / (t.runs * 2)) max_single_run_time
     from (
         select
             -- The query id is the same for both servers, so no need to divide here.

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -785,7 +785,12 @@ create view query_display_names as select * from
 create table flagged_queries engine File(TSV, 'analyze-confirm/flagged-queries.tsv')
     as select
         query_metric_stats.test test, query_metric_stats.query_index query_index,
-        diff, stat_threshold
+        diff, stat_threshold,
+        -- Carried along so the confirmation rerun is held to the same
+        -- per-query bar as the flagging rule (not just the 0.15 floor):
+        -- historically noisy queries have learned thresholds above the floor.
+        ceil(greatest(0.15, historical_thresholds.max_diff,
+            test_thresholds.report_threshold), 2) changed_threshold
     from query_metric_stats
     left join query_display_names
         on query_metric_stats.test = query_display_names.test
@@ -832,6 +837,20 @@ fi
 if ! restart
 then
     echo "confirm_changes: server restart failed, skipping confirmation"
+    while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
+    echo all killed
+    return 0
+fi
+
+# The caller runs us with errexit disabled (fail-open), which also masks
+# failures inside restart: its return value only reflects the last check.
+# Verify both servers explicitly before spending the rerun budget.
+if ! clickhouse-client --port "$LEFT_SERVER_PORT" --receive_timeout=5 \
+        --query "select 1 format Null" \
+    || ! clickhouse-client --port "$RIGHT_SERVER_PORT" --receive_timeout=5 \
+        --query "select 1 format Null"
+then
+    echo "confirm_changes: servers not healthy after restart, skipping confirmation"
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
     return 0
@@ -974,13 +993,15 @@ parallel -v -j "$(nproc --all)" --joblog analyze-confirm/parallel-log.txt --null
     || echo "confirm_changes: some rerun stats failed to compute, those queries keep their original verdict"
 
 # 5. Demote the flagged queries whose rerun does not reproduce the change.
-# Confirmed = same-direction diff clearing the rerun noise threshold, in the
-# same shape as the production rule (0.15 floor, non-strict >=). The inner
-# join means only queries with rerun stats can be demoted: if the rerun failed
-# or produced no stats, the original verdict stands (fail-open).
+# Confirmed = same-direction diff clearing the exact production rule again:
+# the per-query changed threshold carried from the flagging step (strict >)
+# and the rerun's own noise threshold (non-strict >=). The inner join means
+# only queries with rerun stats can be demoted: if the rerun failed or
+# produced no stats, the original verdict stands (fail-open).
 if ! clickhouse-local --query "
 create view flagged_queries as select * from file('analyze-confirm/flagged-queries.tsv',
-    TSV, 'test text, query_index int, diff float, stat_threshold float');
+    TSV, 'test text, query_index int, diff float, stat_threshold float,
+        changed_threshold float');
 
 create view rerun_stats as
     select test, query_index,
@@ -998,7 +1019,8 @@ create table unconfirmed_queries engine File(TSV, 'analyze-confirm/unconfirmed-q
         on flagged_queries.test = rerun_stats.test
             and flagged_queries.query_index = rerun_stats.query_index
     where not (sign(diff_rerun) = sign(diff)
-        and abs(diff_rerun) >= greatest(0.15, stat_threshold_rerun))
+        and abs(diff_rerun) > changed_threshold
+        and abs(diff_rerun) >= stat_threshold_rerun)
     order by test, query_index
     ;
 " $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2>> analyze-confirm/errors.log
@@ -1116,7 +1138,11 @@ create table queries engine File(TSVWithNamesAndTypes, 'report/queries.tsv')
                 (select test, query_index from unconfirmed_queries)) as changed_fail,
         abs(diff) > changed_threshold - 0.05 and abs(diff) >= stat_threshold as changed_show,
 
-        not changed_fail and stat_threshold > unstable_threshold as unstable_fail,
+        -- Demoted queries are excluded here too: a demotion must not resurface
+        -- as an 'unstable' failure through the flipped changed_fail.
+        not changed_fail and stat_threshold > unstable_threshold
+            and ((query_metric_stats.test, query_metric_stats.query_index) not in
+                (select test, query_index from unconfirmed_queries)) as unstable_fail,
         not changed_show and stat_threshold > unstable_threshold - 0.05 as unstable_show,
 
         left, right, diff, stat_threshold,

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1398,6 +1398,13 @@ create table all_query_metrics_tsv engine File(TSV, 'report/all-query-metrics.ts
         on query_display_names.test = report_thresholds.test
             and query_display_names.query_index = report_thresholds.query_index
             and query_display_names.query_display_name = report_thresholds.query_display_name
+    -- Queries demoted by the confirmation rerun are retracted entirely (all
+    -- their metrics): this file feeds the CIDB upload, so the database keeps
+    -- only comparisons that reproduced after a server restart. The demoted
+    -- ones remain in the report's 'Unconfirmed Changes' table (and the raw
+    -- per-run measurements are uploaded unconditionally elsewhere).
+    where (query_metric_stats.test, query_metric_stats.query_index) not in
+        (select test, query_index from unconfirmed_queries)
     order by test, query_index;
 " $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a report/errors.log 1>&2)
 

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -185,8 +185,11 @@ function match_reference_debug_info
 # (arm has real cores only and is unchanged). Must stay in sync with
 # get_physical_core_cpu_list in ci/jobs/performance_tests.py, which pins the
 # initial server starts the same way.
-function cpu_pinning_prefix
+function pinned_cpu_list
 {
+    # One hyperthread per physical core, as a comma-separated list; empty on
+    # non-x86_64. Must stay in sync with get_physical_core_cpu_list in
+    # ci/jobs/performance_tests.py.
     if [ "$(uname -m)" != "x86_64" ]
     then
         return 0
@@ -202,27 +205,41 @@ function cpu_pinning_prefix
         # all physical cores on our runners).
         half=$(( $(nproc) / 2 ))
         if [ "$half" -lt 1 ]; then half=1; fi
-        cpus="0-$(( half - 1 ))"
+        cpus=$(seq -s, 0 $(( half - 1 )))
     fi
-    echo "taskset -c $cpus"
+    echo "$cpus"
+}
+
+function cpu_pinning_prefix
+{
+    local cpus
+    cpus=$(pinned_cpu_list)
+    if [ -n "$cpus" ]
+    then
+        echo "taskset -c $cpus"
+    fi
 }
 
 function write_max_threads_override
 {
     # Pinning and max_threads must travel together: with taskset limiting both
-    # servers to one hyperthread per physical core (8 CPUs on m7i.4xlarge),
-    # the static default max_threads=12 would oversubscribe the pinned set and
-    # reintroduce the scheduler noise the pinning removes. The CI flow writes
-    # this override from performance_tests.py (MAX_THREADS_OVERRIDE_XML, keep
-    # in sync); the standalone entrypoints (stage=run_tests, the manual README
-    # flow, compare-releases.sh) prepare their configs here, so emit the same
-    # x86_64-only override for them. The zzz- prefix sorts the file after the
-    # static users.d files, overriding them.
-    if [ "$(uname -m)" != "x86_64" ]
+    # servers to one hyperthread per physical core, the static default
+    # max_threads=12 would oversubscribe the pinned set and reintroduce the
+    # scheduler noise the pinning removes. max_threads is derived from the
+    # pinned CPU list (one query thread per pinned CPU, e.g. 8 on
+    # m7i.4xlarge) so the invariant holds on any x86_64 shape. The CI flow
+    # writes the same override from performance_tests.py
+    # (MAX_THREADS_OVERRIDE_XML, keep in sync); the standalone entrypoints
+    # (stage=run_tests, the manual README flow, compare-releases.sh) prepare
+    # their configs here. The zzz- prefix sorts the file after the static
+    # users.d files, overriding them.
+    local cpus max_threads dir
+    cpus=$(pinned_cpu_list)
+    if [ -z "$cpus" ]
     then
         return 0
     fi
-    local dir
+    max_threads=$(( $(echo "$cpus" | tr -cd , | wc -c) + 1 ))
     for dir in left right
     do
         if [ -d "$dir/config/users.d" ]
@@ -231,7 +248,7 @@ function write_max_threads_override
 <clickhouse>
     <profiles>
         <default>
-            <max_threads>8</max_threads>
+            <max_threads>$max_threads</max_threads>
         </default>
     </profiles>
 </clickhouse>

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -94,8 +94,6 @@ function configure
     rm left/config/config.d/backups.xml ||:
     cp -rv right/config left ||:
 
-    write_max_threads_override
-
     # Start a temporary server to rename the tables
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
@@ -203,15 +201,20 @@ import os
 import re
 from pathlib import Path
 
-allowed = os.sched_getaffinity(0)
+try:
+    allowed = os.sched_getaffinity(0)
+except OSError:
+    raise SystemExit(1)
 cores = {}
 for path in Path("/sys/devices/system/cpu").glob(
     "cpu[0-9]*/topology/thread_siblings_list"
 ):
-    # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
+    # Formats seen in the wild: "0,8", "0-1", "0" (no SMT). Per-file
+    # tolerance, matching get_physical_core_cpu_list in
+    # ci/jobs/performance_tests.py.
     try:
         siblings = [int(s) for s in re.split(r"[,-]", path.read_text().strip()) if s]
-    except ValueError:
+    except (OSError, ValueError):
         continue
     usable = [c for c in siblings if c in allowed]
     if usable:
@@ -226,6 +229,7 @@ PYEOF
         # Fallback: the first half of the ALLOWED cpus (siblings are
         # enumerated after all physical cores on our runners), so that a
         # cpuset-limited run cannot end up with disallowed CPU ids.
+        echo "pinned_cpu_list: sysfs topology probe failed, falling back to the first half of the allowed cpus" >&2
         local allowed_expanded
         allowed_expanded=$(sed -n 's/^Cpus_allowed_list:[[:space:]]*//p' /proc/self/status 2>/dev/null \
             | tr ',' '\n' \
@@ -264,7 +268,7 @@ function write_max_threads_override
     # m7i.4xlarge) so the invariant holds on any x86_64 shape. The CI flow
     # writes the same override from performance_tests.py
     # (MAX_THREADS_OVERRIDE_XML, keep in sync); the standalone entrypoints
-    # (stage=run_tests, the manual README flow, compare-releases.sh) prepare
+    # (stage=run_tests, the manual README flow) prepare
     # their configs here. The zzz- prefix sorts the file after the static
     # users.d files, overriding them.
     local cpus max_threads dir
@@ -276,8 +280,10 @@ function write_max_threads_override
     max_threads=$(( $(echo "$cpus" | tr -cd , | wc -c) + 1 ))
     for dir in left right
     do
-        if [ -d "$dir/config/users.d" ]
+        if ! [ -d "$dir/config/users.d" ]
         then
+            echo "write_max_threads_override: $dir/config/users.d does not exist, pinned servers would keep the static max_threads" >&2
+        else
             cat > "$dir/config/users.d/zzz-cpu-pinning-max-threads.xml" <<EOF
 <clickhouse>
     <profiles>
@@ -295,6 +301,13 @@ function restart
 {
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
+
+    # All measured (pinned) servers are started by this function: the stage
+    # cascade invokes it before run_tests, and the confirm_changes rerun
+    # calls it directly. Writing the override here guarantees taskset and
+    # max_threads travel together even when configure was skipped and stale
+    # users.d content is on disk.
+    write_max_threads_override
 
     match_reference_debug_info
 
@@ -609,6 +622,12 @@ function analyze_queries
 rm -v analyze-commands.txt analyze-errors.log all-queries.tsv unstable-queries.tsv ./*-report.tsv raw-queries.tsv ||:
 rm -rf analyze ||:
 mkdir analyze analyze/tmp ||:
+
+# Demotions belong to a specific analysis: re-analyzing invalidates any
+# earlier confirmation results, otherwise a later `stage=report` run would
+# silently demote current rows with a stale unconfirmed-queries.tsv left in
+# the workspace. confirm_changes recreates the file after this stage.
+rm -f analyze-confirm/unconfirmed-queries.tsv ||:
 
 # Split the raw test output into files suitable for analysis.
 # To debug calculations only for a particular test, substitute a suitable
@@ -990,18 +1009,24 @@ do
 
     # The test file goes first: argparse would swallow it into the greedy
     # nargs='*' --queries-to-run otherwise. No profiling on reruns.
+    # The output goes through a temp file renamed only on success: a partial
+    # raw file from a failed rerun could otherwise demote the queries that
+    # did rerun, contradicting "the whole test keeps its original verdict".
     # shellcheck disable=SC2086
-    if ! "$perf_py" "$confirm_test_file" \
+    if "$perf_py" "$confirm_test_file" \
         --host localhost localhost \
         --port "$LEFT_SERVER_PORT" "$RIGHT_SERVER_PORT" \
         --binary left/clickhouse right/clickhouse \
         --http-port "$LEFT_SERVER_HTTP_PORT" "$RIGHT_SERVER_HTTP_PORT" \
         ${CHPC_RUNS:+--runs "$CHPC_RUNS"} --max-queries 0 --profile-seconds 0 \
         --queries-to-run $confirm_indexes \
-        > "analyze-confirm/$confirm_test-raw.tsv" \
+        > "analyze-confirm/$confirm_test-raw.tsv.tmp" \
         2> "analyze-confirm/$confirm_test-err.log"
     then
+        mv "analyze-confirm/$confirm_test-raw.tsv.tmp" "analyze-confirm/$confirm_test-raw.tsv"
+    else
         echo "confirm_changes: rerun of $confirm_test failed, its queries keep their original verdict"
+        rm -f "analyze-confirm/$confirm_test-raw.tsv.tmp" ||:
     fi
 done
 
@@ -1372,17 +1397,41 @@ create view query_runs as select * from file('analyze/query-runs.tsv', TSV,
 --
 create view test_runs as
     select test,
-        -- Default to 7 runs if we can't determine the number of runs.
-        if((ceil(median(t.runs), 0) as r) != 0, r, 7) runs
+        -- The adaptive policy gives every query its own run count, so the
+        -- per-test wall-clock budget must follow the actual totals: use the
+        -- average of the per-query counts (total-preserving), not a median
+        -- that a few high-count microqueries could inflate. Kept integer
+        -- (ceil) so the test-times.tsv schema and its CIDB upload stay
+        -- unchanged. Default to 7 runs if we can't determine the number.
+        if((ceil(sum(t.runs) / count(*), 0) as r) != 0, r, 7) runs,
+        -- The worst per-single-run wall time across the queries of the test:
+        -- each query is judged against its own run count, so a mixed test
+        -- cannot hide a genuinely slow query behind a high average count.
+        max(t.client / ((t.runs + 1) * 2)) max_single_run_time
     from (
         select
             -- The query id is the same for both servers, so no need to divide here.
-            uniqExact(query_id) runs,
-            test, query_index
+            uniqExact(query_runs.query_id) runs,
+            any(client_times.client) client,
+            query_runs.test test, query_runs.query_index query_index
         from query_runs
-        group by test, query_index
+        left join (
+            select * from file('analyze/client-times.tsv', TSV,
+                'test text, query_index int, client float, server float')
+            ) client_times
+            on client_times.test = query_runs.test
+                and client_times.query_index = query_runs.query_index
+        group by query_runs.test, query_runs.query_index
         ) t
     group by test
+    ;
+
+-- The worst per-single-run wall time per test, in a separate file so that the
+-- test-times.tsv schema (and its CIDB upload) stays unchanged. Consumed by
+-- report.py's single-query slow gate.
+create table max_single_run_report engine File(TSV, 'report/max-single-run-times.tsv')
+    as select test, round(max_single_run_time, 3)
+    from test_runs
     ;
 
 create view test_times_view as

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1322,14 +1322,20 @@ create table unstable_queries_report engine File(TSV, 'report/unstable-queries.t
 create view test_speedup as
     select
         test,
-        exp2(avg(log2(left / right))) times_speedup,
+        -- Demoted queries (confirmation rerun did not reproduce the change)
+        -- stay visible in the per-query tables via *_show, but must not
+        -- contribute to the per-test aggregates: these feed
+        -- test-perf-changes.tsv and the perf_test_perf_changes_v1 upload,
+        -- which carry the pipeline's confirmed results. That applies to the
+        -- speedup average too - a demoted +20% row must not tilt
+        -- times_speedup - while count(*) stays a plain coverage count.
+        -- ifNotFinite guards the all-rows-demoted case (empty avgIf = nan);
+        -- 1.0x is the neutral value.
+        exp2(ifNotFinite(avgIf(log2(left / right),
+            (queries.test, queries.query_index) not in
+                (select test, query_index from unconfirmed_queries)), 0)) times_speedup,
         count(*) queries,
         unstable + changed bad,
-        -- Demoted queries (confirmation rerun did not reproduce the change)
-        -- stay visible in the per-query tables via *_show, but must not count
-        -- in the per-test aggregates: these feed test-perf-changes.tsv and
-        -- the perf_test_perf_changes_v1 upload, which carry the pipeline's
-        -- confirmed results.
         sum(changed_show and ((queries.test, queries.query_index) not in
             (select test, query_index from unconfirmed_queries))) changed,
         sum(unstable_show and ((queries.test, queries.query_index) not in

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -187,25 +187,59 @@ function match_reference_debug_info
 # initial server starts the same way.
 function pinned_cpu_list
 {
-    # One hyperthread per physical core, as a comma-separated list; empty on
-    # non-x86_64. Must stay in sync with get_physical_core_cpu_list in
+    # One ALLOWED hyperthread per physical core, as a comma-separated list;
+    # empty on non-x86_64. Sysfs exposes the host topology, so on a
+    # cpuset-limited run the sibling list is intersected with the process
+    # affinity mask - a disallowed CPU in taskset would fail to start the
+    # servers. Must stay in sync with get_physical_core_cpu_list in
     # ci/jobs/performance_tests.py.
     if [ "$(uname -m)" != "x86_64" ]
     then
         return 0
     fi
     local cpus half
-    # thread_siblings_list formats: "0,8", "0-1", "0" (no SMT). Keep the
-    # first sibling of each unique pair.
-    cpus=$(sed 's/[,-].*//' /sys/devices/system/cpu/cpu*/topology/thread_siblings_list 2>/dev/null \
-        | sort -un | paste -sd, - ||:)
+    cpus=$(python3 - 2>/dev/null <<'PYEOF' ||:
+import os
+import re
+from pathlib import Path
+
+allowed = os.sched_getaffinity(0)
+cores = {}
+for path in Path("/sys/devices/system/cpu").glob(
+    "cpu[0-9]*/topology/thread_siblings_list"
+):
+    # Formats seen in the wild: "0,8", "0-1", "0" (no SMT).
+    try:
+        siblings = [int(s) for s in re.split(r"[,-]", path.read_text().strip()) if s]
+    except ValueError:
+        continue
+    usable = [c for c in siblings if c in allowed]
+    if usable:
+        cores[min(siblings)] = min(usable)
+cpus = sorted(set(cores.values()))
+if cpus:
+    print(",".join(map(str, cpus)))
+PYEOF
+)
     if [ -z "$cpus" ]
     then
-        # Fallback: the first half of the cpus (siblings are enumerated after
-        # all physical cores on our runners).
-        half=$(( $(nproc) / 2 ))
-        if [ "$half" -lt 1 ]; then half=1; fi
-        cpus=$(seq -s, 0 $(( half - 1 )))
+        # Fallback: the first half of the ALLOWED cpus (siblings are
+        # enumerated after all physical cores on our runners), so that a
+        # cpuset-limited run cannot end up with disallowed CPU ids.
+        local allowed_expanded
+        allowed_expanded=$(sed -n 's/^Cpus_allowed_list:[[:space:]]*//p' /proc/self/status 2>/dev/null \
+            | tr ',' '\n' \
+            | awk -F- '{ if (NF == 2) { for (i = $1; i <= $2; i++) print i } else if ($1 != "") print $1 }')
+        if [ -n "$allowed_expanded" ]
+        then
+            half=$(( $(echo "$allowed_expanded" | wc -l) / 2 ))
+            if [ "$half" -lt 1 ]; then half=1; fi
+            cpus=$(echo "$allowed_expanded" | head -n "$half" | paste -sd, -)
+        else
+            half=$(( $(nproc) / 2 ))
+            if [ "$half" -lt 1 ]; then half=1; fi
+            cpus=$(seq -s, 0 $(( half - 1 )))
+        fi
     fi
     echo "$cpus"
 }

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1410,12 +1410,15 @@ create view test_runs as
         -- each query is judged against its own run count, so a mixed test
         -- cannot hide a genuinely slow query behind a high average count.
         -- client-time excludes prewarm (perf.py measures from after it), so
-        -- the divisor is the measured runs only: runs per server x 2 servers.
-        max(t.client / (t.runs * 2)) max_single_run_time
+        -- the divisor is the measured runs only: runs per server times the
+        -- number of servers that actually ran the query (backward-
+        -- incompatible 'partial' queries run on the new server only).
+        max(t.client / (t.runs * t.versions)) max_single_run_time
     from (
         select
             -- The query id is the same for both servers, so no need to divide here.
             uniqExact(query_runs.query_id) runs,
+            uniqExact(query_runs.version) versions,
             any(client_times.client) client,
             query_runs.test test, query_runs.query_index query_index
         from query_runs

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -186,12 +186,14 @@ function match_reference_debug_info
 function pinned_cpu_list
 {
     # One ALLOWED hyperthread per physical core, as a comma-separated list;
-    # empty on non-x86_64. Sysfs exposes the host topology, so on a
-    # cpuset-limited run the sibling list is intersected with the process
-    # affinity mask - a disallowed CPU in taskset would fail to start the
-    # servers. Must stay in sync with get_physical_core_cpu_list in
-    # ci/jobs/performance_tests.py.
-    if [ "$(uname -m)" != "x86_64" ]
+    # empty when pinning is disabled. Pinning requires Linux x86_64 (taskset,
+    # sysfs topology, sched_getaffinity are Linux-only - a local Intel Mac
+    # must not get a taskset prefix it cannot execute). Sysfs exposes the
+    # host topology, so on a cpuset-limited run the sibling list is
+    # intersected with the process affinity mask - a disallowed CPU in
+    # taskset would fail to start the servers. Must stay in sync with
+    # get_physical_core_cpu_list in ci/jobs/performance_tests.py.
+    if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]
     then
         return 0
     fi

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -175,12 +175,46 @@ function match_reference_debug_info
     fi
 }
 
+# On x86_64 the measured servers are pinned to one hyperthread per physical
+# core (m7i.4xlarge: 8 physical cores x 2 HT), so that whether two query
+# threads share a hyperthread sibling does not depend on the scheduler; the
+# matching max_threads=8 users.d override is written at job setup. Prints a
+# "taskset -c <list>" prefix on x86_64 and nothing on other architectures
+# (arm has real cores only and is unchanged). Must stay in sync with
+# get_physical_core_cpu_list in ci/jobs/performance_tests.py, which pins the
+# initial server starts the same way.
+function cpu_pinning_prefix
+{
+    if [ "$(uname -m)" != "x86_64" ]
+    then
+        return 0
+    fi
+    local cpus half
+    # thread_siblings_list formats: "0,8", "0-1", "0" (no SMT). Keep the
+    # first sibling of each unique pair.
+    cpus=$(sed 's/[,-].*//' /sys/devices/system/cpu/cpu*/topology/thread_siblings_list 2>/dev/null \
+        | sort -un | paste -sd, - ||:)
+    if [ -z "$cpus" ]
+    then
+        # Fallback: the first half of the cpus (siblings are enumerated after
+        # all physical cores on our runners).
+        half=$(( $(nproc) / 2 ))
+        if [ "$half" -lt 1 ]; then half=1; fi
+        cpus="0-$(( half - 1 ))"
+    fi
+    echo "taskset -c $cpus"
+}
+
 function restart
 {
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
 
     match_reference_debug_info
+
+    # Intentionally unquoted below: expands to nothing on non-x86_64.
+    local pinning_prefix
+    pinning_prefix=$(cpu_pinning_prefix)
 
     set -m # Spawn servers in their own process groups
 
@@ -204,7 +238,7 @@ function restart
         --interserver_http_port $LEFT_SERVER_INTERSERVER_PORT
         --jemalloc_profiler_sampling_rate $JEMALLOC_PROFILER_SAMPLING_RATE
     )
-    left/clickhouse-server "${left_server_opts[@]}" &>> left-server-log.log &
+    $pinning_prefix left/clickhouse-server "${left_server_opts[@]}" &>> left-server-log.log &
     left_pid=$!
     kill -0 $left_pid
     disown $left_pid
@@ -226,7 +260,7 @@ function restart
         --interserver_http_port $RIGHT_SERVER_INTERSERVER_PORT
         --jemalloc_profiler_sampling_rate $JEMALLOC_PROFILER_SAMPLING_RATE
     )
-    right/clickhouse-server "${right_server_opts[@]}" &>> right-server-log.log &
+    $pinning_prefix right/clickhouse-server "${right_server_opts[@]}" &>> right-server-log.log &
     right_pid=$!
     kill -0 $right_pid
     disown $right_pid

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -699,6 +699,284 @@ create table query_metric_stats_denorm engine File(TSVWithNamesAndTypes,
 " $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2> >(tee -a analyze/errors.log 1>&2)
 }
 
+# Confirm the queries flagged as changed by rerunning them on freshly restarted
+# servers. The changed_fail verdict from a single test pass is sensitive to
+# one-off environmental noise (page cache state, CPU frequency, noisy
+# neighbours), so before failing the check we rerun only the flagged queries
+# after a full server restart and demote the changes that do not reproduce.
+# Demoted queries stay visible in a separate 'Unconfirmed Changes' report table.
+#
+# This step is strictly advisory and FAIL-OPEN: on any error we log, leave
+# analyze-confirm/unconfirmed-queries.tsv absent or empty (which report() reads
+# as "demote nothing"), and return success, so a confirmation failure can never
+# change today's verdicts or fail the job. For the same reason nothing here
+# writes to analyze/errors.log or report/errors.log (a non-empty
+# report/errors.log fails the check) -- confirmation errors go to the job log
+# and analyze-confirm/errors.log only. The caller must invoke it as
+# `confirm_changes ||:` (this also disables errexit inside, so partial failures
+# fall through the explicit guards below instead of killing the script).
+function confirm_changes
+{
+rm -rf analyze-confirm ||:
+mkdir analyze-confirm analyze-confirm/tmp ||:
+
+# report() joins the per-query thresholds from historical-thresholds.tsv,
+# which may be absent in manual runs. Use a private empty copy then, instead
+# of creating the file at the path report() reads (fail-open: do not alter
+# the inputs of the main flow).
+if [ -e historical-thresholds.tsv ]
+then
+    cp historical-thresholds.tsv analyze-confirm/historical-thresholds.tsv
+else
+    touch analyze-confirm/historical-thresholds.tsv
+fi
+
+# 1. Collect the (test, query_index) pairs flagged as changed_fail, with the
+# same rule and thresholds as the 'queries' table in report(): client_time
+# metric, per-query threshold = ceil(greatest(0.15, historical, per-test), 2),
+# non-strict comparison with stat_threshold.
+if ! clickhouse-local --query "
+create view query_metric_stats as
+    select * from file('analyze/query-metric-stats-denorm.tsv',
+        TSVWithNamesAndTypes,
+        'test text, query_index int, metric_name text, left float, right float,
+            diff float, stat_threshold float')
+    ;
+
+create view query_display_names as select * from
+    file('analyze/query-display-names.tsv', TSV,
+        'test text, query_index int, query_display_name text')
+    ;
+
+create table flagged_queries engine File(TSV, 'analyze-confirm/flagged-queries.tsv')
+    as select
+        query_metric_stats.test test, query_metric_stats.query_index query_index,
+        diff, stat_threshold
+    from query_metric_stats
+    left join query_display_names
+        on query_metric_stats.test = query_display_names.test
+            and query_metric_stats.query_index = query_display_names.query_index
+    left join file('analyze-confirm/historical-thresholds.tsv', TSV,
+        'test text, query_index int, max_diff float, max_stat_threshold float,
+            query_display_name text') historical_thresholds
+        on query_metric_stats.test = historical_thresholds.test
+            and query_metric_stats.query_index = historical_thresholds.query_index
+            and query_display_names.query_display_name = historical_thresholds.query_display_name
+    left join file('analyze/report-thresholds.tsv', TSV,
+        'test text, report_threshold float') test_thresholds
+        on query_metric_stats.test = test_thresholds.test
+    where metric_name = 'client_time'
+        and abs(diff) > ceil(greatest(0.15, historical_thresholds.max_diff,
+            test_thresholds.report_threshold), 2)
+        and abs(diff) >= stat_threshold
+    order by test, query_index
+    ;
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2>> analyze-confirm/errors.log
+then
+    echo "confirm_changes: failed to compute the flagged query list, skipping confirmation"
+    return 0
+fi
+
+local flagged_count
+flagged_count=$(wc -l < analyze-confirm/flagged-queries.tsv)
+if [ "$flagged_count" -eq 0 ]
+then
+    echo "confirm_changes: no queries flagged as changed, nothing to confirm"
+    return 0
+fi
+# Cap the total confirmation cost: a PR that flags very many queries (e.g. a
+# global slowdown or a runaway environment) would double the test time, and
+# such wholesale changes do not need per-query confirmation anyway.
+if [ "$flagged_count" -gt 100 ]
+then
+    echo "confirm_changes: WARNING: $flagged_count flagged queries exceed the cap of 100, skipping confirmation"
+    return 0
+fi
+
+# 2. Restart both servers so that the reruns measure a fresh process state
+# (empty caches, unfragmented heap), reusing the main restart machinery.
+if ! restart
+then
+    echo "confirm_changes: server restart failed, skipping confirmation"
+    while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
+    echo all killed
+    return 0
+fi
+
+# 3. Rerun each affected test limited to its flagged query indexes, writing
+# raw results into analyze-confirm/ so the main *-raw.tsv files stay intact.
+# Mirror run_tests' test file resolution; fall back to the in-repo tests for
+# the CI flow where performance_tests.py runs the tests itself.
+local test_prefix
+if [ -v CHPC_TEST_PATH ]
+then
+    test_prefix="$CHPC_TEST_PATH"
+elif [ -d right/performance ]
+then
+    test_prefix=right/performance
+else
+    test_prefix="$script_dir/../../../../tests/performance"
+fi
+
+local perf_py="$script_dir/perf.py"
+if ! [ -e "$perf_py" ]
+then
+    perf_py="$script_dir/../../../../tests/performance/scripts/perf.py"
+fi
+
+# Also cap the confirmation wall-clock time. Tests not rerun keep their
+# original verdict (fail-open in the strict direction: no demotion).
+local confirm_deadline=$(( SECONDS + 1200 ))
+local confirm_test confirm_test_file confirm_indexes
+for confirm_test in $(cut -f1 analyze-confirm/flagged-queries.tsv | sort | uniq)
+do
+    if [ "$SECONDS" -ge "$confirm_deadline" ]
+    then
+        echo "confirm_changes: WARNING: time budget exhausted, queries of the remaining tests keep their original verdict"
+        break
+    fi
+
+    confirm_test_file="$test_prefix/$confirm_test.xml"
+    if ! [ -e "$confirm_test_file" ]
+    then
+        echo "confirm_changes: cannot find $confirm_test_file, its queries keep their original verdict"
+        continue
+    fi
+
+    confirm_indexes=$(awk -F'\t' -v t="$confirm_test" '$1 == t { print $2 }' \
+        analyze-confirm/flagged-queries.tsv | sort -n | uniq | tr '\n' ' ')
+
+    # The test file goes first: argparse would swallow it into the greedy
+    # nargs='*' --queries-to-run otherwise. No profiling on reruns.
+    # shellcheck disable=SC2086
+    if ! "$perf_py" "$confirm_test_file" \
+        --host localhost localhost \
+        --port "$LEFT_SERVER_PORT" "$RIGHT_SERVER_PORT" \
+        --binary left/clickhouse right/clickhouse \
+        --http-port "$LEFT_SERVER_HTTP_PORT" "$RIGHT_SERVER_HTTP_PORT" \
+        --runs "${CHPC_RUNS:-7}" --max-queries 0 --profile-seconds 0 \
+        --queries-to-run $confirm_indexes \
+        > "analyze-confirm/$confirm_test-raw.tsv" \
+        2> "analyze-confirm/$confirm_test-err.log"
+    then
+        echo "confirm_changes: rerun of $confirm_test failed, its queries keep their original verdict"
+    fi
+done
+
+# Stop the servers again: the subsequent report stages run memory-heavy
+# clickhouse-local queries and expect the servers to be down.
+while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
+echo all killed
+
+# 4. Recompute the eqmed.sql statistics on the rerun data, exactly like
+# analyze_queries does. The confirmation verdict is made on client_time (the
+# same metric as changed_fail), which comes from the perf.py-reported run
+# times, so the query logs are not needed and the metrics array has a single
+# element.
+touch analyze-confirm/query-runs.tsv
+local raw_file rerun_test_name
+for raw_file in analyze-confirm/*-raw.tsv
+do
+    [ -e "$raw_file" ] || continue
+    rerun_test_name=$(basename "$raw_file" "-raw.tsv")
+    sed -n "s/^query\t/$rerun_test_name\t/p" < "$raw_file" >> analyze-confirm/query-runs.tsv
+done
+
+if ! clickhouse-local --query "
+create view query_runs as select * from file('analyze-confirm/query-runs.tsv', TSV,
+    'test text, query_index int, query_id text, version UInt8, time float');
+
+-- Same even-run-count filter as analyze_queries: a server death mid-test
+-- leaves an odd number of runs, which would break the median split.
+create view broken_queries as
+    select test, query_index
+    from query_runs
+    group by test, query_index
+    having count(*) % 2 != 0
+    ;
+
+create table query_run_metrics_for_stats engine File(
+        TSV, 'analyze-confirm/query-run-metrics-for-stats.tsv')
+    as select test, query_index, 0 run, version, [toFloat64(time)] metrics
+    from query_runs
+    where (test, query_index) not in broken_queries
+    order by test, query_index, run, version
+    ;
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2>> analyze-confirm/errors.log
+then
+    echo "confirm_changes: failed to prepare the rerun measurements, skipping confirmation"
+    return 0
+fi
+
+# The same per-query eqmed.sql invocation path as in analyze_queries. A failed
+# invocation only loses that query's rerun stats, so it keeps its original
+# verdict.
+touch analyze-confirm/commands.txt analyze-confirm/query-metric-stats.tsv
+( set +x # do not bloat the log
+IFS=$'\n'
+for prefix in $(cut -f1,2 "analyze-confirm/query-run-metrics-for-stats.tsv" | sort | uniq)
+do
+    file="analyze-confirm/tmp/${prefix//	/_}.tsv"
+    rg "^$prefix	" "analyze-confirm/query-run-metrics-for-stats.tsv" > "$file" &
+    printf "%s\0\n" \
+        "clickhouse-local \
+            --file \"$file\" \
+            --structure 'test text, query text, run int, version UInt8, metrics Array(float)' \
+            --query \"$(cat "$script_dir/eqmed.sql")\" \
+            $CHPC_REPORT_LOCAL_QUERY_SETTINGS \
+            -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS \
+            >> \"analyze-confirm/query-metric-stats.tsv\"" \
+            2>> analyze-confirm/errors.log \
+        >> analyze-confirm/commands.txt
+done
+wait
+unset IFS
+)
+
+# The rerun arrays are single-metric and tiny, no need for the memory-bounded
+# job count of the main analysis.
+parallel -v -j "$(nproc --all)" --joblog analyze-confirm/parallel-log.txt --null \
+    < analyze-confirm/commands.txt 2>> analyze-confirm/errors.log \
+    || echo "confirm_changes: some rerun stats failed to compute, those queries keep their original verdict"
+
+# 5. Demote the flagged queries whose rerun does not reproduce the change.
+# Confirmed = same-direction diff clearing the rerun noise threshold, in the
+# same shape as the production rule (0.15 floor, non-strict >=). The inner
+# join means only queries with rerun stats can be demoted: if the rerun failed
+# or produced no stats, the original verdict stands (fail-open).
+if ! clickhouse-local --query "
+create view flagged_queries as select * from file('analyze-confirm/flagged-queries.tsv',
+    TSV, 'test text, query_index int, diff float, stat_threshold float');
+
+create view rerun_stats as
+    select test, query_index,
+        diff[1] diff_rerun, stat_threshold[1] stat_threshold_rerun
+    from file('analyze-confirm/query-metric-stats.tsv', TSV,
+        'left Array(float), right Array(float), diff Array(float),
+            stat_threshold Array(float), test text, query_index int')
+    ;
+
+create table unconfirmed_queries engine File(TSV, 'analyze-confirm/unconfirmed-queries.tsv')
+    as select flagged_queries.test test, flagged_queries.query_index query_index,
+        diff_rerun, stat_threshold_rerun
+    from flagged_queries
+    join rerun_stats
+        on flagged_queries.test = rerun_stats.test
+            and flagged_queries.query_index = rerun_stats.query_index
+    where not (sign(diff_rerun) = sign(diff)
+        and abs(diff_rerun) >= greatest(0.15, stat_threshold_rerun))
+    order by test, query_index
+    ;
+" $CHPC_REPORT_LOCAL_QUERY_SETTINGS -- $CHPC_REPORT_LOCAL_SERVER_SETTINGS 2>> analyze-confirm/errors.log
+then
+    echo "confirm_changes: failed to compute the confirmation verdicts, skipping confirmation"
+    rm -f analyze-confirm/unconfirmed-queries.tsv ||:
+    return 0
+fi
+
+echo "confirm_changes: $(wc -l < analyze-confirm/unconfirmed-queries.tsv) of $flagged_count flagged queries did not reproduce after restart"
+}
+
 # Analyze results
 function report
 {
@@ -709,6 +987,12 @@ rm ./*.{rep,svg} test-times.tsv test-dump.tsv unstable.tsv unstable-query-ids.ts
 
 cat analyze/errors.log >> report/errors.log ||:
 cat profile-errors.log >> report/errors.log ||:
+
+# The confirmation step (confirm_changes) is optional and fail-open: when it
+# was skipped or failed, the demotion list is absent or empty, which must read
+# as "demote nothing".
+mkdir -p analyze-confirm ||:
+touch analyze-confirm/unconfirmed-queries.tsv ||:
 
 clickhouse-local --query "
 create view query_display_names as select * from
@@ -737,6 +1021,15 @@ create view query_metric_stats as
         TSVWithNamesAndTypes,
         'test text, query_index int, metric_name text, left float, right float,
             diff float, stat_threshold float')
+    ;
+
+-- Queries flagged as changed whose difference did not reproduce when rerun
+-- after a server restart (see confirm_changes). Empty unless the confirmation
+-- step completed. They are demoted from changed_fail below, but stay visible
+-- in the 'Unconfirmed Changes' table so that nothing silently disappears.
+create view unconfirmed_queries as
+    select * from file('analyze-confirm/unconfirmed-queries.tsv', TSV,
+        'test text, query_index int, diff_rerun float, stat_threshold_rerun float')
     ;
 
 create table report_thresholds engine File(TSVWithNamesAndTypes, 'report/thresholds.tsv')
@@ -781,7 +1074,12 @@ create table queries engine File(TSVWithNamesAndTypes, 'report/queries.tsv')
         -- uncaught regressions, because for the default 7 runs we do for PRs,
         -- the randomization distribution has only 16 values, so the max quantile
         -- is actually 0.9375.
-        abs(diff) > changed_threshold        and abs(diff) >= stat_threshold as changed_fail,
+        -- A change is demoted from changed_fail (but not from changed_show, so
+        -- it stays visible) when the confirmation rerun after a server restart
+        -- did not reproduce it.
+        abs(diff) > changed_threshold        and abs(diff) >= stat_threshold
+            and ((query_metric_stats.test, query_metric_stats.query_index) not in
+                (select test, query_index from unconfirmed_queries)) as changed_fail,
         abs(diff) > changed_threshold - 0.05 and abs(diff) >= stat_threshold as changed_show,
 
         not changed_fail and stat_threshold > unstable_threshold as unstable_fail,
@@ -820,6 +1118,21 @@ create table changed_perf_report engine File(TSV, 'report/changed-perf.tsv')
         round(diff, 3), round(stat_threshold, 3),
         changed_fail, test, query_index, query_display_name
     from queries where changed_show order by abs(diff) desc;
+
+-- Flagged changes that did not reproduce on the confirmation rerun. They no
+-- longer fail the check (changed_fail was demoted above), but are reported
+-- with both the original and the rerun statistics so demotions are auditable.
+create table unconfirmed_changes_report engine File(TSV, 'report/unconfirmed-changes.tsv')
+    as select
+        round(left, 3), round(right, 3),
+        round(diff, 3), round(stat_threshold, 3),
+        round(diff_rerun, 3), round(stat_threshold_rerun, 3),
+        queries.test test, queries.query_index query_index, query_display_name
+    from queries
+    join unconfirmed_queries
+        on queries.test = unconfirmed_queries.test
+            and queries.query_index = unconfirmed_queries.query_index
+    order by abs(diff) desc;
 
 create table unstable_queries_report engine File(TSV, 'report/unstable-queries.tsv')
     as select
@@ -1458,6 +1771,13 @@ case "$stage" in
     ;&
 "analyze_queries")
     time analyze_queries ||:
+    ;&
+"confirm_changes")
+    # Rerun the changed queries on freshly restarted servers and demote the
+    # changes that do not reproduce. Advisory and fail-open: `||:` both keeps
+    # a confirmation failure from failing the job and disables errexit inside,
+    # so the function's explicit guards decide what to skip.
+    time confirm_changes ||:
     ;&
 "report")
     time report ||:

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -195,7 +195,7 @@ function pinned_cpu_list
     then
         return 0
     fi
-    local cpus half
+    local cpus
     cpus=$(python3 - 2>/dev/null <<'PYEOF' ||:
 import os
 import re
@@ -226,23 +226,20 @@ PYEOF
 )
     if [ -z "$cpus" ]
     then
-        # Fallback: the first half of the ALLOWED cpus (siblings are
-        # enumerated after all physical cores on our runners), so that a
-        # cpuset-limited run cannot end up with disallowed CPU ids.
-        echo "pinned_cpu_list: sysfs topology probe failed, falling back to the first half of the allowed cpus" >&2
-        local allowed_expanded
-        allowed_expanded=$(sed -n 's/^Cpus_allowed_list:[[:space:]]*//p' /proc/self/status 2>/dev/null \
+        # Without topology, halving would be a guess that drops real cores on
+        # non-SMT hosts and on masks that already expose one sibling per core
+        # (e.g. Cpus_allowed_list: 1,3). Keep every allowed CPU instead: the
+        # degraded mode allows hyperthread sharing (the pre-pinning behavior)
+        # but never skews measurements by idling half the cores. Must stay in
+        # sync with get_physical_core_cpu_list in ci/jobs/performance_tests.py.
+        echo "pinned_cpu_list: sysfs topology probe failed; using all allowed cpus (sibling pairs unknown, hyperthread sharing possible)" >&2
+        cpus=$(sed -n 's/^Cpus_allowed_list:[[:space:]]*//p' /proc/self/status 2>/dev/null \
             | tr ',' '\n' \
-            | awk -F- '{ if (NF == 2) { for (i = $1; i <= $2; i++) print i } else if ($1 != "") print $1 }')
-        if [ -n "$allowed_expanded" ]
+            | awk -F- '{ if (NF == 2) { for (i = $1; i <= $2; i++) print i } else if ($1 != "") print $1 }' \
+            | paste -sd, -)
+        if [ -z "$cpus" ]
         then
-            half=$(( $(echo "$allowed_expanded" | wc -l) / 2 ))
-            if [ "$half" -lt 1 ]; then half=1; fi
-            cpus=$(echo "$allowed_expanded" | head -n "$half" | paste -sd, -)
-        else
-            half=$(( $(nproc) / 2 ))
-            if [ "$half" -lt 1 ]; then half=1; fi
-            cpus=$(seq -s, 0 $(( half - 1 )))
+            cpus=$(seq -s, 0 $(( $(nproc) - 1 )))
         fi
     fi
     echo "$cpus"

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1245,8 +1245,15 @@ create view test_speedup as
         exp2(avg(log2(left / right))) times_speedup,
         count(*) queries,
         unstable + changed bad,
-        sum(changed_show) changed,
-        sum(unstable_show) unstable
+        -- Demoted queries (confirmation rerun did not reproduce the change)
+        -- stay visible in the per-query tables via *_show, but must not count
+        -- in the per-test aggregates: these feed test-perf-changes.tsv and
+        -- the perf_test_perf_changes_v1 upload, which carry the pipeline's
+        -- confirmed results.
+        sum(changed_show and ((queries.test, queries.query_index) not in
+            (select test, query_index from unconfirmed_queries))) changed,
+        sum(unstable_show and ((queries.test, queries.query_index) not in
+            (select test, query_index from unconfirmed_queries))) unstable
     from queries
     group by test
     order by times_speedup desc

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -94,6 +94,8 @@ function configure
     rm left/config/config.d/backups.xml ||:
     cp -rv right/config left ||:
 
+    write_max_threads_override
+
     # Start a temporary server to rename the tables
     while pkill -f clickhouse-serv ; do echo . ; sleep 1 ; done
     echo all killed
@@ -203,6 +205,39 @@ function cpu_pinning_prefix
         cpus="0-$(( half - 1 ))"
     fi
     echo "taskset -c $cpus"
+}
+
+function write_max_threads_override
+{
+    # Pinning and max_threads must travel together: with taskset limiting both
+    # servers to one hyperthread per physical core (8 CPUs on m7i.4xlarge),
+    # the static default max_threads=12 would oversubscribe the pinned set and
+    # reintroduce the scheduler noise the pinning removes. The CI flow writes
+    # this override from performance_tests.py (MAX_THREADS_OVERRIDE_XML, keep
+    # in sync); the standalone entrypoints (stage=run_tests, the manual README
+    # flow, compare-releases.sh) prepare their configs here, so emit the same
+    # x86_64-only override for them. The zzz- prefix sorts the file after the
+    # static users.d files, overriding them.
+    if [ "$(uname -m)" != "x86_64" ]
+    then
+        return 0
+    fi
+    local dir
+    for dir in left right
+    do
+        if [ -d "$dir/config/users.d" ]
+        then
+            cat > "$dir/config/users.d/zzz-cpu-pinning-max-threads.xml" <<EOF
+<clickhouse>
+    <profiles>
+        <default>
+            <max_threads>8</max_threads>
+        </default>
+    </profiles>
+</clickhouse>
+EOF
+        fi
+    done
 }
 
 function restart
@@ -370,10 +405,11 @@ function run_tests
     #    CHPC_MAX_QUERIES=${CHPC_MAX_QUERIES:-0}
     #fi
 
-    CHPC_RUNS=${CHPC_RUNS:-7}
+    # CHPC_RUNS has no default any more: it is forwarded to perf.py --runs
+    # ("at least N runs per query") only when the caller set it; otherwise the
+    # adaptive run policy decides the counts.
     CHPC_MAX_QUERIES=${CHPC_MAX_QUERIES:-10}
 
-    export CHPC_RUNS
     export CHPC_MAX_QUERIES
 
     # Determine which concurrent benchmarks to run. For now, the only test
@@ -434,7 +470,9 @@ function run_tests
                 # reads. They are parallel to --host/--port (left, then right).
                 --binary left/clickhouse right/clickhouse
                 --http-port "$LEFT_SERVER_HTTP_PORT" "$RIGHT_SERVER_HTTP_PORT"
-                --runs "$CHPC_RUNS"
+                # Only when the caller explicitly set CHPC_RUNS ("at least N
+                # runs"); otherwise the adaptive run policy decides.
+                ${CHPC_RUNS:+--runs "$CHPC_RUNS"}
                 --max-queries "$max_queries"
                 --profile-seconds "$profile_seconds"
 
@@ -907,7 +945,7 @@ do
         --port "$LEFT_SERVER_PORT" "$RIGHT_SERVER_PORT" \
         --binary left/clickhouse right/clickhouse \
         --http-port "$LEFT_SERVER_HTTP_PORT" "$RIGHT_SERVER_HTTP_PORT" \
-        --runs "${CHPC_RUNS:-7}" --max-queries 0 --profile-seconds 0 \
+        ${CHPC_RUNS:+--runs "$CHPC_RUNS"} --max-queries 0 --profile-seconds 0 \
         --queries-to-run $confirm_indexes \
         > "analyze-confirm/$confirm_test-raw.tsv" \
         2> "analyze-confirm/$confirm_test-err.log"

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -603,7 +603,7 @@ if args.report == "main":
             "Longest query, total for measured runs,&nbsp;s",  # 4
             "Average query wall clock time,&nbsp;s",  # 5
             "Shortest query, total for measured runs,&nbsp;s",  # 6
-            "",  # Runs                                               #7
+            "",  # Runs (average per query)                          #7
         ]
         attrs = ["" for c in columns]
         attrs[7] = None
@@ -611,10 +611,25 @@ if args.report == "main":
         text = tableStart("Test Times")
         text += tableHeader(columns, attrs)
 
+        # Worst per-single-run wall time per test, written by compare.sh:
+        # each query is judged against its own adaptive run count, so a mixed
+        # test cannot hide a slow query behind a high average count. Absent in
+        # older workspaces - the legacy per-test approximation applies then
+        # (the existence check keeps tsvRows from recording a report error).
+        max_single_run_times = {}
+        if os.path.exists("report/max-single-run-times.tsv"):
+            max_single_run_times = {
+                r[0]: float(r[1])
+                for r in tsvRows("report/max-single-run-times.tsv")
+            }
+
         allowed_average_run_time = 3.75  # 60 seconds per test at (7 + 1) * 2 runs
         for r in rows:
             anchor = f"{currentTableAnchor()}.{r[0]}"
-            total_runs = (int(r[7]) + 1) * 2  # one prewarm run, two servers
+            # Run counts are adaptive per query; r[7] is the per-test average
+            # (ceil), which keeps this budget proportional to the actual total
+            # number of runs of the test instead of a median proxy.
+            total_runs = (float(r[7]) + 1) * 2  # one prewarm run, two servers
             if r[0] != "Total" and float(r[5]) > allowed_average_run_time * total_runs:
                 # FIXME should be 15s max -- investigate parallel_insert
                 slow_average_tests += 1
@@ -627,10 +642,15 @@ if args.report == "main":
             else:
                 attrs[5] = ""
 
-            if (
-                r[0] != "Total"
-                and float(r[4]) > get_allowed_single_run_time(r[0]) * total_runs
-            ):
+            if r[0] in max_single_run_times:
+                query_too_slow = max_single_run_times[
+                    r[0]
+                ] > get_allowed_single_run_time(r[0])
+            else:
+                query_too_slow = float(r[4]) > get_allowed_single_run_time(
+                    r[0]
+                ) * total_runs
+            if r[0] != "Total" and query_too_slow:
                 slow_average_tests += 1
                 attrs[4] = f'style="background: {color_bad}"'
                 errors_explained.append(

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -488,6 +488,45 @@ if args.report == "main":
 
     add_changes()
 
+    def add_unconfirmed_changes():
+        # Queries flagged as changed on the main run whose difference did not
+        # reproduce when rerun after a server restart (compare.sh's
+        # confirm_changes). They do not fail the check, but are kept visible
+        # with both the original and the rerun statistics.
+        #
+        # The confirmation step is optional and fail-open, so a missing file
+        # is normal and must not become a report error (which would fail the
+        # check) -- only read it if it exists.
+        if not os.path.exists("report/unconfirmed-changes.tsv"):
+            return
+        rows = tsvRows("report/unconfirmed-changes.tsv")
+        if not rows:
+            return
+
+        global tables
+        text = tableStart("Unconfirmed Changes")
+        columns = [
+            "Old,&nbsp;s",  # 0
+            "New,&nbsp;s",  # 1
+            "Relative difference (new&nbsp;&minus;&nbsp;old) / old",  # 2
+            "p&nbsp;<&nbsp;0.01 threshold",  # 3
+            "Rerun relative difference",  # 4
+            "Rerun threshold",  # 5
+            "Test",  # 6
+            "#",  # 7
+            "Query",  # 8
+        ]
+        text += tableHeader(columns)
+
+        for row in rows:
+            anchor = f"{currentTableAnchor()}.{row[6]}.{row[7]}"
+            text += tableRow(row, anchor=anchor)
+
+        text += tableEnd()
+        tables.append(text)
+
+    add_unconfirmed_changes()
+
     def add_unstable_queries():
         global unstable_queries, very_unstable_queries, tables
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -102,5 +102,5 @@ TODO
 
 ```
 pip3 install clickhouse_driver scipy
-../../tests/performance/scripts/perf.py --runs 1 insert_parallel.xml
+../../tests/performance/scripts/perf.py --min-runs 1 --cap 1 --cap-fast 1 insert_parallel.xml
 ```

--- a/tests/performance/scripts/README.md
+++ b/tests/performance/scripts/README.md
@@ -150,7 +150,7 @@ More stages are available, e.g. restart servers or run the tests. See the code.
 
 #### Run a single test on the already configured servers
 ```
-tests/performance/scripts/perf.py --host=localhost --port=9000 --runs=1 tests/performance/logical_functions_small.xml
+tests/performance/scripts/perf.py --host=localhost --port=9000 tests/performance/logical_functions_small.xml
 ```
 
 #### Run all tests on some custom configuration

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -180,7 +180,7 @@ parser.add_argument(
 parser.add_argument(
     "--tau",
     type=float,
-    default=0.1,
+    default=0.08,
     help="Precision target: stop the measured runs of a query as soon as its "
     "noise threshold (stat_threshold of the report, the q99 relative "
     "median gap under balanced relabelings) is at most this value.",

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -970,19 +970,20 @@ for query_index in queries_to_run:
 
         avg_time_per_server = server_seconds / len(this_query_connections)
 
-        # Precision-targeted adaptive run policy: always do at least --min-runs
-        # runs per server (each individual run is still bounded by
+        # Precision-targeted adaptive run policy: do at least --min-runs runs
+        # per server (each individual run is still bounded by
         # --max-query-seconds), then stop as soon as the noise threshold of this
         # query drops to --tau, or a cap on the number of runs is reached:
         # --cap runs normally, --cap-fast runs for fast queries (they are cheap
-        # to rerun and, in relative terms, the noisiest). As an escape from
-        # pathologically slow queries, also stop once the cumulative time per
-        # server reaches 30 seconds, regardless of the precision reached.
-        if run < args.min_runs:
-            continue
-
+        # to rerun and, in relative terms, the noisiest). The escape from
+        # pathologically slow queries — stop once the cumulative time per server
+        # reaches 30 seconds — takes precedence over the --min-runs floor, so a
+        # e.g. 12 s query stops after 3 runs instead of burning 5 x 12 s x 2.
         if avg_time_per_server >= 30:
             break
+
+        if run < args.min_runs:
+            continue
 
         # The precision stop needs exactly two servers to compare; partial
         # queries just run to the caps.

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -172,10 +172,12 @@ parser.add_argument(
 parser.add_argument(
     "--runs",
     type=int,
-    default=1,
-    help="Deprecated and ignored, kept so that existing invocations do not "
-    "break. The number of measured runs is now decided adaptively per query, "
-    "see --tau, --min-runs, --cap, --cap-fast.",
+    default=None,
+    help="Run every query at least this many times per server (the historical "
+    "CHPC_RUNS knob). Only widens the adaptive policy: raises the minimum and "
+    "the caps to fit, never lowers them; the --tau precision stop cannot end "
+    "a query before the resulting minimum. Ignored when --min-runs is given. "
+    "Unset by default: the adaptive policy decides.",
 )
 parser.add_argument(
     "--tau",
@@ -188,8 +190,9 @@ parser.add_argument(
 parser.add_argument(
     "--min-runs",
     type=int,
-    default=5,
-    help="Never do fewer than this many measured runs of a query per server.",
+    default=None,
+    help="Never do fewer than this many measured runs of a query per server "
+    "(default 5). When given explicitly, the legacy --runs is ignored.",
 )
 parser.add_argument(
     "--cap",
@@ -273,6 +276,26 @@ parser.add_argument(
     "purges to do asymmetric work during measured queries.",
 )
 args = parser.parse_args()
+
+if args.min_runs is not None:
+    # An explicit --min-runs means the caller speaks the adaptive-policy
+    # language: the legacy --runs is ignored to keep the precedence obvious.
+    args.runs = None
+else:
+    args.min_runs = 5
+if args.runs is not None:
+    # Backward compatibility: --runs (CHPC_RUNS) keeps its historical meaning
+    # of "at least this many measured runs" (on master it was the hard
+    # minimum before the cumulative-time stop). It only ever widens the
+    # policy (never lowers the default minimum), and the tau precision stop
+    # does not end a query before the resulting minimum. CI does not pass it
+    # (the adaptive defaults apply); manual and release-to-release
+    # investigations use e.g. CHPC_RUNS=13 to force a tighter comparison.
+    args.min_runs = max(args.min_runs, args.runs)
+# A minimum above a cap is contradictory; the minimum wins and the caps grow
+# to fit, whichever way it was requested.
+args.cap = max(args.cap, args.min_runs)
+args.cap_fast = max(args.cap_fast, args.cap)
 
 reportStageEnd("start")
 

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -65,6 +65,57 @@ def tsv_escape(s):
     )
 
 
+def ch_median(times):
+    """Median with ClickHouse medianExact semantics, to match the report
+    (eqmed.sql): quantileExact returns sorted[floor(level * size)], so the
+    median of an even-length array is the UPPER middle element."""
+    s = sorted(times)
+    return s[len(s) // 2]
+
+
+# Enumerate all C(2k, k) balanced splits exactly up to this many runs per side
+# (C(16, 8) = 12870); sample beyond that.
+MAX_EXACT_SPLIT_RUNS = 8
+SAMPLED_SPLITS = 2000
+
+
+def stat_threshold(left_times, right_times):
+    """The relative noise threshold of this comparison, replicating the
+    randomization test of the report (ci/jobs/scripts/perf/eqmed.sql):
+    q99 of |median(A) - median(B)| over balanced splits of the pooled
+    measurements, normalized by median(left). An observed relative difference
+    is distinguishable from noise when it exceeds this threshold, so the
+    threshold is the measurement precision reached so far.
+    Returns None if it cannot be computed (no runs, or zero left median)."""
+    k = min(len(left_times), len(right_times))
+    if k == 0:
+        return None
+    left = left_times[:k]
+    pooled = left + right_times[:k]
+    median_left = ch_median(left)
+    if median_left <= 0:
+        return None
+    mid = k // 2
+    gaps = []
+    if k <= MAX_EXACT_SPLIT_RUNS:
+        for a_indexes in itertools.combinations(range(2 * k), k):
+            a_set = set(a_indexes)
+            a = sorted(pooled[i] for i in a_indexes)
+            b = sorted(pooled[i] for i in range(2 * k) if i not in a_set)
+            gaps.append(abs(a[mid] - b[mid]))
+    else:
+        indexes = list(range(2 * k))
+        for _ in range(SAMPLED_SPLITS):
+            random.shuffle(indexes)
+            a = sorted(pooled[i] for i in indexes[:k])
+            b = sorted(pooled[i] for i in indexes[k:])
+            gaps.append(abs(a[mid] - b[mid]))
+    gaps.sort()
+    # quantileExact(0.99) semantics.
+    q99 = gaps[min(int(0.99 * len(gaps)), len(gaps) - 1)]
+    return q99 / median_left
+
+
 parser = argparse.ArgumentParser(description="Run performance test.")
 # Explicitly decode files as UTF-8 because sometimes we have Russian characters in queries, and LANG=C is set.
 parser.add_argument(
@@ -119,7 +170,48 @@ parser.add_argument(
     "for the corresponding server. A shorter list is reused for every server.",
 )
 parser.add_argument(
-    "--runs", type=int, default=1, help="Number of query runs per server."
+    "--runs",
+    type=int,
+    default=1,
+    help="Deprecated and ignored, kept so that existing invocations do not "
+    "break. The number of measured runs is now decided adaptively per query, "
+    "see --tau, --min-runs, --cap, --cap-fast.",
+)
+parser.add_argument(
+    "--tau",
+    type=float,
+    default=0.1,
+    help="Precision target: stop the measured runs of a query as soon as its "
+    "noise threshold (stat_threshold of the report, the q99 relative "
+    "median gap under balanced relabelings) is at most this value.",
+)
+parser.add_argument(
+    "--min-runs",
+    type=int,
+    default=5,
+    help="Never do fewer than this many measured runs of a query per server.",
+)
+parser.add_argument(
+    "--cap",
+    type=int,
+    default=7,
+    help="Maximum number of measured runs of a query per server "
+    "(fast queries get a higher cap, see --cap-fast).",
+)
+parser.add_argument(
+    "--cap-fast",
+    type=int,
+    default=30,
+    help="Maximum number of measured runs per server for fast queries "
+    "(see --fast-query-seconds): their extra runs are cheap and they need "
+    "more runs to reach the precision target.",
+)
+parser.add_argument(
+    "--fast-query-seconds",
+    type=float,
+    default=0.02,
+    help="A query whose median run time is below this on all servers after "
+    "--cap runs is considered fast and is allowed up to --cap-fast runs.",
 )
 parser.add_argument(
     "--max-queries",
@@ -810,6 +902,15 @@ for query_index in queries_to_run:
     for conn_index, c in enumerate(this_query_connections):
         all_server_times.append([])
 
+    # Run counts at which the precision stop condition is evaluated past the
+    # ordinary cap, for fast queries only: computing the threshold is not free,
+    # and the precision gained per extra run diminishes, so check sparsely.
+    fast_check_points = sorted(
+        set(p for p in (8, 10, 14, 20, 30) if args.cap < p < args.cap_fast)
+        | {args.cap_fast}
+    )
+    is_fast_query = False
+
     while True:
         run_id = f"{query_prefix}.run{run}"
 
@@ -869,11 +970,38 @@ for query_index in queries_to_run:
 
         avg_time_per_server = server_seconds / len(this_query_connections)
 
-        # We break if all the min stop conditions are met (1 second arg.runs iterations)
-        # or at lest one of the max stop conditions is met (8 seconds or 500 iterations)
-        if (avg_time_per_server >= 1 and run >= args.runs) or (
-            avg_time_per_server >= 8 or run >= 500
+        # Precision-targeted adaptive run policy: always do at least --min-runs
+        # runs per server (each individual run is still bounded by
+        # --max-query-seconds), then stop as soon as the noise threshold of this
+        # query drops to --tau, or a cap on the number of runs is reached:
+        # --cap runs normally, --cap-fast runs for fast queries (they are cheap
+        # to rerun and, in relative terms, the noisiest). As an escape from
+        # pathologically slow queries, also stop once the cumulative time per
+        # server reaches 30 seconds, regardless of the precision reached.
+        if run < args.min_runs:
+            continue
+
+        if avg_time_per_server >= 30:
+            break
+
+        # The precision stop needs exactly two servers to compare; partial
+        # queries just run to the caps.
+        if len(all_server_times) == 2 and (
+            run <= args.cap or run in fast_check_points
         ):
+            # Connection 0 is the "left" (old) server.
+            threshold = stat_threshold(all_server_times[0], all_server_times[1])
+            if threshold is not None and threshold <= args.tau:
+                break
+
+        if run < args.cap:
+            continue
+        if run == args.cap:
+            is_fast_query = (
+                max(ch_median(t) for t in all_server_times)
+                < args.fast_query_seconds
+            )
+        if not is_fast_query or run >= args.cap_fast:
             break
 
     client_seconds = time.perf_counter() - start_seconds

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -74,9 +74,11 @@ def ch_median(times):
 
 
 # Enumerate all C(2k, k) balanced splits exactly up to this many runs per side
-# (C(16, 8) = 12870); sample beyond that.
+# (C(16, 8) = 12870); sample beyond that. The sample count matches eqmed.sql's
+# numbers(10000) so the stop rule and the final report estimate the same
+# quantile with the same resolution past the enumerable range.
 MAX_EXACT_SPLIT_RUNS = 8
-SAMPLED_SPLITS = 2000
+SAMPLED_SPLITS = 10000
 
 
 def stat_threshold(left_times, right_times):
@@ -924,6 +926,7 @@ for query_index in queries_to_run:
     start_seconds = time.perf_counter()
     server_seconds = 0
     profile_seconds = 0
+    threshold_seconds = 0.0
     run = 0
 
     # Arrays of run times for each connection.
@@ -1019,8 +1022,12 @@ for query_index in queries_to_run:
         if len(all_server_times) == 2 and (
             run <= args.cap or run in fast_check_points
         ):
-            # Connection 0 is the "left" (old) server.
+            # Connection 0 is the "left" (old) server. The computation takes
+            # real wall time (10,000 shuffles in pure python at the sampled
+            # checkpoints), which must not leak into the query's client time.
+            threshold_start_seconds = time.perf_counter()
             threshold = stat_threshold(all_server_times[0], all_server_times[1])
+            threshold_seconds += time.perf_counter() - threshold_start_seconds
             if threshold is not None and threshold <= args.tau:
                 break
 
@@ -1034,7 +1041,7 @@ for query_index in queries_to_run:
         if not is_fast_query or run >= args.cap_fast:
             break
 
-    client_seconds = time.perf_counter() - start_seconds
+    client_seconds = time.perf_counter() - start_seconds - threshold_seconds
     print(f"client-time\t{query_index}\t{client_seconds}\t{server_seconds}")
     median = [statistics.median(t) for t in all_server_times]
     print(f"median\t{query_index}\t{median[0]}")

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -113,7 +113,13 @@ def stat_threshold(left_times, right_times):
     gaps.sort()
     # quantileExact(0.99) semantics.
     q99 = gaps[min(int(0.99 * len(gaps)), len(gaps) - 1)]
-    return q99 / median_left
+    # floor to 3 decimals like eqmed.sql's floor(threshold / l, 3), so the
+    # stop target and the reported stat_threshold round identically at the
+    # tau boundary. The estimators target the same quantile of the same
+    # balanced-split null; this exact enumeration is the deterministic
+    # version of eqmed's 10,000 sampled shuffles (validated: 95.5% equal at
+    # 3 decimals for k <= 8, the residual being the sampling jitter).
+    return int(q99 / median_left * 1000) / 1000
 
 
 parser = argparse.ArgumentParser(description="Run performance test.")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Rework of the performance-comparison run policy based on a quantitative study of ~4.7M identical-build (A/A) query comparisons from the perf CI database. Three changes + one TEMP experiment commit.

**1. Precision-targeted run policy in perf.py** (`tau`-stop)
Instead of accumulating 1s per server, each query now runs until its own permutation-test noise threshold reaches the precision target tau=0.08 (checked from run 5; exact null enumeration for k<=8, sampled above), capped at 30 runs for sub-20ms queries and 7 for the rest, minimum 5 runs. Validated in two ways: replay on recorded run data at tau=0.10 (**~35% less measured-run time**, weighted A/A false-positive rate 0.34% -> 0.21%, power at +25% within 1.6pp of current), and two live 5x60-job rounds on this PR comparing tau=0.10 vs the shipped tau=0.08: identical timings (~2% more runs; 2,513s vs 2,511s wall per shard), 5-run share 96.8% -> 93.6%, and the tighter target cut the arm 'unstable' rate 0.90% -> 0.60% (below the 0.81% master baseline). The old rule's pathologies this fixes: 8s-early-stopped slow queries at n=3 had 30-40x the FPR of n=7; ultra-fast queries ran 150-500 times for no measurable benefit.

**2. Confirmation reruns** (`compare.sh confirm_changes`)
The dominant flaky mechanism is per-process state: one server instance is consistently 10-30% off for a whole check (allocator arenas / memory layout fixed at process start). Servers currently live through the entire check, so every check is one draw of that state. After the analysis stage, queries flagged as changed are rerun once after restarting both servers, and kept only if the change reproduces with the same direction against the same per-query thresholds. Demoted rows stay visible in a new 'Unconfirmed Changes' report table. Upper-bound estimate from cross-check resampling: ~17x fewer false 'changed' rows, ~94% of chronically flaky series cured, at ~1-2% extra job time. Strictly fail-open: any error in confirmation leaves today's behavior.

**3. CPU pinning + max_threads=8 on x86_64**
amd runners (m7i.4xlarge) have 8 physical cores x 2 HT; with max_threads=12 the scheduler decides which threads share a hyperthread pair, differently every run. Both servers are now pinned to one hyperthread per physical core (topology-derived, same set for both — the paired design needs a shared environment) with max_threads=8. arm (m8g.4xlarge, 16 real cores) unchanged. Expected to close part of amd's excess noise (A/A flag rate 0.51% vs arm 0.42%, same-build cross-machine gap 6.3% vs 2.5%).

**4. TEMP DO NOT MERGE**: the last commits run Performance Comparison 5x per push and skip unrelated CI jobs to measure the effect. Note: bump `ci/jobs/scripts/perf/EXPERIMENT_NONCE` on every push that should re-measure (praktika's success cache would otherwise skip perf jobs when no perf-digest path changed). Skipped required checks will show as absent — this PR is an experiment vehicle, not for merge until the TEMP commit is reverted.

### Documentation entry for user-facing changes

Implementation was cross-validated against a reference implementation of the eqmed.sql statistic (exact match on enumerable nulls) and adversarially reviewed; measured numbers above come from replaying policies on recorded per-run CI data (Apr-Jul 2026, 327-series stratified sample + all flagged/identical-build verdict rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1336` (included in `26.7` and later)
<!-- ch-version-info:end -->