### PR TITLE
Add ORDER BY sort-elision regression case to 04500

### DIFF
--- a/tests/queries/0_stateless/04500_read_in_order_through_partial_merge_join.reference
+++ b/tests/queries/0_stateless/04500_read_in_order_through_partial_merge_join.reference
@@ -22,3 +22,4 @@
 500
 ReadType: Default
 ReadType: Default
+1

--- a/tests/queries/0_stateless/04500_read_in_order_through_partial_merge_join.sql
+++ b/tests/queries/0_stateless/04500_read_in_order_through_partial_merge_join.sql
@@ -54,5 +54,17 @@ SELECT trim(explain) FROM (
              optimize_aggregation_in_order = 1, max_threads = 1
 ) WHERE explain LIKE '%ReadType%';
 
+-- #110662 (no-aggregation manifestation): a plain top-level ORDER BY over a partial_merge
+-- JOIN must be truly sorted. Pre-fix the sort was elided because the plan wrongly trusted the
+-- join output to already be sorted by the left key. Self-checking: the join is 1:1 on n and k
+-- spans 0..499, so a correctly sorted stream emits exactly [0, 1, ..., 499] == range(500).
+-- The read-in-order gates are pinned on (and swap off) so the defective path is always exercised;
+-- otherwise a run that randomizes them off would sort correctly and pass without testing the fix.
+SELECT groupArray(k) = range(500) FROM (
+    SELECT l.k AS k FROM t2 AS l LEFT JOIN t2 AS r ON l.n = r.n ORDER BY l.k
+) SETTINGS enable_analyzer = 1, join_algorithm = 'partial_merge', max_threads = 1,
+           optimize_read_in_order = 1, query_plan_read_in_order = 1,
+           query_plan_read_in_order_through_join = 1, query_plan_join_swap_table = 'false';
+
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/110662
Related: https://github.com/ClickHouse/ClickHouse/pull/110671
-->

Related: #110662
Related: #110671

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Description

Follow-up to #110671, which fixed read-in-order propagation through PartialMergeJoin (issue #110662) via the `IJoin::preservesLeftBlockOrder()` gate in `optimizeReadInOrder.cpp`. That gate sits at the shared read-in-order source, so it also protects the plain top-level `ORDER BY` consumer, not just aggregation-in-order and distinct-in-order.

The existing `04500_read_in_order_through_partial_merge_join` test covers the aggregation-in-order and distinct-in-order consumers plus an `EXPLAIN` `ReadType` check, but not the plain `ORDER BY` sort-elision path reported on #110662 as a no-aggregation manifestation. This adds that case.

The new query is self-checking: the `partial_merge` self-join is 1:1 on `n` and `k` spans `0..499`, so a correctly sorted stream emits exactly `[0, 1, ..., 499] = range(500)`. It returns `0` on the pre-fix binary (`ORDER BY` elided, rows out of order) and `1` on fixed master. Verified in both directions and stable over 50 randomized runs.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.164` (included in `26.8` and later)
<!-- ch-version-info:end -->