### PR TITLE
docs: clarify multi-name and multi-table ROW POLICY syntax

### DIFF
--- a/docs/reference/statements/alter/row-policy.mdx
+++ b/docs/reference/statements/alter/row-policy.mdx
@@ -11,10 +11,56 @@ Changes row policy.
 Syntax:
 
 ```sql
-ALTER [ROW] POLICY [IF EXISTS] name1 [ON CLUSTER cluster_name1] ON [database1.]table1 [RENAME TO new_name1]
-        [, name2 [ON CLUSTER cluster_name2] ON [database2.]table2 [RENAME TO new_name2] ...]
+-- Rename: exactly one fully qualified policy (one name on one target)
+ALTER [ROW] POLICY [IF EXISTS] name
+    ON { [database.]table | database.* }
+    RENAME TO new_name
+    [ON CLUSTER cluster_name]
+
+-- Multiple names on one table target (no RENAME)
+ALTER [ROW] POLICY [IF EXISTS] name [, ...]
+    [ON CLUSTER cluster_name]
+    ON { [database.]table | database.* }
     [AS {PERMISSIVE | RESTRICTIVE}]
     [FOR SELECT]
     [USING {condition | NONE}][,...]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
+
+-- One name on multiple table targets (no RENAME)
+ALTER [ROW] POLICY [IF EXISTS] name
+    [ON CLUSTER cluster_name]
+    ON { [database.]table | database.* } [, ...]
+    [AS {PERMISSIVE | RESTRICTIVE}]
+    [FOR SELECT]
+    [USING {condition | NONE}][,...]
+    [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
+
+-- Mixed packing: each name paired with its own table target (no RENAME)
+ALTER [ROW] POLICY [IF EXISTS]
+    name ON { [database.]table | database.* } [, name ON { [database.]table | database.* } ...]
+    [ON CLUSTER cluster_name]
+    [AS {PERMISSIVE | RESTRICTIVE}]
+    [FOR SELECT]
+    [USING {condition | NONE}][,...]
+    [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
+```
+
+`RENAME TO` is only accepted when the statement names **exactly one** policy on **one** table target. Packed multi-name or multi-table lists cannot include `RENAME TO` — rename those policies in separate statements.
+
+Without `RENAME TO`, packing matches `ParserRowPolicyNames`: multiple names on **one** target, one name on **multiple** targets, or mixed `name ON target` pairs. Multi-name × multi-table (`p1, p2 ON t1, t2`) is **not** accepted. Optional `ON CLUSTER` applies once to the whole statement; run separate `ALTER ROW POLICY` statements when different clusters are required.
+
+Examples:
+
+```sql
+-- Single-policy rename
+ALTER ROW POLICY p1 ON db.table RENAME TO p1_new;
+
+-- Multiple names, one table
+ALTER POLICY p1, p2 ON db.table TO ALL;
+
+-- One name, multiple tables
+ALTER POLICY p1 ON db.table, db.table2 USING NONE;
+
+-- Mixed targets without rename
+ALTER POLICY p1 ON db.table, p2 ON db2.table2 TO ALL;
 ```

--- a/docs/reference/statements/alter/row-policy.mdx
+++ b/docs/reference/statements/alter/row-policy.mdx
@@ -11,11 +11,16 @@ Changes row policy.
 Syntax:
 
 ```sql
--- Rename: exactly one fully qualified policy (one name on one target)
+-- Rename: exactly one fully qualified policy (one name on one target).
+-- RENAME TO may be combined with the same optional alteration clauses as below.
 ALTER [ROW] POLICY [IF EXISTS] name
     ON { [database.]table | database.* }
     RENAME TO new_name
     [ON CLUSTER cluster_name]
+    [AS {PERMISSIVE | RESTRICTIVE}]
+    [FOR SELECT]
+    [USING {condition | NONE}][,...]
+    [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 
 -- Multiple names on one table target (no RENAME)
 ALTER [ROW] POLICY [IF EXISTS] name [, ...]
@@ -45,7 +50,7 @@ ALTER [ROW] POLICY [IF EXISTS]
     [TO {role [,...] | ALL | ALL EXCEPT role [,...]}]
 ```
 
-`RENAME TO` is only accepted when the statement names **exactly one** policy on **one** table target. Packed multi-name or multi-table lists cannot include `RENAME TO` — rename those policies in separate statements.
+`RENAME TO` is only accepted when the statement names **exactly one** policy on **one** table target. Packed multi-name or multi-table lists cannot include `RENAME TO` — rename those policies in separate statements. On that single-policy form, `RENAME TO` can still be combined with other alterations such as `AS`, `USING`, and `TO` in the same statement.
 
 Without `RENAME TO`, packing matches `ParserRowPolicyNames`: multiple names on **one** target, one name on **multiple** targets, or mixed `name ON target` pairs. Multi-name × multi-table (`p1, p2 ON t1, t2`) is **not** accepted. Optional `ON CLUSTER` applies once to the whole statement; run separate `ALTER ROW POLICY` statements when different clusters are required.
 
@@ -54,6 +59,9 @@ Examples:
 ```sql
 -- Single-policy rename
 ALTER ROW POLICY p1 ON db.table RENAME TO p1_new;
+
+-- Rename plus other alterations on the same single policy
+ALTER POLICY old_name ON db.table RENAME TO new_name USING id > 10;
 
 -- Multiple names, one table
 ALTER POLICY p1, p2 ON db.table TO ALL;

--- a/docs/reference/statements/create/row-policy.mdx
+++ b/docs/reference/statements/create/row-policy.mdx
@@ -15,12 +15,79 @@ Row policies make sense only for users with readonly access. If a user can modif
 Syntax:
 
 ```sql
-CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name1 [ON CLUSTER cluster_name1] ON [db1.]table1|db1.*
-        [, policy_name2 [ON CLUSTER cluster_name2] ON [db2.]table2|db2.* ...]
+-- Multiple names on one table target
+CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name [, ...]
+    [ON CLUSTER cluster_name]
+    ON { [db.]table | db.* }
     [IN access_storage_type]
     [FOR SELECT] USING condition
     [AS {PERMISSIVE | RESTRICTIVE}]
     [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
+
+-- One name on multiple table targets
+CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE] policy_name
+    [ON CLUSTER cluster_name]
+    ON { [db.]table | db.* } [, ...]
+    [IN access_storage_type]
+    [FOR SELECT] USING condition
+    [AS {PERMISSIVE | RESTRICTIVE}]
+    [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
+
+-- Mixed packing: each name paired with its own table target
+CREATE [ROW] POLICY [IF NOT EXISTS | OR REPLACE]
+    policy_name ON { [db.]table | db.* } [, policy_name ON { [db.]table | db.* } ...]
+    [ON CLUSTER cluster_name]
+    [IN access_storage_type]
+    [FOR SELECT] USING condition
+    [AS {PERMISSIVE | RESTRICTIVE}]
+    [TO {role1 [, role2 ...] | ALL | ALL EXCEPT role1 [, role2 ...]}]
+```
+
+`ParserRowPolicyNames` accepts **three** packing forms (not a full Cartesian product):
+
+1. **Multiple names, one target** — `pol1, pol2 ON table1` creates each listed name on that single table (or `db.*`).
+2. **One name, multiple targets** — `pol1 ON table1, table2` creates the same short name on each listed target.
+3. **Mixed pairs** — `p1 ON t1, p2 ON t2` creates each name only on its paired target.
+
+A multi-name list **cannot** be combined with a multi-table `ON` list in one group: `p1, p2 ON t1, t2` is rejected. After a multi-name group, you also cannot append another comma-separated `name ON target` group in the same statement.
+
+Optional `ON CLUSTER` applies to the whole statement (one cluster name). ClickHouse does **not** accept a different `ON CLUSTER` per policy name packed into a single create — run separate `CREATE ROW POLICY` statements when policies must be created on different clusters.
+
+## Multiple names and tables {#multiple-names-and-tables}
+
+Valid:
+
+```sql
+-- Several policy names, one table
+CREATE ROW POLICY pol1, pol2, pol3 ON table1
+    FOR SELECT USING id = 1
+    TO accountant;
+
+-- One policy name, several tables
+CREATE ROW POLICY IF NOT EXISTS pol1 ON table1, table2, table3
+    FOR SELECT USING id = 1
+    TO accountant;
+
+-- Mixed packing: different name per table
+CREATE ROW POLICY p4 ON db.table, p5 ON db2.table2
+    USING a = b;
+
+-- Same policy on several tables, on a cluster
+CREATE ROW POLICY IF NOT EXISTS pol1 ON CLUSTER replicated_cluster ON table1, table2
+    FOR SELECT USING id = 1
+    TO accountant;
+```
+
+Invalid:
+
+```sql
+-- Multi-name × multi-table in one ON-group (not a Cartesian product)
+CREATE ROW POLICY p1, p2 ON t1, t2
+    FOR SELECT USING id = 1
+    TO accountant;
+
+-- Different clusters per name in one statement
+CREATE ROW POLICY pol1 ON CLUSTER cluster1 ON table1, pol2 ON CLUSTER cluster2 ON table2
 ```
 
 ## USING Clause {#using-clause}


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):


## Summary
Updates CREATE/ALTER ROW POLICY reference docs so multi-policy and multi-table packing is explicit, and so readers do not infer a per-name `ON CLUSTER` list that the parser rejects.

## Motivation
Issue #69865 reported valid forms missing from the docs (several names on one table; one name on several tables) and a misleading "different clusters per name in one statement" reading of the old BNF.

## Changes
- `docs/reference/statements/create/row-policy.mdx` — clearer grammar, multi-name/multi-table examples, invalid multi-cluster packing example
- `docs/reference/statements/alter/row-policy.mdx` — aligned syntax + same ON CLUSTER caveat

## Verification
- Manual check against issue #69865 cases 1–4
- Docs-only; no server code

Fixes #69865

AI-assisted; human-reviewed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.975` (included in `26.8` and later)
<!-- ch-version-info:end -->