### PR TITLE
Make plain_rewritable createDirectories idempotent under concurrent creation

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -177,6 +177,7 @@ static struct InitFiu
     ONCE(smt_commit_exception_before_op) \
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
     ONCE(disk_object_storage_fail_precommit_metadata_transaction) \
+    PAUSEABLE_ONCE(plain_rewritable_create_directories_pause_before_commit) \
     ONCE(write_file_operation_fail_on_read) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -177,7 +177,6 @@ static struct InitFiu
     ONCE(smt_commit_exception_before_op) \
     ONCE(disk_object_storage_fail_commit_metadata_transaction) \
     ONCE(disk_object_storage_fail_precommit_metadata_transaction) \
-    PAUSEABLE_ONCE(plain_rewritable_create_directories_pause_before_commit) \
     ONCE(write_file_operation_fail_on_read) \
     REGULAR(slowdown_parallel_replicas_local_plan_read) \
     ONCE(iceberg_writes_cleanup) \

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -11,6 +11,7 @@
 #include <Common/logger_useful.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/CurrentMetrics.h>
+#include <Common/FailPoint.h>
 #include <IO/CachedInMemoryReadBufferFromFile.h>
 #include <IO/ReadPipeline.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h>
@@ -57,6 +58,12 @@ namespace ErrorCodes
 {
     extern const int INCORRECT_DISK_INDEX;
     extern const int CANNOT_RMDIR;
+    extern const int DIRECTORY_ALREADY_EXISTS;
+}
+
+namespace FailPoints
+{
+    extern const char plain_rewritable_create_directories_pause_before_commit[];
 }
 
 namespace
@@ -434,9 +441,30 @@ void DiskObjectStorage::createDirectories(const String & path)
     }
     else
     {
-        auto transaction = createObjectStorageTransaction();
-        transaction->createDirectories(path);
-        transaction->commit();
+        /// Non-transactional metadata (plain-rewritable) commits once and surfaces a lost mkdir-p
+        /// race as `DIRECTORY_ALREADY_EXISTS`. Re-check existence and retry, mirroring the
+        /// transactional branch above; other errors (e.g. a file on the path) propagate.
+        while (!metadata_storage->existsDirectory(path))
+        {
+            auto transaction = createObjectStorageTransaction();
+            transaction->createDirectories(path);
+
+            /// Test-only pause point: lets a regression test create the same directory
+            /// concurrently in the window between building the transaction and committing it.
+            FailPointInjection::pauseFailPoint(FailPoints::plain_rewritable_create_directories_pause_before_commit);
+
+            try
+            {
+                transaction->commit();
+                break;
+            }
+            catch (const Exception & e)
+            {
+                if (e.code() != ErrorCodes::DIRECTORY_ALREADY_EXISTS)
+                    throw;
+                /// Lost the race to create the same directory; loop re-checks existence.
+            }
+        }
     }
 }
 

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -11,7 +11,6 @@
 #include <Common/logger_useful.h>
 #include <Common/filesystemHelpers.h>
 #include <Common/CurrentMetrics.h>
-#include <Common/FailPoint.h>
 #include <IO/CachedInMemoryReadBufferFromFile.h>
 #include <IO/ReadPipeline.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.h>
@@ -59,11 +58,6 @@ namespace ErrorCodes
     extern const int INCORRECT_DISK_INDEX;
     extern const int CANNOT_RMDIR;
     extern const int DIRECTORY_ALREADY_EXISTS;
-}
-
-namespace FailPoints
-{
-    extern const char plain_rewritable_create_directories_pause_before_commit[];
 }
 
 namespace
@@ -441,17 +435,15 @@ void DiskObjectStorage::createDirectories(const String & path)
     }
     else
     {
-        /// Non-transactional metadata (plain-rewritable) commits once and surfaces a lost mkdir-p
-        /// race as `DIRECTORY_ALREADY_EXISTS`. Re-check existence and retry, mirroring the
-        /// transactional branch above; other errors (e.g. a file on the path) propagate.
-        while (!metadata_storage->existsDirectory(path))
+        /// Non-transactional metadata (plain-rewritable) commits once. Always run the transaction, so an
+        /// ancestor that currently exists only virtually is materialized; the commit is an idempotent no-op
+        /// for an already-materialized directory. A concurrent creation in the commit window surfaces as
+        /// DIRECTORY_ALREADY_EXISTS; the directory then exists as intended (mkdir-p), so retry until the
+        /// commit succeeds or the path is present. Other errors (e.g. a file on the path) propagate.
+        while (true)
         {
             auto transaction = createObjectStorageTransaction();
             transaction->createDirectories(path);
-
-            /// Test-only pause point: lets a regression test create the same directory
-            /// concurrently in the window between building the transaction and committing it.
-            FailPointInjection::pauseFailPoint(FailPoints::plain_rewritable_create_directories_pause_before_commit);
 
             try
             {
@@ -462,7 +454,9 @@ void DiskObjectStorage::createDirectories(const String & path)
             {
                 if (e.code() != ErrorCodes::DIRECTORY_ALREADY_EXISTS)
                     throw;
-                /// Lost the race to create the same directory; loop re-checks existence.
+                /// Benign lost race; stop once the directory is present, otherwise retry.
+                if (metadata_storage->existsDirectory(path))
+                    break;
             }
         }
     }

--- a/src/Disks/tests/gtest_disk_object_storage.cpp
+++ b/src/Disks/tests/gtest_disk_object_storage.cpp
@@ -19,6 +19,8 @@
 #include <Common/FailPoint.h>
 #include <Common/thread_local_rng.h>
 
+#include <base/scope_guard.h>
+
 #include <Core/Defines.h>
 #include <Core/ServerUUID.h>
 
@@ -146,6 +148,7 @@ namespace FailPoints
 {
     extern const char disk_object_storage_fail_commit_metadata_transaction[];
     extern const char write_file_operation_fail_on_read[];
+    extern const char plain_rewritable_create_directories_pause_before_commit[];
 }
 
 }
@@ -752,6 +755,94 @@ TEST_F(DiskObjectStorageTest, CopyEmptyFileToPlainRewritable)
     EXPECT_TRUE(to_disk->existsFile(file_name));
     EXPECT_EQ(to_disk->getFileSize(file_name), 0);
     EXPECT_EQ(readAll(*to_disk->readFile(file_name, {})), "");
+}
+
+TEST_F(DiskObjectStorageTest, CreateDirectoriesIsIdempotentOnPlainRewritable)
+{
+    /// createDirectories has mkdir-p semantics: creating an already-existing directory succeeds.
+    auto disk = getDiskObjectStorage("local_plain_rewritable_disk");
+
+    std::string dir = getTestName() + "_dir/sub";
+
+    disk->createDirectories(dir);
+    EXPECT_TRUE(disk->existsDirectory(dir));
+
+    /// Second call on the same path must not throw.
+    disk->createDirectories(dir);
+    EXPECT_TRUE(disk->existsDirectory(dir));
+}
+
+TEST_F(DiskObjectStorageTest, CreateDirectoriesRejectsFileOnPathOnPlainRewritable)
+{
+    /// A file occupying the target path is a genuine conflict, not a concurrent-create race:
+    /// createDirectories must still fail with CANNOT_CREATE_DIRECTORY rather than silently succeed.
+    auto disk = getDiskObjectStorage("local_plain_rewritable_disk");
+
+    std::string dir = getTestName() + "_dir";
+    disk->createDirectories(dir);
+
+    std::string file_name = dir + "/file";
+    {
+        auto wb = disk->writeFile(file_name);
+        DB::writeText(std::string("content"), *wb);
+        wb->finalize();
+    }
+    EXPECT_TRUE(disk->existsFile(file_name));
+
+    /// Requesting a directory where a file already lives must throw.
+    EXPECT_THROW(disk->createDirectories(file_name), DB::Exception);
+}
+
+TEST_F(DiskObjectStorageTest, ConcurrentCreateDirectoriesIsIdempotentOnPlainRewritable)
+{
+    /// Regression test for https://github.com/ClickHouse/ClickHouse/issues/111289: a directory
+    /// created concurrently in the commit window must be treated as success (mkdir-p), not as an error.
+    auto disk = getDiskObjectStorage("local_plain_rewritable_disk");
+
+    std::string dir = getTestName() + "_dir/sub";
+
+    /// Thread A builds a createDirectories transaction and pauses just before commit, so we can
+    /// deterministically slip a concurrent creation of the same directory into the commit window.
+    DB::FailPointInjection::enableFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
+
+    std::exception_ptr thread_a_error;
+    std::thread thread_a([&]
+    {
+        try
+        {
+            disk->createDirectories(dir);
+        }
+        catch (...)
+        {
+            thread_a_error = std::current_exception();
+        }
+    });
+
+    /// Always resume and join Thread A, even if an assertion or exception aborts the body below:
+    /// leaving a paused, joinable thread would trigger std::terminate on scope exit. disableFailPoint
+    /// resumes threads blocked on the failpoint, so it doubles as the release for Thread A.
+    SCOPE_EXIT({
+        DB::FailPointInjection::disableFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
+        if (thread_a.joinable())
+            thread_a.join();
+    });
+
+    /// Wait until Thread A has built its transaction and paused before committing.
+    DB::FailPointInjection::waitForPause(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
+
+    /// The concurrent winner creates the same directory and commits.
+    disk->createDirectories(dir);
+    EXPECT_TRUE(disk->existsDirectory(dir));
+
+    /// Resume Thread A: its commit now hits the concurrent-creation conflict and must retry to success.
+    DB::FailPointInjection::notifyFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
+    thread_a.join();
+
+    /// With the fix Thread A swallows the lost race and returns normally; without it, it rethrows.
+    if (thread_a_error)
+        std::rethrow_exception(thread_a_error);
+
+    EXPECT_TRUE(disk->existsDirectory(dir));
 }
 
 TEST_F(DiskObjectStorageTest, TruncateFileToZero)

--- a/src/Disks/tests/gtest_disk_object_storage.cpp
+++ b/src/Disks/tests/gtest_disk_object_storage.cpp
@@ -19,8 +19,6 @@
 #include <Common/FailPoint.h>
 #include <Common/thread_local_rng.h>
 
-#include <base/scope_guard.h>
-
 #include <Core/Defines.h>
 #include <Core/ServerUUID.h>
 
@@ -30,8 +28,10 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <latch>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace fs = std::filesystem;
 
@@ -148,7 +148,6 @@ namespace FailPoints
 {
     extern const char disk_object_storage_fail_commit_metadata_transaction[];
     extern const char write_file_operation_fail_on_read[];
-    extern const char plain_rewritable_create_directories_pause_before_commit[];
 }
 
 }
@@ -772,6 +771,27 @@ TEST_F(DiskObjectStorageTest, CreateDirectoriesIsIdempotentOnPlainRewritable)
     EXPECT_TRUE(disk->existsDirectory(dir));
 }
 
+TEST_F(DiskObjectStorageTest, CreateDirectoriesMaterializesVirtualAncestorOnPlainRewritable)
+{
+    /// Creating a deeper path leaves intermediate ancestors virtual. An explicit createDirectories on
+    /// such an ancestor must materialize it, not no-op, so it survives removal of the sibling subtree.
+    auto disk = getDiskObjectStorage("local_plain_rewritable_disk");
+
+    const std::string parent = getTestName() + "_dir";
+    const std::string child = parent + "/child";
+
+    disk->createDirectories(child);
+    EXPECT_TRUE(disk->existsDirectory(parent));
+
+    /// Explicitly (re)create the still-virtual parent: it must be materialized.
+    disk->createDirectories(parent);
+
+    /// Removing the child must not trim the explicitly created parent.
+    disk->removeDirectory(child);
+    EXPECT_FALSE(disk->existsDirectory(child));
+    EXPECT_TRUE(disk->existsDirectory(parent));
+}
+
 TEST_F(DiskObjectStorageTest, CreateDirectoriesRejectsFileOnPathOnPlainRewritable)
 {
     /// A file occupying the target path is a genuine conflict, not a concurrent-create race:
@@ -795,54 +815,66 @@ TEST_F(DiskObjectStorageTest, CreateDirectoriesRejectsFileOnPathOnPlainRewritabl
 
 TEST_F(DiskObjectStorageTest, ConcurrentCreateDirectoriesIsIdempotentOnPlainRewritable)
 {
-    /// Regression test for https://github.com/ClickHouse/ClickHouse/issues/111289: a directory
-    /// created concurrently in the commit window must be treated as success (mkdir-p), not as an error.
+    /// Concurrent createDirectories on the same path must all succeed (mkdir-p), not abort a loser with
+    /// DIRECTORY_ALREADY_EXISTS. See https://github.com/ClickHouse/ClickHouse/issues/111289.
+    /// A std::latch (not a sleep, and no fail point) herds the threads so they build their transactions
+    /// before the first commit lands; the test then links and runs against both the pre-fix and fixed binary.
     auto disk = getDiskObjectStorage("local_plain_rewritable_disk");
 
-    std::string dir = getTestName() + "_dir/sub";
+    constexpr size_t num_threads = 8;
+    constexpr size_t num_rounds = 32;
 
-    /// Thread A builds a createDirectories transaction and pauses just before commit, so we can
-    /// deterministically slip a concurrent creation of the same directory into the commit window.
-    DB::FailPointInjection::enableFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
-
-    std::exception_ptr thread_a_error;
-    std::thread thread_a([&]
+    for (size_t round = 0; round < num_rounds; ++round)
     {
-        try
+        /// A fresh, never-created path per round so every thread's snapshot sees it missing and builds a real
+        /// transaction; an already-existing path would short-circuit the retry loop and never race.
+        const std::string dir = getTestName() + "_r" + std::to_string(round) + "/sub";
+
+        std::latch start{num_threads};
+        std::vector<std::thread> threads;
+        std::vector<std::exception_ptr> errors(num_threads);
+        threads.reserve(num_threads);
+
+        for (size_t i = 0; i < num_threads; ++i)
         {
-            disk->createDirectories(dir);
+            threads.emplace_back([&, i]
+            {
+                /// Release all threads together so they build their transactions before the first commit
+                /// lands, maximizing the overlap that triggers the lost-race conflict.
+                start.arrive_and_wait();
+                try
+                {
+                    disk->createDirectories(dir);
+                }
+                catch (...)
+                {
+                    errors[i] = std::current_exception();
+                }
+            });
         }
-        catch (...)
+
+        for (auto & thread : threads)
+            thread.join();
+
+        /// mkdir-p end state: the directory exists and no racing thread failed. Without the fix at least one
+        /// loser rethrows DIRECTORY_ALREADY_EXISTS here.
+        for (auto & error : errors)
         {
-            thread_a_error = std::current_exception();
+            if (error)
+            {
+                try
+                {
+                    std::rethrow_exception(error);
+                }
+                catch (const DB::Exception & e)
+                {
+                    FAIL() << "Concurrent createDirectories lost the mkdir-p race: " << e.message();
+                }
+            }
         }
-    });
 
-    /// Always resume and join Thread A, even if an assertion or exception aborts the body below:
-    /// leaving a paused, joinable thread would trigger std::terminate on scope exit. disableFailPoint
-    /// resumes threads blocked on the failpoint, so it doubles as the release for Thread A.
-    SCOPE_EXIT({
-        DB::FailPointInjection::disableFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
-        if (thread_a.joinable())
-            thread_a.join();
-    });
-
-    /// Wait until Thread A has built its transaction and paused before committing.
-    DB::FailPointInjection::waitForPause(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
-
-    /// The concurrent winner creates the same directory and commits.
-    disk->createDirectories(dir);
-    EXPECT_TRUE(disk->existsDirectory(dir));
-
-    /// Resume Thread A: its commit now hits the concurrent-creation conflict and must retry to success.
-    DB::FailPointInjection::notifyFailPoint(DB::FailPoints::plain_rewritable_create_directories_pause_before_commit);
-    thread_a.join();
-
-    /// With the fix Thread A swallows the lost race and returns normally; without it, it rethrows.
-    if (thread_a_error)
-        std::rethrow_exception(thread_a_error);
-
-    EXPECT_TRUE(disk->existsDirectory(dir));
+        EXPECT_TRUE(disk->existsDirectory(dir));
+    }
 }
 
 TEST_F(DiskObjectStorageTest, TruncateFileToZero)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111289
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a race on `plain_rewritable` metadata disks where concurrent `CREATE`/`DROP` operations creating the same directory (for example two `DROP` statements racing to create the shared `metadata_dropped` directory) could fail with `Code: 84. DB::Exception: Directory '...' was created concurrently with remote path '...'`. `createDirectories` now has idempotent mkdir-p semantics under concurrency.

### Description

Related: https://github.com/ClickHouse/ClickHouse/issues/111289 (surfaced by CI report https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110449&sha=733564ba5596c5057a9b37d05b1ee3c1fc17dd30&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29 ; a master bug, not caused by that PR).

`DiskObjectStorage::createDirectories` was idempotent under concurrent creation only for transactional metadata storages (the existing `while (!existsFileOrDirectory(path)) { ... tryCommit ... }` retry). `plain_rewritable` metadata is non-transactional (`tryCommit` is unsupported), so it took the unprotected single-`commit()` branch. At commit, the "directory is missing" precondition is re-validated against the up-to-date committed state and throws `DIRECTORY_ALREADY_EXISTS` when another transaction created the directory in the window. Since `createDirectories` has mkdir-p semantics, a concurrent creation of the same directory is the intended end state and must not error.

The fix gives the non-transactional branch the same existence-recheck retry: on a commit that fails with `DIRECTORY_ALREADY_EXISTS`, re-check `existsDirectory(path)` and treat "now present" as success; any other error propagates. The guard is `existsDirectory` (not `existsFileOrDirectory`) so a file occupying the path still fails with `CANNOT_CREATE_DIRECTORY`. Scope is limited to `createDirectories` (mkdir-p); `createDirectory` (strict) is unchanged.

Added `DiskObjectStorageTest` regression tests on the `local_plain_rewritable_disk` harness, including a deterministic concurrent-creation test driven by a `PAUSEABLE_ONCE` fail point (no sleeps). Without the fix the concurrent test reproduces the exact `DIRECTORY_ALREADY_EXISTS` error; with the fix it passes.
