### PR TITLE
Remove dead code in Backups

### DIFF
--- a/src/Backups/BackupCoordinationFileInfos.cpp
+++ b/src/Backups/BackupCoordinationFileInfos.cpp
@@ -10,7 +10,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BACKUP_ENTRY_ALREADY_EXISTS;
-    extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
 }
 
@@ -43,14 +42,6 @@ void BackupCoordinationFileInfos::forEachFileInfoForAllHosts(const std::function
     prepare();
     for (const auto * file_info : file_infos_for_all_hosts)
         callback(*file_info);
-}
-
-BackupFileInfo BackupCoordinationFileInfos::getFileInfoByDataFileIndex(size_t data_file_index) const
-{
-    prepare();
-    if (data_file_index >= file_infos_for_all_hosts.size())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid data file index: {}", data_file_index);
-    return *(file_infos_for_all_hosts[data_file_index]);
 }
 
 namespace

--- a/src/Backups/BackupCoordinationFileInfos.h
+++ b/src/Backups/BackupCoordinationFileInfos.h
@@ -44,9 +44,6 @@ public:
     /// Iterates the file infos of all hosts in place, without copying them into a vector.
     void forEachFileInfoForAllHosts(const std::function<void(const BackupFileInfo &)> & callback) const;
 
-    /// Returns a file info by data file index (see BackupFileInfo::data_file_index).
-    BackupFileInfo getFileInfoByDataFileIndex(size_t data_file_index) const;
-
     /// Returns the number of files after deduplication and excluding empty files.
     size_t getNumFiles() const;
 

--- a/src/Backups/BackupCoordinationOnCluster.h
+++ b/src/Backups/BackupCoordinationOnCluster.h
@@ -89,7 +89,6 @@ public:
 
 private:
     void createRootNodes();
-    bool tryFinishImpl() noexcept;
 
     void serializeToMultipleZooKeeperNodes(const String & path, const String & value, const String & logging_name);
     String deserializeFromMultipleZooKeeperNodes(const String & path, const String & logging_name) const;

--- a/src/Backups/BackupIO_AzureBlobStorage.cpp
+++ b/src/Backups/BackupIO_AzureBlobStorage.cpp
@@ -327,15 +327,6 @@ void BackupWriterAzureBlobStorage::removeFiles(const Strings & file_names)
 
 }
 
-void BackupWriterAzureBlobStorage::removeFilesBatch(const Strings & file_names)
-{
-    StoredObjects objects;
-    for (const auto & file_name : file_names)
-        objects.emplace_back(fs::path(blob_path) / file_name);
-
-    object_storage->removeObjectsIfExist(objects);
-}
-
 }
 
 #endif

--- a/src/Backups/BackupIO_AzureBlobStorage.h
+++ b/src/Backups/BackupIO_AzureBlobStorage.h
@@ -84,7 +84,6 @@ public:
 
 private:
     std::unique_ptr<ReadBuffer> readFile(const String & file_name, size_t expected_file_size) override;
-    void removeFilesBatch(const Strings & file_names);
 
     const DataSourceDescription data_source_description;
     std::shared_ptr<const AzureBlobStorage::ContainerClient> client;

--- a/src/Backups/BackupsWorker.h
+++ b/src/Backups/BackupsWorker.h
@@ -133,9 +133,6 @@ private:
         size_t only_shard_num, size_t only_replica_num, ContextMutablePtr context, const AccessRightsElements & access_to_check,
         const ZooKeeperRetriesInfo & retries_info) const;
 
-    /// Run data restoring tasks which insert data to tables.
-    void restoreTablesData(const BackupOperationID & restore_id, BackupPtr backup, DataRestoreTasks && tasks, ThreadPool & thread_pool, QueryStatusPtr process_list_element);
-
     std::pair<bool, BackupStatus> addInfo(const BackupOperationID & id, const String & name, const String & base_backup_name, const String & query_id,
                                           bool internal, QueryStatusPtr process_list_element, BackupStatus status, std::map<String, String> settings);
 

--- a/src/Backups/RestoreCoordinationOnCluster.h
+++ b/src/Backups/RestoreCoordinationOnCluster.h
@@ -73,7 +73,6 @@ public:
 
 private:
     void createRootNodes();
-    bool tryFinishImpl() noexcept;
 
     const String root_zookeeper_path;
     const BackupKeeperSettings keeper_settings;

--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -1005,15 +1005,6 @@ void RestorerFromBackup::addDataRestoreTask(DataRestoreTask && new_task)
     data_restore_tasks.push_back(std::move(new_task));
 }
 
-void RestorerFromBackup::addDataRestoreTasks(DataRestoreTasks && new_tasks)
-{
-    if (current_stage != Stage::INSERTING_DATA_TO_TABLES)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Adding of data-restoring tasks is not allowed");
-
-    std::lock_guard lock{mutex};
-    insertAtEnd(data_restore_tasks, std::move(new_tasks));
-}
-
 void RestorerFromBackup::runDataRestoreTasks()
 {
     /// Iterations are required here because data restore tasks are allowed to call addDataRestoreTask() and add other data restore tasks.

--- a/src/Backups/RestorerFromBackup.h
+++ b/src/Backups/RestorerFromBackup.h
@@ -62,7 +62,6 @@ public:
     /// Adds a data restore task which will be later returned by getDataRestoreTasks().
     /// This function can be called by implementations of IStorage::restoreFromBackup() in inherited storage classes.
     void addDataRestoreTask(DataRestoreTask && new_task);
-    void addDataRestoreTasks(DataRestoreTasks && new_tasks);
 
     /// Returns the list of access entities to restore.
     AccessEntitiesToRestore getAccessEntitiesToRestore(const String & data_path_in_backup) const;


### PR DESCRIPTION
Removes six functions that have no callers in either the public or the private repository:

- `BackupCoordinationFileInfos::getFileInfoByDataFileIndex`
- `BackupsWorker::restoreTablesData` (orphan declaration, never defined)
- `BackupCoordinationOnCluster::tryFinishImpl` (orphan declaration)
- `RestoreCoordinationOnCluster::tryFinishImpl` (orphan declaration)
- `RestorerFromBackup::addDataRestoreTasks` (plural; the used API is the singular `addDataRestoreTask`)
- `BackupWriterAzureBlobStorage::removeFilesBatch`

Also drops the `BAD_ARGUMENTS` error code that only `getFileInfoByDataFileIndex` used. Verified callerless in both repos; the affected translation units compile.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1362` (included in `26.7` and later)
<!-- ch-version-info:end -->