### PR TITLE
Fix flaky test 02435_rollback_cancelled_queries 

### DIFF
--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -26,7 +26,12 @@ function insert_data
     TXN_SETTINGS="session_id=$SESSION_ID&throw_on_unsupported_query_inside_transaction=0&implicit_transaction=$IMPLICIT"
     BEGIN=""
     COMMIT=""
-    SETTINGS="query_id=$ID&$TXN_SETTINGS&max_insert_block_size=110000&min_insert_block_size_rows=110000"
+    # write_through_distributed_cache=0: on the distributed-cache CI variant the default profile enables
+    # write-through, which makes each of a part's ~11 files (mostly tiny metadata) pay a synchronous cache
+    # round-trip; a 1M-row insert then needs ~200 round-trips and can exceed the client timeout. This test
+    # exercises query cancellation / transaction rollback, not the write-through path, so disable it to keep
+    # the insert bounded by data volume. A no-op where distributed cache is not configured.
+    SETTINGS="query_id=$ID&$TXN_SETTINGS&max_insert_block_size=110000&min_insert_block_size_rows=110000&write_through_distributed_cache=0"
     if [[ "$IMPLICIT" -eq 0 ]]; then
         $CLICKHOUSE_CURL -sS -d 'begin transaction' "$CLICKHOUSE_URL&$TXN_SETTINGS"
         SETTINGS="$SETTINGS&session_check=1"
@@ -51,6 +56,7 @@ function insert_data
         # safeExit via interruptSignalHandler) to deadlock acquiring the same lock. The client then ignores
         # SIGTERM too, so without -k the timeout wrapper waits forever, keeping the pipe open.
         timeout -k 5s 120 $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
+            --write_through_distributed_cache 0 \
             --max_block_size=1000 --max_insert_block_size=1000 -q \
             "${BEGIN}insert into dedup_test settings max_insert_block_size=110000, min_insert_block_size_rows=110000 format TSV$COMMIT" < $DATA_FILE \
             | grep -Fv "Transaction is not in RUNNING state" | grep -Fv "There is no current transaction"


### PR DESCRIPTION
## Problem

`02435_rollback_cancelled_queries` flakes on the distributed-cache CI variant (e.g. `amd_debug`): a 1M-row insert can exceed the client's 120s timeout, so `curl` prints `curl: (28) Operation timed out after 120001 milliseconds` and the test fails on non-empty stderr. The dumped query is not cancelled, just slow — `is_cancelled: 0`, elapsed ~160s.

## Root cause

The test is a query-cancellation / transaction-rollback stress test; distributed cache is incidental to it. But on that variant the default profile enables `write_through_distributed_cache`, so every one of a part's ~11 files — mostly tiny metadata (`checksums.txt`, `columns.txt`, `count.txt`, `txn_version.txt`, marks, primary index) — pays a synchronous cache round-trip, and the part writer finalizes files sequentially. A 1M-row insert creates ~19 parts × ~11 files ≈ 200 files, so it needs ~200 round-trips; on the loaded shared cache server those add up past 120s. The insert time is bound by file count × cache round-trip, not by data volume.

## Solution

Set `write_through_distributed_cache=0` on the test's inserts (all six send modes). The test exercises cancellation and rollback, not the write-through path — which has its own dedicated coverage in `04410_distributed_cache_write_cancellation` — so skipping write-through here is safe and keeps the insert bounded by data volume. It is a no-op on configs where distributed cache is not enabled, so the test stays green everywhere.

This is the minimal, test-scoped fix. The underlying write-latency cost is addressed separately in the private repo by making write-through skip small files; this change only stops the test from timing out.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog (CI Fix or Improvement).
