### PR TITLE
Fix Iceberg schema evolution for Array(Map(...)) columns

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ComplexTypeSchemaProcessorFunctions.cpp
@@ -257,7 +257,7 @@ void IIcebergSchemaTransform::transform(ComplexNode & initial_node)
                     }
                     else if (current_tuple[subfield_index].tryGet(tmp_node_map))
                     {
-                        current_node = std::move(tmp_node_array);
+                        current_node = std::move(tmp_node_map);
                     }
 
                     else

--- a/tests/integration/test_storage_iceberg_schema_evolution/test_array_of_map_evolved_nested.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_array_of_map_evolved_nested.py
@@ -1,0 +1,159 @@
+
+import pytest
+
+from helpers.iceberg_utils import (
+    get_uuid_str,
+    check_schema_and_data,
+    default_upload_directory,
+    get_creation_expression
+)
+
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/106207
+#
+# When an Iceberg column is an `ARRAY` whose element is a `MAP` holding a
+# `STRUCT` value, evolving that inner struct forces the schema transform to
+# descend `ARRAY` -> (map element) -> `STRUCT`. The `ARRAY` branch of
+# `IIcebergSchemaTransform::transform` used to move the wrong (empty) variable
+# into `current_node` for a map element, corrupting the evolved schema.
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+def test_array_of_map_evolved_nested(
+    started_cluster_iceberg_schema_evolution, format_version, storage_type
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    spark = started_cluster_iceberg_schema_evolution.spark_session
+    TABLE_NAME = (
+        "test_array_of_map_evolved_nested_"
+        + format_version
+        + "_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        spark.sql(query)
+        default_upload_directory(
+            started_cluster_iceberg_schema_evolution,
+            storage_type,
+            f"/iceberg_data/default/{TABLE_NAME}/",
+            f"/iceberg_data/default/{TABLE_NAME}/",
+        )
+        return
+
+    execute_spark_query(
+        f"""
+            DROP TABLE IF EXISTS {TABLE_NAME};
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            CREATE TABLE {TABLE_NAME}   (
+                address ARRAY<MAP<STRING, STRUCT<
+                    foo: STRING,
+                    bar: INT
+                >>>
+            )
+            USING iceberg
+            OPTIONS ('format-version'='{format_version}')
+        """
+    )
+
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES (ARRAY(MAP('key1', named_struct('foo', 'some_value', 'bar', 40))));
+        """
+    )
+
+    table_function = get_creation_expression(
+        storage_type, TABLE_NAME, started_cluster_iceberg_schema_evolution, table_function=True
+    )
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['address', 'Array(Map(String, Tuple(\\n    foo Nullable(String),\\n    bar Nullable(Int32))))']
+        ],
+        [
+            ["[{'key1':('some_value',40)}]"]
+        ],
+    )
+
+    # Adding a field to the struct nested inside the map value of the array.
+    # Reading the old data file now requires the ARRAY -> map-element -> STRUCT
+    # descent that used to hit the buggy branch.
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} ADD COLUMNS ( address.element.value.baz INT );
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['address', 'Array(Map(String, Tuple(\\n    foo Nullable(String),\\n    bar Nullable(Int32),\\n    baz Nullable(Int32))))']
+        ],
+        [
+            ["[{'key1':('some_value',40,NULL)}]"]
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            INSERT INTO {TABLE_NAME} VALUES (ARRAY(MAP('key2', named_struct('foo', 'some_value2', 'bar', 1, 'baz', 7))));
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['address', 'Array(Map(String, Tuple(\\n    foo Nullable(String),\\n    bar Nullable(Int32),\\n    baz Nullable(Int32))))']
+        ],
+        [
+            ["[{'key1':('some_value',40,NULL)}]"],
+            ["[{'key2':('some_value2',1,7)}]"],
+        ],
+    )
+
+    # Reorder the struct fields: the reordering transform must also descend
+    # through the ARRAY -> map-element edge.
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} ALTER COLUMN address.element.value.baz FIRST;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['address', 'Array(Map(String, Tuple(\\n    baz Nullable(Int32),\\n    foo Nullable(String),\\n    bar Nullable(Int32))))']
+        ],
+        [
+            ["[{'key1':(NULL,'some_value',40)}]"],
+            ["[{'key2':(7,'some_value2',1)}]"],
+        ],
+    )
+
+    # Drop a struct field: exercises the deleting transform on the same edge.
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} DROP COLUMN address.element.value.foo;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_function,
+        [
+            ['address', 'Array(Map(String, Tuple(\\n    baz Nullable(Int32),\\n    bar Nullable(Int32))))']
+        ],
+        [
+            ["[{'key1':(NULL,40)}]"],
+            ["[{'key2':(7,1)}]"],
+        ],
+    )


### PR DESCRIPTION
Reading an Iceberg `Array(Map(...))` column threw `std::bad_variant_access` once the map's value struct had been evolved (e.g. via `ADD COLUMN`).

In the `ARRAY` case of `IIcebergSchemaTransform::transform`, the branch handling a `Map` array element moved the empty `tmp_node_array` into `current_node` instead of the `tmp_node_map` that `tryGet` had just filled. The following `Map` dispatch therefore received an empty `Array` and the read failed with `std::bad_variant_access`.

The fix moves `tmp_node_map`, matching the `STRUCT` and `MAP` branches of the same function and the traversal in `traverseAllPaths`.

Also adds an integration test for `ARRAY<MAP<STRING, STRUCT>>` schema evolution (add / reorder / drop of the nested struct fields) across s3, azure and local storage and format versions 1 and 2. It reproduces the exception without the fix (6/6 cases fail) and passes with it (6/6 pass).

Closes: https://github.com/ClickHouse/ClickHouse/issues/106207

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `std::bad_variant_access` when reading an Iceberg table with an `Array(Map(...))` column whose nested struct had been changed by schema evolution.
