### PR TITLE
Fsync access entities in DiskAccessStorage to survive power loss

### DIFF
--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -317,7 +317,11 @@ void DiskAccessStorage::writeLists()
     if (types_of_lists_to_write.empty())
         return;
 
-    const bool fsync = shouldFsyncMetadata();
+    /// Honor the strongest fsync requirement pending for this batch (a session `fsync_metadata=1`
+    /// carried over from `scheduleWriteLists`) on top of whatever the current context resolves to.
+    /// This matters most in the deferred background thread, which has no query context and would
+    /// otherwise silently downgrade to the global `fsync_metadata` and leave the `.list` unsynced.
+    const bool fsync = pending_lists_fsync || shouldFsyncMetadata();
 
     for (const auto & type : types_of_lists_to_write)
     {
@@ -336,6 +340,9 @@ void DiskAccessStorage::writeLists()
             tryLogCurrentException(getLogger(), "Could not write " + file_path);
             failed_to_write_lists = true;
             types_of_lists_to_write.clear();
+            /// Keep pending_lists_fsync: the batch was not durably written, so the fsync
+            /// obligation must survive to the eventual rebuild (reloadAllAndRebuildLists),
+            /// even if that rebuild's own context has fsync_metadata=0.
             return;
         }
     }
@@ -348,6 +355,7 @@ void DiskAccessStorage::writeLists()
     }
 
     types_of_lists_to_write.clear();
+    pending_lists_fsync = false;
 }
 
 
@@ -361,6 +369,13 @@ void DiskAccessStorage::scheduleWriteLists(AccessEntityType type)
 
     types_of_lists_to_write.insert(type);
 
+    /// Remember the strongest fsync requirement of the DDLs that scheduled this pending `.list`
+    /// rewrite. The rewrite itself runs later in the background thread (or at shutdown) with no
+    /// query context, so `writeLists()` cannot see this DDL's session `fsync_metadata`; carry it
+    /// here so a session `fsync_metadata=1` is not dropped to the global value there.
+    const bool fsync = shouldFsyncMetadata();
+    pending_lists_fsync = pending_lists_fsync || fsync;
+
     /// Create the 'need_rebuild_lists.mark' file.
     /// This file will be used later to find out if writing lists is successful or not.
     /// It must be durable: the marker is what tells the next startup to rescan the (already
@@ -373,7 +388,6 @@ void DiskAccessStorage::scheduleWriteLists(AccessEntityType type)
     /// file with no marker on disk. Fsync the marker file and its parent directory (the
     /// marker's existence is a new directory entry, like a rename), gated on fsync_metadata.
     const auto mark_file_path = getNeedRebuildListsMarkFilePath(directory_path);
-    const bool fsync = shouldFsyncMetadata();
     {
         std::optional<LocalDirectorySyncGuard> dir_sync_guard;
         if (fsync)

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -6,8 +6,12 @@
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/WriteBufferFromFile.h>
+#include <Disks/LocalDirectorySyncGuard.h>
 #include <Interpreters/Access/InterpreterCreateUserQuery.h>
 #include <Interpreters/Access/InterpreterShowGrantsQuery.h>
+#include <Interpreters/Context.h>
+#include <Core/Settings.h>
+#include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
 #include <Common/ThreadPool.h>
 #include <Poco/JSON/JSON.h>
@@ -19,10 +23,16 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 
 
 namespace DB
 {
+namespace Setting
+{
+    extern const SettingsBool fsync_metadata;
+}
+
 namespace ErrorCodes
 {
     extern const int DIRECTORY_DOESNT_EXIST;
@@ -33,6 +43,19 @@ namespace ErrorCodes
 
 namespace
 {
+    /// Whether access-entity files should be fsync'd, honoring the `fsync_metadata` setting.
+    /// Foreground writes (CREATE/ALTER/DROP USER etc.) run on the query thread, so honor its
+    /// session setting; background `.list` writes have no query context and fall back to the
+    /// global one. Absent any context we default to syncing (matches the setting's default).
+    bool shouldFsyncMetadata()
+    {
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            return query_context->getSettingsRef()[Setting::fsync_metadata];
+        if (auto global_context = Context::getGlobalContextInstance())
+            return global_context->getSettingsRef()[Setting::fsync_metadata];
+        return true;
+    }
+
     /// Reads a file containing ATTACH queries and then parses it to build an access entity.
     AccessEntityPtr readEntityFile(const String & file_path)
     {
@@ -60,7 +83,7 @@ namespace
     }
 
     /// Writes ATTACH queries for building a specified access entity to a file.
-    void writeEntityFile(const String & file_path, const IAccessEntity & entity)
+    void writeEntityFile(const String & file_path, const IAccessEntity & entity, bool fsync)
     {
         String file_contents = serializeAccessEntity(entity);
 
@@ -76,10 +99,19 @@ namespace
         /// Write the file.
         WriteBufferFromFile out{tmp_file_path.string()};
         out.write(file_contents.data(), file_contents.size());
+        if (fsync)
+            out.sync();
         out.close();
 
-        /// Rename.
-        std::filesystem::rename(tmp_file_path, file_path);
+        /// Rename. Sync the parent directory so the rename itself survives a power loss:
+        /// fsync of the file alone does not persist the directory entry (open the dir fd
+        /// before the rename; the guard's destructor fsyncs it afterwards).
+        {
+            std::optional<LocalDirectorySyncGuard> dir_sync_guard;
+            if (fsync)
+                dir_sync_guard.emplace(std::filesystem::path{file_path}.parent_path().string());
+            std::filesystem::rename(tmp_file_path, file_path);
+        }
         succeeded = true;
     }
 
@@ -125,7 +157,7 @@ namespace
 
 
     /// Writes a map of name of access entity to UUID for access entities of some type to a file.
-    void writeListFile(const String & file_path, const std::vector<std::pair<UUID, std::string_view>> & id_name_pairs)
+    void writeListFile(const String & file_path, const std::vector<std::pair<UUID, std::string_view>> & id_name_pairs, bool fsync)
     {
         WriteBufferFromFile out(file_path);
         writeVarUInt(id_name_pairs.size(), out);
@@ -134,6 +166,10 @@ namespace
             writeStringBinary(name, out);
             writeUUIDText(id, out);
         }
+        /// The `.list` file is overwritten in place (no rename), so only the file content needs
+        /// to be synced; it is anyway rebuildable from the `.sql` files via need_rebuild_lists.mark.
+        if (fsync)
+            out.sync();
         out.close();
     }
 
@@ -281,6 +317,8 @@ void DiskAccessStorage::writeLists()
     if (types_of_lists_to_write.empty())
         return;
 
+    const bool fsync = shouldFsyncMetadata();
+
     for (const auto & type : types_of_lists_to_write)
     {
         auto file_path = getListFilePath(directory_path, type);
@@ -291,7 +329,7 @@ void DiskAccessStorage::writeLists()
             id_name_pairs.reserve(all_entities.size());
             for (const auto & [id, entity] : all_entities)
                 id_name_pairs.emplace_back(id, entity->getName());
-            writeListFile(file_path, id_name_pairs);
+            writeListFile(file_path, id_name_pairs, fsync);
         }
         catch (...)
         {
@@ -769,7 +807,7 @@ AccessEntityPtr DiskAccessStorage::readAccessEntityFromDisk(const UUID & id) con
 void DiskAccessStorage::writeAccessEntityToDisk(const UUID & id, const IAccessEntity & entity) const
 {
     LOG_TRACE(getLogger(), "Writing file for entity with id {} and name {}", id, entity.getName());
-    writeEntityFile(getEntityFilePath(directory_path, id), entity);
+    writeEntityFile(getEntityFilePath(directory_path, id), entity, shouldFsyncMetadata());
 }
 
 
@@ -777,6 +815,14 @@ void DiskAccessStorage::deleteAccessEntityOnDisk(const UUID & id) const
 {
     auto file_path = getEntityFilePath(directory_path, id);
     LOG_TRACE(getLogger(), "Deleting file {} for entity with id {}", file_path, id);
+
+    /// Sync the parent directory after the unlink so DROP USER / REVOKE (and the old-file
+    /// removal on rename-replace) survive a power loss: like a rename, an unlink is a
+    /// directory-entry change that is not durable until the directory is fsync'd. Open the
+    /// dir fd before removing; the guard's destructor fsyncs it afterwards.
+    std::optional<LocalDirectorySyncGuard> dir_sync_guard;
+    if (shouldFsyncMetadata())
+        dir_sync_guard.emplace(std::filesystem::path{file_path}.parent_path().string());
     if (!std::filesystem::remove(file_path))
         throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Couldn't delete {}", file_path);
 }

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -21,9 +21,9 @@
 #include <boost/range/adaptor/map.hpp>
 #include <base/range.h>
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <optional>
+#include <sstream>
 
 
 namespace DB
@@ -361,17 +361,35 @@ void DiskAccessStorage::scheduleWriteLists(AccessEntityType type)
 
     types_of_lists_to_write.insert(type);
 
+    /// Create the 'need_rebuild_lists.mark' file.
+    /// This file will be used later to find out if writing lists is successful or not.
+    /// It must be durable: the marker is what tells the next startup to rescan the (already
+    /// fsync'd) <id>.sql files instead of trusting the stale .list indexes. If the marker is
+    /// missing on power loss while the background .list rewrite has not run yet, the
+    /// acknowledged CREATE/ALTER/DROP USER would become unreachable after restart even though
+    /// its <id>.sql survived. We must (re)create it even when the writing thread is already
+    /// waiting: `reloadAllAndRebuildLists()` removes the marker without stopping that thread,
+    /// so a following DDL that took the early return below would otherwise commit its entity
+    /// file with no marker on disk. Fsync the marker file and its parent directory (the
+    /// marker's existence is a new directory entry, like a rename), gated on fsync_metadata.
+    const auto mark_file_path = getNeedRebuildListsMarkFilePath(directory_path);
+    const bool fsync = shouldFsyncMetadata();
+    {
+        std::optional<LocalDirectorySyncGuard> dir_sync_guard;
+        if (fsync)
+            dir_sync_guard.emplace(std::filesystem::path{mark_file_path}.parent_path().string());
+        WriteBufferFromFile out{mark_file_path};
+        if (fsync)
+            out.sync();
+        out.close();
+    }
+
     if (lists_writing_thread_is_waiting)
         return; /// If the lists' writing thread is still waiting we can update `types_of_lists_to_write` easily,
-                /// without restarting that thread.
+                /// without restarting that thread. The marker is already (re)created above.
 
     if (lists_writing_thread && lists_writing_thread->joinable())
         lists_writing_thread->join();
-
-    /// Create the 'need_rebuild_lists.mark' file.
-    /// This file will be used later to find out if writing lists is successful or not.
-    std::ofstream out{getNeedRebuildListsMarkFilePath(directory_path)};
-    out.close();
 
     LOG_TRACE(getLogger(), "Created need_rebuild_lists.mark, starting background lists-writing thread");
 

--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -527,6 +527,11 @@ void DiskAccessStorage::reloadAllAndRebuildLists()
     for (auto type : collections::range(AccessEntityType::MAX))
         types_of_lists_to_write.insert(type);
 
+    /// The marker is a restart-surviving proxy for "a durable `.list` is still owed", so a
+    /// marker-driven rebuild must fsync even when the current (context-free) fsync check is false.
+    if (std::filesystem::exists(getNeedRebuildListsMarkFilePath(directory_path)))
+        pending_lists_fsync = true;
+
     /// Write the lists and keep the rebuild marker for now.
     failed_to_write_lists = false;
     has_stale_files_on_disk = true;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -91,6 +91,14 @@ private:
     /// SYSTEM RELOAD USERS or next startup runs reloadAllAndRebuildLists() and resolves the issues.
     bool has_stale_files_on_disk TSA_GUARDED_BY(mutex) = false;
 
+    /// The strongest `fsync_metadata` requirement of the DDL operations that scheduled the pending
+    /// `.list` rewrite. `writeLists()` runs deferred (background thread) or at shutdown with no
+    /// query context, so it cannot re-read the session setting of the DDL that scheduled it;
+    /// re-reading the global `fsync_metadata` there would drop a session `fsync_metadata=1` and
+    /// leave the `.list` unsynced. We OR-accumulate the requirement here so the deferred `.list`
+    /// write is as durable as the most-durable pending change, and reset it once the batch is written.
+    bool pending_lists_fsync TSA_GUARDED_BY(mutex) = false;
+
     /// List files are written in a separate thread.
     std::unique_ptr<ThreadFromGlobalPool> lists_writing_thread;
 

--- a/tests/integration/test_access_storage_fsync/test.py
+++ b/tests/integration/test_access_storage_fsync/test.py
@@ -107,3 +107,104 @@ def test_list_files_are_fsynced():
     )
 
     instance.query(f"DROP USER IF EXISTS {user}")
+
+
+ACCESS_DIR = "/var/lib/clickhouse/access"
+
+
+def _forge_stale_entity(seed, lost):
+    """
+    Reproduce the power-loss window on disk: a fresh `<uuid>.sql` for `lost` that survived
+    (was fsync'd) but is absent from the stale `.list` index, and remove the rebuild marker.
+    Returns the forged file path.
+    """
+    seed_sql = instance.exec_in_container(
+        ["bash", "-c", f"grep -l 'ATTACH USER {seed} ' {ACCESS_DIR}/*.sql"], user="root"
+    ).strip()
+    new_path = f"{ACCESS_DIR}/{uuid.uuid4()}.sql"
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"sed 's/{seed}/{lost}/g' {seed_sql} > {new_path} && "
+            f"rm -f {ACCESS_DIR}/need_rebuild_lists.mark",
+        ],
+        user="root",
+    )
+    return new_path
+
+
+def test_rebuild_marker_makes_stale_sql_recoverable():
+    """
+    Recovery test for the deferred-rebuild marker (need_rebuild_lists.mark).
+
+    A DDL drops the `need_rebuild_lists.mark` marker (scheduleWriteLists) and writes the
+    fsync'd `<uuid>.sql`, then defers the `.list` index rewrite to a background thread. On
+    restart the constructor only rescans the `.sql` files when the marker is present;
+    otherwise it trusts the (possibly stale) `.list` indexes. So the marker must be durable,
+    or a power loss before the background rewrite makes an acknowledged CREATE/ALTER/DROP
+    USER unreachable after restart even though its `.sql` survived.
+
+    We reproduce that on-disk state - a fresh `<uuid>.sql` absent from the stale `.list`
+    index - in both directions:
+      - marker MISSING: the entity is NOT recovered, proving the marker is load-bearing;
+      - marker PRESENT (the durable state the fix guarantees): the entity IS recovered.
+    """
+    seed = "u_recover_seed"
+    lost = "u_recover_lost"
+    instance.query(f"DROP USER IF EXISTS {seed}")
+    instance.query(f"DROP USER IF EXISTS {lost}")
+
+    # A persisted user so the `.list` files and a real `<uuid>.sql` exist on disk.
+    instance.query(f"CREATE USER {seed} IDENTIFIED WITH no_password")
+    # Flush the background writer so the `.list` files are in their steady (post-rebuild)
+    # state and no longer mention any pending entity.
+    instance.query("SYSTEM RELOAD USERS")
+
+    # Direction 1: marker MISSING -> stale .list is trusted, .sql is not rescanned.
+    _forge_stale_entity(seed, lost)
+    instance.restart_clickhouse()
+    assert instance.query(f"SELECT count() FROM system.users WHERE name = '{lost}'").strip() == "0", (
+        "entity became reachable without the marker - the marker is not actually the "
+        "signal that gates the .sql rescan, so this test would not prove its durability"
+    )
+
+    # Direction 2: same on-disk .sql, but with the marker present -> rescan recovers it.
+    instance.exec_in_container(["bash", "-c", f"touch {ACCESS_DIR}/need_rebuild_lists.mark"], user="root")
+    instance.restart_clickhouse()
+    assert instance.query(f"SELECT count() FROM system.users WHERE name = '{lost}'").strip() == "1", (
+        "entity with a durable .sql but stale .list was not recovered on restart - "
+        "the need_rebuild_lists.mark marker did not trigger a rescan"
+    )
+
+    # `lost` is now reachable, so DROP removes its `.sql` cleanly (avoids an orphan file that
+    # a later rebuild would resurrect).
+    instance.query(f"DROP USER IF EXISTS {lost}")
+    instance.query(f"DROP USER IF EXISTS {seed}")
+
+
+def test_rebuild_marker_is_fsynced():
+    """
+    The `need_rebuild_lists.mark` marker written by scheduleWriteLists() must itself be
+    durable (fsync the file and its parent directory), gated on `fsync_metadata`. It is
+    (re)written on every DDL that schedules a list rewrite, so a CREATE USER syncs the marker
+    (file + directory) on top of the `<uuid>.sql` write -> at least 2 file and 2 directory
+    syncs. Without the marker fsync only the entity file is synced (1 each), so this asserts
+    the marker sync specifically rather than just the entity write.
+    """
+    user = "u_marker_fsync"
+    instance.query(f"DROP USER IF EXISTS {user}")
+
+    file_sync, dir_sync = _run(f"CREATE USER {user} IDENTIFIED WITH no_password", 1)
+    assert file_sync >= 2 and dir_sync >= 2, (
+        f"marker not fsynced alongside entity file: FileSync={file_sync}, DirectorySync={dir_sync}"
+    )
+
+    # fsync_metadata = 0 -> neither the entity file nor the marker is synced.
+    instance.query(f"DROP USER IF EXISTS {user}")
+    file_sync, dir_sync = _run(f"CREATE USER {user} IDENTIFIED WITH no_password", 0)
+    assert file_sync == 0 and dir_sync == 0, (
+        f"fsync_metadata=0 not honored on marker: FileSync={file_sync}, DirectorySync={dir_sync}"
+    )
+
+    instance.query(f"DROP USER IF EXISTS {user}")

--- a/tests/integration/test_access_storage_fsync/test.py
+++ b/tests/integration/test_access_storage_fsync/test.py
@@ -1,0 +1,109 @@
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+# The default node uses the `local_directory` access storage (DiskAccessStorage),
+# so access DDL writes `<uuid>.sql` files to disk - unlike stateless tests which
+# override the storage to `<memory/>`.
+instance = cluster.add_instance("instance", stay_alive=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _profile_events(query_id):
+    """FileSync and DirectorySync counted for the given query."""
+    instance.query("SYSTEM FLUSH LOGS query_log")
+    row = instance.query(
+        "SELECT ProfileEvents['FileSync'], ProfileEvents['DirectorySync'] "
+        "FROM system.query_log "
+        f"WHERE query_id = '{query_id}' AND type = 'QueryFinish' "
+        "ORDER BY event_time_microseconds DESC LIMIT 1"
+    ).strip()
+    file_sync, dir_sync = (int(x) for x in row.split("\t"))
+    return file_sync, dir_sync
+
+
+def _run(query, fsync_metadata):
+    query_id = str(uuid.uuid4())
+    instance.query(query, query_id=query_id, settings={"fsync_metadata": fsync_metadata})
+    return _profile_events(query_id)
+
+
+def test_access_entity_writes_are_fsynced():
+    """
+    Regression test for https://github.com/ClickHouse/ClickHouse/issues/68958
+
+    DiskAccessStorage used to write access-entity `.sql` files (and remove them)
+    without any fsync, so an acknowledged CREATE/ALTER/DROP USER could be silently
+    lost on power loss. It must now honor `fsync_metadata` like the other on-disk
+    DDL-entity stores.
+
+    We assert the fsync path is taken (rather than simulating power loss) by reading
+    the FileSync / DirectorySync ProfileEvents of each DDL query: the `.sql` write runs
+    synchronously on the query thread, so its fsync is attributed to the query.
+    """
+    user = "u_fsync"
+    instance.query(f"DROP USER IF EXISTS {user}")
+
+    # With fsync_metadata = 1 the file content and the parent directory are both synced.
+    # CREATE / GRANT / ALTER rewrite the entity `.sql` file (file + directory fsync);
+    # DROP only unlinks it (directory fsync, no file content to sync).
+    file_sync, dir_sync = _run(f"CREATE USER {user} IDENTIFIED WITH no_password", 1)
+    assert file_sync >= 1 and dir_sync >= 1, f"CREATE USER: {file_sync}, {dir_sync}"
+
+    file_sync, dir_sync = _run(f"GRANT SELECT ON default.* TO {user}", 1)
+    assert file_sync >= 1 and dir_sync >= 1, f"GRANT: {file_sync}, {dir_sync}"
+
+    file_sync, dir_sync = _run(
+        f"ALTER USER {user} IDENTIFIED WITH plaintext_password BY 'p'", 1
+    )
+    assert file_sync >= 1 and dir_sync >= 1, f"ALTER USER: {file_sync}, {dir_sync}"
+
+    file_sync, dir_sync = _run(f"DROP USER {user}", 1)
+    assert dir_sync >= 1, f"DROP USER directory not synced: {file_sync}, {dir_sync}"
+
+    # With fsync_metadata = 0 the setting must be honored: no forced sync.
+    instance.query(f"DROP USER IF EXISTS {user}")
+    file_sync, dir_sync = _run(f"CREATE USER {user} IDENTIFIED WITH no_password", 0)
+    assert file_sync == 0 and dir_sync == 0, (
+        f"fsync_metadata=0 not honored: {file_sync}, {dir_sync}"
+    )
+    file_sync, dir_sync = _run(f"DROP USER {user}", 0)
+    assert file_sync == 0 and dir_sync == 0, (
+        f"fsync_metadata=0 not honored on DROP: {file_sync}, {dir_sync}"
+    )
+
+
+def test_list_files_are_fsynced():
+    """
+    The `.list` index files are written by `writeListFile`, which must also honor
+    `fsync_metadata`. `SYSTEM RELOAD USERS` rebuilds and rewrites every `.list` file
+    synchronously on the query thread, so its FileSync ProfileEvent covers that path.
+    """
+    user = "u_fsync_list"
+    instance.query(f"DROP USER IF EXISTS {user}")
+    instance.query(f"CREATE USER {user} IDENTIFIED WITH no_password")
+
+    # SYSTEM RELOAD USERS -> reloadAllAndRebuildLists() -> writeLists() writes all the
+    # `.list` files in-place; with fsync_metadata = 1 each one is fsync'd (file content only,
+    # no rename -> no directory sync).
+    file_sync, _ = _run("SYSTEM RELOAD USERS", 1)
+    assert file_sync >= 1, f"list files not fsynced on RELOAD USERS: FileSync={file_sync}"
+
+    # fsync_metadata = 0 -> no forced sync.
+    file_sync, _ = _run("SYSTEM RELOAD USERS", 0)
+    assert file_sync == 0, (
+        f"fsync_metadata=0 not honored on RELOAD USERS: FileSync={file_sync}"
+    )
+
+    instance.query(f"DROP USER IF EXISTS {user}")

--- a/tests/integration/test_access_storage_fsync/test.py
+++ b/tests/integration/test_access_storage_fsync/test.py
@@ -208,3 +208,32 @@ def test_rebuild_marker_is_fsynced():
     )
 
     instance.query(f"DROP USER IF EXISTS {user}")
+
+
+def test_deferred_list_write_preserves_session_fsync():
+    """
+    The deferred `.list` rewrite must honor the session `fsync_metadata` of the DDL that
+    scheduled it, not the global value it would otherwise read with no query context.
+
+    A CREATE USER at fsync_metadata=1 records the pending requirement; a following
+    SYSTEM RELOAD USERS at fsync_metadata=0 rewrites the `.list` files synchronously. The
+    reload's own context says "do not sync", so the only thing that can force the `.list`
+    fsync is the requirement carried from the CREATE USER. Restart first so no earlier
+    background writer is mid-wait, making the carry deterministic.
+    """
+    user = "u_deferred_fsync"
+    instance.query(f"DROP USER IF EXISTS {user}")
+    instance.restart_clickhouse()
+
+    instance.query(
+        f"CREATE USER {user} IDENTIFIED WITH no_password",
+        settings={"fsync_metadata": 1},
+    )
+
+    file_sync, _ = _run("SYSTEM RELOAD USERS", 0)
+    assert file_sync >= 1, (
+        "deferred .list rewrite dropped the session fsync_metadata=1 requirement: "
+        f"FileSync={file_sync}"
+    )
+
+    instance.query(f"DROP USER IF EXISTS {user}")

--- a/tests/integration/test_access_storage_fsync/test.py
+++ b/tests/integration/test_access_storage_fsync/test.py
@@ -237,3 +237,46 @@ def test_deferred_list_write_preserves_session_fsync():
     )
 
     instance.query(f"DROP USER IF EXISTS {user}")
+
+
+def test_marker_driven_rebuild_forces_list_fsync():
+    """
+    A marker-driven rebuild - `need_rebuild_lists.mark` present at rebuild entry, i.e. startup
+    recovery or after a latched write failure - must fsync the rebuilt `.list` files even when
+    the current context has `fsync_metadata=0`.
+
+    The in-process `pending_lists_fsync` requirement does not survive a restart, so the marker
+    is the only persistent proxy for "a durable `.list` is still owed". Without forcing the fsync,
+    `reloadAllAndRebuildLists()` would rewrite the `.list` unsynced and then drop the marker, so a
+    second power loss could leave stale `.list` files with no marker while the fsync'd `.sql`
+    survives - reopening the window across a restart.
+
+    `SYSTEM RELOAD USERS` runs `reloadAllAndRebuildLists()` on the query thread, the same code path
+    as the startup recovery, so its FileSync ProfileEvent covers it.
+    """
+    user = "u_marker_rebuild"
+    instance.query(f"DROP USER IF EXISTS {user}")
+    instance.query(f"CREATE USER {user} IDENTIFIED WITH no_password")
+    # Reach steady state: the background writer has run and removed the marker.
+    instance.query("SYSTEM RELOAD USERS")
+
+    # Baseline: with no marker present, a rebuild at fsync_metadata=0 is NOT forced to sync.
+    # This proves the fix is targeted to the marker-driven recovery path, not a blanket fsync.
+    # Remove the marker explicitly so the precondition is deterministic regardless of prior tests.
+    instance.exec_in_container(
+        ["bash", "-c", f"rm -f {ACCESS_DIR}/need_rebuild_lists.mark"], user="root"
+    )
+    file_sync, _ = _run("SYSTEM RELOAD USERS", 0)
+    assert file_sync == 0, f".list fsync forced without a rebuild marker: FileSync={file_sync}"
+
+    # The durable marker survived a power loss; the in-process requirement did not.
+    instance.exec_in_container(
+        ["bash", "-c", f"touch {ACCESS_DIR}/need_rebuild_lists.mark"], user="root"
+    )
+    file_sync, _ = _run("SYSTEM RELOAD USERS", 0)
+    assert file_sync >= 1, (
+        "marker-driven rebuild dropped the durability obligation and rewrote the .list unsynced: "
+        f"FileSync={file_sync}"
+    )
+
+    instance.query(f"DROP USER IF EXISTS {user}")


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/68958
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Access entities stored on local disk (users, roles, grants, quotas, row policies, settings profiles created via SQL) are now fsync'd when `fsync_metadata` is enabled, so an acknowledged `CREATE`/`ALTER`/`DROP USER` (and `GRANT`/`REVOKE`) is no longer silently lost on power loss. Previously `DiskAccessStorage` wrote and removed the `.sql` entity files without any fsync.


### Description

`DiskAccessStorage` wrote access-entity `.sql` files (and the `*.list` index files), and removed them, without any fsync, so an acknowledged access change could be lost on power loss. It was the only on-disk DDL-entity store not honoring `fsync_metadata` (UDFs, named collections, workload entities and table metadata all do).

Reported and reproduced 3/3 on master with a `dm-flakey` power-loss simulation in #68958: after `CREATE USER` + `GRANT` and a power cut, the `<uuid>.sql` file is gone and the user cannot authenticate (`AUTHENTICATION_FAILED`). The tmp->final rename was never forced to disk.

Fix, gated on `fsync_metadata` (default `true`), matching the sibling stores:
- `writeEntityFile` (create/insert and update): fsync the file content, then fsync the parent directory around the rename (a rename is durable only once the directory entry is persisted).
- `deleteAccessEntityOnDisk` (`DROP USER`/`REVOKE`, and the old-file removal on rename-replace): fsync the parent directory around the unlink.
- `writeListFile`: fsync the file content (the `.list` files are rebuilt from the `.sql` files, so no directory fsync).

The parent-directory fsync reuses `LocalDirectorySyncGuard`. The setting is resolved from the query context (session value) and falls back to the global context for the background `.list` writer, mirroring `getWriteSettings()`.

Regression test `tests/integration/test_access_storage_fsync` asserts, via `system.query_log` ProfileEvents, that `CREATE`/`GRANT`/`ALTER`/`DROP USER` take the `FileSync`/`DirectorySync` path when `fsync_metadata=1` and take neither when `fsync_metadata=0`. It is an integration test because stateless tests override the access storage to `<memory/>`.
