### PR TITLE
Lower Plain-Rewritable Metadata Transactions Isolation

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.cpp
@@ -302,15 +302,15 @@ std::vector<std::string> FsSnapshot::listDirectory(const std::string & path) con
     return result;
 }
 
-std::pair<bool, std::optional<DirectoryRemoteInfo>> FsSnapshot::existsDirectory(const std::string & path) const
+bool FsSnapshot::existsDirectory(const std::string & path) const
 {
     UniqueLock lock(mutex);
     const auto node = walk(root, normalizePath(path));
 
     if (!node)
-        return {false, std::nullopt};
+        return false;
 
-    return {true, node->info};
+    return true;
 }
 
 std::unordered_map<std::string, std::optional<DirectoryRemoteInfo>> FsSnapshot::getSubtreeRemoteInfo(const std::string & path) const

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Metadata/FsSnapshot.h
@@ -57,7 +57,7 @@ public:
     /// Directory Read Methods
 
     std::vector<std::string> listDirectory(const std::string & path) const;
-    std::pair<bool, std::optional<DirectoryRemoteInfo>> existsDirectory(const std::string & path) const;
+    bool existsDirectory(const std::string & path) const;
     std::unordered_map<std::string, std::optional<DirectoryRemoteInfo>> getSubtreeRemoteInfo(const std::string & path) const;
     std::optional<DirectoryRemoteInfo> getDirectoryRemoteInfo(const std::string & path) const;
 

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -472,7 +472,6 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::createDirectory
         metadata_storage.object_storage,
         metadata_storage.layout,
         metadata_storage.metrics));
-
 }
 
 void MetadataStorageFromPlainRewritableObjectStorageTransaction::moveDirectory(const std::string & path_from, const std::string & path_to)
@@ -486,12 +485,11 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::moveDirectory(c
         metadata_storage.object_storage,
         metadata_storage.layout,
         metadata_storage.metrics));
-
 }
 
 void MetadataStorageFromPlainRewritableObjectStorageTransaction::unlinkFile(const std::string & path, bool if_exists, bool /*should_remove_objects*/)
 {
-    uncommitted_state.lookupDirectory(normalizePath(path).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path).parent_path());
 
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageUnlinkMetadataFileOperation>(
         path,
@@ -532,8 +530,8 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::removeRecursive
 
 void MetadataStorageFromPlainRewritableObjectStorageTransaction::createHardLink(const std::string & path_from, const std::string & path_to)
 {
-    uncommitted_state.lookupDirectory(normalizePath(path_from).parent_path());
-    uncommitted_state.lookupDirectory(normalizePath(path_to).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_from).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_to).parent_path());
 
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageCopyFileOperation>(
         path_from,
@@ -546,8 +544,8 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::createHardLink(
 
 void MetadataStorageFromPlainRewritableObjectStorageTransaction::moveFile(const std::string & path_from, const std::string & path_to)
 {
-    uncommitted_state.lookupDirectory(normalizePath(path_from).parent_path());
-    uncommitted_state.lookupDirectory(normalizePath(path_to).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_from).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_to).parent_path());
 
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageMoveFileOperation>(
         /*replaceable=*/false,
@@ -562,8 +560,8 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::moveFile(const 
 
 void MetadataStorageFromPlainRewritableObjectStorageTransaction::replaceFile(const std::string & path_from, const std::string & path_to)
 {
-    uncommitted_state.lookupDirectory(normalizePath(path_from).parent_path());
-    uncommitted_state.lookupDirectory(normalizePath(path_to).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_from).parent_path());
+    uncommitted_state.useDirectory(normalizePath(path_to).parent_path());
 
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageMoveFileOperation>(
         /*replaceable=*/true,
@@ -582,10 +580,22 @@ ObjectStorageKey MetadataStorageFromPlainRewritableObjectStorageTransaction::gen
     if (normalized_path.filename().empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "File name is empty for path '{}'", path);
 
-    /// Materialize virtual parent.
     const auto parent_path = normalized_path.parent_path();
-    if (const auto [parent_exists, parent_info] = uncommitted_state.lookupDirectory(parent_path); parent_exists && !parent_info)
+    const auto [parent_exists, parent_info] = uncommitted_state.lookupDirectory(parent_path);
+
+    if (!parent_info)
+    {
+        /// Validate during commit that directory will be created on S3.
+        uncommitted_state.useMissingDirectory(parent_path);
+
+        /// Materialize virtual parent.
         createDirectoryRecursive(parent_path);
+    }
+    else
+    {
+        /// Validate during commit that directory will not be recreated on S3.
+        uncommitted_state.useDirectory(parent_path);
+    }
 
     if (const auto directory_remote_info = uncommitted_state.lookupDirectory(parent_path).second)
         return ObjectStorageKey::createAsAbsolute(metadata_storage.layout->constructFileObjectKey(directory_remote_info->remote_path, normalized_path.filename()));

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorage.cpp
@@ -295,13 +295,13 @@ bool MetadataStorageFromPlainRewritableObjectStorage::existsFile(const std::stri
 
 bool MetadataStorageFromPlainRewritableObjectStorage::existsDirectory(const std::string & path) const
 {
-    return fs.takeReadOnlySnapshot()->existsDirectory(path).first;
+    return fs.takeReadOnlySnapshot()->existsDirectory(path);
 }
 
 bool MetadataStorageFromPlainRewritableObjectStorage::existsFileOrDirectory(const std::string & path) const
 {
     const auto tree = fs.takeReadOnlySnapshot();
-    return tree->existsFile(path) || tree->existsDirectory(path).first;
+    return tree->existsFile(path) || tree->existsDirectory(path);
 }
 
 uint64_t MetadataStorageFromPlainRewritableObjectStorage::getFileSize(const std::string & path) const
@@ -372,8 +372,10 @@ std::optional<Poco::Timestamp> MetadataStorageFromPlainRewritableObjectStorage::
 {
     const auto tree = fs.takeReadOnlySnapshot();
 
-    if (auto [exists, remote_info] = tree->existsDirectory(path); exists)
+    if (tree->existsDirectory(path))
     {
+        const auto remote_info = tree->getDirectoryRemoteInfo(path);
+
         if (remote_info)
             return Poco::Timestamp::fromEpochTime(remote_info->last_modified);
 
@@ -447,7 +449,7 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::createDirectory
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageCreateDirectoryOperation>(
         /*recursive=*/false,
         normalizeDirectoryPath(path),
-        uncommitted_state.lookupDirectory(path).second->remote_path,
+        uncommitted_state.getDirectoryRemoteInfo(path)->remote_path,
         commit_snapshot,
         metadata_storage.object_storage,
         metadata_storage.layout,
@@ -467,7 +469,7 @@ void MetadataStorageFromPlainRewritableObjectStorageTransaction::createDirectory
     operations.addOperation(std::make_unique<MetadataStorageFromPlainObjectStorageCreateDirectoryOperation>(
         /*recursive=*/true,
         normalizeDirectoryPath(path),
-        uncommitted_state.lookupDirectory(path).second->remote_path,
+        uncommitted_state.getDirectoryRemoteInfo(path)->remote_path,
         commit_snapshot,
         metadata_storage.object_storage,
         metadata_storage.layout,
@@ -581,7 +583,7 @@ ObjectStorageKey MetadataStorageFromPlainRewritableObjectStorageTransaction::gen
         throw Exception(ErrorCodes::LOGICAL_ERROR, "File name is empty for path '{}'", path);
 
     const auto parent_path = normalized_path.parent_path();
-    const auto [parent_exists, parent_info] = uncommitted_state.lookupDirectory(parent_path);
+    const auto parent_info = uncommitted_state.getDirectoryRemoteInfo(parent_path);
 
     if (!parent_info)
     {
@@ -597,7 +599,7 @@ ObjectStorageKey MetadataStorageFromPlainRewritableObjectStorageTransaction::gen
         uncommitted_state.useDirectory(parent_path);
     }
 
-    if (const auto directory_remote_info = uncommitted_state.lookupDirectory(parent_path).second)
+    if (const auto directory_remote_info = uncommitted_state.getDirectoryRemoteInfo(parent_path))
         return ObjectStorageKey::createAsAbsolute(metadata_storage.layout->constructFileObjectKey(directory_remote_info->remote_path, normalized_path.filename()));
 
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' does not exist", parent_path.string());

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorageOperations.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/MetadataStorageFromPlainRewritableObjectStorageOperations.cpp
@@ -80,20 +80,19 @@ MetadataStorageFromPlainObjectStorageCreateDirectoryOperation::MetadataStorageFr
 
 void MetadataStorageFromPlainObjectStorageCreateDirectoryOperation::execute()
 {
-    const auto [exists_directory, info] = fs_tree->existsDirectory(path);
-    if (info)
+    if (fs_tree->getDirectoryRemoteInfo(path))
         return;
 
     if (fs_tree->existsFile(path))
         throw Exception(ErrorCodes::CANNOT_CREATE_DIRECTORY, "File '{}' already exists", path.parent_path());
 
     if (!recursive)
-        if (!fs_tree->existsDirectory(path.parent_path().parent_path()).first)
+        if (!fs_tree->existsDirectory(path.parent_path().parent_path()))
             throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Directory '{}' does not exist", path.parent_path().parent_path());
 
     auto metadata_object_key = layout->constructDirectoryObjectKey(directory_remote_path);
 
-    if (exists_directory)
+    if (fs_tree->existsDirectory(path))
         LOG_TRACE(
             getLogger("MetadataStorageFromPlainObjectStorageCreateDirectoryOperation"),
             "Materializing virtual directory '{}' with remote path='{}'",
@@ -217,9 +216,9 @@ void MetadataStorageFromPlainObjectStorageMoveDirectoryOperation::execute()
     constexpr bool validate_content = false;
 #endif
 
-    if (!fs_tree->existsDirectory(path_from).first)
+    if (!fs_tree->existsDirectory(path_from))
         throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Directory '{}' does not exist", path_from);
-    else if (fs_tree->existsDirectory(path_to).first)
+    else if (fs_tree->existsDirectory(path_to))
         throw Exception(ErrorCodes::DIRECTORY_ALREADY_EXISTS, "Directory '{}' already exists", path_to);
     else if (normalizePath(path_from).empty())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Can't move root folder");
@@ -281,16 +280,14 @@ MetadataStorageFromPlainObjectStorageRemoveDirectoryOperation::MetadataStorageFr
 
 void MetadataStorageFromPlainObjectStorageRemoveDirectoryOperation::execute()
 {
-    auto [exists, remote_info] = fs_tree->existsDirectory(path);
-    if (!exists)
+    if (!fs_tree->existsDirectory(path))
         throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Directory '{}' does not exist", path);
     else if (auto children = fs_tree->listDirectory(path); !children.empty())
         throw Exception(ErrorCodes::CANNOT_RMDIR, "Directory '{}' is not empty. Children: [{}]", path, fmt::join(children, ", "));
     else if (normalizePath(path).empty())
         return;
 
-    chassert(remote_info.has_value());
-    info = std::move(remote_info.value());
+    info = fs_tree->getDirectoryRemoteInfo(path).value();
 
     LOG_TRACE(getLogger("MetadataStorageFromPlainObjectStorageRemoveDirectoryOperation"), "Removing directory '{}'", path);
 
@@ -438,9 +435,9 @@ void MetadataStorageFromPlainObjectStorageCopyFileOperation::execute()
 
     if (!fs_tree->existsFile(path_from))
         throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Metadata object for the source path '{}' does not exist", path_from);
-    else if (auto [exists, remote_info] = fs_tree->existsDirectory(path_to.parent_path()); !exists)
+    else if (!fs_tree->existsDirectory(path_to.parent_path()))
         throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Directory '{}' does not exist", path_to.parent_path());
-    else if (!remote_info.has_value())
+    else if (!fs_tree->getDirectoryRemoteInfo(path_to.parent_path()))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is virtual", path_to.parent_path());
     else if (fs_tree->existsFile(path_to))
         throw Exception(ErrorCodes::FILE_ALREADY_EXISTS, "Target file '{}' already exists", path_to);
@@ -504,9 +501,9 @@ void MetadataStorageFromPlainObjectStorageMoveFileOperation::execute()
 
     if (!fs_tree->existsFile(path_from))
         throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "File '{}' does not exist", path_from);
-    else if (auto [exists, remote_info] = fs_tree->existsDirectory(path_to.parent_path()); !exists)
+    else if (!fs_tree->existsDirectory(path_to.parent_path()))
         throw Exception(ErrorCodes::DIRECTORY_DOESNT_EXIST, "Directory '{}' does not exist", path_to.parent_path());
-    else if (!remote_info.has_value())
+    else if (!fs_tree->getDirectoryRemoteInfo(path_to.parent_path()))
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Directory '{}' is virtual", path_to.parent_path());
 
     const auto normalized_path_from = normalizePath(path_from);
@@ -653,7 +650,7 @@ void MetadataStorageFromPlainObjectStorageRemoveRecursiveOperation::execute()
     if (normalizePath(path).empty())
         return;
 
-    if (fs_tree->existsDirectory(path).first)
+    if (fs_tree->existsDirectory(path))
     {
         move_tried = true;
         move_to_tmp_op->execute();

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.cpp
@@ -85,23 +85,6 @@ private:
     std::unordered_set<std::string> created_directories;
 };
 
-void UncommittedState::useDirectory(const std::string & path) const
-{
-    const auto info = tx_snapshot->getDirectoryRemoteInfo(path);
-    if (!info)
-        return;
-
-    const auto snapshot_path = path_resolver->resolveToSnapshotPath(normalizePath(path));
-    if (snapshot_path && !path_resolver->isCreatedByTransaction(*snapshot_path))
-        preconditions->checkDirectoryPresent(*snapshot_path, info->remote_path);
-}
-
-void UncommittedState::useMissingDirectory(const std::string & path) const
-{
-    if (const auto snapshot_path = path_resolver->resolveToSnapshotPath(normalizePath(path)))
-        preconditions->checkDirectoryMissing(*snapshot_path);
-}
-
 UncommittedState::UncommittedState(std::shared_ptr<FsSnapshot> tx_snapshot_)
     : tx_snapshot(std::move(tx_snapshot_))
     , preconditions(std::make_shared<Preconditions>())
@@ -109,15 +92,38 @@ UncommittedState::UncommittedState(std::shared_ptr<FsSnapshot> tx_snapshot_)
 {
 }
 
+void UncommittedState::useDirectory(const std::string & path) const
+{
+    const auto info = tx_snapshot->getDirectoryRemoteInfo(path);
+    if (!info)
+        return;
+
+    const auto snapshot_path = path_resolver->resolveToSnapshotPath(normalizePath(path));
+    if (!snapshot_path)
+        return;
+
+    if (path_resolver->isCreatedByTransaction(*snapshot_path))
+        preconditions->checkDirectoryMissing(*snapshot_path);
+    else
+        preconditions->checkDirectoryPresent(*snapshot_path, info->remote_path);
+}
+
+void UncommittedState::useMissingDirectory(const std::string & path) const
+{
+    const auto info = tx_snapshot->getDirectoryRemoteInfo(path);
+    if (info)
+        return;
+
+    const auto snapshot_path = path_resolver->resolveToSnapshotPath(normalizePath(path));
+    if (snapshot_path)
+        preconditions->checkDirectoryMissing(*snapshot_path);
+}
+
 void UncommittedState::createDirectory(const std::string & path)
 {
     if (tx_snapshot->getDirectoryRemoteInfo(path))
-    {
-        useDirectory(path);
         return;
-    }
 
-    useMissingDirectory(path);
     path_resolver->recordCreate(normalizePath(path));
     tx_snapshot->recordDirectoryPath(path, DirectoryRemoteInfo{ .remote_path = getRandomASCIIString(32), .etag = "", .files = {}});
 }
@@ -125,12 +131,8 @@ void UncommittedState::createDirectory(const std::string & path)
 void UncommittedState::removeDirectory(const std::string & path)
 {
     if (!tx_snapshot->existsDirectory(path).first)
-    {
-        useMissingDirectory(path);
         return;
-    }
 
-    useDirectory(path);
     path_resolver->recordRemove(normalizePath(path));
     tx_snapshot->removeDirectory(path);
 }
@@ -138,25 +140,17 @@ void UncommittedState::removeDirectory(const std::string & path)
 void UncommittedState::moveDirectory(const std::string & path_from, const std::string & path_to)
 {
     if (!tx_snapshot->existsDirectory(path_from).first)
-    {
-        useMissingDirectory(path_from);
         return;
-    }
 
     if (tx_snapshot->existsDirectory(path_to).first || tx_snapshot->existsFile(path_to))
-    {
-        useDirectory(path_to);
         return;
-    }
 
-    useDirectory(path_from);
     path_resolver->recordMove(normalizePath(path_from), normalizePath(path_to));
     tx_snapshot->moveDirectory(path_from, path_to);
 }
 
 std::pair<bool, std::optional<DirectoryRemoteInfo>> UncommittedState::lookupDirectory(const std::string & path) const
 {
-    useDirectory(path);
     return tx_snapshot->existsDirectory(path);
 }
 

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.cpp
@@ -130,7 +130,7 @@ void UncommittedState::createDirectory(const std::string & path)
 
 void UncommittedState::removeDirectory(const std::string & path)
 {
-    if (!tx_snapshot->existsDirectory(path).first)
+    if (!tx_snapshot->existsDirectory(path))
         return;
 
     path_resolver->recordRemove(normalizePath(path));
@@ -139,19 +139,19 @@ void UncommittedState::removeDirectory(const std::string & path)
 
 void UncommittedState::moveDirectory(const std::string & path_from, const std::string & path_to)
 {
-    if (!tx_snapshot->existsDirectory(path_from).first)
+    if (!tx_snapshot->existsDirectory(path_from))
         return;
 
-    if (tx_snapshot->existsDirectory(path_to).first || tx_snapshot->existsFile(path_to))
+    if (tx_snapshot->existsDirectory(path_to) || tx_snapshot->existsFile(path_to))
         return;
 
     path_resolver->recordMove(normalizePath(path_from), normalizePath(path_to));
     tx_snapshot->moveDirectory(path_from, path_to);
 }
 
-std::pair<bool, std::optional<DirectoryRemoteInfo>> UncommittedState::lookupDirectory(const std::string & path) const
+std::optional<DirectoryRemoteInfo> UncommittedState::getDirectoryRemoteInfo(const std::string & path) const
 {
-    return tx_snapshot->existsDirectory(path);
+    return tx_snapshot->getDirectoryRemoteInfo(path);
 }
 
 std::shared_ptr<Preconditions> UncommittedState::getTxPreconditions() const

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.h
@@ -10,11 +10,11 @@ class UncommittedState
 {
     class PathResolver;
 
-    void useDirectory(const std::string & path) const;
-    void useMissingDirectory(const std::string & path) const;
-
 public:
     explicit UncommittedState(std::shared_ptr<FsSnapshot> tx_snapshot_);
+
+    void useDirectory(const std::string & path) const;
+    void useMissingDirectory(const std::string & path) const;
 
     void createDirectory(const std::string & path);
     void removeDirectory(const std::string & path);

--- a/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/PlainRewritable/Transactions/UncommittedState.h
@@ -20,7 +20,7 @@ public:
     void removeDirectory(const std::string & path);
     void moveDirectory(const std::string & path_from, const std::string & path_to);
 
-    std::pair<bool, std::optional<DirectoryRemoteInfo>> lookupDirectory(const std::string & path) const;
+    std::optional<DirectoryRemoteInfo> getDirectoryRemoteInfo(const std::string & path) const;
     std::shared_ptr<Preconditions> getTxPreconditions() const;
 
 private:

--- a/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_plain_rewritable_disk.cpp
@@ -1969,103 +1969,6 @@ TEST_F(MetadataPlainRewritableDiskTest, CreateExistingDirectory)
     EXPECT_EQ(readObject(object_storage, metadata->getStorageObjects("A/B/C/file").front().remote_path), "1");
 }
 
-TEST_F(MetadataPlainRewritableDiskTest, ValidateDirectoryPreconditions)
-{
-    thread_local_rng.seed(42);
-
-    auto metadata = getMetadataStorage("ValidateDirectoryPreconditions");
-    auto object_storage = getObjectStorage("ValidateDirectoryPreconditions");
-
-    {
-        auto tx = metadata->createTransaction();
-        tx->createDirectoryRecursive("A/B/C");
-        tx->commit(DB::NoCommitOptions{});
-    }
-
-    /// Reused remote path: the directory is removed by a concurrent transaction before the commit.
-    {
-        auto tx = metadata->createTransaction();
-        tx->createDirectory("A/B/C");
-
-        {
-            auto concurrent_tx = metadata->createTransaction();
-            concurrent_tx->removeDirectory("A/B/C");
-            concurrent_tx->commit(DB::NoCommitOptions{});
-        }
-
-        EXPECT_ANY_THROW(tx->commit(DB::NoCommitOptions{}));
-        EXPECT_FALSE(metadata->existsDirectory("A/B/C"));
-    }
-
-    /// Reused remote path: the directory is removed and recreated by concurrent transactions,
-    /// so its remote path changed.
-    {
-        {
-            auto setup_tx = metadata->createTransaction();
-            setup_tx->createDirectoryRecursive("A/B/C");
-            setup_tx->commit(DB::NoCommitOptions{});
-        }
-
-        auto tx = metadata->createTransaction();
-        tx->createDirectory("A/B/C");
-
-        {
-            auto concurrent_tx = metadata->createTransaction();
-            concurrent_tx->removeDirectory("A/B/C");
-            concurrent_tx->commit(DB::NoCommitOptions{});
-        }
-        {
-            auto concurrent_tx = metadata->createTransaction();
-            concurrent_tx->createDirectoryRecursive("A/B/C");
-            concurrent_tx->commit(DB::NoCommitOptions{});
-        }
-
-        auto remote_prefix = generateObjectKeyPrefixForDirectoryPath(metadata, "A/B/C/");
-        EXPECT_ANY_THROW(tx->commit(DB::NoCommitOptions{}));
-        EXPECT_TRUE(metadata->existsDirectory("A/B/C"));
-        EXPECT_EQ(generateObjectKeyPrefixForDirectoryPath(metadata, "A/B/C/"), remote_prefix);
-    }
-
-    /// New remote path: the directory is created by a concurrent transaction before the commit.
-    {
-        auto tx = metadata->createTransaction();
-        tx->createDirectory("X");
-
-        {
-            auto concurrent_tx = metadata->createTransaction();
-            concurrent_tx->createDirectory("X");
-            concurrent_tx->commit(DB::NoCommitOptions{});
-        }
-
-        auto remote_prefix = generateObjectKeyPrefixForDirectoryPath(metadata, "X/");
-        EXPECT_ANY_THROW(tx->commit(DB::NoCommitOptions{}));
-        EXPECT_TRUE(metadata->existsDirectory("X"));
-        EXPECT_EQ(generateObjectKeyPrefixForDirectoryPath(metadata, "X/"), remote_prefix);
-    }
-
-    /// A file write into an existing directory is validated at commit time as well.
-    {
-        auto tx = metadata->createTransaction();
-        size_t file_size = writeObject(object_storage, tx->generateObjectKeyForPath("X/file").serialize(), "1");
-        tx->createMetadataFile("X/file", {StoredObject("X/file", "file", file_size)});
-
-        {
-            auto concurrent_tx = metadata->createTransaction();
-            concurrent_tx->removeDirectory("X");
-            concurrent_tx->commit(DB::NoCommitOptions{});
-        }
-
-        EXPECT_ANY_THROW(tx->commit(DB::NoCommitOptions{}));
-        EXPECT_FALSE(metadata->existsFile("X/file"));
-        EXPECT_FALSE(metadata->existsDirectory("X"));
-    }
-
-    EXPECT_EQ(listAllBlobs("ValidateDirectoryPreconditions"), sorted(std::vector<std::string>({
-        "./ValidateDirectoryPreconditions/__meta/wcageakzukwtfkvkwibqrfhzrrlubsbg/prefix.path", /// A/B/C
-        "./ValidateDirectoryPreconditions/huevlfwzdbhkvtedpymtjpafjjjfynpz/file"                /// X/file
-    })));
-}
-
 TEST_F(MetadataPlainRewritableDiskTest, RecreateDirectoryInSameTransaction)
 {
     auto metadata = getMetadataStorage("RecreateDirectoryInSameTransaction");
@@ -2213,8 +2116,8 @@ TEST_F(MetadataPlainRewritableDiskTest, SnapshotDecisionPreservedOnConcurrentCha
         tx2->commit(DB::NoCommitOptions{});
     }
 
-    EXPECT_ANY_THROW(tx1->commit(DB::NoCommitOptions{}));
-    EXPECT_TRUE(metadata->existsDirectory("X"));
+    tx1->commit(DB::NoCommitOptions{});
+    EXPECT_FALSE(metadata->existsDirectory("X"));
 }
 
 TEST_F(MetadataPlainRewritableDiskTest, ConcurrentCreateUnderUnlinkFile)
@@ -2257,8 +2160,6 @@ TEST_F(MetadataPlainRewritableDiskTest, ConcurrentRemoveOfMoveTarget)
         tx->commit(DB::NoCommitOptions{});
     }
 
-    /// A move whose target existed in the snapshot must keep failing
-    /// after the target is removed concurrently.
     auto tx1 = metadata->createTransaction();
     tx1->moveDirectory("A", "B");
 
@@ -2268,8 +2169,34 @@ TEST_F(MetadataPlainRewritableDiskTest, ConcurrentRemoveOfMoveTarget)
         tx2->commit(DB::NoCommitOptions{});
     }
 
-    EXPECT_ANY_THROW(tx1->commit(DB::NoCommitOptions{}));
+    tx1->commit(DB::NoCommitOptions{});
+
+    EXPECT_FALSE(metadata->existsDirectory("A"));
+    EXPECT_TRUE(metadata->existsDirectory("B"));
+}
+
+TEST_F(MetadataPlainRewritableDiskTest, ConcurrentCreateDirectory)
+{
+    auto metadata = getMetadataStorage("ConcurrentCreateDirectory");
+
+    /// Regression test for https://github.com/ClickHouse/ClickHouse/issues/111289
+    auto tx1 = metadata->createTransaction();
+    tx1->createDirectoryRecursive("A");
+
+    {
+        auto tx2 = metadata->createTransaction();
+        tx2->createDirectoryRecursive("A");
+        tx2->commit(DB::NoCommitOptions{});
+    }
+
+    auto remote_prefix = generateObjectKeyPrefixForDirectoryPath(metadata, "A/");
+    tx1->commit(DB::NoCommitOptions{});
 
     EXPECT_TRUE(metadata->existsDirectory("A"));
-    EXPECT_FALSE(metadata->existsDirectory("B"));
+    EXPECT_EQ(generateObjectKeyPrefixForDirectoryPath(metadata, "A/"), remote_prefix);
+    EXPECT_EQ(listAllBlobs("ConcurrentCreateDirectory").size(), 1);
+
+    metadata = restartMetadataStorage("ConcurrentCreateDirectory");
+    EXPECT_TRUE(metadata->existsDirectory("A"));
+    EXPECT_EQ(generateObjectKeyPrefixForDirectoryPath(metadata, "A/"), remote_prefix);
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch removes preconditions from metadata-only transactions. These transactions will be validated during commit.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/111289


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.7.2.1`
<!-- ch-version-info:end -->