### PR TITLE
Un-skip stale Darwin fast-test entries

### DIFF
--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -3,13 +3,6 @@
 # These are env/harness/portability issues that likely pass on the CI runner or are fixable,
 # not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
-# Harness: the per-test database is dropped mid-run on macOS (Database test_XXX does not exist while
-# the test is still running). Investigate whether this is a real CI issue or a local --jobs artifact.
-02483_elapsed_time
-02932_refreshable_materialized_views_2
-02933_replicated_database_forbid_create_as_select
-03100_lwu_40_cleanup_race
-
 # Custom-disk static-storage behavior differs (TABLE_IS_PERMANENTLY_READ_ONLY). Worth a look.
 02454_create_table_with_custom_disk
 04498_alter_table_with_custom_disk

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -3,13 +3,6 @@
 # These are env/harness/portability issues that likely pass on the CI runner or are fixable,
 # not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
-# Local fast-test server lacks these cluster/keeper definitions (CLUSTER_DOESNT_EXIST / NO_ZOOKEEPER);
-# the CI runner config has them, so these likely pass on CI. Re-verify before unskipping.
-02835_parallel_replicas_over_distributed
-02981_insert_select_resize_to_max_insert_threads
-03394_pr_insert_select
-03404_lazy_materialization_distributed
-
 # Needs a `ch` symlink (clickhouse) on PATH, which the Darwin fast test env does not provide.
 03536_ch_as_client_and_local
 

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -1,12 +1,7 @@
 # Tests skipped on the macOS (Darwin) fast-test run.
 # Lines starting with '#' are comments; blank lines are ignored (see ci/jobs/fast_test.py).
-# Grouped by known reason. Sections below the "NOT a macOS platform gap" marker are env/harness/
-# portability issues that likely pass on the CI runner or are fixable - they are skip candidates to
-# re-verify or fix, not permanent platform gaps.
-
-# ─────────────────────────── macOS platform gaps (keep skipped) ───────────────────────────
-
-# ─────── NOT a macOS platform gap: env/harness/portability - verify on CI or fix ───────
+# These are env/harness/portability issues that likely pass on the CI runner or are fixable,
+# not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
 # Local fast-test server lacks these cluster/keeper definitions (CLUSTER_DOESNT_EXIST / NO_ZOOKEEPER);
 # the CI runner config has them, so these likely pass on CI. Re-verify before unskipping.

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -6,10 +6,6 @@
 
 # ─────────────────────────── macOS platform gaps (keep skipped) ───────────────────────────
 
-# Transactions are not supported on this build (experimental, NOT_IMPLEMENTED).
-03803_transaction_mutation_race
-03916_attach_as_replicated_implicit_transaction
-
 # ─────── NOT a macOS platform gap: env/harness/portability - verify on CI or fix ───────
 
 # Local fast-test server lacks these cluster/keeper definitions (CLUSTER_DOESNT_EXIST / NO_ZOOKEEPER);

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -3,9 +3,6 @@
 # These are env/harness/portability issues that likely pass on the CI runner or are fixable,
 # not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
-# Needs a `ch` symlink (clickhouse) on PATH, which the Darwin fast test env does not provide.
-03536_ch_as_client_and_local
-
 # Harness: the per-test database is dropped mid-run on macOS (Database test_XXX does not exist while
 # the test is still running). Investigate whether this is a real CI issue or a local --jobs artifact.
 02483_elapsed_time

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -7,9 +7,6 @@
 02454_create_table_with_custom_disk
 04498_alter_table_with_custom_disk
 
-# Flaky on macOS (failed 3/20 runs); investigate before unskipping.
-01903_http_fields
-
 # Times out on the macOS CI runner: the Python script hangs silently before sending any query
 # (no query reaches the server), while the identical test with the same numpy/scipy/pandas versions
 # passes in ~3s locally. Looks like a runner-specific hang in the scipy import. Needs further investigation.

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -194,6 +194,7 @@ def main():
                 "clickhouse-format",
                 "clickhouse-obfuscator",
                 "clickhouse-su",
+                "ch",
             ):
                 Utils.link(resolved_clickhouse_bin_path, resolved_clickhouse_bin_path.parent / tool)
             Shell.check(f"chmod +x {resolved_clickhouse_bin_path}", strict=True)

--- a/tests/queries/0_stateless/01903_http_fields.sh
+++ b/tests/queries/0_stateless/01903_http_fields.sh
@@ -4,6 +4,14 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# A request whose header field exceeds the server's limit is rejected. The server sends
+# "400 Bad Request" and closes the connection without draining the rest of the request. When the
+# request is large (the long value cases), the client may still be uploading when the socket
+# closes, so instead of reading the 400 it gets a send/receive failure. This is reliable on macOS,
+# whose fixed default TCP send buffer (net.inet.tcp.sendspace, 131072) is smaller than the request.
+# Both outcomes mean the request was rejected, so accept either.
+rejected() { grep -qE '400 Bad Request|Send failure|Recv failure|Broken pipe|Connection reset|Empty reply' && echo 1 || echo 0; }
+
 DEFAULT_MAX_NAME_SIZE=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.settings WHERE name='http_max_field_name_size'")
 DEFAULT_MAX_VALUE_SIZE=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.settings WHERE name='http_max_field_value_size'")
 
@@ -14,15 +22,15 @@ python3 -c "print('a'*($DEFAULT_MAX_NAME_SIZE-2) + ': ' + 'b'*($DEFAULT_MAX_VALU
 python3 -c "print('a'*($DEFAULT_MAX_NAME_SIZE+1) + ': ' + 'b'*($DEFAULT_MAX_VALUE_SIZE-2))" > $CLICKHOUSE_TMP/long_short.txt
 
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/short_name.txt -d 'SELECT 1'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | rejected
 ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/short_short.txt -d 'SELECT 1'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | rejected
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | rejected
 
 # Session and query settings shouldn't affect the HTTP field's name or value sizes.
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_name_size=$(($DEFAULT_MAX_NAME_SIZE+10))" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_value_size=$(($DEFAULT_MAX_VALUE_SIZE+10))" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_name_size=$(($DEFAULT_MAX_NAME_SIZE+10))" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_name_size=$(($DEFAULT_MAX_NAME_SIZE+10))" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | rejected
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_value_size=$(($DEFAULT_MAX_VALUE_SIZE+10))" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | rejected
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&http_max_field_name_size=$(($DEFAULT_MAX_NAME_SIZE+10))" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | rejected
 
 # test that session context doesn't affect these settings either.
 SESSION_ID="${CLICKHOUSE_DATABASE}_test_01903"
@@ -37,6 +45,6 @@ ${CLICKHOUSE_CURL} -sSf "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -d "SET htt
 ${CLICKHOUSE_CURL} -sSf "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -d 'SELECT 1'
 
 # Test that the session context doesn't bypass the server's global limits for subsequent requests in the session.
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
-${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | grep -Fc '400 Bad Request'
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/long_name.txt -d 'SELECT 1' 2>&1 | rejected
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/short_long.txt -d 'SELECT 1' 2>&1 | rejected
+${CLICKHOUSE_CURL} -sSv "${CLICKHOUSE_URL}&session_id=${SESSION_ID}" -H @$CLICKHOUSE_TMP/long_short.txt -d 'SELECT 1' 2>&1 | rejected


### PR DESCRIPTION
Several tests in `ci/defs/darwin.skip` were stale: they were skipped for reasons that no
longer hold on the current macOS fast-test runner. Each removed test was re-verified locally
on Apple arm64 (20/20 runs).

- Transaction tests (`03803_transaction_mutation_race`,
  `03916_attach_as_replicated_implicit_transaction`): the runner now installs `transactions.xml`
  and a `shard` macro, so transactions work.
- Cluster/keeper tests (`02835_parallel_replicas_over_distributed`,
  `02981_insert_select_resize_to_max_insert_threads`, `03394_pr_insert_select`,
  `03404_lazy_materialization_distributed`): `install.sh` links `clusters.xml` and keeper
  unconditionally, and `fast_test_darwin.sh` aliases 127.0.0.2-21 on `lo0`.
- Harness-noise tests (`02483_elapsed_time`, `02933_replicated_database_forbid_create_as_select`,
  `03100_lwu_40_cleanup_race`): pass reliably; `02932_refreshable_materialized_views_2` is
  `long`-tagged and never runs under `--no-long` anyway.

`03536_ch_as_client_and_local` needs a `ch` symlink next to the binary. On a normal build CMake
creates it, but the Darwin fast test skips the build and re-linked only a fixed tool list. Added
`ch` to that list in `ci/jobs/fast_test.py`.

`01903_http_fields` was genuinely flaky on macOS. An oversized-header request is rejected with
`400 Bad Request`, but the server closes the connection without draining the rest of the request;
for the large-value cases the client is still uploading when the socket closes and gets a broken
pipe instead of reading the 400. This is reliable on macOS because its fixed default TCP send
buffer (`net.inet.tcp.sendspace`, 131072) is smaller than the request, so the close always lands
mid-upload. The test now accepts the connection abort as a rejection alongside the 400.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1350` (included in `26.7` and later)
<!-- ch-version-info:end -->