### PR TITLE
Fsync DETACH TABLE ... PERMANENTLY flag to survive power loss

### DIFF
--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -289,12 +289,20 @@ void DatabaseOnDisk::createTable(
 
 /// If the table was detached permanently we will have a flag file with
 /// .sql.detached extension, is not needed anymore since we attached the table back
-void DatabaseOnDisk::removeDetachedPermanentlyFlag(ContextPtr, const String & table_name, const String & table_metadata_path, bool)
+void DatabaseOnDisk::removeDetachedPermanentlyFlag(ContextPtr local_context, const String & table_name, const String & table_metadata_path, bool)
 {
     auto db_disk = getDisk();
     try
     {
         fs::path detached_permanently_flag(table_metadata_path + detached_suffix);
+
+        /// fsync the parent directory so the unlink survives a power loss (a directory-entry
+        /// change is durable only after the directory is fsync'd; the guard fsyncs on destruction).
+        /// Only when a marker exists: createTable calls this on every CREATE TABLE, usually without one.
+        SyncGuardPtr dir_sync_guard;
+        if (local_context->getSettingsRef()[Setting::fsync_metadata] && db_disk->existsFile(detached_permanently_flag))
+            dir_sync_guard = db_disk->getDirectorySyncGuard(getMetadataPath());
+
         db_disk->removeFileIfExists(detached_permanently_flag);
     }
     catch (Exception & e)
@@ -337,6 +345,15 @@ void DatabaseOnDisk::detachTablePermanently(ContextPtr query_context, const Stri
     try
     {
         auto db_disk = getDisk();
+
+        /// fsync the parent directory so the marker survives a power loss, else the table silently
+        /// re-attaches on restart. The marker is an empty file, so only its directory entry matters
+        /// (a directory-entry change is durable only after the directory is fsync'd; the guard
+        /// fsyncs on destruction).
+        SyncGuardPtr dir_sync_guard;
+        if (query_context->getSettingsRef()[Setting::fsync_metadata])
+            dir_sync_guard = db_disk->getDirectorySyncGuard(getMetadataPath());
+
         db_disk->createFile(detached_permanently_flag);
 
         std::lock_guard lock(mutex);

--- a/tests/queries/0_stateless/03471_detach_permanently_fsync.reference
+++ b/tests/queries/0_stateless/03471_detach_permanently_fsync.reference
@@ -1,3 +1,4 @@
 detach permanently, fsync_metadata=1: DirectorySync >= 1
 attach, fsync_metadata=1: DirectorySync >= 1
 detach permanently, fsync_metadata=0: DirectorySync = 0
+attach, fsync_metadata=0: DirectorySync = 0

--- a/tests/queries/0_stateless/03471_detach_permanently_fsync.reference
+++ b/tests/queries/0_stateless/03471_detach_permanently_fsync.reference
@@ -1,0 +1,3 @@
+detach permanently, fsync_metadata=1: DirectorySync >= 1
+attach, fsync_metadata=1: DirectorySync >= 1
+detach permanently, fsync_metadata=0: DirectorySync = 0

--- a/tests/queries/0_stateless/03471_detach_permanently_fsync.sh
+++ b/tests/queries/0_stateless/03471_detach_permanently_fsync.sh
@@ -31,9 +31,11 @@ qid_attach="attach-${CLICKHOUSE_DATABASE}"
 $CLICKHOUSE_CLIENT --query_id "$qid_detach" --fsync_metadata 1 -q "DETACH TABLE tbl PERMANENTLY"
 $CLICKHOUSE_CLIENT --query_id "$qid_attach" --fsync_metadata 1 -q "ATTACH TABLE tbl"
 
-# fsync_metadata = 0 must not fsync the directory.
+# fsync_metadata = 0 must not fsync the directory, for both the marker create and remove sides.
 qid_detach_off="detach-off-${CLICKHOUSE_DATABASE}"
+qid_attach_off="attach-off-${CLICKHOUSE_DATABASE}"
 $CLICKHOUSE_CLIENT --query_id "$qid_detach_off" --fsync_metadata 0 -q "DETACH TABLE tbl PERMANENTLY"
+$CLICKHOUSE_CLIENT --query_id "$qid_attach_off" --fsync_metadata 0 -q "ATTACH TABLE tbl"
 
 $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
 
@@ -43,6 +45,7 @@ echo -n "attach, fsync_metadata=1: "
 [[ "$(dir_sync "$qid_attach")" -ge 1 ]] && echo "DirectorySync >= 1" || echo "FAIL: no DirectorySync"
 echo -n "detach permanently, fsync_metadata=0: "
 echo "DirectorySync = $(dir_sync "$qid_detach_off")"
+echo -n "attach, fsync_metadata=0: "
+echo "DirectorySync = $(dir_sync "$qid_attach_off")"
 
-$CLICKHOUSE_CLIENT -q "ATTACH TABLE tbl"
 $CLICKHOUSE_CLIENT -q "DROP TABLE tbl"

--- a/tests/queries/0_stateless/03471_detach_permanently_fsync.sh
+++ b/tests/queries/0_stateless/03471_detach_permanently_fsync.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-object-storage
+# no-object-storage: object-storage disks do not fsync directories (DirectorySync stays 0)
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# DETACH TABLE ... PERMANENTLY writes a `<table>.sql.detached` marker and ATTACH removes it.
+# Both must fsync the metadata directory (under fsync_metadata) so the acknowledged transition
+# survives a power loss. We can't cut power in a stateless test, so assert the DirectorySync
+# ProfileEvent fires for the DETACH/ATTACH query (>=1 with fsync_metadata=1, 0 with =0), the
+# same technique as 02361_fsync_profile_events.sh.
+
+dir_sync() {
+    # $1 = query_id
+    $CLICKHOUSE_CLIENT --param_qid "$1" -q "
+        SELECT ProfileEvents['DirectorySync']
+        FROM system.query_log
+        WHERE current_database = currentDatabase()
+          AND query_id = {qid:String}
+          AND type = 'QueryFinish'
+        ORDER BY event_time_microseconds DESC
+        LIMIT 1"
+}
+
+$CLICKHOUSE_CLIENT -q "CREATE TABLE tbl (id UInt64) ENGINE = MergeTree ORDER BY id"
+
+qid_detach="detach-${CLICKHOUSE_DATABASE}"
+qid_attach="attach-${CLICKHOUSE_DATABASE}"
+$CLICKHOUSE_CLIENT --query_id "$qid_detach" --fsync_metadata 1 -q "DETACH TABLE tbl PERMANENTLY"
+$CLICKHOUSE_CLIENT --query_id "$qid_attach" --fsync_metadata 1 -q "ATTACH TABLE tbl"
+
+# fsync_metadata = 0 must not fsync the directory.
+qid_detach_off="detach-off-${CLICKHOUSE_DATABASE}"
+$CLICKHOUSE_CLIENT --query_id "$qid_detach_off" --fsync_metadata 0 -q "DETACH TABLE tbl PERMANENTLY"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+
+echo -n "detach permanently, fsync_metadata=1: "
+[[ "$(dir_sync "$qid_detach")" -ge 1 ]] && echo "DirectorySync >= 1" || echo "FAIL: no DirectorySync"
+echo -n "attach, fsync_metadata=1: "
+[[ "$(dir_sync "$qid_attach")" -ge 1 ]] && echo "DirectorySync >= 1" || echo "FAIL: no DirectorySync"
+echo -n "detach permanently, fsync_metadata=0: "
+echo "DirectorySync = $(dir_sync "$qid_detach_off")"
+
+$CLICKHOUSE_CLIENT -q "ATTACH TABLE tbl"
+$CLICKHOUSE_CLIENT -q "DROP TABLE tbl"


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111322
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make `DETACH TABLE ... PERMANENTLY` durable: the `.sql.detached` marker file (and its removal on `ATTACH`) is now persisted by fsync'ing the metadata directory, gated on `fsync_metadata`. Previously the marker's creation/removal was not synced, so a power loss right after an acknowledged `DETACH ... PERMANENTLY` could silently re-attach the table on restart (or, symmetrically, undo an acknowledged `ATTACH`).


### Description

Closes #111322.

`DatabaseOnDisk::detachTablePermanently` creates the empty `<table>.sql.detached` marker via `db_disk->createFile`, and `removeDetachedPermanentlyFlag` removes it via `removeFileIfExists`. Neither fsync'd the parent metadata directory. A file's existence is a directory-entry change that is not durable until the directory is fsync'd, so an acknowledged `DETACH ... PERMANENTLY` (or `ATTACH`) could be lost on power loss, silently violating the acknowledged contract. This is the same `fsync_metadata` gap as #68958, applied to a marker file.

Fix: fsync the metadata directory around both the marker creation and its removal, via `IDisk::getDirectorySyncGuard` (fsyncs on local disks, no-op on object storage), gated on `fsync_metadata` (default true). On the removal path the sync is taken only when the marker actually exists, so plain `CREATE TABLE` (which always calls `removeDetachedPermanentlyFlag`) is unaffected. Covers Ordinary, Atomic, and Replicated databases.

Verified with the `DirectorySync` profile event (as in `02361_fsync_profile_events.sh`): `DirectorySync` is 1 for `DETACH ... PERMANENTLY` / `ATTACH` under `fsync_metadata=1` and 0 under `fsync_metadata=0`; 0 on both before the fix. Test: `03471_detach_permanently_fsync`.
