### PR TITLE
Fsync detached directory on DROP DETACHED PART/PARTITION

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -8497,6 +8497,10 @@ void MergeTreeData::validateDetachedPartName(const String & name)
 
 void MergeTreeData::dropDetached(const ASTPtr & partition, bool part, ContextPtr local_context)
 {
+    /// Declared before `renamed_parts` so the guards outlive it and fsync the `detached/`
+    /// directory after the destructor of `PartsTemporaryRename`, covering the rename and its rollback.
+    std::vector<SyncGuardPtr> dir_sync_guards;
+
     PartsTemporaryRename renamed_parts(*this, DETACHED_DIR_NAME);
 
     if (part)
@@ -8520,6 +8524,21 @@ void MergeTreeData::dropDetached(const ASTPtr & partition, bool part, ContextPtr
     }
 
     LOG_DEBUG(log, "Will drop {} detached parts.", renamed_parts.old_and_new_names.size());
+
+    if ((*getSettings())[MergeTreeSetting::fsync_part_directory])
+    {
+        /// Source `<part>` and renamed `deleting_<part>` share the `detached/` directory, so one
+        /// guard per distinct disk covers both the rename and the unlink. The descriptor is opened
+        /// now (before the rename) and fsync'd on destruction; close-reopen-fsync is kernel-dependent.
+        std::unordered_set<String> synced_disks;
+        for (const auto & rename_info : renamed_parts.old_and_new_names)
+        {
+            if (!synced_disks.emplace(rename_info.disk->getName()).second)
+                continue;
+            if (auto guard = rename_info.disk->getDirectorySyncGuard(fs::path(relative_data_path) / DETACHED_DIR_NAME))
+                dir_sync_guards.push_back(std::move(guard));
+        }
+    }
 
     renamed_parts.tryRenameAll();
 

--- a/tests/queries/0_stateless/04620_drop_detached_part_fsync.reference
+++ b/tests/queries/0_stateless/04620_drop_detached_part_fsync.reference
@@ -1,0 +1,6 @@
+fsync_part_directory = 1: DirectorySync>=1, part removed
+1
+0
+fsync_part_directory = 0: DirectorySync=0 (setting honored), part removed
+0
+0

--- a/tests/queries/0_stateless/04620_drop_detached_part_fsync.sh
+++ b/tests/queries/0_stateless/04620_drop_detached_part_fsync.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tags: no-object-storage
+# Tag no-object-storage: object storage disks do not fsync local directories.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/111349
+# The DirectorySync ProfileEvent is used as a durability proxy for the detached/
+# directory fsync (instead of simulating a power loss).
+# storage_policy = 'default' pins the table to local disk: the stress test does not pass
+# --s3-storage (so no-object-storage does not skip it) yet may make an object storage policy
+# the MergeTree default, where the directory fsync is a no-op.
+
+run_case() {
+    local fsync=$1
+    $CLICKHOUSE_CLIENT -m -q "
+        drop table if exists t_dd;
+        create table t_dd (x UInt32) engine = MergeTree order by x settings fsync_part_directory = $fsync, storage_policy = 'default';
+        insert into t_dd values (1);
+        alter table t_dd detach partition tuple();
+    "
+    local part
+    part=$($CLICKHOUSE_CLIENT -q "select name from system.detached_parts where database = currentDatabase() and table = 't_dd' limit 1")
+    local query_id="drop-detached-fsync${fsync}-$CLICKHOUSE_DATABASE"
+    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "alter table t_dd drop detached part '$part' settings allow_drop_detached = 1"
+    $CLICKHOUSE_CLIENT -m --param_query_id "$query_id" -q "
+        system flush logs query_log;
+        select ProfileEvents['DirectorySync'] >= 1
+        from system.query_log
+        where event_date >= yesterday() and current_database = currentDatabase()
+          and query_id = {query_id:String} and type = 'QueryFinish'
+        order by event_time_microseconds desc limit 1;
+    "
+    # The part must be gone regardless of the setting.
+    $CLICKHOUSE_CLIENT -q "select count() from system.detached_parts where database = currentDatabase() and table = 't_dd'"
+    $CLICKHOUSE_CLIENT -q "drop table t_dd"
+}
+
+echo "fsync_part_directory = 1: DirectorySync>=1, part removed"
+run_case 1
+echo "fsync_part_directory = 0: DirectorySync=0 (setting honored), part removed"
+run_case 0


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111349

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`ALTER TABLE ... DROP DETACHED PART/PARTITION` now fsyncs the `detached` directory when the `fsync_part_directory` MergeTree setting is enabled, so an acknowledged drop of a detached part is no longer rolled back by a power loss (the removed part could previously reappear).


### Description

`MergeTreeData::dropDetached` renames `detached/<part>` to `detached/deleting_<part>` and then unlinks it, but never fsync'd the `detached` directory and consulted no durability setting. A rename or unlink is durable only once the parent directory is fsync'd, so after a power loss in the filesystem journal window the directory-entry changes could roll back and the acknowledged-dropped detached part reappeared intact. Reported and reproduced 3/3 with a `dm-flakey` power-loss simulation in #111349.

Fix, gated on the existing `fsync_part_directory` setting (default `false`, so no behavior change by default): before the rename, acquire one directory sync guard per involved disk on the `detached` directory and hold it across the rename and the removal; the guard fsyncs the directory on destruction. The guards are declared before `PartsTemporaryRename` so they outlive it and also cover the rollback rename on the error path. This uses the disk-agnostic `IDisk::getDirectorySyncGuard` (local disks fsync; object storage is a no-op), matching the existing `fsync_part_directory` handling for part directories in `IMergeTreeDataPart::renameTo`.

Test: `04620_drop_detached_part_fsync` asserts the `DirectorySync` ProfileEvent is emitted for `DROP DETACHED PART` when `fsync_part_directory = 1` and not when `0`, and that the part is removed in both cases.
