### PR TITLE
Reduce disk usage of performance tests

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import os
 import re
+import shutil
 import subprocess
 import time
 import traceback
@@ -1302,6 +1303,21 @@ def main():
         print(f"Test Files ({len(test_files)}): [{test_files}]")
         assert test_files
 
+        def cleanup_user_files():
+            # Tests can write into user_files (INSERT INTO FUNCTION file(...)) and nothing else removes those files.
+            # drop_query only drops tables. Keep the symlinks made in Configure, remove everything else.
+            for server_path in (perf_left, perf_right):
+                user_files = Path(server_path) / "db" / "user_files"
+                if not user_files.is_dir():
+                    continue
+                for entry in user_files.iterdir():
+                    if entry.is_symlink():
+                        continue
+                    if entry.is_dir():
+                        shutil.rmtree(entry)
+                    else:
+                        entry.unlink()
+
         def run_tests():
             # Run 10 random queries per test by default, but all queries for benchmarks
             benchmarks = {"clickbench.xml", "tpch.xml", "tpcds.xml"}
@@ -1313,6 +1329,7 @@ def main():
                     max_queries=max_queries,
                     results_path=perf_wd,
                 )
+                cleanup_user_files()
             return True
 
         commands = [

--- a/tests/performance/file_table_function.xml
+++ b/tests/performance/file_table_function.xml
@@ -32,11 +32,13 @@
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value UInt64')
         SELECT number, number FROM numbers(10000000)
+        SETTINGS engine_file_truncate_on_insert = 1
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
         SELECT number, number, number, number, number, number FROM numbers(1000000)
+        SETTINGS engine_file_truncate_on_insert = 1
     </query>
 
     <!-- Disabled in 36538, broken now

--- a/tests/performance/file_table_function.xml
+++ b/tests/performance/file_table_function.xml
@@ -32,13 +32,11 @@
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value UInt64')
         SELECT number, number FROM numbers(10000000)
-        SETTINGS engine_file_truncate_on_insert = 1
     </query>
 
     <query>
         INSERT INTO FUNCTION file('test_file', '{format}', 'key UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
         SELECT number, number, number, number, number, number FROM numbers(1000000)
-        SETTINGS engine_file_truncate_on_insert = 1
     </query>
 
 </test>

--- a/tests/performance/file_table_function.xml
+++ b/tests/performance/file_table_function.xml
@@ -41,18 +41,4 @@
         SETTINGS engine_file_truncate_on_insert = 1
     </query>
 
-    <!-- Disabled in 36538, broken now
-    <query>
-        INSERT INTO FUNCTION file('test_file_{{_partition_id}}', '{format}', 'partition_id UInt64, value UInt64')
-        PARTITION BY partition_id
-        SELECT (number % {partitions_count}) as partition_id, number FROM numbers(50000)
-    </query>
-
-    <query>
-        INSERT INTO FUNCTION file('test_file_{{_partition_id}}', '{format}', 'partition_id UInt64, value1 UInt64, value2 UInt64, value3 UInt64, value4 UInt64, value5 UInt64')
-        PARTITION BY partition_id
-        SELECT (number % {partitions_count}) as partition_id, number, number, number, number, number FROM numbers(50000)
-    </query>
-    -->
-
 </test>

--- a/tests/performance/join_convert_to_fixed_hash_table.xml
+++ b/tests/performance/join_convert_to_fixed_hash_table.xml
@@ -12,7 +12,7 @@
     <fill_query>INSERT INTO build_5k SELECT number FROM numbers(5000) ORDER BY rand()</fill_query>
     <fill_query>INSERT INTO build_10k SELECT number FROM numbers(10000) ORDER BY rand()</fill_query>
     <fill_query>INSERT INTO build_50k SELECT number FROM numbers(50000) ORDER BY rand()</fill_query>
-    <fill_query>INSERT INTO probe SELECT randUniform(4500, 9500), randUniform(9000, 19000), randUniform(45000, 95000), randUniform(500, 5500), randUniform(1000, 11000), randUniform(5000, 55000) FROM numbers(200000000)</fill_query>
+    <fill_query>INSERT INTO probe SELECT randUniform(4500, 9500), randUniform(9000, 19000), randUniform(45000, 95000), randUniform(500, 5500), randUniform(1000, 11000), randUniform(5000, 55000) FROM numbers(50000000)</fill_query>
 
     <!-- LEFT JOIN with low selectivity -->
     <query>SELECT p.id0, b.id0 FROM probe p LEFT JOIN build_5k b ON p.id0 = b.id0 FORMAT Null SETTINGS join_algorithm = 'hash', enable_join_fixed_hash_table_conversion = 0</query>

--- a/tests/performance/min_max_index.xml
+++ b/tests/performance/min_max_index.xml
@@ -1,7 +1,7 @@
 <test>
     <create_query>CREATE TABLE index_test (z UInt32, INDEX i_x (mortonDecode(2, z).1) TYPE minmax, INDEX i_y (mortonDecode(2, z).2) TYPE minmax) ENGINE = MergeTree ORDER BY z</create_query>
 
-    <fill_query>INSERT INTO index_test SELECT number * 10 FROM numbers_mt(toUInt64(0x100000000 / 10)) SETTINGS max_insert_threads=8</fill_query>
+    <fill_query>INSERT INTO index_test SELECT number * 10 FROM numbers_mt(toUInt64(0x100000000 / 40)) SETTINGS max_insert_threads=8</fill_query>
     <fill_query>OPTIMIZE TABLE index_test FINAL</fill_query>
 
     <query><![CDATA[

--- a/tests/performance/number_formatting_formats.xml
+++ b/tests/performance/number_formatting_formats.xml
@@ -33,7 +33,7 @@
     <create_query>CREATE TABLE IF NOT EXISTS table_{format_fast} (x UInt64) ENGINE = File(`{format}`)</create_query>
 
     <query>INSERT INTO table_{format}      SELECT number FROM numbers(10000000) SETTINGS engine_file_truncate_on_insert = 1</query>
-    <query>INSERT INTO table_{format_fast} SELECT number FROM numbers(20000000)</query>
+    <query>INSERT INTO table_{format_fast} SELECT number FROM numbers(20000000) SETTINGS engine_file_truncate_on_insert = 1</query>
 
     <drop_query>DROP TABLE IF EXISTS table_{format}</drop_query>
     <drop_query>DROP TABLE IF EXISTS table_{format_fast}</drop_query>

--- a/tests/performance/number_formatting_formats.xml
+++ b/tests/performance/number_formatting_formats.xml
@@ -33,7 +33,7 @@
     <create_query>CREATE TABLE IF NOT EXISTS table_{format_fast} (x UInt64) ENGINE = File(`{format}`)</create_query>
 
     <query>INSERT INTO table_{format}      SELECT number FROM numbers(10000000) SETTINGS engine_file_truncate_on_insert = 1</query>
-    <query>INSERT INTO table_{format_fast} SELECT number FROM numbers(20000000) SETTINGS engine_file_truncate_on_insert = 1</query>
+    <query>INSERT INTO table_{format_fast} SELECT number FROM numbers(20000000)</query>
 
     <drop_query>DROP TABLE IF EXISTS table_{format}</drop_query>
     <drop_query>DROP TABLE IF EXISTS table_{format_fast}</drop_query>


### PR DESCRIPTION
Performance tests started failing with out-of-disk errors [[1](https://github.com/ClickHouse/ClickHouse/actions/runs/29763693443/job/88696781496), [2](https://github.com/ClickHouse/ClickHouse/actions/runs/29755086595/job/88576888577?pr=110844), [3](https://github.com/ClickHouse/ClickHouse/actions/runs/29838936576/job/88761171320)]. This PR adds a clean up of files created during performance tests by `INSERT INTO FUNCTION file(...)`. Previously, they used to accumulate until the end of the job. 

It also decreases table sizes of really heavy tests:

- `min_max_index`: 429M -> 107M rows, disk 15.2 GB -> 3.0 GB.
- `join_convert_to_fixed_hash_table`: 200M -> 50M rows, disk 27.4 GB -> 6.1 GB.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1337` (included in `26.7` and later)
<!-- ch-version-info:end -->