### PR TITLE
Fsync restored part files on RESTORE to survive power loss

### DIFF
--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -1048,14 +1048,19 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
     /// branch, which is already correct for every source (this backup, base backup, archive).
     if (!sync && info.size && !info.base_size && !use_archive)
     {
-        /// Data comes completely from this backup.
+        /// Data comes completely from this backup. The reader copies without exposing a write
+        /// buffer we could fsync, so this fast path is used only when `sync` isn't requested.
         reader->copyFileToDisk(info.data_file_name, info.size, info.encrypted_by_disk, destination_disk, destination_path, write_mode);
         file_copied = true;
     }
-    else if (!sync && info.size && (info.size == info.base_size))
+    else if (info.size && (info.size == info.base_size))
     {
-        /// Data comes completely from the base backup (nothing comes from this backup).
-        getBaseBackup()->copyFileToDisk(std::pair{info.base_size, info.base_checksum}, destination_disk, destination_path, write_mode, /* sync= */ false);
+        /// Data comes completely from the base backup (nothing comes from this backup). The base
+        /// backup is itself a BackupImpl that honours `sync` and can read its own encrypted-by-disk
+        /// entries, so forward the copy (and the `sync` request) there. Going through the generic
+        /// branch below instead would read the base via the public readFile(), which always requests
+        /// unencrypted data and would fail on an encrypted entry (CANNOT_RESTORE_TO_NONENCRYPTED_DISK).
+        getBaseBackup()->copyFileToDisk(std::pair{info.base_size, info.base_checksum}, destination_disk, destination_path, write_mode, sync);
         file_copied = true;
     }
 

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -988,18 +988,18 @@ String BackupImpl::getObjectKey(const String & file_name) const
 }
 
 size_t BackupImpl::copyFileToDisk(const String & file_name,
-                                  DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const
+                                  DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const
 {
 #if CLICKHOUSE_CLOUD
     String object_key = getObjectKey(file_name);
     if (!object_key.empty())
         return copyFileToDiskByObjectKey(object_key, destination_disk, destination_path, write_mode);
 #endif
-    return copyFileToDisk(getFileSizeAndChecksum(file_name), destination_disk, destination_path, write_mode);
+    return copyFileToDisk(getFileSizeAndChecksum(file_name), destination_disk, destination_path, write_mode, sync);
 }
 
 size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
-                                  DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const
+                                  DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const
 {
     if (open_mode == OpenMode::WRITE)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "The backup file should not be opened for writing. Something is wrong internally");
@@ -1042,13 +1042,17 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
 
     bool file_copied = false;
 
-    if (info.size && !info.base_size && !use_archive)
+    /// When `sync` is requested we must copy through a live destination buffer so we can fsync its
+    /// contents below. The optimized delegate paths (reader->copyFileToDisk / base backup) may use
+    /// fs::copy or an object-storage copy and expose no buffer, so skip them and take the buffered
+    /// branch, which is already correct for every source (this backup, base backup, archive).
+    if (!sync && info.size && !info.base_size && !use_archive)
     {
         /// Data comes completely from this backup.
         reader->copyFileToDisk(info.data_file_name, info.size, info.encrypted_by_disk, destination_disk, destination_path, write_mode);
         file_copied = true;
     }
-    else if (info.size && (info.size == info.base_size))
+    else if (!sync && info.size && (info.size == info.base_size))
     {
         /// Data comes completely from the base backup (nothing comes from this backup).
         getBaseBackup()->copyFileToDisk(std::pair{info.base_size, info.base_checksum}, destination_disk, destination_path, write_mode);
@@ -1066,7 +1070,7 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
     {
         /// Use the generic way to copy data. `readFile()` will update `num_read_files`.
         auto read_buffer = readFileImpl(info.file_name, size_and_checksum, /* read_encrypted= */ info.encrypted_by_disk);
-        std::unique_ptr<WriteBuffer> write_buffer;
+        std::unique_ptr<WriteBufferFromFileBase> write_buffer;
         size_t buf_size = std::min<size_t>(info.size, reader->getWriteBufferSize());
         if (info.encrypted_by_disk)
             write_buffer = destination_disk->writeEncryptedFile(destination_path, buf_size, write_mode, reader->getWriteSettings());
@@ -1074,6 +1078,10 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
             write_buffer = destination_disk->writeFile(destination_path, buf_size, write_mode, reader->getWriteSettings());
         copyData(*read_buffer, *write_buffer, info.size);
         write_buffer->finalize();
+        /// fdatasync the contents so a restored part survives power loss, matching the durability
+        /// an inserted part gets from fsync_after_insert (the caller passes `sync` accordingly).
+        if (sync)
+            write_buffer->sync();
     }
 
     return info.size;

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -1055,7 +1055,7 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
     else if (!sync && info.size && (info.size == info.base_size))
     {
         /// Data comes completely from the base backup (nothing comes from this backup).
-        getBaseBackup()->copyFileToDisk(std::pair{info.base_size, info.base_checksum}, destination_disk, destination_path, write_mode);
+        getBaseBackup()->copyFileToDisk(std::pair{info.base_size, info.base_checksum}, destination_disk, destination_path, write_mode, /* sync= */ false);
         file_copied = true;
     }
 

--- a/src/Backups/BackupImpl.cpp
+++ b/src/Backups/BackupImpl.cpp
@@ -990,12 +990,65 @@ String BackupImpl::getObjectKey(const String & file_name) const
 size_t BackupImpl::copyFileToDisk(const String & file_name,
                                   DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const
 {
-#if CLICKHOUSE_CLOUD
     String object_key = getObjectKey(file_name);
     if (!object_key.empty())
+    {
+        /// The optimized object-key copy exposes no buffer to fsync, so the sync case needs a buffered path.
+        if (sync)
+            return copyObjectKeyEntryToDiskSynced(object_key, destination_disk, destination_path, write_mode);
+#if CLICKHOUSE_CLOUD
         return copyFileToDiskByObjectKey(object_key, destination_disk, destination_path, write_mode);
 #endif
+    }
     return copyFileToDisk(getFileSizeAndChecksum(file_name), destination_disk, destination_path, write_mode, sync);
+}
+
+size_t BackupImpl::copyObjectKeyEntryToDiskSynced(
+    const String & object_key, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const
+{
+    if (open_mode == OpenMode::WRITE)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "The backup file should not be opened for writing. Something is wrong internally");
+
+    BackupFileInfo info;
+    {
+        std::lock_guard lock{mutex};
+        auto it = lightweight_snapshot_file_infos.find(object_key);
+        if (it == lightweight_snapshot_file_infos.end())
+            throw Exception(
+                ErrorCodes::BACKUP_ENTRY_NOT_FOUND,
+                "Backup {}: Entry with object key {} not found in the backup",
+                backup_name_for_logging, object_key);
+        info = it->second;
+    }
+
+    if (info.encrypted_by_disk && !destination_disk->getDataSourceDescription().is_encrypted)
+    {
+        throw Exception(
+            ErrorCodes::CANNOT_RESTORE_TO_NONENCRYPTED_DISK,
+            "File {} is encrypted in the backup, it can be restored only to an encrypted disk",
+            info.data_file_name);
+    }
+
+    auto read_buffer = readFileByObjectKey(info);
+    size_t buf_size = std::min<size_t>(info.size ? info.size : DBMS_DEFAULT_BUFFER_SIZE, reader->getWriteBufferSize());
+    std::unique_ptr<WriteBufferFromFileBase> write_buffer;
+    /// readFileByObjectKey returns the bytes as stored (still encrypted for encrypted-by-disk entries),
+    /// so write them through writeEncryptedFile to avoid re-encrypting, mirroring the generic copy path.
+    if (info.encrypted_by_disk)
+        write_buffer = destination_disk->writeEncryptedFile(destination_path, buf_size, write_mode, reader->getWriteSettings());
+    else
+        write_buffer = destination_disk->writeFile(destination_path, buf_size, write_mode, reader->getWriteSettings());
+    copyData(*read_buffer, *write_buffer, info.size);
+    write_buffer->finalize();
+    /// fdatasync the contents so a restored part survives power loss (see copyFileToDisk above).
+    write_buffer->sync();
+
+    {
+        std::lock_guard lock{mutex};
+        ++num_read_files;
+        num_read_bytes += info.size;
+    }
+    return info.size;
 }
 
 size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
@@ -1009,8 +1062,18 @@ size_t BackupImpl::copyFileToDisk(const SizeAndChecksum & size_and_checksum,
         /// Entry's data is empty.
         if (write_mode == WriteMode::Rewrite)
         {
-            /// Just create an empty file.
-            destination_disk->createFile(destination_path);
+            if (sync)
+            {
+                /// createFile() leaves the empty contents unsynced; a live buffer lets us fsync it.
+                auto write_buffer = destination_disk->writeFile(destination_path, DBMS_DEFAULT_BUFFER_SIZE, write_mode, reader->getWriteSettings());
+                write_buffer->finalize();
+                write_buffer->sync();
+            }
+            else
+            {
+                /// Just create an empty file.
+                destination_disk->createFile(destination_path);
+            }
         }
         std::lock_guard lock{mutex};
         ++num_read_files;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -84,8 +84,8 @@ public:
     SizeAndChecksum getFileSizeAndChecksum(const String & file_name) const override;
     std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name) const override;
     std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name, const SizeAndChecksum & size_and_checksum) const override;
-    size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const override;
-    size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const override;
+    size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
+    size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const override;
     void writeFile(const BackupFileInfo & info, BackupEntryPtr entry) override;
     bool supportsWritingInMultipleThreads() const override { return !use_archive; }
     void finalizeWriting() override;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -84,8 +84,8 @@ public:
     SizeAndChecksum getFileSizeAndChecksum(const String & file_name) const override;
     std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name) const override;
     std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name, const SizeAndChecksum & size_and_checksum) const override;
-    size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const override;
-    size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const override;
+    size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const override;
+    size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const override;
     void writeFile(const BackupFileInfo & info, BackupEntryPtr entry) override;
     bool supportsWritingInMultipleThreads() const override { return !use_archive; }
     void finalizeWriting() override;

--- a/src/Backups/BackupImpl.h
+++ b/src/Backups/BackupImpl.h
@@ -110,6 +110,11 @@ private:
     String getObjectKey(const String & file_name) const;
     std::unique_ptr<ReadBufferFromFileBase> readFileByObjectKey(const BackupFileInfo & info) const;
 
+    /// Copies a lightweight-snapshot (object-key) entry to the destination through a live write buffer
+    /// and fsyncs it (the optimized object-key copy exposes no buffer to fsync). Reached only in the
+    /// cloud build, where object keys are present; defined unconditionally so it is type-checked everywhere.
+    size_t copyObjectKeyEntryToDiskSynced(const String & object_key, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const;
+
     /// Returns the base backup or null if there is no base backup.
     std::shared_ptr<const IBackup> getBaseBackupUnlocked() const TSA_REQUIRES(mutex);
 

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -119,9 +119,11 @@ public:
     virtual std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name, const SizeAndChecksum & size_and_checksum) const = 0;
 
     /// Copies a file from the backup to a specified destination disk. Returns the number of bytes written.
-    virtual size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const = 0;
+    /// When `sync` is true the destination file's contents are fsynced before this call returns, so a
+    /// restored part can be made as durable as an inserted one (see MergeTreeData::restorePartFromBackup).
+    virtual size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const = 0;
 
-    virtual size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode) const = 0;
+    virtual size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const = 0;
 
     /// Puts a new entry to the backup.
     virtual void writeFile(const BackupFileInfo & file_info, BackupEntryPtr entry) = 0;

--- a/src/Backups/IBackup.h
+++ b/src/Backups/IBackup.h
@@ -121,9 +121,9 @@ public:
     /// Copies a file from the backup to a specified destination disk. Returns the number of bytes written.
     /// When `sync` is true the destination file's contents are fsynced before this call returns, so a
     /// restored part can be made as durable as an inserted one (see MergeTreeData::restorePartFromBackup).
-    virtual size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const = 0;
+    virtual size_t copyFileToDisk(const String & file_name, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const = 0;
 
-    virtual size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync = false) const = 0;
+    virtual size_t copyFileToDisk(const SizeAndChecksum & size_and_checksum, DiskPtr destination_disk, const String & destination_path, WriteMode write_mode, bool sync) const = 0;
 
     /// Puts a new entry to the backup.
     virtual void writeFile(const BackupFileInfo & file_info, BackupEntryPtr entry) = 0;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -7803,6 +7803,12 @@ void MergeTreeData::restorePartFromBackup(std::shared_ptr<RestoredPartsHolder> r
     /// Subdirectories in the part's directory. It's used to restore projections.
     std::unordered_set<String> subdirs;
 
+    /// A restored part is committed data the moment RESTORE is acknowledged, so it must get the same
+    /// durability an inserted part gets: fsync the file contents when the table enables fsync_after_insert.
+    /// Only meaningful on a local disk - on object storage the object is durable once finalized. The part
+    /// directory itself is fsynced later by IMergeTreeDataPart::renameTo (gated on fsync_part_directory).
+    const bool fsync_files = (*getSettings())[MergeTreeSetting::fsync_after_insert] && !disk->isRemote();
+
     /// Copy files from the backup to the directory `tmp_part_dir`.
     disk->createDirectories(temp_part_dir);
 
@@ -7829,7 +7835,7 @@ void MergeTreeData::restorePartFromBackup(std::shared_ptr<RestoredPartsHolder> r
             continue;
         }
 
-        size_t file_size = backup->copyFileToDisk(part_path_in_backup_fs / filename, disk, temp_part_dir / filename, WriteMode::Rewrite);
+        size_t file_size = backup->copyFileToDisk(part_path_in_backup_fs / filename, disk, temp_part_dir / filename, WriteMode::Rewrite, fsync_files);
         reservation->update(reservation->getSize() - file_size);
     }
 

--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -1271,7 +1271,7 @@ void StorageLog::restoreDataImpl(const BackupPtr & backup, const String & data_p
             if (!backup->fileExists(file_path_in_backup))
                 throw Exception(ErrorCodes::CANNOT_RESTORE_TABLE, "File {} in backup is required to restore table", file_path_in_backup);
 
-            backup->copyFileToDisk(file_path_in_backup, disk, data_file.path, WriteMode::Append);
+            backup->copyFileToDisk(file_path_in_backup, disk, data_file.path, WriteMode::Append, /* sync= */ false);
         }
 
         if (use_marks_file)

--- a/src/Storages/StorageStripeLog.cpp
+++ b/src/Storages/StorageStripeLog.cpp
@@ -698,7 +698,7 @@ void StorageStripeLog::restoreDataImpl(const BackupPtr & backup, const String & 
             if (!backup->fileExists(file_path_in_backup))
                 throw Exception(ErrorCodes::CANNOT_RESTORE_TABLE, "File {} in backup is required to restore table", file_path_in_backup);
 
-            backup->copyFileToDisk(file_path_in_backup, disk, data_file_path, WriteMode::Append);
+            backup->copyFileToDisk(file_path_in_backup, disk, data_file_path, WriteMode::Append, /* sync= */ false);
         }
 
         /// Append the index.

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
@@ -1,0 +1,4 @@
+count on:  1000
+count off: 1000
+restore with fsync_after_insert=1, all part files fsynced: 	1
+restore with fsync_after_insert=0, all part files fsynced: 	0

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
@@ -2,3 +2,5 @@ count on:  1000
 count off: 1000
 restore with fsync_after_insert=1, all part files fsynced: 	1
 restore with fsync_after_insert=0, all part files fsynced: 	0
+encrypted incremental count: 1000
+encrypted incremental restore with fsync_after_insert=1, all part files fsynced: 	1

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.reference
@@ -1,6 +1,6 @@
+has zero-byte part file: 1
 count on:  1000
 count off: 1000
-restore with fsync_after_insert=1, all part files fsynced: 	1
-restore with fsync_after_insert=0, all part files fsynced: 	0
+restore fsync delta covers all part files: 	1
 encrypted incremental count: 1000
 encrypted incremental restore with fsync_after_insert=1, all part files fsynced: 	1

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-object-storage, no-random-merge-tree-settings
+# Tags: no-object-storage, no-random-merge-tree-settings, no-replicated-database, no-shared-merge-tree
 # no-object-storage: object storage does not fsync file contents (the fix is gated on !isRemote()).
 # no-random-merge-tree-settings: the test asserts on FileSync counts, which depend on the part layout.
+# no-replicated-database, no-shared-merge-tree: the encrypted case below pins a custom local disk.
 
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/111321
 # RESTORE must fsync the restored part file contents when the table enables fsync_after_insert,
@@ -65,3 +66,36 @@ $CLICKHOUSE_CLIENT --param_query_id "$qid_off" --param_files "$files_in_part" -q
     ORDER BY event_time_microseconds DESC LIMIT 1"
 
 $CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_restore_fsync_off SYNC;"
+
+# Encrypted incremental restore: files that come entirely from the base backup are copied via
+# getBaseBackup()->copyFileToDisk(..., sync). That branch must forward the encrypted read (else the
+# restore fails with CANNOT_RESTORE_TO_NONENCRYPTED_DISK) and still fsync the files when requested.
+enc_disk="disk(type = encrypted, disk = disk(type = local, path = '${CLICKHOUSE_DISKS_FILES}/${CLICKHOUSE_TEST_UNIQUE_NAME}_enc/'), key = '1234567812345678')"
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS t_restore_fsync_enc;
+    CREATE TABLE t_restore_fsync_enc (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    SETTINGS fsync_after_insert = 1, fsync_part_directory = 1, min_bytes_for_wide_part = 0, disk = $enc_disk;
+    INSERT INTO t_restore_fsync_enc SELECT number, toString(number) FROM numbers(1000);
+"
+enc_files=$($CLICKHOUSE_CLIENT -q "SELECT files FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_enc' AND active")
+
+# Full backup, then an unchanged incremental backup so every file is served by the base backup.
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_enc TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_base')" > /dev/null
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_enc TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_incr') SETTINGS base_backup = Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_base')" > /dev/null
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_restore_fsync_enc SYNC"
+
+qid_enc="restore-enc-$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT --query_id "$qid_enc" -q "RESTORE TABLE t_restore_fsync_enc FROM Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_incr') SETTINGS base_backup = Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_enc_base')" > /dev/null
+
+# Before the fix the restore threw and the table stayed empty; now it restores every row.
+echo "encrypted incremental count: $($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_restore_fsync_enc")"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+$CLICKHOUSE_CLIENT --param_query_id "$qid_enc" --param_files "$enc_files" -q "
+    SELECT 'encrypted incremental restore with fsync_after_insert=1, all part files fsynced: ',
+           ProfileEvents['FileSync'] >= {files:UInt64}
+    FROM system.query_log
+    WHERE query_id = {query_id:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
+    ORDER BY event_time_microseconds DESC LIMIT 1"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_restore_fsync_enc SYNC"

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Tags: no-object-storage, no-random-merge-tree-settings
+# no-object-storage: object storage does not fsync file contents (the fix is gated on !isRemote()).
+# no-random-merge-tree-settings: the test asserts on FileSync counts, which depend on the part layout.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/111321
+# RESTORE must fsync the restored part file contents when the table enables fsync_after_insert,
+# otherwise a power loss right after RESTORE returns leaves the parts torn and the table empty.
+# We assert the per-query FileSync ProfileEvent on the RESTORE query row (parallel-safe: filtered
+# by query_id + current_database). RESTORE performs a couple of fsyncs on backup-side metadata
+# regardless, so the discriminating signal is "were all of the part's data files fsynced", i.e.
+# FileSync >= number of files in the restored part.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -m -q "
+    DROP TABLE IF EXISTS t_restore_fsync_on;
+    DROP TABLE IF EXISTS t_restore_fsync_off;
+
+    CREATE TABLE t_restore_fsync_on (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    SETTINGS fsync_after_insert = 1, fsync_part_directory = 1, min_bytes_for_wide_part = 0;
+    INSERT INTO t_restore_fsync_on SELECT number, toString(number) FROM numbers(1000);
+
+    CREATE TABLE t_restore_fsync_off (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    SETTINGS fsync_after_insert = 0, fsync_part_directory = 0, min_bytes_for_wide_part = 0;
+    INSERT INTO t_restore_fsync_off SELECT number, toString(number) FROM numbers(1000);
+"
+
+# Number of files in the (single) part - the restored part has the same file set.
+files_in_part=$($CLICKHOUSE_CLIENT -q "SELECT files FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_on' AND active")
+
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_on TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_on')" > /dev/null
+$CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_off TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_off')" > /dev/null
+$CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_restore_fsync_off SYNC;"
+
+qid_on="restore-on-$CLICKHOUSE_DATABASE"
+qid_off="restore-off-$CLICKHOUSE_DATABASE"
+$CLICKHOUSE_CLIENT --query_id "$qid_on" -q "RESTORE TABLE t_restore_fsync_on FROM Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_on')" > /dev/null
+$CLICKHOUSE_CLIENT --query_id "$qid_off" -q "RESTORE TABLE t_restore_fsync_off FROM Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_off')" > /dev/null
+
+# Data must be intact after restore.
+echo "count on:  $($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_restore_fsync_on")"
+echo "count off: $($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_restore_fsync_off")"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
+
+# With fsync_after_insert=1 every file in the restored part must be fdatasynced, so the RESTORE row
+# reports FileSync >= number of files in the part. Before the fix no part file was synced (FileSync
+# only reflected a couple of backup-side metadata syncs, far below the file count).
+$CLICKHOUSE_CLIENT --param_query_id "$qid_on" --param_files "$files_in_part" -q "
+    SELECT 'restore with fsync_after_insert=1, all part files fsynced: ',
+           ProfileEvents['FileSync'] >= {files:UInt64}
+    FROM system.query_log
+    WHERE query_id = {query_id:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
+    ORDER BY event_time_microseconds DESC LIMIT 1"
+
+# With fsync_after_insert=0 the part files must NOT be fsynced, so FileSync stays below the file count.
+$CLICKHOUSE_CLIENT --param_query_id "$qid_off" --param_files "$files_in_part" -q "
+    SELECT 'restore with fsync_after_insert=0, all part files fsynced: ',
+           ProfileEvents['FileSync'] >= {files:UInt64}
+    FROM system.query_log
+    WHERE query_id = {query_id:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
+    ORDER BY event_time_microseconds DESC LIMIT 1"
+
+$CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_restore_fsync_off SYNC;"

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-object-storage, no-random-merge-tree-settings, no-replicated-database, no-shared-merge-tree
+# Tags: no-fasttest, no-object-storage, no-random-merge-tree-settings, no-replicated-database, no-shared-merge-tree
+# no-fasttest: the encrypted case below needs the encrypted disk type, which is built only with SSL.
 # no-object-storage: object storage does not fsync file contents (the fix is gated on !isRemote()).
 # no-random-merge-tree-settings: the test asserts on FileSync counts, which depend on the part layout.
 # no-replicated-database, no-shared-merge-tree: the encrypted case below pins a custom local disk.

--- a/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
+++ b/tests/queries/0_stateless/04550_restore_fsync_after_insert.sh
@@ -8,30 +8,42 @@
 # Regression test for https://github.com/ClickHouse/ClickHouse/issues/111321
 # RESTORE must fsync the restored part file contents when the table enables fsync_after_insert,
 # otherwise a power loss right after RESTORE returns leaves the parts torn and the table empty.
-# We assert the per-query FileSync ProfileEvent on the RESTORE query row (parallel-safe: filtered
-# by query_id + current_database). RESTORE performs a couple of fsyncs on backup-side metadata
-# regardless, so the discriminating signal is "were all of the part's data files fsynced", i.e.
-# FileSync >= number of files in the restored part.
+# We assert on the RESTORE query's FileSync ProfileEvent (parallel-safe: filtered by query_id +
+# current_database). RESTORE also performs a few backup-side FileSync events unrelated to the part
+# files, so the discriminating signal is the on-vs-off FileSync DELTA: that constant backup-side
+# noise cancels out, and the remaining delta must cover every physical file of the restored part
+# (an empty Array column contributes a zero-byte .bin, which INSERT fsyncs too).
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+# `arr` is Array(UInt32) left empty for every row, so its `.bin` is a required zero-byte part file -
+# INSERT fsyncs it, so RESTORE must too. Two tables with identical data, differing only in fsync_after_insert.
 $CLICKHOUSE_CLIENT -m -q "
     DROP TABLE IF EXISTS t_restore_fsync_on;
     DROP TABLE IF EXISTS t_restore_fsync_off;
 
-    CREATE TABLE t_restore_fsync_on (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    CREATE TABLE t_restore_fsync_on (id UInt64, s String, arr Array(UInt32)) ENGINE = MergeTree ORDER BY id
     SETTINGS fsync_after_insert = 1, fsync_part_directory = 1, min_bytes_for_wide_part = 0;
-    INSERT INTO t_restore_fsync_on SELECT number, toString(number) FROM numbers(1000);
+    INSERT INTO t_restore_fsync_on SELECT number, toString(number), [] FROM numbers(1000);
 
-    CREATE TABLE t_restore_fsync_off (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    CREATE TABLE t_restore_fsync_off (id UInt64, s String, arr Array(UInt32)) ENGINE = MergeTree ORDER BY id
     SETTINGS fsync_after_insert = 0, fsync_part_directory = 0, min_bytes_for_wide_part = 0;
-    INSERT INTO t_restore_fsync_off SELECT number, toString(number) FROM numbers(1000);
+    INSERT INTO t_restore_fsync_off SELECT number, toString(number), [] FROM numbers(1000);
 "
 
-# Number of files in the (single) part - the restored part has the same file set.
-files_in_part=$($CLICKHOUSE_CLIENT -q "SELECT files FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_on' AND active")
+# Count the physical files RESTORE actually copies (and therefore must fsync). This is the real target,
+# larger than system.parts.files (= checksums entries) - it includes checksums.txt, columns.txt and the
+# zero-byte arr.bin - but excludes the version-metadata files RESTORE deliberately skips (see
+# restorePartFromBackup: txn_version.txt[.tmp] and metadata_version.txt are not copied). The restored
+# part has the same on-disk file set.
+part_path=$($CLICKHOUSE_CLIENT -q "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_on' AND active")
+copied_files=$(find "$part_path" -type f \
+    ! -name 'txn_version.txt' ! -name 'txn_version.txt.tmp' ! -name 'metadata_version.txt' | wc -l)
+# Sanity: there is a required zero-byte file in the part (the empty Array's .bin), which INSERT fsyncs too.
+zero_byte_files=$(find "$part_path" -type f -size 0 | wc -l)
+echo "has zero-byte part file: $([ "$zero_byte_files" -ge 1 ] && echo 1 || echo 0)"
 
 $CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_on TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_on')" > /dev/null
 $CLICKHOUSE_CLIENT -q "BACKUP TABLE t_restore_fsync_off TO Disk('backups', '${CLICKHOUSE_TEST_UNIQUE_NAME}_off')" > /dev/null
@@ -48,23 +60,19 @@ echo "count off: $($CLICKHOUSE_CLIENT -q "SELECT count() FROM t_restore_fsync_of
 
 $CLICKHOUSE_CLIENT -q "SYSTEM FLUSH LOGS query_log"
 
-# With fsync_after_insert=1 every file in the restored part must be fdatasynced, so the RESTORE row
-# reports FileSync >= number of files in the part. Before the fix no part file was synced (FileSync
-# only reflected a couple of backup-side metadata syncs, far below the file count).
-$CLICKHOUSE_CLIENT --param_query_id "$qid_on" --param_files "$files_in_part" -q "
-    SELECT 'restore with fsync_after_insert=1, all part files fsynced: ',
-           ProfileEvents['FileSync'] >= {files:UInt64}
-    FROM system.query_log
-    WHERE query_id = {query_id:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
-    ORDER BY event_time_microseconds DESC LIMIT 1"
-
-# With fsync_after_insert=0 the part files must NOT be fsynced, so FileSync stays below the file count.
-$CLICKHOUSE_CLIENT --param_query_id "$qid_off" --param_files "$files_in_part" -q "
-    SELECT 'restore with fsync_after_insert=0, all part files fsynced: ',
-           ProfileEvents['FileSync'] >= {files:UInt64}
-    FROM system.query_log
-    WHERE query_id = {query_id:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
-    ORDER BY event_time_microseconds DESC LIMIT 1"
+# The on/off FileSync delta cancels the constant backup-side syncs that both restores perform and
+# isolates the restored part-file syncs. With fsync_after_insert=1 every restore-copied file (incl. the
+# zero-byte arr.bin) is fsynced, so the delta must be >= the number of files restore copied. Before the
+# fix no part file was synced and the delta was ~0.
+$CLICKHOUSE_CLIENT --param_qid_on "$qid_on" --param_qid_off "$qid_off" --param_copied "$copied_files" -q "
+    WITH
+        (SELECT ProfileEvents['FileSync'] FROM system.query_log
+         WHERE query_id = {qid_on:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
+         ORDER BY event_time_microseconds DESC LIMIT 1) AS sync_on,
+        (SELECT ProfileEvents['FileSync'] FROM system.query_log
+         WHERE query_id = {qid_off:String} AND type = 'QueryFinish' AND current_database = currentDatabase()
+         ORDER BY event_time_microseconds DESC LIMIT 1) AS sync_off
+    SELECT 'restore fsync delta covers all part files: ', (toInt64(sync_on) - toInt64(sync_off)) >= {copied:UInt64}"
 
 $CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_restore_fsync_off SYNC;"
 
@@ -74,9 +82,9 @@ $CLICKHOUSE_CLIENT -m -q "DROP TABLE t_restore_fsync_on SYNC; DROP TABLE t_resto
 enc_disk="disk(type = encrypted, disk = disk(type = local, path = '${CLICKHOUSE_DISKS_FILES}/${CLICKHOUSE_TEST_UNIQUE_NAME}_enc/'), key = '1234567812345678')"
 $CLICKHOUSE_CLIENT -q "
     DROP TABLE IF EXISTS t_restore_fsync_enc;
-    CREATE TABLE t_restore_fsync_enc (id UInt64, s String) ENGINE = MergeTree ORDER BY id
+    CREATE TABLE t_restore_fsync_enc (id UInt64, s String, arr Array(UInt32)) ENGINE = MergeTree ORDER BY id
     SETTINGS fsync_after_insert = 1, fsync_part_directory = 1, min_bytes_for_wide_part = 0, disk = $enc_disk;
-    INSERT INTO t_restore_fsync_enc SELECT number, toString(number) FROM numbers(1000);
+    INSERT INTO t_restore_fsync_enc SELECT number, toString(number), [] FROM numbers(1000);
 "
 enc_files=$($CLICKHOUSE_CLIENT -q "SELECT files FROM system.parts WHERE database = currentDatabase() AND table = 't_restore_fsync_enc' AND active")
 


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111321
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`RESTORE` now fsyncs the restored part files when the destination table has `fsync_after_insert` enabled, so a restored part is as durable against power loss as an inserted one. Previously restored files were only written and closed (never fsynced), so a power loss right after `RESTORE` returned `RESTORED` could leave the parts torn and the table empty.


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/111321

`RESTORE` materializes a MergeTree part outside the `INSERT` write path: `MergeTreeData::restorePartFromBackup` copies each part file via `IBackup::copyFileToDisk`, which only does `copyData` + `finalize()` (no `fdatasync`). The part is then attached through the rename machinery, so the part directory is fsynced when `fsync_part_directory` is set, but the file contents are never fsynced, even when the table sets `fsync_after_insert`. On a filesystem with delayed allocation the file data blocks are therefore not durable when `RESTORED` is returned; a power loss shortly after can leave every restored file at 0 bytes and the part is dropped as broken on the next start.

The two other part-materialization paths already fsync file contents: `INSERT` (via `fsync_after_insert` -> `MergedBlockOutputStream`) and the replicated fetch path (`DataPartsExchange`, `if (sync) file->sync()`). This makes `RESTORE` consistent with them.

Change: `IBackup::copyFileToDisk` takes a `bool sync`. When set, `BackupImpl` copies through a live destination buffer and `fdatasync`s its contents before returning. `MergeTreeData::restorePartFromBackup` passes `sync = fsync_after_insert && !disk->isRemote()`, so a restored part on a local disk gets exactly the durability the table's fsync settings already promise an inserted part. On object storage the object is durable once finalized, so the flag is a no-op there.

Three restore copy paths carry `sync`:
- the generic buffered path (this backup / concat / archive), and encrypted incremental restore where a full-base entry is delegated to the base backup;
- object-key (lightweight snapshot) entries, which the object-key copy could not fsync, now go through a live buffer + `finalize` + `sync` when `sync` is requested, mirroring the generic path's encryption handling (reject encrypted -> non-encrypted disk, `writeEncryptedFile` for encrypted-by-disk entries);
- required zero-byte entries (e.g. the `.bin` of an all-empty `Array` column), which `INSERT` also fsyncs, are created through a live buffer + `finalize` + `sync` instead of `createFile`.

Regression test `04550_restore_fsync_after_insert` asserts, via the per-query `FileSync` `ProfileEvents`, that the on/off `FileSync` delta covers the number of files `RESTORE` actually copies (including a zero-byte file) with `fsync_after_insert = 1`, and stays below it with `= 0`. It also covers encrypted incremental restore.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.1548` (included in `26.8` and later)
- Backported to: `26.7.4.49`, `26.6.3.48`, `26.5.7.59`, `26.3.19.3`, `25.8.31.7`
<!-- ch-version-info:end -->