### PR TITLE
Ignore false results from the github search

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -83,9 +83,7 @@ def recover_git_state() -> None:
         return
     lock = Path(git_dir) / "index.lock"
     if lock.exists():
-        logging.warning(
-            "Removing stale %s left by a crashed git process", lock
-        )
+        logging.warning("Removing stale %s left by a crashed git process", lock)
         try:
             lock.unlink()
         except OSError as e:
@@ -205,12 +203,28 @@ close it.
                 # this pr is not for the current branch
                 continue
             if pr.head.ref.startswith(f"cherrypick/{self.name}"):
-                self.cherrypick_pr = pr
                 to_pop.append(i)
+                if not any(label.name == Labels.PR_CHERRYPICK for label in pr.labels):
+                    logging.warning(
+                        "The cherry-pick PR #%s is found but doesn't have %s label. The "
+                        "GitHub search index is stuck",
+                        pr.number,
+                        Labels.PR_CHERRYPICK,
+                    )
+                    continue
+                self.cherrypick_pr = pr
             elif pr.head.ref.startswith(f"backport/{self.name}"):
+                to_pop.append(i)
+                if not any(label.name == Labels.PR_BACKPORT for label in pr.labels):
+                    logging.warning(
+                        "The backport PR #%s is found but doesn't have %s label. The "
+                        "GitHub search index is stuck",
+                        pr.number,
+                        Labels.PR_BACKPORT,
+                    )
+                    continue
                 self.backport_pr = pr
                 self._backported = True
-                to_pop.append(i)
             else:
                 assert False, f"BUG! Invalid PR's branch [{pr.head.ref}]"
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A stale GitHub search index can respond with stale cherry-pick or backport PRs while the labels there were actually removed. Filter out such PRs from the process.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1372` (included in `26.7` and later)
<!-- ch-version-info:end -->