### PR TITLE
Publish clickhouse-examples from ARM release builds

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -497,6 +497,7 @@ class ArtifactNames:
 
     ARM_FUZZERS = "ARM_FUZZERS"
     FUZZERS_CORPUS = "FUZZERS_CORPUS"
+    CLICKHOUSE_EXAMPLES = "CLICKHOUSE_EXAMPLES"
 
     TOOLCHAIN_PGO_BOLT_AMD = "TOOLCHAIN_PGO_BOLT_AMD"
     TOOLCHAIN_PGO_BOLT_ARM = "TOOLCHAIN_PGO_BOLT_ARM"
@@ -695,6 +696,11 @@ class ArtifactConfigs:
         name=ArtifactNames.FUZZERS_CORPUS,
         type=Artifact.Type.S3,
         path=f"{TEMP_DIR}/build/programs/*_seed_corpus.zip",
+    )
+    clickhouse_examples = Artifact.Config(
+        name=ArtifactNames.CLICKHOUSE_EXAMPLES,
+        type=Artifact.Type.S3,
+        path=f"{TEMP_DIR}/build/src/Examples/clickhouse-examples",
     )
     toolchain_pgo_bolt_amd = Artifact.Config(
         name=ArtifactNames.TOOLCHAIN_PGO_BOLT_AMD,

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -378,6 +378,14 @@ class JobConfigs:
             runs_on=RunnerLabels.ARM_LARGE,
         ),
     )
+    release_build_jobs_with_examples = [
+        job.set_command(f"{job.command} --build-examples").set_provides(
+            ArtifactNames.CLICKHOUSE_EXAMPLES
+        )
+        if f"({BuildTypes.ARM_RELEASE})" in job.name
+        else job
+        for job in release_build_jobs
+    ]
     cfi_build_job = common_build_job_config.parametrize(
         Job.ParamSet(
             parameter=BuildTypes.AMD_CFI,

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -418,17 +418,22 @@ class JobConfigs:
     # populates the cache so that read-only PR release builds get cache hits.
     # They provide no artifacts and run no profile/master-head post hooks - the
     # only purpose is to warm sccache.
-    sccache_warmup_build_jobs = common_build_job_config.parametrize(
-        Job.ParamSet(
-            parameter=BuildTypes.AMD_RELEASE_PR_CACHE_WARMUP,
-            runs_on=RunnerLabels.ARM_LARGE,
-            timeout=3 * 3600,
-        ),
-        Job.ParamSet(
-            parameter=BuildTypes.ARM_RELEASE_PR_CACHE_WARMUP,
-            runs_on=RunnerLabels.ARM_LARGE,
-        ),
-    )
+    sccache_warmup_build_jobs = [
+        job.set_command(f"{job.command} --build-examples")
+        if f"({BuildTypes.ARM_RELEASE_PR_CACHE_WARMUP})" in job.name
+        else job
+        for job in common_build_job_config.parametrize(
+            Job.ParamSet(
+                parameter=BuildTypes.AMD_RELEASE_PR_CACHE_WARMUP,
+                runs_on=RunnerLabels.ARM_LARGE,
+                timeout=3 * 3600,
+            ),
+            Job.ParamSet(
+                parameter=BuildTypes.ARM_RELEASE_PR_CACHE_WARMUP,
+                runs_on=RunnerLabels.ARM_LARGE,
+            ),
+        )
+    ]
     extra_validation_build_jobs = common_build_job_config.set_post_hooks(
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/build_master_head_hook.py",

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -177,9 +177,10 @@ def main():
     assert (
         build_type in BUILD_TYPE_TO_CMAKE
     ), f"--build_type option is invalid [{build_type}]"
-    assert not args.build_examples or build_type == BuildTypes.ARM_RELEASE, (
-        "--build-examples is only supported for the ARM release build"
-    )
+    assert not args.build_examples or build_type in (
+        BuildTypes.ARM_RELEASE,
+        BuildTypes.ARM_RELEASE_PR_CACHE_WARMUP,
+    ), "--build-examples is only supported for ARM release builds"
 
     cmake_cmd = BUILD_TYPE_TO_CMAKE[build_type]
     if args.build_examples:

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -96,6 +96,11 @@ def parse_args():
         help="Optional user-defined job start stage (for local run)",
         default=None,
     )
+    parser.add_argument(
+        "--build-examples",
+        help="Build `clickhouse-examples` in addition to the regular targets",
+        action="store_true",
+    )
     return parser.parse_args()
 
 
@@ -172,8 +177,13 @@ def main():
     assert (
         build_type in BUILD_TYPE_TO_CMAKE
     ), f"--build_type option is invalid [{build_type}]"
+    assert not args.build_examples or build_type == BuildTypes.ARM_RELEASE, (
+        "--build-examples is only supported for the ARM release build"
+    )
 
     cmake_cmd = BUILD_TYPE_TO_CMAKE[build_type]
+    if args.build_examples:
+        cmake_cmd += " -DENABLE_EXAMPLES=1"
     info = Info()
 
     # Cache-warmup build (MasterCI): compile with the PR release build's cmake
@@ -370,6 +380,8 @@ def main():
     if res and JobStages.BUILD in stages:
         if build_type == BuildTypes.ARM_FUZZERS:
             targets = "fuzzers"
+        elif args.build_examples:
+            targets = "clickhouse-bundle clickhouse-examples"
         elif build_type == BuildTypes.ARM_BINARY:
             targets = "clickhouse-bundle"
         elif build_type in (

--- a/ci/workflows/master.py
+++ b/ci/workflows/master.py
@@ -27,7 +27,7 @@ workflow = Workflow.Config(
         *JobConfigs.tidy_build_arm_jobs,
         *JobConfigs.build_jobs,
         *JobConfigs.build_llvm_coverage_job,
-        *JobConfigs.release_build_jobs,
+        *JobConfigs.release_build_jobs_with_examples,
         *JobConfigs.sccache_warmup_build_jobs,
         *[
             job.set_run_after(
@@ -69,6 +69,7 @@ workflow = Workflow.Config(
         *ArtifactConfigs.clickhouse_tgzs,
         ArtifactConfigs.fuzzers,
         ArtifactConfigs.fuzzers_corpus,
+        ArtifactConfigs.clickhouse_examples,
         *ArtifactConfigs.llvm_profdata_file,
         ArtifactConfigs.llvm_coverage_info_file,
     ],

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -73,7 +73,7 @@ workflow = Workflow.Config(
         ],
         *[
             job.set_run_after(REGULAR_BUILD_NAMES)
-            for job in JobConfigs.release_build_jobs
+            for job in JobConfigs.release_build_jobs_with_examples
         ],
         *[
             job.set_run_after(CORE_BLOCKING_JOB_NAMES)
@@ -213,6 +213,7 @@ workflow = Workflow.Config(
         *ArtifactConfigs.clickhouse_tgzs,
         ArtifactConfigs.fuzzers,
         ArtifactConfigs.fuzzers_corpus,
+        ArtifactConfigs.clickhouse_examples,
         *ArtifactConfigs.llvm_profdata_file,
         ArtifactConfigs.llvm_coverage_info_file,
         ArtifactConfigs.toolchain_pgo_bolt_amd,


### PR DESCRIPTION
Publish `clickhouse-examples` as a regular Praktika artifact from the ARM release build. The standalone `parser_memory_profiler` artifact stopped being published when the examples were consolidated into the `clickhouse-examples` multicall binary, leaving the parser-memory CI check without a master binary to compare against.

Only PR and master workflows enable and publish the additional binary. Backport and release-branch ARM release builds remain unchanged, avoiding unnecessary uploads of the large artifact. After this change reaches master, the artifact will be available under `REFs/master/<sha>/build_arm_release/clickhouse-examples`.

Related: https://github.com/ClickHouse/ClickHouse/pull/96199

Failing CI log: https://s3.amazonaws.com/clickhouse-test-reports/PRs/96199/ebbae7f1776ece4e50c423e2f03ab7d210b819d6/parser_memory_check/job.log


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.260` (included in `26.8` and later)
<!-- ch-version-info:end -->