### PR TITLE
Merge all Sync PRs for a merge-queue batch, not just the latest

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -1,49 +1,75 @@
+import re
 import traceback
 
-from praktika.info import Info
 from praktika.utils import Shell
 
 SYNC_REPO = "ClickHouse/clickhouse-private"
 
+# The merge queue can merge several PRs in a single batch, so a single push to
+# master may contain multiple merge commits, each corresponding to a different
+# upstream PR (and therefore a different Sync PR). Look back this many commits on
+# master to make sure all of them get their Sync PRs merged, not just the PR for
+# the latest commit.
+NUM_COMMITS = 5
 
-def check():
-    info = Info()
 
-    if not info.linked_pr_number > 0:
-        print(f"WARNING: Invalid or unknown pr number: {info.linked_pr_number}")
-        return
+def get_linked_pr_numbers():
+    """
+    Extract linked PR numbers from the last NUM_COMMITS commits on master.
 
+    Merge commits produced by the merge queue look like:
+        Merge pull request #77106 from XXXX
+    Uses --first-parent so only the merge commits on master are inspected, not
+    the individual commits from the merged branches.
+    """
     raw = Shell.get_output(
-        f"gh pr list --state open --head sync-upstream/pr/{info.linked_pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
+        f"git log --first-parent -n {NUM_COMMITS} --format=%s HEAD",
+        verbose=True,
+    )
+    pr_numbers = []
+    for line in raw.splitlines():
+        match = re.search(r"pull request #(\d+)", line)
+        if match:
+            pr_number = int(match.group(1))
+            if pr_number not in pr_numbers:
+                pr_numbers.append(pr_number)
+    return pr_numbers
+
+
+def merge_sync_pr(linked_pr_number):
+    raw = Shell.get_output(
+        f"gh pr list --state open --head sync-upstream/pr/{linked_pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
         verbose=True,
         retries=5,
     )
     if not raw:
-        print("WARNING: Failed to retrieve Sync PR list after retries - skipping merge")
+        print(
+            f"WARNING: Failed to retrieve Sync PR list for pr {linked_pr_number} after retries - skipping merge"
+        )
         return
 
     sync_pr_numbers = [n.strip() for n in raw.splitlines() if n.strip()]
 
     if len(sync_pr_numbers) == 0:
-        print("WARNING: No open Sync PR found - skipping merge")
+        print(f"WARNING: No open Sync PR found for pr {linked_pr_number} - skipping merge")
         return
 
     if len(sync_pr_numbers) > 1:
         print(
-            f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{info.linked_pr_number}, "
+            f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{linked_pr_number}, "
             f"found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge"
         )
         return
 
     sync_pr_number = sync_pr_numbers[0]
     if not sync_pr_number.isdigit() or not int(sync_pr_number):
-        print("WARNING: Failed to retrieve Sync PR number")
+        print(f"WARNING: Failed to retrieve Sync PR number for pr {linked_pr_number}")
         return
 
     if not Shell.check(
         f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5
     ):
-        print("WARNING: Failed to set Sync PR as ready")
+        print(f"WARNING: Failed to set Sync PR {sync_pr_number} as ready")
         return
 
     if not Shell.check(
@@ -51,11 +77,24 @@ def check():
         verbose=True,
         retries=5,
     ):
-        print("WARNING: Failed to merge Sync PR")
+        print(f"WARNING: Failed to merge Sync PR {sync_pr_number}")
         return
 
-    print("Sync PR merged")
-    return
+    print(f"Sync PR {sync_pr_number} merged (for pr {linked_pr_number})")
+
+
+def check():
+    linked_pr_numbers = get_linked_pr_numbers()
+
+    if not linked_pr_numbers:
+        print(
+            f"WARNING: No linked PR numbers found in the last {NUM_COMMITS} commits - skipping merge"
+        )
+        return
+
+    print(f"Found linked PR numbers to sync: {linked_pr_numbers}")
+    for linked_pr_number in linked_pr_numbers:
+        merge_sync_pr(linked_pr_number)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -32,6 +32,10 @@ def get_linked_pr_numbers():
     from the head commit backwards and stop at the first commit that is not a
     merge-queue merge commit. This picks up exactly the batch and avoids matching
     unrelated commits deeper in the push (e.g. a revert of an old merge commit).
+
+    The result is returned oldest-to-newest (public batch merge order) so the
+    Sync PRs are replayed into the private repo in the same order they were
+    merged into public master.
     """
     event_file_path = os.getenv("GITHUB_EVENT_PATH", "")
     if not event_file_path or not Path(event_file_path).is_file():
@@ -58,6 +62,9 @@ def get_linked_pr_numbers():
         pr_number = int(match.group(1))
         if pr_number not in pr_numbers:
             pr_numbers.append(pr_number)
+    # Collected newest-to-oldest while walking from the head; reverse back to the
+    # public batch merge order (oldest-to-newest) before returning.
+    pr_numbers.reverse()
     return pr_numbers
 
 
@@ -122,9 +129,10 @@ def check():
     linked_pr_numbers = get_linked_pr_numbers()
 
     if not linked_pr_numbers:
-        msg = "No linked PR numbers found in the push event - skipping Sync PR merge"
-        print(f"WARNING: {msg}")
-        Info().add_workflow_warning(msg)
+        # Expected no-op for any push whose tip is not a merge-queue merge commit
+        # (e.g. direct automation commits to master) - nothing to sync. Genuine
+        # payload-read failures are already reported inside get_linked_pr_numbers.
+        print("No linked PR numbers found in the push event - nothing to sync")
         return
 
     print(f"Found linked PR numbers to sync: {linked_pr_numbers}")

--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -4,6 +4,7 @@ import re
 import traceback
 from pathlib import Path
 
+from praktika.info import Info
 from praktika.utils import Shell
 
 SYNC_REPO = "ClickHouse/clickhouse-private"
@@ -25,7 +26,9 @@ def get_linked_pr_numbers():
     """
     event_file_path = os.getenv("GITHUB_EVENT_PATH", "")
     if not event_file_path or not Path(event_file_path).is_file():
-        print(f"WARNING: GITHUB_EVENT_PATH is not set or missing: '{event_file_path}'")
+        msg = f"GITHUB_EVENT_PATH is not set or missing: '{event_file_path}' - skipping Sync PR merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return []
 
     with open(event_file_path, "r", encoding="utf-8") as f:
@@ -33,7 +36,9 @@ def get_linked_pr_numbers():
 
     commits = github_event.get("commits", [])
     if not commits:
-        print("WARNING: No commits found in the push event payload")
+        msg = "No commits found in the push event payload - skipping Sync PR merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return []
 
     pr_numbers = []
@@ -54,26 +59,36 @@ def merge_sync_pr(linked_pr_number):
         retries=5,
     )
     if not raw:
-        print(f"WARNING: Failed to retrieve Sync PR list for pr {linked_pr_number} after retries - skipping merge")
+        msg = f"Failed to retrieve Sync PR list for pr {linked_pr_number} after retries - skipping merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     sync_pr_numbers = [n.strip() for n in raw.splitlines() if n.strip()]
 
     if len(sync_pr_numbers) == 0:
-        print(f"WARNING: No open Sync PR found for pr {linked_pr_number} - skipping merge")
+        msg = f"No open Sync PR found for pr {linked_pr_number} - skipping merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     if len(sync_pr_numbers) > 1:
-        print(f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{linked_pr_number}, found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge")
+        msg = f"Expected at most one open Sync PR for branch sync-upstream/pr/{linked_pr_number}, found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     sync_pr_number = sync_pr_numbers[0]
     if not sync_pr_number.isdigit() or not int(sync_pr_number):
-        print(f"WARNING: Failed to retrieve Sync PR number for pr {linked_pr_number}")
+        msg = f"Failed to retrieve Sync PR number for pr {linked_pr_number}"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     if not Shell.check(f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5):
-        print(f"WARNING: Failed to set Sync PR {sync_pr_number} as ready")
+        msg = f"Failed to set Sync PR {sync_pr_number} as ready"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     if not Shell.check(
@@ -81,7 +96,9 @@ def merge_sync_pr(linked_pr_number):
         verbose=True,
         retries=5,
     ):
-        print(f"WARNING: Failed to merge Sync PR {sync_pr_number}")
+        msg = f"Failed to merge Sync PR {sync_pr_number}"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     print(f"Sync PR {sync_pr_number} merged (for pr {linked_pr_number})")
@@ -91,7 +108,9 @@ def check():
     linked_pr_numbers = get_linked_pr_numbers()
 
     if not linked_pr_numbers:
-        print("WARNING: No linked PR numbers found in the push event - skipping merge")
+        msg = "No linked PR numbers found in the push event - skipping Sync PR merge"
+        print(f"WARNING: {msg}")
+        Info().add_workflow_warning(msg)
         return
 
     print(f"Found linked PR numbers to sync: {linked_pr_numbers}")

--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -1,34 +1,45 @@
+import json
+import os
 import re
 import traceback
+from pathlib import Path
 
 from praktika.utils import Shell
 
 SYNC_REPO = "ClickHouse/clickhouse-private"
 
-# The merge queue can merge several PRs in a single batch, so a single push to
-# master may contain multiple merge commits, each corresponding to a different
-# upstream PR (and therefore a different Sync PR). Look back this many commits on
-# master to make sure all of them get their Sync PRs merged, not just the PR for
-# the latest commit.
-NUM_COMMITS = 5
-
 
 def get_linked_pr_numbers():
     """
-    Extract linked PR numbers from the last NUM_COMMITS commits on master.
+    Extract linked PR numbers from the GitHub push event payload.
+
+    The merge queue can merge several PRs in a single batch, so a single push to
+    master may contain multiple merge commits, each corresponding to a different
+    upstream PR (and therefore a different Sync PR). The push event payload lists
+    every commit in the batch under "commits", so it is a reliable source for all
+    of them - unlike the head commit message or local git state, which only
+    reflect the latest PR.
 
     Merge commits produced by the merge queue look like:
         Merge pull request #77106 from XXXX
-    Uses --first-parent so only the merge commits on master are inspected, not
-    the individual commits from the merged branches.
     """
-    raw = Shell.get_output(
-        f"git log --first-parent -n {NUM_COMMITS} --format=%s HEAD",
-        verbose=True,
-    )
+    event_file_path = os.getenv("GITHUB_EVENT_PATH", "")
+    if not event_file_path or not Path(event_file_path).is_file():
+        print(f"WARNING: GITHUB_EVENT_PATH is not set or missing: '{event_file_path}'")
+        return []
+
+    with open(event_file_path, "r", encoding="utf-8") as f:
+        github_event = json.load(f)
+
+    commits = github_event.get("commits", [])
+    if not commits:
+        print("WARNING: No commits found in the push event payload")
+        return []
+
     pr_numbers = []
-    for line in raw.splitlines():
-        match = re.search(r"pull request #(\d+)", line)
+    for commit in commits:
+        message = commit.get("message", "")
+        match = re.search(r"pull request #(\d+)", message)
         if match:
             pr_number = int(match.group(1))
             if pr_number not in pr_numbers:
@@ -43,9 +54,7 @@ def merge_sync_pr(linked_pr_number):
         retries=5,
     )
     if not raw:
-        print(
-            f"WARNING: Failed to retrieve Sync PR list for pr {linked_pr_number} after retries - skipping merge"
-        )
+        print(f"WARNING: Failed to retrieve Sync PR list for pr {linked_pr_number} after retries - skipping merge")
         return
 
     sync_pr_numbers = [n.strip() for n in raw.splitlines() if n.strip()]
@@ -55,10 +64,7 @@ def merge_sync_pr(linked_pr_number):
         return
 
     if len(sync_pr_numbers) > 1:
-        print(
-            f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{linked_pr_number}, "
-            f"found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge"
-        )
+        print(f"WARNING: Expected at most one open Sync PR for branch sync-upstream/pr/{linked_pr_number}, found {len(sync_pr_numbers)}: {sync_pr_numbers} - skipping merge")
         return
 
     sync_pr_number = sync_pr_numbers[0]
@@ -66,9 +72,7 @@ def merge_sync_pr(linked_pr_number):
         print(f"WARNING: Failed to retrieve Sync PR number for pr {linked_pr_number}")
         return
 
-    if not Shell.check(
-        f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5
-    ):
+    if not Shell.check(f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5):
         print(f"WARNING: Failed to set Sync PR {sync_pr_number} as ready")
         return
 
@@ -87,9 +91,7 @@ def check():
     linked_pr_numbers = get_linked_pr_numbers()
 
     if not linked_pr_numbers:
-        print(
-            f"WARNING: No linked PR numbers found in the last {NUM_COMMITS} commits - skipping merge"
-        )
+        print("WARNING: No linked PR numbers found in the push event - skipping merge")
         return
 
     print(f"Found linked PR numbers to sync: {linked_pr_numbers}")

--- a/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
+++ b/ci/jobs/scripts/workflow_hooks/merge_sync_pr.py
@@ -9,6 +9,13 @@ from praktika.utils import Shell
 
 SYNC_REPO = "ClickHouse/clickhouse-private"
 
+# Matches only the force-merge commit the merge queue creates for each PR, e.g.
+#   Merge pull request #77106 from XXXX
+# Anchored at the start so it does NOT match subjects that merely contain the
+# phrase, such as a Revert (`Revert "Merge pull request #12345 from ..."`) or a
+# cherry-picked merge commit.
+MERGE_COMMIT_RE = re.compile(r"^Merge pull request #(\d+)")
+
 
 def get_linked_pr_numbers():
     """
@@ -17,12 +24,14 @@ def get_linked_pr_numbers():
     The merge queue can merge several PRs in a single batch, so a single push to
     master may contain multiple merge commits, each corresponding to a different
     upstream PR (and therefore a different Sync PR). The push event payload lists
-    every commit in the batch under "commits", so it is a reliable source for all
-    of them - unlike the head commit message or local git state, which only
-    reflect the latest PR.
+    every commit in the batch under "commits" (oldest first, head commit last),
+    so it is a reliable source for all of them - unlike the head commit message
+    or local git state, which only reflect the latest PR.
 
-    Merge commits produced by the merge queue look like:
-        Merge pull request #77106 from XXXX
+    The batch's merge commits sit contiguously at the tip of the push, so walk
+    from the head commit backwards and stop at the first commit that is not a
+    merge-queue merge commit. This picks up exactly the batch and avoids matching
+    unrelated commits deeper in the push (e.g. a revert of an old merge commit).
     """
     event_file_path = os.getenv("GITHUB_EVENT_PATH", "")
     if not event_file_path or not Path(event_file_path).is_file():
@@ -42,19 +51,23 @@ def get_linked_pr_numbers():
         return []
 
     pr_numbers = []
-    for commit in commits:
-        message = commit.get("message", "")
-        match = re.search(r"pull request #(\d+)", message)
-        if match:
-            pr_number = int(match.group(1))
-            if pr_number not in pr_numbers:
-                pr_numbers.append(pr_number)
+    for commit in reversed(commits):
+        match = MERGE_COMMIT_RE.match(commit.get("message", ""))
+        if not match:
+            break
+        pr_number = int(match.group(1))
+        if pr_number not in pr_numbers:
+            pr_numbers.append(pr_number)
     return pr_numbers
 
 
 def merge_sync_pr(linked_pr_number):
+    # Keep the full JSON array (do not extract with --jq): `gh pr list` exits 0
+    # with an empty result when nothing matches, and returning "[]" lets us tell
+    # "no open Sync PR" (a quiet no-op) apart from a genuine retrieval failure
+    # (empty stdout after retries).
     raw = Shell.get_output(
-        f"gh pr list --state open --head sync-upstream/pr/{linked_pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
+        f"gh pr list --state open --head sync-upstream/pr/{linked_pr_number} --repo {SYNC_REPO} --json number",
         verbose=True,
         retries=5,
     )
@@ -64,12 +77,18 @@ def merge_sync_pr(linked_pr_number):
         Info().add_workflow_warning(msg)
         return
 
-    sync_pr_numbers = [n.strip() for n in raw.splitlines() if n.strip()]
-
-    if len(sync_pr_numbers) == 0:
-        msg = f"No open Sync PR found for pr {linked_pr_number} - skipping merge"
+    try:
+        sync_pr_numbers = [pr["number"] for pr in json.loads(raw)]
+    except (json.JSONDecodeError, KeyError, TypeError):
+        msg = f"Failed to parse Sync PR list for pr {linked_pr_number}: {raw!r}"
         print(f"WARNING: {msg}")
         Info().add_workflow_warning(msg)
+        return
+
+    if len(sync_pr_numbers) == 0:
+        # Expected on reruns (Sync PR already merged) or before the Sync PR is
+        # created - not a problem, so keep it quiet.
+        print(f"No open Sync PR found for pr {linked_pr_number} - nothing to merge")
         return
 
     if len(sync_pr_numbers) > 1:
@@ -79,11 +98,6 @@ def merge_sync_pr(linked_pr_number):
         return
 
     sync_pr_number = sync_pr_numbers[0]
-    if not sync_pr_number.isdigit() or not int(sync_pr_number):
-        msg = f"Failed to retrieve Sync PR number for pr {linked_pr_number}"
-        print(f"WARNING: {msg}")
-        Info().add_workflow_warning(msg)
-        return
 
     if not Shell.check(f"gh pr ready {sync_pr_number} --repo {SYNC_REPO}", verbose=True, retries=5):
         msg = f"Failed to set Sync PR {sync_pr_number} as ready"


### PR DESCRIPTION
The merge queue can merge several PRs in a single batch, so a single push to master may contain multiple merge commits, each corresponding to a different upstream PR and its Sync PR. The `merge_sync_pr.py` hook previously used only `Info.linked_pr_number`, which is parsed from the head commit message, so only the latest PR's Sync PR got merged and the rest were left behind.

Now the hook derives the batch from the GitHub push event payload (`GITHUB_EVENT_PATH`), which lists every commit in the push under `commits`. Starting from the head commit it walks the list backwards and collects the linked PR numbers from the merge-queue merge commits (`^Merge pull request #<n>`), stopping at the first non-merge commit — the batch's merge commits are contiguous at the tip. The anchored, head-relative match avoids picking up unrelated subjects such as a `Revert "Merge pull request #..."` or a cherry-picked merge deeper in the push. It then merges each corresponding Sync PR.

This relies on the push event payload rather than local git, so it is unaffected by the shallow checkout used by the master workflow, and it has no fixed history window.

Warnings are surfaced on the job and workflow report pages via `Info.add_workflow_warning` (with plain prints kept for the job log). The "no open Sync PR" case — expected on reruns once the Sync PR is already merged — is a quiet no-op rather than a warning.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.82` (included in `26.8` and later)
<!-- ch-version-info:end -->