### PR TITLE
Make mutation entry lifecycle crash-durable on plain MergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTreeMutationEntry.cpp
+++ b/src/Storages/MergeTree/MergeTreeMutationEntry.cpp
@@ -49,13 +49,14 @@ UInt64 MergeTreeMutationEntry::parseFileName(const String & file_name_)
 }
 
 MergeTreeMutationEntry::MergeTreeMutationEntry(MutationCommands commands_, DiskPtr disk_, const String & path_prefix_, UInt64 tmp_number,
-                                               const TransactionID & tid_, const WriteSettings & settings)
+                                               const TransactionID & tid_, const WriteSettings & settings, bool fsync_directory_)
     : create_time(time(nullptr))
     , commands(std::make_shared<MutationCommands>(std::move(commands_)))
     , disk(std::move(disk_))
     , path_prefix(path_prefix_)
     , file_name("tmp_mutation_" + toString(tmp_number) + ".txt")
     , is_temp(true)
+    , fsync_directory(fsync_directory_)
     , tid(tid_)
 {
     try
@@ -91,6 +92,10 @@ void MergeTreeMutationEntry::commit(UInt64 block_number_)
     chassert(block_number_);
     block_number = block_number_;
     String new_file_name = versionToFileName(block_number);
+    /// Open the guard before the rename so it fsyncs the directory on destruction. See #111380.
+    SyncGuardPtr sync_guard;
+    if (fsync_directory)
+        sync_guard = disk->getDirectorySyncGuard(path_prefix);
     disk->moveFile(path_prefix + file_name, path_prefix + new_file_name);
     is_temp = false;
     file_name = new_file_name;
@@ -103,6 +108,10 @@ void MergeTreeMutationEntry::removeFile()
         if (!disk->existsFile(path_prefix + file_name))
             return;
 
+        /// Open the guard before the unlink so it fsyncs the directory on destruction. See #111380.
+        SyncGuardPtr sync_guard;
+        if (fsync_directory)
+            sync_guard = disk->getDirectorySyncGuard(path_prefix);
         disk->removeFileIfExists(path_prefix + file_name);
         file_name.clear();
     }
@@ -167,6 +176,7 @@ MergeTreeMutationEntry::MergeTreeMutationEntry(MergeTreeMutationEntry && other) 
     , file_name(std::exchange(other.file_name, {}))
     , is_temp(std::exchange(other.is_temp, false))
     , is_registered(std::exchange(other.is_registered, false))
+    , fsync_directory(other.fsync_directory)
     , is_done(other.is_done)
     , block_number(other.block_number)
     , latest_failed_part(std::move(other.latest_failed_part))

--- a/src/Storages/MergeTree/MergeTreeMutationEntry.h
+++ b/src/Storages/MergeTree/MergeTreeMutationEntry.h
@@ -33,6 +33,12 @@ struct MergeTreeMutationEntry
     /// mutation against rolled-back metadata. See #80648.
     bool is_registered = false;
 
+    /// Whether `commit` (rename) and `removeFile` (unlink) fsync the parent directory.
+    /// Set from `fsync_part_directory` for entries created by `startMutation`; stays
+    /// `false` for entries loaded by `loadMutations` (`killMutation` sets it before
+    /// removing such an entry). See #111380.
+    bool fsync_directory = false;
+
     /// This flag is set periodically in a background thread.
     /// If it is true, then mutation is done. If it is false,
     /// then mutation may be already done but not processed by this thread.
@@ -54,7 +60,7 @@ struct MergeTreeMutationEntry
 
     /// Create a new entry and write it to a temporary file.
     MergeTreeMutationEntry(MutationCommands commands_, DiskPtr disk, const String & path_prefix_, UInt64 tmp_number,
-                           const TransactionID & tid_, const WriteSettings & settings);
+                           const TransactionID & tid_, const WriteSettings & settings, bool fsync_directory_);
     MergeTreeMutationEntry(const MergeTreeMutationEntry &) = delete;
     /// Must clear the moved-from ownership token (`file_name`, `is_temp`,
     /// `is_registered`); a defaulted move leaves `file_name` unspecified (SSO

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -620,6 +620,7 @@ inserts, not recommended to use with wide parts.
 )", 0) \
     DECLARE(Bool, fsync_part_directory, false, R"(
 Do fsync for part directory after all part operations (writes, renames, etc.).
+Also fsyncs the table directory when a mutation entry file is created or removed (including `KILL MUTATION`), so the mutation is durable across power loss.
 )", 0) \
     DECLARE(UInt64, non_replicated_deduplication_window, 0, R"(
 The number of the most recently inserted blocks in the non-replicated

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -118,6 +118,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsDeduplicateMergeProjectionMode deduplicate_merge_projection_mode;
     extern const MergeTreeSettingsBool enable_replacing_merge_with_cleanup_for_min_age_to_force_merge;
     extern const MergeTreeSettingsUInt64 finished_mutations_to_keep;
+    extern const MergeTreeSettingsBool fsync_part_directory;
     extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
     extern const MergeTreeSettingsBool min_age_to_force_merge_on_partition_only;
     extern const MergeTreeSettingsUInt64 min_age_to_force_merge_seconds;
@@ -888,7 +889,8 @@ StorageMergeTree::PreparedMutationEntry StorageMergeTree::prepareMutationEntry(
         additional_info = fmt::format(" (TID: {}; TIDH: {})", current_tid, current_tid.getHash());
     }
 
-    MergeTreeMutationEntry entry(commands, disk, relative_data_path, insert_increment.get(), current_tid, getContext()->getWriteSettings());
+    MergeTreeMutationEntry entry(commands, disk, relative_data_path, insert_increment.get(), current_tid, getContext()->getWriteSettings(),
+                                 (*getSettings())[MergeTreeSetting::fsync_part_directory]);
     auto block_holder = allocateBlockNumber(CommittingBlock::Op::Mutation);
 
     Int64 version = block_holder->block.number;
@@ -1422,6 +1424,9 @@ CancellationCode StorageMergeTree::killMutation(const String & mutation_id)
     }
 
     getContext()->getMergeList().cancelPartMutations(getStorageID(), {}, to_kill->block_number);
+    /// Entries loaded by `loadMutations` do not carry the setting, so apply the current one so the
+    /// removal fsyncs the directory. See #111380.
+    to_kill->fsync_directory = (*getSettings())[MergeTreeSetting::fsync_part_directory];
     to_kill->removeFile();
     LOG_TRACE(log, "Cancelled part mutations and removed mutation file {}", mutation_id);
     {

--- a/tests/queries/0_stateless/04621_mutation_entry_fsync.reference
+++ b/tests/queries/0_stateless/04621_mutation_entry_fsync.reference
@@ -1,0 +1,18 @@
+create-commit fsync_part_directory = 1: DirectorySync>=1, mutation registered
+1
+1
+create-commit fsync_part_directory = 0: DirectorySync=0 (setting honored), mutation registered
+0
+1
+kill fsync_part_directory = 1: DirectorySync>=1, mutation removed
+1
+0
+kill fsync_part_directory = 0: DirectorySync=0 (setting honored), mutation removed
+0
+0
+rollback fsync_part_directory = 1: DirectorySync>=2 (rename + unlink), no mutation left
+1
+0
+rollback fsync_part_directory = 0: DirectorySync=0 (setting honored), no mutation left
+0
+0

--- a/tests/queries/0_stateless/04621_mutation_entry_fsync.sh
+++ b/tests/queries/0_stateless/04621_mutation_entry_fsync.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Tags: no-object-storage, no-shared-merge-tree, no-parallel
+# Tag no-object-storage: object storage disks do not fsync local directories.
+# Tag no-shared-merge-tree: the mutation_*.txt entry file is a plain-MergeTree-only durability record;
+#   SharedMergeTree keeps mutations in Keeper.
+# Tag no-parallel: the rollback case toggles the server-global failpoint mt_throw_after_mutation_commit,
+#   which would affect any concurrent plain-MergeTree mutation (same reason as 04308).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/111380
+# Both mutation-entry lifecycle transitions on plain MergeTree must fsync the table directory
+# when fsync_part_directory = 1, so they survive a power loss (the mutation_*.txt file is the only
+# on-disk commit record). The DirectorySync ProfileEvent is the durability proxy (a real power cut
+# cannot be simulated in a stateless test). The transition is attributed to the ALTER / KILL query,
+# so the count is read from system.query_log.
+
+# Direction 1: the create-commit rename (tmp_mutation_N.txt -> mutation_N.txt).
+run_create() {
+    local fsync=$1
+    $CLICKHOUSE_CLIENT -m -q "
+        drop table if exists t_me_c;
+        create table t_me_c (id UInt64) engine = MergeTree order by id settings fsync_part_directory = $fsync;
+        insert into t_me_c values (1);
+    "
+    local query_id="me-create-fsync${fsync}-$CLICKHOUSE_DATABASE"
+    # throwIf keeps the mutation pending, so its presence is the entry file, not a completed mutation.
+    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "alter table t_me_c delete where throwIf(id >= 0) settings mutations_sync = 0"
+    $CLICKHOUSE_CLIENT -m --param_query_id "$query_id" -q "
+        system flush logs query_log;
+        select ProfileEvents['DirectorySync'] >= 1
+        from system.query_log
+        where event_date >= yesterday() and current_database = currentDatabase()
+          and query_id = {query_id:String} and type = 'QueryFinish'
+        order by event_time_microseconds desc limit 1;
+    "
+    # The mutation must be registered regardless of the setting.
+    $CLICKHOUSE_CLIENT -q "select count() from system.mutations where database = currentDatabase() and table = 't_me_c'"
+    $CLICKHOUSE_CLIENT -q "drop table t_me_c"
+}
+
+# Direction 3: the compensating unlink when an ALTER throws after the commit rename (before the
+# entry is registered). Once the rename is durable, its rollback unlink must be durable too, or a
+# power loss could restore a mutation for an ALTER that returned an error. mt_throw_after_mutation_commit
+# fires right after commit, so the entry destructor removes the orphaned file: with fsync on the query
+# performs two directory syncs (the commit rename and the orphan unlink).
+run_rollback() {
+    local fsync=$1
+    $CLICKHOUSE_CLIENT -m -q "
+        drop table if exists t_me_r;
+        create table t_me_r (id UInt64) engine = MergeTree order by id settings fsync_part_directory = $fsync;
+        insert into t_me_r values (1);
+    "
+    local query_id="me-rollback-fsync${fsync}-$CLICKHOUSE_DATABASE"
+    $CLICKHOUSE_CLIENT -q "system enable failpoint mt_throw_after_mutation_commit"
+    # The ALTER must throw; the orphaned mutation_N.txt is removed by the entry destructor.
+    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "alter table t_me_r delete where id >= 0 settings mutations_sync = 0" 2>/dev/null \
+        && echo "FAIL: ALTER unexpectedly succeeded; failpoint did not fire"
+    $CLICKHOUSE_CLIENT -q "system disable failpoint mt_throw_after_mutation_commit"
+    # Expect two directory syncs at fsync=1: the commit rename AND the compensating unlink. Asserting
+    # >=2 (not >=1) is what catches a regression in the destructor-side unlink sync, because the commit
+    # rename alone already contributes one sync before the failpoint fires.
+    $CLICKHOUSE_CLIENT -m --param_query_id "$query_id" -q "
+        system flush logs query_log;
+        select ProfileEvents['DirectorySync'] >= 2
+        from system.query_log
+        where event_date >= yesterday() and current_database = currentDatabase()
+          and query_id = {query_id:String} and type = 'ExceptionBeforeStart'
+        order by event_time_microseconds desc limit 1;
+    "
+    # No mutation must remain: the rolled-back entry was removed.
+    $CLICKHOUSE_CLIENT -q "select count() from system.mutations where database = currentDatabase() and table = 't_me_r'"
+    $CLICKHOUSE_CLIENT -q "drop table t_me_r"
+}
+
+# Direction 2: the KILL MUTATION unlink of mutation_N.txt.
+run_kill() {
+    local fsync=$1
+    $CLICKHOUSE_CLIENT -m -q "
+        drop table if exists t_me_k;
+        create table t_me_k (id UInt64) engine = MergeTree order by id settings fsync_part_directory = $fsync;
+        insert into t_me_k values (1);
+        alter table t_me_k delete where throwIf(id >= 0) settings mutations_sync = 0;
+    "
+    # Wait until the mutation is registered (and failing) before killing it.
+    for _ in {1..50}; do
+        [ "$($CLICKHOUSE_CLIENT -q "select count() from system.mutations where database = currentDatabase() and table = 't_me_k'")" = "1" ] && break
+        sleep 0.3
+    done
+    local query_id="me-kill-fsync${fsync}-$CLICKHOUSE_DATABASE"
+    $CLICKHOUSE_CLIENT --query_id "$query_id" -q "kill mutation where database = currentDatabase() and table = 't_me_k' sync" > /dev/null
+    $CLICKHOUSE_CLIENT -m --param_query_id "$query_id" -q "
+        system flush logs query_log;
+        select ProfileEvents['DirectorySync'] >= 1
+        from system.query_log
+        where event_date >= yesterday() and current_database = currentDatabase()
+          and query_id = {query_id:String} and type = 'QueryFinish'
+        order by event_time_microseconds desc limit 1;
+    "
+    # The mutation must be gone regardless of the setting.
+    $CLICKHOUSE_CLIENT -q "select count() from system.mutations where database = currentDatabase() and table = 't_me_k'"
+    $CLICKHOUSE_CLIENT -q "drop table t_me_k"
+}
+
+echo "create-commit fsync_part_directory = 1: DirectorySync>=1, mutation registered"
+run_create 1
+echo "create-commit fsync_part_directory = 0: DirectorySync=0 (setting honored), mutation registered"
+run_create 0
+echo "kill fsync_part_directory = 1: DirectorySync>=1, mutation removed"
+run_kill 1
+echo "kill fsync_part_directory = 0: DirectorySync=0 (setting honored), mutation removed"
+run_kill 0
+echo "rollback fsync_part_directory = 1: DirectorySync>=2 (rename + unlink), no mutation left"
+run_rollback 1
+echo "rollback fsync_part_directory = 0: DirectorySync=0 (setting honored), no mutation left"
+run_rollback 0


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111380
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a durability gap where a mutation on a plain `MergeTree` table could be lost or resurrected after a power loss. With `fsync_part_directory = 1`, the `mutation_<N>.txt` entry file's creation (rename) and its `KILL MUTATION` removal now fsync the table directory, so an acknowledged `ALTER ... DELETE`/`UPDATE` is not silently dropped and a killed mutation does not come back on restart.


### Description

Closes #111380.

On plain (non-replicated) `MergeTree`, `mutation_<N>.txt` is the only on-disk commit record of a mutation, and both of its lifecycle transitions were non-durable:

- **Create:** `MergeTreeMutationEntry` fsyncs the entry content as `tmp_mutation_<N>.txt`, but `commit()` renamed it to `mutation_<N>.txt` without fsyncing the parent directory. A power loss could leave only the `tmp_` name, which `loadMutations` deletes at startup, silently dropping an acknowledged mutation.
- **Kill:** `KILL MUTATION` removed `mutation_<N>.txt` with a bare unlink and no directory fsync. A power loss could resurrect the entry, and `loadMutations` re-loads the killed mutation.

`ReplicatedMergeTree` is unaffected (mutations are Keeper transactions).

Fix: gate a directory fsync behind the existing `fsync_part_directory` MergeTree setting (default off, so no behavior change by default), matching how part renames are made durable (`getDirectorySyncGuard`, as in #111375). `MergeTreeMutationEntry::commit` and `removeFile` acquire the guard before the rename/unlink. The setting is carried on the entry so the removals that compensate a durable create (orphan cleanup on a failed registration, metadata-rollback of a rename mutation) are also durable; `killMutation` applies the current setting to entries loaded from disk. The guard is a no-op on object storage.

Regression test `04621_mutation_entry_fsync.sh` uses the `DirectorySync` ProfileEvent as the durability proxy (a real power loss cannot be simulated in a stateless test) and checks both directions with the setting on and off.
