### PR TITLE
Fix transform_null_in=1 for a non-Nullable key IN/NOT IN a Nullable subquery

### DIFF
--- a/src/DataTypes/Utils.cpp
+++ b/src/DataTypes/Utils.cpp
@@ -126,21 +126,21 @@ bool canBeSafelyCast(const DataTypePtr & from_type, const DataTypePtr & to_type)
         }
         case TypeIndex::Nullable:
         {
-            if (to_type_was_nullable)
-            {
-                const auto & from_type_nullable = assert_cast<const DataTypeNullable &>(*from_type);
-                return canBeSafelyCast(from_type_nullable.getNestedType(), to_type_unwrapped);
-            }
+            /// A Nullable source is only safely castable to a Nullable target: a NULL value cannot be
+            /// represented in a non-Nullable column, so a strict cast would throw or drop the null.
+            if (!to_type_was_nullable)
+                return false;
 
-            if (to_which_type.isString())
-                return true;
-
-            return false;
+            const auto & from_type_nullable = assert_cast<const DataTypeNullable &>(*from_type);
+            return canBeSafelyCast(from_type_nullable.getNestedType(), to_type_unwrapped);
         }
         case TypeIndex::LowCardinality:
         {
+            /// Recurse against the LowCardinality-stripped target, keeping its Nullable wrapper, so a
+            /// LowCardinality(Nullable(X)) source is still judged against the target's real nullability
+            /// (otherwise LowCardinality(Nullable(X)) -> Nullable(X) is wrongly rejected as unsafe).
             const auto & from_type_low_cardinality = assert_cast<const DataTypeLowCardinality &>(*from_type);
-            return canBeSafelyCast(from_type_low_cardinality.getDictionaryType(), to_type_unwrapped);
+            return canBeSafelyCast(from_type_low_cardinality.getDictionaryType(), removeLowCardinality(to_type));
         }
         case TypeIndex::Array:
         {

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -2355,7 +2355,8 @@ static bool tryPrepareSetColumnsForIndex(
     const std::vector<std::optional<DeterministicKeyTransformDag>> & set_transforming_dags,
     const DataTypes & data_types,
     const std::vector<MergeTreeSetIndex::KeyTuplePositionMapping> & indexes_mapping,
-    size_t args_count)
+    size_t args_count,
+    bool & set_is_relaxed)
 {
     Columns new_columns;
     DataTypes new_types;
@@ -2473,6 +2474,16 @@ static bool tryPrepareSetColumnsForIndex(
         {
             for (size_t i = 0; i < nullable_set_column_null_map_size; ++i)
             {
+                /// A NULL element of a Nullable source set is kept in the pruning set as the nested
+                /// default (it is not filtered out here), so the set no longer matches the original
+                /// exactly. That weakens `IN` and, after negation, strengthens `NOT IN`, so a
+                /// single-point key range (partition pruning, minmax) could be pruned incorrectly.
+                /// Mark the atom relaxed so `checkInRange()` never reports an exact `can_be_false`.
+                /// Cast-produced NULLs, in contrast, are dropped by the filter below and keep the set
+                /// exact, so they must not relax it.
+                if (i < set_column_null_map->size() && (*set_column_null_map)[i])
+                    set_is_relaxed = true;
+
                 if (nullable_set_column_null_map_size < set_column_null_map->size())
                     filter[i] &= (*set_column_null_map)[i] || !nullable_set_column_null_map[i];
                 else
@@ -2571,8 +2582,9 @@ bool KeyCondition::tryPrepareSetIndexForIn(
         }
     }
 
+    bool set_is_relaxed = false;
     if (!tryPrepareSetColumnsForIndex(
-            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, left_args_count))
+            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, left_args_count, set_is_relaxed))
         return false;
 
     out.set_index = std::make_shared<MergeTreeSetIndex>(set_columns, std::move(indexes_mapping));
@@ -2597,7 +2609,10 @@ bool KeyCondition::tryPrepareSetIndexForIn(
     ///    For partition pruning we may transform set elements via functions from the key expression,
     ///    which relaxes the predicate. Example: `PARTITION BY toDate(ts)` allows turning
     ///    `ts NOT IN ('2026-02-03 19:00:00')` into `toDate(ts) NOT IN ('2026-02-03')`, which is not equivalent.
-    if (adjusted_indexes_mapping.size() < set_types.size())
+    ///
+    /// - `set_is_relaxed` is set when `tryPrepareSetColumnsForIndex` sees a NULL set element that has
+    ///    no exact counterpart in the non-Nullable key (e.g. a NULL from a Nullable source set).
+    if (adjusted_indexes_mapping.size() < set_types.size() || set_is_relaxed)
         out.relaxed = true;
 
     return true;
@@ -2655,8 +2670,9 @@ bool KeyCondition::tryPrepareSetIndexForHas(
     Columns set_columns = {array_elements};
     DataTypes set_types = {array_nested_type};
 
+    bool set_is_relaxed = false;
     if (!tryPrepareSetColumnsForIndex(
-            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, key_args_count))
+            set_columns, set_types, set_transforming_dags, data_types, indexes_mapping, key_args_count, set_is_relaxed))
         return false;
 
     out.set_index = std::make_shared<MergeTreeSetIndex>(set_columns, std::move(indexes_mapping));
@@ -2682,7 +2698,10 @@ bool KeyCondition::tryPrepareSetIndexForHas(
     ///    which relaxes the predicate. Example: `PARTITION BY toDate(ts)` allows turning
     ///    `has([toDateTime('2026-02-03 19:00:00')], ts)` into `has([toDate('2026-02-03')], toDate(ts))`,
     ///    which is not equivalent.
-    if (adjusted_indexes_mapping.size() < set_types.size())
+    ///
+    /// - `set_is_relaxed` is set when `tryPrepareSetColumnsForIndex` sees a NULL set element that has
+    ///    no exact counterpart in the non-Nullable key (e.g. a NULL from a Nullable source set).
+    if (adjusted_indexes_mapping.size() < set_types.size() || set_is_relaxed)
         out.relaxed = true;
 
     return true;

--- a/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.reference
+++ b/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.reference
@@ -1,0 +1,41 @@
+String key IN
+a
+b
+c
+FixedString key IN
+ab
+cd
+Int64 key IN
+1
+2
+3
+LowCardinality(String) key IN
+a
+b
+Date key IN
+2020-01-01
+2020-01-02
+String key IN, transform_null_in=0
+a
+b
+c
+Non-PK String column IN
+a
+b
+c
+String key NOT IN, partition pruning
+
+b
+Int64 key NOT IN, partition pruning
+0
+7
+String key NOT has, partition pruning
+
+b
+Nullable(String) key IN
+a
+b
+c
+\N
+1
+Column count mismatch still rejected

--- a/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.reference
+++ b/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.reference
@@ -26,12 +26,15 @@ c
 String key NOT IN, partition pruning
 
 b
+1
 Int64 key NOT IN, partition pruning
 0
 7
+1
 String key NOT has, partition pruning
 
 b
+1
 Nullable(String) key IN
 a
 b

--- a/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.sql
+++ b/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.sql
@@ -1,0 +1,86 @@
+-- Regression test for issue #111340: `transform_null_in = 1`, non-Nullable key column, `IN`/`NOT IN`
+-- a subquery whose result is Nullable. Previously threw CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN (349).
+
+SET transform_null_in = 1;
+
+SELECT 'String key IN';
+DROP TABLE IF EXISTS t_str;
+CREATE TABLE t_str (s String) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t_str VALUES ('a'), ('b'), ('c');
+SELECT s FROM t_str WHERE s IN (SELECT s FROM t_str UNION ALL SELECT NULL) ORDER BY s;
+
+SELECT 'FixedString key IN';
+DROP TABLE IF EXISTS t_fs;
+CREATE TABLE t_fs (s FixedString(2)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t_fs VALUES ('ab'), ('cd');
+SELECT s FROM t_fs WHERE s IN (SELECT s FROM t_fs UNION ALL SELECT NULL) ORDER BY s;
+
+SELECT 'Int64 key IN';
+DROP TABLE IF EXISTS t_int;
+CREATE TABLE t_int (s Int64) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t_int VALUES (1), (2), (3);
+SELECT s FROM t_int WHERE s IN (SELECT s FROM t_int UNION ALL SELECT NULL) ORDER BY s;
+
+SELECT 'LowCardinality(String) key IN';
+DROP TABLE IF EXISTS t_lc;
+CREATE TABLE t_lc (s LowCardinality(String)) ENGINE = MergeTree ORDER BY s;
+INSERT INTO t_lc VALUES ('a'), ('b');
+SELECT s FROM t_lc WHERE s IN (SELECT s FROM t_lc UNION ALL SELECT NULL) ORDER BY s;
+
+SELECT 'Date key IN';
+DROP TABLE IF EXISTS t_date;
+CREATE TABLE t_date (d Date) ENGINE = MergeTree ORDER BY d;
+INSERT INTO t_date VALUES ('2020-01-01'), ('2020-01-02');
+SELECT d FROM t_date WHERE d IN (SELECT d FROM t_date UNION ALL SELECT NULL) ORDER BY d;
+
+SELECT 'String key IN, transform_null_in=0';
+SELECT s FROM t_str WHERE s IN (SELECT s FROM t_str UNION ALL SELECT NULL) ORDER BY s SETTINGS transform_null_in = 0;
+
+SELECT 'Non-PK String column IN';
+DROP TABLE IF EXISTS t_nopk;
+CREATE TABLE t_nopk (id UInt32, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO t_nopk VALUES (1, 'a'), (2, 'b'), (3, 'c');
+SELECT s FROM t_nopk WHERE s IN (SELECT s FROM t_nopk UNION ALL SELECT NULL) ORDER BY s;
+
+-- NOT IN must not prune away rows whose value equals the nested default a dropped NULL produces
+-- ('' for String, 0 for Int64). The `NULL` set element makes the pruning set inexact, so the
+-- partition/index atom must be relaxed; otherwise `NOT IN` prunes the '' / 0 row incorrectly.
+SELECT 'String key NOT IN, partition pruning';
+DROP TABLE IF EXISTS t_np;
+CREATE TABLE t_np (s String) ENGINE = MergeTree ORDER BY s PARTITION BY s;
+INSERT INTO t_np VALUES ('a'), ('b'), ('');
+SELECT s FROM t_np WHERE s NOT IN (SELECT 'a' UNION ALL SELECT NULL) ORDER BY s;
+
+SELECT 'Int64 key NOT IN, partition pruning';
+DROP TABLE IF EXISTS t_ip;
+CREATE TABLE t_ip (s Int64) ENGINE = MergeTree ORDER BY s PARTITION BY s;
+INSERT INTO t_ip VALUES (5), (7), (0);
+SELECT s FROM t_ip WHERE s NOT IN (SELECT 5 UNION ALL SELECT NULL) ORDER BY s;
+
+-- Same relaxation must protect the NOT has() sibling caller (a Nullable array with a NULL element
+-- against a non-Nullable partition key). optimize_rewrite_has_to_in=0 keeps it on the has() path.
+SELECT 'String key NOT has, partition pruning';
+SELECT s FROM t_np WHERE NOT has([CAST('a', 'Nullable(String)'), NULL], s) ORDER BY s SETTINGS optimize_rewrite_has_to_in = 0;
+
+-- A Nullable key must keep working and keep using the set index; NULL on the left matches NULL
+-- in the set under transform_null_in=1.
+SELECT 'Nullable(String) key IN';
+DROP TABLE IF EXISTS t_nk;
+CREATE TABLE t_nk (s Nullable(String)) ENGINE = MergeTree ORDER BY s SETTINGS allow_nullable_key = 1;
+INSERT INTO t_nk VALUES ('a'), ('b'), ('c'), (NULL);
+SELECT s FROM t_nk WHERE s IN (SELECT s FROM t_nk) ORDER BY s;
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT s FROM t_nk WHERE s IN (SELECT s FROM t_nk)) WHERE explain ILIKE '%Condition:%in%set%';
+
+-- IN error semantics must be preserved: a column-count mismatch still throws.
+SELECT 'Column count mismatch still rejected';
+SELECT 1 WHERE 1 IN (SELECT 1, 2); -- { serverError NUMBER_OF_COLUMNS_DOESNT_MATCH }
+
+DROP TABLE t_str;
+DROP TABLE t_fs;
+DROP TABLE t_int;
+DROP TABLE t_lc;
+DROP TABLE t_date;
+DROP TABLE t_nopk;
+DROP TABLE t_np;
+DROP TABLE t_ip;
+DROP TABLE t_nk;

--- a/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.sql
+++ b/tests/queries/0_stateless/04545_transform_null_in_non_nullable_key.sql
@@ -50,17 +50,23 @@ DROP TABLE IF EXISTS t_np;
 CREATE TABLE t_np (s String) ENGINE = MergeTree ORDER BY s PARTITION BY s;
 INSERT INTO t_np VALUES ('a'), ('b'), ('');
 SELECT s FROM t_np WHERE s NOT IN (SELECT 'a' UNION ALL SELECT NULL) ORDER BY s;
+-- The result above is also correct if set-index analysis silently declines and the engine
+-- full-scans. Assert the relaxed set-index path stays live: KeyCondition must build a
+-- `notIn ... set` atom (declining yields `Condition: true` instead, which this ILIKE misses).
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT s FROM t_np WHERE s NOT IN (SELECT 'a' UNION ALL SELECT NULL)) WHERE explain ILIKE '%Condition:%not%in%set%';
 
 SELECT 'Int64 key NOT IN, partition pruning';
 DROP TABLE IF EXISTS t_ip;
 CREATE TABLE t_ip (s Int64) ENGINE = MergeTree ORDER BY s PARTITION BY s;
 INSERT INTO t_ip VALUES (5), (7), (0);
 SELECT s FROM t_ip WHERE s NOT IN (SELECT 5 UNION ALL SELECT NULL) ORDER BY s;
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT s FROM t_ip WHERE s NOT IN (SELECT 5 UNION ALL SELECT NULL)) WHERE explain ILIKE '%Condition:%not%in%set%';
 
 -- Same relaxation must protect the NOT has() sibling caller (a Nullable array with a NULL element
 -- against a non-Nullable partition key). optimize_rewrite_has_to_in=0 keeps it on the has() path.
 SELECT 'String key NOT has, partition pruning';
 SELECT s FROM t_np WHERE NOT has([CAST('a', 'Nullable(String)'), NULL], s) ORDER BY s SETTINGS optimize_rewrite_has_to_in = 0;
+SELECT count() > 0 FROM (EXPLAIN indexes = 1 SELECT s FROM t_np WHERE NOT has([CAST('a', 'Nullable(String)'), NULL], s) SETTINGS optimize_rewrite_has_to_in = 0) WHERE explain ILIKE '%Condition:%not%in%set%';
 
 -- A Nullable key must keep working and keep using the set index; NULL on the left matches NULL
 -- in the set under transform_null_in=1.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/111340


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Cannot convert NULL value to non-Nullable type` error when a non-Nullable column is used in `IN` with a subquery whose result is `Nullable` (for example `UNION ALL SELECT NULL`) and `transform_null_in = 1`.


### Description

`canBeSafelyCast(Nullable(X), T)` returned `true` when `T` is a non-Nullable `String` (and, via element recursion, `Array`/`Map`/`Tuple`). A `Nullable` source cannot be safely cast to a non-Nullable target: a `NULL` value has no representation there, so a strict cast throws `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` (error 349).

This surfaced in MergeTree `KeyCondition` set-index analysis (`tryPrepareSetColumnsForIndex`). For

```sql
CREATE TABLE t (s String) ENGINE = MergeTree ORDER BY s;
INSERT INTO t VALUES ('a'), ('b'), ('c');
SELECT s FROM t WHERE s IN (SELECT s FROM t UNION ALL SELECT NULL) SETTINGS transform_null_in = 1;
```

the subquery set element type is `Nullable(String)` and the key type is `String`. `canBeSafelyCast` returned `true`, so the code took the strict `castColumn` branch and threw 349 on the `NULL` element instead of the NULL-safe `castColumnAccurateOrNull` fallback. `Int64` was unaffected because `Nullable(Int64) -> Int64` already returned `false` and used the correct fallback.

Fix is in the predicate so all five callers route `Nullable`-source / non-Nullable-target casts through their NULL-safe path:
- `Nullable` case: return `false` unless the target is also `Nullable`.
- `LowCardinality` case: recurse against `removeLowCardinality(to_type)` (keeping the target's `Nullable` wrapper) instead of the fully unwrapped type, so `LowCardinality(Nullable(X)) -> Nullable(X)` stays safe and set-index construction is preserved for a `Nullable` key.
