### PR TITLE
Fix flaky 02417_opentelemetry_insert_on_distributed_table

### DIFF
--- a/tests/queries/0_stateless/02417_opentelemetry_insert_on_distributed_table.sh
+++ b/tests/queries/0_stateless/02417_opentelemetry_insert_on_distributed_table.sh
@@ -48,18 +48,39 @@ ${CLICKHOUSE_CLIENT} -q "
 
 #
 # $1 - OpenTelemetry Trace Id
-# $2 - value of distributed_foreground_insert
+# $2 - span kind to count
+# $3 - expected number of spans of that kind
+#
+# For a distributed INSERT the counted spans come from several scopes and are all
+# enqueued into the async opentelemetry_span_log. The racy ones are the remote-shard
+# SERVER spans: each is written from that shard's TCPHandler TracingContextHolder on
+# its own thread, which can still be finishing after the initiator's client call
+# returned. So counting once can read the log before the last span lands and return a
+# short count (e.g. 2 instead of 3) under slow builds. Poll until the expected count
+# is reached instead.
 function check_span_kind()
 {
-${CLICKHOUSE_CLIENT} -q "
-    SYSTEM FLUSH LOGS opentelemetry_span_log;
+    local count=0
+    for _ in {1..30}; do
+        count=$(${CLICKHOUSE_CLIENT} -q "
+            SYSTEM FLUSH LOGS opentelemetry_span_log;
 
-    SELECT count()
-    FROM system.opentelemetry_span_log
-    WHERE finish_date >= yesterday()
-    AND   lower(hex(trace_id))           = '${1}'
-    AND   kind                           = '${2}'
-    ;"
+            SELECT count()
+            FROM system.opentelemetry_span_log
+            WHERE finish_date >= yesterday()
+            AND   lower(hex(trace_id))           = '${1}'
+            AND   kind                           = '${2}'
+            ;")
+        # Retry only while we got a numeric count below the expected value; a
+        # non-numeric result (client/flush error) breaks out and is reported as-is
+        # so the failure surfaces immediately instead of looping for 30s.
+        [[ "$count" =~ ^[0-9]+$ ]] || break
+        [[ "$count" -ge "$3" ]] && break
+        sleep 1
+    done
+    # Print the final count. If a span is genuinely missing the loop times out
+    # and this still reports the short count, so the test keeps catching it.
+    echo "$count"
 }
 
 
@@ -84,7 +105,7 @@ trace_id=$(${CLICKHOUSE_CLIENT} -q "select lower(hex(generateUUIDv4()))");
 insert $trace_id 0 1 "async-insert-writeToLocal"
 check_span $trace_id
 # 1 HTTP SERVER spans
-check_span_kind $trace_id 'SERVER'
+check_span_kind $trace_id 'SERVER' 1
 
 #
 # test2
@@ -94,9 +115,9 @@ trace_id=$(${CLICKHOUSE_CLIENT} -q "select lower(hex(generateUUIDv4()))");
 insert $trace_id 0 0 "async-insert-writeToRemote"
 check_span $trace_id
 # 3 SERVER spans, 1 for HTTP, 2 for TCP
-check_span_kind $trace_id 'SERVER'
+check_span_kind $trace_id 'SERVER' 3
 # 2 CLIENT spans
-check_span_kind $trace_id 'CLIENT'
+check_span_kind $trace_id 'CLIENT' 2
 
 #
 # test3
@@ -106,7 +127,7 @@ insert $trace_id 1 1  "sync-insert-writeToLocal"
 echo "===3==="
 check_span $trace_id
 # 1 HTTP SERVER spans
-check_span_kind $trace_id 'SERVER'
+check_span_kind $trace_id 'SERVER' 1
 
 #
 # test4
@@ -116,9 +137,9 @@ trace_id=$(${CLICKHOUSE_CLIENT} -q "select lower(hex(generateUUIDv4()))");
 insert $trace_id 1 0  "sync-insert-writeToRemote"
 check_span $trace_id
 # 3 SERVER spans, 1 for HTTP, 2 for TCP
-check_span_kind $trace_id 'SERVER'
+check_span_kind $trace_id 'SERVER' 3
 # 2 CLIENT spans
-check_span_kind $trace_id 'CLIENT'
+check_span_kind $trace_id 'CLIENT' 2
 
 #
 # Cleanup


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/107366
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flakiness of `02417_opentelemetry_insert_on_distributed_table` under `Stateless tests (amd_tsan, s3 storage, parallel)`. The reference diff is a short SERVER-span count in the writeToRemote case (`===4===`: expected 3, got 2).

Root cause: `check_span_kind` did a single `SYSTEM FLUSH LOGS opentelemetry_span_log` + `SELECT count()` with no retry. For a distributed INSERT the 3 SERVER spans come from independent threads (the initiator HTTPHandler plus the two remote-shard TCPHandlers). Each span is written to `system.opentelemetry_span_log` from `TracingContextHolder::~TracingContextHolder()` via the async system-log queue, and the remote TCPHandler holders are destroyed on their own threads after the client call returns. So a single count can read the log before the last remote span is flushed and return 2. Under tsan/s3/parallel the teardown and flush lag more, which is why it only shows up there.

Fix: give `check_span_kind` an expected-count argument and poll (up to 30x1s) until the count reaches it, then print the final count. This is the same approach already merged for the sibling test `01455_opentelemetry_distributed`. The `.reference` file is unchanged (it still asserts 1/3/1/3 SERVER and 2/2 CLIENT), the poll only waits until the count reaches the expected value and never caps or accepts a wrong value, so a genuinely missing span still fails (the loop times out and prints the short count). Happy path adds no latency (the loop breaks immediately when the count is already correct).

Note on validation: the exact CI timing needs the full amd_tsan/s3/parallel stack (S3 backend, ZooKeeper) and is not reproducible on a single-node local build. Locally I confirmed the single-shot count is non-robust (reads < 3 via the same HTTP+traceparent path the test uses) and that the fixed helper preserves the reference output and still reports a short count when a span is genuinely absent. Siblings `02421`/`02423` were checked and their recent CI failures are unrelated (host OOM / quota / timeout), not this span-count race, so they are left unchanged.
