### PR TITLE
Fix peer certificate leak in Poco `SecureSocketImpl::verifyPeerCertificateImpl`

### DIFF
--- a/base/poco/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
+++ b/base/poco/NetSSL_OpenSSL/src/SecureSocketImpl.cpp
@@ -468,23 +468,27 @@ long SecureSocketImpl::verifyPeerCertificateImpl(const std::string& hostName)
 	    (mode != Context::VERIFY_STRICT && isLocalHost(hostName)))
 		return X509_V_OK;
 
+	// SSL_get1_peer_certificate returns a certificate whose reference count has
+	// been incremented; the caller owns that reference and must X509_free it,
+	// otherwise the peer certificate leaks on every verified handshake.
 	X509* pCert = SSL_get1_peer_certificate(_pSSL);
 	if (pCert)
 	{
+        long result = X509_V_ERR_APPLICATION_VERIFICATION;
         if (X509_check_host(pCert, hostName.c_str(), hostName.length(), 0, nullptr) == 1)
         {
-            return X509_V_OK;
+            result = X509_V_OK;
         }
         else
         {
             IPAddress ip;
             if (IPAddress::tryParse(hostName, ip))
             {
-                auto result = X509_check_ip_asc(pCert, hostName.c_str(), 0) == 1;
-                return result ? X509_V_OK : X509_V_ERR_APPLICATION_VERIFICATION;
+                result = X509_check_ip_asc(pCert, hostName.c_str(), 0) == 1 ? X509_V_OK : X509_V_ERR_APPLICATION_VERIFICATION;
             }
         }
-        return X509_V_ERR_APPLICATION_VERIFICATION;;
+        X509_free(pCert);
+        return result;
 	}
 	else return X509_V_OK;
 }


### PR DESCRIPTION
`SecureSocketImpl::verifyPeerCertificateImpl` obtains the peer certificate via `SSL_get1_peer_certificate`, which increments the certificate's reference count and transfers ownership to the caller, but the function never called `X509_free`. As a result, every TLS handshake that reached the hostname check (any `VERIFY_STRICT` client, or any non-loopback peer with verification enabled) leaked the peer certificate and its ASN.1 sub-objects.

The leaking hostname-verification body was introduced in https://github.com/ClickHouse/ClickHouse/commit/d6886097d96a ("Remove Poco::Crypto"), first released in v25.5. The fix consolidates the return paths so the certificate is freed exactly once, preserving the exact verification verdicts.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a memory leak of the peer certificate on every TLS handshake with certificate verification enabled: `SecureSocketImpl::verifyPeerCertificateImpl` did not free the certificate returned by `SSL_get1_peer_certificate`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.87` (included in `26.8` and later)
- Backported to: `26.7.2.16`, `26.6.2.113`, `26.5.6.80`, `26.4.5.160`, `26.3.17.80`, `25.8.29.35`
<!-- ch-version-info:end -->