### PR TITLE
Fix format() table function returning no columns on zero-row input

### DIFF
--- a/src/TableFunctions/TableFunctionFormat.cpp
+++ b/src/TableFunctions/TableFunctionFormat.cpp
@@ -132,7 +132,14 @@ Block TableFunctionFormat::parseData(const ColumnsDescription & columns, const S
 
     /// In case when data contains more then 1 block we combine
     /// them all to one big block (this is considered a rare case).
-    return concatenateBlocks(blocks);
+    Block res = concatenateBlocks(blocks);
+
+    /// When no rows are produced the result carries no columns, which would make
+    /// `StorageValues` unable to resolve them. Preserve the inferred structure.
+    if (res.columns() == 0)
+        res = reader->getHeader().cloneEmpty();
+
+    return res;
 }
 
 StoragePtr TableFunctionFormat::executeImpl(const ASTPtr & /*ast_function*/, ContextPtr context, const std::string & table_name, ColumnsDescription /*cached_columns*/, bool /*is_insert_query*/) const

--- a/tests/queries/0_stateless/04545_format_table_function_zero_rows_schema.reference
+++ b/tests/queries/0_stateless/04545_format_table_function_zero_rows_schema.reference
@@ -1,0 +1,14 @@
+a
+UInt32
+0
+a	UInt32					
+a	b
+UInt32	String
+0
+a
+UInt32
+id	geometry	properties
+Nullable(String)	Geometry	Nullable(JSON)
+0
+1
+2

--- a/tests/queries/0_stateless/04545_format_table_function_zero_rows_schema.sql
+++ b/tests/queries/0_stateless/04545_format_table_function_zero_rows_schema.sql
@@ -1,0 +1,25 @@
+-- Regression test for issue #111390: the `format` table function used to return
+-- a schema-less block (0 columns) when the input parsed to zero rows, so any
+-- column reference failed with `NOT_FOUND_COLUMN_IN_BLOCK` even though `DESCRIBE`
+-- reported the columns. The result must keep the column structure with 0 rows.
+
+-- Explicit structure, empty input: the minimal repro.
+SELECT * FROM format(JSONEachRow, 'a UInt32', '') FORMAT TSVWithNamesAndTypes;
+SELECT count() FROM format(JSONEachRow, 'a UInt32', '');
+DESCRIBE format(JSONEachRow, 'a UInt32', '');
+-- Referencing a column no longer throws; it returns zero rows.
+SELECT a FROM format(JSONEachRow, 'a UInt32', '') WHERE a > 0;
+
+-- Format-agnostic: the same holds for other input formats.
+SELECT * FROM format(TSV, 'a UInt32, b String', '') FORMAT TSVWithNamesAndTypes;
+SELECT count() FROM format(Values, 'x UInt32', '');
+
+-- Inferred (not explicit) structure that yields a header but zero data rows.
+SELECT * FROM format(JSONCompactEachRowWithNamesAndTypes, '["a"]\n["UInt32"]\n') FORMAT TSVWithNamesAndTypes;
+
+-- GeoJSON empty FeatureCollection: the motivating fuzzer case.
+SELECT * FROM format(GeoJSON, '{"type":"FeatureCollection","features":[]}') FORMAT TSVWithNamesAndTypes;
+SELECT count() FROM format(GeoJSON, '{"type":"FeatureCollection","features":[]}');
+
+-- Non-empty input keeps working (the `concatenateBlocks` path is unchanged).
+SELECT * FROM format(JSONEachRow, 'a UInt32', '{"a":1}\n{"a":2}') ORDER BY a;


### PR DESCRIPTION

Closes: https://github.com/ClickHouse/ClickHouse/issues/111390

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix the `format` table function throwing `NOT_FOUND_COLUMN_IN_BLOCK` when the input data parses to zero rows (for example an empty JSON, or a GeoJSON `FeatureCollection` with no features). It now returns an empty result with the correct columns.

### Description
`TableFunctionFormat::parseData` returned `concatenateBlocks(blocks)`, and `concatenateBlocks` returns a block with no columns for an empty input vector. When the input produced zero rows, `blocks` was empty, so the result carried no columns and `StorageValues` could not resolve them: `SELECT *`, `count()`, or any column reference failed with `NOT_FOUND_COLUMN_IN_BLOCK`, while `DESCRIBE` (a separate schema path) reported the columns correctly.

The fix restores the structure when the result has no columns, using the pipeline's output header, so an empty input yields zero rows with the correct columns. `concatenateBlocks` and the non-empty path are unchanged.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1361` (included in `26.7` and later)
<!-- ch-version-info:end -->