### PR TITLE
Minor generic cleanups and build helpers

### DIFF
--- a/base/base/defines.h
+++ b/base/base/defines.h
@@ -55,21 +55,23 @@
 
 /// Macros for Clang Thread Safety Analysis (TSA). They can be safely ignored by other compilers.
 /// Feel free to extend, but please stay close to https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#mutexheader
-#define TSA_GUARDED_BY(...) __attribute__((guarded_by(__VA_ARGS__)))                       /// data is protected by given capability
-#define TSA_PT_GUARDED_BY(...) __attribute__((pt_guarded_by(__VA_ARGS__)))                 /// pointed-to data is protected by the given capability
-#define TSA_REQUIRES(...) __attribute__((requires_capability(__VA_ARGS__)))                /// thread needs exclusive possession of given capability
-#define TSA_REQUIRES_SHARED(...) __attribute__((requires_shared_capability(__VA_ARGS__)))  /// thread needs shared possession of given capability
-#define TSA_ACQUIRED_AFTER(...) __attribute__((acquired_after(__VA_ARGS__)))               /// annotated lock must be locked after given lock
-#define TSA_NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))           /// disable TSA for a function
-#define TSA_CAPABILITY(...) __attribute__((capability(__VA_ARGS__)))                       /// object of a class can be used as capability
+#define TSA_GUARDED_BY(...) __attribute__((guarded_by(__VA_ARGS__)))                             /// data is protected by given capability
+#define TSA_PT_GUARDED_BY(...) __attribute__((pt_guarded_by(__VA_ARGS__)))                       /// pointed-to data is protected by the given capability
+#define TSA_REQUIRES(...) __attribute__((requires_capability(__VA_ARGS__)))                      /// thread needs exclusive possession of given capability
+#define TSA_REQUIRES_SHARED(...) __attribute__((requires_shared_capability(__VA_ARGS__)))        /// thread needs shared possession of given capability
+#define TSA_ACQUIRED_AFTER(...) __attribute__((acquired_after(__VA_ARGS__)))                     /// annotated lock must be locked after given lock
+#define TSA_NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))                 /// disable TSA for a function
+#define TSA_CAPABILITY(...) __attribute__((capability(__VA_ARGS__)))                             /// object of a class can be used as capability
 #define TSA_ACQUIRE(...) __attribute__((acquire_capability(__VA_ARGS__)))                        /// function acquires a capability, but does not release it
 #define TSA_TRY_ACQUIRE(...) __attribute__((try_acquire_capability(__VA_ARGS__)))                /// function tries to acquire a capability and returns a boolean value indicating success or failure
 #define TSA_RELEASE(...) __attribute__((release_capability(__VA_ARGS__)))                        /// function releases the given capability
 #define TSA_ACQUIRE_SHARED(...) __attribute__((acquire_shared_capability(__VA_ARGS__)))          /// function acquires a shared capability, but does not release it
 #define TSA_TRY_ACQUIRE_SHARED(...) __attribute__((try_acquire_shared_capability(__VA_ARGS__)))  /// function tries to acquire a shared capability and returns a boolean value indicating success or failure
 #define TSA_RELEASE_SHARED(...) __attribute__((release_shared_capability(__VA_ARGS__)))          /// function releases the given shared capability
-#define TSA_SCOPED_LOCKABLE __attribute__((scoped_lockable)) /// object of a class has scoped lockable capability
-#define TSA_RETURN_CAPABILITY(...) __attribute__((lock_returned(__VA_ARGS__)))             /// to return capabilities in functions
+#define TSA_SCOPED_LOCKABLE __attribute__((scoped_lockable))                                     /// object of a class has scoped lockable capability
+#define TSA_RETURN_CAPABILITY(...) __attribute__((lock_returned(__VA_ARGS__)))                   /// to return capabilities in functions
+#define TSA_ASSERT_CAPABILITY(...) __attribute__((assert_exclusive_lock(__VA_ARGS__)))           /// assert that exclusive capability is acquired
+#define TSA_ASSERT_SHARED_CAPABILITY(...) __attribute__((assert_shared_lock(__VA_ARGS__)))       /// assert that shared capability is acquired
 
 /// Macros for suppressing TSA warnings for specific reads/writes (instead of suppressing it for the whole function)
 /// They use a lambda function to apply function attribute to a single statement. This enable us to suppress warnings locally instead of

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -71,6 +71,12 @@ set (JEMALLOC_CONFIG_MALLOC_CONF_OVERRIDE "" CACHE STRING "Change default config
 if (JEMALLOC_CONFIG_MALLOC_CONF_OVERRIDE)
     set (JEMALLOC_CONFIG_MALLOC_CONF "${JEMALLOC_CONFIG_MALLOC_CONF_OVERRIDE}")
 endif()
+
+option (ENABLE_JEMALLOC_UAF_SAN "Enable jemalloc sanitizer mode: junk fill, guard pages, use-after-free detection")
+if (ENABLE_JEMALLOC_UAF_SAN)
+    set (JEMALLOC_CONFIG_MALLOC_CONF "${JEMALLOC_CONFIG_MALLOC_CONF},abort_conf:true,junk:true,san_guard_small:100,san_guard_large:1,lg_san_uaf_align:12")
+endif ()
+
 message (STATUS "jemalloc malloc_conf: ${JEMALLOC_CONFIG_MALLOC_CONF}")
 
 set (LIBRARY_DIR "${ClickHouse_SOURCE_DIR}/contrib/jemalloc")
@@ -206,6 +212,10 @@ target_compile_definitions(_jemalloc INTERFACE -DJEMALLOC_NO_RENAME)
 target_compile_options(_jemalloc PRIVATE ${WITHOUT_COVERAGE_FLAGS_LIST})
 
 target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_PROF=1)
+
+if (ENABLE_JEMALLOC_UAF_SAN)
+    target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_UAF_DETECTION)
+endif ()
 
 # jemalloc provides support two unwind flavors:
 # - JEMALLOC_PROF_LIBUNWIND - unw_backtrace() - gnu libunwind (compatible with llvm libunwind)

--- a/src/Common/BufferAllocationPolicy.cpp
+++ b/src/Common/BufferAllocationPolicy.cpp
@@ -48,7 +48,7 @@ class ExpBufferAllocationPolicy : public DB::BufferAllocationPolicy
 
 public:
     explicit ExpBufferAllocationPolicy(const BufferAllocationPolicy::Settings & settings_)
-        : first_size(std::max(settings_.max_single_size, settings_.min_size))
+        : first_size(std::clamp(settings_.max_single_size, settings_.min_size, settings_.max_size))
         , second_size(settings_.min_size)
         , multiply_factor(settings_.multiply_factor)
         , multiply_threshold(settings_.multiply_parts_count_threshold)

--- a/src/Disks/DiskCommitTransactionOptions.h
+++ b/src/Disks/DiskCommitTransactionOptions.h
@@ -20,7 +20,7 @@ struct MetaInKeeperCommitOptions
 {
     bool need_rollback_blobs = true;
     bool may_retry = false;
-    ZooKeeperConnection * zookeeper;
+    ZooKeeperConnection * zookeeper = nullptr;
     Coordination::Requests additional_requests;
 };
 

--- a/src/Functions/FunctionsStringHash.cpp
+++ b/src/Functions/FunctionsStringHash.cpp
@@ -396,7 +396,7 @@ struct MinHashImpl
             }
         }
 
-        MapWithMemoryTracking<UInt64, BytesRef, Comp> values;
+        MapWithMemoryTracking<UInt64, BytesRef, Comp> values{};
     };
 
     using MaxHeap = Heap<std::less<>>;

--- a/src/Processors/QueryPlan/Optimizations/removeUnusedColumns.cpp
+++ b/src/Processors/QueryPlan/Optimizations/removeUnusedColumns.cpp
@@ -237,7 +237,7 @@ static ChildUpdateResult removeSingleChildOutput(
 /// returned by the parent's `removeUnusedColumns` call. If `required_input_positions` is
 /// non-empty, use those positions directly; otherwise fall back to computing positions
 /// from headers (for the case where the caller doesn't have positions yet).
-RemoveChildrenOutputResult removeChildrenOutputs(
+static RemoveChildrenOutputResult removeChildrenOutputs(
     QueryPlan::Nodes & nodes,
     QueryPlan::Node & node,
     const std::vector<std::vector<size_t>> & required_input_positions)

--- a/utils/memcpy-bench/FastMemcpy.h
+++ b/utils/memcpy-bench/FastMemcpy.h
@@ -654,12 +654,12 @@ __attribute__((__no_sanitize__("undefined"))) inline void *memcpy_tiny(void * __
 //---------------------------------------------------------------------
 // main routine
 //---------------------------------------------------------------------
+void* memcpy_fast_sse(void * __restrict destination, const void * __restrict source, size_t size);
 void* memcpy_fast_sse(void * __restrict destination, const void * __restrict source, size_t size) /// NOLINT(misc-definitions-in-headers)
 {
     unsigned char *dst = (unsigned char*)destination;
     const unsigned char *src = (const unsigned char*)source;
     static size_t cachesize = 0x200000; // L2-cache size
-    size_t padding;
 
     // small memory copy
     if (size <= 128)
@@ -668,7 +668,7 @@ void* memcpy_fast_sse(void * __restrict destination, const void * __restrict sou
     }
 
     // align destination to 16 bytes boundary
-    padding = (16 - (((size_t)dst) & 15)) & 15;
+    size_t padding = (16 - (((size_t)dst) & 15)) & 15;
 
     if (padding > 0)
     {

--- a/utils/memcpy-bench/FastMemcpy_Avx.h
+++ b/utils/memcpy-bench/FastMemcpy_Avx.h
@@ -371,12 +371,12 @@ static INLINE void *memcpy_tiny_avx(void * __restrict dst, const void * __restri
 //---------------------------------------------------------------------
 // main routine
 //---------------------------------------------------------------------
+void* memcpy_fast_avx(void * __restrict destination, const void * __restrict source, size_t size);
 void* memcpy_fast_avx(void * __restrict destination, const void * __restrict source, size_t size) /// NOLINT(misc-definitions-in-headers)
 {
     unsigned char *dst = reinterpret_cast<unsigned char*>(destination);
     const unsigned char *src = reinterpret_cast<const unsigned char*>(source);
     static size_t cachesize = 0x200000; // L3-cache size
-    size_t padding;
 
     // small memory copy
     if (size <= 256)
@@ -387,7 +387,7 @@ void* memcpy_fast_avx(void * __restrict destination, const void * __restrict sou
     }
 
     // align destination to 16 bytes boundary
-    padding = (32 - (((size_t)dst) & 31)) & 31;
+    size_t padding = (32 - (((size_t)dst) & 31)) & 31;
 
 #if 0
     if (padding > 0)

--- a/utils/memcpy-bench/memcpy-bench.cpp
+++ b/utils/memcpy-bench/memcpy-bench.cpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <stdexcept>
 #include <string>
-#include <random>
 #include <iostream>
 #include <iomanip>
 #include <thread>
@@ -134,14 +133,13 @@ static void * memcpySSE2(void * __restrict destination, const void * __restrict 
 {
     unsigned char *dst = reinterpret_cast<unsigned char *>(destination);
     const unsigned char *src = reinterpret_cast<const unsigned char *>(source);
-    size_t padding;
 
     // small memory copy
     if (size <= 16)
         return memcpy_tiny(dst, src, size);
 
     // align destination to 16 bytes boundary
-    padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
+    size_t padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
 
     if (padding > 0)
     {
@@ -171,14 +169,13 @@ static void * memcpySSE2Unrolled2(void * __restrict destination, const void * __
 {
     unsigned char *dst = reinterpret_cast<unsigned char *>(destination);
     const unsigned char *src = reinterpret_cast<const unsigned char *>(source);
-    size_t padding;
 
     // small memory copy
     if (size <= 32)
         return memcpy_tiny(dst, src, size);
 
     // align destination to 16 bytes boundary
-    padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
+    size_t padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
 
     if (padding > 0)
     {
@@ -211,14 +208,13 @@ static void * memcpySSE2Unrolled4(void * __restrict destination, const void * __
 {
     unsigned char *dst = reinterpret_cast<unsigned char *>(destination);
     const unsigned char *src = reinterpret_cast<const unsigned char *>(source);
-    size_t padding;
 
     // small memory copy
     if (size <= 64)
         return memcpy_tiny(dst, src, size);
 
     // align destination to 16 bytes boundary
-    padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
+    size_t padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
 
     if (padding > 0)
     {
@@ -258,14 +254,13 @@ static void * memcpySSE2Unrolled8(void * __restrict destination, const void * __
 {
     unsigned char *dst = reinterpret_cast<unsigned char *>(destination);
     const unsigned char *src = reinterpret_cast<const unsigned char *>(source);
-    size_t padding;
 
     // small memory copy
     if (size <= 128)
         return memcpy_tiny(dst, src, size);
 
     // align destination to 16 bytes boundary
-    padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
+    size_t padding = (16 - (reinterpret_cast<size_t>(dst) & 15)) & 15;
 
     if (padding > 0)
     {
@@ -364,8 +359,9 @@ memcpy_my_medium_sse(uint8_t * __restrict & dst, const uint8_t * __restrict & sr
     }
 }
 
+#if 0
 __attribute__((__target__("avx")))
-void memcpy_my_medium_avx(uint8_t * __restrict & __restrict dst, const uint8_t * __restrict & __restrict src, size_t & __restrict size)
+static void memcpy_my_medium_avx(uint8_t * __restrict & __restrict dst, const uint8_t * __restrict & __restrict src, size_t & __restrict size)
 {
     size_t padding = (32 - (reinterpret_cast<size_t>(dst) & 31)) & 31;
 
@@ -411,6 +407,7 @@ void memcpy_my_medium_avx(uint8_t * __restrict & __restrict dst, const uint8_t *
         size -= 256;
     }
 }
+#endif
 
 bool have_avx = true;
 
@@ -833,7 +830,8 @@ static uint8_t * memcpy_my2(uint8_t * __restrict dst, const uint8_t * __restrict
     return ret;
 }
 
-__attribute__((target("sse,sse2,sse3,ssse3,sse4.2,popcnt,avx,avx2,avx512f,avx512bw,avx512vl,avx512vbmi,avx512vbmi2,bmi2"))) void *
+__attribute__((target("sse,sse2,sse3,ssse3,sse4.2,popcnt,avx,avx2,avx512f,avx512bw,avx512vl,avx512vbmi,avx512vbmi2,bmi2")))
+static void *
 ch_memcpy_avx512(void * __restrict dst_, const void * __restrict src_, size_t size)
 {
     char * __restrict dst = reinterpret_cast<char * __restrict>(dst_);
@@ -917,14 +915,14 @@ extern "C" void * __memcpy_avx512_unaligned_erms(void * __restrict destination, 
 extern "C" void * __memcpy_avx512_no_vzeroupper(void * __restrict destination, const void * __restrict source, size_t size); /// NOLINT
 
 
-void * sz_copy_haswell_cast(void * __restrict destination, const void * __restrict source, size_t size)
+static void * sz_copy_haswell_cast(void * __restrict destination, const void * __restrict source, size_t size)
 {
     void * dst = destination;
     sz_copy_haswell(static_cast<sz_ptr_t>(destination), static_cast<sz_cptr_t>(source), size);
     return dst;
 }
 
-void * sz_copy_skylake_cast(void * __restrict destination, const void * __restrict source, size_t size)
+static void * sz_copy_skylake_cast(void * __restrict destination, const void * __restrict source, size_t size)
 {
     void * dst = destination;
     sz_copy_skylake(static_cast<sz_ptr_t>(destination), static_cast<sz_cptr_t>(source), size);
@@ -971,7 +969,7 @@ uint64_t dispatchMemcpyVariants(size_t memcpy_variant, uint8_t * dst, uint8_t * 
     return 0;
 }
 
-uint64_t dispatchVariants(
+static uint64_t dispatchVariants(
     size_t memcpy_variant, size_t generator_variant, uint8_t * dst, uint8_t * src, size_t size, size_t iterations, size_t num_threads)
 {
     if (generator_variant == 1)
@@ -1004,7 +1002,7 @@ int main(int argc, char ** argv)
     boost::program_options::variables_map options;
     boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), options);
 
-    if (options.count("help") || !options.count("variant"))
+    if (options.contains("help") || !options.contains("variant"))
     {
         std::cout << R"(Usage:
 
@@ -1048,8 +1046,8 @@ clickhouse-local --structure '
     size_t memcpy_variant = options["variant"].as<size_t>();
     size_t generator_variant = options["distribution"].as<size_t>();
 
-    size_t iterations;
-    if (options.count("iterations"))
+    size_t iterations = 0;
+    if (options.contains("iterations"))
     {
         iterations = options["iterations"].as<size_t>();
     }
@@ -1075,7 +1073,7 @@ clickhouse-local --structure '
 
     std::cout << std::fixed << std::setprecision(3);
 
-    if (options.count("tsv"))
+    if (options.contains("tsv"))
     {
         std::cout
             << '\t' << size


### PR DESCRIPTION
A set of small, self-contained improvements with no behavior change for existing code paths:

- `base/base/defines.h`: add `TSA_ASSERT_CAPABILITY` / `TSA_ASSERT_SHARED_CAPABILITY` Clang thread-safety-analysis macros.
- `contrib/jemalloc-cmake`: add an opt-in `ENABLE_JEMALLOC_UAF_SAN` option (junk fill, guard pages, use-after-free detection), default OFF.
- `utils/memcpy-bench`: forward-declare header-defined functions, hoist a `size_t` to its point of initialization, give file-local helpers internal linkage, and drop an unused include.
- `BufferAllocationPolicy`: clamp the first buffer size by `max_size` instead of only flooring it by `min_size`.
- `FunctionsStringHash`: value-initialize the `MinHash` values member.
- `removeUnusedColumns`: give the file-local helper internal linkage.
- `DiskCommitTransactionOptions`: initialize the raw `zookeeper` pointer.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.78` (included in `26.8` and later)
<!-- ch-version-info:end -->