### PR TITLE
Fix log-check false positive from test 04367 comments

### DIFF
--- a/tests/queries/0_stateless/04367_lambda_arg_backquoted_dot_no_logical_error.sql
+++ b/tests/queries/0_stateless/04367_lambda_arg_backquoted_dot_no_logical_error.sql
@@ -1,7 +1,10 @@
 -- Regression test: a backquoted lambda argument whose name contains a dot
--- (e.g. `__table1.`) used to abort the server with Logical error '!part.empty()'
+-- (e.g. `__table1.`) used to abort the server on the failed assertion `!part.empty()`
 -- when the query tree was converted back to AST for an error message.
 -- The lambda argument name is atomic, so it must not be split on '.'.
+-- NOTE: the comments here deliberately avoid the literal wording of the assertion-failure
+-- log message: the expected errors below echo the query text (comments included) into the
+-- server log, and the CI log checker would report that wording as a genuine failure.
 
 -- A type mismatch forces the analyzer to format the offending expression as AST,
 -- which is where the abort happened. Now it must be a clean exception, server stays up.


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

The comments of `04367_lambda_arg_backquoted_dot_no_logical_error` (added in https://github.com/ClickHouse/ClickHouse/pull/108735) contain the literal wording of the assertion-failure log message the test guards against. The test's expected `TYPE_MISMATCH` errors echo the full query text — comments included — into the server log, and the CI log checker (`ci/jobs/scripts/log_parser.py`) matches that wording with its `Logical error.*` pattern, reporting a red check (STID 2735-47bf) even though the test passes and nothing aborts. On 2026-07-22 alone, 12 runs across 10 unrelated PRs (including the docs-only https://github.com/ClickHouse/ClickHouse/pull/111251) went red on this false positive.

This rewords the comments so the log checker's patterns cannot match them, and leaves a note explaining why the wording is avoided. Test behavior and reference output are unchanged.

The same STID also clusters a genuine abort (`Arguments of 'multiply' have incorrect data types` during partial-result evaluation, from the `EXCHANGE TABLES` race) — that one is tracked separately in https://github.com/ClickHouse/ClickHouse/issues/110133 with fixes in https://github.com/ClickHouse/ClickHouse/pull/109747 and https://github.com/ClickHouse/ClickHouse/pull/110048; this PR only removes the false-positive component.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109005&sha=f7ca4ee7718df28cabcf397348a5f3cd342966a4&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20old%20analyzer%2C%20s3%20storage%2C%20DBReplicated%2C%20WasmEdge%2C%20parallel%2C%202%2F3%29

Related: https://github.com/ClickHouse/ClickHouse/pull/108735
Related: https://github.com/ClickHouse/ClickHouse/pull/109005


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.177` (included in `26.8` and later)
- Backported to: `26.7.12.10`
<!-- ch-version-info:end -->