### PR TITLE
Fix ORDER BY WITH FILL applied per shard on Distributed tables

### DIFF
--- a/src/Interpreters/InterpreterSelectQuery.cpp
+++ b/src/Interpreters/InterpreterSelectQuery.cpp
@@ -2310,7 +2310,11 @@ void InterpreterSelectQuery::executeImpl(QueryPlan & query_plan, std::optional<P
                 executeLimitBy(query_plan);
             }
 
-            executeWithFill(query_plan);
+            /// WITH FILL fills the final ordered result, so it must run once on the initiator over the
+            /// merged shard streams, not on each shard (that duplicates fill rows once per shard). Skip
+            /// it when this node stops at an aggregation state for later merging, like the guards below.
+            if (!to_aggregation_stage)
+                executeWithFill(query_plan);
 
             /// If we have 'WITH TIES', we need execute limit before projection,
             /// because in that case columns from 'ORDER BY' are used.

--- a/src/Planner/Planner.cpp
+++ b/src/Planner/Planner.cpp
@@ -2629,7 +2629,11 @@ void Planner::buildPlanForQueryNode()
             addLimitByStep(query_plan, limit_by_analysis_result, query_analysis_result, false /*do_not_skip_offset*/);
         }
 
-        if (query_node.hasOrderBy())
+        /// WITH FILL fills the final ordered result, so it must run once on the initiator over the
+        /// merged shard streams, not on each shard (that duplicates fill rows once per shard and
+        /// positions them per-shard rather than globally). Skip it when the plan stops at an
+        /// aggregation state for later merging, mirroring the OFFSET / LIMIT / "Project names" guards below.
+        if (query_node.hasOrderBy() && !query_processing_info.isToAggregationState())
             addWithFillStepIfNeeded(query_plan, query_analysis_result, expression_analysis_result.getSort(), planner_context, query_node, select_query_options, useful_sets);
 
         const bool apply_limit = query_processing_info.getToStage() != QueryProcessingStage::WithMergeableStateAfterAggregation;

--- a/tests/queries/0_stateless/04545_with_fill_distributed_per_shard.reference
+++ b/tests/queries/0_stateless/04545_with_fill_distributed_per_shard.reference
@@ -1,0 +1,34 @@
+empty analyzer=1
+0
+1
+2
+3
+4
+empty analyzer=0
+0
+1
+2
+3
+4
+data analyzer=1
+0
+1
+2
+100
+100
+data analyzer=0
+0
+1
+2
+100
+100
+no push down limit analyzer=1
+0
+1
+2
+3
+4
+step analyzer=1
+0
+2
+4

--- a/tests/queries/0_stateless/04545_with_fill_distributed_per_shard.sql
+++ b/tests/queries/0_stateless/04545_with_fill_distributed_per_shard.sql
@@ -1,0 +1,51 @@
+-- Tags: distributed
+
+-- ORDER BY ... WITH FILL over a Distributed table must fill once on the initiator over the
+-- merged shard streams, not on each shard. Before the fix each fill row was returned once per
+-- shard (duplicated) and positioned per-shard rather than globally. See issue #111212.
+-- The two shards below read the same table, so DATA rows are legitimately duplicated per shard,
+-- but FILL rows must NOT be.
+--
+-- serialize_query_plan = 0 because WITH FILL is not supported in serialized sort descriptions
+-- (serializeSortDescription throws NOT_IMPLEMENTED) and the CI `distributed plan` shard turns
+-- serialize_query_plan on globally; that path is orthogonal to the step placement tested here.
+
+DROP TABLE IF EXISTS t_with_fill_dist;
+CREATE TABLE t_with_fill_dist (k Int64) ENGINE = MergeTree ORDER BY k;
+INSERT INTO t_with_fill_dist VALUES (100);
+
+-- Fill-only result (no data rows pass the filter): fill rows must appear exactly once.
+SELECT 'empty analyzer=1';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+WHERE k < 0 ORDER BY k WITH FILL FROM 0 TO 5
+SETTINGS enable_analyzer = 1, serialize_query_plan = 0;
+
+SELECT 'empty analyzer=0';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+WHERE k < 0 ORDER BY k WITH FILL FROM 0 TO 5
+SETTINGS enable_analyzer = 0, serialize_query_plan = 0;
+
+-- With data rows: the k=100 row is duplicated across shards (correct), fill rows 0,1,2 appear once.
+SELECT 'data analyzer=1';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+ORDER BY k WITH FILL FROM 0 TO 3
+SETTINGS enable_analyzer = 1, serialize_query_plan = 0;
+
+SELECT 'data analyzer=0';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+ORDER BY k WITH FILL FROM 0 TO 3
+SETTINGS enable_analyzer = 0, serialize_query_plan = 0;
+
+-- Also with distributed_push_down_limit=0 (shards asked to process to WithMergeableStateAfterAggregation).
+SELECT 'no push down limit analyzer=1';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+WHERE k < 0 ORDER BY k WITH FILL FROM 0 TO 5
+SETTINGS enable_analyzer = 1, distributed_push_down_limit = 0, serialize_query_plan = 0;
+
+-- WITH FILL STEP.
+SELECT 'step analyzer=1';
+SELECT k FROM remote('127.0.0.1,127.0.0.1', currentDatabase(), t_with_fill_dist)
+WHERE k < 0 ORDER BY k WITH FILL FROM 0 TO 5 STEP 2
+SETTINGS enable_analyzer = 1, serialize_query_plan = 0;
+
+DROP TABLE t_with_fill_dist;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111212

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `ORDER BY ... WITH FILL` returning wrong results over `Distributed` tables: fill rows were generated on each shard and concatenated, so every fill row was returned once per shard and positioned per-shard instead of once over the merged result. The fill step now runs only on the initiator.


### Description

For a `Distributed` non-aggregate query with `ORDER BY`, each shard is asked to process to `WithMergeableStateAfterAggregation[AndLimit]` so it can pre-sort. On the shard `isSecondStage()` is true, and the `WITH FILL` step was added unconditionally, unlike the sibling final-result-only steps (`OFFSET`, `LIMIT`, `Project names`) which are guarded by `!isToAggregationState()`. As a result `FillingStep` ran on every shard.

Fix: gate the `WITH FILL` step with the same condition in both the new analyzer (`Planner.cpp`) and the old interpreter (`InterpreterSelectQuery.cpp`), so it runs only on the initiator over the merged, ordered result. Per-shard sorting is unchanged (the initiator still merge-sorts the shard streams).

`distributed_group_by_no_merge=1` (shards process to `Complete`) is unaffected, since `isToAggregationState()` is false there and per-shard filling is the intended behavior.
