### PR TITLE
Use vector similarity index for SELECT DISTINCT vector search queries

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/annindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/annindexes.md
@@ -356,6 +356,8 @@ ClickHouse will fetch 3.0 x 10 = 30 nearest neighbors from the vector index in e
 Only the ten closest neighbors will be returned.
 We note that setting `vector_search_index_fetch_multiplier` can mitigate the problem but in extreme cases (very selective WHERE condition), it is still possible that less than N requested rows returned.
 
+A `SELECT DISTINCT` query behaves the same way: the vector similarity index is used, but because duplicate rows are removed after the index read, fewer than `LIMIT` rows may be returned. Setting `vector_search_index_fetch_multiplier` mitigates this in the same manner.
+
 **Rescoring**
 
 Skip indexes in ClickHouse generally filter at the granule level, i.e. a lookup in a skip index (internally) returns a list of potentially matching granules which reduces the number of read data in the subsequent scan.

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7943,7 +7943,7 @@ If a vector search query has a WHERE clause, this setting determines if it is ev
 - 'prefilter' - Evaluate other filters first, then perform brute-force search to identify neighbours.
 )", 0) \
     DECLARE_WITH_ALIAS(Float, vector_search_index_fetch_multiplier, 1.0, R"(
-Multiply the number of fetched nearest neighbors from the vector similarity index by this number. Only applied for post-filtering with other predicates or if setting 'vector_search_with_rescoring = 1'. Valid range: [1.0, 1000.0]. Values outside this range are rejected.
+Multiply the number of fetched nearest neighbors from the vector similarity index by this number. Only applied when rows may be removed after the index read (post-filtering with other predicates or a `DISTINCT` clause) or if setting 'vector_search_with_rescoring = 1'. Valid range: [1.0, 1000.0]. Values outside this range are rejected.
 )", 0, vector_search_postfilter_multiplier) \
     DECLARE(Bool, vector_search_use_quantized_codes, false, R"(
 Enables a two-stage approximate vector search without index (brute force scan) over a `Quantized`-compressed column. When enabled, `ORDER BY L2Distance|cosineDistance(vec, reference) LIMIT k` against a column encoded with a `Quantized(...)` codec will

--- a/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
+++ b/src/Interpreters/ClusterProxy/distributedIndexAnalysis.cpp
@@ -157,7 +157,7 @@ std::pair<Scalars, std::string> buildAnalyzeIndexQuery(const StorageID & storage
         query += fmt::format(", 'vector_search_index_analysis', array('{}', '{}', {}, {}, {}, {})",
                         vector_search_parameters->column, vector_search_parameters->distance_function,
                         vector_search_parameters->limit, vector_search_parameters->reference_vector,
-                        vector_search_parameters->additional_filters_present, vector_search_parameters->return_distances);
+                        vector_search_parameters->post_read_row_reduction, vector_search_parameters->return_distances);
     }
     query += ")";
 

--- a/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useVectorSearch.cpp
@@ -7,6 +7,7 @@
 #include <Functions/IFunction.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Processors/QueryPlan/DistinctStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
 #include <Processors/QueryPlan/LimitStep.h>
@@ -53,15 +54,25 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
     constexpr size_t no_layers_updated = 0;
 
     bool additional_filters_present = false; /// WHERE or PREWHERE
+    bool distinct_present = false; /// SELECT DISTINCT
 
     /// Expect this query plan:
     /// LimitStep
+    ///    ^
+    ///    |
+    /// (optional: DistinctStep)         -- SELECT DISTINCT (final)
     ///    ^
     ///    |
     /// SortingStep
     ///    ^
     ///    |
     /// ExpressionStep
+    ///    ^
+    ///    |
+    /// (optional: DistinctStep)         -- SELECT DISTINCT (preliminary)
+    ///    ^
+    ///    |
+    /// (optional: ExpressionStep)       -- present only together with the preliminary DistinctStep
     ///    ^
     ///    |
     /// (optional: FilterStep)
@@ -76,6 +87,14 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
     if (node->children.size() != 1)
         return no_layers_updated;
     node = node->children.front();
+    /// SELECT DISTINCT inserts the final DistinctStep between LimitStep and SortingStep (issue #111343).
+    if (auto * final_distinct_step = typeid_cast<DistinctStep *>(node->step.get()); final_distinct_step && !final_distinct_step->isPreliminary())
+    {
+        distinct_present = true;
+        if (node->children.size() != 1)
+            return no_layers_updated;
+        node = node->children.front();
+    }
     auto * sorting_step = typeid_cast<SortingStep *>(node->step.get());
     if (!sorting_step)
         return no_layers_updated;
@@ -83,6 +102,32 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
     if (node->children.size() != 1)
         return no_layers_updated;
     node = node->children.front();
+    /// Steps over a preliminary DistinctStep if the current node is one. Returns whether it did; sets
+    /// `stepped_ok` to false if the tree shape is unexpected (a step with multiple children).
+    bool stepped_ok = true;
+    auto step_over_preliminary_distinct = [&]() -> bool
+    {
+        if (auto * preliminary_distinct_step = typeid_cast<DistinctStep *>(node->step.get());
+            preliminary_distinct_step && preliminary_distinct_step->isPreliminary())
+        {
+            distinct_present = true;
+            if (node->children.size() != 1)
+            {
+                stepped_ok = false;
+                return false;
+            }
+            node = node->children.front();
+            return true;
+        }
+        return false;
+    };
+
+    /// The old analyzer places the preliminary DistinctStep BELOW the SortingStep and ABOVE the ORDER BY
+    /// ExpressionStep.
+    step_over_preliminary_distinct();
+    if (!stepped_ok)
+        return no_layers_updated;
+
     auto * expression_step = typeid_cast<ExpressionStep *>(node->step.get());
     if (!expression_step)
         return no_layers_updated;
@@ -90,6 +135,21 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
     if (node->children.size() != 1)
         return no_layers_updated;
     node = node->children.front();
+    /// The analyzer instead places the preliminary DistinctStep BELOW the ORDER BY ExpressionStep,
+    /// followed by a projection ExpressionStep. Step over both.
+    if (step_over_preliminary_distinct())
+    {
+        /// A projection ExpressionStep usually sits between the preliminary DistinctStep and the read.
+        /// Step over it if present; if it was merged away, we are already at the read/filter node.
+        if (typeid_cast<ExpressionStep *>(node->step.get()))
+        {
+            if (node->children.size() != 1)
+                return no_layers_updated;
+            node = node->children.front();
+        }
+    }
+    if (!stepped_ok)
+        return no_layers_updated;
     auto * read_from_mergetree_step = typeid_cast<ReadFromMergeTree *>(node->step.get());
     FilterStep * filter_step = nullptr;
     if (!read_from_mergetree_step)
@@ -244,8 +304,11 @@ size_t tryUseVectorSearchWithVectorIndexFirstPass(QueryPlan::Node * parent_node,
             "The `_distance` column is an internal virtual column of vector search and cannot be referenced directly in queries. "
             "Use the distance function (e.g. `L2Distance`, `cosineDistance`) in ORDER BY instead");
 
+    /// DISTINCT, like a filter, can remove rows after the read (see VectorSearchParameters::post_read_row_reduction).
+    const bool post_read_row_reduction = additional_filters_present || distinct_present;
+
     /// All set for 2nd pass
-    auto vector_search_parameters = std::make_optional<VectorSearchParameters>(search_column, distance_function, n, reference_vector, additional_filters_present, true);
+    auto vector_search_parameters = std::make_optional<VectorSearchParameters>(search_column, distance_function, n, reference_vector, post_read_row_reduction, true);
     read_from_mergetree_step->setVectorSearchParameters(std::move(vector_search_parameters));
 
     return no_layers_updated;

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -558,8 +558,8 @@ NearestNeighbours MergeTreeIndexConditionVectorSimilarity::calculateApproximateN
         granule->scalar_kind, ErrorCodes::INCORRECT_QUERY, "reference vector in the SELECT query");
 
     size_t limit = parameters->limit;
-    if (parameters->additional_filters_present || is_rescoring)
-        /// Additional filters mean post-filtering which means that matches may be removed. To compensate, allow to fetch more rows by a factor.
+    if (parameters->post_read_row_reduction || is_rescoring)
+        /// A post-read row reduction (a WHERE/PREWHERE filter or a DISTINCT) may remove matches. To compensate, allow to fetch more rows by a factor.
         /// Similarly, if rescoring is on, fetch more neighbours from the index and pass them for the final re-ranking by ORDER BY ... LIMIT.
         limit = std::min(static_cast<size_t>(static_cast<double>(limit) * static_cast<double>(index_fetch_multiplier)), max_limit);
 

--- a/src/Storages/MergeTree/VectorSearchUtils.h
+++ b/src/Storages/MergeTree/VectorSearchUtils.h
@@ -15,7 +15,9 @@ struct VectorSearchParameters
     VectorWithMemoryTracking<Float64> reference_vector;
 
     /// Other metadata
-    bool additional_filters_present; /// SELECT contains a WHERE or PREWHERE clause
+    /// True if rows may be removed after the index read (a WHERE/PREWHERE filter or a DISTINCT), so the index
+    /// should over-fetch neighbours (by 'vector_search_index_fetch_multiplier') to still satisfy the LIMIT.
+    bool post_read_row_reduction;
     bool return_distances;
 };
 

--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -223,7 +223,7 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const 
             vector_search_args[1].safeGet<String>(), /// distance function
             vector_search_args[2].safeGet<UInt64>(), /// limit
             reference_vector, /// search vector
-            static_cast<bool>(vector_search_args[4].safeGet<bool>()), /// additional filters
+            static_cast<bool>(vector_search_args[4].safeGet<bool>()), /// post-read row reduction (filter or DISTINCT)
             static_cast<bool>(vector_search_args[5].safeGet<bool>())}; /// return distances
     }
 }

--- a/tests/queries/0_stateless/02354_vector_search_distinct.reference
+++ b/tests/queries/0_stateless/02354_vector_search_distinct.reference
@@ -1,0 +1,20 @@
+DISTINCT should use the vector index
+1
+DISTINCT on multiple columns should use the vector index
+1
+DISTINCT with a WHERE clause should use the vector index
+1
+Non-DISTINCT still uses the vector index
+1
+DISTINCT should use the vector index (old analyzer)
+1
+DISTINCT over a non-value-preserving index expression should be brute force
+0
+Brute-force DISTINCT result
+1
+2
+3
+Indexed DISTINCT result (equal with sufficient over-fetch)
+1
+2
+3

--- a/tests/queries/0_stateless/02354_vector_search_distinct.sql
+++ b/tests/queries/0_stateless/02354_vector_search_distinct.sql
@@ -1,0 +1,80 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+-- Vector similarity (HNSW) index should be used for SELECT DISTINCT ... ORDER BY distance LIMIT N (issue #111343)
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 2) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 3;
+INSERT INTO tab VALUES (1, [1.0, 0.0]), (2, [1.1, 0.0]), (3, [1.2, 0.0]), (4, [1.3, 0.0]), (5, [1.4, 0.0]), (6, [1.5, 0.0]), (7, [1.6, 0.0]), (8, [1.7, 0.0]), (9, [1.8, 0.0]), (10, [1.9, 0.0]), (11, [2.0, 0.0]), (12, [2.1, 0.0]);
+
+-- Each check returns 1 if the vector similarity index 'idx' appears in the plan, 0 otherwise.
+
+SELECT 'DISTINCT should use the vector index';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT DISTINCT id FROM tab ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+
+SELECT 'DISTINCT on multiple columns should use the vector index';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT DISTINCT id, vec FROM tab ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+
+SELECT 'DISTINCT with a WHERE clause should use the vector index';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT DISTINCT id FROM tab WHERE id > 2 ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+
+SELECT 'Non-DISTINCT still uses the vector index';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT id FROM tab ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+
+-- The old analyzer arranges the DISTINCT plan steps differently, so cover it explicitly.
+SET enable_analyzer = 0;
+SELECT 'DISTINCT should use the vector index (old analyzer)';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT DISTINCT id FROM tab ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+SET enable_analyzer = 1;
+
+DROP TABLE tab;
+
+-- The index is built over a non-value-preserving expression. DISTINCT (like the non-DISTINCT case)
+-- must fall back to brute force, otherwise raw-vector queries would be answered against transformed
+-- index data and return wrong nearest neighbours.
+DROP TABLE IF EXISTS tab_transformed;
+CREATE TABLE tab_transformed(id Int32, vec Array(Float32), INDEX idx arrayMap(x -> 100 - x, vec) TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 2) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 3;
+INSERT INTO tab_transformed VALUES (1, [1.0, 0.0]), (2, [1.1, 0.0]), (3, [1.2, 0.0]), (4, [1.3, 0.0]), (5, [1.4, 0.0]), (6, [1.5, 0.0]), (7, [1.6, 0.0]), (8, [1.7, 0.0]), (9, [1.8, 0.0]), (10, [1.9, 0.0]), (11, [2.0, 0.0]), (12, [2.1, 0.0]);
+
+SELECT 'DISTINCT over a non-value-preserving index expression should be brute force';
+SELECT count() > 0 FROM (
+    EXPLAIN indexes = 1 SELECT DISTINCT id FROM tab_transformed ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3
+)
+WHERE explain ILIKE '%Name: idx%';
+
+DROP TABLE tab_transformed;
+
+-- Correctness: with enough over-fetch (vector_search_index_fetch_multiplier), the indexed DISTINCT result
+-- matches the brute-force result even when duplicate projection values collapse below the LIMIT.
+DROP TABLE IF EXISTS tab_idx;
+DROP TABLE IF EXISTS tab_bruteforce;
+CREATE TABLE tab_idx(id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 2) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 3;
+CREATE TABLE tab_bruteforce(id Int32, vec Array(Float32)) ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 3;
+-- id = 1 occupies the three positions nearest to [1., 0.]
+INSERT INTO tab_idx VALUES (1, [1.00, 0.0]), (1, [1.01, 0.0]), (1, [1.02, 0.0]), (2, [1.50, 0.0]), (3, [1.60, 0.0]), (4, [1.70, 0.0]), (5, [1.80, 0.0]), (6, [1.90, 0.0]), (7, [2.00, 0.0]), (8, [2.10, 0.0]), (9, [2.20, 0.0]), (10, [2.30, 0.0]);
+INSERT INTO tab_bruteforce SELECT * FROM tab_idx;
+
+SELECT 'Brute-force DISTINCT result';
+SELECT DISTINCT id FROM tab_bruteforce ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3;
+SELECT 'Indexed DISTINCT result (equal with sufficient over-fetch)';
+SELECT DISTINCT id FROM tab_idx ORDER BY L2Distance(vec, [1., 0.]) ASC LIMIT 3 SETTINGS vector_search_index_fetch_multiplier = 100;
+
+DROP TABLE tab_idx;
+DROP TABLE tab_bruteforce;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111343
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use the vector similarity (HNSW) index for `SELECT DISTINCT ... ORDER BY <distance function> LIMIT N` queries. Previously the index was silently skipped when the query contained `DISTINCT`, forcing a brute-force scan.


### Description

Closes #111343.

The vector search optimizer has two passes. The first pass (`tryUseVectorSearch`) recognizes a vector search by walking a fixed query-plan chain `LimitStep -> SortingStep -> ExpressionStep -> [FilterStep] -> ReadFromMergeTree` and enables index usage. The second pass (`optimizeVectorSearchWithVectorIndexSecondPass`) applies the `_distance` substitution when `vector_search_with_rescoring = 0` and the candidate-row filter when `vector_search_with_rescoring = 1`.

`SELECT DISTINCT` inserts two `DistinctStep` nodes (a final one between `LimitStep` and `SortingStep`, and a preliminary one whose position differs between the old and new analyzers). Both passes matched the fixed chain and bailed on those `DistinctStep` nodes, so the index was never considered for `DISTINCT`. Both passes now step over the `DistinctStep` nodes:

- First pass: the index is considered for `DISTINCT` queries.
- Second pass: `DISTINCT` queries also get the `_distance` substitution (`vector_search_with_rescoring = 0`) and candidate-row filtering (`vector_search_with_rescoring = 1`). When substituting `_distance`, the interposed preliminary `DistinctStep` and its projection `ExpressionStep` have their headers refreshed bottom-up so `_distance` replaces `vec` up to the ORDER BY `ExpressionStep`. If `vec` feeds a surviving computed column (e.g. `SELECT DISTINCT arraySum(vec)`), the substitution is skipped and the query falls back to rescoring (which keeps `vec`); the index is still used.

`DISTINCT` removes duplicate rows after the read, so - like a `WHERE`/`PREWHERE` filter - it can shrink the result below the requested `LIMIT`. It reuses the existing post-filter over-fetch path (`vector_search_index_fetch_multiplier`). The `VectorSearchParameters` flag is renamed `additional_filters_present` -> `post_read_row_reduction` to reflect that it now also covers `DISTINCT`, and the setting docs and ANN guide are updated.

"Look for other skip indexes as well": only the vector similarity index was affected. `set`, `minmax` and `bloom_filter` indexes are analyzed inside `ReadFromMergeTree` from the `WHERE` predicate and are independent of the outer plan shape - verified with `EXPLAIN indexes = 1` that they keep firing under `DISTINCT`. The vector similarity index is the only skip index driven by a plan-shape match, hence the only one that regressed.

The fallback to brute force for a non-value-preserving index expression (e.g. `arrayMap(x -> 100 - x, vec)`) is preserved and covered by the tests.
