### PR TITLE
Make Keeper cross-disk snapshot/changelog moves durable

### DIFF
--- a/src/Coordination/KeeperCommon.cpp
+++ b/src/Coordination/KeeperCommon.cpp
@@ -56,8 +56,24 @@ void moveFileBetweenDisks(
     /// if a copy is complete we don't care from which disk we use the same file
     /// so it's okay if a failure happens after removing of tmp file but before we remove
     /// the file from the source disk
-    auto from_path = fs::path(path_from);
-    auto tmp_file_name = from_path.parent_path() / (std::string{tmp_keeper_file_prefix} + from_path.filename().string());
+    /// The marker is named after the target: it lives next to the copied file on disk_to and
+    /// startup recovery pairs a tmp_ marker with the file of the same name to drop an incomplete
+    /// copy. A move may rename the file (changelog rotation shrinks the index range), so keying
+    /// the marker off path_from would leave a partial renamed target unmarked.
+    auto to_path = fs::path(path_to);
+    auto tmp_file_name = to_path.parent_path() / (std::string{tmp_keeper_file_prefix} + to_path.filename().string());
+
+    /// Directories whose entries change during the move. Made durable so a power loss cannot
+    /// leave a target that looks complete (marker absent, content present) without it actually
+    /// being on stable storage. getDirectorySyncGuard is a no-op (nullptr) on non-local disks.
+    /// The marker and the copied file share a directory on disk_to; the source is on disk_from.
+    const auto target_dir = to_path.parent_path();
+    const auto source_dir = fs::path(path_from).parent_path();
+    auto fsync_dir = [](const DiskPtr & disk, const fs::path & dir)
+    {
+        /// RAII: opens the directory fd now, fdatasyncs it on scope exit.
+        SyncGuardPtr dir_sync_guard = disk->getDirectorySyncGuard(dir.generic_string());
+    };
 
     const auto & coordination_settings = keeper_context->getFixedCoordinationSettings();
     auto max_retries_on_init = coordination_settings[CoordinationSetting::disk_move_retries_during_init].value;
@@ -103,14 +119,31 @@ void moveFileBetweenDisks(
             {
                 auto buf = disk_to->writeFile(tmp_file_name);
                 buf->finalize();
+                /// Persist the marker's directory entry before the copy starts, so its presence
+                /// (== "copy in progress") is durable. Otherwise a crash mid-copy could leave a
+                /// partial target while the marker's creation is lost, making the partial target
+                /// look complete on restart.
+                fsync_dir(disk_to, target_dir);
             },
             "creating temporary file"))
         return;
 
-    if (!run_with_retries([&] { disk_from->copyFile(from_path, *disk_to, path_to, {}); }, "copying file"))
+    /// sync = true: fsync the copied content so it is on stable storage before we drop the marker.
+    if (!run_with_retries(
+            [&] { disk_from->copyFile(path_from, *disk_to, path_to, /*read_settings=*/{}, /*write_settings=*/{}, /*cancellation_hook=*/{}, /*sync=*/true); },
+            "copying file"))
         return;
 
-    if (!run_with_retries([&] { disk_to->removeFileIfExists(tmp_file_name); }, "removing temporary file"))
+    if (!run_with_retries(
+            [&]
+            {
+                disk_to->removeFileIfExists(tmp_file_name);
+                /// Persist the marker removal (and, in the same directory, the copied file's entry)
+                /// before publishing: after this returns, "marker absent + target present" is
+                /// durable, so a restart keeps the target instead of deleting it as an incomplete copy.
+                fsync_dir(disk_to, target_dir);
+            },
+            "removing temporary file"))
         return;
 
     if (before_file_remove_op && !before_file_remove_op())
@@ -119,7 +152,14 @@ void moveFileBetweenDisks(
         return;
     }
 
-    if (!run_with_retries([&] { disk_from->removeFileIfExists(path_from); }, "removing file from source disk"))
+    if (!run_with_retries(
+            [&]
+            {
+                disk_from->removeFileIfExists(path_from);
+                /// Persist the source removal so the file does not reappear after a power loss.
+                fsync_dir(disk_from, source_dir);
+            },
+            "removing file from source disk"))
         return;
 }
 }

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -21,6 +21,7 @@
 #include <Disks/DiskLocal.h>
 
 #include <IO/ReadBufferFromFileBase.h>
+#include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromFileDecorator.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
@@ -42,6 +43,8 @@ namespace DB::CoordinationSetting
 {
     extern const CoordinationSettingsBool compress_snapshots_with_zstd_format;
     extern const CoordinationSettingsUInt64 snapshot_transfer_chunk_size;
+    extern const CoordinationSettingsUInt64 disk_move_retries_during_init;
+    extern const CoordinationSettingsUInt64 disk_move_retries_wait_ms;
 }
 
 namespace
@@ -3016,6 +3019,194 @@ TEST(KeeperSnapshotFileNameTest, CanonicalSnapshotS3Name)
     EXPECT_EQ(DB::getCanonicalSnapshotS3Name("snapshot_100.bin.zstd"), "snapshot_100.bin.zstd");
     EXPECT_EQ(DB::getCanonicalSnapshotS3Name("snapshot_100.bin"), "snapshot_100.bin");
     EXPECT_EQ(DB::getCanonicalSnapshotS3Name("/var/lib/x/snapshot_5_deadbeef.bin.zstd"), "snapshot_5.bin.zstd");
+}
+
+namespace
+{
+
+/// Flags when the copied target file's content is fsynced (WriteBuffer::sync).
+class SyncCountingWriteBuffer : public DB::WriteBufferFromFileDecorator
+{
+public:
+    SyncCountingWriteBuffer(std::unique_ptr<DB::WriteBuffer> impl_, std::atomic<size_t> & synced_)
+        : DB::WriteBufferFromFileDecorator(std::move(impl_)), synced(synced_) {}
+
+    void sync() override
+    {
+        ++synced;
+        DB::WriteBufferFromFileDecorator::sync();
+    }
+
+private:
+    std::atomic<size_t> & synced;
+};
+
+/// A DiskLocal that counts directory sync guards (per directory) and content fsyncs on written
+/// files, records every tmp_ marker path created, and can be told to fail the next copyFile,
+/// while delegating to the real implementation so genuine fsyncs still happen. Used to assert
+/// moveFileBetweenDisks() makes a cross-disk move durable (issue #111339 move-path sibling).
+class DurabilityCountingDisk : public DB::DiskLocal
+{
+public:
+    DurabilityCountingDisk(const std::string & disk_name, const std::string & disk_path)
+        : DB::DiskLocal(disk_name, disk_path) {}
+
+    DB::SyncGuardPtr getDirectorySyncGuard(const String & path) const override
+    {
+        ++dir_syncs[path];
+        return DB::DiskLocal::getDirectorySyncGuard(path);
+    }
+
+    std::unique_ptr<DB::WriteBufferFromFileBase>
+    writeFile(const String & path, size_t buf_size, DB::WriteMode mode, const DB::WriteSettings & settings) override
+    {
+        if (fs::path(path).filename().string().starts_with(DB::tmp_keeper_file_prefix))
+            markers_created.push_back(path);
+        auto impl = DB::DiskLocal::writeFile(path, buf_size, mode, settings);
+        return std::make_unique<SyncCountingWriteBuffer>(std::move(impl), content_syncs);
+    }
+
+    void copyFile(
+        const String & from_file_path,
+        IDisk & to_disk,
+        const String & to_file_path,
+        const DB::ReadSettings & read_settings,
+        const DB::WriteSettings & write_settings,
+        const std::function<void()> & cancellation_hook,
+        bool sync) override
+    {
+        if (fail_copy)
+            throw std::runtime_error("injected copyFile failure");
+        DB::DiskLocal::copyFile(from_file_path, to_disk, to_file_path, read_settings, write_settings, cancellation_hook, sync);
+    }
+
+    size_t dirSyncs(const String & path) const
+    {
+        auto it = dir_syncs.find(path);
+        return it == dir_syncs.end() ? 0 : it->second;
+    }
+    size_t contentSyncs() const { return content_syncs.load(); }
+    const std::vector<String> & markersCreated() const { return markers_created; }
+
+    bool fail_copy = false;
+
+private:
+    mutable std::map<String, size_t> dir_syncs;
+    std::atomic<size_t> content_syncs{0};
+    std::vector<String> markers_created;
+};
+
+}
+
+/// A cross-disk move (with a rename, as changelog rotation does) fsyncs the copied content and
+/// every touched directory, and names the tmp_ marker after the target. A counting disk observes
+/// the fsyncs and the marker path instead of simulating power loss.
+TEST(KeeperMoveFileBetweenDisksTest, CrossDiskMoveIsDurable)
+{
+    ChangelogDirTest root("./move_root");
+    auto settings = std::make_shared<DB::CoordinationSettings>();
+    /// INIT with a bounded retry count: a failing filesystem op gives up after a few retries
+    /// instead of looping until shutdown, so a regression fails the test quickly rather than hanging.
+    (*settings)[DB::CoordinationSetting::disk_move_retries_during_init] = 3;
+    (*settings)[DB::CoordinationSetting::disk_move_retries_wait_ms] = 1;
+    auto keeper_context = std::make_shared<DB::KeeperContext>(true, settings);
+    keeper_context->setServerState(DB::KeeperContext::Phase::INIT);
+
+    auto disk_from = std::make_shared<DurabilityCountingDisk>("MoveSrc", "./move_root/src");
+    auto disk_to = std::make_shared<DurabilityCountingDisk>("MoveDst", "./move_root/dst");
+    disk_from->createDirectories("logs");
+    disk_to->createDirectories("logs");
+
+    /// Rename on move: changelog rotation shrinks the index range, e.g. 1_100 -> 1_57.
+    const std::string source_path = "logs/changelog_1_100.bin";
+    const std::string target_path = "logs/changelog_1_57.bin";
+    {
+        auto buf = disk_from->writeFile(source_path, DB::DBMS_DEFAULT_BUFFER_SIZE, DB::WriteMode::Rewrite, DB::WriteSettings{});
+        buf->write("payload", 7);
+        buf->finalize();
+    }
+    ASSERT_TRUE(disk_from->existsFile(source_path));
+
+    bool publish_called = false;
+    DB::moveFileBetweenDisks(
+        disk_from,
+        source_path,
+        disk_to,
+        target_path,
+        [&] { publish_called = true; return true; },
+        getLogger("KeeperMoveFileBetweenDisksTest"),
+        keeper_context);
+
+    /// The move published, the (renamed) target is present with the source's content, the source
+    /// is gone, and no tmp_ marker is left behind.
+    EXPECT_TRUE(publish_called);
+    EXPECT_TRUE(disk_to->existsFile(target_path));
+    EXPECT_FALSE(disk_from->existsFile(source_path));
+    {
+        auto in = disk_to->readFile(target_path, DB::ReadSettings{});
+        std::string content;
+        DB::readStringUntilEOF(content, *in);
+        EXPECT_EQ(content, "payload");
+    }
+
+    /// The marker is created on the TARGET disk and named after the TARGET file (changelog_1_57),
+    /// not the source (changelog_1_100). Recovery pairs a marker with the file of the same name,
+    /// so a source-named marker would fail to flag a partial renamed target as incomplete.
+    ASSERT_EQ(disk_to->markersCreated().size(), 1u);
+    EXPECT_EQ(disk_to->markersCreated()[0], "logs/" + std::string{DB::tmp_keeper_file_prefix} + "changelog_1_57.bin");
+    EXPECT_TRUE(disk_from->markersCreated().empty());
+
+    /// Content fsynced once. The target directory ("logs" on disk_to) is fsynced at least twice:
+    /// after creating the marker (marker presence durable before copy) and after removing it
+    /// (marker-absent + target-present durable before publish). Requiring >= 2 means neither
+    /// barrier can regress undetected. The source directory is fsynced after the source removal.
+    EXPECT_GE(disk_to->contentSyncs(), 1u);
+    EXPECT_GE(disk_to->dirSyncs("logs"), 2u);
+    EXPECT_GE(disk_from->dirSyncs("logs"), 1u);
+}
+
+/// A move interrupted after marker creation (copy fails and exhausts retries) must leave a
+/// marker named after the target file, so startup recovery pairs it with the partial target.
+TEST(KeeperMoveFileBetweenDisksTest, InterruptedRenameMoveLeavesTargetNamedMarker)
+{
+    ChangelogDirTest root("./move_root_fail");
+    auto settings = std::make_shared<DB::CoordinationSettings>();
+    (*settings)[DB::CoordinationSetting::disk_move_retries_during_init] = 2;
+    (*settings)[DB::CoordinationSetting::disk_move_retries_wait_ms] = 1;
+    auto keeper_context = std::make_shared<DB::KeeperContext>(true, settings);
+    keeper_context->setServerState(DB::KeeperContext::Phase::INIT);
+
+    auto disk_from = std::make_shared<DurabilityCountingDisk>("MoveSrcF", "./move_root_fail/src");
+    auto disk_to = std::make_shared<DurabilityCountingDisk>("MoveDstF", "./move_root_fail/dst");
+    disk_from->createDirectories("logs");
+    disk_to->createDirectories("logs");
+
+    const std::string source_path = "logs/changelog_1_100.bin";
+    const std::string target_path = "logs/changelog_1_57.bin";
+    {
+        auto buf = disk_from->writeFile(source_path, DB::DBMS_DEFAULT_BUFFER_SIZE, DB::WriteMode::Rewrite, DB::WriteSettings{});
+        buf->write("payload", 7);
+        buf->finalize();
+    }
+
+    disk_from->fail_copy = true;
+    bool publish_called = false;
+    DB::moveFileBetweenDisks(
+        disk_from,
+        source_path,
+        disk_to,
+        target_path,
+        [&] { publish_called = true; return true; },
+        getLogger("KeeperMoveFileBetweenDisksTest"),
+        keeper_context);
+
+    /// The copy never succeeded, so the move did not publish and did not remove the source.
+    EXPECT_FALSE(publish_called);
+    EXPECT_TRUE(disk_from->existsFile(source_path));
+    /// The leftover marker on the target disk is named after the target file, matching what
+    /// recovery expects to pair with a partial "changelog_1_57.bin".
+    EXPECT_TRUE(disk_to->existsFile("logs/" + std::string{DB::tmp_keeper_file_prefix} + "changelog_1_57.bin"));
+    EXPECT_FALSE(disk_to->existsFile("logs/" + std::string{DB::tmp_keeper_file_prefix} + "changelog_1_100.bin"));
 }
 
 #endif

--- a/src/Disks/DiskEncrypted.cpp
+++ b/src/Disks/DiskEncrypted.cpp
@@ -400,7 +400,8 @@ void DiskEncrypted::copyFile(
     const String & to_file_path,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
-    const std::function<void()> & cancellation_hook)
+    const std::function<void()> & cancellation_hook,
+    bool sync)
 {
     /// Check if we can copy the file without deciphering.
     if (isSameDiskType(*this, to_disk))
@@ -416,14 +417,14 @@ void DiskEncrypted::copyFile(
                 auto wrapped_from_path = wrappedPath(from_file_path);
                 auto to_delegate = to_disk_enc->delegate;
                 auto wrapped_to_path = to_disk_enc->wrappedPath(to_file_path);
-                delegate->copyFile(wrapped_from_path, *to_delegate, wrapped_to_path, read_settings, write_settings, cancellation_hook);
+                delegate->copyFile(wrapped_from_path, *to_delegate, wrapped_to_path, read_settings, write_settings, cancellation_hook, sync);
                 return;
             }
         }
     }
 
     /// Copy the file through buffers with deciphering.
-    IDisk::copyFile(from_file_path, to_disk, to_file_path, read_settings, write_settings, cancellation_hook);
+    IDisk::copyFile(from_file_path, to_disk, to_file_path, read_settings, write_settings, cancellation_hook, sync);
 }
 
 

--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -124,7 +124,8 @@ public:
         const String & to_file_path,
         const ReadSettings & read_settings,
         const WriteSettings & write_settings,
-        const std::function<void()> & cancellation_hook) override;
+        const std::function<void()> & cancellation_hook,
+        bool sync) override;
 
     void prepareRead(
         const String & path,

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -293,12 +293,14 @@ void DiskObjectStorage::copyFile( /// NOLINT
     const String & to_file_path,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
-    const std::function<void()> & cancellation_hook)
+    const std::function<void()> & cancellation_hook,
+    bool sync)
 {
     auto component_guard = Coordination::setCurrentComponent("DiskObjectStorage::copyFile");
     if (getDataSourceDescription() == to_disk.getDataSourceDescription())
     {
-        /// It may use s3-server-side copy
+        /// It may use s3-server-side copy. Remote object storage is durable once the copy
+        /// transaction commits, so the `sync` request is satisfied by the commit below.
         auto & to_disk_object_storage = dynamic_cast<DiskObjectStorage &>(to_disk);
         auto transaction = createObjectStorageTransactionToAnotherDisk(to_disk_object_storage);
         try
@@ -317,7 +319,7 @@ void DiskObjectStorage::copyFile( /// NOLINT
     else
     {
         /// Copy through buffers
-        IDisk::copyFile(from_file_path, to_disk, to_file_path, read_settings, write_settings, cancellation_hook);
+        IDisk::copyFile(from_file_path, to_disk, to_file_path, read_settings, write_settings, cancellation_hook, sync);
     }
 }
 

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.h
@@ -181,7 +181,8 @@ public:
         const String & to_file_path,
         const ReadSettings & read_settings,
         const WriteSettings & write_settings = {},
-        const std::function<void()> & cancellation_hook = {}
+        const std::function<void()> & cancellation_hook = {},
+        bool sync = false
         ) override;
 
     void waitBlobsCleanup();

--- a/src/Disks/IDisk.cpp
+++ b/src/Disks/IDisk.cpp
@@ -66,7 +66,8 @@ void IDisk::copyFile( /// NOLINT
     const String & to_file_path,
     const ReadSettings & read_settings,
     const WriteSettings & write_settings,
-    const std::function<void()> & cancellation_hook
+    const std::function<void()> & cancellation_hook,
+    bool sync
     )
 {
     LOG_DEBUG(getLogger("IDisk"), "Copying from {} (path: {}) {} to {} (path: {}) {}.",
@@ -76,6 +77,8 @@ void IDisk::copyFile( /// NOLINT
     auto out = to_disk.writeFile(to_file_path, DBMS_DEFAULT_BUFFER_SIZE, WriteMode::Rewrite, write_settings);
     copyData(*in, *out, cancellation_hook);
     out->finalize();
+    if (sync)
+        out->sync();
 }
 
 std::unique_ptr<ReadBufferFromFileBase> IDisk::readFile(

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -230,13 +230,17 @@ public:
         const std::function<void()> & cancellation_hook);
 
     /// Copy file `from_file_path` to `to_file_path` located at `to_disk`.
+    /// With `sync = true` the target file content is fsynced before returning (buffered copy
+    /// path only). Genuinely remote object storage is durable once the copy transaction commits;
+    /// local object storage does not honor the flag. Default `false` keeps existing callers as-is.
     virtual void copyFile( /// NOLINT
         const String & from_file_path,
         IDisk & to_disk,
         const String & to_file_path,
         const ReadSettings & read_settings,
         const WriteSettings & write_settings = {},
-        const std::function<void()> & cancellation_hook = {});
+        const std::function<void()> & cancellation_hook = {},
+        bool sync = false);
 
     /// List files at `path` and add their names to `file_names`
     virtual void listFiles(const String & path, std::vector<String> & file_names) const = 0;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/111339
-->

Related: #111339

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a durability gap when Keeper relocates a snapshot or changelog file between configured disks (multi-disk setups, e.g. `latest_snapshot_storage_disk` plus a main disk). The cross-disk move now fsyncs the copied file content and the affected directory entries before dropping the completion marker and removing the source, so a power loss during the move can no longer leave a snapshot or changelog that looks complete but is not on stable storage.

### Description

Keeper moves snapshot and changelog files across disks through the shared `moveFileBetweenDisks` helper (`src/Coordination/KeeperCommon.cpp`). Crash safety there relies on a `tmp_` marker: on restart a target with a leftover marker is deleted as an incomplete copy, and a target with no marker is accepted as complete. None of the move's filesystem operations were made durable:

- `IDisk::copyFile` only `finalize()`s the target buffer, never `sync()`, so copied content can remain in the page cache.
- The marker creation, marker removal, and source removal are directory-entry changes that a file fsync does not persist.

On power loss the directory transaction removing the source and the marker can commit while the target's data blocks are lost. The next constructor then sees a marker-less target and accepts it as complete, corrupting the snapshot/changelog (or losing it entirely if the source was already removed). This is the cross-disk-move sibling of #111339 (the snapshot write path).

Fix, in `moveFileBetweenDisks`:
- fsync the marker's directory after creating the marker (its presence is durable before the copy starts);
- copy with a new `IDisk::copyFile(..., sync = true)` so the content is fsynced;
- fsync the marker directory and the target directory after removing the marker, before publishing;
- fsync the source directory after removing the source.

Directory fsyncs use `getDirectorySyncGuard`, a no-op on non-local disks; remote object storage is durable once its copy transaction commits. The new `copyFile` `sync` parameter defaults to `false`, so all existing callers are unchanged.

Covered by a unit test (`KeeperMoveFileBetweenDisksTest.CrossDiskMoveIsDurable`) that fails without the fix and passes with it.
