### PR TITLE
Honor SQL SECURITY for parameterized views without the analyzer

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2983,7 +2983,17 @@ StoragePtr Context::executeTableFunction(const ASTPtr & table_expression, const 
 
             ASTCreateQuery create;
             create.set(create.select, query);
-            auto sample_block = InterpreterSelectWithUnionQuery::getSampleBlock(query, getQueryContext());
+
+            /// The sample block must be analyzed under the view's SQL security context, not the
+            /// invoker's (mirrors buildParameterizedViewStorage).
+            auto sql_security = make_intrusive<ASTSQLSecurity>();
+            sql_security->type = view_metadata->sql_security_type;
+            if (view_metadata->definer)
+                sql_security->definer = make_intrusive<ASTUserNameWithHost>(*view_metadata->definer);
+            create.set(create.sql_security, sql_security);
+
+            auto view_context = view_metadata->getSQLSecurityOverriddenContext(shared_from_this());
+            auto sample_block = InterpreterSelectWithUnionQuery::getSampleBlock(query, view_context);
             auto res = std::make_shared<StorageView>(StorageID(database_name, table_name),
                                                      create,
                                                      ColumnsDescription(sample_block->getNamesAndTypesList()),

--- a/tests/queries/0_stateless/04545_parameterized_view_sql_security.reference
+++ b/tests/queries/0_stateless/04545_parameterized_view_sql_security.reference
@@ -1,0 +1,11 @@
+--- enable_analyzer=1 ---
+definer: 5001
+none:    5001
+invoker: ACCESS_DENIED
+--- enable_analyzer=0 ---
+definer: 5001
+none:    5001
+invoker: ACCESS_DENIED
+--- parallel replicas ---
+definer pr: 5001
+parallel replicas used: 1

--- a/tests/queries/0_stateless/04545_parameterized_view_sql_security.sh
+++ b/tests/queries/0_stateless/04545_parameterized_view_sql_security.sh
@@ -32,7 +32,7 @@ EOF
 
 # The invoker has SELECT on the views only, not on the base table.
 # DEFINER/NONE must return rows; INVOKER must be denied. This must hold for BOTH the
-# new analyzer and the old analyzer (the old-analyzer path was the bug: issue #84188).
+# default analyzer and the old analyzer (the old-analyzer path was the bug: issue #84188).
 for analyzer in 1 0; do
     echo "--- enable_analyzer=$analyzer ---"
     echo -n "definer: "

--- a/tests/queries/0_stateless/04545_parameterized_view_sql_security.sh
+++ b/tests/queries/0_stateless/04545_parameterized_view_sql_security.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tags: no-parallel-replicas
+# Tag no-parallel-replicas: sets cluster_for_parallel_replicas explicitly.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+db=${CLICKHOUSE_DATABASE}
+definer="definer_04545_${CLICKHOUSE_DATABASE}_$RANDOM"
+invoker="invoker_04545_${CLICKHOUSE_DATABASE}_$RANDOM"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP USER IF EXISTS $definer, $invoker;
+CREATE USER $definer, $invoker;
+
+CREATE TABLE $db.nums (x Int64) ENGINE = MergeTree ORDER BY x SETTINGS index_granularity = 128;
+INSERT INTO $db.nums SELECT * FROM numbers(10000);
+
+-- The definer can read the base table; the invoker cannot.
+GRANT SELECT ON $db.nums TO $definer;
+
+-- Parameterized views with each SQL SECURITY kind.
+CREATE VIEW $db.pv_definer DEFINER = $definer SQL SECURITY DEFINER AS SELECT x FROM $db.nums WHERE x <= {lim:Int64};
+CREATE VIEW $db.pv_invoker DEFINER = $definer SQL SECURITY INVOKER AS SELECT x FROM $db.nums WHERE x <= {lim:Int64};
+CREATE VIEW $db.pv_none SQL SECURITY NONE AS SELECT x FROM $db.nums WHERE x <= {lim:Int64};
+
+GRANT SELECT ON $db.pv_definer TO $invoker;
+GRANT SELECT ON $db.pv_invoker TO $invoker;
+GRANT SELECT ON $db.pv_none TO $invoker;
+EOF
+
+# The invoker has SELECT on the views only, not on the base table.
+# DEFINER/NONE must return rows; INVOKER must be denied. This must hold for BOTH the
+# new analyzer and the old analyzer (the old-analyzer path was the bug: issue #84188).
+for analyzer in 1 0; do
+    echo "--- enable_analyzer=$analyzer ---"
+    echo -n "definer: "
+    ${CLICKHOUSE_CLIENT} --user "$invoker" --query \
+        "SELECT count() FROM $db.pv_definer(lim = 5000) SETTINGS enable_analyzer = $analyzer, enable_parallel_replicas = 0"
+    echo -n "none:    "
+    ${CLICKHOUSE_CLIENT} --user "$invoker" --query \
+        "SELECT count() FROM $db.pv_none(lim = 5000) SETTINGS enable_analyzer = $analyzer, enable_parallel_replicas = 0"
+    echo -n "invoker: "
+    ${CLICKHOUSE_CLIENT} --user "$invoker" --query \
+        "SELECT count() FROM $db.pv_invoker(lim = 5000) SETTINGS enable_analyzer = $analyzer, enable_parallel_replicas = 0" 2>&1 \
+        | grep -m1 -oF "ACCESS_DENIED" || echo "UNEXPECTED"
+done
+
+# Originally reported scenario: parameterized DEFINER view read via parallel replicas by a
+# low-privilege invoker must succeed (no ACCESS_DENIED, no data leak) and must actually use
+# parallel replicas (guard against a silent fallback masking the bug).
+echo "--- parallel replicas ---"
+# automatic_parallel_replicas_mode = 0 forces the explicit parallel-replicas path so the
+# ParallelReplicasUsedCount guard below is deterministic (otherwise the coordinator may skip
+# parallel replicas for this small table and the guard would flap).
+pr_settings="enable_parallel_replicas = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_min_number_of_rows_per_replica = 1, parallel_replicas_only_with_analyzer = 0, automatic_parallel_replicas_mode = 0"
+echo -n "definer pr: "
+${CLICKHOUSE_CLIENT} --user "$invoker" --query \
+    "SELECT count() FROM $db.pv_definer(lim = 5000) SETTINGS $pr_settings, log_comment = '04545_pr_${CLICKHOUSE_DATABASE}'"
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+echo -n "parallel replicas used: "
+${CLICKHOUSE_CLIENT} --query "
+    SELECT ProfileEvents['ParallelReplicasUsedCount'] > 0
+    FROM system.query_log
+    WHERE current_database = currentDatabase()
+      AND log_comment = '04545_pr_${CLICKHOUSE_DATABASE}'
+      AND type = 'QueryFinish'
+      AND initial_query_id = query_id
+    SETTINGS enable_parallel_replicas = 0"
+
+${CLICKHOUSE_CLIENT} <<EOF
+DROP VIEW $db.pv_definer, $db.pv_invoker, $db.pv_none;
+DROP TABLE $db.nums;
+DROP USER $definer, $invoker;
+EOF


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/84188
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SQL SECURITY DEFINER` (and `SQL SECURITY NONE`) not being honored for parameterized views when the analyzer is disabled (`enable_analyzer = 0`). Previously selecting from such a view as a user without privileges on the underlying table failed with `ACCESS_DENIED`, even though the same view works with the analyzer enabled.


### Description

Selecting from a parameterized view with `SQL SECURITY DEFINER`/`NONE` failed with `ACCESS_DENIED` when the old analyzer was used (`enable_analyzer = 0`), while the new analyzer works correctly. Issue #84188 observed this via parallel replicas; the reported parallel-replicas + default-analyzer scenario is already correct on master, but the underlying old-analyzer path was still broken and is analyzer-dependent, not parallel-replicas-specific.

Root cause: `Context::executeTableFunction` (the old-analyzer parameterized-view path) built the temporary `StorageView` for the substituted inner query using the invoker's context and did not propagate the view's `SQL SECURITY`. So the sample block was analyzed (and the view later executed) under the invoker. `Context::buildParameterizedViewStorage` (the new-analyzer path) already does this correctly (added in #69984); this change mirrors it in the old-analyzer path: set `create.sql_security` from the view metadata and compute the sample block under `getSQLSecurityOverriddenContext`. `INVOKER` views are unaffected (still evaluated with the invoker's grants).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1374` (included in `26.7` and later)
<!-- ch-version-info:end -->