### PR TITLE
Check drop privilege before the swap in CREATE OR REPLACE

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2660,7 +2660,17 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
             [&current_context](const StorageID & to_drop_id)
             {
                 if (auto to_drop = DatabaseCatalog::instance().tryGetTable(to_drop_id, current_context))
+                {
+                    /// The replaced table is dropped after the swap, under an internal temporary name that
+                    /// grants cannot cover, so check the drop privilege for its kind here, on its real name.
+                    AccessType drop_access = AccessType::DROP_TABLE;
+                    if (to_drop->isView())
+                        drop_access = AccessType::DROP_VIEW;
+                    else if (to_drop->isDictionary())
+                        drop_access = AccessType::DROP_DICTIONARY;
+                    current_context->checkAccess(drop_access, to_drop_id);
                     to_drop->checkTableSizeBelowDropLimit(current_context);
+                }
             });
         try
         {
@@ -2688,7 +2698,10 @@ BlockIO InterpreterCreateQuery::doCreateOrReplaceTable(ASTCreateQuery & create,
             /// kind than the new one (e.g. a dictionary replaced by a view), so the drop must match its kind.
             if (auto replaced = DatabaseCatalog::instance().tryGetTable(StorageID{create.getDatabase(), create.getTable()}, current_context))
                 ast_drop->is_dictionary = replaced->isDictionary();
-            /// `pre_swap_check` already gated this; bypass to avoid double-consuming
+            /// `pre_swap_check` already authorized this drop against the replaced table's real name.
+            /// The temporary name cannot be covered by grants, so skip the access check on it.
+            ast_drop->no_access_check = true;
+            /// `pre_swap_check` also gated the size; bypass to avoid double-consuming
             /// the `force_drop_table` flag inside `Context::checkCanBeDropped`.
             auto drop_context = make_drop_context(/*bypass_size_guard=*/true);
             InterpreterDropQuery(ast_drop, drop_context).execute();

--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -331,7 +331,8 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
         }
         else if (query.kind == ASTDropQuery::Kind::Drop)
         {
-            context_->checkAccess(drop_storage, table_id);
+            if (!query.no_access_check)
+                context_->checkAccess(drop_storage, table_id);
 
             if (table->isDictionary())
             {

--- a/src/Parsers/ASTDropQuery.h
+++ b/src/Parsers/ASTDropQuery.h
@@ -26,6 +26,10 @@ public:
     /// Useful if we already have a DDL lock
     bool no_ddl_lock{false};
 
+    /// Skip the access check on Drop. Set only for internal cleanup drops whose access was already
+    /// authorized against the dropped object's user-visible name. Never parsed nor serialized.
+    bool no_access_check{false};
+
     /// For `TRUNCATE ALL TABLES` query
     bool has_all{false};
 

--- a/tests/queries/0_stateless/04626_create_or_replace_drop_privilege_preflight.reference
+++ b/tests/queries/0_stateless/04626_create_or_replace_drop_privilege_preflight.reference
@@ -1,0 +1,7 @@
+-- [scoped DROP DICTIONARY grant] replacing the dictionary with a view must succeed:
+42
+-- [no DROP DICTIONARY grant] the replace must be denied:
+ACCESS_DENIED
+-- [no DROP DICTIONARY grant] and the denied replace must leave the dictionary intact and no leftovers:
+1
+0

--- a/tests/queries/0_stateless/04626_create_or_replace_drop_privilege_preflight.sh
+++ b/tests/queries/0_stateless/04626_create_or_replace_drop_privilege_preflight.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# `CREATE OR REPLACE` drops the replaced table after the swap, under an internal `_tmp_replace_*` name.
+# The drop privilege for the replaced table's kind must be enforced before the swap: a denied query
+# must leave the replaced table intact instead of failing after the replace is already committed.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+granted="granted_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+nogrant="nogrant_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+db=${CLICKHOUSE_DATABASE}
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE src (key String, value UInt64) ENGINE = MergeTree ORDER BY key;
+INSERT INTO src VALUES ('k1', 1);
+CREATE DICTIONARY dict_granted (key String, value UInt64) PRIMARY KEY key SOURCE(CLICKHOUSE(TABLE 'src')) LAYOUT(DIRECT());
+CREATE DICTIONARY dict_denied (key String, value UInt64) PRIMARY KEY key SOURCE(CLICKHOUSE(TABLE 'src')) LAYOUT(DIRECT());
+DROP USER IF EXISTS ${granted}, ${nogrant};
+CREATE USER ${granted} IDENTIFIED WITH plaintext_password BY '${granted}';
+CREATE USER ${nogrant} IDENTIFIED WITH plaintext_password BY '${nogrant}';
+GRANT SELECT, INSERT, CREATE TABLE, DROP TABLE, CREATE VIEW, DROP VIEW ON ${db}.* TO ${granted}, ${nogrant};
+-- The drop grant scoped to the replaced dictionary's real name must be sufficient.
+GRANT DROP DICTIONARY ON ${db}.dict_granted TO ${granted};
+"
+
+echo "-- [scoped DROP DICTIONARY grant] replacing the dictionary with a view must succeed:"
+${CLICKHOUSE_CLIENT} --user "${granted}" --password "${granted}" --query "CREATE OR REPLACE VIEW ${db}.dict_granted AS SELECT 42 AS x"
+${CLICKHOUSE_CLIENT} --query "SELECT x FROM dict_granted"
+
+echo "-- [no DROP DICTIONARY grant] the replace must be denied:"
+${CLICKHOUSE_CLIENT} --user "${nogrant}" --password "${nogrant}" --query "CREATE OR REPLACE VIEW ${db}.dict_denied AS SELECT 42 AS x" 2>&1 | grep -Fo ACCESS_DENIED | uniq
+
+echo "-- [no DROP DICTIONARY grant] and the denied replace must leave the dictionary intact and no leftovers:"
+${CLICKHOUSE_CLIENT} --query "
+SELECT dictGet(dict_denied, 'value', 'k1');
+SELECT count() FROM system.tables WHERE database = '${db}' AND startsWith(name, '_tmp_replace_');
+"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER ${granted}, ${nogrant}"


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1006
<!-- End of fixes issue link part, do not remove -->

`CREATE OR REPLACE` checked the replaced object's drop privilege only after the swap — a denied query left the object behind under the internal `_tmp_replace_*` name. Now the same check runs before the swap.

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/111142.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CREATE OR REPLACE` leaving the replaced object behind under an internal name when the caller lacks the drop privilege on it.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.681` (included in `26.8` and later)
- Backported to: `26.7.6.56`, `26.6.5.88`, `26.3.33.34`
<!-- ch-version-info:end -->