### PR TITLE
Populate before-worktree submodules at the merge-base pin in unit-test bugfix validation

### DIFF
--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -236,11 +236,13 @@ def ensure_primary_submodules():
 def prepare_before_worktree(merge_base, pr_sha, test_files):
     """Create an isolated worktree at the merge-base with only the test files overlaid.
 
-    Submodule working trees are populated by hardlinking from the primary checkout
-    (fast, no network) so the build sees contrib sources.  This is content-correct
-    whenever the PR did not bump submodule pointers, which is the normal case for a
-    unit-test bugfix.  Returns True iff the worktree ended up with its submodules
-    populated (checked via SUBMODULE_MARKER) — the caller must fail close otherwise.
+    Each submodule is populated by hardlinking the primary checkout (fast, no network)
+    when the merge-base pins the same commit the primary has on disk, and by fetching the
+    submodule at its own merge-base pin when they differ (drift). Hardlinking master's
+    content for a drifted submodule is content-incorrect: the before-worktree uses the
+    merge-base cmake wrappers, which reference the merge-base submodule's file layout.
+    Returns True iff every submodule the merge-base needs ended up populated at that pin;
+    the caller must fail close otherwise.
     """
     Shell.check(f"git worktree remove --force {BEFORE_SRC} ||:", verbose=True)
     Shell.check(f"rm -rf {BEFORE_SRC}", verbose=True)
@@ -265,15 +267,18 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
     # hardlink them across (see ensure_primary_submodules).
     ensure_primary_submodules()
 
-    # Populate submodules by hardlinking from the primary checkout.
+    # Populate the submodules the merge-base needs. Iterate the merge-base's own
+    # `.gitmodules` (the set the before-binary actually builds against), NOT the primary's
+    # — master may have added or removed submodules relative to the merge-base.
     sub_paths = Shell.get_output(
-        "git config --file .gitmodules --get-regexp '^submodule\\..*\\.path$' "
-        "| awk '{print $2}'"
+        f"git config --file {shlex.quote(BEFORE_SRC)}/.gitmodules "
+        "--get-regexp '^submodule\\..*\\.path$' | awk '{print $2}'"
     ).splitlines()
     before_src_real = os.path.realpath(BEFORE_SRC)
+    drifted = []
     for path in sub_paths:
         path = path.strip()
-        if not path or not os.path.isdir(path) or not os.listdir(path):
+        if not path:
             continue
         dst = os.path.join(BEFORE_SRC, path)
         # SECURITY: defense in depth against a traversal path that somehow slipped past
@@ -289,18 +294,82 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
                 f"refusing to populate submodule '{path}': destination '{dst}' "
                 f"escapes '{BEFORE_SRC}'"
             )
-        # SECURITY: submodule paths come from the PR's `.gitmodules` and are PR-controlled,
-        # so shell-quote them (and use `--`) before Shell.check to avoid command/option
+        # SECURITY: submodule paths come from `.gitmodules` (PR-controlled), so shell-quote
+        # them (and use `--`) before any Shell.check (shell=True) to avoid command/option
         # injection on the runner.
         q_path, q_dst, q_dst_parent = (
             shlex.quote(path),
             shlex.quote(dst),
             shlex.quote(os.path.dirname(dst)),
         )
-        Shell.check(f"rm -rf -- {q_dst} && mkdir -p -- {q_dst_parent}", verbose=False)
-        # cp -al = recursive hardlink copy (instant, no data duplication).
-        Shell.check(f"cp -al -- {q_path} {q_dst}", verbose=False)
 
+        # "want" = the commit the merge-base pins for this submodule; "have" = the commit
+        # the primary checkout has on disk. They differ only when master moved the pointer
+        # after the merge-base (a submodule bump/URL switch on master, or a submodule the
+        # primary lacks). Hardlinking is content-correct only when want == have.
+        want = Shell.get_output(
+            f"git -C {shlex.quote(BEFORE_SRC)} rev-parse --verify --quiet "
+            f"HEAD:{q_path}",
+            verbose=False,
+        ).strip()
+        have = (
+            Shell.get_output(
+                f"git -C {q_path} rev-parse --verify --quiet HEAD",
+                verbose=False,
+            ).strip()
+            if os.path.isdir(path) and os.listdir(path)
+            else ""
+        )
+
+        if want and want == have:
+            # No drift: hardlink the primary's content (fast, no network).
+            Shell.check(
+                f"rm -rf -- {q_dst} && mkdir -p -- {q_dst_parent}", verbose=False
+            )
+            # cp -al = recursive hardlink copy (instant, no data duplication).
+            Shell.check(f"cp -al -- {q_path} {q_dst}", verbose=False)
+        else:
+            # Drift (or the primary lacks this submodule): populate the before-worktree's
+            # own copy at its merge-base pin. `submodule sync` first, so the merge-base URL
+            # is used (it may itself differ from master, e.g. a fork->upstream switch). A
+            # network fetch is unavoidable: the merge-base pin is generally not local once
+            # master has moved the pointer.
+            drifted.append(path)
+            Shell.check(f"rm -rf -- {q_dst}", verbose=False)
+            ok = Shell.check(
+                f"git -C {shlex.quote(BEFORE_SRC)} submodule sync -- {q_path} && "
+                f"git -C {shlex.quote(BEFORE_SRC)} submodule update --init --depth 1 "
+                f"-- {q_path}",
+                retries=3,
+                verbose=True,
+            )
+            if not ok:
+                print(
+                    f"WARNING: failed to populate drifted submodule '{path}' at its "
+                    f"merge-base pin '{want}'; before-binary configure may fail."
+                )
+
+    if drifted:
+        print(
+            "Submodule pointers drift between the merge-base and master; populated at the "
+            f"merge-base pin instead of hardlinking master content: {drifted}"
+        )
+
+    # Fail close: every submodule the merge-base needs must be populated with a working
+    # tree, else the before-binary cannot configure/build. Checking only SUBMODULE_MARKER
+    # (a single unrelated submodule) would miss a drifted submodule that failed to
+    # repopulate. Report the first missing one so the caller's ERROR verdict is specific.
+    for path in sub_paths:
+        path = path.strip()
+        if not path:
+            continue
+        dst = os.path.join(BEFORE_SRC, path)
+        if not os.path.isdir(dst) or not os.listdir(dst):
+            print(
+                f"ERROR: submodule '{path}' is not populated in the before-worktree; "
+                "cannot build the before-binary."
+            )
+            return False
     return os.path.isfile(os.path.join(BEFORE_SRC, SUBMODULE_MARKER))
 
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -160,21 +160,26 @@ def determine_merge_base(info):
 SUBMODULE_MARKER = "contrib/sysroot/README.md"
 
 
-def gitmodules_shape_violation():
-    """Return an error string if the PR's `.gitmodules` has an unsafe submodule entry
-    (a URL that is not a plain `https://github.com/...`, or a name that differs from its
-    path); return None if it is clean.
+def gitmodules_shape_violation(gitmodules=".gitmodules"):
+    """Return an error string if `gitmodules` has an unsafe submodule entry (a URL that is
+    not a plain `https://github.com/...`, or a name that differs from its path); return
+    None if it is clean. Defaults to the cwd `.gitmodules` (the PR checkout); pass the
+    merge-base worktree's file to validate it before fetching from it.
 
-    SECURITY: this job populates submodules over the network from the PR-controlled
-    `.gitmodules`, inside the privileged binary-builder container, and — because it now
-    starts early — BEFORE the regular `check_submodules.sh` (run in build_arm_tidy) would
-    reject bad metadata. Validating the URL/path shape here, before any `git submodule`
-    network access, stops a PR from pointing a submodule at an arbitrary URL and having
-    the self-hosted runner fetch it. Mirrors the URL/name rules of
+    SECURITY: this job populates submodules over the network from a `.gitmodules` file,
+    inside the privileged binary-builder container, and — because it now starts early —
+    BEFORE the regular `check_submodules.sh` (run in build_arm_tidy) would reject bad
+    metadata. Validating the URL/path shape here, before any `git submodule` network
+    access, stops a PR from pointing a submodule at an arbitrary URL and having the
+    self-hosted runner fetch it. This must cover BOTH the PR's `.gitmodules` AND the
+    merge-base's (the drift path fetches using the merge-base file, which is equally
+    attacker-influenced — an older merge-base can carry a non-GitHub URL or unsafe path
+    even when the PR's current file is clean). Mirrors the URL/name rules of
     ci/jobs/scripts/check_style/check_submodules.sh.
     """
+    q_file = shlex.quote(gitmodules)
     for line in Shell.get_output(
-        "git config --file .gitmodules --get-regexp 'submodule\\..+\\.url'"
+        f"git config --file {q_file} --get-regexp 'submodule\\..+\\.url'"
     ).splitlines():
         line = line.strip()
         if not line:
@@ -184,7 +189,7 @@ def gitmodules_shape_violation():
             name = key.removeprefix("submodule.").removesuffix(".url")
             return f"submodule '{name}' has a non-github URL '{url}'"
     for line in Shell.get_output(
-        "git config --file .gitmodules --get-regexp 'submodule\\..+\\.path'"
+        f"git config --file {q_file} --get-regexp 'submodule\\..+\\.path'"
     ).splitlines():
         line = line.strip()
         if not line:
@@ -267,6 +272,18 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
     # The primary checkout must have populated submodule working trees before we can
     # hardlink them across (see ensure_primary_submodules).
     ensure_primary_submodules()
+
+    # SECURITY: the drift path below fetches submodules using the merge-base's own
+    # `.gitmodules`, so it must satisfy the same URL/path allow-list as the PR's
+    # `.gitmodules` (checked in main()). An older merge-base can carry a non-GitHub URL or
+    # an unsafe path even when the PR's current file is clean. Validate before any fetch;
+    # a violation is a fail-close infra stop, never a reproduction.
+    mb_gitmodules_error = gitmodules_shape_violation(f"{BEFORE_SRC}/.gitmodules")
+    if mb_gitmodules_error:
+        return (
+            False,
+            f"merge-base .gitmodules is unsafe: {mb_gitmodules_error}",
+        )
 
     # Populate the submodules the merge-base needs. Iterate the merge-base's own
     # `.gitmodules` (the set the before-binary actually builds against), NOT the primary's

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -241,8 +241,9 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
     submodule at its own merge-base pin when they differ (drift). Hardlinking master's
     content for a drifted submodule is content-incorrect: the before-worktree uses the
     merge-base cmake wrappers, which reference the merge-base submodule's file layout.
-    Returns True iff every submodule the merge-base needs ended up populated at that pin;
-    the caller must fail close otherwise.
+    Returns `(ok, detail)`: `ok` is True iff every submodule the merge-base needs ended up
+    populated at that pin; on failure `detail` names the offending submodule so the caller
+    can fail close with a specific infrastructure error.
     """
     Shell.check(f"git worktree remove --force {BEFORE_SRC} ||:", verbose=True)
     Shell.check(f"rm -rf {BEFORE_SRC}", verbose=True)
@@ -343,10 +344,14 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
                 retries=3,
                 verbose=True,
             )
+            # Fail close: a failed update can leave the path containing only a `.git`
+            # gitlink (nonempty, but no sources), so the final populated-check below would
+            # not catch it. Stop here with the specific submodule.
             if not ok:
-                print(
-                    f"WARNING: failed to populate drifted submodule '{path}' at its "
-                    f"merge-base pin '{want}'; before-binary configure may fail."
+                return (
+                    False,
+                    f"failed to populate drifted submodule '{path}' at its merge-base "
+                    f"pin '{want}'",
                 )
 
     if drifted:
@@ -355,22 +360,24 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
             f"merge-base pin instead of hardlinking master content: {drifted}"
         )
 
-    # Fail close: every submodule the merge-base needs must be populated with a working
-    # tree, else the before-binary cannot configure/build. Checking only SUBMODULE_MARKER
-    # (a single unrelated submodule) would miss a drifted submodule that failed to
-    # repopulate. Report the first missing one so the caller's ERROR verdict is specific.
+    # Fail close: every submodule the merge-base needs must be populated with a real
+    # working tree, else the before-binary cannot configure/build. Checking only
+    # SUBMODULE_MARKER (a single unrelated submodule) would miss a drifted submodule that
+    # failed to repopulate. `.git` alone does not count as populated — require at least one
+    # non-`.git` entry. Return the first missing path so the caller's ERROR is specific.
     for path in sub_paths:
         path = path.strip()
         if not path:
             continue
         dst = os.path.join(BEFORE_SRC, path)
-        if not os.path.isdir(dst) or not os.listdir(dst):
-            print(
-                f"ERROR: submodule '{path}' is not populated in the before-worktree; "
-                "cannot build the before-binary."
+        if not os.path.isdir(dst) or not [e for e in os.listdir(dst) if e != ".git"]:
+            return (
+                False,
+                f"submodule '{path}' is not populated in the before-worktree",
             )
-            return False
-    return os.path.isfile(os.path.join(BEFORE_SRC, SUBMODULE_MARKER))
+    if not os.path.isfile(os.path.join(BEFORE_SRC, SUBMODULE_MARKER)):
+        return (False, f"submodule marker '{SUBMODULE_MARKER}' is missing")
+    return (True, "")
 
 
 def configure_before_binary(info):
@@ -563,7 +570,9 @@ def main():
         )
         return
 
-    submodules_ok = prepare_before_worktree(merge_base, pr_sha, test_files)
+    submodules_ok, submodules_detail = prepare_before_worktree(
+        merge_base, pr_sha, test_files
+    )
 
     # Fail close: building unit_tests_dbms needs submodules. If they are missing, cmake
     # aborts with a generic "Submodules are not initialized" error that must NOT be
@@ -575,8 +584,8 @@ def main():
                     name="Bugfix validation (unit tests)",
                     status=Result.Status.ERROR,
                     info=(
-                        f"Submodules were not populated in the before-worktree (missing "
-                        f"'{SUBMODULE_MARKER}'); cannot build the before-binary. This is "
+                        f"Could not populate the before-worktree submodules "
+                        f"({submodules_detail}); cannot build the before-binary. This is "
                         "an infrastructure error — NOT a reproduction."
                     ),
                 )

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -348,5 +348,122 @@ def test_before_run_started_a_test_handles_no_files():
     assert before_run_started_a_test(_FakeResult([])) is False
 
 
+# --------------------------------------------------------------------------
+# prepare_before_worktree submodule population: hardlink only when the
+# merge-base pins the same commit the primary has checked out; otherwise
+# (pin/URL drift, e.g. the abseil-cpp fork->upstream switch) populate the
+# before-worktree's own copy at the merge-base pin instead of hardlinking
+# master's content — which would break configure against the merge-base
+# cmake wrappers.
+# --------------------------------------------------------------------------
+def _drive_prepare_before_worktree(monkeypatch, want_by_path, have_by_path):
+    """Run prepare_before_worktree with Shell + os stubbed, returning the issued
+    commands. `want_by_path` = merge-base gitlink SHA per submodule; `have_by_path`
+    = primary checked-out SHA per submodule ("" = primary lacks it)."""
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    calls = []
+
+    def fake_check(cmd, **kwargs):
+        calls.append(cmd)
+        return True
+
+    def fake_get_output(cmd, **kwargs):
+        calls.append(cmd)
+        # merge-base .gitmodules path listing
+        if "--get-regexp" in cmd and ".gitmodules" in cmd:
+            return "\n".join(want_by_path)
+        # want: `git -C before_src rev-parse ... HEAD:<path>`
+        if "rev-parse" in cmd and "HEAD:" in cmd:
+            for p in want_by_path:
+                if f"HEAD:{shlex.quote(p)}" in cmd or f"HEAD:{p}" in cmd:
+                    return want_by_path[p]
+            return ""
+        # have: `git -C <path> rev-parse ... HEAD`
+        if "rev-parse" in cmd and "HEAD" in cmd:
+            for p in have_by_path:
+                if f"-C {shlex.quote(p)} " in cmd or f"-C {p} " in cmd:
+                    return have_by_path[p]
+            return ""
+        return ""
+
+    monkeypatch.setattr(job.Shell, "check", staticmethod(fake_check))
+    monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
+    monkeypatch.setattr(job, "ensure_primary_submodules", lambda: None)
+    # Primary has a populated dir iff it recorded a "have" SHA; the before-worktree
+    # dst dir is treated as populated after the loop (fail-close check passes).
+    monkeypatch.setattr(job.os.path, "realpath", lambda p: "/abs/" + p)
+    monkeypatch.setattr(
+        job.os.path, "isdir", lambda p: True
+    )  # both primary paths and before_src dsts exist
+    monkeypatch.setattr(job.os.path, "isfile", lambda p: True)  # SUBMODULE_MARKER present
+    monkeypatch.setattr(job.os, "listdir", lambda p: ["x"])  # never-empty
+
+    ok = job.prepare_before_worktree("mb_sha", "pr_sha", ["src/X/tests/gtest_x.cpp"])
+    return ok, calls
+
+
+def test_prepare_before_worktree_hardlinks_when_pin_matches(monkeypatch):
+    # A submodule whose merge-base pin equals the primary's checked-out SHA is
+    # content-correct to hardlink.
+    ok, calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={"contrib/sysroot": "samesha"},
+        have_by_path={"contrib/sysroot": "samesha"},
+    )
+    assert ok is True
+    assert any("cp -al -- contrib/sysroot" in c for c in calls), (
+        "matching pin must hardlink from the primary checkout"
+    )
+    assert not any("submodule update" in c for c in calls), (
+        "matching pin must not trigger a submodule fetch"
+    )
+
+
+def test_prepare_before_worktree_repopulates_drifted_submodule(monkeypatch):
+    # abseil-cpp drift: the merge-base pins the fork commit, master has upstream
+    # checked out. Hardlinking master content breaks the merge-base wrapper, so the
+    # before-worktree's own copy must be fetched at the merge-base pin.
+    ok, calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={
+            "contrib/sysroot": "samesha",
+            "contrib/abseil-cpp": "forkpin",
+        },
+        have_by_path={
+            "contrib/sysroot": "samesha",
+            "contrib/abseil-cpp": "upstreampin",
+        },
+    )
+    assert ok is True
+    # sysroot (no drift) is hardlinked; abseil (drift) is NOT.
+    assert any("cp -al -- contrib/sysroot" in c for c in calls)
+    assert not any("cp -al -- contrib/abseil-cpp" in c for c in calls), (
+        "a drifted submodule must not be hardlinked from the primary"
+    )
+    # abseil is sync'd then updated in the before-worktree at its own pin.
+    assert any(
+        "submodule sync -- contrib/abseil-cpp" in c for c in calls
+    ), "drifted submodule must be re-synced to the merge-base URL"
+    assert any(
+        "submodule update --init" in c and "contrib/abseil-cpp" in c for c in calls
+    ), "drifted submodule must be populated at the merge-base pin"
+
+
+def test_prepare_before_worktree_repopulates_when_primary_lacks_submodule(monkeypatch):
+    # A submodule the merge-base needs but the primary lacks (master removed it) must
+    # be populated from the before-worktree's own pin, not silently skipped.
+    ok, calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={"contrib/removed_on_master": "mbpin"},
+        have_by_path={"contrib/removed_on_master": ""},
+    )
+    assert ok is True
+    assert any(
+        "submodule update --init" in c and "contrib/removed_on_master" in c
+        for c in calls
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -356,16 +356,22 @@ def test_before_run_started_a_test_handles_no_files():
 # master's content — which would break configure against the merge-base
 # cmake wrappers.
 # --------------------------------------------------------------------------
-def _drive_prepare_before_worktree(monkeypatch, want_by_path, have_by_path):
-    """Run prepare_before_worktree with Shell + os stubbed, returning the issued
-    commands. `want_by_path` = merge-base gitlink SHA per submodule; `have_by_path`
-    = primary checked-out SHA per submodule ("" = primary lacks it)."""
+def _drive_prepare_before_worktree(
+    monkeypatch, want_by_path, have_by_path, fail_update_for=(), git_only_dirs=()
+):
+    """Run prepare_before_worktree with Shell + os stubbed, returning `((ok, detail),
+    calls)`. `want_by_path` = merge-base gitlink SHA per submodule; `have_by_path` =
+    primary checked-out SHA per submodule ("" = primary lacks it). `fail_update_for` =
+    paths whose `submodule update` should return False. `git_only_dirs` = before-worktree
+    dst paths that contain only a `.git` entry (a failed-update remnant)."""
     import ci.jobs.unit_tests_bugfix_validation_job as job
 
     calls = []
 
     def fake_check(cmd, **kwargs):
         calls.append(cmd)
+        if "submodule update" in cmd:
+            return not any(p in cmd for p in fail_update_for)
         return True
 
     def fake_get_output(cmd, **kwargs):
@@ -387,26 +393,28 @@ def _drive_prepare_before_worktree(monkeypatch, want_by_path, have_by_path):
             return ""
         return ""
 
+    def fake_listdir(p):
+        # A dst path listed in git_only_dirs holds only a `.git` remnant.
+        if any(p.endswith(d) for d in git_only_dirs):
+            return [".git"]
+        return ["x"]
+
     monkeypatch.setattr(job.Shell, "check", staticmethod(fake_check))
     monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
     monkeypatch.setattr(job, "ensure_primary_submodules", lambda: None)
-    # Primary has a populated dir iff it recorded a "have" SHA; the before-worktree
-    # dst dir is treated as populated after the loop (fail-close check passes).
     monkeypatch.setattr(job.os.path, "realpath", lambda p: "/abs/" + p)
-    monkeypatch.setattr(
-        job.os.path, "isdir", lambda p: True
-    )  # both primary paths and before_src dsts exist
+    monkeypatch.setattr(job.os.path, "isdir", lambda p: True)
     monkeypatch.setattr(job.os.path, "isfile", lambda p: True)  # SUBMODULE_MARKER present
-    monkeypatch.setattr(job.os, "listdir", lambda p: ["x"])  # never-empty
+    monkeypatch.setattr(job.os, "listdir", fake_listdir)
 
-    ok = job.prepare_before_worktree("mb_sha", "pr_sha", ["src/X/tests/gtest_x.cpp"])
-    return ok, calls
+    result = job.prepare_before_worktree("mb_sha", "pr_sha", ["src/X/tests/gtest_x.cpp"])
+    return result, calls
 
 
 def test_prepare_before_worktree_hardlinks_when_pin_matches(monkeypatch):
     # A submodule whose merge-base pin equals the primary's checked-out SHA is
     # content-correct to hardlink.
-    ok, calls = _drive_prepare_before_worktree(
+    (ok, _detail), calls = _drive_prepare_before_worktree(
         monkeypatch,
         want_by_path={"contrib/sysroot": "samesha"},
         have_by_path={"contrib/sysroot": "samesha"},
@@ -424,7 +432,7 @@ def test_prepare_before_worktree_repopulates_drifted_submodule(monkeypatch):
     # abseil-cpp drift: the merge-base pins the fork commit, master has upstream
     # checked out. Hardlinking master content breaks the merge-base wrapper, so the
     # before-worktree's own copy must be fetched at the merge-base pin.
-    ok, calls = _drive_prepare_before_worktree(
+    (ok, _detail), calls = _drive_prepare_before_worktree(
         monkeypatch,
         want_by_path={
             "contrib/sysroot": "samesha",
@@ -450,10 +458,38 @@ def test_prepare_before_worktree_repopulates_drifted_submodule(monkeypatch):
     ), "drifted submodule must be populated at the merge-base pin"
 
 
+def test_prepare_before_worktree_fails_closed_on_failed_update(monkeypatch):
+    # A failed `submodule update` for a drifted submodule can leave only a `.git`
+    # remnant (nonempty dir). The function must fail closed (ok=False) and name the
+    # submodule, never report success on a known-incomplete tree.
+    (ok, detail), _calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={"contrib/abseil-cpp": "forkpin"},
+        have_by_path={"contrib/abseil-cpp": "upstreampin"},
+        fail_update_for=("contrib/abseil-cpp",),
+        git_only_dirs=("contrib/abseil-cpp",),
+    )
+    assert ok is False
+    assert "contrib/abseil-cpp" in detail
+
+
+def test_prepare_before_worktree_fails_closed_on_git_only_dir(monkeypatch):
+    # Even if the update command reports success, a dst holding only `.git` (no sources)
+    # must not count as populated — the final fail-close check catches it.
+    (ok, detail), _calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={"contrib/sysroot": "samesha"},
+        have_by_path={"contrib/sysroot": "samesha"},
+        git_only_dirs=("contrib/sysroot",),
+    )
+    assert ok is False
+    assert "contrib/sysroot" in detail
+
+
 def test_prepare_before_worktree_repopulates_when_primary_lacks_submodule(monkeypatch):
     # A submodule the merge-base needs but the primary lacks (master removed it) must
     # be populated from the before-worktree's own pin, not silently skipped.
-    ok, calls = _drive_prepare_before_worktree(
+    (ok, _detail), calls = _drive_prepare_before_worktree(
         monkeypatch,
         want_by_path={"contrib/removed_on_master": "mbpin"},
         have_by_path={"contrib/removed_on_master": ""},

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -282,6 +282,23 @@ def test_gitmodules_shape_rejects_traversal_path(tmp_path, monkeypatch, path):
     assert violation and "unsafe path" in violation
 
 
+def test_gitmodules_shape_validates_an_explicit_file(tmp_path, monkeypatch):
+    # The merge-base worktree's `.gitmodules` is validated by passing its path explicitly;
+    # a non-github URL there must be rejected just like the cwd file. Guards against a
+    # clean PR file but an unsafe merge-base file driving the drift fetch.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitmodules").write_text(_GOOD_GITMODULES)  # cwd is clean
+    mb = tmp_path / "before_src"
+    mb.mkdir()
+    (mb / ".gitmodules").write_text(
+        '[submodule "contrib/evil"]\n\tpath = contrib/evil\n'
+        "\turl = git@example.com:evil/repo.git\n"
+    )
+    assert gitmodules_shape_violation() is None  # PR file clean
+    violation = gitmodules_shape_violation(str(mb / ".gitmodules"))
+    assert violation and "non-github URL" in violation
+
+
 # --------------------------------------------------------------------------
 # determine_merge_base: must anchor on the PR head (info.sha), not `git HEAD`,
 # because the default checkout is the base+PR merge commit.
@@ -357,13 +374,20 @@ def test_before_run_started_a_test_handles_no_files():
 # cmake wrappers.
 # --------------------------------------------------------------------------
 def _drive_prepare_before_worktree(
-    monkeypatch, want_by_path, have_by_path, fail_update_for=(), git_only_dirs=()
+    monkeypatch,
+    want_by_path,
+    have_by_path,
+    fail_update_for=(),
+    git_only_dirs=(),
+    mb_bad_url=None,
 ):
     """Run prepare_before_worktree with Shell + os stubbed, returning `((ok, detail),
     calls)`. `want_by_path` = merge-base gitlink SHA per submodule; `have_by_path` =
     primary checked-out SHA per submodule ("" = primary lacks it). `fail_update_for` =
     paths whose `submodule update` should return False. `git_only_dirs` = before-worktree
-    dst paths that contain only a `.git` entry (a failed-update remnant)."""
+    dst paths that contain only a `.git` entry (a failed-update remnant). `mb_bad_url` =
+    when set, the merge-base `.gitmodules` reports this non-github URL (so the merge-base
+    shape guard must reject before any fetch)."""
     import ci.jobs.unit_tests_bugfix_validation_job as job
 
     calls = []
@@ -376,7 +400,15 @@ def _drive_prepare_before_worktree(
 
     def fake_get_output(cmd, **kwargs):
         calls.append(cmd)
-        # merge-base .gitmodules path listing
+        # gitmodules_shape_violation URL query (merge-base file, quoted before_src path)
+        if "--get-regexp" in cmd and ".url" in cmd:
+            if mb_bad_url and "before_src" in cmd:
+                return f"submodule.contrib/evil.url {mb_bad_url}"
+            return ""
+        # gitmodules_shape_violation path query (name==path shape)
+        if "--get-regexp" in cmd and "\\.path'" in cmd:
+            return "\n".join(f"submodule.{p}.path {p}" for p in want_by_path)
+        # merge-base .gitmodules path listing (awk '{print $2}' form)
         if "--get-regexp" in cmd and ".gitmodules" in cmd:
             return "\n".join(want_by_path)
         # want: `git -C before_src rev-parse ... HEAD:<path>`
@@ -456,6 +488,23 @@ def test_prepare_before_worktree_repopulates_drifted_submodule(monkeypatch):
     assert any(
         "submodule update --init" in c and "contrib/abseil-cpp" in c for c in calls
     ), "drifted submodule must be populated at the merge-base pin"
+
+
+def test_prepare_before_worktree_rejects_unsafe_merge_base_gitmodules(monkeypatch):
+    # SECURITY: an unsafe URL in the MERGE-BASE .gitmodules (even if the PR's current file
+    # is clean) must fail closed before any submodule fetch — the drift path fetches using
+    # the merge-base file.
+    (ok, detail), calls = _drive_prepare_before_worktree(
+        monkeypatch,
+        want_by_path={"contrib/abseil-cpp": "forkpin"},
+        have_by_path={"contrib/abseil-cpp": "upstreampin"},
+        mb_bad_url="git@evil.example.com:x/y.git",
+    )
+    assert ok is False
+    assert "merge-base" in detail and "unsafe" in detail
+    assert not any("submodule update" in c for c in calls), (
+        "must not fetch any submodule when the merge-base .gitmodules is unsafe"
+    )
 
 
 def test_prepare_before_worktree_fails_closed_on_failed_update(monkeypatch):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes `Bugfix validation (unit tests)` erroring with "the before-binary failed to CONFIGURE (cmake)" for bugfix PRs whose merge-base predates a submodule pin/URL change on master.

Root cause: `prepare_before_worktree` in `ci/jobs/unit_tests_bugfix_validation_job.py` builds the "before" binary in a merge-base worktree and populates its submodules by hardlinking (`cp -al`) the primary (master) checkout's submodule content. That is content-correct only when the merge-base pins the same commit the primary has checked out. When master bumps a submodule after the merge-base, the before-worktree gets master's content but uses the merge-base cmake wrappers, which reference the merge-base submodule's file layout. The 2026-07-20 `abseil-cpp` switch from the `ClickHouse/abseil-cpp` fork (`255c84dadd`) to upstream `abseil/abseil-cpp` (`5650e9cf`) is the trigger: the merge-base wrapper references `absl/base/internal/throw_delegate.cc` and `absl/debugging/internal/borrowed_fixup_buffer.cc`, which do not exist at those paths upstream, so configure fails with "Cannot find source file". The old fail-close check only looked for a single unrelated submodule marker (`contrib/sysroot/README.md`), so it did not catch this.

Fix: populate each submodule the merge-base needs by comparing the merge-base gitlink SHA to the primary's checked-out SHA. When they match, hardlink as before (fast, no network). When they differ (drift), or the primary lacks the submodule, fetch that submodule at its own merge-base pin (`git -C before_src submodule sync/update`, so the merge-base URL is used). The submodule list is taken from the merge-base's own `.gitmodules` so submodules added or removed on master are handled correctly. The fail-close now reports the specific unpopulated submodule instead of a generic marker. All existing security guards (path shape validation, realpath containment, shell-quoting) are preserved.

Verified locally by reproducing the exact CI cmake error against a pre-2026-07-20 merge-base (upstream abseil hardlinked -> configure fails) and confirming the fix repopulates the 6 drifted submodules for that merge-base and configure succeeds. Added unit tests covering the match/drift/primary-absent cases.

No related open issue found.
