### PR TITLE
docs: fix h3Distance sample output (7 → 6)

### DIFF
--- a/docs/reference/functions/regular-functions/geo/h3.mdx
+++ b/docs/reference/functions/regular-functions/geo/h3.mdx
@@ -1172,7 +1172,7 @@ Returns a negative number if finding the distance fails.
 
 ```text title="Response"
 ┌─distance─┐
-│        7 │
+│        6 │
 └──────────┘
 ```
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry
N/A — docs only.

### Summary
The long-form and reference docs for `h3Distance` still showed sample output `7` for
`h3Distance(590080540275638271, 590103561300344831)`. The H3 grid distance for those
indices is `6` (see registered `FunctionDocumentation` example in `h3Distance.cpp`,
already corrected). This brings `docs/en` and `docs/reference` in line.

Closes #102844

Verified against ClickHouse Fiddle linked from the issue.

AI-assisted; human-reviewed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.842` (included in `26.8` and later)
<!-- ch-version-info:end -->