### PR TITLE
docs: extractKeyValuePairs default unexpected_quoting strategy is PROMOTE

### DIFF
--- a/src/Functions/extractKeyValuePairs.cpp
+++ b/src/Functions/extractKeyValuePairs.cpp
@@ -184,7 +184,7 @@ extractKeyValuePairs(data, [key_value_delimiter], [pair_delimiter], [quoting_cha
 - `key_value_delimiter` - Character to be used as delimiter between the key and the value. Defaults to `:`. [String](/reference/data-types/string) or [FixedString](/reference/data-types/fixedstring).
 - `pair_delimiters` - Set of character to be used as delimiters between pairs. Defaults to `\space`, `,` and `;`. [String](/reference/data-types/string) or [FixedString](/reference/data-types/fixedstring).
 - `quoting_character` - Character to be used as quoting character. Defaults to `"`. [String](/reference/data-types/string) or [FixedString](/reference/data-types/fixedstring).
-- `unexpected_quoting_character_strategy` - Strategy to handle quoting characters in unexpected places during `read_key` and `read_value` phase. Possible values: `invalid`, `accept` and `promote`. Invalid will discard key/value and transition back to `WAITING_KEY` state. Accept will treat it as a normal character. Promote will transition to `READ_QUOTED_{KEY/VALUE}` state and start from next character. The default value is `INVALID`
+- `unexpected_quoting_character_strategy` - Strategy to handle quoting characters in unexpected places during `read_key` and `read_value` phase. Possible values: `invalid`, `accept` and `promote`. Invalid will discard key/value and transition back to `WAITING_KEY` state. Accept will treat it as a normal character. Promote will transition to `READ_QUOTED_{KEY/VALUE}` state and start from next character. The default value is `PROMOTE`
 
 **Returned values**
 - The extracted key-value pairs in a Map(String, String).

--- a/src/Functions/extractKeyValuePairs.cpp
+++ b/src/Functions/extractKeyValuePairs.cpp
@@ -176,7 +176,7 @@ A key-value pair consists of a key followed by a `key_value_delimiter` and a val
 
 **Syntax**
 ```sql
-extractKeyValuePairs(data, [key_value_delimiter], [pair_delimiter], [quoting_character])
+extractKeyValuePairs(data, [key_value_delimiter], [pair_delimiter], [quoting_character], [unexpected_quoting_character_strategy])
 ```
 
 **Arguments**
@@ -299,7 +299,7 @@ Query id: e9fd26ee-b41f-4a11-b17f-25af6fd5d356
 │ {'age':'a\\x0A\\n\\0'} │
 └────────────────────────┘
 ```)",
-            .syntax = "extractKeyValuePairs(input)",
+            .syntax = "extractKeyValuePairs(data, [key_value_delimiter], [pair_delimiter], [quoting_character], [unexpected_quoting_character_strategy])",
             .introduced_in = {23, 4},
             .category = FunctionDocumentation::Category::Map
         }
@@ -332,7 +332,7 @@ Query id: 44c114f0-5658-4c75-ab87-4574de3a1645
 │ {'age':'a\n\n\0'} │
 └───────────────────┘
 ```)",
-            .syntax = "extractKeyValuePairsWithEscaping(input)",
+            .syntax = "extractKeyValuePairsWithEscaping(data, [key_value_delimiter], [pair_delimiter], [quoting_character], [unexpected_quoting_character_strategy])",
             .introduced_in = {23, 4},
             .category = FunctionDocumentation::Category::Map
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (documentation fix)

### Changelog entry
N/A — documentation alignment with existing default.

### Summary
`extractKeyValuePairs` documentation (REGISTER string in `extractKeyValuePairs.cpp` and the reference / tuple-map pages) said the default `unexpected_quoting_character_strategy` is `INVALID`. The builder default has been `PROMOTE` for backwards compatibility (`KeyValuePairExtractorBuilder.h`). Users who omit the 5th argument get PROMOTE behavior — document that.

Issue #101908. Fiddle proof is in the issue.

AI-assisted; human-reviewed.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.307` (included in `26.8` and later)
<!-- ch-version-info:end -->