### PR TITLE
Fix flaky 03915_spilling_hash_join by pinning query_plan_join_swap_table

### DIFF
--- a/tests/queries/0_stateless/03915_spilling_hash_join.sql
+++ b/tests/queries/0_stateless/03915_spilling_hash_join.sql
@@ -4,6 +4,10 @@ SET explain_query_plan_default = 'legacy';
 SET max_bytes_before_external_join = 1000000000;
 SET grace_hash_join_initial_buckets = 1;
 SET query_plan_optimize_join_order_randomize = 0;
+-- The JoinNonJoinedTransform* counters checked below depend on which physical side of the join
+-- emits non-joined rows. With the default `auto`, the optimizer swaps sides based on row-count
+-- estimates, so randomized settings can flip the orientation. Pin it to keep the counters stable.
+SET query_plan_join_swap_table = 0;
 
 -- Ensure it shows up in query plan nicely
 SELECT trim(explain)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/111192
-->

Related: https://github.com/ClickHouse/ClickHouse/pull/111192

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `03915_spilling_hash_join` ("result differs with reference", 0 master / 19 hits across 7 unrelated PRs in 30d; e.g. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111192&sha=740ce3bcdecf657aabf88e39ca1a647709b1ac3f&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29).

Root cause: the tail `profile events` block asserts per-query `JoinNonJoinedTransform*` counters. For `LEFT`/`RIGHT`/`FULL` joins the physical side that emits non-joined rows depends on whether the planner swaps the join's build/probe sides. With `query_plan_join_swap_table = auto` (default) the swap fires when the left row estimate is smaller than the right (`optimizeJoin.cpp`). Those estimates come from the join-reordering statistics cache (`use_hash_table_stats_for_join_reordering`, randomized and on by default), so under randomized settings the cached estimates flip the swap decision, reverse the join kind, and move the counters between queries (q12/q13/q15), producing the reference diff. Query results (`COUNT`/`SUM`) stay correct; only the ProfileEvents shift. The test already pinned `query_plan_optimize_join_order_randomize = 0` but not the swap decision itself.

Fix: pin `query_plan_join_swap_table = 0` so the physical plan is deterministic regardless of the cached estimates. The counter assertions and spill checks are unchanged.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.137` (included in `26.8` and later)
<!-- ch-version-info:end -->