### PR TITLE
Fix flaky test_s3_table_functions_timeouts

### DIFF
--- a/tests/integration/test_s3_table_functions/test.py
+++ b/tests/integration/test_s3_table_functions/test.py
@@ -78,14 +78,25 @@ def test_s3_table_functions(started_cluster):
 
 def test_s3_table_functions_timeouts(started_cluster):
     """
-    Test with timeout limit of 1200ms.
-    This should raise an Exception and pass.
+    A 1200ms network delay must make the S3 write time out and raise.
     """
+
+    # Make the S3 request timeout (not the connect timeout) the single failure mechanism:
+    # disable adaptive timeouts and keep the connect timeout above the delay, so the write
+    # can only fail via s3_request_timeout_ms. This exercises the send/receive idleness
+    # timeout that applies to every attempt on both fresh and reused (pooled keep-alive)
+    # connections, which is the path that was silently not timing out before.
+    timeout_settings = {
+        **settings,
+        "s3_use_adaptive_timeouts": "0",
+        "s3_connect_timeout_ms": "10000",
+        "s3_request_timeout_ms": "500",
+    }
 
     with PartitionManager() as pm:
         pm.add_network_delay(node, 1200)
 
-        with pytest.raises(QueryRuntimeException):
+        with pytest.raises(QueryRuntimeException, match="Timeout"):
             node.query(
                 """
                 INSERT INTO FUNCTION s3
@@ -98,5 +109,5 @@ def test_s3_table_functions_timeouts(started_cluster):
                     )
                 SELECT * FROM numbers(1000000)
             """,
-                settings=settings,
+                settings=timeout_settings,
             )


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/111370
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

`test_s3_table_functions/test.py::test_s3_table_functions_timeouts` injects a 1200ms network delay and expects an S3 INSERT to time out and raise. It set no explicit S3 timeout, so the raise relied on a default timeout being below 1200ms on the connection path actually taken:

- Fresh connection: the adaptive connect timeout (500ms first attempt, 1000ms on retries) is below 1200ms, so the connect times out and the query raises. This is the normal path.
- Reused pooled keep-alive connection: no fresh TCP connect happens, so the connect timeout does not apply. The only remaining gate is the send/receive idleness timeout, whose default (adaptive 3000ms / configured 30000ms) is far above 1200ms, so the write completes and `pytest.raises` sees no exception. This is the rare `DID NOT RAISE` failure reported on the report for #111370 (one occurrence in 40 days of CI, 0 on master).

Fix: set `s3_request_timeout_ms=500` for the timeout query. This idleness timeout applies to every attempt on both fresh and reused connections, so the 1200ms delay always exceeds it and the write times out deterministically. Test intent is preserved (a slow network still makes the write fail), and the change is confined to the timeout query settings.

Validated: reproduced `DID NOT RAISE` deterministically by modeling the reused-connection path (no sub-1200ms timeout governing), confirmed the fix raises with `s3_request_timeout_ms=500`, and ran the modified test 5 times (`--count 5 --random-order`), all passing.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.39` (included in `26.8` and later)
<!-- ch-version-info:end -->