### PR TITLE
Add test: Keep-on-match inline-filter branch `if(token IN/NOT IN (...), token, '')` in `tryExtractInlineFilter` is untested

### DIFF
--- a/tests/queries/0_stateless/04626_text_index_postprocessor_keep_filter.reference
+++ b/tests/queries/0_stateless/04626_text_index_postprocessor_keep_filter.reference
@@ -1,0 +1,8 @@
+if(token IN (...), token, ...): only the listed tokens survive
+fox the
+2
+0
+if(token NOT IN (...), token, ...): keep-on-match combined with NOT IN inversion
+a brown end here is quick
+0
+1

--- a/tests/queries/0_stateless/04626_text_index_postprocessor_keep_filter.sql
+++ b/tests/queries/0_stateless/04626_text_index_postprocessor_keep_filter.sql
@@ -1,0 +1,39 @@
+-- Tags: no-fasttest
+-- Test the keep-on-match spelling of the filter-only text-index postprocessor:
+-- if(token IN/NOT IN (...), token, '') keeps the token on the true branch and drops it on the false branch,
+-- the inverse of the drop-on-match if(cond, '', token) form covered by the PR's own test.
+
+DROP TABLE IF EXISTS tab_keep_in;
+CREATE TABLE tab_keep_in (
+  id UInt32,
+  s String,
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s IN ('the', 'fox'), s, ''))
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tab_keep_in VALUES (1, 'the quick brown fox'), (2, 'a fox is here'), (3, 'is the end');
+
+SELECT 'if(token IN (...), token, ...): only the listed tokens survive';
+SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_keep_in, idx);
+SELECT count() FROM tab_keep_in WHERE hasToken(s, 'fox');
+SELECT count() FROM tab_keep_in WHERE hasToken(s, 'brown');
+
+SELECT 'if(token NOT IN (...), token, ...): keep-on-match combined with NOT IN inversion';
+DROP TABLE IF EXISTS tab_keep_notin;
+CREATE TABLE tab_keep_notin (
+  id UInt32,
+  s String,
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s NOT IN ('the', 'fox'), s, ''))
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tab_keep_notin VALUES (1, 'the quick brown fox'), (2, 'a fox is here'), (3, 'is the end');
+
+SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_keep_notin, idx);
+SELECT count() FROM tab_keep_notin WHERE hasToken(s, 'fox');
+SELECT count() FROM tab_keep_notin WHERE hasToken(s, 'brown');
+
+DROP TABLE tab_keep_in;
+DROP TABLE tab_keep_notin;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path, found during automated review of [PR #109049](https://github.com/ClickHouse/ClickHouse/pull/109049).
The PR adds a fast path to the text-index aggregator for filter-only postprocessors of the shape `if`/`multiIf(token IN/NOT IN (<string literals>), '', token)`. `tryExtractInlineFilter` in `MergeTreeIndexTextPostprocessor.cpp` parses the postprocessor AST into a `MergeTreeIndexTextInlineFilter` …

**1. Keep-on-match inline-filter branch `if(token IN/NOT IN (...), token, '')` in `tryExtractInlineFilter` is untested**
  `src/Storages/MergeTree/MergeTreeIndexTextPostprocessor.cpp:109`
  **Risk:** `tryExtractInlineFilter` at `MergeTreeIndexTextPostprocessor.cpp`:108-109 takes the `drop_on_condition = false` branch only when the token identifier is the then-branch and '' is the else-branch. `filter.drop_on_match` is then computed as `is_not_in ? !drop_on_condition : drop_on_condition` and drives `shouldDrop` in `addToken`, which decides per distinct token whether it enters the index. RISK: if this branch or the `drop_on_match` inversion is broken, the keep-on-match filter silently …
  **What's unique vs PR tests:** The PR's own test (02346_text_index_postprocessor_in_filter.sql) only covers the drop-on-match spelling if(cond, '', token) — token on the else-branch. This test covers the mirror keep-on-match spelling if(cond, token, '') — token on the then-branch — which is the only trigger of the line 108-109 branch, plus its NOT IN inversion.
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: text indexes are not built in the FastTest minimal build
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/14580f9b-539b-4abf-aadb-75310558444f)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)