### PR TITLE
Fix Min-Max index file-order hint after part_minmax_index_columns downgrade

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -346,26 +346,15 @@ Names IMergeTreeDataPart::MinMaxIndex::getProbablyWrittenFiles(const IMergeTreeD
     const auto data_settings = part.storage.getSettings();
     const auto & data_part_storage = part.getDataPartStorage();
 
-    auto to_file_names = [&](const NamesAndTypesList & minmax_columns)
-    {
-        return minmax_columns.getNames()
-            | std::views::transform([&](const auto & column_name) { return "minmax_" + getFileColumnName(column_name, data_settings, data_part_storage) + ".idx"; })
-            | std::ranges::to<Names>();
-    };
+    /// The hyperrectangle may hold more columns than the current setting prescribes (a wider index that
+    /// has not been re-materialized yet), so clamp to what `store` actually writes: its leading prefix.
+    auto minmax_columns = MergeTreeData::getMinMaxColumns(partition_key, data_settings);
+    if (minmax_columns.size() > hyperrectangle.size())
+        minmax_columns.resize(hyperrectangle.size());
 
-    {
-        auto minmax_columns = MergeTreeData::getMinMaxColumns(partition_key, data_settings, MergeTreePartMinMaxIndexColumns::PARTITION_KEY_ONLY);
-        if (hyperrectangle.size() == minmax_columns.size())
-            return to_file_names(minmax_columns);
-    }
-
-    {
-        auto minmax_columns = MergeTreeData::getMinMaxColumns(partition_key, data_settings, MergeTreePartMinMaxIndexColumns::WITH_BLOCK_NUMBER_OFFSET);
-        if (hyperrectangle.size() == minmax_columns.size())
-            return to_file_names(minmax_columns);
-    }
-
-    throw Exception(ErrorCodes::LOGICAL_ERROR, "Part level Min-Max index was constructed from unexpected columns set.");
+    return minmax_columns.getNames()
+        | std::views::transform([&](const auto & column_name) { return "minmax_" + getFileColumnName(column_name, data_settings, data_part_storage) + ".idx"; })
+        | std::ranges::to<Names>();
 }
 
 String IMergeTreeDataPart::MinMaxIndex::getFileColumnName(const String & column_name, const MergeTreeSettingsPtr & storage_settings_, const IDataPartStorage & data_part_storage)

--- a/tests/queries/0_stateless/04626_minmax_block_number_downgrade_merge.reference
+++ b/tests/queries/0_stateless/04626_minmax_block_number_downgrade_merge.reference
@@ -1,0 +1,7 @@
+3
+3
+1	Compact	Packed
+3
+1
+2
+3

--- a/tests/queries/0_stateless/04626_minmax_block_number_downgrade_merge.sql
+++ b/tests/queries/0_stateless/04626_minmax_block_number_downgrade_merge.sql
@@ -1,0 +1,46 @@
+-- Tags: no-shared-merge-tree, no-random-merge-tree-settings
+-- Tag no-shared-merge-tree: RMT/SMT allocate block numbers starting from 0
+-- Tag no-random-merge-tree-settings: the test toggles part_minmax_index_columns and needs
+--   enable_block_number_column/enable_block_offset_column fixed to 1 (randomizing them breaks the setup)
+
+-- Regression test for a LOGICAL_ERROR "Part level Min-Max index was constructed from unexpected
+-- columns set" that used to abort the merge below in getProbablyWrittenFiles. The min-max file-order
+-- hint (built by getPreferredFileOrder for compact parts) rejected an in-memory hyperrectangle that
+-- was larger than the current part_minmax_index_columns setting, which happens after the setting is
+-- lowered while a part still carries a cached with_block_number_offset index. The hint is consumed
+-- by packed storage to lay out the archive, so the table uses packed compact parts (the CI case).
+
+DROP TABLE IF EXISTS t;
+
+-- min_bytes_for_wide_part = huge -> compact parts; min_bytes_for_full_part_storage = huge -> packed
+-- storage, whose archive layout actually consumes the file-order hint returned by getProbablyWrittenFiles.
+CREATE TABLE t (id UInt64, p UInt64) ENGINE = MergeTree PARTITION BY p ORDER BY id
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1,
+         part_minmax_index_columns = 'with_block_number_offset',
+         min_bytes_for_wide_part = '1G', min_bytes_for_full_part_storage = '1G';
+
+SYSTEM STOP MERGES t;
+
+INSERT INTO t SELECT 1, 1;
+INSERT INTO t SELECT 2, 1;
+INSERT INTO t SELECT 3, 1;
+
+-- Load and cache each part's minmax index at the with_block_number_offset size.
+SELECT count() FROM t WHERE _block_number >= 0;
+SELECT count() FROM t WHERE _block_offset >= 0;
+
+-- Lower the setting; the cached in-memory index keeps the larger column set.
+ALTER TABLE t MODIFY SETTING part_minmax_index_columns = 'partition_key_only' SETTINGS alter_sync = 2;
+
+SYSTEM START MERGES t;
+
+-- The merge used to abort with a LOGICAL_ERROR here.
+OPTIMIZE TABLE t FINAL;
+
+-- The merge must have completed into a single active packed compact part.
+SELECT count(), any(part_type), any(part_storage_type) FROM system.parts WHERE database = currentDatabase() AND table = 't' AND active;
+-- Reading back proves the packed archive (laid out using the hint) is intact.
+SELECT count() FROM t;
+SELECT id FROM t WHERE _block_number >= 0 ORDER BY id;
+
+DROP TABLE t;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/42701
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` ("Part level Min-Max index was constructed from unexpected columns set") that could abort a background merge in debug/sanitizer builds after `part_minmax_index_columns` was lowered (for example from `with_block_number_offset` back to `partition_key_only`).


### Description

Found by the Stress test (arm_asan_ubsan) on PR #42701 (unrelated to that PR):
report https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=42701&sha=3f6eab14d9d3cac7d7f3add30f551a43820e4ddb&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29 , STID 5721-5ce7.

`MinMaxIndex::getProbablyWrittenFiles` (reached from `getPreferredFileOrder` during merge/mutation finalize) accepted the in-memory hyperrectangle only when its size exactly matched one of two column sets derived from the current `part_minmax_index_columns` setting, and threw a `LOGICAL_ERROR` otherwise.

The min-max index has upgrade semantics: a part written under a wider `part_minmax_index_columns` keeps its extra hyperrectangle entries (partition key plus `_block_number`/`_block_offset`) until a merge or mutation re-materializes it. After the setting is lowered, such a part's index is legitimately larger than the current setting prescribes, so the exact-size check failed and the merge aborted.

`getProbablyWrittenFiles` only produces a best-effort file-ordering hint for the packed-part archive layout, and `store()` already writes just the leading `min(current column count, hyperrectangle size)` min-max files. The hint now mirrors that same clamp instead of requiring an exact match, so a valid transitional index no longer aborts the merge. On-disk output is unchanged.

Reproduced deterministically (see the new stateless test `04626_minmax_block_number_downgrade_merge`): insert parts under `part_minmax_index_columns='with_block_number_offset'`, load their min-max index into memory, `ALTER` the setting down to `partition_key_only`, then merge. The test fails on the current server (merge aborts) and passes with this change. No related open issue was found.
