### PR TITLE
Fix flaky test 01661_extract_all_groups_throw_fast under memory pressure

### DIFF
--- a/tests/queries/0_stateless/01661_extract_all_groups_throw_fast.sql
+++ b/tests/queries/0_stateless/01661_extract_all_groups_throw_fast.sql
@@ -1,2 +1,4 @@
-SELECT repeat('abcdefghijklmnopqrstuvwxyz', number * 100) AS haystack, extractAllGroupsHorizontal(haystack, '(\\w)') AS matches FROM numbers(1023); -- { serverError TOO_LARGE_ARRAY_SIZE }
+-- 1001 matches in one row exceeds `regexp_max_matches_per_row` (default 1000) and trips the fast-throw.
+-- The low `max_memory_usage` also guards against regressing to a huge fixture that could hit MEMORY_LIMIT_EXCEEDED first.
+SELECT extractAllGroupsHorizontal(materialize(repeat('a', 1001)), '(\\w)') FORMAT Null SETTINGS max_memory_usage = 100000000; -- { serverError TOO_LARGE_ARRAY_SIZE }
 SELECT count(extractAllGroupsHorizontal(materialize('a'), '(a)')) FROM numbers(1000000) FORMAT Null; -- shouldn't fail


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110567
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The first query materialized a ~1.3 GB `haystack` column (`numbers(1023)`, each row up to 2.66 MB) only to trip the per-row `regexp_max_matches_per_row` (default 1000) fast-throw `TOO_LARGE_ARRAY_SIZE` in `extractAllGroupsHorizontal`. The throw fires on the first row (2600 matches); the rest of the column is wasted allocation. Under the shared parallel-runner memory budget, building it could hit `MEMORY_LIMIT_EXCEEDED` before the expected throw, so the test intermittently failed (0 master failures, 27 unrelated PRs in 30 days).

Replaced it with a single materialized 1001-character row, which crosses the same per-row limit at ~1 KB instead of 1.3 GB. `materialize()` keeps the runtime (non-const) code path the throw lives in. A low `max_memory_usage` on the query also makes the throw deterministic under memory pressure and guards against regressing to a large fixture. The second "shouldn't fail" query is unchanged.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110567&sha=59463dc81a15d063a99e8803ccaaa66e374133da&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29

Verified with a debug build: the old fixture throws `MEMORY_LIMIT_EXCEEDED` (241) under a 100 MB query cap, the new one throws `TOO_LARGE_ARRAY_SIZE` (128) even under a 20 MB cap; both queries pass 20/20 against a live server. `regexp_max_matches_per_row` and `max_memory_usage` are not in the CI random-settings pool, so the throw is deterministic.
