### PR TITLE
Highlight the commands in the output of the universal installation script

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -89,13 +89,25 @@ echo
 echo "Will download ${URL} into ${clickhouse}"
 echo
 curl "${URL}" -o "${clickhouse}" && chmod a+x "${clickhouse}" || exit 1
+
+# Highlight the commands with increased intensity when the output is a terminal,
+# in the same style as `clickhouse install` does.
+if [ -t 1 ]
+then
+    HILITE="$(printf '\033[1m')"
+    END_HILITE="$(printf '\033[0m')"
+else
+    HILITE=""
+    END_HILITE=""
+fi
+
 echo
 echo "Successfully downloaded the ClickHouse binary, you can run it as:
-    ./${clickhouse}"
+    ${HILITE}./${clickhouse}${END_HILITE}"
 
 echo
 echo "You can also install it:
-sudo ./${clickhouse} install"
+${HILITE}sudo ./${clickhouse} install${END_HILITE}"
 
 # Also install clickhousectl, the CLI for ClickHouse local and Cloud.
 # Set CLICKHOUSE_ONLY=1 to skip.


### PR DESCRIPTION
The universal installation script (`curl https://clickhouse.com/ | sh`) ends with hints about what to do next. Highlight the two commands in these hints — `./clickhouse` and `sudo ./clickhouse install` — with increased intensity (`\033[1m`), so they stand out from the surrounding text. This is the same style that `clickhouse install` uses for its hints.

The escape codes are emitted only when the output is a terminal, so redirecting the output to a file keeps it free of escape sequences.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Highlight the `./clickhouse` and `sudo ./clickhouse install` commands in the output of the universal installation script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)