### PR TITLE
Ignore repo-local tmp/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # local CI environment overrides (see ci/local.env.example)
 ci/local.env
 
+# scratch / temporary working files
+/tmp/
+
 # emacs files
 *~
 *\#


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/clickhouse-private/pull/65325
-->

Add `/tmp/` to `.gitignore` so the repo-local scratch directory used for temporary working files (logs, downloads, throwaway scripts) is not tracked by git.

This originated as a review comment on the private repository (https://github.com/ClickHouse/clickhouse-private/pull/65325#discussion_r3626815305), where it was flagged as a public-related change and better placed in the public repository.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1373` (included in `26.7` and later)
<!-- ch-version-info:end -->