### PR TITLE
Reject dimension-tagged empty points (POINT Z/M/ZM EMPTY) in readWKT

### DIFF
--- a/src/Functions/readWkt.cpp
+++ b/src/Functions/readWkt.cpp
@@ -9,6 +9,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/geometry/core/tags.hpp>
 
+#include <cctype>
 #include <string>
 #include <memory>
 #include <type_traits>
@@ -37,6 +38,17 @@ bool isEmptyPointWKT(const String & str)
         return false;
     auto rest = normalized.substr(strlen("point"));
     boost::trim(rest);
+    /// Strip an optional WKT dimension tag (Z, M or ZM), matched only as a whole space-separated token.
+    for (std::string_view tag : {"zm", "z", "m"})
+    {
+        if (rest.starts_with(tag) && rest.size() > tag.size()
+            && isspace(static_cast<unsigned char>(rest[tag.size()])))
+        {
+            rest.erase(0, tag.size());
+            boost::trim(rest);
+            break;
+        }
+    }
     return rest == "empty";
 }
 

--- a/tests/queries/0_stateless/04540_read_wkt_point_empty.sql
+++ b/tests/queries/0_stateless/04540_read_wkt_point_empty.sql
@@ -11,6 +11,17 @@ SELECT readWKT('POINT EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
 SELECT readWKT(' POINT EMPTY '); -- { serverError CANNOT_PARSE_TEXT }
 SELECT readWKT('point   empty'); -- { serverError CANNOT_PARSE_TEXT }
 
+-- WKT allows an optional dimension tag (Z, M, ZM) between the type and EMPTY. boost accepts
+-- the M form for a 2D point without writing coordinates, so it must be rejected the same way.
+SELECT readWKTPoint('POINT Z EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKTPoint('POINT M EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKTPoint('POINT ZM EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKTPoint('point m empty'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKTPoint(' POINT M EMPTY '); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKTPoint('POINT   M   EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKT('POINT M EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+SELECT readWKT('POINT ZM EMPTY'); -- { serverError CANNOT_PARSE_TEXT }
+
 -- Valid points are unaffected.
 SELECT readWKTPoint('POINT (1.2 3.4)');
 SELECT readWKT('POINT (5 6)');
@@ -21,6 +32,13 @@ CREATE TABLE geo_point_empty (s String, id Int) engine=Memory();
 INSERT INTO geo_point_empty VALUES ('POINT (11 22)', 1), ('POINT EMPTY', 2), ('POINT (33 44)', 3);
 SELECT readWKTPoint(s) FROM geo_point_empty ORDER BY id; -- { serverError CANNOT_PARSE_TEXT }
 DROP TABLE geo_point_empty;
+
+-- Same for a dimension-tagged empty row (the M form bypassed the old guard and leaked prior coords).
+DROP TABLE IF EXISTS geo_point_m_empty;
+CREATE TABLE geo_point_m_empty (s String, id Int) engine=Memory();
+INSERT INTO geo_point_m_empty VALUES ('POINT (11 22)', 1), ('POINT M EMPTY', 2), ('POINT (33 44)', 3);
+SELECT readWKTPoint(s) FROM geo_point_m_empty ORDER BY id; -- { serverError CANNOT_PARSE_TEXT }
+DROP TABLE geo_point_m_empty;
 
 -- Non-point empty geometries remain valid.
 SELECT readWKTLineString('LINESTRING EMPTY');


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111505
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111505

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `readWKTPoint`/`readWKT` returning uninitialized (scalar) or previous-row (vectorized) coordinates for a dimension-tagged empty point such as `POINT M EMPTY`. Such inputs are now rejected with `CANNOT_PARSE_TEXT`, consistent with `POINT EMPTY`.

### Description

`isEmptyPointWKT` (added in #110692 to reject bare `POINT EMPTY`) stripped only the `point` prefix and required the remainder to equal exactly `empty`. The valid WKT dimension tags `Z`/`M`/`ZM` that may sit between `POINT` and `EMPTY` bypassed the guard. `boost::geometry::read_wkt` accepts `POINT M EMPTY` for a 2D point without writing coordinates, so the empty form was not detected: the scalar path returned garbage subnormal/nan coordinates and the vectorized path silently returned the previous row's coordinates.

The fix strips an optional `Z`/`M`/`ZM` dimension tag (matched only as a whole space-separated token) before the empty check, so the entire `POINT <dim> EMPTY` family is rejected. Non-point EMPTY geometries (`LINESTRING`/`POLYGON`/`MULTIPOLYGON`/`MULTILINESTRING EMPTY`) and valid points remain unaffected.

Found by the clickgapai QA agent (#111505).

CI report / reproduction (against master `e161dcbb`, debug build):
- Before: `SELECT readWKTPoint('POINT M EMPTY')` returned `(3.92157427e-314,5.1699321719474e-310)`; vectorized `('POINT (11 22)'),('POINT M EMPTY'),('POINT (33 44)')` returned `(11,22),(11,22),(33,44)`.
- After: both throw `CANNOT_PARSE_TEXT`.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.165` (included in `26.8` and later)
<!-- ch-version-info:end -->