### PR TITLE
Reuse the merge-queue enqueue helper for the release changelog PR

### DIFF
--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -538,15 +538,25 @@ def main():
             # origin/master (-f, so the switch can't abort on "local changes would
             # be overwritten"), restore those paths, and stage only them. -B so a
             # rerun re-creates the branch instead of failing on "already exists".
-            porcelain = Shell.get_output(
-                "git status --porcelain --no-renames --untracked-files=all -- "
+            # Collect the paths as clean, one-per-line names (NOT via
+            # `git status --porcelain` slicing: Shell.get_output strips the
+            # output, which eats the leading space of a worktree-modified line and
+            # would drop a char off the first path). Tracked changes vs HEAD +
+            # any untracked new files, scoped to the artifact paths.
+            pathspec = (
                 "utils/list-versions/version_date.tsv "
                 f"{shlex.quote(f'docs/changelogs/{release_tag}.md')} SECURITY.md "
-                "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'",
-                strict=True,
+                "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'"
             )
-            # Porcelain line is "XY <path>"; the path starts at column 3.
-            artifact_files = [ln[3:] for ln in porcelain.splitlines() if ln.strip()]
+            changed = Shell.get_output(
+                f"git diff --name-only HEAD -- {pathspec}", strict=True
+            )
+            untracked = Shell.get_output(
+                f"git ls-files --others --exclude-standard -- {pathspec}", strict=True
+            )
+            artifact_files = sorted(
+                {f for f in changed.splitlines() + untracked.splitlines() if f.strip()}
+            )
             backup_dir = tempfile.mkdtemp(prefix="changelog-artifacts-")
             for f in artifact_files:
                 dst = os.path.join(backup_dir, f)

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -392,13 +392,11 @@ def main():
     # patch, the version-bump PR for a new release. Ensure it exists and is
     # merged, idempotently: create it if absent, merge it if open, skip if it is
     # already merged. This converges a fresh release and a recovery / rerun after
-    # a failed merge through the same path. only-repo/only-docker are targeted
-    # artifact re-publish recoveries: they never *create* this PR, but they do
-    # enqueue an already-open one, so a cheap recovery run can finish landing a
-    # release whose original run created the PR but failed to enqueue it (e.g.
-    # the enqueue lost the race with a still-pending `CH Inc sync` required
-    # check). Hence the branch lookup runs regardless of the recovery flags; only
-    # PR creation stays gated to a full run.
+    # a failed create-or-merge through the same path. These PR operations key off
+    # the PR's actual state, not the run mode, so they run regardless of
+    # only-repo/only-docker: a cheap recovery run can create a missing release PR
+    # or enqueue an open-but-unmerged one (e.g. when the original run's enqueue
+    # lost the race with a still-pending `CH Inc sync` required check).
     if args.dry_run:
         # No gh reads on dry-run (it may be a local run without gh auth): fall
         # back to the fresh-release signal so the generation is still previewed.
@@ -422,16 +420,7 @@ def main():
                 f"Release PR branch [{release_pr_branch}] state: "
                 + (release_pr_state or "absent — will create")
             )
-        # Recovery re-publishes an existing release and must never mint the PR,
-        # so creation is gated to a full run.
-        recovery = args.only_repo or args.only_docker
-        release_pr_absent = (
-            not recovery
-            and release_pr_branch is not None
-            and release_pr_state == ""
-        )
-        # The enqueue runs on recovery too: an existing-but-unmerged PR gets
-        # landed without re-publishing the whole release.
+        release_pr_absent = release_pr_branch is not None and release_pr_state == ""
         release_pr_needs_merge = (
             release_pr_branch is not None and release_pr_state != "MERGED"
         )

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -176,9 +176,20 @@ def main():
             ok = False
 
     step(
-        name="Fetch Full Repository",
+        name="Fetch Repository History (treeless)",
         command=[
-            "git fetch --unshallow --no-recurse-submodules origin ||:",
+            # This job only needs full commit history - for the version tweak
+            # (commit count since the previous tag), changelog.py, and the
+            # all-time contributors `git shortlog` - not the file contents of that
+            # history. A treeless partial clone (`--filter=tree:0`) fetches every
+            # commit but no trees/blobs, so the unshallow is far cheaper than a
+            # full one; any tree/blob a later step actually reads is fetched
+            # lazily from the promisor remote.
+            #
+            # No `|| true`: the runner is ephemeral, so the checkout is always the
+            # fresh depth-1 shallow clone and --unshallow always applies - a
+            # failure here is real and must fail the step, not be swallowed.
+            "git fetch --filter=tree:0 --unshallow --no-recurse-submodules origin",
             # actions/checkout configures origin to fetch only the workflow ref,
             # but prepare reads origin/<release_branch> and a commit_sha that an
             # auto_releases run may pass from a different branch. Fetch all heads
@@ -399,6 +410,9 @@ def main():
             release_pr_branch is not None and release_pr_state != "MERGED"
         )
 
+    # Fail-fast: verify the release packages exist (this downloads them) before
+    # pushing the tag or opening the changelog PR, so a missing-artifacts run
+    # aborts without leaving a tag / PR behind.
     if args.release_type == "patch" and not args.only_docker:
         step(
             name="Download All Release Artifacts",

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -543,13 +543,21 @@ def main():
             # output, which eats the leading space of a worktree-modified line and
             # would drop a char off the first path). Tracked changes vs HEAD +
             # any untracked new files, scoped to the artifact paths.
+            # The exact files the generation steps touch. update-docker-version.sh
+            # bumps `ARG VERSION` in these Dockerfiles (keeper's Dockerfile.alpine
+            # / Dockerfile.ubuntu are symlinks to keeper/Dockerfile, so the edit
+            # lands on keeper/Dockerfile itself). Listed explicitly rather than
+            # globbed so nothing unexpected is ever swept in.
             pathspec = " ".join(
                 [
                     "utils/list-versions/version_date.tsv",
                     "docs/changelogs/" + shlex.quote(release_tag) + ".md",
                     "SECURITY.md",
-                    "'docker/keeper/Dockerfile*'",
-                    "'docker/server/Dockerfile*'",
+                    "docker/keeper/Dockerfile",
+                    "docker/keeper/Dockerfile.distroless",
+                    "docker/server/Dockerfile.alpine",
+                    "docker/server/Dockerfile.distroless",
+                    "docker/server/Dockerfile.ubuntu",
                 ]
             )
             changed = Shell.get_output(

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -517,7 +517,8 @@ def main():
             # rerun re-creates the branch instead of failing on "already exists".
             porcelain = Shell.get_output(
                 "git status --porcelain --no-renames --untracked-files=all -- "
-                "utils/list-versions/version_date.tsv docs/changelogs SECURITY.md "
+                "utils/list-versions/version_date.tsv "
+                f"{shlex.quote(f'docs/changelogs/{release_tag}.md')} SECURITY.md "
                 "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'",
                 strict=True,
             )

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -1,3 +1,13 @@
+"""ClickHouse release pipeline job.
+
+INVARIANT: every run starts in a clean, empty GitHub Actions `_work` directory -
+the runner is ephemeral and the workspace is a fresh `actions/checkout` (a depth-1
+shallow clone). There is NO state carried over from a previous run. So do not add
+"in case a previous run left X on a reused runner" defenses here: there is no
+reuse. The repo is always shallow at the start (hence the unconditional
+`--unshallow`), and no leftover files/branches/credentials can exist.
+"""
+
 import argparse
 import json
 import os

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -543,10 +543,14 @@ def main():
             # output, which eats the leading space of a worktree-modified line and
             # would drop a char off the first path). Tracked changes vs HEAD +
             # any untracked new files, scoped to the artifact paths.
-            pathspec = (
-                "utils/list-versions/version_date.tsv "
-                f"docs/changelogs/{shlex.quote(release_tag)}.md SECURITY.md "
-                "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'"
+            pathspec = " ".join(
+                [
+                    "utils/list-versions/version_date.tsv",
+                    "docs/changelogs/" + shlex.quote(release_tag) + ".md",
+                    "SECURITY.md",
+                    "'docker/keeper/Dockerfile*'",
+                    "'docker/server/Dockerfile*'",
+                ]
             )
             changed = Shell.get_output(
                 f"git diff --name-only HEAD -- {pathspec}", strict=True

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -365,6 +365,34 @@ def main():
 
         step(name="Validate Recovery Ref", command=_require_recovery_ref)
 
+    # A recovery / rerun of an already-published patch release must still land its
+    # changelog PR if it went missing - e.g. a previous PR was closed unmerged or
+    # a failed run never opened one. Recreate it when there is neither an open nor
+    # a merged PR for the changelog branch (a merged PR means the changelog is
+    # already in master, so there is nothing to redo). only-repo/only-docker are
+    # targeted artifact re-publish recoveries and must not open PRs or run
+    # changelog.py, so they are excluded. This lets the create-changelog / merge
+    # steps below, otherwise gated on create_new_release, run for a plain rerun.
+    recreate_changelog_pr = False
+    if (
+        ok
+        and args.release_type == "patch"
+        and not create_new_release
+        and not args.only_repo
+        and not args.only_docker
+        and not args.dry_run
+    ):
+        with open(RELEASE_INFO_FILE) as f:
+            _tag = json.load(f)["release_tag"]
+        existing = GH.get_pr_url_by_branch(
+            branch=f"auto/{_tag}", repo="ClickHouse/ClickHouse"
+        )
+        recreate_changelog_pr = not existing
+        print(
+            f"ChangeLog PR for auto/{_tag}: "
+            + (f"exists [{existing}]" if existing else "missing — will recreate")
+        )
+
     if args.release_type == "patch" and not args.only_docker:
         step(
             name="Download All Release Artifacts",
@@ -396,10 +424,10 @@ def main():
         )
 
     # For a "new" release the version bump also opens the master bump PR that
-    # --merge-prs merges below, so it must run here, before that merge. For a
+    # the merge_prs step merges below, so it must run here, before that merge. For a
     # "patch" release the bump is only a direct push of the branch version file
     # and nothing downstream depends on it; it is deferred to the very end of the
-    # run (after --merge-prs) so that a rerun after any failure between the tag
+    # run (after the merge_prs step) so that a rerun after any failure between the tag
     # push and the end always sees an un-bumped branch. prepare then reads the
     # branch tip as the just-released version, recovers the existing release, and
     # never refuses a rerun as "out-of-order" or mints a release below the tip —
@@ -414,7 +442,11 @@ def main():
             workdir=REPO_PATH,
         )
 
-    if ok and args.release_type == "patch" and create_new_release:
+    if (
+        ok
+        and args.release_type == "patch"
+        and (create_new_release or recreate_changelog_pr)
+    ):
         with open(RELEASE_INFO_FILE) as f:
             release_tag = json.load(f)["release_tag"]
         uid = os.getuid()
@@ -450,7 +482,12 @@ def main():
             workdir=REPO_PATH,
         )
 
-    if ok and args.release_type == "patch" and not args.dry_run and create_new_release:
+    if (
+        ok
+        and args.release_type == "patch"
+        and not args.dry_run
+        and (create_new_release or recreate_changelog_pr)
+    ):
         with open(RELEASE_INFO_FILE) as f:
             release_tag = json.load(f)["release_tag"]
 
@@ -469,10 +506,39 @@ def main():
                 strict=True,
             )
             Shell.check("git config user.name robot-clickhouse", strict=True)
-            # -B so a rerun after a partial failure re-creates the branch instead
-            # of failing on "branch already exists".
-            Shell.check(f"git checkout -B {pr_branch}", strict=True)
-            Shell.check("git add -A", strict=True)
+            # The PR must contain ONLY the generated release artifacts, on a clean
+            # master base - never the unrelated commits HEAD carries when the
+            # release runs from a feature branch, nor any file `git add -A` would
+            # sweep in. Capture whatever the generation steps above changed, but
+            # scope the scan to exactly their output paths so a stray file left
+            # elsewhere on a reused runner cannot leak in; then hard-reset onto
+            # origin/master (-f, so the switch can't abort on "local changes would
+            # be overwritten"), restore those paths, and stage only them. -B so a
+            # rerun re-creates the branch instead of failing on "already exists".
+            porcelain = Shell.get_output(
+                "git status --porcelain --no-renames --untracked-files=all -- "
+                "utils/list-versions/version_date.tsv docs/changelogs SECURITY.md "
+                "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'",
+                strict=True,
+            )
+            # Porcelain line is "XY <path>"; the path starts at column 3.
+            artifact_files = [ln[3:] for ln in porcelain.splitlines() if ln.strip()]
+            backup_dir = tempfile.mkdtemp(prefix="changelog-artifacts-")
+            for f in artifact_files:
+                dst = os.path.join(backup_dir, f)
+                os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+                shutil.copy2(f, dst)
+            Shell.check(f"git checkout -f -B {pr_branch} origin/master", strict=True)
+            for f in artifact_files:
+                os.makedirs(os.path.dirname(f) or ".", exist_ok=True)
+                shutil.copy2(os.path.join(backup_dir, f), f)
+            shutil.rmtree(backup_dir, ignore_errors=True)
+            if artifact_files:
+                Shell.check(
+                    "git add -- "
+                    + " ".join(shlex.quote(f) for f in artifact_files),
+                    strict=True,
+                )
             # If the changelog PR was already merged on a previous run, master
             # (and this branch, freshly checked out from it) already contain the
             # generated files, so there is nothing to commit — `git commit`
@@ -514,7 +580,7 @@ def main():
                 # this branch (the branch is force-pushed above); `gh pr create`
                 # would then fail with "already exists". Only treat an OPEN or
                 # MERGED PR as reusable — a PR closed without merge must be
-                # recreated, otherwise the downstream --merge-prs (which looks up
+                # recreated, otherwise the downstream merge_prs step (which looks up
                 # open/merged PRs) would find nothing and fail after publication.
                 existing_pr = GH.get_pr_url_by_branch(
                     branch=pr_branch, repo="ClickHouse/ClickHouse"
@@ -761,7 +827,7 @@ def main():
     # Always restore git state — equivalent to `if: ${{ !cancelled() }}`, so it
     # must run even after a failure (hence Result.from_commands_run, not step()
     # which skips when ok is already False). But a failed restore must still
-    # block the release mutation below (--merge-prs), so fold its result into ok.
+    # block the release mutation below (the merge_prs step), so fold its result into ok.
     results.append(
         Result.from_commands_run(
             name="Checkout Back",
@@ -782,12 +848,23 @@ def main():
     # changelog (or version-bump) PR open, and merge_prs must land it. merge_prs
     # looks the PR up by branch and is a no-op when it is absent or already
     # merged, so running it unconditionally is safe.
+    def merge_created_prs():
+        # Imported lazily so the module-level boto3 dependency of create_release
+        # is only needed on the release machine, not at praktika config time.
+        from ci.jobs.scripts.create_release import (
+            ReleaseContextManager,
+            ReleaseProgress,
+        )
+
+        with ReleaseContextManager(
+            release_progress=ReleaseProgress.MERGE_CREATED_PRS
+        ) as release_info:
+            release_info.update_release_info(dry_run=args.dry_run)
+            release_info.merge_prs(dry_run=args.dry_run)
+
     step(
         name="Update Release Info and Merge Created PRs",
-        command=[
-            f"python3 ./ci/jobs/scripts/create_release.py --merge-prs"
-            f" {dry_run_flag}".strip()
-        ],
+        command=merge_created_prs,
         workdir=REPO_PATH,
     )
 
@@ -797,7 +874,7 @@ def main():
     # in that window sees an un-bumped branch and prepare recovers the existing
     # release instead of refusing it or minting a below-tip release. `step` skips
     # it when a prior step already failed, so a failed publish leaves the branch
-    # un-bumped and recoverable. ("new" bumps earlier, above, because --merge-prs
+    # un-bumped and recoverable. ("new" bumps earlier, above, because the merge_prs step
     # merges the master bump PR it opens.)
     if create_new_release and args.release_type == "patch":
         step(

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -777,18 +777,19 @@ def main():
     # False — so if anything failed, the Slack post below reports the failing
     # step instead of merging.
     #
-    # Only a release that created the changelog/version-bump PRs has anything to
-    # merge; a recovery / out-of-order run did not create them, so skip
-    # --merge-prs there (it would fail looking up a non-existent changelog PR).
-    if create_new_release:
-        step(
-            name="Update Release Info and Merge Created PRs",
-            command=[
-                f"python3 ./ci/jobs/scripts/create_release.py --merge-prs"
-                f" {dry_run_flag}".strip()
-            ],
-            workdir=REPO_PATH,
-        )
+    # Run this whenever the release PR still needs merging, not only on a fresh
+    # `create_new_release` run: a recovery / rerun after a failed merge leaves the
+    # changelog (or version-bump) PR open, and merge_prs must land it. merge_prs
+    # looks the PR up by branch and is a no-op when it is absent or already
+    # merged, so running it unconditionally is safe.
+    step(
+        name="Update Release Info and Merge Created PRs",
+        command=[
+            f"python3 ./ci/jobs/scripts/create_release.py --merge-prs"
+            f" {dry_run_flag}".strip()
+        ],
+        workdir=REPO_PATH,
+    )
 
     # Deferred patch version bump — the LAST release mutation. Bumping the branch
     # version file here (rather than right after the tag push) keeps the branch

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -545,7 +545,7 @@ def main():
             # any untracked new files, scoped to the artifact paths.
             pathspec = (
                 "utils/list-versions/version_date.tsv "
-                f"{shlex.quote(f'docs/changelogs/{release_tag}.md')} SECURITY.md "
+                f"docs/changelogs/{shlex.quote(release_tag)}.md SECURITY.md "
                 "'docker/keeper/Dockerfile*' 'docker/server/Dockerfile*'"
             )
             changed = Shell.get_output(

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -238,10 +238,16 @@ def main():
                 f"command -v geesefs && geesefs --version 2>&1 | grep -qF {_GEESEFS_VERSION.lstrip('v')} ||"
                 f" (curl -fsSL https://github.com/yandex-cloud/geesefs/releases/download/{_GEESEFS_VERSION}/geesefs-linux-{arch}"
                 f" -o {geesefs_bin_dir}/geesefs && chmod +x {geesefs_bin_dir}/geesefs)",
-                "command -v createrepo_c || sudo apt-get install -y createrepo-c ||:",
+                # `apt-get update` before each install: the runner's apt index can
+                # be stale and point at a superseded package version (e.g.
+                # `libarchive-dev 3.6.0-1ubuntu1.7`) that Ubuntu already removed
+                # from the mirror pool, which makes `apt-get install` fail with a
+                # 404. Refreshing the index first resolves to the current version.
+                "command -v createrepo_c || (sudo apt-get update && sudo apt-get install -y createrepo-c) ||:",
                 # reprepro 5.4.4+ is required for the 'Limit' field in distributions config.
                 # Ubuntu Jammy only has 5.3.0, so build from source if needed.
                 "reprepro --version 2>&1 | grep -qE '5\\.[4-9]' || ("
+                "  sudo apt-get update &&"
                 "  sudo apt-get install -y dpkg-dev fakeroot libgpgme-dev libdb-dev libbz2-dev liblzma-dev libarchive-dev shunit2 db-util debhelper &&"
                 "  git clone https://salsa.debian.org/debian/reprepro.git /tmp/reprepro-src &&"
                 "  cd /tmp/reprepro-src &&"

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -393,7 +393,12 @@ def main():
     # merged, idempotently: create it if absent, merge it if open, skip if it is
     # already merged. This converges a fresh release and a recovery / rerun after
     # a failed merge through the same path. only-repo/only-docker are targeted
-    # artifact re-publish recoveries and never touch this PR.
+    # artifact re-publish recoveries: they never *create* this PR, but they do
+    # enqueue an already-open one, so a cheap recovery run can finish landing a
+    # release whose original run created the PR but failed to enqueue it (e.g.
+    # the enqueue lost the race with a still-pending `CH Inc sync` required
+    # check). Hence the branch lookup runs regardless of the recovery flags; only
+    # PR creation stays gated to a full run.
     if args.dry_run:
         # No gh reads on dry-run (it may be a local run without gh auth): fall
         # back to the fresh-release signal so the generation is still previewed.
@@ -402,7 +407,7 @@ def main():
     else:
         release_pr_branch = None
         release_pr_state = ""  # "MERGED" | "OPEN" | ""
-        if ok and not args.only_repo and not args.only_docker:
+        if ok:
             with open(RELEASE_INFO_FILE) as f:
                 _info = json.load(f)
             release_pr_branch = (
@@ -417,7 +422,16 @@ def main():
                 f"Release PR branch [{release_pr_branch}] state: "
                 + (release_pr_state or "absent — will create")
             )
-        release_pr_absent = release_pr_branch is not None and release_pr_state == ""
+        # Recovery re-publishes an existing release and must never mint the PR,
+        # so creation is gated to a full run.
+        recovery = args.only_repo or args.only_docker
+        release_pr_absent = (
+            not recovery
+            and release_pr_branch is not None
+            and release_pr_state == ""
+        )
+        # The enqueue runs on recovery too: an existing-but-unmerged PR gets
+        # landed without re-publishing the whole release.
         release_pr_needs_merge = (
             release_pr_branch is not None and release_pr_state != "MERGED"
         )

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -365,32 +365,38 @@ def main():
 
         step(name="Validate Recovery Ref", command=_require_recovery_ref)
 
-    # A recovery / rerun of an already-published patch release must still land its
-    # changelog PR if it went missing - e.g. a previous PR was closed unmerged or
-    # a failed run never opened one. Recreate it when there is neither an open nor
-    # a merged PR for the changelog branch (a merged PR means the changelog is
-    # already in master, so there is nothing to redo). only-repo/only-docker are
-    # targeted artifact re-publish recoveries and must not open PRs or run
-    # changelog.py, so they are excluded. This lets the create-changelog / merge
-    # steps below, otherwise gated on create_new_release, run for a plain rerun.
-    recreate_changelog_pr = False
-    if (
-        ok
-        and args.release_type == "patch"
-        and not create_new_release
-        and not args.only_repo
-        and not args.only_docker
-        and not args.dry_run
-    ):
-        with open(RELEASE_INFO_FILE) as f:
-            _tag = json.load(f)["release_tag"]
-        existing = GH.get_pr_url_by_branch(
-            branch=f"auto/{_tag}", repo="ClickHouse/ClickHouse"
-        )
-        recreate_changelog_pr = not existing
-        print(
-            f"ChangeLog PR for auto/{_tag}: "
-            + (f"exists [{existing}]" if existing else "missing — will recreate")
+    # The release opens exactly one PR against master - the changelog PR for a
+    # patch, the version-bump PR for a new release. Ensure it exists and is
+    # merged, idempotently: create it if absent, merge it if open, skip if it is
+    # already merged. This converges a fresh release and a recovery / rerun after
+    # a failed merge through the same path. only-repo/only-docker are targeted
+    # artifact re-publish recoveries and never touch this PR.
+    if args.dry_run:
+        # No gh reads on dry-run (it may be a local run without gh auth): fall
+        # back to the fresh-release signal so the generation is still previewed.
+        release_pr_absent = create_new_release
+        release_pr_needs_merge = create_new_release
+    else:
+        release_pr_branch = None
+        release_pr_state = ""  # "MERGED" | "OPEN" | ""
+        if ok and not args.only_repo and not args.only_docker:
+            with open(RELEASE_INFO_FILE) as f:
+                _info = json.load(f)
+            release_pr_branch = (
+                f"auto/{_info['release_tag']}"
+                if args.release_type == "patch"
+                else f"bump_version_{_info['version']}"
+            )
+            release_pr_state = GH.get_pr_state_by_branch(
+                release_pr_branch, "ClickHouse/ClickHouse"
+            )
+            print(
+                f"Release PR branch [{release_pr_branch}] state: "
+                + (release_pr_state or "absent — will create")
+            )
+        release_pr_absent = release_pr_branch is not None and release_pr_state == ""
+        release_pr_needs_merge = (
+            release_pr_branch is not None and release_pr_state != "MERGED"
         )
 
     if args.release_type == "patch" and not args.only_docker:
@@ -432,7 +438,7 @@ def main():
     # branch tip as the just-released version, recovers the existing release, and
     # never refuses a rerun as "out-of-order" or mints a release below the tip —
     # all without scanning git tags. See the deferred step near the end of main.
-    if create_new_release and args.release_type == "new":
+    if args.release_type == "new" and release_pr_absent:
         step(
             name="Bump CH Version and Update Contributors' List",
             command=[
@@ -442,11 +448,7 @@ def main():
             workdir=REPO_PATH,
         )
 
-    if (
-        ok
-        and args.release_type == "patch"
-        and (create_new_release or recreate_changelog_pr)
-    ):
+    if ok and args.release_type == "patch" and release_pr_absent:
         with open(RELEASE_INFO_FILE) as f:
             release_tag = json.load(f)["release_tag"]
         uid = os.getuid()
@@ -482,12 +484,7 @@ def main():
             workdir=REPO_PATH,
         )
 
-    if (
-        ok
-        and args.release_type == "patch"
-        and not args.dry_run
-        and (create_new_release or recreate_changelog_pr)
-    ):
+    if ok and args.release_type == "patch" and not args.dry_run and release_pr_absent:
         with open(RELEASE_INFO_FILE) as f:
             release_tag = json.load(f)["release_tag"]
 
@@ -844,11 +841,10 @@ def main():
     # False — so if anything failed, the Slack post below reports the failing
     # step instead of merging.
     #
-    # Run this whenever the release PR still needs merging, not only on a fresh
-    # `create_new_release` run: a recovery / rerun after a failed merge leaves the
-    # changelog (or version-bump) PR open, and merge_prs must land it. merge_prs
-    # looks the PR up by branch and is a no-op when it is absent or already
-    # merged, so running it unconditionally is safe.
+    # Merge the release PR (just created above, or left open by a failed prior
+    # run). Skipped only when it is already merged - the "merged -> continue"
+    # branch of the algorithm. merge_prs looks the PR up by branch and enqueues
+    # it (best-effort); it is a no-op if the lookup finds nothing.
     def merge_created_prs():
         # Imported lazily so the module-level boto3 dependency of create_release
         # is only needed on the release machine, not at praktika config time.
@@ -863,11 +859,12 @@ def main():
             release_info.update_release_info(dry_run=args.dry_run)
             release_info.merge_prs(dry_run=args.dry_run)
 
-    step(
-        name="Update Release Info and Merge Created PRs",
-        command=merge_created_prs,
-        workdir=REPO_PATH,
-    )
+    if release_pr_needs_merge:
+        step(
+            name="Update Release Info and Merge Created PRs",
+            command=merge_created_prs,
+            workdir=REPO_PATH,
+        )
 
     # Deferred patch version bump — the LAST release mutation. Bumping the branch
     # version file here (rather than right after the tag push) keeps the branch

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -860,15 +860,31 @@ def main():
     if results[-1].status != Result.Status.OK:
         ok = False
 
-    # Merging the created PRs is a release mutation that must only happen when
-    # every preceding step succeeded. Use step(), which skips when ok is already
-    # False — so if anything failed, the Slack post below reports the failing
-    # step instead of merging.
-    #
-    # Merge the release PR (just created above, or left open by a failed prior
-    # run). Skipped only when it is already merged - the "merged -> continue"
-    # branch of the algorithm. merge_prs looks the PR up by branch and enqueues
-    # it (best-effort); it is a no-op if the lookup finds nothing.
+    # Deferred patch version bump. Bumping the branch version file here (rather
+    # than right after the tag push) keeps the branch tip equal to the released
+    # commit for the whole publish phase, so any rerun in that window sees an
+    # un-bumped branch and prepare recovers the existing release instead of
+    # refusing it or minting a below-tip release. `step` skips it when a prior
+    # step already failed, so a failed publish leaves the branch un-bumped and
+    # recoverable. ("new" bumps earlier, above, because the merge step below
+    # merges the master bump PR it opens.)
+    if create_new_release and args.release_type == "patch":
+        step(
+            name="Bump CH Version and Update Contributors' List",
+            command=[
+                f"python3 ./ci/jobs/scripts/create_release.py --create-bump-version-pr"
+                f" {dry_run_flag}".strip()
+            ],
+            workdir=REPO_PATH,
+        )
+
+    # Enqueue the release PR - the LAST release action, so its `CH Inc sync`
+    # required check gets the maximum time (the whole publish above) to complete
+    # before we enqueue. Only when every preceding step succeeded (step() skips
+    # when ok is already False). Merge the PR created earlier (or left open by a
+    # failed prior run); skipped only when it is already merged (the "merged ->
+    # continue" branch). merge_prs looks the PR up by branch and enqueues it
+    # (best-effort); a no-op if the lookup finds nothing.
     def merge_created_prs():
         # Imported lazily so the module-level boto3 dependency of create_release
         # is only needed on the release machine, not at praktika config time.
@@ -887,24 +903,6 @@ def main():
         step(
             name="Update Release Info and Merge Created PRs",
             command=merge_created_prs,
-            workdir=REPO_PATH,
-        )
-
-    # Deferred patch version bump — the LAST release mutation. Bumping the branch
-    # version file here (rather than right after the tag push) keeps the branch
-    # tip equal to the released commit for the whole publish phase, so any rerun
-    # in that window sees an un-bumped branch and prepare recovers the existing
-    # release instead of refusing it or minting a below-tip release. `step` skips
-    # it when a prior step already failed, so a failed publish leaves the branch
-    # un-bumped and recoverable. ("new" bumps earlier, above, because the merge_prs step
-    # merges the master bump PR it opens.)
-    if create_new_release and args.release_type == "patch":
-        step(
-            name="Bump CH Version and Update Contributors' List",
-            command=[
-                f"python3 ./ci/jobs/scripts/create_release.py --create-bump-version-pr"
-                f" {dry_run_flag}".strip()
-            ],
             workdir=REPO_PATH,
         )
 

--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -199,13 +199,15 @@ def main():
             # No `|| true`: the runner is ephemeral, so the checkout is always the
             # fresh depth-1 shallow clone and --unshallow always applies - a
             # failure here is real and must fail the step, not be swallowed.
-            "git fetch --filter=tree:0 --unshallow --no-recurse-submodules origin",
+            #
+            # `--quiet` on all three: without it fetch prints a "[new ref]" line
+            # per branch/tag, which floods the log for a repo with this many refs.
+            "git fetch --quiet --filter=tree:0 --unshallow --no-recurse-submodules origin",
             # actions/checkout configures origin to fetch only the workflow ref,
-            # but prepare reads origin/<release_branch> and a commit_sha that an
-            # auto_releases run may pass from a different branch. Fetch all heads
-            # and tags so those refs are always present.
-            "git fetch --no-recurse-submodules origin '+refs/heads/*:refs/remotes/origin/*'",
-            "git fetch --tags --no-recurse-submodules origin",
+            # but prepare needs origin/<release_branch> (and origin/master); fetch
+            # all heads so those refs are present regardless of the release branch.
+            "git fetch --quiet --no-recurse-submodules origin '+refs/heads/*:refs/remotes/origin/*'",
+            "git fetch --quiet --tags --no-recurse-submodules origin",
         ],
         workdir=REPO_PATH,
     )

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -12,6 +12,7 @@ sys.path.append(".")
 
 from ci.praktika.cidb import CIDB
 from ci.praktika.gh import GH
+from ci.praktika.git import Git
 from ci.praktika.interactive import UserPrompt
 from ci.praktika.issue import Issue, IssueLabels, TestCaseIssueCatalog
 from ci.praktika.result import Result
@@ -1040,63 +1041,8 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    # `gh pr merge --auto` calls the `enablePullRequestAutoMerge` mutation,
-    # which the repo disables in favor of a merge queue on `master`. Call
-    # `enqueuePullRequest` directly: it is the mutation the "Merge when ready"
-    # button on github.com uses.
-    pr_node_id = Shell.get_output(
-        f"gh pr view {pr_number} --json id --jq '.id' --repo ClickHouse/ClickHouse"
-    ).strip()
-    if not pr_node_id:
-        print(f"ERROR: Failed to fetch node ID for PR #{pr_number}")
+    if not Git.enqueue_pull_request(pr_number, "ClickHouse/ClickHouse"):
         sys.exit(1)
-
-    enqueue_cmd = (
-        "gh api graphql "
-        "-f 'query=mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id})"
-        "{mergeQueueEntry{position state}}}' "
-        f"-f id={pr_node_id}"
-    )
-    returncode, stdout, stderr = Shell.get_res_stdout_stderr(enqueue_cmd, verbose=True)
-    # GitHub rejects `enqueuePullRequest` with "Pull request is already in the
-    # queue" when the PR is already queued - e.g. the "Merge when ready" button
-    # was clicked on github.com, or a previous run of this tool already enqueued
-    # it. That is the desired end state, so treat it as success instead of
-    # bailing out with an error.
-    already_queued = "already in the queue" in (stdout + stderr).lower()
-    if returncode != 0 and not already_queued:
-        # Surface the real gh output so auth/permission/validation/rate-limit
-        # failures stay diagnosable, as the previous verbose Shell.check did.
-        if stdout:
-            print(stdout)
-        if stderr:
-            print(stderr)
-        print(
-            f"ERROR: Failed to add PR #{pr_number} to the merge queue. "
-            f"This often happens when mergeStateStatus is UNKNOWN "
-            f"(GitHub is still computing mergeability after a recent push) "
-            f"or the PR is not yet eligible (failing required checks, "
-            f"missing approvals, out of date with base). "
-            f"Retry manually:\n  {enqueue_cmd}"
-        )
-        sys.exit(1)
-    if already_queued:
-        print(f"PR #{pr_number} is already in the merge queue")
-
-    # Give GitHub a moment to update the PR's merge state, then verify it
-    # actually landed in the queue.
-    time.sleep(5)
-    merge_status = Shell.get_output(
-        f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo ClickHouse/ClickHouse"
-    )
-    if merge_status == "QUEUED":
-        print(f"OK: PR #{pr_number} added to the merge queue")
-    else:
-        print(
-            f"WARNING: PR #{pr_number} enqueue mutation succeeded but "
-            f"mergeStateStatus is {merge_status} (expected QUEUED). "
-            f"Check the PR on github.com."
-        )
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -752,20 +752,30 @@ class ReleaseInfo:
         """
         pr_num = 23456 if dry_run else int(pr_url.rsplit("/", 1)[-1])
         if not dry_run:
+            # Best-effort throughout: the release is already published by now, so a
+            # transient `gh` failure here must not fail the release - use
+            # non-strict reads and return False (merge_prs then only warns).
+            #
             # Idempotent for recovery / reruns: only an open PR needs enqueuing.
-            state = Shell.get_output_or_raise(
+            state = Shell.get_output(
                 f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
                 f" --json state --jq .state"
             ).strip()
+            if not state:
+                print(f"ERROR: could not fetch state for {label} PR #{pr_num}")
+                return False
             if state != "OPEN":
                 print(f"{label} PR #{pr_num} is {state}, nothing to merge")
                 return True
         print(f"Enqueuing {label} PR to the merge queue")
         if not dry_run:
-            head_sha = Shell.get_output_or_raise(
+            head_sha = Shell.get_output(
                 f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
                 f" --json headRefOid --jq .headRefOid"
             ).strip()
+            if not head_sha:
+                print(f"ERROR: could not fetch head sha for {label} PR #{pr_num}")
+                return False
             GH.post_commit_status(
                 CH_INC_SYNC,
                 Result.Status.OK,

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -1058,11 +1058,6 @@ def parse_args() -> argparse.Namespace:
         help="Create GH Release object and attach all packages",
     )
     parser.add_argument(
-        "--merge-prs",
-        action="store_true",
-        help="Merge PRs with version, changelog updates",
-    )
-    parser.add_argument(
         "--post-status",
         action="store_true",
         help="Post release status (prints summary; Slack integration removed)",
@@ -1159,13 +1154,6 @@ if __name__ == "__main__":
         # fail is conveyed by the workflow job result, not re-derived here.
         print(f"{title}: {release_info.release_tag}")
         print(json.dumps(dataclasses.asdict(release_info), indent=2))
-
-    if args.merge_prs:
-        with ReleaseContextManager(
-            release_progress=ReleaseProgress.MERGE_CREATED_PRS
-        ) as release_info:
-            release_info.update_release_info(dry_run=args.dry_run)
-            release_info.merge_prs(dry_run=args.dry_run)
 
     if _ssh_agent and _key_pub:
         _ssh_agent.remove(_key_pub)

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -735,25 +735,22 @@ class ReleaseInfo:
 
     def merge_prs(self, dry_run: bool) -> None:
         res = True
+        # Both PRs target `master`, which is behind a merge queue: `gh pr merge
+        # --auto` (the `enablePullRequestAutoMerge` mutation) is disabled there,
+        # so enqueue them via `enqueuePullRequest` instead.
         if self.release_type == "patch":
             assert self.changelog_pr
-            print("Merging ChangeLog PR")
+            print("Enqueuing ChangeLog PR to the merge queue")
             changelog_pr_num = 23456 if dry_run else int(self.changelog_pr.rsplit("/", 1)[-1])
-            res = Shell.check(
-                f"gh pr merge {changelog_pr_num} --repo {GITHUB_REPOSITORY} --merge --auto",
-                verbose=True,
-                dry_run=dry_run,
-                strict=True,
+            res = Git.enqueue_pull_request(
+                changelog_pr_num, GITHUB_REPOSITORY, dry_run=dry_run
             )
         if self.release_type == "new":
             assert self.version_bump_pr
-            print("Merging Version Bump PR")
+            print("Enqueuing Version Bump PR to the merge queue")
             version_bump_pr_num = 23456 if dry_run else int(self.version_bump_pr.rsplit("/", 1)[-1])
-            res = res and Shell.check(
-                f"gh pr merge {version_bump_pr_num} --repo {GITHUB_REPOSITORY} --merge --auto",
-                verbose=True,
-                dry_run=dry_run,
-                strict=True,
+            res = res and Git.enqueue_pull_request(
+                version_bump_pr_num, GITHUB_REPOSITORY, dry_run=dry_run
             )
         else:
             if not dry_run:

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -56,7 +56,13 @@ from ci.jobs.scripts.clickhouse_version import (
 )
 from ci.praktika.gh import GH
 from ci.praktika.git import Git
+from ci.praktika.result import Result
 from ci.praktika.utils import Shell
+
+# The release changelog / version-bump PRs carry `do not test`, so the real
+# `CH Inc sync` required check takes ~10+ min to even start; force it to success
+# on the PR head so the merge queue accepts these bot PRs right away.
+CH_INC_SYNC = "CH Inc sync"
 
 # S3Helper requires boto3 (installed on release machines); ssh has no external deps.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../tests/ci"))
@@ -733,24 +739,45 @@ class ReleaseInfo:
             self.release_url = "dry-run"
         self.dump()
 
+    def _enqueue_release_pr(self, pr_url: str, label: str, dry_run: bool) -> bool:
+        """Add a release bot PR to `master`'s merge queue so it actually merges.
+
+        `master` is behind a merge queue, and `gh pr merge --auto`
+        (`enablePullRequestAutoMerge`) is disabled there, so the PR is added via
+        `enqueuePullRequest` - GitHub then merges it from the queue once its
+        checks pass. GitHub refuses to enqueue a PR whose required `CH Inc sync`
+        check has not completed, so force that status to success on the PR head
+        first, then enqueue with a few retries to ride out the transient
+        `mergeStateStatus == UNKNOWN` GitHub reports right after the status write.
+        """
+        print(f"Enqueuing {label} PR to the merge queue")
+        pr_num = 23456 if dry_run else int(pr_url.rsplit("/", 1)[-1])
+        if not dry_run:
+            head_sha = Shell.get_output_or_raise(
+                f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
+                f" --json headRefOid --jq .headRefOid"
+            ).strip()
+            GH.post_commit_status(
+                CH_INC_SYNC,
+                Result.Status.OK,
+                "release PR: dummy sync status to enable the merge queue",
+                "",
+                sha=head_sha,
+                repo=GITHUB_REPOSITORY,
+            )
+        return Git.enqueue_pull_request(
+            pr_num, GITHUB_REPOSITORY, dry_run=dry_run, retries=10, delay=30
+        )
+
     def merge_prs(self, dry_run: bool) -> None:
         res = True
-        # Both PRs target `master`, which is behind a merge queue: `gh pr merge
-        # --auto` (the `enablePullRequestAutoMerge` mutation) is disabled there,
-        # so enqueue them via `enqueuePullRequest` instead.
         if self.release_type == "patch":
             assert self.changelog_pr
-            print("Enqueuing ChangeLog PR to the merge queue")
-            changelog_pr_num = 23456 if dry_run else int(self.changelog_pr.rsplit("/", 1)[-1])
-            res = Git.enqueue_pull_request(
-                changelog_pr_num, GITHUB_REPOSITORY, dry_run=dry_run
-            )
+            res = self._enqueue_release_pr(self.changelog_pr, "ChangeLog", dry_run)
         if self.release_type == "new":
             assert self.version_bump_pr
-            print("Enqueuing Version Bump PR to the merge queue")
-            version_bump_pr_num = 23456 if dry_run else int(self.version_bump_pr.rsplit("/", 1)[-1])
-            res = res and Git.enqueue_pull_request(
-                version_bump_pr_num, GITHUB_REPOSITORY, dry_run=dry_run
+            res = res and self._enqueue_release_pr(
+                self.version_bump_pr, "Version Bump", dry_run
             )
         else:
             if not dry_run:
@@ -759,11 +786,8 @@ class ReleaseInfo:
         if not res:
             # Best-effort: by the time this runs the release itself (tag, GitHub
             # release, packages) is already published, so a failed PR enqueue must
-            # not fail the release. The changelog / version-bump PR carries `do
-            # not test`, so GitHub refuses to add it to the merge queue while a
-            # required status check (e.g. `CH Inc sync`) is still "expected"
-            # (UNPROCESSABLE). Leave the PR open to be landed separately and only
-            # warn - do not raise.
+            # not fail the release. Leave the PR open to be landed separately and
+            # only warn - do not raise.
             print(
                 "WARNING: could not enqueue the release PR(s) to the merge queue; "
                 "they must be landed separately. The release itself is unaffected."

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -756,12 +756,18 @@ class ReleaseInfo:
             if not dry_run:
                 assert not self.version_bump_pr
         self.prs_merged = res
-        # A failed enqueue must fail the release step (the previous `gh pr merge
-        # --auto` ran with strict=True and raised). `merge_prs`' only failure
-        # signal is an exception - the context manager does not inspect
-        # `prs_merged` - so surface it explicitly instead of exiting 0.
         if not res:
-            raise RuntimeError("Failed to enqueue the release PR(s) to the merge queue")
+            # Best-effort: by the time this runs the release itself (tag, GitHub
+            # release, packages) is already published, so a failed PR enqueue must
+            # not fail the release. The changelog / version-bump PR carries `do
+            # not test`, so GitHub refuses to add it to the merge queue while a
+            # required status check (e.g. `CH Inc sync`) is still "expected"
+            # (UNPROCESSABLE). Leave the PR open to be landed separately and only
+            # warn - do not raise.
+            print(
+                "WARNING: could not enqueue the release PR(s) to the merge queue; "
+                "they must be landed separately. The release itself is unaffected."
+            )
 
 
 class RepoTypes:

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -756,6 +756,12 @@ class ReleaseInfo:
             if not dry_run:
                 assert not self.version_bump_pr
         self.prs_merged = res
+        # A failed enqueue must fail the release step (the previous `gh pr merge
+        # --auto` ran with strict=True and raised). `merge_prs`' only failure
+        # signal is an exception - the context manager does not inspect
+        # `prs_merged` - so surface it explicitly instead of exiting 0.
+        if not res:
+            raise RuntimeError("Failed to enqueue the release PR(s) to the merge queue")
 
 
 class RepoTypes:

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -56,13 +56,7 @@ from ci.jobs.scripts.clickhouse_version import (
 )
 from ci.praktika.gh import GH
 from ci.praktika.git import Git
-from ci.praktika.result import Result
 from ci.praktika.utils import Shell
-
-# The release changelog / version-bump PRs carry `do not test`, so the real
-# `CH Inc sync` required check takes ~10+ min to even start; force it to success
-# on the PR head so the merge queue accepts these bot PRs right away.
-CH_INC_SYNC = "CH Inc sync"
 
 # S3Helper requires boto3 (installed on release machines); ssh has no external deps.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../tests/ci"))
@@ -619,7 +613,10 @@ class ReleaseInfo:
                     else:
                         Shell.check(
                             f"gh pr create --repo {GITHUB_REPOSITORY} --title 'Update version after release' "
-                            f"--head {branch_upd} --base master --body \"{body}\" --assignee {actor}",
+                            f"--head {branch_upd} --base master --body \"{body}\" --assignee {actor}"
+                            # 'do not test': this bot PR is auto-enqueued to the
+                            # merge queue, so it must not run the full PR CI.
+                            f" --label 'do not test'",
                             strict=True,
                             dry_run=dry_run,
                             verbose=True,
@@ -744,19 +741,18 @@ class ReleaseInfo:
 
         `master` is behind a merge queue, and `gh pr merge --auto`
         (`enablePullRequestAutoMerge`) is disabled there, so the PR is added via
-        `enqueuePullRequest` - GitHub then merges it from the queue once its
-        checks pass. GitHub refuses to enqueue a PR whose required `CH Inc sync`
-        check has not completed, so force that status to success on the PR head
-        first, then enqueue with a few retries to ride out the transient
-        `mergeStateStatus == UNKNOWN` GitHub reports right after the status write.
+        `enqueuePullRequest` - GitHub merges it from the queue once its required
+        checks pass. The PR is opened before the long package export / docker
+        publish, so its `CH Inc sync` check has time to run before this enqueue at
+        the end of the release; the retries ride out any short remaining wait.
+        Best-effort: it never raises, so a PR that is not yet mergeable does not
+        fail the already-published release (merge_prs then only warns; a later
+        rerun re-enqueues it).
         """
         pr_num = 23456 if dry_run else int(pr_url.rsplit("/", 1)[-1])
         if not dry_run:
-            # Best-effort throughout: the release is already published by now, so a
-            # transient `gh` failure here must not fail the release - use
-            # non-strict reads and return False (merge_prs then only warns).
-            #
             # Idempotent for recovery / reruns: only an open PR needs enqueuing.
+            # Non-strict read: a transient gh failure must not fail the release.
             state = Shell.get_output(
                 f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
                 f" --json state --jq .state"
@@ -768,22 +764,6 @@ class ReleaseInfo:
                 print(f"{label} PR #{pr_num} is {state}, nothing to merge")
                 return True
         print(f"Enqueuing {label} PR to the merge queue")
-        if not dry_run:
-            head_sha = Shell.get_output(
-                f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
-                f" --json headRefOid --jq .headRefOid"
-            ).strip()
-            if not head_sha:
-                print(f"ERROR: could not fetch head sha for {label} PR #{pr_num}")
-                return False
-            GH.post_commit_status(
-                CH_INC_SYNC,
-                Result.Status.OK,
-                "release PR: dummy sync status to enable the merge queue",
-                "",
-                sha=head_sha,
-                repo=GITHUB_REPOSITORY,
-            )
         return Git.enqueue_pull_request(
             pr_num, GITHUB_REPOSITORY, dry_run=dry_run, retries=10, delay=30
         )

--- a/ci/jobs/scripts/create_release.py
+++ b/ci/jobs/scripts/create_release.py
@@ -750,8 +750,17 @@ class ReleaseInfo:
         first, then enqueue with a few retries to ride out the transient
         `mergeStateStatus == UNKNOWN` GitHub reports right after the status write.
         """
-        print(f"Enqueuing {label} PR to the merge queue")
         pr_num = 23456 if dry_run else int(pr_url.rsplit("/", 1)[-1])
+        if not dry_run:
+            # Idempotent for recovery / reruns: only an open PR needs enqueuing.
+            state = Shell.get_output_or_raise(
+                f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
+                f" --json state --jq .state"
+            ).strip()
+            if state != "OPEN":
+                print(f"{label} PR #{pr_num} is {state}, nothing to merge")
+                return True
+        print(f"Enqueuing {label} PR to the merge queue")
         if not dry_run:
             head_sha = Shell.get_output_or_raise(
                 f"gh pr view {pr_num} --repo {GITHUB_REPOSITORY}"
@@ -771,14 +780,20 @@ class ReleaseInfo:
 
     def merge_prs(self, dry_run: bool) -> None:
         res = True
+        # A recovery / rerun may find no PR (it was already merged and the branch
+        # lookup returned nothing) - that is a no-op, not a failure.
         if self.release_type == "patch":
-            assert self.changelog_pr
-            res = self._enqueue_release_pr(self.changelog_pr, "ChangeLog", dry_run)
+            if self.changelog_pr:
+                res = self._enqueue_release_pr(self.changelog_pr, "ChangeLog", dry_run)
+            else:
+                print("No ChangeLog PR to merge")
         if self.release_type == "new":
-            assert self.version_bump_pr
-            res = res and self._enqueue_release_pr(
-                self.version_bump_pr, "Version Bump", dry_run
-            )
+            if self.version_bump_pr:
+                res = res and self._enqueue_release_pr(
+                    self.version_bump_pr, "Version Bump", dry_run
+                )
+            else:
+                print("No Version Bump PR to merge")
         else:
             if not dry_run:
                 assert not self.version_bump_pr

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -1119,7 +1119,11 @@ class GH:
         """'MERGED' / 'OPEN' / '' for the PR whose head is `branch`.
 
         Merged takes priority: an already-merged PR means the change is in master,
-        so the caller should stop even if a stray open PR also exists. Same
+        so the caller should stop even if a stray open PR also exists. (This is
+        the opposite order from `get_pr_url_by_branch`, which checks open first;
+        they agree unless one branch has both an open and a merged PR - which the
+        release flow's "never recreate once present" invariant prevents for the
+        `auto/<tag>` / `bump_version_<version>` branches this is used with.) Same
         retry / fail-close semantics as `get_pr_url_by_branch` - a failed lookup
         raises rather than being mistaken for 'no PR' (which would recreate a PR
         or skip a needed merge after the release is already published).

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -1114,6 +1114,36 @@ class GH:
             print(f"No {state} PR found for branch [{branch}]")
         return ""
 
+    @classmethod
+    def get_pr_state_by_branch(cls, branch, repo=None):
+        """'MERGED' / 'OPEN' / '' for the PR whose head is `branch`.
+
+        Merged takes priority: an already-merged PR means the change is in master,
+        so the caller should stop even if a stray open PR also exists. Same
+        retry / fail-close semantics as `get_pr_url_by_branch` - a failed lookup
+        raises rather than being mistaken for 'no PR' (which would recreate a PR
+        or skip a needed merge after the release is already published).
+        """
+        if not repo:
+            repo = _Environment.get().REPOSITORY
+        safe_repo = shlex.quote(repo)
+        safe_branch = shlex.quote(branch)
+        for state in ("merged", "open"):
+            cmd = (
+                f"gh pr list --repo {safe_repo} --head {safe_branch}"
+                f" --state {state} --json url"
+            )
+            raw = cls.get_output_with_retries(cmd)
+            if not raw:
+                raise RuntimeError(
+                    f"gh pr list failed for branch [{branch}] in repo [{repo}] "
+                    f"(state {state}) after retries; refusing to treat a failed "
+                    f"lookup as 'no PR'"
+                )
+            if json.loads(raw):
+                return state.upper()
+        return ""
+
     _STATUS_TO_GH = {
         Result.Status.OK: Result.GHStatus.SUCCESS,
         Result.Status.FAIL: Result.GHStatus.FAILURE,

--- a/ci/praktika/git.py
+++ b/ci/praktika/git.py
@@ -147,7 +147,6 @@ class Git:
         pr: int,
         repo: str,
         dry_run: bool = False,
-        verify: bool = True,
         verbose: bool = True,
     ) -> bool:
         """Add PR #`pr` in `repo` to the merge queue via `enqueuePullRequest`.
@@ -205,9 +204,6 @@ class Git:
             return False
         if already_queued:
             print(f"PR #{pr} is already in the merge queue")
-
-        if not verify:
-            return True
 
         # Give GitHub a moment to update the PR's merge state, then verify it
         # actually landed in the queue.

--- a/ci/praktika/git.py
+++ b/ci/praktika/git.py
@@ -164,8 +164,8 @@ class Git:
         desired end state, so it is treated as success rather than a failure.
 
         A PR is only accepted once its required status checks have completed, so
-        while a required check (e.g. `CH Inc sync`) is still expected/pending the
-        mutation is refused with UNPROCESSABLE. Retry up to `retries` times with
+        while a required check is still expected/pending the mutation is refused
+        with UNPROCESSABLE. Retry up to `retries` times with
         `delay` seconds between attempts to wait that out; the same delay covers a
         transient `mergeStateStatus == UNKNOWN` right after a push.
 

--- a/ci/praktika/git.py
+++ b/ci/praktika/git.py
@@ -1,5 +1,6 @@
 import re
 import shlex
+import time
 
 from praktika.utils import Shell
 
@@ -140,6 +141,90 @@ class Git:
             strict=True,
             retries=retries,
         )
+
+    @staticmethod
+    def enqueue_pull_request(
+        pr: int,
+        repo: str,
+        dry_run: bool = False,
+        verify: bool = True,
+        verbose: bool = True,
+    ) -> bool:
+        """Add PR #`pr` in `repo` to the merge queue via `enqueuePullRequest`.
+
+        `gh pr merge --auto` calls the `enablePullRequestAutoMerge` mutation,
+        which the repo disables in favor of a merge queue on `master`; this calls
+        `enqueuePullRequest` directly - the mutation the "Merge when ready" button
+        on github.com uses.
+
+        GitHub rejects `enqueuePullRequest` with "Pull request is already in the
+        queue" when the PR is already queued (the "Merge when ready" button was
+        clicked on github.com, or a previous run already enqueued it). That is the
+        desired end state, so it is treated as success rather than a failure.
+
+        Returns whether the PR is in the queue. A normal enqueue failure returns
+        `False` (with the real `gh` output surfaced) rather than raising, so the
+        caller decides how to react.
+        """
+        if dry_run:
+            print(f"Dry-run, would enqueue PR #{pr} in {repo} to the merge queue")
+            return True
+
+        pr_node_id = Shell.get_output(
+            f"gh pr view {pr} --json id --jq '.id' --repo {shlex.quote(repo)}"
+        ).strip()
+        if not pr_node_id:
+            print(f"ERROR: Failed to fetch node ID for PR #{pr}")
+            return False
+
+        enqueue_cmd = (
+            "gh api graphql "
+            "-f 'query=mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id})"
+            "{mergeQueueEntry{position state}}}' "
+            f"-f id={pr_node_id}"
+        )
+        returncode, stdout, stderr = Shell.get_res_stdout_stderr(
+            enqueue_cmd, verbose=verbose
+        )
+        already_queued = "already in the queue" in (stdout + stderr).lower()
+        if returncode != 0 and not already_queued:
+            # Surface the real gh output so auth/permission/validation/rate-limit
+            # failures stay diagnosable.
+            if stdout:
+                print(stdout)
+            if stderr:
+                print(stderr)
+            print(
+                f"ERROR: Failed to add PR #{pr} to the merge queue. "
+                f"This often happens when mergeStateStatus is UNKNOWN "
+                f"(GitHub is still computing mergeability after a recent push) "
+                f"or the PR is not yet eligible (failing required checks, "
+                f"missing approvals, out of date with base). "
+                f"Retry manually:\n  {enqueue_cmd}"
+            )
+            return False
+        if already_queued:
+            print(f"PR #{pr} is already in the merge queue")
+
+        if not verify:
+            return True
+
+        # Give GitHub a moment to update the PR's merge state, then verify it
+        # actually landed in the queue.
+        time.sleep(5)
+        merge_status = Shell.get_output(
+            f"gh pr view {pr} --json mergeStateStatus --jq '.mergeStateStatus'"
+            f" --repo {shlex.quote(repo)}"
+        )
+        if merge_status == "QUEUED":
+            print(f"OK: PR #{pr} added to the merge queue")
+        else:
+            print(
+                f"WARNING: PR #{pr} enqueue mutation succeeded but "
+                f"mergeStateStatus is {merge_status} (expected QUEUED). "
+                f"Check the PR on github.com."
+            )
+        return True
 
     def __init__(self):
         self.latest_tag = Shell.get_output("git describe --tags --abbrev=0") or ""

--- a/ci/praktika/git.py
+++ b/ci/praktika/git.py
@@ -173,6 +173,7 @@ class Git:
         returns `False` (with the real `gh` output surfaced) rather than raising,
         so the caller decides how to react.
         """
+        assert retries >= 1, "retries must be >= 1"
         if dry_run:
             print(f"Dry-run, would enqueue PR #{pr} in {repo} to the merge queue")
             return True
@@ -188,7 +189,7 @@ class Git:
             "gh api graphql "
             "-f 'query=mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id})"
             "{mergeQueueEntry{position state}}}' "
-            f"-f id={pr_node_id}"
+            f"-f id={shlex.quote(pr_node_id)}"
         )
         for attempt in range(1, retries + 1):
             returncode, stdout, stderr = Shell.get_res_stdout_stderr(

--- a/ci/praktika/git.py
+++ b/ci/praktika/git.py
@@ -148,6 +148,8 @@ class Git:
         repo: str,
         dry_run: bool = False,
         verbose: bool = True,
+        retries: int = 1,
+        delay: int = 60,
     ) -> bool:
         """Add PR #`pr` in `repo` to the merge queue via `enqueuePullRequest`.
 
@@ -161,9 +163,15 @@ class Git:
         clicked on github.com, or a previous run already enqueued it). That is the
         desired end state, so it is treated as success rather than a failure.
 
-        Returns whether the PR is in the queue. A normal enqueue failure returns
-        `False` (with the real `gh` output surfaced) rather than raising, so the
-        caller decides how to react.
+        A PR is only accepted once its required status checks have completed, so
+        while a required check (e.g. `CH Inc sync`) is still expected/pending the
+        mutation is refused with UNPROCESSABLE. Retry up to `retries` times with
+        `delay` seconds between attempts to wait that out; the same delay covers a
+        transient `mergeStateStatus == UNKNOWN` right after a push.
+
+        Returns whether the PR is in the queue. A persistent enqueue failure
+        returns `False` (with the real `gh` output surfaced) rather than raising,
+        so the caller decides how to react.
         """
         if dry_run:
             print(f"Dry-run, would enqueue PR #{pr} in {repo} to the merge queue")
@@ -182,13 +190,26 @@ class Git:
             "{mergeQueueEntry{position state}}}' "
             f"-f id={pr_node_id}"
         )
-        returncode, stdout, stderr = Shell.get_res_stdout_stderr(
-            enqueue_cmd, verbose=verbose
-        )
-        already_queued = "already in the queue" in (stdout + stderr).lower()
-        if returncode != 0 and not already_queued:
-            # Surface the real gh output so auth/permission/validation/rate-limit
-            # failures stay diagnosable.
+        for attempt in range(1, retries + 1):
+            returncode, stdout, stderr = Shell.get_res_stdout_stderr(
+                enqueue_cmd, verbose=verbose
+            )
+            already_queued = "already in the queue" in (stdout + stderr).lower()
+            if returncode == 0 or already_queued:
+                break
+            if attempt < retries:
+                # A required check is likely still expected/pending, or GitHub is
+                # still computing mergeability; wait and retry.
+                reason = (stderr or stdout).strip().splitlines()
+                print(
+                    f"Enqueue attempt {attempt}/{retries} for PR #{pr} failed"
+                    f"{' [' + reason[-1] + ']' if reason else ''};"
+                    f" retrying in {delay}s"
+                )
+                time.sleep(delay)
+        else:
+            # Every attempt failed. Surface the real gh output so
+            # auth/permission/validation/rate-limit failures stay diagnosable.
             if stdout:
                 print(stdout)
             if stderr:
@@ -197,7 +218,7 @@ class Git:
                 f"ERROR: Failed to add PR #{pr} to the merge queue. "
                 f"This often happens when mergeStateStatus is UNKNOWN "
                 f"(GitHub is still computing mergeability after a recent push) "
-                f"or the PR is not yet eligible (failing required checks, "
+                f"or the PR is not yet eligible (failing/pending required checks, "
                 f"missing approvals, out of date with base). "
                 f"Retry manually:\n  {enqueue_cmd}"
             )

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -1021,25 +1021,12 @@ def test_enqueue_release_pr_skips_already_merged(monkeypatch):
     assert not enqueued
 
 
-def test_enqueue_release_pr_open_forces_sync_then_enqueues(monkeypatch):
-    """An OPEN PR: force CH Inc sync on its head, then enqueue it."""
+def test_enqueue_release_pr_open_enqueues(monkeypatch):
+    """An OPEN PR is enqueued (no status is force-set — CH Inc sync runs on its
+    own; the PR is opened early enough to complete by enqueue time)."""
     cr = _create_release_module()
     ri = _make_release_info(cr)
-    outputs = iter(["OPEN", "abc123sha"])  # state, then headRefOid
-    monkeypatch.setattr(
-        cr.Shell, "get_output", staticmethod(lambda *a, **k: next(outputs))
-    )
-    posted = {}
-    monkeypatch.setattr(
-        cr.GH,
-        "post_commit_status",
-        staticmethod(
-            lambda name, status, desc, url, sha="", repo="": posted.update(
-                name=name, sha=sha
-            )
-            or True
-        ),
-    )
+    monkeypatch.setattr(cr.Shell, "get_output", staticmethod(lambda *a, **k: "OPEN"))
     enq = {}
     monkeypatch.setattr(
         cr.Git,
@@ -1047,5 +1034,4 @@ def test_enqueue_release_pr_open_forces_sync_then_enqueues(monkeypatch):
         staticmethod(lambda pr, repo, **k: enq.update(pr=pr) or True),
     )
     assert ri._enqueue_release_pr("https://x/pull/111", "ChangeLog", False) is True
-    assert posted["name"] == cr.CH_INC_SYNC and posted["sha"] == "abc123sha"
     assert enq["pr"] == 111

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -141,15 +141,15 @@ def test_release_job_points_at_moved_paths():
 
 
 def test_patch_version_bump_is_deferred_after_merge_prs():
-    """The patch branch version bump must run after --merge-prs, the new one before.
+    """The patch branch version bump must run after the merge-PRs step, new before.
 
     Deferring the patch bump to the end keeps the release branch tip equal to the
     released commit throughout publishing, so a rerun after any failure sees an
     un-bumped branch and prepare recovers the existing release instead of
     refusing it as out-of-order or minting a below-tip release — the root-cause
     fix for the rerun/stale-branch review comments, without scanning git tags.
-    The "new" release bump must stay before --merge-prs because it opens the
-    master bump PR that --merge-prs merges.
+    The "new" release bump must stay before the merge step because it opens the
+    master bump PR that the merge step merges.
     """
     text = _read(RELEASE_JOB)
     # Match the actual create_release.py invocations, not prose in comments.
@@ -157,17 +157,19 @@ def test_patch_version_bump_is_deferred_after_merge_prs():
         m.start()
         for m in re.finditer(r"create_release\.py --create-bump-version-pr", text)
     ]
-    merge_pos = text.find("create_release.py --merge-prs")
+    # The merge step is an in-process function call (merge_created_prs), anchored
+    # by its unique step name rather than a CLI string.
+    merge_pos = text.find('name="Update Release Info and Merge Created PRs"')
     assert len(bump_positions) >= 2, (
         "expected a separate 'new' and deferred 'patch' --create-bump-version-pr"
     )
-    assert merge_pos != -1, "release_job.py should invoke --merge-prs"
+    assert merge_pos != -1, "release_job.py should have the merge-PRs step"
     assert any(p < merge_pos for p in bump_positions), (
-        "the 'new' version bump must run before --merge-prs (it opens the PR that "
-        "--merge-prs merges)"
+        "the 'new' version bump must run before the merge step (it opens the PR "
+        "that the merge step merges)"
     )
     assert any(p > merge_pos for p in bump_positions), (
-        "the 'patch' version bump must be deferred to after --merge-prs"
+        "the 'patch' version bump must be deferred to after the merge step"
     )
 
 

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -140,16 +140,17 @@ def test_release_job_points_at_moved_paths():
     assert "tests/ci/artifactory.py" not in text
 
 
-def test_patch_version_bump_is_deferred_after_merge_prs():
-    """The patch branch version bump must run after the merge-PRs step, new before.
+def test_enqueue_is_last_and_patch_bump_is_deferred():
+    """The PR enqueue must be the last release step, and the patch bump deferred.
 
-    Deferring the patch bump to the end keeps the release branch tip equal to the
-    released commit throughout publishing, so a rerun after any failure sees an
-    un-bumped branch and prepare recovers the existing release instead of
-    refusing it as out-of-order or minting a below-tip release — the root-cause
-    fix for the rerun/stale-branch review comments, without scanning git tags.
-    The "new" release bump must stay before the merge step because it opens the
-    master bump PR that the merge step merges.
+    Enqueue runs last so the release PR's `CH Inc sync` check gets the maximum
+    time (the whole publish) to complete before we add the PR to the merge queue.
+    The patch version bump is still deferred to near the end (after the changelog
+    PR is created, not right after the tag push): that keeps the branch tip equal
+    to the released commit through publishing, so a rerun after any failure sees
+    an un-bumped branch and prepare recovers the existing release instead of
+    minting a below-tip one. The "new" release bump stays early (it opens the
+    master bump PR the enqueue later merges).
     """
     text = _read(RELEASE_JOB)
     # Match the actual create_release.py invocations, not prose in comments.
@@ -157,19 +158,26 @@ def test_patch_version_bump_is_deferred_after_merge_prs():
         m.start()
         for m in re.finditer(r"create_release\.py --create-bump-version-pr", text)
     ]
-    # The merge step is an in-process function call (merge_created_prs), anchored
+    # The enqueue step is an in-process function call (merge_created_prs), anchored
     # by its unique step name rather than a CLI string.
     merge_pos = text.find('name="Update Release Info and Merge Created PRs"')
+    changelog_pr_pos = text.find('name="Create ChangeLog PR"')
     assert len(bump_positions) >= 2, (
         "expected a separate 'new' and deferred 'patch' --create-bump-version-pr"
     )
-    assert merge_pos != -1, "release_job.py should have the merge-PRs step"
-    assert any(p < merge_pos for p in bump_positions), (
-        "the 'new' version bump must run before the merge step (it opens the PR "
-        "that the merge step merges)"
+    assert merge_pos != -1, "release_job.py should have the enqueue step"
+    assert changelog_pr_pos != -1, "release_job.py should have the Create ChangeLog PR step"
+    # Enqueue is the last release action: after both version bumps.
+    assert all(p < merge_pos for p in bump_positions), (
+        "the enqueue step must run after both version bumps (it is the last step)"
     )
-    assert any(p > merge_pos for p in bump_positions), (
-        "the 'patch' version bump must be deferred to after the merge step"
+    # The 'new' bump is early (before the changelog PR step); the 'patch' bump is
+    # deferred to after it.
+    assert min(bump_positions) < changelog_pr_pos, (
+        "the 'new' version bump must run early (before the changelog PR step)"
+    )
+    assert max(bump_positions) > changelog_pr_pos, (
+        "the 'patch' version bump must be deferred to after the changelog PR step"
     )
 
 

--- a/ci/tests/test_create_release.py
+++ b/ci/tests/test_create_release.py
@@ -971,3 +971,81 @@ def test_prepare_fails_closed_on_stale_branch_version_file(tmp_path):
     )
     assert result.returncode != 0, "stale branch version file should have failed"
     assert "is stale" in (result.stdout + result.stderr)
+
+
+# --- ReleaseInfo._enqueue_release_pr (merge_prs helper) ----------------------
+
+
+def _make_release_info(cr, **overrides):
+    kwargs = dict(
+        version="26.5.6.64",
+        release_type="patch",
+        release_tag="v26.5.6.64-stable",
+        release_branch="26.5",
+        commit_sha="deadbeef",
+        latest=False,
+        codename="stable",
+    )
+    kwargs.update(overrides)
+    return cr.ReleaseInfo(**kwargs)
+
+
+def test_enqueue_release_pr_transient_gh_failure_is_best_effort(monkeypatch):
+    """A transient `gh pr view` failure must not raise (the release is already
+    published) — return False so merge_prs only warns, and never enqueue."""
+    cr = _create_release_module()
+    ri = _make_release_info(cr)
+    monkeypatch.setattr(cr.Shell, "get_output", staticmethod(lambda *a, **k: ""))
+    enqueued = []
+    monkeypatch.setattr(
+        cr.Git,
+        "enqueue_pull_request",
+        staticmethod(lambda *a, **k: enqueued.append(1) or True),
+    )
+    assert ri._enqueue_release_pr("https://x/pull/111", "ChangeLog", False) is False
+    assert not enqueued
+
+
+def test_enqueue_release_pr_skips_already_merged(monkeypatch):
+    """A non-OPEN (e.g. already merged) PR is a no-op, not an enqueue."""
+    cr = _create_release_module()
+    ri = _make_release_info(cr)
+    monkeypatch.setattr(cr.Shell, "get_output", staticmethod(lambda *a, **k: "MERGED"))
+    enqueued = []
+    monkeypatch.setattr(
+        cr.Git,
+        "enqueue_pull_request",
+        staticmethod(lambda *a, **k: enqueued.append(1) or True),
+    )
+    assert ri._enqueue_release_pr("https://x/pull/111", "ChangeLog", False) is True
+    assert not enqueued
+
+
+def test_enqueue_release_pr_open_forces_sync_then_enqueues(monkeypatch):
+    """An OPEN PR: force CH Inc sync on its head, then enqueue it."""
+    cr = _create_release_module()
+    ri = _make_release_info(cr)
+    outputs = iter(["OPEN", "abc123sha"])  # state, then headRefOid
+    monkeypatch.setattr(
+        cr.Shell, "get_output", staticmethod(lambda *a, **k: next(outputs))
+    )
+    posted = {}
+    monkeypatch.setattr(
+        cr.GH,
+        "post_commit_status",
+        staticmethod(
+            lambda name, status, desc, url, sha="", repo="": posted.update(
+                name=name, sha=sha
+            )
+            or True
+        ),
+    )
+    enq = {}
+    monkeypatch.setattr(
+        cr.Git,
+        "enqueue_pull_request",
+        staticmethod(lambda pr, repo, **k: enq.update(pr=pr) or True),
+    )
+    assert ri._enqueue_release_pr("https://x/pull/111", "ChangeLog", False) is True
+    assert posted["name"] == cr.CH_INC_SYNC and posted["sha"] == "abc123sha"
+    assert enq["pr"] == 111

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -282,3 +282,49 @@ def test_post_commit_status_converts_transparently(monkeypatch):
         sha="abc123", repo="test/repo",
     )
     assert "state=success" in captured["cmd"], f"Expected state=success in command, got: {captured['cmd']}"
+
+
+# --- GH.get_pr_state_by_branch ------------------------------------------------
+
+
+def _install_fake_pr_list(monkeypatch, *, merged, open_):
+    """Stub GH.get_output_with_retries to answer per --state. Returns nothing;
+    each `gh pr list --json url` yields `[]` or a one-element array."""
+    gh_mod = sys.modules[GH.__module__]
+
+    def fake(cmd, *_a, **_k):
+        if "--state merged" in cmd:
+            return '[{"url": "m"}]' if merged else "[]"
+        if "--state open" in cmd:
+            return '[{"url": "o"}]' if open_ else "[]"
+        return "[]"
+
+    monkeypatch.setattr(gh_mod.GH, "get_output_with_retries", staticmethod(fake))
+
+
+def test_get_pr_state_by_branch_merged_takes_priority(monkeypatch):
+    _install_fake_pr_list(monkeypatch, merged=True, open_=True)
+    assert GH.get_pr_state_by_branch("auto/v1.1.1.1-stable", "o/r") == "MERGED"
+
+
+def test_get_pr_state_by_branch_open(monkeypatch):
+    _install_fake_pr_list(monkeypatch, merged=False, open_=True)
+    assert GH.get_pr_state_by_branch("auto/v1.1.1.1-stable", "o/r") == "OPEN"
+
+
+def test_get_pr_state_by_branch_absent(monkeypatch):
+    _install_fake_pr_list(monkeypatch, merged=False, open_=False)
+    assert GH.get_pr_state_by_branch("auto/v1.1.1.1-stable", "o/r") == ""
+
+
+def test_get_pr_state_by_branch_fails_closed(monkeypatch):
+    """An empty read (lookup failed) must raise, not be read as 'no PR'."""
+    gh_mod = sys.modules[GH.__module__]
+    monkeypatch.setattr(
+        gh_mod.GH, "get_output_with_retries", staticmethod(lambda *_a, **_k: "")
+    )
+    try:
+        GH.get_pr_state_by_branch("auto/v1.1.1.1-stable", "o/r")
+        assert False, "should have raised on a failed lookup"
+    except RuntimeError as e:
+        assert "refusing to treat a failed lookup as 'no PR'" in str(e)

--- a/ci/tests/test_git_enqueue.py
+++ b/ci/tests/test_git_enqueue.py
@@ -49,6 +49,23 @@ def test_enqueue_uses_graphql_mutation(monkeypatch):
     assert "id=PR_node" in cmds[0]
 
 
+def test_enqueue_quotes_repo(monkeypatch):
+    """The `repo` argument is shell-quoted in the `gh pr view` commands."""
+    view_cmds = []
+
+    def fake_get_output(command, *_a, **_k):
+        view_cmds.append(command)
+        return "PR_node" if "--json id" in command else "QUEUED"
+
+    monkeypatch.setattr(GIT_MOD.Shell, "get_output", staticmethod(fake_get_output))
+    monkeypatch.setattr(
+        GIT_MOD.Shell, "get_res_stdout_stderr", staticmethod(lambda *_a, **_k: (0, "", ""))
+    )
+    monkeypatch.setattr(GIT_MOD.time, "sleep", lambda *_a, **_k: None)
+    assert Git.enqueue_pull_request(1, "owner/repo; rm -rf /") is True
+    assert view_cmds and all("'owner/repo; rm -rf /'" in c for c in view_cmds)
+
+
 def test_enqueue_dry_run_touches_nothing(monkeypatch):
     def unexpected(*_a, **_k):
         raise AssertionError("dry run must not call Shell")

--- a/ci/tests/test_git_enqueue.py
+++ b/ci/tests/test_git_enqueue.py
@@ -88,6 +88,38 @@ def test_enqueue_real_failure_returns_false(monkeypatch):
     assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is False
 
 
+def test_enqueue_retries_until_check_completes(monkeypatch):
+    """A required check pending on the first attempts, then the enqueue succeeds:
+    retry must wait it out and return True without sleeping against the clock."""
+    calls = {"n": 0}
+
+    def fake_get_output(command, *_a, **_k):
+        if "--json id" in command:
+            return "PR_node"
+        return "QUEUED"
+
+    def fake_get_res(command, *_a, **_k):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return (1, "", 'Required status check "CH Inc sync" is pending.')
+        return (0, "", "")
+
+    monkeypatch.setattr(GIT_MOD.Shell, "get_output", staticmethod(fake_get_output))
+    monkeypatch.setattr(GIT_MOD.Shell, "get_res_stdout_stderr", staticmethod(fake_get_res))
+    monkeypatch.setattr(GIT_MOD.time, "sleep", lambda *_a, **_k: None)
+    assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse", retries=5, delay=1) is True
+    assert calls["n"] == 3
+
+
+def test_enqueue_exhausts_retries_returns_false(monkeypatch):
+    _install_fake_shell(
+        monkeypatch, enqueue=(1, "", 'Required status check "CH Inc sync" is pending.')
+    )
+    assert (
+        Git.enqueue_pull_request(7, "ClickHouse/ClickHouse", retries=3, delay=1) is False
+    )
+
+
 def test_enqueue_missing_node_id_returns_false(monkeypatch):
     _install_fake_shell(monkeypatch, node_id="")
     assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is False

--- a/ci/tests/test_git_enqueue.py
+++ b/ci/tests/test_git_enqueue.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for `Git.enqueue_pull_request`.
+
+The release flow and `check_ci.py` both add a PR to `master`'s merge queue via
+the `enqueuePullRequest` GraphQL mutation (the repo disables `gh pr merge
+--auto`'s `enablePullRequestAutoMerge`). These tests pin the contract of the
+shared helper: it uses the mutation, treats "already in the queue" as success,
+surfaces real failures, and never sleeps against the real clock.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.git import Git
+
+GIT_MOD = sys.modules[Git.__module__]
+
+
+def _install_fake_shell(monkeypatch, *, node_id="PR_node", enqueue=(0, "", ""),
+                        merge_state="QUEUED"):
+    """Stub `Shell`/`time.sleep` in the `git` module. Returns the recorded
+    `gh api graphql` enqueue commands so tests can assert on the mutation."""
+    enqueue_cmds = []
+
+    def fake_get_output(command, *_a, **_k):
+        if "--json id" in command:
+            return node_id
+        if "mergeStateStatus" in command:
+            return merge_state
+        return ""
+
+    def fake_get_res(command, *_a, **_k):
+        enqueue_cmds.append(command)
+        return enqueue
+
+    monkeypatch.setattr(GIT_MOD.Shell, "get_output", staticmethod(fake_get_output))
+    monkeypatch.setattr(GIT_MOD.Shell, "get_res_stdout_stderr", staticmethod(fake_get_res))
+    monkeypatch.setattr(GIT_MOD.time, "sleep", lambda *_a, **_k: None)
+    return enqueue_cmds
+
+
+def test_enqueue_uses_graphql_mutation(monkeypatch):
+    cmds = _install_fake_shell(monkeypatch)
+    assert Git.enqueue_pull_request(123, "ClickHouse/ClickHouse") is True
+    assert len(cmds) == 1
+    assert "enqueuePullRequest" in cmds[0]
+    assert "id=PR_node" in cmds[0]
+
+
+def test_enqueue_dry_run_touches_nothing(monkeypatch):
+    def unexpected(*_a, **_k):
+        raise AssertionError("dry run must not call Shell")
+
+    monkeypatch.setattr(GIT_MOD.Shell, "get_output", staticmethod(unexpected))
+    monkeypatch.setattr(GIT_MOD.Shell, "get_res_stdout_stderr", staticmethod(unexpected))
+    assert Git.enqueue_pull_request(1, "ClickHouse/ClickHouse", dry_run=True) is True
+
+
+def test_enqueue_already_queued_is_success(monkeypatch):
+    _install_fake_shell(
+        monkeypatch,
+        enqueue=(1, "", "Pull request is already in the queue"),
+    )
+    assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is True
+
+
+def test_enqueue_real_failure_returns_false(monkeypatch):
+    _install_fake_shell(monkeypatch, enqueue=(1, "", "some other error"))
+    assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is False
+
+
+def test_enqueue_missing_node_id_returns_false(monkeypatch):
+    _install_fake_shell(monkeypatch, node_id="")
+    assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is False
+
+
+def test_enqueue_succeeds_even_when_not_yet_queued(monkeypatch):
+    # A non-QUEUED merge state after a successful mutation is only a warning:
+    # GitHub may still be updating the PR's merge state.
+    _install_fake_shell(monkeypatch, merge_state="BEHIND")
+    assert Git.enqueue_pull_request(7, "ClickHouse/ClickHouse") is True


### PR DESCRIPTION
Both `check_ci.py` and the release job add a pull request to `master`'s merge queue, but they did it in different ways. `check_ci.py` called the `enqueuePullRequest` GraphQL mutation inline, because the repository disables `enablePullRequestAutoMerge` (the mutation behind `gh pr merge --auto`) in favor of a merge queue on `master`. The release job's `merge_prs`, however, still ran `gh pr merge --merge --auto` for the changelog and version-bump PRs. Since both of those PRs target `master` and are behind the same merge queue, `--auto` cannot land them.

This extracts the enqueue logic into a reusable `Git.enqueue_pull_request` helper in `ci/praktika/git.py` and calls it from both `check_ci.py` and `create_release.merge_prs`.

The helper keeps the existing behavior: it uses the `enqueuePullRequest` mutation, treats GitHub's "already in the queue" rejection as success, surfaces the real `gh` output on failure, and verifies the PR reached the queue. It returns a `bool` instead of exiting the process, so each caller decides how to react, and it supports `dry_run`.

New unit tests in `ci/tests/test_git_enqueue.py` cover the helper contract: the mutation is used, dry-run touches nothing, "already queued" and a non-`QUEUED` merge state are treated as success, and a real failure or a missing PR node id return `False`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

