### PR TITLE
Remove unnecessary parens special cases left after #92340

### DIFF
--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -511,25 +511,22 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 arguments->children[0]->format(ostr, settings, state, nested_need_parens);
                 ostr << it->operator_name;
 
-                /// Format x IN 1 as x IN (1): put parens around rhs even if there is a single element in set.
+                /// Format `x IN 1` as `x IN (1)`: put parens around the right-hand side even if
+                /// there is a single element in the set (some external databases the query can be
+                /// forwarded to require them). Self-grouping forms — subqueries, function calls,
+                /// tuple and array literals — emit their own brackets; an aliased right-hand side
+                /// is wrapped in parens by the generic aliased-expression handling.
                 const auto * second_arg_func = arguments->children[1]->as<ASTFunction>();
                 const auto * second_arg_literal = arguments->children[1]->as<ASTLiteral>();
                 bool is_literal_tuple_or_array = second_arg_literal
                     && (second_arg_literal->value.getType() == Field::Types::Tuple
                         || second_arg_literal->value.getType() == Field::Types::Array);
 
-                /** Conditions for extra parens:
-                 *  1. Is IN operator
-                 *  2. 2nd arg is not subquery, function, or literal tuple or array
-                 *  3. If the 2nd argument has alias, we ignore condition 2 and add extra parens
-                 *
-                 *  Condition 3 is needed to avoid inconsistency in format-parse-format debug check in executeQuery.cpp
-                 */
-                bool extra_parents_around_in_rhs = is_in_operator
-                    && ((!arguments->children[1]->as<ASTSubquery>() && !second_arg_func && !is_literal_tuple_or_array)
-                        || !arguments->children[1]->tryGetAlias().empty());
+                bool extra_parens_around_in_rhs = is_in_operator
+                    && !arguments->children[1]->as<ASTSubquery>() && !second_arg_func && !is_literal_tuple_or_array
+                    && arguments->children[1]->tryGetAlias().empty();
 
-                if (extra_parents_around_in_rhs)
+                if (extra_parens_around_in_rhs)
                 {
                     ostr << '(';
                     /// We have just emitted `(` around the right-hand side, so suppress the
@@ -539,8 +536,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                     arguments->children[1]->format(ostr, settings, state, inner_frame);
                     ostr << ')';
                 }
-
-                if (!extra_parents_around_in_rhs)
+                else
                     arguments->children[1]->format(ostr, settings, state, nested_need_parens);
 
                 /// LIKE/ILIKE with ESCAPE clause: format the 3rd argument as ESCAPE 'char'
@@ -560,7 +556,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                 if (frame.need_parens)
                     ostr << '(';
 
-                /// Don't allow moving operators like '-' before parents,
+                /// Don't allow moving operators like '-' before parens,
                 /// otherwise (-(42))[3] will be formatted as -(42)[3] that will be parsed as -(42[3]);
                 nested_need_parens.allow_moving_operators_before_parens = false;
                 arguments->children[0]->format(ostr, settings, state, nested_need_parens);
@@ -640,7 +636,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
                             ostr << '(';
                         }
 
-                        /// Don't allow moving operators like '-' before parents,
+                        /// Don't allow moving operators like '-' before parens,
                         /// otherwise (-(42)).1 will be formatted as -(42).1 that will be parsed as -((42).1)
                         nested_need_parens.allow_moving_operators_before_parens = false;
                         arguments->children[0]->format(ostr, settings, state, nested_need_parens);
@@ -735,7 +731,10 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
             written = true;
         }
 
-        if (!written && arguments->children.size() >= 2 && name == "tuple"sv && isOperator() && !(frame.need_parens && !alias.empty()))
+        /// Note: `frame.need_parens` cannot be set here together with a non-empty alias:
+        /// the generic aliased-expression handling consumes it (emitting the wrapping parens)
+        /// before calling `formatImplWithoutAlias`.
+        if (!written && arguments->children.size() >= 2 && name == "tuple"sv && isOperator())
         {
             ostr << '(';
 

--- a/src/Parsers/ASTHypotheticalIndexQuery.cpp
+++ b/src/Parsers/ASTHypotheticalIndexQuery.cpp
@@ -45,7 +45,6 @@ ASTPtr ASTHypotheticalIndexQuery::clone() const
 void ASTHypotheticalIndexQuery::formatQueryImpl(
     WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const
 {
-    frame.need_parens = false;
     std::string indent_str = settings.one_line ? "" : std::string(4u * frame.indent, ' ');
     ostr << indent_str;
 

--- a/src/Parsers/ASTInterpolateElement.cpp
+++ b/src/Parsers/ASTInterpolateElement.cpp
@@ -20,24 +20,12 @@ void ASTInterpolateElement::formatImpl(WriteBuffer & ostr, const FormatSettings 
     settings.writeIdentifier(ostr, column, /*ambiguous=*/true);
     ostr << " AS ";
 
-    /// If the expression has an alias, we need to wrap it in parentheses
+    /// If the expression has an alias, it must be wrapped in parentheses
     /// to avoid ambiguity with double AS: `col AS expr AS alias` is not parseable,
-    /// but `col AS (expr AS alias)` is.
-    bool need_parens = !expr->tryGetAlias().empty();
-    if (need_parens)
-    {
-        ostr << '(';
-        /// We have just emitted `(` around the expression, so suppress the
-        /// child's own `parenthesized` parens (which would otherwise duplicate ours).
-        FormatStateStacked inner_frame = frame;
-        inner_frame.wrapped_in_parens = true;
-        expr->format(ostr, settings, state, inner_frame);
-        ostr << ')';
-    }
-    else
-    {
-        expr->format(ostr, settings, state, frame);
-    }
+    /// but `col AS (expr AS alias)` is. Setting `need_parens` makes the generic
+    /// aliased-expression handling produce the wrap.
+    frame.need_parens = !expr->tryGetAlias().empty();
+    expr->format(ostr, settings, state, frame);
 }
 
 }

--- a/src/Parsers/ASTTablesInSelectQuery.cpp
+++ b/src/Parsers/ASTTablesInSelectQuery.cpp
@@ -264,35 +264,13 @@ void ASTTableJoin::formatImplAfterTable(WriteBuffer & ostr, const FormatSettings
     {
         ostr << " ON ";
 
-       /** If there is an alias for the whole expression we wrap the ON clause in parens in two cases:
-         *  1. collapse_identical_nodes_to_aliases is true (meaning old analyzer is being used) AND the alias was
-         *     defined earlier in the query
-         *  2. collapse_identical_nodes_to_aliases is false (the analyzer) - because we will not make any substitutions
-         */
-        bool on_need_parens = false;
-        auto on_alias = on_expression->tryGetAlias();
-        if (!on_alias.empty())
-        {
-            bool was_alias_defined_earlier = state.printed_asts_with_alias.contains(
-                {frame.current_select, on_alias, on_expression->getTreeHash(/*ignore_aliases=*/true)});
-            on_need_parens = settings.collapse_identical_nodes_to_aliases ? !was_alias_defined_earlier : true;
-        }
-
-
-        if (on_need_parens)
-        {
-            ostr << "(";
-            /// We have just emitted `(` around the ON expression, so suppress the
-            /// child's own `parenthesized` parens (which would otherwise duplicate ours).
-            FormatStateStacked inner_frame = frame;
-            inner_frame.wrapped_in_parens = true;
-            on_expression->format(ostr, settings, state, inner_frame);
-            ostr << ")";
-        }
-        else
-        {
-            on_expression->format(ostr, settings, state, frame);
-        }
+        /// If there is an alias for the whole expression, it must be wrapped in parentheses:
+        /// `ON a = b AS x` would attach the alias to `b` on re-parse instead of to the whole
+        /// condition. Setting `need_parens` makes the generic aliased-expression handling
+        /// produce the wrap (and, with `collapse_identical_nodes_to_aliases`, correctly print
+        /// just the alias when the expression was already printed earlier in the query).
+        frame.need_parens = !on_expression->tryGetAlias().empty();
+        on_expression->format(ostr, settings, state, frame);
     }
 }
 

--- a/src/Parsers/IAST.cpp
+++ b/src/Parsers/IAST.cpp
@@ -417,29 +417,6 @@ static bool decideParensEmission(const IAST & node, IAST::FormatStateStacked & f
         return false;
     }
 
-    /// Inside `CODEC` / `STATISTICS` / `BACKUP_NAME` argument lists `frame.allow_operators`
-    /// is forced to `false`, so a multi-argument `Function_tuple` falls back to its
-    /// function-call form `tuple(arg, arg, ...)` instead of the operator form
-    /// `(arg, arg, ...)`. The `RoundBracketsLayer::getResultImpl` single-element path
-    /// sets `parenthesized = true` on any node it unwraps from outer `(...)`, so a query
-    /// like `CODEC(not((tuple(1, 2))))` re-parses to `Function_tuple` with
-    /// `parenthesized = true`. Emitting those parens here would produce
-    /// `CODEC(not((tuple(1, 2))))` on first format but `CODEC(not(((tuple(1, 2)))))` on
-    /// re-format, because the re-parsed inner `Function_not` carries the outer paren on
-    /// itself and the re-parsed `Function_tuple` then adds another one — breaking the
-    /// format-parse-format round-trip with `Inconsistent AST formatting` (STID 1941-1bfa).
-    /// Suppress them here for consistency with the literal-tuple case above; the parser
-    /// canonicalises `(tuple(a, b))` and `tuple(a, b)` to the same value.
-    if (!frame.allow_operators)
-    {
-        if (const auto * func = dynamic_cast<const ASTFunction *>(&node);
-            func && func->name == "tuple"
-                && func->arguments && func->arguments->children.size() > 1)
-        {
-            return false;
-        }
-    }
-
     /// `ASTSubquery` without an alias always emits its own enclosing `(SELECT ...)` parens.
     /// Adding the `parenthesized` flag's parens on top would produce `((SELECT ...))`,
     /// which the parser collapses back to a non-parenthesized subquery, breaking the

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -372,7 +372,7 @@ public:
         bool expression_list_prepend_whitespace = false; /// Prepend whitespace (if it is required)
         bool surround_each_list_element_with_parens = false;
         bool allow_operators = true; /// Format some functions, such as "plus", "in", etc. as operators.
-        bool allow_moving_operators_before_parens = true; /// Allow moving operators like "-" before parents: (-...) -> -(...)
+        bool allow_moving_operators_before_parens = true; /// Allow moving operators like "-" before parens: (-...) -> -(...)
         size_t list_element_index = 0;
         std::string create_engine_name;
         const IAST * current_select = nullptr;


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/92340

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

The goal of #92340 was to simplify AST formatting by remembering whether an expression was parenthesized instead of deciding it with special cases. Some of the complex code became unnecessary but was not removed. This cleans up the remnants (`-59` lines net, behavior-invariant):

- `decideParensEmission`: the multi-argument `tuple` suppression branch is dead code — it is fully subsumed by the general function-call-form suppression for `ASTFunction` added ten days later in the same function.
- `ASTFunction`: the `!(frame.need_parens && !alias.empty())` guard on the `tuple` operator branch is dead since #92340 — both `ASTWithAlias::formatImpl` and `decideParensEmission` clear `need_parens` before calling `formatImplWithoutAlias` whenever the alias wrap fires, so the condition can never be true.
- `ASTFunction`: the aliased-right-hand-side condition ("condition 3") for the extra parens around the `IN` right-hand side duplicates the generic aliased-expression handling, which produces an identical wrap. The bare-literal normalization `x IN 1` → `x IN (1)` itself is kept: external databases reached through `transformQueryForExternalDatabase` require the parens. Also fixes the `extra_parents_around_in_rhs` typo.
- `ASTInterpolateElement` and the `ASTTableJoin` `ON` clause wrapped aliased expressions in parens manually (the latter with a duplicated `printed_asts_with_alias` lookup replicating `ASTWithAlias` logic); both now defer to the generic handling via `frame.need_parens`.
- `ASTHypotheticalIndexQuery`: a no-op statement-level `frame.need_parens = false` remained; removed, matching what #92340 did for the other statement formatters.

Verification that the change is behavior-invariant:
- `clickhouse format --multiquery` output over all 9372 stateless test files is byte-identical before and after the change, and formatting stays idempotent on all of them (0 unstable, no new parse-back failures).
- The parser and `TransformQueryForExternalDatabase` gtests pass (137 tests).
- A battery of 34 formatting-related stateless tests passes against an ASan build (which checks format-parse-format consistency for every executed query), including distributed queries with aliased `ON` expressions and `IN` with CTE right-hand sides under both analyzers.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.42` (included in `26.8` and later)
<!-- ch-version-info:end -->