### PR TITLE
Integration tests: capture Keeper sanitizer stderr in collected logs

### DIFF
--- a/tests/integration/compose/docker_compose_keeper.yml
+++ b/tests/integration/compose/docker_compose_keeper.yml
@@ -23,7 +23,7 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir1:-}
               target: /var/lib/clickhouse
-        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config1.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
+        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config1.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log -- --logger.stderr=/var/log/clickhouse-keeper/stderr.log --logger.stdout=/var/log/clickhouse-keeper/stdout.log"
         cap_add:
             - SYS_PTRACE
             - NET_ADMIN
@@ -62,7 +62,7 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir1:-}
               target: /var/lib/clickhouse
-        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config2.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
+        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config2.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log -- --logger.stderr=/var/log/clickhouse-keeper/stderr.log --logger.stdout=/var/log/clickhouse-keeper/stdout.log"
         cap_add:
             - SYS_PTRACE
             - NET_ADMIN
@@ -101,7 +101,7 @@ services:
             - type: ${keeper_fs:-tmpfs}
               source: ${keeper_db_dir1:-}
               target: /var/lib/clickhouse
-        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config3.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log"
+        entrypoint: "${keeper_cmd_prefix:-clickhouse keeper} --config=/etc/clickhouse-keeper/keeper_config3.xml --log-file=/var/log/clickhouse-keeper/clickhouse-keeper.log --errorlog-file=/var/log/clickhouse-keeper/clickhouse-keeper.err.log -- --logger.stderr=/var/log/clickhouse-keeper/stderr.log --logger.stdout=/var/log/clickhouse-keeper/stdout.log"
         cap_add:
             - SYS_PTRACE
             - NET_ADMIN

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4321,6 +4321,28 @@ class ClickHouseCluster:
                         if SANITIZER_SIGN in line:
                             sanitizer_assert_instance = line.split("|")[0].strip()
                             break
+
+            if not sanitizer_assert_instance and not ignore_sanitizer and self.use_keeper:
+                # Keeper (zooN) containers are not in self.instances, so the per-instance
+                # scan above never covers them. Sanitizers write to raw stderr, which the
+                # keeper entrypoint redirects (via --logger.stderr) to a host-mounted
+                # stderr.log; scan it so a Keeper sanitizer report is detected reliably
+                # and ends up in the collected logs.
+                for i in range(1, 4):
+                    keeper_stderr = os.path.join(
+                        self.keeper_instance_dir_prefix + f"{i}", "log", "stderr.log"
+                    )
+                    if not os.path.exists(keeper_stderr):
+                        continue
+                    with open(keeper_stderr, "r", errors="replace") as f:
+                        if any(SANITIZER_SIGN in line for line in f):
+                            sanitizer_assert_instance = f"zoo{i}"
+                            logging.error(
+                                "Sanitizer in Keeper instance zoo%s log %s",
+                                i,
+                                keeper_stderr,
+                            )
+                            break
         else:
             logging.warning(
                 "docker compose up was not called. Trying to export docker.log for running containers"

--- a/tests/integration/test_keeper_sanitizer_logs/test.py
+++ b/tests/integration/test_keeper_sanitizer_logs/test.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster, SANITIZER_SIGN
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", with_zookeeper=True, stay_alive=True)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        # The test injects a sanitizer marker into a Keeper's stderr, so the
+        # normal teardown would re-raise; ignore it here.
+        cluster.shutdown(ignore_sanitizer=True)
+
+
+def keeper_stderr_path(i):
+    return os.path.join(cluster.keeper_instance_dir_prefix + f"{i}", "log", "stderr.log")
+
+
+def test_keeper_stderr_is_collected():
+    # The Keeper entrypoint redirects stderr to a host-mounted file, so each
+    # Keeper instance must have a stderr.log next to its other logs. This is
+    # where a sanitizer report (written to raw fd 2) ends up, so it is archived
+    # with the rest of the integration-test logs.
+    for i in range(1, 4):
+        path = keeper_stderr_path(i)
+        assert os.path.exists(path), f"Keeper stderr log not collected: {path}"
+
+
+def test_keeper_sanitizer_report_is_detected():
+    # Write the sanitizer marker to zoo2's real stderr (fd 2). It must reach the
+    # host-mounted stderr.log through the entrypoint redirect, and shutdown() must
+    # detect it and fail for that instance. Without the redirect + scan the report
+    # would only reach the container stream and go unnoticed.
+    marker = SANITIZER_SIGN + " WARNING: ThreadSanitizer: data race (injected by test)"
+    cluster.exec_in_container(
+        cluster.get_container_id("zoo2"),
+        ["bash", "-c", f"echo '{marker}' > /proc/1/fd/2"],
+        user="root",
+    )
+
+    with open(keeper_stderr_path(2)) as f:
+        assert SANITIZER_SIGN in f.read(), "marker did not reach the host-mounted stderr.log"
+
+    with pytest.raises(Exception, match="Sanitizer assert found for instance zoo2"):
+        cluster.shutdown()


### PR DESCRIPTION

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/110917
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

A Keeper sanitizer report (e.g. a TSan data race in `clickhouse-keeper`) is written to raw process stderr (fd 2). `clickhouse-keeper` (a `BaseDaemon`) only redirects fd 2 to a file when `logger.stderr` is set, and the integration keeper configs set only `<log>`/`<errorlog>`, so the report reaches only the container stderr stream. The `zoo*` containers are not in `cluster.instances`, so the per-instance `stderr.log` scan in `shutdown()` never covers Keeper; detection falls back to the `docker compose logs --follow` capture, which is torn down at shutdown and does not archive the report into `logs.tar.gz`. This is why the Keeper report was not found in the archived logs on #110917.

Fix:
- `docker_compose_keeper.yml`: redirect Keeper `stderr`/`stdout` to `/var/log/clickhouse-keeper/` (already bind-mounted and archived) via `-- --logger.stderr=... --logger.stdout=...`, mirroring what server nodes already do.
- `cluster.py` `shutdown()`: also scan each Keeper instance's `stderr.log` for the sanitizer sign, so the report is detected deterministically (Keeper fd 2 no longer reaches the `docker.log` capture once redirected).

The TSan race itself is unrelated to this change and is tracked/fixed separately in #107083.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.162` (included in `26.8` and later)
<!-- ch-version-info:end -->