### PR TITLE
Refresh the apt index before installing the release packaging tools

### DIFF
--- a/ci/jobs/release_job.py
+++ b/ci/jobs/release_job.py
@@ -238,10 +238,16 @@ def main():
                 f"command -v geesefs && geesefs --version 2>&1 | grep -qF {_GEESEFS_VERSION.lstrip('v')} ||"
                 f" (curl -fsSL https://github.com/yandex-cloud/geesefs/releases/download/{_GEESEFS_VERSION}/geesefs-linux-{arch}"
                 f" -o {geesefs_bin_dir}/geesefs && chmod +x {geesefs_bin_dir}/geesefs)",
-                "command -v createrepo_c || sudo apt-get install -y createrepo-c ||:",
+                # `apt-get update` before each install: the runner's apt index can
+                # be stale and point at a superseded package version (e.g.
+                # `libarchive-dev 3.6.0-1ubuntu1.7`) that Ubuntu already removed
+                # from the mirror pool, which makes `apt-get install` fail with a
+                # 404. Refreshing the index first resolves to the current version.
+                "command -v createrepo_c || (sudo apt-get update && sudo apt-get install -y createrepo-c) ||:",
                 # reprepro 5.4.4+ is required for the 'Limit' field in distributions config.
                 # Ubuntu Jammy only has 5.3.0, so build from source if needed.
                 "reprepro --version 2>&1 | grep -qE '5\\.[4-9]' || ("
+                "  sudo apt-get update &&"
                 "  sudo apt-get install -y dpkg-dev fakeroot libgpgme-dev libdb-dev libbz2-dev liblzma-dev libarchive-dev shunit2 db-util debhelper &&"
                 "  git clone https://salsa.debian.org/debian/reprepro.git /tmp/reprepro-src &&"
                 "  cd /tmp/reprepro-src &&"


### PR DESCRIPTION
The release job installs `createrepo_c` and `reprepro`'s build dependencies with `apt-get install`, but never refreshes the apt index first. When the runner's index is stale and still points at a package version that Ubuntu has superseded and removed from the mirror pool, `apt-get install` fails with a 404. This happened on a recovery run with `libarchive-dev 3.6.0-1ubuntu1.7`:

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/liba/libarchive/libarchive-dev_3.6.0-1ubuntu1.7_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
ERROR: createrepo_c and reprepro 5.4+ must be installed for a release
```

Because the dependencies could not be fetched, the `reprepro` source build could not proceed and the fail-closed precondition check aborted the whole release.

This runs `apt-get update` inside each install guard, so it only runs on a cache miss (when a tool is actually missing) and the index resolves to the package version currently on the mirror.

CI report: https://github.com/ClickHouse/ClickHouse/actions/runs/29980853317

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.33` (included in `26.8` and later)
<!-- ch-version-info:end -->