### PR TITLE
Fix unit-test bugfix validation: force submodule checkout so the before-binary configures

### DIFF
--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -209,6 +209,39 @@ def gitmodules_shape_violation():
     return None
 
 
+def get_submodule_state_changes(merge_base, pr_sha):
+    """Paths whose submodule state differs between the merge-base and the PR head.
+
+    Returns the list of changed submodule gitlinks (mode 160000 entries in either tree)
+    plus `.gitmodules` itself if it changed. The before-worktree is populated by
+    hardlinking submodule working trees from the primary checkout, which is at the PR's
+    submodule revisions — content-correct only while the PR does not touch submodule
+    state. If it does, the "before" binary would silently build against PR-head
+    submodule content (or miss a merge-base-only submodule entirely), so the caller
+    must fail close instead of validating against the wrong code.
+    """
+    # `--ignore-submodules=none` is essential: a `diff.ignoreSubmodules=all` config (set
+    # in some environments) would otherwise silently drop every gitlink change from the
+    # diff and this guard would never fire.
+    diff = Shell.get_output(
+        "git diff --raw --ignore-submodules=none "
+        f"{shlex.quote(merge_base)} {shlex.quote(pr_sha)}"
+    )
+    changed = []
+    for line in diff.splitlines():
+        # raw format: ':<old_mode> <new_mode> <old_sha> <new_sha> <status>\t<path>'
+        if not line.startswith(":"):
+            continue
+        meta, _, path = line.partition("\t")
+        parts = meta.lstrip(":").split()
+        if len(parts) < 4 or not path:
+            continue
+        old_mode, new_mode = parts[0], parts[1]
+        if old_mode == "160000" or new_mode == "160000" or path == ".gitmodules":
+            changed.append(path)
+    return sorted(set(changed))
+
+
 def ensure_primary_submodules():
     """Populate the primary checkout's submodule working trees.
 
@@ -249,8 +282,10 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
     Submodule working trees are populated by hardlinking from the primary checkout
     (fast, no network) so the build sees contrib sources.  This is content-correct
     whenever the PR did not bump submodule pointers, which is the normal case for a
-    unit-test bugfix.  Returns True iff every submodule the primary checkout has was
-    hardlinked into the worktree non-empty — the caller must fail close otherwise.
+    unit-test bugfix — main() fails close (via get_submodule_state_changes) before
+    calling this when the PR changes any gitlink or `.gitmodules`.  Returns True iff
+    every submodule the primary checkout has was hardlinked into the worktree
+    non-empty — the caller must fail close otherwise.
     """
     # Populate the primary checkout's submodule working trees FIRST, before touching the
     # worktree: the hardlink step below has nothing to copy otherwise, and doing it up
@@ -526,6 +561,35 @@ def main():
             ],
             "Bugfix validation inconclusive: refused unsafe .gitmodules before any "
             f"submodule fetch ({gitmodules_error}).",
+        )
+        return
+
+    # Fail close if the PR changes submodule state (any gitlink or `.gitmodules`): the
+    # before-worktree's submodules are hardlinked from the primary checkout, which is at
+    # the PR-head revisions, so the "before" binary would be built against the PR's
+    # submodule content (or miss a merge-base-only submodule entirely) — the validator
+    # could report a false reproduction or refutation. Inconclusive (ERROR), not a pass.
+    submodule_changes = get_submodule_state_changes(merge_base, pr_sha)
+    if submodule_changes:
+        finalize(
+            [
+                Result(
+                    name="Bugfix validation (unit tests)",
+                    status=Result.Status.ERROR,
+                    info=(
+                        "The PR changes submodule state ("
+                        + ", ".join(submodule_changes)
+                        + "), but the before-worktree can only be populated with the "
+                        "primary checkout's (PR-head) submodule content, not the "
+                        "merge-base's. Building the before-binary would validate "
+                        "against the wrong submodule code, so this is inconclusive — "
+                        "NOT a reproduction or a refutation."
+                    ),
+                )
+            ],
+            "Bugfix validation inconclusive: the PR changes submodule pointers or "
+            "`.gitmodules`, and the before-worktree cannot be populated at the "
+            "merge-base submodule revisions.",
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -209,23 +209,27 @@ def gitmodules_shape_violation():
     return None
 
 
-def get_submodule_state_changes(merge_base, pr_sha):
-    """Paths whose submodule state differs between the merge-base and the PR head.
+def get_submodule_state_changes(merge_base, checkout_sha):
+    """Paths whose submodule state differs between the merge-base and the checkout.
 
     Returns the list of changed submodule gitlinks (mode 160000 entries in either tree)
     plus `.gitmodules` itself if it changed. The before-worktree is populated by
-    hardlinking submodule working trees from the primary checkout, which is at the PR's
-    submodule revisions — content-correct only while the PR does not touch submodule
-    state. If it does, the "before" binary would silently build against PR-head
-    submodule content (or miss a merge-base-only submodule entirely), so the caller
-    must fail close instead of validating against the wrong code.
+    hardlinking submodule working trees from the primary checkout, whose submodules are
+    checked out at `checkout_sha`'s recorded revisions — in this workflow that is `HEAD`,
+    normally GitHub's synthetic base+PR merge ref. That content is correct for the
+    merge-base build only while no submodule state differs between the two commits. A
+    difference can come from the PR itself (a gitlink or `.gitmodules` edit) or from the
+    base branch moving a submodule after the branch split — comparing against the PR
+    head instead of the checkout would miss the latter, and the "before" binary would
+    silently build merge-base sources against base-tip submodule content. Either way
+    the caller must fail close instead of validating against the wrong code.
     """
     # `--ignore-submodules=none` is essential: a `diff.ignoreSubmodules=all` config (set
     # in some environments) would otherwise silently drop every gitlink change from the
     # diff and this guard would never fire.
     diff = Shell.get_output(
         "git diff --raw --ignore-submodules=none "
-        f"{shlex.quote(merge_base)} {shlex.quote(pr_sha)}"
+        f"{shlex.quote(merge_base)} {shlex.quote(checkout_sha)}"
     )
     changed = []
     for line in diff.splitlines():
@@ -281,9 +285,10 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
 
     Submodule working trees are populated by hardlinking from the primary checkout
     (fast, no network) so the build sees contrib sources.  This is content-correct
-    whenever the PR did not bump submodule pointers, which is the normal case for a
-    unit-test bugfix — main() fails close (via get_submodule_state_changes) before
-    calling this when the PR changes any gitlink or `.gitmodules`.  Returns True iff
+    whenever the checkout's submodule state equals the merge-base's, which is the
+    normal case for a unit-test bugfix — main() fails close (via
+    get_submodule_state_changes, merge-base vs the checkout `HEAD`) before calling
+    this when any gitlink or `.gitmodules` differs.  Returns True iff
     every submodule the primary checkout has was hardlinked into the worktree
     non-empty — the caller must fail close otherwise.
     """
@@ -564,12 +569,20 @@ def main():
         )
         return
 
-    # Fail close if the PR changes submodule state (any gitlink or `.gitmodules`): the
-    # before-worktree's submodules are hardlinked from the primary checkout, which is at
-    # the PR-head revisions, so the "before" binary would be built against the PR's
-    # submodule content (or miss a merge-base-only submodule entirely) — the validator
-    # could report a false reproduction or refutation. Inconclusive (ERROR), not a pass.
-    submodule_changes = get_submodule_state_changes(merge_base, pr_sha)
+    # Fail close if submodule state (any gitlink or `.gitmodules`) differs between the
+    # merge-base and the checkout `HEAD`: the before-worktree's submodules are
+    # hardlinked from the primary checkout, whose submodules are at HEAD's recorded
+    # revisions (normally the synthetic base+PR merge ref). Comparing against HEAD —
+    # not the PR head — also catches a base-only submodule bump after the branch split,
+    # which would otherwise leak base-tip contrib sources into the merge-base build.
+    # Either way the "before" binary would be built against the wrong submodule content
+    # (or miss a merge-base-only submodule entirely) and the validator could report a
+    # false reproduction or refutation. Inconclusive (ERROR), not a pass.
+    checkout_head = Shell.get_output("git rev-parse HEAD").strip()
+    assert (
+        checkout_head
+    ), "Failed to resolve the checkout HEAD; cannot verify submodule state"
+    submodule_changes = get_submodule_state_changes(merge_base, checkout_head)
     if submodule_changes:
         finalize(
             [
@@ -577,19 +590,20 @@ def main():
                     name="Bugfix validation (unit tests)",
                     status=Result.Status.ERROR,
                     info=(
-                        "The PR changes submodule state ("
-                        + ", ".join(submodule_changes)
-                        + "), but the before-worktree can only be populated with the "
-                        "primary checkout's (PR-head) submodule content, not the "
-                        "merge-base's. Building the before-binary would validate "
-                        "against the wrong submodule code, so this is inconclusive — "
-                        "NOT a reproduction or a refutation."
+                        "Submodule state differs between the merge-base and the "
+                        "checkout (" + ", ".join(submodule_changes) + ") — either the "
+                        "PR changes submodule state, or the base branch moved a "
+                        "submodule after the branch split. The before-worktree can "
+                        "only be populated with the primary checkout's submodule "
+                        "content, not the merge-base's, so building the before-binary "
+                        "would validate against the wrong submodule code. This is "
+                        "inconclusive — NOT a reproduction or a refutation."
                     ),
                 )
             ],
-            "Bugfix validation inconclusive: the PR changes submodule pointers or "
-            "`.gitmodules`, and the before-worktree cannot be populated at the "
-            "merge-base submodule revisions.",
+            "Bugfix validation inconclusive: submodule state differs between the "
+            "merge-base and the checkout, and the before-worktree cannot be populated "
+            "at the merge-base submodule revisions.",
         )
         return
 

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -226,10 +226,14 @@ def get_submodule_state_changes(merge_base, checkout_sha):
     """
     # `--ignore-submodules=none` is essential: a `diff.ignoreSubmodules=all` config (set
     # in some environments) would otherwise silently drop every gitlink change from the
-    # diff and this guard would never fire.
+    # diff and this guard would never fire. `strict=True` is equally essential: a failed
+    # diff (missing object in the partial/shallow checkout, transient git error) must
+    # raise rather than yield an empty string — otherwise the guard would fail open and
+    # the validator would proceed against potentially wrong submodule content.
     diff = Shell.get_output(
         "git diff --raw --ignore-submodules=none "
-        f"{shlex.quote(merge_base)} {shlex.quote(checkout_sha)}"
+        f"{shlex.quote(merge_base)} {shlex.quote(checkout_sha)}",
+        strict=True,
     )
     changed = []
     for line in diff.splitlines():
@@ -244,6 +248,17 @@ def get_submodule_state_changes(merge_base, checkout_sha):
         if old_mode == "160000" or new_mode == "160000" or path == ".gitmodules":
             changed.append(path)
     return sorted(set(changed))
+
+
+def submodule_worktree_populated(path):
+    """True iff `path` contains real working-tree content, not just the bookkeeping
+    `.git` entry. After the working-tree files of a cached submodule are removed, git
+    can leave the directory holding exactly `['.git']` (a plain `git submodule update`
+    exits 0 in that state), so a bare `os.listdir` non-empty check would accept a
+    sourceless tree and the hardlink copy would propagate it into the before-worktree,
+    reintroducing the misleading cmake "cannot find source file" failure.
+    """
+    return any(entry != ".git" for entry in os.listdir(path))
 
 
 def ensure_primary_submodules():
@@ -327,12 +342,13 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
         path = path.strip()
         if not path or not os.path.isdir(path):
             continue
-        if not os.listdir(path):
-            # The primary checkout left this submodule empty. There is nothing to
-            # hardlink, and the build needs its sources, so record it as a hard failure
-            # instead of silently skipping it: a silent skip previously surfaced as a
-            # misleading cmake "cannot find source file" error rather than the
-            # infrastructure error it really is (see ensure_primary_submodules).
+        if not submodule_worktree_populated(path):
+            # The primary checkout left this submodule empty (possibly holding only the
+            # bookkeeping `.git` entry). There is nothing to hardlink, and the build
+            # needs its sources, so record it as a hard failure instead of silently
+            # skipping it: a silent skip previously surfaced as a misleading cmake
+            # "cannot find source file" error rather than the infrastructure error it
+            # really is (see ensure_primary_submodules).
             failures.append(f"{path}: empty in the primary checkout, cannot hardlink it")
             continue
         dst = os.path.join(BEFORE_SRC, path)
@@ -358,14 +374,14 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
             shlex.quote(os.path.dirname(dst)),
         )
         # cp -al = recursive hardlink copy (instant, no data duplication). Check the exit
-        # status AND that the destination ended up non-empty: an unchecked failed copy
-        # (e.g. cross-device link, ENOSPC) would otherwise leave the submodule empty and
-        # only fail much later inside cmake.
+        # status AND that the destination ended up with real content (not just a stray
+        # `.git` entry): an unchecked failed copy (e.g. cross-device link, ENOSPC) would
+        # otherwise leave the submodule empty and only fail much later inside cmake.
         ok = Shell.check(
             f"rm -rf -- {q_dst} && mkdir -p -- {q_dst_parent} && cp -al -- {q_path} {q_dst}",
             verbose=False,
         )
-        if not ok or not (os.path.isdir(dst) and os.listdir(dst)):
+        if not ok or not (os.path.isdir(dst) and submodule_worktree_populated(dst)):
             failures.append(f"{path}: hardlink copy into the before-worktree failed")
 
     if failures:

--- a/ci/jobs/unit_tests_bugfix_validation_job.py
+++ b/ci/jobs/unit_tests_bugfix_validation_job.py
@@ -223,8 +223,18 @@ def ensure_primary_submodules():
     ), "Failed to init submodules in the primary checkout"
     if os.path.isdir(".git/modules/contrib") and os.listdir(".git/modules/contrib"):
         print("Submodule cache detected — populating working trees from cache")
+        # `--force` is essential here (unlike build_clickhouse.py's checkout): the S3 cache
+        # restores each submodule's `.git/modules` data with `HEAD` already at the recorded
+        # gitlink, but the *working tree* is empty. Without `--force`, `git submodule update`
+        # sees `HEAD` == the recorded commit, considers the submodule up-to-date, and leaves
+        # the working tree empty. The hardlink step then finds nothing to copy and the
+        # before-binary fails to configure with a misleading "cannot find source file"
+        # error. `--force` runs `git checkout --force` unconditionally, repopulating the
+        # empty working tree from objects already present in the cache.
         ok = Shell.check(
-            "git submodule update --depth 1 --single-branch", retries=3, verbose=True
+            "git submodule update --force --depth 1 --single-branch",
+            retries=3,
+            verbose=True,
         )
     else:
         ok = Shell.check(
@@ -239,9 +249,14 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
     Submodule working trees are populated by hardlinking from the primary checkout
     (fast, no network) so the build sees contrib sources.  This is content-correct
     whenever the PR did not bump submodule pointers, which is the normal case for a
-    unit-test bugfix.  Returns True iff the worktree ended up with its submodules
-    populated (checked via SUBMODULE_MARKER) — the caller must fail close otherwise.
+    unit-test bugfix.  Returns True iff every submodule the primary checkout has was
+    hardlinked into the worktree non-empty — the caller must fail close otherwise.
     """
+    # Populate the primary checkout's submodule working trees FIRST, before touching the
+    # worktree: the hardlink step below has nothing to copy otherwise, and doing it up
+    # front keeps the worktree machinery from racing with submodule checkout.
+    ensure_primary_submodules()
+
     Shell.check(f"git worktree remove --force {BEFORE_SRC} ||:", verbose=True)
     Shell.check(f"rm -rf {BEFORE_SRC}", verbose=True)
     assert Shell.check(
@@ -261,19 +276,24 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
         verbose=True,
     ), "Failed to overlay unit-test files onto the merge-base worktree"
 
-    # The primary checkout must have populated submodule working trees before we can
-    # hardlink them across (see ensure_primary_submodules).
-    ensure_primary_submodules()
-
     # Populate submodules by hardlinking from the primary checkout.
     sub_paths = Shell.get_output(
         "git config --file .gitmodules --get-regexp '^submodule\\..*\\.path$' "
         "| awk '{print $2}'"
     ).splitlines()
     before_src_real = os.path.realpath(BEFORE_SRC)
+    failures = []
     for path in sub_paths:
         path = path.strip()
-        if not path or not os.path.isdir(path) or not os.listdir(path):
+        if not path or not os.path.isdir(path):
+            continue
+        if not os.listdir(path):
+            # The primary checkout left this submodule empty. There is nothing to
+            # hardlink, and the build needs its sources, so record it as a hard failure
+            # instead of silently skipping it: a silent skip previously surfaced as a
+            # misleading cmake "cannot find source file" error rather than the
+            # infrastructure error it really is (see ensure_primary_submodules).
+            failures.append(f"{path}: empty in the primary checkout, cannot hardlink it")
             continue
         dst = os.path.join(BEFORE_SRC, path)
         # SECURITY: defense in depth against a traversal path that somehow slipped past
@@ -297,10 +317,25 @@ def prepare_before_worktree(merge_base, pr_sha, test_files):
             shlex.quote(dst),
             shlex.quote(os.path.dirname(dst)),
         )
-        Shell.check(f"rm -rf -- {q_dst} && mkdir -p -- {q_dst_parent}", verbose=False)
-        # cp -al = recursive hardlink copy (instant, no data duplication).
-        Shell.check(f"cp -al -- {q_path} {q_dst}", verbose=False)
+        # cp -al = recursive hardlink copy (instant, no data duplication). Check the exit
+        # status AND that the destination ended up non-empty: an unchecked failed copy
+        # (e.g. cross-device link, ENOSPC) would otherwise leave the submodule empty and
+        # only fail much later inside cmake.
+        ok = Shell.check(
+            f"rm -rf -- {q_dst} && mkdir -p -- {q_dst_parent} && cp -al -- {q_path} {q_dst}",
+            verbose=False,
+        )
+        if not ok or not (os.path.isdir(dst) and os.listdir(dst)):
+            failures.append(f"{path}: hardlink copy into the before-worktree failed")
 
+    if failures:
+        print(
+            "Failed to populate before-worktree submodules:\n  " + "\n  ".join(failures)
+        )
+        return False
+
+    # Belt-and-suspenders on top of the per-submodule checks above: the marker file must
+    # exist in the worktree, confirming at least the reference submodule is really there.
     return os.path.isfile(os.path.join(BEFORE_SRC, SUBMODULE_MARKER))
 
 
@@ -506,9 +541,10 @@ def main():
                     name="Bugfix validation (unit tests)",
                     status=Result.Status.ERROR,
                     info=(
-                        f"Submodules were not populated in the before-worktree (missing "
-                        f"'{SUBMODULE_MARKER}'); cannot build the before-binary. This is "
-                        "an infrastructure error — NOT a reproduction."
+                        "Submodules were not fully populated in the before-worktree "
+                        "(see the job log for the specific submodule that could not be "
+                        "hardlinked); cannot build the before-binary. This is an "
+                        "infrastructure error — NOT a reproduction."
                     ),
                 )
             ],

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -333,17 +333,21 @@ def _run_submodule_state_changes(monkeypatch, raw_diff):
     calls = []
 
     def fake_get_output(cmd, **kwargs):
-        calls.append(cmd)
+        calls.append((cmd, kwargs))
         return raw_diff
 
     monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
     changed = job.get_submodule_state_changes("mergebase123", "checkouthead456")
 
     assert len(calls) == 1
-    cmd = calls[0]
+    cmd, kwargs = calls[0]
     # `diff.ignoreSubmodules=all` in the environment would otherwise silently
     # drop every gitlink change and the guard would never fire.
     assert "--ignore-submodules=none" in cmd
+    # The guard must fail CLOSE on a failed diff: without strict, Shell.get_output
+    # swallows a non-zero git exit (missing object in the shallow checkout, transient
+    # error) into an empty string and the guard would silently disable itself.
+    assert kwargs.get("strict") is True
     # The diff endpoints are exactly the two commits the caller chose — the
     # merge-base and the checkout whose submodule trees are actually copied.
     assert "mergebase123" in cmd and "checkouthead456" in cmd
@@ -399,6 +403,57 @@ def test_submodule_state_changes_ignores_malformed_lines(monkeypatch):
         ":160000 160000 3333333 4444444 M\tcontrib/zstd\n"
     )
     assert _run_submodule_state_changes(monkeypatch, raw_diff) == ["contrib/zstd"]
+
+
+def test_submodule_state_changes_raises_on_diff_failure(monkeypatch):
+    # A failed `git diff` must propagate (fail close), not be treated as "no
+    # changes": with strict=True, Shell.get_output raises on a non-zero exit,
+    # and the guard must not catch it.
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    def fake_get_output(cmd, **kwargs):
+        if kwargs.get("strict"):
+            raise RuntimeError("command failed with, exit_code 128")
+        return ""
+
+    monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
+    with pytest.raises(RuntimeError):
+        job.get_submodule_state_changes("mergebase123", "checkouthead456")
+
+
+# --------------------------------------------------------------------------
+# submodule_worktree_populated: a submodule directory holding only the
+# bookkeeping `.git` entry has no sources — git can leave exactly that state
+# after a plain `git submodule update` when the cached gitdir exists but the
+# working-tree files were removed. A bare `os.listdir` non-empty check would
+# accept it and the hardlink copy would propagate an unbuildable tree.
+# --------------------------------------------------------------------------
+def test_submodule_worktree_populated_rejects_git_only_dir(tmp_path):
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    sub = tmp_path / "contrib" / "abseil-cpp"
+    sub.mkdir(parents=True)
+    (sub / ".git").write_text("gitdir: ../../.git/modules/contrib/abseil-cpp\n")
+    assert job.submodule_worktree_populated(str(sub)) is False
+
+
+def test_submodule_worktree_populated_rejects_empty_dir(tmp_path):
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    sub = tmp_path / "contrib" / "zstd"
+    sub.mkdir(parents=True)
+    assert job.submodule_worktree_populated(str(sub)) is False
+
+
+def test_submodule_worktree_populated_accepts_real_content(tmp_path):
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    sub = tmp_path / "contrib" / "zstd"
+    sub.mkdir(parents=True)
+    (sub / ".git").write_text("gitdir: ../../.git/modules/contrib/zstd\n")
+    (sub / "lib").mkdir()
+    (sub / "lib" / "zstd.h").write_text("// header\n")
+    assert job.submodule_worktree_populated(str(sub)) is True
 
 
 def test_main_guard_compares_merge_base_against_checkout_head(monkeypatch):

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -317,6 +317,85 @@ def test_determine_merge_base_uses_pr_head_not_git_head(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# get_submodule_state_changes: the fail-close guard against a bugfix PR that
+# changes submodule state. The before-worktree hardlinks submodule working
+# trees from the primary checkout (at PR-head revisions), so a changed gitlink
+# or `.gitmodules` would make the "before" binary silently build against the
+# wrong submodule content — the guard must detect it from the raw diff.
+# --------------------------------------------------------------------------
+def _run_submodule_state_changes(monkeypatch, raw_diff):
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    calls = []
+
+    def fake_get_output(cmd, **kwargs):
+        calls.append(cmd)
+        return raw_diff
+
+    monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
+    changed = job.get_submodule_state_changes("mergebase123", "prhead456")
+
+    assert len(calls) == 1
+    cmd = calls[0]
+    # `diff.ignoreSubmodules=all` in the environment would otherwise silently
+    # drop every gitlink change and the guard would never fire.
+    assert "--ignore-submodules=none" in cmd
+    assert "mergebase123" in cmd and "prhead456" in cmd
+    return changed
+
+
+def test_submodule_state_changes_detects_gitlink_bump(monkeypatch):
+    raw_diff = (
+        ":100644 100644 1111111 2222222 M\tsrc/Common/tests/gtest_foo.cpp\n"
+        ":160000 160000 3333333 4444444 M\tcontrib/zstd\n"
+    )
+    assert _run_submodule_state_changes(monkeypatch, raw_diff) == ["contrib/zstd"]
+
+
+def test_submodule_state_changes_detects_added_and_removed_gitlinks(monkeypatch):
+    # An added submodule has old_mode 000000, a removed one new_mode 000000 —
+    # 160000 appears on only one side, and both must still be caught.
+    raw_diff = (
+        ":000000 160000 0000000 5555555 A\tcontrib/new-lib\n"
+        ":160000 000000 6666666 0000000 D\tcontrib/old-lib\n"
+    )
+    assert _run_submodule_state_changes(monkeypatch, raw_diff) == [
+        "contrib/new-lib",
+        "contrib/old-lib",
+    ]
+
+
+def test_submodule_state_changes_detects_gitmodules_only_edit(monkeypatch):
+    raw_diff = ":100644 100644 7777777 8888888 M\t.gitmodules\n"
+    assert _run_submodule_state_changes(monkeypatch, raw_diff) == [".gitmodules"]
+
+
+def test_submodule_state_changes_clean_diff(monkeypatch):
+    # Regular file changes only — no gitlinks, no `.gitmodules` — must not trip
+    # the guard, or every bugfix PR would fail close.
+    raw_diff = (
+        ":100644 100644 1111111 2222222 M\tsrc/Common/tests/gtest_foo.cpp\n"
+        ":100644 100644 3333333 4444444 M\tsrc/Common/Foo.cpp\n"
+    )
+    assert _run_submodule_state_changes(monkeypatch, raw_diff) == []
+
+
+def test_submodule_state_changes_empty_diff(monkeypatch):
+    assert _run_submodule_state_changes(monkeypatch, "") == []
+
+
+def test_submodule_state_changes_ignores_malformed_lines(monkeypatch):
+    # Non-raw output lines (or a truncated raw entry) must be skipped, not crash
+    # or produce bogus paths.
+    raw_diff = (
+        "warning: some noise from git\n"
+        ":160000\tcontrib/truncated-meta\n"
+        ":160000 160000 3333333 4444444 M\tcontrib/zstd\n"
+    )
+    assert _run_submodule_state_changes(monkeypatch, raw_diff) == ["contrib/zstd"]
+
+
+# --------------------------------------------------------------------------
 # before_run_started_a_test: the "[ RUN ]"-marker guard. A clean before-run
 # that executed no touched test (marker absent) must NOT be treated as a
 # refutation — `unit_tests_dbms` is built from `gtest*.cpp` only, so a touched

--- a/ci/tests/test_unit_tests_bugfix_validation.py
+++ b/ci/tests/test_unit_tests_bugfix_validation.py
@@ -317,11 +317,15 @@ def test_determine_merge_base_uses_pr_head_not_git_head(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# get_submodule_state_changes: the fail-close guard against a bugfix PR that
-# changes submodule state. The before-worktree hardlinks submodule working
-# trees from the primary checkout (at PR-head revisions), so a changed gitlink
-# or `.gitmodules` would make the "before" binary silently build against the
-# wrong submodule content — the guard must detect it from the raw diff.
+# get_submodule_state_changes: the fail-close guard against submodule state
+# differing between the merge-base and the checkout. The before-worktree
+# hardlinks submodule working trees from the primary checkout, whose
+# submodules are at the checkout `HEAD`'s recorded revisions (normally the
+# synthetic base+PR merge ref) — so both a PR-side gitlink/`.gitmodules` edit
+# and a base-only submodule bump after the branch split would make the
+# "before" binary silently build against the wrong submodule content. The
+# guard must detect any such difference from the raw diff of the two commits
+# it is given (main() passes merge-base and `git rev-parse HEAD`).
 # --------------------------------------------------------------------------
 def _run_submodule_state_changes(monkeypatch, raw_diff):
     import ci.jobs.unit_tests_bugfix_validation_job as job
@@ -333,14 +337,16 @@ def _run_submodule_state_changes(monkeypatch, raw_diff):
         return raw_diff
 
     monkeypatch.setattr(job.Shell, "get_output", staticmethod(fake_get_output))
-    changed = job.get_submodule_state_changes("mergebase123", "prhead456")
+    changed = job.get_submodule_state_changes("mergebase123", "checkouthead456")
 
     assert len(calls) == 1
     cmd = calls[0]
     # `diff.ignoreSubmodules=all` in the environment would otherwise silently
     # drop every gitlink change and the guard would never fire.
     assert "--ignore-submodules=none" in cmd
-    assert "mergebase123" in cmd and "prhead456" in cmd
+    # The diff endpoints are exactly the two commits the caller chose — the
+    # merge-base and the checkout whose submodule trees are actually copied.
+    assert "mergebase123" in cmd and "checkouthead456" in cmd
     return changed
 
 
@@ -393,6 +399,59 @@ def test_submodule_state_changes_ignores_malformed_lines(monkeypatch):
         ":160000 160000 3333333 4444444 M\tcontrib/zstd\n"
     )
     assert _run_submodule_state_changes(monkeypatch, raw_diff) == ["contrib/zstd"]
+
+
+def test_main_guard_compares_merge_base_against_checkout_head(monkeypatch):
+    """main() must pass the checkout `HEAD` — the commit whose submodule working trees
+    are actually hardlinked into the before-worktree — to the fail-close guard, NOT the
+    PR head. Diffing merge-base vs the PR head misses a base-only submodule bump after
+    the branch split (the PR's own diff is clean), yet `ensure_primary_submodules`
+    checks out the base-tip revision and the hardlink step copies it into the
+    merge-base worktree, so the before-binary would build against the wrong contrib
+    sources and could report a false reproduction/refutation.
+    """
+    import ci.jobs.unit_tests_bugfix_validation_job as job
+
+    class _Info:
+        pr_labels = ["pr-bugfix"]
+        sha = "prheadsha777"
+        base_branch = "master"
+        is_local_run = False
+
+        def get_changed_files(self):
+            return []
+
+    guard_calls = []
+    finalized = []
+
+    monkeypatch.setattr(job, "Info", _Info)
+    monkeypatch.setattr(
+        job, "get_changed_unit_test_files", lambda info: ["src/X/tests/gtest_a.cpp"]
+    )
+    monkeypatch.setattr(job, "derive_test_suites", lambda files: ["SuiteA"])
+    monkeypatch.setattr(job, "gitmodules_shape_violation", lambda: None)
+    monkeypatch.setattr(job, "determine_merge_base", lambda info: "mergebase123")
+    # HEAD resolves to the synthetic merge-ref commit, different from the PR head.
+    monkeypatch.setattr(
+        job.Shell,
+        "get_output",
+        staticmethod(lambda cmd, **kw: "mergerefhead999" if "rev-parse HEAD" in cmd else ""),
+    )
+
+    def fake_guard(merge_base, checkout_sha):
+        guard_calls.append((merge_base, checkout_sha))
+        # Report a base-side drift so main() stops at the guard (fail close).
+        return ["contrib/zstd"]
+
+    monkeypatch.setattr(job, "get_submodule_state_changes", fake_guard)
+    monkeypatch.setattr(
+        job, "finalize", lambda results, info_lines: finalized.append(info_lines)
+    )
+
+    job.main()
+
+    assert guard_calls == [("mergebase123", "mergerefhead999")]
+    assert finalized and "inconclusive" in finalized[0]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110833
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix the `Bugfix validation (unit tests)` job failing to configure the "before" binary.


### Description

The `Bugfix validation (unit tests)` job builds a "before" binary from the merge-base sources (with only the PR's unit-test files overlaid) and checks that the new test fails without the fix. It populates the before-worktree's submodule working trees by hardlinking them from the primary checkout, whose submodules are checked out by `ensure_primary_submodules` with `git submodule update --depth 1 --single-branch`.

When the runner restores the submodule S3 cache, each submodule's `.git/modules` data is present with `HEAD` already at the recorded gitlink, but the working tree is empty. In that state `git submodule update` (without `--force`) sees `HEAD` == the recorded commit, considers the submodule up to date, and leaves the working tree empty. The hardlink loop then found `contrib/abseil-cpp` empty in the primary checkout, silently `continue`d past it, and `cmake` later failed with a misleading `Cannot find source file ... throw_delegate.cc / borrowed_fixup_buffer.cc`. This is an infrastructure problem that surfaced as a red job which never actually validated the bugfix.

Fixes:

- `ensure_primary_submodules`: add `--force` so `git submodule update` runs `git checkout --force` unconditionally and repopulates a submodule whose `HEAD` already matches but whose working tree is empty. Verified in isolation: with the `.git` link and module `HEAD` present at the recorded commit but the files removed, plain `update` leaves the working tree empty while `--force` restores it.
- `prepare_before_worktree`: run `ensure_primary_submodules` before creating the worktree; check the `cp -al` exit status and that the destination ended up with real content (a directory holding only the bookkeeping `.git` entry counts as empty); treat a submodule that is empty in the primary checkout as a hard failure instead of silently skipping it. Any failure now fails close with a precise per-submodule message and the job reports an infrastructure `ERROR` rather than a spurious `cmake` source-file error.
- Fail close when submodule state (any gitlink or `.gitmodules`) differs between the merge-base and the checkout `HEAD` (normally GitHub's synthetic base+PR merge ref, whose submodule working trees are what gets hardlinked): whether the PR edits submodule state or the base branch moved a submodule after the branch split, the before-binary would otherwise silently build merge-base sources against the wrong submodule content and could report a false reproduction/refutation. The job reports an infrastructure `ERROR` (inconclusive) instead. The guard's `git diff` is strict: a failed diff raises instead of silently disabling the guard. Covered by focused unit tests in `ci/tests/test_unit_tests_bugfix_validation.py`.

Surfaced by the `Bugfix validation (unit tests)` job on https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110833&sha=1fd7b845e718f6d4ce0f2dbffb5a44b20d43eb9e&name_0=PR&name_1=Bugfix%20validation%20%28unit%20tests%29 (PR https://github.com/ClickHouse/ClickHouse/pull/110833).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.129` (included in `26.8` and later)
<!-- ch-version-info:end -->