### PR TITLE
Skip async insert dedup prewarm when deduplication is disabled; extend prewarm test coverage

### DIFF
--- a/src/Interpreters/InsertDeduplication.cpp
+++ b/src/Interpreters/InsertDeduplication.cpp
@@ -473,6 +473,11 @@ std::vector<DeduplicationHash> DeduplicationInfo::getDeduplicationHashes(const s
 
 void DeduplicationInfo::prewarmDataHashes() const
 {
+    /// When disabled the hashes are never consumed (deduplicateSelf/getDeduplicationHashes
+    /// early-return), so warming them would be a wasted O(rows x cols x tokens) pass.
+    if (disabled)
+        return;
+
     if (!original_block || !original_block->rows())
         return;
 

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -66,6 +66,8 @@ protected:
     friend std::vector<Int64> testSelfDeduplicate(std::vector<Int64> data, std::vector<size_t> offsets, std::vector<String> hashes);
     friend std::vector<String> testSelfDeduplicateStrings(std::vector<String> data, std::vector<size_t> offsets, std::vector<String> hashes);
     friend std::vector<String> testPrewarmDataHashes(std::vector<String> data, std::vector<size_t> offsets);
+    friend std::vector<String> testPrewarmFilterToPartition(std::vector<String> data, std::vector<size_t> token_offsets, std::vector<UInt64> row_to_partition, size_t num_partitions, bool prewarm);
+    friend bool testPrewarmPopulatesCache(std::vector<String> data, std::vector<size_t> token_offsets, std::vector<UInt64> row_to_partition, size_t num_partitions);
 
 public:
     using Ptr = std::shared_ptr<DeduplicationInfo>;

--- a/src/Interpreters/InsertDeduplication.h
+++ b/src/Interpreters/InsertDeduplication.h
@@ -68,6 +68,7 @@ protected:
     friend std::vector<String> testPrewarmDataHashes(std::vector<String> data, std::vector<size_t> offsets);
     friend std::vector<String> testPrewarmFilterToPartition(std::vector<String> data, std::vector<size_t> token_offsets, std::vector<UInt64> row_to_partition, size_t num_partitions, bool prewarm);
     friend bool testPrewarmPopulatesCache(std::vector<String> data, std::vector<size_t> token_offsets, std::vector<UInt64> row_to_partition, size_t num_partitions);
+    friend bool testPrewarmDisabledIsNoop(std::vector<String> data, std::vector<size_t> token_offsets);
 
 public:
     using Ptr = std::shared_ptr<DeduplicationInfo>;

--- a/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
+++ b/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
@@ -315,4 +315,41 @@ TEST(AsyncInsertsTest, testPrewarmPopulatesCache)
     EXPECT_TRUE(testPrewarmPopulatesCache({"A","X","A","X","B","Y"}, {2,4,6}, {0,0,0,0,1,1}, 2));
 }
 
+
+/// A disabled info (async insert with async_insert_deduplicate=0, the default) reaches the sink prewarm
+/// call because the guard tests the sink-level `deduplicate` (replicated_deduplication_window!=0), not
+/// `disabled`; but deduplicateSelf/getDeduplicationHashes early-return, so warming hashes is wasted work.
+/// Returns true iff prewarmDataHashes left every empty-token cache untouched on a disabled info.
+bool testPrewarmDisabledIsNoop(std::vector<String> data, std::vector<size_t> token_offsets)
+{
+    MutableColumnPtr column = DataTypeString().createColumn();
+    for (const auto & datum : data)
+        column->insert(datum);
+    Block block({ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "a")});
+
+    auto info = DeduplicationInfo::create(true);
+    info->setRootViewID({});
+    /// Populate the block with dedup enabled, then flip to disabled to model the state the sink sees:
+    /// block present, tokens set, but deduplication off (updateOriginalBlock skips a disabled info).
+    info->disabled = false;
+    info->updateOriginalBlock(Chunk(block.getColumns(), block.rows()), std::make_shared<const Block>(block.cloneEmpty()));
+    info->setUserToken("", token_offsets[0]);
+    for (size_t i = 1; i < token_offsets.size(); ++i)
+        info->setUserToken("", token_offsets[i] - token_offsets[i - 1]);
+    info->disabled = true;
+
+    info->prewarmDataHashes();
+
+    for (const auto & t : info->tokens)
+        if (t.by_user.empty() && t.data_hash_batch.has_value())
+            return false;
+    return true;
+}
+
+TEST(AsyncInsertsTest, testPrewarmDisabledIsNoop)
+{
+    EXPECT_TRUE(testPrewarmDisabledIsNoop({"A","A","B","B","C","A"}, {1,2,3,4,5,6}));
+    EXPECT_TRUE(testPrewarmDisabledIsNoop({"A","X","A","X","B","Y"}, {2,4,6}));
+}
+
 }

--- a/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
+++ b/src/Storages/MergeTree/tests/gtest_async_inserts.cpp
@@ -192,4 +192,127 @@ TEST(AsyncInsertsTest, testPrewarmDataHashes)
     test_impl({"x","x","x"}, {1,2,3}, {"x"});
 }
 
+
+/// Drive the real sink hot path: prewarm the batched block once, then split it per partition via
+/// filterToPartition (which builds a per-partition DeduplicationInfo copy) and self-deduplicate each
+/// partition. Returns surviving rows in (partition, row) order. With prewarm the cached hash is
+/// carried into each per-partition copy; without it each copy recomputes — the result must match.
+std::vector<String> testPrewarmFilterToPartition(
+    std::vector<String> data, std::vector<size_t> token_offsets,
+    std::vector<UInt64> row_to_partition, size_t num_partitions, bool prewarm)
+{
+    MutableColumnPtr column = DataTypeString().createColumn();
+    for (const auto & datum : data)
+        column->insert(datum);
+    Block block({ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "a")});
+
+    auto deduplication_info = DeduplicationInfo::create(true);
+    deduplication_info->setRootViewID({});
+    deduplication_info->disabled = false;
+    deduplication_info->updateOriginalBlock(Chunk(block.getColumns(), block.rows()), std::make_shared<const Block>(block.cloneEmpty()));
+
+    /// Empty user token → data-hash path (the one prewarmDataHashes covers). One token per entry.
+    deduplication_info->setUserToken("", token_offsets[0]);
+    for (size_t i = 1; i < token_offsets.size(); ++i)
+        deduplication_info->setUserToken("", token_offsets[i] - token_offsets[i - 1]);
+
+    if (prewarm)
+        deduplication_info->prewarmDataHashes();
+
+    PaddedPODArray<UInt64> selector;
+    for (auto p : row_to_partition)
+        selector.push_back(p);
+
+    std::vector<String> result;
+    for (size_t p = 0; p < num_partitions; ++p)
+    {
+        /// partition_id does not affect empty-token grouping (data hash is partition-independent).
+        auto part_info = deduplication_info->filterToPartition(selector, p);
+        auto filtered = part_info->filterImpl(part_info->filterSelf("all"));
+
+        const auto & out_block = (filtered.removed_rows == 0 || !filtered.filtered_block)
+            ? part_info->original_block : filtered.filtered_block;
+        if (!out_block)
+            continue;
+        ColumnPtr col = out_block->getColumns()[0];
+        for (size_t i = 0; i < col->size(); ++i)
+            result.push_back(String(col->getDataAt(i)));
+    }
+    return result;
+}
+
+TEST(AsyncInsertsTest, testPrewarmFilterToPartition)
+{
+    auto build = [](std::vector<String> data, std::vector<size_t> offsets, std::vector<UInt64> rtp, size_t parts)
+    {
+        auto warm = testPrewarmFilterToPartition(data, offsets, rtp, parts, /*prewarm=*/true);
+        auto cold = testPrewarmFilterToPartition(data, offsets, rtp, parts, /*prewarm=*/false);
+        /// The prewarm optimization must not change the deduplication result.
+        EXPECT_EQ(warm, cold);
+        return warm;
+    };
+
+    /// Single-row tokens across 2 partitions. p0 rows {0,1,4}=[A,A,C]->[A,C]; p1 rows {2,3,5}=[B,B,A]->[B,A].
+    EXPECT_EQ(build({"A","A","B","B","C","A"}, {1,2,3,4,5,6}, {0,0,1,1,0,1}, 2),
+              (std::vector<String>{"A","C","B","A"}));
+    /// Multi-row tokens. p0 keeps tokens {0,1}=[A,X,A,X]->[A,X] (dup dropped); p1 keeps token{2}=[B,Y].
+    EXPECT_EQ(build({"A","X","A","X","B","Y"}, {2,4,6}, {0,0,0,0,1,1}, 2),
+              (std::vector<String>{"A","X","B","Y"}));
+    /// All tokens in one partition: filterToPartition keeps everything, self-dedup collapses duplicates.
+    EXPECT_EQ(build({"A","B","A","B","C"}, {1,2,3,4,5}, {0,0,0,0,0}, 1),
+              (std::vector<String>{"A","B","C"}));
+}
+
+
+/// Verify prewarmDataHashes populates the per-token cache and that filterToPartition carries it into
+/// the per-partition copies, while without prewarm those copies start cold (cache filled lazily later).
+bool testPrewarmPopulatesCache(
+    std::vector<String> data, std::vector<size_t> token_offsets,
+    std::vector<UInt64> row_to_partition, size_t num_partitions)
+{
+    auto build = [&](bool prewarm)
+    {
+        MutableColumnPtr column = DataTypeString().createColumn();
+        for (const auto & datum : data)
+            column->insert(datum);
+        Block block({ColumnWithTypeAndName(std::move(column), std::make_shared<DataTypeString>(), "a")});
+
+        auto info = DeduplicationInfo::create(true);
+        info->setRootViewID({});
+        info->disabled = false;
+        info->updateOriginalBlock(Chunk(block.getColumns(), block.rows()), std::make_shared<const Block>(block.cloneEmpty()));
+        info->setUserToken("", token_offsets[0]);
+        for (size_t i = 1; i < token_offsets.size(); ++i)
+            info->setUserToken("", token_offsets[i] - token_offsets[i - 1]);
+        if (prewarm)
+            info->prewarmDataHashes();
+        return info;
+    };
+
+    PaddedPODArray<UInt64> selector;
+    for (auto p : row_to_partition)
+        selector.push_back(p);
+
+    auto warm = build(true);
+    auto cold = build(false);
+    for (size_t p = 0; p < num_partitions; ++p)
+    {
+        auto warm_part = warm->filterToPartition(selector, p);
+        auto cold_part = cold->filterToPartition(selector, p);
+        for (const auto & t : warm_part->tokens)
+            if (t.by_user.empty() && !t.data_hash_batch.has_value())
+                return false;
+        for (const auto & t : cold_part->tokens)
+            if (t.by_user.empty() && t.data_hash_batch.has_value())
+                return false;
+    }
+    return true;
+}
+
+TEST(AsyncInsertsTest, testPrewarmPopulatesCache)
+{
+    EXPECT_TRUE(testPrewarmPopulatesCache({"A","A","B","B","C","A"}, {1,2,3,4,5,6}, {0,0,1,1,0,1}, 2));
+    EXPECT_TRUE(testPrewarmPopulatesCache({"A","X","A","X","B","Y"}, {2,4,6}, {0,0,0,0,1,1}, 2));
+}
+
 }

--- a/tests/queries/0_stateless/04603_async_insert_dedup_multi_partition.reference
+++ b/tests/queries/0_stateless/04603_async_insert_dedup_multi_partition.reference
@@ -1,5 +1,16 @@
+single-flush
 4
 4
+8
+0	A
+0	E
+1	B
+1	F
+2	C
+2	G
+3	D
+3	H
+batched-flush
 8
 0	A
 0	E

--- a/tests/queries/0_stateless/04603_async_insert_dedup_multi_partition.sql
+++ b/tests/queries/0_stateless/04603_async_insert_dedup_multi_partition.sql
@@ -1,15 +1,20 @@
 -- Async insert deduplication must work correctly when an INSERT spans multiple partitions.
 -- The deduplication hash for each token is computed once (via prewarmDataHashes) and then
--- inherited by per-partition clones, so this test verifies both correctness and that the
--- optimisation does not introduce any hash-collision false positives or false negatives.
+-- inherited by per-partition clones, so this verifies both correctness and that the optimisation
+-- introduces no hash-collision false positives or negatives. The batched scenario below queues
+-- several async inserts into one flush so the sink builds multi-token per-partition
+-- DeduplicationInfo copies (the prewarmDataHashes -> filterToPartition -> filterImpl hot path).
 
 DROP TABLE IF EXISTS t;
+DROP TABLE IF EXISTS t2;
 
 CREATE TABLE t (key Int64, value String)
 ENGINE = MergeTree
 PARTITION BY key % 4
 ORDER BY tuple()
 SETTINGS non_replicated_deduplication_window = 100;
+
+SELECT 'single-flush';
 
 -- First insert: 4 rows spread across 4 partitions.
 INSERT INTO t SETTINGS async_insert = 1, wait_for_async_insert = 1, async_insert_deduplicate = 1
@@ -31,4 +36,28 @@ SELECT count() FROM t;
 
 SELECT * FROM t ORDER BY key, value;
 
+SELECT 'batched-flush';
+
+CREATE TABLE t2 (key Int64, value String)
+ENGINE = MergeTree
+PARTITION BY key % 4
+ORDER BY tuple()
+SETTINGS non_replicated_deduplication_window = 100;
+
+-- Queue several multi-partition async inserts into ONE flush (wait_for_async_insert = 0 + adaptive
+-- timeout off) so the sink sees multiple tokens in one consume and filterToPartition must split them.
+SET async_insert = 1, wait_for_async_insert = 0, async_insert_deduplicate = 1;
+SET async_insert_use_adaptive_busy_timeout = 0, async_insert_busy_timeout_min_ms = 5000, async_insert_busy_timeout_max_ms = 600000;
+
+INSERT INTO t2 VALUES (0,'A'),(1,'B'),(2,'C'),(3,'D');
+INSERT INTO t2 VALUES (0,'A'),(1,'B'),(2,'C'),(3,'D');  -- identical -> fully deduplicated
+INSERT INTO t2 VALUES (0,'E'),(1,'F'),(2,'G'),(3,'H');  -- distinct -> survives
+
+SYSTEM FLUSH ASYNC INSERT QUEUE t2;
+
+-- Regardless of how the entries coalesce, the deduplicated result is 8 rows.
+SELECT count() FROM t2;
+SELECT * FROM t2 ORDER BY key, value;
+
 DROP TABLE t;
+DROP TABLE t2;


### PR DESCRIPTION
`prewarmDataHashes` is called from the sinks before the per-partition loop. When the `DeduplicationInfo` is disabled, the warmed hashes are never consumed (`deduplicateSelf`/`getDeduplicationHashes` early-return), so the warm-up would be a wasted O(rows × cols × tokens) pass; return early inside the method as well, in addition to the `isDisabled` check at the call sites.

Also extends test coverage for the prewarm path introduced in https://github.com/ClickHouse/ClickHouse/pull/111150: unit tests driving the real `prewarmDataHashes` -> `filterToPartition` -> self-deduplication hot path with multi-row tokens across partitions, a cache-population assertion, a disabled-is-noop assertion, and a batched-flush scenario in `04603_async_insert_dedup_multi_partition` where several async inserts coalesce into a single flush.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Related: https://github.com/ClickHouse/ClickHouse/pull/111150


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.37` (included in `26.8` and later)
<!-- ch-version-info:end -->