### PR TITLE
clickhouse-test: fix lldb backtrace collection on hung/dead server

### DIFF
--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -24,6 +24,7 @@ Post-fix: the helpers run to completion against a live server.
 
 import argparse
 import io
+import os
 import runpy
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -64,6 +65,10 @@ def _make_args():
         replicated_database=False,
         shared_catalog=False,
         force_color=False,
+        binary=os.environ.get("CLICKHOUSE_BINARY", "clickhouse"),
+        # A reachable server means __main__ collected build flags at startup;
+        # a non-ASan set keeps print_c_stacktraces on its lldb path.
+        build_flags=set(),
     )
 
 
@@ -96,3 +101,28 @@ def test_print_sql_stacktraces_against_live_server():
     # output confirms the round-trip succeeded.
     assert "Collecting stacktraces from system.stack_trace table" in output, output
     assert "trace_str" in output or "thread_name" in output, output
+
+
+def test_is_asan_build_uses_collected_flags():
+    # Normal path: build flags were collected while the server was reachable,
+    # so membership in the set decides — no binary query needed.
+    ct = _load_clickhouse_test()
+    args = _make_args()
+
+    args.build_flags = {ct["BuildFlags"].ADDRESS}
+    assert ct["is_asan_build"](args) is True
+
+    args.build_flags = set()
+    assert ct["is_asan_build"](args) is False
+
+
+def test_is_asan_build_falls_back_to_binary_when_flags_missing():
+    # Startup-failure path: flags were never collected (server never served a
+    # query), so the ASan bit is read from the binary itself rather than from
+    # ASAN_OPTIONS. The CI tests job runs a master release build, not an ASan
+    # build, so this must resolve to False without raising.
+    ct = _load_clickhouse_test()
+    args = _make_args()
+    delattr(args, "build_flags")
+
+    assert ct["is_asan_build"](args) is False

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1112,16 +1112,18 @@ def get_all_server_pids():
 
 
 def is_asan_build(args):
-    """Check if the server is an ASan build — attaching a debugger disables LeakSanitizer detections."""
-    try:
-        result = clickhouse_execute(
-            args,
-            "SELECT count() FROM system.build_options WHERE name = 'CXX_FLAGS' AND position('sanitize=address' IN value)",
-        )
-        return result != b"0"
-    except Exception:
-        # If we can't query the server, check environment variable as fallback.
-        return bool(os.environ.get("ASAN_OPTIONS"))
+    """Check if the server is an ASan build — attaching a debugger disables LeakSanitizer detections.
+
+    Use the build flags collected at startup rather than a live query. This function gates
+    `print_c_stacktraces`, which runs precisely when the server is hung or dead: a live query
+    would then throw and fall back to `ASAN_OPTIONS`, which is exported on some runners (e.g.
+    macOS) even for non-ASan builds, wrongly reporting ASan and suppressing the lldb backtraces.
+    """
+    build_flags = getattr(args, "build_flags", None)
+    if build_flags is not None:
+        return BuildFlags.ADDRESS in build_flags
+    # Build flags not collected yet (server never started): fall back to the environment.
+    return bool(os.environ.get("ASAN_OPTIONS"))
 
 
 def print_c_stacktraces(args) -> None:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1128,7 +1128,8 @@ def is_asan_build(args):
     # hung-check path). Read the ASan bit straight from the binary via `clickhouse
     # local`, which is independent of server state. ASAN_OPTIONS is not a usable
     # signal here: the fast macOS runners export it even for non-ASan builds.
-    local = find_clickhouse_command(args.binary, "local")
+    binary = getattr(args, "binary", "clickhouse")
+    local = find_clickhouse_command(binary, "local")
     out = shell_get_output(
         f"{local} --query \"SELECT count() FROM system.build_options "
         f"WHERE name = 'CXX_FLAGS' AND position('sanitize=address' IN value)\"",

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1115,15 +1115,26 @@ def is_asan_build(args):
     """Check if the server is an ASan build — attaching a debugger disables LeakSanitizer detections.
 
     Use the build flags collected at startup rather than a live query. This function gates
-    `print_c_stacktraces`, which runs precisely when the server is hung or dead: a live query
-    would then throw and fall back to `ASAN_OPTIONS`, which is exported on some runners (e.g.
-    macOS) even for non-ASan builds, wrongly reporting ASan and suppressing the lldb backtraces.
+    `print_c_stacktraces`, which runs precisely when the server is hung or dead, so a live
+    query would throw. If the flags were never collected (server never started), read the bit
+    from the binary via `clickhouse local` instead of trusting `ASAN_OPTIONS`, which is
+    exported on some runners (e.g. macOS) even for non-ASan builds and would wrongly report
+    ASan and suppress the lldb backtraces.
     """
     build_flags = getattr(args, "build_flags", None)
     if build_flags is not None:
         return BuildFlags.ADDRESS in build_flags
-    # Build flags not collected yet (server never started): fall back to the environment.
-    return bool(os.environ.get("ASAN_OPTIONS"))
+    # Build flags not collected yet (server never started, e.g. the startup-failure
+    # hung-check path). Read the ASan bit straight from the binary via `clickhouse
+    # local`, which is independent of server state. ASAN_OPTIONS is not a usable
+    # signal here: the fast macOS runners export it even for non-ASan builds.
+    local = find_clickhouse_command(args.binary, "local")
+    out = shell_get_output(
+        f"{local} --query \"SELECT count() FROM system.build_options "
+        f"WHERE name = 'CXX_FLAGS' AND position('sanitize=address' IN value)\"",
+        timeout=60,
+    )
+    return out.strip() not in ("", "0")
 
 
 def print_c_stacktraces(args) -> None:


### PR DESCRIPTION
On the `Fast test (arm_darwin)` runner the server occasionally hangs (all query execution wedged while background threads keep running), and the hung check reports `Server died`. `clickhouse-test` already tries to dump C++ backtraces via lldb in that situation (`print_c_stacktraces`), but on macOS it self-skips with `Cannot collect C stacktraces under ASan: debugger attach is disabled.` even though the fast build is not an ASan build.

The cause is `is_asan_build`: it decided the build type with a live query against `system.build_options`. On a hung check the server is unresponsive by definition, so the query throws and the code falls back to `bool(os.environ.get("ASAN_OPTIONS"))`. That env var is exported on the macOS runner even for the non-ASan fast build, producing a false ASan positive and suppressing lldb precisely when the backtraces are most needed.

`is_asan_build` now reads the build flags already collected at startup (`args.build_flags`, populated from `system.build_options` while the server was reachable), and only falls back to the environment when the flags were never collected (server never started). Real ASan runs keep skipping lldb (attach disables `LeakSanitizer`); non-ASan hung/dead servers now get their thread backtraces dumped.

CI report that motivated this: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110975&sha=b60402e9e7543932cd7576f12219485a5c8c5c12&name_0=PR&name_1=Fast+test+%28arm_darwin%29

Related: https://github.com/ClickHouse/ClickHouse/issues/108689

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.96` (included in `26.8` and later)
<!-- ch-version-info:end -->