### PR TITLE
Document the S3Queue/AzureQueue power-loss data-loss window and its fsync mitigation

### DIFF
--- a/docs/en/engines/table-engines/integrations/azure-queue.md
+++ b/docs/en/engines/table-engines/integrations/azure-queue.md
@@ -195,3 +195,7 @@ exception:
 1 row in set. Elapsed: 0.002 sec.
 
 ```
+
+## Limitations {#limitations}
+
+`AzureQueue` shares the same implementation as `S3Queue` and has the same [limitations](/engines/table-engines/integrations/s3queue#limitations). In particular, a device-level power loss of the ClickHouse node can silently lose consumed rows: a file is recorded as processed in Keeper (and, with `after_processing = 'delete'`, its source blob removed) as soon as the insert finishes, but the inserted rows are only durable once the target part is fsynced, which does not happen synchronously by default (`fsync_after_insert = 0`). For the recommended materialized-view consumption path, setting `fsync_after_insert = 1` (and `fsync_part_directory = 1`) on the target `MergeTree` table narrows this window substantially.

--- a/docs/en/engines/table-engines/integrations/s3queue.md
+++ b/docs/en/engines/table-engines/integrations/s3queue.md
@@ -448,6 +448,8 @@ Constructions with `{}` are similar to the [remote](../../../sql-reference/table
 
 2. `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and `Ordered` mode is used, then `s3queue_loading_retries` will not work. This will be fixed soon.
 
+3. Lost rows on a device-level power loss of the ClickHouse node. A consumed file is recorded as processed in Keeper (and its source object removed when `after_processing = 'delete'`) as soon as the insert finishes, but the inserted rows are only durable once the target part is fsynced, which does not happen synchronously by default (`fsync_after_insert = 0`). Keeper is force-synced and usually runs on a separate node, so it survives this node's power loss. If the node loses power after the file is committed as processed but before the target part is fsynced, the file is not re-read on restart and its rows are lost (unrecoverable with `after_processing = 'delete'`). A plain process kill does not expose this, because the page cache survives it. For the recommended materialized-view consumption path (the file is committed only after the whole insert pipeline finishes), setting `fsync_after_insert = 1` (and `fsync_part_directory = 1`) on the target `MergeTree` table makes the inserted part durable before the file is committed as processed, which narrows this window substantially. This does not apply to direct `INSERT ... SELECT` with `commit_on_select = 1`, where the file is committed at the end of the read before the destination sink finalizes its last part.
+
 ## Introspection {#introspection}
 
 For introspection use `system.s3queue_metadata_cache` stateless table and `system.s3queue_log` persistent table.

--- a/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
+++ b/src/Storages/ObjectStorageQueue/registerQueueStorage.cpp
@@ -603,6 +603,8 @@ Constructions with `{}` are similar to the [remote](../../../sql-reference/table
 
 2. `S3Queue` is configured on multiple servers pointing to the same path in zookeeper and `Ordered` mode is used, then `s3queue_loading_retries` will not work. This will be fixed soon.
 
+3. Lost rows on a device-level power loss of the ClickHouse node. A consumed file is recorded as processed in Keeper (and its source object removed when `after_processing = 'delete'`) as soon as the insert finishes, but the inserted rows are only durable once the target part is fsynced, which does not happen synchronously by default (`fsync_after_insert = 0`). Keeper is force-synced and usually runs on a separate node, so it survives this node's power loss. If the node loses power after the file is committed as processed but before the target part is fsynced, the file is not re-read on restart and its rows are lost (unrecoverable with `after_processing = 'delete'`). A plain process kill does not expose this, because the page cache survives it. For the recommended materialized-view consumption path (the file is committed only after the whole insert pipeline finishes), setting `fsync_after_insert = 1` (and `fsync_part_directory = 1`) on the target `MergeTree` table makes the inserted part durable before the file is committed as processed, which narrows this window substantially. This does not apply to direct `INSERT ... SELECT` with `commit_on_select = 1`, where the file is committed at the end of the read before the destination sink finalizes its last part.
+
 ## Introspection {#introspection}
 
 For introspection use `system.s3queue_metadata_cache` stateless table and `system.s3queue_log` persistent table.
@@ -915,6 +917,10 @@ exception:
 1 row in set. Elapsed: 0.002 sec.
 
 ```
+
+## Limitations {#limitations}
+
+`AzureQueue` shares the same implementation as `S3Queue` and has the same [limitations](/engines/table-engines/integrations/s3queue#limitations). In particular, a device-level power loss of the ClickHouse node can silently lose consumed rows: a file is recorded as processed in Keeper (and, with `after_processing = 'delete'`, its source blob removed) as soon as the insert finishes, but the inserted rows are only durable once the target part is fsynced, which does not happen synchronously by default (`fsync_after_insert = 0`). For the recommended materialized-view consumption path, setting `fsync_after_insert = 1` (and `fsync_part_directory = 1`) on the target `MergeTree` table narrows this window substantially.
 )DOCS_MD",
             .syntax = "ENGINE = AzureQueue(connection_string | storage_account_url, container_name, blobpath, [account_name, account_key,] format [, compression]) SETTINGS mode = '...', ...",
             .related = {"S3Queue", "AzureBlobStorage"}});


### PR DESCRIPTION

<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/111537
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Closes: https://github.com/ClickHouse/ClickHouse/issues/111537

The `S3Queue`/`AzureQueue` "Limitations" docs listed "abnormal server termination" only as a cause of *duplicated* rows. As reported in #111537, a device-level power loss of the ClickHouse node can also silently *lose* consumed rows: `StorageObjectStorageQueue::commit` records a file as processed in Keeper (and, with `after_processing = 'delete'`, removes the source object) as soon as the insert pipeline finishes, but the rows inserted into the target `MergeTree` table are only durable once the part is fsynced, which does not happen synchronously by default (`fsync_after_insert = 0`). Keeper is force-synced and usually runs on a separate node, so it survives this node's power loss; if the node loses power after the file is committed as processed but before the target part is fsynced, the file is not re-read on restart and its rows are gone (unrecoverable with `after_processing = 'delete'`). A plain process kill does not expose this because the page cache survives it.

This documents the loss window and the operator mitigation the reporter measured (`fsync_after_insert = 1` and `fsync_part_directory = 1` on the target table), scoped to the recommended materialized-view consumption path where the file is committed only after the whole insert pipeline finishes. It updates all four doc copies: the standalone `s3queue.md` and `azure-queue.md` pages and the embedded engine documentation in `registerQueueStorage.cpp` (surfaced via `system.table_engines.description`). `AzureQueue` is covered because it uses the identical `StorageObjectStorageQueue` implementation.

Documentation only, no behavior change. A code-level fix that lets the engine force target durability before the processed-commit would be a cross-engine durability-contract change (the same ordering exists in `Kafka` and `FileLog`) with backward-compatibility and default-behavior implications; that design decision is raised separately on the issue for the component owner.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.90` (included in `26.8` and later)
<!-- ch-version-info:end -->