### PR TITLE
Temporarily disable the query and memory profilers on macOS

### DIFF
--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -3,16 +3,15 @@
 # These are env/harness/portability issues that likely pass on the CI runner or are fixable,
 # not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
-# The sampling query profiler is temporarily disabled on macOS because its async-signal stack
-# unwinding crashes the server (https://github.com/ClickHouse/ClickHouse/issues/111579), so
-# system.trace_log gets no Real/CPU samples. Remove this block when the profiler is re-enabled.
+# The query and memory profilers are temporarily disabled on macOS because their backtrace()
+# stack capture crashes the server on fiber stacks (https://github.com/ClickHouse/ClickHouse/issues/111579),
+# so system.trace_log gets no Real/CPU/Memory/MemorySample rows. Only tests that depend on those
+# trace types are skipped here (ProfileEvent traces and part_log ProfileEvents still work). Remove
+# this block when the profilers are re-enabled.
 01473_event_time_microseconds
 01569_query_profiler_big_query_id
-02494_trace_log_profile_events
 02818_memory_profiler_sample_min_max_allocation_size
 03150_trace_log_add_build_id
-03221_merge_profile_events
-03761_trace_profile_events_list
 04509_query_profiler_cpu_trace
 
 # Times out on the macOS CI runner: the Python script hangs silently before sending any query

--- a/ci/defs/darwin.skip
+++ b/ci/defs/darwin.skip
@@ -3,6 +3,18 @@
 # These are env/harness/portability issues that likely pass on the CI runner or are fixable,
 # not permanent platform gaps - each is a candidate to re-verify or fix, not to keep forever.
 
+# The sampling query profiler is temporarily disabled on macOS because its async-signal stack
+# unwinding crashes the server (https://github.com/ClickHouse/ClickHouse/issues/111579), so
+# system.trace_log gets no Real/CPU samples. Remove this block when the profiler is re-enabled.
+01473_event_time_microseconds
+01569_query_profiler_big_query_id
+02494_trace_log_profile_events
+02818_memory_profiler_sample_min_max_allocation_size
+03150_trace_log_add_build_id
+03221_merge_profile_events
+03761_trace_profile_events_list
+04509_query_profiler_cpu_trace
+
 # Times out on the macOS CI runner: the Python script hangs silently before sending any query
 # (no query reaches the server), while the identical test with the same numpy/scipy/pandas versions
 # passes in ~3s locally. Looks like a runner-specific hang in the scipy import. Needs further investigation.

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -208,7 +208,18 @@ public:
 
     void injectFault() const;
 
-    void setSampleProbability(double value) { sample_probability.store(value, std::memory_order_relaxed); }
+    void setSampleProbability(double value)
+    {
+#if defined(OS_DARWIN)
+        /// Memory-profiler stack sampling is temporarily disabled on macOS: capturing a StackTrace via
+        /// backtrace() for an allocation that happens on a boost::context fiber stack faults in
+        /// __thread_stack_pcs and crashes the server (https://github.com/ClickHouse/ClickHouse/issues/111579).
+        /// Re-enable once the macOS stack unwind is made safe on fiber stacks.
+        (void)value;
+#else
+        sample_probability.store(value, std::memory_order_relaxed);
+#endif
+    }
 
     struct SampleConfig
     {
@@ -256,8 +267,14 @@ public:
 
     void setProfilerStep(Int64 value)
     {
+#if defined(OS_DARWIN)
+        /// See setSampleProbability: memory-profiler stack capture is disabled on macOS because
+        /// backtrace() faults on fiber stacks (https://github.com/ClickHouse/ClickHouse/issues/111579).
+        (void)value;
+#else
         profiler_step.store(value, std::memory_order_relaxed);
         setOrRaiseProfilerLimit(value);
+#endif
     }
 
     /// next should be changed only once: from nullptr to some value.

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -652,6 +652,12 @@ void ThreadStatus::resetPerformanceCountersLastUsage()
 
 void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_real_time_period, [[maybe_unused]] UInt64 global_profiler_cpu_time_period)
 {
+#if defined(OS_DARWIN)
+    /// Temporarily disabled on macOS: the sampling profiler's async-signal stack unwinding faults
+    /// in Darwin's __thread_stack_pcs and crashes the server (https://github.com/ClickHouse/ClickHouse/issues/111579).
+    /// Re-enable once the macOS unwinder is made signal-safe.
+    return;
+#endif
 #if defined(SIGEV_THREAD_ID) || defined(OS_DARWIN)
     /// profilers are useless without trace collector
     auto context = Context::getGlobalContextInstance();
@@ -678,6 +684,12 @@ void ThreadStatus::initGlobalProfiler([[maybe_unused]] UInt64 global_profiler_re
 
 void ThreadStatus::initQueryProfiler()
 {
+#if defined(OS_DARWIN)
+    /// See initGlobalProfiler: the sampling profiler is temporarily disabled on macOS because its
+    /// async-signal stack unwinding crashes the server (https://github.com/ClickHouse/ClickHouse/issues/111579).
+    return;
+#endif
+
     /// query profilers are useless without trace collector
     auto global_context_ptr = global_context.lock();
     if (!global_context_ptr || !global_context_ptr->hasTraceCollector())

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -349,8 +349,14 @@ void ThreadStatus::applyQuerySettings()
     initQueryProfiler();
 
     untracked_memory_limit = settings[Setting::max_untracked_memory];
+#if !defined(OS_DARWIN)
+    /// The memory profiler is disabled on macOS (see MemoryTracker::setProfilerStep,
+    /// https://github.com/ClickHouse/ClickHouse/issues/111579), so memory_profiler_step must not
+    /// tighten untracked_memory_limit there: it would force per-allocation flushes / earlier memory
+    /// limit checks without ever producing a sample.
     if (settings[Setting::memory_profiler_step] && settings[Setting::memory_profiler_step] < static_cast<UInt64>(untracked_memory_limit))
         untracked_memory_limit = settings[Setting::memory_profiler_step];
+#endif
 
     /// Populate the cache from authoritative query settings; on the initiator this runs before ProcessList::insert, on workers after (idempotent)
     /// (we cannot do this for all threads, even though it is no-op, since it is a data-race)


### PR DESCRIPTION
Temporary stopgap for the `Fast test (arm_darwin)` `Server died` failures hitting unrelated PRs since 2026-07-21 (enabled by #109825, which turned on the sampling/query and memory profilers and `trace_log` symbolization on macOS).

Root cause (from a macOS `.ips` crash report of a local reproduction): a profiler captures a stack via the system `backtrace()` (Darwin `__thread_stack_pcs`) while a thread is running on a `boost::context` **fiber** stack (e.g. the async reader of a `remote(...)` query). `__thread_stack_pcs` walks the frame-pointer chain off the end of the fiber stack into unmapped memory and the server crashes with `SIGSEGV`. The faulting path observed was the **memory profiler**: `MemoryTracker` allocation sampling → `AllocationTrace::onAllocImpl` → `StackTrace()` → `backtrace()`, which is not protected by the `asynchronous_stack_unwinding` recovery, so there is no `siglongjmp` fallback and the crash is fatal. The memory profiler is active by default (`total_memory_profiler_step`/`memory_profiler_step` = 4 MiB).

This disables the profiler stack capture on macOS until the unwind is made safe on fiber stacks:
- **Query profiler** (`QueryProfilerReal`/`QueryProfilerCPU`): not constructed in `initGlobalProfiler`/`initQueryProfiler`.
- **Memory profiler**: `MemoryTracker::setProfilerStep`/`setSampleProbability` are no-ops on macOS, so allocation sampling never captures a stack (memory limits/accounting are unaffected).

The profiler/`trace_log` tests unskipped/added by #109825 are restored to `ci/defs/darwin.skip` since `system.trace_log` no longer gets these samples on macOS.

Follow-up (proper fix, separate PR): make the macOS stack capture safe on fiber stacks (bounded frame-pointer walk that stops at the current stack-segment boundary, and/or guard every `StackTrace()` capture with the existing async-unwind recovery).

Caused by: https://github.com/ClickHouse/ClickHouse/pull/109825
Related: https://github.com/ClickHouse/ClickHouse/issues/111579

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

