### PR TITLE
Fix flaky test 04011_predicate_statistics_log under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/04011_predicate_statistics_log.reference
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.reference
@@ -14,3 +14,5 @@
 1	1	1	1
 --- passed <= input ---
 1
+--- q7 parallel-replica reads logged ---
+1	1	0.1

--- a/tests/queries/0_stateless/04011_predicate_statistics_log.sh
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.sh
@@ -18,9 +18,11 @@ Q3="${TABLE}_q3"
 Q4="${TABLE}_q4"
 Q5="${TABLE}_q5"
 Q6="${TABLE}_q6"
+Q7="${TABLE}_q7"
 
-# Under parallel replicas the reads run on remote sub-queries, so predicate_statistics_log rows land
-# under the sub-query ids rather than the client query_id. Match all of them through initial_query_id.
+# Under parallel replicas the reads run on remote sub-queries, so `system.predicate_statistics_log`
+# rows are keyed by the sub-query `query_id` rather than the client one. Match them all through
+# `initial_query_id`.
 qids() { echo "query_id IN (SELECT query_id FROM system.query_log WHERE initial_query_id = '$1' AND event_date >= yesterday() AND type = 'QueryFinish')"; }
 
 $CLICKHOUSE_CLIENT -m --query "
@@ -73,6 +75,11 @@ $CLICKHOUSE_CLIENT --query_id="$Q5" --query "SET predicate_statistics_sample_rat
 
 # Q6: conjunction split across multiple prewhere steps — total_selectivity is consistent and low
 $CLICKHOUSE_CLIENT --query_id="$Q6" --query "$ENABLE_STATS_MULTI_STEP; SELECT * FROM $TABLE WHERE status = 'active' AND category = 'cat_a' FORMAT Null"
+
+# Q7: force real remote parallel-replica reads so the initial_query_id mapping is always exercised,
+# independent of the randomized parallel_replicas_local_plan. Rows land under the remote sub-query ids.
+ENABLE_STATS_PR="$ENABLE_STATS, enable_parallel_replicas = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 0, automatic_parallel_replicas_mode = 0, parallel_replicas_min_number_of_rows_per_replica = 0, parallel_replicas_only_with_analyzer = 0"
+$CLICKHOUSE_CLIENT --query_id="$Q7" --query "$ENABLE_STATS_PR; SELECT * FROM $TABLE WHERE status = 'active' FORMAT Null"
 
 $CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS predicate_statistics_log, query_log"
 
@@ -150,6 +157,20 @@ $CLICKHOUSE_CLIENT --query "
 SELECT count() = 0 AS ok
 FROM system.predicate_statistics_log
 WHERE table = '$TABLE' AND passed_rows > input_rows;
+"
+
+# Q7: remote parallel-replica reads were actually used, and their predicate statistics are captured
+# and reachable through initial_query_id (guards against silently dropping parallel-replica coverage).
+echo '--- q7 parallel-replica reads logged ---'
+$CLICKHOUSE_CLIENT -m --query "
+SELECT
+    (SELECT sum(ProfileEvents['ParallelReplicasUsedCount']) > 0
+     FROM system.query_log
+     WHERE initial_query_id = '$Q7' AND event_date >= yesterday() AND type = 'QueryFinish') AS used_parallel_replicas,
+    sum(passed_rows) > 0 AS has_passed,
+    round(sum(passed_rows) / sum(input_rows), 1) AS sel
+FROM system.predicate_statistics_log
+WHERE table = '$TABLE' AND $(qids "$Q7") AND predicate_expression != '';
 "
 
 $CLICKHOUSE_CLIENT --query "DROP TABLE $TABLE"

--- a/tests/queries/0_stateless/04011_predicate_statistics_log.sh
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel-replicas
-# no-parallel-replicas: `system.predicate_statistics_log` rows are keyed by the reading thread's
-# `query_id`. Under parallel replicas the reads happen on remote sub-queries, so the rows land under
-# sub-query ids and the assertions below (which filter by the client `query_id`) find nothing.
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -21,6 +18,10 @@ Q3="${TABLE}_q3"
 Q4="${TABLE}_q4"
 Q5="${TABLE}_q5"
 Q6="${TABLE}_q6"
+
+# Under parallel replicas the reads run on remote sub-queries, so predicate_statistics_log rows land
+# under the sub-query ids rather than the client query_id. Match all of them through initial_query_id.
+qids() { echo "query_id IN (SELECT query_id FROM system.query_log WHERE initial_query_id = '$1' AND event_date >= yesterday() AND type = 'QueryFinish')"; }
 
 $CLICKHOUSE_CLIENT -m --query "
 $ENABLE_STATS;
@@ -73,7 +74,7 @@ $CLICKHOUSE_CLIENT --query_id="$Q5" --query "SET predicate_statistics_sample_rat
 # Q6: conjunction split across multiple prewhere steps — total_selectivity is consistent and low
 $CLICKHOUSE_CLIENT --query_id="$Q6" --query "$ENABLE_STATS_MULTI_STEP; SELECT * FROM $TABLE WHERE status = 'active' AND category = 'cat_a' FORMAT Null"
 
-$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS predicate_statistics_log"
+$CLICKHOUSE_CLIENT --query "SYSTEM FLUSH LOGS predicate_statistics_log, query_log"
 
 # Q1: equality ~10% selectivity, predicate_expression is not empty
 echo '--- q1 equality selectivity ~10% ---'
@@ -84,7 +85,7 @@ SELECT
     sum(passed_rows) > 0 AS has_passed,
     round(sum(passed_rows) / sum(input_rows), 1) AS sel
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND query_id = '$Q1' AND predicate_expression != '';
+WHERE table = '$TABLE' AND $(qids "$Q1") AND predicate_expression != '';
 "
 
 # Q2: 100% selectivity
@@ -92,7 +93,7 @@ echo '--- q2 100% selectivity ---'
 $CLICKHOUSE_CLIENT --query "
 SELECT round(max(filter_selectivity), 1) AS sel
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND query_id = '$Q2' AND predicate_expression != '';
+WHERE table = '$TABLE' AND $(qids "$Q2") AND predicate_expression != '';
 "
 
 # Q3: 0% selectivity
@@ -102,7 +103,7 @@ SELECT
     sum(input_rows) > 0 AS has_input,
     sum(passed_rows) = 0 AS zero_passed
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND query_id = '$Q3' AND predicate_expression != '';
+WHERE table = '$TABLE' AND $(qids "$Q3") AND predicate_expression != '';
 "
 
 # Q4: multi-column predicate logged with non-empty predicate_expression
@@ -110,7 +111,7 @@ echo '--- q4 multi-column logged ---'
 $CLICKHOUSE_CLIENT --query "
 SELECT count() > 0 AS logged
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE_MC' AND query_id = '$Q4' AND predicate_expression != '';
+WHERE table = '$TABLE_MC' AND $(qids "$Q4") AND predicate_expression != '';
 "
 
 # Q5: disabled — nothing logged
@@ -118,7 +119,7 @@ echo '--- q5 disabled ---'
 $CLICKHOUSE_CLIENT --query "
 SELECT count() = 0 AS nothing_logged
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE_OFF' AND query_id = '$Q5';
+WHERE table = '$TABLE_OFF' AND $(qids "$Q5");
 "
 
 # Q6: conjunction — total_selectivity consistent across step rows and low
@@ -128,7 +129,7 @@ SELECT
     round(min(total_selectivity), 2) = round(max(total_selectivity), 2) AS same_whole_sel,
     min(total_selectivity) < 0.1 AS selective
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND query_id = '$Q6' AND predicate_expression != '';
+WHERE table = '$TABLE' AND $(qids "$Q6") AND predicate_expression != '';
 "
 
 # Selectivity bounds

--- a/tests/queries/0_stateless/04011_predicate_statistics_log.sh
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.sh
@@ -76,8 +76,8 @@ $CLICKHOUSE_CLIENT --query_id="$Q5" --query "SET predicate_statistics_sample_rat
 # Q6: conjunction split across multiple prewhere steps — total_selectivity is consistent and low
 $CLICKHOUSE_CLIENT --query_id="$Q6" --query "$ENABLE_STATS_MULTI_STEP; SELECT * FROM $TABLE WHERE status = 'active' AND category = 'cat_a' FORMAT Null"
 
-# Q7: force real remote parallel-replica reads so the initial_query_id mapping is always exercised,
-# independent of the randomized parallel_replicas_local_plan. Rows land under the remote sub-query ids.
+# Q7: force real remote parallel-replica reads so the `initial_query_id` mapping is always exercised,
+# independent of the randomized `parallel_replicas_local_plan`. Rows land under the remote sub-query ids.
 ENABLE_STATS_PR="$ENABLE_STATS, enable_parallel_replicas = 1, max_parallel_replicas = 3, cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost', parallel_replicas_for_non_replicated_merge_tree = 1, parallel_replicas_local_plan = 0, automatic_parallel_replicas_mode = 0, parallel_replicas_min_number_of_rows_per_replica = 0, parallel_replicas_only_with_analyzer = 0"
 $CLICKHOUSE_CLIENT --query_id="$Q7" --query "$ENABLE_STATS_PR; SELECT * FROM $TABLE WHERE status = 'active' FORMAT Null"
 
@@ -160,13 +160,15 @@ WHERE table = '$TABLE' AND passed_rows > input_rows;
 "
 
 # Q7: remote parallel-replica reads were actually used, and their predicate statistics are captured
-# and reachable through initial_query_id (guards against silently dropping parallel-replica coverage).
+# and reachable through `initial_query_id` (guards against silently dropping parallel-replica coverage).
 echo '--- q7 parallel-replica reads logged ---'
+# The `current_database` filter belongs on the initiator row (it holds the profile event); the remote
+# sub-query rows run under `default`, so `qids` must NOT filter by it or the linkage would drop them.
 $CLICKHOUSE_CLIENT -m --query "
 SELECT
     (SELECT sum(ProfileEvents['ParallelReplicasUsedCount']) > 0
      FROM system.query_log
-     WHERE initial_query_id = '$Q7' AND event_date >= yesterday() AND type = 'QueryFinish') AS used_parallel_replicas,
+     WHERE initial_query_id = '$Q7' AND current_database = currentDatabase() AND event_date >= yesterday() AND type = 'QueryFinish') AS used_parallel_replicas,
     sum(passed_rows) > 0 AS has_passed,
     round(sum(passed_rows) / sum(input_rows), 1) AS sel
 FROM system.predicate_statistics_log

--- a/tests/queries/0_stateless/04011_predicate_statistics_log.sh
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel-replicas
+# no-parallel-replicas: `system.predicate_statistics_log` rows are keyed by the reading thread's
+# `query_id`. Under parallel replicas the reads happen on remote sub-queries, so the rows land under
+# sub-query ids and the assertions below (which filter by the client `query_id`) find nothing.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04011_predicate_statistics_log.sh
+++ b/tests/queries/0_stateless/04011_predicate_statistics_log.sh
@@ -12,18 +12,26 @@ TABLE_OFF="${TABLE}_disabled"
 ENABLE_STATS="SET predicate_statistics_sample_rate = 1, optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1"
 ENABLE_STATS_MULTI_STEP="$ENABLE_STATS, enable_multiple_prewhere_read_steps = 1"
 
-Q1="${TABLE}_q1"
-Q2="${TABLE}_q2"
-Q3="${TABLE}_q3"
-Q4="${TABLE}_q4"
-Q5="${TABLE}_q5"
-Q6="${TABLE}_q6"
-Q7="${TABLE}_q7"
+# Per-invocation token so that re-running against a fixed database (direct `bash`, or
+# `clickhouse-test --database=...`) never matches `query_log` / `predicate_statistics_log`
+# rows left by an earlier run.
+RUN="${CLICKHOUSE_DATABASE}_$$_${RANDOM}"
+Q1="q1_${RUN}"
+Q2="q2_${RUN}"
+Q3="q3_${RUN}"
+Q4="q4_${RUN}"
+Q5="q5_${RUN}"
+Q6="q6_${RUN}"
+Q7="q7_${RUN}"
+
+# Start of this run: every log read below is bounded to `event_time` >= $START so an earlier
+# run's rows are excluded even within the `event_date` >= yesterday() window.
+START=$($CLICKHOUSE_CLIENT --query "SELECT now()")
 
 # Under parallel replicas the reads run on remote sub-queries, so `system.predicate_statistics_log`
 # rows are keyed by the sub-query `query_id` rather than the client one. Match them all through
-# `initial_query_id`.
-qids() { echo "query_id IN (SELECT query_id FROM system.query_log WHERE initial_query_id = '$1' AND event_date >= yesterday() AND type = 'QueryFinish')"; }
+# `initial_query_id`, scoped to this run.
+qids() { echo "query_id IN (SELECT query_id FROM system.query_log WHERE initial_query_id = '$1' AND event_date >= yesterday() AND event_time >= '$START' AND type = 'QueryFinish')"; }
 
 $CLICKHOUSE_CLIENT -m --query "
 $ENABLE_STATS;
@@ -148,7 +156,7 @@ SELECT
     min(total_selectivity) >= 0 AS total_min_ok,
     max(total_selectivity) <= 1 AS total_max_ok
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND predicate_expression != '';
+WHERE table = '$TABLE' AND event_time >= '$START' AND predicate_expression != '';
 "
 
 # passed_rows <= input_rows invariant
@@ -156,7 +164,7 @@ echo '--- passed <= input ---'
 $CLICKHOUSE_CLIENT --query "
 SELECT count() = 0 AS ok
 FROM system.predicate_statistics_log
-WHERE table = '$TABLE' AND passed_rows > input_rows;
+WHERE table = '$TABLE' AND event_time >= '$START' AND passed_rows > input_rows;
 "
 
 # Q7: remote parallel-replica reads were actually used, and their predicate statistics are captured
@@ -168,7 +176,7 @@ $CLICKHOUSE_CLIENT -m --query "
 SELECT
     (SELECT sum(ProfileEvents['ParallelReplicasUsedCount']) > 0
      FROM system.query_log
-     WHERE initial_query_id = '$Q7' AND current_database = currentDatabase() AND event_date >= yesterday() AND type = 'QueryFinish') AS used_parallel_replicas,
+     WHERE initial_query_id = '$Q7' AND current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= '$START' AND type = 'QueryFinish') AS used_parallel_replicas,
     sum(passed_rows) > 0 AS has_passed,
     round(sum(passed_rows) / sum(input_rows), 1) AS sel
 FROM system.predicate_statistics_log


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110567
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):



### Description

`04011_predicate_statistics_log` asserts predicate selectivity aggregates from `system.predicate_statistics_log`, filtered by the client `query_id`. Those rows are keyed by the reading thread's query id (`CurrentThread::getQueryId()`). Under parallel replicas with `parallel_replicas_local_plan = 0` the reads run on remote replica sub-queries, so the rows are keyed by the sub-query ids and the assertions that filter by the client `query_id` find nothing (`0 0 0 nan`). `parallel_replicas_local_plan` is randomized by the test runner, so the dedicated `ParallelReplicas` job flakes.

Instead of tagging the test `no-parallel-replicas` (which would drop all parallel-replica coverage of `system.predicate_statistics_log`), match the rows through `initial_query_id` (link the remote sub-queries via `system.query_log`), keeping the test enabled under parallel replicas. A new query (Q7) forces real remote parallel-replica reads and asserts both that parallel replicas were used and that the remote predicate statistics are reachable through `initial_query_id`, so a regression that stops emitting predicate statistics for parallel-replica reads is still caught.

Failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110567&sha=e5a02459b5ac42dc531952c51b3eb5893a44bc04&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

Validated locally: dedicated `ParallelReplicas` job profile 20/20 pass (was 8/15 fail before the rework), 50/50 randomized runs pass, and Q7's parallel-replica oracle fails as expected when the `initial_query_id` linkage is broken.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.161` (included in `26.8` and later)
<!-- ch-version-info:end -->