### PR TITLE
Fix OOB when deserializing bad aggregate function states

### DIFF
--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -364,6 +364,9 @@ void ColumnString::deserializeAndInsertFromArena(ReadBuffer & in, const IColumn:
     readBinaryLittleEndian<size_t>(string_size, in);
 
     bool serialize_string_with_zero_byte = settings && settings->serialize_string_with_zero_byte;
+    if (string_size < serialize_string_with_zero_byte)
+        throw Exception(ErrorCodes::INCORRECT_DATA,
+            "Malformed serialized string in aggregation state: size {} is smaller than the zero-byte terminator", string_size);
     const size_t old_size = chars.size();
     const size_t new_size = old_size + string_size - serialize_string_with_zero_byte;
     chars.resize(new_size);

--- a/tests/queries/0_stateless/02477_invalid_reads.sql
+++ b/tests/queries/0_stateless/02477_invalid_reads.sql
@@ -59,3 +59,8 @@ SELECT finalizeAggregation(CAST(unhex('0F0000000000000000'),
                                 'AggregateFunction(quantileExact, UInt64)')); -- { serverError CANNOT_READ_ALL_DATA }
 SELECT finalizeAggregation(CAST(unhex('0F000000000000803F'),
                                 'AggregateFunction(quantileTDigest, UInt64)')); -- { serverError CANNOT_READ_ALL_DATA }
+
+-- groupUniqArray over a composite type deserializes each stored key through the ColumnString arena path;
+-- a zero string_size must be rejected instead of underflowing to a huge/OOB allocation.
+SELECT finalizeAggregation(CAST(unhex('01080000000000000000'),
+                                'AggregateFunction(groupUniqArray, Tuple(String))')); -- { serverError INCORRECT_DATA }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a segfault due to out-of-bounds memory access when deserializing a malformed aggregate function state containing a `String` value. Such states are now validated and rejected instead of leading to segfaults.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.270` (included in `26.8` and later)
- Backported to: `26.7.2.31`, `26.6.2.124`, `26.5.6.86`, `26.3.17.88`, `25.8.29.40`
<!-- ch-version-info:end -->