### PR TITLE
Fix Paimon DLF request signing: sign every request, cache only credentials

### DIFF
--- a/src/Databases/DataLake/PaimonRestCatalog.cpp
+++ b/src/Databases/DataLake/PaimonRestCatalog.cpp
@@ -248,9 +248,10 @@ void PaimonRestCatalog::createAuthHeaders(
         String date_time = get_or_default(headers_map, DLF_DATE_HEADER_KEY, fmt::format(AUTH_DATE_TIME_FORMATTER, *utc_tm));
         String date = date_time.substr(0, 8);
         generate_sign_headers(data, date_time, std::nullopt);
-        String authorization
-            = token->dlf_generated_authorization.empty() ? get_authorization(date, date_time) : token->dlf_generated_authorization;
-        token->dlf_generated_authorization = authorization;
+        /// The DLF v4 signature covers the canonical request (method, resource path, query
+        /// parameters and signed headers), so it must be computed for every request anew:
+        /// a signature from an earlier request is invalid for any other one.
+        String authorization = get_authorization(date, date_time);
         headers_map.emplace(DLF_AUTHORIZATION_HEADER_KEY, authorization);
         current_headers.clear();
         for (const auto & entry : headers_map)
@@ -301,22 +302,8 @@ DB::ReadWriteBufferFromHTTPPtr PaimonRestCatalog::createReadBuffer(
             .create(credentials);
     };
 
-    bool refresh_token = true;
     LOG_TRACE(log, "Requesting endpoint: {}", endpoint);
-    try
-    {
-        return create_buffer();
-    }
-    catch (DB::HTTPException & e)
-    {
-        if (e.code() == Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED && refresh_token && token->token_provider == "dlf")
-        {
-            refresh_token = false;
-            token->dlf_generated_authorization = "";
-            return create_buffer();
-        }
-        throw;
-    }
+    return create_buffer();
 }
 
 void PaimonRestCatalog::forEachDatabase(DB::Strings & databases, StopCondition stop_condition, ExecuteFunc execute_func) const
@@ -485,7 +472,7 @@ bool PaimonRestCatalog::existsTable(const String & database_name, const String &
     }
     catch (const DB::HTTPException & e)
     {
-        if (e.code() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+        if (e.getHTTPStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
         {
             return false;
         }
@@ -600,7 +587,7 @@ bool PaimonRestCatalog::tryGetTableMetadata(const String & database_name, const 
     }
     catch (const DB::HTTPException & e)
     {
-        if (e.code() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+        if (e.getHTTPStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
         {
             return false;
         }

--- a/src/Databases/DataLake/PaimonRestCatalog.h
+++ b/src/Databases/DataLake/PaimonRestCatalog.h
@@ -59,7 +59,6 @@ struct PaimonToken
     const String bearer_token;
     const String dlf_access_key_id;
     const String dlf_access_key_secret;
-    mutable String dlf_generated_authorization;
 
     explicit PaimonToken(const String & bearer_token_)
         : token_provider("bearer")

--- a/tests/integration/test_paimon_rest_catalog/test.py
+++ b/tests/integration/test_paimon_rest_catalog/test.py
@@ -1,5 +1,9 @@
 # coding: utf-8
 
+import base64
+import hashlib
+import hmac
+import json
 import os
 import time
 
@@ -17,7 +21,10 @@ cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance("node", stay_alive=True, main_configs=[])
 
 cluster.base_cmd.extend(
-    ["--file", os.path.join(DOCKER_COMPOSE_PATH, "docker_compose_paimon_rest_catalog.yml")]
+    [
+        "--file",
+        os.path.join(DOCKER_COMPOSE_PATH, "docker_compose_paimon_rest_catalog.yml"),
+    ]
 )
 
 
@@ -50,7 +57,9 @@ def test_paimon_rest_catalog(started_cluster):
 
     # clean warehouse data path
     run_and_check(
-        [f'docker exec {bearer_container_id} bash -c "rm -rf /var/lib/clickhouse/user_files/warehouse/*"'],
+        [
+            f'docker exec {bearer_container_id} bash -c "rm -rf /var/lib/clickhouse/user_files/warehouse/*"'
+        ],
         shell=True,
     )
 
@@ -104,21 +113,14 @@ def test_paimon_rest_catalog(started_cluster):
         headers={"Authorization": "Bearer bearer-token-xxx-xxx-xxx"},
     )
 
-    assert (
-        node.query("SHOW TABLES;", database="paimon_rest_db")
-        == "test.test_table\n"
-    )
-    assert node.query(
-        "DESC `test.test_table`;", database="paimon_rest_db"
-    ) == (
+    assert node.query("SHOW TABLES;", database="paimon_rest_db") == "test.test_table\n"
+    assert node.query("DESC `test.test_table`;", database="paimon_rest_db") == (
         "f_string\tNullable(String)\t\t\t\t\t\n"
         "f_int\tNullable(Int32)\t\t\t\t\t\n"
         "f_bigint\tNullable(Int64)\t\t\t\t\t\n"
     )
     assert (
-        node.query(
-            "SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db"
-        )
+        node.query("SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db")
         == "0\n"
     )
 
@@ -130,14 +132,13 @@ def test_paimon_rest_catalog(started_cluster):
     )
 
     assert (
-        node.query(
-            "SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db"
-        )
+        node.query("SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db")
         == "10\n"
     )
 
     # Test DLF authentication
     dlf_ip = cluster.get_instance_ip("paimon-rest-dlf")
+    dlf_container_id = cluster.get_instance_docker_id("paimon-rest-dlf")
     node.query("DROP DATABASE IF EXISTS paimon_rest_db_dlf SYNC;")
     node.query(
         f"CREATE DATABASE paimon_rest_db_dlf ENGINE = DataLakeCatalog('http://{dlf_ip}:{DLF_PORT}')"
@@ -146,25 +147,119 @@ def test_paimon_rest_catalog(started_cluster):
         f" region='cn-hangzhou';",
         settings={"allow_experimental_database_paimon_rest_catalog": 1},
     )
-    # The DLF server shares the warehouse with the bearer server, so the table
-    # created above must be visible. Every request is signed individually (the
-    # DLF v4 signature covers method, path and query parameters), so these
-    # queries verify that signing works for requests other than the initial
-    # config one made at CREATE DATABASE time.
+
+    # The DLF server keeps its catalog in memory, separately from the bearer
+    # server, so create a database and a table on it. The requests must be
+    # signed the same way the server signs them (a Python port of Paimon's
+    # `DLFAuthSignature`): the DLF v4 signature covers the concrete request
+    # (method, resource path, query parameters and signed headers), so each
+    # request gets its own signature.
+    def dlf_request(method, resource_path, body=None):
+        date_time = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        date = date_time[:8]
+        region = "cn-hangzhou"
+        scope = f"{date}/{region}/DlfNext/aliyun_v4_request"
+        sign_headers = {
+            "x-dlf-date": date_time,
+            "x-dlf-content-sha256": "UNSIGNED-PAYLOAD",
+            "x-dlf-version": "v1",
+            "x-dlf-security-token": "",
+        }
+        if body:
+            sign_headers["content-type"] = "application/json"
+            sign_headers["content-md5"] = base64.b64encode(
+                hashlib.md5(body.encode()).digest()
+            ).decode()
+        canonical_request = "\n".join(
+            [method, resource_path, ""]
+            + [f"{k}:{v}" for k, v in sorted(sign_headers.items())]
+            + ["UNSIGNED-PAYLOAD"]
+        )
+        string_to_sign = "\n".join(
+            [
+                "DLF4-HMAC-SHA256",
+                date_time,
+                scope,
+                hashlib.sha256(canonical_request.encode()).hexdigest(),
+            ]
+        )
+        key = b"aliyun_v4accessKeySecret"
+        for part in (date, region, "DlfNext", "aliyun_v4_request"):
+            key = hmac.new(key, part.encode(), hashlib.sha256).digest()
+        signature = hmac.new(key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+        headers = dict(sign_headers)
+        headers["Authorization"] = (
+            f"DLF4-HMAC-SHA256 Credential=accessKeyId/{scope},Signature={signature}"
+        )
+        response = requests.request(
+            method,
+            f"http://{dlf_ip}:{DLF_PORT}{resource_path}",
+            data=body,
+            headers=headers,
+        )
+        assert response.status_code == 200, (resource_path, response.status_code)
+
+    dlf_request("POST", "/v1/paimon/databases", json.dumps({"name": "test_dlf"}))
+    dlf_request(
+        "POST",
+        "/v1/paimon/databases/test_dlf/tables",
+        json.dumps(
+            {
+                "identifier": {"database": "test_dlf", "object": "test_table"},
+                "schema": {
+                    "fields": [
+                        {
+                            "id": 0,
+                            "name": "f_string",
+                            "type": "string",
+                            "description": "string",
+                        },
+                        {
+                            "id": 1,
+                            "name": "f_int",
+                            "type": "int",
+                            "description": "int",
+                        },
+                    ],
+                    "partitionKeys": ["f_string"],
+                    "primaryKeys": [],
+                    "options": {},
+                    "comment": "test table",
+                },
+            }
+        ),
+    )
+
+    # Every catalog request made by these queries is signed individually, so
+    # they verify that signing works for requests other than the initial
+    # config one made at CREATE DATABASE time. Before the per-request signing
+    # fix the listing silently returned an empty result and the metadata
+    # requests failed with HTTP 401.
     assert (
         node.query("SHOW TABLES;", database="paimon_rest_db_dlf")
-        == "test.test_table\n"
+        == "test_dlf.test_table\n"
     )
-    assert node.query(
-        "DESC `test.test_table`;", database="paimon_rest_db_dlf"
-    ) == (
-        "f_string\tNullable(String)\t\t\t\t\t\n"
-        "f_int\tNullable(Int32)\t\t\t\t\t\n"
-        "f_bigint\tNullable(Int64)\t\t\t\t\t\n"
+    assert node.query("DESC `test_dlf.test_table`;", database="paimon_rest_db_dlf") == (
+        "f_string\tNullable(String)\t\t\t\t\t\n" "f_int\tNullable(Int32)\t\t\t\t\t\n"
     )
     assert (
         node.query(
-            "SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db_dlf"
+            "SELECT count(1) FROM `test_dlf.test_table`;",
+            database="paimon_rest_db_dlf",
+        )
+        == "0\n"
+    )
+
+    insert_cmd = 'java -jar /opt/paimon/paimon-server.jar "insert" "file:///var/lib/clickhouse/user_files/warehouse/" "test_dlf" "test_table"'
+    run_and_check(
+        [f"docker exec {dlf_container_id} bash -c '{insert_cmd}'"],
+        shell=True,
+    )
+
+    assert (
+        node.query(
+            "SELECT count(1) FROM `test_dlf.test_table`;",
+            database="paimon_rest_db_dlf",
         )
         == "10\n"
     )

--- a/tests/integration/test_paimon_rest_catalog/test.py
+++ b/tests/integration/test_paimon_rest_catalog/test.py
@@ -146,7 +146,28 @@ def test_paimon_rest_catalog(started_cluster):
         f" region='cn-hangzhou';",
         settings={"allow_experimental_database_paimon_rest_catalog": 1},
     )
-    node.query("SHOW TABLES;", database="paimon_rest_db_dlf")
+    # The DLF server shares the warehouse with the bearer server, so the table
+    # created above must be visible. Every request is signed individually (the
+    # DLF v4 signature covers method, path and query parameters), so these
+    # queries verify that signing works for requests other than the initial
+    # config one made at CREATE DATABASE time.
+    assert (
+        node.query("SHOW TABLES;", database="paimon_rest_db_dlf")
+        == "test.test_table\n"
+    )
+    assert node.query(
+        "DESC `test.test_table`;", database="paimon_rest_db_dlf"
+    ) == (
+        "f_string\tNullable(String)\t\t\t\t\t\n"
+        "f_int\tNullable(Int32)\t\t\t\t\t\n"
+        "f_bigint\tNullable(Int64)\t\t\t\t\t\n"
+    )
+    assert (
+        node.query(
+            "SELECT count(1) FROM `test.test_table`;", database="paimon_rest_db_dlf"
+        )
+        == "10\n"
+    )
 
     node.query("DROP DATABASE IF EXISTS paimon_rest_db_dlf SYNC;")
     with pytest.raises(QueryRuntimeException) as exc_info:


### PR DESCRIPTION
The DLF v4 `Authorization` header for the Paimon REST catalog was computed once for the first request (`GET /v1/paimon/config` at `CREATE DATABASE` time), cached in `PaimonToken::dlf_generated_authorization`, and reused for every subsequent request. The DLF v4 signature covers the canonical request (method, resource path, query parameters and signed headers), so a cached signature is invalid for any other request, and the server answers 401 to e.g. `GET /v1/paimon/databases?maxResults=100`. A retry that was supposed to recover never fired because it compared `HTTPException::code` (the ClickHouse error code, 86) with the HTTP status 401. The bug stayed invisible because table listing swallows catalog errors, so `SHOW TABLES` on a DLF-authenticated catalog silently returned an empty list.

This follows the reference implementation (`DLFAuthSignature` in Apache Paimon), which computes the signature for every request anew and caches only the credentials — in our case already stored in `PaimonToken`. The signature cache is removed (it was also a data race: a `mutable` string written without synchronization from concurrent listing threads) together with the dead retry.

The same `code`-vs-HTTP-status confusion is fixed in `existsTable` and `tryGetTableMetadata`: HTTP 404 there was meant to map to "table does not exist" but was rethrown instead, because `e.code()` is never 404.

`test_paimon_rest_catalog` is extended to create a database and a table on the DLF mock server through its REST API (signing the requests with a Python port of `DLFAuthSignature` from Apache Paimon 1.1.1, the version the mock server is built with) and to assert that listing, `DESC` and `SELECT` work through the DLF-authenticated catalog. The mock servers keep their catalogs in memory, so the DLF server needs its own content; without the fix, the listing silently returns an empty result and the metadata requests fail with HTTP 401.

Related: https://github.com/ClickHouse/ClickHouse/pull/92011
Related: https://github.com/ClickHouse/ClickHouse/pull/111379

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix DLF authentication in the Paimon REST catalog: the request signature was computed once and reused, so every catalog request after the first one failed with HTTP 401 and `SHOW TABLES` returned an empty list. Also fix HTTP 404 detection in table existence checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
