### PR TITLE
Add projection PK memory/disk metrics to system.parts for accurate parent part total calculation

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -470,6 +470,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
 
                         for (const auto & [_, proj_part] : part->getProjectionParts())
                         {
+                            total_primary_key_bytes_memory += proj_part->getIndexSizeInBytes();
+                            total_primary_key_bytes_memory_allocated += proj_part->getIndexSizeInAllocatedBytes();
                             total_projection_primary_key_bytes_memory += proj_part->getIndexSizeInBytes();
                             total_projection_primary_key_bytes_memory_allocated += proj_part->getIndexSizeInAllocatedBytes();
                             total_projection_index_granularity_bytes_in_memory += proj_part->getIndexGranularityBytes();
@@ -547,8 +549,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
         new_values["TotalRowsOfMergeTreeTablesSystem"] = { total_number_of_rows_system, "Total amount of rows (records) stored in tables of MergeTree family in the system database." };
         new_values["TotalPartsOfMergeTreeTablesSystem"] = { total_number_of_parts_system, "Total amount of data parts in tables of MergeTree family in the system database." };
 
-        new_values["TotalPrimaryKeyBytesInMemory"] = { total_primary_key_bytes_memory, "The total amount of memory (in bytes) used by primary key values (only takes active parts into account)." };
-        new_values["TotalPrimaryKeyBytesInMemoryAllocated"] = { total_primary_key_bytes_memory_allocated, "The total amount of memory (in bytes) reserved for primary key values (only takes active parts into account)." };
+        new_values["TotalPrimaryKeyBytesInMemory"] = { total_primary_key_bytes_memory, "The total amount of memory (in bytes) used by primary key values, including projection primary keys (only takes active parts into account)." };
+        new_values["TotalPrimaryKeyBytesInMemoryAllocated"] = { total_primary_key_bytes_memory_allocated, "The total amount of memory (in bytes) reserved for primary key values, including projection primary keys (only takes active parts into account)." };
         new_values["TotalIndexGranularityBytesInMemory"] = { total_index_granularity_bytes_in_memory, "The total amount of memory (in bytes) used by index granules (only takes active parts into account)." };
         new_values["TotalIndexGranularityBytesInMemoryAllocated"] = { total_index_granularity_bytes_in_memory_allocated, "The total amount of memory (in bytes) reserved for index granules (only takes active parts into account)." };
 

--- a/src/Storages/System/StorageSystemParts.cpp
+++ b/src/Storages/System/StorageSystemParts.cpp
@@ -75,7 +75,7 @@ Name of the data part. The part naming structure can be used to determine many a
         {"bytes_on_disk",                               std::make_shared<DataTypeUInt64>(),    "Total size of all the data part files in bytes."},
         {"data_compressed_bytes",                       std::make_shared<DataTypeUInt64>(),    "Total size of compressed data in the data part. All the auxiliary files (for example, files with marks) are not included."},
         {"data_uncompressed_bytes",                     std::make_shared<DataTypeUInt64>(),    "Total size of uncompressed data in the data part. All the auxiliary files (for example, files with marks) are not included."},
-        {"primary_key_size",                            std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) used by primary key values in the primary.idx/cidx file on disk."},
+        {"primary_key_size",                            std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) used by primary key values in the primary.idx/cidx file on disk, including primary keys of projections stored in this part."},
         {"marks_bytes",                                 std::make_shared<DataTypeUInt64>(),    "The size of the file with marks."},
         {"secondary_indices_compressed_bytes",          std::make_shared<DataTypeUInt64>(),    "Total size of compressed data for secondary indices in the data part. All the auxiliary files (for example, files with marks) are not included."},
         {"secondary_indices_uncompressed_bytes",        std::make_shared<DataTypeUInt64>(),    "Total size of uncompressed data for secondary indices in the data part. All the auxiliary files (for example, files with marks) are not included."},
@@ -92,8 +92,8 @@ Name of the data part. The part naming structure can be used to determine many a
         {"max_block_number",                            std::make_shared<DataTypeInt64>(),     "The maximum number of data parts that make up the current part after merging."},
         {"level",                                       std::make_shared<DataTypeUInt32>(),    "Depth of the merge tree. Zero means that the current part was created by insert rather than by merging other parts."},
         {"data_version",                                std::make_shared<DataTypeUInt64>(),    "Number that is used to determine which mutations should be applied to the data part (mutations with a version higher than data_version)."},
-        {"primary_key_bytes_in_memory",                 std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) used by primary key values. Will be 0 when `primary_key_lazy_load` is enabled and the key is not loaded. When non-zero the bytes live in the part itself and are accounted within `jemalloc.mergetree_arena.active_bytes`. They are NEVER counted in `PrimaryIndexCacheBytes` — those are mutually exclusive per part: an index lives either in the part (this metric) or in the shared `PrimaryIndexCache` (the other), depending on `primary_key_lazy_load` and `use_primary_key_cache`."},
-        {"primary_key_bytes_in_memory_allocated",       std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) reserved for primary key values. Will be 0 when `primary_key_lazy_load` is enabled and the key is not loaded. When non-zero, included in `jemalloc.mergetree_arena.active_bytes`. See the note on `primary_key_bytes_in_memory` for the relationship with `PrimaryIndexCacheBytes`."},
+        {"primary_key_bytes_in_memory",                 std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) used by primary key values, including primary keys of projections stored in this part. Will be 0 when `primary_key_lazy_load` is enabled and the key is not loaded. When non-zero the bytes live in the part itself and are accounted within `jemalloc.mergetree_arena.active_bytes`. They are NEVER counted in `PrimaryIndexCacheBytes` — those are mutually exclusive per part: an index lives either in the part (this metric) or in the shared `PrimaryIndexCache` (the other), depending on `primary_key_lazy_load` and `use_primary_key_cache`."},
+        {"primary_key_bytes_in_memory_allocated",       std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) reserved for primary key values, including primary keys of projections stored in this part. Will be 0 when `primary_key_lazy_load` is enabled and the key is not loaded. When non-zero, included in `jemalloc.mergetree_arena.active_bytes`. See the note on `primary_key_bytes_in_memory` for the relationship with `PrimaryIndexCacheBytes`."},
         {"index_granularity_bytes_in_memory",           std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) used by index granularity values (will be 0 in case of primary_key_lazy_load=1 and use_primary_key_cache=1). When non-zero the bytes are part-owned and accounted within `jemalloc.mergetree_arena.active_bytes`."},
         {"index_granularity_bytes_in_memory_allocated", std::make_shared<DataTypeUInt64>(),    "The amount of memory (in bytes) reserved for index granularity values (will be 0 in case of primary_key_lazy_load=1 and use_primary_key_cache=1). When non-zero, included in `jemalloc.mergetree_arena.active_bytes`."},
         {"is_frozen",                                   std::make_shared<DataTypeUInt8>(),     "Flag that shows that a partition data backup exists. 1, the backup exists. 0, the backup does not exist. For more details, see FREEZE PARTITION."},
@@ -161,6 +161,20 @@ void StorageSystemParts::processNextStorage(
         const auto & part = all_parts[part_number];
         auto part_state = all_parts_state[part_number];
 
+        UInt64 primary_key_bytes_in_memory = part->getIndexSizeInBytes();
+        UInt64 primary_key_bytes_in_memory_allocated = part->getIndexSizeInAllocatedBytes();
+        auto primary_key_size = part->getIndexSizeFromFile();
+        UInt64 primary_key_size_on_disk = primary_key_size.data_compressed > 0 ? primary_key_size.data_compressed : primary_key_size.data_uncompressed;
+        for (const auto & [_, projection_part] : part->getProjectionParts())
+        {
+            primary_key_bytes_in_memory += projection_part->getIndexSizeInBytes();
+            primary_key_bytes_in_memory_allocated += projection_part->getIndexSizeInAllocatedBytes();
+            auto projection_primary_key_size = projection_part->getIndexSizeFromFile();
+            primary_key_size_on_disk += projection_primary_key_size.data_compressed > 0
+                ? projection_primary_key_size.data_compressed
+                : projection_primary_key_size.data_uncompressed;
+        }
+
         std::unique_ptr<ColumnSize> columns_size;
         auto get_columns_size = [&]()
         {
@@ -202,8 +216,7 @@ void StorageSystemParts::processNextStorage(
             columns[res_index++]->insert(get_columns_size().data_uncompressed);
         if (columns_mask[src_index++])
         {
-            auto index_size = part->getIndexSizeFromFile();
-            columns[res_index++]->insert(index_size.data_compressed > 0 ? index_size.data_compressed : index_size.data_uncompressed);
+            columns[res_index++]->insert(primary_key_size_on_disk);
         }
         if (columns_mask[src_index++])
             columns[res_index++]->insert(get_columns_size().marks);
@@ -248,9 +261,9 @@ void StorageSystemParts::processNextStorage(
         if (columns_mask[src_index++])
             columns[res_index++]->insert(static_cast<UInt64>(part->info.getDataVersion()));
         if (columns_mask[src_index++])
-            columns[res_index++]->insert(part->getIndexSizeInBytes());
+            columns[res_index++]->insert(primary_key_bytes_in_memory);
         if (columns_mask[src_index++])
-            columns[res_index++]->insert(part->getIndexSizeInAllocatedBytes());
+            columns[res_index++]->insert(primary_key_bytes_in_memory_allocated);
         if (columns_mask[src_index++])
             columns[res_index++]->insert(part->getIndexGranularityBytes());
         if (columns_mask[src_index++])

--- a/src/Storages/System/StorageSystemPartsColumns.cpp
+++ b/src/Storages/System/StorageSystemPartsColumns.cpp
@@ -49,8 +49,8 @@ StorageSystemPartsColumns::StorageSystemPartsColumns(const StorageID & table_id_
         {"max_block_number",                           std::make_shared<DataTypeInt64>(),  "The maximum number of data parts that make up the current part after merging."},
         {"level",                                      std::make_shared<DataTypeUInt32>(), "Depth of the merge tree. Zero means that the current part was created by insert rather than by merging other parts."},
         {"data_version",                               std::make_shared<DataTypeUInt64>(), "Number that is used to determine which mutations should be applied to the data part (mutations with a version higher than data_version)."},
-        {"primary_key_bytes_in_memory",                std::make_shared<DataTypeUInt64>(), "The amount of memory (in bytes) used by primary key values."},
-        {"primary_key_bytes_in_memory_allocated",      std::make_shared<DataTypeUInt64>(), "The amount of memory (in bytes) reserved for primary key values."},
+        {"primary_key_bytes_in_memory",                std::make_shared<DataTypeUInt64>(), "The amount of memory (in bytes) used by primary key values, including primary keys of projections stored in this part."},
+        {"primary_key_bytes_in_memory_allocated",      std::make_shared<DataTypeUInt64>(), "The amount of memory (in bytes) reserved for primary key values, including primary keys of projections stored in this part."},
 
         {"database",                                   std::make_shared<DataTypeString>(), "Name of the database."},
         {"table",                                      std::make_shared<DataTypeString>(), "Name of the table."},
@@ -132,8 +132,13 @@ void StorageSystemPartsColumns::processNextStorage(
         auto min_max_date = part->getMinMaxDate();
         auto min_max_time = part->getMinMaxTime();
 
-        auto index_size_in_bytes = part->getIndexSizeInBytes();
-        auto index_size_in_allocated_bytes = part->getIndexSizeInAllocatedBytes();
+        UInt64 index_size_in_bytes = part->getIndexSizeInBytes();
+        UInt64 index_size_in_allocated_bytes = part->getIndexSizeInAllocatedBytes();
+        for (const auto & [_, projection_part] : part->getProjectionParts())
+        {
+            index_size_in_bytes += projection_part->getIndexSizeInBytes();
+            index_size_in_allocated_bytes += projection_part->getIndexSizeInAllocatedBytes();
+        }
         std::optional<Estimates> estimates;
 
         /// Lazy initialize statistics estimates if they are queried.

--- a/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
+++ b/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
@@ -252,3 +252,85 @@ def test_total_proj_pk_ig_in_memory_fields(started_cluster):
 
     # finally drop the table
     node.query("DROP TABLE test_proj_pk_bytes;")
+
+
+def test_projection_primary_key_counted_in_total_pk_fields(started_cluster):
+    node.query("""CREATE TABLE test_projection_only_pk_bytes
+    (
+       a UInt64,
+       b UInt64,
+       PROJECTION p (SELECT b, a ORDER BY b)
+    )
+    Engine=MergeTree()
+    ORDER BY tuple()
+    SETTINGS index_granularity=1""")
+
+    query_total_pk_bytes = "SELECT value FROM system.asynchronous_metrics WHERE metric = 'TotalPrimaryKeyBytesInMemory';"
+    query_total_pk_bytes_allocated = """SELECT value FROM system.asynchronous_metrics
+                                  WHERE metric = 'TotalPrimaryKeyBytesInMemoryAllocated';"""
+    query_parts_pk_bytes = """SELECT sum(primary_key_bytes_in_memory)
+                              FROM system.parts
+                              WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_parts_pk_bytes_allocated = """SELECT sum(primary_key_bytes_in_memory_allocated)
+                                        FROM system.parts
+                                        WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_parts_pk_size = """SELECT sum(primary_key_size)
+                             FROM system.parts
+                             WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_projection_parts_pk_bytes = """SELECT sum(primary_key_bytes_in_memory)
+                                         FROM system.projection_parts
+                                         WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_projection_parts_pk_bytes_allocated = """SELECT sum(primary_key_bytes_in_memory_allocated)
+                                                   FROM system.projection_parts
+                                                   WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_parts_columns_pk_bytes = """SELECT max(primary_key_bytes_in_memory)
+                                      FROM system.parts_columns
+                                      WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+    query_parts_columns_pk_bytes_allocated = """SELECT max(primary_key_bytes_in_memory_allocated)
+                                                FROM system.parts_columns
+                                                WHERE active AND database = currentDatabase() AND table = 'test_projection_only_pk_bytes';"""
+
+    total_pk_bytes_before = int(node.query(query_total_pk_bytes).strip())
+    total_pk_bytes_allocated_before = int(node.query(query_total_pk_bytes_allocated).strip())
+
+    node.query("""INSERT INTO test_projection_only_pk_bytes SELECT number, number * 2 FROM numbers(10000)""")
+    node.query("""SELECT b, a FROM test_projection_only_pk_bytes WHERE b = 1000
+                  SETTINGS optimize_use_projections=1, force_optimize_projection=1""")
+
+    def res_total_pk_bytes():
+        return int(node.query(query_total_pk_bytes).strip())
+
+    def res_total_pk_bytes_allocated():
+        return int(node.query(query_total_pk_bytes_allocated).strip())
+
+    _, total_pk_bytes_after = query_until_condition(
+        total_pk_bytes_before, res_total_pk_bytes, condition=greater
+    )
+    assert total_pk_bytes_after > total_pk_bytes_before
+
+    _, total_pk_bytes_allocated_after = query_until_condition(
+        total_pk_bytes_allocated_before, res_total_pk_bytes_allocated, condition=greater
+    )
+    assert total_pk_bytes_allocated_after > total_pk_bytes_allocated_before
+
+    def res_projection_parts_pk_bytes():
+        return int(node.query(query_projection_parts_pk_bytes).strip())
+
+    _, projection_parts_pk_bytes = query_until_condition(
+        0, res_projection_parts_pk_bytes, condition=greater
+    )
+
+    def res_projection_parts_pk_bytes_allocated():
+        return int(node.query(query_projection_parts_pk_bytes_allocated).strip())
+
+    _, projection_parts_pk_bytes_allocated = query_until_condition(
+        0, res_projection_parts_pk_bytes_allocated, condition=greater
+    )
+
+    assert int(node.query(query_parts_pk_bytes).strip()) >= projection_parts_pk_bytes
+    assert int(node.query(query_parts_pk_bytes_allocated).strip()) >= projection_parts_pk_bytes_allocated
+    assert int(node.query(query_parts_pk_size).strip()) > 0
+    assert int(node.query(query_parts_columns_pk_bytes).strip()) >= projection_parts_pk_bytes
+    assert int(node.query(query_parts_columns_pk_bytes_allocated).strip()) >= projection_parts_pk_bytes_allocated
+
+    node.query("DROP TABLE test_projection_only_pk_bytes;")


### PR DESCRIPTION
Resolves: https://github.com/ClickHouse/ClickHouse/issues/109803

**Changelog category (leave one):**

- Bug Fix (user-visible misbehavior in an official stable release)

**Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):**

- Projection primary keys were accounted only through projection-specific metrics and system.projection_parts, while the aggregate primary key metrics and parent system.parts fields did not include them.
- This change makes TotalPrimaryKeyBytesInMemory, TotalPrimaryKeyBytesInMemoryAllocated, system.parts.primary_key_size, system.parts.primary_key_bytes_in_memory, system.parts.primary_key_bytes_in_memory_allocated, and the corresponding system.parts_columns memory fields include primary keys from projections stored inside the parent part. Projection-specific metrics and system.projection_parts remain available for inspecting projection-only usage.
- system.tables does not currently expose primary-key-memory fields, so there is no matching system.tables column to update. Existing system.tables row, part, and byte counters keep their current semantics.

**Documentation entry for user-facing changes**

- [ ] Documentation is written (mandatory for new features)