### PR TITLE
Fix flaky NATS test_cancel/stop_during_insert_does_not_duplicate by widening ack_wait past the slow insert

### DIFF
--- a/tests/integration/test_storage_nats/test_system_stop.py
+++ b/tests/integration/test_storage_nats/test_system_stop.py
@@ -502,8 +502,9 @@ def test_stop_during_insert_does_not_duplicate(nats_cluster):
     # (incorrectly) skipped would be redelivered after ack_wait and surface as a duplicate.
     time.sleep(1)
     instance.query(f"SYSTEM STOP test.{table}")
-    instance.query(f"SYSTEM START test.{table}")
-    instance.wait_for_log_line(f"test.{table}.*Started streaming to 1 attached views")
+    # Wait for the fresh post-START subscription (a new "Started streaming" line), not the stale one from
+    # table creation, so the stability window below actually covers the resubscribed consumer.
+    start_and_wait_for_streaming(table)
 
     # The block is acked exactly once: the rows appear and never grow past n, none are missing, and the
     # consumer reports nothing still pending acknowledgement. Watch for longer than ack_wait so a skipped

--- a/tests/integration/test_storage_nats/test_system_stop.py
+++ b/tests/integration/test_storage_nats/test_system_stop.py
@@ -463,8 +463,15 @@ def test_stop_during_insert_does_not_duplicate(nats_cluster):
     table = "nats_stop_during_insert"
     n = 5
 
-    # A short ack-wait so a missing ack surfaces quickly as a redelivery.
-    jetstream_setup(nats_cluster, stream, subject, durable, ack_wait_seconds=3)
+    # The block is acked only after the insert (its durable boundary), so `ack_wait` must exceed the
+    # insert time or the broker redelivers a correctly-acked block before its ack lands (a spurious
+    # duplicate). The view sleeps a fixed `insert_secs` (cap lifted below), so the margin is
+    # deterministic: `ack_wait=3` used to duplicate under this load; `ack_wait` well above insert_secs
+    # does not. A wrongly skipped ack is still detected two ways: as a redelivery duplicate (caught by
+    # the longer-than-`ack_wait` stability window below) and immediately by a non-zero `num_ack_pending`.
+    insert_secs = 5
+    ack_wait = 30
+    jetstream_setup(nats_cluster, stream, subject, durable, ack_wait_seconds=ack_wait)
 
     instance.query(
         f"""
@@ -483,7 +490,8 @@ def test_stop_during_insert_does_not_duplicate(nats_cluster):
             ENGINE = MergeTree ORDER BY key;
 
         CREATE MATERIALIZED VIEW test.{table}_mv TO test.{table}_dst AS
-            SELECT key, value FROM test.{table} WHERE sleepEachRow(0.4) = 0;
+            SELECT key, value FROM test.{table} WHERE sleepEachRow({insert_secs / n}) = 0
+            SETTINGS function_sleep_max_microseconds_per_block = 60000000;
         """
     )
     instance.wait_for_log_line(f"test.{table}.*Started streaming to 1 attached views")
@@ -497,10 +505,11 @@ def test_stop_during_insert_does_not_duplicate(nats_cluster):
     instance.query(f"SYSTEM START test.{table}")
     instance.wait_for_log_line(f"test.{table}.*Started streaming to 1 attached views")
 
-    # The block is acked exactly once: the rows appear and never grow past n (past the 3s ack-wait there
-    # is no redelivery), none are missing, and the consumer reports nothing still pending acknowledgement.
+    # The block is acked exactly once: the rows appear and never grow past n, none are missing, and the
+    # consumer reports nothing still pending acknowledgement. Watch for longer than ack_wait so a skipped
+    # ack, which would be redelivered only after ack_wait, still surfaces as a duplicate within the window.
     wait_dst_count_at_least(table, n)
-    assert_dst_count_stable(table, n, seconds=8)
+    assert_dst_count_stable(table, n, seconds=ack_wait + 5)
     assert jetstream_ack_pending(nats_cluster, stream, durable) == 0
 
 
@@ -514,8 +523,15 @@ def test_cancel_during_insert_does_not_duplicate(nats_cluster):
     table = "nats_cancel_during_insert"
     n = 5
 
-    # A short ack-wait so a missing ack surfaces quickly as a redelivery.
-    jetstream_setup(nats_cluster, stream, subject, durable, ack_wait_seconds=3)
+    # The block is acked only after the insert (its durable boundary), so `ack_wait` must exceed the
+    # insert time or the broker redelivers a correctly-acked block before its ack lands (a spurious
+    # duplicate). The view sleeps a fixed `insert_secs` (cap lifted below), so the margin is
+    # deterministic: `ack_wait=3` used to duplicate under this load; `ack_wait` well above insert_secs
+    # does not. A wrongly skipped ack is still detected two ways: as a redelivery duplicate (caught by
+    # the longer-than-`ack_wait` stability window below) and immediately by a non-zero `num_ack_pending`.
+    insert_secs = 5
+    ack_wait = 30
+    jetstream_setup(nats_cluster, stream, subject, durable, ack_wait_seconds=ack_wait)
 
     instance.query(
         f"""
@@ -534,7 +550,8 @@ def test_cancel_during_insert_does_not_duplicate(nats_cluster):
             ENGINE = MergeTree ORDER BY key;
 
         CREATE MATERIALIZED VIEW test.{table}_mv TO test.{table}_dst AS
-            SELECT key, value FROM test.{table} WHERE sleepEachRow(0.4) = 0;
+            SELECT key, value FROM test.{table} WHERE sleepEachRow({insert_secs / n}) = 0
+            SETTINGS function_sleep_max_microseconds_per_block = 60000000;
         """
     )
     instance.wait_for_log_line(f"test.{table}.*Started streaming to 1 attached views")
@@ -545,10 +562,11 @@ def test_cancel_during_insert_does_not_duplicate(nats_cluster):
     time.sleep(1)
     instance.query(f"SYSTEM CANCEL test.{table}")
 
-    # Acked exactly once: count reaches n and never grows (no duplicate, no loss), and nothing is
-    # left pending acknowledgement.
+    # Acked exactly once: count reaches n and never grows (no duplicate, no loss), and nothing is left
+    # pending acknowledgement. Watch for longer than ack_wait so a skipped ack, which would be
+    # redelivered only after ack_wait, still surfaces as a duplicate within the window.
     wait_dst_count_at_least(table, n)
-    assert_dst_count_stable(table, n, seconds=8)
+    assert_dst_count_stable(table, n, seconds=ack_wait + 5)
     assert jetstream_ack_pending(nats_cluster, stream, durable) == 0
 
 


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110760
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Investigated at the request of @alexey-milovidov (#110760).

`test_storage_nats/test_system_stop.py::test_cancel_during_insert_does_not_duplicate` failed once with `assert 10 == 5` (rows duplicated after a cancelled insert) and passed on retry. Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=110760&sha=df8cc6136e6c0c35d33bf29f310498569c16bc66&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29

Root cause (from that job's server log, thread 67):
- 04:07:14.209 the streaming cycle reads the 5 JetStream messages and starts the slow materialized-view insert (`sleepEachRow(0.4)` over 5 rows).
- 04:07:15.915 `SYSTEM CANCEL` runs. By then the block has already passed the source's abort fence, so it is committed to the normal insert-then-ack path (the cancel does not abort it).
- 04:07:16.659 the 5-row block is committed and acked. `NATSStreamingTask: Execution took 2571 ms`.
- 04:07:19.035 a second 5-row block is committed => 10 rows.

The block was inserted and acked exactly once, but the ack landed after JetStream's `ack_wait=3s` (measured from delivery ~04:07:13.6): the durable boundary is the deliberately slow insert (~2s nominal, 2.57s under ASAN here), leaving no margin for delivery plus ack latency. JetStream redelivered the still-pending block and it was inserted again. This is a redelivery-vs-ack timing race baked into the test config, not the NATS cancel path; the `SYSTEM CANCEL` is causally irrelevant.

The ack must stay after the insert (at-least-once; `test_jetstream_failed_insert_does_not_lose_messages` relies on exactly this), so the engine is correct and unchanged. The fix, in the two tests that combine a slow insert with a tight `ack_wait` (`test_stop_during_insert_does_not_duplicate` and `test_cancel_during_insert_does_not_duplicate`), makes the margin explicit and deterministic: the view sleeps a fixed 5s per block (the per-block sleep cap is lifted for that view via `function_sleep_max_microseconds_per_block`) and `ack_wait` is raised to 30s, so a correctly-acked block is never redelivered. The tests keep their regression coverage two ways: a wrongly skipped ack is redelivered after `ack_wait` and caught by the stability window (now kept longer than `ack_wait`), and it is also caught immediately by the existing `assert jetstream_ack_pending(...) == 0`, which reads consumer state directly. The other `ack_wait=3` tests use a trivial view whose insert finishes in milliseconds, so they are not affected and are left unchanged.

Verified locally (debug build): with the fix both tests pass; reverting only `ack_wait` to 3 makes them fail deterministically with the original `assert 10 == 5`, so they are a genuine regression test for the timing bug rather than relying on incidental sanitizer overhead.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.160` (included in `26.8` and later)
<!-- ch-version-info:end -->