### PR TITLE
Reject vectors with overflowing magnitude in i8-quantized vector similarity index

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -307,9 +307,12 @@ MergeTreeIndexGranulePtr MergeTreeIndexAggregatorVectorSimilarity::getGranuleAnd
 namespace
 {
 
-/// Check two things to prevent undefined behavior further down in Usearch
+/// Check three things to prevent undefined behavior further down in Usearch
 /// - No vector element is +inf, -inf or nan.
-/// - In the case of i8 quantization (which is obscure): additionally, the vector magnitude must not be zero.
+/// - In the case of i8 quantization (which is obscure): additionally, the squared vector magnitude must be neither zero nor
+///   overflow to infinity. Usearch's i8 cast scales each element as x * 127.0 / sqrt(sum(x^2)); a zero magnitude produces 0.0/0.0
+///   and an infinite magnitude produces inf/inf (elements above DBL_MAX/127 overflow the numerator too) - both are NaN, and
+///   casting NaN to int8 is undefined behavior.
 template <typename T>
 void checkVectorIsSane(
     const T * vector,
@@ -345,6 +348,10 @@ void checkVectorIsSane(
     if (scalar_kind == unum::usearch::scalar_kind_t::i8_k && magnitude_squared == 0.0)
         throw Exception(error_code,
             "Zero-magnitude vectors for vector similarity index ({}) are not supported with `i8` quantization", context);
+
+    if (scalar_kind == unum::usearch::scalar_kind_t::i8_k && !std::isfinite(magnitude_squared))
+        throw Exception(error_code,
+            "Vectors with too large magnitude for vector similarity index ({}) are not supported with `i8` quantization", context);
 }
 
 template <typename Column>

--- a/tests/queries/0_stateless/04627_vector_search_i8_magnitude_overflow.sql
+++ b/tests/queries/0_stateless/04627_vector_search_i8_magnitude_overflow.sql
@@ -1,0 +1,33 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+-- With i8 quantization, vectors whose squared magnitude overflows to infinity used to cause undefined behavior in usearch:
+-- its i8 cast scales each element as x * 127.0 / sqrt(sum(x^2)), and inf/inf is NaN, which is then cast to int8.
+-- Such vectors must be rejected, like non-finite and zero-magnitude vectors.
+-- Issue: https://github.com/ClickHouse/ClickHouse/issues/111621
+
+DROP TABLE IF EXISTS tab;
+
+-- Only Float64 vectors can overflow the double magnitude accumulator.
+CREATE TABLE tab (id Int32, vec Array(Float64), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3, 'i8', 32, 128))
+ENGINE = MergeTree ORDER BY id;
+
+-- In INSERT
+INSERT INTO tab VALUES (1, [1e307, 1.0, 1.0]); -- { serverError INCORRECT_DATA }
+
+-- Insert dummy values, otherwise the SELECT earlies out before the magnitude check
+INSERT INTO tab VALUES (0, [1.0, 0.0, 0.0]), (1, [0.0, 1.0, 0.0]), (2, [0.0, 0.0, 1.0]);
+
+-- In reference vector
+SELECT id FROM tab ORDER BY L2Distance(vec, [1e307, 1.0, 1.0]) LIMIT 1; -- { serverError INCORRECT_QUERY }
+
+DROP TABLE tab;
+
+-- The reference vector is Float64 regardless of the column type, so the search path must be guarded for Float32 columns too.
+CREATE TABLE tab (id Int32, vec Array(Float32), INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 3, 'i8', 32, 128))
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (0, [1.0, 0.0, 0.0]), (1, [0.0, 1.0, 0.0]), (2, [0.0, 0.0, 1.0]);
+
+SELECT id FROM tab ORDER BY L2Distance(vec, [1e307, 1.0, 1.0]) LIMIT 1; -- { serverError INCORRECT_QUERY }
+
+DROP TABLE tab;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/111621

With `i8` quantization, a vector whose squared magnitude overflows to infinity used to cause undefined behavior inside usearch: its `i8` cast scales each element as `x * 127.0 / sqrt(sum(x^2))`, and for finite `Float64` elements above ~1.4e306 both the numerator and the magnitude overflow to `inf`, so `inf/inf` produces `NaN`, which is then cast to `int8` — caught by UBSan in stress tests as `STID: 8146-795a` at `contrib/usearch/include/usearch/index_plugins.hpp:1216`.

`checkVectorIsSane` already rejects non-finite elements and zero-magnitude vectors (the two neighbouring hazards of the same cast); this adds the missing third guard — the squared magnitude must be finite — on both the insert path and the reference-vector (search) path. Only `Float64` vectors can overflow the `double` accumulator, but the reference vector is always `Float64`, so the search path is guarded for all column types; the new test covers `Float64` and `Float32` columns.

Verified: without the fix, the new test fails (`The query succeeded but the server error was expected` — the UB executes silently in non-sanitized builds); with the fix, it passes.

CI report where the UB fired: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111549&sha=45f2ca57a09f8627e509b7615cf4f1ea33d74588&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Vector similarity indexes with `i8` quantization now reject vectors whose magnitude overflows (elements around `1e306` and above) instead of running into undefined behavior in the underlying usearch library.
