### PR TITLE
Docs: document in-place `MODIFY REFRESH` behavior

### DIFF
--- a/docs/en/sql-reference/statements/alter/view.md
+++ b/docs/en/sql-reference/statements/alter/view.md
@@ -201,6 +201,10 @@ ALTER TABLE [db.]name MODIFY REFRESH EVERY|AFTER ... [RANDOMIZE FOR ...] [DEPEND
 
 The schedule (`EVERY` or `AFTER`) is mandatory: the statement replaces *all* refresh parameters at once. Any clause not specified — `RANDOMIZE FOR`, `DEPENDS ON`, or `SETTINGS` — is removed or reset to defaults. To change only refresh settings, repeat the current schedule.
 
+The command updates the refresh configuration of the existing view in place without recreating the materialized view or its target table, clearing existing target data, or canceling an already-running refresh. Reads continue against the existing target table while the configuration is changed.
+
+Repeating the command with the same complete `REFRESH` specification is safe. Make sure to repeat every clause that should remain configured, because each execution replaces all refresh parameters as described above.
+
 ```sql
 -- Change the schedule.
 ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE;

--- a/docs/en/sql-reference/statements/alter/view.md
+++ b/docs/en/sql-reference/statements/alter/view.md
@@ -210,7 +210,7 @@ Repeating the command with the same complete `REFRESH` specification is safe. Ma
 ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE;
 
 -- Change retry settings (schedule must be repeated).
-ALTER TABLE rmv MODIFY REFRESH EVERY 1 HOUR
+ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE
 SETTINGS refresh_retries = 5,
          refresh_retry_initial_backoff_ms = 500,
          refresh_retry_max_backoff_ms = 60000;

--- a/docs/reference/statements/alter/view.mdx
+++ b/docs/reference/statements/alter/view.mdx
@@ -200,12 +200,16 @@ ALTER TABLE [db.]name MODIFY REFRESH EVERY|AFTER ... [RANDOMIZE FOR ...] [DEPEND
 
 The schedule (`EVERY` or `AFTER`) is mandatory: the statement replaces *all* refresh parameters at once. Any clause not specified — `RANDOMIZE FOR`, `DEPENDS ON`, or `SETTINGS` — is removed or reset to defaults. To change only refresh settings, repeat the current schedule.
 
+The command updates the refresh configuration of the existing view in place without recreating the materialized view or its target table, clearing existing target data, or canceling an already-running refresh. Reads continue against the existing target table while the configuration is changed.
+
+Repeating the command with the same complete `REFRESH` specification is safe. Make sure to repeat every clause that should remain configured, because each execution replaces all refresh parameters as described above.
+
 ```sql
 -- Change the schedule.
 ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE;
 
 -- Change retry settings (schedule must be repeated).
-ALTER TABLE rmv MODIFY REFRESH EVERY 1 HOUR
+ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE
 SETTINGS refresh_retries = 5,
          refresh_retry_initial_backoff_ms = 500,
          refresh_retry_max_backoff_ms = 60000;


### PR DESCRIPTION
Document that `ALTER TABLE ... MODIFY REFRESH` updates an existing refreshable materialized view's configuration in place without recreating its target, clearing existing data, or canceling an active refresh. Clarify that repeating the same complete `REFRESH` specification is safe while emphasizing that omitted refresh parameters are removed or reset.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.246` (included in `26.8` and later)
<!-- ch-version-info:end -->