### PR TITLE
Fix LOGICAL_ERROR when loading an existing Compact part under a non-adaptive table policy

### DIFF
--- a/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
@@ -39,7 +39,6 @@ MergeTreeDataPartBuilder::MergeTreeDataPartBuilder(
 std::shared_ptr<IMergeTreeDataPart> MergeTreeDataPartBuilder::build()
 {
     using PartType = MergeTreeDataPartType;
-    using PartStorageType = MergeTreeDataPartStorageType;
 
     /// Route every allocation produced while constructing the part (the `IMergeTreeDataPart`
     /// object itself, its initializer-list members `Poco::LRUCache<String, ColumnSize>`,
@@ -59,14 +58,9 @@ std::shared_ptr<IMergeTreeDataPart> MergeTreeDataPartBuilder::build()
     if (parent_part && data.format_version == MERGE_TREE_DATA_OLD_FORMAT_VERSION)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot create projection part in MergeTree table created in old syntax");
 
-    auto part_storage_type = part_storage->getType();
-    if (!data.canUsePolymorphicParts() &&
-        (part_type != PartType::Wide || part_storage_type != PartStorageType::Full))
-    {
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
-            "Cannot create part with type {} and storage type {} because table does not support polymorphic parts",
-            part_type->toString(), part_storage_type.toString());
-    }
+    /// No polymorphic-parts policy check here: it governs only the format of NEW parts and is
+    /// enforced by MergeTreeData::choosePartFormat. The type reaching build() otherwise belongs to
+    /// an existing part (loaded from disk, or inherited by a mutation), where it is a physical fact.
 
     if (!part_info)
         part_info = MergeTreePartInfo::fromPartName(name, data.format_version);

--- a/src/Storages/MergeTree/MergeTreeDataPartCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartCompact.h
@@ -12,7 +12,8 @@ namespace DB
   * In compact format one mark is an array of marks for every column and a number of rows in granule.
   * Format of other data part files is not changed.
   * It's considered to store only small parts in compact format (up to 10M).
-  * NOTE: Compact parts aren't supported for tables with non-adaptive granularity.
+  * NOTE: New Compact parts aren't created for tables with non-adaptive granularity (a Compact
+  *       part is always adaptive), but an existing Compact part can still be loaded by such a table.
   * NOTE: In compact part compressed and uncompressed size of single column is unknown.
   */
 class MergeTreeDataPartCompact : public IMergeTreeDataPart

--- a/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexGranularityInfo.cpp
@@ -119,7 +119,8 @@ MergeTreeIndexGranularityInfo::MergeTreeIndexGranularityInfo(
     const MergeTreeData & storage, const MergeTreeSettings & storage_settings, MergeTreeDataPartType type_)
     : MergeTreeIndexGranularityInfo(
           storage_settings,
-          {storage.canUseAdaptiveGranularity(),
+          {/// Only Wide parts can be non-adaptive; a Compact part is always adaptive (MarkType ctor).
+           storage.canUseAdaptiveGranularity() || type_ != MergeTreeDataPartType::Wide,
            storage_settings[MergeTreeSetting::compress_marks],
            storage_settings[MergeTreeSetting::write_marks_for_substreams_in_compact_parts],
            type_.getValue()})

--- a/tests/integration/test_merge_tree_load_parts/test.py
+++ b/tests/integration/test_merge_tree_load_parts/test.py
@@ -205,11 +205,6 @@ def test_merge_tree_load_parts_corrupted(started_cluster):
 
 def test_merge_tree_load_parts_filesystem_error(started_cluster):
     table = f"mt_load_parts_fs_error_{random_string(6)}"
-    if node3.is_built_with_sanitizer() or node3.is_debug_build():
-        pytest.skip(
-            "Skip with debug build and sanitizers. \
-            This test intentionally triggers LOGICAL_ERROR which leads to crash with those builds"
-        )
 
     node3.query(
         f"""
@@ -223,14 +218,13 @@ def test_merge_tree_load_parts_filesystem_error(started_cluster):
     for i in range(2):
         node3.query(f"INSERT INTO {table} VALUES ({i})")
 
-    # We want to somehow check that exception thrown on part creation is handled during part loading.
-    # It can be a filesystem exception triggered at initialization of part storage but it hard
-    # to trigger it because it should be an exception on stat/listDirectory.
-    # The most easy way to trigger such exception is to use chmod but clickhouse server
-    # is run with root user in integration test and this won't work. So let's do
-    # some stupid things: create a table without adaptive granularity and change mark
-    # extensions of data files in part to make clickhouse think that it's a compact part which
-    # cannot be created in such table. This will trigger a LOGICAL_ERROR on part creation.
+    # We want to check that an exception thrown while loading a part is handled: the part is
+    # detached as broken instead of taking down the server. To provoke a load-time exception we
+    # rename the part's mark file extension so the (non-adaptive) Wide part looks like a Compact
+    # part. Loading such a part fails later, when its columns/marks are read, and it is detached.
+    # (Building the part no longer raises a LOGICAL_ERROR - a Compact part is always adaptive, so
+    # a non-adaptive table can still load an existing Compact part - hence this runs on debug and
+    # sanitizer builds too.)
 
     def corrupt_part(table, part_name):
         part_path = node3.query(

--- a/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.reference
+++ b/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.reference
@@ -2,3 +2,5 @@ writer part type:
 Compact
 reader after restart:
 1	Hello
+reader after background refresh:
+1	Hello

--- a/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.reference
+++ b/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.reference
@@ -1,0 +1,4 @@
+writer part type:
+Compact
+reader after restart:
+1	Hello

--- a/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
+++ b/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
@@ -4,10 +4,11 @@
 
 # A writer table (adaptive granularity) creates a Compact part on a plain_rewritable path. A reader
 # table with non-adaptive granularity (index_granularity_bytes = 0, so canUsePolymorphicParts() is
-# false) shares the same backing path. SYSTEM RESTART DISK makes the reader re-scan and load the
-# writer's Compact part. Previously the part-load path rejected the Compact part with a LOGICAL_ERROR
-# ("... table does not support polymorphic parts"), aborting the server in debug/sanitizer builds. An
-# existing Compact part is always adaptive, so it must load regardless of the reader's current policy.
+# false) shares the same backing path. Previously the part-load path rejected the Compact part with a
+# LOGICAL_ERROR ("... table does not support polymorphic parts"), aborting the server in
+# debug/sanitizer builds. An existing Compact part is always adaptive, so it must load regardless of
+# the reader's current policy. Both callers that reach the load path are covered: SYSTEM RESTART DISK
+# and the background `refresh_parts_interval` task.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -15,6 +16,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader_refresh SYNC"
 
 ${CLICKHOUSE_CLIENT} --query "
 CREATE TABLE writer (s String) ORDER BY ()
@@ -42,6 +44,23 @@ SETTINGS table_disk = true, index_granularity_bytes = 0, min_bytes_for_wide_part
       path = 'disks/04371/${CLICKHOUSE_DATABASE}/')
 "
 
+# Same shared path and settings, but this reader picks parts up via the background
+# `refresh_parts_interval` task. Created before the insert on purpose: the part must arrive after the
+# initial load, so the refresh task rather than startup is what loads it. The disk must stay readonly,
+# otherwise the task is not started at all.
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE reader_refresh (s String) ORDER BY ()
+SETTINGS table_disk = true, refresh_parts_interval = 1,
+         index_granularity_bytes = 0, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
+  disk = disk(
+      readonly = true,
+      name = poly_load_refresh_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04371/${CLICKHOUSE_DATABASE}/')
+"
+
 # A single small insert produces a Compact part.
 ${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('Hello')"
 echo "writer part type:"
@@ -52,5 +71,14 @@ ${CLICKHOUSE_CLIENT} --query "SYSTEM RESTART DISK poly_load_reader_${CLICKHOUSE_
 echo "reader after restart:"
 ${CLICKHOUSE_CLIENT} --query "SELECT count(), min(s) FROM reader"
 
+# Wait for the background refresh to observe the part written above.
+for _ in {1..300}; do
+    [ "$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM reader_refresh")" = "1" ] && break
+    sleep 0.1
+done
+echo "reader after background refresh:"
+${CLICKHOUSE_CLIENT} --query "SELECT count(), min(s) FROM reader_refresh"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE reader_refresh SYNC"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE reader SYNC"
 ${CLICKHOUSE_CLIENT} --query "DROP TABLE writer SYNC"

--- a/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
+++ b/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-object-storage, no-replicated-database, no-shared-merge-tree
+# Tag no-replicated-database: plain rewritable should not be shared between replicas
+
+# A writer table (adaptive granularity) creates a Compact part on a plain_rewritable path. A reader
+# table with non-adaptive granularity (index_granularity_bytes = 0, so canUsePolymorphicParts() is
+# false) shares the same backing path. SYSTEM RESTART DISK makes the reader re-scan and load the
+# writer's Compact part. Previously the part-load path rejected the Compact part with a LOGICAL_ERROR
+# ("... table does not support polymorphic parts"), aborting the server in debug/sanitizer builds. An
+# existing Compact part is always adaptive, so it must load regardless of the reader's current policy.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader SYNC"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE writer (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = poly_load_writer_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04371/${CLICKHOUSE_DATABASE}/')
+"
+
+# Same backing path, readonly, and non-adaptive granularity (index_granularity_bytes = 0) so that
+# canUsePolymorphicParts() is false for this table.
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE reader (s String) ORDER BY ()
+SETTINGS table_disk = true, index_granularity_bytes = 0,
+  disk = disk(
+      readonly = true,
+      name = poly_load_reader_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04371/${CLICKHOUSE_DATABASE}/')
+"
+
+# A single small insert produces a Compact part.
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('Hello')"
+echo "writer part type:"
+${CLICKHOUSE_CLIENT} --query "SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 'writer' AND active"
+
+# Reloads the readonly reader's part list; it now loads the writer's Compact part.
+${CLICKHOUSE_CLIENT} --query "SYSTEM RESTART DISK poly_load_reader_${CLICKHOUSE_DATABASE}"
+echo "reader after restart:"
+${CLICKHOUSE_CLIENT} --query "SELECT count(), min(s) FROM reader"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE reader SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE writer SYNC"

--- a/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
+++ b/tests/queries/0_stateless/04371_load_compact_part_non_adaptive_reader.sh
@@ -28,10 +28,11 @@ SETTINGS table_disk = true,
 "
 
 # Same backing path, readonly, and non-adaptive granularity (index_granularity_bytes = 0) so that
-# canUsePolymorphicParts() is false for this table.
+# canUsePolymorphicParts() is false for this table. Keep min_*_for_wide_part = 0: on a non-adaptive
+# table a nonzero threshold logs a "settings will be ignored" warning at CREATE that trips the empty-stderr check.
 ${CLICKHOUSE_CLIENT} --query "
 CREATE TABLE reader (s String) ORDER BY ()
-SETTINGS table_disk = true, index_granularity_bytes = 0,
+SETTINGS table_disk = true, index_granularity_bytes = 0, min_bytes_for_wide_part = 0, min_rows_for_wide_part = 0,
   disk = disk(
       readonly = true,
       name = poly_load_reader_${CLICKHOUSE_DATABASE},


### PR DESCRIPTION

<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/109360
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a `LOGICAL_ERROR` (`Cannot create part with type Compact and storage type Full because table does not support polymorphic parts`) raised when a `MergeTree` table loads a pre-existing `Compact` part while its current settings disable polymorphic parts (non-adaptive granularity). This could happen, for example, when a read-only table shares an on-disk path with another table and reloads its parts via `SYSTEM RESTART DISK` or on server startup. In debug and sanitizer builds the exception aborts the server.

### Description

Found by the `Stress test (amd_msan)` check on an unrelated PR (STID 3286-0cd6), with the same error recurring across several unrelated PRs and check types (Stress msan/tsan/asan, Integration msan/tsan) over the last two months. No tracking issue existed.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109360&sha=3791a7836dd7b2f089113ba6666a14b6f9c26492&name_0=PR&name_1=Stress%20test%20%28amd_msan%29

**Root cause.** `MergeTreeData::canUsePolymorphicParts()` is equivalent to `canUseAdaptiveGranularity()`. When a table's current settings make it `false` (non-adaptive granularity), the part LOAD path rejected an already-existing `Compact` part in two places, both deriving the part's validity from the table's current create-time policy rather than the part's physical on-disk reality:

1. `MergeTreeDataPartBuilder::build()` threw the `... does not support polymorphic parts` `LOGICAL_ERROR` directly.
2. Even without (1), the `IMergeTreeDataPart` constructor initializes `index_granularity_info` from the current policy, building `MarkType(adaptive=false, Compact)`, which throws `Non-Wide data part type with non-adaptive granularity`.

But a `Compact` part is always adaptive by invariant (see the `MarkType` constructor), and an existing on-disk part's type is a fact, not a choice. The current policy only governs the format chosen for NEW parts, which `MergeTreeData::choosePartFormat()` already enforces (it returns `{Wide, Full}` when polymorphic parts are disabled).

**Fix.**
- `MergeTreeIndexGranularityInfo(storage, settings, type)`: a `Compact` part type now always yields an adaptive mark type, regardless of the table's current policy. `Wide` keeps its policy-derived adaptivity (a `Wide` part may legitimately be non-adaptive). This covers both the load path and mutations that inherit a `Compact` source part's format.
- `MergeTreeDataPartBuilder::build()`: removed the redundant polymorphic-parts guard. New-part format selection is enforced by `choosePartFormat`; the type reaching `build()` otherwise belongs to an existing part (read from disk, or inherited by a mutation), where it is a physical fact.

New-part creation behavior is unchanged. The change only makes ClickHouse load pre-existing `Compact` parts it currently rejects.

Added regression test `04371_load_compact_part_non_adaptive_reader.sh` (a non-adaptive reader shares a `plain_rewritable` path with an adaptive writer and loads the writer's `Compact` part via `SYSTEM RESTART DISK`). It aborts the server without the fix and passes with it.
