### PR TITLE
Document Cloud `BACKUP` privilege prerequisite

### DIFF
--- a/docs/products/cloud/guides/backups/bring-your-own-backup/export-backups-to-own-cloud-account.mdx
+++ b/docs/products/cloud/guides/backups/bring-your-own-backup/export-backups-to-own-cloud-account.mdx
@@ -19,6 +19,8 @@ Cross-Cloud backups are only supported via the backup/restore commands outlined 
 
 ## Requirements {#requirements}
 
+To run the `BACKUP` commands in this guide, the ClickHouse user must have the `BACKUP` privilege. This privilege isn't included in `default_role` in ClickHouse Cloud, and granting it requires assistance from [ClickHouse Support](https://clickhouse.com/support/program). Request the privilege before exporting backups.
+
 You will need the following details to export/restore backups to your own CSP storage bucket.
 
 ### AWS {#aws}


### PR DESCRIPTION
Add the missing ClickHouse-side prerequisite to the guide for exporting backups to a customer's own cloud account. The guide now explains that the user running `BACKUP` must have the `BACKUP` privilege, that ClickHouse Cloud's `default_role` does not include it, and that granting it requires assistance from ClickHouse Support.

This prevents users from completing the cloud-storage setup only to discover that their database role cannot run the documented backup commands.

Related: https://linear.app/clickhouse/issue/DOC-920/mention-backup-privilege-prerequisite-for-byo-backups

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.