### PR TITLE
Increase coverage for text index postprocessor fast path for #111509

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.reference
+++ b/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.reference
@@ -3,6 +3,10 @@ brown end fox here quick
 2
 1
 if(token NOT IN (keep-set)): only the keep-set survives
+if(token IN (tuple)): listed stop words retained, non-stop words dropped
+brown end fox here quick
+2
+1
 fox the
 if(token IN (array)): array right-hand side, same as tuple
 brown end fox here quick

--- a/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.reference
+++ b/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.reference
@@ -3,11 +3,11 @@ brown end fox here quick
 2
 1
 if(token NOT IN (keep-set)): only the keep-set survives
-if(token IN (tuple)): listed stop words retained, non-stop words dropped
-brown end fox here quick
-2
-1
 fox the
+if(token IN (tuple)): listed stop words retained, non-stop words dropped
+a is the
+0
+0
 if(token IN (array)): array right-hand side, same as tuple
 brown end fox here quick
 multiIf(token IN (tuple)): CASE spelling drops the same tokens

--- a/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
+++ b/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
@@ -30,6 +30,22 @@ ORDER BY id;
 
 INSERT INTO tab_notin VALUES (1, 'the quick brown fox'), (2, 'a fox is here'), (3, 'is the end');
 
+SELECT 'if(token IN (tuple)): listed stop words retained, non-stop words dropped';
+
+CREATE TABLE tab_in_reversed (
+  id UInt32,
+  s String,
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s IN ('the', 'a', 'is'), '', s))
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tab_in_reversed VALUES (1, 'the quick brown fox'), (2, 'a fox is here'), (3, 'is the end');
+
+SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_in_reversed, idx);
+SELECT count() FROM tab_in_reversed WHERE hasToken(s, 'fox');
+SELECT count() FROM tab_in_reversed WHERE hasToken(s, 'end');
+
 SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_notin, idx);
 
 SELECT 'if(token IN (array)): array right-hand side, same as tuple';
@@ -90,6 +106,7 @@ SELECT count() FROM tab_materialized WHERE hasToken(s, 'the');
 
 DROP TABLE tab_in;
 DROP TABLE tab_notin;
+DROP TABLE tab_in_reversed;
 DROP TABLE tab_array;
 DROP TABLE tab_multiif;
 DROP TABLE tab_fixed;

--- a/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
+++ b/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
@@ -23,7 +23,7 @@ SELECT 'if(token NOT IN (keep-set)): only the keep-set survives';
 CREATE TABLE tab_notin (
   id UInt32,
   s String,
-  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s NOT IN ('the', 'fox'), s, ''))
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s NOT IN ('the', 'fox'), '', s))
 )
 ENGINE = MergeTree
 ORDER BY id;
@@ -37,7 +37,7 @@ SELECT 'if(token IN (tuple)): listed stop words retained, non-stop words dropped
 CREATE TABLE tab_in_reversed (
   id UInt32,
   s String,
-  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s IN ('the', 'a', 'is'), '', s))
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s IN ('the', 'a', 'is'), s, ''))
 )
 ENGINE = MergeTree
 ORDER BY id;
@@ -106,7 +106,6 @@ SELECT count() FROM tab_materialized WHERE hasToken(s, 'the');
 
 DROP TABLE tab_in;
 DROP TABLE tab_notin;
-DROP TABLE tab_in_reversed;
 DROP TABLE tab_array;
 DROP TABLE tab_multiif;
 DROP TABLE tab_fixed;

--- a/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
+++ b/tests/queries/0_stateless/02346_text_index_postprocessor_in_filter.sql
@@ -23,12 +23,14 @@ SELECT 'if(token NOT IN (keep-set)): only the keep-set survives';
 CREATE TABLE tab_notin (
   id UInt32,
   s String,
-  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s NOT IN ('the', 'fox'), '', s))
+  INDEX idx(s) TYPE text(tokenizer = 'splitByNonAlpha', postprocessor = if(s NOT IN ('the', 'fox'), s, ''))
 )
 ENGINE = MergeTree
 ORDER BY id;
 
 INSERT INTO tab_notin VALUES (1, 'the quick brown fox'), (2, 'a fox is here'), (3, 'is the end');
+
+SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_notin, idx);
 
 SELECT 'if(token IN (tuple)): listed stop words retained, non-stop words dropped';
 
@@ -45,8 +47,6 @@ INSERT INTO tab_in_reversed VALUES (1, 'the quick brown fox'), (2, 'a fox is her
 SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_in_reversed, idx);
 SELECT count() FROM tab_in_reversed WHERE hasToken(s, 'fox');
 SELECT count() FROM tab_in_reversed WHERE hasToken(s, 'end');
-
-SELECT arrayStringConcat(arraySort(groupArray(token)), ' ') FROM mergeTreeTextIndex(currentDatabase(), tab_notin, idx);
 
 SELECT 'if(token IN (array)): array right-hand side, same as tuple';
 CREATE TABLE tab_array (


### PR DESCRIPTION
Follow-up to #111509

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.91` (included in `26.8` and later)
<!-- ch-version-info:end -->