### PR TITLE
Finalize the 26.7 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Watch all release presentations and videos at [ClickHouse Theater](https://presentations.clickhouse.com/) and [YouTube Playlist](https://www.youtube.com/playlist?list=PL0Z2YDlm0b3jAlSy1JxyP8zluvXaN3nxU).
 
 ### Table of Contents
-**[ClickHouse release v26.7, FIXME](#267)**<br/>
+**[ClickHouse release v26.7, 2026-07-22](#267)**<br/>
 **[ClickHouse release v26.6, 2026-06-25](#266)**<br/>
 **[ClickHouse release v26.5, 2026-05-21](#265)**<br/>
 **[ClickHouse release v26.4, 2026-04-30](#264)**<br/>
@@ -20,7 +20,7 @@
 
 # 2026 Changelog
 
-### <a id="267"></a> ClickHouse release 26.7, FIXME (in progress)
+### <a id="267"></a> ClickHouse release 26.7, 2026-07-22. [Presentation](https://presentations.clickhouse.com/2026-release-26.7/), [Video](https://www.youtube.com/watch?v=mKBNLaFOVDA)
 
 #### Backward Incompatible Change
 * S3 access originating from user SQL no longer resolves the server's own cloud credentials (environment, IMDS/IRSA, instance profile, AWS config files, `role_arn`-based STS, GCP OAuth metadata) by default; such a request must use explicit credentials or `NOSIGN`. Named collections now default `use_environment_credentials` to `0`. The previous behaviour can be restored per request with `use_environment_credentials = 1` (or globally via the `<s3>` config) together with the new setting `s3_allow_server_credentials_in_user_queries` (disabled by default). Explicitly supplied and operator-provisioned config credentials are unaffected. On server startup or `RESTORE`, a persistent `S3`/`S3Queue` table, dynamic S3 disk, or `DataLakeCatalog` whose definition resolves such credentials is loaded anonymously (inaccessible until re-credentialed) instead of aborting startup, controlled by the new server setting `s3_load_table_anonymously_if_credentials_restricted` (enabled by default). [#106855](https://github.com/ClickHouse/ClickHouse/pull/106855) ([Raúl Marín](https://github.com/Algunenano)).

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ curl https://clickhouse.com/ | sh
 
 The [ClickHouse **26.7** Release Call](https://www.youtube.com/watch?v=mKBNLaFOVDA) took place on July 23, 2026 — watch the recording and the [slides](https://presentations.clickhouse.com/2026-release-26.7/).
 
+The [ClickHouse **26.6** special "10 Year Anniversary" Release Call](https://www.youtube.com/watch?v=-NmqMH9y4EY) — recording and [slides](https://presentations.clickhouse.com/2026-release-26.6/).
+
 Watch all release presentations and videos at [ClickHouse Theater](https://presentations.clickhouse.com/) and [YouTube Playlist](https://www.youtube.com/playlist?list=PL0Z2YDlm0b3jAlSy1JxyP8zluvXaN3nxU).
 
 ## Upcoming Events

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ curl https://clickhouse.com/ | sh
 
 ## Monthly Release & Community Call
 
-Join us for the [ClickHouse **26.5** Release Call](https://clickhouse.com/company/events/v26-5-community-release-call) on May 21, 2026.
+The [ClickHouse **26.7** Release Call](https://www.youtube.com/watch?v=mKBNLaFOVDA) took place on July 23, 2026 — watch the recording and the [slides](https://presentations.clickhouse.com/2026-release-26.7/).
 
 Watch all release presentations and videos at [ClickHouse Theater](https://presentations.clickhouse.com/) and [YouTube Playlist](https://www.youtube.com/playlist?list=PL0Z2YDlm0b3jAlSy1JxyP8zluvXaN3nxU).
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Post-release finalization for 26.7:

**CHANGELOG.md** — fills in the FIXME placeholders now that the release is out and the release call has happened:
- Release date: **2026-07-22** (the `v26.7.1.1315-stable` tag), in the table of contents and the section header.
- [Presentation](https://presentations.clickhouse.com/2026-release-26.7/) and [Video](https://www.youtube.com/watch?v=mKBNLaFOVDA) links in the section header, following the format of the previous releases.

**README.md** — the "Monthly Release & Community Call" section still advertised the 26.5 call from May; it now links the 26.7 recording and slides. (No 26.8 event page exists yet to point to; it can be swapped in when the next call is scheduled.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.52` (included in `26.8` and later)
<!-- ch-version-info:end -->