### PR TITLE
Harden `04624_part_loading_tree_rollback_startup_recovery` against stress restarts and leaked tables

### DIFF
--- a/tests/queries/0_stateless/04624_part_loading_tree_rollback_startup_recovery.sh
+++ b/tests/queries/0_stateless/04624_part_loading_tree_rollback_startup_recovery.sh
@@ -42,7 +42,11 @@ recover_leaked_table()
 }
 trap recover_leaked_table EXIT
 
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${TABLE}"
+# A plain `DROP TABLE IF EXISTS` would silently do nothing on a table leaked in the
+# permanently detached state by a previous run that was killed before its `EXIT` trap ran,
+# while the leftover name would still block the `CREATE TABLE` below — so recover at startup
+# the same way the rollback tests' `cleanup` does.
+recover_leaked_table
 
 # --- Simulate a previous failed attempt that leaked a permanently detached table. ---
 $CLICKHOUSE_CLIENT -q "CREATE TABLE ${TABLE} (x UInt32) ENGINE = MergeTree ORDER BY x"
@@ -51,6 +55,22 @@ DATA_PATH=$($CLICKHOUSE_CLIENT -q "
     SELECT data_paths[1] FROM system.tables
     WHERE database = currentDatabase() AND name = '${TABLE}'")
 $CLICKHOUSE_CLIENT -q "DETACH TABLE ${TABLE} PERMANENTLY"
+
+# The detach client call alone is not a sufficient gate: if it fails (e.g. the connection is
+# lost because a stress-test restart lands on it), the script would keep running under plain
+# `bash` and mutate a table directory that may still be attached. Verify the detach
+# postcondition and fail fast before touching anything under `DATA_PATH`, the same way the
+# four rollback tests do.
+DETACHED=$($CLICKHOUSE_CLIENT -q "
+    SELECT (SELECT count() FROM system.tables
+            WHERE database = currentDatabase() AND name = '${TABLE}') = 0
+       AND (SELECT count() FROM system.detached_tables
+            WHERE database = currentDatabase() AND table = '${TABLE}' AND is_permanently) = 1
+")
+if [ "${DETACHED}" != "1" ]; then
+    echo "FAIL: table ${TABLE} is not detached permanently, refusing to modify its data directory"
+    exit 1
+fi
 
 # Leave a fabricated part directory with a corrupted `txn_version.txt` behind, exactly the kind
 # of leftover that could make a plain `ATTACH TABLE` throw.


### PR DESCRIPTION
### Description

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/111055, addressing two review comments on the regression test `04624_part_loading_tree_rollback_startup_recovery.sh` that arrived shortly before that PR was merged:

- The plain `DROP TABLE IF EXISTS` at startup silently does nothing on a table leaked in the permanently detached state by a previous run that was hard-killed before its `EXIT` trap ran, while the leftover name still blocks the following `CREATE TABLE`. The test now calls `recover_leaked_table` once at startup, mirroring the `cleanup` of the four `part_loading_tree_rollback` tests.

- The test fabricated a corrupt `txn_version.txt` right after `DETACH TABLE ... PERMANENTLY` without verifying the detach postcondition. Under stress a restart can land on the detach and, under plain `bash`, the script would fall through and write into a still-attached table's directory — the exact metadata corruption #111055 fixes. The test now verifies the same fail-fast gate as the four rollback tests: the table is absent from `system.tables` and present in `system.detached_tables` with `is_permanently = 1` before anything under `DATA_PATH` is touched.

The test output is unchanged; it passes locally against a 26.7.1 server.

Related: https://github.com/ClickHouse/ClickHouse/pull/111055

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.60` (included in `26.8` and later)
<!-- ch-version-info:end -->