### PR TITLE
Move join_runtime_filter_min_probe_rows settings-history entry from 26.7 to 26.8

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -42,6 +42,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "26.8",
         {
             {"allow_lossy_numeric_supertype", false, false, "New setting that lets if/multiIf/coalesce/ifNull/array/map resolve all-numeric branches with no lossless common type (e.g. Decimal + Float64) to a numeric supertype (Float64, with possible precision loss), so the result can be aggregated. Independent of use_variant_as_common_type: with it off such branches previously raised NO_COMMON_TYPE, with it on they became a Variant; either way they now resolve to Float64."},
+            {"join_runtime_filter_min_probe_rows", 0, 1000, "New setting to control minimum probe side size for installing JOIN runtime filters. It wasn't limited before, so previous value is 0 meaning always install."},
         });
         addSettingsChanges(settings_changes_history, "26.7",
         {
@@ -72,7 +73,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"skip_unavailable_shards_mode", "unavailable_or_table_missing", "unavailable_or_table_missing", "New setting to control which exceptions from a remote shard are ignored when `skip_unavailable_shards` is enabled. The default matches the historical behavior: a shard whose table is missing is treated as unavailable."},
             {"use_text_index_tokens_cache", false, true, "Enabled the text index tokens cache globally."},
             {"use_text_index_header_cache", false, true, "Enabled the text index header cache globally."},
-            {"join_runtime_filter_min_probe_rows", 0, 1000, "New setting to control minimum probe side size for installing JOIN runtime filters. It wasn't limited before, so previous value is 0 meaning always install."},
             {"optimize_aggregation_in_order_limit", false, true, "New setting to push the `LIMIT` into aggregation-in-order for early termination when the `ORDER BY` is a prefix of the `GROUP BY` sort description."},
             {"explain_query_plan_default", "legacy", "pretty", "From 26.7, `EXPLAIN PLAN` defaults to `actions=1, compact=1, pretty=1`. Set this to `legacy` to restore the pre-26.7 output."},
             {"format_geojson_validate_geometry", true, true, "New setting that controls whether the GeoJSON format enforces RFC 7946 geometry validity (minimum points per line and ring, ring closure, non-empty multi-geometries) when reading and writing"},


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/104860
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: https://github.com/ClickHouse/ClickHouse/pull/104860

`join_runtime_filter_min_probe_rows` was added in #104860 with its `SettingsChangesHistory.cpp` entry placed in the `26.7` section. Master is now `26.8.1.1`, so the entry belongs in the `26.8` section.

The Upgrade check treats a setting as documented only when its history-entry version is strictly greater than the previous release version (`upgrade_runner.sh`: `(major*100 + minor) > old_version`). The previous release is now `v26.7.1.1315-stable`, so `old_version = 2607`. With the entry in `26.7`, `2607 > 2607` is false, so the check reports `join_runtime_filter_min_probe_rows` as an undocumented new/changed setting and `Upgrade check (amd_release)` fails on every PR. Moving it to `26.8` gives `2608 > 2607` = true, and the check passes.

Same-day precedent: commit bce71f11a687 ("allow_lossy_numeric_supertype goes to v26.8") moved another straggler from `26.7` to `26.8` for the same reason. `#104860` merged after that move, so its entry landed in the stale `26.7` section.

Verified against a local build (version 26.8.1.1): `system.settings_changes` now attributes the setting to `26.8`, and the exact upgrade check suppression query with `old_version = 2607` returns 1 (documented).
