### PR TITLE
Fix flaky test_kafka_formats_with_broken_message

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -288,7 +288,6 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
             data_prefix = data_prefix + [""]
         if format_opts.get("printable", False) == False:
             raw_message = "hex(_raw_message)"
-        k.kafka_produce(kafka_cluster, topic_name, data_prefix + data_sample)
         create_query = create_query_generator(
             f"kafka_{format_name}",
             "id Int64, blockNo UInt16, val1 String, val2 Float32, val3 UInt8",
@@ -300,6 +299,10 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
                 "kafka_flush_interval_ms": 1000,
             },
         )
+        # Create both materialized views, then detach/re-attach the Kafka table,
+        # before producing any message. Creating the first view starts the
+        # streaming loop, so producing earlier lets the loop consume and commit
+        # the broken message before the errors view is attached, leaving it empty.
         instance.query(
             f"""
             DROP TABLE IF EXISTS test.kafka_{format_name};
@@ -315,8 +318,12 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
             CREATE MATERIALIZED VIEW test.kafka_errors_{format_name}_mv ENGINE=MergeTree ORDER BY tuple() AS
                 SELECT {raw_message} as raw_message, _error as error, _topic as topic, _partition as partition, _offset as offset FROM test.kafka_{format_name}
                 WHERE length(_error) > 0;
+
+            DETACH TABLE test.kafka_{format_name};
+            ATTACH TABLE test.kafka_{format_name};
             """
         )
+        k.kafka_produce(kafka_cluster, topic_name, data_prefix + data_sample)
 
     raw_expected = """\
 0	0	AM	0.5	1	{topic_name}	0	{offset_0}


### PR DESCRIPTION
Fix flaky test_kafka_formats_with_broken_message

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/108252
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Found by @ alexey-milovidov on #109369 (report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=109369&sha=119f160ca922641691ce1c4bf7dffbe6119a5bb1&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%204%2F6%29). Unrelated to that PR.

The per-format setup produced the whole batch (including the tail broken message) to the topic, then created the Kafka table, the data materialized view, and the errors materialized view in sequence. Creating the first materialized view starts the streaming loop, so on slow (sanitizer) builds the loop could consume and commit the broken message before the errors materialized view was attached. The broken message is then past the committed offset and never reaches the errors view: the data view has its rows but the errors view stays empty, and the test fails at "Error row for format X did not appear in kafka_errors_X_mv".

Fix: create both materialized views, detach/re-attach the Kafka table, and only then produce the messages, so nothing is consumable until both views exist. This mirrors the same fix already accepted for the sibling test test_kafka_engine_put_errors_to_stream in #107025.

CIDB: 0 master failures, 25 PR failures over 45 days (both create-query parameters, random format each time, across amd_msan / amd_asan_ubsan / amd_tsan / amd_llvm_coverage). #108252 only added a diagnostic guard and a retry bump; it did not address this ordering race.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.92` (included in `26.8` and later)
- Backported to: `26.7.6.42`, `26.6.4.31`, `26.3.33.66`
<!-- ch-version-info:end -->