### PR TITLE
Reduce peak memory of test 03216_arrayWithConstant_limits

### DIFF
--- a/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
+++ b/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
@@ -2,7 +2,10 @@ SELECT arrayWithConstant(96142475, ['qMUF']); -- { serverError TOO_LARGE_ARRAY_S
 SELECT arrayWithConstant(100000000, materialize([[[[[[[[[['Hello, world!']]]]]]]]]])); -- { serverError TOO_LARGE_ARRAY_SIZE }
 SELECT length(arrayWithConstant(10000000, materialize([[[[[[[[[['Hello world']]]]]]]]]])));
 
-CREATE TABLE args (value Array(Int)) ENGINE=Memory AS SELECT [1, 1, 1, 1] as value FROM numbers(1, 100);
--- With the default max_block_size all 100 rows form a single ~1.6 GiB block, which does not fit
--- into the memory limit on a loaded test runner. Smaller blocks exercise the same code path.
-SELECT length(arrayWithConstant(1000000, value)) FROM args FORMAT NULL SETTINGS max_block_size = 8;
+CREATE TABLE args (value Array(Int)) ENGINE=Memory;
+-- If all 100 rows form a single block, the query below builds a single ~1.6 GiB column, which does
+-- not fit into the memory limit on a loaded test runner. `Memory` returns stored blocks as-is
+-- (`max_block_size` cannot split them on read), so store small blocks at insert time instead.
+-- Small blocks exercise the same code path with a peak allocation two orders of magnitude smaller.
+INSERT INTO args SELECT [1, 1, 1, 1] FROM numbers(1, 100) SETTINGS max_block_size = 2, min_insert_block_size_rows = 2, min_insert_block_size_bytes = 1;
+SELECT length(arrayWithConstant(1000000, value)) FROM args FORMAT NULL SETTINGS max_threads = 1;

--- a/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
+++ b/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
@@ -3,4 +3,6 @@ SELECT arrayWithConstant(100000000, materialize([[[[[[[[[['Hello, world!']]]]]]]
 SELECT length(arrayWithConstant(10000000, materialize([[[[[[[[[['Hello world']]]]]]]]]])));
 
 CREATE TABLE args (value Array(Int)) ENGINE=Memory AS SELECT [1, 1, 1, 1] as value FROM numbers(1, 100);
-SELECT length(arrayWithConstant(1000000, value)) FROM args FORMAT NULL;
+-- With the default max_block_size all 100 rows form a single ~1.6 GiB block, which does not fit
+-- into the memory limit on a loaded test runner. Smaller blocks exercise the same code path.
+SELECT length(arrayWithConstant(1000000, value)) FROM args FORMAT NULL SETTINGS max_block_size = 8;

--- a/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
+++ b/tests/queries/0_stateless/03216_arrayWithConstant_limits.sql
@@ -3,9 +3,10 @@ SELECT arrayWithConstant(100000000, materialize([[[[[[[[[['Hello, world!']]]]]]]
 SELECT length(arrayWithConstant(10000000, materialize([[[[[[[[[['Hello world']]]]]]]]]])));
 
 CREATE TABLE args (value Array(Int)) ENGINE=Memory;
--- If all 100 rows form a single block, the query below builds a single ~1.6 GiB column, which does
+-- If all rows form a single block, the query below builds a single huge column, which does
 -- not fit into the memory limit on a loaded test runner. `Memory` returns stored blocks as-is
 -- (`max_block_size` cannot split them on read), so store small blocks at insert time instead.
--- Small blocks exercise the same code path with a peak allocation two orders of magnitude smaller.
-INSERT INTO args SELECT [1, 1, 1, 1] FROM numbers(1, 100) SETTINGS max_block_size = 2, min_insert_block_size_rows = 2, min_insert_block_size_bytes = 1;
+-- Small blocks exercise the same code path with a much smaller peak allocation, and 10 rows
+-- instead of 100 keep the test under the time limit with sanitizers.
+INSERT INTO args SELECT [1, 1, 1, 1] FROM numbers(1, 10) SETTINGS max_block_size = 2, min_insert_block_size_rows = 2, min_insert_block_size_bytes = 1;
 SELECT length(arrayWithConstant(1000000, value)) FROM args FORMAT NULL SETTINGS max_threads = 1;


### PR DESCRIPTION
<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
ci/jobs/scripts/gh/pr_formatter.py
-->
### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Reduce the peak memory usage and runtime of the test `03216_arrayWithConstant_limits` to stop it flaking with `MEMORY_LIMIT_EXCEEDED` on loaded parallel runners.

### Documentation entry for user-facing changes

The final query of the test built a single ~1.6 GiB block (100 rows, each holding a 1-million-element `Array(Array(Int))` produced by `arrayWithConstant`). On a loaded parallel runner, when the server's RSS is close to the total memory limit, the allocation fails with `MEMORY_LIMIT_EXCEEDED` (the `OvercommitTracker` selects the query to stop).

Setting `max_block_size` on the final `SELECT` (the first attempt in this PR) does not help: the `Memory` engine returns its stored blocks unchanged, and `CREATE TABLE ... AS SELECT ... FROM numbers(1, 100)` stores a single 100-row block, so the flaky check on this PR still failed with the same single 1.49 GiB chunk allocation. Instead, the table is now populated with an explicit `INSERT ... SELECT` under `max_block_size = 2, min_insert_block_size_rows = 2, min_insert_block_size_bytes = 1`, so it stores small two-row blocks, and the final `SELECT` reads with `max_threads = 1` to bound the number of blocks in flight.

The second attempt (100 rows in two-row blocks) then failed the flaky check with `Test runs too long (> 180s)` under TSan: generating 100 rows with 1-million-element arrays takes ~2.7 s in a release build, an order of magnitude more with sanitizers, and the flaky check runs the test in a loop. The table is therefore reduced to 10 rows, keeping the 1 million elements per array and the two-row stored blocks, so the same code path is exercised in ~0.13 s (release) with a peak allocation two orders of magnitude smaller than the original (verified with `clickhouse-local`: the old query fails under a 500 MB memory cap with the same 1.49 GiB chunk as in CI, the new one passes under a 300 MB cap).

This is a broad master-side flake: on 2026-07-23 alone it failed on five unrelated pull requests (#93111, #111502, #111570, #111241, #110833), and 24 failures were recorded on 2026-07-15.

Failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=111103&sha=5f9a7dc8a262eab4e2268940baf6eb4afd6b3cd8&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/111103


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.127` (included in `26.8` and later)
<!-- ch-version-info:end -->