### PR TITLE
Docs: UUIDv7 is RFC 9562, drop draft-status note

### DIFF
--- a/docs/en/sql-reference/data-types/uuid.md
+++ b/docs/en/sql-reference/data-types/uuid.md
@@ -9,7 +9,7 @@ doc_type: 'reference'
 
 A Universally Unique Identifier (UUID) is a 16-byte value used to identify records. For detailed information about UUIDs, see [Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier).
 
-While different UUID variants exist, e.g. UUIDv4 and UUIDv7 (see [here](https://datatracker.ietf.org/doc/html/draft-ietf-uuidrev-rfc4122bis)), ClickHouse does not validate that inserted UUIDs conform to a particular variant.
+While different UUID variants exist, e.g. UUIDv4 and UUIDv7 (see [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562)), ClickHouse does not validate that inserted UUIDs conform to a particular variant.
 UUIDs are internally treated as a sequence of 16 random bytes with [8-4-4-4-12 representation](https://en.wikipedia.org/wiki/Universally_unique_identifier#Textual_representation) at SQL level.
 
 Example UUID value:

--- a/src/DataTypes/DataTypeUUID.cpp
+++ b/src/DataTypes/DataTypeUUID.cpp
@@ -33,7 +33,7 @@ void registerDataTypeUUID(DataTypeFactory & factory)
             .description = R"DOCS_MD(
 A Universally Unique Identifier (UUID) is a 16-byte value used to identify records. For detailed information about UUIDs, see [Wikipedia](https://en.wikipedia.org/wiki/Universally_unique_identifier).
 
-While different UUID variants exist, e.g. UUIDv4 and UUIDv7 (see [here](https://datatracker.ietf.org/doc/html/draft-ietf-uuidrev-rfc4122bis)), ClickHouse does not validate that inserted UUIDs conform to a particular variant.
+While different UUID variants exist, e.g. UUIDv4 and UUIDv7 (see [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562)), ClickHouse does not validate that inserted UUIDs conform to a particular variant.
 UUIDs are internally treated as a sequence of 16 random bytes with [8-4-4-4-12 representation](https://en.wikipedia.org/wiki/Universally_unique_identifier#Textual_representation) at SQL level.
 
 Example UUID value:

--- a/src/Functions/dateTimeToUUIDv7.cpp
+++ b/src/Functions/dateTimeToUUIDv7.cpp
@@ -99,13 +99,9 @@ REGISTER_FUNCTION(DateTimeToUUIDv7)
 {
     /// dateTimeToUUIDv7 documentation
     FunctionDocumentation::Description description = R"(
-Converts a [DateTime](../data-types/datetime.md) value to a [UUIDv7](https://en.wikipedia.org/wiki/UUID#Version_7) at the given time.
+Converts a [DateTime](../data-types/datetime.md) value to a [UUIDv7](https://www.rfc-editor.org/rfc/rfc9562) at the given time, as defined by [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562).
 
 See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID structure, counter management, and concurrency guarantees.
-
-:::note
-As of September 2025, version 7 UUIDs are in draft status and their layout may change in future.
-:::
     )";
     FunctionDocumentation::Syntax syntax = "dateTimeToUUIDv7(value)";
     FunctionDocumentation::Arguments arguments = {

--- a/src/Functions/generateUUIDv7.cpp
+++ b/src/Functions/generateUUIDv7.cpp
@@ -77,13 +77,9 @@ REGISTER_FUNCTION(GenerateUUIDv7)
 {
     /// generateUUIDv7 documentation
     FunctionDocumentation::Description description = R"(
-Generates a [version 7](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04) [UUID](../data-types/uuid.md).
+Generates a [version 7](https://www.rfc-editor.org/rfc/rfc9562) [UUID](../data-types/uuid.md) as defined by [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562).
 
 See section ["UUIDv7 generation"](#uuidv7-generation) for details on UUID structure, counter management, and concurrency guarantees.
-
-:::note
-As of September 2025, version 7 UUIDs are in draft status and their layout may change in future.
-:::
     )";
     FunctionDocumentation::Syntax syntax = "generateUUIDv7([expr])";
     FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
Drop the stale "UUIDv7 is still in draft as of September 2025" note from `generateUUIDv7` / `dateTimeToUUIDv7` REGISTER docs. Point version-7 links at [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562) (Proposed Standard, May 2024) instead of expired Internet-Draft URLs. Same RFC link on the `UUID` data-type page under `docs/en`.

AI-assisted; human-reviewed.

Closes #90963

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.192` (included in `26.8` and later)
<!-- ch-version-info:end -->