### PR TITLE
docs(formats): document JSONEachRowWithProgress stream object kinds

### DIFF
--- a/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONCompactEachRowWithProgressRowOutputFormat.cpp
@@ -142,17 +142,30 @@ void registerOutputFormatJSONCompactEachRowWithProgress(FormatFactory & factory)
 
 ## Description {#description}
 
-This format combines the compact row-by-row output of JSONCompactEachRow with streaming progress
-information.
-It outputs data as separate JSON objects for metadata, individual rows, progress updates,
-totals, and exceptions. Values are represented in their native types.
+Combines the compact row-by-row output of [`JSONCompactEachRow`](/reference/formats/JSON/JSONCompactEachRow) with streaming progress information. ClickHouse streams each event as a separate JSON object; column values keep their native JSON types.
 
-Key features:
-- Outputs metadata first with column names and types
-- Each row is a separate JSON object with a "row" key containing an array of values
-- Includes progress updates during query execution (as `{"progress":...}` objects)
-- Supports totals and extremes
-- Values keep their native types (numbers as numbers, strings as strings)
+The related `JSONCompactStringsEachRowWithProgress` format uses the same top-level object kinds; field values are serialized as strings.
+
+Shares the same stream contract as [`JSONEachRowWithProgress`](/reference/formats/JSON/JSONEachRowWithProgress) (`writesProgressConcurrently` / `finalizeImpl`), except that `row` / `totals` / `min` / `max` payloads are **arrays** of values in column order rather than named objects.
+
+## Stream objects {#stream-objects}
+
+Each line of the response is one JSON object. Clients should dispatch on the top-level key:
+
+| Top-level key | When it appears | Shape |
+|---------------|-----------------|-------|
+| `meta` | Once, before the first `row` (a `progress` object may be emitted before it) | `{"meta":[{"name":...,"type":...}, ...]}` — column names and types |
+| `row` | Once per result row | `{"row":[...]}` — column values in header order |
+| `progress` | Periodically while the query runs | `{"progress":{...}}` — counters such as `read_rows`, `read_bytes`, `total_rows_to_read` |
+| `totals` | When totals are present | `{"totals":[...]}` — totals row values in header order |
+| `min` / `max` | When extremes are present | `{"min":[...]}` / `{"max":[...]}` — extreme row values in header order |
+| `rows_before_limit_at_least` | When the query contains `LIMIT` | `{"rows_before_limit_at_least":N}` — lower estimate of rows there would have been without `LIMIT` (not proof that rows were dropped) |
+| `rows_before_aggregation` | When the query performs aggregation and the `rows_before_aggregation` counter is enabled | `{"rows_before_aggregation":N}` |
+| `exception` | When the query fails, on the HTTP path with `http_write_exception_in_output_format=1` | `{"exception":"..."}` — error text as a **top-level string**, not nested under `row` |
+
+The `rows_before_limit_at_least` object is emitted when the query contains `LIMIT`, even if the limit did not drop any rows. It is a lower estimate of the number of rows there would have been without `LIMIT` (same meaning as in `JSON`); clients must not treat it as proof that rows were dropped.
+
+`meta` is emitted once before the first `row`, but a `progress` object can arrive before `meta`. The top-level `exception` object is emitted on the HTTP path only when `http_write_exception_in_output_format=1`; otherwise the error surfaces through the transport. When emitted it is a separate top-level object, not nested under `row`.
 
 ## Example usage {#example-usage}
 
@@ -185,14 +198,9 @@ FORMAT JSONCompactEachRowWithProgress
 
 ## Description {#description}
 
-Similar to [`JSONCompactEachRowWithProgress`](/reference/formats/JSON/JSONCompactEachRowWithProgress), but all values are converted to strings.
-This is useful when you need consistent string representation of all data types.
+Similar to [`JSONCompactEachRowWithProgress`](/interfaces/formats/JSONCompactEachRowWithProgress), but all values are converted to strings. Uses the same top-level object kinds (`meta`, `row`, `progress`, `totals`, `min`/`max`, `rows_before_limit_at_least`, `rows_before_aggregation`, and a top-level `exception`); `row` / `totals` / `min` / `max` payloads remain **arrays** in column order, with each element serialized as a string.
 
-Key features:
-- Same structure as `JSONCompactEachRowWithProgress`
-- All values are represented as strings (numbers, arrays, etc. are all quoted strings)
-- Includes progress updates, totals, and exception handling
-- Useful for clients that prefer or require string-based data
+See [`JSONCompactEachRowWithProgress`](/interfaces/formats/JSONCompactEachRowWithProgress) for the full stream-object contract (`progress` may arrive before `meta`; `rows_before_limit_at_least` is a lower estimate when the query contains `LIMIT`, not proof rows were dropped; `exception` is only written on the HTTP path with `http_write_exception_in_output_format=1`).
 
 ## Example usage {#example-usage}
 

--- a/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/JSONEachRowWithProgressRowOutputFormat.cpp
@@ -142,7 +142,30 @@ void registerOutputFormatJSONEachRowWithProgress(FormatFactory & factory)
 
 ## Description {#description}
 
-Differs from [`JSONEachRow`](/reference/formats/JSON/JSONEachRow)/[`JSONStringsEachRow`](/reference/formats/JSON/JSONStringsEachRow) in that ClickHouse will also yield progress information as JSON values.
+Differs from [`JSONEachRow`](/reference/formats/JSON/JSONEachRow)/[`JSONStringsEachRow`](/reference/formats/JSON/JSONStringsEachRow) in that ClickHouse streams each event as a separate JSON object and also yields progress information.
+
+The related `JSONStringsEachRowWithProgress` format uses the same top-level object kinds; field values are serialized as strings.
+
+The compact siblings `JSONCompactEachRowWithProgress` and `JSONCompactStringsEachRowWithProgress` share the same stream-object kinds and progress/`LIMIT`/exception caveats; their `row` / `totals` / `min` / `max` payloads are value arrays instead of named objects.
+
+## Stream objects {#stream-objects}
+
+Each line of the response is one JSON object. Clients should dispatch on the top-level key:
+
+| Top-level key | When it appears | Shape |
+|---------------|-----------------|-------|
+| `meta` | Once, before the first `row` (a `progress` object may be emitted before it) | `{"meta":[{"name":...,"type":...}, ...]}` — column names and types |
+| `row` | Once per result row | `{"row":{...}}` — column values for that row |
+| `progress` | Periodically while the query runs | `{"progress":{...}}` — counters such as `read_rows`, `read_bytes`, `total_rows_to_read` |
+| `totals` | When totals are present | `{"totals":{...}}` — totals row values |
+| `min` / `max` | When extremes are present | `{"min":{...}}` / `{"max":{...}}` — extreme row values |
+| `rows_before_limit_at_least` | When the query contains `LIMIT` | `{"rows_before_limit_at_least":N}` — lower estimate of rows there would have been without `LIMIT` (not proof that rows were dropped) |
+| `rows_before_aggregation` | When the query performs aggregation and the `rows_before_aggregation` counter is enabled | `{"rows_before_aggregation":N}` |
+| `exception` | When the query fails, on the HTTP path with `http_write_exception_in_output_format=1` | `{"exception":"..."}` — error text as a **top-level string**, not nested under `row` |
+
+The `rows_before_limit_at_least` object is emitted when the query contains `LIMIT`, even if the limit did not drop any rows. It is a lower estimate of the number of rows there would have been without `LIMIT` (same meaning as in `JSON`); clients must not treat it as proof that rows were dropped.
+
+`meta` is emitted once before the first `row`, but a `progress` object can arrive before `meta`. The top-level `exception` object is emitted on the HTTP path only when `http_write_exception_in_output_format=1`; otherwise the error surfaces through the transport. When emitted it is a separate top-level object, not nested under `row`.
 
 ## Example usage {#example-usage}
 
@@ -160,14 +183,19 @@ Differs from [`JSONEachRow`](/reference/formats/JSON/JSONEachRow)/[`JSONStringsE
         .description = R"DOCS_MD(
 ## Description {#description}
 
-Differs from `JSONEachRow`/`JSONStringsEachRow` in that ClickHouse will also yield progress information as JSON values.
+Differs from `JSONEachRow`/`JSONStringsEachRow` in that ClickHouse streams each event as a separate JSON object and also yields progress information.
+
+All field values are serialized as strings (including complex types): for example `arr` is emitted as `"arr":"[0,1]"`, not as a nested JSON array. Scalars are likewise stringified (`"num":"42"`).
+
+The top-level object kinds match [`JSONEachRowWithProgress`](/reference/formats/JSON/JSONEachRowWithProgress) (`meta`, `row`, `progress`, `totals`/`min`/`max`, `rows_before_limit_at_least`, `rows_before_aggregation`, and top-level `exception`). Follow that page for the full stream contract: a `progress` object may arrive before `meta`; `rows_before_limit_at_least` is a lower estimate when the query contains `LIMIT` (not proof rows were dropped); `exception` is only written on the HTTP path with `http_write_exception_in_output_format=1`.
 
 ## Example usage {#example-usage}
 
 ```json
-{"row":{"num":42,"str":"hello","arr":[0,1]}}
-{"row":{"num":43,"str":"hello","arr":[0,1,2]}}
-{"row":{"num":44,"str":"hello","arr":[0,1,2,3]}}
+{"meta":[{"name":"num","type":"UInt8"},{"name":"str","type":"String"},{"name":"arr","type":"Array(UInt8)"}]}
+{"row":{"num":"42","str":"hello","arr":"[0,1]"}}
+{"row":{"num":"43","str":"hello","arr":"[0,1,2]"}}
+{"row":{"num":"44","str":"hello","arr":"[0,1,2,3]"}}
 {"progress":{"read_rows":"3","read_bytes":"24","written_rows":"0","written_bytes":"0","total_rows_to_read":"3"}}
 ```
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry
N/A — documentation only.

### Summary
Document every top-level stream object that `JSONEachRowWithProgress` emits (`meta`, `row`, `progress`, `totals`/`min`/`max`, limit counters, top-level `exception`). Expand the example to include the leading `meta` line and a separate exception sample. Keep `JSONStringsEachRowWithProgress` factory docs aligned.

Closes #83493.

Matched docs table keys against `JSONEachRowWithProgressRowOutputFormat` methods. No behavior change.

AI-assisted; human-reviewed.

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=111707&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/111707](https://github.com/search?q=head%3Async-upstream%2Fpr%2F111707+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
