### PR TITLE
Trim verbose comments in 04549_text_index_prewhere_where_dup_over_merge_distributed

### DIFF
--- a/tests/queries/0_stateless/04549_text_index_prewhere_where_dup_over_merge_distributed.sql
+++ b/tests/queries/0_stateless/04549_text_index_prewhere_where_dup_over_merge_distributed.sql
@@ -1,15 +1,10 @@
 -- Tags: no-parallel-replicas
 
--- Regression test for a query-plan optimizer abort: the same text-index predicate placed in both
--- PREWHERE and WHERE, walked through a Merge -> Distributed -> MergeTree plan, made
--- optimizeDirectReadFromTextIndex register the synthetic __text_index_..._has_<hash> read column
--- twice for the same reading step (the step is optimized on more than one pass), aborting with
--- "Column ... already added for reading". See https://github.com/ClickHouse/ClickHouse/issues/110697
+-- Regression test for #110697.
 
 SET enable_analyzer = 1;
 SET allow_experimental_full_text_index = 1;
--- The double-registration is reached only when the whole Merge -> Distributed -> MergeTree plan is
--- built and optimized on the initiator (local replica).
+-- The abort only reproduces with the whole plan built on the local initiator.
 SET prefer_localhost_replica = 1;
 
 DROP TABLE IF EXISTS logs;
@@ -32,22 +27,13 @@ INSERT INTO logs VALUES (1, {'ip':'192.168.1.1'}, 'alpha beta'), (2, {'ip':'10.0
 CREATE TABLE logs_dist AS logs ENGINE = Distributed(test_shard_localhost, currentDatabase(), logs);
 CREATE TABLE logs_merge AS logs ENGINE = Merge(currentDatabase(), '^logs_dist$');
 
--- The trigger: identical text-index predicate in PREWHERE and WHERE over the Merge table.
--- force_data_skipping_indices guarantees the text-index direct-read path engages.
--- query_plan_direct_read_from_text_index is pinned to 1: the double-registration only happens when
--- direct read is actually enabled and the whole Merge -> Distributed -> MergeTree pipeline is built
--- (the abort is thrown during pipeline build, not plan optimization). The runner randomizes this
--- setting to 0 on ~5% of runs, which disables the optimization and would silently skip the crash
--- path, so this repro query must pin it to exercise the fix deterministically on every run.
+-- `query_plan_direct_read_from_text_index` is randomized off ~5%; pin it on so the abort path is exercised.
 SELECT count() FROM logs_merge
 PREWHERE has(mapValues(attributes), toNullable('192.168.1.1'))
 WHERE has(mapValues(attributes), toNullable('192.168.1.1'))
 SETTINGS force_data_skipping_indices = 'attributes_vals_idx', query_plan_direct_read_from_text_index = 1;
 
--- Direct read from the text index must remain engaged (optimization preserved, not disabled).
--- query_plan_direct_read_from_text_index is pinned to 1 here: it is randomized by the test runner and
--- when off it disables the whole optimization, so the __text_index_..._has_<hash> column would be
--- absent and this visibility check would spuriously report the optimization as disabled.
+-- The direct-read column stays in the plan (optimization preserved).
 SELECT count() > 0 FROM
 (
     EXPLAIN actions = 1
@@ -58,18 +44,12 @@ SELECT count() > 0 FROM
 )
 WHERE explain ILIKE '%__text_index_attributes_vals_idx_has%';
 
--- Non-equal predicates in PREWHERE and WHERE still return correct results.
 SELECT count() FROM logs_merge
 PREWHERE has(mapValues(attributes), toNullable('192.168.1.1'))
 WHERE has(mapValues(attributes), toNullable('10.0.0.1'))
 SETTINGS force_data_skipping_indices = 'attributes_vals_idx';
 
--- Direct-read PREWHERE predicate plus a DIFFERENT text-index predicate in WHERE that uses a
--- tokenizing text function (hasAnyTokens). The fix gates only the direct-read virtual-column
--- registration on a re-visited step; the tokenizer/preprocessor rewrite of the WHERE predicate must
--- still run so row-level evaluation returns the same result whether direct read is on or off.
--- Compare both values of query_plan_direct_read_from_text_index: if the rewrite were dropped, the two
--- would diverge. rows with ip 192.168.1.1 = {1,3}; of those hasAnyTokens(msg, ['delta']) matches {3}.
+-- Direct read off then on must give the same result (the `WHERE` tokenizer rewrite is preserved).
 SELECT count() FROM logs_merge
 PREWHERE has(mapValues(attributes), toNullable('192.168.1.1'))
 WHERE hasAnyTokens(msg, ['delta'])
@@ -80,9 +60,7 @@ PREWHERE has(mapValues(attributes), toNullable('192.168.1.1'))
 WHERE hasAnyTokens(msg, ['delta'])
 SETTINGS query_plan_direct_read_from_text_index = 1;
 
--- The WHERE tokenizing predicate keeps its tokenizer rewrite (the 3-argument form with the index
--- tokenizer 'splitByNonAlpha' appended) even though the step is re-visited after the PREWHERE already
--- registered a direct-read column. This is the exact second-pass rewrite the fix preserves.
+-- The 3-argument tokenizer rewrite (`splitByNonAlpha`) survives on the re-visited step.
 SELECT count() > 0 FROM
 (
     EXPLAIN actions = 1


### PR DESCRIPTION

<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110710
Related: https://github.com/ClickHouse/ClickHouse/issues/110697
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to the review on the merged #110710: the test file carried long block comments
explaining the root cause and the setting-pin rationale. Per reviewer feedback I moved that
narrative to this commit message and kept only short inline notes on the two non-obvious pins.

The executable SQL is byte-for-byte identical to the current test (verified: non-comment lines
diff empty against HEAD); the `.reference` is unchanged. No behavior change.

Root cause the removed comments described (kept here for the record):
`optimizeDirectReadFromTextIndex` registered the synthetic `__text_index_..._has_<hash>` read
column twice for one reading step when the same text-index predicate appears in both PREWHERE and
WHERE over a Merge -> Distributed -> MergeTree plan (the step is optimized on more than one pass),
aborting the pipeline build with "Column ... already added for reading" (issue #110697, fixed by
#110710). Two settings are pinned because the runner randomizes them: `prefer_localhost_replica = 1`
(the whole plan must be built on the local initiator to reach the double registration) and
`query_plan_direct_read_from_text_index = 1` (randomized off ~5%; the abort only fires with direct
read enabled).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.110` (included in `26.8` and later)
<!-- ch-version-info:end -->