### PR TITLE
Derive `DATA_PATH` only after the detach gate in `04624_part_loading_tree_rollback_startup_recovery`

### DIFF
--- a/tests/queries/0_stateless/04624_part_loading_tree_rollback_startup_recovery.sh
+++ b/tests/queries/0_stateless/04624_part_loading_tree_rollback_startup_recovery.sh
@@ -51,16 +51,13 @@ recover_leaked_table
 # --- Simulate a previous failed attempt that leaked a permanently detached table. ---
 $CLICKHOUSE_CLIENT -q "CREATE TABLE ${TABLE} (x UInt32) ENGINE = MergeTree ORDER BY x"
 $CLICKHOUSE_CLIENT -q "INSERT INTO ${TABLE} VALUES (42)"
-DATA_PATH=$($CLICKHOUSE_CLIENT -q "
-    SELECT data_paths[1] FROM system.tables
-    WHERE database = currentDatabase() AND name = '${TABLE}'")
 $CLICKHOUSE_CLIENT -q "DETACH TABLE ${TABLE} PERMANENTLY"
 
 # The detach client call alone is not a sufficient gate: if it fails (e.g. the connection is
 # lost because a stress-test restart lands on it), the script would keep running under plain
 # `bash` and mutate a table directory that may still be attached. Verify the detach
-# postcondition and fail fast before touching anything under `DATA_PATH`, the same way the
-# four rollback tests do.
+# postcondition and fail fast before touching anything in the table's data directory, the
+# same way the four rollback tests do.
 DETACHED=$($CLICKHOUSE_CLIENT -q "
     SELECT (SELECT count() FROM system.tables
             WHERE database = currentDatabase() AND name = '${TABLE}') = 0
@@ -69,6 +66,23 @@ DETACHED=$($CLICKHOUSE_CLIENT -q "
 ")
 if [ "${DETACHED}" != "1" ]; then
     echo "FAIL: table ${TABLE} is not detached permanently, refusing to modify its data directory"
+    exit 1
+fi
+
+# Derive the data path only after the detach postcondition holds — from the detached table's
+# own `uuid`, the same way `recover_leaked_table` does — and verify the source part exists
+# before the out-of-band copy. The detach gate alone is not enough: if a stress-test restart
+# had landed on the earlier `INSERT` (no part to copy) or on a `SELECT` reading `data_paths`
+# from `system.tables` before the detach (empty path), the `cp`/`printf` below would fail
+# silently under plain `bash` and the test would print the reference output without ever
+# fabricating the corrupted `txn_version.txt` it is supposed to recover from.
+DETACHED_UUID=$($CLICKHOUSE_CLIENT -q "
+    SELECT uuid FROM system.detached_tables
+    WHERE database = currentDatabase() AND table = '${TABLE}'")
+DISK_PATH=$($CLICKHOUSE_CLIENT -q "SELECT path FROM system.disks WHERE name = 'default'")
+DATA_PATH="${DISK_PATH}store/${DETACHED_UUID:0:3}/${DETACHED_UUID}/"
+if [ -z "${DETACHED_UUID}" ] || [ -z "${DISK_PATH}" ] || [ ! -d "${DATA_PATH}all_1_1_0" ]; then
+    echo "FAIL: source part ${DATA_PATH}all_1_1_0 is missing, refusing to fabricate parts"
     exit 1
 fi
 


### PR DESCRIPTION
### Description

Follow-up to https://github.com/ClickHouse/ClickHouse/pull/111661 (merged), addressing the remaining review comment on `04624_part_loading_tree_rollback_startup_recovery.sh`: the detach-postcondition gate alone did not prove that the copy source exists. If a stress-test restart lands on the earlier `INSERT` or on the `SELECT data_paths[1]` client call, the gate could still pass while `DATA_PATH` is empty or the part `all_1_1_0` is missing; under plain `bash` the `cp`/`printf` would then fail silently, `recover_leaked_table` would re-attach a healthy table, and the test would print the reference output without ever fabricating the corrupted `txn_version.txt` it is supposed to recover from.

Now `DATA_PATH` is derived only after the detach gate, from `system.detached_tables.uuid` and `system.disks` (the same way `recover_leaked_table` does), and the test fails fast unless the source part directory `${DATA_PATH}all_1_1_0` exists before the out-of-band copy.

The test output is unchanged; it passes locally against a 26.7.1 server.

Related: https://github.com/ClickHouse/ClickHouse/pull/111661
Related: https://github.com/ClickHouse/ClickHouse/pull/111055

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)
