### PR TITLE
Fix SYSTEM RELOAD/UNLOAD DICTIONARY ON CLUSTER losing the current database

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -352,14 +352,29 @@ BlockIO InterpreterSystemQuery::execute()
 {
     auto & query = query_ptr->as<ASTSystemQuery &>();
 
+    using Type = ASTSystemQuery::Type;
+
+    /// Resolve the target dictionary against the current database before the query may be
+    /// dispatched to a cluster. Otherwise, when the cluster nodes receive the query
+    /// it will not have a database specified. Which in the case of RELOAD/UNLOAD DICTIONARY
+    /// may end up either targeting the wrong dictionary or not finding any.
+    if (query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY)
+    {
+        if (query.table)
+        {
+            String dictionary_name = query.database ? query.getDatabase() + "." + query.getTable() : query.getTable();
+            auto qualified_name = getContext()->getExternalDictionariesLoader().qualifyDictionaryNameWithDatabase(dictionary_name, getContext());
+            query.setDatabase(qualified_name.database);
+            query.setTable(qualified_name.table);
+        }
+    }
+
     if (!query.cluster.empty())
     {
         DDLQueryOnClusterParams params;
         params.access_to_check = getRequiredAccessForDDLOnCluster();
         return executeDDLQueryOnCluster(query_ptr, getContext(), params);
     }
-
-    using Type = ASTSystemQuery::Type;
 
     /// Use global context with fresh system profile settings
     auto system_context = Context::createCopy(getContext()->getGlobalContext());
@@ -368,13 +383,7 @@ BlockIO InterpreterSystemQuery::execute()
     bool check_constraints = false;
     system_context->setCurrentProfile(getContext()->getSystemProfileName(), check_constraints);
 
-    /// Make canonical query for simpler processing
-    if (query.type == Type::RELOAD_DICTIONARY || query.type == Type::UNLOAD_DICTIONARY)
-    {
-        if (query.database)
-            query.setTable(query.getDatabase() + "." + query.getTable());
-    }
-    else if (query.table)
+    if (query.table && query.type != Type::RELOAD_DICTIONARY && query.type != Type::UNLOAD_DICTIONARY)
     {
         StorageID id_in_query(query.getDatabase(), query.getTable());
         /// `IF EXISTS` (currently parsed for `SYSTEM SYNC REPLICA`) must suppress
@@ -759,7 +768,8 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.reloadDictionary(query.getTable(), getContext());
+            String dictionary_name = query.database ? query.getDatabase() + "." + query.getTable() : query.getTable();
+            external_dictionaries_loader.reloadDictionary(dictionary_name, getContext());
 
             ExternalDictionariesLoader::resetAll();
             break;
@@ -779,7 +789,8 @@ BlockIO InterpreterSystemQuery::execute()
             getContext()->checkAccess(AccessType::SYSTEM_RELOAD_DICTIONARY);
 
             auto & external_dictionaries_loader = system_context->getExternalDictionariesLoader();
-            external_dictionaries_loader.unloadDictionary(query.getTable(), getContext());
+            String dictionary_name = query.database ? query.getDatabase() + "." + query.getTable() : query.getTable();
+            external_dictionaries_loader.unloadDictionary(dictionary_name, getContext());
             ExternalDictionariesLoader::resetAll();
             break;
         }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -362,8 +362,19 @@ BlockIO InterpreterSystemQuery::execute()
     {
         if (query.table)
         {
+            const auto & external_dictionaries_loader = getContext()->getExternalDictionariesLoader();
             String dictionary_name = query.database ? query.getDatabase() + "." + query.getTable() : query.getTable();
-            auto qualified_name = getContext()->getExternalDictionariesLoader().qualifyDictionaryNameWithDatabase(dictionary_name, getContext());
+            auto qualified_name = external_dictionaries_loader.qualifyDictionaryNameWithDatabase(dictionary_name, getContext());
+
+            /// `qualifyDictionaryNameWithDatabase` only fills the database when this server can
+            /// resolve the dictionary locally. On a coordinator/gateway node that enqueues the
+            /// `ON CLUSTER` DDL but does not itself host the dictionary the name would stay bare,
+            /// and each worker would re-resolve it against its own default database instead of the
+            /// initiator's current one. So, unless it is an XML dictionary (which is referenced by
+            /// a bare name), stamp the current database explicitly to preserve the initiator's context.
+            if (qualified_name.database.empty() && !external_dictionaries_loader.has(qualified_name.table))
+                qualified_name.database = getContext()->getCurrentDatabase();
+
             query.setDatabase(qualified_name.database);
             query.setTable(qualified_name.table);
         }

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -364,16 +364,14 @@ BlockIO InterpreterSystemQuery::execute()
         {
             const auto & external_dictionaries_loader = getContext()->getExternalDictionariesLoader();
             String dictionary_name = query.database ? query.getDatabase() + "." + query.getTable() : query.getTable();
-            auto qualified_name = external_dictionaries_loader.qualifyDictionaryNameWithDatabase(dictionary_name, getContext());
 
-            /// `qualifyDictionaryNameWithDatabase` only fills the database when this server can
-            /// resolve the dictionary locally. On a coordinator/gateway node that enqueues the
-            /// `ON CLUSTER` DDL but does not itself host the dictionary the name would stay bare,
-            /// and each worker would re-resolve it against its own default database instead of the
-            /// initiator's current one. So, unless it is an XML dictionary (which is referenced by
-            /// a bare name), stamp the current database explicitly to preserve the initiator's context.
-            if (qualified_name.database.empty() && !external_dictionaries_loader.has(qualified_name.table))
-                qualified_name.database = getContext()->getCurrentDatabase();
+            /// `qualifyDictionaryNameWithDatabase` resolves the name in the same order as local
+            /// execution does: an XML dictionary referenced by a bare name wins over a dictionary
+            /// with the same name in the current database. A name that this server cannot resolve
+            /// at all is left bare, so a node that only enqueues the `ON CLUSTER` DDL without
+            /// hosting the dictionary never rewrites a bare XML name that only the workers host -
+            /// each worker still resolves such a name against its own XML dictionaries.
+            auto qualified_name = external_dictionaries_loader.qualifyDictionaryNameWithDatabase(dictionary_name, getContext());
 
             query.setDatabase(qualified_name.database);
             query.setTable(qualified_name.table);

--- a/tests/integration/test_dictionary_ddl_on_cluster/configs/config.d/clusters.xml
+++ b/tests/integration/test_dictionary_ddl_on_cluster/configs/config.d/clusters.xml
@@ -24,5 +24,27 @@
             </replica>
         </shard>
     </cluster>
+    <!-- A cluster that does not contain ch1, so ch1 can act as a gateway that enqueues
+         ON CLUSTER DDL without hosting the target dictionary itself. -->
+    <worker_cluster>
+        <shard>
+            <replica>
+                <host>ch2</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+        <shard>
+            <replica>
+                <host>ch3</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+        <shard>
+            <replica>
+                <host>ch4</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </worker_cluster>
 </remote_servers>
 </clickhouse>

--- a/tests/integration/test_dictionary_ddl_on_cluster/configs/dictionaries/xml_dict.xml
+++ b/tests/integration/test_dictionary_ddl_on_cluster/configs/dictionaries/xml_dict.xml
@@ -1,0 +1,33 @@
+<clickhouse>
+    <!-- An XML dictionary is referenced by its bare name, without a database.
+         It is deployed only to the worker nodes, so that the node initiating an
+         `ON CLUSTER` query does not have it. -->
+    <dictionary>
+        <name>xml_only_dict</name>
+        <source>
+            <clickhouse>
+                <host>localhost</host>
+                <port>9000</port>
+                <user>default</user>
+                <password></password>
+                <db>default</db>
+                <table>xml_dict_source</table>
+            </clickhouse>
+        </source>
+        <!-- Never reload on its own, so that a reload is observable. -->
+        <lifetime>0</lifetime>
+        <layout>
+            <flat/>
+        </layout>
+        <structure>
+            <id>
+                <name>key</name>
+            </id>
+            <attribute>
+                <name>value</name>
+                <type>String</type>
+                <null_value></null_value>
+            </attribute>
+        </structure>
+    </dictionary>
+</clickhouse>

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -9,19 +9,24 @@ ch1 = cluster.add_instance(
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
     with_zookeeper=True,
 )
+# The XML dictionary is deployed only to the nodes of `worker_cluster`, so that ch1 can
+# initiate an `ON CLUSTER` query for a dictionary it does not know anything about.
 ch2 = cluster.add_instance(
     "ch2",
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+    dictionaries=["configs/dictionaries/xml_dict.xml"],
     with_zookeeper=True,
 )
 ch3 = cluster.add_instance(
     "ch3",
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+    dictionaries=["configs/dictionaries/xml_dict.xml"],
     with_zookeeper=True,
 )
 ch4 = cluster.add_instance(
     "ch4",
     main_configs=["configs/config.d/clusters.xml", "configs/config.d/ddl.xml"],
+    dictionaries=["configs/dictionaries/xml_dict.xml"],
     with_zookeeper=True,
 )
 
@@ -114,18 +119,17 @@ def test_dictionary_ddl_on_cluster(started_cluster):
 def test_reload_dictionary_on_cluster_preserves_initiator_database(started_cluster):
     # Regression test for `SYSTEM RELOAD DICTIONARY <bare name> ON CLUSTER`.
     #
-    # ch1 acts as a gateway: it enqueues the ON CLUSTER DDL for `worker_cluster`
-    # (ch2, ch3, ch4) but is not a member of it, so it does not host the target
-    # dictionary. The bare dictionary name must be qualified with the initiator's
-    # current database before the query is dispatched, otherwise every worker
-    # re-resolves the bare name against its own `default` database and reloads the
-    # wrong dictionary.
+    # ch1 initiates the query for `worker_cluster` (ch2, ch3, ch4) without being a member
+    # of it, so it never executes the query itself. The bare dictionary name must be
+    # qualified with the initiator's current database before the query is dispatched,
+    # otherwise every worker re-resolves the bare name against its own current database,
+    # which for a query arriving over the DDL queue is `default`.
     #
-    # To make the wrong-target case observable, each worker also has a decoy
-    # dictionary with the same bare name `reload_dict` in `default` (its fallback
-    # database), whose source carries a different value.
+    # To make the wrong-target case observable, each worker also has a decoy dictionary
+    # with the same bare name `reload_dict` in `default`, whose source carries a
+    # different value.
 
-    for node in [ch2, ch3, ch4]:
+    for node in [ch1, ch2, ch3, ch4]:
         node.query("CREATE DATABASE IF NOT EXISTS initiator_db")
 
         # Real dictionary in a non-default database.
@@ -143,6 +147,7 @@ def test_reload_dictionary_on_cluster_preserves_initiator_database(started_clust
             """
         )
 
+    for node in [ch2, ch3, ch4]:
         # Decoy dictionary with the same bare name in the worker's fallback database.
         node.query(
             "CREATE TABLE default.dict_source (key UInt64, value String) ENGINE = Memory"
@@ -179,9 +184,6 @@ def test_reload_dictionary_on_cluster_preserves_initiator_database(started_clust
         node.query("TRUNCATE TABLE default.dict_source")
         node.query("INSERT INTO default.dict_source VALUES (1, 'decoy_new')")
 
-    # The gateway knows the database but does not host the dictionary.
-    ch1.query("CREATE DATABASE IF NOT EXISTS initiator_db")
-
     # Bare name, resolved against the initiator's current database (`initiator_db`).
     ch1.query(
         "SYSTEM RELOAD DICTIONARY reload_dict ON CLUSTER 'worker_cluster'",
@@ -204,9 +206,84 @@ def test_reload_dictionary_on_cluster_preserves_initiator_database(started_clust
             == "decoy_old\n"
         )
 
-    ch1.query("DROP DATABASE initiator_db SYNC")
-    for node in [ch2, ch3, ch4]:
-        node.query("DROP DICTIONARY initiator_db.reload_dict")
-        node.query("DROP DICTIONARY default.reload_dict")
+    for node in [ch1, ch2, ch3, ch4]:
         node.query("DROP DATABASE initiator_db SYNC")
+    for node in [ch2, ch3, ch4]:
+        node.query("DROP DICTIONARY default.reload_dict")
         node.query("DROP TABLE default.dict_source")
+
+
+def test_reload_xml_dictionary_on_cluster_from_non_hosting_initiator(started_cluster):
+    # An XML dictionary is referenced by its bare name, without a database. Qualifying such
+    # a name with the initiator's current database would make it unresolvable on the
+    # workers, or would make it resolve to a same-named dictionary created by DDL.
+    #
+    # ch1 initiates the query for `worker_cluster` (ch2, ch3, ch4) without being a member
+    # of it, and `xml_only_dict` is deployed only to those workers, so ch1 cannot resolve
+    # the name at all and must forward it unchanged.
+    #
+    # To make the wrong-target case observable, each worker also has a decoy dictionary
+    # created by DDL, named `default.xml_only_dict`, whose source carries a different value.
+
+    for node in [ch2, ch3, ch4]:
+        node.query(
+            "CREATE TABLE default.xml_dict_source (key UInt64, value String) ENGINE = Memory"
+        )
+        node.query("INSERT INTO default.xml_dict_source VALUES (1, 'xml_old')")
+
+        node.query(
+            "CREATE TABLE default.decoy_dict_source (key UInt64, value String) ENGINE = Memory"
+        )
+        node.query("INSERT INTO default.decoy_dict_source VALUES (1, 'decoy_old')")
+        node.query(
+            """
+            CREATE DICTIONARY default.xml_only_dict (key UInt64, value String)
+            PRIMARY KEY key
+            LAYOUT(FLAT())
+            SOURCE(CLICKHOUSE(TABLE 'decoy_dict_source' DB 'default'))
+            LIFETIME(0)
+            """
+        )
+
+        # The XML dictionary is resolved by its bare name, the decoy one only when qualified.
+        node.query("SYSTEM RELOAD DICTIONARY xml_only_dict")
+        node.query("SYSTEM RELOAD DICTIONARY default.xml_only_dict")
+        assert (
+            node.query("SELECT dictGetString('xml_only_dict', 'value', toUInt64(1))")
+            == "xml_old\n"
+        )
+        assert (
+            node.query(
+                "SELECT dictGetString('default.xml_only_dict', 'value', toUInt64(1))"
+            )
+            == "decoy_old\n"
+        )
+
+        # Make both dictionaries stale so that a reload is observable.
+        node.query("TRUNCATE TABLE default.xml_dict_source")
+        node.query("INSERT INTO default.xml_dict_source VALUES (1, 'xml_new')")
+        node.query("TRUNCATE TABLE default.decoy_dict_source")
+        node.query("INSERT INTO default.decoy_dict_source VALUES (1, 'decoy_new')")
+
+    # The initiator has neither the XML dictionary nor a dictionary with that name in its
+    # current database, so the bare name must reach the workers unchanged.
+    ch1.query("SYSTEM RELOAD DICTIONARY xml_only_dict ON CLUSTER 'worker_cluster'")
+
+    for node in [ch2, ch3, ch4]:
+        # The XML dictionary must have been reloaded.
+        assert (
+            node.query("SELECT dictGetString('xml_only_dict', 'value', toUInt64(1))")
+            == "xml_new\n"
+        )
+        # The same-named dictionary created by DDL must be untouched.
+        assert (
+            node.query(
+                "SELECT dictGetString('default.xml_only_dict', 'value', toUInt64(1))"
+            )
+            == "decoy_old\n"
+        )
+
+    for node in [ch2, ch3, ch4]:
+        node.query("DROP DICTIONARY default.xml_only_dict")
+        node.query("DROP TABLE default.decoy_dict_source")
+        node.query("DROP TABLE default.xml_dict_source")

--- a/tests/integration/test_dictionary_ddl_on_cluster/test.py
+++ b/tests/integration/test_dictionary_ddl_on_cluster/test.py
@@ -109,3 +109,104 @@ def test_dictionary_ddl_on_cluster(started_cluster):
     for node in [ch1, ch2, ch3, ch4]:
         with pytest.raises(QueryRuntimeException):
             node.query("SELECT dictGetString('default.somedict', 'value', toUInt64(1))")
+
+
+def test_reload_dictionary_on_cluster_preserves_initiator_database(started_cluster):
+    # Regression test for `SYSTEM RELOAD DICTIONARY <bare name> ON CLUSTER`.
+    #
+    # ch1 acts as a gateway: it enqueues the ON CLUSTER DDL for `worker_cluster`
+    # (ch2, ch3, ch4) but is not a member of it, so it does not host the target
+    # dictionary. The bare dictionary name must be qualified with the initiator's
+    # current database before the query is dispatched, otherwise every worker
+    # re-resolves the bare name against its own `default` database and reloads the
+    # wrong dictionary.
+    #
+    # To make the wrong-target case observable, each worker also has a decoy
+    # dictionary with the same bare name `reload_dict` in `default` (its fallback
+    # database), whose source carries a different value.
+
+    for node in [ch2, ch3, ch4]:
+        node.query("CREATE DATABASE IF NOT EXISTS initiator_db")
+
+        # Real dictionary in a non-default database.
+        node.query(
+            "CREATE TABLE initiator_db.dict_source (key UInt64, value String) ENGINE = Memory"
+        )
+        node.query("INSERT INTO initiator_db.dict_source VALUES (1, 'real_old')")
+        node.query(
+            """
+            CREATE DICTIONARY initiator_db.reload_dict (key UInt64, value String)
+            PRIMARY KEY key
+            LAYOUT(FLAT())
+            SOURCE(CLICKHOUSE(TABLE 'dict_source' DB 'initiator_db'))
+            LIFETIME(0)
+            """
+        )
+
+        # Decoy dictionary with the same bare name in the worker's fallback database.
+        node.query(
+            "CREATE TABLE default.dict_source (key UInt64, value String) ENGINE = Memory"
+        )
+        node.query("INSERT INTO default.dict_source VALUES (1, 'decoy_old')")
+        node.query(
+            """
+            CREATE DICTIONARY default.reload_dict (key UInt64, value String)
+            PRIMARY KEY key
+            LAYOUT(FLAT())
+            SOURCE(CLICKHOUSE(TABLE 'dict_source' DB 'default'))
+            LIFETIME(0)
+            """
+        )
+
+        node.query("SYSTEM RELOAD DICTIONARY initiator_db.reload_dict")
+        node.query("SYSTEM RELOAD DICTIONARY default.reload_dict")
+        assert (
+            node.query(
+                "SELECT dictGetString('initiator_db.reload_dict', 'value', toUInt64(1))"
+            )
+            == "real_old\n"
+        )
+        assert (
+            node.query(
+                "SELECT dictGetString('default.reload_dict', 'value', toUInt64(1))"
+            )
+            == "decoy_old\n"
+        )
+
+        # Make both dictionaries stale so that a reload is observable.
+        node.query("TRUNCATE TABLE initiator_db.dict_source")
+        node.query("INSERT INTO initiator_db.dict_source VALUES (1, 'real_new')")
+        node.query("TRUNCATE TABLE default.dict_source")
+        node.query("INSERT INTO default.dict_source VALUES (1, 'decoy_new')")
+
+    # The gateway knows the database but does not host the dictionary.
+    ch1.query("CREATE DATABASE IF NOT EXISTS initiator_db")
+
+    # Bare name, resolved against the initiator's current database (`initiator_db`).
+    ch1.query(
+        "SYSTEM RELOAD DICTIONARY reload_dict ON CLUSTER 'worker_cluster'",
+        database="initiator_db",
+    )
+
+    for node in [ch2, ch3, ch4]:
+        # The dictionary in the initiator's database must have been reloaded.
+        assert (
+            node.query(
+                "SELECT dictGetString('initiator_db.reload_dict', 'value', toUInt64(1))"
+            )
+            == "real_new\n"
+        )
+        # The decoy in `default` must be untouched.
+        assert (
+            node.query(
+                "SELECT dictGetString('default.reload_dict', 'value', toUInt64(1))"
+            )
+            == "decoy_old\n"
+        )
+
+    ch1.query("DROP DATABASE initiator_db SYNC")
+    for node in [ch2, ch3, ch4]:
+        node.query("DROP DICTIONARY initiator_db.reload_dict")
+        node.query("DROP DICTIONARY default.reload_dict")
+        node.query("DROP DATABASE initiator_db SYNC")
+        node.query("DROP TABLE default.dict_source")

--- a/tests/queries/0_stateless/04626_system_reload_unload_dictionary_on_cluster_database.reference
+++ b/tests/queries/0_stateless/04626_system_reload_unload_dictionary_on_cluster_database.reference
@@ -1,0 +1,6 @@
+before	current	LOADED
+before	default	LOADED
+after unload on cluster	current	NOT_LOADED
+after unload on cluster	default	LOADED
+after reload on cluster	current	LOADED
+after reload on cluster	default	LOADED

--- a/tests/queries/0_stateless/04626_system_reload_unload_dictionary_on_cluster_database.sh
+++ b/tests/queries/0_stateless/04626_system_reload_unload_dictionary_on_cluster_database.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# no-parallel: creates a same-named decoy dictionary in the shared `default` database
+#              and asserts on its status, so it must not run alongside other tests
+#              (e.g. global `SYSTEM RELOAD/UNLOAD DICTIONARIES`).
+
+# Regression test for `SYSTEM RELOAD/UNLOAD DICTIONARY <name> ON CLUSTER`.
+# The dictionary name must be resolved against the initiator's current database
+# before the query is sent to the cluster.
+# To make the wrong-target case observable, a decoy dictionary with the same bare
+# name `dict` is created in `default` (the worker's fallback database).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Decoy dictionary with the same bare name in the worker's fallback database.
+${CLICKHOUSE_CLIENT} --multiquery "
+DROP DICTIONARY IF EXISTS default.dict;
+DROP TABLE IF EXISTS default.dict_source;
+CREATE TABLE default.dict_source (id UInt64, val String) ENGINE = Memory;
+INSERT INTO default.dict_source VALUES (1, 'decoy');
+CREATE DICTIONARY default.dict (id UInt64, val String)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'dict_source' DB 'default'))
+LAYOUT(FLAT())
+LIFETIME(0);
+SYSTEM RELOAD DICTIONARY default.dict;
+"
+
+${CLICKHOUSE_CLIENT} --multiquery "
+DROP DICTIONARY IF EXISTS dict;
+DROP TABLE IF EXISTS dict_source;
+
+CREATE TABLE dict_source (id UInt64, val String) ENGINE = Memory;
+INSERT INTO dict_source VALUES (1, 'real');
+
+CREATE DICTIONARY dict (id UInt64, val String)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'dict_source' DB '${CLICKHOUSE_DATABASE}'))
+LAYOUT(FLAT())
+LIFETIME(0);
+
+SYSTEM RELOAD DICTIONARY dict;
+SELECT 'before', if(database = currentDatabase(), 'current', 'default') AS which, status
+FROM system.dictionaries WHERE name = 'dict' AND database IN (currentDatabase(), 'default') ORDER BY which;
+
+-- Disable output from ON CLUSTER DDLs
+SET distributed_ddl_output_mode = 'none';
+
+-- Must resolve 'dict' against the current database, not the worker's fallback ('default').
+
+SYSTEM UNLOAD DICTIONARY dict ON CLUSTER test_shard_localhost;
+SELECT 'after unload on cluster', if(database = currentDatabase(), 'current', 'default') AS which, status
+FROM system.dictionaries WHERE name = 'dict' AND database IN (currentDatabase(), 'default') ORDER BY which;
+
+SYSTEM RELOAD DICTIONARY dict ON CLUSTER test_shard_localhost;
+SELECT 'after reload on cluster', if(database = currentDatabase(), 'current', 'default') AS which, status
+FROM system.dictionaries WHERE name = 'dict' AND database IN (currentDatabase(), 'default') ORDER BY which;
+
+DROP DICTIONARY dict;
+DROP TABLE dict_source;
+DROP DICTIONARY default.dict;
+DROP TABLE default.dict_source;
+"


### PR DESCRIPTION
`SYSTEM RELOAD DICTIONARY <name> ON CLUSTER` and `SYSTEM UNLOAD DICTIONARY <name> ON CLUSTER`
did not resolve the dictionary name against the initiator's current database before
dispatching the query to the cluster. The bare dictionary name was forwarded as-is, so
each worker node re-resolved it against *its own* current database — which for a query
arriving over the DDL queue is `default`, not the database the user issued the statement
from.

As a result, `SYSTEM RELOAD/UNLOAD DICTIONARY dict ON CLUSTER ...` executed from database
`mydb` would target `default.dict` on the workers instead of `mydb.dict`. This meant the
command either did nothing (no such dictionary in `default`), threw an error, or — worse —
silently operated on a different, same-named dictionary

The fix qualifies the dictionary name with the current database in
`InterpreterSystemQuery::execute` *before* the `ON CLUSTER` dispatch, using
`ExternalDictionariesLoader::qualifyDictionaryNameWithDatabase`, so the fully-qualified
name is what gets sent to the cluster nodes. The previous "canonicalization" step that ran
only on the local path was removed in favor of this earlier, dispatch-aware resolution, and
the non-cluster `RELOAD`/`UNLOAD` handlers now build the qualified name consistently.

A regression test (`04626_system_reload_unload_dictionates a
decoy dictionary with the same bare name in `default` and asserts that the `ON CLUSTER`
command acts on the dictionary in the current database rather than the decoy.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `SYSTEM RELOAD DICTIONARY` and `SYSTEM UNLOAD DICTIONARY` with `ON CLUSTER` losing the initiator's current database: the dictionary name is now resolved against the current database before the query is sent to the cluster, so the command no longer targets `default` (the worker's fallback database) instead of the database the query was issued from.