### PR TITLE
Fix server failing to start on a transient I/O error reading part transaction metadata

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -49,6 +49,9 @@ static struct InitFiu
     ONCE(smt_commit_write_zk_fail_after_op) \
     ONCE(smt_commit_write_zk_fail_before_op) \
     ONCE(smt_restore_attach_retry) \
+    ONCE(part_loading_tree_read_txn_status_fault) \
+    REGULAR(part_loading_tree_read_txn_status_persistent_fault) \
+    ONCE(part_loading_tree_read_txn_status_permanent_fault) \
     PAUSEABLE_ONCE(smt_commit_tweaks_gate_open) \
     PAUSEABLE_ONCE(smt_commit_tweaks_gate_close) \
     ONCE(smt_commit_merge_change_version_before_op) \

--- a/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
@@ -41,6 +41,20 @@ void VersionInfo::fromString(const String & content, bool one_line)
     }
 }
 
+String VersionInfo::readMetadataString(ReadBuffer & buf)
+{
+    String content;
+    /// Read one byte past the cap so a returned length of MAX_METADATA_SIZE + 1 unambiguously means
+    /// "content is larger than the cap", regardless of what the on-disk file size claims.
+    while (content.size() <= MAX_METADATA_SIZE && !buf.eof())
+    {
+        char c;
+        readChar(c, buf);
+        content.push_back(c);
+    }
+    return content;
+}
+
 void VersionInfo::readFromBuffer(ReadBuffer & buf, bool one_line)
 {
     if (one_line)
@@ -127,6 +141,10 @@ void VersionInfo::readFromMultiLineBuffer(ReadBuffer & buf)
 
     assertString(String("\n") + REMOVAL_CSN_STR, buf);
     readText(current_removal_csn, buf);
+
+    /// The current format ends here; trailing bytes indicate a truncated/overwritten/garbage file.
+    /// (The legacy pre-`storing_version` format returns early above and is intentionally exempt.)
+    assertEOF(buf);
 
     storing_version = current_storing_version;
     creation_tid = current_creation_tid;

--- a/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
@@ -48,7 +48,7 @@ String VersionInfo::readMetadataString(ReadBuffer & buf)
     /// "content is larger than the cap", regardless of what the on-disk file size claims.
     while (content.size() <= MAX_METADATA_SIZE && !buf.eof())
     {
-        char c;
+        char c = 0;
         readChar(c, buf);
         content.push_back(c);
     }

--- a/src/Interpreters/MergeTreeTransaction/VersionInfo.h
+++ b/src/Interpreters/MergeTreeTransaction/VersionInfo.h
@@ -22,6 +22,14 @@ struct VersionInfo
     /// Initial value for storing_version indicating that the metadata has not been persisted to storage yet.
     static constexpr Int32 UNSTORED_VERSION = -1;
 
+    /// Hard upper bound on a serialized txn_version.txt. Real metadata is a few dozen bytes; a larger
+    /// file is corrupt. Used to cap reads without trusting a possibly-corrupt on-disk file size.
+    static constexpr size_t MAX_METADATA_SIZE = 4096;
+
+    /// Reads at most MAX_METADATA_SIZE + 1 bytes from `buf`. A returned length of MAX_METADATA_SIZE + 1
+    /// proves (from bytes actually read) that the content exceeds the cap.
+    static String readMetadataString(ReadBuffer & buf);
+
     /// Checks if the object is visible to a transaction with `snapshot_version` and `current_tid`.
     /// Returns true if visible (created before snapshot and not removed, or being created by current transaction).
     /// Returns false if not visible (removed before snapshot, created after snapshot, or being removed by current transaction).

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadataOnDisk.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadataOnDisk.cpp
@@ -27,6 +27,7 @@ namespace ErrorCodes
 extern const int LOGICAL_ERROR;
 extern const int CANNOT_OPEN_FILE;
 extern const int NOT_IMPLEMENTED;
+extern const int CORRUPTED_DATA;
 }
 
 namespace MergeTreeSetting
@@ -261,14 +262,16 @@ std::optional<VersionInfo> VersionMetadataOnDisk::readMetadataUnlocked()
         return std::nullopt;
 
 
-    size_t small_file_size = 4096;
+    size_t small_file_size = VersionInfo::MAX_METADATA_SIZE;
     auto read_settings = getReadSettings().adjustBufferSize(small_file_size);
     /// Avoid cannot allocated thread error. No need in threadpool read method here.
     read_settings.local_fs_settings.method = LocalFSReadMethod::pread;
     auto buf = data_part_storage.readFile(TXN_VERSION_METADATA_FILE_NAME, read_settings, small_file_size);
 
-    String content;
-    readStringUntilEOF(content, *buf);
+    String content = VersionInfo::readMetadataString(*buf);
+    if (content.size() > VersionInfo::MAX_METADATA_SIZE)
+        throw Exception(ErrorCodes::CORRUPTED_DATA, "Version metadata file {} exceeds {} bytes",
+            TXN_VERSION_METADATA_FILE_NAME, VersionInfo::MAX_METADATA_SIZE);
     LOG_DEBUG(log, "Object {}, read content:\n{}", getObjectName(), content);
 
     VersionInfo info;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -373,6 +373,8 @@ namespace ErrorCodes
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
     extern const int CORRUPTED_DATA;
+    extern const int NETWORK_ERROR;
+    extern const int CANNOT_OPEN_FILE;
     extern const int BAD_TYPE_OF_FIELD;
     extern const int BAD_ARGUMENTS;
     extern const int INVALID_PARTITION_VALUE;
@@ -413,6 +415,16 @@ namespace FailPoints
     /// transient error (e.g. temporary disk unavailability). Used to test that the refresh task
     /// reschedules itself after such an error instead of stopping permanently.
     extern const char merge_tree_refresh_parts_throw_once[];
+    /// Throws once while reading a part's txn_version.txt during PartLoadingTree build, to emulate
+    /// a transient I/O error and test that the read is retried (rather than mis-reported as corruption).
+    extern const char part_loading_tree_read_txn_status_fault[];
+    /// Like the above but throws on every read (REGULAR), to test that retries are bounded and an
+    /// exhausted transient error is rethrown as-is (fail-close) rather than reported as corruption.
+    extern const char part_loading_tree_read_txn_status_persistent_fault[];
+    /// Throws a non-retryable I/O error once (ONCE), to test that a permanent access failure is
+    /// rethrown as-is without retrying (a wrongful retry would consume this one-shot fault and let
+    /// the read succeed) and is not reported as corruption.
+    extern const char part_loading_tree_read_txn_status_permanent_fault[];
 }
 
 static String getPartNameFromAST(const ASTPtr & partition)
@@ -2057,6 +2069,10 @@ Int64 MergeTreeData::getMaxBlockNumber() const
     return max_block_num;
 }
 
+static constexpr size_t loading_parts_initial_backoff_ms = 100;
+static constexpr size_t loading_parts_max_backoff_ms = 5000;
+static constexpr size_t loading_parts_max_tries = 3;
+
 void MergeTreeData::PartLoadingTree::add(const MergeTreePartInfo & info, const String & name, const DiskPtr & disk)
 {
     auto & current_ptr = root_by_partition[info.getPartitionId()];
@@ -2078,65 +2094,126 @@ void MergeTreeData::PartLoadingTree::add(const MergeTreePartInfo & info, const S
     /// favors keeping the unambiguously committed peer.
     enum class RollbackStatus
     {
-        RolledBack,  /// definitively rolled back
-        Committed,   /// definitively committed
-        NoMetadata,  /// txn_version.txt does not exist → non-transactional part
-        UnknownCSN,  /// transaction is still running and creation_csn is not yet known
-        Unreadable,  /// file exists but could not be parsed → corruption or partial write in progress
+        RolledBack,        /// definitively rolled back
+        Committed,         /// definitively committed
+        NoMetadata,        /// txn_version.txt does not exist → non-transactional part
+        UnknownCSN,        /// transaction is still running and creation_csn is not yet known
+        UnreadableContent, /// file was read in full but its content could not be parsed → corruption
     };
 
+    /// Classifies a part's transaction status from its txn_version.txt.
+    ///
+    /// Failures are handled by where they occur, not lumped together: a transient I/O error (S3/Keeper/
+    /// memory blip) is retried and, if it outlives the retries, rethrown; a permanent access error is
+    /// rethrown too. Both propagate the real error and fail startup close, instead of being mis-reported
+    /// as data corruption. Only a fully-read-but-unparsable file is `UnreadableContent`. `build` runs
+    /// outside `loadDataPartWithRetries`, so the retry lives here.
     auto read_txn_status = [&](const String & part_name, const DiskPtr & part_disk) -> RollbackStatus
     {
         if (relative_data_path.empty())
             return RollbackStatus::NoMetadata;
 
-        auto version_path = fs::path(relative_data_path) / part_name / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME;
-        if (!part_disk->existsFile(version_path))
+        const auto version_path = fs::path(relative_data_path) / part_name / VersionMetadata::TXN_VERSION_METADATA_FILE_NAME;
+        const auto tmp_version_path = fs::path(relative_data_path) / part_name / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME;
+
+        size_t backoff_ms = loading_parts_initial_backoff_ms;
+        for (size_t try_no = 0; try_no < loading_parts_max_tries; ++try_no)
         {
-            /// Mirror VersionMetadataOnDisk::loadMetadata: a lone txn_version.txt.tmp (no final
-            /// txn_version.txt) means the creating transaction never renamed its metadata into place,
-            /// i.e. it was interrupted before commit. Such a part is rolled back, so classify it as
-            /// such here too — otherwise it would be treated as a non-transactional part and an
-            /// intersecting committed peer would fall through to the LOGICAL_ERROR path below.
-            auto tmp_version_path = fs::path(relative_data_path) / part_name / VersionMetadata::TMP_TXN_VERSION_METADATA_FILE_NAME;
-            if (part_disk->existsFile(tmp_version_path))
-                return RollbackStatus::RolledBack;
-            return RollbackStatus::NoMetadata;
-        }
-
-        try
-        {
-            VersionInfo version_info;
-            auto buf = part_disk->readFile(version_path, ReadSettings{});
-            version_info.readFromBuffer(*buf, /*one_line=*/false);
-
-            CSN csn = version_info.creation_csn;
-            if (csn == Tx::RolledBackCSN)
-                return RollbackStatus::RolledBack;
-            if (csn != Tx::UnknownCSN)
-                return RollbackStatus::Committed;
-
-            /// On-disk CSN is unresolved — consult TransactionLog (mirrors VersionMetadata::tryGetCSN).
-            csn = TransactionLog::getCSN(version_info.creation_tid);
-            if (!csn
-                && TransactionLog::instance().tryGetRunningTransaction(version_info.creation_tid.getHash()) == nullptr)
+            String content;
+            try
             {
-                csn = TransactionLog::getCSN(version_info.creation_tid);  /// re-check after the race window
-                if (!csn)
-                    return RollbackStatus::RolledBack;
+                /// I/O stage: a failure here is an access/transport error, never corrupt content.
+                fiu_do_on(FailPoints::part_loading_tree_read_txn_status_fault,
+                {
+                    throw Exception(ErrorCodes::NETWORK_ERROR, "Injected transient fault while reading txn metadata of part {}", part_name);
+                });
+                fiu_do_on(FailPoints::part_loading_tree_read_txn_status_persistent_fault,
+                {
+                    throw Exception(ErrorCodes::NETWORK_ERROR, "Injected persistent fault while reading txn metadata of part {}", part_name);
+                });
+                fiu_do_on(FailPoints::part_loading_tree_read_txn_status_permanent_fault,
+                {
+                    throw Exception(ErrorCodes::CANNOT_OPEN_FILE, "Injected permanent I/O fault while reading txn metadata of part {}", part_name);
+                });
+                if (!part_disk->existsFile(version_path))
+                {
+                    /// A lone txn_version.txt.tmp (no final file) means the creating transaction was
+                    /// interrupted before the commit rename → rolled back. No file at all → a
+                    /// non-transactional part. (Classifying tmp-only as RolledBack keeps an intersecting
+                    /// committed peer from falling through to the LOGICAL_ERROR path below.)
+                    if (part_disk->existsFile(tmp_version_path))
+                        return RollbackStatus::RolledBack;
+                    return RollbackStatus::NoMetadata;
+                }
+                auto buf = part_disk->readFile(version_path, ReadSettings{});
+                content = VersionInfo::readMetadataString(*buf);
             }
-            if (csn == Tx::RolledBackCSN)
-                return RollbackStatus::RolledBack;
-            if (csn)
-                return RollbackStatus::Committed;
+            catch (...)
+            {
+                if (isRetryableException(std::current_exception()) && try_no + 1 < loading_parts_max_tries)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+                    backoff_ms = std::min(backoff_ms * 2, loading_parts_max_backoff_ms);
+                    continue;
+                }
+                throw;
+            }
 
-            return RollbackStatus::UnknownCSN;
+            /// A file over the cap cannot be valid metadata; proven from bytes read, not the on-disk size.
+            if (content.size() > VersionInfo::MAX_METADATA_SIZE)
+            {
+                LOG_WARNING(getLogger("MergeTreeData"), "Version metadata of part {} exceeds {} bytes", part_name, VersionInfo::MAX_METADATA_SIZE);
+                return RollbackStatus::UnreadableContent;
+            }
+
+            VersionInfo version_info;
+            try
+            {
+                version_info.fromString(content, /*one_line=*/false);
+            }
+            catch (...)
+            {
+                tryLogCurrentException(getLogger("MergeTreeData"), fmt::format("Failed to parse version metadata of part {}", part_name));
+                return RollbackStatus::UnreadableContent;
+            }
+
+            try
+            {
+                /// Resolve stage: consulting TransactionLog can hit transient errors too.
+                CSN csn = version_info.creation_csn;
+                if (csn == Tx::RolledBackCSN)
+                    return RollbackStatus::RolledBack;
+                if (csn != Tx::UnknownCSN)
+                    return RollbackStatus::Committed;
+
+                /// On-disk CSN is unresolved — consult TransactionLog (mirrors VersionMetadata::tryGetCSN).
+                csn = TransactionLog::getCSN(version_info.creation_tid);
+                if (!csn
+                    && TransactionLog::instance().tryGetRunningTransaction(version_info.creation_tid.getHash()) == nullptr)
+                {
+                    csn = TransactionLog::getCSN(version_info.creation_tid);  /// re-check after the race window
+                    if (!csn)
+                        return RollbackStatus::RolledBack;
+                }
+                if (csn == Tx::RolledBackCSN)
+                    return RollbackStatus::RolledBack;
+                if (csn)
+                    return RollbackStatus::Committed;
+
+                return RollbackStatus::UnknownCSN;
+            }
+            catch (...)
+            {
+                if (isRetryableException(std::current_exception()) && try_no + 1 < loading_parts_max_tries)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+                    backoff_ms = std::min(backoff_ms * 2, loading_parts_max_backoff_ms);
+                    continue;
+                }
+                throw;
+            }
         }
-        catch (...)
-        {
-            tryLogCurrentException(getLogger("MergeTreeData"), fmt::format("Failed to read version metadata for part {}", part_name));
-            return RollbackStatus::Unreadable;
-        }
+        UNREACHABLE();
     };
 
     auto * current = current_ptr.get();
@@ -2192,7 +2269,7 @@ void MergeTreeData::PartLoadingTree::add(const MergeTreePartInfo & info, const S
                 const auto incoming_status = read_txn_status(name, disk);
                 const auto existing_status = read_txn_status(prev->second->name, prev->second->disk);
 
-                if (incoming_status == RollbackStatus::Unreadable || existing_status == RollbackStatus::Unreadable)
+                if (incoming_status == RollbackStatus::UnreadableContent || existing_status == RollbackStatus::UnreadableContent)
                     throw Exception(ErrorCodes::CORRUPTED_DATA,
                         "Part {} intersects previous part {} and the transaction metadata of at least one"
                         " of them could not be read. This indicates disk corruption or a partial write.",
@@ -2256,7 +2333,7 @@ void MergeTreeData::PartLoadingTree::add(const MergeTreePartInfo & info, const S
                 const auto incoming_status = read_txn_status(name, disk);
                 const auto existing_status = read_txn_status(it->second->name, it->second->disk);
 
-                if (incoming_status == RollbackStatus::Unreadable || existing_status == RollbackStatus::Unreadable)
+                if (incoming_status == RollbackStatus::UnreadableContent || existing_status == RollbackStatus::UnreadableContent)
                     throw Exception(ErrorCodes::CORRUPTED_DATA,
                         "Part {} intersects next part {} and the transaction metadata of at least one"
                         " of them could not be read. This indicates disk corruption or a partial write.",
@@ -2377,10 +2454,6 @@ static void preparePartForRemoval(const MergeTreeMutableDataPartPtr & part)
         part->version->setAndStoreNonTransactionalRemovalTID(transaction_context);
     }
 }
-
-static constexpr size_t loading_parts_initial_backoff_ms = 100;
-static constexpr size_t loading_parts_max_backoff_ms = 5000;
-static constexpr size_t loading_parts_max_tries = 3;
 
 void MergeTreeData::loadUnexpectedDataPart(UnexpectedPartLoadState & state)
 {

--- a/tests/queries/0_stateless/04627_startup_txn_metadata_transient_io.reference
+++ b/tests/queries/0_stateless/04627_startup_txn_metadata_transient_io.reference
@@ -1,0 +1,6 @@
+phase1: OK
+phase2: OK
+phase3: OK
+phase4: OK
+phase5: OK
+phase6: OK

--- a/tests/queries/0_stateless/04627_startup_txn_metadata_transient_io.sh
+++ b/tests/queries/0_stateless/04627_startup_txn_metadata_transient_io.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Tags: no-ordinary-database, no-replicated-database, no-shared-merge-tree, no-encrypted-storage, no-object-storage, no-parallel
+#
+# Regression test for classifying and retrying failures while reading a part's txn_version.txt
+# during PartLoadingTree build (via ATTACH, which drives loadDataParts -> PartLoadingTree::build ->
+# read_txn_status). Intersecting parts are fabricated so the intersection resolution reads the
+# transaction metadata of both parts.
+#
+# no-parallel: the failpoints below are server-global, so a concurrent test hitting a part
+# intersection could otherwise consume the injected fault.
+#
+# Phases:
+#   1. transient error (ONCE) is retried -> ATTACH succeeds.
+#   2. persistent transient error (REGULAR) exhausts retries -> ATTACH fails, but NOT as
+#      CORRUPTED_DATA (the real transient error is rethrown).
+#   3. legacy pre-`storing_version` metadata is still accepted (strict EOF must not reject it).
+#   4. current-format metadata with trailing bytes -> rejected as CORRUPTED_DATA (strict EOF).
+#   5. oversized metadata (> cap) -> rejected as CORRUPTED_DATA.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+ROLLED_BACK='version: 1
+storing_version: 0
+creation_tid: (2, 33, 00000000-0000-0000-0000-000000000000)
+creation_csn: 18446744073709551615
+removal_tid: (0, 0, 00000000-0000-0000-0000-000000000000)
+removal_csn: 0'
+# Old format: `creation_tid:` immediately after the version header, no `storing_version` field.
+LEGACY='version: 1
+creation_tid: (2, 33, 00000000-0000-0000-0000-000000000000)
+creation_csn: 42
+removal_tid: (0, 0, 00000000-0000-0000-0000-000000000000)
+removal_csn: 0'
+# Valid current-format record followed by trailing garbage.
+GARBAGE="${ROLLED_BACK}
+trailing garbage that must not be accepted"
+
+TABLES="t_txn_io_1 t_txn_io_2 t_txn_io_3 t_txn_io_4 t_txn_io_5 t_txn_io_6"
+
+cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_fault" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_persistent_fault" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_permanent_fault" 2>/dev/null
+    local t uuid disk_path data_path
+    disk_path=$($CLICKHOUSE_CLIENT -q "SELECT path FROM system.disks WHERE name = 'default'" 2>/dev/null)
+    for t in ${TABLES}; do
+        uuid=$($CLICKHOUSE_CLIENT -q "SELECT uuid FROM system.detached_tables WHERE database = currentDatabase() AND table = '${t}'" 2>/dev/null)
+        if [ -n "${uuid}" ] && [ -n "${disk_path}" ]; then
+            data_path="${disk_path}store/${uuid:0:3}/${uuid}"
+            rm -rf "${data_path:?}/all_1_5_4_1" "${data_path:?}/all_5_6_1_0"
+            $CLICKHOUSE_CLIENT -q "ATTACH TABLE ${t}" 2>/dev/null
+        fi
+        $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${t}" 2>/dev/null
+    done
+}
+trap cleanup EXIT
+cleanup
+
+# Creates ${TABLE}, detaches it permanently, and sets DATA_PATH. Fails fast if the detach
+# postcondition does not hold (never modify a still-attached table's data directory).
+setup()
+{
+    local table=$1
+    $CLICKHOUSE_CLIENT -q "CREATE TABLE ${table} (x UInt32) ENGINE = MergeTree ORDER BY x"
+    $CLICKHOUSE_CLIENT -q "INSERT INTO ${table} VALUES (42)"
+    DATA_PATH=$($CLICKHOUSE_CLIENT -q "SELECT data_paths[1] FROM system.tables WHERE database = currentDatabase() AND name = '${table}'")
+    $CLICKHOUSE_CLIENT -q "DETACH TABLE ${table} PERMANENTLY"
+    local ok
+    ok=$($CLICKHOUSE_CLIENT -q "
+        SELECT (SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = '${table}') = 0
+           AND (SELECT count() FROM system.detached_tables WHERE database = currentDatabase() AND table = '${table}' AND is_permanently) = 1")
+    if [ "${ok}" != "1" ]; then echo "FAIL: ${table} not detached permanently"; exit 1; fi
+    SOURCE="${DATA_PATH}/all_1_1_0"
+}
+
+# fabricate <part_name> <content>   (empty content => no txn_version.txt, i.e. non-transactional)
+fabricate()
+{
+    local part=$1 content=$2
+    cp -r "${SOURCE}" "${DATA_PATH}/${part}"
+    if [ -n "${content}" ]; then
+        printf '%s' "${content}" > "${DATA_PATH}/${part}/txn_version.txt.tmp"
+        mv "${DATA_PATH}/${part}/txn_version.txt.tmp" "${DATA_PATH}/${part}/txn_version.txt"
+    fi
+}
+
+# --- Phase 1: transient error retried, ATTACH succeeds ---
+setup t_txn_io_1
+fabricate all_1_5_4_1 "${ROLLED_BACK}"
+fabricate all_5_6_1_0 ""
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT part_loading_tree_read_txn_status_fault"
+if ! $CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_1" 2>/dev/null; then echo "FAIL phase1: ATTACH threw (transient not retried)"; exit 1; fi
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_fault"
+A56=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM system.parts WHERE database=currentDatabase() AND table='t_txn_io_1' AND name='all_5_6_1_0' AND active")
+[ "${A56}" -eq 1 ] || { echo "FAIL phase1: all_5_6_1_0 active=${A56}"; exit 1; }
+echo "phase1: OK"
+
+# --- Phase 2: persistent transient error exhausts retries, fails but NOT as corruption ---
+setup t_txn_io_2
+fabricate all_1_5_4_1 "${ROLLED_BACK}"
+fabricate all_5_6_1_0 ""
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT part_loading_tree_read_txn_status_persistent_fault"
+ERR=$($CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_2" 2>&1)
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_persistent_fault"
+if echo "${ERR}" | grep -q "CORRUPTED_DATA"; then echo "FAIL phase2: exhausted transient mis-reported as CORRUPTED_DATA"; exit 1; fi
+if ! echo "${ERR}" | grep -qE "NETWORK_ERROR|transient"; then echo "FAIL phase2: expected transient error, got: ${ERR}"; exit 1; fi
+echo "phase2: OK"
+
+# --- Phase 3: legacy metadata accepted (strict EOF must not reject the legacy format) ---
+setup t_txn_io_3
+fabricate all_1_5_4_1 "${ROLLED_BACK}"
+fabricate all_5_6_1_0 "${LEGACY}"
+if ! $CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_3" 2>/dev/null; then echo "FAIL phase3: legacy metadata wrongly rejected"; exit 1; fi
+echo "phase3: OK"
+
+# --- Phase 4: current-format metadata with trailing bytes rejected (strict EOF) ---
+setup t_txn_io_4
+fabricate all_1_5_4_1 ""
+fabricate all_5_6_1_0 "${GARBAGE}"
+ERR=$($CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_4" 2>&1)
+if ! echo "${ERR}" | grep -q "CORRUPTED_DATA"; then echo "FAIL phase4: trailing garbage not rejected, got: ${ERR}"; exit 1; fi
+echo "phase4: OK"
+
+# --- Phase 5: oversized metadata rejected ---
+setup t_txn_io_5
+fabricate all_1_5_4_1 ""
+cp -r "${SOURCE}" "${DATA_PATH}/all_5_6_1_0"
+head -c 5000 /dev/zero | tr '\0' 'x' > "${DATA_PATH}/all_5_6_1_0/txn_version.txt"
+ERR=$($CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_5" 2>&1)
+if ! echo "${ERR}" | grep -q "CORRUPTED_DATA"; then echo "FAIL phase5: oversized metadata not rejected, got: ${ERR}"; exit 1; fi
+echo "phase5: OK"
+
+# --- Phase 6: non-retryable I/O error is propagated as-is (not retried, not corruption) ---
+# The permanent failpoint is ONCE: if the code wrongly retried a non-retryable error, the one-shot
+# fault would be consumed and ATTACH would succeed, so the grep below would fail the phase.
+setup t_txn_io_6
+fabricate all_1_5_4_1 "${ROLLED_BACK}"
+fabricate all_5_6_1_0 ""
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT part_loading_tree_read_txn_status_permanent_fault"
+ERR=$($CLICKHOUSE_CLIENT -q "ATTACH TABLE t_txn_io_6" 2>&1)
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT part_loading_tree_read_txn_status_permanent_fault"
+if echo "${ERR}" | grep -q "CORRUPTED_DATA"; then echo "FAIL phase6: permanent I/O error mis-reported as CORRUPTED_DATA"; exit 1; fi
+if ! echo "${ERR}" | grep -qE "CANNOT_OPEN_FILE|permanent I/O fault"; then echo "FAIL phase6: expected the original I/O error, got: ${ERR}"; exit 1; fi
+echo "phase6: OK"


### PR DESCRIPTION
### Problem

On startup (or `ATTACH`), a table can fail to load with a spurious data-corruption error when a **transient** I/O error (an S3, Keeper, or memory hiccup) occurs while reading a data part's `txn_version.txt`:

```
Code: 246. DB::Exception ... Part all_5_6_1_0 intersects previous part all_1_5_4_1 and the transaction metadata of at least one of them could not be read. This indicates disk corruption or a partial write.
```

Consequences:
- The transient error is mis-reported as disk corruption.
- The server does not start / the table does not attach, with **no retry** — a single transient blip during part loading is fatal.

### Root cause

When two block-range-intersecting parts are found during `PartLoadingTree::build`, `PartLoadingTree::add` reads each part's transaction status via the `read_txn_status` lambda in `src/Storages/MergeTree/MergeTreeData.cpp`. Its `catch (...)` collapsed **every** exception into a single `Unreadable` state, and `add` then threw `CORRUPTED_DATA`. Because `build` runs outside `loadDataPartWithRetries`, a transient error was neither classified as transient nor retried.

### Fix

`read_txn_status` now classifies failures by where they occur, inside a bounded retry loop (reusing the existing `loading_parts_max_tries` / backoff constants):
- **Transient I/O** (`isRetryableException`) → retried; if it outlives the retries, the original exception is rethrown (fail-close with the accurate error, not `CORRUPTED_DATA`).
- **Permanent, non-retryable I/O** → rethrown as-is (never reported as corruption).
- **Content corruption** (file fully read, then parse / strict-EOF / size-cap fails) → `UnreadableContent`, which `add` maps to `CORRUPTED_DATA` as before.

Hardening: a shared bounded reader `VersionInfo::readMetadataString` (reads at most `MAX_METADATA_SIZE + 1` bytes; oversize is proven from bytes actually read, not from a possibly-corrupt on-disk file size), used by both `read_txn_status` and `VersionMetadataOnDisk::readMetadataUnlocked`; strict EOF for the current `txn_version.txt` format (the legacy pre-`storing_version` format returns early and is exempt).

Regression test `04627_startup_txn_metadata_transient_io.sh` drives the path via `ATTACH` behind `ONCE`/`REGULAR` failpoints and covers: transient-retry success, retry exhaustion staying non-corruption, non-retryable propagation (not retried), legacy acceptance, and strict-EOF and oversize rejection.

### Scope / precedent

This gap was found by **code inspection** of the startup part-loading path, not from an observed incident — there is **no logged occurrence** of a real transient error hitting `read_txn_status`; this is defense-in-depth / robustness hardening. The justification is structural and consistency-based: the surrounding part-loading code already retries transient I/O and refuses to treat it as a broken part, via `loadDataPartWithRetries` + `isRetryableException` (`src/Storages/MergeTree/checkDataPart.cpp`). `PartLoadingTree::build` (which calls `read_txn_status`) simply runs *outside* that retry wrapper and used a blanket `catch (...)`; this PR brings the same established treatment to that path (reusing the same `loading_parts_max_tries` / backoff constants).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server failing to start (or a table failing to `ATTACH`) with a spurious "disk corruption" error when a temporary I/O hiccup occurred while reading a data part's transaction metadata during startup. Such transient errors are now retried instead of being reported as data corruption.



