### PR TITLE
Run distributed-plan sanitizer stateless on runner with more mem instead of cutting concurrency

### DIFF
--- a/.github/workflows/backport_branches.yml
+++ b/.github/workflows/backport_branches.yml
@@ -578,7 +578,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Compatibility check (arm_release)' --workflow "BackportPR" --ci --timestamp
 
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel:
-    runs-on: [self-hosted, amd-medium-cpu]
+    runs-on: [self-hosted, amd-large]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhbWRfYXNhbl91YnNhbiwgZGlzdHJpYnV0ZWQgcGxhbiwgcGFyYWxsZWwp') }}
     name: "Stateless tests (amd_asan_ubsan, distributed plan, parallel)"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1556,7 +1556,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Compatibility check (arm_release)' --workflow "MasterCI" --ci --timestamp
 
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel:
-    runs-on: [self-hosted, amd-medium-cpu]
+    runs-on: [self-hosted, amd-large]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhbWRfYXNhbl91YnNhbiwgZGlzdHJpYnV0ZWQgcGxhbiwgcGFyYWxsZWwp') }}
     name: "Stateless tests (amd_asan_ubsan, distributed plan, parallel)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1803,7 +1803,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Bugfix validation (unit tests)' --workflow "PR" --ci --timestamp
 
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel:
-    runs-on: [self-hosted, pr-amd-medium-cpu]
+    runs-on: [self-hosted, pr-amd-large]
     needs: [build_amd_asan_ubsan, build_arm_tidy, config_workflow, dockers_build_amd, dockers_build_arm, dockers_build_multiplatform_manifest, fast_test, style_check]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhbWRfYXNhbl91YnNhbiwgZGlzdHJpYnV0ZWQgcGxhbiwgcGFyYWxsZWwp') }}
     name: "Stateless tests (amd_asan_ubsan, distributed plan, parallel)"

--- a/.github/workflows/release_branches.yml
+++ b/.github/workflows/release_branches.yml
@@ -681,7 +681,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Install packages (arm_release)' --workflow "ReleaseBranchCI" --ci --timestamp
 
   stateless_tests_amd_asan_ubsan_distributed_plan_parallel:
-    runs-on: [self-hosted, amd-medium-cpu]
+    runs-on: [self-hosted, amd-large]
     needs: [build_amd_asan_ubsan, config_workflow, dockers_build_amd, dockers_build_arm]
     if: ${{ !cancelled() && !contains(needs.*.outputs.pipeline_status, 'failure') && !contains(needs.*.outputs.pipeline_status, 'undefined') && !contains(fromJson(needs.config_workflow.outputs.data).workflow_config.cache_success_base64, 'U3RhdGVsZXNzIHRlc3RzIChhbWRfYXNhbl91YnNhbiwgZGlzdHJpYnV0ZWQgcGxhbiwgcGFyYWxsZWwp') }}
     name: "Stateless tests (amd_asan_ubsan, distributed plan, parallel)"

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -681,16 +681,16 @@ class JobConfigs:
     functional_tests_jobs = common_ft_job_config.parametrize(
         Job.ParamSet(
             parameter="amd_asan_ubsan, distributed plan, parallel",
-            runs_on=RunnerLabels.AMD_MEDIUM_CPU,
+            # `--distributed-plan` fans each query across local parallel replicas,
+            # multiplying the server-side memory of every in-flight query, so the
+            # aggregate RSS of the parallel suite's co-scheduled queries is heavier
+            # than a normal ASan run and overruns the sanitizer memory cap on the
+            # default 64 GiB runner. Use a LARGE runner (same 32 vCPU as MEDIUM_CPU,
+            # but 128 GiB instead of 64 GiB RAM) so the suite keeps full concurrency
+            # and the default timeout instead of cutting workers - which barely
+            # moved peak RSS and only made the job slower.
+            runs_on=RunnerLabels.AMD_LARGE,
             requires=[ArtifactNames.CH_AMD_ASAN_UBSAN],
-            # This variant runs the parallel suite at reduced concurrency (see the
-            # distributed-plan branch in `functional_tests.py`) to keep the
-            # aggregate server RSS under the sanitizer memory cap, which lowers
-            # throughput. Allow more wall-clock than the common 2.5h budget so the
-            # reduced concurrency cannot turn into a job timeout: the job ran ~2h36m
-            # at 8 workers, and the further cut to 7 workers pushes it to ~2h57m, so
-            # 3.5h keeps a comfortable margin.
-            timeout=int(3600 * 3.5),
         ),
         *[
             Job.ParamSet(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -21,8 +21,8 @@ temp_dir = f"{Utils.cwd()}/ci/tmp"
 
 # Substrings identifying a sanitizer build in a build type ("amd_asan_ubsan"),
 # a job parameter string ("amd_asan_ubsan, distributed plan, parallel"), or a
-# job name. Sanitizer builds get the tighter server memory cap and reduced
-# concurrency (see the `set_memory_ratio` and `nproc` logic in `main`).
+# job name. Sanitizer builds get the tighter server memory cap (see the
+# `set_memory_ratio` logic in `main`).
 SANITIZERS = ("asan", "tsan", "msan", "ubsan")
 
 
@@ -327,7 +327,6 @@ def main():
     is_llvm_coverage = False
     is_excluded_from_llvm = False
     is_per_test_coverage = False
-    is_distributed_plan = False
     runner_options = ""
     # optimal value for most of the jobs
     nproc = int(Utils.cpu_count() * 0.6)
@@ -383,8 +382,6 @@ def main():
             is_shared_catalog = True
         if "ParallelReplicas" in to:
             is_parallel_replicas = True
-        if "distributed plan" in to:
-            is_distributed_plan = True
 
     # If this PR only touches test files (no production/config code changed),
     # this job only needs to run if one of the changed tests would even be
@@ -481,40 +478,6 @@ def main():
             # shared server memory cap, so the OvercommitTracker kills queries across
             # all co-scheduled tests. Lower concurrency to keep peak total RSS under it.
             nproc = int(Utils.cpu_count() * 0.4)
-        elif (
-            is_distributed_plan
-            and "parallel" in test_options
-            and any(san in args.options for san in SANITIZERS)
-        ):
-            # `--distributed-plan` fans each query across local parallel replicas,
-            # multiplying the server-side memory of every in-flight query. Under the
-            # parallel runner dozens of such queries share one server, so their
-            # aggregate RSS overruns the sanitizer memory cap
-            # (`max_server_memory_usage_to_ram_ratio` 0.7) and the OvercommitTracker
-            # rejects queries across all co-scheduled tests with
-            # `MEMORY_LIMIT_EXCEEDED`. This is the same failure mode as azure above,
-            # but the per-query multiplication makes it heavier, so cut concurrency
-            # below the azure level to keep peak total RSS under the cap. The job
-            # gets a larger `timeout` (see `job_configs.py`) to absorb the reduced
-            # throughput. Gated to sanitizer builds: only they carry the 0.7 cap,
-            # and the non-sanitizer distributed-plan parallel jobs (e.g. amd_debug)
-            # run comfortably at the default concurrency.
-            #
-            # Tuned down in steps against observed peak RSS on the 32-vCPU
-            # `c7i.8xlarge` runner (cap 41.84 GiB at ratio 0.7): 0.35 -> 11 workers
-            # hit Code 241 at 43.01 GiB (~3% over); 0.3 -> 9 workers still landed
-            # right on the cap (41.90 GiB); 0.25 -> 8 workers reached 41.76 GiB;
-            # 0.22 -> 7 workers reached 41.71 GiB - each run still grazing the cap
-            # with a single rejected query. That near-flat response shows the RSS
-            # baseline is dominated by ASan overhead that accumulates with the
-            # amount of work done, not with concurrency, so cutting workers
-            # further cannot open a gap under the cap; the residual headroom comes
-            # from this job's slightly higher memory ratio instead (0.75, see the
-            # install stage below). The concurrency cut stays: it is what shrank
-            # the aggregate client RSS enough to make the higher server cap safe
-            # for the host, and 7 workers finish in ~2h44m, inside the 3.5h
-            # `timeout` (see `job_configs.py`).
-            nproc = int(Utils.cpu_count() * 0.22)
         elif is_per_test_coverage:
             cidb_cluster = CIDBCluster()
             if not info.is_local_run:
@@ -810,8 +773,10 @@ def main():
         # test subset at reduced concurrency). 0.7 stays comfortably above the
         # largest legitimate single-query need (the ~25 GiB stateful-load INSERT).
         # The heaviest configs also cut test concurrency (see the `nproc` block
-        # above, e.g. azure and distributed-plan) so that the *aggregate* RSS of
-        # concurrent queries stays under this cap too.
+        # above, e.g. azure) so that the *aggregate* RSS of concurrent queries
+        # stays under this cap too; the memory-heavy distributed-plan parallel
+        # job instead runs on a larger 128 GiB runner (see `job_configs.py`),
+        # where the cap sits well above its aggregate RSS at full concurrency.
         #
         # The cap must follow the binary actually being launched, not the job
         # option string: bugfix validation passes only `BugfixValidation` in
@@ -819,30 +784,9 @@ def main():
         # (always `*_asan_ubsan`), and its validation loop later swaps to the
         # other build types, re-deriving the cap on every swap (sanitizer ->
         # 0.7, debug -> server default; see the TEST stage below).
-        #
-        # The distributed-plan parallel job gets a slightly higher cap (0.75).
-        # The global memory check compares the server's *OS RSS* against the
-        # cap, and on an ASan server RSS carries tens of GiB the tracker can
-        # neither see nor free by killing queries: ASan shadow memory,
-        # quarantine and redzones, plus file-backed pages from mmap reads. On
-        # the 32-vCPU runner that overhead accumulates over the run towards
-        # ~41.7 GiB regardless of concurrency - cutting workers 11 -> 9 -> 8
-        # -> 7 moved the peak RSS only 43.01 -> 41.90 -> 41.76 -> 41.71 GiB
-        # against the 41.84 GiB cap that 0.7 yields, and every run still
-        # grazed the cap (one query rejected on a 512 MiB chunk while RSS sat
-        # just under it). Concurrency is exhausted as a lever, so the cap
-        # itself must give the untrackable overhead room: 0.75 (~44.8 GiB)
-        # leaves ~3 GiB of headroom above the observed RSS equilibrium. The
-        # host-OOM invariant this cap protects (server cap + aggregate client
-        # RSS < RAM) still holds with >10 GiB to spare, because this job's
-        # concurrency is already cut to 0.22 * CPU (see `nproc` above), which
-        # shrinks the ASan client footprint from ~17 GiB to ~3 GiB.
         memory_cap_source = build_types[0] if is_bugfix_validation else args.options
         if any(san in memory_cap_source for san in SANITIZERS):
-            memory_ratio = (
-                0.75 if is_distributed_plan and "parallel" in test_options else 0.7
-            )
-            commands.append(lambda: CH.set_memory_ratio(memory_ratio))
+            commands.append(lambda: CH.set_memory_ratio(0.7))
 
         if is_flaky_check:
             commands.append(CH.enable_thread_fuzzer_config)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/110574
Related: https://github.com/ClickHouse/ClickHouse/issues/108689
-->

Reimplements #110574. That PR fixed the `MEMORY_LIMIT_EXCEEDED` (Code 241) flood in *Stateless tests (amd_asan_ubsan, distributed plan, parallel)* by cutting the job's test concurrency to `0.22 * CPU` (7 workers on the 32-vCPU runner), giving it a higher `0.75` memory ratio, and raising its `timeout` to 3.5h. That kept the job green but made it **much slower**, and its own tuning runs showed the concurrency lever barely moved peak server RSS anyway (43.01 -> 41.71 GiB across 11 -> 7 workers) - the ASan RSS baseline accumulates with work done, not concurrency.

Fix it the right way: move the job from `AMD_MEDIUM_CPU` (32 vCPU, 64 GiB) to `AMD_LARGE` (same 32 vCPU, but **128 GiB** RAM). With double the RAM the sanitizer `max_server_memory_usage_to_ram_ratio` cap of `0.7` sits well above the job's aggregate RSS at full concurrency, so the suite runs at the default `0.6 * CPU` workers and the default 2.5h timeout without overrunning the cap.

- `ci/defs/job_configs.py`: `runs_on` `AMD_MEDIUM_CPU` -> `AMD_LARGE`; drop the 3.5h `timeout` override (restore the default).
- `ci/jobs/functional_tests.py`: drop the distributed-plan `nproc` concurrency cut and the `is_distributed_plan` plumbing; drop the distributed-plan `0.75` memory-ratio special case (all sanitizer runs keep the `0.7` cap).
- Regenerated `.github/workflows/*.yml`.

The general sanitizer `0.7` memory cap and the all-config-tree `set_memory_ratio` / bugfix-validation handling from #110574 stay - those are the host-OOM (`Server died`) fix, not the slowness cause.

Related: https://github.com/ClickHouse/ClickHouse/pull/110574
Related: https://github.com/ClickHouse/ClickHouse/issues/108689

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.118` (included in `26.8` and later)
<!-- ch-version-info:end -->