### PR TITLE
Fix parameterized view with a subquery-valued Array/Tuple parameter

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -4514,6 +4514,10 @@ void QueryAnalyzer::resolveTableFunction(QueryTreeNodePtr & table_function_node,
 
                 if (auto * identifier_node = nodes[0]->as<IdentifierNode>())
                 {
+                    bool previous_parameterized_view_arguments_in_resolve_process = parameterized_view_arguments_in_resolve_process;
+                    parameterized_view_arguments_in_resolve_process = true;
+                    SCOPE_EXIT({ parameterized_view_arguments_in_resolve_process = previous_parameterized_view_arguments_in_resolve_process; });
+
                     resolveExpressionNode(nodes[1], scope, /* allow_lambda_expression */false, /* allow_table_function */false);
                     if (auto * constant = nodes[1]->as<ConstantNode>())
                     {

--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -345,6 +345,10 @@ private:
     /// header), so scalar subqueries in their arguments must be executed for real instead of
     /// being replaced with type-only placeholders. See evaluateScalarSubqueryIfNeeded.
     bool table_function_arguments_in_resolve_process = false;
+
+    /// True while a parameterized view argument value is resolved: a scalar subquery there must
+    /// fold to a literal, not a `__getScalar` reference. See `evaluateScalarSubqueryIfNeeded`.
+    bool parameterized_view_arguments_in_resolve_process = false;
 };
 
 }

--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -97,13 +97,16 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
 
     auto & context = scope.context;
 
-    /// Scalar subqueries in table function arguments are executed even in only-analyze mode.
-    /// The table function is resolved into a storage during analysis (its header is needed),
-    /// so it requires real argument values rather than type-only placeholders. Otherwise
-    /// a placeholder would be passed to the table function, e.g. an empty URL to `s3`:
+    /// Scalar subqueries in table function or parameterized view arguments are executed even in
+    /// only-analyze mode. The table function / view is resolved into a storage during analysis
+    /// (its header is needed), so it requires real argument values rather than type-only
+    /// placeholders. Otherwise a placeholder would be passed, e.g. an empty URL to `s3`:
     /// CREATE TABLE t ENGINE = MergeTree ORDER BY () AS
     /// WITH (SELECT path FROM table_with_paths) AS path SELECT * FROM s3(path, NOSIGN);
-    const bool only_analyze_subquery = only_analyze && !table_function_arguments_in_resolve_process;
+    /// or a default (empty) value substituted for a parameterized view parameter.
+    const bool only_analyze_subquery = only_analyze
+        && !table_function_arguments_in_resolve_process
+        && !parameterized_view_arguments_in_resolve_process;
 
     Block scalar_block;
 

--- a/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
+++ b/src/Analyzer/Resolve/evaluateScalarSubqueryIfNeeded.cpp
@@ -369,9 +369,11 @@ void QueryAnalyzer::evaluateScalarSubqueryIfNeeded(QueryTreeNodePtr & node, Iden
     static const std::set<std::string_view> useless_literal_types = {"Array", "Tuple", "AggregateFunction", "Function", "Set", "LowCardinality"};
     auto * nearest_query_scope = scope.getNearestQueryScope();
 
-    /// Always convert to literals when there is no query context
+    /// Always convert to literals when there is no query context, or when resolving a
+    /// parameterized view argument (its value must fold to a literal to be matched against
+    /// the view's query parameters, see `parameterized_view_arguments_in_resolve_process`).
     if (!context->getSettingsRef()[Setting::enable_scalar_subquery_optimization] || !useless_literal_types.contains(scalar_type_name)
-        || !context->hasQueryContext() || !nearest_query_scope)
+        || !context->hasQueryContext() || !nearest_query_scope || parameterized_view_arguments_in_resolve_process)
     {
         ConstantValue constant_value{ ConstantValue::wrapToColumnConst(scalar_column_with_type.column), scalar_type };
         auto constant_node = std::make_shared<ConstantNode>(constant_value, node);

--- a/src/Parsers/FunctionParameterValuesVisitor.cpp
+++ b/src/Parsers/FunctionParameterValuesVisitor.cpp
@@ -3,19 +3,19 @@
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
+#include <Parsers/ASTSubquery.h>
 #include <Common/FieldVisitorToString.h>
 #include <Parsers/ASTHelpers.h>
-#include <Common/assert_cast.h>
 #include <Interpreters/evaluateConstantExpression.h>
+#include <Columns/IColumn.h>
+#include <DataTypes/IDataType.h>
+#include <DataTypes/Serializations/ISerialization.h>
+#include <Formats/FormatSettings.h>
+#include <IO/WriteBufferFromString.h>
 
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
-}
 
 class FunctionParameterValuesVisitor
 {
@@ -29,7 +29,14 @@ public:
     void visit(const ASTPtr & ast)
     {
         if (const auto * function = ast->as<ASTFunction>())
-            visitFunction(*function);
+        {
+            /// A recognized `parameter = value` assignment consumes the whole subtree: the value
+            /// expression must not be descended into, otherwise an inner predicate that happens to
+            /// reference the same parameter name (e.g. a subquery `... WHERE p = 1`) would overwrite
+            /// the collected value.
+            if (visitFunction(*function))
+                return;
+        }
         for (const auto & child : ast->children)
             visit(child);
     }
@@ -38,41 +45,43 @@ private:
     NameToNameMap & parameter_values;
     ContextPtr context;
 
-    void visitFunction(const ASTFunction & parameter_function)
+    /// Returns true if this function is a `parameter = value` assignment that was collected.
+    bool visitFunction(const ASTFunction & parameter_function)
     {
         if (parameter_function.name != "equals" && parameter_function.children.size() != 1)
-            return;
+            return false;
 
         const auto * expression_list = parameter_function.children[0]->as<ASTExpressionList>();
 
-        if (expression_list && expression_list->children.size() != 2)
-            return;
+        if (!expression_list || expression_list->children.size() != 2)
+            return false;
 
-        if (const auto * identifier = expression_list->children[0]->as<ASTIdentifier>())
+        const auto * identifier = expression_list->children[0]->as<ASTIdentifier>();
+        if (!identifier)
+            return false;
+
+        const ASTPtr & value = expression_list->children[1];
+
+        if (const auto * literal = value->as<ASTLiteral>())
         {
-            if (const auto * literal = expression_list->children[1]->as<ASTLiteral>())
-            {
-                parameter_values[identifier->name()] = convertFieldToString(literal->value);
-            }
-            else if (const auto * function = expression_list->children[1]->as<ASTFunction>())
-            {
-                if (isFunctionCast(function))
-                {
-                    const auto * cast_expression = assert_cast<ASTExpressionList*>(function->arguments.get());
-                    if (cast_expression->children.size() != 2)
-                        throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH, "Function CAST must have exactly two arguments");
-                    if (const auto * cast_literal = cast_expression->children[0]->as<ASTLiteral>())
-                    {
-                        parameter_values[identifier->name()] = convertFieldToString(cast_literal->value);
-                    }
-                }
-                else
-                {
-                    ASTPtr res = evaluateConstantExpressionOrIdentifierAsLiteral(expression_list->children[1], context);
-                    parameter_values[identifier->name()] = convertFieldToString(res->as<ASTLiteral>()->value);
-                }
-            }
+            parameter_values[identifier->name()] = convertFieldToString(literal->value);
+            return true;
         }
+
+        /// Serialize with the value's own data type so the result is text-escaped the way
+        /// `ReplaceQueryParameterVisitor` expects (see `QueryAnalyzer` for the analyzer counterpart).
+        if (value->as<ASTFunction>() || value->as<ASTSubquery>())
+        {
+            auto [field, type] = evaluateConstantExpression(value, context);
+            auto column = type->createColumn();
+            column->insert(field);
+            WriteBufferFromOwnString buffer;
+            type->getDefaultSerialization()->serializeTextEscaped(*column, 0, buffer, {});
+            parameter_values[identifier->name()] = buffer.str();
+            return true;
+        }
+
+        return false;
     }
 };
 

--- a/src/Parsers/FunctionParameterValuesVisitor.cpp
+++ b/src/Parsers/FunctionParameterValuesVisitor.cpp
@@ -4,8 +4,6 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTSubquery.h>
-#include <Common/FieldVisitorToString.h>
-#include <Parsers/ASTHelpers.h>
 #include <Interpreters/evaluateConstantExpression.h>
 #include <Columns/IColumn.h>
 #include <DataTypes/IDataType.h>
@@ -62,15 +60,11 @@ private:
 
         const ASTPtr & value = expression_list->children[1];
 
-        if (const auto * literal = value->as<ASTLiteral>())
-        {
-            parameter_values[identifier->name()] = convertFieldToString(literal->value);
-            return true;
-        }
-
-        /// Serialize with the value's own data type so the result is text-escaped the way
-        /// `ReplaceQueryParameterVisitor` expects (see `QueryAnalyzer` for the analyzer counterpart).
-        if (value->as<ASTFunction>() || value->as<ASTSubquery>())
+        /// Evaluate the value to a constant and serialize it with its own data type so the result
+        /// is text-escaped the way `ReplaceQueryParameterVisitor` expects (it reads the value back
+        /// with `deserializeTextEscaped`). This mirrors the analyzer counterpart in `QueryAnalyzer`,
+        /// which likewise has no separate literal path.
+        if (value->as<ASTLiteral>() || value->as<ASTFunction>() || value->as<ASTSubquery>())
         {
             auto [field, type] = evaluateConstantExpression(value, context);
             auto column = type->createColumn();

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
@@ -43,3 +43,9 @@ direct literal param, legacy analyzer
 direct literal param, EXPLAIN SYNTAX
 1
 1
+analyzer-only header inference, value-dependent type (Array)
+FixedString(3)
+FixedString(3)
+analyzer-only header inference across type matrix (Tuple, LowCardinality)
+1
+2

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
@@ -19,6 +19,17 @@ Tuple param
 1
 LowCardinality(String) param
 2
+4
 Array(LowCardinality(String)) param
 1
 2
+CAST(subquery) param
+1
+2
+3
+subquery predicate references param name
+EXPLAIN SYNTAX subquery param
+1
+1
+1
+1

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
@@ -1,0 +1,24 @@
+Array(Int32) param
+1
+2
+3
+1
+2
+3
+1
+2
+3
+1
+2
+3
+0
+Array(String) param
+1
+2
+Tuple param
+1
+LowCardinality(String) param
+2
+Array(LowCardinality(String)) param
+1
+2

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.reference
@@ -33,3 +33,13 @@ EXPLAIN SYNTAX subquery param
 1
 1
 1
+direct literal param, legacy analyzer
+4
+5
+6
+10
+11
+12
+direct literal param, EXPLAIN SYNTAX
+1
+1

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
@@ -83,13 +83,42 @@ SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_lc(nm = (SELECT toLowCardin
 -- an inner predicate referencing the parameter name must not overwrite the collected value on the AST path
 SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_array(AccountIds = (SELECT groupArray(AccountIds) FROM pv_self WHERE AccountIds = 9))) WHERE explain LIKE '%[9]%';
 
+-- A direct (non-subquery, non-function) string literal must be text-escaped on the AST path too.
+-- A top-level string literal used to be stored as raw bytes, but `ReplaceQueryParameterVisitor`
+-- reads it back with `deserializeTextEscaped`, so a value with a tab / newline / backslash was
+-- truncated or mis-parsed and the query returned wrong rows or threw `BAD_QUERY_PARAMETER`.
+-- Exercise both AST-path entry points: legacy execution (`enable_analyzer = 0`, via
+-- `Context::executeTableFunction`) and `EXPLAIN SYNTAX`, for both `String` and `LowCardinality(String)`.
+INSERT INTO pv_lc_data VALUES (5, 'c\nd') (6, 'e\\f');
+DROP TABLE IF EXISTS pv_str_data;
+CREATE TABLE pv_str_data (id Int32, s String) ENGINE = Memory;
+INSERT INTO pv_str_data VALUES (10, 'p\tq') (11, 'r\ns') (12, 't\\u');
+DROP VIEW IF EXISTS pv_str_scalar;
+CREATE VIEW pv_str_scalar AS SELECT * FROM pv_str_data WHERE s = {ss : String};
+
+SELECT 'direct literal param, legacy analyzer';
+SET enable_analyzer = 0;
+SELECT id FROM pv_lc(nm = 'a\tb') ORDER BY id;
+SELECT id FROM pv_lc(nm = 'c\nd') ORDER BY id;
+SELECT id FROM pv_lc(nm = 'e\\f') ORDER BY id;
+SELECT id FROM pv_str_scalar(ss = 'p\tq') ORDER BY id;
+SELECT id FROM pv_str_scalar(ss = 'r\ns') ORDER BY id;
+SELECT id FROM pv_str_scalar(ss = 't\\u') ORDER BY id;
+SET enable_analyzer = 1;
+
+SELECT 'direct literal param, EXPLAIN SYNTAX';
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_lc(nm = 'a\tb')) WHERE explain LIKE '%a\\tb%';
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_str_scalar(ss = 'p\tq')) WHERE explain LIKE '%p\\tq%';
+
 DROP VIEW pv_array;
 DROP VIEW pv_str;
 DROP VIEW pv_tuple;
 DROP VIEW pv_lc;
 DROP VIEW pv_lc_arr;
+DROP VIEW pv_str_scalar;
 DROP TABLE pv_data;
 DROP TABLE pv_ids;
 DROP TABLE pv_tuple_data;
 DROP TABLE pv_lc_data;
+DROP TABLE pv_str_data;
 DROP TABLE pv_self;

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
@@ -1,0 +1,66 @@
+-- Parameterized view with a subquery-valued argument of a type that scalar subquery
+-- optimization keeps unfolded (`Array`, `Tuple`, `LowCardinality`, ...). Such a value used
+-- to stay a `__getScalar` reference instead of a literal, so it was not collected as a view
+-- parameter and the query failed with `UNKNOWN_QUERY_PARAMETER`. See issue #68041.
+SET enable_analyzer = 1;
+-- Pin the scalar subquery optimization on: with it disabled the value would fold to a literal
+-- through the pre-existing path, so the regression cases below must run with it enabled.
+SET enable_scalar_subquery_optimization = 1;
+
+DROP TABLE IF EXISTS pv_data;
+DROP TABLE IF EXISTS pv_ids;
+CREATE TABLE pv_data (AccountId Int32, v String) ENGINE = Memory;
+INSERT INTO pv_data VALUES (1, 'a') (2, 'b') (3, 'c') (5, 'e');
+CREATE TABLE pv_ids (AccountId Int32) ENGINE = Memory;
+INSERT INTO pv_ids VALUES (1) (2) (3);
+
+SELECT 'Array(Int32) param';
+DROP VIEW IF EXISTS pv_array;
+CREATE VIEW pv_array AS SELECT * FROM pv_data WHERE AccountId IN {AccountIds : Array(Int32)};
+-- literal and `array` function forms already worked; keep them as guards
+SELECT AccountId FROM pv_array(AccountIds = [1, 2, 3]) ORDER BY AccountId;
+SELECT AccountId FROM pv_array(AccountIds = array(1, 2, 3)) ORDER BY AccountId;
+-- subquery-valued form is the regression from #68041
+SELECT AccountId FROM pv_array(AccountIds = (SELECT groupArray(AccountId) FROM pv_ids)) ORDER BY AccountId;
+SELECT AccountId FROM pv_array(AccountIds = CAST((SELECT groupArray(AccountId) FROM pv_ids), 'Array(Int32)')) ORDER BY AccountId;
+-- empty subquery result: matches nothing
+SELECT count() FROM pv_array(AccountIds = (SELECT groupArray(AccountId) FROM pv_ids WHERE AccountId > 100));
+
+SELECT 'Array(String) param';
+DROP VIEW IF EXISTS pv_str;
+CREATE VIEW pv_str AS SELECT * FROM pv_data WHERE v IN {names : Array(String)};
+SELECT AccountId FROM pv_str(names = (SELECT groupArray(v) FROM pv_data WHERE AccountId <= 2)) ORDER BY AccountId;
+
+SELECT 'Tuple param';
+DROP TABLE IF EXISTS pv_tuple_data;
+CREATE TABLE pv_tuple_data (id Int32, pair Tuple(Int32, Int32)) ENGINE = Memory;
+INSERT INTO pv_tuple_data VALUES (1, (10, 20)) (2, (30, 40));
+DROP VIEW IF EXISTS pv_tuple;
+CREATE VIEW pv_tuple AS SELECT * FROM pv_tuple_data WHERE pair = {p : Tuple(Int32, Int32)};
+-- multi-column subquery packages the result as a top-level `Tuple` (a single-column
+-- `(SELECT (10, 20))` would be `Nullable(Tuple(...))`, which already folds without this fix)
+SELECT id FROM pv_tuple(p = (SELECT toInt32(10), toInt32(20))) ORDER BY id;
+
+SELECT 'LowCardinality(String) param';
+DROP TABLE IF EXISTS pv_lc_data;
+CREATE TABLE pv_lc_data (id Int32, name LowCardinality(String)) ENGINE = Memory;
+INSERT INTO pv_lc_data VALUES (1, 'x') (2, 'y') (3, 'z');
+DROP VIEW IF EXISTS pv_lc;
+-- scalar `LowCardinality(String)` param (top-level family `LowCardinality`, not `Array`)
+CREATE VIEW pv_lc AS SELECT * FROM pv_lc_data WHERE name = {nm : LowCardinality(String)};
+SELECT id FROM pv_lc(nm = (SELECT toLowCardinality('y'))) ORDER BY id;
+
+SELECT 'Array(LowCardinality(String)) param';
+DROP VIEW IF EXISTS pv_lc_arr;
+CREATE VIEW pv_lc_arr AS SELECT * FROM pv_lc_data WHERE name IN {names : Array(LowCardinality(String))};
+SELECT id FROM pv_lc_arr(names = (SELECT groupArray(name) FROM pv_lc_data WHERE id <= 2)) ORDER BY id;
+
+DROP VIEW pv_array;
+DROP VIEW pv_str;
+DROP VIEW pv_tuple;
+DROP VIEW pv_lc;
+DROP VIEW pv_lc_arr;
+DROP TABLE pv_data;
+DROP TABLE pv_ids;
+DROP TABLE pv_tuple_data;
+DROP TABLE pv_lc_data;

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
@@ -44,16 +44,44 @@ SELECT id FROM pv_tuple(p = (SELECT toInt32(10), toInt32(20))) ORDER BY id;
 SELECT 'LowCardinality(String) param';
 DROP TABLE IF EXISTS pv_lc_data;
 CREATE TABLE pv_lc_data (id Int32, name LowCardinality(String)) ENGINE = Memory;
-INSERT INTO pv_lc_data VALUES (1, 'x') (2, 'y') (3, 'z');
+INSERT INTO pv_lc_data VALUES (1, 'x') (2, 'y') (3, 'z') (4, 'a\tb');
 DROP VIEW IF EXISTS pv_lc;
 -- scalar `LowCardinality(String)` param (top-level family `LowCardinality`, not `Array`)
 CREATE VIEW pv_lc AS SELECT * FROM pv_lc_data WHERE name = {nm : LowCardinality(String)};
 SELECT id FROM pv_lc(nm = (SELECT toLowCardinality('y'))) ORDER BY id;
+-- string value with a tab must be text-escaped, otherwise it is parsed as an incomplete value
+SELECT id FROM pv_lc(nm = (SELECT toLowCardinality('a\tb'))) ORDER BY id;
 
 SELECT 'Array(LowCardinality(String)) param';
 DROP VIEW IF EXISTS pv_lc_arr;
 CREATE VIEW pv_lc_arr AS SELECT * FROM pv_lc_data WHERE name IN {names : Array(LowCardinality(String))};
 SELECT id FROM pv_lc_arr(names = (SELECT groupArray(name) FROM pv_lc_data WHERE id <= 2)) ORDER BY id;
+
+-- `CAST` wrapping a subquery must also be substituted (during execution and in `EXPLAIN SYNTAX`)
+SELECT 'CAST(subquery) param';
+SELECT AccountId FROM pv_array(AccountIds = CAST((SELECT groupArray(AccountId) FROM pv_ids), 'Array(Int32)')) ORDER BY AccountId;
+
+-- A subquery whose own predicate references the parameter name must not overwrite the parameter
+-- value (the collector must not descend into the value expression).
+SELECT 'subquery predicate references param name';
+DROP TABLE IF EXISTS pv_self;
+CREATE TABLE pv_self (AccountIds Int32) ENGINE = Memory;
+INSERT INTO pv_self VALUES (1) (2) (9);
+SELECT AccountId FROM pv_array(AccountIds = (SELECT groupArray(AccountIds) FROM pv_self WHERE AccountIds = 9)) ORDER BY AccountId;
+
+-- `EXPLAIN SYNTAX` expands parameterized views through a separate AST path
+-- (`analyzeFunctionParamValues`) that also dropped the subquery-valued parameter and threw
+-- `UNKNOWN_QUERY_PARAMETER`. These assertions run through that AST path (the queries above run
+-- through the analyzer's own path), and check the exact substituted value is present (not just
+-- any substitution), so the test also catches a wrong value being substituted. See issue #68041.
+SELECT 'EXPLAIN SYNTAX subquery param';
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_array(AccountIds = (SELECT groupArray(AccountId) FROM pv_ids))) WHERE explain LIKE '%[1, 2, 3]%';
+-- `CAST` wrapping a subquery must also be substituted on the AST path
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_array(AccountIds = CAST((SELECT groupArray(AccountId) FROM pv_ids), 'Array(Int32)'))) WHERE explain LIKE '%[1, 2, 3]%';
+-- a string value with a tab must be text-escaped by the AST path (otherwise it renders unescaped)
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_lc(nm = (SELECT toLowCardinality('a\tb')))) WHERE explain LIKE '%a\\tb%';
+-- an inner predicate referencing the parameter name must not overwrite the collected value on the AST path
+SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_array(AccountIds = (SELECT groupArray(AccountIds) FROM pv_self WHERE AccountIds = 9))) WHERE explain LIKE '%[9]%';
 
 DROP VIEW pv_array;
 DROP VIEW pv_str;
@@ -64,3 +92,4 @@ DROP TABLE pv_data;
 DROP TABLE pv_ids;
 DROP TABLE pv_tuple_data;
 DROP TABLE pv_lc_data;
+DROP TABLE pv_self;

--- a/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
+++ b/tests/queries/0_stateless/03690_parameterized_view_array_subquery_param.sql
@@ -110,15 +110,43 @@ SELECT 'direct literal param, EXPLAIN SYNTAX';
 SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_lc(nm = 'a\tb')) WHERE explain LIKE '%a\\tb%';
 SELECT count() FROM (EXPLAIN SYNTAX SELECT * FROM pv_str_scalar(ss = 'p\tq')) WHERE explain LIKE '%p\\tq%';
 
+-- Analyzer header inference (`getSampleBlock`, only-analyze mode, e.g. `CREATE TABLE ... AS
+-- SELECT`) must resolve a subquery-valued parameter to its real value, not a default
+-- placeholder. When the projected type depends on the parameter value the default (empty
+-- array, length 0) made `toFixedString` throw `size must be positive`, so `CREATE TABLE ...
+-- AS SELECT` failed while real execution produced `FixedString(3)`. See issue #68041.
+SELECT 'analyzer-only header inference, value-dependent type (Array)';
+DROP VIEW IF EXISTS pv_fixed;
+CREATE VIEW pv_fixed AS SELECT toFixedString('v', length({p : Array(Int32)})) AS s;
+DROP TABLE IF EXISTS pv_cts_fixed;
+CREATE TABLE pv_cts_fixed ENGINE = Memory AS SELECT s FROM pv_fixed(p = (SELECT groupArray(AccountId) FROM pv_ids));
+-- the header-inferred column type must equal the execution type
+SELECT type FROM system.columns WHERE database = currentDatabase() AND table = 'pv_cts_fixed' AND name = 's';
+SELECT toTypeName(s) FROM pv_fixed(p = (SELECT groupArray(AccountId) FROM pv_ids)) LIMIT 1;
+
+-- Same only-analyze header path (`CREATE TABLE ... AS SELECT`) across the Tuple /
+-- LowCardinality subquery-argument matrix.
+SELECT 'analyzer-only header inference across type matrix (Tuple, LowCardinality)';
+DROP TABLE IF EXISTS pv_cts_tuple;
+CREATE TABLE pv_cts_tuple ENGINE = Memory AS SELECT id FROM pv_tuple(p = (SELECT toInt32(10), toInt32(20)));
+SELECT id FROM pv_cts_tuple ORDER BY id;
+DROP TABLE IF EXISTS pv_cts_lc;
+CREATE TABLE pv_cts_lc ENGINE = Memory AS SELECT id FROM pv_lc(nm = (SELECT toLowCardinality('y')));
+SELECT id FROM pv_cts_lc ORDER BY id;
+
 DROP VIEW pv_array;
 DROP VIEW pv_str;
 DROP VIEW pv_tuple;
 DROP VIEW pv_lc;
 DROP VIEW pv_lc_arr;
 DROP VIEW pv_str_scalar;
+DROP VIEW pv_fixed;
 DROP TABLE pv_data;
 DROP TABLE pv_ids;
 DROP TABLE pv_tuple_data;
 DROP TABLE pv_lc_data;
 DROP TABLE pv_str_data;
 DROP TABLE pv_self;
+DROP TABLE pv_cts_fixed;
+DROP TABLE pv_cts_tuple;
+DROP TABLE pv_cts_lc;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/68041   (auto-closes the issue when this PR is merged into the default branch)
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/68041

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `UNKNOWN_QUERY_PARAMETER` when a parameterized view is called with a subquery-valued argument whose type is `Array`, `Tuple` or `LowCardinality`, e.g. `SELECT * FROM v(param = (SELECT groupArray(x) FROM t))`.


### Description

When a parameterized view argument value is a scalar subquery, the analyzer resolves it and then collects the parameter only if the resolved node is a `ConstantNode` (`QueryAnalyzer::resolveTableFunction`). For the large-literal types in `useless_literal_types` (`Array`, `Tuple`, `AggregateFunction`, `Function`, `Set`, `LowCardinality`), `evaluateScalarSubqueryIfNeeded` keeps the value as a `__getScalar` reference instead of folding it to a literal (the scalar subquery optimization). The parameter was therefore silently dropped and the view failed with `Code 456. Substitution '...' is not set. (UNKNOWN_QUERY_PARAMETER)`. Scalar-typed subquery arguments (e.g. `Int32`) were unaffected because they are always folded to a literal.

A parameterized view argument value must fold to a literal to be matched against the view's query parameters, so the fix forces literal folding for that narrow resolution window via a new `parameterized_view_arguments_in_resolve_process` flag (mirrors the existing `table_function_arguments_in_resolve_process`). The scalar subquery optimization is unchanged everywhere else.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.158` (included in `26.8` and later)
<!-- ch-version-info:end -->