### PR TITLE
Fix DeltaLake partitioned writes corrupting path-like partition values and rejecting NULL

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.cpp
@@ -5,6 +5,7 @@
 #include <Common/ArenaUtils.h>
 #include <Common/Arena.h>
 #include <Common/PODArray.h>
+#include <base/hex.h>
 #include <Core/UUID.h>
 #include <Core/Settings.h>
 
@@ -20,7 +21,6 @@
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.h>
 #include <Storages/ObjectStorage/DataLakes/DeltaLake/KernelUtils.h>
 #include <Storages/ObjectStorage/StorageObjectStorageSink.h>
-#include <Storages/HivePartitioningUtils.h>
 
 #include <fmt/ranges.h>
 
@@ -29,6 +29,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int INCORRECT_DATA;
+    extern const int CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN;
 }
 
 namespace Setting
@@ -39,6 +40,76 @@ namespace Setting
 
 namespace
 {
+    /// Delta placeholder for a missing partition value (also committed as a JSON null).
+    constexpr std::string_view HIVE_DEFAULT_PARTITION = "__HIVE_DEFAULT_PARTITION__";
+
+    /// delta-kernel-rs `partition::hive::needs_escaping` (non-Windows set). `-`, space and
+    /// non-ASCII stay unescaped. Controls 0x00-0x1F and 0x7F are covered by the range checks.
+    bool needsHiveEscaping(unsigned char c)
+    {
+        return c <= 0x1F || c == 0x7F
+            || c == '"' || c == '#' || c == '%' || c == '\'' || c == '*' || c == '/'
+            || c == ':' || c == '=' || c == '?' || c == '\\' || c == '{' || c == '[' || c == ']' || c == '^';
+    }
+
+    String hiveEscape(std::string_view s)
+    {
+        String result;
+        result.reserve(s.size());
+        for (char ch : s)
+        {
+            auto c = static_cast<unsigned char>(ch);
+            if (needsHiveEscaping(c))
+            {
+                result += '%';
+                result += hexDigitUppercase(c / 16);
+                result += hexDigitUppercase(c % 16);
+            }
+            else
+                result += ch;
+        }
+        return result;
+    }
+
+    /// Directory component `name=hiveEscape(value)`; a null-equivalent value uses the placeholder.
+    String buildPartitionPathComponent(const DeltaLakePartitionedSink::PartitionValue & pv)
+    {
+        String component = hiveEscape(pv.name);
+        component += '=';
+        component += pv.is_null ? String(HIVE_DEFAULT_PARTITION) : hiveEscape(pv.value);
+        return component;
+    }
+
+    /// delta-kernel-rs `partition::hive::HADOOP_URI_PATH_ENCODE_SET` (Hadoop Path.toUri()).
+    bool needsUriEncoding(unsigned char c)
+    {
+        return c <= 0x1F || c >= 0x80
+            || c == ' ' || c == '"' || c == '#' || c == '%' || c == '<' || c == '>' || c == '?'
+            || c == '[' || c == '\\' || c == ']' || c == '^' || c == '`' || c == '{' || c == '|' || c == '}';
+    }
+
+    /// URI-encode the on-disk relative path for `add.path`. The reader decodes it with a single
+    /// `unescapeForFileName` (which decodes every `%XX`), so one encode round-trips to the exact
+    /// on-disk path. `/` separators are kept so the path structure survives.
+    String uriEncodePath(const String & relative_path)
+    {
+        String result;
+        result.reserve(relative_path.size());
+        for (char ch : relative_path)
+        {
+            auto c = static_cast<unsigned char>(ch);
+            if (c != '/' && needsUriEncoding(c))
+            {
+                result += '%';
+                result += hexDigitUppercase(c / 16);
+                result += hexDigitUppercase(c % 16);
+            }
+            else
+                result += ch;
+        }
+        return result;
+    }
+
     /// Given partition columns list,
     /// create Hive style partition strategy with partition by expression
     /// created as Tuple function containing those columns: (a, b, ..).
@@ -90,11 +161,46 @@ DeltaLakePartitionedSink::DeltaLakePartitionedSink(
     , write_compression_method(write_compression_method_)
 {
     delta_transaction->validateSchema(getHeader());
+
+    /// One `toString(<column>)` expression per partition column (Nullable columns yield
+    /// `Nullable(String)`, keeping nulls distinguishable). Nullability is taken from the Delta
+    /// write schema, which is authoritative over the user-supplied header.
+    const auto & write_schema = delta_transaction->getWriteSchema();
+    partition_value_actions.reserve(partition_columns.size());
+    partition_column_nullable.reserve(partition_columns.size());
+    for (const auto & column : partition_columns)
+    {
+        ASTs to_string_args{make_intrusive<ASTIdentifier>(column)};
+        ASTPtr to_string_ast = makeASTFunction("toString", std::move(to_string_args));
+        partition_value_actions.push_back(partition_strategy->getPartitionExpressionActions(to_string_ast));
+
+        auto schema_column = write_schema.tryGetByName(column);
+        if (!schema_column)
+            throw Exception(
+                ErrorCodes::INCORRECT_DATA,
+                "Partition column '{}' is not present in the DeltaLake table schema", column);
+        partition_column_nullable.push_back(schema_column->type->isNullable());
+    }
+}
+
+Columns DeltaLakePartitionedSink::computePartitionValueColumns(const Chunk & chunk) const
+{
+    Columns result;
+    result.reserve(partition_value_actions.size());
+    for (const auto & actions_with_column : partition_value_actions)
+    {
+        Block block = getHeader().cloneWithoutColumns();
+        block.setColumns(chunk.getColumns());
+        actions_with_column.actions->execute(block);
+        result.push_back(block.getByName(actions_with_column.column_name).column->convertToFullColumnIfConst());
+    }
+    return result;
 }
 
 void DeltaLakePartitionedSink::consume(Chunk & chunk)
 {
-    const ColumnPtr partition_by_result_column = partition_strategy->computePartitionKey(chunk);
+    /// Serialized (toString) value of each partition column, preserving nulls.
+    const Columns partition_value_columns = computePartitionValueColumns(chunk);
 
     /// Not all columns are serialized using the format writer
     /// (e.g, hive partitioning stores partition columns in the file path)
@@ -110,15 +216,53 @@ void DeltaLakePartitionedSink::consume(Chunk & chunk)
     chunk_row_index_to_partition_index.resize(chunk_rows);
 
     HashMapWithSavedHash<std::string_view, size_t> partition_id_to_chunk_index;
+    std::vector<PartitionValues> partition_index_to_values;
 
     for (size_t row = 0; row < chunk_rows; ++row)
     {
-        auto partition_key = partition_by_result_column->getDataAt(row);
+        /// Grouping key is null-tagged and embeds the escaped value, so a real NULL and the
+        /// literal `__HIVE_DEFAULT_PARTITION__` (same directory) stay distinct, and values that
+        /// differ only by reserved characters do not merge.
+        PartitionValues row_values;
+        row_values.reserve(partition_columns.size());
+        String grouping_key;
+        for (size_t col = 0; col < partition_columns.size(); ++col)
+        {
+            const IColumn & column = *partition_value_columns[col];
+            /// Delta treats both SQL NULL and an empty string as null-equivalent partition values.
+            const bool is_null = column.isNullAt(row);
+            String value = is_null ? String{} : String{column.getDataAt(row)};
+            const bool is_null_equivalent = is_null || value.empty();
+
+            /// A null-equivalent value is committed as a JSON null in `partitionValues`; for a
+            /// non-nullable partition column the reader would then fail with
+            /// CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN, so reject it here (delta-rs rejects it too).
+            if (is_null_equivalent && !partition_column_nullable[col])
+                throw Exception(
+                    ErrorCodes::CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN,
+                    "Cannot write {} partition value into non-nullable DeltaLake partition column '{}'",
+                    is_null ? "NULL" : "empty-string", partition_columns[col]);
+
+            PartitionValue pv;
+            pv.name = partition_columns[col];
+            pv.is_null = is_null_equivalent;
+            if (!is_null_equivalent)
+                pv.value = std::move(value);
+
+            grouping_key += pv.is_null ? '\0' : '\1';
+            grouping_key += buildPartitionPathComponent(pv);
+            grouping_key += '/';
+            row_values.push_back(std::move(pv));
+        }
+
         auto [it, inserted] = partition_id_to_chunk_index.insert(
-            makePairNoInit(partition_key, partition_id_to_chunk_index.size()));
+            makePairNoInit(std::string_view(grouping_key), partition_id_to_chunk_index.size()));
 
         if (inserted)
-            it->value.first = copyStringInArena(partition_keys_arena, partition_key);
+        {
+            it->value.first = copyStringInArena(partition_keys_arena, std::string_view(grouping_key));
+            partition_index_to_values.push_back(std::move(row_values));
+        }
 
         chunk_row_index_to_partition_index[row] = it->getMapped();
     }
@@ -152,7 +296,7 @@ void DeltaLakePartitionedSink::consume(Chunk & chunk)
 
     for (const auto & [partition_key, partition_index] : partition_id_to_chunk_index)
     {
-        auto & data_files = getPartitionDataForPartitionKey(partition_key)->data_files;
+        auto & data_files = getPartitionDataForPartitionKey(partition_key, partition_index_to_values[partition_index])->data_files;
         auto & partition_chunk = partition_index_to_chunk[partition_index];
 
         if (data_files.empty()
@@ -170,18 +314,24 @@ void DeltaLakePartitionedSink::consume(Chunk & chunk)
 }
 
 DeltaLakePartitionedSink::PartitionInfoPtr
-DeltaLakePartitionedSink::getPartitionDataForPartitionKey(std::string_view partition_key)
+DeltaLakePartitionedSink::getPartitionDataForPartitionKey(std::string_view partition_key, const PartitionValues & partition_values)
 {
     auto it = partitions_data.find(partition_key);
     if (it == partitions_data.end())
-        std::tie(it, std::ignore) = partitions_data.emplace(partition_key, std::make_shared<PartitionInfo>(partition_key));
+        std::tie(it, std::ignore) = partitions_data.emplace(partition_key, std::make_shared<PartitionInfo>(partition_key, partition_values));
     return it->second;
 }
 
 DeltaLakePartitionedSink::StorageSinkPtr
 DeltaLakePartitionedSink::createSinkForPartition(std::string_view partition_key)
 {
-    auto data_prefix = std::filesystem::path(delta_transaction->getDataPath()) / partition_key;
+    /// The grouping key is null-tagged and not a filesystem path; build the physical Hive
+    /// directory (`col=escape(value)/...`) from the true partition values instead.
+    const auto & partition_values = partitions_data.at(partition_key)->partition_values;
+    std::filesystem::path data_prefix(delta_transaction->getDataPath());
+    for (const auto & pv : partition_values)
+        data_prefix /= buildPartitionPathComponent(pv);
+
     return std::make_unique<StorageObjectStorageSink>(
         DeltaLake::generateWritePath(std::move(data_prefix), write_format),
         object_storage,
@@ -203,19 +353,23 @@ void DeltaLakePartitionedSink::onFinish()
 
     for (auto & [_, partition_info] : partitions_data)
     {
-        auto & [partition_key, data_files] = *partition_info;
-        std::string partition_key_str{partition_key};
-        auto keys_and_values = HivePartitioningUtils::parseHivePartitioningKeysAndValues(partition_key_str);
+        auto & data_files = partition_info->data_files;
+
+        /// Build `partitionValues` from the true logical values, never by parsing them back out
+        /// of the path (which cannot round-trip values containing `/` or `=`). Null-equivalent
+        /// values (SQL NULL and empty string) are committed as a JSON null, per the Delta protocol.
         Map partition_values;
-        partition_values.reserve(keys_and_values.size());
-        for (const auto & [key, value] : keys_and_values)
-            partition_values.emplace_back(DB::Tuple({key, value}));
+        partition_values.reserve(partition_info->partition_values.size());
+        for (const auto & pv : partition_info->partition_values)
+            partition_values.emplace_back(DB::Tuple({Field(pv.name), pv.is_null ? Field() : Field(pv.value)}));
 
         for (const auto & [sink, written_bytes, written_rows] : data_files)
         {
             sink->onFinish();
             files.emplace_back(
-                sink->getPath().substr(data_prefix.size()),
+                /// `add.path` is the URI-encoded on-disk path, so the reader's single
+                /// `unescapeForFileName` (TableSnapshot) recovers the real relative path.
+                uriEncodePath(sink->getPath().substr(data_prefix.size())),
                 /// We use file size from sink to count all file, not just actual data.
                 sink->getFileSize(),
                 written_rows,

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/DeltaLakePartitionedSink.h
@@ -47,6 +47,17 @@ public:
 
     void onFinish() override;
 
+    /// A single partition column's logical value for one partition.
+    /// `is_null` covers the Delta null-equivalent forms (SQL NULL and empty string);
+    /// `value` is the `toString`-serialized value and is meaningless when `is_null`.
+    struct PartitionValue
+    {
+        String name;
+        String value;
+        bool is_null = false;
+    };
+    using PartitionValues = std::vector<PartitionValue>;
+
 private:
     using StorageSinkPtr = std::unique_ptr<StorageObjectStorageSink>;
 
@@ -60,9 +71,14 @@ private:
     };
     struct PartitionInfo
     {
-        explicit PartitionInfo(std::string_view partition_key_) : partition_key(partition_key_) {}
+        explicit PartitionInfo(std::string_view partition_key_, PartitionValues partition_values_)
+            : partition_key(partition_key_), partition_values(std::move(partition_values_)) {}
 
+        /// Null-tagged grouping key that uniquely identifies this partition (not a path).
         const std::string_view partition_key;
+        /// The true logical partition values; the physical directory and `partitionValues` are
+        /// built from these, never parsed back out of a path.
+        const PartitionValues partition_values;
         std::vector<DataFileInfo> data_files;
     };
     using PartitionInfoPtr = std::shared_ptr<PartitionInfo>;
@@ -83,8 +99,21 @@ private:
     IColumn::Selector chunk_row_index_to_partition_index;
     Arena partition_keys_arena;
 
+    /// Per-partition-column expressions that serialize each value with `toString`,
+    /// preserving nulls (result columns are `Nullable(String)`). Built once, in order.
+    std::vector<IPartitionStrategy::PartitionExpressionActionsAndColumnName> partition_value_actions;
+
+    /// Whether each partition column (in `partition_columns` order) is nullable in the table
+    /// schema. A null-equivalent value for a non-nullable column is rejected up front, because
+    /// Delta stores it as a JSON null, which cannot be read back into a non-nullable column.
+    std::vector<UInt8> partition_column_nullable;
+
+    /// Serialize the partition columns of `chunk` to `Nullable(String)` (one column per
+    /// partition column, in `partition_columns` order).
+    Columns computePartitionValueColumns(const Chunk & chunk) const;
+
     StorageSinkPtr createSinkForPartition(std::string_view partition_key);
-    PartitionInfoPtr getPartitionDataForPartitionKey(std::string_view partition_key);
+    PartitionInfoPtr getPartitionDataForPartitionKey(std::string_view partition_key, const PartitionValues & partition_values);
 };
 
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.cpp
@@ -10,6 +10,7 @@
 
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeString.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeTuple.h>
@@ -72,9 +73,11 @@ std::shared_ptr<arrow::Table> getWriteMetadata(
 {
     DB::ColumnsWithTypeAndName names_and_types{
         {std::make_shared<DB::DataTypeString>(), "path"},
+        /// Partition values are nullable: Delta commits a JSON null for a null-equivalent
+        /// partition value (SQL NULL or empty string), distinct from the string "null".
         {std::make_shared<DB::DataTypeMap>(
             std::make_shared<DB::DataTypeString>(),
-            std::make_shared<DB::DataTypeString>()), "partitionValues"},
+            std::make_shared<DB::DataTypeNullable>(std::make_shared<DB::DataTypeString>())), "partitionValues"},
         {std::make_shared<DB::DataTypeInt64>(), "size"},
         {std::make_shared<DB::DataTypeInt64>(), "modificationTime"},
         {std::make_shared<DB::DataTypeTuple>(
@@ -145,6 +148,12 @@ const std::string & WriteTransaction::getDataPath() const
 {
     assertTransactionCreated();
     return path_prefix;
+}
+
+const DB::NamesAndTypesList & WriteTransaction::getWriteSchema() const
+{
+    assertTransactionCreated();
+    return write_schema;
 }
 
 void WriteTransaction::create(const DB::Names & partition_columns, const DB::NamesAndTypesList & table_schema)

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.h
@@ -34,6 +34,10 @@ public:
     /// Validate if schema is consistent with the write schema of the transaction.
     void validateSchema(const DB::Block & header) const;
 
+    /// The Delta table's write schema (authoritative types and nullability, one entry per
+    /// column). Nullable Delta columns are wrapped in `DataTypeNullable`.
+    const DB::NamesAndTypesList & getWriteSchema() const;
+
 private:
     using KernelTransaction = DeltaLake::KernelPointerWrapper<ffi::ExclusiveTransaction, ffi::free_transaction>;
     using KernelExternEngine = DeltaLake::KernelPointerWrapper<ffi::SharedExternEngine, ffi::free_engine>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -335,7 +335,6 @@ struct DeltaLakeMetadataImpl
                             auto & current_partition_columns = file_partition_columns[full_path];
                             for (const auto & partition_name : partition_values->getNames())
                             {
-                                const auto value = partition_values->getValue<String>(partition_name);
                                 auto name_and_type = file_schema.tryGetByName(partition_name);
                                 if (!name_and_type)
                                 {
@@ -344,6 +343,16 @@ struct DeltaLakeMetadataImpl
                                         "No such column in schema: {} (schema: {})",
                                         partition_name, file_schema.toNamesAndTypesDescription());
                                 }
+
+                                /// A null-equivalent partition value is committed as a JSON null; read it
+                                /// back as NULL instead of throwing while extracting it as a String.
+                                if (partition_values->isNull(partition_name))
+                                {
+                                    current_partition_columns.emplace_back(*name_and_type, Field{});
+                                    continue;
+                                }
+
+                                const auto value = partition_values->getValue<String>(partition_name);
 
                                 LOG_TEST(log, "Partition {} value is {} (data type: {}, file: {})",
                                          partition_name, value, name_and_type->type->getName(), filename);
@@ -584,6 +593,16 @@ struct DeltaLakeMetadataImpl
                                 "No such column in schema: {} (schema: {})",
                                 partition_name, file_schema.toString());
                         }
+
+                        /// A null-equivalent partition value is committed as a JSON null; read it
+                        /// back as NULL instead of throwing while extracting it as a String.
+                        if (tuple[1].isNull())
+                        {
+                            current_partition_columns.emplace_back(std::move(name_and_type.value()), Field{});
+                            LOG_TEST(log, "Partition {} value is NULL (for {})", partition_name, filename);
+                            continue;
+                        }
+
                         const auto value = tuple[1].safeGet<String>();
                         auto field = DB::DeltaLakeMetadata::getFieldValue(value, name_and_type->type);
                         current_partition_columns.emplace_back(std::move(name_and_type.value()), std::move(field));

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <set>
 #include <Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.h>
 #include <Storages/ObjectStorage/Utils.h>
@@ -197,7 +198,11 @@ struct DeltaLakeMetadataImpl
         }
         else
         {
-            const auto keys = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
+            /// Commits must be replayed in version order: `metaData` establishes the schema that
+            /// later `add` actions are resolved against, and a later `remove` supersedes an earlier
+            /// `add`. Object listing is unordered, so sort the zero-padded version file names.
+            auto keys = listFiles(*object_storage, table_path, deltalake_metadata_directory, metadata_file_suffix);
+            std::sort(keys.begin(), keys.end());
             for (const String & key : keys)
                 processMetadataFile(key, current_schema, current_partition_columns, result_files);
         }
@@ -335,7 +340,6 @@ struct DeltaLakeMetadataImpl
                             auto & current_partition_columns = file_partition_columns[full_path];
                             for (const auto & partition_name : partition_values->getNames())
                             {
-                                const auto value = partition_values->getValue<String>(partition_name);
                                 auto name_and_type = file_schema.tryGetByName(partition_name);
                                 if (!name_and_type)
                                 {
@@ -344,6 +348,16 @@ struct DeltaLakeMetadataImpl
                                         "No such column in schema: {} (schema: {})",
                                         partition_name, file_schema.toNamesAndTypesDescription());
                                 }
+
+                                /// A null-equivalent partition value is committed as a JSON null; read it
+                                /// back as NULL instead of throwing while extracting it as a String.
+                                if (partition_values->isNull(partition_name))
+                                {
+                                    current_partition_columns.emplace_back(*name_and_type, Field{});
+                                    continue;
+                                }
+
+                                const auto value = partition_values->getValue<String>(partition_name);
 
                                 LOG_TEST(log, "Partition {} value is {} (data type: {}, file: {})",
                                          partition_name, value, name_and_type->type->getName(), filename);

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -335,6 +335,7 @@ struct DeltaLakeMetadataImpl
                             auto & current_partition_columns = file_partition_columns[full_path];
                             for (const auto & partition_name : partition_values->getNames())
                             {
+                                const auto value = partition_values->getValue<String>(partition_name);
                                 auto name_and_type = file_schema.tryGetByName(partition_name);
                                 if (!name_and_type)
                                 {
@@ -343,16 +344,6 @@ struct DeltaLakeMetadataImpl
                                         "No such column in schema: {} (schema: {})",
                                         partition_name, file_schema.toNamesAndTypesDescription());
                                 }
-
-                                /// A null-equivalent partition value is committed as a JSON null; read it
-                                /// back as NULL instead of throwing while extracting it as a String.
-                                if (partition_values->isNull(partition_name))
-                                {
-                                    current_partition_columns.emplace_back(*name_and_type, Field{});
-                                    continue;
-                                }
-
-                                const auto value = partition_values->getValue<String>(partition_name);
 
                                 LOG_TEST(log, "Partition {} value is {} (data type: {}, file: {})",
                                          partition_name, value, name_and_type->type->getName(), filename);

--- a/tests/queries/0_stateless/04628_delta_lake_partition_special_values.reference
+++ b/tests/queries/0_stateless/04628_delta_lake_partition_special_values.reference
@@ -1,0 +1,41 @@
+-- slash: 'a/b' must round-trip (was truncated to 'a'); committed inside one path segment
+1	a/b
+committed path: part=a%252Fb/<uuid>.parquet
+-- percent: '%' must round-trip (committed file was previously unreadable)
+1	%
+committed path: part=%2525/<uuid>.parquet
+-- assorted reserved characters must round-trip
+1	a/b
+2	%
+3	a b
+4	a=b
+5	plain
+-- dash and other Hive-safe characters are NOT escaped in the directory (readable names),
+-- but the committed add.path is URI-encoded (space -> %20)
+1	comment-0
+2	a b
+committed paths: part=a%20b/<uuid>.parquet
+part=comment-0/<uuid>.parquet
+-- null: NULL partition value must be accepted and read back as NULL (was NOT_IMPLEMENTED)
+1	\N
+committed path: part=__HIVE_DEFAULT_PARTITION__/<uuid>.parquet
+-- empty string is null-equivalent per the Delta protocol (reads back as NULL)
+1	\N
+committed path: part=__HIVE_DEFAULT_PARTITION__/<uuid>.parquet
+-- NULL and the literal string '__HIVE_DEFAULT_PARTITION__' stay distinct
+1	\N
+2	__HIVE_DEFAULT_PARTITION__
+-- null-equivalent value into a non-nullable partition column is rejected up front
+CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN
+-- rejection uses the Delta schema, not the input header: an explicit Nullable structure
+-- over a non-nullable Delta partition column must still reject a NULL
+CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN
+-- non-string (Int32) partition column serializes with toString, not raw bytes
+1	42
+2	-7
+3	\N
+-- multiple partition columns with reserved characters round-trip
+1	a/b	c%d
+2	p	q
+committed paths: a=a%252Fb/b=c%2525d/<uuid>.parquet
+a=p/b=q/<uuid>.parquet

--- a/tests/queries/0_stateless/04628_delta_lake_partition_special_values.reference
+++ b/tests/queries/0_stateless/04628_delta_lake_partition_special_values.reference
@@ -19,9 +19,11 @@ part=comment-0/<uuid>.parquet
 -- null: NULL partition value must be accepted and read back as NULL (was NOT_IMPLEMENTED)
 1	\N
 committed path: part=__HIVE_DEFAULT_PARTITION__/<uuid>.parquet
+committed partitionValues: "partitionValues":{"part":null}
 -- empty string is null-equivalent per the Delta protocol (reads back as NULL)
 1	\N
 committed path: part=__HIVE_DEFAULT_PARTITION__/<uuid>.parquet
+committed partitionValues: "partitionValues":{"part":null}
 -- NULL and the literal string '__HIVE_DEFAULT_PARTITION__' stay distinct
 1	\N
 2	__HIVE_DEFAULT_PARTITION__
@@ -39,3 +41,16 @@ CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN
 2	p	q
 committed paths: a=a%252Fb/b=c%2525d/<uuid>.parquet
 a=p/b=q/<uuid>.parquet
+-- Unicode (UTF-8) partition values round-trip; non-ASCII bytes stay literal in the
+-- directory and are URI-encoded in the committed add.path
+1	café
+2	日本語
+3	a/münchen
+committed paths: part=%E6%97%A5%E6%9C%AC%E8%AA%9E/<uuid>.parquet
+part=a%252Fm%C3%BCnchen/<uuid>.parquet
+part=caf%C3%A9/<uuid>.parquet
+-- the legacy (non-kernel) reader must also read a null partition value back as NULL
+-- (the committed JSON null previously threw in the String-only parsing path)
+1	\N
+2	x
+3	\N

--- a/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
+++ b/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-msan
+# Tag no-fasttest: delta-kernel pulls in extra dependencies.
+# Tag no-msan: delta-kernel-rs (Rust) is not built under MSan, so DeltaLakeLocal is absent.
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/111758
+# DeltaLake partitioned INSERT corrupted path-like partition values and rejected NULL:
+#   'a/b' was committed and read back as 'a' (the '/' was treated as a path separator and
+#   the partition value was reverse-parsed out of the path); '%' produced a file the reader
+#   could not open (the committed path was decoded once by unescapeForFileName); NULL threw
+#   NOT_IMPLEMENTED. The sink now percent-encodes each value into a single Hive path segment,
+#   commits the true value in partitionValues (never parsed from the path), and represents a
+#   null (or empty-string) partition value as __HIVE_DEFAULT_PARTITION__ + a JSON null.
+#
+# The empty Delta tables are bootstrapped by hand (a v0 _delta_log with only protocol +
+# metaData), because ClickHouse cannot initialize a Delta transaction log itself.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+ROOT="${USER_FILES_PATH}/${CLICKHOUSE_DATABASE}_delta_part"
+trap 'rm -rf "${ROOT}" 2>/dev/null' EXIT
+rm -rf "${ROOT}"
+
+# Create an empty partitioned Delta table at $1 with the given JSON schema string ($2) and
+# partitionColumns array ($3), using a minimal v0 transaction log (what delta-rs writes for an
+# empty overwrite).
+bootstrap() {
+    local path="$1"
+    local schema="$2"
+    local partition_cols="$3"
+    mkdir -p "${path}/_delta_log"
+    cat > "${path}/_delta_log/00000000000000000000.json" <<EOF
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+{"metaData":{"id":"${CLICKHOUSE_DATABASE}-$(basename "${path}")","format":{"provider":"parquet","options":{}},"schemaString":"${schema}","partitionColumns":${partition_cols},"configuration":{},"createdTime":1700000000000}}
+EOF
+}
+
+# List the committed data-file paths (add.path) from the _delta_log, with the random UUID
+# file name normalized to a stable token so the reference is deterministic. Only the partition
+# directory and its encoding (the thing under test) are shown.
+committed_paths() {
+    local path="$1"
+    grep -h '"add"' "${path}"/_delta_log/*.json \
+        | sed -E 's/.*"path":"([^"]*)".*/\1/' \
+        | sed -E 's:/[0-9a-f-]{36}\.parquet$:/<uuid>.parquet:' \
+        | sort
+}
+
+# schema for (number Int32 NOT NULL, part Nullable(String)) partitioned by part
+SCHEMA_PART='{\"type\":\"struct\",\"fields\":[{\"name\":\"number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"part\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}'
+
+echo "-- slash: 'a/b' must round-trip (was truncated to 'a'); committed inside one path segment"
+bootstrap "${ROOT}/slash" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/slash') VALUES (1, 'a/b');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/slash') ORDER BY number;
+"
+echo "committed path: $(committed_paths "${ROOT}/slash")"
+
+echo "-- percent: '%' must round-trip (committed file was previously unreadable)"
+bootstrap "${ROOT}/percent" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/percent') VALUES (1, '%');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/percent') ORDER BY number;
+"
+echo "committed path: $(committed_paths "${ROOT}/percent")"
+
+echo "-- assorted reserved characters must round-trip"
+bootstrap "${ROOT}/mixed" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/mixed') VALUES (1, 'a/b'), (2, '%'), (3, 'a b'), (4, 'a=b'), (5, 'plain');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/mixed') ORDER BY number;
+"
+
+echo "-- dash and other Hive-safe characters are NOT escaped in the directory (readable names),"
+echo "-- but the committed add.path is URI-encoded (space -> %20)"
+bootstrap "${ROOT}/dash" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/dash') VALUES (1, 'comment-0'), (2, 'a b');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/dash') ORDER BY number;
+"
+echo "committed paths: $(committed_paths "${ROOT}/dash")"
+
+echo "-- null: NULL partition value must be accepted and read back as NULL (was NOT_IMPLEMENTED)"
+bootstrap "${ROOT}/null" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/null') VALUES (1, NULL);
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/null') ORDER BY number;
+"
+echo "committed path: $(committed_paths "${ROOT}/null")"
+
+echo "-- empty string is null-equivalent per the Delta protocol (reads back as NULL)"
+bootstrap "${ROOT}/empty" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/empty') VALUES (1, '');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/empty') ORDER BY number;
+"
+echo "committed path: $(committed_paths "${ROOT}/empty")"
+
+echo "-- NULL and the literal string '__HIVE_DEFAULT_PARTITION__' stay distinct"
+bootstrap "${ROOT}/collide" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/collide') VALUES (1, NULL), (2, '__HIVE_DEFAULT_PARTITION__');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/collide') ORDER BY number;
+"
+
+# schema for (number Int32 NOT NULL, part String NOT NULL) partitioned by part
+SCHEMA_NONNULL='{\"type\":\"struct\",\"fields\":[{\"name\":\"number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"part\",\"type\":\"string\",\"nullable\":false,\"metadata\":{}}]}'
+
+echo "-- null-equivalent value into a non-nullable partition column is rejected up front"
+bootstrap "${ROOT}/nonnull" "${SCHEMA_NONNULL}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/nonnull') VALUES (1, '');
+" 2>&1 | grep -o "CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN" | head -1
+
+echo "-- rejection uses the Delta schema, not the input header: an explicit Nullable structure"
+echo "-- over a non-nullable Delta partition column must still reject a NULL"
+bootstrap "${ROOT}/nonnull2" "${SCHEMA_NONNULL}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO TABLE FUNCTION deltaLakeLocal('${ROOT}/nonnull2', 'Parquet', 'number Int32, part Nullable(String)') VALUES (1, NULL);
+" 2>&1 | grep -o "CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN" | head -1
+
+# schema for (number Int32 NOT NULL, k Nullable(Int32)) partitioned by k
+SCHEMA_INT='{\"type\":\"struct\",\"fields\":[{\"name\":\"number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"k\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}'
+
+echo "-- non-string (Int32) partition column serializes with toString, not raw bytes"
+bootstrap "${ROOT}/int" "${SCHEMA_INT}" '["k"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/int') VALUES (1, 42), (2, -7), (3, NULL);
+    SELECT number, k FROM deltaLakeLocal('${ROOT}/int') ORDER BY number;
+"
+
+# schema for (number Int32, a Nullable(String), b Nullable(String)) partitioned by a, b
+SCHEMA_TWO='{\"type\":\"struct\",\"fields\":[{\"name\":\"number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"a\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}},{\"name\":\"b\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}'
+
+echo "-- multiple partition columns with reserved characters round-trip"
+bootstrap "${ROOT}/two" "${SCHEMA_TWO}" '["a","b"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/two') VALUES (1, 'a/b', 'c%d'), (2, 'p', 'q');
+    SELECT number, a, b FROM deltaLakeLocal('${ROOT}/two') ORDER BY number;
+"
+echo "committed paths: $(committed_paths "${ROOT}/two")"

--- a/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
+++ b/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
@@ -45,7 +45,7 @@ committed_paths() {
     grep -h '"add"' "${path}"/_delta_log/*.json \
         | sed -E 's/.*"path":"([^"]*)".*/\1/' \
         | sed -E 's:/[0-9a-f-]{36}\.parquet$:/<uuid>.parquet:' \
-        | sort
+        | LC_ALL=C sort
 }
 
 # List the committed `partitionValues` object of every add action, sorted. This shows the exact
@@ -55,7 +55,7 @@ committed_partition_values() {
     local path="$1"
     grep -h '"add"' "${path}"/_delta_log/*.json \
         | sed -E 's/.*("partitionValues":\{[^}]*\}).*/\1/' \
-        | sort
+        | LC_ALL=C sort
 }
 
 # schema for (number Int32 NOT NULL, part Nullable(String)) partitioned by part

--- a/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
+++ b/tests/queries/0_stateless/04628_delta_lake_partition_special_values.sh
@@ -48,6 +48,16 @@ committed_paths() {
         | sort
 }
 
+# List the committed `partitionValues` object of every add action, sorted. This shows the exact
+# JSON committed for a null partition (`{"part":null}`), so a writer that omitted the key (which
+# the reader would still materialize as NULL) would be caught here.
+committed_partition_values() {
+    local path="$1"
+    grep -h '"add"' "${path}"/_delta_log/*.json \
+        | sed -E 's/.*("partitionValues":\{[^}]*\}).*/\1/' \
+        | sort
+}
+
 # schema for (number Int32 NOT NULL, part Nullable(String)) partitioned by part
 SCHEMA_PART='{\"type\":\"struct\",\"fields\":[{\"name\":\"number\",\"type\":\"integer\",\"nullable\":false,\"metadata\":{}},{\"name\":\"part\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}'
 
@@ -90,6 +100,7 @@ ${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
     SELECT number, part FROM deltaLakeLocal('${ROOT}/null') ORDER BY number;
 "
 echo "committed path: $(committed_paths "${ROOT}/null")"
+echo "committed partitionValues: $(committed_partition_values "${ROOT}/null")"
 
 echo "-- empty string is null-equivalent per the Delta protocol (reads back as NULL)"
 bootstrap "${ROOT}/empty" "${SCHEMA_PART}" '["part"]'
@@ -98,6 +109,7 @@ ${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
     SELECT number, part FROM deltaLakeLocal('${ROOT}/empty') ORDER BY number;
 "
 echo "committed path: $(committed_paths "${ROOT}/empty")"
+echo "committed partitionValues: $(committed_partition_values "${ROOT}/empty")"
 
 echo "-- NULL and the literal string '__HIVE_DEFAULT_PARTITION__' stay distinct"
 bootstrap "${ROOT}/collide" "${SCHEMA_PART}" '["part"]'
@@ -142,3 +154,22 @@ ${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
     SELECT number, a, b FROM deltaLakeLocal('${ROOT}/two') ORDER BY number;
 "
 echo "committed paths: $(committed_paths "${ROOT}/two")"
+
+echo "-- Unicode (UTF-8) partition values round-trip; non-ASCII bytes stay literal in the"
+echo "-- directory and are URI-encoded in the committed add.path"
+bootstrap "${ROOT}/unicode" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/unicode') VALUES (1, 'café'), (2, '日本語'), (3, 'a/münchen');
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/unicode') ORDER BY number;
+"
+echo "committed paths: $(committed_paths "${ROOT}/unicode")"
+
+echo "-- the legacy (non-kernel) reader must also read a null partition value back as NULL"
+echo "-- (the committed JSON null previously threw in the String-only parsing path)"
+bootstrap "${ROOT}/legacy_null" "${SCHEMA_PART}" '["part"]'
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --query "
+    INSERT INTO FUNCTION deltaLakeLocal('${ROOT}/legacy_null') VALUES (1, NULL), (2, 'x'), (3, '');
+"
+${CLICKHOUSE_LOCAL} --allow_experimental_delta_lake_writes=1 --allow_experimental_delta_kernel_rs=0 --query "
+    SELECT number, part FROM deltaLakeLocal('${ROOT}/legacy_null') ORDER BY number;
+"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/111758
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/111758

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed DeltaLake partitioned `INSERT` (`allow_experimental_delta_lake_writes=1`) corrupting partition values that contain path characters and rejecting `NULL`. A value like `a/b` was silently committed as `a`, `%` produced a data file that could not be read back, and a `NULL` partition value failed with `NOT_IMPLEMENTED`. Partition values are now percent-encoded into a single path segment, the true value is stored in `partitionValues` instead of being parsed back out of the path, and a `NULL` (or empty-string) partition value is written as `__HIVE_DEFAULT_PARTITION__` with a null `partitionValues` entry.

### Description

Report: partitioned writes to a Delta table mangled several valid partition values (found by fuzzing, confirmed with both `DeltaLakeLocal` and `DeltaLake` over S3).

Root cause, all on the write side (`DeltaLakePartitionedSink`):

- The Hive directory was built by concatenating raw partition values, so `/` became a path separator (`a/b` -> `part=a/b/...`) and `%` was written literally.
- `onFinish()` recovered `partitionValues` by parsing that directory back, which cannot round-trip a value containing `/` or `=`.
- The committed `add.path` was the raw relative path, but the reader resolves it through a single `unescapeForFileName`, so a literal `%` was decoded into a different, non-existent path.
- `NULL` reached `getDataAt` on a `Nullable` column and threw `NOT_IMPLEMENTED`.

Fix:

- Serialize each partition column with `toString` (nulls preserved) and keep the true per-column value.
- Build the physical directory as `col=escapeForFileName(value)`, and represent a null-equivalent value (SQL `NULL` or empty string, per the Delta protocol) as `__HIVE_DEFAULT_PARTITION__`.
- Commit `partitionValues` from the true value (a JSON null for null-equivalent values); the `partitionValues` map value type is now `Nullable(String)`.
- Percent-encode `add.path` one extra level so the reader's single `unescapeForFileName` reproduces the exact on-disk path.
- Group rows by a null-tagged, escaped key so a real `NULL` and the literal string `__HIVE_DEFAULT_PARTITION__` stay distinct.

The kernel reader already reads these values back correctly. During review the legacy (non-kernel) reader (`DeltaLakeMetadata.cpp`, used with `allow_experimental_delta_kernel_rs = 0`) was found to assume every partition value is a `String`, so the new JSON-null `partitionValues` entry made a table with a null partition unreadable there. Both legacy parsing branches (JSON log and checkpoint) now read a JSON/Map null back as a `NULL` value, keeping the fallback reader working.

Output verified to round-trip in ClickHouse (both readers) and to be read back identically by delta-rs for `/`, `%`, space, `=`, Unicode, `NULL`, empty string, `Int`/`Date` partition columns, and multi-column partitions.
